### PR TITLE
feat: streaming queries (WS async-gen + SSE HTTP) (PLAN2 #11)

### DIFF
--- a/packages/client/__tests__/stream.test.ts
+++ b/packages/client/__tests__/stream.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { CirrusClient } from "../src/cirrus-client.js";
+import { createStream, DEFAULT_MAX_BUFFER } from "../src/stream.js";
+import type { FunctionReference } from "../src/types.js";
+
+// --- Mock WebSocket ---------------------------------------------------------
+
+interface MockSocket {
+    addEventListener: (type: string, listener: (event?: unknown) => void) => void;
+    close: () => void;
+    onclose?: ((event?: unknown) => void) | null;
+    onerror?: ((event?: unknown) => void) | null;
+    onmessage?: ((event: { data: unknown }) => void) | null;
+    onopen?: ((event?: unknown) => void) | null;
+    open: () => void;
+    readyState: number;
+    receive: (payload: unknown) => void;
+    send: (data: string) => void;
+    sent: string[];
+}
+
+const sockets: MockSocket[] = [];
+
+const createMockWebSocket = (): typeof WebSocket => {
+    class WS {
+        public readonly url: string;
+
+        public readyState = 0;
+
+        public sent: string[] = [];
+
+        public onopen: ((event?: unknown) => void) | null = null;
+
+        public onmessage: ((event: { data: unknown }) => void) | null = null;
+
+        public onclose: ((event?: unknown) => void) | null = null;
+
+        public onerror: ((event?: unknown) => void) | null = null;
+
+        private readonly listeners = new Map<string, Array<(event?: unknown) => void>>();
+
+        public constructor(url: string) {
+            this.url = url;
+            sockets.push(this as unknown as MockSocket);
+        }
+
+        public addEventListener(type: string, listener: (event?: unknown) => void): void {
+            const existing = this.listeners.get(type) ?? [];
+
+            existing.push(listener);
+            this.listeners.set(type, existing);
+        }
+
+        private dispatch(type: string, event?: unknown): void {
+            for (const listener of this.listeners.get(type) ?? []) {
+                listener(event);
+            }
+        }
+
+        public open(): void {
+            this.readyState = 1;
+            this.onopen?.();
+            this.dispatch("open");
+        }
+
+        public receive(payload: unknown): void {
+            const data = typeof payload === "string" ? payload : JSON.stringify(payload);
+
+            this.onmessage?.({ data });
+            this.dispatch("message", { data });
+        }
+
+        public send(data: string): void {
+            this.sent.push(data);
+        }
+
+        public close(): void {
+            this.readyState = 3;
+            this.onclose?.();
+            this.dispatch("close");
+        }
+    }
+
+    return WS as unknown as typeof WebSocket;
+};
+
+const latestSocket = (): MockSocket => {
+    const last = sockets.at(-1);
+
+    if (!last) {
+        throw new Error("no socket has been created yet");
+    }
+
+    return last;
+};
+
+const fn = <T = unknown>(reference: string): FunctionReference<"stream", Record<string, never>, T> =>
+    ({ __cirrusRef: reference }) as FunctionReference<"stream", Record<string, never>, T>;
+
+beforeEach(() => {
+    sockets.length = 0;
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+// --- createStream unit tests ------------------------------------------------
+
+describe("createStream", () => {
+    test("delivers pushed values to consumers in order", async () => {
+        const { handle, iterable } = createStream<number>({ onCancel: () => {} });
+
+        for (const value of [1, 2]) {
+            handle.push(value);
+        }
+
+        const iter = iterable[Symbol.asyncIterator]();
+
+        await expect(iter.next()).resolves.toEqual({ done: false, value: 1 });
+        await expect(iter.next()).resolves.toEqual({ done: false, value: 2 });
+
+        handle.complete();
+
+        await expect(iter.next()).resolves.toEqual({ done: true, value: undefined });
+    });
+
+    test("pending consumer resolves when a value is pushed later", async () => {
+        const { handle, iterable } = createStream<string>({ onCancel: () => {} });
+        const iter = iterable[Symbol.asyncIterator]();
+
+        const promise = iter.next();
+
+        // Resolve the pending next() with a delayed push.
+        queueMicrotask(() => {
+            handle.push("delivered");
+        });
+
+        await expect(promise).resolves.toEqual({ done: false, value: "delivered" });
+    });
+
+    test("error surfaces as a rejection on the next pull", async () => {
+        const { handle, iterable } = createStream<number>({ onCancel: () => {} });
+
+        handle.fail(new Error("boom"));
+
+        const iter = iterable[Symbol.asyncIterator]();
+
+        await expect(iter.next()).rejects.toThrow("boom");
+    });
+
+    test("cancel() invokes onCancel exactly once and closes the iterator", async () => {
+        const onCancel = vi.fn();
+        const { iterable } = createStream<number>({ onCancel });
+
+        iterable.cancel();
+        iterable.cancel(); // idempotent
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+
+        const iter = iterable[Symbol.asyncIterator]();
+
+        await expect(iter.next()).resolves.toEqual({ done: true, value: undefined });
+    });
+
+    test("backpressure overflow surfaces a STREAM_BACKPRESSURE error", async () => {
+        const { handle, iterable } = createStream<number>({ maxBuffer: 2, onCancel: () => {} });
+
+        for (const value of [1, 2, 3]) {
+            handle.push(value); // third triggers fail
+        }
+
+        const iter = iterable[Symbol.asyncIterator]();
+
+        // The first two queued items get cleared on fail; consumer sees the error.
+        await expect(iter.next()).rejects.toMatchObject({ code: "STREAM_BACKPRESSURE" });
+    });
+
+    test("default buffer is at least 64 chunks", () => {
+        expect(DEFAULT_MAX_BUFFER).toBeGreaterThanOrEqual(64);
+    });
+});
+
+// --- CirrusClient.stream() integration tests --------------------------------
+
+describe("cirrusClient.stream()", () => {
+    test("opens a WS, sends a stream frame, and yields chunks until complete", async () => {
+        const client = new CirrusClient({ url: "https://app.example", WebSocket: createMockWebSocket() });
+
+        const iterable = client.stream(fn<{ tick: number }>("metrics:tick"), {});
+
+        // Drive the socket to "open" so the stream frame flushes.
+        latestSocket().open();
+
+        const sent = latestSocket().sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+        const streamFrame = sent.find((f) => f.type === "stream");
+
+        expect(streamFrame).toBeDefined();
+        expect(streamFrame).toMatchObject({
+            type: "stream",
+            query: { functionPath: "metrics:tick", args: {} },
+        });
+
+        const id = streamFrame?.id as string;
+
+        // Server sends chunks.
+        latestSocket().receive({ type: "chunk", id, data: { tick: 1 } });
+        latestSocket().receive({ type: "chunk", id, data: { tick: 2 } });
+        latestSocket().receive({ type: "complete", id });
+
+        const collected: { tick: number }[] = [];
+
+        for await (const chunk of iterable) {
+            collected.push(chunk);
+        }
+
+        expect(collected).toEqual([{ tick: 1 }, { tick: 2 }]);
+
+        client.close();
+    });
+
+    test("cancel() sends an unsubscribe frame and resolves the iterator", async () => {
+        const client = new CirrusClient({ url: "https://app.example", WebSocket: createMockWebSocket() });
+
+        const iterable = client.stream(fn<number>("metrics:loop"), {});
+
+        latestSocket().open();
+        const sent = latestSocket().sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+        const id = sent.find((f) => f.type === "stream")?.id as string;
+
+        // Push a value, then cancel before consuming all.
+        latestSocket().receive({ type: "chunk", id, data: 1 });
+
+        iterable.cancel();
+
+        const cancelFrame = latestSocket()
+            .sent
+            .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+            .find((f) => f.type === "unsubscribe" && f.id === id);
+
+        expect(cancelFrame).toBeDefined();
+
+        // The iterator resolves to done after cancel.
+        const collected: number[] = [];
+
+        for await (const chunk of iterable) {
+            collected.push(chunk);
+        }
+
+        // Either we read the buffered chunk before cancel cleared it, or we saw nothing — both are valid termination states.
+        expect(collected.length).toBeLessThanOrEqual(1);
+
+        client.close();
+    });
+
+    test("server-side error surfaces as a rejection on the consumer", async () => {
+        const client = new CirrusClient({ url: "https://app.example", WebSocket: createMockWebSocket() });
+
+        const iterable = client.stream(fn<number>("metrics:boom"), {});
+
+        latestSocket().open();
+        const id = (JSON.parse(latestSocket().sent[0] as string) as Record<string, unknown>).id as string;
+
+        latestSocket().receive({ type: "error", id, error: { code: "FORBIDDEN", message: "nope" } });
+
+        const consumer = (async () => {
+            for await (const _chunk of iterable) {
+                /* unreachable */
+            }
+        })();
+
+        await expect(consumer).rejects.toMatchObject({ message: "nope", code: "FORBIDDEN" });
+
+        client.close();
+    });
+
+    test("client.close() fails any in-flight streams", async () => {
+        const client = new CirrusClient({ url: "https://app.example", WebSocket: createMockWebSocket() });
+
+        const iterable = client.stream(fn<number>("metrics:keepalive"), {});
+
+        latestSocket().open();
+
+        client.close();
+
+        const consumer = (async () => {
+            for await (const _chunk of iterable) {
+                /* unreachable */
+            }
+        })();
+
+        await expect(consumer).rejects.toMatchObject({ code: "CLIENT_CLOSED" });
+    });
+
+    test("buffers the start frame while the socket is connecting and flushes it on open", async () => {
+        const client = new CirrusClient({ url: "https://app.example", WebSocket: createMockWebSocket() });
+        const iterable = client.stream(fn<number>("metrics:tick"), {});
+
+        // Before open: nothing has gone over the wire yet.
+        expect(latestSocket().sent).toHaveLength(0);
+
+        latestSocket().open();
+
+        const flushed = latestSocket().sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+
+        expect(flushed.some((f) => f.type === "stream")).toBe(true);
+
+        // Cleanly tear down so the iterator doesn't hang the test process.
+        iterable.cancel();
+        client.close();
+    });
+});

--- a/packages/client/src/cirrus-client.ts
+++ b/packages/client/src/cirrus-client.ts
@@ -1,6 +1,7 @@
 import { createInMemoryBookmarkStorage } from "./bookmark.js";
 import { OfflineQueue } from "./offline-queue.js";
 import { createReconnect, type ReconnectCalculator } from "./reconnect.js";
+import { createStream, type StreamHandle, type StreamIterable } from "./stream.js";
 import { type SubscriptionCallback, type SubscriptionErrorCallback, SubscriptionRegistry, type SubscriptionState } from "./subscription.js";
 import type {
     ArgsOf,
@@ -60,6 +61,8 @@ interface MutationCallOptions<TCurrent, TValue> {
  * are all per-connection so one shard dropping doesn't disturb the others.
  */
 interface ShardConnection {
+    /** Stream-start frames buffered while the socket was (re)connecting. Flushed on `open`. */
+    pendingStreams?: ClientMessage[];
     pendingUnsubscribes: string[];
     reconnect: ReconnectCalculator;
     reconnectTimer: ReturnType<typeof setTimeout> | null;
@@ -130,6 +133,16 @@ export class CirrusClient {
     private lastStatus: ConnectionStatus = "idle";
 
     private nextSubId = 0;
+
+    private nextStreamId = 0;
+
+    /**
+     * In-flight client-side stream readers, keyed by the stream id sent on the
+     * wire. The handle drives the underlying iterator queue and `shardKey`
+     * tells us which socket to push the cancel frame onto when the consumer
+     * calls `.cancel()` or the iterator is garbage-collected.
+     */
+    private readonly streams = new Map<string, { handle: StreamHandle; shardKey: string | undefined }>();
 
     public constructor(opts: CirrusClientOptions) {
         this.url = opts.url;
@@ -624,8 +637,83 @@ export class CirrusClient {
         };
     }
 
+    /**
+     * Open a streaming query. The function reference must point at a
+     * `kind:"stream"` registration (built with `c.query.input(...).stream(...)`);
+     * the returned iterable yields one element per chunk frame the server
+     * pushes, terminating when the server sends `complete` or the consumer
+     * calls `.cancel()`. Errors arrive as a rejection on the next `next()`.
+     *
+     * Streams ride the same WS as subscriptions and share the unsubscribe
+     * channel: cancelling sends `{type:"unsubscribe", id}` with the stream id,
+     * which the DO recognises as an abort signal for the in-flight iterator.
+     */
+    public stream<F extends FunctionReference>(fn: F, args: ArgsOf<F>, opts: { maxBuffer?: number; shardKey?: string } = {}): StreamIterable<ReturnOf<F>> {
+        if (this.closed) {
+            throw new Error("CirrusClient: stream() called after close()");
+        }
+
+        if (this.WebSocketImpl === undefined) {
+            throw new Error("CirrusClient: streams require a WebSocket implementation");
+        }
+
+        this.nextStreamId += 1;
+        const id = `stream_${this.nextStreamId}`;
+        const { shardKey } = opts;
+        const argsRecord = (args ?? {}) as Record<string, unknown>;
+
+        const { handle, iterable } = createStream<ReturnOf<F>>({
+            maxBuffer: opts.maxBuffer,
+            onCancel: () => {
+                // Send the cancel frame on the matching connection (if any).
+                // If the socket is down we drop the cancel: the DO has already
+                // lost its handle on close, so there's nothing to abort.
+                const conn = this.getConnection(shardKey);
+
+                if (conn) {
+                    this.sendOn(conn, { type: "unsubscribe", id });
+                }
+
+                this.streams.delete(id);
+            },
+        });
+
+        // Record before sending so an immediate ack/chunk reaching the dispatch
+        // path before we return finds its target.
+        this.streams.set(id, { handle: handle as StreamHandle, shardKey });
+
+        this.ensureSocket(shardKey);
+
+        const conn = this.getConnection(shardKey);
+        const message: ClientMessage = {
+            type: "stream",
+            id,
+            query: { args: argsRecord, functionPath: fn.__cirrusRef, shardKey },
+        };
+
+        if (conn?.wsState === "open") {
+            this.sendOn(conn, message);
+        } else if (conn) {
+            // Defer the send to the open handler — the existing pending logic
+            // is for unsubscribes, so stash the stream-start frame separately.
+            conn.pendingStreams = conn.pendingStreams ?? [];
+            conn.pendingStreams.push(message);
+        }
+
+        return iterable;
+    }
+
     public close(): void {
         this.closed = true;
+
+        // Fail any in-flight streams so consumers see a deterministic
+        // termination instead of an iterator that hangs forever after the
+        // underlying socket goes away.
+        for (const stream of this.streams.values()) {
+            stream.handle.fail(Object.assign(new Error("CirrusClient closed"), { code: "CLIENT_CLOSED" }));
+        }
+
+        this.streams.clear();
 
         for (const conn of this.connections.values()) {
             if (conn.reconnectTimer !== null) {
@@ -845,6 +933,20 @@ export class CirrusClient {
                 }
             }
 
+            // Flush stream-start frames queued while we were (re)connecting.
+            // Reconnect-after-close: in-flight streams have already torn down
+            // on the server, so the only entries here are brand-new ones that
+            // raced the connect.
+            if (conn.pendingStreams && conn.pendingStreams.length > 0) {
+                const pending = conn.pendingStreams;
+
+                conn.pendingStreams = [];
+
+                for (const message of pending) {
+                    this.sendOn(conn, message);
+                }
+            }
+
             this.flushOfflineQueue(shardKey);
         });
 
@@ -938,13 +1040,43 @@ export class CirrusClient {
             return;
         }
 
+        if (message.type === "chunk") {
+            const { id, data } = message;
+            const stream = this.streams.get(id);
+
+            if (stream) {
+                stream.handle.push(data);
+            }
+
+            return;
+        }
+
         if (message.type === "error") {
+            // Stream-scoped errors arrive on the same `error` envelope as
+            // subscription errors; dispatch by id-prefix lookup.
+            const { id } = message;
+            const stream = id === undefined ? undefined : this.streams.get(id);
+
+            if (stream && id !== undefined) {
+                const code = typeof (message.error as { code?: unknown } | undefined)?.code === "string" ? (message.error as { code: string }).code : undefined;
+                const messageText =
+                    (typeof message.message === "string" ? message.message : undefined) ??
+                    (typeof (message.error as { message?: unknown } | undefined)?.message === "string"
+                        ? (message.error as { message: string }).message
+                        : "stream error");
+                const error = Object.assign(new Error(messageText), code ? { code } : undefined);
+
+                stream.handle.fail(error);
+                this.streams.delete(id);
+
+                return;
+            }
+
             // A subscription-scoped rejection (e.g. an admin subscription on a
             // socket that didn't clear the admin gate). Surface it to the
             // subscriber's onError so the UI can react instead of silently
             // never receiving data; the registration is left in place so a
             // later reconnect with proper credentials can still succeed.
-            const { id } = message;
             const state = id === undefined ? undefined : this.subscriptions.getById(id);
 
             if (state) {
@@ -987,6 +1119,19 @@ export class CirrusClient {
         }
 
         if (message.type === "complete") {
+            // Streams complete normally — close the iterator. Subscriptions
+            // can also receive `complete` (cancelled server-side); remove them
+            // from the registry. The two id-spaces don't overlap (`sub_*` vs
+            // `stream_*`) so the two lookups are mutually exclusive.
+            const stream = this.streams.get(message.id);
+
+            if (stream) {
+                stream.handle.complete();
+                this.streams.delete(message.id);
+
+                return;
+            }
+
             const state = this.subscriptions.getById(message.id);
 
             if (state) {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -8,6 +8,8 @@ export { createIndexedDbPersistence, createInMemoryPersistence } from "./persist
 export { preloadedQueryResult, preloadQuery } from "./preload.js";
 export type { ReconnectCalculator } from "./reconnect.js";
 export { createReconnect } from "./reconnect.js";
+export type { StreamHandle, StreamIterable } from "./stream.js";
+export { createStream, DEFAULT_MAX_BUFFER } from "./stream.js";
 export type { SubscriptionCallback, SubscriptionError, SubscriptionErrorCallback, SubscriptionState } from "./subscription.js";
 export { SubscriptionRegistry } from "./subscription.js";
 export type {

--- a/packages/client/src/stream.ts
+++ b/packages/client/src/stream.ts
@@ -1,0 +1,185 @@
+/**
+ * Bounded async-iterator queue backing {@link CirrusClient.stream}.
+ *
+ * The server pushes one {@link ServerChunkMessage} per yielded value while the
+ * client iterates with `for await (const chunk of stream)`. A producer that
+ * outruns its consumer would otherwise OOM the page, so the buffer is bounded
+ * — exceeding {@link DEFAULT_MAX_BUFFER} surfaces a `STREAM_BACKPRESSURE`
+ * error to the iterator (and to the server-side cancel path).
+ *
+ * The queue is closed exactly once via {@link StreamHandle.complete} (success)
+ * or {@link StreamHandle.fail} (transport / server error). Subsequent calls
+ * are silent no-ops so a duplicate `complete` frame after a cancel doesn't
+ * crash the page.
+ */
+export const DEFAULT_MAX_BUFFER = 1024;
+
+export interface StreamHandle<T = unknown> {
+    /** Mark the stream complete (no more chunks); resolves any pending consumer to `done:true`. */
+    readonly complete: () => void;
+    /** Surface an error to any pending consumer; subsequent pushes are dropped. */
+    readonly fail: (error: Error) => void;
+    /** Push one chunk; throws if the buffer is full. */
+    readonly push: (value: T) => void;
+}
+
+export interface StreamIterable<T> extends AsyncIterable<T> {
+    /** Cancel the stream from the consumer side: closes the iterator and notifies the registered canceller. */
+    cancel: () => void;
+}
+
+interface PendingResolve<T> {
+    reject: (error: Error) => void;
+    resolve: (value: IteratorResult<T>) => void;
+}
+
+/**
+ * Build a stream handle paired with an async-iterable. The handle is the
+ * server-driven side (the WS dispatcher pushes chunks / completes / errors);
+ * the iterable is what the user awaits. `onCancel` is invoked exactly once
+ * when the consumer calls `.cancel()` (or `.return()`) so the client can
+ * send a `{type:"unsubscribe"}` frame to the server.
+ */
+export const createStream = <T>(options: { maxBuffer?: number; onCancel: () => void }): { handle: StreamHandle<T>; iterable: StreamIterable<T> } => {
+    const maxBuffer = options.maxBuffer ?? DEFAULT_MAX_BUFFER;
+    const buffer: T[] = [];
+    const pending: PendingResolve<T>[] = [];
+
+    let done = false;
+    let failure: Error | undefined;
+    let cancelled = false;
+
+    const flushOne = (): boolean => {
+        const waiter = pending.shift();
+
+        if (!waiter) {
+            return false;
+        }
+
+        if (failure) {
+            waiter.reject(failure);
+
+            return true;
+        }
+
+        const value = buffer.shift();
+
+        if (value !== undefined) {
+            waiter.resolve({ done: false, value });
+
+            return true;
+        }
+
+        if (done) {
+            waiter.resolve({ done: true, value: undefined as unknown as T });
+
+            return true;
+        }
+
+        // Nothing to flush — put the waiter back at the head.
+        pending.unshift(waiter);
+
+        return false;
+    };
+
+    const handle: StreamHandle<T> = {
+        complete() {
+            if (done || failure) {
+                return;
+            }
+
+            done = true;
+
+            // Flush every pending waiter so they see done:true (or the buffered tail first).
+            while (flushOne()) {
+                /* keep flushing */
+            }
+        },
+        fail(error) {
+            if (done || failure) {
+                return;
+            }
+
+            failure = error;
+            // Drain buffered values — once a stream errors we deliver the error
+            // immediately rather than handing out stale chunks.
+            buffer.length = 0;
+
+            while (flushOne()) {
+                /* keep flushing */
+            }
+        },
+        push(value) {
+            if (done || failure || cancelled) {
+                return;
+            }
+
+            if (buffer.length >= maxBuffer) {
+                handle.fail(
+                    Object.assign(new Error(`stream buffer overflow (max=${maxBuffer}); the consumer cannot keep up with the producer`), {
+                        code: "STREAM_BACKPRESSURE",
+                    }),
+                );
+
+                return;
+            }
+
+            buffer.push(value);
+            flushOne();
+        },
+    };
+
+    const cancel = (): void => {
+        if (cancelled) {
+            return;
+        }
+
+        cancelled = true;
+        done = true;
+        buffer.length = 0;
+
+        try {
+            options.onCancel();
+        } catch {
+            /* swallow opaque cancel errors — the iterator is closing anyway */
+        }
+
+        while (flushOne()) {
+            /* keep flushing */
+        }
+    };
+
+    const iterable: StreamIterable<T> = {
+        cancel,
+        [Symbol.asyncIterator]() {
+            return {
+                next(): Promise<IteratorResult<T>> {
+                    if (failure) {
+                        return Promise.reject(failure);
+                    }
+
+                    if (buffer.length > 0) {
+                        const value = buffer.shift() as T;
+
+                        return Promise.resolve({ done: false, value });
+                    }
+
+                    if (done) {
+                        return Promise.resolve({ done: true, value: undefined as unknown as T });
+                    }
+
+                    return new Promise<IteratorResult<T>>((resolve, reject) => {
+                        pending.push({ reject, resolve });
+                    });
+                },
+                return(): Promise<IteratorResult<T>> {
+                    cancel();
+
+                    return Promise.resolve({ done: true, value: undefined as unknown as T });
+                },
+            };
+        },
+    };
+
+    return { handle, iterable };
+};

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,5 +1,5 @@
-/** The three registered function kinds a {@link FunctionReference} can describe. */
-export type FunctionKind = "action" | "mutation" | "query";
+/** The registered function kinds a {@link FunctionReference} can describe. `stream` is a query that yields multiple frames over the WS. */
+export type FunctionKind = "action" | "mutation" | "query" | "stream";
 
 /**
  * Opaque reference to a registered function emitted by `@cirrus/codegen`.
@@ -136,7 +136,20 @@ export interface ClientAckMessage {
     type: "ack";
 }
 
-export type ClientMessage = ClientSubscribeMessage | ClientUnsubscribeMessage | ClientAckMessage;
+/**
+ * Start a streaming query. The id namespaces a fresh stream and is echoed on
+ * every {@link ServerChunkMessage} the server pushes back. Cancel a running
+ * stream by sending a {@link ClientUnsubscribeMessage} with the same id —
+ * subscription and stream id-spaces share the cancel channel; the prefix
+ * (`sub_*` vs `stream_*`) keeps the local registries searchable.
+ */
+export interface ClientStreamMessage {
+    id: string;
+    query: { args?: Record<string, unknown>; functionPath: string; shardKey?: string };
+    type: "stream";
+}
+
+export type ClientMessage = ClientAckMessage | ClientStreamMessage | ClientSubscribeMessage | ClientUnsubscribeMessage;
 
 /** Subscription protocol — server → client. */
 export interface ServerDataMessage {
@@ -163,7 +176,14 @@ export interface ServerCompleteMessage {
     type: "complete";
 }
 
-export type ServerMessage = ServerDataMessage | ServerErrorMessage | ServerAckMessage | ServerCompleteMessage;
+/** One frame of a streaming query — `data` carries the user-yielded chunk. */
+export interface ServerChunkMessage {
+    data: unknown;
+    id: string;
+    type: "chunk";
+}
+
+export type ServerMessage = ServerAckMessage | ServerChunkMessage | ServerCompleteMessage | ServerDataMessage | ServerErrorMessage;
 
 export interface User {
     readonly email?: string;

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/server.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/server.ts
@@ -93,9 +93,14 @@ export const internalAction = internalActionBase as unknown as <A extends ArgsVa
  * registered function.
  */
 export interface RegisteredCirrusFunction {
-    kind: "action" | "mutation" | "query";
+    kind: "action" | "mutation" | "query" | "stream";
     args: Record<string, unknown>;
-    handler: (context: unknown, args: Record<string, unknown>) => Promise<unknown> | unknown;
+    /**
+     * For `"action" | "mutation" | "query"` the handler is awaited and its result returned.
+     * For `"stream"` the handler returns an `AsyncIterable` synchronously and takes an
+     * `AbortSignal` as a third argument — the runtime drives it frame-by-frame.
+     */
+    handler: ((context: unknown, args: Record<string, unknown>) => Promise<unknown> | unknown) | ((context: unknown, args: Record<string, unknown>, signal: AbortSignal) => AsyncIterable<unknown>);
     /** `"internal"` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
 }

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -200,6 +200,20 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             return { result, tables };
         }
 
+        protected override executeStream(functionPath: string, args: Record<string, unknown>): null | { iterator: (signal: AbortSignal) => AsyncIterable<unknown> } {
+            const registered = CIRRUS_FUNCTIONS[functionPath];
+
+            if (!registered || registered.kind !== "stream" || registered.visibility === "internal") {
+                return null;
+            }
+
+            this.ensureMigrated();
+
+            return {
+                iterator: (signal) => (registered.handler as (context: unknown, args: Record<string, unknown>, signal: AbortSignal) => AsyncIterable<unknown>)(this.buildCtx(), args, signal),
+            };
+        }
+
         protected override tableRefs(table: string): Record<string, string> | undefined {
             return CIRRUS_TABLE_REFS[table];
         }

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -8,7 +8,7 @@ import type { FunctionIR, ValidatorIR } from "./ir.js";
 import { parseObjectShape } from "./parse-validator.js";
 import { sanitizeNamespace } from "./paths.js";
 
-const FUNCTION_KINDS = new Set(["action", "mutation", "query"]);
+const FUNCTION_KINDS = new Set(["action", "mutation", "query", "stream"]);
 
 /**
  * Internal factory names exported from `@cirrus/server`, mapped to the kind
@@ -146,11 +146,13 @@ const unwrapHandlerReturn = (handler: Node): string => {
 
     let returnType = signature.getReturnType();
 
-    // Unwrap a single layer of `Promise<…>`. The runtime always awaits the
-    // handler, so callers should see the resolved type — not the wrapper.
+    // Unwrap a single layer of `Promise<…>` / `AsyncIterable<…>` /
+    // `AsyncGenerator<…, …, …>`. The runtime awaits / iterates the handler,
+    // so callers should see the inner element type — not the wrapper.
     const symbol = returnType.getSymbol() ?? returnType.getAliasSymbol();
+    const wrapperName = symbol?.getName();
 
-    if (symbol?.getName() === "Promise") {
+    if (wrapperName === "Promise" || wrapperName === "AsyncIterable" || wrapperName === "AsyncIterableIterator" || wrapperName === "AsyncGenerator") {
         const innerTypeArgument = returnType.getTypeArguments()[0];
 
         if (innerTypeArgument) {

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -792,9 +792,14 @@ export const internalAction = internalActionBase as unknown as <A extends ArgsVa
  * registered function.
  */
 export interface RegisteredCirrusFunction {
-    kind: "action" | "mutation" | "query";
+    kind: "action" | "mutation" | "query" | "stream";
     args: Record<string, unknown>;
-    handler: (context: unknown, args: Record<string, unknown>) => Promise<unknown> | unknown;
+    /**
+     * For \`"action" | "mutation" | "query"\` the handler is awaited and its result returned.
+     * For \`"stream"\` the handler returns an \`AsyncIterable\` synchronously and takes an
+     * \`AbortSignal\` as a third argument — the runtime drives it frame-by-frame.
+     */
+    handler: ((context: unknown, args: Record<string, unknown>) => Promise<unknown> | unknown) | ((context: unknown, args: Record<string, unknown>, signal: AbortSignal) => AsyncIterable<unknown>);
     /** \`"internal"\` functions are rejected on the external RPC path; absence === public. */
     visibility?: "internal" | "public";
 }
@@ -1226,6 +1231,20 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const result = await registered.handler(ctx, args);
 
             return { result, tables };
+        }
+
+        protected override executeStream(functionPath: string, args: Record<string, unknown>): null | { iterator: (signal: AbortSignal) => AsyncIterable<unknown> } {
+            const registered = CIRRUS_FUNCTIONS[functionPath];
+
+            if (!registered || registered.kind !== "stream" || registered.visibility === "internal") {
+                return null;
+            }
+
+            this.ensureMigrated();
+
+            return {
+                iterator: (signal) => (registered.handler as (context: unknown, args: Record<string, unknown>, signal: AbortSignal) => AsyncIterable<unknown>)(this.buildCtx(), args, signal),
+            };
         }
 
         protected override tableRefs(table: string): Record<string, string> | undefined {

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -100,7 +100,7 @@ export interface FunctionIR {
     exportName: string;
     /** Path relative to `<projectRoot>/cirrus/` without extension, e.g. "messages". */
     filePath: string;
-    kind: "action" | "mutation" | "query";
+    kind: "action" | "mutation" | "query" | "stream";
     /**
      * Serialized TS source for the handler's return type, with `Promise<T>`
      * unwrapped so callers see `T` directly. Defaults to `"unknown"` when

--- a/packages/do/__tests__/shard-do.stream.test.ts
+++ b/packages/do/__tests__/shard-do.stream.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do.js";
+import { ShardDO } from "../src/shard-do.js";
+import type { SocketAttachment, SubscriptionEnvelope } from "../src/types.js";
+import { createSqliteExec } from "./_helpers/node-sqlite.js";
+
+interface FakeWebSocket {
+    attachment: SocketAttachment | undefined;
+    closeCalled: boolean;
+    deserializeAttachment: () => unknown;
+    send: (data: string) => void;
+    sent: string[];
+    serializeAttachment: (value: unknown) => void;
+}
+
+const createFakeWebSocket = (): FakeWebSocket => ({
+    attachment: undefined,
+    closeCalled: false,
+    sent: [],
+    send(data: string) {
+        this.sent.push(data);
+    },
+    serializeAttachment(value: unknown) {
+        this.attachment = value as SocketAttachment | undefined;
+    },
+    deserializeAttachment() {
+        return this.attachment;
+    },
+});
+
+const parseFrames = (ws: FakeWebSocket) => ws.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+
+/**
+ * Drive the runtime forward until either a terminating frame (`complete` /
+ * `error`) lands on the socket or the deadline fires. The DO handler is
+ * fire-and-forget (it returns from `webSocketMessage` before the iterator
+ * drains), so tests need an explicit join point.
+ */
+const waitForTerminator = async (ws: FakeWebSocket, deadlineMs = 200): Promise<void> => {
+    const start = Date.now();
+
+    while (Date.now() - start < deadlineMs) {
+        if (parseFrames(ws).some((f) => f.type === "complete" || f.type === "error")) {
+            return;
+        }
+
+        await new Promise<void>((r) => setTimeout(r, 1));
+    }
+};
+
+/**
+ * Test ShardDO that wires `executeStream` to user-supplied async generators
+ * keyed by functionPath. Lets the suite swap the iterator per case without
+ * recompiling the class.
+ */
+class StreamShard extends ShardDO {
+    public registered = new Map<string, (args: Record<string, unknown>, signal: AbortSignal) => AsyncIterable<unknown>>();
+
+    public override async handleRpc(): Promise<unknown> {
+        return null;
+    }
+
+    protected override executeStream(
+        functionPath: string,
+        args: Record<string, unknown>,
+    ): null | { iterator: (signal: AbortSignal) => AsyncIterable<unknown> } {
+        const fn = this.registered.get(functionPath);
+
+        if (!fn) {
+            return null;
+        }
+
+        return { iterator: (signal) => fn(args, signal) };
+    }
+
+    public driveMessage(ws: FakeWebSocket, envelope: SubscriptionEnvelope): Promise<void> {
+        return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
+    }
+
+    public driveClose(ws: FakeWebSocket): Promise<void> {
+        return this.webSocketClose(ws as unknown as WebSocket, 1000, "test", true);
+    }
+
+    public registerSocket(ws: FakeWebSocket, attachment: SocketAttachment): void {
+        this.state.acceptWebSocket(ws as unknown as WebSocket);
+        ws.serializeAttachment(attachment);
+    }
+}
+
+describe("shardDO streaming queries", () => {
+    let db: ReturnType<typeof createSqliteExec>;
+    let sockets: FakeWebSocket[];
+    let state: ShardDOState;
+
+    beforeEach(() => {
+        db = createSqliteExec();
+        db.raw(`CREATE TABLE "messages" ("__id__" TEXT PRIMARY KEY, "text" TEXT)`);
+
+        sockets = [];
+        state = {
+            id: { name: "shard-stream" },
+            storage: { sql: db.sql as unknown as ShardDOState["storage"]["sql"] },
+            acceptWebSocket(ws) {
+                sockets.push(ws as unknown as FakeWebSocket);
+            },
+            getWebSockets() {
+                return sockets as unknown as WebSocket[];
+            },
+        } as unknown as ShardDOState;
+    });
+
+    afterEach(() => {
+        db.close();
+    });
+
+    test("drives an async generator into ack -> chunk frames -> complete", async () => {
+        const shard = new StreamShard(state, {});
+
+        shard.registered.set("metrics:tick", async function* tickGen(_args) {
+            yield { tick: 1 };
+            yield { tick: 2 };
+            yield { tick: 3 };
+        });
+
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws, { subs: {} });
+        await shard.driveMessage(ws, { type: "stream", id: "stream_1", query: { functionPath: "metrics:tick" } });
+        await waitForTerminator(ws);
+
+        const frames = parseFrames(ws);
+        const types = frames.map((f) => f.type);
+
+        expect(types[0]).toBe("ack");
+        expect(types.filter((t) => t === "chunk")).toHaveLength(3);
+        expect(types.at(-1)).toBe("complete");
+        expect(frames.filter((f) => f.type === "chunk").map((f) => f.data)).toEqual([{ tick: 1 }, { tick: 2 }, { tick: 3 }]);
+    });
+
+    test("client unsubscribe mid-stream aborts the iterator and stops further chunks", async () => {
+        const shard = new StreamShard(state, {});
+        const yielded: number[] = [];
+
+        shard.registered.set("metrics:loop", async function* loopGen(_args, signal) {
+            for (let index = 0; index < 100; index += 1) {
+                if (signal.aborted) {
+                    return;
+                }
+
+                yielded.push(index);
+                yield index;
+                // Yield to the event loop so the cancel message can interleave.
+                await new Promise<void>((r) => setTimeout(r, 0));
+            }
+        });
+
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws, { subs: {} });
+        await shard.driveMessage(ws, { type: "stream", id: "stream_2", query: { functionPath: "metrics:loop" } });
+
+        // Wait for a couple of chunks to land before cancelling.
+        await new Promise<void>((r) => setTimeout(r, 5));
+        await shard.driveMessage(ws, { type: "unsubscribe", id: "stream_2" });
+
+        // Give the iterator a few ticks to honor the abort.
+        await new Promise<void>((r) => setTimeout(r, 20));
+
+        const types = parseFrames(ws).map((f) => f.type);
+
+        // Producer should have stopped well short of 100.
+        expect(yielded.length).toBeLessThan(50);
+        // Cancel acked, no "complete" frame for the aborted stream.
+        expect(types).toContain("ack");
+        expect(types).not.toContain("complete");
+    });
+
+    test("returns NOT_FOUND error when the function isn't a registered stream", async () => {
+        const shard = new StreamShard(state, {});
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws, { subs: {} });
+        await shard.driveMessage(ws, { type: "stream", id: "stream_3", query: { functionPath: "missing:stream" } });
+        await waitForTerminator(ws);
+
+        const errorFrame = parseFrames(ws).find((f) => f.type === "error");
+
+        expect(errorFrame).toBeDefined();
+        expect((errorFrame?.error as { code?: string }).code).toBe("NOT_FOUND");
+    });
+
+    test("admin-prefixed function path is rejected before lookup", async () => {
+        const shard = new StreamShard(state, {});
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws, { subs: {}, admin: true });
+        await shard.driveMessage(ws, { type: "stream", id: "stream_4", query: { functionPath: "__cirrus_admin__:tick" } });
+
+        const errorFrame = parseFrames(ws).find((f) => f.type === "error");
+
+        expect(errorFrame).toBeDefined();
+        expect(errorFrame?.message).toContain("public");
+    });
+
+    test("webSocketClose aborts in-flight streams bound to that socket", async () => {
+        const shard = new StreamShard(state, {});
+        let abortedSignal: AbortSignal | undefined;
+
+        shard.registered.set("metrics:hang", async function* hangGen(_args, signal) {
+            abortedSignal = signal;
+
+            // Yield once, then await an unresolved promise — the only way out
+            // is the close-driven abort.
+            yield 0;
+            await new Promise<void>((r) => {
+                signal.addEventListener("abort", () => {
+                    r();
+                });
+            });
+        });
+
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws, { subs: {} });
+        const driving = shard.driveMessage(ws, { type: "stream", id: "stream_5", query: { functionPath: "metrics:hang" } });
+
+        // Give the iterator a turn so its first yield lands and it's parked on the abort promise.
+        await new Promise<void>((r) => setTimeout(r, 5));
+        await shard.driveClose(ws);
+        await driving;
+
+        expect(abortedSignal?.aborted).toBe(true);
+    });
+
+    test("a handler that throws surfaces an event-shaped error frame with code + message", async () => {
+        const shard = new StreamShard(state, {});
+
+        shard.registered.set("metrics:boom", async function* boomGen() {
+            yield 1;
+            throw Object.assign(new Error("kaboom"), { code: "FORBIDDEN" });
+        });
+
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws, { subs: {} });
+        await shard.driveMessage(ws, { type: "stream", id: "stream_6", query: { functionPath: "metrics:boom" } });
+        await waitForTerminator(ws);
+
+        const frames = parseFrames(ws);
+        const errorFrame = frames.find((f) => f.type === "error");
+
+        expect(errorFrame).toBeDefined();
+        expect((errorFrame?.error as { code?: string; message?: string })?.code).toBe("FORBIDDEN");
+        expect((errorFrame?.error as { code?: string; message?: string })?.message).toBe("kaboom");
+        expect(frames.filter((f) => f.type === "complete")).toHaveLength(0);
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -262,6 +262,15 @@ export abstract class ShardDO {
     private readonly subMemos = new WeakMap<WebSocket, Map<string, SubscriptionMemo>>();
 
     /**
+     * Per-socket {@link AbortController} map keyed by stream id, used to
+     * propagate a client unsubscribe (or a socket close) into the user
+     * handler. In-memory only: a hibernation drops the controllers, which is
+     * fine because the corresponding socket is gone too — the iterator
+     * pumping into it would have nowhere to write.
+     */
+    private readonly streamCancellers = new WeakMap<WebSocket, Map<string, AbortController>>();
+
+    /**
      * Opt-in per-shard reactive query cache. When the subclass passes
      * `ReactiveCacheOptions` to `super(state, env, { reactiveCache: { … } })`
      * the cache is instantiated here and exposed to subclasses via
@@ -891,9 +900,93 @@ export abstract class ShardDO {
             return;
         }
 
+        if (envelope.type === "stream" && envelope.query?.functionPath) {
+            // Streams are public-only: there is no admin-streaming surface, so
+            // anything matching the admin prefix is rejected up front rather
+            // than allowed to slip through executeStream().
+            if (envelope.query.functionPath.startsWith(ADMIN_FUNCTION_PREFIX)) {
+                ws.send(JSON.stringify({ type: "error", id: envelope.id, message: "streams must be public" }));
+
+                return;
+            }
+
+            void this.handleStream(ws, envelope.id, envelope.query.functionPath, envelope.query.args ?? {});
+
+            return;
+        }
+
         if (envelope.type === "unsubscribe") {
+            // Stream cancel: abort the in-flight iterator (if any) before
+            // touching the subscription registry. unsubscribe() on a non-sub
+            // id is a no-op, so this stays safe even when id namespaces overlap.
+            const cancellers = this.streamCancellers.get(ws);
+            const controller = cancellers?.get(envelope.id);
+
+            if (controller) {
+                controller.abort();
+                cancellers?.delete(envelope.id);
+            }
+
             this.unsubscribe(ws, envelope.id);
             ws.send(JSON.stringify({ type: "ack", id: envelope.id }));
+        }
+    }
+
+    /**
+     * Drive a streaming-query iterator end-to-end:
+     *   1. Allocate a per-id {@link AbortController} so a later `unsubscribe`
+     *      (or socket close) tears the user iterator down.
+     *   2. Send a `{type:"ack"}` so the client knows the stream started before
+     *      any chunks land.
+     *   3. Pump every yielded chunk through a `{type:"chunk"}` frame.
+     *   4. On normal completion send `{type:"complete"}`; on throw send
+     *      `{type:"error"}`. Either way drop the controller.
+     */
+    private async handleStream(ws: WebSocket, id: string, functionPath: string, args: Record<string, unknown>): Promise<void> {
+        const iterable = this.executeStream(functionPath, args);
+
+        if (!iterable) {
+            ws.send(JSON.stringify({ type: "error", id, error: { code: "NOT_FOUND", message: `stream not registered: ${functionPath}` } }));
+
+            return;
+        }
+
+        const controller = new AbortController();
+        let cancellers = this.streamCancellers.get(ws);
+
+        if (!cancellers) {
+            cancellers = new Map();
+            this.streamCancellers.set(ws, cancellers);
+        }
+
+        cancellers.set(id, controller);
+        ws.send(JSON.stringify({ type: "ack", id }));
+
+        try {
+            for await (const chunk of iterable.iterator(controller.signal)) {
+                if (controller.signal.aborted) {
+                    break;
+                }
+
+                ws.send(JSON.stringify({ type: "chunk", id, data: chunk }));
+            }
+
+            if (!controller.signal.aborted) {
+                ws.send(JSON.stringify({ type: "complete", id }));
+            }
+        } catch (error: unknown) {
+            const { code } = error as { code?: string };
+            const message = error instanceof Error ? error.message : String(error);
+
+            ws.send(
+                JSON.stringify({
+                    type: "error",
+                    id,
+                    error: { code: typeof code === "string" ? code : "INTERNAL_SERVER_ERROR", message },
+                }),
+            );
+        } finally {
+            cancellers.delete(id);
         }
     }
 
@@ -903,6 +996,19 @@ export abstract class ShardDO {
      * again would throw "WebSocket has been closed" in the Workers runtime.
      */
     public async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): Promise<void> {
+        // Abort in-flight stream iterators bound to this socket so user
+        // handlers stop pumping into a closed channel rather than discovering
+        // it on the next yield.
+        const cancellers = this.streamCancellers.get(ws);
+
+        if (cancellers) {
+            for (const controller of cancellers.values()) {
+                controller.abort();
+            }
+
+            this.streamCancellers.delete(ws);
+        }
+
         // Clear the attachment so a future reconnection starts clean.
         (ws as HibernatableWebSocket).serializeAttachment?.(undefined);
 
@@ -1022,6 +1128,24 @@ export abstract class ShardDO {
         void args;
 
         return Promise.resolve(null);
+    }
+
+    /**
+     * Look up a streaming-query function and return a thunk that produces the
+     * `AsyncIterable<unknown>` when handed an {@link AbortSignal}. The codegen
+     * subclass overrides this to dispatch via `CIRRUS_FUNCTIONS`; the base
+     * default returns `null`, which surfaces as `{type:"error", code:"NOT_FOUND"}`
+     * to the client.
+     *
+     * The deferred-iterator shape (`(signal) => AsyncIterable<unknown>`) keeps
+     * the cancel signal pluggable per-call without coupling this signature to
+     * the wire-frame loop in {@link handleStream}.
+     */
+    protected executeStream(functionPath: string, args: Record<string, unknown>): null | { iterator: (signal: AbortSignal) => AsyncIterable<unknown> } {
+        void functionPath;
+        void args;
+
+        return null;
     }
 
     /**

--- a/packages/do/src/types.ts
+++ b/packages/do/src/types.ts
@@ -18,7 +18,13 @@ export interface SubscriptionQuery {
 export interface SubscriptionEnvelope {
     id: string;
     query?: SubscriptionQuery;
-    type: "subscribe" | "unsubscribe" | "ack";
+    /**
+     * `subscribe`/`unsubscribe`/`ack` drive live queries; `stream` opens a
+     * streaming-query iterator that yields {@link ServerChunkMessage} frames
+     * until the server emits `complete` (or the client cancels with
+     * `unsubscribe` on the same id).
+     */
+    type: "ack" | "stream" | "subscribe" | "unsubscribe";
 }
 
 export interface MutationDelta {

--- a/packages/react/__tests__/use-stream.test.tsx
+++ b/packages/react/__tests__/use-stream.test.tsx
@@ -1,0 +1,152 @@
+import type { CirrusClient, FunctionReference, StreamHandle, StreamIterable } from "@cirrus/client";
+import { createStream } from "@cirrus/client";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { CirrusProvider } from "../src/cirrus-provider.js";
+import { useStream } from "../src/use-stream.js";
+
+const fn = (reference: string): FunctionReference => ({ __cirrusRef: reference });
+
+interface MockEntry {
+    handle: StreamHandle;
+    iterable: StreamIterable<unknown>;
+    onCancel: ReturnType<typeof vi.fn>;
+}
+
+const buildClientWithStream = (): { client: CirrusClient; opened: MockEntry[]; openStream: () => MockEntry } => {
+    const opened: MockEntry[] = [];
+    const streamFn = vi.fn((_fn: FunctionReference, _args: unknown) => {
+        const onCancel = vi.fn();
+        const { handle, iterable } = createStream<unknown>({ onCancel });
+        const entry: MockEntry = { handle, iterable, onCancel };
+
+        opened.push(entry);
+
+        return iterable;
+    });
+
+    const client = { stream: streamFn } as unknown as CirrusClient;
+
+    return {
+        client,
+        openStream: () => {
+            const entry = opened.at(-1);
+
+            if (!entry) {
+                throw new Error("client.stream was never called");
+            }
+
+            return entry;
+        },
+        opened,
+    };
+};
+
+const Display = ({ args = {} as Record<string, unknown> }: { args?: Record<string, unknown> | "skip" } = {}): ReactElement => {
+    const { chunks, error, status } = useStream(fn("metrics:tick"), args as Record<string, unknown> | "skip");
+
+    return (
+        <div>
+            <span data-testid="status">{status}</span>
+            <span data-testid="error">{error?.message ?? ""}</span>
+            <span data-testid="chunks">{JSON.stringify(chunks)}</span>
+        </div>
+    );
+};
+
+describe("useStream", () => {
+    test("opens a stream on mount and appends chunks as they arrive", async () => {
+        const { client, openStream } = buildClientWithStream();
+
+        render(
+            <CirrusProvider client={client}>
+                <Display />
+            </CirrusProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("status").textContent).not.toBe("idle");
+        });
+
+        await act(async () => {
+            openStream().handle.push({ tick: 1 });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId("chunks").textContent).toBe(JSON.stringify([{ tick: 1 }]));
+        });
+
+        await act(async () => {
+            openStream().handle.push({ tick: 2 });
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId("chunks").textContent).toBe(JSON.stringify([{ tick: 1 }, { tick: 2 }]));
+        });
+
+        await act(async () => {
+            openStream().handle.complete();
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId("status").textContent).toBe("complete");
+        });
+    });
+
+    test('"skip" leaves the stream un-opened', () => {
+        const { client, opened } = buildClientWithStream();
+
+        render(
+            <CirrusProvider client={client}>
+                <Display args="skip" />
+            </CirrusProvider>,
+        );
+
+        expect(opened).toHaveLength(0);
+        expect(screen.getByTestId("status").textContent).toBe("idle");
+    });
+
+    test("unmount cancels the in-flight stream", async () => {
+        const { client, openStream } = buildClientWithStream();
+
+        const view = render(
+            <CirrusProvider client={client}>
+                <Display />
+            </CirrusProvider>,
+        );
+
+        await waitFor(() => {
+            expect(openStream).not.toThrow();
+        });
+
+        view.unmount();
+
+        expect(openStream().onCancel).toHaveBeenCalledWith();
+    });
+
+    test("server error transitions status to 'error' and surfaces the error", async () => {
+        const { client, openStream } = buildClientWithStream();
+
+        render(
+            <CirrusProvider client={client}>
+                <Display />
+            </CirrusProvider>,
+        );
+
+        await waitFor(() => {
+            expect(openStream).not.toThrow();
+        });
+
+        await act(async () => {
+            openStream().handle.fail(new Error("forbidden"));
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId("status").textContent).toBe("error");
+        });
+
+        expect(screen.getByTestId("error").textContent).toBe("forbidden");
+    });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -29,4 +29,6 @@ export { usePreloadedQuery } from "./use-preloaded-query.js";
 export { useQuery } from "./use-query.js";
 export type { UseRateLimitOptions, UseRateLimitResult } from "./use-rate-limit.js";
 export { useRateLimit } from "./use-rate-limit.js";
+export type { UseStreamOptions, UseStreamResult, UseStreamStatus } from "./use-stream.js";
+export { useStream } from "./use-stream.js";
 export { useSubscription } from "./use-subscription.js";

--- a/packages/react/src/use-stream.ts
+++ b/packages/react/src/use-stream.ts
@@ -1,0 +1,158 @@
+import type { ArgsOf, FunctionReference, ReturnOf } from "@cirrus/client";
+import { useEffect, useReducer, useRef } from "react";
+
+import { useCirrus } from "./cirrus-provider.js";
+
+/** The lifecycle of a stream the hook is observing. */
+export type UseStreamStatus = "complete" | "error" | "idle" | "streaming";
+
+export interface UseStreamResult<T> {
+    /** Force-cancel the stream and resolve the iterator. Safe to call multiple times. */
+    cancel: () => void;
+    /** Chunks the server has pushed so far, in arrival order. */
+    chunks: ReadonlyArray<T>;
+    error: Error | undefined;
+    status: UseStreamStatus;
+}
+
+export interface UseStreamOptions {
+    /** Forwarded to `client.stream()` — caps the in-flight chunk buffer. */
+    maxBuffer?: number;
+    shardKey?: string;
+}
+
+interface State<T> {
+    chunks: T[];
+    error: Error | undefined;
+    status: UseStreamStatus;
+}
+
+type Action<T> = { chunk: T; type: "chunk" } | { type: "complete" } | { error: Error; type: "error" } | { type: "reset" } | { type: "start" };
+
+const reducer = <T>(state: State<T>, action: Action<T>): State<T> => {
+    switch (action.type) {
+        case "chunk": {
+            // Append immutably so consumers comparing by identity see a change.
+            return { chunks: [...state.chunks, action.chunk], error: undefined, status: "streaming" };
+        }
+        case "complete": {
+            return { ...state, status: "complete" };
+        }
+        case "error": {
+            return { ...state, error: action.error, status: "error" };
+        }
+        case "reset": {
+            return { chunks: [], error: undefined, status: "idle" };
+        }
+        case "start": {
+            // Distinct from `chunk` so the UI can render "loading" before the
+            // first frame arrives without conflating it with the idle state.
+            return { ...state, status: "streaming" };
+        }
+        default: {
+            return state;
+        }
+    }
+};
+
+const stableStringify = (value: unknown): string => {
+    if (value === null || typeof value !== "object") {
+        return JSON.stringify(value);
+    }
+
+    if (Array.isArray(value)) {
+        return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+
+    return `{${entries.map(([key, value_]) => `${JSON.stringify(key)}:${stableStringify(value_)}`).join(",")}}`;
+};
+
+/**
+ * Subscribe to a streaming query. Returns the chunks pushed so far plus a
+ * lifecycle status and a cancel function. Changing `fn` or the serialized
+ * `args` resets the stream — the previous iterator is cancelled and a fresh
+ * one opens with empty `chunks`.
+ *
+ * Pass `"skip"` for `args` to keep the hook mounted without opening a stream
+ * (mirrors `useQuery` / `useSubscription`).
+ */
+export function useStream<F extends FunctionReference>(fn: F, args: "skip" | ArgsOf<F>, options: UseStreamOptions = {}): UseStreamResult<ReturnOf<F>> {
+    const client = useCirrus();
+    const [state, dispatch] = useReducer<State<ReturnOf<F>>, [Action<ReturnOf<F>>]>(reducer<ReturnOf<F>>, { chunks: [], error: undefined, status: "idle" });
+
+    const skipped = args === "skip";
+    const serialized = skipped ? "skip" : stableStringify(args);
+
+    // Stash the live cancel handle so unmount + manual cancel call into the
+    // same function. The reducer doesn't own it because cancel is a side
+    // effect, not part of the rendered state.
+    const cancelRef = useRef<(() => void) | undefined>(undefined);
+
+    useEffect(() => {
+        if (skipped) {
+            return;
+        }
+
+        dispatch({ type: "reset" });
+        dispatch({ type: "start" });
+
+        let stillMounted = true;
+        let cancelled = false;
+        const iterable = client.stream(fn, args as ArgsOf<F>, { maxBuffer: options.maxBuffer, shardKey: options.shardKey });
+        const cancel = (): void => {
+            if (cancelled) {
+                return;
+            }
+
+            cancelled = true;
+            iterable.cancel();
+        };
+
+        cancelRef.current = cancel;
+
+        // Run the consumer loop in a background async IIFE so the effect body
+        // stays synchronous; the cancel handle is what the cleanup uses. The
+        // `void` mark tells the linter we intentionally don't await — the IIFE
+        // owns its own try/catch so any error already lands in the reducer.
+        void (async () => {
+            try {
+                for await (const chunk of iterable) {
+                    if (!stillMounted) {
+                        return;
+                    }
+
+                    dispatch({ type: "chunk", chunk: chunk as ReturnOf<F> });
+                }
+
+                if (stillMounted) {
+                    dispatch({ type: "complete" });
+                }
+            } catch (error: unknown) {
+                if (!stillMounted) {
+                    return;
+                }
+
+                const normalized = error instanceof Error ? error : new Error(String(error));
+
+                dispatch({ type: "error", error: normalized });
+            }
+        })();
+
+        return () => {
+            stillMounted = false;
+            cancel();
+            cancelRef.current = undefined;
+        };
+    }, [client, fn.__cirrusRef, serialized, skipped, options.shardKey, options.maxBuffer]);
+
+    return {
+        cancel: () => {
+            cancelRef.current?.();
+        },
+        chunks: state.chunks,
+        error: state.error,
+        status: state.status,
+    };
+}

--- a/packages/server/__tests__/builder-stream.test.ts
+++ b/packages/server/__tests__/builder-stream.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+
+import { initCirrus, v } from "../src/index.js";
+
+const c = initCirrus.dataModel<Record<string, never>>().create();
+
+const collect = async <T>(iter: AsyncIterable<T>, signal?: AbortSignal): Promise<T[]> => {
+    const out: T[] = [];
+
+    for await (const value of iter) {
+        if (signal?.aborted) {
+            break;
+        }
+
+        out.push(value);
+    }
+
+    return out;
+};
+
+describe("c.query.stream() terminal", () => {
+    test("registers with kind:'stream' and an async-iterable handler", async () => {
+        const counter = c.query.input({ count: v.number() }).stream(async function* counterStream({ args }) {
+            for (let index = 0; index < args.count; index += 1) {
+                yield index;
+            }
+        });
+
+        expect(counter.kind).toBe("stream");
+        expect(counter.args.count.kind).toBe("number");
+
+        const { signal } = new AbortController();
+        const chunks = await collect(counter.handler({}, { count: 3 }, signal));
+
+        expect(chunks).toEqual([0, 1, 2]);
+    });
+
+    test("middleware ctx narrows for the streaming handler", async () => {
+        let observedCtx: unknown;
+
+        const authedStream = c.query
+            .use(async ({ next }) => next({ ctx: { userId: "u_42" } }))
+            .stream(async function* authedGen({ ctx }) {
+                observedCtx = ctx;
+                yield ctx.userId;
+            });
+
+        const { signal } = new AbortController();
+        const chunks = await collect(authedStream.handler({}, {}, signal));
+
+        expect(chunks).toEqual(["u_42"]);
+        expect(observedCtx).toMatchObject({ userId: "u_42" });
+    });
+
+    test("aborting the signal stops further yields", async () => {
+        const ac = new AbortController();
+        const yields: number[] = [];
+        const stream = c.query.stream(async function* abortableGen() {
+            for (let index = 0; index < 10; index += 1) {
+                yields.push(index);
+                yield index;
+
+                if (index === 2) {
+                    // Mid-stream: simulate a client cancel.
+                    ac.abort();
+                }
+            }
+        });
+
+        const observed = await collect(stream.handler({}, {}, ac.signal), ac.signal);
+
+        // The for-await loop on the caller side breaks at the first aborted
+        // check after a yield, so we see [0,1,2] (the cancel fires after 2).
+        expect(observed).toEqual([0, 1, 2]);
+        // The wrapper bails out of the user iterator early, so the producer
+        // never reaches index 3 even though its loop counted to 10.
+        expect(yields).toEqual([0, 1, 2, 3]);
+    });
+
+    test("rejects bad args synchronously at handler call time", () => {
+        const guarded = c.query.input({ rooms: v.number() }).stream(async function* guardedGen() {
+            yield "should not yield";
+        });
+
+        const { signal } = new AbortController();
+
+        // Validation runs synchronously so the runtime's outer try/catch
+        // turns it into a single error frame instead of a stream that emits
+        // chunks and then fails on close.
+        expect(() => guarded.handler({}, { rooms: "abc" as unknown as number }, signal)).toThrow(/args\.rooms/u);
+    });
+});

--- a/packages/server/__tests__/http-stream.test.ts
+++ b/packages/server/__tests__/http-stream.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import type { CirrusRouteHandler, HttpActionCtx } from "../src/index.js";
+import { CirrusError, httpRoute, httpRouter, v } from "../src/index.js";
+
+const ctx = {} as HttpActionCtx;
+
+const dispatch = async (route: CirrusRouteHandler, method: string, path: string, request: Request): Promise<Response> => {
+    const app = httpRouter();
+
+    app.on(method, path, route);
+
+    return app.fetch(request, { __cirrusCtx: ctx });
+};
+
+const readSse = async (response: Response): Promise<{ events: { data: unknown; event: string }[]; raw: string }> => {
+    const text = await response.text();
+    const events: { data: unknown; event: string }[] = [];
+
+    for (const block of text.split("\n\n")) {
+        if (block.trim() === "") {
+            continue;
+        }
+
+        let event = "message";
+        const dataLines: string[] = [];
+
+        for (const line of block.split("\n")) {
+            if (line.startsWith("event: ")) {
+                event = line.slice("event: ".length);
+            } else if (line.startsWith("data: ")) {
+                dataLines.push(line.slice("data: ".length));
+            }
+        }
+
+        if (dataLines.length === 0) {
+            continue;
+        }
+
+        events.push({ data: JSON.parse(dataLines.join("\n")), event });
+    }
+
+    return { events, raw: text };
+};
+
+describe("httpRoute stream() terminal", () => {
+    test("returns text/event-stream with data frames + a terminal event:complete", async () => {
+        const route = httpRoute.get("/api/ticks").stream(async function* ticksGen() {
+            yield { tick: 1 };
+            yield { tick: 2 };
+            yield { tick: 3 };
+        });
+
+        const response = await dispatch(route, "GET", "/api/ticks", new Request("https://x/api/ticks"));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+        const { events } = await readSse(response);
+
+        expect(events.map((e) => e.event)).toEqual(["message", "message", "message", "complete"]);
+        expect(events.slice(0, 3).map((e) => e.data)).toEqual([{ tick: 1 }, { tick: 2 }, { tick: 3 }]);
+    });
+
+    test("coerces searchParams + params and routes them through the stream handler", async () => {
+        const route = httpRoute
+            .get("/api/feed/:room")
+            .params({ room: v.string() })
+            .searchParams({ limit: v.number() })
+            .stream(async function* feedGen({ params, searchParams }) {
+                for (let index = 0; index < searchParams.limit; index += 1) {
+                    yield { index, room: params.room };
+                }
+            });
+
+        const response = await dispatch(route, "GET", "/api/feed/:room", new Request("https://x/api/feed/lobby?limit=2"));
+        const { events } = await readSse(response);
+        const chunks = events.filter((event) => event.event === "message").map((event) => event.data);
+
+        expect(chunks).toEqual([
+            { index: 0, room: "lobby" },
+            { index: 1, room: "lobby" },
+        ]);
+    });
+
+    test("surfaces a thrown CirrusError as an event:error frame", async () => {
+        // eslint-disable-next-line require-yield, sonarjs/generator-without-yield -- intentional: this generator only throws.
+        const route = httpRoute.get("/api/boom").stream(async function* boomGen() {
+            throw new CirrusError("FORBIDDEN", "nope");
+        });
+
+        const response = await dispatch(route, "GET", "/api/boom", new Request("https://x/api/boom"));
+        const { events } = await readSse(response);
+        const error = events.find((event) => event.event === "error");
+
+        expect(error).toBeDefined();
+        expect(error?.data).toMatchObject({ code: "FORBIDDEN", message: "nope" });
+    });
+
+    test("returns 400 when search-param decoding fails (rejection happens before the stream starts)", async () => {
+        const route = httpRoute
+            .get("/api/feed")
+            .searchParams({ limit: v.number() })
+            .stream(async function* limitGen() {
+                yield 1;
+            });
+
+        const response = await dispatch(route, "GET", "/api/feed", new Request("https://x/api/feed?limit=not-a-number"));
+
+        expect(response.status).toBe(400);
+    });
+});

--- a/packages/server/src/builder/index.ts
+++ b/packages/server/src/builder/index.ts
@@ -87,18 +87,57 @@ const makeHandler =
         userHandler: (options: { args: InferArgs<Args>; ctx: Ctx }) => Promise<R> | R,
         output?: Validator,
     ) =>
-    async (context: unknown, rawArgs: InferArgs<Args>): Promise<Awaited<R>> => {
-        const parsed = validateArgs(args, rawArgs as Record<string, unknown>);
-        const ctx = await runMiddleware(middlewares, context);
-        const result = await userHandler({ args: parsed, ctx: ctx as Ctx });
+        async (context: unknown, rawArgs: InferArgs<Args>): Promise<Awaited<R>> => {
+            const parsed = validateArgs(args, rawArgs as Record<string, unknown>);
+            const ctx = await runMiddleware(middlewares, context);
+            const result = await userHandler({ args: parsed, ctx: ctx as Ctx });
 
-        return (output ? output.parse(result) : result) as Awaited<R>;
-    };
+            return (output ? output.parse(result) : result) as Awaited<R>;
+        };
+
+/**
+ * Wrap a streaming user handler in the same arg-validation + middleware shell
+ * as `makeHandler`, but return the user's `AsyncIterable<R>` directly so the
+ * runtime can drive it frame-by-frame. The handler receives an `AbortSignal`
+ * the caller flips when they unsubscribe; it's the user's responsibility to
+ * honour it (or to wire it into any awaited I/O).
+ */
+const makeStreamHandler =
+    <Args extends ArgsValidator, Ctx, R>(
+        args: Args,
+        middlewares: ReadonlyArray<Middleware<unknown, unknown>>,
+        userHandler: (options: { args: InferArgs<Args>; ctx: Ctx; signal: AbortSignal }) => AsyncGenerator<R, void, void> | AsyncIterable<R>,
+    ) =>
+        (context: unknown, rawArgs: InferArgs<Args>, signal: AbortSignal): AsyncIterable<R> => {
+        // Args validation runs synchronously at call time so a bad envelope
+        // surfaces before the iterator is consumed.
+            const parsed = validateArgs(args, rawArgs as Record<string, unknown>);
+
+            // The middleware chain may be async, but we don't want to block the
+            // caller before returning an iterable — defer the chain to the first
+            // `next()` pump by wrapping the iterator with an outer async generator.
+            return (async function* drive(): AsyncGenerator<R, void, void> {
+                const ctx = await runMiddleware(middlewares, context);
+                const iterator = userHandler({ args: parsed, ctx: ctx as Ctx, signal });
+
+                for await (const chunk of iterator) {
+                    yield chunk;
+
+                    if (signal.aborted) {
+                        return;
+                    }
+                }
+            })();
+        };
 
 /**
  * Construct a kind-specific builder. The terminal method is keyed by the kind
  * (`query` / `mutation` / `action`) so codegen reads the kind from the call
  * expression's property name without tracing the builder across files.
+ * `QueryBuilder` (and `InternalQueryBuilder`) also expose a `.stream()` terminal
+ * that produces a `RegisteredStream` — codegen reads `"stream"` from the
+ * terminal name and the runtime routes the registration through the WS stream
+ * dispatcher instead of the request/response one.
  *
  * Internal builders carry an extra `__cirrusVisibility: "internal"` brand and
  * stamp `visibility: "internal"` onto the registered function. Public builders
@@ -115,6 +154,26 @@ const makeBuilder = (kind: FunctionKind, state: BuilderState, visibility?: "inte
     }),
     input: (validators: ArgsValidator) => makeBuilder(kind, { ...state, args: { ...state.args, ...validators } }, visibility),
     output: (validator: Validator) => makeBuilder(kind, { ...state, output: validator }, visibility),
+    // `.stream()` is meaningful only on query builders. It's harmless to expose
+    // on every builder shape (callers can't hit it from action/mutation builders
+    // anyway since the type system narrows it away), but emitting it
+    // unconditionally keeps the runtime free of per-kind branching.
+    ...(kind === "query"
+        ? {
+            stream: <R>(
+                userHandler: (options: {
+                    args: Record<string, unknown>;
+                    ctx: unknown;
+                    signal: AbortSignal;
+                }) => AsyncGenerator<R, void, void> | AsyncIterable<R>,
+            ) => ({
+                args: state.args,
+                handler: makeStreamHandler(state.args, state.middlewares, userHandler),
+                kind: "stream" as const,
+                ...(visibility ? { visibility } : {}),
+            }),
+        }
+        : {}),
     use: (middleware: Middleware<unknown, unknown>) => makeBuilder(kind, { ...state, middlewares: [...state.middlewares, middleware] }, visibility),
 });
 

--- a/packages/server/src/builder/types.ts
+++ b/packages/server/src/builder/types.ts
@@ -10,6 +10,7 @@ import type {
     RegisteredAction,
     RegisteredMutation,
     RegisteredQuery,
+    RegisteredStream,
 } from "../types.js";
 
 /** Builder discriminator. Codegen reads this kind. */
@@ -54,6 +55,17 @@ export interface QueryBuilder<Ctx, Args extends ArgsValidator, Output = undefine
     query: [Output] extends [undefined]
         ? <R>(handler: (options: { args: InferArgs<Args>; ctx: Ctx }) => Promise<R> | R) => RegisteredQuery<Args, Awaited<R>>
         : (handler: (options: { args: InferArgs<Args>; ctx: Ctx }) => Output | Promise<Output>) => RegisteredQuery<Args, Output>;
+    /**
+     * Terminal: declare this procedure as a streaming query. The handler is an
+     * async generator (or any function returning an `AsyncIterable<R>`) that
+     * yields one chunk per server-pushed frame. The third `signal` argument is
+     * tripped when the client cancels — break out of the loop or check
+     * `signal.aborted` between yields. `.output()` does not apply: per-chunk
+     * validation is opt-in via the handler itself.
+     */
+    stream: <R>(
+        handler: (options: { args: InferArgs<Args>; ctx: Ctx; signal: AbortSignal }) => AsyncGenerator<R, void, void> | AsyncIterable<R>,
+    ) => RegisteredStream<Args, R>;
     use: <CtxOut>(middleware: Middleware<Ctx, CtxOut>) => QueryBuilder<CtxOut, Args, Output>;
 }
 
@@ -91,6 +103,10 @@ export interface InternalQueryBuilder<Ctx, Args extends ArgsValidator, Output = 
     query: [Output] extends [undefined]
         ? <R>(handler: (options: { args: InferArgs<Args>; ctx: Ctx }) => Promise<R> | R) => RegisteredQuery<Args, Awaited<R>>
         : (handler: (options: { args: InferArgs<Args>; ctx: Ctx }) => Output | Promise<Output>) => RegisteredQuery<Args, Output>;
+    /** See {@link QueryBuilder.stream}; the internal variant routes the registration into `internal` instead of `api`. */
+    stream: <R>(
+        handler: (options: { args: InferArgs<Args>; ctx: Ctx; signal: AbortSignal }) => AsyncGenerator<R, void, void> | AsyncIterable<R>,
+    ) => RegisteredStream<Args, R>;
     use: <CtxOut>(middleware: Middleware<Ctx, CtxOut>) => InternalQueryBuilder<CtxOut, Args, Output>;
 }
 

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -47,8 +47,8 @@ export type CirrusRouteHandler = (c: Context<CirrusHttpEnv>) => Promise<Response
  */
 export const httpAction =
     (handler: HttpActionHandler): CirrusRouteHandler =>
-    async (c) =>
-        handler(c.get("cirrus"), c.req.raw);
+        async (c) =>
+            handler(c.get("cirrus"), c.req.raw);
 
 /**
  * Create the hono app for HTTP actions. Pre-wired with a middleware that lifts
@@ -99,6 +99,20 @@ export interface HttpRouteHandlerOptions<SearchParams extends ArgsValidator, Bod
 }
 
 /**
+ * The `{ ctx, searchParams, params, request, signal }` a streaming HTTP
+ * handler receives. There is no parsed `body` — streams are typically GET, and
+ * the raw `request` is exposed if a handler needs to read the body itself.
+ * `signal` is tripped when the client disconnects.
+ */
+export interface HttpStreamHandlerOptions<SearchParams extends ArgsValidator, Params extends ArgsValidator> {
+    ctx: HttpActionCtx;
+    params: InferArgs<Params>;
+    request: Request;
+    searchParams: InferArgs<SearchParams>;
+    signal: AbortSignal;
+}
+
+/**
  * A typed REST route under construction. `.searchParams()` / `.body()` /
  * `.params()` accumulate validator maps (later calls merge, a colliding key
  * wins) that decode the URL query, JSON body, and hono path params into the
@@ -120,6 +134,16 @@ export interface HttpRouteBuilder<SearchParams extends ArgsValidator, Body exten
     output: <V extends Validator>(validator: V) => HttpRouteBuilder<SearchParams, Body, Params, Infer<V>>;
     params: <P extends ArgsValidator>(validators: P) => HttpRouteBuilder<SearchParams, Body, P & Params, Output>;
     searchParams: <S extends ArgsValidator>(validators: S) => HttpRouteBuilder<S & SearchParams, Body, Params, Output>;
+    /**
+     * Terminal: declare this route as a streaming Server-Sent Events endpoint.
+     * The handler is an async generator (or any function returning an
+     * `AsyncIterable<R>`) that yields one chunk per SSE `data:` frame; on
+     * iterator completion the route writes a final `event: complete` frame; on
+     * throw, an `event: error` frame is written with `{code, message}` before
+     * the stream closes. The chunks are JSON-encoded; `R` is inferred from the
+     * handler's yielded type.
+     */
+    stream: <R>(handler: (options: HttpStreamHandlerOptions<SearchParams, Params>) => AsyncGenerator<R, void, void> | AsyncIterable<R>) => CirrusRouteHandler;
 }
 
 /** Opens a fresh {@link HttpRouteBuilder}. The `path` documents intent; hono owns the actual routing at mount. */
@@ -352,20 +376,113 @@ const errorResponse = (error: unknown): Response => {
  */
 const buildRouteHandler =
     (state: RouteState, userHandler: LooseHandler): CirrusRouteHandler =>
-    async (c) => {
-        try {
-            const ctx = c.get("cirrus");
-            const searchParams = Object.keys(state.searchParams).length > 0 ? parseSearchParams(state.searchParams, c) : {};
-            const params = Object.keys(state.params).length > 0 ? parseParams(state.params, c) : {};
-            const body = Object.keys(state.body).length > 0 ? await parseBody(state.body, c) : {};
-            const result = await userHandler({ body, ctx, params, searchParams });
-            const payload = state.output ? applyOutput(state.output, result) : result;
+        async (c) => {
+            try {
+                const ctx = c.get("cirrus");
+                const searchParams = Object.keys(state.searchParams).length > 0 ? parseSearchParams(state.searchParams, c) : {};
+                const params = Object.keys(state.params).length > 0 ? parseParams(state.params, c) : {};
+                const body = Object.keys(state.body).length > 0 ? await parseBody(state.body, c) : {};
+                const result = await userHandler({ body, ctx, params, searchParams });
+                const payload = state.output ? applyOutput(state.output, result) : result;
 
-            return payload === undefined ? new Response(null, { status: 204 }) : Response.json(payload);
-        } catch (error: unknown) {
-            return errorResponse(error);
-        }
-    };
+                return payload === undefined ? new Response(null, { status: 204 }) : Response.json(payload);
+            } catch (error: unknown) {
+                return errorResponse(error);
+            }
+        };
+
+type LooseStreamHandler = (options: {
+    ctx: HttpActionCtx;
+    params: Record<string, unknown>;
+    request: Request;
+    searchParams: Record<string, unknown>;
+    signal: AbortSignal;
+}) => AsyncGenerator<unknown, void, void> | AsyncIterable<unknown>;
+
+/**
+ * Format one SSE frame. Each frame ends with `\n\n`, the spec-required
+ * separator. `event:` is omitted for `data` (the default event name); we use
+ * named events only for the terminal sentinels (`complete`, `error`).
+ */
+const sseFrame = (chunk: unknown, event?: "complete" | "error"): string => {
+    const data = JSON.stringify(chunk);
+    const prefix = event ? `event: ${event}\n` : "";
+
+    return `${prefix}data: ${data}\n\n`;
+};
+
+/**
+ * Compile the accumulated route state into an SSE {@link CirrusRouteHandler}.
+ * Pumps the user iterator into a `text/event-stream` `ReadableStream`. The
+ * stream wires the client `request.signal` through to the user handler so a
+ * disconnect aborts in-flight work, and surfaces handler-thrown errors as an
+ * `event: error` SSE frame (so clients see a structured payload instead of an
+ * opaque transport-level disconnect).
+ */
+const buildStreamHandler =
+    (state: RouteState, userHandler: LooseStreamHandler): CirrusRouteHandler =>
+        async (c) => {
+            let searchParams: Record<string, unknown>;
+            let params: Record<string, unknown>;
+
+            try {
+                searchParams = Object.keys(state.searchParams).length > 0 ? parseSearchParams(state.searchParams, c) : {};
+                params = Object.keys(state.params).length > 0 ? parseParams(state.params, c) : {};
+            } catch (error: unknown) {
+                return errorResponse(error);
+            }
+
+            const ctx = c.get("cirrus");
+            const request = c.req.raw;
+            const encoder = new TextEncoder();
+            const ac = new AbortController();
+
+            request.signal.addEventListener("abort", () => {
+                ac.abort();
+            });
+
+            const stream = new ReadableStream<Uint8Array>({
+                async start(controller) {
+                    try {
+                        const iterator = userHandler({ ctx, params, request, searchParams, signal: ac.signal });
+
+                        for await (const chunk of iterator) {
+                            if (ac.signal.aborted) {
+                                break;
+                            }
+
+                            controller.enqueue(encoder.encode(sseFrame(chunk)));
+                        }
+
+                        controller.enqueue(encoder.encode(sseFrame({}, "complete")));
+                    } catch (error: unknown) {
+                        const payload =
+                            error instanceof CirrusError
+                                ? { code: error.code, message: error.message }
+                                : { code: "INTERNAL_SERVER_ERROR", message: error instanceof Error ? error.message : String(error) };
+
+                        controller.enqueue(encoder.encode(sseFrame(payload, "error")));
+                    } finally {
+                        controller.close();
+                    }
+                },
+                cancel() {
+                // The downstream consumer dropped the stream — propagate the
+                // cancel to the user iterator so any in-flight work bails out.
+                    ac.abort();
+                },
+            });
+
+            return new Response(stream, {
+                headers: {
+                    "cache-control": "no-cache, no-transform",
+                    "content-type": "text/event-stream; charset=utf-8",
+                    // Hint to proxies (including Cloudflare's own buffering layer)
+                    // that this response must not be coalesced.
+                    "x-accel-buffering": "no",
+                },
+            });
+        };
 
 const makeRouteBuilder = (state: RouteState): Record<string, unknown> => ({
     body: (validators: ArgsValidator) => makeRouteBuilder({ ...state, body: { ...state.body, ...validators } }),
@@ -373,12 +490,13 @@ const makeRouteBuilder = (state: RouteState): Record<string, unknown> => ({
     output: (validator: Validator) => makeRouteBuilder({ ...state, output: validator }),
     params: (validators: ArgsValidator) => makeRouteBuilder({ ...state, params: { ...state.params, ...validators } }),
     searchParams: (validators: ArgsValidator) => makeRouteBuilder({ ...state, searchParams: { ...state.searchParams, ...validators } }),
+    stream: (userHandler: LooseStreamHandler): CirrusRouteHandler => buildStreamHandler(state, userHandler),
 });
 
 const makeRouteFactory =
     (method: HttpMethod): HttpRouteFactory =>
-    (path: string) =>
-        makeRouteBuilder({ body: {}, method, params: {}, path, searchParams: {} }) as unknown as HttpRouteBuilder<EmptyArgs, EmptyArgs, EmptyArgs>;
+        (path: string) =>
+            makeRouteBuilder({ body: {}, method, params: {}, path, searchParams: {} }) as unknown as HttpRouteBuilder<EmptyArgs, EmptyArgs, EmptyArgs>;
 
 /**
  * Typed REST route builder. Compiles down to a {@link CirrusRouteHandler}, so a

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -29,6 +29,7 @@ export type {
     HttpRouteBuilder,
     HttpRouteFactory,
     HttpRouteHandlerOptions,
+    HttpStreamHandlerOptions,
 } from "./http.js";
 export { httpAction, httpRoute, httpRouter } from "./http.js";
 export type { MigrationDefinition, MigrationDocument, MigrationTransform, RegisteredMigration } from "./migration.js";
@@ -77,6 +78,7 @@ export type {
     RegisteredFunction,
     RegisteredMutation,
     RegisteredQuery,
+    RegisteredStream,
     RelationDefinition,
     Scheduler,
     Schema,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -188,7 +188,7 @@ export interface Schema<T extends Record<string, TableDefinition> = Record<strin
 
 // --- Function registration ---------------------------------------------------
 
-export type FunctionKind = "action" | "mutation" | "query";
+export type FunctionKind = "action" | "mutation" | "query" | "stream";
 
 /**
  * Call surface a function is exposed on. `public` functions are reachable from
@@ -209,6 +209,21 @@ export interface RegisteredFunction<A extends ArgsValidator, R, Kind extends Fun
 export type RegisteredQuery<A extends ArgsValidator, R> = RegisteredFunction<A, R, "query">;
 export type RegisteredMutation<A extends ArgsValidator, R> = RegisteredFunction<A, R, "mutation">;
 export type RegisteredAction<A extends ArgsValidator, R> = RegisteredFunction<A, R, "action">;
+
+/**
+ * A streaming query registration. Unlike {@link RegisteredFunction} the handler
+ * returns an `AsyncIterable<R>` synchronously (it does NOT `Promise<R>`); the
+ * runtime drives it frame by frame and forwards each chunk to the caller. The
+ * third `signal` argument is wired to the caller's cancel signal so the handler
+ * can stop early — break out of the loop or check `signal.aborted` between
+ * yields.
+ */
+export interface RegisteredStream<A extends ArgsValidator, R> {
+    readonly args: A;
+    readonly handler: (context: unknown, args: InferArgs<A>, signal: AbortSignal) => AsyncIterable<R>;
+    readonly kind: "stream";
+    readonly visibility?: FunctionVisibility;
+}
 
 // --- Context types -----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements PLAN2 item #11 — streaming query results — on both transports the plan called for.

**WebSocket transport** (the default): a query builder gains a `.stream()` terminal that takes an async generator + `AbortSignal`. The runtime registers it with `kind:"stream"`; client → server sends `{type:"stream", id, query}`, server → client emits one `{type:"chunk", id, data}` per yield, terminated by `{type:"complete", id}` or `{type:"error", id}`. Cancel reuses the existing `unsubscribe` channel.

**HTTP transport**: the typed REST builder gains a parallel `.stream()` terminal that compiles to a Server-Sent Events response. Chunks land as `data: <json>\n\n`; completion as `event: complete`; errors as `event: error`.

**Stack:**
- `@cirrus/server` — `.stream()` on `QueryBuilder` (public + internal) and on `HttpRouteBuilder`; new `RegisteredStream` shape.
- `@cirrus/do` — `webSocketMessage` recognises stream envelopes; `executeStream` (parallel to `executeSubscription`) is overridable by codegen; close + unsubscribe abort in-flight iterators.
- `@cirrus/client` — `client.stream(fn, args, opts?)` returns `AsyncIterable<T> & { cancel() }` backed by a bounded queue (default 1024 chunks).
- `@cirrus/codegen` — discovers `.stream()` terminals; unwraps `AsyncIterable<R>`/`AsyncGenerator<R>` return types; emits `executeStream` override on the generated shard.
- `@cirrus/react` — new `useStream(fn, args)` hook returns `{chunks, status, error, cancel}`.

## Test plan

- [x] `pnpm --filter @cirrus/server run test` — 129/129 (incl. 4 new builder-stream + 4 new http-stream)
- [x] `pnpm --filter @cirrus/do run test` — 374/374 (incl. 6 new shard-do.stream)
- [x] `pnpm --filter @cirrus/client run test` — 77/77 (incl. 11 new stream)
- [x] `pnpm --filter @cirrus/codegen run test` — 81/81 (fixture updated for new shape)
- [x] `pnpm --filter @cirrus/react run test` — 37/37 (incl. 4 new useStream)
- [ ] Manual: add a `streamLogs` example to `apps/playground` and verify `useStream` renders chunks then `complete`
- [ ] Manual: `curl -N <route>` against an SSE endpoint and verify `data:` framing

## Dispatch invariant

The `CIRRUS_FUNCTIONS[":ns:fn"]` table now hosts entries with `kind:"stream"` alongside `query`/`mutation`/`action`. Existing dispatch (`handleRpc`) is untouched; streams route through a new `executeStream` hook that the generated shard subclass overrides. PLAN2-IMPL's invariant — `{kind, args, handler}` — holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)