### PR TITLE
feat(react): swap QueryCache for TanStack Query substrate (PLAN2 #20)

### DIFF
--- a/packages/react/__tests__/byo-query-client.test.tsx
+++ b/packages/react/__tests__/byo-query-client.test.tsx
@@ -1,0 +1,91 @@
+import type { FunctionReference } from "@cirrus/client";
+import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, test } from "vitest";
+
+import { CirrusProvider } from "../src/cirrus-provider.js";
+import { useQuery } from "../src/use-query.js";
+import { createMockClient } from "./mock-client.js";
+
+const fn = (reference: string): FunctionReference => ({ __cirrusRef: reference });
+
+const Display = (): ReactElement => {
+    const value = useQuery(fn("posts:list"), {});
+    const qc = useQueryClient();
+
+    // We expose the queryClient identity via a data-* attribute so we can
+    // assert the BYO client is the one in use without depending on `===`
+    // semantics across hooks (the public surface is opaque).
+    return (
+        <div data-qc-defaults={JSON.stringify(qc.getDefaultOptions().queries ?? {})} data-testid="display">
+            {value === undefined ? "pending" : JSON.stringify(value)}
+        </div>
+    );
+};
+
+describe("cirrusProvider — bring-your-own QueryClient", () => {
+    test("uses an explicit queryClient prop instead of creating one", async () => {
+        const mock = createMockClient(() => ({ count: 7 }));
+        const myQc = new QueryClient({ defaultOptions: { queries: { gcTime: 99, retry: 0 } } });
+
+        render(
+            <CirrusProvider client={mock.asClient} queryClient={myQc}>
+                <Display />
+            </CirrusProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 7 }));
+        });
+
+        const defaults = JSON.parse(screen.getByTestId("display").dataset.qcDefaults ?? "{}");
+
+        expect(defaults.gcTime).toBe(99);
+    });
+
+    test("inherits the QueryClient from a parent <QueryClientProvider> without double-wrapping", async () => {
+        const mock = createMockClient(() => ({ count: 3 }));
+        const parentQc = new QueryClient({ defaultOptions: { queries: { gcTime: 12_345, retry: 0 } } });
+
+        render(
+            <QueryClientProvider client={parentQc}>
+                <CirrusProvider client={mock.asClient}>
+                    <Display />
+                </CirrusProvider>
+            </QueryClientProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 3 }));
+        });
+
+        const defaults = JSON.parse(screen.getByTestId("display").dataset.qcDefaults ?? "{}");
+
+        // The marker for "we used the parent client" — its non-default gcTime
+        // shows through the hook's useQueryClient() lookup.
+        expect(defaults.gcTime).toBe(12_345);
+    });
+
+    test("creates a default QueryClient when none is provided", async () => {
+        const mock = createMockClient(() => ({ count: 1 }));
+
+        render(
+            <CirrusProvider client={mock.asClient}>
+                <Display />
+            </CirrusProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 1 }));
+        });
+
+        const defaults = JSON.parse(screen.getByTestId("display").dataset.qcDefaults ?? "{}");
+
+        // Default settings from createDefaultQueryClient.
+        expect(defaults.retry).toBe(0);
+        // staleTime: Infinity does not survive JSON.stringify (Infinity → null);
+        // but the absence of `cacheTime` being 0 demonstrates a real client was created.
+        expect(defaults).toMatchObject({ gcTime: 5 * 60_000, retry: 0 });
+    });
+});

--- a/packages/react/__tests__/use-preloaded-query.test.tsx
+++ b/packages/react/__tests__/use-preloaded-query.test.tsx
@@ -55,7 +55,11 @@ describe("usePreloadedQuery", () => {
             mock.emit("posts:list", { count: 5 });
         });
 
-        expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 5 }));
+        // TanStack v5 schedules cache notifications on a microtask, so the
+        // post-emit update lands on a later commit — waitFor lets it flush.
+        await waitFor(() => {
+            expect(screen.getByTestId("display").textContent).toBe(JSON.stringify({ count: 5 }));
+        });
     });
 
     test("server-renders the preloaded value (SSR getServerSnapshot, no effects)", () => {

--- a/packages/react/__tests__/use-query.test.tsx
+++ b/packages/react/__tests__/use-query.test.tsx
@@ -9,7 +9,10 @@ import { createMockClient } from "./mock-client.js";
 
 const fn = (ref: string): FunctionReference => ({ __cirrusRef: ref });
 
-const Display = ({ args = {} as Record<string, unknown> }: { args?: Record<string, unknown> | "skip" }): ReactElement => {
+const DEFAULT_ARGS: Record<string, unknown> = {};
+const SHARED_ARGS: Record<string, unknown> = { a: 1 };
+
+const Display = ({ args = DEFAULT_ARGS }: { args?: Record<string, unknown> | "skip" }): ReactElement => {
     const data = useQuery(fn("posts:list"), args as Record<string, unknown> | "skip");
 
     return <div data-testid="display">{data === undefined ? "loading" : JSON.stringify(data)}</div>;
@@ -53,8 +56,8 @@ describe("useQuery", () => {
 
         render(
             <CirrusProvider client={mock.asClient}>
-                <Display args={{ a: 1 }} />
-                <Display args={{ a: 1 }} />
+                <Display args={SHARED_ARGS} />
+                <Display args={SHARED_ARGS} />
             </CirrusProvider>,
         );
 
@@ -89,6 +92,10 @@ describe("useQuery", () => {
             mock.emit("posts:list", 42);
         });
 
-        expect(screen.getByTestId("display").textContent).toBe("42");
+        // TanStack v5 schedules cache notifications on a microtask, so the
+        // post-emit update lands on a later commit — waitFor lets it flush.
+        await waitFor(() => {
+            expect(screen.getByTestId("display").textContent).toBe("42");
+        });
     });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
         "@cirrus/ratelimit": "workspace:*"
     },
     "devDependencies": {
+        "@tanstack/react-query": "catalog:frontend",
         "@testing-library/dom": "catalog:frontend",
         "@testing-library/react": "catalog:frontend",
         "@types/node": "catalog:types",
@@ -44,10 +45,14 @@
         "vitest": "catalog:test"
     },
     "peerDependencies": {
+        "@tanstack/react-query": "^5.93.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },
     "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+            "optional": false
+        },
         "react": {
             "optional": false
         },

--- a/packages/react/src/cache.ts
+++ b/packages/react/src/cache.ts
@@ -1,177 +1,138 @@
 import type { CirrusClient, FunctionReference, Unsubscribe } from "@cirrus/client";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
 
-export type CacheStatus = "idle" | "loading" | "ready" | "error";
-
-interface CacheEntry {
-    data: unknown;
-    error: Error | undefined;
-    /** Subscriber callbacks to notify when this entry changes. */
-    listeners: Set<() => void>;
-    /** Polling timer when WS fallback is in effect. */
+/**
+ * Per-key bookkeeping: a single WS subscription is shared across every hook
+ * that observes the same `queryKey`. {@link refCount} tracks the consumers so
+ * we close the underlying subscription on the last `detach()`.
+ */
+interface RegistryEntry {
+    /** Polling fallback when `client.subscribe` is unavailable (e.g. no WS). */
     pollTimer: ReturnType<typeof setInterval> | undefined;
-    /** Number of active consumers (useQuery / useSubscription mounts). */
     refCount: number;
-    status: CacheStatus;
-    /** WS unsubscribe for the active subscription, if one is open. */
+    /** WS unsubscribe handle, set on first successful attach. */
     unsubscribe: Unsubscribe | undefined;
 }
 
+/** Stringified queryKey used as the internal index key for {@link CirrusSubscriptionRegistry}. */
+const keyHash = (queryKey: QueryKey): string => JSON.stringify(queryKey);
+
 /**
- * Shared, per-client query cache. Multiple components calling `useQuery` with
- * the same `(functionPath, args, shardKey)` share a single subscription and
- * a single snapshot, so re-renders are coordinated through one listener set.
+ * Per-client subscription dedup layer that sits *next to* TanStack Query.
+ *
+ * Where the old `QueryCache` owned both the data *and* the subscription
+ * lifecycle, this adapter only owns the subscription side: data lives in the
+ * TanStack {@link QueryClient}. The flow on every push:
+ *
+ *   client.subscribe(fn, args, value => qc.setQueryData(queryKey, value))
+ *
+ * Every hook that mounts a `useQuery({queryKey: ["cirrus", fn, args, shard]})`
+ * also calls `registry.attach(qc, queryKey, fn, args, shardKey)`; the registry
+ * dedupes by hashed queryKey so two components observing the same query open a
+ * single WS subscription. On the last `detach()` the subscription is closed
+ * (or the polling fallback is cleared).
+ *
+ * Polling fallback: if `client.subscribe` throws (no WS in the environment),
+ * the registry installs a 5s interval that calls `qc.invalidateQueries({
+ * queryKey })`, letting TanStack's own `refetch` loop drive freshness.
  */
-export class QueryCache {
-    private readonly entries = new Map<string, CacheEntry>();
+export class CirrusSubscriptionRegistry {
+    private readonly entries = new Map<string, RegistryEntry>();
 
     public constructor(private readonly client: CirrusClient) {}
 
-    public keyOf(fn: FunctionReference, args: unknown, shardKey: string | undefined): string {
-        return `${fn.__cirrusRef}::${JSON.stringify(args ?? {})}::${shardKey ?? ""}`;
-    }
-
-    public peek(key: string): CacheEntry | undefined {
-        return this.entries.get(key);
+    /**
+     * Hash a TanStack `queryKey` to the internal registry index. Exposed so a
+     * hook can look up the registry without re-implementing the hash.
+     */
+    public keyOf(queryKey: QueryKey): string {
+        return keyHash(queryKey);
     }
 
     /**
-     * Acquire (or reuse) a cache entry for the given query. Increments the
-     * refcount; callers must invoke the returned `release()` exactly once.
+     * Attach a consumer to the live subscription for `queryKey`. The first
+     * attach opens the underlying WS subscription; subsequent attaches reuse
+     * it (refcount-bumped). Returns the detach function — call it exactly once
+     * per attach.
      */
-    public acquire(
+    public attach(
+        queryClient: QueryClient,
+        queryKey: QueryKey,
         fn: FunctionReference,
         args: Record<string, unknown>,
         shardKey: string | undefined,
-        listener: () => void,
-        options: { initialData?: { value: unknown }; pollIntervalMs?: number } = {},
-    ): { entry: CacheEntry; key: string; release: () => void } {
-        const key = this.keyOf(fn, args, shardKey);
+        options: { pollIntervalMs?: number } = {},
+    ): () => void {
+        const key = keyHash(queryKey);
         let entry = this.entries.get(key);
 
         if (!entry) {
-            const seeded = options.initialData !== undefined;
-
-            entry = {
-                refCount: 0,
-                status: seeded ? "ready" : "loading",
-                data: seeded ? options.initialData?.value : undefined,
-                error: undefined,
-                listeners: new Set(),
-                unsubscribe: undefined,
-                pollTimer: undefined,
-            };
+            entry = { pollTimer: undefined, refCount: 0, unsubscribe: undefined };
             this.entries.set(key, entry);
-            // A preloaded entry already carries the server value, so skip the
-            // initial HTTP fetch and only attach the live subscription.
-            this.beginFetch(entry, fn, args, shardKey, options.pollIntervalMs ?? 5000, seeded);
+
+            try {
+                entry.unsubscribe = this.client.subscribe(
+                    fn,
+                    args,
+                    (value) => {
+                        queryClient.setQueryData(queryKey, value);
+                    },
+                    { shardKey },
+                );
+            } catch {
+                // WS unavailable — fall back to periodic invalidation so
+                // TanStack Query's own refetch loop keeps the cache fresh.
+                entry.pollTimer = setInterval(() => {
+                    void queryClient.invalidateQueries({ queryKey });
+                }, options.pollIntervalMs ?? 5000);
+            }
         }
 
         entry.refCount += 1;
-        entry.listeners.add(listener);
 
-        return {
-            entry,
-            key,
-            release: () => {
-                if (!entry) {
-                    return;
-                }
+        return () => {
+            // `entries.get(key)` is read again because a sibling detach may have
+            // already torn the entry down. Calling detach twice is a no-op.
+            const current = this.entries.get(key);
 
-                entry.listeners.delete(listener);
-                entry.refCount -= 1;
-
-                if (entry.refCount <= 0) {
-                    entry.unsubscribe?.();
-
-                    if (entry.pollTimer) {
-                        clearInterval(entry.pollTimer);
-                    }
-
-                    this.entries.delete(key);
-                }
-            },
-        };
-    }
-
-    /** Notify all listeners of a given entry that something changed. */
-    public emit(entry: CacheEntry): void {
-        for (const listener of entry.listeners) {
-            try {
-                listener();
-            } catch {
-                /* listener threw — ignore so other consumers still update */
+            if (!current) {
+                return;
             }
-        }
-    }
 
-    private beginFetch(
-        entry: CacheEntry,
-        fn: FunctionReference,
-        args: Record<string, unknown>,
-        shardKey: string | undefined,
-        pollIntervalMs: number,
-        skipInitialFetch = false,
-    ): void {
-        // Initial fetch (HTTP) so that even WS-less environments see a value.
-        // Skipped when the entry was seeded from a preloaded server value.
-        if (!skipInitialFetch) {
-            this.client
-                .query(fn as FunctionReference, args, { shardKey })
-                .then((value) => {
-                    entry.status = "ready";
-                    entry.data = value;
-                    entry.error = undefined;
-                    this.emit(entry);
-                })
-                .catch((error: unknown) => {
-                    entry.status = "error";
-                    entry.error = error instanceof Error ? error : new Error(String(error));
-                    this.emit(entry);
-                });
-        }
+            current.refCount -= 1;
 
-        // Live updates via WS subscription. The client subscribes regardless;
-        // if the WS implementation is missing, the subscribe call still wires
-        // the callback but never receives data.
-        try {
-            entry.unsubscribe = this.client.subscribe(
-                fn as FunctionReference,
-                args,
-                (value) => {
-                    entry.status = "ready";
-                    entry.data = value;
-                    entry.error = undefined;
-                    this.emit(entry);
-                },
-                { shardKey },
-            );
-        } catch {
-            // Fallback: poll over HTTP if subscribe is unavailable in this environment.
-            entry.pollTimer = setInterval(() => {
-                this.client
-                    .query(fn as FunctionReference, args, { shardKey })
-                    .then((value) => {
-                        entry.status = "ready";
-                        entry.data = value;
-                        entry.error = undefined;
-                        this.emit(entry);
-                    })
-                    .catch(() => undefined);
-            }, pollIntervalMs);
-        }
+            if (current.refCount <= 0) {
+                current.unsubscribe?.();
+
+                if (current.pollTimer) {
+                    clearInterval(current.pollTimer);
+                }
+
+                this.entries.delete(key);
+            }
+        };
     }
 }
 
-const cacheByClient = new WeakMap<CirrusClient, QueryCache>();
+/**
+ * Project a Cirrus `(fn, args, shardKey)` triple into the structural query key
+ * TanStack hashes for dedup. The `"cirrus"` literal namespaces our entries so
+ * an app's own queries can't collide with ours.
+ */
+export const cirrusQueryKey = (fn: FunctionReference, args: Record<string, unknown>, shardKey: string | undefined): QueryKey => {
+    return ["cirrus", fn.__cirrusRef, args, shardKey ?? null];
+};
 
-/** Returns the shared cache instance for `client`, creating it on first access. */
-export const getCache = (client: CirrusClient): QueryCache => {
-    let cache = cacheByClient.get(client);
+const registryByClient = new WeakMap<CirrusClient, CirrusSubscriptionRegistry>();
 
-    if (!cache) {
-        cache = new QueryCache(client);
-        cacheByClient.set(client, cache);
+/** Returns the shared subscription registry for `client`, creating it on first access. */
+export const getSubscriptionRegistry = (client: CirrusClient): CirrusSubscriptionRegistry => {
+    let registry = registryByClient.get(client);
+
+    if (!registry) {
+        registry = new CirrusSubscriptionRegistry(client);
+        registryByClient.set(client, registry);
     }
 
-    return cache;
+    return registry;
 };

--- a/packages/react/src/cirrus-provider.tsx
+++ b/packages/react/src/cirrus-provider.tsx
@@ -1,20 +1,90 @@
 import type { CirrusClient } from "@cirrus/client";
-import { createContext, type ReactElement, type ReactNode, useContext } from "react";
+import { QueryClient, QueryClientContext, QueryClientProvider } from "@tanstack/react-query";
+import { createContext, type ReactElement, type ReactNode, use, useState } from "react";
 
 const CirrusContext = createContext<CirrusClient | null>(null);
 
 export interface CirrusProviderProps {
     children: ReactNode;
     client: CirrusClient;
+    /**
+     * Bring-your-own QueryClient. When omitted, the provider creates one with
+     * defaults tuned for Cirrus's push-driven model:
+     *  - `staleTime: Infinity` — the WS subscription is the only invalidation signal.
+     *  - `retry: 0` — failures route through the offline queue on the client.
+     *  - `gcTime: 5min` — keep results around for a short return-to-view window.
+     *
+     * If a parent `<QueryClientProvider>` is already mounted, the provider
+     * uses *that* client and does NOT install an inner one (so apps with their
+     * own setup don't double-wrap).
+     */
+    queryClient?: QueryClient;
 }
 
-export const CirrusProvider = ({ client, children }: CirrusProviderProps): ReactElement => {
-    return <CirrusContext.Provider value={client}>{children}</CirrusContext.Provider>;
+const createDefaultQueryClient = (): QueryClient =>
+    new QueryClient({
+        defaultOptions: {
+            queries: {
+                gcTime: 5 * 60_000,
+                retry: 0,
+                staleTime: Number.POSITIVE_INFINITY,
+            },
+            mutations: { retry: 0 },
+        },
+    });
+
+/**
+ * Provides both the {@link CirrusClient} and a TanStack `QueryClient` to the
+ * tree. The detection logic for a parent QueryClientProvider keeps this safe to
+ * drop into an app that already runs TanStack Query for its own purposes.
+ */
+export const CirrusProvider = ({ children, client, queryClient }: CirrusProviderProps): ReactElement => {
+    const parentQueryClient = use(QueryClientContext);
+
+    // The TanStack client we'll *render* with. Priority:
+    //   1. Explicit `queryClient` prop wins.
+    //   2. Inherit from a parent <QueryClientProvider> when present.
+    //   3. Create one lazily (useState initializer) so the same instance
+    //      survives re-renders.
+    const [internalClient] = useState<QueryClient | undefined>(() => {
+        if (queryClient) {
+            return undefined;
+        }
+
+        if (parentQueryClient) {
+            return undefined;
+        }
+
+        return createDefaultQueryClient();
+    });
+
+    const effectiveClient = queryClient ?? parentQueryClient ?? internalClient;
+
+    if (!effectiveClient) {
+        // The useState branch always produces a client when we need one, so
+        // this is unreachable; the throw makes the type narrow for downstream
+        // code without an `as`.
+        throw new Error("CirrusProvider: failed to resolve a QueryClient");
+    }
+
+    const content = <CirrusContext value={client}>{children}</CirrusContext>;
+
+    // Don't double-wrap when a parent already provides the client.
+    if (parentQueryClient === effectiveClient) {
+        return content;
+    }
+
+    return <QueryClientProvider client={effectiveClient}>{content}</QueryClientProvider>;
 };
 
-/** Read the {@link CirrusClient} from the nearest `<CirrusProvider>`. */
+/**
+ * Read the {@link CirrusClient} from the nearest `<CirrusProvider>`.
+ *
+ * eslint-disable-next-line react-refresh/only-export-components — kept colocated with the provider for back-compat.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
 export const useCirrus = (): CirrusClient => {
-    const client = useContext(CirrusContext);
+    const client = use(CirrusContext);
 
     if (!client) {
         throw new Error("useCirrus must be used inside <CirrusProvider />");

--- a/packages/react/src/use-infinite-query.ts
+++ b/packages/react/src/use-infinite-query.ts
@@ -1,7 +1,9 @@
 import type { FunctionReference } from "@cirrus/client";
+import type { QueryKey } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
-import { getCache } from "./cache.js";
+import { cirrusQueryKey, getSubscriptionRegistry } from "./cache.js";
 import { useCirrus } from "./cirrus-provider.js";
 import type { PaginationResult, PaginationStatus, UseInfiniteQueryOptions, UseInfiniteQueryResult } from "./types.js";
 import type { PageItemOf, PaginatedArgs } from "./use-paginated-query.js";
@@ -31,7 +33,7 @@ export function useInfiniteQuery<F extends FunctionReference>(
     options: UseInfiniteQueryOptions,
 ): UseInfiniteQueryResult<PageItemOf<F>> {
     const client = useCirrus();
-    const cache = getCache(client);
+    const queryClient = useQueryClient();
     const { initialNumItems, shardKey } = options;
 
     const skipped = args === "skip";
@@ -41,10 +43,6 @@ export function useInfiniteQuery<F extends FunctionReference>(
     const [, forceRender] = useReducer((tick: number) => tick + 1, 0);
     const [pages, setPages] = useState<PageRequest[]>(() => [{ cursor: null, numItems: initialNumItems }]);
 
-    // Reset to the first page whenever the query identity, base args, or page
-    // size changes. Set-state-during-render (guarded by a ref) is React's
-    // sanctioned way to derive state from changing inputs without an extra
-    // commit.
     const resetKey = `${fn.__cirrusRef}::${baseArgsKey}::${String(initialNumItems)}::${shardKey ?? ""}`;
     const resetKeyRef = useRef(resetKey);
 
@@ -53,79 +51,91 @@ export function useInfiniteQuery<F extends FunctionReference>(
         setPages([{ cursor: null, numItems: initialNumItems }]);
     }
 
-    const pageEntries: Array<[string, Record<string, unknown>]> = pages.map((page) => {
+    const pageEntries = pages.map((page) => {
         const pageArgs = { ...baseArgs, paginationOpts: { cursor: page.cursor, numItems: page.numItems } };
+        const key: QueryKey = cirrusQueryKey(fn, pageArgs, shardKey);
 
-        return [cache.keyOf(fn, pageArgs, shardKey), pageArgs];
+        return { args: pageArgs, key };
     });
-    const pageKeys = pageEntries.map(([key]) => key);
-    const pageKeysKey = pageKeys.join("|");
+    const pageKeysHash = pageEntries.map(({ key }) => JSON.stringify(key)).join("|");
 
-    // The effect reads the latest desired (key → args) mapping from a ref so the
-    // dependency array can stay keyed on `pageKeysKey` alone, matching useQuery.
-    const desiredRef = useRef<{ entries: Array<[string, Record<string, unknown>]>; fn: F; shardKey: string | undefined }>({
-        entries: [],
-        fn,
-        shardKey,
-    });
+    const desiredRef = useRef<{ entries: typeof pageEntries; fn: F; shardKey: string | undefined }>({ entries: [], fn, shardKey });
 
     desiredRef.current = { entries: pageEntries, fn, shardKey };
 
-    const handlesRef = useRef(new Map<string, () => void>());
+    const detachesRef = useRef(new Map<string, () => void>());
 
     useEffect(() => {
-        const handles = handlesRef.current;
-        const notify = (): void => {
-            forceRender();
-        };
+        const detaches = detachesRef.current;
 
         if (skipped) {
-            for (const release of handles.values()) {
-                release();
+            for (const detach of detaches.values()) {
+                detach();
             }
 
-            handles.clear();
+            detaches.clear();
 
             return;
         }
 
         const desired = desiredRef.current;
-        const wanted = new Set(desired.entries.map(([key]) => key));
+        const registry = getSubscriptionRegistry(client);
+        const wanted = new Set(desired.entries.map(({ key }) => JSON.stringify(key)));
 
-        // Release pages that fell out of the request set, keeping survivors live
-        // so a `fetchNextPage` never flickers earlier pages back to a loading
-        // state.
-        for (const [key, release] of handles) {
-            if (!wanted.has(key)) {
-                release();
-                handles.delete(key);
+        for (const [hash, detach] of detaches) {
+            if (!wanted.has(hash)) {
+                detach();
+                detaches.delete(hash);
             }
         }
 
-        for (const [key, pageArgs] of desired.entries) {
-            if (!handles.has(key)) {
-                handles.set(key, cache.acquire(desired.fn, pageArgs, desired.shardKey, notify).release);
+        for (const entry of desired.entries) {
+            const hash = JSON.stringify(entry.key);
+
+            if (detaches.has(hash)) {
+                continue;
             }
+
+            void queryClient.fetchQuery({
+                queryFn: () =>
+                    (client.query as (fn: F, args: unknown, options: { shardKey?: string }) => Promise<unknown>)(desired.fn, entry.args, {
+                        shardKey: desired.shardKey,
+                    }),
+                queryKey: entry.key,
+                staleTime: Number.POSITIVE_INFINITY,
+            });
+
+            detaches.set(hash, registry.attach(queryClient, entry.key, desired.fn, entry.args, desired.shardKey));
         }
+    }, [client, queryClient, pageKeysHash, skipped]);
 
-        notify();
-    }, [cache, pageKeysKey, skipped]);
-
-    // Release every page on unmount.
     useEffect(
         () => () => {
-            for (const release of handlesRef.current.values()) {
-                release();
+            for (const detach of detachesRef.current.values()) {
+                detach();
             }
 
-            handlesRef.current.clear();
+            detachesRef.current.clear();
         },
         [],
     );
 
+    useEffect(() => {
+        const cache = queryClient.getQueryCache();
+        const unsubscribe = cache.subscribe((event) => {
+            const hash = JSON.stringify(event.query.queryKey);
+
+            if (pageEntries.some(({ key }) => JSON.stringify(key) === hash)) {
+                forceRender();
+            }
+        });
+
+        return unsubscribe;
+    }, [queryClient, pageKeysHash]);
+
     const pageResults: Array<PaginationResult<PageItemOf<F>> | undefined> = skipped
         ? []
-        : pageKeys.map((key) => cache.peek(key)?.data as PaginationResult<PageItemOf<F>> | undefined);
+        : pageEntries.map(({ key }) => queryClient.getQueryData<PaginationResult<PageItemOf<F>>>(key));
 
     const resolvedPages: PageItemOf<F>[][] = [];
 
@@ -153,9 +163,6 @@ export function useInfiniteQuery<F extends FunctionReference>(
         }
     }
 
-    // Stash the cursor `fetchNextPage` should append (and the default page size)
-    // so the callback identity stays stable while still reading the freshest
-    // tail cursor.
     const nextRef = useRef<{ cursor: null | string | undefined; defaultNumItems: number }>({ cursor: undefined, defaultNumItems: initialNumItems });
 
     nextRef.current = { cursor: status === "CanLoadMore" ? nextCursor : undefined, defaultNumItems: initialNumItems };
@@ -173,9 +180,7 @@ export function useInfiniteQuery<F extends FunctionReference>(
     return {
         fetchNextPage,
         hasNextPage: status === "CanLoadMore",
-        // A pending page beyond the first is a `fetchNextPage` in flight, distinct from the first-page load.
         isFetchingNextPage: !skipped && status === "LoadingMore",
-        // `skip` is an intentional pause, not a pending fetch, so it never counts as loading.
         isLoading: !skipped && status === "LoadingFirstPage",
         pages: resolvedPages,
         status,

--- a/packages/react/src/use-paginated-query.ts
+++ b/packages/react/src/use-paginated-query.ts
@@ -1,7 +1,9 @@
 import type { ArgsOf, FunctionReference, ReturnOf } from "@cirrus/client";
+import type { QueryKey } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
-import { getCache } from "./cache.js";
+import { cirrusQueryKey, getSubscriptionRegistry } from "./cache.js";
 import { useCirrus } from "./cirrus-provider.js";
 import type { PaginationResult, PaginationStatus, UsePaginatedQueryOptions, UsePaginatedQueryResult } from "./types.js";
 
@@ -28,6 +30,10 @@ interface PageRequest {
  *
  * Changing `fn`, the base `args`, or `initialNumItems` resets the feed to its
  * first page.
+ *
+ * Pages live in TanStack Query's cache under per-page queryKeys; the
+ * subscription registry keeps one WS subscription per page open so a delta on
+ * any cursor patches the right slice without dropping the rest.
  */
 export function usePaginatedQuery<F extends FunctionReference>(
     fn: F,
@@ -35,7 +41,7 @@ export function usePaginatedQuery<F extends FunctionReference>(
     options: UsePaginatedQueryOptions,
 ): UsePaginatedQueryResult<PageItemOf<F>> {
     const client = useCirrus();
-    const cache = getCache(client);
+    const queryClient = useQueryClient();
     const { initialNumItems, shardKey } = options;
 
     const skipped = args === "skip";
@@ -57,78 +63,100 @@ export function usePaginatedQuery<F extends FunctionReference>(
         setPages([{ cursor: null, numItems: initialNumItems }]);
     }
 
-    const pageEntries: Array<[string, Record<string, unknown>]> = pages.map((page) => {
+    // Build the (queryKey, args) pair for each loaded page.
+    const pageEntries = pages.map((page) => {
         const pageArgs = { ...baseArgs, paginationOpts: { cursor: page.cursor, numItems: page.numItems } };
+        const key: QueryKey = cirrusQueryKey(fn, pageArgs, shardKey);
 
-        return [cache.keyOf(fn, pageArgs, shardKey), pageArgs];
+        return { args: pageArgs, key };
     });
-    const pageKeys = pageEntries.map(([key]) => key);
-    const pageKeysKey = pageKeys.join("|");
+    // Stable hash of every loaded page key — used as the effect-dep so we only
+    // re-attach when the page set actually changes.
+    const pageKeysHash = pageEntries.map(({ key }) => JSON.stringify(key)).join("|");
 
-    // The effect reads the latest desired (key → args) mapping from a ref so the
-    // dependency array can stay keyed on `pageKeysKey` alone, matching useQuery.
-    const desiredRef = useRef<{ entries: Array<[string, Record<string, unknown>]>; fn: F; shardKey: string | undefined }>({
-        entries: [],
-        fn,
-        shardKey,
-    });
+    // Read latest desired entries from a ref so the effect dep list can stay
+    // keyed on `pageKeysHash` alone — args/fn changes already invalidate the hash.
+    const desiredRef = useRef<{ entries: typeof pageEntries; fn: F; shardKey: string | undefined }>({ entries: [], fn, shardKey });
 
     desiredRef.current = { entries: pageEntries, fn, shardKey };
 
-    const handlesRef = useRef(new Map<string, () => void>());
+    // Track per-page detach handles so a page falling out of the request set
+    // releases its subscription without disturbing the others.
+    const detachesRef = useRef(new Map<string, () => void>());
 
     useEffect(() => {
-        const handles = handlesRef.current;
-        const notify = (): void => {
-            forceRender();
-        };
+        const detaches = detachesRef.current;
 
         if (skipped) {
-            for (const release of handles.values()) {
-                release();
+            for (const detach of detaches.values()) {
+                detach();
             }
 
-            handles.clear();
+            detaches.clear();
 
             return;
         }
 
         const desired = desiredRef.current;
-        const wanted = new Set(desired.entries.map(([key]) => key));
+        const registry = getSubscriptionRegistry(client);
+        const wanted = new Set(desired.entries.map(({ key }) => JSON.stringify(key)));
 
-        // Release pages that fell out of the request set, keeping survivors live
-        // so a `loadMore` never flickers earlier pages back to a loading state.
-        for (const [key, release] of handles) {
-            if (!wanted.has(key)) {
-                release();
-                handles.delete(key);
+        for (const [hash, detach] of detaches) {
+            if (!wanted.has(hash)) {
+                detach();
+                detaches.delete(hash);
             }
         }
 
-        for (const [key, pageArgs] of desired.entries) {
-            if (!handles.has(key)) {
-                handles.set(key, cache.acquire(desired.fn, pageArgs, desired.shardKey, notify).release);
-            }
-        }
+        for (const entry of desired.entries) {
+            const hash = JSON.stringify(entry.key);
 
-        notify();
-    }, [cache, pageKeysKey, skipped]);
+            if (detaches.has(hash)) {
+                continue;
+            }
+
+            // Trigger the initial fetch via TanStack so its dedup applies
+            // even when two mounts ask for the same page.
+            void queryClient.fetchQuery({
+                queryFn: () => client.query(desired.fn, entry.args as ArgsOf<F>, { shardKey: desired.shardKey }),
+                queryKey: entry.key,
+                staleTime: Number.POSITIVE_INFINITY,
+            });
+
+            detaches.set(hash, registry.attach(queryClient, entry.key, desired.fn, entry.args, desired.shardKey));
+        }
+    }, [client, queryClient, pageKeysHash, skipped]);
 
     // Release every page on unmount.
     useEffect(
         () => () => {
-            for (const release of handlesRef.current.values()) {
-                release();
+            for (const detach of detachesRef.current.values()) {
+                detach();
             }
 
-            handlesRef.current.clear();
+            detachesRef.current.clear();
         },
         [],
     );
 
+    // Subscribe to TanStack cache events so a setQueryData from the registry
+    // triggers a re-render here.
+    useEffect(() => {
+        const cache = queryClient.getQueryCache();
+        const unsubscribe = cache.subscribe((event) => {
+            const hash = JSON.stringify(event.query.queryKey);
+
+            if (pageEntries.some(({ key }) => JSON.stringify(key) === hash)) {
+                forceRender();
+            }
+        });
+
+        return unsubscribe;
+    }, [queryClient, pageKeysHash]);
+
     const pageResults: Array<PaginationResult<PageItemOf<F>> | undefined> = skipped
         ? []
-        : pageKeys.map((key) => cache.peek(key)?.data as PaginationResult<PageItemOf<F>> | undefined);
+        : pageEntries.map(({ key }) => queryClient.getQueryData<PaginationResult<PageItemOf<F>>>(key));
 
     const results: PageItemOf<F>[] = [];
 
@@ -156,8 +184,6 @@ export function usePaginatedQuery<F extends FunctionReference>(
         }
     }
 
-    // Stash the cursor `loadMore` should append so the callback identity stays
-    // stable while still reading the freshest tail cursor.
     const nextCursorRef = useRef<null | string | undefined>(undefined);
 
     nextCursorRef.current = status === "CanLoadMore" ? nextCursor : undefined;
@@ -173,7 +199,6 @@ export function usePaginatedQuery<F extends FunctionReference>(
     }, []);
 
     return {
-        // `skip` is an intentional pause, not a pending fetch, so it never counts as loading.
         isLoading: !skipped && (status === "LoadingFirstPage" || status === "LoadingMore"),
         loadMore,
         results,

--- a/packages/react/src/use-preloaded-query.ts
+++ b/packages/react/src/use-preloaded-query.ts
@@ -1,68 +1,51 @@
 import type { FunctionReference, Preloaded } from "@cirrus/client";
-import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useQuery as useTanStackQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
 
-import { getCache } from "./cache.js";
+import { cirrusQueryKey, getSubscriptionRegistry } from "./cache.js";
 import { useCirrus } from "./cirrus-provider.js";
 
 /**
  * Hydrate a query from a {@link Preloaded} token produced by `preloadQuery`
  * during SSR, then keep it live.
  *
- * The first render — on the server and on the client before effects run —
- * returns the preloaded value, so the server markup and the initial client
- * markup match (no hydration mismatch, no loading flash). Once mounted, the
- * hook seeds the shared query cache with that value (skipping the redundant
- * initial fetch) and attaches a WS subscription, so later server pushes update
- * the value just like {@link useQuery}.
+ * The first render returns the preloaded value (TanStack's `initialData`),
+ * so the server markup and the initial client markup match — no hydration
+ * mismatch, no loading flash. After mount, a WS subscription attaches so
+ * later server pushes update the value just like {@link useQuery}.
+ *
+ * The {@link Preloaded} token's `value` seeds `initialData`; we don't need a
+ * full dehydrate/hydrate dance because the consumer hands us the resolved
+ * value directly. Apps that want to share a pre-populated QueryClient across
+ * many preloaded queries can pass their own `queryClient` to `CirrusProvider`
+ * and hydrate it themselves via TanStack's `hydrate(qc, dehydratedState)`.
  */
 export function usePreloadedQuery<T>(preloaded: Preloaded<T>): T {
     const client = useCirrus();
-    const cache = getCache(client);
+    const queryClient = useQueryClient();
 
     const { args, functionPath, shardKey, value } = preloaded;
     const fn = useMemo<FunctionReference>(() => ({ __cirrusRef: functionPath }), [functionPath]);
-    const key = cache.keyOf(fn, args, shardKey);
+    const queryKey = useMemo(() => cirrusQueryKey(fn, args, shardKey), [fn.__cirrusRef, JSON.stringify(args), shardKey]);
 
-    // Stable subscribe handle so useSyncExternalStore doesn't churn (mirrors useQuery).
-    const listenersRef = useRef(new Set<() => void>());
-    const subscribe = useRef((cb: () => void) => {
-        listenersRef.current.add(cb);
-
-        return () => {
-            listenersRef.current.delete(cb);
-        };
-    }).current;
-
-    const acquireRef = useRef({ args, fn, shardKey, value });
-
-    acquireRef.current = { args, fn, shardKey, value };
+    const { data } = useTanStackQuery<T>({
+        // Seed the cache with the server value so the first paint doesn't
+        // re-fetch. TanStack treats `initialData` as fresh — the WS push from
+        // the registry is what supplies subsequent updates.
+        initialData: value,
+        queryFn: () => client.query(fn, args as Record<string, never>, { shardKey }) as Promise<T>,
+        queryKey,
+        staleTime: Number.POSITIVE_INFINITY,
+    });
 
     useEffect(() => {
-        const notify = (): void => {
-            for (const listener of listenersRef.current) {
-                listener();
-            }
-        };
+        const registry = getSubscriptionRegistry(client);
 
-        const { args: currentArgs, fn: currentFn, shardKey: currentShardKey, value: currentValue } = acquireRef.current;
-        const handle = cache.acquire(currentFn, currentArgs, currentShardKey, notify, { initialData: { value: currentValue } });
+        return registry.attach(queryClient, queryKey, fn, args, shardKey);
+    }, [client, queryClient, JSON.stringify(queryKey)]);
 
-        notify();
-
-        return () => {
-            handle.release();
-        };
-    }, [cache, key]);
-
-    const getSnapshot = (): T => {
-        const entry = cache.peek(key);
-
-        // Fall back to the preloaded value until live data lands — covers both
-        // the pre-effect first render and an entry another hook left "loading".
-        return (entry?.data ?? value) as T;
-    };
-
-    const getServerSnapshot = (): T => value;
-
-    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+    // `data` is typed as `T | undefined` because TanStack hedges its type
+    // against an empty initialData, but our `initialData: value` is always
+    // present so the cast is safe.
+    return data as T;
 }

--- a/packages/react/src/use-query.ts
+++ b/packages/react/src/use-query.ts
@@ -1,7 +1,8 @@
 import type { ArgsOf, FunctionReference, ReturnOf } from "@cirrus/client";
-import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useQuery as useTanStackQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
 
-import { getCache } from "./cache.js";
+import { cirrusQueryKey, getSubscriptionRegistry } from "./cache.js";
 import { useCirrus } from "./cirrus-provider.js";
 import type { UseQueryOptions } from "./types.js";
 
@@ -9,77 +10,52 @@ import type { UseQueryOptions } from "./types.js";
  * Subscribe to a server query.
  *
  * Returns `undefined` until the first response lands. Pass `"skip"` for
- * `args` to short-circuit the query (no network call, no cache entry).
+ * `args` to short-circuit the query (no network call, no subscription).
  *
- * Multiple components calling `useQuery` with the same arguments share a
- * single underlying network call thanks to the shared cache in `cache.ts`.
+ * Internally this routes through TanStack Query: the queryKey is
+ * `["cirrus", fn.__cirrusRef, args, shardKey]` (TanStack hashes structurally
+ * so an args object built in a different key order still dedupes). The
+ * subscription registry shares a single WS subscription across every consumer
+ * of the same queryKey; pushes call `queryClient.setQueryData(...)`.
  */
 export function useQuery<F extends FunctionReference>(fn: F, args: ArgsOf<F> | "skip", options: UseQueryOptions = {}): ReturnOf<F> | undefined {
     const client = useCirrus();
-    const cache = getCache(client);
+    const queryClient = useQueryClient();
+    const { shardKey } = options;
 
     const skipped = args === "skip";
     const argsRecord = (skipped ? {} : (args as Record<string, unknown>)) ?? {};
-    const { shardKey } = options;
-    const key = cache.keyOf(fn, argsRecord, shardKey);
 
-    const releaseRef = useRef<(() => void) | null>(null);
-    const lastKeyRef = useRef<string | null>(null);
+    // Memoise the queryKey so the effect dep array tracks structural equality
+    // via TanStack's hash, not reference equality of the args object.
+    const queryKey = useMemo(() => cirrusQueryKey(fn, argsRecord, shardKey), [fn.__cirrusRef, JSON.stringify(argsRecord), shardKey]);
 
-    // Maintain a stable subscribe handle so useSyncExternalStore doesn't churn.
-    const listenersRef = useRef(new Set<() => void>());
-
-    const subscribe = useRef((cb: () => void) => {
-        listenersRef.current.add(cb);
-
-        return () => {
-            listenersRef.current.delete(cb);
-        };
-    }).current;
-
-    // Latest acquire inputs. `key` already encodes (fn, argsRecord, shardKey),
-    // so the effect re-runs whenever any of them changes; reading them from a
-    // ref keeps the dependency array honest without re-acquiring every render.
-    const acquireRef = useRef({ argsRecord, fn, shardKey });
-
-    acquireRef.current = { argsRecord, fn, shardKey };
+    const { data } = useTanStackQuery<ReturnOf<F>>({
+        enabled: !skipped,
+        queryFn: () => client.query<F>(fn, argsRecord as ArgsOf<F>, { shardKey }) as Promise<ReturnOf<F>>,
+        queryKey,
+        // Cirrus is push-driven: once the initial fetch resolves, the WS owns
+        // freshness. Staleness only matters when the subscription is missing,
+        // and the registry handles that with a polling fallback.
+        staleTime: Number.POSITIVE_INFINITY,
+    });
 
     useEffect(() => {
         if (skipped) {
             return;
         }
 
-        const notify = (): void => {
-            for (const listener of listenersRef.current) {
-                listener();
-            }
-        };
+        const registry = getSubscriptionRegistry(client);
 
-        const { argsRecord: currentArgs, fn: currentFn, shardKey: currentShardKey } = acquireRef.current;
-        const handle = cache.acquire(currentFn, currentArgs, currentShardKey, notify);
+        return registry.attach(queryClient, queryKey, fn, argsRecord, shardKey);
+    }, [client, queryClient, registry_key(queryKey), skipped]);
 
-        releaseRef.current = handle.release;
-        lastKeyRef.current = key;
-
-        // Trigger an immediate notify in case data already exists.
-        notify();
-
-        return () => {
-            handle.release();
-            releaseRef.current = null;
-            lastKeyRef.current = null;
-        };
-    }, [cache, key, skipped]);
-
-    const getSnapshot = (): ReturnOf<F> | undefined => {
-        if (skipped) {
-            return undefined;
-        }
-
-        const entry = cache.peek(key);
-
-        return entry?.data as ReturnOf<F> | undefined;
-    };
-
-    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+    return data;
 }
+
+/**
+ * Stringify the queryKey for the effect's dependency array. TanStack hashes
+ * queryKeys structurally, so we use the same shape here to avoid re-attaching
+ * on every render when the args object identity changes but its contents don't.
+ */
+const registry_key = (queryKey: ReturnType<typeof cirrusQueryKey>): string => JSON.stringify(queryKey);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ catalogs:
       specifier: ^1.60.0
       version: 1.60.0
   frontend:
+    '@tanstack/react-query':
+      specifier: ^5.93.0
+      version: 5.100.14
     '@tanstack/react-table':
       specifier: ^8.21.3
       version: 8.21.3
@@ -991,6 +994,9 @@ importers:
         specifier: workspace:*
         version: link:../ratelimit
     devDependencies:
+      '@tanstack/react-query':
+        specifier: catalog:frontend
+        version: 5.100.14(react@19.2.6)
       '@testing-library/dom':
         specifier: catalog:frontend
         version: 10.4.1
@@ -4669,6 +4675,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
+
+  '@tanstack/react-query@5.100.14':
+    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
@@ -13753,6 +13767,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.100.14': {}
+
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      react: 19.2.6
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,6 +73,7 @@ catalogs:
     jsonc-parser: ^3.3.1
     vite: ^8.0.14
   frontend:
+    "@tanstack/react-query": ^5.93.0
     "@tanstack/react-table": ^8.21.3
     "@tanstack/react-virtual": ^3.13.26
     "@testing-library/dom": ^10.4.1


### PR DESCRIPTION
## Summary

Implements PLAN2 item #20 — replace the bespoke `QueryCache` in `@cirrus/react` with `@tanstack/react-query` as the internal cache substrate. **Every public hook signature stays byte-identical.**

**Changes:**

- `CirrusProvider` now wraps children in a `QueryClientProvider`. Resolution order: (1) explicit `queryClient` prop, (2) inherited parent `QueryClientProvider` (detected via context — apps with their own setup don't double-wrap), (3) one created internally with Cirrus-tuned defaults (`staleTime: Infinity`, `retry: 0`, `gcTime: 5min`).
- `cache.ts` becomes a thin `CirrusSubscriptionRegistry` that owns only WS subscription dedup (per `queryKey`, ref-counted). Data lives in TanStack's `QueryCache`: subscribe callbacks call `qc.setQueryData(queryKey, value)`; WS-down falls back to `qc.invalidateQueries` on an interval.
- `useQuery` wraps TanStack's `useQuery({queryKey: ["cirrus", ref, args, shardKey], queryFn, staleTime: Infinity})`.
- `usePaginatedQuery` + `useInfiniteQuery` manage per-page subscriptions via the registry; reads via `getQueryData` + `cache.subscribe`.
- `usePreloadedQuery` seeds via TanStack's `initialData`.
- `useMutation`, `useSubscription`, `useAuth`, `useConnectionStatus`, `useRateLimit` — **unchanged**.

**New peer dep:** `@tanstack/react-query@^5.93.0` (also added to the `frontend` catalog in `pnpm-workspace.yaml`).

**Breaking change for direct consumers of `cache.ts`:** the package never exported it publicly, so this is internal-only. Apps that wrote against `useQuery`/etc. need no code changes.

## Test plan

- [x] `pnpm --filter @cirrus/react run lint:types` ✓
- [x] `pnpm --filter @cirrus/react run test` — 36/36 passing
- [x] New `byo-query-client.test.tsx` covers all three QueryClient resolution paths
- [ ] Manual: `apps/playground` Chat.tsx (useQuery + useMutation) behaves identically
- [ ] Manual: open TanStack DevTools → Cirrus queries appear under `["cirrus", ...]` keys
- [ ] Documentation: migration guide page (deferred — would land in a separate doc PR)

## Notes

- TanStack v5 schedules cache notifications on a microtask, so two pre-existing tests gained a `waitFor` after `setQueryData` — the post-emit re-render lands on a later commit than the synchronous setQueryData call (verified independently against a minimal TanStack-only fixture).
- Pre-existing lint debt in `use-query.test.tsx` (`as expression` default prop + inline JSX object) was repaired inline rather than in a separate refactor commit since the vis hook blocked the feature commit on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)