### PR TITLE
chore(react): bump react peer to ^19.2.6 + approve pnpm v11 builds

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,8 +46,8 @@
     },
     "peerDependencies": {
         "@tanstack/react-query": "^5.93.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6"
     },
     "peerDependenciesMeta": {
         "@tanstack/react-query": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,3 +108,14 @@ saveWorkspaceProtocol: true
 sharedWorkspaceLockfile: true
 
 strictPeerDependencies: false
+
+# pnpm v11 refuses to install when transitive deps want to run post-install
+# scripts unless the workspace explicitly approves them. Re-run
+# `pnpm approve-builds` to repopulate this list when a new package joins.
+allowBuilds:
+  esbuild: true
+  msgpackr-extract: true
+  rs-module-lexer: true
+  sharp: true
+  unrs-resolver: true
+  workerd: true


### PR DESCRIPTION
## Summary

- Bump `@cirrus/react` peer range for `react` and `react-dom` from `^18.3.1` to `^19.2.6`. The frontend catalog already pins 19.2.6 and tests run against it; the published peer range just hadn't caught up. Replaces #4 (renovate's branch had drifted too far to merge directly).
- Approve pnpm v11 build scripts in `pnpm-workspace.yaml`. PR #3 bumped to pnpm 11 without adding the now-required `allowBuilds:` block, so every commit was failing `ERR_PNPM_IGNORED_BUILDS` when the vis pre-commit hook re-ran `pnpm install`.

## Test plan

- [x] `pnpm install` exits clean under pnpm v11.3.0
- [x] Pre-commit hook (vis secrets + vis staged + react-doctor + commitlint) runs through without errors on this branch
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)