### PR TITLE
feat(storage): widen store() opts, base64 sha256, ranged read

### DIFF
--- a/packages/scheduler/__tests__/create-scheduler.test.ts
+++ b/packages/scheduler/__tests__/create-scheduler.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import createScheduler from "../src/create-scheduler.js";
 import { createCronTrigger } from "../src/cron.js";
-import type { DurableObjectNamespaceLike, DurableObjectStubLike, FunctionReference } from "../src/types.js";
+import type { DurableObjectNamespaceLike, DurableObjectStubLike, FunctionReference, ScheduleRecord } from "../src/types.js";
 
 const NAMESPACE_PATTERN = /namespace/;
 const ORIGIN_URL_PATTERN = /originUrl/;
@@ -25,6 +25,17 @@ const fakeNamespace = (responses: Record<string, unknown> = DEFAULT_RESPONSES): 
             const path = new URL(url).pathname;
 
             calls.push({ body, url });
+
+            // The DO's `/get?id=` route is derived from the same `/list` records
+            // the fake is seeded with: look the id up and answer `{ record }` on a
+            // hit, `{}` on a miss (mirroring the real DO's absent-field contract).
+            if (path === "/get") {
+                const id = new URL(url).searchParams.get("id");
+                const seeded = (responses["/list"] as { records?: ScheduleRecord[] } | undefined)?.records ?? [];
+                const record = seeded.find((candidate) => candidate.id === id);
+
+                return Response.json(record ? { record } : {}, { headers: { "content-type": "application/json" }, status: 200 });
+            }
 
             const responseBody = responses[path] ?? { ok: true };
 
@@ -129,15 +140,21 @@ describe("createScheduler", () => {
         expect(calls).toHaveLength(1);
     });
 
-    it("get() resolves a single record by id, or null when absent", async () => {
-        expect.assertions(2);
+    it("get() resolves a single record via the direct GET /get?id= route", async () => {
+        expect.assertions(4);
 
         const records = [{ args: {}, enqueuedAt: 1, functionPath: "messages.send", id: "a", scheduledFor: 10 }];
-        const { namespace } = fakeNamespace({ "/list": { records } });
+        const { calls, namespace } = fakeNamespace({ "/list": { records } });
         const scheduler = createScheduler({ namespace, originUrl: "https://app.test" });
 
         await expect(scheduler.get("a")).resolves.toEqual(records[0]);
         await expect(scheduler.get("missing")).resolves.toBeNull();
+
+        // O(1) lookup: a dedicated `/get` read, not a full `/list` scan.
+        const url = new URL(calls[0]!.url);
+
+        expect(url.pathname).toBe("/get");
+        expect(url.searchParams.get("id")).toBe("a");
     });
 
     it("list()/get() stay robust when the DO 200s without a `records` array", async () => {

--- a/packages/scheduler/__tests__/scheduler-do.test.ts
+++ b/packages/scheduler/__tests__/scheduler-do.test.ts
@@ -57,6 +57,8 @@ const post = (path: string, body: unknown): Request =>
         method: "POST",
     });
 
+const get = (path: string): Request => new Request(`https://scheduler.internal${path}`, { method: "GET" });
+
 /** Read a /schedule response and return the typed id. */
 const scheduledId = async (response: Response): Promise<string> => {
     const body = await response.json<ScheduleResponseBody>();
@@ -154,6 +156,38 @@ describe("schedulerDO", () => {
         expect(scheduler.dispatched[0]?.args).toEqual({ x: 1 });
         // The "later" record stays pending and the alarm is rescheduled to its time.
         expect(state.alarm).toBe(now + 60_000);
+    });
+
+    it("/get returns a single record by id (direct O(1) read), or {} when absent", async () => {
+        expect.assertions(4);
+
+        const state = createFakeState();
+        const scheduler = new TestScheduler(state, { CIRRUS_ORIGIN_URL: "https://app.test" });
+        const scheduledFor = Date.now() + 60_000;
+
+        const id = await scheduledId(await scheduler.fetch(post("/schedule", { args: { text: "hi" }, functionPath: "messages.send", scheduledFor })));
+
+        const hit = await scheduler.fetch(get(`/get?id=${id}`));
+        const hitBody = await hit.json<{ record?: ScheduleRecord }>();
+
+        expect(hit.status).toBe(200);
+        expect(hitBody.record?.functionPath).toBe("messages.send");
+
+        const miss = await scheduler.fetch(get("/get?id=nope"));
+        const missBody = await miss.json<{ record?: ScheduleRecord }>();
+
+        expect(miss.status).toBe(200);
+        expect(missBody.record).toBeUndefined();
+    });
+
+    it("/get requires an id", async () => {
+        expect.assertions(1);
+
+        const state = createFakeState();
+        const scheduler = new TestScheduler(state, { CIRRUS_ORIGIN_URL: "https://app.test" });
+        const response = await scheduler.fetch(get("/get"));
+
+        expect(response.status).toBe(400);
     });
 
     it("returns 404 for unknown routes", async () => {

--- a/packages/scheduler/src/create-scheduler.ts
+++ b/packages/scheduler/src/create-scheduler.ts
@@ -84,18 +84,19 @@ const createScheduler = (options: CirrusSchedulerOptions): Scheduler => {
     const list = async (): Promise<ScheduleRecord[]> => {
         const body = await getDO<{ records?: ScheduleRecord[] }>(options, "/list");
 
-        // Keep the return type honest (never `undefined`) so `get()` can `.find`
-        // without throwing if the DO ever responds 200 without a `records` array.
+        // Keep the return type honest (never `undefined`) if the DO ever responds
+        // 200 without a `records` array.
         return Array.isArray(body.records) ? body.records : [];
     };
 
-    // Derived from `/list` rather than a dedicated endpoint — the DO has no
-    // single-record GET, and the pending set is small enough to scan.
+    // Direct single-record lookup against the DO's `GET /get?id=` route, which
+    // reads the `id:<id>` storage key in O(1) — instead of scanning the whole
+    // `/list` view. The DO omits `record` on a miss, which becomes `null` here.
     const get = async (id: string): Promise<ScheduleRecord | null> => {
-        const records = await list();
+        const body = await getDO<{ record?: ScheduleRecord }>(options, `/get?id=${encodeURIComponent(id)}`);
 
         // eslint-disable-next-line unicorn/no-null -- public contract returns `ScheduleRecord | null` (Convex `get` convention), not undefined
-        return records.find((record) => record.id === id) ?? null;
+        return body.record ?? null;
     };
 
     return { cancel, get, list, runAfter, runAt };

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -140,6 +140,10 @@ class SchedulerDO {
             return this.handleCancel(request);
         }
 
+        if (url.pathname === "/get" && request.method === "GET") {
+            return this.handleGet(url);
+        }
+
         if (url.pathname === "/list" && request.method === "GET") {
             return this.handleList();
         }
@@ -477,6 +481,24 @@ class SchedulerDO {
 
     private async handleList(): Promise<Response> {
         return SchedulerDO.json({ records: await this.listRecords() });
+    }
+
+    /**
+     * Resolve a single pending job by id via a direct `id:&lt;id>` storage read —
+     * O(1), versus scanning the whole `/list` view. Responds `{ record }` on a
+     * hit and `{}` on a miss (an absent `record` field — JSON has no `undefined`
+     * — which the client reads back as `null`).
+     */
+    private async handleGet(url: URL): Promise<Response> {
+        const id = url.searchParams.get("id");
+
+        if (id === null || id.length === 0) {
+            return SchedulerDO.error(400, "INVALID_INPUT", "id is required");
+        }
+
+        const record = await this.state.storage.get<ScheduleRecord>(`${HEADER_PREFIX}${id}`);
+
+        return SchedulerDO.json(record === undefined ? {} : { record });
     }
 
     private async removeRecord(record: ScheduleRecord): Promise<void> {

--- a/packages/server/__tests__/serve-storage-object.test.ts
+++ b/packages/server/__tests__/serve-storage-object.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { serveStorageObject } from "../src/index.js";
 
-/** Minimal storage-object double; `body` carries the bytes, `arrayBuffer` backs range slicing. */
-const fakeObject = (bytes: Uint8Array, options: { contentType?: string; etag?: string; sha256?: string } = {}) => {
-    const buffer = new ArrayBuffer(bytes.byteLength);
+interface FakeObjectOptions {
+    contentType?: string;
+    etag?: string;
+    sha256Base64?: string;
+}
 
-    new Uint8Array(buffer).set(bytes);
-
+/** A single-use object view; `body` streams `bytes` (a fresh stream per download). */
+const fakeObject = (bytes: Uint8Array, size: number, options: FakeObjectOptions) => {
     return {
-        arrayBuffer: async () => buffer,
         body: new ReadableStream<Uint8Array>({
             start(controller) {
                 controller.enqueue(bytes);
@@ -19,13 +20,34 @@ const fakeObject = (bytes: Uint8Array, options: { contentType?: string; etag?: s
         etag: options.etag ?? "etag-1",
         httpMetadata: { contentType: options.contentType ?? "application/octet-stream" },
         key: "k",
-        sha256: options.sha256,
-        size: bytes.byteLength,
+        sha256Base64: options.sha256Base64,
+        // `size` is always the full object size, even for a ranged read (mirrors R2).
+        size,
     };
 };
 
-const ctxWith = (object: ReturnType<typeof fakeObject> | null) => {
-    return { storage: { download: async () => object } };
+/**
+ * Build a ctx whose `download` mirrors R2's ranged-read contract: a plain
+ * `download(key)` streams the whole object, while `download(key, { range })`
+ * streams only the requested window (but still reports the full `size`). A fresh
+ * stream is produced on every call so the two reads a range request makes don't
+ * share a consumed body.
+ */
+const ctxWith = (bytes: Uint8Array | null, options: FakeObjectOptions = {}) => {
+    return {
+        storage: {
+            download: async (_key: string, downloadOptions?: { range?: { length: number; offset: number } }) => {
+                if (bytes === null) {
+                    return null;
+                }
+
+                const range = downloadOptions?.range;
+                const slice = range ? bytes.subarray(range.offset, range.offset + range.length) : bytes;
+
+                return fakeObject(slice, bytes.byteLength, options);
+            },
+        },
+    };
 };
 
 const BODY = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -34,7 +56,7 @@ describe("serveStorageObject", () => {
     it("returns 200 with full body + metadata headers when no Range is sent", async () => {
         expect.assertions(5);
 
-        const ctx = ctxWith(fakeObject(BODY, { contentType: "text/plain", etag: "abc", sha256: "deadbeef" }));
+        const ctx = ctxWith(BODY, { contentType: "text/plain", etag: "abc", sha256Base64: "3q2+7w==" });
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k"));
 
         expect(response.status).toBe(200);
@@ -43,13 +65,14 @@ describe("serveStorageObject", () => {
         // `serveStorageObject` wraps it.
         expect(response.headers.get("etag")).toBe('"abc"');
         expect(response.headers.get("accept-ranges")).toBe("bytes");
-        expect(response.headers.get("digest")).toBe("sha-256=deadbeef");
+        // RFC 9530 representation digest: base64 byte-sequence wrapped in colons.
+        expect(response.headers.get("repr-digest")).toBe("sha-256=:3q2+7w==:");
     });
 
     it("does not double-quote an already-quoted (weak) ETag", async () => {
         expect.assertions(1);
 
-        const ctx = ctxWith(fakeObject(BODY, { etag: 'W/"weak"' }));
+        const ctx = ctxWith(BODY, { etag: 'W/"weak"' });
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k"));
 
         expect(response.headers.get("etag")).toBe('W/"weak"');
@@ -58,7 +81,7 @@ describe("serveStorageObject", () => {
     it("rejects a CRLF-bearing Content-Type to prevent header injection", async () => {
         expect.assertions(2);
 
-        const ctx = ctxWith(fakeObject(BODY, { contentType: "text/html\r\nset-cookie: pwned=1" }));
+        const ctx = ctxWith(BODY, { contentType: "text/html\r\nset-cookie: pwned=1" });
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k"));
 
         // Falls back to the safe default rather than reflecting the injected value.
@@ -77,7 +100,7 @@ describe("serveStorageObject", () => {
     it("returns 206 with Content-Range/Content-Length for a byte range", async () => {
         expect.assertions(4);
 
-        const ctx = ctxWith(fakeObject(BODY));
+        const ctx = ctxWith(BODY);
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k", { headers: { range: "bytes=2-5" } }));
 
         expect(response.status).toBe(206);
@@ -92,7 +115,7 @@ describe("serveStorageObject", () => {
     it("clamps an open-ended range (bytes=7-) to the object end", async () => {
         expect.assertions(2);
 
-        const ctx = ctxWith(fakeObject(BODY));
+        const ctx = ctxWith(BODY);
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k", { headers: { range: "bytes=7-" } }));
 
         expect(response.status).toBe(206);
@@ -102,7 +125,7 @@ describe("serveStorageObject", () => {
     it("serves a suffix range (bytes=-3) as the final bytes", async () => {
         expect.assertions(2);
 
-        const ctx = ctxWith(fakeObject(BODY));
+        const ctx = ctxWith(BODY);
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k", { headers: { range: "bytes=-3" } }));
 
         expect(response.status).toBe(206);
@@ -110,19 +133,23 @@ describe("serveStorageObject", () => {
     });
 
     it("returns 416 with Content-Range */size for an out-of-bounds range", async () => {
-        expect.assertions(2);
+        expect.assertions(4);
 
-        const ctx = ctxWith(fakeObject(BODY));
+        const ctx = ctxWith(BODY, { contentType: "video/mp4", sha256Base64: "3q2+7w==" });
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k", { headers: { range: "bytes=50-60" } }));
 
         expect(response.status).toBe(416);
         expect(response.headers.get("content-range")).toBe("bytes */10");
+        // The error body is plain text — it must not be mislabelled with the
+        // object's Content-Type, nor carry the object's representation digest.
+        expect(response.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+        expect(response.headers.get("repr-digest")).toBeNull();
     });
 
     it("ignores a multi-range request and serves the whole object (200)", async () => {
         expect.assertions(1);
 
-        const ctx = ctxWith(fakeObject(BODY));
+        const ctx = ctxWith(BODY);
         const response = await serveStorageObject(ctx, "k", new Request("https://x/k", { headers: { range: "bytes=0-1,4-5" } }));
 
         expect(response.status).toBe(200);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -561,8 +561,6 @@ const httpRoute: HttpRoute = {
  * runtime dependency on `@cirrus/storage`; the real binding satisfies the shape.
  */
 interface StorageObjectBody {
-    /** Read the whole body into memory — the fallback when range slicing isn't supported. */
-    arrayBuffer: () => Promise<ArrayBuffer>;
     /** The object body stream (`null` for a zero-byte object). */
     body: ReadableStream | null;
     etag: string;
@@ -570,12 +568,20 @@ interface StorageObjectBody {
     key: string;
     /** Hex SHA-256, when R2 carries a checksum (surfaced by `@cirrus/storage`). */
     sha256?: string;
+    /** Base64 SHA-256 (RFC 9530 digest encoding), when R2 carries a checksum. */
+    sha256Base64?: string;
     size: number;
+}
+
+/** Byte window forwarded to `download()` so R2 streams just the requested slice. */
+interface StorageRange {
+    length: number;
+    offset: number;
 }
 
 /** The minimal storage surface {@link serveStorageObject} needs: a metadata-rich `download`. */
 interface StorageDownloader {
-    download: (key: string) => Promise<StorageObjectBody | null>;
+    download: (key: string, options?: { range?: StorageRange }) => Promise<StorageObjectBody | null>;
 }
 
 /** Any ctx that carries a {@link StorageDownloader} on `.storage` (Query/Mutation/Action ctx all do). */
@@ -687,13 +693,12 @@ const parseRange = (header: null | string, size: number): RangeResult => {
  * **404**; an out-of-bounds range is a **416** with a `Content-Range` of
  * `bytes` star-slash-size.
  *
- * Range slicing is done by buffering the body (`arrayBuffer()`) and slicing the
- * requested window. The `@cirrus/storage` `download()` returns the whole object
- * body (R2's binding does not expose a partial-read API through that helper), so
- * a range request still fetches the full object server-side — the saving is on
- * the wire to the client, not on the R2 read. For very large objects prefer a
- * signed URL (`ctx.storage.getSignedUrl`) so the client ranges against R2/CDN
- * directly.
+ * A range request re-issues the `download()` with the resolved `{ offset, length }`
+ * window so R2 streams only those bytes back to the Worker — the slice is never
+ * buffered in the isolate. The first `download()` is used only for the object's
+ * size + metadata (its body is left unread and cancelled). For very large
+ * objects a signed URL (`ctx.storage.getSignedUrl`) is still cheaper since the
+ * client then ranges against R2/CDN directly with no Worker hop.
  */
 const serveStorageObject = async (context: ContextWithStorage, key: string, request: Request): Promise<Response> => {
     const object = await context.storage.download(key);
@@ -715,16 +720,29 @@ const serveStorageObject = async (context: ContextWithStorage, key: string, requ
         etag: toHttpEtag(object.etag),
     };
 
-    if (object.sha256 !== undefined) {
-        // RFC 3230 / Cloudflare-style digest hint so clients can verify integrity.
-        baseHeaders.digest = `sha-256=${object.sha256}`;
+    if (object.sha256Base64 !== undefined) {
+        // RFC 9530 representation digest so clients can verify integrity. The
+        // value is a structured-field byte-sequence (base64 wrapped in colons),
+        // and it covers the full representation, so it's correct on a 206 too.
+        baseHeaders["repr-digest"] = `sha-256=:${object.sha256Base64}:`;
     }
 
     const range = parseRange(request.headers.get("range"), object.size);
 
     if (range.kind === "unsatisfiable") {
+        // The body here is a plain-text error, not the object — so it carries
+        // neither the object's `Content-Type` nor its digest. Only the
+        // range-relevant headers (and the resource ETag) ride along. The unread
+        // object body is cancelled so the stream isn't left dangling.
+        object.body?.cancel().catch(() => {});
+
         return new Response("Range Not Satisfiable", {
-            headers: { ...baseHeaders, "content-range": `bytes */${String(object.size)}` },
+            headers: {
+                "accept-ranges": "bytes",
+                "content-range": `bytes */${String(object.size)}`,
+                "content-type": "text/plain; charset=utf-8",
+                etag: toHttpEtag(object.etag),
+            },
             status: 416,
         });
     }
@@ -736,15 +754,22 @@ const serveStorageObject = async (context: ContextWithStorage, key: string, requ
         });
     }
 
-    // Single range: buffer + slice. See the doc comment for why this fetches the
-    // whole object server-side.
-    const buffer = await object.arrayBuffer();
-    const slice = buffer.slice(range.start, range.end + 1);
+    // Single range: re-fetch just the window so R2 streams only those bytes (the
+    // first download's body is unused — cancel it rather than leak the stream).
+    object.body?.cancel().catch(() => {});
 
-    return new Response(slice, {
+    const length = range.end - range.start + 1;
+    const slice = await context.storage.download(key, { range: { length, offset: range.start } });
+
+    if (!slice) {
+        // Raced with a delete between the metadata read and the ranged read.
+        return new Response("Not Found", { status: 404 });
+    }
+
+    return new Response(slice.body, {
         headers: {
             ...baseHeaders,
-            "content-length": String(slice.byteLength),
+            "content-length": String(length),
             "content-range": `bytes ${String(range.start)}-${String(range.end)}/${String(object.size)}`,
         },
         status: 206,

--- a/packages/storage/__tests__/create-storage.test.ts
+++ b/packages/storage/__tests__/create-storage.test.ts
@@ -243,10 +243,41 @@ describe("createStorage", () => {
         expect(bucket.puts[0]?.options).toMatchObject({ httpMetadata: { contentType: "text/plain" } });
     });
 
-    it("download()/list() surface a hex sha256 from R2 checksums", async () => {
+    it("store() honors the full UploadOptions guards (maxSize/allowedContentTypes)", async () => {
         expect.assertions(3);
 
-        // 0x01,0x02,0x03,0xff -> "010203ff"
+        const bucket = fakeBucket();
+        const storage = createStorage({ bucket });
+
+        // The Convex-style `store` alias must not silently drop upload()'s guards.
+        await expect(storage.store("big.bin", new ArrayBuffer(16), { maxSize: 8 })).rejects.toThrow(/exceeds maxSize/);
+        await expect(storage.store("note.txt", new ArrayBuffer(4), { allowedContentTypes: ["image/png"], contentType: "text/plain" })).rejects.toThrow(
+            /not in allowedContentTypes/,
+        );
+        expect(bucket.puts).toHaveLength(0);
+    });
+
+    it("download() forwards a byte range to the bucket (ranged read)", async () => {
+        expect.assertions(2);
+
+        const bucket = fakeBucket();
+        const storage = createStorage({ bucket });
+
+        await storage.download("clip.mp4", { range: { length: 4, offset: 2 } });
+
+        expect(bucket.get).toHaveBeenCalledWith("clip.mp4", { range: { length: 4, offset: 2 } });
+
+        // A plain download forwards no range (single-arg `get`) so R2 streams the
+        // whole object — and the call avoids R2's `onlyIf` overload.
+        await storage.download("clip.mp4");
+
+        expect(bucket.get).toHaveBeenLastCalledWith("clip.mp4");
+    });
+
+    it("download()/list() surface a hex + base64 sha256 from R2 checksums", async () => {
+        expect.assertions(5);
+
+        // 0x01,0x02,0x03,0xff -> hex "010203ff", base64 "AQID/w=="
         const checksum = new Uint8Array([1, 2, 3, 255]).buffer;
         const bucket = fakeBucket();
 
@@ -272,11 +303,13 @@ describe("createStorage", () => {
         const object = await storage.download("uploads/x.png");
 
         expect(object?.sha256).toBe("010203ff");
+        expect(object?.sha256Base64).toBe("AQID/w==");
         expect(object?.etag).toBe("etag-1");
 
         const listed = await storage.list();
 
         expect(listed.objects[0]?.sha256).toBe("010203ff");
+        expect(listed.objects[0]?.sha256Base64).toBe("AQID/w==");
     });
 
     it("download() preserves native methods/getters of a frozen (non-extensible) R2 object", async () => {

--- a/packages/storage/__tests__/workerd/create-storage.integration.test.ts
+++ b/packages/storage/__tests__/workerd/create-storage.integration.test.ts
@@ -37,6 +37,20 @@ describe("createStorage (workerd + Miniflare R2 integration)", () => {
         await expect(got!.text()).resolves.toBe("hello cirrus");
     });
 
+    it("download with a byte range streams only the requested window", async () => {
+        expect.assertions(2);
+
+        const sut = storage();
+
+        await sut.upload("clip.txt", new TextEncoder().encode("abcdefghij").buffer, { contentType: "text/plain" });
+
+        // R2 resolves the range server-side, so only these bytes come back.
+        const ranged = await sut.download("clip.txt", { range: { length: 4, offset: 2 } });
+
+        expect(ranged).not.toBeNull();
+        await expect(ranged!.text()).resolves.toBe("cdef");
+    });
+
     it("list returns objects matching the given prefix", async () => {
         expect.assertions(1);
 

--- a/packages/storage/src/create-storage.ts
+++ b/packages/storage/src/create-storage.ts
@@ -1,5 +1,5 @@
 import { buildSignedUrl } from "./signed-url.js";
-import type { CirrusStorageOptions, ListOptions, R2ObjectBodyLike, R2ObjectLike, SignedUrlOptions, Storage, UploadOptions } from "./types.js";
+import type { CirrusStorageOptions, ListOptions, R2ObjectBodyLike, R2ObjectLike, R2RangeLike, SignedUrlOptions, Storage, UploadOptions } from "./types.js";
 
 /** R2's documented key-length ceiling. */
 const MAX_KEY_LENGTH = 1024;
@@ -22,8 +22,21 @@ const toHex = (buffer: ArrayBuffer): string => {
     return out;
 };
 
+/** Base64-encode an `ArrayBuffer` (RFC 9530 digest headers want base64, not hex). */
+const toBase64 = (buffer: ArrayBuffer): string => {
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+
+    for (const byte of bytes) {
+        binary += String.fromCodePoint(byte);
+    }
+
+    return btoa(binary);
+};
+
 /**
- * Surface R2's SHA-256 checksum as a hex `sha256` field on the object metadata.
+ * Surface R2's SHA-256 checksum as `sha256` (hex) and `sha256Base64` (base64)
+ * fields on the object metadata.
  *
  * A real `R2Object`/`R2ObjectBody` is a workerd host object: its properties are
  * `readonly`, it is **non-extensible**, and accessors like `body` plus methods
@@ -34,12 +47,13 @@ const toHex = (buffer: ArrayBuffer): string => {
  * strict mode (ESM is always strict); and an `Object.create(object)` wrapper
  * rebinds `this` for the native accessors and breaks them.
  *
- * So we wrap the object in a `Proxy` that answers `sha256` itself and forwards
- * every other access to the underlying host object with the host object as the
- * receiver (so native getters keep their `this`), binding function-valued
- * properties to the target (so native methods keep their `this`). A no-op
- * pass-through when R2 carries no checksum, so the field stays absent rather
- * than `undefined`-valued and we avoid an allocation on the common path.
+ * So we wrap the object in a `Proxy` that answers `sha256`/`sha256Base64` itself
+ * and forwards every other access to the underlying host object with the host
+ * object as the receiver (so native getters keep their `this`), binding
+ * function-valued properties to the target (so native methods keep their
+ * `this`). A no-op pass-through when R2 carries no checksum, so the fields stay
+ * absent rather than `undefined`-valued and we avoid an allocation on the common
+ * path.
  */
 const withSha256 = <T extends R2ObjectLike>(object: T): T => {
     const raw = object.checksums?.sha256;
@@ -49,11 +63,16 @@ const withSha256 = <T extends R2ObjectLike>(object: T): T => {
     }
 
     const sha256 = toHex(raw);
+    const sha256Base64 = toBase64(raw);
 
     return new Proxy(object, {
         get(target, property) {
             if (property === "sha256") {
                 return sha256;
+            }
+
+            if (property === "sha256Base64") {
+                return sha256Base64;
             }
 
             // Forward with `target` as the receiver so native accessors (e.g.
@@ -65,7 +84,7 @@ const withSha256 = <T extends R2ObjectLike>(object: T): T => {
             return typeof value === "function" ? (value as (...args: unknown[]) => unknown).bind(target) : value;
         },
         has(target, property) {
-            return property === "sha256" || Reflect.has(target, property);
+            return property === "sha256" || property === "sha256Base64" || Reflect.has(target, property);
         },
     });
 };
@@ -183,10 +202,15 @@ export const createStorage = (options: CirrusStorageOptions): Storage => {
         return { etag: object.etag, key: object.key };
     };
 
-    const download = async (key: string): Promise<R2ObjectBodyLike | null> => {
+    const download = async (key: string, downloadOptions: { range?: R2RangeLike } = {}): Promise<R2ObjectBodyLike | null> => {
         validateKey(key);
 
-        const object = await options.bucket.get(key);
+        // Forward `range` so R2 resolves the byte window server-side and streams
+        // only those bytes back — the unwanted bytes never reach the Worker, so
+        // a partial read of a large object doesn't buffer the whole thing. The
+        // two-arg and one-arg calls are split so neither hits R2's `get` overload
+        // that pairs `options` with a mandatory `onlyIf`.
+        const object = await (downloadOptions.range ? options.bucket.get(key, { range: downloadOptions.range }) : options.bucket.get(key));
 
         // `withSha256` is a no-op (and a pass-through) for a null result, so a
         // single call covers both the hit and miss cases without a `null` literal.
@@ -256,16 +280,15 @@ export const createStorage = (options: CirrusStorageOptions): Storage => {
     };
 
     // Convex-compatible aliases over the primitives above. `generateUploadUrl`
-    // mints a signed PUT (optionally pinning the content-type into the
-    // signature); `store` is `upload` under Convex's name.
+    // mints a signed PUT (optionally pinning the content-type into the signature).
     const generateUploadUrl = async (key: string, uploadUrlOptions: { contentType?: string; expiresInSeconds?: number } = {}): Promise<string> =>
         getSignedUrl(key, { contentType: uploadUrlOptions.contentType, expiresInSeconds: uploadUrlOptions.expiresInSeconds, method: "PUT" });
 
-    const store = async (
-        key: string,
-        body: ReadableStream | ArrayBuffer | Blob,
-        storeOptions: { contentType?: string } = {},
-    ): Promise<{ etag: string; key: string }> => upload(key, body, { contentType: storeOptions.contentType });
+    // `store` is `upload` under Convex's name; it forwards the full
+    // `UploadOptions` so the `maxSize` / `allowedContentTypes` guards are
+    // available through the alias too, not just `contentType`.
+    const store = async (key: string, body: ReadableStream | ArrayBuffer | Blob, storeOptions: UploadOptions = {}): Promise<{ etag: string; key: string }> =>
+        upload(key, body, storeOptions);
 
     return { delete: deleteObject, download, generateUploadUrl, getSignedUrl, getUrl, list, store, upload };
 };

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,10 +1,18 @@
 /**
+ * A single-range read against R2: an `{ offset, length }` window (at least one
+ * bound required, mirroring R2's own `R2Range`) or a `{ suffix }` tail. The
+ * subset of `R2Range` that {@link Storage.download} forwards so a caller can
+ * stream just the bytes it needs instead of the whole object.
+ */
+export type R2RangeLike = { length: number; offset?: number } | { length?: number; offset: number } | { suffix: number };
+
+/**
  * Minimal projection of `R2Bucket`. Declared structurally so unit tests can
  * pass a plain object double; the real binding satisfies the same shape.
  */
 export interface R2BucketLike {
     delete: (key: string) => Promise<void>;
-    get: (key: string) => Promise<R2ObjectBodyLike | null>;
+    get: (key: string, options?: { range?: R2RangeLike }) => Promise<R2ObjectBodyLike | null>;
     list: (options?: { cursor?: string; delimiter?: string; limit?: number; prefix?: string }) => Promise<{
         cursor?: string;
         objects: R2ObjectLike[];
@@ -34,6 +42,14 @@ export interface R2ObjectLike {
      * when R2 carries a checksum (derived from {@link R2ObjectLike.checksums}).
      */
     sha256?: string;
+
+    /**
+     * Base64-encoded SHA-256 of the object body, surfaced alongside
+     * {@link R2ObjectLike.sha256} from the same checksum. Base64 is the encoding
+     * RFC 9530 digest headers (`Repr-Digest`/`Content-Digest`) require, so HTTP
+     * layers can emit a spec-compliant digest without re-deriving it.
+     */
+    sha256Base64?: string;
     size: number;
 }
 
@@ -86,7 +102,13 @@ export interface SignedUrlOptions {
 
 export interface Storage {
     delete: (key: string) => Promise<void>;
-    download: (key: string) => Promise<R2ObjectBodyLike | null>;
+
+    /**
+     * Fetch a stored object's metadata + body. Pass `options.range` to stream
+     * only a byte window (R2 resolves the range server-side, so the unwanted
+     * bytes never reach the Worker) — `download(key)` reads the whole object.
+     */
+    download: (key: string, options?: { range?: R2RangeLike }) => Promise<R2ObjectBodyLike | null>;
 
     /**
      * Mint a short-lived signed `PUT` URL a client can upload directly to,
@@ -100,8 +122,9 @@ export interface Storage {
 
     /**
      * Upload `body` to `key`, returning the stored key + etag. Convex-compatible
-     * alias for {@link Storage.upload}.
+     * alias for {@link Storage.upload} — it accepts the same {@link UploadOptions}
+     * so the `maxSize` / `allowedContentTypes` guards aren't lost behind the alias.
      */
-    store: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: { contentType?: string }) => Promise<{ etag: string; key: string }>;
+    store: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: UploadOptions) => Promise<{ etag: string; key: string }>;
     upload: (key: string, body: ReadableStream | ArrayBuffer | Blob, options?: UploadOptions) => Promise<{ etag: string; key: string }>;
 }


### PR DESCRIPTION
- store() now accepts the full UploadOptions so the maxSize /
  allowedContentTypes guards aren't lost behind the Convex-style alias
- surface sha256Base64 alongside the hex sha256 (RFC 9530 digests want
  base64), computed from the same R2 checksum in the withSha256 proxy
- download(key, { range }) forwards an R2 byte-range so a partial read
  streams only the requested window instead of buffering the whole object

https://claude.ai/code/session_01SKvzYaKCRGyHRFgNUk4uLT