### PR TITLE
feat(cli): add cirrus agent skills for the intent registry

### DIFF
--- a/.agents/skills/cirrus
+++ b/.agents/skills/cirrus
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus

--- a/.agents/skills/cirrus-create-package
+++ b/.agents/skills/cirrus-create-package
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-create-package

--- a/.agents/skills/cirrus-deploy
+++ b/.agents/skills/cirrus-deploy
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-deploy

--- a/.agents/skills/cirrus-functions
+++ b/.agents/skills/cirrus-functions
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-functions

--- a/.agents/skills/cirrus-migration-helper
+++ b/.agents/skills/cirrus-migration-helper
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-migration-helper

--- a/.agents/skills/cirrus-performance-audit
+++ b/.agents/skills/cirrus-performance-audit
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-performance-audit

--- a/.agents/skills/cirrus-quickstart
+++ b/.agents/skills/cirrus-quickstart
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-quickstart

--- a/.agents/skills/cirrus-realtime
+++ b/.agents/skills/cirrus-realtime
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-realtime

--- a/.agents/skills/cirrus-setup-auth
+++ b/.agents/skills/cirrus-setup-auth
@@ -1,0 +1,1 @@
+../../packages/cli/skills/cirrus-setup-auth

--- a/.claude/skills/cirrus
+++ b/.claude/skills/cirrus
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus

--- a/.claude/skills/cirrus-create-package
+++ b/.claude/skills/cirrus-create-package
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-create-package

--- a/.claude/skills/cirrus-deploy
+++ b/.claude/skills/cirrus-deploy
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-deploy

--- a/.claude/skills/cirrus-functions
+++ b/.claude/skills/cirrus-functions
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-functions

--- a/.claude/skills/cirrus-migration-helper
+++ b/.claude/skills/cirrus-migration-helper
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-migration-helper

--- a/.claude/skills/cirrus-performance-audit
+++ b/.claude/skills/cirrus-performance-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-performance-audit

--- a/.claude/skills/cirrus-quickstart
+++ b/.claude/skills/cirrus-quickstart
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-quickstart

--- a/.claude/skills/cirrus-realtime
+++ b/.claude/skills/cirrus-realtime
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-realtime

--- a/.claude/skills/cirrus-setup-auth
+++ b/.claude/skills/cirrus-setup-auth
@@ -1,0 +1,1 @@
+../../.agents/skills/cirrus-setup-auth

--- a/apps/docs/content/docs/api/cli.mdx
+++ b/apps/docs/content/docs/api/cli.mdx
@@ -215,6 +215,7 @@ you to run this when the rules are missing.
 cirrus rules install              # copy the skills into .agents/skills/ (skips edited files)
 cirrus rules install --overwrite  # reinstall, replacing local edits
 cirrus rules check                # report which skills are present
+cirrus rules check --strict       # exit non-zero when missing (CI gate)
 ```
 
 ### `cirrus analyze`

--- a/apps/docs/content/docs/api/cli.mdx
+++ b/apps/docs/content/docs/api/cli.mdx
@@ -19,6 +19,7 @@ cirrus view [--remote]                  # open the Cirrus studio in your browser
 cirrus docs [section]                   # open the docs site in your browser
 cirrus info [--json]                    # print versions, wrangler summary, schema overview
 cirrus registry <add|list|view|build>   # component registry
+cirrus rules <install|check>            # install the AI agent skills into .agents/skills/
 
 # Develop
 cirrus dev [--port n] [--worker-port n] # wrangler worker + studio + codegen watch
@@ -82,10 +83,10 @@ cirrus add auth --yes           # default provider (email & password), no prompt
 cirrus add email                # transactional email (Cloudflare Email Workers + dev mail catcher)
 ```
 
-| Feature | Installs | Notes |
-| ------- | -------- | ----- |
+| Feature | Installs                                                  | Notes                                                                                                              |
+| ------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `auth`  | the `auth` registry item (or `auth-clerk` / `auth-auth0`) | Adds `@cirrus/auth` + a D1 `DB` binding; verification / reset mail is captured into the studio **Mail** tab in dev |
-| `email` | the `mail` registry item | Cloudflare Email Workers transport (`SEND_EMAIL` binding) + the dev mail catcher |
+| `email` | the `mail` registry item                                  | Cloudflare Email Workers transport (`SEND_EMAIL` binding) + the dev mail catcher                                   |
 
 Flags: `--provider <auth\|clerk\|auth0>`, `--yes`, `--from <dir>` (local registry root), `--source <ref>`, `--allow-unsafe-source`.
 
@@ -201,6 +202,19 @@ cirrus registry list
 cirrus registry view auth/session-token
 cirrus registry add auth/session-token
 cirrus registry build   # regenerate the local catalog index.json
+```
+
+### `cirrus rules`
+
+Installs the Cirrus **agent skills** — portable instructions that teach AI
+coding agents (Claude Code, Cursor, Copilot) how to use Cirrus — into the
+project's `.agents/skills/`. `cirrus dev`, the Vite plugin, and the studio nudge
+you to run this when the rules are missing.
+
+```bash
+cirrus rules install              # copy the skills into .agents/skills/ (skips edited files)
+cirrus rules install --overwrite  # reinstall, replacing local edits
+cirrus rules check                # report which skills are present
 ```
 
 ### `cirrus analyze`

--- a/packages/cli/__tests__/commands/rules.test.ts
+++ b/packages/cli/__tests__/commands/rules.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { runRulesCheck, runRulesInstall } from "../../src/commands/rules/handler";
+import { resolveBundledSkillsDirectory, runRulesCheck, runRulesInstall } from "../../src/commands/rules/handler";
 import type { Logger } from "../../src/util/logger";
 
 const captureLogger = (): { logger: Logger; messages: string[] } => {
@@ -74,5 +74,34 @@ describe("cirrus rules", () => {
         const after = runRulesCheck({ cwd: workdir, logger });
 
         expect(after.installed.length).toBeGreaterThan(before.installed.length);
+    });
+
+    it("check --strict exits non-zero only when rules are missing", () => {
+        expect.assertions(2);
+
+        const { logger } = captureLogger();
+
+        expect(runRulesCheck({ cwd: workdir, logger, strict: true }).code).toBe(1);
+
+        runRulesInstall({ cwd: workdir, logger });
+
+        expect(runRulesCheck({ cwd: workdir, logger, strict: true }).code).toBe(0);
+    });
+
+    it("resolveBundledSkillsDirectory walks up a dist layout to the package skills/", () => {
+        expect.assertions(2);
+
+        // Simulate `node_modules/@cirrus/cli/dist/chunks/handler.mjs` next to a
+        // sibling `skills/` — the resolver should walk up to the package root.
+        const pkgRoot = join(workdir, "node_modules", "@cirrus", "cli");
+        const start = join(pkgRoot, "dist", "chunks");
+
+        mkdirSync(start, { recursive: true });
+        mkdirSync(join(pkgRoot, "skills"), { recursive: true });
+        writeFileSync(join(pkgRoot, "package.json"), JSON.stringify({ name: "@cirrus/cli" }), "utf8");
+
+        expect(resolveBundledSkillsDirectory(start)).toBe(join(pkgRoot, "skills"));
+        // No @cirrus/cli package.json above an unrelated dir → undefined.
+        expect(resolveBundledSkillsDirectory(mkdtempSync(join(tmpdir(), "cirrus-no-pkg-")))).toBeUndefined();
     });
 });

--- a/packages/cli/__tests__/commands/rules.test.ts
+++ b/packages/cli/__tests__/commands/rules.test.ts
@@ -1,0 +1,78 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runRulesCheck, runRulesInstall } from "../../src/commands/rules/handler";
+import type { Logger } from "../../src/util/logger";
+
+const captureLogger = (): { logger: Logger; messages: string[] } => {
+    const messages: string[] = [];
+    const record = (message: string): void => {
+        messages.push(message);
+    };
+
+    return {
+        logger: { error: record, info: record, success: record, warn: record },
+        messages,
+    };
+};
+
+let workdir: string;
+
+describe("cirrus rules", () => {
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "cirrus-cli-rules-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("install copies the bundled skills into .agents/skills/", () => {
+        expect.assertions(3);
+
+        const { logger } = captureLogger();
+        const result = runRulesInstall({ cwd: workdir, logger });
+
+        expect(result.code).toBe(0);
+        expect(result.installed).toContain("cirrus");
+        expect(existsSync(join(workdir, ".agents", "skills", "cirrus", "SKILL.md"))).toBe(true);
+    });
+
+    it("install skips existing files unless --overwrite is set", () => {
+        expect.assertions(3);
+
+        const skillFile = join(workdir, ".agents", "skills", "cirrus", "SKILL.md");
+
+        mkdirSync(join(workdir, ".agents", "skills", "cirrus"), { recursive: true });
+        writeFileSync(skillFile, "EDITED", "utf8");
+
+        const { logger } = captureLogger();
+
+        const skipped = runRulesInstall({ cwd: workdir, logger });
+
+        expect(skipped.skipped).toContain("cirrus");
+        expect(readFileSync(skillFile, "utf8")).toBe("EDITED");
+
+        const overwritten = runRulesInstall({ cwd: workdir, logger, overwrite: true });
+
+        expect(overwritten.installed).toContain("cirrus");
+    });
+
+    it("check reports installed status", () => {
+        expect.assertions(2);
+
+        const { logger, messages } = captureLogger();
+
+        const before = runRulesCheck({ cwd: workdir, logger });
+
+        expect(messages.some((message) => message.includes("not installed"))).toBe(true);
+
+        runRulesInstall({ cwd: workdir, logger });
+        const after = runRulesCheck({ cwd: workdir, logger });
+
+        expect(after.installed.length).toBeGreaterThan(before.installed.length);
+    });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,9 @@
         "cli",
         "codegen",
         "deploy",
-        "vite"
+        "vite",
+        "tanstack-intent",
+        "agent-skills"
     ],
     "bin": {
         "cirrus": "./dist/bin.mjs"
@@ -32,6 +34,7 @@
     "files": [
         "dist",
         "__assets__",
+        "skills",
         "README.md",
         "LICENSE.md"
     ],

--- a/packages/cli/skills/README.md
+++ b/packages/cli/skills/README.md
@@ -9,14 +9,17 @@ framework correctly. They ship inside `@cirrus/cli` and are discovered by the
 Each skill is a `SKILL.md` with YAML frontmatter (`name`, `description`) in its
 own directory:
 
-| Skill                      | Use for                                                       |
-| -------------------------- | ------------------------------------------------------------- |
-| `cirrus`                   | Router — start here, then switch to the matching skill below. |
-| `cirrus-quickstart`        | `cirrus init` / adding Cirrus to an app + first round-trip.   |
-| `cirrus-setup-auth`        | Authentication via `cirrus registry add auth` (+ providers).  |
-| `cirrus-create-package`    | Building a reusable registry item or `@cirrus/*` package.     |
-| `cirrus-migration-helper`  | Schema/data migrations, `.global()` D1 flow, the drift gate.  |
-| `cirrus-performance-audit` | Scans, indexes, OCC write conflicts, sharding/`.global()`.    |
+| Skill                      | Use for                                                                     |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `cirrus`                   | Router — start here, then switch to the matching skill below.               |
+| `cirrus-quickstart`        | `cirrus init` / adding Cirrus to an app + first round-trip.                 |
+| `cirrus-functions`         | Core authoring rules — schema, validators, query/mutation/action, `ctx.db`. |
+| `cirrus-realtime`          | Client reactivity — live hooks, optimistic updates, `@cirrus/db`.           |
+| `cirrus-setup-auth`        | Authentication via `cirrus registry add auth` (+ providers).                |
+| `cirrus-create-package`    | Building a reusable registry item or `@cirrus/*` package.                   |
+| `cirrus-migration-helper`  | Schema/data migrations, `.global()` D1 flow, the drift gate.                |
+| `cirrus-deploy`            | Deploying to Cloudflare — wrangler bindings, secrets, the gate.             |
+| `cirrus-performance-audit` | Scans, indexes, OCC write conflicts, sharding/`.global()`.                  |
 
 These are mirrored into `.agents/skills/` and `.claude/skills/` (via symlinks)
 so agents working inside this repo pick them up directly. The source of truth

--- a/packages/cli/skills/README.md
+++ b/packages/cli/skills/README.md
@@ -1,0 +1,23 @@
+# Cirrus Agent Skills
+
+First-party [Agent Skills](https://tanstack.com/intent/latest/docs/registry) for
+Cirrus — portable instructions that teach AI coding agents how to use the
+framework correctly. They ship inside `@cirrus/cli` and are discovered by the
+[TanStack Intent registry](https://tanstack.com/intent/registry) via the
+`tanstack-intent` package keyword.
+
+Each skill is a `SKILL.md` with YAML frontmatter (`name`, `description`) in its
+own directory:
+
+| Skill                      | Use for                                                       |
+| -------------------------- | ------------------------------------------------------------- |
+| `cirrus`                   | Router — start here, then switch to the matching skill below. |
+| `cirrus-quickstart`        | `cirrus init` / adding Cirrus to an app + first round-trip.   |
+| `cirrus-setup-auth`        | Authentication via `cirrus registry add auth` (+ providers).  |
+| `cirrus-create-package`    | Building a reusable registry item or `@cirrus/*` package.     |
+| `cirrus-migration-helper`  | Schema/data migrations, `.global()` D1 flow, the drift gate.  |
+| `cirrus-performance-audit` | Scans, indexes, OCC write conflicts, sharding/`.global()`.    |
+
+These are mirrored into `.agents/skills/` and `.claude/skills/` (via symlinks)
+so agents working inside this repo pick them up directly. The source of truth
+lives here so the published `@cirrus/cli` tarball carries them.

--- a/packages/cli/skills/cirrus-create-package/SKILL.md
+++ b/packages/cli/skills/cirrus-create-package/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: cirrus-create-package
+description: Builds a reusable Cirrus capability — either a registry item installed with
+    `cirrus registry add`, or a publishable `@cirrus/*` workspace package. Use for
+    packaging schema + functions + bindings others can drop into their app.
+---
+
+# Cirrus Create Package
+
+Package a reusable Cirrus capability. There are two distribution shapes; pick
+based on whether the capability is **copied into the user's `cirrus/`** or
+**imported as a dependency**.
+
+| Shape             | Distribution                     | Use for                                                  |
+| ----------------- | -------------------------------- | -------------------------------------------------------- |
+| **Registry item** | `cirrus registry add <name>`     | App-owned code (schema/functions) the user edits + wires |
+| **Workspace pkg** | `import … from "@cirrus/<name>"` | Reusable library code imported as a dependency           |
+
+Many capabilities use **both**: a thin `@cirrus/<name>` package holding the
+reusable runtime, plus a registry item that scaffolds the glue (`cirrus/<name>/`
+files, bindings, env vars) into the user's project. `auth`, `mail`, `ratelimit`,
+and `storage` all follow this pattern.
+
+## When to Use
+
+- Extracting schema + functions you have written into something reusable.
+- Authoring a new capability (presence, search, payments, …) for other apps.
+- Adding a new item to this repo's `registry/`.
+
+## When Not to Use
+
+- A one-off feature for a single app — just write it in `cirrus/`.
+- The capability already exists as a registry item or `@cirrus/*` package — use
+  it (`cirrus registry list` to browse).
+
+## Path A: Registry Item
+
+A registry item is a directory under `registry/<name>/` with three files:
+
+- `registry.json` — the manifest (deps, bindings, env vars, files, requires).
+- `index.ts` (and any siblings) — the code copied into the user's project.
+- `README.md` — install + configuration docs.
+
+### Manifest shape
+
+```jsonc
+// registry/<name>/registry.json
+{
+    "$schema": "../schema/registry-item.schema.json",
+    "name": "<name>",
+    "title": "Human Title",
+    "description": "One-paragraph summary shown in `cirrus registry list`.",
+    "docs": "Post-install steps surfaced to the user after `cirrus registry add`.",
+    "requires": [], // other item names this one depends on
+    "deps": { "@cirrus/server": "workspace:*" },
+    "bindings": [
+        // reconciled into wrangler.jsonc
+        { "path": ["d1_databases"], "value": [{ "binding": "DB", "database_name": "REPLACE_ME-db", "database_id": "<replace-with-d1-create-id>" }] },
+    ],
+    "envVars": [{ "name": "MY_SECRET", "description": "What it is and how to generate it.", "secret": true }],
+    "files": [{ "from": "index.ts", "to": "cirrus/<name>/index.ts", "merge": "create-or-skip" }],
+}
+```
+
+- `files[].merge` is typically `create-or-skip` (never clobber edited user code);
+  `bindings` are reconciled into `wrangler.jsonc`; `envVars` are scaffolded into
+  `.dev.vars` (secret-looking ones get generated values).
+- `requires` lets a provider item (e.g. `auth-clerk`) build on a base item
+  (`auth`). The resolver installs the chain.
+
+### Register and validate
+
+Add an entry to `registry/index.json`, then rebuild and check the index:
+
+```bash
+cirrus registry build              # regenerate registry/index.json
+cirrus registry build --check      # verify the index is up to date (CI)
+cirrus registry view <name>        # preview what `add` would do
+cirrus registry add <name>         # install into the current project
+```
+
+## Path B: Workspace Package
+
+Scaffold a fresh `@cirrus/<name>` package with the generator (always use the
+`--name=value` form):
+
+```bash
+vis generate cirrus-package --name=search --description='Typed full-text search over Cirrus tables'
+```
+
+This creates `packages/search/` following the repo's package shape: `src/index.ts`,
+`__tests__/`, `vitest.config.ts`, `tsconfig.json` (extends `../../tsconfig.base.json`),
+`project.json` (vis tags `type:package` + `category:<slug>`), `package.json` (ESM,
+`"sideEffects": false`, conditional exports), and `.releaserc.json`.
+
+### Repo conventions to honor
+
+- **No `.js` extensions** in relative imports (`moduleResolution: "bundler"`).
+  The lone exception is `@cirrus/codegen`'s emitted output.
+- **No mixed default + named exports** in one file — named-only when there is
+  more than one export.
+- **Use the dependency catalogs** in `pnpm-workspace.yaml` (`catalog:test`,
+  `catalog:lint`, …) — never hard-code a version that lives in a catalog.
+- Tag `project.json` with `type:package` and a `category:<slug>`.
+
+Build and test the new package in isolation:
+
+```bash
+pnpm --filter "@cirrus/search" run lint:types
+pnpm --filter "@cirrus/search" run test
+```
+
+## Codegen-Wired Capabilities
+
+If your capability surfaces functions on a context (e.g. `ctx.ai`, `ctx.containers`)
+or new generated tables, it must be discoverable by `@cirrus/codegen` — codegen
+parses `cirrus/schema.ts` and the function files. Document any `cirrus/*.ts`
+declaration the user must add so codegen wires the typed surface.
+
+## Checklist
+
+- [ ] Chose the right shape (registry item, workspace package, or both).
+- [ ] Registry item: `registry.json` + `index.ts` + `README.md` authored;
+      `bindings`/`envVars`/`requires`/`files` correct.
+- [ ] `cirrus registry build` run; `cirrus registry build --check` passes.
+- [ ] Workspace package: scaffolded via `vis generate cirrus-package`; no `.js`
+      extensions, no mixed default+named exports, catalog versions used.
+- [ ] `lint:types` and `test` pass for the new package.
+- [ ] README documents install, bindings, env vars, and any `cirrus/` glue.

--- a/packages/cli/skills/cirrus-deploy/SKILL.md
+++ b/packages/cli/skills/cirrus-deploy/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: cirrus-deploy
+description: Deploys a Cirrus app to Cloudflare. Use for `cirrus deploy`, wrangler.jsonc
+    bindings (SHARD/SESSION DOs, D1, R2), provisioning databases/buckets, secrets
+    (`wrangler secret` vs `.dev.vars`), the `cirrus doctor` preflight, the
+    schema-drift gate, and dev-vs-prod separation.
+---
+
+# Cirrus Deploy
+
+Ship a Cirrus app to Cloudflare Workers + Durable Objects. Unlike a managed
+backend, deployment owns real Cloudflare resources — Durable Object bindings, a
+D1 database, R2 buckets, and secrets — so the work is mostly making
+`wrangler.jsonc` and the remote resources line up.
+
+## When to Use
+
+- Deploying to production (or a Cloudflare environment) for the first time.
+- A deploy fails on a binding, a placeholder id, or the schema-drift gate.
+- Provisioning D1 / R2 / secrets for a Cirrus app.
+
+## When Not to Use
+
+- Local development — that is `cirrus dev` (see `cirrus-quickstart`).
+- A schema/data change that needs migrating — do that first with
+  `cirrus-migration-helper`, then deploy.
+
+## What `cirrus deploy` Does
+
+`cirrus deploy` runs a fixed pipeline:
+
+1. **Codegen** — regenerates `cirrus/_generated/` and typechecks.
+2. **Validate `wrangler.jsonc`** — required `compatibility_date`, the
+   `nodejs_compat` flag, and the `SHARD` Durable Object binding.
+3. **Schema-drift gate** — blocks if the committed baseline
+   (`cirrus/.cirrus-schema.json`) drifted with a breaking change and no
+   accompanying migration. The baseline is re-blessed only after the deploy
+   succeeds.
+4. **`wrangler deploy`** — builds and pushes the worker (and any container
+   images).
+
+Useful flags: `--env <name>` (Cloudflare environment), `--migrate` (run pending
+data migrations against the live worker after deploy, with `--migrate-token` /
+`--migrate-url`), `--allow-schema-drift` (override the gate — use sparingly), and
+`--update-schema-baseline` (re-bless the baseline with the current shape).
+
+## Preflight: `cirrus doctor`
+
+Run the read-only preflight before deploying. It checks:
+
+- `wrangler.jsonc` present with the `SHARD` durable-object binding.
+- D1 `database_id`s are real, not placeholders (`<replace>` / empty).
+- `send_email` destination addresses aren't placeholders.
+- `.dev.vars` secret-looking keys are filled.
+- Declared containers are exported by the worker entry.
+
+```bash
+cirrus doctor   # FAIL → exit 1; WARN/INFO don't block
+```
+
+`cirrus verify` and `cirrus prepare` run related checks (drift gate, wrangler
+validation) — wire `cirrus verify` into CI to catch drift before a deploy.
+
+## `wrangler.jsonc` — the binding contract
+
+A Cirrus worker needs the ShardDO (and SessionDO when auth is wired), the
+SQLite-DO migration tag, and whatever D1/R2 the app uses:
+
+```jsonc
+{
+    "name": "my-app",
+    "main": "src/index.ts",
+    "compatibility_date": "2026-04-07",
+    "compatibility_flags": ["nodejs_compat"],
+    "durable_objects": {
+        "bindings": [
+            { "name": "SHARD", "class_name": "ShardDO" },
+            { "name": "SESSION", "class_name": "SessionDO" }, // only with @cirrus/auth
+        ],
+    },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO", "SessionDO"] }],
+    "d1_databases": [{ "binding": "DB", "database_name": "my-app-global", "database_id": "<replace>" }],
+    "r2_buckets": [{ "binding": "FILES", "bucket_name": "my-app-files" }],
+}
+```
+
+`cirrus dev` auto-reconciles most of this (and `cirrus registry add` adds the
+bindings an item needs), but the **resources themselves** must exist and their
+ids must be filled in:
+
+```bash
+wrangler d1 create my-app-global   # paste the returned database_id into wrangler.jsonc
+wrangler r2 bucket create my-app-files
+```
+
+The DO `class_name`s must be exported by your worker entry (the
+`createShardDO()` / generated container exports) — wrangler rejects a binding
+whose class the worker doesn't export. `cirrus doctor` surfaces a missing
+container export proactively.
+
+## Secrets: `wrangler secret`, not `.dev.vars`
+
+`.dev.vars` is **dev only** — it is git-ignored and never deployed. Production
+secrets (`BETTER_AUTH_SECRET`, `RESEND_API_KEY`, provider client secrets, …) go
+into Cloudflare:
+
+```bash
+wrangler secret put BETTER_AUTH_SECRET   # prompts for the value, stored encrypted
+wrangler secret list
+```
+
+Set every secret your app reads (mirror the secret-looking keys in `.dev.vars`)
+before the first request hits production.
+
+## Dev vs Production
+
+- **Development:** `cirrus dev` (Vite + workerd + Studio + codegen-on-save). The
+  schema baseline and `.dev.vars` belong to dev.
+- **Production:** `cirrus deploy`. Separate D1 database / R2 buckets / secrets
+  from dev. Never point a dev worker at prod resources.
+
+For `.global()` table DDL, generate and commit SQL migrations with `cirrus
+migrate generate` before deploying; `@cirrus/d1`'s runner applies them. For data
+backfills, deploy first, then `cirrus deploy --migrate` (or `cirrus migrate up
+--prod`). See `cirrus-migration-helper`.
+
+## Common Pitfalls
+
+1. **Placeholder `database_id`.** The D1 binding ships with `<replace>`; run
+   `wrangler d1 create` and paste the id. `cirrus doctor` catches this.
+2. **DO class not exported.** `wrangler deploy` fails if a `class_name` isn't
+   exported by the worker entry — export `ShardDO`/`SessionDO`/generated
+   containers.
+3. **Secrets only in `.dev.vars`.** They never reach production; use `wrangler
+secret put` for every prod secret.
+4. **Bypassing the drift gate.** `--allow-schema-drift` ships a breaking schema
+   with no migration — stage the change (`cirrus-migration-helper`) instead.
+5. **Deploying with uncommitted codegen.** Commit `cirrus/_generated/` and
+   `cirrus/.cirrus-schema.json` so CI and the gate see the same baseline.
+
+## Checklist
+
+- [ ] `cirrus doctor` passes (no FAIL).
+- [ ] `wrangler.jsonc` has `compatibility_date`, `nodejs_compat`, the `SHARD` DO
+      binding, and the SQLite migration tag.
+- [ ] D1 / R2 resources created; real ids pasted into `wrangler.jsonc`.
+- [ ] DO + container `class_name`s exported by the worker entry.
+- [ ] Production secrets set via `wrangler secret put`.
+- [ ] Schema changes migrated; the drift gate is green (no `--allow-schema-drift`).
+- [ ] `cirrus deploy` succeeded; `--migrate` run if data backfills were pending.

--- a/packages/cli/skills/cirrus-functions/SKILL.md
+++ b/packages/cli/skills/cirrus-functions/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: cirrus-functions
+description: Authoring rules for Cirrus schema and functions. Use when writing or reviewing
+    `cirrus/` code — `defineSchema`/`defineTable`, `v.*` validators, query vs
+    mutation vs action (and `internal*`), indexes & `withIndex`, the `ctx.db` API,
+    pagination, scheduling, and `httpAction`.
+---
+
+# Cirrus Functions
+
+The core authoring rules for Cirrus backend code. Read this before writing or
+changing anything under `cirrus/`. After every edit, run `cirrus codegen` — it
+regenerates `cirrus/_generated/` and typechecks your schema + functions.
+
+## When to Use
+
+- Writing or editing schema, queries, mutations, or actions.
+- Reviewing `cirrus/` code for correctness and idiom.
+- Deciding query vs mutation vs action, or public vs internal.
+
+## When Not to Use
+
+- Setting up a new project (`cirrus-quickstart`) or auth (`cirrus-setup-auth`).
+- Diagnosing a slow query or write conflict (`cirrus-performance-audit`).
+- Changing an existing schema with data at rest (`cirrus-migration-helper`).
+
+## Schema: `defineSchema` + `defineTable`
+
+`cirrus/schema.ts` exports `defineSchema` as the default export. Every column is
+a `v.*` validator. Declare an index for every access pattern you query by.
+
+```ts
+import { defineSchema, defineTable, v } from "@cirrus/server";
+
+export default defineSchema({
+    messages: defineTable({
+        channelId: v.id("channels"),
+        authorId: v.id("users"),
+        body: v.string(),
+        createdAt: v.number(),
+    }).index("by_channel", ["channelId", "createdAt"]),
+
+    channels: defineTable({
+        name: v.string(),
+    }),
+});
+```
+
+- Cirrus injects `_id` and `_creationTime` on every row — do **not** declare
+  them.
+- `.index("name", ["a", "b"])` — columns are ordered; put equality columns
+  first, then the range/sort column.
+- `.shardBy("ownerId")` partitions the table across Durable Objects by key;
+  `.global()` replicates it to D1 for cross-region reads. Default (neither) is a
+  single root-scoped ShardDO.
+
+### Validators (`v.*`)
+
+`string`, `number`, `boolean`, `id("table")`, `null`, `any`, `bigint`, `bytes`,
+`literal(value)`, `array(item)`, `object({...})`, `record(key, value)`,
+`union(a, b, …)`, `optional(inner)`, plus the convenience types `date`,
+`timestamp`, and `storage` (an R2 object key). Use `v.optional(...)` for nullable
+fields — required is the default.
+
+## Functions: query / mutation / action
+
+Each function declares `args` (a `v.*` map) and a `handler`. Export them as named
+consts from `cirrus/*.ts`; codegen surfaces them as `api.<file>.<name>`.
+
+| Kind       | Reads `ctx.db`                    | Writes `ctx.db` | Side effects / `fetch` | Reactive |
+| ---------- | --------------------------------- | --------------- | ---------------------- | -------- |
+| `query`    | yes                               | no              | no                     | yes      |
+| `mutation` | yes                               | yes             | no                     | —        |
+| `action`   | no (use `runQuery`/`runMutation`) | no              | yes                    | —        |
+
+```ts
+import type { Id } from "@cirrus/server";
+import { action, CirrusError, mutation, query, v } from "@cirrus/server";
+
+// `api` / `internal` come from codegen:
+// import { api, internal } from "./_generated/api";
+
+export const listByChannel = query({
+    args: { channelId: v.id("channels") },
+    handler: async (ctx, { channelId }) =>
+        ctx.db
+            .query("messages")
+            .withIndex("by_channel", (q) => q.eq("channelId", channelId))
+            .collect(),
+});
+
+export const send = mutation({
+    args: { channelId: v.id("channels"), body: v.string() },
+    handler: async (ctx, { channelId, body }): Promise<Id<"messages">> => {
+        if (!ctx.auth.userId) {
+            throw new CirrusError("UNAUTHORIZED", "not signed in");
+        }
+        return ctx.db.insert("messages", {
+            channelId,
+            authorId: ctx.auth.userId as Id<"users">,
+            body,
+            createdAt: Date.now(),
+        });
+    },
+});
+
+export const notifySlack = action({
+    args: { messageId: v.id("messages") },
+    handler: async (ctx, { messageId }) => {
+        const message = await ctx.runQuery(api.messages.getById, { messageId });
+        await fetch(SLACK_WEBHOOK, { method: "POST", body: JSON.stringify(message) });
+    },
+});
+```
+
+- **Pick the right kind.** Reactive read → `query`. Transactional write →
+  `mutation`. External I/O (`fetch`, third-party SDKs, calling other functions)
+  → `action`. An action has no `ctx.db`; it reaches data via `ctx.runQuery` /
+  `ctx.runMutation`.
+- **`internal*` variants** (`internalQuery`, `internalMutation`,
+  `internalAction`) are not exposed to clients — use them for server-only logic
+  called from actions, crons, or other functions.
+- **Throw `CirrusError`** (`import { CirrusError } from "@cirrus/server"`) with a
+  code + message for expected failures; it serializes cleanly to the client.
+
+## The `ctx.db` API
+
+Reads:
+
+```ts
+await ctx.db.get(id);                                  // one row by id (or null)
+ctx.db.query("t").withIndex("by_x", (q) => q.eq("x", v)); // indexed query
+  .collect();   // all matching rows
+  .first();     // first row or null
+  .unique();    // exactly one (throws if 0 or >1)
+  .take(n);     // first n rows
+  .order("asc" | "desc")  // sort by the index range
+  .paginate(opts);        // cursor page (pair with usePaginatedQuery)
+```
+
+Writes (mutations only):
+
+```ts
+await ctx.db.insert("t", { ...fields }); // returns the new Id
+await ctx.db.patch(id, { field: next }); // shallow-merge update
+await ctx.db.replace(id, { ...allFields }); // full overwrite
+await ctx.db.delete(id);
+```
+
+**Prefer `withIndex` over `.filter`.** A `.filter(...)` with no covering index
+scans the whole table — `@cirrus/advisor` flags it as `filter-without-index`.
+Declare the index and constrain with `.withIndex`.
+
+## Other `ctx` capabilities
+
+`ctx.auth` (the resolved session: `ctx.auth.userId`), `ctx.scheduler`
+(`runAfter` / `runAt` for deferred work), `ctx.storage` (R2), `ctx.vectors`
+(Vectorize), and — when their packages are wired — `ctx.ai` and `ctx.containers`.
+
+## HTTP endpoints
+
+For webhooks or non-RPC HTTP, use `httpRouter` / `httpRoute` + `httpAction`:
+
+```ts
+import { httpAction, httpRouter } from "@cirrus/server";
+
+export default httpRouter({
+    "/webhooks/stripe": httpAction(async (ctx, request) => {
+        const event = await request.json();
+        await ctx.runMutation(internal.billing.record, { event });
+        return new Response("ok");
+    }),
+});
+```
+
+## Checklist
+
+- [ ] Schema columns are `v.*` validators; `_id`/`_creationTime` not declared.
+- [ ] An index exists for every access pattern; queries use `withIndex`, not
+      `.filter`.
+- [ ] Right function kind: `query` (reactive read) / `mutation` (write) /
+      `action` (side effects via `runQuery`/`runMutation`).
+- [ ] Server-only logic uses `internal*`; expected failures throw `CirrusError`.
+- [ ] `ctx.db` writes only inside mutations; ids typed with `Id<"table">`.
+- [ ] Ran `cirrus codegen`; typecheck is clean.

--- a/packages/cli/skills/cirrus-migration-helper/SKILL.md
+++ b/packages/cli/skills/cirrus-migration-helper/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: cirrus-migration-helper
+description: Plans Cirrus schema and data migrations with widen-migrate-narrow. Use for
+    breaking schema changes, backfills, table reshaping, online data migrations
+    (`defineMigration` + `cirrus migrate up`), the `.global()` D1 SQL flow, and the
+    pre-deploy schema-drift gate.
+---
+
+# Cirrus Migration Helper
+
+Safely change a Cirrus schema and migrate data when making breaking changes.
+
+## When to Use
+
+- Adding required fields to existing tables.
+- Changing field types or structure.
+- Splitting/merging tables, renaming/removing fields.
+- Reshaping `.global()` (D1-backed) tables.
+
+## When Not to Use
+
+- Greenfield schema with no data at rest.
+- Adding **optional** fields that need no backfill.
+- Adding new tables or indexes with no correctness concern.
+
+## Two Storage Layers — Know Which You Are Migrating
+
+Cirrus tables live in one of two backends, and they migrate differently:
+
+- **ShardDO SQLite (default `root`, and `.shardBy(key)` tables).** State lives in
+  the per-app / per-shard Durable Object. Data is reshaped with **online data
+  migrations** — `defineMigration` declarations run by `cirrus migrate up`,
+  resumable per shard.
+- **`.global()` tables (D1).** Replicated to D1 for cross-region reads. Their
+  structural DDL gets versioned **SQL migrations** via `cirrus migrate generate`,
+  applied by `@cirrus/d1`'s runner at deploy time.
+
+A breaking change to a `.global()` table needs a generated SQL migration; a data
+backfill (either layer) is an online `defineMigration`. Both follow the same
+**widen → migrate → narrow** discipline.
+
+## Key Principle: Widen, Migrate, Narrow
+
+The schema-drift gate (and D1 itself) will not let a breaking change deploy
+without an accompanying migration. So every breaking change is staged:
+
+1. **Widen** — make the schema accept both old and new shapes (add the new field
+   as `v.optional`, keep the old one). Update reads to handle both; start writing
+   the new shape for new rows. Deploy.
+2. **Migrate** — backfill existing rows to the new shape (an online
+   `defineMigration` run with `cirrus migrate up`; plus `cirrus migrate generate`
+   for `.global()` structural DDL). Verify completeness with `cirrus migrate
+status`.
+3. **Narrow** — make the field required / drop the old field, remove the
+   both-shapes read code. Deploy.
+
+### Prefer new fields over changing types
+
+When changing a field's shape, add a new field rather than mutating the existing
+one — safer transition, easier rollback.
+
+### Don't delete data prematurely
+
+Prefer deprecating: mark the old field `v.optional` with a `// deprecated:` code
+comment explaining why it existed. Delete only once you are sure nothing reads
+it.
+
+## Safe Changes (No Migration Needed)
+
+```ts
+// Adding an optional field — safe.
+users: defineTable({
+    name: v.string(),
+    bio: v.optional(v.string()),
+});
+
+// Adding a new table — safe.
+posts: defineTable({ userId: v.id("users"), title: v.string() }).index("by_user", ["userId"]);
+
+// Adding an index — safe.
+users: defineTable({ name: v.string(), email: v.string() }).index("by_email", ["email"]);
+```
+
+## Online Data Migrations (the backfill workhorse)
+
+For backfilling/reshaping rows, declare a migration with `defineMigration` from
+`@cirrus/server`. It transforms one document at a time, runs **inside each
+shard's** Durable Object in keyset batches, and is **resumable** — per-shard
+progress is tracked in a reserved `__cirrus_migrations` table, so an interrupted
+run resumes where it stopped. Codegen discovers declarations and emits them into
+the registry the DO and CLI look up by `id`.
+
+```ts
+// cirrus/migrations/backfill-display-name.ts
+import { defineMigration } from "@cirrus/server";
+
+export default defineMigration({
+    id: "backfill-display-name",
+    table: "users",
+    batchSize: 200, // optional; defaults to the runner's batch size
+    up: (doc) => {
+        if (typeof doc.displayName === "string") {
+            return; // already migrated — return undefined to skip (not counted as changed)
+        }
+        return { ...doc, displayName: doc.name ?? "Anonymous" };
+    },
+    // optional reverse transform applied by `cirrus migrate down`
+    down: (doc) => {
+        const { displayName, ...rest } = doc as Record<string, unknown>;
+        return rest;
+    },
+});
+```
+
+The transform must preserve row identity — the runner always keeps the original
+`_id` / `_creationTime`, so do not change them.
+
+### Run it
+
+```bash
+cirrus migrate create backfill-display-name   # scaffold the migration file
+cirrus codegen                                 # discover + register it
+cirrus migrate up backfill-display-name --dry-run   # preview, no rows rewritten
+cirrus migrate up backfill-display-name        # run across shards (keyset batches)
+cirrus migrate status backfill-display-name    # per-shard progress
+cirrus migrate down backfill-display-name      # revert (if `down` defined)
+```
+
+Useful flags: `--batch-size <n>`, `--steps <n>` (cap batches this run), and
+`--prod --url <worker> --yes` to target production (with `CIRRUS_ADMIN_TOKEN`).
+
+## `.global()` (D1) Structural Migration Flow
+
+```bash
+# 1. Edit cirrus/schema.ts (widen: add the optional new field to the .global() table).
+cirrus codegen
+
+# 2. Generate the SQL migration by diffing schema against the snapshot baseline.
+cirrus migrate generate --name=add_user_status
+
+# Writes cirrus/migrations/<timestamp>_add_user_status.sql and updates
+# cirrus/migrations/.snapshot.json. Review the SQL before committing.
+
+# 3. Deploy — @cirrus/d1's runner applies pending migrations.
+cirrus deploy
+```
+
+`cirrus migrate generate` only considers `.global()` tables (root/sharded tables
+are not D1-backed). Run it after each schema edit in the widen and narrow steps;
+backfill data with an online migration between them.
+
+## The Schema-Drift Gate
+
+`cirrus deploy` (and `verify` / `prepare`) run a **pre-deploy schema-drift gate**:
+it compares the committed structural baseline (`cirrus/.cirrus-schema.json`)
+against the snapshot codegen produced this run. Breaking drift **without an
+accompanying data migration blocks the deploy**. The baseline is only re-blessed
+_after_ the deploy succeeds, so a failed deploy never advances it past a change
+that never shipped.
+
+If the gate blocks you: that is the signal to stage the change (widen first) or
+add the migration — not to bypass it.
+
+## Common Pitfalls
+
+1. **Making a field required before backfilling.** The drift gate / D1 rejects
+   the deploy because existing rows lack it. Widen first.
+2. **Reshaping rows by hand instead of `defineMigration`.** A hand-rolled
+   `internalMutation` that `.collect()`s a large table hits transaction limits
+   and is not resumable. Use `defineMigration` — it batches and tracks per-shard
+   progress.
+3. **Not writing the new shape during the migration window.** Rows created mid-
+   migration get missed, leaving unmigrated data after it "completes." Start
+   dual-writing in the widen step.
+4. **Skipping the dry run.** `cirrus migrate up <id> --dry-run` validates the
+   transform before it touches real rows.
+5. **Deleting a field prematurely.** Deprecate with `v.optional` + a comment;
+   delete only once nothing references it.
+6. **Migrating the wrong layer.** A `.global()` structural change needs `cirrus
+migrate generate` (SQL); a data backfill needs a `defineMigration`. Check the
+   table's `.global()` / `.shardBy()` modifier first.
+
+## Checklist
+
+- [ ] Identified the change and which layer it touches (ShardDO vs `.global()`).
+- [ ] Widened the schema to accept both shapes; `cirrus codegen` clean.
+- [ ] Updated reads to handle both shapes; started writing the new shape.
+- [ ] Deployed the widened schema.
+- [ ] Authored a `defineMigration`; previewed with `cirrus migrate up --dry-run`.
+- [ ] Ran `cirrus migrate up`; `cirrus migrate generate` + deploy for `.global()`
+      structural changes.
+- [ ] Verified completion with `cirrus migrate status`.
+- [ ] Narrowed the schema (required / drop old field); removed both-shapes code.
+- [ ] Deployed the final schema; schema-drift gate passed.

--- a/packages/cli/skills/cirrus-performance-audit/SKILL.md
+++ b/packages/cli/skills/cirrus-performance-audit/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: cirrus-performance-audit
+description: Diagnoses and fixes Cirrus performance problems — full-table scans, missing
+    indexes, OCC write conflicts, oversized subscriptions, and sharding/`.global()`
+    scaling. Use when queries are slow, mutations conflict, or `@cirrus/advisor`
+    flags a table.
+---
+
+# Cirrus Performance Audit
+
+Systematically diagnose Cirrus performance issues, route to the right fix, and
+apply it across sibling functions consistently.
+
+## When to Use
+
+- Queries feel slow or read far more rows than they return.
+- Mutations retry or conflict under load (OCC).
+- Subscriptions fan out updates too broadly or re-run too often.
+- The Cirrus Studio **Advisors** tab or `@cirrus/advisor` flags a table.
+
+## When Not to Use
+
+- Scale is small, traffic is modest, and there is no measured problem — prefer
+  simpler code. Do not introduce sharding, digests, or splits on speculation.
+
+## Core Workflow
+
+1. **Scope** one concrete user flow with a clear entry and exit.
+2. **Trace** every `ctx.db` read and write in that flow.
+3. **Route** to the matching problem class below.
+4. **Fix siblings** consistently — every function touching the same table should
+   read it the same indexed way.
+5. **Verify** behavior is unchanged and the advisor finding clears.
+
+## Signal Gathering
+
+Start with the static advisors — they need no traffic:
+
+- **Cirrus Studio → Advisors tab** surfaces `@cirrus/advisor` findings live in
+  dev.
+- `@cirrus/advisor` runs static lints over `defineSchema` + discovered query
+  reads / insert writes. Relevant performance/schema rules:
+    - `filter-without-index` — a query filters a table with no covering index.
+    - `unindexed-foreign-key` — a relation/FK column has no index.
+    - `duplicate-index` / `empty-index` — wasted or malformed indexes.
+    - `index-references-unknown-field`, `relation-references-unknown-field`,
+      `relation-references-unknown-table` — broken index/relation definitions.
+    - `table-without-insert` — a table is read but never written (often a
+      schema/typo signal).
+
+## Problem Class: Read Amplification (the common one)
+
+**Symptom:** a query reads the whole table to return a few rows;
+`filter-without-index` fires.
+
+**Fix:** read through an index, not `.filter()`. Declare the index on the table
+and use `.withIndex()` with an equality/range on the leading columns.
+
+```ts
+// Bad — scans every row, then filters in memory.
+const mine = (await ctx.db.query("documents").collect()).filter((d) => d.orgId === orgId);
+
+// Good — declare the index…
+documents: defineTable({ orgId: v.string(), createdAt: v.number() /* … */ }).index("by_org_created", ["orgId", "createdAt"]);
+
+// …and read through it.
+const mine = await ctx.db
+    .query("documents")
+    .withIndex("by_org_created", (q) => q.eq("orgId", orgId))
+    .collect();
+```
+
+Index columns are ordered: put equality columns first, then the range/sort
+column. Fix every sibling query on the table the same way.
+
+## Problem Class: Write Conflicts (OCC)
+
+**Symptom:** mutations on hot rows retry or fail under concurrency. ShardDO uses
+optimistic concurrency control — concurrent writes to the same DO that touch
+overlapping state conflict and retry.
+
+**Fixes, in order of preference:**
+
+1. **Narrow the write.** Patch only the fields that changed; avoid read-modify-
+   write over rows another mutation also touches.
+2. **Partition with `.shardBy(key)`.** Move per-user / per-tenant / per-room
+   state into its own DO so writes for different keys never contend. This is the
+   primary horizontal-scale lever — most write contention is a single-DO
+   hotspot.
+3. **Avoid unbounded counters/aggregates in the hot path.** Accumulate in a
+   sharded/append shape and fold lazily rather than serializing every writer
+   through one row.
+
+## Problem Class: Subscription Cost
+
+**Symptom:** a `useQuery` re-runs and re-pushes to many clients on unrelated
+writes.
+
+**Fixes:**
+
+- **Scope query args tightly** so a subscription only depends on the rows it
+  renders — a query keyed by `orgId` should not re-run for another org's write.
+- **Read through indexes** (above) so the reactive dependency is the narrow
+  index range, not the whole table.
+- ShardDO subscriptions are **hibernated WebSockets** — idle connections cost
+  nothing; the lever is _how many rows each live query depends on_, not raw
+  connection count.
+
+## Problem Class: Cross-Region Reads
+
+**Symptom:** read-heavy, rarely-written data is slow for far-away users.
+
+**Fix:** chain `.global()` on the table to replicate it to D1 for low-latency
+cross-region reads (with read-your-writes via the Sessions API). Reserve it for
+read-mostly tables — `.global()` adds the D1 migration flow (see the
+`cirrus-migration-helper` skill) and write-path cost.
+
+## Guardrails
+
+- Prefer simpler code when scale is small or the signal is weak.
+- Do not recommend structural changes (digest tables, document splitting,
+  sharding) without a measured signal or a known hot path.
+- When you change how one function reads/writes a table, change its siblings to
+  match — half-migrated access patterns are their own bug.
+
+## Checklist
+
+- [ ] Scoped one concrete flow; traced every `ctx.db` read/write.
+- [ ] Checked the Studio Advisors tab / `@cirrus/advisor` findings.
+- [ ] Read amplification: replaced `.filter()` with an indexed `.withIndex()`.
+- [ ] Write conflicts: narrowed writes and/or partitioned with `.shardBy(key)`.
+- [ ] Subscription cost: scoped query args so live queries depend on few rows.
+- [ ] Cross-region: applied `.global()` only to read-mostly tables.
+- [ ] Fixed sibling functions consistently; verified behavior unchanged.

--- a/packages/cli/skills/cirrus-quickstart/SKILL.md
+++ b/packages/cli/skills/cirrus-quickstart/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: cirrus-quickstart
+description: Creates or adds Cirrus to an app. Use for new Cirrus projects, `cirrus init`,
+    framework/provider wiring, the first `cirrus dev` run, env vars, or writing
+    the first schema + query/mutation round-trip.
+---
+
+# Cirrus Quickstart
+
+Set up a working Cirrus project as fast as possible.
+
+## When to Use
+
+- Starting a brand new project with Cirrus.
+- Adding Cirrus to an existing Vite, Next.js, Astro, Nuxt, SvelteKit, or
+  TanStack Start app.
+- Scaffolding a Cirrus app for prototyping.
+
+## When Not to Use
+
+- The project already has Cirrus installed and `cirrus/` exists — just build,
+  and run `cirrus codegen` after schema/function edits.
+- You only need to add auth to an existing Cirrus app — use the
+  `cirrus-setup-auth` skill.
+
+## Workflow
+
+1. Determine the starting point: new project or existing app.
+2. New project: scaffold with `cirrus init` and pick a template.
+3. Existing app: run `cirrus init --here` to patch the Vite config and wire
+   Cirrus into the current project.
+4. Run `cirrus codegen` to generate `cirrus/_generated/` and typecheck the
+   schema + functions. This is the agent's feedback loop.
+5. Start the dev loop with `cirrus dev` (ask the user to run it locally, or
+   start it in the background for cloud/headless agents — it is long-running and
+   does not exit).
+6. Verify a query/mutation round-trip works end to end.
+
+## Path 1: New Project (Recommended)
+
+`cirrus init` fetches a whole-project template (frontend + worker entry + Vite
+plugin + `cirrus/` already wired together).
+
+```bash
+cirrus init my-app --template vite
+cd my-app
+pnpm install
+```
+
+### Pick a template
+
+| Template               | Stack                                          |
+| ---------------------- | ---------------------------------------------- |
+| `vite`                 | React + Vite (the simplest full-stack starter) |
+| `standalone`           | Worker-only Cirrus backend, no frontend        |
+| `astro`                | Astro integration                              |
+| `nuxt`                 | Nuxt (Vue)                                     |
+| `sveltekit`            | SvelteKit                                      |
+| `tanstack-start-react` | TanStack Start (React)                         |
+| `tanstack-start-solid` | TanStack Start (Solid)                         |
+
+If the user has not specified a preference, default to `vite`. Pass `--template`
+explicitly to avoid the interactive prompt. Templates are fetched remotely (via
+`giget`) from `gh:anolilab/cirrus/templates/<type>`; pass `--from <dir>` to use a
+local template directory offline.
+
+### Generate types and push the first run
+
+Run this yourself — it is one-shot and exits cleanly:
+
+```bash
+cirrus codegen
+```
+
+It writes `cirrus/_generated/` and typechecks your schema + functions. Read its
+output to find out whether the code you just wrote is valid.
+
+### Start the dev loop
+
+```bash
+cirrus dev
+```
+
+`cirrus dev` runs the Vite dev server with the Cloudflare Worker on the same
+origin, plus codegen-on-save and the Cirrus Studio. It is long-running and does
+not exit, so:
+
+- **Local development (user at the keyboard):** ask the user to run `cirrus dev`
+  in a terminal.
+- **Cloud or headless agents:** start `cirrus dev` in the background.
+
+Vite serves on `http://localhost:5173` by default; the Worker is served on the
+same origin via `@cloudflare/vite-plugin`.
+
+## Path 2: Add Cirrus to an Existing App
+
+Use this when the user already has a Vite-based frontend and wants Cirrus as the
+backend.
+
+```bash
+cirrus init --here
+```
+
+This finds the existing `vite.config.*` (or creates a minimal one), patches in
+the Cirrus Vite plugin, and scaffolds a starter `cirrus/`. Then run
+`cirrus codegen` and `cirrus dev` as above.
+
+### Wire up the client provider
+
+Create the `CirrusClient` once at module scope (never inside a component) and
+wrap the app with the framework provider. React example:
+
+```tsx
+// src/client/main.tsx
+import { CirrusClient } from "@cirrus/client";
+import { CirrusProvider } from "@cirrus/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// @cloudflare/vite-plugin serves the Worker on the same origin as Vite.
+const url = (import.meta.env.VITE_CIRRUS_URL as string | undefined) ?? globalThis.location.origin;
+const client = new CirrusClient({ url });
+
+createRoot(document.querySelector("#root")!).render(
+    <StrictMode>
+        <CirrusProvider client={client}>
+            <App />
+        </CirrusProvider>
+    </StrictMode>,
+);
+```
+
+Vue, Solid, and Svelte have matching providers in `@cirrus/vue`, `@cirrus/solid`,
+and `@cirrus/svelte`. `VITE_CIRRUS_URL` is optional — it defaults to
+`location.origin`, which is correct for the single-origin dev setup.
+
+## Writing Your First Function
+
+Create a schema and a query/mutation to verify the full loop.
+
+`cirrus/schema.ts`:
+
+```ts
+import { defineSchema, defineTable, v } from "@cirrus/server";
+
+export default defineSchema({
+    todos: defineTable({
+        text: v.string(),
+        done: v.boolean(),
+        createdAt: v.number(),
+    }).index("by_creation", ["createdAt"]),
+});
+```
+
+`cirrus/todos.ts`:
+
+```ts
+import type { Id } from "@cirrus/server";
+import { mutation, query, v } from "@cirrus/server";
+
+export const list = query({
+    args: {},
+    handler: async (ctx) => ctx.db.query("todos").withIndex("by_creation").collect(),
+});
+
+export const add = mutation({
+    args: { text: v.string() },
+    handler: async (ctx, { text }): Promise<Id<"todos">> => ctx.db.insert("todos", { text, done: false, createdAt: Date.now() }),
+});
+```
+
+Run `cirrus codegen`, then use it in a component. The `api` object and `Doc` /
+`Id` types come from `cirrus/_generated/`:
+
+```tsx
+import { useMutation, useQuery } from "@cirrus/react";
+
+import { api } from "../../cirrus/_generated/api";
+import type { Doc } from "../../cirrus/_generated/dataModel";
+
+function Todos() {
+    const todos = useQuery(api.todos.list, {}) as Doc<"todos">[] | undefined;
+    const { mutate: add, pending } = useMutation(api.todos.add);
+
+    return (
+        <div>
+            <button disabled={pending} onClick={() => add({ text: "New todo" })}>
+                Add
+            </button>
+            {todos?.map((t) => (
+                <div key={t._id}>{t.text}</div>
+            ))}
+        </div>
+    );
+}
+```
+
+`useQuery` opens a live subscription: the list re-renders the instant any
+mutation changes the queried rows.
+
+## Development vs Production
+
+Use `cirrus dev` during development. When ready to ship:
+
+```bash
+cirrus deploy
+```
+
+`cirrus deploy` runs codegen, the schema-drift gate, and `wrangler deploy`. Do
+not use it during day-to-day development.
+
+Before deploying, run the preflight:
+
+```bash
+cirrus doctor
+```
+
+It checks `wrangler.jsonc` (the `SHARD` durable-object binding), D1 placeholder
+ids, `.dev.vars` secrets, and container exports.
+
+## Next Steps
+
+- Add authentication: use the `cirrus-setup-auth` skill.
+- Add a prebuilt capability (mail, presence, storage, rate limit, crons):
+  `cirrus registry add <item>`.
+- Build your own reusable capability: use the `cirrus-create-package` skill.
+- Plan a schema change: use the `cirrus-migration-helper` skill.
+- Scaffold more functions: `vis generate cirrus-query --name=listMessages`,
+  `cirrus-mutation`, `cirrus-action`, `cirrus-table`, `cirrus-cron` (always use
+  the `--name=value` form).
+
+## Checklist
+
+- [ ] Determined starting point: new project or existing app.
+- [ ] New project: scaffolded with `cirrus init --template <t>`.
+- [ ] Existing app: ran `cirrus init --here` and wired `CirrusProvider`.
+- [ ] Ran `cirrus codegen`: `cirrus/_generated/` exists and typecheck is clean.
+- [ ] `cirrus dev` is running — user terminal, or background for cloud agents.
+- [ ] Verified a query/mutation round-trip re-renders the client live.

--- a/packages/cli/skills/cirrus-realtime/SKILL.md
+++ b/packages/cli/skills/cirrus-realtime/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: cirrus-realtime
+description: Wires Cirrus's live data into a client. Use for `CirrusClient`/`CirrusProvider`,
+    reactive `useQuery`/`useSubscription`, `useMutation` with optimistic updates,
+    pagination, connection status, the React/Vue/Solid/Svelte adapters, and the
+    `@cirrus/db` TanStack binding.
+---
+
+# Cirrus Realtime
+
+Consume Cirrus functions reactively from the client. Queries are live
+subscriptions over WebSocket — a `useQuery` re-renders the instant a mutation
+changes the rows it reads — and mutations can paint optimistically with
+automatic rollback.
+
+## When to Use
+
+- Wiring a frontend to a Cirrus backend (React, Vue, Solid, Svelte).
+- Adding optimistic updates, pagination, or presence to the UI.
+- Choosing between live hooks and the `@cirrus/db` collection layer.
+
+## When Not to Use
+
+- Writing the server functions themselves — that's `cirrus-functions`.
+- Initial project/provider scaffolding — that's `cirrus-quickstart`.
+
+## Provider Setup
+
+Create the `CirrusClient` once at module scope and wrap the app. The client owns
+the WebSocket, the optimistic cache, and the offline queue.
+
+```tsx
+import { CirrusClient } from "@cirrus/client";
+import { CirrusProvider } from "@cirrus/react";
+
+const url = (import.meta.env.VITE_CIRRUS_URL as string | undefined) ?? globalThis.location.origin;
+const client = new CirrusClient({ url });
+
+// <CirrusProvider client={client}>…</CirrusProvider>
+```
+
+Vue / Solid / Svelte have matching providers in `@cirrus/vue`, `@cirrus/solid`,
+`@cirrus/svelte`; the hook names and semantics below mirror across them.
+
+## Live Queries
+
+`useQuery(reference, args)` opens a subscription and returns the value, or
+`undefined` while it loads. The reference comes from codegen
+(`api.<file>.<name>`).
+
+```tsx
+import { useQuery } from "@cirrus/react";
+
+import { api } from "../../cirrus/_generated/api";
+import type { Doc } from "../../cirrus/_generated/dataModel";
+
+const todos = useQuery(api.todos.list, {}) as Doc<"todos">[] | undefined;
+```
+
+- `undefined` means "loading" — render a skeleton/spinner for it.
+- The subscription tears down on unmount and re-runs only when `args` change or
+  the underlying rows change. Keep `args` narrow so a write elsewhere doesn't
+  re-push unrelated data (see `cirrus-performance-audit`).
+- `useSubscription` is the lower-level primitive for streaming subscriptions;
+  `usePreloadedQuery` + `cirrusQueryOptions` support SSR/preload handoff via
+  `@cirrus/react/server`.
+
+## Mutations + Optimistic Updates
+
+`useMutation(reference)` returns `{ mutate, pending }`. Pass an `optimistic`
+callback to paint the next state immediately; if the server rejects the call the
+runtime rolls the cache back automatically.
+
+```tsx
+import { useMutation } from "@cirrus/react";
+
+import type { Doc, Id } from "../../cirrus/_generated/dataModel";
+
+const { mutate: add, pending } = useMutation(api.todos.add);
+
+await add(
+    { text },
+    {
+        optimistic: (current) => {
+            const list = (current as Doc<"todos">[] | undefined) ?? [];
+            const provisional: Doc<"todos"> = {
+                _id: `optimistic_${Date.now()}` as Id<"todos">,
+                _creationTime: Date.now(),
+                text,
+                done: false,
+                createdAt: Date.now(),
+            };
+            return [provisional, ...list];
+        },
+    },
+);
+```
+
+- The `optimistic` callback receives the current cached value and returns the
+  provisional one. When the server delta arrives it replaces the optimistic
+  entry; on failure the cache reverts.
+- `pending` is `true` while the call is in flight — disable the submit button
+  with it.
+- **Offline queue:** mutations made while disconnected are queued by
+  `CirrusClient` and replayed on reconnect (client-id-keyed, so they aren't
+  double-applied).
+
+## Pagination, Connection, Presence
+
+- `usePaginatedQuery` / `useInfiniteQuery` — cursor pagination over a query that
+  ends in `.paginate(...)` on the server.
+- `useConnectionStatus` — live socket state for an offline/reconnecting banner.
+- `usePresence` — who's-here + heartbeat (pairs with the `presence` registry
+  item).
+- `useAuth` + the `Authenticated` / `Unauthenticated` / `AuthLoading` gates —
+  see `cirrus-setup-auth`.
+
+## `@cirrus/db` — TanStack DB Collections
+
+For richer client state (indexed local collections, cross-query joins, a durable
+offline-transactions outbox), use `@cirrus/db` instead of raw hooks. Scaffold
+with `vis generate cirrus-collections` (wires `defineCollections` from your
+schema + functions into live TanStack DB collections). Reach for it when the app
+needs client-side indexes/joins or a persistent optimistic outbox; raw `useQuery`
+/`useMutation` are enough for straightforward live lists.
+
+## Common Pitfalls
+
+1. **Creating `CirrusClient` inside a component.** It re-opens the socket every
+   render — create it once at module scope.
+2. **Treating `undefined` as empty.** `undefined` is "loading", `[]` is "loaded,
+   empty" — branch on both.
+3. **Broad query args.** A subscription keyed too broadly re-renders on
+   unrelated writes; scope `args` to what the component shows.
+4. **Optimistic shape drift.** The provisional value must match the query's
+   element shape (including `_id`/`_creationTime`) or the UI flickers when the
+   real delta lands.
+
+## Checklist
+
+- [ ] `CirrusClient` created once at module scope; app wrapped in the provider.
+- [ ] Live reads use `useQuery`; `undefined` handled as loading.
+- [ ] Writes use `useMutation`; `pending` disables submit; `optimistic` matches
+      the row shape.
+- [ ] Query `args` scoped narrowly to avoid over-broad re-renders.
+- [ ] Pagination via `usePaginatedQuery`/`useInfiniteQuery` over `.paginate`.
+- [ ] Considered `@cirrus/db` if the app needs local indexes/joins or an outbox.

--- a/packages/cli/skills/cirrus-setup-auth/SKILL.md
+++ b/packages/cli/skills/cirrus-setup-auth/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: cirrus-setup-auth
+description: Adds authentication to a Cirrus app. Use for sign-up/sign-in, email/password,
+    OAuth (Clerk, Auth0), magic link, or email OTP via `cirrus registry add auth`,
+    wiring the auth handler into the Worker, and gating functions on the session.
+---
+
+# Cirrus Setup Auth
+
+Wire authentication into a Cirrus app using the `auth` registry item, which is
+built on `@cirrus/auth` (a thin wrapper over
+[better-auth](https://www.better-auth.com)) with sessions persisted in
+`SessionDO` and identity tables in D1.
+
+## When to Use
+
+- Adding sign-up / sign-in to a Cirrus app.
+- Adding an OAuth/OIDC provider (Clerk, Auth0), magic link, or email OTP.
+- Gating queries/mutations on the signed-in user.
+
+## When Not to Use
+
+- The project has no Cirrus backend yet — use `cirrus-quickstart` first.
+- You only need to read `ctx.auth.userId` in a function and auth is already
+  installed — just use it.
+
+## Workflow
+
+1. Add the base `auth` item.
+2. Mount the auth request handler in the Worker entry.
+3. Configure env vars and the D1 database.
+4. (Optional) Layer a provider item (Clerk / Auth0 / magic link / OTP) on top.
+5. Gate functions on `ctx.auth.userId`; gate UI with the auth gates/hooks.
+
+## Step 1: Add the base item
+
+```bash
+cirrus registry add auth
+```
+
+This:
+
+1. Adds `@cirrus/auth`, `@cirrus/mail`, and `@cirrus/server` to `package.json`
+   (run `pnpm install` afterwards).
+2. Copies `cirrus/auth/index.ts` — the auth instance (`buildAuth` / `getAuth`)
+   and the `/api/auth/*` request handler (`mountAuth`) — into your project. It is
+   **yours** to edit.
+3. Adds a D1 `DB` binding to `wrangler.jsonc` (better-auth persists
+   users/sessions there).
+4. Scaffolds `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, and `MAIL_FROM` into
+   `.dev.vars`.
+
+## Step 2: Mount the handler
+
+In your Worker entry, route `/api/auth/*` to the scaffolded handler (see the
+generated `cirrus/auth/index.ts` README block). `createWorker` handles the rest
+of the RPC surface; the auth handler owns the better-auth endpoints.
+
+## Step 3: Env vars and the D1 database
+
+| Var                  | Secret | Notes                                                               |
+| -------------------- | ------ | ------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET` | yes    | Encryption secret, min 32 chars. `openssl rand -base64 32`.         |
+| `BETTER_AUTH_URL`    | no     | Public base URL, e.g. `http://localhost:8787` in dev, your domain.  |
+| `MAIL_FROM`          | no     | Sender for verification / reset mail. Captured in the dev Mail tab. |
+
+Create the D1 database and paste its id into the `DB` binding in
+`wrangler.jsonc`:
+
+```bash
+wrangler d1 create my-app-db
+```
+
+The better-auth schema (user/session/account/verification tables) is **not**
+declared in `cirrus/schema.ts` — it is managed by better-auth in D1. In dev,
+`ensureMigrated(auth)` auto-applies it; in production prefer
+`compileMigrationsSql(auth.options)` piped to `wrangler d1 execute`. Run
+`cirrus doctor` to confirm the `DB` binding has a real `database_id` (not a
+placeholder).
+
+Verification and password-reset emails are **captured into the Cirrus Studio
+Mail tab** in dev with zero email setup. For real delivery, `cirrus registry add
+mail` (adds the `SEND_EMAIL` binding) or set `RESEND_API_KEY`.
+
+## Step 4: Add a provider (optional)
+
+Each provider item builds on the base `auth` item (`requires: ["auth"]`):
+
+```bash
+cirrus registry add auth-clerk        # Clerk via better-auth genericOAuth
+cirrus registry add auth-auth0        # Auth0 via better-auth genericOAuth
+cirrus registry add auth-magic-link   # passwordless magic-link (mail)
+cirrus registry add auth-otp          # passwordless email one-time-password
+```
+
+Add the base `auth` item first (or let the registry resolve the `requires`
+dependency). OAuth items need the provider's client id/secret added to
+`.dev.vars`.
+
+## Step 5: Use the session
+
+### In functions
+
+The runtime resolves the session and exposes the user on every context:
+
+```ts
+import { CirrusError, mutation, v } from "@cirrus/server";
+
+export const createDocument = mutation({
+    args: { title: v.string() },
+    handler: async (ctx, { title }) => {
+        if (!ctx.auth.userId) {
+            throw new CirrusError("UNAUTHORIZED", "not signed in");
+        }
+        return ctx.db.insert("documents", { ownerId: ctx.auth.userId, title, createdAt: Date.now() });
+    },
+});
+```
+
+For richer checks (org membership, roles), compose `withAuthPlugins(auth)` and
+call the better-auth server API — see the scaffolded `cirrus/auth/index.ts`.
+
+### In the UI (React)
+
+```tsx
+import { Authenticated, Unauthenticated, useAuth } from "@cirrus/react";
+
+function Account() {
+    const { user, signIn, signOut } = useAuth();
+
+    return (
+        <>
+            <Authenticated>
+                <span>Signed in as {user?.email}</span>
+                <button type="button" onClick={() => signOut()}>
+                    Sign out
+                </button>
+            </Authenticated>
+            <Unauthenticated>
+                <button type="button" onClick={() => signIn()}>
+                    Sign in
+                </button>
+            </Unauthenticated>
+        </>
+    );
+}
+```
+
+`@cirrus/react` also exports `AuthLoading` and `useAuthState` for the loading
+window before the session resolves.
+
+## Common Pitfalls
+
+1. **Declaring better-auth tables in `cirrus/schema.ts`.** They live in D1 and
+   are managed by better-auth — do not add them to `defineSchema`.
+2. **Placeholder `database_id`.** The `DB` binding ships with a placeholder;
+   `wrangler d1 create` + paste the id, then `cirrus doctor` to confirm.
+3. **Missing/short `BETTER_AUTH_SECRET`.** better-auth needs ≥32 chars;
+   `@cirrus/auth` surfaces a clear error when it is absent.
+4. **Expecting prod email to "just work".** Dev captures mail into the Studio;
+   production needs `mail` (the `SEND_EMAIL` binding) or `RESEND_API_KEY` and a
+   verified sender domain.
+
+## Checklist
+
+- [ ] `cirrus registry add auth` run, `pnpm install` done.
+- [ ] Auth handler mounted in the Worker entry.
+- [ ] `BETTER_AUTH_SECRET` / `BETTER_AUTH_URL` / `MAIL_FROM` set in `.dev.vars`.
+- [ ] D1 database created and its id pasted into the `DB` binding (`cirrus
+doctor` clean).
+- [ ] Provider item added if needed (Clerk / Auth0 / magic link / OTP).
+- [ ] Functions gate on `ctx.auth.userId`; UI uses the auth gates/`useAuth`.
+- [ ] Verified sign-in → session → an authenticated query round-trip.

--- a/packages/cli/skills/cirrus/SKILL.md
+++ b/packages/cli/skills/cirrus/SKILL.md
@@ -42,11 +42,16 @@ these defaults.
 After codegen is green, use the most specific Cirrus skill for the task:
 
 - New project, or adding Cirrus to an existing app: `cirrus-quickstart`
+- Writing or reviewing schema + functions (the core authoring rules):
+  `cirrus-functions`
+- Wiring live data into a client (hooks, optimistic updates): `cirrus-realtime`
 - Authentication setup (email/password, OAuth, magic link, OTP):
   `cirrus-setup-auth`
 - Building a reusable capability — a registry item or an `@cirrus/*` package:
   `cirrus-create-package`
 - Planning or running a schema/data migration: `cirrus-migration-helper`
+- Deploying to Cloudflare (wrangler, bindings, secrets, the drift gate):
+  `cirrus-deploy`
 - Investigating performance, scan, or write-conflict issues:
   `cirrus-performance-audit`
 

--- a/packages/cli/skills/cirrus/SKILL.md
+++ b/packages/cli/skills/cirrus/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cirrus
+description: Routes general Cirrus requests to the right project skill. Use when the user
+    asks which Cirrus skill to use, or gives an underspecified task for a Cirrus
+    app (a type-safe, real-time backend on Cloudflare Workers + Durable Objects
+    with a Vite-first DX).
+---
+
+# Cirrus
+
+Use this as the routing skill for Cirrus work in this repo.
+
+Cirrus exposes a Convex-style functional API (`defineSchema`, `query`,
+`mutation`, `action`) on top of Cloudflare Workers and Durable Objects. State
+lives in a per-app `ShardDO` (SQLite, OCC, hibernated WebSocket subscriptions)
+by default; `.shardBy(key)` partitions it across many DOs and `.global()`
+replicates a table to D1 for low-latency cross-region reads. A Vite plugin
+drives codegen and end-to-end type sync.
+
+If a more specific Cirrus skill clearly matches the request, use that instead.
+
+## Start Here
+
+Before writing or changing any `cirrus/` code, make sure the generated types are
+current — they are the contract the client and server share.
+
+```bash
+cirrus codegen
+```
+
+This regenerates `cirrus/_generated/` (`api.ts`, `server.ts`, `dataModel.ts`,
+`shard.ts`, `openapi.ts`, …) from `cirrus/schema.ts` and your function files. The
+output typechecks your schema and functions, so it doubles as the agent's main
+feedback loop after each edit. Commit `cirrus/_generated/` — it is part of the
+source tree, not a build artifact to gitignore.
+
+If a project-level `AGENTS.md` / `CLAUDE.md` exists, read it first — it overrides
+these defaults.
+
+## Route to the Right Skill
+
+After codegen is green, use the most specific Cirrus skill for the task:
+
+- New project, or adding Cirrus to an existing app: `cirrus-quickstart`
+- Authentication setup (email/password, OAuth, magic link, OTP):
+  `cirrus-setup-auth`
+- Building a reusable capability — a registry item or an `@cirrus/*` package:
+  `cirrus-create-package`
+- Planning or running a schema/data migration: `cirrus-migration-helper`
+- Investigating performance, scan, or write-conflict issues:
+  `cirrus-performance-audit`
+
+If one of those clearly matches the user's goal, switch to it instead of staying
+in this skill.
+
+## Core Mental Model
+
+- **Functions** live in `cirrus/*.ts` and are one of `query` (reactive read),
+  `mutation` (transactional write), or `action` (side effects / `fetch` / no
+  direct db). `internalQuery` / `internalMutation` / `internalAction` are the
+  non-public variants.
+- **Schema** lives in `cirrus/schema.ts` via `defineSchema` + `defineTable`,
+  with validators from `v.*` (re-exported by `@cirrus/server`).
+- **Reads go through indexes.** Prefer `ctx.db.query("t").withIndex(...)` over
+  `.filter(...)`; declare the index with `.index("by_x", ["x"])`.
+- **Clients** subscribe over WebSocket. `useQuery`/`useMutation` (React, Vue,
+  Solid, Svelte) re-render the moment a mutation changes the queried rows.
+
+## When Not to Use
+
+- The user has already named a more specific Cirrus workflow.
+- Another Cirrus skill obviously fits the request better.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ import { migrateCommand } from "./commands/migrate";
 import { prepareCommand } from "./commands/prepare";
 import { registryCommand } from "./commands/registry/command";
 import { resetCommand } from "./commands/reset";
+import { rulesCommand } from "./commands/rules";
 import { runCommand } from "./commands/run";
 import { verifyCommand } from "./commands/verify";
 import { viewCommand } from "./commands/view";
@@ -50,6 +51,7 @@ const COMMANDS = [
     "view",
     "docs",
     "registry",
+    "rules",
 ] as const;
 
 type CommandName = (typeof COMMANDS)[number];
@@ -80,6 +82,7 @@ const CLI_COMMANDS = [
     viewCommand,
     documentationCommand,
     registryCommand,
+    rulesCommand,
 ];
 
 interface RunCliOptions {

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -2,6 +2,8 @@ import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
 
 import {
+    AGENT_RULES_HINT,
+    claimAgentRulesHint,
     createConfirm,
     detectAgentRules,
     ensureDevVariables,
@@ -285,11 +287,11 @@ const printBanner = (logger: Logger, plan: DevCommandPlan, studioUrl: string | u
  * them so the AI knows how to use Cirrus. Non-blocking — just one info line.
  */
 const printAgentRulesHint = (logger: Logger, cwd: string): void => {
-    if (detectAgentRules(cwd).installed) {
+    if (detectAgentRules(cwd).installed || !claimAgentRulesHint()) {
         return;
     }
 
-    logger.info("  ⓘ  AI rules not installed — run `cirrus rules install` so your coding agent knows Cirrus.");
+    logger.info(`  ⓘ  ${AGENT_RULES_HINT}`);
     logger.info("");
 };
 

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -3,6 +3,7 @@ import { spawn as nodeSpawn } from "node:child_process";
 
 import {
     createConfirm,
+    detectAgentRules,
     ensureDevVariables,
     formatCirrusEvent,
     materializeRemoteWranglerConfig,
@@ -278,6 +279,20 @@ const printBanner = (logger: Logger, plan: DevCommandPlan, studioUrl: string | u
     logger.info("");
 };
 
+/**
+ * When the Cirrus agent skills ("rules") aren't installed in the project, nudge
+ * the developer (and any cloud/headless coding agent reading stdout) to install
+ * them so the AI knows how to use Cirrus. Non-blocking — just one info line.
+ */
+const printAgentRulesHint = (logger: Logger, cwd: string): void => {
+    if (detectAgentRules(cwd).installed) {
+        return;
+    }
+
+    logger.info("  ⓘ  AI rules not installed — run `cirrus rules install` so your coding agent knows Cirrus.");
+    logger.info("");
+};
+
 interface Teardown {
     codegen?: CodegenWatcherHandle;
     /** Disposer for the materialized remote wrangler temp config (idempotent, never throws). */
@@ -359,6 +374,7 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         const worker = (options.startWorker ?? defaultWorkerSpawner)(plan.wrangler, logger);
 
         printBanner(logger, plan, studioUrl);
+        printAgentRulesHint(logger, cwd);
 
         let sigintCount = 0;
         let escalationTimer: NodeJS.Timeout | undefined;

--- a/packages/cli/src/commands/rules/handler.ts
+++ b/packages/cli/src/commands/rules/handler.ts
@@ -1,0 +1,180 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules } from "@cirrus/config";
+import { dirname, join, relative } from "@visulima/path";
+
+import type { CommandHandler } from "../../util/command";
+import { defineHandler } from "../../util/command";
+import type { Logger } from "../../util/logger";
+import type { RulesOptions } from "./index";
+
+interface RunRulesOptions {
+    cwd?: string;
+    logger: Logger;
+    /** Overwrite skill files that already exist in the project (default: skip them). */
+    overwrite?: boolean;
+}
+
+interface RunRulesResult {
+    code: number;
+    /** Skill names written this run (install). */
+    installed: ReadonlyArray<string>;
+    /** Skill names left untouched because they already existed (install, no `--overwrite`). */
+    skipped: ReadonlyArray<string>;
+}
+
+/**
+ * Resolve the `skills/` directory bundled with `@cirrus/cli`. Walks up from this
+ * module (works from both `dist/*.mjs` and `src/`) to the package root, then
+ * appends `skills`. Returns `undefined` when it can't be located.
+ */
+const resolveBundledSkillsDirectory = (): string | undefined => {
+    let directory = dirname(fileURLToPath(import.meta.url));
+
+    for (let index = 0; index < 6; index += 1) {
+        const packageJson = join(directory, "package.json");
+
+        if (existsSync(packageJson)) {
+            try {
+                const parsed = JSON.parse(readFileSync(packageJson, "utf8")) as { name?: string };
+
+                if (parsed.name === "@cirrus/cli") {
+                    const skills = join(directory, "skills");
+
+                    return existsSync(skills) ? skills : undefined;
+                }
+            } catch {
+                // keep walking
+            }
+        }
+
+        const parent = dirname(directory);
+
+        if (parent === directory) {
+            break;
+        }
+
+        directory = parent;
+    }
+
+    return undefined;
+};
+
+/** List the skill directories (those containing a `SKILL.md`) under the bundled `skills/` dir. */
+const listBundledSkills = (skillsDirectory: string): string[] =>
+    readdirSync(skillsDirectory).filter((name) => {
+        const directory = join(skillsDirectory, name);
+
+        return statSync(directory).isDirectory() && existsSync(join(directory, "SKILL.md"));
+    });
+
+/** Recursively copy a skill directory's files into the destination, returning whether any file was written. */
+const copySkill = (source: string, destination: string, overwrite: boolean): boolean => {
+    mkdirSync(destination, { recursive: true });
+
+    let wrote = false;
+
+    for (const entry of readdirSync(source)) {
+        const from = join(source, entry);
+        const to = join(destination, entry);
+
+        if (statSync(from).isDirectory()) {
+            wrote = copySkill(from, to, overwrite) || wrote;
+
+            continue;
+        }
+
+        if (existsSync(to) && !overwrite) {
+            continue;
+        }
+
+        writeFileSync(to, readFileSync(from));
+        wrote = true;
+    }
+
+    return wrote;
+};
+
+/**
+ * `cirrus rules install` — copy the bundled Cirrus agent skills into the
+ * project's `.agents/skills/`. Existing skill files are left untouched unless
+ * `--overwrite` is set, so local edits survive a re-run.
+ */
+const runRulesInstall = (options: RunRulesOptions): RunRulesResult => {
+    const cwd = options.cwd ?? process.cwd();
+    const overwrite = options.overwrite === true;
+    const skillsDirectory = resolveBundledSkillsDirectory();
+
+    if (skillsDirectory === undefined) {
+        options.logger.error("rules: could not locate the bundled skills (is @cirrus/cli installed correctly?).");
+
+        return { code: 1, installed: [], skipped: [] };
+    }
+
+    const installed: string[] = [];
+    const skipped: string[] = [];
+
+    for (const name of listBundledSkills(skillsDirectory)) {
+        const destination = join(cwd, AGENT_RULES_DIR, name);
+        const wrote = copySkill(join(skillsDirectory, name), destination, overwrite);
+
+        if (wrote) {
+            installed.push(name);
+        } else {
+            skipped.push(name);
+        }
+    }
+
+    const target = relative(cwd, join(cwd, AGENT_RULES_DIR)) || AGENT_RULES_DIR;
+
+    if (installed.length > 0) {
+        options.logger.success(`Installed ${String(installed.length)} Cirrus skill(s) into ${target}/: ${installed.join(", ")}.`);
+    }
+
+    if (skipped.length > 0) {
+        options.logger.info(`Skipped ${String(skipped.length)} existing skill(s) (re-run with --overwrite to replace): ${skipped.join(", ")}.`);
+    }
+
+    options.logger.info("Your AI coding agent will pick these up automatically. Start with the `cirrus` skill.");
+
+    return { code: 0, installed, skipped };
+};
+
+/** `cirrus rules check` — report which Cirrus skills are installed in the project. */
+const runRulesCheck = (options: RunRulesOptions): RunRulesResult => {
+    const cwd = options.cwd ?? process.cwd();
+    const status = detectAgentRules(cwd);
+
+    if (status.installed) {
+        options.logger.success(`Cirrus agent rules are installed (${String(status.present.length)}/${String(CIRRUS_SKILL_NAMES.length)} skills).`);
+
+        if (status.missing.length > 0) {
+            options.logger.info(`Missing: ${status.missing.join(", ")}. Run \`cirrus rules install\` to add them.`);
+        }
+    } else {
+        options.logger.warn("Cirrus agent rules are not installed. Run `cirrus rules install` so your AI agent knows how to use Cirrus.");
+    }
+
+    return { code: 0, installed: status.present, skipped: [] };
+};
+
+/** `cirrus rules &lt;install|check>` handler (lazy-loaded via the command's `loader`). */
+const execute: CommandHandler<RulesOptions> = defineHandler<RulesOptions>(({ argument, cwd, logger, options }) => {
+    const subcommand = argument[0] ?? "check";
+
+    if (subcommand === "install") {
+        return runRulesInstall({ cwd, logger, overwrite: options.overwrite === true });
+    }
+
+    if (subcommand === "check") {
+        return runRulesCheck({ cwd, logger });
+    }
+
+    logger.error("rules: unknown subcommand. Usage: cirrus rules <install|check>");
+
+    return { code: 1 };
+});
+
+export { execute, runRulesCheck, runRulesInstall };
+export type { RunRulesOptions, RunRulesResult };

--- a/packages/cli/src/commands/rules/handler.ts
+++ b/packages/cli/src/commands/rules/handler.ts
@@ -14,6 +14,8 @@ interface RunRulesOptions {
     logger: Logger;
     /** Overwrite skill files that already exist in the project (default: skip them). */
     overwrite?: boolean;
+    /** `check` only: exit non-zero when the rules are missing, so CI can gate on it. */
+    strict?: boolean;
 }
 
 interface RunRulesResult {
@@ -25,12 +27,14 @@ interface RunRulesResult {
 }
 
 /**
- * Resolve the `skills/` directory bundled with `@cirrus/cli`. Walks up from this
- * module (works from both `dist/*.mjs` and `src/`) to the package root, then
- * appends `skills`. Returns `undefined` when it can't be located.
+ * Resolve the `skills/` directory bundled with `@cirrus/cli`. Walks up from
+ * `startDirectory` (this module by default — works from both `dist/*.mjs` and
+ * `src/`, and from the published `node_modules/@cirrus/cli/dist/...` layout) to
+ * the package root, then appends `skills`. Returns `undefined` when it can't be
+ * located. `startDirectory` is injectable so the walk is unit-testable.
  */
-const resolveBundledSkillsDirectory = (): string | undefined => {
-    let directory = dirname(fileURLToPath(import.meta.url));
+const resolveBundledSkillsDirectory = (startDirectory: string = dirname(fileURLToPath(import.meta.url))): string | undefined => {
+    let directory = startDirectory;
 
     for (let index = 0; index < 6; index += 1) {
         const packageJson = join(directory, "package.json");
@@ -152,11 +156,14 @@ const runRulesCheck = (options: RunRulesOptions): RunRulesResult => {
         if (status.missing.length > 0) {
             options.logger.info(`Missing: ${status.missing.join(", ")}. Run \`cirrus rules install\` to add them.`);
         }
-    } else {
-        options.logger.warn("Cirrus agent rules are not installed. Run `cirrus rules install` so your AI agent knows how to use Cirrus.");
+
+        return { code: 0, installed: status.present, skipped: [] };
     }
 
-    return { code: 0, installed: status.present, skipped: [] };
+    options.logger.warn("Cirrus agent rules are not installed. Run `cirrus rules install` so your AI agent knows how to use Cirrus.");
+
+    // `--strict` turns a missing rule set into a non-zero exit so CI can gate on it.
+    return { code: options.strict === true ? 1 : 0, installed: status.present, skipped: [] };
 };
 
 /** `cirrus rules &lt;install|check>` handler (lazy-loaded via the command's `loader`). */
@@ -168,7 +175,7 @@ const execute: CommandHandler<RulesOptions> = defineHandler<RulesOptions>(({ arg
     }
 
     if (subcommand === "check") {
-        return runRulesCheck({ cwd, logger });
+        return runRulesCheck({ cwd, logger, strict: options.strict === true });
     }
 
     logger.error("rules: unknown subcommand. Usage: cirrus rules <install|check>");
@@ -176,5 +183,5 @@ const execute: CommandHandler<RulesOptions> = defineHandler<RulesOptions>(({ arg
     return { code: 1 };
 });
 
-export { execute, runRulesCheck, runRulesInstall };
+export { execute, resolveBundledSkillsDirectory, runRulesCheck, runRulesInstall };
 export type { RunRulesOptions, RunRulesResult };

--- a/packages/cli/src/commands/rules/index.ts
+++ b/packages/cli/src/commands/rules/index.ts
@@ -14,6 +14,7 @@ const rulesCommand: Command = {
         ["cirrus rules install", "Copy the Cirrus agent skills into .agents/skills/"],
         ["cirrus rules install --overwrite", "Reinstall, replacing edited skill files"],
         ["cirrus rules check", "Report which Cirrus skills are installed"],
+        ["cirrus rules check --strict", "Exit non-zero when rules are missing (CI gate)"],
     ],
     group: "Project",
     loader: () =>
@@ -21,9 +22,12 @@ const rulesCommand: Command = {
             return { default: m.execute as CommandExecute<Toolbox> };
         }),
     name: "rules",
-    options: [{ description: "Overwrite skill files that already exist (default: skip them)", name: "overwrite", type: Boolean }],
+    options: [
+        { description: "install: overwrite skill files that already exist (default: skip them)", name: "overwrite", type: Boolean },
+        { description: "check: exit non-zero when the rules are missing (for CI gating)", name: "strict", type: Boolean },
+    ],
 };
 
 export { rulesCommand };
 
-export type RulesOptions = CreateOptions<{ overwrite: boolean | undefined }>;
+export type RulesOptions = CreateOptions<{ overwrite: boolean | undefined; strict: boolean | undefined }>;

--- a/packages/cli/src/commands/rules/index.ts
+++ b/packages/cli/src/commands/rules/index.ts
@@ -1,0 +1,29 @@
+import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
+
+/**
+ * `cirrus rules` — manage the Cirrus agent skills ("rules") in the current
+ * project. `install` copies the skills bundled with `@cirrus/cli` into
+ * `.agents/skills/` (the Convex `ai-files install` analog); `check` reports
+ * which are present. The dev server and Vite plugin nudge you to run `install`
+ * when the rules are missing.
+ */
+const rulesCommand: Command = {
+    argument: { description: "install | check", name: "subcommand", type: String },
+    description: "Install the Cirrus agent skills (AI rules) into .agents/skills/, or check they're present",
+    examples: [
+        ["cirrus rules install", "Copy the Cirrus agent skills into .agents/skills/"],
+        ["cirrus rules install --overwrite", "Reinstall, replacing edited skill files"],
+        ["cirrus rules check", "Report which Cirrus skills are installed"],
+    ],
+    group: "Project",
+    loader: () =>
+        import("./handler").then((m) => {
+            return { default: m.execute as CommandExecute<Toolbox> };
+        }),
+    name: "rules",
+    options: [{ description: "Overwrite skill files that already exist (default: skip them)", name: "overwrite", type: Boolean }],
+};
+
+export { rulesCommand };
+
+export type RulesOptions = CreateOptions<{ overwrite: boolean | undefined }>;

--- a/packages/cli/src/util/studio-server.ts
+++ b/packages/cli/src/util/studio-server.ts
@@ -17,6 +17,7 @@ import { createServer, request as httpRequest } from "node:http";
 import { connect } from "node:net";
 import type { Duplex } from "node:stream";
 
+import { detectAgentRules } from "@cirrus/config";
 import { loadStudioAssets, renderStudioHtml, resolveAdminToken, studioAssetsStamp } from "@cirrus/config/studio-host";
 
 /** Request paths the studio server reverse-proxies to the worker (admin RPC, RPC, WS). */
@@ -122,6 +123,7 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
         adminToken: resolveAdminToken(options.cwd),
         basePath: "/",
         dataEditable: isLoopback,
+        rulesInstalled: detectAgentRules(options.cwd).installed,
         runAsIdentity: isLoopback,
         scriptSrc: "/studio.js",
         styleHref: "/styles.css",

--- a/packages/config/__tests__/agent-rules.test.ts
+++ b/packages/config/__tests__/agent-rules.test.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules } from "../src/agent-rules";
+
+let workdir: string;
+
+/** Write `&lt;workdir>/.agents/skills/&lt;name>/SKILL.md`. */
+const installSkill = (name: string): void => {
+    const directory = join(workdir, AGENT_RULES_DIR, name);
+
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, "SKILL.md"), `# ${name}\n`, "utf8");
+};
+
+describe("detectAgentRules", () => {
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "cirrus-agent-rules-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("reports not installed for an empty project", () => {
+        expect.assertions(3);
+
+        const status = detectAgentRules(workdir);
+
+        expect(status.installed).toBe(false);
+        expect(status.present).toHaveLength(0);
+        expect(status.missing).toStrictEqual([...CIRRUS_SKILL_NAMES]);
+    });
+
+    it("counts the router skill as installed even when others are missing", () => {
+        expect.assertions(3);
+
+        installSkill("cirrus");
+
+        const status = detectAgentRules(workdir);
+
+        expect(status.installed).toBe(true);
+        expect(status.present).toStrictEqual(["cirrus"]);
+        expect(status.missing).not.toContain("cirrus");
+    });
+
+    it("lists every installed skill as present", () => {
+        expect.assertions(2);
+
+        for (const name of CIRRUS_SKILL_NAMES) {
+            installSkill(name);
+        }
+
+        const status = detectAgentRules(workdir);
+
+        expect(status.installed).toBe(true);
+        expect(status.present).toStrictEqual([...CIRRUS_SKILL_NAMES]);
+    });
+});

--- a/packages/config/__tests__/agent-rules.test.ts
+++ b/packages/config/__tests__/agent-rules.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules } from "../src/agent-rules";
+import { AGENT_RULES_DIR, AGENT_RULES_HINT_ENV, CIRRUS_SKILL_NAMES, claimAgentRulesHint, detectAgentRules } from "../src/agent-rules";
 
 let workdir: string;
 
@@ -58,5 +58,27 @@ describe("detectAgentRules", () => {
 
         expect(status.installed).toBe(true);
         expect(status.present).toStrictEqual([...CIRRUS_SKILL_NAMES]);
+    });
+});
+
+describe("claimAgentRulesHint", () => {
+    const previous = process.env[AGENT_RULES_HINT_ENV];
+
+    afterEach(() => {
+        if (previous === undefined) {
+            Reflect.deleteProperty(process.env, AGENT_RULES_HINT_ENV);
+        } else {
+            process.env[AGENT_RULES_HINT_ENV] = previous;
+        }
+    });
+
+    it("returns true once, then false for the rest of the process", () => {
+        expect.assertions(3);
+
+        Reflect.deleteProperty(process.env, AGENT_RULES_HINT_ENV);
+
+        expect(claimAgentRulesHint()).toBe(true);
+        expect(claimAgentRulesHint()).toBe(false);
+        expect(process.env[AGENT_RULES_HINT_ENV]).toBe("1");
     });
 });

--- a/packages/config/__tests__/studio-host/render-html.test.ts
+++ b/packages/config/__tests__/studio-host/render-html.test.ts
@@ -37,6 +37,20 @@ describe("renderStudioHtml", () => {
         expect(off).not.toContain("__CIRRUS_RUN_AS_IDENTITY__");
     });
 
+    it("injects the rules flag only when rulesInstalled is explicitly false", () => {
+        expect.assertions(3);
+
+        const missing = renderStudioHtml({ basePath: "/", rulesInstalled: false, scriptSrc: "/studio.js", styleHref: "/styles.css" });
+        const installed = renderStudioHtml({ basePath: "/", rulesInstalled: true, scriptSrc: "/studio.js", styleHref: "/styles.css" });
+        const unset = renderStudioHtml({ basePath: "/", scriptSrc: "/studio.js", styleHref: "/styles.css" });
+
+        // eslint-disable-next-line no-secrets/no-secrets -- a static JS assignment string, not a credential
+        expect(missing).toContain("window.__CIRRUS_RULES_INSTALLED__=false;");
+        // Installed and unset both leave the global off, so the studio shows no banner.
+        expect(installed).not.toContain("__CIRRUS_RULES_INSTALLED__");
+        expect(unset).not.toContain("__CIRRUS_RULES_INSTALLED__");
+    });
+
     it("injects the admin token when provided, escaping `<` for safe inline embedding", () => {
         expect.assertions(2);
 

--- a/packages/config/src/agent-rules.ts
+++ b/packages/config/src/agent-rules.ts
@@ -1,0 +1,71 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Project-relative directory the Cirrus agent skills ("rules") install into.
+ * This is the portable [Agent Skills](https://tanstack.com/intent/latest/docs/registry)
+ * location — Cursor, Claude Code, and GitHub Copilot all discover skills here.
+ */
+const AGENT_RULES_DIR = ".agents/skills";
+
+/**
+ * The Cirrus agent skills shipped by `@cirrus/cli`. The first entry (`cirrus`)
+ * is the router skill — its presence is what {@link detectAgentRules} treats as
+ * "rules installed", since every other skill is reachable through it.
+ */
+const CIRRUS_SKILL_NAMES: ReadonlyArray<string> = [
+    "cirrus",
+    "cirrus-quickstart",
+    "cirrus-functions",
+    "cirrus-realtime",
+    "cirrus-setup-auth",
+    "cirrus-create-package",
+    "cirrus-migration-helper",
+    "cirrus-deploy",
+    "cirrus-performance-audit",
+];
+
+/** The router skill whose presence marks the rule set as installed. */
+const ROOT_SKILL_NAME = "cirrus";
+
+interface AgentRulesStatus {
+    /**
+     * True when the `cirrus` router skill is installed. We key on the router
+     * (not "all nine present") so a project that intentionally trims the set
+     * still counts as installed and isn't nagged.
+     */
+    readonly installed: boolean;
+    /** Skill names with no `SKILL.md` under `&lt;root>/.agents/skills/&lt;name>/`. */
+    readonly missing: ReadonlyArray<string>;
+
+    /** Skill names found under `&lt;root>/.agents/skills/&lt;name>/SKILL.md`. */
+    readonly present: ReadonlyArray<string>;
+}
+
+/** Absolute path to a skill's `SKILL.md` under a project root. */
+const skillFile = (projectRoot: string, name: string): string => join(projectRoot, AGENT_RULES_DIR, name, "SKILL.md");
+
+/**
+ * Detect whether the Cirrus agent skills are installed in `projectRoot` by
+ * checking the skills folder for each `SKILL.md`. Pure filesystem reads, safe to
+ * call on every dev-server / CLI startup — the CLI, the Vite plugin, and the
+ * studio host all use it to decide whether to surface the "rules not installed"
+ * hint.
+ */
+const detectAgentRules = (projectRoot: string): AgentRulesStatus => {
+    const present: string[] = [];
+    const missing: string[] = [];
+
+    for (const name of CIRRUS_SKILL_NAMES) {
+        if (existsSync(skillFile(projectRoot, name))) {
+            present.push(name);
+        } else {
+            missing.push(name);
+        }
+    }
+
+    return { installed: existsSync(skillFile(projectRoot, ROOT_SKILL_NAME)), missing, present };
+};
+
+export type { AgentRulesStatus };
+export { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules, ROOT_SKILL_NAME };

--- a/packages/config/src/agent-rules.ts
+++ b/packages/config/src/agent-rules.ts
@@ -8,6 +8,9 @@ import { join } from "node:path";
  */
 const AGENT_RULES_DIR = ".agents/skills";
 
+/** Env var the once-per-process-tree hint guard ({@link claimAgentRulesHint}) sets. */
+const AGENT_RULES_HINT_ENV = "CIRRUS_RULES_HINT_SHOWN";
+
 /**
  * The Cirrus agent skills shipped by `@cirrus/cli`. The first entry (`cirrus`)
  * is the router skill — its presence is what {@link detectAgentRules} treats as
@@ -27,6 +30,29 @@ const CIRRUS_SKILL_NAMES: ReadonlyArray<string> = [
 
 /** The router skill whose presence marks the rule set as installed. */
 const ROOT_SKILL_NAME = "cirrus";
+
+/**
+ * The single "rules not installed" message shared by every surface (the CLI
+ * `cirrus dev` summary and the Vite dev plugin), so the wording and the
+ * pointer at `cirrus rules install` stay identical wherever it appears.
+ */
+const AGENT_RULES_HINT = "Cirrus AI rules not installed — run `cirrus rules install` so your coding agent knows how to use Cirrus.";
+
+/**
+ * Process-tree guard so the hint is emitted at most once. The first surface to
+ * print it sets {@link AGENT_RULES_HINT_ENV} on `process.env`; later surfaces (a
+ * Vite dev-server restart, or a child process that inherited the env) read it
+ * and stay quiet. Returns `true` the first time, `false` afterwards.
+ */
+const claimAgentRulesHint = (): boolean => {
+    if (process.env[AGENT_RULES_HINT_ENV] === "1") {
+        return false;
+    }
+
+    process.env[AGENT_RULES_HINT_ENV] = "1";
+
+    return true;
+};
 
 interface AgentRulesStatus {
     /**
@@ -68,4 +94,4 @@ const detectAgentRules = (projectRoot: string): AgentRulesStatus => {
 };
 
 export type { AgentRulesStatus };
-export { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules, ROOT_SKILL_NAME };
+export { AGENT_RULES_DIR, AGENT_RULES_HINT, AGENT_RULES_HINT_ENV, CIRRUS_SKILL_NAMES, claimAgentRulesHint, detectAgentRules, ROOT_SKILL_NAME };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,5 @@
+export type { AgentRulesStatus } from "./agent-rules";
+export { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules, ROOT_SKILL_NAME } from "./agent-rules";
 export type { ContainerIR, DiscoverContainerInfoResult } from "./container-info";
 export { discoverContainerInfo } from "./container-info";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,13 @@
 export type { AgentRulesStatus } from "./agent-rules";
-export { AGENT_RULES_DIR, CIRRUS_SKILL_NAMES, detectAgentRules, ROOT_SKILL_NAME } from "./agent-rules";
+export {
+    AGENT_RULES_DIR,
+    AGENT_RULES_HINT,
+    AGENT_RULES_HINT_ENV,
+    CIRRUS_SKILL_NAMES,
+    claimAgentRulesHint,
+    detectAgentRules,
+    ROOT_SKILL_NAME,
+} from "./agent-rules";
 export type { ContainerIR, DiscoverContainerInfoResult } from "./container-info";
 export { discoverContainerInfo } from "./container-info";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";

--- a/packages/config/src/studio-host/render-html.ts
+++ b/packages/config/src/studio-host/render-html.ts
@@ -36,6 +36,12 @@ const renderStudioHtml = (config: StudioHtmlConfig): string => {
         settings.push("window.__CIRRUS_RUN_AS_IDENTITY__=true;");
     }
 
+    if (config.rulesInstalled === false) {
+        // Only emitted when explicitly missing, so a static deploy (flag unset) never nags.
+        // eslint-disable-next-line no-secrets/no-secrets -- a static JS assignment string, not a credential
+        settings.push("window.__CIRRUS_RULES_INSTALLED__=false;");
+    }
+
     return `<!doctype html>
 <html lang="en">
     <head>

--- a/packages/config/src/studio-host/types.ts
+++ b/packages/config/src/studio-host/types.ts
@@ -14,6 +14,14 @@ export interface StudioHtmlConfig {
     readonly dataEditable?: boolean;
 
     /**
+     * Whether the project's Cirrus agent skills ("rules") are installed. Injected
+     * as `window.__CIRRUS_RULES_INSTALLED__` **only when `false`**, so the studio
+     * shows a "rules not installed" banner on the loopback dev hosts (which detect
+     * it) and stays quiet on a static deploy (which leaves it unset).
+     */
+    readonly rulesInstalled?: boolean;
+
+    /**
      * Enable the function runner's "Run as identity" tool (execute a function as a
      * chosen user to test auth/RLS). Injected as `window.__CIRRUS_RUN_AS_IDENTITY__`.
      * Like {@link StudioHtmlConfig.dataEditable}, only the loopback-only dev hosts set

--- a/packages/studio/__tests__/app/app.test.tsx
+++ b/packages/studio/__tests__/app/app.test.tsx
@@ -8,6 +8,7 @@ const TOKEN_KEY = "cirrus-studio-admin-token";
 describe("studioApp", () => {
     afterEach(() => {
         sessionStorage.clear();
+        localStorage.clear();
     });
 
     it("renders the header and token input", () => {
@@ -50,6 +51,34 @@ describe("studioApp", () => {
         render(<StudioApp baseUrl="https://app.example" />);
 
         expect(screen.getByTestId<HTMLInputElement>("dash-app-token").value).toBe("s3cret");
+    });
+
+    it("shows the rules banner only when rulesInstalled is false", () => {
+        expect.assertions(2);
+
+        const { unmount } = render(<StudioApp baseUrl="https://app.example" />);
+
+        expect(screen.queryByTestId("dash-app-rules-banner")).toBeNull();
+
+        unmount();
+        render(<StudioApp baseUrl="https://app.example" rulesInstalled={false} />);
+
+        expect(screen.getByTestId("dash-app-rules-banner")).toBeDefined();
+    });
+
+    it("dismisses the rules banner and remembers it across remounts", () => {
+        expect.assertions(2);
+
+        const { unmount } = render(<StudioApp baseUrl="https://app.example" rulesInstalled={false} />);
+
+        fireEvent.click(screen.getByTestId("dash-app-rules-banner-dismiss"));
+
+        expect(screen.queryByTestId("dash-app-rules-banner")).toBeNull();
+
+        unmount();
+        render(<StudioApp baseUrl="https://app.example" rulesInstalled={false} />);
+
+        expect(screen.queryByTestId("dash-app-rules-banner")).toBeNull();
     });
 
     it("clear removes the persisted token", () => {

--- a/packages/studio/scripts/build-standalone.mjs
+++ b/packages/studio/scripts/build-standalone.mjs
@@ -34,6 +34,9 @@ const entry = [
     // `__CIRRUS_DATA_EDITABLE__` / `__CIRRUS_RUN_AS_IDENTITY__`, so a plain static
     // deploy stays read-only and can't forge an identity unless the embedder opts in.
     "  studio: { dataEditable: g.__CIRRUS_DATA_EDITABLE__ === true, runAsIdentity: g.__CIRRUS_RUN_AS_IDENTITY__ === true },",
+    // The loopback dev hosts inject `__CIRRUS_RULES_INSTALLED__=false` when the
+    // project's agent skills are missing; absent (static deploy) means installed.
+    "  rulesInstalled: g.__CIRRUS_RULES_INSTALLED__ !== false,",
     "});",
 ].join("\n");
 

--- a/packages/studio/src/app/app.tsx
+++ b/packages/studio/src/app/app.tsx
@@ -89,6 +89,27 @@ interface StudioAppBodyProps {
     readonly token: string;
 }
 
+/** `localStorage` key remembering that the developer dismissed the rules banner. */
+const RULES_BANNER_DISMISSED_KEY = "cirrus.studio.rulesBannerDismissed";
+
+/** Read the persisted "rules banner dismissed" flag, tolerating storage being unavailable. */
+const readBannerDismissed = (): boolean => {
+    try {
+        return globalThis.localStorage.getItem(RULES_BANNER_DISMISSED_KEY) === "1";
+    } catch {
+        return false;
+    }
+};
+
+/** Persist the "rules banner dismissed" flag, swallowing storage failures (private mode / disabled). */
+const writeBannerDismissed = (): void => {
+    try {
+        globalThis.localStorage.setItem(RULES_BANNER_DISMISSED_KEY, "1");
+    } catch {
+        // ignore — dismissal just won't survive a reload
+    }
+};
+
 /**
  * The header + composed studio. Kept separate from {@link StudioApp}
  * because its `useT` (for the top-bar strings and the error-boundary label) must
@@ -97,6 +118,16 @@ interface StudioAppBodyProps {
  */
 const StudioAppBody = ({ basePath, clearToken, studio, onToggleTheme, onTokenChange, rulesInstalled, theme, token }: StudioAppBodyProps): ReactElement => {
     const t = useT();
+
+    // The "rules not installed" banner is a one-time nudge — let the developer
+    // dismiss it, persisted so it stays gone across reloads. Reads lazily and
+    // tolerates storage being unavailable (private mode / embeddings).
+    const [rulesBannerDismissed, setRulesBannerDismissed] = useState<boolean>(() => readBannerDismissed());
+
+    const dismissRulesBanner = useCallback((): void => {
+        setRulesBannerDismissed(true);
+        writeBannerDismissed();
+    }, []);
 
     return (
         <>
@@ -238,7 +269,7 @@ const StudioAppBody = ({ basePath, clearToken, studio, onToggleTheme, onTokenCha
                 </div>
             </header>
 
-            {rulesInstalled === false && (
+            {rulesInstalled === false && !rulesBannerDismissed && (
                 <div
                     className="flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[12px] text-foreground"
                     data-testid="dash-app-rules-banner"
@@ -252,6 +283,25 @@ const StudioAppBody = ({ basePath, clearToken, studio, onToggleTheme, onTokenCha
                         <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">cirrus rules install</code>{" "}
                         {t("lets your coding agent use Cirrus correctly.")}
                     </span>
+                    <button
+                        aria-label={t("Dismiss")}
+                        className="ms-auto flex size-5 items-center justify-center rounded text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent"
+                        data-testid="dash-app-rules-banner-dismiss"
+                        onClick={dismissRulesBanner}
+                        type="button"
+                    >
+                        <svg
+                            aria-hidden="true"
+                            className="size-3.5"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeWidth={1.8}
+                            viewBox="0 0 24 24"
+                        >
+                            <path d="M18 6 6 18M6 6l12 12" />
+                        </svg>
+                    </button>
                 </div>
             )}
 

--- a/packages/studio/src/app/app.tsx
+++ b/packages/studio/src/app/app.tsx
@@ -53,6 +53,14 @@ interface StudioAppProps {
     /** UI language for the studio's own strings. Defaults to `en`. */
     readonly locale?: string;
 
+    /**
+     * Whether the project's Cirrus agent skills ("rules") are installed. When
+     * explicitly `false`, the studio shows a one-line banner pointing at
+     * `cirrus rules install`. The loopback dev hosts inject this; a static deploy
+     * leaves it unset (no banner).
+     */
+    readonly rulesInstalled?: boolean;
+
     /** Forwarded to the composed {@link Studio} (functions, initialShardKey, scheduled overrides). */
     readonly studio?: Omit<StudioProps, "children" | "i18n" | "locale">;
 }
@@ -75,6 +83,7 @@ interface StudioAppBodyProps {
     readonly clearToken: () => void;
     readonly onToggleTheme: () => void;
     readonly onTokenChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    readonly rulesInstalled?: boolean;
     readonly studio?: StudioAppProps["studio"];
     readonly theme: "dark" | "light";
     readonly token: string;
@@ -86,7 +95,7 @@ interface StudioAppBodyProps {
  * read the `StudioI18nProvider` the app renders above it. The composed
  * `&lt;Studio>` inherits that same provider, so it isn't handed an instance here.
  */
-const StudioAppBody = ({ basePath, clearToken, studio, onToggleTheme, onTokenChange, theme, token }: StudioAppBodyProps): ReactElement => {
+const StudioAppBody = ({ basePath, clearToken, studio, onToggleTheme, onTokenChange, rulesInstalled, theme, token }: StudioAppBodyProps): ReactElement => {
     const t = useT();
 
     return (
@@ -229,6 +238,23 @@ const StudioAppBody = ({ basePath, clearToken, studio, onToggleTheme, onTokenCha
                 </div>
             </header>
 
+            {rulesInstalled === false && (
+                <div
+                    className="flex shrink-0 items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[12px] text-foreground"
+                    data-testid="dash-app-rules-banner"
+                    role="note"
+                >
+                    <span aria-hidden="true" className="text-amber-500">
+                        ⚠
+                    </span>
+                    <span>
+                        {t("Cirrus AI rules aren't installed.")}{" "}
+                        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">cirrus rules install</code>{" "}
+                        {t("lets your coding agent use Cirrus correctly.")}
+                    </span>
+                </div>
+            )}
+
             <ErrorBoundary fallbackTitle={t("Studio failed")} label={t("Studio")} retryLabel={t("Try again")}>
                 <Studio
                     basePath={basePath}
@@ -270,7 +296,7 @@ const resolveBaseUrl = (explicit: string | undefined): string => {
  * yourself. For embedding into an existing admin UI, use the individual panels
  * or `&lt;Studio>` under your own provider instead.
  */
-export const StudioApp = ({ adminToken, basePath, baseUrl, client: injectedClient, studio, locale }: StudioAppProps = {}): ReactElement => {
+export const StudioApp = ({ adminToken, basePath, baseUrl, client: injectedClient, rulesInstalled, studio, locale }: StudioAppProps = {}): ReactElement => {
     // Seed from the prop, else a token persisted in a prior session (so a reload
     // doesn't force a re-paste). The prop wins when explicitly provided.
     const [token, setToken] = useState<string>(() => adminToken ?? loadToken());
@@ -353,6 +379,7 @@ export const StudioApp = ({ adminToken, basePath, baseUrl, client: injectedClien
                             clearToken={clearToken}
                             onToggleTheme={onToggleTheme}
                             onTokenChange={onTokenChange}
+                            rulesInstalled={rulesInstalled}
                             studio={studio}
                             theme={theme}
                             token={token}

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -16,6 +16,7 @@ import type { Messages } from "@lingui/core";
 const MESSAGE_IDS = [
     "Cirrus AI rules aren't installed.",
     "lets your coding agent use Cirrus correctly.",
+    "Dismiss",
     ", changed",
     "(no subject)",
     "(root)",

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -14,6 +14,8 @@ import type { Messages } from "@lingui/core";
  * register it via `createStudioI18n(locale, { en: enMessages, de: deMessages })`.
  */
 const MESSAGE_IDS = [
+    "Cirrus AI rules aren't installed.",
+    "lets your coding agent use Cirrus correctly.",
     ", changed",
     "(no subject)",
     "(root)",

--- a/packages/studio/src/mount.tsx
+++ b/packages/studio/src/mount.tsx
@@ -36,6 +36,7 @@ export const mountStudio = (options: MountStudioOptions = {}): Root => {
             basePath={appProps.basePath}
             baseUrl={appProps.baseUrl}
             locale={appProps.locale}
+            rulesInstalled={appProps.rulesInstalled}
             studio={appProps.studio}
         />,
     );

--- a/packages/vite/src/agent-rules-hint-plugin.ts
+++ b/packages/vite/src/agent-rules-hint-plugin.ts
@@ -1,4 +1,4 @@
-import { detectAgentRules } from "@cirrus/config";
+import { AGENT_RULES_HINT, claimAgentRulesHint, detectAgentRules } from "@cirrus/config";
 import type { Plugin } from "vite";
 
 import type { ResolvedCirrusPluginOptions } from "./types";
@@ -16,11 +16,11 @@ const agentRulesHintPlugin = (options: ResolvedCirrusPluginOptions): Plugin => {
             // Defer to `configureServer`'s return hook so the notice prints after
             // Vite's own startup output rather than getting buried above it.
             return () => {
-                if (detectAgentRules(options.projectRoot).installed) {
+                if (detectAgentRules(options.projectRoot).installed || !claimAgentRulesHint()) {
                     return;
                 }
 
-                server.config.logger.warn("\n  [cirrus] AI rules not installed — run `cirrus rules install` so your coding agent knows how to use Cirrus.\n");
+                server.config.logger.warn(`\n  [cirrus] ${AGENT_RULES_HINT}\n`);
             };
         },
         name: "cirrus:agent-rules-hint",

--- a/packages/vite/src/agent-rules-hint-plugin.ts
+++ b/packages/vite/src/agent-rules-hint-plugin.ts
@@ -1,0 +1,30 @@
+import { detectAgentRules } from "@cirrus/config";
+import type { Plugin } from "vite";
+
+import type { ResolvedCirrusPluginOptions } from "./types";
+
+/**
+ * Dev-only plugin that nudges the developer to install the Cirrus agent skills
+ * ("rules") when they're absent from the project. Mirrors the `cirrus dev`
+ * hint so the `vite dev` path surfaces it too — a one-line, non-blocking notice
+ * pointing at `cirrus rules install`. Skips silently once the rules are present.
+ */
+const agentRulesHintPlugin = (options: ResolvedCirrusPluginOptions): Plugin => {
+    return {
+        apply: "serve",
+        configureServer(server) {
+            // Defer to `configureServer`'s return hook so the notice prints after
+            // Vite's own startup output rather than getting buried above it.
+            return () => {
+                if (detectAgentRules(options.projectRoot).installed) {
+                    return;
+                }
+
+                server.config.logger.warn("\n  [cirrus] AI rules not installed — run `cirrus rules install` so your coding agent knows how to use Cirrus.\n");
+            };
+        },
+        name: "cirrus:agent-rules-hint",
+    };
+};
+
+export default agentRulesHintPlugin;

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -2,6 +2,7 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import errorOverlayPlugin from "@visulima/vite-overlay";
 import type { Plugin } from "vite";
 
+import agentRulesHintPlugin from "./agent-rules-hint-plugin";
 import codegenPlugin from "./codegen-plugin";
 import devVariablesPlugin from "./dev-variables-plugin";
 import { createCommandProbe, withDevWorkerEnv } from "./dev-worker-env";
@@ -90,6 +91,7 @@ const cirrus = (options?: CirrusPluginOptions): CirrusPlugins => {
         devVariablesPlugin(resolved),
         codegenPlugin(resolved),
         logStreamPlugin(),
+        agentRulesHintPlugin(resolved),
     ];
 
     if (resolved.studio) {

--- a/packages/vite/src/studio-plugin.ts
+++ b/packages/vite/src/studio-plugin.ts
@@ -6,6 +6,7 @@ import type { AddressInfo } from "node:net";
 // the CLI server render an identical studio. The heavy `@cirrus/studio` SPA it
 // hosts stays an optional peer — these helpers resolve its prebuilt assets
 // lazily (and degrade gracefully when it isn't installed).
+import { detectAgentRules } from "@cirrus/config";
 import type { StudioAssets } from "@cirrus/config/studio-host";
 import { loadStudioAssets, renderStudioHtml, resolveAdminToken, studioAssetsStamp } from "@cirrus/config/studio-host";
 import type { Plugin, ViteDevServer } from "vite";
@@ -130,17 +131,18 @@ const createStudioHandler = (
         }
 
         // Built once per dev session: the basepath is fixed, and the admin token
-        // is read from `.dev.vars` at startup. `config.root` is absent on mocked
-        // test servers — fall back to cwd.
+        // is read from `.dev.vars` at startup. `config.root` is typed as a
+        // required string but is absent on mocked test servers — fall back to cwd.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime value can be undefined on a mocked server even though the type says string
+        const projectRoot = server.config.root ?? process.cwd();
+
         html ??= renderStudioHtml({
-            // `config.root` is typed as a required string but is absent on mocked
-            // test servers, so the cwd fallback is real despite the type.
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime value can be undefined on a mocked server even though the type says string
-            adminToken: resolveAdminToken(server.config.root ?? process.cwd()),
+            adminToken: resolveAdminToken(projectRoot),
             basePath: STUDIO_PATH,
             // Loopback-only dev route (it 403s on a non-loopback bind), so the
             // developer owns the data — let them edit rows and run-as a user by default.
             dataEditable: true,
+            rulesInstalled: detectAgentRules(projectRoot).installed,
             runAsIdentity: true,
             scriptSrc: STUDIO_SCRIPT_PATH,
             styleHref: STUDIO_STYLE_PATH,


### PR DESCRIPTION
Adapt Convex's agent-skills into six first-party Cirrus skills that teach
AI coding agents how to use the framework:

- cirrus: router/entry skill
- cirrus-quickstart: `cirrus init` / `dev` + provider wiring + first round-trip
- cirrus-setup-auth: `cirrus registry add auth` (+ Clerk/Auth0/magic-link/OTP)
- cirrus-create-package: building a registry item or `@cirrus/*` package
- cirrus-migration-helper: defineMigration + `cirrus migrate`, drift gate
- cirrus-performance-audit: @cirrus/advisor, indexes, OCC, sharding/.global()

The skills live in packages/cli/skills so the published @cirrus/cli tarball
carries them, and are discovered by the TanStack Intent registry via the
`tanstack-intent` package keyword. They are mirrored into .agents/skills and
.claude/skills (via symlinks) so agents working in this repo pick them up.