### PR TITLE
feat(scheduler): support cron jobs targeting workflows

### DIFF
--- a/.vis/templates/lunora-cron.ts
+++ b/.vis/templates/lunora-cron.ts
@@ -32,7 +32,15 @@ import { internal } from "./_generated/api.js";
  *   crons.daily(name, { hourUTC: 9, minuteUTC: 0 }, fn, args)  // daily at a UTC time
  *   crons.weekly(name, { dayOfWeek: "monday", hourUTC: 9, minuteUTC: 0 }, fn, args)
  *   crons.monthly(name, { day: 1, hourUTC: 9, minuteUTC: 0 }, fn, args)
- *   crons.cron(name, "0 * * * *", fn, args)                    // raw cron escape hatch
+ *   crons.cron(name, "0 9 * * 1L", fn, args)                   // raw cron escape hatch (full cron-parser grammar)
+ *
+ * The target can be an \`internal.<file>.<fn>\` function reference (one-shot
+ * dispatch) OR a durable workflow via the generated \`workflows.<name>\`
+ * reference — targeting a workflow starts a fresh, multi-step, retried instance
+ * on each fire (the args, type-checked against the workflow's \`params\`, become
+ * its \`params\`):
+ *   import { workflows } from "./_generated/api.js";
+ *   crons.daily(name, { hourUTC: 9, minuteUTC: 0 }, workflows.digestPipeline, args)
  */
 const crons = cronJobs();
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -92,6 +92,7 @@ const STORAGE_URL_PATH = "/_lunora/admin/storage/url";
 const STORAGE_BUCKETS_PATH = "/_lunora/admin/storage/buckets";
 const FUNCTIONS_PATH = "/_lunora/admin/functions";
 const CRON_JOBS_PATH = "/_lunora/admin/cron-jobs";
+const CRON_JOBS_RUN_PATH = "/_lunora/admin/cron-jobs/run";
 const OPENAPI_PATH = "/_lunora/admin/openapi";
 const OPENRPC_PATH = "/_lunora/admin/openrpc";
 const GLOBAL_TABLES_PATH = "/_lunora/admin/global/tables";
@@ -1015,6 +1016,25 @@ class LunoraClient {
         const body = (await this.adminFetch(CRON_JOBS_PATH, "GET")) as { jobs?: CronJobInfo[] };
 
         return body.jobs ?? [];
+    }
+
+    /**
+     * Manually fire one code-defined cron job by name — the same dispatch the
+     * scheduled trigger runs (dispatch the function, or start the durable
+     * workflow), on demand. Hits the admin-gated `POST /_lunora/admin/cron-jobs/run`
+     * endpoint; the worker must be built with a `cronJobs` map and `adminToken`,
+     * and this client's auth token must match. Resolves when the job has run (a
+     * function job's shard response is 2xx, or the workflow instance was created)
+     * and rejects with the dispatch error otherwise.
+     */
+    public async runCronJob(name: string): Promise<{ name: string; ran: boolean }> {
+        if (this.closed) {
+            throw new Error("LunoraClient is closed");
+        }
+
+        const body = (await this.adminFetch(CRON_JOBS_RUN_PATH, "POST", { name })) as { name?: string; ran?: boolean };
+
+        return { name: body.name ?? name, ran: body.ran === true };
     }
 
     /**

--- a/packages/codegen/__tests__/discover-crons.test.ts
+++ b/packages/codegen/__tests__/discover-crons.test.ts
@@ -6,6 +6,7 @@ import { Project } from "ts-morph";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import discoverCrons from "../src/discover-crons";
+import { discoverWorkflows } from "../src/discover-workflows";
 import { emitCrons, emitWranglerCronTriggers } from "../src/emit";
 
 let workdir: string;
@@ -206,6 +207,86 @@ describe("discover-crons", () => {
 
         expect(() => discoverCrons(newProject(), workdir)).toThrow(/non-empty string-literal name/u);
     });
+
+    it("resolves the generated `workflows.<name>` reference into a workflow target", () => {
+        expect.assertions(1);
+
+        writeSource(
+            "workflows.ts",
+            `
+            import { defineWorkflow } from "@lunora/workflow";
+            export const digestPipeline = defineWorkflow({ handler: async () => undefined });
+        `,
+        );
+        writeSource(
+            "crons.ts",
+            `
+            import { cronJobs } from "@lunora/scheduler";
+            import { workflows } from "./_generated/api.js";
+            const crons = cronJobs();
+            crons.daily("nightly digest", { hourUTC: 9, minuteUTC: 0 }, workflows.digestPipeline, { region: "eu" });
+            export default crons;
+        `,
+        );
+
+        const project = newProject();
+        const workflows = discoverWorkflows(project, workdir);
+
+        expect(discoverCrons(project, workdir, workflows)).toEqual([
+            {
+                args: { region: "eu" },
+                cron: "0 9 * * *",
+                name: "nightly digest",
+                workflow: { binding: "WORKFLOW_DIGEST_PIPELINE", exportName: "digestPipeline" },
+            },
+        ]);
+    });
+
+    it("also resolves a bare identifier naming a declared workflow (direct import)", () => {
+        expect.assertions(1);
+
+        writeSource(
+            "workflows.ts",
+            `
+            import { defineWorkflow } from "@lunora/workflow";
+            export const digestPipeline = defineWorkflow({ handler: async () => undefined });
+        `,
+        );
+        writeSource(
+            "crons.ts",
+            `
+            import { cronJobs } from "@lunora/scheduler";
+            import { digestPipeline } from "./workflows.js";
+            const crons = cronJobs();
+            crons.daily("nightly digest", { hourUTC: 9, minuteUTC: 0 }, digestPipeline, {});
+            export default crons;
+        `,
+        );
+
+        const project = newProject();
+        const workflows = discoverWorkflows(project, workdir);
+
+        expect(discoverCrons(project, workdir, workflows)).toEqual([
+            { args: {}, cron: "0 9 * * *", name: "nightly digest", workflow: { binding: "WORKFLOW_DIGEST_PIPELINE", exportName: "digestPipeline" } },
+        ]);
+    });
+
+    it("throws when `workflows.<name>` names a workflow that isn't declared", () => {
+        expect.assertions(1);
+
+        writeSource(
+            "crons.ts",
+            `
+            import { cronJobs } from "@lunora/scheduler";
+            import { workflows } from "./_generated/api.js";
+            const crons = cronJobs();
+            crons.daily("oops", { hourUTC: 9, minuteUTC: 0 }, workflows.missingFlow, {});
+            export default crons;
+        `,
+        );
+
+        expect(() => discoverCrons(newProject(), workdir, [])).toThrow(/no such workflow is declared/u);
+    });
 });
 
 describe("emitCrons", () => {
@@ -228,6 +309,22 @@ describe("emitCrons", () => {
 
         // …and the distinct expression has its own list.
         expect(output).toContain('"*/5 * * * *": [');
+    });
+
+    it("emits a workflow binding target instead of a functionPath for a workflow cron", () => {
+        expect.assertions(3);
+
+        const output = emitCrons([
+            { args: { region: "eu" }, cron: "0 9 * * *", name: "nightly digest", workflow: { binding: "WORKFLOW_DIGEST", exportName: "digest" } },
+            { args: {}, cron: "0 9 * * *", functionPath: "email:report", name: "report" },
+        ]);
+
+        // The workflow job carries `workflow: "<binding>"` and no functionPath…
+        expect(output).toContain('{ name: "nightly digest", workflow: "WORKFLOW_DIGEST", args: {"region":"eu"} },');
+        // …while the function job is unchanged.
+        expect(output).toContain('{ name: "report", functionPath: "email:report", args: {} },');
+        // The emitted interface allows either target.
+        expect(output).toContain("workflow?: string;");
     });
 
     it("emits empty structures when there are no crons", () => {

--- a/packages/codegen/__tests__/emit-api.test.ts
+++ b/packages/codegen/__tests__/emit-api.test.ts
@@ -7,9 +7,38 @@
 import { describe, expect, it } from "vitest";
 
 import { emitApi, emitFunctions } from "../src/emit";
-import type { FunctionIR } from "../src/ir";
+import type { FunctionIR, WorkflowIR } from "../src/ir";
 
 describe("emitApi", () => {
+    it("emits a typed `workflows.*` reference object when the project declares workflows", () => {
+        expect.assertions(5);
+
+        const workflows: ReadonlyArray<WorkflowIR> = [
+            { bindingName: "WORKFLOW_DIGEST_PIPELINE", className: "DigestPipelineWorkflow", exportName: "digestPipeline", name: "digest-pipeline" },
+        ];
+
+        const rendered = emitApi([], workflows);
+
+        // Imports the workflow definitions so params can be inferred from `__params`.
+        expect(rendered).toContain('import type * as lunoraWorkflowDefinitions from "../workflows.js";');
+        // Typed reference carries the inferred params.
+        // eslint-disable-next-line no-secrets/no-secrets -- generated TS generic, not a credential
+        expect(rendered).toContain("digestPipeline: WorkflowReference<WorkflowParamsOf<typeof lunoraWorkflowDefinitions.digestPipeline>>;");
+        // Runtime object carries the WORKFLOW_* binding + name.
+        expect(rendered).toContain('digestPipeline: { isLunoraWorkflow: true, binding: "WORKFLOW_DIGEST_PIPELINE", name: "digestPipeline" },');
+        expect(rendered).toContain("export const workflows: WorkflowsRef = {");
+        expect(rendered).toContain("export interface WorkflowsRef {");
+    });
+
+    it("omits the `workflows` block entirely when no workflows are declared", () => {
+        expect.assertions(2);
+
+        const rendered = emitApi([]);
+
+        expect(rendered).not.toContain("WorkflowsRef");
+        expect(rendered).not.toContain("lunoraWorkflowDefinitions");
+    });
+
     it("rewrites `import('./_generated/X')` qualifiers to `import('./X')` so paths resolve inside _generated/", () => {
         expect.assertions(2);
 

--- a/packages/codegen/src/discover-crons.ts
+++ b/packages/codegen/src/discover-crons.ts
@@ -3,7 +3,7 @@ import type { CallExpression, Identifier, ObjectLiteralExpression, Project, Prop
 import { Node, SyntaxKind } from "ts-morph";
 
 import { listLunoraSourceFiles } from "./discover-functions";
-import type { CronJobIR } from "./ir";
+import type { CronJobIR, WorkflowIR } from "./ir";
 import sanitizeNamespace from "./paths";
 
 /** All builder method names — the structured schedules plus the raw `.cron`. */
@@ -189,8 +189,90 @@ const functionPathFromArgument = (call: CallExpression, index: number, jobName: 
     return `${sanitizeNamespace(namespace)}:${functionName}`;
 };
 
+/** Build a workflow target IR from a resolved {@link WorkflowIR}. */
+const workflowTarget = (workflow: WorkflowIR): Pick<CronJobIR, "workflow"> => {
+    return { workflow: { binding: workflow.bindingName, exportName: workflow.exportName } };
+};
+
+/**
+ * Resolve the cron's target argument into either a function dispatch
+ * (`{ functionPath }`) or a durable-workflow start
+ * (`{ workflow: { binding, exportName } }`).
+ *
+ * Targets mirror the generated reference objects in `_generated/api.ts`: a
+ * `workflows.NAME` access is the canonical generated workflow reference; a bare
+ * `NAME` identifier is a `defineWorkflow` export imported directly; and an
+ * `internal.file.fn` / `api.file.fn` access is a function dispatch.
+ *
+ * A `workflows.NAME` / bare identifier that doesn't name a declared workflow, or
+ * anything else, is a static-resolution error.
+ */
+const resolveTarget = (
+    call: CallExpression,
+    index: number,
+    jobName: string,
+    workflowsByName: ReadonlyMap<string, WorkflowIR>,
+): Pick<CronJobIR, "functionPath" | "workflow"> => {
+    const argument = call.getArguments()[index];
+
+    // Canonical workflow target: `workflows.<name>` — the generated reference
+    // object. The receiver is the bare `workflows` identifier (a single property
+    // access), which distinguishes it from a `internal.file.fn` function ref (a
+    // double access whose receiver is itself a property access).
+    if (argument && Node.isPropertyAccessExpression(argument)) {
+        const receiver = argument.getExpression();
+
+        if (Node.isIdentifier(receiver) && receiver.getText() === "workflows") {
+            const workflow = workflowsByName.get(argument.getName());
+
+            if (workflow) {
+                return workflowTarget(workflow);
+            }
+
+            throw Object.assign(
+                new Error(`Cron job "${jobName}" targets workflows.${argument.getName()}, but no such workflow is declared in lunora/workflows.ts.`),
+                {
+                    code: "CRON_NON_STATIC_FN",
+                    name: "LunoraError",
+                    status: 500,
+                },
+            );
+        }
+
+        return { functionPath: functionPathFromArgument(call, index, jobName) };
+    }
+
+    // Workflow target via a bare identifier referencing a `defineWorkflow` export
+    // (e.g. `digestPipeline` imported from `./workflows`).
+    if (argument && Node.isIdentifier(argument)) {
+        const workflow = workflowsByName.get(argument.getText());
+
+        if (workflow) {
+            return workflowTarget(workflow);
+        }
+
+        throw Object.assign(
+            new Error(
+                `Cron job "${jobName}" references "${argument.getText()}", which is neither a function (internal.file.fn / api.file.fn) nor a declared workflow in lunora/workflows.ts.`,
+            ),
+            {
+                code: "CRON_NON_STATIC_FN",
+                name: "LunoraError",
+                status: 500,
+            },
+        );
+    }
+
+    return { functionPath: functionPathFromArgument(call, index, jobName) };
+};
+
 /** Lift one `crons.method(name, schedule, fnRef, args?)` call into {@link CronJobIR}. */
-const cronFromCall = (call: CallExpression, callee: PropertyAccessExpression, builderNames: Set<string>): CronJobIR | undefined => {
+const cronFromCall = (
+    call: CallExpression,
+    callee: PropertyAccessExpression,
+    builderNames: Set<string>,
+    workflowsByName: ReadonlyMap<string, WorkflowIR>,
+): CronJobIR | undefined => {
     const method = callee.getName();
 
     if (!CRON_METHODS.has(method)) {
@@ -247,11 +329,11 @@ const cronFromCall = (call: CallExpression, callee: PropertyAccessExpression, bu
         cron = compileCronSchedule(method as "daily" | "interval" | "monthly" | "weekly", objectLiteralValue(scheduleArgument, name));
     }
 
-    const functionPath = functionPathFromArgument(call, 2, name);
+    const target = resolveTarget(call, 2, name, workflowsByName);
     const argumentsNode = call.getArguments()[3];
     const args = argumentsNode && Node.isObjectLiteralExpression(argumentsNode) ? objectLiteralValue(argumentsNode, name) : {};
 
-    return { args, cron, functionPath, name };
+    return { args, cron, name, ...target };
 };
 
 /** Reject duplicate cron job names — runtime keys the dispatcher by name. */
@@ -283,12 +365,14 @@ const assertUniqueNames = (crons: ReadonlyArray<CronJobIR>): void => {
  * Scan every `.ts` file under `lunoraDir` for `cronJobs()` builder registrations
  * (`crons.interval(...)`, `crons.daily(...)`, `crons.cron(...)`, …) and lift them
  * into {@link CronJobIR}. Schedules are compiled to standard cron expressions;
- * function references are resolved to their `namespace:fn` dispatch path. Names
- * must be unique across the project.
+ * function references are resolved to their `namespace:fn` dispatch path, while a
+ * bare identifier naming a declared workflow (`workflows`) resolves to a durable
+ * workflow start. Names must be unique across the project.
  */
-const discoverCrons = (project: Project, lunoraDirectory: string): CronJobIR[] => {
+const discoverCrons = (project: Project, lunoraDirectory: string, workflows: ReadonlyArray<WorkflowIR> = []): CronJobIR[] => {
     const filePaths = listLunoraSourceFiles(lunoraDirectory);
     const crons: CronJobIR[] = [];
+    const workflowsByName = new Map<string, WorkflowIR>(workflows.map((workflow) => [workflow.exportName, workflow]));
 
     for (const filePath of filePaths) {
         const source: SourceFile = project.getSourceFile(filePath) ?? project.addSourceFileAtPath(filePath);
@@ -305,7 +389,7 @@ const discoverCrons = (project: Project, lunoraDirectory: string): CronJobIR[] =
                 continue;
             }
 
-            const cron = cronFromCall(call, callee, builderNames);
+            const cron = cronFromCall(call, callee, builderNames, workflowsByName);
 
             if (cron) {
                 crons.push(cron);

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -515,13 +515,68 @@ const renderApiBody = (functions: ReadonlyArray<FunctionIR>): string => {
 };
 
 /**
- * Emit `_generated/api.ts` — the typed `api.*` registry (public functions) plus
- * the `internal.*` registry. Both are the same `anyApi` proxy at runtime (the
- * `__lunoraRef` is identical); visibility is enforced server-side at dispatch,
- * not in the reference. Splitting the *types* keeps internal functions off the
- * client-facing `api` surface.
+ * Render the `workflows.*` typed-reference block for `_generated/api.ts` (its
+ * import line + the type/value). Each `lunora/workflows.ts` export becomes a
+ * `workflows.&lt;name>` reference carrying its `WORKFLOW_*` binding and — via the
+ * definition's phantom `__params` — its `params` type, so a `cronJobs()`
+ * registration that targets it infers the args. Returns empty strings when the
+ * project declares no workflows. The reference shape is defined locally (not
+ * imported from `@lunora/scheduler`) so a workflow-only project needs no
+ * scheduler dependency; it matches `@lunora/scheduler`'s `WorkflowReference`
+ * structurally at the cron call site.
  */
-const emitApi = (functions: ReadonlyArray<FunctionIR>): string => {
+/* eslint-disable no-secrets/no-secrets -- the emitted `WorkflowReference`/`WorkflowParamsOf` generic strings are dense generated TS, not credentials */
+const renderWorkflowsRef = (workflows: ReadonlyArray<WorkflowIR>): { block: string; importLine: string } => {
+    if (workflows.length === 0) {
+        return { block: "", importLine: "" };
+    }
+
+    const sorted = [...workflows].toSorted((a, b) => a.exportName.localeCompare(b.exportName));
+    const refMembers = sorted
+        .map((workflow) => `    ${workflow.exportName}: WorkflowReference<WorkflowParamsOf<typeof lunoraWorkflowDefinitions.${workflow.exportName}>>;`)
+        .join("\n");
+    const objectMembers = sorted
+        .map(
+            (workflow) =>
+                `    ${workflow.exportName}: { isLunoraWorkflow: true, binding: ${JSON.stringify(workflow.bindingName)}, name: ${JSON.stringify(workflow.exportName)} },`,
+        )
+        .join("\n");
+
+    const block = `
+/** Params type carried by a \`defineWorkflow\` definition (its phantom \`__params\`). */
+type WorkflowParamsOf<Definition> = Definition extends { __params?: infer Params } ? (unknown extends Params ? Record<string, unknown> : Params) : Record<string, unknown>;
+
+/** A typed reference to a durable workflow, addressable for \`cronJobs()\` targets. Mirrors \`@lunora/scheduler\`'s \`WorkflowReference\` structurally. */
+export interface WorkflowReference<Params = Record<string, unknown>> {
+    readonly isLunoraWorkflow: true;
+    readonly __params?: Params;
+    readonly binding: string;
+    readonly name: string;
+}
+
+/** This project's durable workflows, addressable as typed references (e.g. \`crons.daily("digest", …, workflows.digestPipeline, params)\`). */
+export interface WorkflowsRef {
+${refMembers}
+}
+
+export const workflows: WorkflowsRef = {
+${objectMembers}
+};
+`;
+
+    return { block, importLine: `import type * as lunoraWorkflowDefinitions from "../workflows.js";\n` };
+};
+/* eslint-enable no-secrets/no-secrets -- re-enable after the workflows-ref emitter */
+
+/**
+ * Emit `_generated/api.ts` — the typed `api.*` registry (public functions), the
+ * `internal.*` registry, and (when the project declares workflows) the typed
+ * `workflows.*` reference object. `api`/`internal` are the same `anyApi` proxy
+ * at runtime (the `__lunoraRef` is identical); visibility is enforced
+ * server-side at dispatch, not in the reference. Splitting the *types* keeps
+ * internal functions off the client-facing `api` surface.
+ */
+const emitApi = (functions: ReadonlyArray<FunctionIR>, workflows: ReadonlyArray<WorkflowIR> = []): string => {
     const publicFunctions = functions.filter((definition) => definition.visibility !== "internal");
     const internalFunctions = functions.filter((definition) => definition.visibility === "internal");
 
@@ -538,9 +593,11 @@ const emitApi = (functions: ReadonlyArray<FunctionIR>): string => {
     const apiBlock = publicBody ? `\n${publicBody}\n` : "";
     const internalBlock = internalBody ? `\n${internalBody}\n` : "";
 
+    const workflowsRef = renderWorkflowsRef(workflows);
+
     return `${GENERATED_HEADER}import { anyApi } from "@lunora/server/types";
 import type { FunctionReference } from "@lunora/client";
-${dataModelImportLine}
+${workflowsRef.importLine}${dataModelImportLine}
 export interface ApiTypes {${apiBlock}}
 
 export const api = anyApi as unknown as ApiTypes;
@@ -549,7 +606,7 @@ export const api = anyApi as unknown as ApiTypes;
 export interface InternalApiTypes {${internalBlock}}
 
 export const internal = anyApi as unknown as InternalApiTypes;
-`;
+${workflowsRef.block}`;
 };
 
 /**
@@ -3105,10 +3162,16 @@ const emitCrons = (crons: ReadonlyArray<CronJobIR>): string => {
     const mapEntries = [...byExpression.entries()]
         .map(([expression, jobs]) => {
             const jobEntries = jobs
-                .map(
-                    (job) =>
-                        `        { name: ${JSON.stringify(job.name)}, functionPath: ${JSON.stringify(job.functionPath)}, args: ${JSON.stringify(job.args)} },`,
-                )
+                .map((job) => {
+                    // A workflow target starts a durable instance per fire (args ⇒
+                    // its `params`); a function target dispatches `namespace:fn` to
+                    // the shard. The two are mutually exclusive in the emitted entry.
+                    const targetField = job.workflow
+                        ? `workflow: ${JSON.stringify(job.workflow.binding)}`
+                        : `functionPath: ${JSON.stringify(job.functionPath)}`;
+
+                    return `        { name: ${JSON.stringify(job.name)}, ${targetField}, args: ${JSON.stringify(job.args)} },`;
+                })
                 .join("\n");
 
             return `    ${JSON.stringify(expression)}: [\n${jobEntries}\n    ],`;
@@ -3118,13 +3181,17 @@ const emitCrons = (crons: ReadonlyArray<CronJobIR>): string => {
     const mapBody = mapEntries.length > 0 ? `\n${mapEntries}\n` : "";
 
     return `${GENERATED_HEADER}/**
- * One scheduled cron invocation. \`functionPath\` is the \`namespace:fn\`
- * dispatch ref (matches \`__lunoraRef\`); \`args\` are forwarded verbatim.
+ * One scheduled cron invocation. Exactly one target is set: \`functionPath\` is
+ * the \`namespace:fn\` dispatch ref (matches \`__lunoraRef\`), invoked on the
+ * shard; \`workflow\` is a \`WORKFLOW_*\` binding name whose durable workflow is
+ * started fresh per fire. \`args\` are forwarded verbatim (a workflow's become
+ * its \`params\`).
  */
 export interface LunoraCronJob {
     args: Record<string, unknown>;
-    functionPath: string;
+    functionPath?: string;
     name: string;
+    workflow?: string;
 }
 
 /**

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -183,10 +183,19 @@ export interface CronJobIR {
     args: Record<string, unknown>;
     /** Compiled standard cron expression, e.g. `"0 9 * * *"`. */
     cron: string;
-    /** Target function ref `namespace:fn`. */
-    functionPath: string;
+    /** Target function ref `namespace:fn`. Present for a function target; absent when {@link CronJobIR.workflow} is set. */
+    functionPath?: string;
     /** Unique, human-readable job name. */
     name: string;
+
+    /**
+     * Set when the job targets a durable workflow (a `lunora/workflows.ts`
+     * export) instead of a function: the workflow's `WORKFLOW_*` binding name
+     * plus its export name. On each fire the worker starts a new workflow
+     * INSTANCE (the {@link CronJobIR.args} become its `params`) rather than
+     * dispatching a one-shot function.
+     */
+    workflow?: { binding: string; exportName: string };
 }
 
 /**

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -203,7 +203,13 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     const functions = discoverFunctions(project, lunoraDirectory);
     const httpRoutes = discoverHttpRoutes(project, lunoraDirectory);
     const migrations = discoverMigrations(project, lunoraDirectory);
-    const crons = discoverCrons(project, lunoraDirectory);
+
+    // Workflows declared via `defineWorkflow` exports in `lunora/workflows.ts`.
+    // Discovered before crons so a `cronJobs()` registration can target a
+    // workflow by its export name (the cron then starts a durable instance per
+    // fire instead of dispatching a one-shot function).
+    const workflows = discoverWorkflows(project, lunoraDirectory);
+    const crons = discoverCrons(project, lunoraDirectory, workflows);
 
     // Static advisories (unindexed FKs, redundant indexes, unknown index/relation
     // fields, filter-without-index, …). Cheap, derived from the schema + the
@@ -219,12 +225,10 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // the `container_*` advisor lints below.
     const containers = discoverContainers(project, lunoraDirectory);
 
-    // Workflows declared via `defineWorkflow` exports in `lunora/workflows.ts`.
-    // Gates `_generated/workflows.ts` (the WorkflowEntrypoint classes) + the
-    // typed `ctx.workflows` on Mutation/Action contexts, and feeds the config
-    // layer's wrangler reconciliation (the `workflows[]` array — NOT a Durable
-    // Object binding or migration; workflows are not DOs).
-    const workflows = discoverWorkflows(project, lunoraDirectory);
+    // Workflows (`_generated/workflows.ts` — the WorkflowEntrypoint classes — the
+    // typed `ctx.workflows` on Mutation/Action contexts, and the config layer's
+    // wrangler reconciliation of the `workflows[]` array) are discovered above,
+    // ahead of crons, so a cron may target one.
 
     const advisories =
         options.lint === false
@@ -300,7 +304,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     });
 
     const dataModelContent = emitDataModel(schema);
-    const apiContent = emitApi(functions);
+    const apiContent = emitApi(functions, workflows);
     const serverContent = emitServer({
         containers,
         hasAi,

--- a/packages/runtime/__tests__/cron-jobs-run.test.ts
+++ b/packages/runtime/__tests__/cron-jobs-run.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionContextLike } from "../src/create-worker";
+import { createWorker } from "../src/create-worker";
+import type { ShardNamespaceLike } from "../src/resolve-shard";
+
+const fakeContext: ExecutionContextLike = {
+    passThroughOnException: () => undefined,
+    waitUntil: () => undefined,
+};
+
+const ADMIN_TOKEN = "admin-bear";
+const RUN_PATH = "https://app.example/_lunora/admin/cron-jobs/run";
+
+interface ShardSpy {
+    calls: { body: unknown; shardKey: string }[];
+    namespace: ShardNamespaceLike;
+    response: Response;
+}
+
+const createShardSpy = (response = new Response("ok", { status: 200 })): ShardSpy => {
+    const calls: { body: unknown; shardKey: string }[] = [];
+    const spy = { calls, response } as ShardSpy;
+
+    spy.namespace = {
+        get: (id) => {
+            const shardKey = (id as { __name: string }).__name;
+
+            return {
+                fetch: async (request: Request) => {
+                    calls.push({ body: await request.clone().json(), shardKey });
+
+                    return spy.response;
+                },
+            };
+        },
+        idFromName: (name) => {
+            return { __name: name };
+        },
+    };
+
+    return spy;
+};
+
+const CRON_JOBS = {
+    "*/5 * * * *": [{ args: { tenant: "acme" }, functionPath: "presence:clear", name: "clear presence", shardKey: "acme" }],
+    "0 9 * * *": [{ args: { region: "eu" }, name: "nightly digest", workflow: "WORKFLOW_DIGEST" }],
+};
+
+const runRequest = (name: string): Request =>
+    new Request(RUN_PATH, {
+        body: JSON.stringify({ name }),
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}`, "content-type": "application/json" },
+        method: "POST",
+    });
+
+describe("createWorker — cron-jobs run endpoint", () => {
+    it("rejects without a valid admin bearer (403)", async () => {
+        expect.assertions(1);
+
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, cronJobs: CRON_JOBS, shardDO: createShardSpy().namespace });
+
+        const response = await worker.fetch(new Request(RUN_PATH, { body: JSON.stringify({ name: "clear presence" }), method: "POST" }), {}, fakeContext);
+
+        expect(response.status).toBe(403);
+    });
+
+    it("dispatches a function job to its shard and reports it ran", async () => {
+        expect.assertions(4);
+
+        const shard = createShardSpy();
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, cronJobs: CRON_JOBS, shardDO: shard.namespace });
+
+        const response = await worker.fetch(runRequest("clear presence"), {}, fakeContext);
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({ name: "clear presence", ran: true });
+        expect(shard.calls).toHaveLength(1);
+        expect(shard.calls[0]).toStrictEqual({ body: { args: { tenant: "acme" }, functionPath: "presence:clear" }, shardKey: "acme" });
+    });
+
+    it("starts a workflow instance for a workflow-targeting job", async () => {
+        expect.assertions(2);
+
+        const created: { params?: unknown }[] = [];
+        const env = {
+            WORKFLOW_DIGEST: {
+                create: async (options?: { params?: unknown }) => {
+                    created.push(options ?? {});
+
+                    return { id: "wf-1" };
+                },
+            },
+        };
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, cronJobs: CRON_JOBS, shardDO: createShardSpy().namespace });
+
+        const response = await worker.fetch(runRequest("nightly digest"), env, fakeContext);
+
+        expect(response.status).toBe(200);
+        expect(created).toStrictEqual([{ params: { region: "eu" } }]);
+    });
+
+    it("returns 404 for an unknown job name", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, cronJobs: CRON_JOBS, shardDO: createShardSpy().namespace });
+
+        const response = await worker.fetch(runRequest("does not exist"), {}, fakeContext);
+
+        expect(response.status).toBe(404);
+
+        const body: { error: { code: string } } = await response.json();
+
+        expect(body.error.code).toBe("CRON_JOB_NOT_FOUND");
+    });
+
+    it("reports CRON_JOBS_NOT_CONFIGURED when no map is bound (400)", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, shardDO: createShardSpy().namespace });
+
+        const response = await worker.fetch(runRequest("clear presence"), {}, fakeContext);
+
+        expect(response.status).toBe(400);
+
+        const body: { error: { code: string } } = await response.json();
+
+        expect(body.error.code).toBe("CRON_JOBS_NOT_CONFIGURED");
+    });
+
+    it("propagates a failing function dispatch as an error", async () => {
+        expect.assertions(1);
+
+        const shard = createShardSpy(new Response("boom", { status: 500 }));
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, cronJobs: CRON_JOBS, shardDO: shard.namespace });
+
+        const response = await worker.fetch(runRequest("clear presence"), {}, fakeContext);
+
+        expect(response.status).toBe(500);
+    });
+});

--- a/packages/runtime/__tests__/scheduled-crons.test.ts
+++ b/packages/runtime/__tests__/scheduled-crons.test.ts
@@ -106,6 +106,46 @@ describe("createWorker — code-defined cron jobs", () => {
         await expect(worker.scheduled({ cron: CRON, scheduledTime: 0 }, {}, fakeContext)).rejects.toThrow(/clear presence/u);
     });
 
+    it("starts a workflow instance for a workflow-targeting cron job", async () => {
+        expect.assertions(3);
+
+        const shard = createShardSpy();
+        const created: { params?: unknown }[] = [];
+        const env = {
+            WORKFLOW_DIGEST: {
+                create: async (options?: { params?: unknown }) => {
+                    created.push(options ?? {});
+
+                    return { id: "wf-1" };
+                },
+            },
+        };
+
+        const worker = createWorker({
+            cronJobs: { [CRON]: [{ args: { region: "eu" }, name: "nightly digest", workflow: "WORKFLOW_DIGEST" }] },
+            shardDO: shard.namespace,
+        });
+
+        await worker.scheduled({ cron: CRON, scheduledTime: 0 }, env, fakeContext);
+
+        // The workflow binding's create() is called with args as params; no shard dispatch.
+        expect(created).toStrictEqual([{ params: { region: "eu" } }]);
+        expect(shard.calls).toHaveLength(0);
+        expect(created).toHaveLength(1);
+    });
+
+    it("fails the cron invocation when a workflow-targeting job's binding is missing", async () => {
+        expect.assertions(1);
+
+        const shard = createShardSpy();
+        const worker = createWorker({
+            cronJobs: { [CRON]: [{ args: {}, name: "nightly digest", workflow: "WORKFLOW_MISSING" }] },
+            shardDO: shard.namespace,
+        });
+
+        await expect(worker.scheduled({ cron: CRON, scheduledTime: 0 }, {}, fakeContext)).rejects.toThrow(/WORKFLOW_MISSING/u);
+    });
+
     it("denies dispatch when authorizeShard rejects the system identity", async () => {
         expect.assertions(2);
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -343,9 +343,27 @@ type CronHandler = (controller: ScheduledControllerLike, env: unknown, context: 
  */
 interface CronJobDispatch {
     args?: Record<string, unknown>;
-    functionPath: string;
+    functionPath?: string;
     name: string;
     shardKey?: string;
+
+    /**
+     * Set when the job targets a durable workflow instead of a function: the
+     * `WORKFLOW_*` binding name on `env`. On a firing trigger the worker starts a
+     * NEW workflow instance (the {@link CronJobDispatch.args} become its
+     * `params`) rather than dispatching {@link CronJobDispatch.functionPath} to a
+     * shard. Mutually exclusive with `functionPath`.
+     */
+    workflow?: string;
+}
+
+/**
+ * Structural view of a Cloudflare `Workflow` binding — just the `create` the
+ * cron dispatcher needs to start an instance. Kept structural so the runtime
+ * stays free of a hard dependency on `@lunora/workflow` / workers-types.
+ */
+interface WorkflowBindingLike {
+    create: (options?: { id?: string; params?: Record<string, unknown> }) => Promise<unknown>;
 }
 
 /**
@@ -358,9 +376,11 @@ interface CronJobInfo {
     args?: Record<string, unknown>;
     /** The compiled cron expression, e.g. `"0 9 * * *"`. */
     cron: string;
-    functionPath: string;
+    functionPath?: string;
     name: string;
     shardKey?: string;
+    /** The `WORKFLOW_*` binding name when the job starts a durable workflow instead of a function. */
+    workflow?: string;
 }
 
 /**
@@ -803,6 +823,8 @@ const NDJSON_ENCODER = new TextEncoder();
 const RPC_PATH = "/_lunora/rpc";
 const WS_PATH = "/_lunora/ws";
 const SCHEDULER_DISPATCH_PATH = "/_lunora/scheduler/dispatch";
+/** Admin-gated POST that manually fires one code-defined cron job by name (studio "Run now"). */
+const CRON_JOBS_RUN_PATH = "/_lunora/admin/cron-jobs/run";
 // The cross-shard orchestration (`migrate` / `rank` / `rankpage` / `shard-traffic`)
 // + `pitr`, data-movement (`export` / `import` / `sync` / `connector/sync` /
 // `apply`), static-introspection (`functions` / `cron-jobs` / `openapi` /
@@ -1243,11 +1265,63 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     };
 
     /**
+     * Start the durable workflow a cron job targets: resolve its `WORKFLOW_*`
+     * binding off `env` and `create()` a fresh instance with the job's `args` as
+     * `params`. A missing/malformed binding is a hard failure (the job can't run)
+     * — surfaced like a function-dispatch failure so the cron invocation fails.
+     */
+    const startCronWorkflow = async (binding: string, job: CronJobDispatch, env: unknown): Promise<void> => {
+        const candidate = (env as Record<string, unknown> | null | undefined)?.[binding];
+
+        if (!candidate || typeof (candidate as { create?: unknown }).create !== "function") {
+            throw new LunoraError(`cron job "${job.name}" targets workflow binding "${binding}", which is not bound on env`, {
+                code: "CRON_JOB_FAILED",
+                status: 500,
+            });
+        }
+
+        await (candidate as WorkflowBindingLike).create({ params: job.args ?? {} });
+    };
+
+    /**
+     * Run one code-defined cron job: start its durable workflow instance, or
+     * dispatch its function to the shard (a non-2xx response is a failure).
+     * Throws a {@link LunoraError} on failure so both the scheduled-fire loop and
+     * the manual `/cron-jobs/run` trigger surface the same error shape.
+     */
+    const runOneCronJob = async (job: CronJobDispatch, env: unknown): Promise<void> => {
+        if (job.workflow) {
+            await startCronWorkflow(job.workflow, job, env);
+
+            return;
+        }
+
+        if (job.functionPath === undefined) {
+            throw new LunoraError(`cron job "${job.name}" has neither a function target nor a workflow target`, {
+                code: "CRON_JOB_FAILED",
+                status: 500,
+            });
+        }
+
+        const response = await dispatchToShard(job.functionPath, job.args ?? {}, job.shardKey ?? defaultShard);
+
+        if (!response.ok) {
+            // A failed background job is operationally a 500-class "didn't run",
+            // not a client error — keep the shard's transport status in the
+            // message rather than overloading the error `status`.
+            throw new LunoraError(`cron job "${job.name}" (${job.functionPath}) failed with shard status ${String(response.status)}`, {
+                code: "CRON_JOB_FAILED",
+                status: 500,
+            });
+        }
+    };
+
+    /**
      * Dispatch every code-defined cron job declared under the firing expression,
      * collecting per-job failures into `errors` so one failing job neither aborts
-     * the others nor is swallowed. A non-2xx shard response is itself a failure.
+     * the others nor is swallowed.
      */
-    const runCronJobs = async (cron: string, errors: Error[], toError: (error: unknown) => Error): Promise<void> => {
+    const runCronJobs = async (cron: string, env: unknown, errors: Error[], toError: (error: unknown) => Error): Promise<void> => {
         const cronJobs = options.cronJobs?.[cron];
 
         if (!cronJobs) {
@@ -1256,22 +1330,52 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         for (const job of cronJobs) {
             try {
-                // eslint-disable-next-line no-await-in-loop -- intentional: jobs on one expression dispatch sequentially for deterministic order and to avoid a concurrent-RPC herd against a single shard
-                const response = await dispatchToShard(job.functionPath, job.args ?? {}, job.shardKey ?? defaultShard);
-
-                if (!response.ok) {
-                    // A failed background job is operationally a 500-class "didn't
-                    // run", not a client error — keep the shard's transport status
-                    // in the message rather than overloading the error `status`.
-                    throw new LunoraError(`cron job "${job.name}" (${job.functionPath}) failed with shard status ${String(response.status)}`, {
-                        code: "CRON_JOB_FAILED",
-                        status: 500,
-                    });
-                }
+                // eslint-disable-next-line no-await-in-loop -- intentional: jobs on one expression run sequentially for deterministic order and to avoid a concurrent-RPC herd against a single shard
+                await runOneCronJob(job, env);
             } catch (error: unknown) {
                 errors.push(toError(error));
             }
         }
+    };
+
+    /**
+     * Manually trigger one code-defined cron job by name — the same dispatch the
+     * scheduled fire uses, on demand from the studio's "Run now" action. Looks the
+     * job up across every cron expression (names are unique project-wide), runs it
+     * once, and reports success or the dispatch error. Admin-gated like the other
+     * `/_lunora/admin/*` mutations.
+     */
+    const handleRunCronJob = async (request: Request, env: unknown): Promise<Response> => {
+        if (!checkAdminAuth(request, options.adminToken)) {
+            throw new LunoraError("admin endpoint requires a valid admin bearer", { code: "ADMIN_FORBIDDEN", status: 403 });
+        }
+
+        if (request.method !== "POST") {
+            throw new LunoraError("cron-jobs run endpoint requires POST", { code: "METHOD_NOT_ALLOWED", status: 405 });
+        }
+
+        if (!options.cronJobs) {
+            throw new LunoraError("cron-jobs run endpoint requires a `cronJobs` map on the worker", { code: "CRON_JOBS_NOT_CONFIGURED", status: 400 });
+        }
+
+        const body = (await readJsonBodyWithLimit(request)) as { name?: unknown };
+        const name = typeof body.name === "string" ? body.name : "";
+
+        if (name === "") {
+            throw new LunoraError("cron-jobs run endpoint requires a job `name`", { code: "BAD_REQUEST", status: 400 });
+        }
+
+        const job = Object.values(options.cronJobs)
+            .flat()
+            .find((candidate) => candidate.name === name);
+
+        if (!job) {
+            throw new LunoraError(`no cron job named "${name}" is registered`, { code: "CRON_JOB_NOT_FOUND", status: 404 });
+        }
+
+        await runOneCronJob(job, env);
+
+        return Response.json({ name, ran: true }, { status: 200 });
     };
 
     /**
@@ -2110,8 +2214,9 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         }
 
         // Code-defined crons: run every job declared under the firing expression.
-        // Failures join `errors` for the combined rethrow below.
-        await runCronJobs(controller.cron, errors, toError);
+        // Failures join `errors` for the combined rethrow below. `env` carries the
+        // `WORKFLOW_*` bindings a workflow-targeting job starts an instance on.
+        await runCronJobs(controller.cron, env, errors, toError);
 
         if (options.backupStore && options.backupCron !== undefined && options.backupCron === controller.cron) {
             try {
@@ -2206,6 +2311,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         [WS_PATH]: (request, env, url) => handleWebSocketUpgrade(request, env, url),
         [RPC_PATH]: (request, env) => handleRpc(request, env),
         [SCHEDULER_DISPATCH_PATH]: (request, env) => handleSchedulerDispatch(request, env),
+        [CRON_JOBS_RUN_PATH]: (request, env) => handleRunCronJob(request, env),
         // Extracted handler clusters built above, merged in (mirroring the auth
         // plane below): orchestration (migrate / rank / rankpage / shard-traffic /
         // pitr), data-movement (export / import / sync / connector-sync / apply),

--- a/packages/runtime/src/introspection-admin-routes.ts
+++ b/packages/runtime/src/introspection-admin-routes.ts
@@ -152,6 +152,7 @@ const buildIntrospectionAdminRoutes = (deps: IntrospectionAdminRouteDeps): Recor
                         functionPath: dispatch.functionPath,
                         name: dispatch.name,
                         shardKey: dispatch.shardKey,
+                        workflow: dispatch.workflow,
                     };
                 }),
             )

--- a/packages/scheduler/__tests__/cron-jobs.test.ts
+++ b/packages/scheduler/__tests__/cron-jobs.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CronScheduleKind } from "../src/jobs";
 import { compileCronSchedule, cronJobs } from "../src/jobs";
-import type { FunctionReference } from "../src/types";
+import type { FunctionReference, WorkflowReference } from "../src/types";
 
 interface ParityCase {
     expected: string;
@@ -58,6 +58,30 @@ describe("cronJobs", () => {
         expect(() => crons.cron("bad", "every minute", fnRef("foo.bar"))).toThrow(/invalid cron expression/u);
     });
 
+    it("accepts the full cron grammar via cron-parser (names, lists, ranges, steps, L/#, seconds)", () => {
+        expect.assertions(6);
+
+        const crons = cronJobs();
+
+        // Named months/weekdays, lists, ranges, and steps.
+        crons.cron("named", "0 0 * JAN-MAR MON,FRI", fnRef("a.b"));
+        // Quartz-style last-weekday-of-month.
+        crons.cron("last-friday", "0 9 * * 5L", fnRef("a.c"));
+        // Nth weekday of the month.
+        crons.cron("second-monday", "0 0 * * 1#2", fnRef("a.d"));
+        // 6-field, seconds-leading.
+        crons.cron("with-seconds", "*/15 * * * * *", fnRef("a.e"));
+
+        expect(crons.jobs()).toHaveLength(4);
+        expect(crons.jobs()[0]?.cron).toBe("0 0 * JAN-MAR MON,FRI");
+        expect(crons.jobs()[1]?.cron).toBe("0 9 * * 5L");
+        expect(crons.jobs()[2]?.cron).toBe("0 0 * * 1#2");
+
+        // Still rejects clearly malformed expressions and prose.
+        expect(() => crons.cron("garbage", "0 0 0", fnRef("a.f"))).toThrow(/invalid cron expression/u);
+        expect(() => crons.cron("prose", "hourly please", fnRef("a.g"))).toThrow(/invalid cron expression/u);
+    });
+
     it("defaults args to an empty object and records the function path", () => {
         expect.assertions(1);
 
@@ -97,6 +121,36 @@ describe("cronJobs", () => {
         expect(() => crons.interval("dup", { minutes: 2 }, fnRef("a.c"))).toThrow(/duplicate cron job name/u);
         // @ts-expect-error - intentional misuse: missing function reference
         expect(() => crons.interval("nofn", { minutes: 1 }, undefined)).toThrow(/requires a function reference/u);
+    });
+
+    it("records a workflow target (no functionPath) when passed a workflow reference", () => {
+        expect.assertions(2);
+
+        const crons = cronJobs();
+
+        // Shaped like the generated `workflows.<name>` reference object.
+        crons.daily("nightly digest", { hourUTC: 9, minuteUTC: 0 }, { binding: "WORKFLOW_DIGEST", isLunoraWorkflow: true, name: "digest" }, { region: "eu" });
+        crons.interval("anon flow", { minutes: 30 }, { isLunoraWorkflow: true });
+
+        expect(crons.jobs()[0]).toEqual({ args: { region: "eu" }, cron: "0 9 * * *", name: "nightly digest", workflow: "digest" });
+        // A workflow with no stable-name override records an empty marker (codegen resolves the real binding).
+        expect(crons.jobs()[1]).toEqual({ args: {}, cron: "*/30 * * * *", name: "anon flow", workflow: "" });
+    });
+
+    it("infers a workflow target's args from its params type", () => {
+        expect.assertions(1);
+
+        const crons = cronJobs();
+        // A generated `workflows.<name>` ref carries the workflow's params in `__params`.
+        const digest: WorkflowReference<{ region: string }> = { binding: "WORKFLOW_DIGEST", isLunoraWorkflow: true, name: "digest" };
+
+        crons.daily("digest", { hourUTC: 9, minuteUTC: 0 }, digest, { region: "eu" });
+        // @ts-expect-error -- `region` must be a string (inferred from the workflow's params)
+        crons.daily("typo", { hourUTC: 9, minuteUTC: 0 }, digest, { region: 123 });
+        // @ts-expect-error -- `reglon` is not a declared param
+        crons.daily("typo2", { hourUTC: 9, minuteUTC: 0 }, digest, { reglon: "eu" });
+
+        expect(crons.jobs()).toHaveLength(3);
     });
 
     it("is chainable across builder methods", () => {

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -69,5 +69,8 @@
     },
     "engines": {
         "node": "^22.15.0 || >=24.10.0"
+    },
+    "dependencies": {
+        "cron-parser": "5.5.0"
     }
 }

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -9,13 +9,14 @@ export type { SchedulerDOState, SchedulerEnv, SchedulerPoolStatus, SchedulerStat
 export { SchedulerDO } from "./scheduler-do";
 export type {
     ArgsOf,
-    LunoraSchedulerOptions,
+    CronTarget,
     DurableObjectIdLike,
     DurableObjectNamespaceLike,
     DurableObjectStubLike,
     EnqueueOptions,
     FunctionReference,
     HttpDispatcherOptions,
+    LunoraSchedulerOptions,
     MessageBatchLike,
     QueueConsumerOptions,
     QueueDispatch,
@@ -31,7 +32,9 @@ export type {
     RunOptions,
     Scheduler,
     ScheduleRecord,
+    WorkflowReference,
     Workpool,
     WorkpoolOptions,
 } from "./types";
+export { isWorkflowReference } from "./types";
 export { assertValidCronExpression, isValidCronExpression } from "./validate-cron";

--- a/packages/scheduler/src/jobs.ts
+++ b/packages/scheduler/src/jobs.ts
@@ -15,11 +15,22 @@
  * export default crons;
  * ```
  *
+ * A job's target may be a function reference (a one-shot dispatch, above) or a
+ * durable workflow — passing the generated `workflows.&lt;name>` reference starts a
+ * fresh, multi-step, retried workflow INSTANCE on each fire, and the args are
+ * type-checked against the workflow's `params`:
+ *
+ * ```ts
+ * import { workflows } from "./_generated/api";
+ * crons.daily("nightly digest", { hourUTC: 9, minuteUTC: 0 }, workflows.digestPipeline, { region: "eu" });
+ * ```
+ *
  * `@lunora/codegen` discovers the registered jobs and emits both the
  * wrangler.jsonc schedule array and a dispatcher map the runtime's
  * `scheduled()` handler consumes — the user never edits wrangler by hand.
  */
-import type { FunctionReference } from "./types";
+import type { CronTarget, CronTargetArgs } from "./types";
+import { isWorkflowReference } from "./types";
 import { assertValidCronExpression } from "./validate-cron";
 
 /** Sub-day recurrence. Exactly one unit must be provided. */
@@ -55,14 +66,27 @@ interface MonthlySchedule extends DailySchedule {
  * and the runtime dispatcher — keep the shape stable across all three.
  */
 interface CronJob {
-    /** Args forwarded to the function on each fire. */
+    /** Args forwarded to the function (or, for a workflow target, used as its `params`) on each fire. */
     args: Record<string, unknown>;
     /** Compiled standard cron expression, e.g. `"0 9 * * *"`. */
     cron: string;
-    /** `__lunoraRef` of the target function. */
-    functionPath: string;
+
+    /**
+     * `__lunoraRef` of the target function. Present for a function target;
+     * absent when the job targets a workflow ({@link CronJob.workflow} instead).
+     */
+    functionPath?: string;
     /** Human-readable identifier — must be unique within one `cronJobs()`. */
     name: string;
+
+    /**
+     * Set when the job targets a durable workflow rather than a function: the
+     * workflow's stable name (`defineWorkflow({ name })`) when one was declared,
+     * otherwise `""`. `@lunora/codegen` statically resolves the concrete
+     * `lunora/workflows.ts` export + its `WORKFLOW_*` binding for the emitted
+     * dispatch map, so this authoring-time value is informational only.
+     */
+    workflow?: string;
 }
 
 const WEEKDAY_INDEX: Record<WeeklySchedule["dayOfWeek"], number> = {
@@ -176,18 +200,22 @@ const compileCronSchedule = (kind: CronScheduleKind, schedule: DailySchedule | I
  * surface at definition time rather than at codegen.
  */
 interface CronJobsBuilder {
-    /** Raw cron expression escape hatch (5- or 6-field). */
-    cron: (name: string, cronExpr: string, function_: FunctionReference, args?: Record<string, unknown>) => CronJobsBuilder;
-    /** Daily at `hourUTC:minuteUTC` (UTC). */
-    daily: (name: string, schedule: DailySchedule, function_: FunctionReference, args?: Record<string, unknown>) => CronJobsBuilder;
-    /** Every `{ seconds | minutes | hours }`. */
-    interval: (name: string, schedule: IntervalSchedule, function_: FunctionReference, args?: Record<string, unknown>) => CronJobsBuilder;
+    /**
+     * Raw cron expression escape hatch (5- or 6-field, full cron-parser grammar).
+     * The target may be a function (`internal.file.fn`) or a durable workflow
+     * (`workflows.&lt;name>`); a workflow's `args` are inferred from its `params`.
+     */
+    cron: <T extends CronTarget>(name: string, cronExpr: string, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
+    /** Daily at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    daily: <T extends CronTarget>(name: string, schedule: DailySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
+    /** Every `{ seconds | minutes | hours }`. The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    interval: <T extends CronTarget>(name: string, schedule: IntervalSchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
     /** Snapshot of the registered jobs, in declaration order. */
     jobs: () => ReadonlyArray<CronJob>;
-    /** Monthly on `day` at `hourUTC:minuteUTC` (UTC). */
-    monthly: (name: string, schedule: MonthlySchedule, function_: FunctionReference, args?: Record<string, unknown>) => CronJobsBuilder;
-    /** Weekly on `dayOfWeek` at `hourUTC:minuteUTC` (UTC). */
-    weekly: (name: string, schedule: WeeklySchedule, function_: FunctionReference, args?: Record<string, unknown>) => CronJobsBuilder;
+    /** Monthly on `day` at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    monthly: <T extends CronTarget>(name: string, schedule: MonthlySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
+    /** Weekly on `dayOfWeek` at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    weekly: <T extends CronTarget>(name: string, schedule: WeeklySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
 }
 
 /**
@@ -199,7 +227,7 @@ const cronJobs = (): CronJobsBuilder => {
     const jobs: CronJob[] = [];
     const seen = new Set<string>();
 
-    const register = (name: string, cron: string, function_: FunctionReference, args: Record<string, unknown> | undefined): void => {
+    const register = (name: string, cron: string, target: CronTarget, args: Record<string, unknown> | undefined): void => {
         if (typeof name !== "string" || name.trim() === "") {
             throw new Error(`@lunora/scheduler: cron job name must be a non-empty string`);
         }
@@ -208,15 +236,28 @@ const cronJobs = (): CronJobsBuilder => {
             throw new Error(`@lunora/scheduler: duplicate cron job name "${name}" — names must be unique within one cronJobs()`);
         }
 
+        // Workflow target — starts a durable workflow INSTANCE per fire (args ⇒
+        // its `params`). The concrete `lunora/workflows.ts` export + `WORKFLOW_*`
+        // binding is resolved statically by `@lunora/codegen`; the builder only
+        // records the optional stable-name override for `.jobs()` introspection.
+        if (isWorkflowReference(target)) {
+            assertValidCronExpression(cron, `cron expression for job "${name}"`);
+
+            seen.add(name);
+            jobs.push({ args: args ?? {}, cron, name, workflow: typeof target.name === "string" ? target.name : "" });
+
+            return;
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- guards untrusted JS callers despite the required type
-        if (!function_ || typeof function_.__lunoraRef !== "string") {
-            throw new Error(`@lunora/scheduler: cron job "${name}" requires a function reference (e.g. internal.email.digest)`);
+        if (!target || typeof target.__lunoraRef !== "string") {
+            throw new Error(`@lunora/scheduler: cron job "${name}" requires a function reference (e.g. internal.email.digest) or a workflow reference`);
         }
 
         assertValidCronExpression(cron, `cron expression for job "${name}"`);
 
         seen.add(name);
-        jobs.push({ args: args ?? {}, cron, functionPath: function_.__lunoraRef, name });
+        jobs.push({ args: args ?? {}, cron, functionPath: target.__lunoraRef, name });
     };
 
     const builder: CronJobsBuilder = {

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -16,6 +16,43 @@ export interface FunctionReference {
 export type ArgsOf<F extends FunctionReference> = F extends { _args?: infer A } ? A : Record<string, unknown>;
 
 /**
+ * Typed reference to a Lunora durable workflow — either the generated
+ * `workflows.&lt;name>` reference object (`_generated/api.ts`, which carries the
+ * `WORKFLOW_*` binding + export name) or, structurally, a `defineWorkflow()`
+ * result imported directly. Both are matched by the `isLunoraWorkflow` brand and
+ * carry the workflow's `params` in the phantom `__params`, so a `cronJobs()`
+ * registration infers them.
+ *
+ * Declared structurally here so `@lunora/scheduler` can let a `cronJobs()`
+ * builder target a workflow without depending on `@lunora/workflow` (and so the
+ * generated `workflows.*` object needs no `@lunora/scheduler` import — it
+ * matches structurally). A cron whose target is a {@link WorkflowReference}
+ * starts a new workflow INSTANCE on each fire (the args become its `params`)
+ * instead of dispatching a one-shot function. `@lunora/codegen` resolves the
+ * concrete `lunora/workflows.ts` export statically; the runtime brand here is
+ * the authoring-time guard.
+ */
+export interface WorkflowReference<Params = Record<string, unknown>> {
+    /** Phantom carrier for the workflow's `params` type — drives `cronJobs()` arg inference. Never read at runtime. */
+    readonly __params?: Params;
+    /** The `WORKFLOW_*` binding name (present on a generated `workflows.&lt;name>` ref). */
+    readonly binding?: string;
+    readonly isLunoraWorkflow: true;
+    /** The workflow's export/stable name (present on a generated ref; a `defineWorkflow({ name })` override otherwise). */
+    readonly name?: string;
+}
+
+/** A cron job's target: either a one-shot function dispatch or a durable workflow start. */
+export type CronTarget = FunctionReference | WorkflowReference;
+
+/** The arguments a cron's target accepts: a workflow's inferred `params`, else an open record (function args aren't inferred). */
+export type CronTargetArgs<T extends CronTarget> = T extends WorkflowReference<infer Params> ? Params : Record<string, unknown>;
+
+/** Narrow a {@link CronTarget} to a {@link WorkflowReference} by its runtime brand. */
+export const isWorkflowReference = (target: unknown): target is WorkflowReference =>
+    typeof target === "object" && target !== null && (target as { isLunoraWorkflow?: unknown }).isLunoraWorkflow === true;
+
+/**
  * Per-job retry policy. Wired into the SchedulerDO's existing attempts/backoff
  * machinery. When omitted, the DO falls back to its built-in defaults
  * (`maxAttempts: 5`, `backoff: "exponential"`, `baseMs: 30_000`) so existing

--- a/packages/scheduler/src/validate-cron.ts
+++ b/packages/scheduler/src/validate-cron.ts
@@ -1,44 +1,37 @@
 /**
- * Shared cron-expression validation + ergonomic-form compilation used by both
- * the imperative `createCronTrigger` (see `./cron.ts`) and the code-first
- * `cronJobs()` builder (see `./jobs.ts`). Keeping the regexes in one place
- * means the two surfaces can never drift apart on what counts as a valid
- * expression.
+ * Shared cron-expression validation used by both the imperative
+ * `createCronTrigger` (see `./cron.ts`) and the code-first `cronJobs()` builder
+ * (see `./jobs.ts`). Keeping the check in one place means the two surfaces can
+ * never drift apart on what counts as a valid expression.
+ *
+ * Validation is delegated to `cron-parser`, so the full standard cron grammar is
+ * accepted — wildcards, lists, ranges, steps, the 3-letter month/weekday names,
+ * the Quartz-style `L`/`W`/`#`/`?` operators, the `@hourly`/`@daily`/… macros,
+ * and both 5-field (minute…dow) and 6-field (seconds-leading) forms. We only
+ * decide *well-formedness* here; out-of-platform values (Cloudflare caps the
+ * number of triggers, doesn't run seconds, etc.) are still rejected downstream
+ * by wrangler/Cloudflare at deploy time.
+ *
+ * `cron-parser` is a Node/codegen-time dependency: this module is pulled in by
+ * the `cronJobs()` builder (authoring) and `@lunora/codegen` (build), never by
+ * the `SchedulerDO` runtime path — so with `sideEffects: false` it tree-shakes
+ * out of the Worker bundle.
  */
+import { CronExpressionParser } from "cron-parser";
 
-// Single cron-piece: `*`, `*` followed by a step, a digit, a range, or a
-// range with a step. Also accepts the standard 3-letter named tokens for
-// months (JAN..DEC) and weekdays (SUN..SAT), case-insensitively and in
-// ranges/lists (e.g. `MON`, `MON-FRI`, `JAN-MAR`), which both standard cron
-// and Cloudflare's parser support. Intentionally permissive on numeric values
-// (we don't enforce minute < 60 etc.) — wrangler/Cloudflare will reject
-// out-of-range values — but strict enough to refuse free-form prose like
-// "every minute" that would otherwise silently no-op.
-// `*` optionally followed by a step (`*/5`).
-const CRON_WILDCARD = /^\*(?:\/\d+)?$/u;
-
-// A numeric value or range, optionally followed by a step (`5`, `1-3`, `1-3/2`).
-const CRON_NUMERIC = /^\d+(?:-\d+)?(?:\/\d+)?$/u;
-
-// A 3-letter named token (month/weekday), optionally as a range, with a step
-// (`MON`, `MON-FRI`, `JAN-MAR/2`).
-const CRON_NAMED = /^[A-Za-z]{3}(?:-[A-Za-z]{3})?(?:\/\d+)?$/u;
-
-const CRON_FIELD_SEPARATOR = /\s+/u;
-
-const isValidCronPiece = (piece: string): boolean => CRON_WILDCARD.test(piece) || CRON_NUMERIC.test(piece) || CRON_NAMED.test(piece);
-
-const isValidCronField = (field: string): boolean => field.split(",").every((piece) => isValidCronPiece(piece));
-
-/** Standard 5-field (minute hour day month dow) or 6-field (with seconds) cron. */
+/** Standard cron expression (5- or 6-field) or a supported `@macro`, per `cron-parser`. */
 const isValidCronExpression = (schedule: string): boolean => {
-    const tokens = schedule.trim().split(CRON_FIELD_SEPARATOR);
-
-    if (tokens.length !== 5 && tokens.length !== 6) {
+    if (typeof schedule !== "string" || schedule.trim() === "") {
         return false;
     }
 
-    return tokens.every((token) => isValidCronField(token));
+    try {
+        CronExpressionParser.parse(schedule.trim());
+
+        return true;
+    } catch {
+        return false;
+    }
 };
 
 /**
@@ -48,7 +41,7 @@ const isValidCronExpression = (schedule: string): boolean => {
  */
 const assertValidCronExpression = (schedule: string, context = "cron expression"): void => {
     if (!isValidCronExpression(schedule)) {
-        throw new Error(`@lunora/scheduler: invalid ${context} "${schedule}" — expected 5 or 6 space-separated fields (e.g. "0 * * * *")`);
+        throw new Error(`@lunora/scheduler: invalid ${context} "${schedule}" — expected a standard 5- or 6-field cron expression (e.g. "0 * * * *")`);
     }
 };
 

--- a/packages/studio/__tests__/features/logs/cron-triggers-panel.test.tsx
+++ b/packages/studio/__tests__/features/logs/cron-triggers-panel.test.tsx
@@ -1,6 +1,6 @@
 import type { CronJobInfo } from "@lunora/client";
 import { LunoraProvider } from "@lunora/react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,6 +14,8 @@ const JOBS: CronJobInfo[] = [
     { args: {}, cron: "0 9 * * *", functionPath: "report:daily", name: "daily digest" },
     { args: { tenant: "acme" }, cron: "*/5 * * * *", functionPath: "presence:clear", name: "clear presence", shardKey: "acme" },
 ];
+
+const WORKFLOW_JOBS: CronJobInfo[] = [{ args: { region: "eu" }, cron: "0 9 * * *", name: "nightly digest", workflow: "WORKFLOW_DIGEST" }];
 
 const loadEmpty = async (): Promise<CronJobInfo[]> => [];
 
@@ -71,5 +73,60 @@ describe("cronTriggersPanel", () => {
         const error = await screen.findByTestId("cron-error");
 
         expect(error.textContent).toContain("boom");
+    });
+
+    it("labels a workflow target with a workflow badge and its binding", async () => {
+        expect.assertions(2);
+
+        const loadCronJobs = vi.fn<() => Promise<CronJobInfo[]>>(async () => WORKFLOW_JOBS);
+
+        render(withProvider(createMockClient(), <CronTriggersPanel loadCronJobs={loadCronJobs} />));
+
+        await screen.findByTestId("cron-table");
+
+        expect(screen.getByText("workflow")).toBeDefined();
+        expect(screen.getByText("WORKFLOW_DIGEST")).toBeDefined();
+    });
+
+    it("runs a cron job on demand and shows it ran", async () => {
+        expect.assertions(2);
+
+        const loadCronJobs = vi.fn<() => Promise<CronJobInfo[]>>(async () => JOBS);
+        const runCronJob = vi.fn<(name: string) => Promise<{ name: string; ran: boolean }>>(async (name: string) => {
+            return { name, ran: true };
+        });
+
+        render(withProvider(createMockClient(), <CronTriggersPanel loadCronJobs={loadCronJobs} runCronJob={runCronJob} />));
+
+        await screen.findByTestId("cron-table");
+
+        // ConfirmButton: first click reveals confirm, second fires.
+        fireEvent.click(screen.getByTestId("cron-run-daily digest"));
+        fireEvent.click(screen.getByTestId("cron-run-daily digest-confirm"));
+
+        await screen.findByTestId("cron-ran-daily digest");
+
+        expect(runCronJob).toHaveBeenCalledWith("daily digest");
+        expect(runCronJob).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces a run error inline without affecting other rows", async () => {
+        expect.assertions(1);
+
+        const loadCronJobs = vi.fn<() => Promise<CronJobInfo[]>>(async () => JOBS);
+        const runCronJob = vi.fn<(name: string) => Promise<{ name: string; ran: boolean }>>(async () => {
+            throw new Error("dispatch failed");
+        });
+
+        render(withProvider(createMockClient(), <CronTriggersPanel loadCronJobs={loadCronJobs} runCronJob={runCronJob} />));
+
+        await screen.findByTestId("cron-table");
+
+        fireEvent.click(screen.getByTestId("cron-run-clear presence"));
+        fireEvent.click(screen.getByTestId("cron-run-clear presence-confirm"));
+
+        await waitFor(() => {
+            expect(screen.getByTestId("cron-run-error-clear presence").textContent).toContain("dispatch failed");
+        });
     });
 });

--- a/packages/studio/__tests__/mock-client.ts
+++ b/packages/studio/__tests__/mock-client.ts
@@ -2,7 +2,6 @@ import type {
     AuthPage,
     AuthSession,
     AuthUser,
-    LunoraClient,
     CronJobInfo,
     FunctionDescriptor,
     FunctionReference,
@@ -10,6 +9,7 @@ import type {
     GlobalFilterClause,
     GlobalTableInfo,
     GlobalTablePage,
+    LunoraClient,
     ScheduleRecord,
     ShardTrafficResult,
     StorageListPage,
@@ -61,6 +61,7 @@ interface MockClientHooks {
     removeAuthUser: ReturnType<typeof vi.fn>;
     revokeAuthSession: ReturnType<typeof vi.fn>;
     revokeAuthUserSessions: ReturnType<typeof vi.fn>;
+    runCronJob: ReturnType<typeof vi.fn>;
     setAuthUserPassword: ReturnType<typeof vi.fn>; // gitleaks:allow -- mock method name, not a secret
     setAuthUserRole: ReturnType<typeof vi.fn>;
     shardTraffic: ReturnType<typeof vi.fn>;
@@ -110,6 +111,7 @@ interface MockClientImpls {
     query?: Impl;
     queryVectorIndex?: (options: { name: string; text: string; topK?: number }) => VectorQueryMatch[];
     readGlobalTablePage?: (options: { filters?: GlobalFilterClause[]; limit?: number; offset?: number; table: string }) => GlobalTablePage;
+    runCronJob?: (name: string) => { name: string; ran: boolean };
     shardTraffic?: (table: string) => ShardTrafficResult;
     signedStorageUrl?: (key: string) => string;
 }
@@ -125,6 +127,9 @@ export const createMockClient = (impls: MockClientImpls = {}): MockClientHooks =
     const getCronJobs = vi.fn<() => Promise<CronJobInfo[]>>(async () => impls.getCronJobs?.() ?? []);
     const cancelScheduledJob = vi.fn<(id: string) => Promise<{ cancelled: boolean }>>(
         async (id: string) => impls.cancelScheduledJob?.(id) ?? { cancelled: true },
+    );
+    const runCronJob = vi.fn<(name: string) => Promise<{ name: string; ran: boolean }>>(
+        async (name: string) => impls.runCronJob?.(name) ?? { name, ran: true },
     );
     const listStorageBuckets = vi.fn<() => Promise<string[]>>(async () => impls.listStorageBuckets?.() ?? []);
     const listStorageObjects = vi.fn<(options?: { bucket?: string; cursor?: string; limit?: number; prefix?: string }) => Promise<StorageListPage>>(
@@ -308,6 +313,7 @@ export const createMockClient = (impls: MockClientImpls = {}): MockClientHooks =
         query,
         queryVectorIndex,
         readGlobalTablePage,
+        runCronJob,
         shardTraffic,
         signedStorageUrl,
         subscribe,
@@ -340,6 +346,7 @@ export const createMockClient = (impls: MockClientImpls = {}): MockClientHooks =
         query,
         queryVectorIndex,
         readGlobalTablePage,
+        runCronJob,
         shardTraffic,
         signedStorageUrl,
         subscribe,

--- a/packages/studio/src/features/logs/cron-triggers-panel.tsx
+++ b/packages/studio/src/features/logs/cron-triggers-panel.tsx
@@ -1,8 +1,10 @@
 import type { CronJobInfo } from "@lunora/client";
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { ConfirmButton } from "../../components/confirm-button";
+import { Badge } from "../../components/ui/badge";
 import { EmptyState } from "../../components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useT } from "../../i18n/i18n-context";
@@ -17,23 +19,51 @@ interface CronTriggersPanelProps {
      * source triggers from elsewhere (e.g. tests).
      */
     readonly loadCronJobs?: () => Promise<CronJobInfo[]>;
+
+    /**
+     * Manually fire one cron job by name. Defaults to `client.runCronJob`, which
+     * hits the admin-gated `POST /_lunora/admin/cron-jobs/run` endpoint (the same
+     * dispatch the scheduled trigger runs). When a custom {@link CronTriggersPanelProps.loadCronJobs}
+     * is supplied without a `runCronJob`, the "Run now" control is hidden — useful
+     * for a read-only view.
+     */
+    readonly runCronJob?: (name: string) => Promise<{ name: string; ran: boolean }>;
 }
+
+/** Per-row run state for the "Run now" control. */
+type RunState = { kind: "error"; message: string } | { kind: "idle" } | { kind: "ok" } | { kind: "running" };
+
+const IDLE: RunState = { kind: "idle" };
 
 /**
  * Read-only view of the **static cron triggers** — the `cronJobs()` map compiled
- * into the worker. Unlike the dynamic `runAfter` / `runAt` schedule, these are
- * fixed for the deployment: Cloudflare exposes no runtime cron introspection, so
- * the injected map is the only source of truth and nothing here is editable. One
- * row per scheduled invocation: its cron expression, the function it runs, and
- * any bound shard / args.
+ * into the worker — with a per-row **Run now** action. Unlike the dynamic
+ * `runAfter` / `runAt` schedule, the triggers themselves are fixed for the
+ * deployment (Cloudflare exposes no runtime cron introspection, so the injected
+ * map is the only source of truth and nothing here is editable). One row per
+ * scheduled invocation: its cron expression, its target (a function dispatch or
+ * a durable workflow start), any bound shard / args, and a button to fire it on
+ * demand.
  */
 
-export const CronTriggersPanel = ({ loadCronJobs }: CronTriggersPanelProps = {}): ReactElement => {
+export const CronTriggersPanel = ({ loadCronJobs, runCronJob }: CronTriggersPanelProps = {}): ReactElement => {
     const client = useLunora();
     const t = useT();
 
     const [jobs, setJobs] = useState<CronJobInfo[] | null>(null);
     const [error, setError] = useState<null | string>(null);
+    const [runStates, setRunStates] = useState<Record<string, RunState>>({});
+
+    // Running is available when the host supplies a runner, or when the panel is
+    // sourcing triggers from the client (then the client can run them too). A
+    // custom `loadCronJobs` without a `runCronJob` stays read-only.
+    const runImpl = useMemo<((name: string) => Promise<{ name: string; ran: boolean }>) | undefined>(() => {
+        if (runCronJob !== undefined) {
+            return runCronJob;
+        }
+
+        return loadCronJobs === undefined ? (name: string) => client.runCronJob(name) : undefined;
+    }, [client, loadCronJobs, runCronJob]);
 
     useEffect(() => {
         const token = { cancelled: false };
@@ -60,6 +90,31 @@ export const CronTriggersPanel = ({ loadCronJobs }: CronTriggersPanelProps = {})
             token.cancelled = true;
         };
     }, [client, loadCronJobs]);
+
+    const run = useCallback(
+        async (name: string): Promise<void> => {
+            if (runImpl === undefined) {
+                return;
+            }
+
+            setRunStates((previous) => {
+                return { ...previous, [name]: { kind: "running" } };
+            });
+
+            try {
+                await runImpl(name);
+
+                setRunStates((previous) => {
+                    return { ...previous, [name]: { kind: "ok" } };
+                });
+            } catch (error_) {
+                setRunStates((previous) => {
+                    return { ...previous, [name]: { kind: "error", message: errorMessage(error_) } };
+                });
+            }
+        },
+        [runImpl],
+    );
 
     return (
         <div className="flex flex-col gap-3" data-testid="lunora-cron-triggers">
@@ -98,19 +153,60 @@ export const CronTriggersPanel = ({ loadCronJobs }: CronTriggersPanelProps = {})
                             <TableRow>
                                 <TableHead>{t("name")}</TableHead>
                                 <TableHead>{t("schedule")}</TableHead>
-                                <TableHead>{t("function")}</TableHead>
+                                <TableHead>{t("target")}</TableHead>
                                 <TableHead>{t("shard")}</TableHead>
+                                {runImpl !== undefined && <TableHead aria-label={t("Actions")} />}
                             </TableRow>
                         </TableHeader>
                         <TableBody>
-                            {jobs.map((job) => (
-                                <TableRow data-testid={`cron-row-${job.name}`} key={`${job.cron}:${job.name}`}>
-                                    <TableCell>{job.name}</TableCell>
-                                    <TableCell className="font-mono text-xs tabular-nums">{job.cron}</TableCell>
-                                    <TableCell className="font-mono text-xs">{job.functionPath}</TableCell>
-                                    <TableCell>{job.shardKey ?? ""}</TableCell>
-                                </TableRow>
-                            ))}
+                            {jobs.map((job) => {
+                                const state = runStates[job.name] ?? IDLE;
+
+                                return (
+                                    <TableRow data-testid={`cron-row-${job.name}`} key={`${job.cron}:${job.name}`}>
+                                        <TableCell>{job.name}</TableCell>
+                                        <TableCell className="font-mono text-xs tabular-nums">{job.cron}</TableCell>
+                                        <TableCell>
+                                            <span className="flex items-center gap-2">
+                                                {job.workflow === undefined ? (
+                                                    <Badge variant="outline">{t("function")}</Badge>
+                                                ) : (
+                                                    <Badge variant="secondary">{t("workflow")}</Badge>
+                                                )}
+                                                <span className="font-mono text-xs">{job.workflow ?? job.functionPath}</span>
+                                            </span>
+                                        </TableCell>
+                                        <TableCell>{job.shardKey ?? ""}</TableCell>
+                                        {runImpl !== undefined && (
+                                            <TableCell className="text-right">
+                                                <span className="flex items-center justify-end gap-2">
+                                                    {state.kind === "ok" && (
+                                                        <span className="text-xs text-muted-foreground" data-testid={`cron-ran-${job.name}`}>
+                                                            {t("ran")}
+                                                        </span>
+                                                    )}
+                                                    {state.kind === "error" && (
+                                                        <span className="text-xs text-destructive" data-testid={`cron-run-error-${job.name}`} role="alert">
+                                                            {state.message}
+                                                        </span>
+                                                    )}
+                                                    <ConfirmButton
+                                                        confirmLabel={t("Run now?")}
+                                                        disabled={state.kind === "running"}
+                                                        // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop -- per-row handler closes over job.name; admin dev-tool render path
+                                                        onConfirm={() => {
+                                                            fireAndForget(run(job.name));
+                                                        }}
+                                                        testId={`cron-run-${job.name}`}
+                                                    >
+                                                        {state.kind === "running" ? t("Running…") : t("Run now")}
+                                                    </ConfirmButton>
+                                                </span>
+                                            </TableCell>
+                                        )}
+                                    </TableRow>
+                                );
+                            })}
                         </TableBody>
                     </Table>
                 </div>

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -294,6 +294,13 @@ const MESSAGE_IDS = [
     "Save widget",
     "Saved",
     "schedule",
+    // Cron triggers panel — target column + "Run now" action.
+    "target",
+    "workflow",
+    "Run now",
+    "Run now?",
+    "Running…",
+    "ran",
     "Schedule view",
     "Scheduled",
     "scheduled for",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1578,7 +1578,7 @@ importers:
         version: 2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@visulima/email':
         specifier: catalog:mail
-        version: 1.0.0-alpha.35(@opentelemetry/api@1.9.1)(@react-email/render@2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@25.9.3)(asn1js@3.0.10)(handlebars@4.7.9)(moment@2.30.1)(unstorage@1.17.5)
+        version: 1.0.0-alpha.35(@opentelemetry/api@1.9.1)(@react-email/render@2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@25.9.3)(asn1js@3.0.10)(handlebars@4.7.9)(luxon@3.7.2)(moment@2.30.1)(unstorage@1.17.5)
       postal-mime:
         specifier: catalog:mail
         version: 2.7.4
@@ -1804,6 +1804,10 @@ importers:
         version: 4.100.0(@cloudflare/workers-types@4.20260613.1)
 
   packages/scheduler:
+    dependencies:
+      cron-parser:
+        specifier: 5.5.0
+        version: 5.5.0
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: catalog:cloudflare
@@ -8826,6 +8830,10 @@ packages:
       typescript:
         optional: true
 
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
+
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -11211,6 +11219,10 @@ packages:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: 19.2.7
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -18383,11 +18395,11 @@ snapshots:
 
   '@visulima/disposable-email-domains@1.0.0-alpha.16': {}
 
-  '@visulima/email@1.0.0-alpha.35(@opentelemetry/api@1.9.1)(@react-email/render@2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@25.9.3)(asn1js@3.0.10)(handlebars@4.7.9)(moment@2.30.1)(unstorage@1.17.5)':
+  '@visulima/email@1.0.0-alpha.35(@opentelemetry/api@1.9.1)(@react-email/render@2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/node@25.9.3)(asn1js@3.0.10)(handlebars@4.7.9)(luxon@3.7.2)(moment@2.30.1)(unstorage@1.17.5)':
     dependencies:
       '@visulima/disposable-email-domains': 1.0.0-alpha.16
       html-to-text: 10.0.0
-      ical-generator: 10.2.0(@types/node@25.9.3)(moment@2.30.1)
+      ical-generator: 10.2.0(@types/node@25.9.3)(luxon@3.7.2)(moment@2.30.1)
       lru-cache: 11.4.0
       mime: 4.1.0
     optionalDependencies:
@@ -19955,6 +19967,10 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
+
+  cron-parser@5.5.0:
+    dependencies:
+      luxon: 3.7.2
 
   cross-env@10.1.0:
     dependencies:
@@ -21981,9 +21997,10 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  ical-generator@10.2.0(@types/node@25.9.3)(moment@2.30.1):
+  ical-generator@10.2.0(@types/node@25.9.3)(luxon@3.7.2)(moment@2.30.1):
     optionalDependencies:
       '@types/node': 25.9.3
+      luxon: 3.7.2
       moment: 2.30.1
 
   iconv-lite@0.4.24:
@@ -22602,6 +22619,8 @@ snapshots:
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
Let a `cronJobs()` registration target a durable workflow, not just a
one-shot function. Passing a `defineWorkflow()` result (imported from
`cirrus/workflows.ts`) as a cron's target starts a fresh, multi-step,
retried workflow INSTANCE on each fire — the args become its `params` —
so scheduled work gets the durability/observability of Cloudflare
Workflows without the cron→mutation→`workflows.create()` indirection.

- scheduler: widen the builder target to `FunctionReference |
  WorkflowReference`; record workflow targets on `CronJob`.
- codegen: `discoverCrons` resolves a bare identifier naming a declared
  workflow into `{ workflow: { binding, exportName } }` (discovered ahead
  of crons); `emitCrons` emits a `WORKFLOW_*` binding target instead of a
  `functionPath`.
- runtime: `scheduled()` starts the workflow via its `env` binding's
  `create({ params })` for workflow jobs; function jobs dispatch to the
  shard as before. The studio cron-jobs view surfaces the workflow target.

Also replace the hand-rolled cron regex validation with `cron-parser`,
so the full standard grammar is accepted (named months/weekdays, lists,
ranges, steps, the Quartz `L`/`W`/`#`/`?` operators, `@macro`s, and 5- or
6-field forms). It is a codegen/authoring-time dependency only and
tree-shakes out of the Worker bundle.

https://claude.ai/code/session_01G6zix18MSjR1UVzMS8fyGw