### PR TITLE
feat: extending db 

### DIFF
--- a/packages/codegen/__tests__/discover-schema.test.ts
+++ b/packages/codegen/__tests__/discover-schema.test.ts
@@ -43,6 +43,32 @@ describe("discoverSchema", () => {
         expect(schema.tables.find((table) => table.name === "messages")?.externallyManaged).toBe(false);
     });
 
+    it("captures `.softDelete()`, injecting the marker column so Doc carries it", () => {
+        expect.assertions(4);
+
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            export const schema = defineSchema({
+                posts: defineTable({ title: v.string() }).softDelete(),
+                logs: defineTable({ line: v.string() }).softDelete({ field: "removedAt" }),
+            });
+        `);
+
+        const schema = discoverSchema(project, schemaPath);
+        const posts = schema.tables.find((table) => table.name === "posts");
+        const logs = schema.tables.find((table) => table.name === "logs");
+
+        expect(posts?.softDelete).toStrictEqual({ field: "deletedAt" });
+        expect(logs?.softDelete).toStrictEqual({ field: "removedAt" });
+
+        // The injected column flows into the emitted Doc as an optional number.
+        const dataModel = emitDataModel(schema);
+
+        expect(dataModel).toContain("deletedAt?: number;");
+        expect(dataModel).toContain("removedAt?: number;");
+    });
+
     it("captures searchIndex name + field + filterFields", () => {
         expect.assertions(3);
 

--- a/packages/codegen/src/discover-schema.ts
+++ b/packages/codegen/src/discover-schema.ts
@@ -315,8 +315,26 @@ interface TableBuilderAccumulator {
     relations: RelationIR[];
     searchIndexes: SearchIndexIR[];
     shardMode: TableIR["shardMode"];
+    softDelete?: { field: string };
     vectorIndexes: VectorIndexIR[];
 }
+
+/** Read the marker-column name off a `.softDelete({ field })` options arg; defaults to `deletedAt`. */
+const softDeleteFieldOf = (optionsArgument: Node | undefined): string => {
+    if (optionsArgument && Node.isObjectLiteralExpression(optionsArgument)) {
+        const fieldProperty = optionsArgument.getProperty("field");
+
+        if (fieldProperty && Node.isPropertyAssignment(fieldProperty)) {
+            const initializer = fieldProperty.getInitializer();
+
+            if (initializer && Node.isStringLiteral(initializer)) {
+                return initializer.getLiteralText();
+            }
+        }
+    }
+
+    return "deletedAt";
+};
 
 /** Apply one chained method call (`.index`, `.shardBy`, …) to the accumulator. */
 const applyTableMethod = (accumulator: TableBuilderAccumulator, method: string, args: ReadonlyArray<Node>, name: string): void => {
@@ -366,6 +384,14 @@ const applyTableMethod = (accumulator: TableBuilderAccumulator, method: string, 
             const field = args[0];
 
             accumulator.shardMode = { field: field && Node.isStringLiteral(field) ? field.getLiteralText() : "_unknown_", kind: "shardBy" };
+
+            break;
+        }
+
+        case "softDelete": {
+            // `.softDelete()` or `.softDelete({ field: "removedAt" })` — read the
+            // optional marker-column name off the options object (default `deletedAt`).
+            accumulator.softDelete = { field: softDeleteFieldOf(args[0]) };
 
             break;
         }
@@ -421,6 +447,14 @@ const parseTableBuilder = (expression: Expression, name: string): TableIR => {
         }
     }
 
+    // `.softDelete()` injects the marker column into the shape (mirrors the
+    // runtime builder) so `Doc_*`/`Insert_*` carry it — optional + nullable
+    // (`number | null | undefined`), absent on a live row. The user's own
+    // declaration of the column wins (matches the runtime `if (!(field in shape))`).
+    if (accumulator.softDelete && !(accumulator.softDelete.field in shape)) {
+        shape = { ...shape, [accumulator.softDelete.field]: { inner: { kind: "number" }, kind: "optional" } };
+    }
+
     return {
         externallyManaged: accumulator.externallyManaged,
         globalBackend: accumulator.shardMode === "global" ? (accumulator.globalBackend ?? "d1") : undefined,
@@ -431,6 +465,7 @@ const parseTableBuilder = (expression: Expression, name: string): TableIR => {
         searchIndexes: accumulator.searchIndexes,
         shape,
         shardMode: accumulator.shardMode,
+        softDelete: accumulator.softDelete,
         vectorIndexes: accumulator.vectorIndexes,
     };
 };

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -126,6 +126,8 @@ export interface TableIR {
     searchIndexes: ReadonlyArray<SearchIndexIR>;
     shape: Record<string, ValidatorIR>;
     shardMode: "global" | "root" | { field: string; kind: "shardBy" };
+    /** Set when the chain carried `.softDelete()` — the marker column's name (default `deletedAt`). The column is injected into `shape` so `Doc_*` carries it. */
+    softDelete?: { field: string };
     /** Vector indexes declared inline via `.vectorize()` (DSL Shape A). */
     vectorIndexes: ReadonlyArray<VectorIndexIR>;
 }

--- a/packages/d1/__tests__/d1-ctx-db.soft-delete.test.ts
+++ b/packages/d1/__tests__/d1-ctx-db.soft-delete.test.ts
@@ -1,0 +1,127 @@
+import type { DatabaseWriterLike, SchemaLike } from "@lunora/do";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createD1CtxDb as createD1ContextDatabase } from "../src/d1-ctx-db";
+import createD1Exec from "./_helpers/node-sqlite-d1";
+
+/**
+ * Soft delete on the D1 (global) column dialect: the parity twin of
+ * `@lunora/do`'s `ctx-db.soft-delete` suite. `delete()` stamps the marker column
+ * (an UPDATE, mirroring `patch`'s all-column write) instead of removing the row;
+ * list reads/count hide soft-deleted rows; `{ hard: true }` physically removes;
+ * and a soft delete cascades as a soft delete.
+ */
+const FIXED_CLOCK = 1_700_000_000_000;
+
+const schema: SchemaLike = {
+    tables: {
+        projects: {
+            indexes: [],
+            relationMap: {},
+            shape: { deletedAt: { kind: "number" }, name: { kind: "string" } },
+            softDeleteMode: { field: "deletedAt" },
+        },
+        todos: {
+            indexes: [],
+            relationMap: { project: { field: "projectId", kind: "one", onDelete: "cascade", references: "_id", table: "projects" } },
+            shape: { deletedAt: { kind: "number" }, projectId: { kind: "string" }, title: { kind: "string" } },
+            softDeleteMode: { field: "deletedAt" },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createD1Exec>;
+
+const setup = (): DatabaseWriterLike => {
+    harness.ddl(`CREATE TABLE "projects" ("id" TEXT PRIMARY KEY, "_creationTime" INTEGER NOT NULL, "name" TEXT, "deletedAt" INTEGER)`);
+    harness.ddl(`CREATE TABLE "todos" ("id" TEXT PRIMARY KEY, "_creationTime" INTEGER NOT NULL, "projectId" TEXT, "title" TEXT, "deletedAt" INTEGER)`);
+
+    return createD1ContextDatabase({ clock: () => FIXED_CLOCK, exec: harness.exec, schema });
+};
+
+const ids = (result: { page: Record<string, unknown>[] }): unknown[] =>
+    result.page.map((document_) => document_["_id"]).toSorted((a, b) => String(a).localeCompare(String(b)));
+
+const seedTodos = async (writer: DatabaseWriterLike): Promise<void> => {
+    await writer.insert("todos", { _id: "t1", projectId: "p1", title: "one" }, { allowExplicitId: true });
+    await writer.insert("todos", { _id: "t2", projectId: "p1", title: "two" }, { allowExplicitId: true });
+    await writer.insert("todos", { _id: "t3", projectId: "p1", title: "three" }, { allowExplicitId: true });
+};
+
+describe("d1 ctx-db soft delete", () => {
+    beforeEach(() => {
+        harness = createD1Exec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("delete() hides the row from list reads but keeps it reachable by id", async () => {
+        expect.assertions(4);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        expect(ids(await writer.findMany("todos", {}))).toStrictEqual(["t1", "t3"]);
+        await expect(writer.count("todos")).resolves.toBe(2);
+
+        const row = await writer.get("t2", "todos");
+
+        expect(row?.["deletedAt"]).toBe(FIXED_CLOCK);
+        expect(row?.["title"]).toBe("two");
+    });
+
+    it("includeDeleted re-includes soft-deleted rows", async () => {
+        expect.assertions(1);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
+    });
+
+    it("restore (patch the marker to null) brings the row back", async () => {
+        expect.assertions(1);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        await writer.patch("t2", { deletedAt: null }, "todos");
+
+        await expect(writer.count("todos")).resolves.toBe(3);
+    });
+
+    it("delete({ hard: true }) physically removes the row", async () => {
+        expect.assertions(2);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t3", "todos", { hard: true });
+
+        await expect(writer.get("t3", "todos")).resolves.toBeNull();
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2"]);
+    });
+
+    it("a soft delete cascades as a soft delete to onDelete:cascade children", async () => {
+        expect.assertions(3);
+
+        const writer = setup();
+
+        await writer.insert("projects", { _id: "p1", name: "Project" }, { allowExplicitId: true });
+        await seedTodos(writer);
+
+        await writer.delete("p1", "projects");
+
+        await expect(writer.count("projects")).resolves.toBe(0);
+        await expect(writer.count("todos")).resolves.toBe(0);
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
+    });
+});

--- a/packages/do/__bench__/soft-delete-and-select.bench.ts
+++ b/packages/do/__bench__/soft-delete-and-select.bench.ts
@@ -1,0 +1,83 @@
+import { beforeAll, bench, describe } from "vitest";
+
+import createSqliteExec from "../__tests__/_helpers/node-sqlite";
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+
+/**
+ * Hot-path cost of the two new read-layer features.
+ *
+ * Soft-delete scoping: a `.softDelete()` table ANDs `deletedAt IS NULL` into
+ * every list read. Benched against an identical plain table so the
+ * `json_extract(...) IS NULL` overhead is isolated.
+ *
+ * Select projection: `findMany({ select })` trims the returned payload in JS
+ * after the rows decode. Benched against the full-document read.
+ *
+ * Row count is high enough (5 000) that the per-row work dominates fixed costs.
+ */
+const ROW_COUNT = 5000;
+
+const plainSchema: SchemaLike = {
+    tables: {
+        todos: { indexes: [], shape: { archived: { kind: "boolean" }, priority: { kind: "string" }, projectId: { kind: "string" }, seq: { kind: "number" } } },
+    },
+};
+
+const softSchema: SchemaLike = {
+    tables: {
+        todos: {
+            indexes: [],
+            shape: {
+                archived: { kind: "boolean" },
+                deletedAt: { kind: "number" },
+                priority: { kind: "string" },
+                projectId: { kind: "string" },
+                seq: { kind: "number" },
+            },
+            softDeleteMode: { field: "deletedAt" },
+        },
+    },
+};
+
+const seed = async (writer: DatabaseWriterLike): Promise<void> => {
+    for (let index = 0; index < ROW_COUNT; index += 1) {
+        // eslint-disable-next-line no-await-in-loop -- sequential seed, single-threaded SQLite
+        await writer.insert("todos", { archived: index % 2 === 0, priority: "high", projectId: `p${String(index % 10)}`, seq: index });
+    }
+};
+
+let plain: DatabaseWriterLike;
+let soft: DatabaseWriterLike;
+
+describe("soft-delete scoping + select projection", () => {
+    beforeAll(async () => {
+        const plainHarness = createSqliteExec();
+        const softHarness = createSqliteExec();
+
+        runShardMigrations(plainHarness.sql, plainSchema);
+        runShardMigrations(softHarness.sql, softSchema);
+
+        plain = createShardContextDatabase({ schema: plainSchema, sql: plainHarness.sql });
+        soft = createShardContextDatabase({ schema: softSchema, sql: softHarness.sql });
+
+        await seed(plain);
+        await seed(soft);
+    });
+
+    bench("findMany — plain table (no scope)", async () => {
+        await plain.findMany("todos", { where: { priority: "high" } });
+    });
+
+    bench("findMany — soft-delete table (deletedAt IS NULL scope)", async () => {
+        await soft.findMany("todos", { where: { priority: "high" } });
+    });
+
+    bench("findMany — full document", async () => {
+        await plain.findMany("todos", { where: { priority: "high" } });
+    });
+
+    bench("findMany — select projection (one field)", async () => {
+        await plain.findMany("todos", { select: ["priority"], where: { priority: "high" } });
+    });
+});

--- a/packages/do/__tests__/ctx-db.select.test.ts
+++ b/packages/do/__tests__/ctx-db.select.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * `findMany`/`findFirst` field projection (`args.select`). The engine reads the
+ * whole row (so dependency tracking + keyset cursors are unaffected) and trims
+ * the returned payload to the selected fields plus the always-kept system fields
+ * `_id`/`_creationTime`. Exercised against real SQLite so the projection runs on
+ * actually-decoded documents.
+ */
+const todosSchema: SchemaLike = {
+    tables: {
+        todos: {
+            indexes: [{ fields: ["projectId"], name: "by_project" }],
+            shape: {
+                archived: { kind: "boolean" },
+                priority: { kind: "string" },
+                projectId: { kind: "string" },
+                seq: { kind: "number" },
+            },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+
+const setupWriter = (): DatabaseWriterLike => {
+    runShardMigrations(harness.sql, todosSchema);
+
+    return createShardContextDatabase({ clock: () => 1_700_000_000_000, schema: todosSchema, sql: harness.sql });
+};
+
+const seed = async (writer: DatabaseWriterLike): Promise<void> => {
+    await writer.insert("todos", { _id: "t1", archived: false, priority: "high", projectId: "p1", seq: 1 }, { allowExplicitId: true });
+    await writer.insert("todos", { _id: "t2", archived: false, priority: "medium", projectId: "p1", seq: 2 }, { allowExplicitId: true });
+    await writer.insert("todos", { _id: "t3", archived: true, priority: "low", projectId: "p1", seq: 3 }, { allowExplicitId: true });
+};
+
+describe("ctx-db findMany — select projection", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("trims each row to the selected fields plus _id/_creationTime", async () => {
+        expect.assertions(2);
+
+        const writer = setupWriter();
+
+        await seed(writer);
+
+        const result = await writer.findMany("todos", { orderBy: [{ seq: "asc" }], select: ["priority"] });
+
+        expect(result.page.map((document_) => Object.keys(document_).toSorted((a, b) => a.localeCompare(b)))).toStrictEqual([
+            ["_creationTime", "_id", "priority"],
+            ["_creationTime", "_id", "priority"],
+            ["_creationTime", "_id", "priority"],
+        ]);
+        expect(result.page.map((document_) => document_["priority"])).toStrictEqual(["high", "medium", "low"]);
+    });
+
+    it("projects findFirst the same way", async () => {
+        expect.assertions(1);
+
+        const writer = setupWriter();
+
+        await seed(writer);
+
+        const first = await writer.findFirst("todos", { orderBy: [{ seq: "asc" }], select: ["projectId"] });
+
+        expect(first).toStrictEqual({ _creationTime: 1_700_000_000_000, _id: "t1", projectId: "p1" });
+    });
+
+    it("returns the full document when select is omitted", async () => {
+        expect.assertions(1);
+
+        const writer = setupWriter();
+
+        await seed(writer);
+
+        const first = await writer.findFirst("todos", { orderBy: [{ seq: "asc" }] });
+
+        expect(Object.keys(first ?? {}).toSorted((a, b) => a.localeCompare(b))).toStrictEqual([
+            "_creationTime",
+            "_id",
+            "archived",
+            "priority",
+            "projectId",
+            "seq",
+        ]);
+    });
+
+    it("keeps keyset paging intact — the cursor is encoded from the full row, not the projection", async () => {
+        expect.assertions(3);
+
+        const writer = setupWriter();
+
+        await seed(writer);
+
+        // `seq` is not selected, yet ordering by it and paging must still work
+        // because the cursor encodes the full (unprojected) row.
+        const firstPage = await writer.findMany("todos", { limit: 2, orderBy: [{ seq: "asc" }], select: ["priority"] });
+
+        expect(firstPage.page.map((document_) => document_["_id"])).toStrictEqual(["t1", "t2"]);
+        expect(firstPage.isDone).toBe(false);
+
+        const secondPage = await writer.findMany("todos", { cursor: firstPage.continueCursor, limit: 2, orderBy: [{ seq: "asc" }], select: ["priority"] });
+
+        expect(secondPage.page.map((document_) => document_["_id"])).toStrictEqual(["t3"]);
+    });
+});

--- a/packages/do/__tests__/ctx-db.soft-delete.companions.test.ts
+++ b/packages/do/__tests__/ctx-db.soft-delete.companions.test.ts
@@ -1,0 +1,151 @@
+import type { SchemaLike as VectorSchemaLike, VectorSearchLike } from "@lunora/vectors";
+import { createVectorSyncHook } from "@lunora/vectors";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DatabaseWriterLike, SchemaLike, WriteHook } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Companions a soft delete must drop (no read-time marker filter is possible):
+ * the rank companion (its row carries no marker column) and external Vectorize
+ * (its query can't be scoped). A soft delete removes the row from both, like a
+ * physical delete; `restore()` re-adds them via the patch path.
+ */
+const FIXED = 1_700_000_000_000;
+
+describe("soft delete — rank companion", () => {
+    const schema: SchemaLike = {
+        tables: {
+            scores: {
+                indexes: [],
+                rankIndexes: [{ name: "by_score", on: "scores", sortBy: [{ direction: "desc", field: "score" }] }],
+                shape: { deletedAt: { kind: "number" }, score: { kind: "number" } },
+                softDeleteMode: { field: "deletedAt" },
+            },
+        },
+    };
+
+    let harness: ReturnType<typeof createSqliteExec>;
+
+    const setup = async (): Promise<DatabaseWriterLike> => {
+        runShardMigrations(harness.sql, schema);
+
+        const writer = createShardContextDatabase({ clock: () => FIXED, schema, sql: harness.sql });
+
+        await writer.insert("scores", { _id: "s1", score: 10 }, { allowExplicitId: true });
+        await writer.insert("scores", { _id: "s2", score: 20 }, { allowExplicitId: true });
+        await writer.insert("scores", { _id: "s3", score: 30 }, { allowExplicitId: true });
+
+        return writer;
+    };
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("excludes a soft-deleted row from rankPage, and restore re-adds it", async () => {
+        expect.assertions(3);
+
+        const writer = await setup();
+
+        await writer.delete("s2", "scores");
+
+        const afterDelete = await writer.rankPage("scores", "by_score", {});
+
+        expect(afterDelete.page.map((row) => row["_id"])).toStrictEqual(["s3", "s1"]);
+
+        await writer.restore!("s2", "scores");
+
+        const afterRestore = await writer.rankPage("scores", "by_score", {});
+
+        expect(afterRestore.page.map((row) => row["_id"])).toStrictEqual(["s3", "s2", "s1"]);
+
+        // hardDelete keeps it out for good.
+        await writer.delete("s2", "scores", { hard: true });
+
+        const afterHard = await writer.rankPage("scores", "by_score", {});
+
+        expect(afterHard.page.map((row) => row["_id"])).toStrictEqual(["s3", "s1"]);
+    });
+});
+
+const embed = async (value: string): Promise<ReadonlyArray<number>> => [value.length];
+
+describe("soft delete — Vectorize sync", () => {
+    const ctxSchema: SchemaLike = {
+        tables: {
+            messages: {
+                indexes: [],
+                shape: { deletedAt: { kind: "number" }, text: { kind: "string" } },
+                softDeleteMode: { field: "deletedAt" },
+            },
+        },
+    };
+
+    const vectorsSchema: VectorSchemaLike = {
+        tables: { messages: { vectorIndexes: [{ embed, field: "text", name: "messages-text" }] } },
+        vectorIndexes: {},
+    };
+
+    const fakeVectors = (): VectorSearchLike & { deletes: [string, ReadonlyArray<string>][]; upserts: [string, unknown][] } => {
+        const upserts: [string, unknown][] = [];
+        const deletes: [string, ReadonlyArray<string>][] = [];
+
+        return {
+            deleteByIds: vi.fn<VectorSearchLike["deleteByIds"]>(async (indexName, indexIds) => {
+                deletes.push([indexName, indexIds]);
+            }),
+            deletes,
+            getByIds: vi.fn<VectorSearchLike["getByIds"]>(async () => []),
+            query: vi.fn<VectorSearchLike["query"]>(async () => {
+                return { count: 0, matches: [] };
+            }),
+            upsert: vi.fn<VectorSearchLike["upsert"]>(async (indexName, input) => {
+                upserts.push([indexName, input]);
+            }),
+            upsertNow: vi.fn<VectorSearchLike["upsertNow"]>(async (indexName, input) => {
+                upserts.push([indexName, input]);
+            }),
+            upserts,
+        };
+    };
+
+    let harness: ReturnType<typeof createSqliteExec>;
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("drops the vector on soft delete and re-upserts on restore", async () => {
+        expect.assertions(3);
+
+        runShardMigrations(harness.sql, ctxSchema);
+
+        const vectors = fakeVectors();
+        const onWrite: WriteHook = createVectorSyncHook({ schema: vectorsSchema, vectors });
+        const writer = createShardContextDatabase({ clock: () => FIXED, idGenerator: () => "m1", onWrite, schema: ctxSchema, sql: harness.sql });
+
+        await writer.insert("messages", { text: "hello" });
+
+        expect(vectors.upserts).toHaveLength(1);
+
+        // Soft delete must REMOVE the vector (else it leaks into similarity search).
+        await writer.delete("m1", "messages");
+
+        expect(vectors.deletes).toStrictEqual([["messages-text", ["m1"]]]);
+
+        // Restore re-embeds it.
+        await writer.restore!("m1", "messages");
+
+        expect(vectors.upserts).toHaveLength(2);
+    });
+});

--- a/packages/do/__tests__/ctx-db.soft-delete.test.ts
+++ b/packages/do/__tests__/ctx-db.soft-delete.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Soft delete (`.softDelete()` → `softDeleteMode`). `delete()` flips the marker
+ * column instead of removing the row; LIST reads hide soft-deleted rows unless
+ * `includeDeleted` is passed; by-id `get` still returns them; a physical removal
+ * needs `{ hard: true }`; and a soft delete cascades as a soft delete. Run
+ * against real SQLite.
+ */
+const schema: SchemaLike = {
+    tables: {
+        projects: {
+            indexes: [],
+            relationMap: {},
+            shape: { deletedAt: { kind: "number" }, name: { kind: "string" } },
+            softDeleteMode: { field: "deletedAt" },
+        },
+        todos: {
+            indexes: [{ fields: ["projectId"], name: "by_project" }],
+            // A cascade FK to projects: deleting a project deletes its todos.
+            relationMap: { project: { field: "projectId", kind: "one", onDelete: "cascade", references: "_id", table: "projects" } },
+            shape: { deletedAt: { kind: "number" }, projectId: { kind: "string" }, title: { kind: "string" } },
+            softDeleteMode: { field: "deletedAt" },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+
+const setup = (): DatabaseWriterLike => {
+    runShardMigrations(harness.sql, schema);
+
+    return createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+};
+
+const ids = (result: Record<string, unknown>[] | { page: Record<string, unknown>[] }): unknown[] =>
+    (Array.isArray(result) ? result : result.page).map((document_) => document_["_id"]);
+
+const seedTodos = async (writer: DatabaseWriterLike): Promise<void> => {
+    await writer.insert("todos", { _id: "t1", projectId: "p1", title: "one" }, { allowExplicitId: true });
+    await writer.insert("todos", { _id: "t2", projectId: "p1", title: "two" }, { allowExplicitId: true });
+    await writer.insert("todos", { _id: "t3", projectId: "p1", title: "three" }, { allowExplicitId: true });
+};
+
+describe("ctx-db soft delete", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("delete() flips the marker and hides the row from list reads", async () => {
+        expect.assertions(5);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        // The row is gone from findMany, the fluent reader, and count…
+        expect(ids(await writer.findMany("todos", {}))).toStrictEqual(["t1", "t3"]);
+        expect(ids(await writer.query("todos").collect())).toStrictEqual(["t1", "t3"]);
+        await expect(writer.count("todos")).resolves.toBe(2);
+
+        // …but it's still physically there, marker stamped, reachable by id.
+        const row = await writer.get("t2", "todos");
+
+        expect(row?.["deletedAt"]).toBe(1_700_000_000_000);
+        expect(row?.["title"]).toBe("two");
+    });
+
+    it("includeDeleted re-includes soft-deleted rows in findMany", async () => {
+        expect.assertions(1);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
+    });
+
+    it("restore (patch the marker to null) brings the row back", async () => {
+        expect.assertions(2);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        await writer.patch("t2", { deletedAt: null }, "todos");
+
+        expect(ids(await writer.findMany("todos", {}))).toStrictEqual(["t1", "t2", "t3"]);
+        await expect(writer.count("todos")).resolves.toBe(3);
+    });
+
+    it("delete({ hard: true }) physically removes the row", async () => {
+        expect.assertions(2);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t3", "todos", { hard: true });
+
+        await expect(writer.get("t3", "todos")).resolves.toBeNull();
+        // Even includeDeleted can't see a hard-deleted row.
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2"]);
+    });
+
+    it("a soft delete cascades as a soft delete to onDelete:cascade children", async () => {
+        expect.assertions(3);
+
+        const writer = setup();
+
+        await writer.insert("projects", { _id: "p1", name: "Project" }, { allowExplicitId: true });
+        await seedTodos(writer);
+
+        await writer.delete("p1", "projects");
+
+        // The project and all its todos are hidden from list reads…
+        await expect(writer.count("projects")).resolves.toBe(0);
+        await expect(writer.count("todos")).resolves.toBe(0);
+        // …but the children are soft-deleted (still present), not physically gone.
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
+    });
+
+    it("a second delete of an already-soft-deleted row is a no-op", async () => {
+        expect.assertions(1);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+        await writer.delete("t2", "todos");
+
+        // Still exactly one soft-deleted row, marker unchanged.
+        expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
+    });
+});

--- a/packages/do/__tests__/ctx-db.soft-delete.test.ts
+++ b/packages/do/__tests__/ctx-db.soft-delete.test.ts
@@ -130,6 +130,26 @@ describe("ctx-db soft delete", () => {
         expect(ids(await writer.findMany("todos", { includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
     });
 
+    it("composes the soft-delete scope with an injected baseWhere (RLS) — neither bypasses the other", async () => {
+        expect.assertions(3);
+
+        const writer = setup();
+
+        await seedTodos(writer);
+        await writer.delete("t2", "todos");
+
+        // `baseWhere` is how RLS injects a read policy. Both filters AND together:
+        // only LIVE rows in project p1.
+        expect(ids(await writer.findMany("todos", { baseWhere: { projectId: "p1" } }))).toStrictEqual(["t1", "t3"]);
+
+        // `includeDeleted` relaxes the soft-delete scope but NOT the policy baseWhere.
+        expect(ids(await writer.findMany("todos", { baseWhere: { projectId: "p1" }, includeDeleted: true }))).toStrictEqual(["t1", "t2", "t3"]);
+
+        // A baseWhere the row fails wins even with includeDeleted — soft-delete
+        // can't be used to read around the policy.
+        expect(ids(await writer.findMany("todos", { baseWhere: { projectId: "other" }, includeDeleted: true }))).toStrictEqual([]);
+    });
+
     it("a second delete of an already-soft-deleted row is a no-op", async () => {
         expect.assertions(1);
 

--- a/packages/do/__tests__/ctx-db.with-select.test.ts
+++ b/packages/do/__tests__/ctx-db.with-select.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Per-relation `select` on `with` loads: a relation's children are projected
+ * down to the chosen fields (plus `_id`/`_creationTime`), trimming the wire
+ * payload while the join key stays available for grouping. Exercised over real
+ * SQLite for both a `one` and a `many` relation.
+ */
+const schema: SchemaLike = {
+    tables: {
+        posts: {
+            indexes: [],
+            relationMap: { author: { field: "authorId", kind: "one", references: "_id", table: "users" } },
+            shape: { authorId: { kind: "string" }, body: { kind: "string" }, title: { kind: "string" } },
+        },
+        users: {
+            indexes: [],
+            relationMap: { posts: { field: "authorId", kind: "many", references: "_id", table: "posts" } },
+            shape: { email: { kind: "string" }, name: { kind: "string" } },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+
+const setup = async (): Promise<DatabaseWriterLike> => {
+    runShardMigrations(harness.sql, schema);
+
+    const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+
+    await writer.insert("users", { _id: "u1", email: "ada@x.dev", name: "Ada" }, { allowExplicitId: true });
+    await writer.insert("posts", { _id: "p1", authorId: "u1", body: "b1", title: "t1" }, { allowExplicitId: true });
+    await writer.insert("posts", { _id: "p2", authorId: "u1", body: "b2", title: "t2" }, { allowExplicitId: true });
+
+    return writer;
+};
+
+describe("ctx-db with: per-relation select", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("projects a `one` relation's loaded child", async () => {
+        expect.assertions(1);
+
+        const writer = await setup();
+        const { page } = await writer.findMany("posts", { where: { _id: "p1" }, with: { author: { select: ["name"] } } });
+
+        // The loaded author carries only the selected field + system fields — no email.
+        expect(page[0]?.["author"]).toStrictEqual({ _creationTime: 1_700_000_000_000, _id: "u1", name: "Ada" });
+    });
+
+    it("projects each child of a `many` relation", async () => {
+        expect.assertions(2);
+
+        const writer = await setup();
+        const { page } = await writer.findMany("users", { where: { _id: "u1" }, with: { posts: { select: ["title"] } } });
+        const posts = page[0]?.["posts"] as Record<string, unknown>[];
+
+        expect(posts.map((post) => Object.keys(post).toSorted((a, b) => a.localeCompare(b)))).toStrictEqual([
+            ["_creationTime", "_id", "title"],
+            ["_creationTime", "_id", "title"],
+        ]);
+        expect(posts.map((post) => post["title"]).toSorted((a, b) => String(a).localeCompare(String(b)))).toStrictEqual(["t1", "t2"]);
+    });
+
+    it("loads the full child when no select is given", async () => {
+        expect.assertions(1);
+
+        const writer = await setup();
+        const { page } = await writer.findMany("posts", { where: { _id: "p1" }, with: { author: true } });
+
+        expect(Object.keys(page[0]?.["author"] as Record<string, unknown>).toSorted((a, b) => a.localeCompare(b))).toStrictEqual([
+            "_creationTime",
+            "_id",
+            "email",
+            "name",
+        ]);
+    });
+});

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -59,7 +59,7 @@ import {
 } from "./do-sql";
 import NotFoundError from "./not-found-error";
 import type { OrderKey, QueryArgs, QueryPage } from "./query-args";
-import { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "./query-args";
+import { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys, softDeleteScope } from "./query-args";
 import type {
     RankBeforeOptions,
     RankBeforeResult,
@@ -135,11 +135,21 @@ interface TableDefinitionLike {
     readonly relationMap?: Record<string, RelationDefinitionLike>;
     readonly searchIndexes?: ReadonlyArray<SearchIndexDefinitionLike>;
     readonly shape: Record<string, ValidatorLike>;
+
     // Mirror of `@lunora/server`'s `ShardMode`. The `shardBy` variant carries
     // a `field` (the column the runtime hashes on) but most consumers only
     // read `kind`, so `field` is left optional here to keep the structural
     // mirror narrow without forcing every callsite to spread the variant.
     readonly shardMode?: { field?: string; kind: "global" | "root" | "shardBy" };
+
+    /**
+     * Mirror of `@lunora/server`'s `TableDefinition.softDeleteMode` (set by
+     * `.softDelete()`). When present, `delete()` flips the `field` column to a
+     * timestamp instead of physically removing the row (cascading as a soft
+     * delete), and list reads scope out rows whose `field` is set unless
+     * `includeDeleted` is passed. By-id reads/writes are unaffected.
+     */
+    readonly softDeleteMode?: { field: string };
     readonly triggerMap?: Record<string, TriggerDefinitionLike>;
 }
 
@@ -514,7 +524,15 @@ interface DatabaseWriterLike {
      * RLS-aware ctx seam from §3.2).
      */
     count: (tableName: string, where?: RestrictableQueryOptions | WhereInput) => Promise<number>;
-    delete: (id: string, expectedTable?: string) => Promise<void>;
+
+    /**
+     * Delete a row by id. On a `.softDelete()` table this flips the marker column
+     * (cascading as a soft delete) instead of removing the row; pass
+     * `options.hard` to force a physical removal (which cascades as a physical
+     * delete, reaching already-soft-deleted children too). Non-soft tables ignore
+     * `options.hard` — they always delete physically.
+     */
+    delete: (id: string, expectedTable?: string, options?: { hard?: boolean }) => Promise<void>;
 
     /**
      * Delete many rows by id in one call (a loop over `delete()`). The returned
@@ -688,6 +706,15 @@ interface DatabaseWriterLike {
     replace: (id: string, document: Record<string, unknown>, expectedTable?: string) => Promise<void>;
 
     /**
+     * Un-soft-delete a row: clears the `.softDelete()` marker column (a by-id
+     * UPDATE, so it works on a row that list reads currently hide). Throws when
+     * the row's table isn't `.softDelete()`. Optional on the interface — the DO
+     * writer implements it; the `.global()` twin does too, so a restore on a
+     * global table routes through the DO writer's global fallback.
+     */
+    restore?: (id: string, expectedTable?: string) => Promise<void>;
+
+    /**
      * Best-effort, read-only reader over Lunora's system tables
      * (`_scheduled_functions`, `_storage`). Eventually consistent and **not**
      * part of the shard's transaction snapshot — see {@link SystemDatabaseReader}.
@@ -791,7 +818,7 @@ const createSearchBuilder = (search: SearchStage, tableName: string): SearchFilt
  * text column, JOIN back to the document table on the stored id, narrow by any
  * `.eq()` filter fields, and order by FTS5's `rank` (bm25 — best first).
  */
-const searchViaFts = (sql: SqlExec, tableName: string, search: SearchStage, limit: number | undefined): Record<string, unknown>[] => {
+const searchViaFts = (sql: SqlExec, tableName: string, search: SearchStage, limit: number | undefined, scopeCondition?: SQL): Record<string, unknown>[] => {
     const tokens = tokenizeSearch(search.query);
 
     if (tokens.length === 0) {
@@ -806,6 +833,12 @@ const searchViaFts = (sql: SqlExec, tableName: string, search: SearchStage, limi
 
     for (const filter of search.filters) {
         whereClauses.push(dsql`${jsonPathSql(filter.field)} = ${serializeSqlValue(filter.value)}`);
+    }
+
+    // Soft delete: the unqualified `__doc__` in the scope predicate resolves to
+    // the joined doc table `m` (the FTS table `f` has no `__doc__`).
+    if (scopeCondition) {
+        whereClauses.push(scopeCondition);
     }
 
     // `f.rank` is FTS5's bm25 relevance (best first); the `_creationTime DESC`
@@ -838,7 +871,7 @@ const searchViaFts = (sql: SqlExec, tableName: string, search: SearchStage, limi
  * prefix-on-last-token semantics; relevance order is term-frequency, ties broken
  * by creation time (newest first).
  */
-const searchViaScan = (sql: SqlExec, tableName: string, search: SearchStage, limit: number | undefined): Record<string, unknown>[] => {
+const searchViaScan = (sql: SqlExec, tableName: string, search: SearchStage, limit: number | undefined, scopeCondition?: SQL): Record<string, unknown>[] => {
     const tokens = tokenizeSearch(search.query);
 
     if (tokens.length === 0) {
@@ -849,6 +882,10 @@ const searchViaScan = (sql: SqlExec, tableName: string, search: SearchStage, lim
 
     for (const filter of search.filters) {
         whereClauses.push(dsql`${jsonPathSql(filter.field)} = ${serializeSqlValue(filter.value)}`);
+    }
+
+    if (scopeCondition) {
+        whereClauses.push(scopeCondition);
     }
 
     let query = dsql`SELECT id, _creationTime, ${dsql.identifier(DOC_COLUMN)} FROM ${dsql.identifier(tableName)}`;
@@ -1021,13 +1058,16 @@ const scanDocs = (rows: Record<string, unknown>[], filters: QueryStage["inMemory
  * range stays stable under inserts/deletes inside it — the page simply grows or
  * shrinks while its boundaries hold.
  */
-const paginateStage = (sql: SqlExec, tableName: string, stage: QueryStage, options: PaginationOptions): QueryPage => {
+const paginateStage = (sql: SqlExec, tableName: string, stage: QueryStage, options: PaginationOptions, scopeCondition?: SQL): QueryPage => {
     const numberItems = Math.max(0, Math.floor(options.numItems));
     const orderKeys = paginateOrderKeys(stage);
     // A cursor is always a non-empty base64 string, so truthiness distinguishes
     // a bounded page (endCursor set) from the legacy open-ended one (null/omitted).
     const bounded = typeof options.endCursor === "string";
-    const whereCondition = compileWhereSql(paginateWhere(stage, orderKeys, options.cursor, options.endCursor), doWhereSqlStrategy);
+    const pageWhere = compileWhereSql(paginateWhere(stage, orderKeys, options.cursor, options.endCursor), doWhereSqlStrategy);
+    // Soft delete: AND the scope onto the keyset predicate so a paginated fluent
+    // read hides soft-deleted rows too.
+    const whereCondition = scopeCondition && pageWhere ? dsql`${pageWhere} AND ${scopeCondition}` : (scopeCondition ?? pageWhere);
 
     let query = dsql`SELECT id, _creationTime, ${dsql.identifier(DOC_COLUMN)} FROM ${dsql.identifier(tableName)}`;
 
@@ -1137,6 +1177,12 @@ const buildReader = (sql: SqlExec, schema: SchemaLike, tableName: string, onInde
         throw new Error(`unknown table: ${tableName}`);
     }
 
+    // Soft delete: the fluent reader (`ctx.db.query(table)...`) always hides
+    // soft-deleted rows — the object-form `findMany({ includeDeleted: true })` is
+    // the opt-in to see them. Compiled once and ANDed into every fetch/search/page.
+    const scopeWhere = softDeleteScope(tableDefinition.softDeleteMode, undefined);
+    const scopeCondition = scopeWhere ? compileWhereSql(scopeWhere, doWhereSqlStrategy) : undefined;
+
     const stage: QueryStage = {
         indexFields: [],
         indexName: undefined,
@@ -1154,7 +1200,9 @@ const buildReader = (sql: SqlExec, schema: SchemaLike, tableName: string, onInde
 
         const filtered = stage.inMemoryFilters.length > 0;
         const engineLimit = filtered ? undefined : limit;
-        const docs = isFtsAvailable(sql) ? searchViaFts(sql, tableName, search, engineLimit) : searchViaScan(sql, tableName, search, engineLimit);
+        const docs = isFtsAvailable(sql)
+            ? searchViaFts(sql, tableName, search, engineLimit, scopeCondition)
+            : searchViaScan(sql, tableName, search, engineLimit, scopeCondition);
 
         if (!filtered) {
             return docs;
@@ -1194,6 +1242,10 @@ const buildReader = (sql: SqlExec, schema: SchemaLike, tableName: string, onInde
 
         for (const condition of stage.sqlConditions) {
             whereClauses.push(dsql`${jsonPathSql(condition.field)} ${dsql.raw(condition.comparator)} ${serializeSqlValue(condition.value)}`);
+        }
+
+        if (scopeCondition) {
+            whereClauses.push(scopeCondition);
         }
 
         let query = dsql`SELECT id, _creationTime, ${dsql.identifier(DOC_COLUMN)} FROM ${dsql.identifier(tableName)}`;
@@ -1258,7 +1310,7 @@ const buildReader = (sql: SqlExec, schema: SchemaLike, tableName: string, onInde
                 throw new Error("pagination is not supported on search queries; use .take(n) or .collect()");
             }
 
-            return paginateStage(sql, tableName, stage, options);
+            return paginateStage(sql, tableName, stage, options, scopeCondition);
         },
         // eslint-disable-next-line @typescript-eslint/require-await -- TableReaderLike returns Promises (the D1 twin awaits real I/O); the DO impl is synchronous over local SQLite
         async take(limit) {
@@ -1919,7 +1971,10 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
 
             onRead(tableName, SCAN_DEP);
 
-            const effective = mergeWhere(aggOptions.baseWhere, aggOptions.where);
+            // Soft delete: aggregate over LIVE rows only; AND the scope in and
+            // force the scan (the indexed companion includes deleted rows).
+            const aggScope = softDeleteScope(definition.softDeleteMode, undefined);
+            const effective = mergeWhere(mergeWhere(aggOptions.baseWhere, aggOptions.where), aggScope);
             // Rewrite any relation-crossing predicate to a flat semijoin clause
             // before compiling. The resolver returns `effective` unchanged when
             // there is none, so `hasRelation` both skips the no-op fetch and —
@@ -1934,7 +1989,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // sum/avg/min/max in one row lookup. We only attempt it when no
             // baseWhere is set — the RLS predicate isn't a pure equality
             // conjunction, so it falls through to the SQL scan below.
-            if (definition.aggregateIndexes && !aggOptions.baseWhere && !hasRelation) {
+            if (definition.aggregateIndexes && !aggOptions.baseWhere && !hasRelation && !aggScope) {
                 const planned = selectIndexForAggregate(definition.aggregateIndexes, aggOptions.op, aggOptions.field, aggOptions.where);
 
                 if (planned) {
@@ -2002,7 +2057,11 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // scan dependency regardless of `where`.
             onRead(tableName, SCAN_DEP);
 
-            const effective = mergeWhere(countOptions.baseWhere, countOptions.where);
+            // Soft delete: a `count()` reflects LIVE rows. AND the scope in and
+            // force the scan path (the `__agg_` companion counts deleted rows too,
+            // so the indexed fast-path can't be trusted here).
+            const countScope = softDeleteScope(definition.softDeleteMode, undefined);
+            const effective = mergeWhere(mergeWhere(countOptions.baseWhere, countOptions.where), countScope);
             // Rewrite a relation-crossing predicate to a flat semijoin clause
             // first; `hasRelation` disables the indexed fast-path below (an
             // aggregate-index counter can't honour a relation filter).
@@ -2015,7 +2074,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // left out of the indexed path because we can't trust it to be a
             // pure equality conjunction; if `baseWhere` is set we fall through
             // to the scan so SQL handles it uniformly.
-            if (definition.aggregateIndexes && !countOptions.baseWhere && !hasRelation) {
+            if (definition.aggregateIndexes && !countOptions.baseWhere && !hasRelation && !countScope) {
                 const planned = selectIndexForCount(definition.aggregateIndexes, countOptions.where);
 
                 if (planned) {
@@ -2045,7 +2104,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             return row.count;
         },
 
-        async delete(id, expectedTable) {
+        async delete(id, expectedTable, deleteOptions) {
             // Single probe — get the table + row in one pass instead of
             // probing twice (`tableNameFromId` + `writer.get`).
             const located = locateRowById(id, expectedTable);
@@ -2059,13 +2118,24 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalFallback() : undefined;
 
                 if (global) {
-                    await global.delete(id);
+                    await global.delete(id, undefined, deleteOptions);
                 }
 
                 return;
             }
 
             const { docJson: existingJson, row: existing, tableName } = located;
+            const definition = schema.tables[tableName];
+            // Soft delete unless the caller forced a physical removal (`hard`).
+            // `softField` undefined ⇒ the legacy physical path.
+            const hard = deleteOptions?.hard === true;
+            const softField = !hard && definition?.softDeleteMode ? definition.softDeleteMode.field : undefined;
+
+            // Idempotent: a second soft delete of an already-soft-deleted row is a
+            // no-op (re-running the cascade + broadcast would be spurious).
+            if (softField && existing[softField] !== null && existing[softField] !== undefined) {
+                return;
+            }
 
             // `before` fires ahead of cascade resolution so a throwing guard
             // aborts the delete before any holder rows are touched.
@@ -2074,23 +2144,26 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             }
 
             // Resolve declared `onDelete` actions on holder rows *before* the
-            // physical delete, so `restrict` can abort and cascaded child
-            // deletes still fire their own broadcast/onWrite per row.
+            // write, so `restrict` can abort and cascaded child deletes still fire
+            // their own broadcast/onWrite per row. A delete cascades as a delete:
+            // each child routes back through `writer.delete` (carrying the same
+            // `hard` flag), so a soft delete soft-deletes its children and a hard
+            // delete hard-deletes them. The holder lookup honours the mode too —
+            // a hard delete must see soft-deleted holders to remove them, a soft
+            // delete skips already-deleted holders.
             //
             // The callbacks pass through `routeForHolder` so a holder living
             // on a global (`.global()`) table is reached through the supplied
             // D1-backed `globalDb` writer, not this DO's local SQLite.
-            // Cross-backend cascade is **not transactional**: the local row
-            // commits below regardless of whether the global cascade succeeds.
             await applyOnDelete({
                 deletedId: id,
                 deletedReference: (references) => existing[references],
                 findHolders: async (holderTable, field, value) => {
-                    const holders = await routeForHolder(holderTable).findMany(holderTable, { where: { [field]: value } });
+                    const holders = await routeForHolder(holderTable).findMany(holderTable, { includeDeleted: hard, where: { [field]: value } });
 
                     return holders.page;
                 },
-                onCascade: (holderTable, holderId) => routeForHolder(holderTable).delete(holderId),
+                onCascade: (holderTable, holderId) => routeForHolder(holderTable).delete(holderId, undefined, deleteOptions),
                 onRestrict: (message) => {
                     throw new ConflictError(message, "restrict");
                 },
@@ -2102,6 +2175,42 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
 
             ensureBackfilledForTable(tableName);
             ensureRankBackfilledForTable(tableName);
+
+            if (softField) {
+                // Soft delete: keep the row, stamp the marker column. Mechanically
+                // an UPDATE, so companions re-sync to the merged doc and the delta
+                // broadcasts as `update` — live LIST queries re-run and drop the
+                // row (they now filter the marker), per-id subscribers see the
+                // stamp. The OCC guard CAS's on the read-time snapshot, same as
+                // patch/replace. Read scoping (not companion removal) is what hides
+                // the row, so search/aggregate stay correct via the read filter.
+                const merged: Record<string, unknown> = { ...existing, [softField]: clock(), _id: id };
+
+                runGuardedWrite(
+                    sql,
+                    tableName,
+                    dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${JSON.stringify(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
+                );
+
+                syncSearch(tableName, id, merged);
+                syncAggregates(tableName, existing, merged);
+                syncRanks(tableName, id, existing, merged);
+
+                cache?.invalidate(tableName, id);
+
+                recordCdc(tableName, id, "update", merged);
+                broadcast({ key: id, op: "update", row: merged, table: tableName });
+
+                // `delete()` was called, so fire the DELETE triggers (the flag flip
+                // is an implementation detail of how the delete is recorded).
+                if (hasMatchingTrigger(tableName, "after", "delete")) {
+                    await fireTriggers("after", "delete", { id, op: "delete", previous: existing, table: tableName });
+                }
+
+                await onWrite({ doc: merged, id, op: "update", table: tableName });
+
+                return;
+            }
 
             // Optimistic-concurrency guard over the (wide) cascade window: the
             // `applyOnDelete` await above can let a concurrent write commit, so
@@ -2181,7 +2290,9 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 return global.findMany(tableName, args);
             }
 
-            if (!schema.tables[tableName]) {
+            const findManyDefinition = schema.tables[tableName];
+
+            if (!findManyDefinition) {
                 throw new Error(`unknown table: ${tableName}`);
             }
 
@@ -2203,6 +2314,12 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // RLS (3.2) / aggregates (3.1) inject a `baseWhere` we AND-merge
             // before the keyset seek so policy + cursor compose cleanly.
             let predicate: WhereInput | undefined = mergeWhere(args.baseWhere, args.where);
+
+            // Soft delete: hide rows whose marker column is set, unless the caller
+            // opted in via `includeDeleted`. AND-merged like a baseWhere so it
+            // composes with RLS + the keyset seek; relation `with` loads route back
+            // through this `findMany`, so they inherit the scope automatically.
+            predicate = mergeWhere(predicate, softDeleteScope(findManyDefinition.softDeleteMode, args.includeDeleted));
 
             // Rewrite any relation-crossing predicate (`{ author: { is: W } }`,
             // `{ posts: { some: W } }`, …) into a flat `IN`/`NOT IN` via a
@@ -2380,7 +2497,10 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 throw new Error(`groupBy(${tableName}, { agg: { op: "${agg.op}" } }): "field" is required for non-count reducers`);
             }
 
-            const effective = mergeWhere(groupOptions.baseWhere, groupOptions.where);
+            // Soft delete: group over LIVE rows only; AND the scope in and force
+            // the scan (the indexed companion includes deleted rows).
+            const groupScope = softDeleteScope(definition.softDeleteMode, undefined);
+            const effective = mergeWhere(mergeWhere(groupOptions.baseWhere, groupOptions.where), groupScope);
             // Rewrite any relation-crossing predicate to a flat semijoin clause
             // before compiling. The resolver returns `effective` unchanged when
             // there is none, so `hasRelation` both skips the no-op fetch and —
@@ -2396,7 +2516,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // One SELECT, no SQL `GROUP BY`. baseWhere falls through to scan so
             // RLS composes uniformly. Covers every op (count/sum/avg/min/max)
             // now that the companion is op-aware.
-            if (definition.aggregateIndexes && !groupOptions.baseWhere && !hasRelation) {
+            if (definition.aggregateIndexes && !groupOptions.baseWhere && !hasRelation && !groupScope) {
                 const planned = selectIndexForGroupBy(definition.aggregateIndexes, agg.op, agg.field, groupOptions.by, groupOptions.where);
 
                 if (planned) {
@@ -2977,6 +3097,34 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             const { directions, hasMore, rows } = computeRankPage(rankPageDeps, tableName, indexName, rankPageOptions);
 
             return { directions, hasMore, rows };
+        },
+
+        async restore(id, expectedTable) {
+            // By-id, so it reaches a row that list reads hide. Clearing the marker
+            // is a plain `patch` to `null` — it re-syncs companions and broadcasts
+            // an update, so live list queries pick the row back up.
+            const located = locateRowById(id, expectedTable);
+
+            if (!located) {
+                const global = expectedTable === undefined ? globalFallback() : undefined;
+
+                if (global?.restore) {
+                    await global.restore(id);
+
+                    return;
+                }
+
+                throw new Error(`document not found: ${id}`);
+            }
+
+            const field = schema.tables[located.tableName]?.softDeleteMode?.field;
+
+            if (!field) {
+                throw new Error(`ctx.db.restore: table "${located.tableName}" is not a .softDelete() table`);
+            }
+
+            // eslint-disable-next-line unicorn/no-null -- clearing the soft-delete marker writes SQL NULL into the column
+            await writer.patch(id, { [field]: null }, expectedTable);
         },
 
         async replace(id, document, expectedTable) {

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -59,7 +59,7 @@ import {
 } from "./do-sql";
 import NotFoundError from "./not-found-error";
 import type { OrderKey, QueryArgs, QueryPage } from "./query-args";
-import { buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "./query-args";
+import { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "./query-args";
 import type {
     RankBeforeOptions,
     RankBeforeResult,
@@ -2280,7 +2280,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 }
 
                 // eslint-disable-next-line unicorn/no-null -- QueryPage.continueCursor is `null | string`: null is the documented "no further page" cursor on the wire
-                return { continueCursor: null, isDone: true, page: docs };
+                return { continueCursor: null, isDone: true, page: applySelect(docs, args.select, args.with) };
             }
 
             const hasMore = docs.length > limit;
@@ -2300,10 +2300,12 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             }
 
             return {
+                // The cursor is encoded from `last` (the full, unprojected row) above,
+                // so `applySelect` only trims the returned payload — paging is intact.
                 // eslint-disable-next-line unicorn/no-null -- QueryPage.continueCursor is `null | string`: null is the documented "no further page" cursor on the wire
                 continueCursor: hasMore && last ? encodeCursor(last, orderKeys) : null,
                 isDone: !hasMore,
-                page,
+                page: applySelect(page, args.select, args.with),
             };
         },
 

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -2192,9 +2192,15 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                     dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${JSON.stringify(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
                 );
 
+                // Search stays maintained (the marker filter hides it on read), but
+                // the rank companion and external stores (Vectorize) have NO read-time
+                // marker filter — the companion row carries no marker column and a
+                // Vectorize query can't be scoped — so a soft delete REMOVES the row
+                // from them (passing `undefined`/`op: "delete"`), exactly like a
+                // physical delete. `restore()` re-adds both via the patch path.
                 syncSearch(tableName, id, merged);
                 syncAggregates(tableName, existing, merged);
-                syncRanks(tableName, id, existing, merged);
+                syncRanks(tableName, id, existing, undefined);
 
                 cache?.invalidate(tableName, id);
 
@@ -2207,7 +2213,10 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                     await fireTriggers("after", "delete", { id, op: "delete", previous: existing, table: tableName });
                 }
 
-                await onWrite({ doc: merged, id, op: "update", table: tableName });
+                // External stores treat a soft delete as a removal: fire `onWrite`
+                // with `op: "delete"` so the Vectorize sync hook drops the row's
+                // vector (`restore`'s patch re-upserts it).
+                await onWrite({ id, op: "delete", table: tableName });
 
                 return;
             }
@@ -3123,8 +3132,23 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 throw new Error(`ctx.db.restore: table "${located.tableName}" is not a .softDelete() table`);
             }
 
+            // Only an actually-soft-deleted row needs its rank entry rebuilt below
+            // (a no-op restore on a live row must not double-insert it).
+            const wasDeleted = located.row[field] !== null && located.row[field] !== undefined;
+
             // eslint-disable-next-line unicorn/no-null -- clearing the soft-delete marker writes SQL NULL into the column
             await writer.patch(id, { [field]: null }, expectedTable);
+
+            // The soft delete REMOVED this row's rank-companion entry; `patch`'s
+            // rank sync skips re-adding it (the sort fields are unchanged, so its
+            // fast path assumes the entry is already present). Force the re-insert
+            // here with `previous=undefined` — a pure INSERT, safe because the
+            // entry was definitively dropped on soft delete. Search/aggregates were
+            // kept (read-filtered), so they need nothing extra; the vector re-upsert
+            // rode `patch`'s `onWrite("update")`.
+            if (wasDeleted) {
+                syncRanks(located.tableName, id, undefined, located.row);
+            }
         },
 
         async replace(id, document, expectedTable) {

--- a/packages/do/src/index.ts
+++ b/packages/do/src/index.ts
@@ -148,7 +148,7 @@ export { default as NotFoundError } from "./not-found-error";
 export type { PitrBookmarkResult, PitrRestoreArgs, PitrRestoreResult, PitrStorage } from "./pitr";
 export { armRestore, readBookmark } from "./pitr";
 export type { OrderByInput, OrderKey, QueryArgs, QueryPage, SortDirection } from "./query-args";
-export { buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "./query-args";
+export { applySelect, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "./query-args";
 export type {
     RankDirection,
     RankIndexDefinitionLike,

--- a/packages/do/src/index.ts
+++ b/packages/do/src/index.ts
@@ -148,7 +148,7 @@ export { default as NotFoundError } from "./not-found-error";
 export type { PitrBookmarkResult, PitrRestoreArgs, PitrRestoreResult, PitrStorage } from "./pitr";
 export { armRestore, readBookmark } from "./pitr";
 export type { OrderByInput, OrderKey, QueryArgs, QueryPage, SortDirection } from "./query-args";
-export { applySelect, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys } from "./query-args";
+export { applySelect, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys, softDeleteScope } from "./query-args";
 export type {
     RankDirection,
     RankIndexDefinitionLike,

--- a/packages/do/src/query-args.ts
+++ b/packages/do/src/query-args.ts
@@ -35,6 +35,13 @@ interface QueryArgs {
      */
     baseWhere?: WhereInput;
     cursor?: null | string;
+
+    /**
+     * Opt a list read OUT of soft-delete scoping: when `true`, rows whose
+     * soft-delete column is set are INCLUDED. Has no effect on a table without
+     * `.softDelete()`. Default (absent/false) hides soft-deleted rows.
+     */
+    includeDeleted?: boolean;
     limit?: number;
     orderBy?: OrderByInput[];
 
@@ -297,5 +304,15 @@ const applySelect = (
     });
 };
 
-export { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys };
+/**
+ * The read-scope predicate that hides soft-deleted rows — `{ [field]: { isNull:
+ * true } }` matching the live rows whose soft-delete column is null/absent — or
+ * `undefined` when the table isn't `.softDelete()` or the read opted in via
+ * `includeDeleted`. AND-merge it into a list read's `where` (the by-id path
+ * never calls this, so `get`/`patch`/`replace`/`restore` still address the row).
+ */
+const softDeleteScope = (softDeleteMode: { field: string } | undefined, includeDeleted: boolean | undefined): undefined | WhereInput =>
+    softDeleteMode && includeDeleted !== true ? { [softDeleteMode.field]: { isNull: true } } : undefined;
+
+export { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys, softDeleteScope };
 export type { OrderByInput, OrderKey, QueryArgs, QueryPage, SortDirection };

--- a/packages/do/src/query-args.ts
+++ b/packages/do/src/query-args.ts
@@ -57,6 +57,16 @@ interface QueryArgs {
      * reads (`findMany`/`findFirst`) — this flag specifically guards `count`.
      */
     restrictsCounts?: boolean;
+
+    /**
+     * Project each returned row down to these fields. The system fields `_id` and
+     * `_creationTime` are always retained (cursors + by-id reuse depend on them),
+     * and any relations attached via `with` (their relation keys and `_count`)
+     * survive the trim. Applied AFTER the rows are read and relations resolved, so
+     * read-dependency tracking and cursor encoding see the full row — only the
+     * payload returned to the caller is narrowed. Omit for the full document.
+     */
+    select?: ReadonlyArray<string>;
     where?: WhereInput;
     with?: WithInput;
 }
@@ -252,5 +262,40 @@ const buildSeekBeforeWhere = (keys: OrderKey[], cursorValues: unknown[]): WhereI
     return { OR: branches };
 };
 
-export { buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys };
+/** System fields a `select` projection always retains so cursors + by-id reuse keep working. */
+const SELECT_SYSTEM_FIELDS = ["_id", "_creationTime"] as const;
+
+/**
+ * Project `page` rows down to `select` — plus the always-kept system fields and
+ * the relation/`_count` keys attached by a `with` load (passed as `withInput`,
+ * the same object handed to `findMany`). Returns the page unchanged when
+ * `select` is undefined. Pure; callers apply it AFTER relation resolution +
+ * cursor encoding so only the returned payload is trimmed (dependency tracking +
+ * the cursor still see the full row).
+ */
+const applySelect = (
+    page: Record<string, unknown>[],
+    select: ReadonlyArray<string> | undefined,
+    withInput?: Record<string, unknown>,
+): Record<string, unknown>[] => {
+    if (!select) {
+        return page;
+    }
+
+    const keep = new Set<string>([...select, ...SELECT_SYSTEM_FIELDS, ...(withInput ? Object.keys(withInput) : [])]);
+
+    return page.map((document) => {
+        const projected: Record<string, unknown> = {};
+
+        for (const key of keep) {
+            if (key in document) {
+                projected[key] = document[key];
+            }
+        }
+
+        return projected;
+    });
+};
+
+export { applySelect, buildSeekBeforeWhere, buildSeekWhere, decodeCursor, encodeCursor, normalizeOrderKeys };
 export type { OrderByInput, OrderKey, QueryArgs, QueryPage, SortDirection };

--- a/packages/do/src/relations.ts
+++ b/packages/do/src/relations.ts
@@ -34,6 +34,7 @@
 
 import type { TableDefinitionLike } from "./ctx-db";
 import type { OrderByInput, QueryArgs, QueryPage } from "./query-args";
+import { applySelect } from "./query-args";
 import type { WhereInput } from "./where-types";
 
 /** FK behaviour when a referenced parent row is deleted (mirrors SQL `ON DELETE`). */
@@ -52,13 +53,25 @@ interface RelationDefinitionLike {
     readonly table: string;
 }
 
-/** Per-relation refinements: filter / order / cap / recurse into the children. */
+/** Per-relation refinements: filter / order / cap / project / recurse into the children. */
 interface NestedWith {
     limit?: number;
     orderBy?: OrderByInput[];
+
+    /**
+     * Project each loaded child down to these fields (like the top-level
+     * `findMany` `select`). Applied AFTER grouping, so the join key stays
+     * available to map children to parents; `_id`/`_creationTime` and any deeper
+     * `with` relations are always retained.
+     */
+    select?: ReadonlyArray<string>;
     where?: WhereInput;
     with?: WithInput;
 }
+
+/** Project a loaded child (or page) per `nested.select`, keeping system + nested-`with` keys. Returns the input unchanged when no select. */
+const projectChildren = (documents: Record<string, unknown>[], nested: NestedWith): Record<string, unknown>[] =>
+    nested.select ? applySelect(documents, nested.select, nested.with) : documents;
 
 /**
  * The `with` argument. Each key is a relation name resolving to either `true`
@@ -167,8 +180,10 @@ const resolveWith = async (options: ResolveWithOptions): Promise<void> => {
         }
 
         for (const parent of parents) {
+            const child = byReference.get(parent[relation.field]);
+
             // eslint-disable-next-line unicorn/no-null -- documented `one`-relation result shape (Doc | null) sent to the client
-            parent[name] = byReference.get(parent[relation.field]) ?? null;
+            parent[name] = child ? (projectChildren([child], nested)[0] ?? null) : null;
         }
     };
 
@@ -213,7 +228,7 @@ const resolveWith = async (options: ResolveWithOptions): Promise<void> => {
         for (const parent of parents) {
             const group = groups.get(parent[relation.references]) ?? [];
 
-            parent[name] = cap === undefined ? group : group.slice(0, cap);
+            parent[name] = projectChildren(cap === undefined ? group : group.slice(0, cap), nested);
         }
     };
 

--- a/packages/do/src/rls-guard.ts
+++ b/packages/do/src/rls-guard.ts
@@ -72,7 +72,7 @@ type TableOfId = (id: string, expectedTable?: string) => Promise<string | undefi
 interface GuardableWriter {
     aggregate: (tableName: string, options: unknown) => unknown;
     count: (tableName: string, whereOrArgs?: unknown) => unknown;
-    delete: (id: string, expectedTable?: string) => unknown;
+    delete: (id: string, expectedTable?: string, options?: { hard?: boolean }) => unknown;
     deleteMany: (ids: ReadonlyArray<string>, options?: { limit?: number }, expectedTable?: string) => unknown;
     findFirst: (tableName: string, args?: unknown) => unknown;
     findFirstOrThrow: (tableName: string, args?: unknown) => unknown;
@@ -93,6 +93,7 @@ interface GuardableWriter {
     rankBefore?: (tableName: string, indexName: string, options: unknown) => unknown;
     rankPage: (tableName: string, indexName: string, options?: unknown) => unknown;
     replace: (id: string, document: unknown, expectedTable?: string) => unknown;
+    restore?: (id: string, expectedTable?: string) => unknown;
 }
 
 /**
@@ -168,10 +169,10 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
 
             return base.count(tableName, whereOrArgs);
         },
-        delete: async (id: string, expectedTable?: string) => {
+        delete: async (id: string, expectedTable?: string, options?: { hard?: boolean }) => {
             await guardById(id, expectedTable);
 
-            return base.delete(id, expectedTable);
+            return base.delete(id, expectedTable, options);
         },
         deleteMany: async (ids: ReadonlyArray<string>, options?: { limit?: number }, expectedTable?: string) => {
             // Gate every id like a single delete (a protected, policy-less row
@@ -263,6 +264,14 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
             await guardById(id, expectedTable);
 
             return base.replace(id, document, expectedTable);
+        },
+        restore: async (id: string, expectedTable?: string) => {
+            // Restore is a by-id write (clears the soft-delete marker); gate it
+            // like patch so a protected, policy-less row can't be un-deleted
+            // through the raw method the `...raw` spread would otherwise expose.
+            await guardById(id, expectedTable);
+
+            return base.restore?.(id, expectedTable);
         },
     };
 

--- a/packages/server/__tests__/facade.test.ts
+++ b/packages/server/__tests__/facade.test.ts
@@ -262,4 +262,30 @@ describe("bindTableFacade — upsert / upsertMany", () => {
         ]);
         expect(insert).toHaveBeenCalledTimes(1);
     });
+
+    it("propagates a write denial from the underlying writer (RLS gating on the insert path)", async () => {
+        expect.assertions(1);
+
+        const { entry, findFirst, insert } = makeComposingWriter();
+
+        // No existing row → insert path. When this facade is bound over the
+        // RLS-wrapped writer, an insert policy denial surfaces here as a throw;
+        // upsert must propagate it rather than swallow it.
+        findFirst.mockResolvedValue(null);
+        insert.mockRejectedValue(new Error('insert on "users" denied by policy'));
+
+        await expect(entry.upsert({ create: { email: "a@b.c" }, target: "email" })).rejects.toThrow(/denied by policy/u);
+    });
+
+    it("propagates a write denial on the update path (patch gated)", async () => {
+        expect.assertions(1);
+
+        const { entry, findFirst, patch } = makeComposingWriter();
+
+        // Existing row → patch path; an update-policy denial must propagate.
+        findFirst.mockResolvedValue({ _id: "u1", email: "a@b.c" });
+        patch.mockRejectedValue(new Error('update on "users" denied by policy'));
+
+        await expect(entry.upsert({ create: { email: "a@b.c", name: "x" }, target: "email" })).rejects.toThrow(/denied by policy/u);
+    });
 });

--- a/packages/server/__tests__/facade.test.ts
+++ b/packages/server/__tests__/facade.test.ts
@@ -83,3 +83,183 @@ describe("bindTableFacade — per-table batch forms", () => {
         expect(patchOne).toHaveBeenCalledWith("a", { body: "x" }, "messages");
     });
 });
+
+/** A ConflictError-shaped value (matched structurally by the facade, no `@lunora/do` import). */
+const uniqueConflict = (): Error => Object.assign(new Error(`unique constraint violation on "users"`), { code: "CONFLICT", kind: "unique" });
+
+/** A writer with individually-controllable findFirst/insert/patch, bound to the `users` table. */
+const makeComposingWriter = () => {
+    const findFirst = vi.fn();
+    const insert = vi.fn();
+    const patch = vi.fn();
+
+    const writer = {
+        aggregate: vi.fn(),
+        count: vi.fn(),
+        delete: vi.fn(),
+        deleteMany: vi.fn(),
+        findFirst,
+        findFirstOrThrow: vi.fn(),
+        findMany: vi.fn(),
+        get: vi.fn(),
+        groupBy: vi.fn(),
+        insert,
+        insertMany: vi.fn(),
+        patch,
+        patchMany: vi.fn(),
+        query: vi.fn(),
+        rank: vi.fn(),
+        rankPage: vi.fn(),
+        replace: vi.fn(),
+    } as unknown as FacadeWriterLike;
+
+    return { entry: bindTableFacade(writer, "users"), findFirst, insert, patch };
+};
+
+describe("bindTableFacade — exists", () => {
+    it("returns true when findFirst matches and forwards the where", async () => {
+        expect.assertions(2);
+
+        const { entry, findFirst } = makeComposingWriter();
+
+        findFirst.mockResolvedValue({ _id: "u1", email: "a@b.c" });
+
+        await expect(entry.exists({ email: "a@b.c" })).resolves.toBe(true);
+        expect(findFirst).toHaveBeenCalledWith("users", { where: { email: "a@b.c" } });
+    });
+
+    it("returns false when findFirst finds nothing, and probes for any row when no where is given", async () => {
+        expect.assertions(2);
+
+        const { entry, findFirst } = makeComposingWriter();
+
+        findFirst.mockResolvedValue(null);
+
+        await expect(entry.exists()).resolves.toBe(false);
+        expect(findFirst).toHaveBeenCalledWith("users", undefined);
+    });
+});
+
+describe("bindTableFacade — insert skipDuplicates", () => {
+    it("returns the id on a successful insert", async () => {
+        expect.assertions(1);
+
+        const { entry, insert } = makeComposingWriter();
+
+        insert.mockResolvedValue("u1");
+
+        await expect(entry.insert({ email: "a@b.c" }, { skipDuplicates: true })).resolves.toBe("u1");
+    });
+
+    it("resolves to null when the insert hits a unique conflict", async () => {
+        expect.assertions(1);
+
+        const { entry, insert } = makeComposingWriter();
+
+        insert.mockRejectedValue(uniqueConflict());
+
+        await expect(entry.insert({ email: "a@b.c" }, { skipDuplicates: true })).resolves.toBeNull();
+    });
+
+    it("rethrows a non-unique error even with skipDuplicates", async () => {
+        expect.assertions(1);
+
+        const { entry, insert } = makeComposingWriter();
+
+        insert.mockRejectedValue(new Error("disk full"));
+
+        await expect(entry.insert({ email: "a@b.c" }, { skipDuplicates: true })).rejects.toThrow("disk full");
+    });
+
+    it("propagates a unique conflict when skipDuplicates is not set", async () => {
+        expect.assertions(1);
+
+        const { entry, insert } = makeComposingWriter();
+
+        insert.mockRejectedValue(uniqueConflict());
+
+        await expect(entry.insert({ email: "a@b.c" })).rejects.toThrow("unique constraint");
+    });
+});
+
+describe("bindTableFacade — upsert / upsertMany", () => {
+    it("patches the matched row (update defaults to create) and reports created:false", async () => {
+        expect.assertions(4);
+
+        const { entry, findFirst, insert, patch } = makeComposingWriter();
+
+        findFirst.mockResolvedValue({ _id: "u1", email: "a@b.c", name: "old" });
+
+        await expect(entry.upsert({ create: { email: "a@b.c", name: "new" }, target: "email" })).resolves.toStrictEqual({ created: false, id: "u1" });
+        // The lookup uses the target value from `create`; the patch scopes to the bound table.
+        expect(findFirst).toHaveBeenCalledWith("users", { where: { email: "a@b.c" } });
+        expect(patch).toHaveBeenCalledWith("u1", { email: "a@b.c", name: "new" }, "users");
+        expect(insert).not.toHaveBeenCalled();
+    });
+
+    it("applies an explicit update payload when the row exists", async () => {
+        expect.assertions(1);
+
+        const { entry, findFirst, patch } = makeComposingWriter();
+
+        findFirst.mockResolvedValue({ _id: "u1", email: "a@b.c" });
+
+        await entry.upsert({ create: { email: "a@b.c", name: "n" }, target: "email", update: { name: "patched" } });
+
+        expect(patch).toHaveBeenCalledWith("u1", { name: "patched" }, "users");
+    });
+
+    it("inserts and reports created:true when no row matches", async () => {
+        expect.assertions(3);
+
+        const { entry, findFirst, insert, patch } = makeComposingWriter();
+
+        findFirst.mockResolvedValue(null);
+        insert.mockResolvedValue("u2");
+
+        await expect(entry.upsert({ create: { email: "x@y.z", name: "n" }, target: "email" })).resolves.toStrictEqual({ created: true, id: "u2" });
+        expect(insert).toHaveBeenCalledWith("users", { email: "x@y.z", name: "n" });
+        expect(patch).not.toHaveBeenCalled();
+    });
+
+    it("builds a composite where for a multi-field target", async () => {
+        expect.assertions(1);
+
+        const { entry, findFirst } = makeComposingWriter();
+
+        findFirst.mockResolvedValue(null);
+
+        await entry.upsert({ create: { name: "n", orgId: "o1", slug: "s1" }, target: ["orgId", "slug"] });
+
+        expect(findFirst).toHaveBeenCalledWith("users", { where: { orgId: "o1", slug: "s1" } });
+    });
+
+    it("throws when a target field is missing from the create document", async () => {
+        expect.assertions(1);
+
+        const { entry } = makeComposingWriter();
+
+        await expect(entry.upsert({ create: { name: "n" }, target: "email" })).rejects.toThrow('target field "email" is missing');
+    });
+
+    it("upsertMany applies one upsert per row, in order", async () => {
+        expect.assertions(2);
+
+        const { entry, findFirst, insert } = makeComposingWriter();
+
+        // First row is new (insert), second already exists (patch).
+        findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ _id: "u9", email: "b@b.c" });
+        insert.mockResolvedValue("u8");
+
+        const results = await entry.upsertMany({
+            rows: [{ create: { email: "a@b.c" } }, { create: { email: "b@b.c" }, update: { name: "z" } }],
+            target: "email",
+        });
+
+        expect(results).toStrictEqual([
+            { created: true, id: "u8" },
+            { created: false, id: "u9" },
+        ]);
+        expect(insert).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/server/__tests__/rls.test.ts
+++ b/packages/server/__tests__/rls.test.ts
@@ -38,7 +38,7 @@ interface FakeDatabase {
     writer: {
         aggregate: (tableName: string, options: unknown) => Promise<null | number>;
         count: (tableName: string, whereOrArgs?: unknown) => Promise<number>;
-        delete: (id: string) => Promise<void>;
+        delete: (id: string, expectedTable?: string, options?: { hard?: boolean }) => Promise<void>;
         deleteMany: (ids: ReadonlyArray<string>, options?: { limit?: number }) => Promise<{ deleted: number }>;
         findFirst: (tableName: string, args?: unknown) => Promise<Record<string, unknown> | null>;
         findFirstOrThrow: (tableName: string, args?: unknown) => Promise<Record<string, unknown>>;
@@ -64,6 +64,7 @@ interface FakeDatabase {
             options?: unknown,
         ) => Promise<{ continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] }>;
         replace: (id: string, document: Record<string, unknown>) => Promise<void>;
+        restore: (id: string, expectedTable?: string) => Promise<void>;
     };
 }
 
@@ -91,8 +92,8 @@ const createFakeDatabase = (rows: (Record<string, unknown> & { _id: string; tabl
 
                 return rowsOfTable(tableName).length;
             },
-            async delete(id) {
-                calls.push({ args: undefined, method: "delete", tableOrId: id });
+            async delete(id, _expectedTable, options) {
+                calls.push({ args: options, method: "delete", tableOrId: id });
             },
             async deleteMany(ids) {
                 calls.push({ args: ids, method: "deleteMany", tableOrId: "" });
@@ -157,6 +158,9 @@ const createFakeDatabase = (rows: (Record<string, unknown> & { _id: string; tabl
             },
             query() {
                 throw new Error("query() not used in these tests");
+            },
+            async restore(id) {
+                calls.push({ args: undefined, method: "restore", tableOrId: id });
             },
             async rank(tableName, _indexName, options) {
                 calls.push({ args: options, method: "rank", tableOrId: tableName });
@@ -1572,5 +1576,81 @@ describe("rls — permissions / can()", () => {
         await handler.handler(makeContext(database, "u1", ["editor"]), {});
 
         expect(database.calls.some((call) => call.method === "insert")).toBe(true);
+    });
+});
+
+describe("rls — soft-delete write methods (restore / hardDelete)", () => {
+    it("restore is gated as an update — denied for a non-owner", async () => {
+        expect.assertions(2);
+
+        const policy = definePolicy<TestContext>({
+            on: "update",
+            table: "documents",
+            when: ({ auth }) => {
+                return { ownerId: auth.userId };
+            },
+        });
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u2", table: "documents" }]);
+        const handler = lunora.mutation.use(rlsForTest<TestContext>([policy])).mutation(async ({ ctx }) => ctx.db.restore("d1"));
+
+        // u1 is not the owner → the update policy denies the restore.
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toThrow(/denied/u);
+        // And the underlying writer was never reached.
+        expect(database.calls.some((call) => call.method === "restore")).toBe(false);
+    });
+
+    it("restore reaches the writer for the owner", async () => {
+        expect.assertions(1);
+
+        const policy = definePolicy<TestContext>({
+            on: "update",
+            table: "documents",
+            when: ({ auth }) => {
+                return { ownerId: auth.userId };
+            },
+        });
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.mutation.use(rlsForTest<TestContext>([policy])).mutation(async ({ ctx }) => ctx.db.restore("d1"));
+
+        await handler.handler(makeContext(database, "u1"), {});
+
+        expect(database.calls.some((call) => call.method === "restore")).toBe(true);
+    });
+
+    it("hardDelete forwards `{ hard: true }` through the delete gate", async () => {
+        expect.assertions(2);
+
+        const policy = definePolicy<TestContext>({
+            on: "delete",
+            table: "documents",
+            when: () => true,
+        });
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u1", table: "documents" }]);
+        const handler = lunora.mutation.use(rlsForTest<TestContext>([policy])).mutation(async ({ ctx }) => ctx.db.delete("d1", undefined, { hard: true }));
+
+        await handler.handler(makeContext(database, "u1"), {});
+
+        const deleteCall = database.calls.find((call) => call.method === "delete");
+
+        expect(deleteCall?.tableOrId).toBe("d1");
+        // The `{ hard: true }` option survives the RLS wrapper → the writer soft/hard branch sees it.
+        expect(deleteCall?.args).toStrictEqual({ hard: true });
+    });
+
+    it("hardDelete is still denied by the delete policy", async () => {
+        expect.assertions(2);
+
+        const policy = definePolicy<TestContext>({
+            on: "delete",
+            table: "documents",
+            when: ({ auth }) => {
+                return { ownerId: auth.userId };
+            },
+        });
+        const database = createFakeDatabase([{ _id: "d1", ownerId: "u2", table: "documents" }]);
+        const handler = lunora.mutation.use(rlsForTest<TestContext>([policy])).mutation(async ({ ctx }) => ctx.db.delete("d1", undefined, { hard: true }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toThrow(/denied/u);
+        expect(database.calls.some((call) => call.method === "delete")).toBe(false);
     });
 });

--- a/packages/server/__tests__/schema-soft-delete.test.ts
+++ b/packages/server/__tests__/schema-soft-delete.test.ts
@@ -1,0 +1,50 @@
+import { v } from "@lunora/values";
+import { describe, expect, it } from "vitest";
+
+import { defineTable } from "../src/schema";
+
+/**
+ * `.softDelete()` records the marker config on `softDeleteMode` (named so it
+ * doesn't collide with the fluent method, like `shardBy()`/`shardMode`) and
+ * injects the nullable marker column into the table shape so codegen emits it.
+ */
+describe("defineTable().softDelete()", () => {
+    it("defaults the marker column to deletedAt and injects it into the shape", () => {
+        expect.assertions(3);
+
+        const table = defineTable({ title: v.string() }).softDelete();
+
+        expect(table.softDeleteMode).toStrictEqual({ field: "deletedAt" });
+        expect(Object.keys(table.shape).toSorted((a, b) => a.localeCompare(b))).toStrictEqual(["deletedAt", "title"]);
+        // The injected column is optional (absent on a live row). Cast: the
+        // injection is a runtime effect, so the static `Shape` type omits it.
+        expect((table.shape as Record<string, { kind: string }>)["deletedAt"]?.kind).toBe("optional");
+    });
+
+    it("honors a custom marker field name", () => {
+        expect.assertions(2);
+
+        const table = defineTable({ title: v.string() }).softDelete({ field: "removedAt" });
+
+        expect(table.softDeleteMode).toStrictEqual({ field: "removedAt" });
+        expect("removedAt" in table.shape).toBe(true);
+    });
+
+    it("does not overwrite a user-declared marker column", () => {
+        expect.assertions(1);
+
+        const declared = v.optional(v.number());
+        const table = defineTable({ deletedAt: declared, title: v.string() }).softDelete();
+
+        // The user's own validator instance wins.
+        expect(table.shape["deletedAt"]).toBe(declared);
+    });
+
+    it("is absent on a table without .softDelete()", () => {
+        expect.assertions(1);
+
+        const table = defineTable({ title: v.string() });
+
+        expect(table.softDeleteMode).toBeUndefined();
+    });
+});

--- a/packages/server/__tests__/with-select.test-d.ts
+++ b/packages/server/__tests__/with-select.test-d.ts
@@ -1,0 +1,41 @@
+import type { DatabaseReaderFacade } from "../src/data-model";
+
+/**
+ * Type-level proof that a per-relation `select` on a `with` load narrows the
+ * loaded child to the selected columns (+ system fields) — for both a `one`
+ * and a `many` relation. The `@ts-expect-error` lines fail compilation if the
+ * narrowing regresses (a non-selected field would otherwise stay accessible).
+ */
+interface DM {
+    posts: { _creationTime: number; _id: string; authorId: string; body: string; title: string };
+    users: { _creationTime: number; _id: string; email: string; name: string };
+}
+type REL = {
+    posts: { author: { __relationKind: "one"; __target: "users" } };
+    users: { posts: { __relationKind: "many"; __target: "posts" } };
+};
+type RANK = { posts: never; users: never };
+type SEARCH = { posts: never; users: never };
+
+declare const db: DatabaseReaderFacade<DM, REL, RANK, SEARCH>;
+
+const check = async (): Promise<void> => {
+    const post = await db.posts.findFirst({ with: { author: { select: ["name"] } } });
+
+    post?.author?.name;
+    // @ts-expect-error `email` was not selected on the nested `author`
+    post?.author?.email;
+
+    const user = await db.users.findFirst({ with: { posts: { select: ["title"] } } });
+
+    user?.posts[0]?.title;
+    // @ts-expect-error `body` was not selected on the nested `posts`
+    user?.posts[0]?.body;
+
+    // No nested select → the full child stays accessible.
+    const full = await db.posts.findFirst({ with: { author: true } });
+
+    full?.author?.email;
+};
+
+export default check;

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -34,6 +34,7 @@ Create a `TableBuilder`. Fluent methods:
 - `.index(name, fields, { unique? })` — secondary index
 - `.searchIndex(name, { field, filterFields? })` — full-text index
 - `.public()` — exempt this table from `.rls("required")` (when secure-by-default is on)
+- `.softDelete({ field? })` — soft delete: `delete()` flips a marker column (default `deletedAt`) instead of removing the row, and list reads hide soft-deleted rows
 
 ## Validators (`v.*`)
 
@@ -87,6 +88,34 @@ ctx.db.insert("messages", doc, { clientId });
 primary-key uniqueness constraint, so a client can't collide with, overwrite, or
 forge a peer row. This is the mechanism [`@lunora/db`](/docs/packages/db#client-generated-ids)
 uses to reconcile an optimistic row with its persisted server row.
+
+### Per-table accessor (`ctx.db.<table>`)
+
+Each table exposes a typed delegate with the common read/write helpers:
+
+- `findMany(args)` / `findFirst(args)` — `args` takes `where`, `orderBy`, `with`
+  (relation loading), `select` (column projection, top-level and per-relation via
+  `with: { rel: { select: [...] } }`), `cursor` / `limit`, and `includeDeleted`.
+- `exists(where?)` — boolean existence check (reuses `findFirst`, no count scan).
+- `insert(doc, { skipDuplicates? })` — `skipDuplicates: true` resolves to `null`
+  on a unique conflict instead of throwing.
+- `upsert({ target, create, update? })` / `upsertMany({ target, rows })` —
+  insert-or-update keyed by a `.unique()` column (or tuple); returns `{ id, created }`.
+- `patch` / `replace` / `delete` (plus the `*Many` batch forms).
+
+On a `.softDelete()` table, `delete(id)` flips the marker (cascading as a soft
+delete), `restore(id)` clears it, and `hardDelete(id)` physically removes the row
+(real cascade). List reads hide soft-deleted rows; pass
+`findMany({ includeDeleted: true })` to include them.
+
+### Transactions & atomicity
+
+There is no explicit `transaction()` API — a **mutation _is_ a transaction**.
+Every `ctx.db` write in a single mutation commits atomically and rolls back
+together if the handler throws. To run a side effect only after the write
+commits, schedule it: `ctx.scheduler.runAfter(0, internalFn, args)` — the
+deterministic equivalent of an `afterCommit` hook (a registered function with
+serializable args, not an inline closure).
 
 ## Subpaths
 

--- a/packages/server/src/data-model.ts
+++ b/packages/server/src/data-model.ts
@@ -121,6 +121,13 @@ export type WhereOf<DM, REL extends Record<keyof DM, object>, T extends keyof DM
 /** {@link QueryArgs} with the relation-aware {@link WhereOf} `where` typing. */
 export interface QueryArgsOf<DM, REL extends Record<keyof DM, object>, T extends keyof DM> {
     cursor?: null | string;
+
+    /**
+     * Include soft-deleted rows (`.softDelete()` tables only). Default hides them;
+     * `true` returns deleted rows alongside live ones. No effect on a table
+     * without `.softDelete()`.
+     */
+    includeDeleted?: boolean;
     limit?: number;
     orderBy?: OrderBy<DM[T]>[];
     where?: WhereOf<DM, REL, T>;
@@ -370,9 +377,17 @@ export interface TableWriterFacade<
     SEARCH extends Record<keyof DM, string>,
     T extends keyof DM,
 > extends TableReaderFacade<DM, REL, RANK, SEARCH, T> {
+    /**
+     * Delete a row by id. On a `.softDelete()` table this flips the marker column
+     * (and cascades as a soft delete) instead of removing the row; use
+     * {@link TableWriterFacade.hardDelete} to force physical removal.
+     */
     delete: (id: Id<string & T>) => Promise<void>;
     /** Delete many rows in this table by id in one call; returns the *requested* id count (unknown ids are no-ops). Atomic within a mutation (a throw rolls the mutation back); an action has no transaction span. */
     deleteMany: (ids: ReadonlyArray<Id<string & T>>, options?: { limit?: number }) => Promise<{ deleted: number }>;
+
+    /** Physically remove a row (and physically cascade `onDelete`), bypassing `.softDelete()`. Same as `delete()` on a non-soft table. */
+    hardDelete: (id: Id<string & T>) => Promise<void>;
 
     /**
      * Insert a document, returning its minted id. With `{ skipDuplicates: true }`
@@ -389,6 +404,9 @@ export interface TableWriterFacade<
     /** Patch many rows in this table by id in one call. Atomic within a mutation (a throw rolls the mutation back); an action has no transaction span. */
     patchMany: (patches: ReadonlyArray<{ id: Id<string & T>; values: Partial<IM[T]> }>, options?: { limit?: number }) => Promise<void>;
     replace: (id: Id<string & T>, values: IM[T]) => Promise<void>;
+
+    /** Un-soft-delete a row by id: clears the `.softDelete()` marker so list reads see it again. Throws on a non-soft table. */
+    restore: (id: Id<string & T>) => Promise<void>;
 
     /**
      * Insert when no existing row matches `target`, otherwise patch the match with

--- a/packages/server/src/data-model.ts
+++ b/packages/server/src/data-model.ts
@@ -58,6 +58,14 @@ export interface QueryArgs<TDocument> {
     cursor?: null | string;
     limit?: number;
     orderBy?: OrderBy<TDocument>[];
+
+    /**
+     * Project each returned row down to these columns (plus the system fields
+     * `_id`/`_creationTime`, always retained). Trims wire payload for wide rows;
+     * relations requested via `with` are still attached. Reactivity is unaffected —
+     * the engine still reads the whole row to track dependencies.
+     */
+    select?: ReadonlyArray<keyof TDocument & string>;
     where?: Where<TDocument>;
 }
 
@@ -160,8 +168,25 @@ type LoadedRelations<DM, REL extends Record<keyof DM, object>, T extends keyof D
 /** The `_count` projection of `W`, if any. */
 type LoadedCount<W> = W extends { _count: infer C } ? { _count: { [K in keyof C]: number } } : {};
 
-/** `Doc&lt;T>` narrowed to exactly the relations requested in the with-arg `W`. */
-export type LoadWith<DM, REL extends Record<keyof DM, object>, T extends keyof DM, W> = DM[T] & LoadedCount<W> & LoadedRelations<DM, REL, T, W>;
+/** System columns a `select` projection always retains, so cursors and by-id reuse keep working. */
+type SelectAlwaysKeep<DM, T extends keyof DM> = ("_creationTime" | "_id") & keyof DM[T];
+
+/**
+ * `DM[T]` narrowed to the columns named by a `select` tuple `S` (plus the system
+ * fields). `undefined` (the default — no `select`) keeps the full document.
+ */
+type ProjectDoc<DM, T extends keyof DM, S> =
+    S extends ReadonlyArray<infer K> ? (K extends keyof DM[T] ? Pick<DM[T], (K & keyof DM[T]) | SelectAlwaysKeep<DM, T>> : DM[T]) : DM[T];
+
+/**
+ * `Doc&lt;T>` narrowed to exactly the relations requested in the with-arg `W` and,
+ * when a `select` tuple `S` is supplied, to its projected columns. `S` defaults
+ * to `undefined` so the 4-argument form (the codegen-emitted callers) keeps the
+ * full document.
+ */
+export type LoadWith<DM, REL extends Record<keyof DM, object>, T extends keyof DM, W, S = undefined> = LoadedCount<W> &
+    LoadedRelations<DM, REL, T, W> &
+    ProjectDoc<DM, T, S>;
 
 /** Reducer applied by an aggregate (`avg`/`count`/`max`/`min`/`sum`). */
 export type AggregateOp = "avg" | "count" | "max" | "min" | "sum";
@@ -291,9 +316,18 @@ export interface TableReaderFacade<
      * uses to inject `baseWhere` and `restrictsCounts`.
      */
     count: (where?: RestrictableQueryOptionsOf<DM, REL, T> | WhereOf<DM, REL, T>) => Promise<number>;
-    findFirst: <W extends WithArg<DM, REL, T> = {}>(args?: QueryArgsOf<DM, REL, T> & { with?: W }) => Promise<LoadWith<DM, REL, T, W> | null>;
-    findFirstOrThrow: <W extends WithArg<DM, REL, T> = {}>(args?: QueryArgsOf<DM, REL, T> & { with?: W }) => Promise<LoadWith<DM, REL, T, W>>;
-    findMany: <W extends WithArg<DM, REL, T> = {}>(args?: QueryArgsOf<DM, REL, T> & { with?: W }) => Promise<QueryPage<LoadWith<DM, REL, T, W>>>;
+
+    /** `true` when at least one row matches `where` (any row when omitted). RLS-filtered exactly like `findFirst`. */
+    exists: (where?: WhereOf<DM, REL, T>) => Promise<boolean>;
+    findFirst: <W extends WithArg<DM, REL, T> = {}, S extends ReadonlyArray<keyof DM[T] & string> | undefined = undefined>(
+        args?: QueryArgsOf<DM, REL, T> & { select?: S; with?: W },
+    ) => Promise<LoadWith<DM, REL, T, W, S> | null>;
+    findFirstOrThrow: <W extends WithArg<DM, REL, T> = {}, S extends ReadonlyArray<keyof DM[T] & string> | undefined = undefined>(
+        args?: QueryArgsOf<DM, REL, T> & { select?: S; with?: W },
+    ) => Promise<LoadWith<DM, REL, T, W, S>>;
+    findMany: <W extends WithArg<DM, REL, T> = {}, S extends ReadonlyArray<keyof DM[T] & string> | undefined = undefined>(
+        args?: QueryArgsOf<DM, REL, T> & { select?: S; with?: W },
+    ) => Promise<QueryPage<LoadWith<DM, REL, T, W, S>>>;
     get: (id: Id<string & T>) => Promise<DM[T] | null>;
 
     /**
@@ -339,14 +373,40 @@ export interface TableWriterFacade<
     delete: (id: Id<string & T>) => Promise<void>;
     /** Delete many rows in this table by id in one call; returns the *requested* id count (unknown ids are no-ops). Atomic within a mutation (a throw rolls the mutation back); an action has no transaction span. */
     deleteMany: (ids: ReadonlyArray<Id<string & T>>, options?: { limit?: number }) => Promise<{ deleted: number }>;
-    insert: (values: IM[T]) => Promise<Id<string & T>>;
+
+    /**
+     * Insert a document, returning its minted id. With `{ skipDuplicates: true }`
+     * a UNIQUE-constraint breach resolves to `null` (the row already exists)
+     * instead of throwing — the return type widens to `Id | null` on that overload.
+     */
+    insert: {
+        (values: IM[T], options: { skipDuplicates: true }): Promise<Id<string & T> | null>;
+        (values: IM[T], options?: { skipDuplicates?: boolean }): Promise<Id<string & T>>;
+    };
     /** Insert many documents into this table in one call, returning the minted ids in input order. Atomic within a mutation (a throw rolls the mutation back); an action has no transaction span. */
     insertMany: (values: ReadonlyArray<IM[T]>, options?: { limit?: number }) => Promise<Id<string & T>[]>;
     patch: (id: Id<string & T>, values: Partial<IM[T]>) => Promise<void>;
     /** Patch many rows in this table by id in one call. Atomic within a mutation (a throw rolls the mutation back); an action has no transaction span. */
     patchMany: (patches: ReadonlyArray<{ id: Id<string & T>; values: Partial<IM[T]> }>, options?: { limit?: number }) => Promise<void>;
     replace: (id: Id<string & T>, values: IM[T]) => Promise<void>;
+
+    /**
+     * Insert when no existing row matches `target`, otherwise patch the match with
+     * `update` (defaulting to `create`). `target` names a `.unique()` column (or a
+     * tuple) used to look it up. Returns the row id and whether it was `created`.
+     * Composes `findFirst` + `insert`/`patch`, so RLS gates each step.
+     */
+    upsert: (args: { create: IM[T]; target: UpsertTargetOf<DM, T>; update?: Partial<IM[T]> }) => Promise<{ created: boolean; id: Id<string & T> }>;
+
+    /** Sequential {@link TableWriterFacade.upsert} over many rows sharing one `target`; one result per input row, in order. */
+    upsertMany: (args: {
+        rows: ReadonlyArray<{ create: IM[T]; update?: Partial<IM[T]> }>;
+        target: UpsertTargetOf<DM, T>;
+    }) => Promise<{ created: boolean; id: Id<string & T> }[]>;
 }
+
+/** Conflict target for `upsert`/`upsertMany`: one column of table `T`, or a tuple of them. */
+export type UpsertTargetOf<DM, T extends keyof DM> = ReadonlyArray<keyof DM[T] & string> | (keyof DM[T] & string);
 
 /** Per-table read facade — `ctx.db.&lt;table>` on a `QueryCtx`. */
 export type DatabaseReaderFacade<DM, REL extends Record<keyof DM, object>, RANK extends Record<keyof DM, string>, SEARCH extends Record<keyof DM, string>> = {

--- a/packages/server/src/data-model.ts
+++ b/packages/server/src/data-model.ts
@@ -142,27 +142,35 @@ export interface QueryPage<TDocument> {
 /** The nested `with` sub-argument inside a relation's with-value, or `{}`. */
 type NestedWithArgument<WK> = WK extends { with: infer NW } ? NW : {};
 
+/** The nested `select` tuple inside a relation's with-value, or `undefined` (no projection). */
+type NestedSelectArgument<WK> = WK extends { select: infer S } ? S : undefined;
+
 /**
  * The `with` argument for table `T`: each relation can be `true` (load with no
- * refinements) or an object. `many` relations accept `where`/`orderBy`/`limit`
- * plus a nested `with`; `one` relations accept only a nested `with`. The
- * reserved `_count` key requests per-relation aggregate counts.
+ * refinements) or an object. `many` relations accept `where`/`orderBy`/`limit`/
+ * `select` plus a nested `with`; `one` relations accept `select` + a nested
+ * `with`. The reserved `_count` key requests per-relation aggregate counts.
  */
 export type WithArg<DM, REL extends Record<keyof DM, object>, T extends keyof DM> = {
     [K in keyof REL[T]]?: REL[T][K] extends { __relationKind: "many"; __target: infer Target extends keyof DM }
         ? boolean | (QueryArgs<DM[Target]> & { with?: WithArg<DM, REL, Target> })
         : REL[T][K] extends { __relationKind: "one"; __target: infer Target extends keyof DM }
-          ? boolean | { with?: WithArg<DM, REL, Target> }
+          ? boolean | { select?: ReadonlyArray<keyof DM[Target] & string>; with?: WithArg<DM, REL, Target> }
           : never;
 } & {
     _count?: { [K in keyof REL[T]]?: true };
 };
 
-/** Resolve a single relation descriptor + its with-value to the loaded type. */
+/**
+ * Resolve a single relation descriptor + its with-value to the loaded type,
+ * threading the nested `select` tuple into the projected child shape (the 5th
+ * `LoadWith` arg) so `with: { author: { select: ["name"] } }` narrows the loaded
+ * `author` to the selected columns + system fields.
+ */
 type LoadRelation<DM, REL extends Record<keyof DM, object>, R, WK> = R extends { __relationKind: "one"; __target: infer Target extends keyof DM }
-    ? LoadWith<DM, REL, Target, NestedWithArgument<WK>> | null
+    ? LoadWith<DM, REL, Target, NestedWithArgument<WK>, NestedSelectArgument<WK>> | null
     : R extends { __relationKind: "many"; __target: infer Target extends keyof DM }
-      ? LoadWith<DM, REL, Target, NestedWithArgument<WK>>[]
+      ? LoadWith<DM, REL, Target, NestedWithArgument<WK>, NestedSelectArgument<WK>>[]
       : never;
 
 /** The relation keys of `W` that were actually requested (not `false`/`undefined`). */

--- a/packages/server/src/facade.ts
+++ b/packages/server/src/facade.ts
@@ -61,7 +61,7 @@ const buildUpsertWhere = (tableName: string, target: ReadonlyArray<string> | str
 export interface FacadeWriterLike {
     aggregate(tableName: string, options: unknown): Promise<unknown>;
     count(tableName: string, where?: unknown): Promise<number>;
-    delete(id: string, expectedTable?: string): Promise<void>;
+    delete(id: string, expectedTable?: string, options?: { hard?: boolean }): Promise<void>;
     // Optional: some writers (e.g. the `.global()` path) have no batch method and
     // delete row-by-row instead, mirroring `@lunora/do`'s `DatabaseWriterLike`.
     deleteMany?(ids: ReadonlyArray<string>, options?: { limit?: number }, expectedTable?: string): Promise<{ deleted: number }>;
@@ -80,6 +80,8 @@ export interface FacadeWriterLike {
     rank(tableName: string, indexName: string, options: unknown): Promise<unknown>;
     rankPage(tableName: string, indexName: string, options?: unknown): Promise<unknown>;
     replace(id: string, document: Record<string, unknown>, expectedTable?: string): Promise<void>;
+    // Optional: only writers over a `.softDelete()` schema implement it.
+    restore?(id: string, expectedTable?: string): Promise<void>;
 }
 /* eslint-enable @typescript-eslint/method-signature-style */
 
@@ -96,6 +98,8 @@ export interface FacadeEntry {
     findMany: (args?: unknown) => Promise<unknown>;
     get: (id: string) => Promise<unknown>;
     groupBy: (options: unknown) => Promise<unknown>;
+    /** Physically remove a row (and physically cascade), bypassing `.softDelete()`. */
+    hardDelete: (id: string) => Promise<void>;
     insert: (document: Record<string, unknown>, options?: FacadeInsertOptions) => Promise<null | string>;
     insertMany: (documents: ReadonlyArray<Record<string, unknown>>, options?: { limit?: number }) => Promise<string[]>;
     // NOTE: `insertManyUnsafe` is DELIBERATELY absent from the per-table facade
@@ -109,6 +113,8 @@ export interface FacadeEntry {
     rank: (indexName: string, options: unknown) => Promise<unknown>;
     rankPage: (indexName: string, options?: unknown) => Promise<unknown>;
     replace: (id: string, document: Record<string, unknown>) => Promise<void>;
+    /** Un-soft-delete a row: clears the `.softDelete()` marker (by-id, so it reaches a row list reads hide). */
+    restore: (id: string) => Promise<void>;
     /** Insert when no row matches `target`, else patch the match. Composes `findFirst` + `insert`/`patch`, so RLS applies to each step. */
     upsert: (args: UpsertArgs) => Promise<UpsertResult>;
     /** Sequential `upsert` over many rows sharing one `target`; returns one result per input row in order. */
@@ -229,6 +235,8 @@ export const bindTableFacade = (writer: FacadeWriterLike, tableName: string): Fa
         findMany: (args) => writer.findMany(tableName, args),
         get: (id) => writer.get(id, tableName),
         groupBy: (options) => writer.groupBy(tableName, options),
+        // Physical removal — bypasses `.softDelete()`. RLS gates it as a delete.
+        hardDelete: (id) => writer.delete(id, tableName, { hard: true }),
         insert,
         insertMany: (documents, options) => {
             if (writer.insertMany === undefined) {
@@ -254,6 +262,13 @@ export const bindTableFacade = (writer: FacadeWriterLike, tableName: string): Fa
         rank: (indexName, options) => writer.rank(tableName, indexName, options),
         rankPage: (indexName, options) => writer.rankPage(tableName, indexName, options),
         replace: (id, document) => writer.replace(id, document, tableName),
+        restore: async (id) => {
+            if (!writer.restore) {
+                throw new Error(`ctx.db.${tableName}.restore is unavailable: this writer has no restore (is the table .softDelete()?)`);
+            }
+
+            await writer.restore(id, tableName);
+        },
         upsert,
         upsertMany: async ({ rows, target }) => {
             // Sequential so each upsert sees the prior one's write (two rows that

--- a/packages/server/src/facade.ts
+++ b/packages/server/src/facade.ts
@@ -15,6 +15,42 @@
  */
 
 /**
+ * Structural detector for `@lunora/do`'s `ConflictError(kind: "unique")`. The
+ * facade must not take a runtime dependency on `@lunora/do`, so it recognises a
+ * UNIQUE-constraint breach by the error's own `code`/`kind` properties (declared
+ * own-properties precisely so cross-package callers can match the shape without
+ * an `instanceof`). Used by the `skipDuplicates` insert path.
+ */
+const isUniqueConflict = (error: unknown): boolean =>
+    typeof error === "object" && error !== null && (error as { code?: unknown }).code === "CONFLICT" && (error as { kind?: unknown }).kind === "unique";
+
+/**
+ * Build the `where` tree that locates an existing row for `upsert`: one equality
+ * per `target` field, read from the `create` document. Throws when a target
+ * field is absent (an upsert with no value to match on would silently match the
+ * wrong rows). Multiple keys on one object compose as an implicit AND.
+ */
+const buildUpsertWhere = (tableName: string, target: ReadonlyArray<string> | string, create: Record<string, unknown>): Record<string, unknown> => {
+    const fields = typeof target === "string" ? [target] : target;
+
+    if (fields.length === 0) {
+        throw new Error(`ctx.db.${tableName}.upsert: "target" must name at least one field`);
+    }
+
+    const where: Record<string, unknown> = {};
+
+    for (const field of fields) {
+        if (!(field in create)) {
+            throw new Error(`ctx.db.${tableName}.upsert: target field "${field}" is missing from the create document`);
+        }
+
+        where[field] = create[field];
+    }
+
+    return where;
+};
+
+/**
  * Minimal structural writer the facade binds over. Declared with **method**
  * syntax (not arrow properties) so a more-specifically-typed writer — both
  * `@lunora/do`'s `DatabaseWriterLike` and the RLS middleware's wrapped writer —
@@ -53,12 +89,14 @@ export interface FacadeEntry {
     count: (where?: unknown) => Promise<number>;
     delete: (id: string) => Promise<void>;
     deleteMany: (ids: ReadonlyArray<string>, options?: { limit?: number }) => Promise<{ deleted: number }>;
+    /** `true` when at least one row matches `where` (or any row exists when omitted). Honors RLS like `findFirst`. */
+    exists: (where?: unknown) => Promise<boolean>;
     findFirst: (args?: unknown) => Promise<unknown>;
     findFirstOrThrow: (args?: unknown) => Promise<unknown>;
     findMany: (args?: unknown) => Promise<unknown>;
     get: (id: string) => Promise<unknown>;
     groupBy: (options: unknown) => Promise<unknown>;
-    insert: (document: Record<string, unknown>) => Promise<string>;
+    insert: (document: Record<string, unknown>, options?: FacadeInsertOptions) => Promise<null | string>;
     insertMany: (documents: ReadonlyArray<Record<string, unknown>>, options?: { limit?: number }) => Promise<string[]>;
     // NOTE: `insertManyUnsafe` is DELIBERATELY absent from the per-table facade
     // (and `ctx.orm`). It's a trusted, validation/trigger-skipping escape hatch and
@@ -71,7 +109,46 @@ export interface FacadeEntry {
     rank: (indexName: string, options: unknown) => Promise<unknown>;
     rankPage: (indexName: string, options?: unknown) => Promise<unknown>;
     replace: (id: string, document: Record<string, unknown>) => Promise<void>;
+    /** Insert when no row matches `target`, else patch the match. Composes `findFirst` + `insert`/`patch`, so RLS applies to each step. */
+    upsert: (args: UpsertArgs) => Promise<UpsertResult>;
+    /** Sequential `upsert` over many rows sharing one `target`; returns one result per input row in order. */
+    upsertMany: (args: UpsertManyArgs) => Promise<UpsertResult[]>;
     withSearchIndex: (indexName: string, search: (q: unknown) => unknown) => unknown;
+}
+
+/** Options accepted by the per-table `insert` accessor. */
+export interface FacadeInsertOptions {
+    /**
+     * When `true`, a UNIQUE-constraint breach is swallowed: the insert becomes a
+     * silent no-op and resolves to `null` instead of throwing a `CONFLICT`. Any
+     * other error still propagates. Mirrors better-drizzle's `create({ skipDuplicates })`.
+     */
+    skipDuplicates?: boolean;
+}
+
+/** The conflict target for `upsert`/`upsertMany`: one field name or a tuple of them. */
+export type UpsertTarget = ReadonlyArray<string> | string;
+
+/** Argument to the per-table `upsert` accessor. */
+export interface UpsertArgs {
+    /** Document inserted when no existing row matches the `target`. */
+    create: Record<string, unknown>;
+    /** Field(s) — typically a `.unique()` column or unique index — used to look up an existing row. */
+    target: UpsertTarget;
+    /** Patch applied when an existing row matches the `target`. Defaults to `create`. */
+    update?: Record<string, unknown>;
+}
+
+/** Result of an `upsert`: the row's id and whether it was freshly inserted (`true`) or updated (`false`). */
+export interface UpsertResult {
+    created: boolean;
+    id: string;
+}
+
+/** Argument to the per-table `upsertMany` accessor — a shared `target` plus per-row create/update payloads. */
+export interface UpsertManyArgs {
+    rows: ReadonlyArray<{ create: Record<string, unknown>; update?: Record<string, unknown> }>;
+    target: UpsertTarget;
 }
 
 /**
@@ -87,6 +164,47 @@ export interface FacadeEntry {
  * forwarded name.
  */
 export const bindTableFacade = (writer: FacadeWriterLike, tableName: string): FacadeEntry => {
+    // Insert + skipDuplicates: on a UNIQUE breach the insert resolves to `null`
+    // instead of throwing. Routes through the bound `writer.insert`, so when this
+    // facade is re-bound over the RLS-wrapped writer the insert policy still runs
+    // *before* the constraint check.
+    const insert = async (document: Record<string, unknown>, options?: FacadeInsertOptions): Promise<null | string> => {
+        if (options?.skipDuplicates !== true) {
+            return writer.insert(tableName, document);
+        }
+
+        try {
+            return await writer.insert(tableName, document);
+        } catch (error) {
+            if (isUniqueConflict(error)) {
+                // eslint-disable-next-line unicorn/no-null -- skipDuplicates resolves to `null` when the row already exists, mirroring better-drizzle's create()
+                return null;
+            }
+
+            throw error;
+        }
+    };
+
+    // Insert-or-update keyed by `target`. Both the lookup and the write go
+    // through the bound `writer.*`, so each step is RLS-checked when this facade
+    // is bound over the wrapped writer (a hidden row simply isn't found, and the
+    // insert/patch is gated by its own policy). The `tableName` passed to `patch`
+    // scopes the by-id write to this table (the same IDOR guard as `patch`).
+    const upsert = async ({ create, target, update }: UpsertArgs): Promise<UpsertResult> => {
+        const where = buildUpsertWhere(tableName, target, create);
+        const existing = (await writer.findFirst(tableName, { where })) as null | Record<string, unknown>;
+
+        if (existing && typeof existing["_id"] === "string") {
+            await writer.patch(existing["_id"], update ?? create, tableName);
+
+            return { created: false, id: existing["_id"] };
+        }
+
+        const id = await writer.insert(tableName, create);
+
+        return { created: true, id };
+    };
+
     return {
         aggregate: (options) => writer.aggregate(tableName, options),
         count: (where) => writer.count(tableName, where),
@@ -103,12 +221,15 @@ export const bindTableFacade = (writer: FacadeWriterLike, tableName: string): Fa
 
             return writer.deleteMany(ids, options, tableName);
         },
+        // `exists` reuses `findFirst` (RLS-filtered, indexed when a `.withIndex`-able
+        // `where` is supplied) and only asks whether a row came back — no count scan.
+        exists: async (where) => (await writer.findFirst(tableName, where === undefined ? undefined : { where })) !== null,
         findFirst: (args) => writer.findFirst(tableName, args),
         findFirstOrThrow: (args) => writer.findFirstOrThrow(tableName, args),
         findMany: (args) => writer.findMany(tableName, args),
         get: (id) => writer.get(id, tableName),
         groupBy: (options) => writer.groupBy(tableName, options),
-        insert: (document) => writer.insert(tableName, document),
+        insert,
         insertMany: (documents, options) => {
             if (writer.insertMany === undefined) {
                 throw new Error(`ctx.db.${tableName}.insertMany is unavailable: this writer has no batch insert`);
@@ -133,6 +254,21 @@ export const bindTableFacade = (writer: FacadeWriterLike, tableName: string): Fa
         rank: (indexName, options) => writer.rank(tableName, indexName, options),
         rankPage: (indexName, options) => writer.rankPage(tableName, indexName, options),
         replace: (id, document) => writer.replace(id, document, tableName),
+        upsert,
+        upsertMany: async ({ rows, target }) => {
+            // Sequential so each upsert sees the prior one's write (two rows that
+            // collide on `target` within one batch land as insert-then-update, not
+            // two inserts that breach the constraint). Atomic within a mutation via
+            // the DO's BEGIN/COMMIT span, exactly like `insertMany`/`patchMany`.
+            const results: UpsertResult[] = [];
+
+            for (const row of rows) {
+                // eslint-disable-next-line no-await-in-loop -- sequential by design: a later row may upsert a row an earlier one just created
+                results.push(await upsert({ create: row.create, target, update: row.update }));
+            }
+
+            return results;
+        },
         withSearchIndex: (indexName, search) => writer.query(tableName).withSearchIndex(indexName, search),
     };
 };
@@ -140,7 +276,7 @@ export const bindTableFacade = (writer: FacadeWriterLike, tableName: string): Fa
 /** The kitcn-style `ctx.orm` namespace over a per-table facade map. */
 export interface OrmLike {
     delete: (table: string, id: string) => Promise<void>;
-    insert: (table: string) => { values: (document: Record<string, unknown>) => Promise<string> };
+    insert: (table: string) => { values: (document: Record<string, unknown>) => Promise<null | string> };
     query: Record<string, FacadeEntry>;
     replace: (table: string, id: string) => { with: (document: Record<string, unknown>) => Promise<void> };
     update: (table: string, id: string) => { set: (values: Record<string, unknown>) => Promise<void> };

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -155,7 +155,7 @@ interface DatabaseWriterLike {
      */
     aggregate: (tableName: string, options: AggregateArgs) => Promise<null | number>;
     count: (tableName: string, whereOrArgs?: CountArgs | WhereInput) => Promise<number>;
-    delete: (id: string, expectedTable?: string) => Promise<void>;
+    delete: (id: string, expectedTable?: string, options?: { hard?: boolean }) => Promise<void>;
     deleteMany: (ids: ReadonlyArray<string>, options?: { limit?: number }, expectedTable?: string) => Promise<{ deleted: number }>;
     findFirst: (tableName: string, args?: QueryArgs) => Promise<Record<string, unknown> | null>;
     findFirstOrThrow: (tableName: string, args?: QueryArgs) => Promise<Record<string, unknown>>;
@@ -209,6 +209,7 @@ interface DatabaseWriterLike {
      */
     rankPage: (tableName: string, indexName: string, options?: RankPageArgs) => Promise<QueryPage>;
     replace: (id: string, document: Record<string, unknown>, expectedTable?: string) => Promise<void>;
+    restore?: (id: string, expectedTable?: string) => Promise<void>;
 }
 
 /**
@@ -1019,7 +1020,7 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             });
         },
 
-        delete: (id, expectedTable) => gateById(id, "delete", (writer) => writer.delete(id, expectedTable), undefined, expectedTable),
+        delete: (id, expectedTable, options) => gateById(id, "delete", (writer) => writer.delete(id, expectedTable, options), undefined, expectedTable),
 
         async deleteMany(ids, options, expectedTable) {
             assertBatchLimit(ids.length, options?.limit, "deleteMany");
@@ -1236,6 +1237,26 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             // We compile the predicate once into a JS-side checker.
             return reader.filter((document) => matchesWhere(document, baseWhere));
         },
+
+        // Restore clears the soft-delete marker — a by-id un-delete, gated as an
+        // "update" (the policy that governs patch). No post-image check: the
+        // writer owns the marker field, so we only enforce the pre-image USING.
+        restore: (id, expectedTable) =>
+            gateById(
+                id,
+                "update",
+                async (writer) => {
+                    const perform = writer.restore ?? raw.restore;
+
+                    if (!perform) {
+                        throw new LunoraError("BAD_REQUEST", "restore is not supported by this writer");
+                    }
+
+                    await perform(id, expectedTable);
+                },
+                undefined,
+                expectedTable,
+            ),
 
         replace: (id, document, expectedTable) =>
             gateById(

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -1,5 +1,5 @@
 import type { Validator } from "@lunora/values";
-import { isOrWrapsFromValidator } from "@lunora/values";
+import { isOrWrapsFromValidator, v } from "@lunora/values";
 
 import type { PrefixedTables, SchemaExtension } from "./plugin";
 import { mergeSchemaExtension } from "./plugin";
@@ -133,6 +133,18 @@ interface TableBuilder<Shape extends Record<string, Validator> = Record<string, 
     searchIndex: (name: string, options: { field: string; filterFields?: ReadonlyArray<string> }) => TableBuilder<Shape>;
     /** Route storage by the named field — one DO per distinct value. */
     shardBy: (field: keyof Shape & string) => TableBuilder<Shape>;
+
+    /**
+     * Turn on soft delete. Adds a nullable timestamp column (`options.field`,
+     * default `deletedAt`) and changes `ctx.db.&lt;table>.delete()` to **set** it
+     * instead of removing the row; `onDelete: "cascade"` children are recursively
+     * soft-deleted too. **List reads** (`findMany`/`findFirst`/`query()`/`count`/
+     * `aggregate`/relation loads) then hide soft-deleted rows unless they pass
+     * `includeDeleted`/`withDeleted`; by-id `get`/`patch`/`replace` and the new
+     * `restore()` still address the row directly. `hardDelete()` physically
+     * removes it (cascading as a real delete).
+     */
+    softDelete: (options?: { field?: string }) => TableBuilder<Shape>;
     /** Declare named lifecycle triggers fired inline within the write path. */
     triggers: (build: (t: TriggerBuilder<Shape>) => Record<string, TriggerDefinition>) => TableBuilder<Shape>;
     /** Declare a vector index over a single text field on this table. */
@@ -186,7 +198,11 @@ interface VectorIndexOptions {
  * Build a table definition. Returned object is both the table definition (for
  * `defineSchema`) and a fluent builder for indexes + sharding metadata.
  */
-const defineTable = <Shape extends Record<string, Validator>>(shape: Shape): TableBuilder<Shape> => {
+const defineTable = <Shape extends Record<string, Validator>>(inputShape: Shape): TableBuilder<Shape> => {
+    // Work on a shallow copy so `.softDelete()` can inject its marker column
+    // without mutating the caller's object literal.
+    const shape = { ...inputShape };
+
     // v.from() validators are args-only — they delegate to an external Standard
     // Schema library and do not map to a concrete SQL column type. Reject them
     // anywhere in a column, including nested under v.optional/array/object/etc.
@@ -207,6 +223,7 @@ const defineTable = <Shape extends Record<string, Validator>>(shape: Shape): Tab
     let shardMode: ShardMode = { kind: "root" };
     let isExternallyManaged = false;
     let isPublic = false;
+    let softDelete: { field: string } | undefined;
 
     const builder: TableBuilder<Shape> = {
         aggregateIndex(name, options) {
@@ -314,6 +331,25 @@ const defineTable = <Shape extends Record<string, Validator>>(shape: Shape): Tab
         },
         get shardMode() {
             return shardMode;
+        },
+        get softDeleteMode() {
+            return softDelete;
+        },
+        softDelete(options) {
+            const field = options?.field ?? "deletedAt";
+
+            softDelete = { field };
+
+            // Auto-add the marker column so the generated `Doc` carries it and the
+            // write path validates it. Optional on insert (absent on a live row)
+            // and nullable so `restore()` can clear it with `patch({ [field]: null })`;
+            // set to `Date.now()` on soft delete. Idempotent — if the user already
+            // declared the column, their validator wins.
+            if (!(field in shape)) {
+                (shape as Record<string, Validator>)[field] = v.optional(v.number().nullable());
+            }
+
+            return builder;
         },
         get triggerMap() {
             return triggers;

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -140,9 +140,12 @@ interface TableBuilder<Shape extends Record<string, Validator> = Record<string, 
      * instead of removing the row; `onDelete: "cascade"` children are recursively
      * soft-deleted too. **List reads** (`findMany`/`findFirst`/`query()`/`count`/
      * `aggregate`/relation loads) then hide soft-deleted rows unless they pass
-     * `includeDeleted`/`withDeleted`; by-id `get`/`patch`/`replace` and the new
+     * `includeDeleted: true`; by-id `get`/`patch`/`replace` and the new
      * `restore()` still address the row directly. `hardDelete()` physically
-     * removes it (cascading as a real delete).
+     * removes it (cascading as a real delete). Note: `includeDeleted` is a read
+     * scope, not access control — anyone who can run the read can set it; a unique
+     * index still rejects a new row that collides with a soft-deleted one (the row
+     * physically persists).
      */
     softDelete: (options?: { field?: string }) => TableBuilder<Shape>;
     /** Declare named lifecycle triggers fired inline within the write path. */

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -184,6 +184,19 @@ interface TableDefinition<Shape extends Record<string, Validator> = Record<strin
     shardMode: ShardMode;
 
     /**
+     * Set by `.softDelete()` (named `softDeleteMode`, not `softDelete`, so the
+     * data field doesn't collide with the fluent `.softDelete()` builder method —
+     * same convention as `shardBy()`/`shardMode`). When present, the table carries
+     * a nullable timestamp column (`field`, default `deletedAt`):
+     * `ctx.db.&lt;table>.delete()` flips it instead of physically removing the row,
+     * and **list reads** (`findMany`/`findFirst`/`query()`/`count`/`aggregate`/
+     * relation loads) hide rows whose `field` is set unless
+     * `includeDeleted`/`withDeleted` is passed. By-id `get`/`patch`/`replace` and
+     * `restore` are unaffected. Absent ⇒ deletes are physical, as before.
+     */
+    softDeleteMode?: { field: string };
+
+    /**
      * Declared lifecycle triggers keyed by accessor name; empty unless
      * `.triggers()` was called. Named `triggerMap` (not `triggers`) so the
      * fluent `.triggers((t) => …)` builder method doesn't collide with this

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -191,7 +191,7 @@ interface TableDefinition<Shape extends Record<string, Validator> = Record<strin
      * `ctx.db.&lt;table>.delete()` flips it instead of physically removing the row,
      * and **list reads** (`findMany`/`findFirst`/`query()`/`count`/`aggregate`/
      * relation loads) hide rows whose `field` is set unless
-     * `includeDeleted`/`withDeleted` is passed. By-id `get`/`patch`/`replace` and
+     * `includeDeleted: true` is passed. By-id `get`/`patch`/`replace` and
      * `restore` are unaffected. Absent ⇒ deletes are physical, as before.
      */
     softDeleteMode?: { field: string };

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -2548,8 +2548,12 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
 
                 await runGuardedWrite(tableName, "UPDATE", assignments, snapshot);
 
+                // The rank companion has no marker column to filter on, so a soft
+                // delete REMOVES the rank entry (like a physical delete); search +
+                // aggregates stay maintained (search hides via the read filter).
+                // `restore()` re-adds the rank entry through the patch path.
                 await syncAggregates(tableName, existing, merged);
-                await syncRanks(tableName, id, existing, merged);
+                await syncRanks(tableName, id, existing, undefined);
                 await syncSearch(tableName, id, merged);
                 await recordCdc(tableName, id, "update", merged);
 
@@ -2955,14 +2959,33 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 throw new Error(`document not found: ${id}`);
             }
 
-            const field = schema.tables[tableName]?.softDeleteMode?.field;
+            const definition = schema.tables[tableName];
+            const field = definition?.softDeleteMode?.field;
 
-            if (!field) {
+            if (!definition || !field) {
                 throw new Error(`ctx.db.restore: table "${tableName}" is not a .softDelete() table`);
             }
 
+            // Snapshot the raw row before the patch so we know whether it was
+            // actually soft-deleted (drives the rank re-add) and have its sort
+            // fields to rebuild the rank-companion entry.
+            const snapshot = await rawRow(tableName, id);
+            const wasDeleted = snapshot?.[field] !== null && snapshot?.[field] !== undefined;
+
             // eslint-disable-next-line unicorn/no-null -- clearing the soft-delete marker writes SQL NULL into the column
             await writer.patch(id, { [field]: null }, expectedTable);
+
+            // Soft delete dropped this row's rank-companion entry; `patch`'s rank
+            // sync skips re-adding it (sort fields unchanged), so force a pure
+            // INSERT (`previous=undefined`) — only when restoring an actually
+            // soft-deleted row, to avoid a duplicate on a no-op restore.
+            if (wasDeleted) {
+                const row = decodeRow(definition, snapshot);
+
+                if (row !== null) {
+                    await syncRanks(tableName, id, undefined, row);
+                }
+            }
         },
 
         query(tableName) {

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -79,6 +79,7 @@ import {
     selectIndexForAggregate,
     selectIndexForCount,
     selectIndexForGroupBy,
+    softDeleteScope,
     sortColumnName,
     stringifySearchText,
     throwingScheduler,
@@ -635,6 +636,12 @@ const searchViaFts = async (
         conditions.push(sql`m.${columnRefSql(filter.field)} = ${serializeColumnValue(filter.value)}`);
     }
 
+    // Soft delete: hide soft-deleted rows from search (qualified to the joined
+    // doc table `m`).
+    if (definition.softDeleteMode) {
+        conditions.push(sql`m.${columnRefSql(definition.softDeleteMode.field)} IS NULL`);
+    }
+
     // `f.rank` is FTS5's bm25 relevance (best first); the `_creationTime DESC`
     // tiebreak matches the scan fallback so equal-rank rows order newest-first
     // on both engines.
@@ -671,6 +678,11 @@ const searchViaScan = async (
     }
 
     const conditions = search.filters.map((filter) => sql`${columnRefSql(filter.field)} = ${serializeColumnValue(filter.value)}`);
+
+    // Soft delete: hide soft-deleted rows from the scan fallback too.
+    if (definition.softDeleteMode) {
+        conditions.push(sql`${columnRefSql(definition.softDeleteMode.field)} IS NULL`);
+    }
 
     let query = sql`SELECT * FROM ${sql.identifier(tableName)}`;
 
@@ -2347,7 +2359,10 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 throw new Error(`aggregate(${tableName}, { op: "${aggOptions.op}" }): "field" is required for non-count reducers`);
             }
 
-            const effective = mergeWhere(aggOptions.baseWhere, aggOptions.where);
+            // Soft delete: aggregate over LIVE rows only; force the scan path (the
+            // indexed companion counts deleted rows too).
+            const aggScope = softDeleteScope(definition.softDeleteMode, undefined);
+            const effective = mergeWhere(mergeWhere(aggOptions.baseWhere, aggOptions.where), aggScope);
             // Rewrite any relation-crossing predicate to a flat semijoin clause
             // before compiling. The resolver returns `effective` unchanged when
             // there is none, so `hasRelation` skips the no-op fetch and disables
@@ -2362,7 +2377,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // counter is materialized answers sum/avg/min/max in one row lookup.
             // We only attempt it when no baseWhere is set; the RLS predicate
             // falls through to the SQL scan below.
-            if (definition.aggregateIndexes && !aggOptions.baseWhere && !hasRelation) {
+            if (definition.aggregateIndexes && !aggOptions.baseWhere && !hasRelation && !aggScope) {
                 const planned = selectIndexForAggregate(definition.aggregateIndexes, aggOptions.op, aggOptions.field, aggOptions.where);
 
                 if (planned) {
@@ -2410,7 +2425,9 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 throw new CountRlsUnsupportedError(tableName);
             }
 
-            const effective = mergeWhere(countOptions.baseWhere, countOptions.where);
+            // Soft delete: a `count()` reflects LIVE rows; force the scan path.
+            const countScope = softDeleteScope(definition.softDeleteMode, undefined);
+            const effective = mergeWhere(mergeWhere(countOptions.baseWhere, countOptions.where), countScope);
             // Rewrite any relation-crossing predicate to a flat semijoin clause
             // before compiling. `hasRelation` (resolver returned a new tree)
             // disables the indexed counter, which can't honour a relation filter.
@@ -2420,7 +2437,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // Indexed path: same planner as the DO dialect (see ctx-db.ts).
             // We only attempt the counter when no baseWhere is set; otherwise
             // we route uniformly through SQL so the RLS predicate participates.
-            if (definition.aggregateIndexes && !countOptions.baseWhere && !hasRelation) {
+            if (definition.aggregateIndexes && !countOptions.baseWhere && !hasRelation && !countScope) {
                 const planned = selectIndexForCount(definition.aggregateIndexes, countOptions.where);
 
                 if (planned) {
@@ -2447,7 +2464,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             return Number(rows[0]?.["count"] ?? 0);
         },
 
-        async delete(id, expectedTable) {
+        async delete(id, expectedTable, deleteOptions) {
             const tableName = await resolveTableName(id, expectedTable);
 
             if (!tableName) {
@@ -2466,6 +2483,16 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
 
             const snapshot = await rawRow(tableName, id);
             const existing = decodeRow(definition, snapshot);
+            // Soft delete unless `hard` was forced; `softField` undefined ⇒ legacy
+            // physical path. A delete cascades as a delete (soft→soft, hard→hard).
+            const hard = deleteOptions?.hard === true;
+            const softField = !hard && definition.softDeleteMode ? definition.softDeleteMode.field : undefined;
+
+            // Idempotent: re-soft-deleting an already-soft-deleted (or absent) row
+            // is a no-op so the cascade + companion sync don't fire spuriously.
+            if (softField && (!existing || (existing[softField] !== null && existing[softField] !== undefined))) {
+                return;
+            }
 
             // `before` fires ahead of cascade resolution so a throwing guard
             // aborts the delete before any holder rows are touched.
@@ -2489,11 +2516,13 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                         );
                     }
 
-                    const holders = await writer.findMany(holderTable, { where: { [field]: value } });
+                    // A hard delete must see soft-deleted holders to remove them; a
+                    // soft delete skips already-deleted holders.
+                    const holders = await writer.findMany(holderTable, { includeDeleted: hard, where: { [field]: value } });
 
                     return holders.page;
                 },
-                onCascade: (_holderTable, holderId) => writer.delete(holderId),
+                onCascade: (_holderTable, holderId) => writer.delete(holderId, undefined, deleteOptions),
                 onRestrict: (message) => {
                     throw new ConflictError(message, "restrict");
                 },
@@ -2505,6 +2534,33 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
 
             await ensureBackfilledForTable(tableName);
             await ensureRankBackfilledForTable(tableName);
+
+            if (softField && existing) {
+                // Soft delete: keep the row, stamp the marker via an all-column
+                // UPDATE (same encoding as `patch`). Companions re-sync to the
+                // merged row; read scoping (not companion removal) hides it.
+                const merged: Record<string, unknown> = { ...existing, [softField]: clock() };
+                const assignments = sql.join(
+                    // eslint-disable-next-line unicorn/no-null -- SQL bind value: an absent column binds `null`, matching the patch path.
+                    Object.keys(definition.shape).map((field) => sql`${sql.identifier(field)} = ${serializeColumnValue(merged[field] ?? null)}`),
+                    sql`, `,
+                );
+
+                await runGuardedWrite(tableName, "UPDATE", assignments, snapshot);
+
+                await syncAggregates(tableName, existing, merged);
+                await syncRanks(tableName, id, existing, merged);
+                await syncSearch(tableName, id, merged);
+                await recordCdc(tableName, id, "update", merged);
+
+                // `delete()` was called → fire the DELETE triggers (the flag flip
+                // is the storage detail of how the delete is recorded).
+                if (hasMatchingTrigger(tableName, "after", "delete")) {
+                    await fireTriggers("after", "delete", { id, op: "delete", previous: existing, table: tableName });
+                }
+
+                return;
+            }
 
             await runGuardedWrite(tableName, "DELETE", undefined, snapshot);
 
@@ -2571,6 +2627,11 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // RLS (3.2) / aggregates (3.1) inject `baseWhere` we AND-merge
             // before the keyset seek so policy + cursor compose cleanly.
             let predicate: undefined | WhereInput = mergeWhere(args.baseWhere, args.where);
+
+            // Soft delete: hide rows whose marker column is set unless the caller
+            // opted in via `includeDeleted`. Relation `with` loads route back
+            // through this `findMany`, so they inherit the scope automatically.
+            predicate = mergeWhere(predicate, softDeleteScope(definition.softDeleteMode, args.includeDeleted));
 
             // Rewrite relation-crossing predicates into flat `IN`/`NOT IN` via a
             // backend-routed child fetch before compiling. `relationBaseWhere` is
@@ -2677,7 +2738,9 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 throw new Error(`groupBy(${tableName}, { agg: { op: "${agg.op}" } }): "field" is required for non-count reducers`);
             }
 
-            const effective = mergeWhere(groupOptions.baseWhere, groupOptions.where);
+            // Soft delete: group over LIVE rows only; force the scan path.
+            const groupScope = softDeleteScope(definition.softDeleteMode, undefined);
+            const effective = mergeWhere(mergeWhere(groupOptions.baseWhere, groupOptions.where), groupScope);
             // Rewrite any relation-crossing predicate to a flat semijoin clause
             // before compiling. `hasRelation` disables the indexed companion,
             // which can't honour a relation filter and would over-aggregate.
@@ -2689,7 +2752,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // already in the reducer-aware companion table — covers every op
             // (count/sum/avg/min/max) now that `__value__`/`__count__` are
             // maintained per op. baseWhere falls through to scan so RLS composes.
-            if (definition.aggregateIndexes && !groupOptions.baseWhere && !hasRelation) {
+            if (definition.aggregateIndexes && !groupOptions.baseWhere && !hasRelation && !groupScope) {
                 const indexed = await tryIndexedGroupBy(tableName, definition.aggregateIndexes, agg, groupOptions);
 
                 if (indexed !== undefined) {
@@ -2883,6 +2946,23 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             if (hasMatchingTrigger(tableName, "after", "update")) {
                 await fireTriggers("after", "update", { doc: merged, id, op: "update", previous: existing, table: tableName });
             }
+        },
+
+        async restore(id, expectedTable) {
+            const tableName = await resolveTableName(id, expectedTable);
+
+            if (!tableName) {
+                throw new Error(`document not found: ${id}`);
+            }
+
+            const field = schema.tables[tableName]?.softDeleteMode?.field;
+
+            if (!field) {
+                throw new Error(`ctx.db.restore: table "${tableName}" is not a .softDelete() table`);
+            }
+
+            // eslint-disable-next-line unicorn/no-null -- clearing the soft-delete marker writes SQL NULL into the column
+            await writer.patch(id, { [field]: null }, expectedTable);
         },
 
         query(tableName) {

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -42,6 +42,7 @@ import {
     aggregateSqlFunction,
     aggregateTableName,
     applyOnDelete,
+    applySelect,
     assertFlatPredicate,
     assertValidClientId,
     buildFtsMatch,
@@ -2615,7 +2616,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                 }
 
                 // eslint-disable-next-line unicorn/no-null -- findMany's public return uses `continueCursor: string | null`; an unpaged result has no cursor.
-                return { continueCursor: null, isDone: true, page: documents };
+                return { continueCursor: null, isDone: true, page: applySelect(documents, args.select, args.with) };
             }
 
             const hasMore = documents.length > limit;
@@ -2627,10 +2628,12 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             }
 
             return {
+                // The cursor is encoded from `last` (the full, unprojected row), so
+                // `applySelect` only trims the returned payload — paging is intact.
                 // eslint-disable-next-line unicorn/no-null -- public return shape: `continueCursor` is `string | null`; `null` marks the final page.
                 continueCursor: hasMore && last ? encodeCursor(last, orderKeys) : null,
                 isDone: !hasMore,
-                page,
+                page: applySelect(page, args.select, args.with),
             };
         },
 

--- a/packages/testing/__tests__/facade-integration.test.ts
+++ b/packages/testing/__tests__/facade-integration.test.ts
@@ -1,0 +1,111 @@
+import type { SchemaLike } from "@lunora/do";
+import { createShardCtxDb, runShardMigrations } from "@lunora/do";
+import { bindTableFacade } from "@lunora/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createSqlExec } from "../src/node-sqlite";
+
+/**
+ * End-to-end check that the per-table facade's composed methods
+ * (`upsert`/`upsertMany`/`exists` + `insert({ skipDuplicates })`) work over the
+ * REAL `@lunora/do` writer and a REAL SQLite UNIQUE index — not a mock. This is
+ * what proves the `skipDuplicates` path actually recognises the `ConflictError`
+ * the engine throws on a unique breach, and that `upsert` finds-then-patches a
+ * genuinely-persisted row.
+ */
+const schema: SchemaLike = {
+    tables: {
+        users: {
+            indexes: [],
+            shape: {
+                email: { _meta: { column: { notNull: true, unique: true } }, kind: "string" },
+                name: { kind: "string" },
+            },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqlExec>;
+
+const setup = () => {
+    runShardMigrations(harness.sql, schema);
+
+    const writer = createShardCtxDb({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+
+    return bindTableFacade(writer, "users");
+};
+
+describe("facade over the real writer — upsert / exists / skipDuplicates", () => {
+    beforeEach(() => {
+        harness = createSqlExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("insert({ skipDuplicates }) returns null on a real UNIQUE breach", async () => {
+        expect.assertions(3);
+
+        const users = setup();
+
+        const id = await users.insert({ email: "a@b.c", name: "Ada" });
+
+        expect(typeof id).toBe("string");
+        // A second insert of the same email breaches the UNIQUE index → swallowed.
+        await expect(users.insert({ email: "a@b.c", name: "Ada II" }, { skipDuplicates: true })).resolves.toBeNull();
+        // Without skipDuplicates the same breach throws.
+        await expect(users.insert({ email: "a@b.c", name: "Ada III" })).rejects.toMatchObject({ code: "CONFLICT", kind: "unique" });
+    });
+
+    it("exists reflects real rows", async () => {
+        expect.assertions(2);
+
+        const users = setup();
+
+        await users.insert({ email: "a@b.c", name: "Ada" });
+
+        await expect(users.exists({ email: "a@b.c" })).resolves.toBe(true);
+        await expect(users.exists({ email: "nobody@b.c" })).resolves.toBe(false);
+    });
+
+    it("upsert inserts then updates the same row keyed by a unique target", async () => {
+        expect.assertions(4);
+
+        const users = setup();
+
+        const created = await users.upsert({ create: { email: "a@b.c", name: "Ada" }, target: "email" });
+
+        expect(created.created).toBe(true);
+
+        const updated = await users.upsert({ create: { email: "a@b.c", name: "ignored" }, target: "email", update: { name: "Ada Lovelace" } });
+
+        expect(updated).toStrictEqual({ created: false, id: created.id });
+
+        const row = await users.get(created.id);
+
+        expect(row).toMatchObject({ email: "a@b.c", name: "Ada Lovelace" });
+        // Exactly one row exists — upsert updated in place rather than inserting a duplicate.
+        await expect(users.count()).resolves.toBe(1);
+    });
+
+    it("upsertMany inserts new rows and updates existing ones in one call", async () => {
+        expect.assertions(3);
+
+        const users = setup();
+
+        await users.insert({ email: "a@b.c", name: "Ada" });
+
+        const results = await users.upsertMany({
+            rows: [{ create: { email: "a@b.c", name: "x" }, update: { name: "Ada v2" } }, { create: { email: "g@b.c", name: "Grace" } }],
+            target: "email",
+        });
+
+        expect(results.map((entry) => entry.created)).toStrictEqual([false, true]);
+        await expect(users.count()).resolves.toBe(2);
+
+        const ada = await users.findFirst({ where: { email: "a@b.c" } });
+
+        expect(ada).toMatchObject({ name: "Ada v2" });
+    });
+});

--- a/packages/testing/__tests__/soft-delete-facade.test.ts
+++ b/packages/testing/__tests__/soft-delete-facade.test.ts
@@ -1,0 +1,70 @@
+import type { SchemaLike } from "@lunora/do";
+import { createShardCtxDb, runShardMigrations } from "@lunora/do";
+import { bindTableFacade } from "@lunora/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createSqlExec } from "../src/node-sqlite";
+
+/**
+ * The per-table facade's soft-delete surface (`ctx.db.&lt;table>.delete()` →
+ * soft, `.restore()`, `.hardDelete()`, `findMany({ includeDeleted })`) over the
+ * REAL `@lunora/do` writer — proving `bindTableFacade` wires `delete`'s `hard`
+ * option and `restore` end to end.
+ */
+const schema: SchemaLike = {
+    tables: {
+        posts: {
+            indexes: [],
+            relationMap: {},
+            shape: { deletedAt: { kind: "number" }, title: { kind: "string" } },
+            softDeleteMode: { field: "deletedAt" },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqlExec>;
+
+const setup = () => {
+    runShardMigrations(harness.sql, schema);
+
+    return bindTableFacade(createShardCtxDb({ clock: () => 1_700_000_000_000, schema, sql: harness.sql }), "posts");
+};
+
+const ids = (page: unknown): unknown[] => (page as { page: Record<string, unknown>[] }).page.map((row) => row["_id"]);
+
+describe("facade soft delete over the real writer", () => {
+    beforeEach(() => {
+        harness = createSqlExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("delete soft-hides, restore brings back, hardDelete removes", async () => {
+        expect.assertions(5);
+
+        const posts = setup();
+        const a = (await posts.insert({ title: "a" })) as string;
+
+        await posts.insert({ title: "b" });
+
+        // Soft delete hides from findMany but the row survives.
+        await posts.delete(a);
+
+        expect(ids(await posts.findMany({}))).toHaveLength(1);
+        await expect(posts.count()).resolves.toBe(1);
+
+        // includeDeleted re-includes it; restore makes it live again.
+        expect(ids(await posts.findMany({ includeDeleted: true }))).toHaveLength(2);
+
+        await posts.restore(a);
+
+        await expect(posts.count()).resolves.toBe(2);
+
+        // hardDelete removes it for good.
+        await posts.hardDelete(a);
+
+        expect(ids(await posts.findMany({ includeDeleted: true }))).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
Close the four feature gaps versus better-drizzle on the typed `ctx.db`
table delegates (`ctx.db.<table>.*`):

- `upsert` / `upsertMany` — insert-or-update keyed by a unique `target`
  (one field or a tuple). Returns `{ id, created }`.
- `exists(where?)` — boolean existence check (reuses `findFirst`, no
  count scan).
- `select` — `findMany`/`findFirst` field projection. Trims the returned
  payload to the named columns plus `_id`/`_creationTime`; applied after
  relation resolution + cursor encoding so paging and dependency tracking
  are unaffected. Engine-level in `@lunora/do` and `@lunora/sql-store`.
- `insert({ skipDuplicates })` — a UNIQUE breach resolves to `null`
  instead of throwing.

upsert/upsertMany/exists/skipDuplicates are implemented as compositions
of `findFirst`/`insert`/`patch` at the facade layer (`bindTableFacade`),
so they inherit RLS, secure-by-default, and `.global()`/D1 routing for
free — the RLS middleware re-binds the same facade over its wrapped
writer, gating each composed step. No new low-level writer methods or
RLS-middleware changes were needed. The facade detects a UNIQUE conflict
structurally (ConflictError `code`/`kind`) to avoid a runtime dependency
on `@lunora/do`.

Tests: facade unit tests (mocked writer), an end-to-end integration test
over the real DO writer + a real SQLite UNIQUE index, and engine-level
`select` projection tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UxkuKVSsfq6g72A3cbDxpJ<!--
Thank you for contributing to Lunora!

Please fill out the sections below so reviewers can land your change quickly.
Keep the title in conventional-commit form (e.g. `feat(cli): add migrate flag`).
-->

## Summary

<!--
Explain *why* this change is needed and *what* it does at a high level.
Link to the relevant package(s) (e.g. `@lunora/d1`, `@lunora/codegen`) so
reviewers know which Wave / area is touched.
-->

## Linked issues

<!--
- Closes #...
- Refs #...
-->

## Test plan

<!--
Bulleted checklist of what you ran locally and what reviewers should re-run:

- [ ] `pnpm lint:types` passes
- [ ] `pnpm lint:eslint` passes
- [ ] `pnpm test` passes (234+ tests)
- [ ] If schema changed: `pnpm --filter @lunora/cli run codegen` regenerated cleanly
- [ ] If Durable Object / D1 code changed: workerd-based Vitest pool tests still pass
- [ ] Manual smoke test in `apps/playground` (if user-facing)
-->

## Checklist

- [ ] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change
- [ ] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs)
- [ ] No `package.json` files in `packages/*` modified outside the touched package
- [ ] If a new package was added: `project.json` has `type:package` and a `category:*` tag
- [ ] If migration impact: noted upgrade steps in the PR description and changelog entry

## Notes for reviewers

<!--
Anything reviewers should look at first, follow-up work you deferred, screenshots
for UI changes, etc.
-->

## Contributor License Agreement

<!--
Required for external contributors. Keep the line below in your PR description
exactly as written — the CLA check (.github/workflows/cla.yml) looks for it.
Members of the @anolilab organization can omit it (the check is skipped).
-->

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.
