### PR TITLE
feat(config): stream dev container logs to terminal

### DIFF
--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -1,12 +1,14 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
 
+import type { ContainerLogStreamHandle } from "@lunora/config";
 import {
     AGENT_RULES_HINT,
     claimAgentRulesHint,
     detectAgentRules,
     DEV_VARS_EXAMPLE_FILE,
     DEV_VARS_FILE,
+    discoverContainerInfo,
     ensureDevVariables,
     ensureDevVarsExample,
     fillDevSecrets,
@@ -17,6 +19,7 @@ import {
     packageNamesFromBindings,
     readProjectRemotePreference,
     resolveRemoteEnabled,
+    streamContainerLogs,
 } from "@lunora/config";
 
 import type { ApiSpec } from "../../util/api-spec";
@@ -308,14 +311,57 @@ const printAgentRulesHint = (logger: Logger, cwd: string): void => {
 
 interface Teardown {
     codegen?: CodegenWatcherHandle;
+    /** Disposer for the dev container log stream (stops polling Docker + detaches). */
+    containerLogs?: ContainerLogStreamHandle;
     /** Disposer for the materialized remote wrangler temp config (idempotent, never throws). */
     remoteCleanup?: () => void;
     studio?: StudioServerHandle;
 }
 
-/** Best-effort shutdown of the studio server, codegen watcher, and remote temp config. */
+/**
+ * Follow the local Docker logs of every declared container and surface each
+ * output line on the dev logger, tagged `[container:&lt;name>]`. Returns a disposer
+ * (or `undefined` when there are no containers, so no Docker work ever starts).
+ *
+ * wrangler builds + runs each declared container locally but only forwards the
+ * worker's console; the container process's own stdout/stderr would otherwise be
+ * invisible. Set `LUNORA_CONTAINER_LOGS=0` to opt out.
+ */
+const startContainerLogStreaming = (cwd: string, logger: Logger): ContainerLogStreamHandle | undefined => {
+    if (process.env.LUNORA_CONTAINER_LOGS === "0") {
+        return undefined;
+    }
+
+    const discovery = discoverContainerInfo(cwd, "lunora");
+    const containers = discovery.containers.map((container) => {
+        return { className: container.className, exportName: container.exportName };
+    });
+
+    if (containers.length === 0) {
+        return undefined;
+    }
+
+    return streamContainerLogs({
+        containers,
+        onLine: (line) => {
+            const tagged = `[container:${line.name}] ${line.text}`;
+
+            if (line.level === "error") {
+                logger.warn(tagged);
+            } else {
+                logger.info(tagged);
+            }
+        },
+        onUnavailable: (message) => {
+            logger.warn(`[container] Docker engine unreachable — container logs unavailable (${message})`);
+        },
+    });
+};
+
+/** Best-effort shutdown of the studio server, codegen watcher, container logs, and remote temp config. */
 const teardown = async (handles: Teardown): Promise<void> => {
     handles.codegen?.close();
+    handles.containerLogs?.close();
     await handles.studio?.close().catch(() => undefined);
     // Unlink the generated remote wrangler config last; the disposer is itself
     // idempotent + swallows errors, but guard the call site too for safety.
@@ -438,6 +484,14 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         }
 
         const worker = (options.startWorker ?? defaultWorkerSpawner)(plan.wrangler, logger);
+
+        // Tail the local dev containers' own stdout/stderr (no-op when the project
+        // declares none). Best-effort — a Docker hiccup must not break dev.
+        try {
+            handles.containerLogs = startContainerLogStreaming(cwd, logger);
+        } catch {
+            /* never fatal */
+        }
 
         printBanner(logger, plan, studioUrl);
         printAgentRulesHint(logger, cwd);

--- a/packages/config/__tests__/container-logs.test.ts
+++ b/packages/config/__tests__/container-logs.test.ts
@@ -1,0 +1,231 @@
+import type { Writable } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ContainerLogLine, DockerLike } from "../src/container-logs";
+import { streamContainerLogs } from "../src/container-logs";
+
+/** Yield to the microtask/timer queues so the stream's async poll + attach settle. */
+const flush = async (): Promise<void> => {
+    await new Promise((resolve) => {
+        setImmediate(resolve);
+    });
+};
+
+/** A fake `dockerode` log stream the test drives by hand: feed bytes, fire `end`/`error`, observe `destroy`. */
+class FakeStream {
+    public destroyed = false;
+
+    public stderr: undefined | Writable;
+
+    public stdout: undefined | Writable;
+
+    readonly #listeners = new Map<string, (() => void)[]>();
+
+    public destroy(): void {
+        this.destroyed = true;
+    }
+
+    /** Write bytes onto the demultiplexed stdout writable (one frame). */
+    public feedStdout(text: string): void {
+        this.stdout?.write(Buffer.from(text, "utf8"));
+    }
+
+    /** Write bytes onto the demultiplexed stderr writable (one frame). */
+    public feedStderr(text: string): void {
+        this.stderr?.write(Buffer.from(text, "utf8"));
+    }
+
+    public fire(event: "end" | "error"): void {
+        for (const listener of this.#listeners.get(event) ?? []) {
+            listener();
+        }
+    }
+
+    public on(event: string, listener: () => void): void {
+        const existing = this.#listeners.get(event) ?? [];
+
+        existing.push(listener);
+        this.#listeners.set(event, existing);
+    }
+}
+
+interface FakeDocker {
+    docker: DockerLike;
+    /** Grab the stream attached for a given container id (after a poll cycle). */
+    streamFor: (id: string) => FakeStream | undefined;
+}
+
+/** Build a fake Docker client over a fixed container list, recording the streams it hands out. */
+const createFakeDocker = (running: { Id: string; Image: string }[], options: { listContainers?: () => { Id: string; Image: string }[] } = {}): FakeDocker => {
+    const streams = new Map<string, FakeStream>();
+
+    const docker: DockerLike = {
+        getContainer: (id: string) => {
+            return {
+                logs: async () => {
+                    const stream = new FakeStream();
+
+                    streams.set(id, stream);
+
+                    return stream;
+                },
+            };
+        },
+        listContainers: async () => (options.listContainers ? options.listContainers() : running),
+        modem: {
+            demuxStream: (stream, stdout, stderr) => {
+                const fake = stream as unknown as FakeStream;
+
+                fake.stdout = stdout;
+                fake.stderr = stderr;
+            },
+        },
+    };
+
+    return { docker, streamFor: (id) => streams.get(id) };
+};
+
+const DEV_IMAGE = "cloudflare-dev/transcodercontainer:abc123";
+
+describe("streamContainerLogs", () => {
+    it("returns an inert handle and never touches docker when no containers are declared", () => {
+        expect.assertions(1);
+
+        const listContainers = vi.fn<DockerLike["listContainers"]>();
+        const docker = { listContainers } as unknown as DockerLike;
+
+        const handle = streamContainerLogs({ containers: [], docker, onLine: () => {} });
+
+        handle.close();
+
+        expect(listContainers).not.toHaveBeenCalled();
+    });
+
+    it("emits stdout lines as info and stderr lines as error, tagged with the export name", async () => {
+        expect.assertions(2);
+
+        const lines: ContainerLogLine[] = [];
+        const { docker, streamFor } = createFakeDocker([{ Id: "c1", Image: DEV_IMAGE }]);
+
+        const handle = streamContainerLogs({
+            containers: [{ className: "TranscoderContainer", exportName: "transcoder" }],
+            docker,
+            onLine: (line) => lines.push(line),
+            pollIntervalMs: 10,
+        });
+
+        await flush();
+
+        const stream = streamFor("c1");
+
+        stream?.feedStdout("encoding frame 1\n");
+        stream?.feedStderr("ffmpeg warning\n");
+        await flush();
+
+        handle.close();
+
+        expect(lines).toContainEqual({ level: "info", name: "transcoder", text: "encoding frame 1" });
+        expect(lines).toContainEqual({ level: "error", name: "transcoder", text: "ffmpeg warning" });
+    });
+
+    it("buffers a line split across two frames and strips a trailing carriage return", async () => {
+        expect.assertions(1);
+
+        const lines: ContainerLogLine[] = [];
+        const { docker, streamFor } = createFakeDocker([{ Id: "c1", Image: DEV_IMAGE }]);
+
+        const handle = streamContainerLogs({
+            containers: [{ className: "TranscoderContainer", exportName: "transcoder" }],
+            docker,
+            onLine: (line) => lines.push(line),
+            pollIntervalMs: 10,
+        });
+
+        await flush();
+
+        const stream = streamFor("c1");
+
+        stream?.feedStdout("hello ");
+        stream?.feedStdout("world\r\n");
+        await flush();
+
+        handle.close();
+
+        expect(lines).toContainEqual({ level: "info", name: "transcoder", text: "hello world" });
+    });
+
+    it("ignores containers whose image is not a declared dev container", async () => {
+        expect.assertions(1);
+
+        const lines: ContainerLogLine[] = [];
+        const { docker, streamFor } = createFakeDocker([
+            { Id: "other", Image: "postgres:16" },
+            { Id: "unknown", Image: "cloudflare-dev/somethingelse:zzz" },
+        ]);
+
+        const handle = streamContainerLogs({
+            containers: [{ className: "TranscoderContainer", exportName: "transcoder" }],
+            docker,
+            onLine: (line) => lines.push(line),
+            pollIntervalMs: 10,
+        });
+
+        await flush();
+        await flush();
+
+        handle.close();
+
+        // Neither container matched, so nothing was attached and no lines emitted.
+        expect(streamFor("other")).toBeUndefined();
+    });
+
+    it("notifies onUnavailable once while the docker engine is unreachable", async () => {
+        expect.assertions(1);
+
+        const onUnavailable = vi.fn<(message: string) => void>();
+        const docker = {
+            getContainer: () => {
+                return { logs: async () => new FakeStream() };
+            },
+            listContainers: async () => {
+                throw new Error("connect ENOENT /var/run/docker.sock");
+            },
+            modem: { demuxStream: () => {} },
+        } as unknown as DockerLike;
+
+        const handle = streamContainerLogs({
+            containers: [{ className: "TranscoderContainer", exportName: "transcoder" }],
+            docker,
+            onLine: () => {},
+            onUnavailable,
+            pollIntervalMs: 5,
+        });
+
+        await flush();
+        await flush();
+
+        handle.close();
+
+        expect(onUnavailable).toHaveBeenCalledTimes(1);
+    });
+
+    it("destroys attached streams on close", async () => {
+        expect.assertions(1);
+
+        const { docker, streamFor } = createFakeDocker([{ Id: "c1", Image: DEV_IMAGE }]);
+
+        const handle = streamContainerLogs({
+            containers: [{ className: "TranscoderContainer", exportName: "transcoder" }],
+            docker,
+            onLine: () => {},
+            pollIntervalMs: 10,
+        });
+
+        await flush();
+
+        handle.close();
+
+        expect(streamFor("c1")?.destroyed).toBe(true);
+    });
+});

--- a/packages/config/__tests__/container-logs.test.ts
+++ b/packages/config/__tests__/container-logs.test.ts
@@ -26,6 +26,11 @@ class FakeStream {
         this.destroyed = true;
     }
 
+    /** Write raw bytes onto the demultiplexed stdout writable (one frame) — for splitting multi-byte chars. */
+    public feedStdoutBytes(bytes: Buffer): void {
+        this.stdout?.write(bytes);
+    }
+
     /** Write bytes onto the demultiplexed stdout writable (one frame). */
     public feedStdout(text: string): void {
         this.stdout?.write(Buffer.from(text, "utf8"));
@@ -153,6 +158,35 @@ describe("streamContainerLogs", () => {
         handle.close();
 
         expect(lines).toContainEqual({ level: "info", name: "transcoder", text: "hello world" });
+    });
+
+    it("reassembles a multi-byte character split across two frames", async () => {
+        expect.assertions(1);
+
+        const lines: ContainerLogLine[] = [];
+        const { docker, streamFor } = createFakeDocker([{ Id: "c1", Image: DEV_IMAGE }]);
+
+        const handle = streamContainerLogs({
+            containers: [{ className: "TranscoderContainer", exportName: "transcoder" }],
+            docker,
+            onLine: (line) => lines.push(line),
+            pollIntervalMs: 10,
+        });
+
+        await flush();
+
+        const stream = streamFor("c1");
+        // "café\n" — the "é" (U+00E9) is two UTF-8 bytes (0xC3 0xA9); split it
+        // across two frames so a naive per-chunk `toString` would corrupt it.
+        const encoded = Buffer.from("café\n", "utf8");
+
+        stream?.feedStdoutBytes(encoded.subarray(0, 4)); // "caf" + first byte of "é"
+        stream?.feedStdoutBytes(encoded.subarray(4)); // second byte of "é" + "\n"
+        await flush();
+
+        handle.close();
+
+        expect(lines).toContainEqual({ level: "info", name: "transcoder", text: "café" });
     });
 
     it("ignores containers whose image is not a declared dev container", async () => {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -68,11 +68,13 @@
         "@lunora/container": "1.0.0-alpha.4",
         "@lunora/seed": "1.0.0-alpha.5",
         "@visulima/colorize": "2.0.0-alpha.14",
+        "dockerode": "catalog:tooling",
         "es-module-lexer": "catalog:vite",
         "jsonc-parser": "catalog:vite",
         "ts-morph": "catalog:tooling"
     },
     "devDependencies": {
+        "@types/dockerode": "catalog:types",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:build",
         "@vitest/coverage-v8": "catalog:test",

--- a/packages/config/src/container-logs.ts
+++ b/packages/config/src/container-logs.ts
@@ -1,0 +1,307 @@
+/**
+ * Stream a project's local dev container logs into the dev terminal.
+ *
+ * During `lunora dev` / `vite dev`, wrangler builds and runs each declared
+ * container locally via Docker, naming the image `cloudflare-dev/&lt;class>:&lt;id>`
+ * (the lowercased Durable Object class name — see wrangler's
+ * `getDevContainerImageName`). Wrangler forwards the *worker's* console output,
+ * but never the container process's own stdout/stderr, so a developer can't see
+ * what their container is doing. This module attaches to those Docker log
+ * streams with `dockerode` and emits each line back to the caller, tagged with
+ * the friendly `lunora/containers.ts` export name.
+ *
+ * Shared by the CLI `dev` command and the Vite plugin (`@lunora/config` is the
+ * common layer), so both surfaces render container output identically. The
+ * `dockerode` import is lazy: a project with no containers — the common case —
+ * never loads it, and a missing/stopped Docker engine degrades to a single
+ * `onUnavailable` notice rather than breaking dev.
+ */
+import { Writable } from "node:stream";
+
+/** Prefix of every image wrangler builds for a local dev container (`cloudflare-dev/&lt;class>:&lt;id>`). */
+const DEV_CONTAINER_IMAGE_PREFIX = "cloudflare-dev/";
+
+/** How often to poll Docker for newly-started (or replaced) dev containers, in ms. */
+const DEFAULT_POLL_INTERVAL_MS = 1500;
+
+/** Severity a container output line is surfaced at: `stderr` → `error`, `stdout` → `info`. */
+type ContainerLogLevel = "error" | "info";
+
+/** One declared container to follow, identified by the names codegen lifts from `defineContainer`. */
+interface ContainerLogSource {
+    /** Generated Durable Object class name, e.g. `TranscoderContainer`. Wrangler's dev image is `cloudflare-dev/&lt;lowercased>`. */
+    className: string;
+    /** The `lunora/containers.ts` export name, e.g. `transcoder` — used as the display tag. */
+    exportName: string;
+}
+
+/** A single line of container output handed back to the caller. */
+interface ContainerLogLine {
+    /** `"error"` for the container's stderr, `"info"` for its stdout. */
+    level: ContainerLogLevel;
+    /** The container's export name (`transcoder`), for tagging the line. */
+    name: string;
+    /** One output line, with the trailing newline (and any `\r`) stripped. */
+    text: string;
+}
+
+interface ContainerLogStreamOptions {
+    /** The declared containers to follow. An empty list yields an inert handle. */
+    containers: ReadonlyArray<ContainerLogSource>;
+    /** Injected Docker client — defaults to a real lazily-imported `dockerode` instance. Tests pass a stub. */
+    docker?: DockerLike;
+    /** Called once per container output line. */
+    onLine: (line: ContainerLogLine) => void;
+    /** Called once when the Docker engine can't be reached (re-armed after it recovers). Defaults to silent. */
+    onUnavailable?: (message: string) => void;
+    /** Poll interval override, in ms. */
+    pollIntervalMs?: number;
+}
+
+/** Handle controlling a running log stream. */
+interface ContainerLogStreamHandle {
+    /** Stop polling and tear down every attached log stream. Idempotent. */
+    close: () => void;
+}
+
+/** The minimal structural slice of a `dockerode` log stream this module consumes. */
+interface DockerLogStream {
+    destroy: () => void;
+    on: (event: "data" | "end" | "error", listener: (chunk?: Buffer) => void) => void;
+}
+
+/** The minimal structural slice of a `dockerode` instance this module consumes. */
+interface DockerLike {
+    getContainer: (id: string) => {
+        logs: (options: { follow: true; stderr: true; stdout: true; tail: "all"; timestamps: false }) => Promise<DockerLogStream>;
+    };
+    listContainers: (options: { filters: { status: ["running"] } }) => Promise<{ Id: string; Image: string }[]>;
+    modem: { demuxStream: (stream: DockerLogStream, stdout: Writable, stderr: Writable) => void };
+}
+
+/** Lazily construct a real `dockerode` client (default socket / `DOCKER_HOST`). Kept out of the module's static import graph. */
+const createDefaultDocker = async (): Promise<DockerLike> => {
+    const { default: Dockerode } = await import("dockerode");
+
+    return new Dockerode() as unknown as DockerLike;
+};
+
+/** Extract the lowercased class segment from a `cloudflare-dev/&lt;class>:&lt;id>` image, or `undefined` for any other image. */
+const classFromImage = (image: string): string | undefined => {
+    if (!image.startsWith(DEV_CONTAINER_IMAGE_PREFIX)) {
+        return undefined;
+    }
+
+    const [segment] = image.slice(DEV_CONTAINER_IMAGE_PREFIX.length).split(":");
+
+    return segment !== undefined && segment.length > 0 ? segment : undefined;
+};
+
+/**
+ * A `Writable` that buffers bytes and emits one trimmed line per `\n`. The
+ * trailing partial is held until the next chunk and flushed on `final`, so a
+ * line split across two Docker frames is never torn.
+ */
+const lineBufferWritable = (emit: (text: string) => void): Writable => {
+    let buffer = "";
+
+    const flushLine = (line: string): void => {
+        emit(line.endsWith("\r") ? line.slice(0, -1) : line);
+    };
+
+    return new Writable({
+        final(callback) {
+            if (buffer.length > 0) {
+                flushLine(buffer);
+                buffer = "";
+            }
+
+            callback();
+        },
+        write(chunk: Buffer, _encoding, callback) {
+            buffer += chunk.toString("utf8");
+
+            const lines = buffer.split("\n");
+
+            buffer = lines.pop() ?? "";
+
+            for (const line of lines) {
+                flushLine(line);
+            }
+
+            callback();
+        },
+    });
+};
+
+/**
+ * Follow the local Docker logs of every declared container, emitting each output
+ * line through `onLine` tagged with its export name. Polls for containers (they
+ * start lazily on first request and may be replaced on restart), attaches once
+ * per container id, and drops streams whose container has gone. Returns
+ * immediately with a `close()` handle; all work happens asynchronously.
+ */
+const streamContainerLogs = (options: ContainerLogStreamOptions): ContainerLogStreamHandle => {
+    // Map the lowercased class name (the image segment wrangler uses) back to the
+    // friendly export name we tag lines with.
+    const classToExport = new Map(options.containers.map((source) => [source.className.toLowerCase(), source.exportName]));
+
+    if (classToExport.size === 0) {
+        return { close: () => {} };
+    }
+
+    const interval = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const attached = new Map<string, DockerLogStream>();
+
+    let closed = false;
+    let unavailableNotified = false;
+    let timer: NodeJS.Timeout | undefined;
+    let dockerPromise: Promise<DockerLike> | undefined;
+
+    const getDocker = async (): Promise<DockerLike> => {
+        dockerPromise ??= options.docker ? Promise.resolve(options.docker) : createDefaultDocker();
+
+        return dockerPromise;
+    };
+
+    const attach = async (docker: DockerLike, id: string, exportName: string): Promise<void> => {
+        try {
+            const stream = await docker.getContainer(id).logs({ follow: true, stderr: true, stdout: true, tail: "all", timestamps: false });
+
+            if (closed) {
+                stream.destroy();
+
+                return;
+            }
+
+            const stdout = lineBufferWritable((text) => {
+                options.onLine({ level: "info", name: exportName, text });
+            });
+            const stderr = lineBufferWritable((text) => {
+                options.onLine({ level: "error", name: exportName, text });
+            });
+
+            docker.modem.demuxStream(stream, stdout, stderr);
+
+            stream.on("end", () => {
+                stdout.end();
+                stderr.end();
+                attached.delete(id);
+            });
+            stream.on("error", () => {
+                attached.delete(id);
+            });
+
+            attached.set(id, stream);
+        } catch {
+            // Transient — the container may have stopped between listing and
+            // attaching; the next poll retries.
+        }
+    };
+
+    // List the running dev containers, or `undefined` when Docker is unreachable
+    // (notified once). Resets the notified flag on a successful call.
+    const listRunning = async (): Promise<{ Id: string; Image: string }[] | undefined> => {
+        try {
+            const docker = await getDocker();
+            const running = await docker.listContainers({ filters: { status: ["running"] } });
+
+            unavailableNotified = false;
+
+            return running;
+        } catch (error: unknown) {
+            if (!unavailableNotified) {
+                unavailableNotified = true;
+                options.onUnavailable?.(error instanceof Error ? error.message : String(error));
+            }
+
+            return undefined;
+        }
+    };
+
+    // Attach to newly-seen declared containers and drop streams whose container
+    // has gone. `live` is the set of ids that matched a declared container.
+    const reconcile = async (docker: DockerLike, running: { Id: string; Image: string }[]): Promise<void> => {
+        const live = new Set<string>();
+
+        for (const summary of running) {
+            const className = classFromImage(summary.Image);
+            const exportName = className === undefined ? undefined : classToExport.get(className);
+
+            if (exportName === undefined) {
+                continue;
+            }
+
+            live.add(summary.Id);
+
+            if (!attached.has(summary.Id)) {
+                // eslint-disable-next-line no-await-in-loop -- attach sequentially; the set of new containers per tick is tiny.
+                await attach(docker, summary.Id, exportName);
+            }
+        }
+
+        for (const [id, stream] of attached) {
+            if (!live.has(id)) {
+                stream.destroy();
+                attached.delete(id);
+            }
+        }
+    };
+
+    const poll = async (): Promise<void> => {
+        if (closed) {
+            return;
+        }
+
+        const running = await listRunning();
+
+        if (running === undefined) {
+            return;
+        }
+
+        // `attach` re-checks `closed` after its own await, so a `close()` that
+        // lands mid-poll still tears every new stream down.
+        await reconcile(await getDocker(), running);
+    };
+
+    // Poll on a fixed interval with an in-flight guard so a slow poll never
+    // overlaps the next tick. The chain ends in `.catch` so a stray rejection is
+    // swallowed (each poll already handles its own errors) and never floats.
+    let polling = false;
+
+    const onTick = (): void => {
+        if (polling || closed) {
+            return;
+        }
+
+        polling = true;
+        poll()
+            .finally(() => {
+                polling = false;
+            })
+            .catch(() => undefined);
+    };
+
+    timer = setInterval(onTick, interval);
+    timer.unref();
+    onTick();
+
+    return {
+        close: () => {
+            closed = true;
+
+            if (timer) {
+                clearInterval(timer);
+                timer = undefined;
+            }
+
+            for (const [id, stream] of attached) {
+                stream.destroy();
+                attached.delete(id);
+            }
+        },
+    };
+};
+
+export type { ContainerLogLevel, ContainerLogLine, ContainerLogSource, ContainerLogStreamHandle, ContainerLogStreamOptions, DockerLike };
+export { streamContainerLogs };

--- a/packages/config/src/container-logs.ts
+++ b/packages/config/src/container-logs.ts
@@ -17,6 +17,7 @@
  * `onUnavailable` notice rather than breaking dev.
  */
 import { Writable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 
 /** Prefix of every image wrangler builds for a local dev container (`cloudflare-dev/&lt;class>:&lt;id>`). */
 const DEV_CONTAINER_IMAGE_PREFIX = "cloudflare-dev/";
@@ -103,6 +104,9 @@ const classFromImage = (image: string): string | undefined => {
  * line split across two Docker frames is never torn.
  */
 const lineBufferWritable = (emit: (text: string) => void): Writable => {
+    // Decode incrementally so a multi-byte UTF-8 character split across two
+    // Docker frames is reassembled rather than turned into replacement chars.
+    const decoder = new StringDecoder("utf8");
     let buffer = "";
 
     const flushLine = (line: string): void => {
@@ -111,6 +115,9 @@ const lineBufferWritable = (emit: (text: string) => void): Writable => {
 
     return new Writable({
         final(callback) {
+            // Flush any bytes the decoder is still holding, then the partial line.
+            buffer += decoder.end();
+
             if (buffer.length > 0) {
                 flushLine(buffer);
                 buffer = "";
@@ -119,7 +126,7 @@ const lineBufferWritable = (emit: (text: string) => void): Writable => {
             callback();
         },
         write(chunk: Buffer, _encoding, callback) {
-            buffer += chunk.toString("utf8");
+            buffer += decoder.write(chunk);
 
             const lines = buffer.split("\n");
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,6 +10,15 @@ export {
 } from "./agent-rules";
 export type { ContainerIR, DiscoverContainerInfoResult } from "./container-info";
 export { discoverContainerInfo } from "./container-info";
+export type {
+    ContainerLogLevel,
+    ContainerLogLine,
+    ContainerLogSource,
+    ContainerLogStreamHandle,
+    ContainerLogStreamOptions,
+    DockerLike,
+} from "./container-logs";
+export { streamContainerLogs } from "./container-logs";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";
 export { detectFramework } from "./detect-framework";
 export { DEV_VARS_EXAMPLE_FILE, DEV_VARS_FILE, DEV_VARS_KEY_PATTERN, parseDevVariableEntries } from "./dev-variables-format";

--- a/packages/vite/src/container-logs-plugin.ts
+++ b/packages/vite/src/container-logs-plugin.ts
@@ -1,0 +1,71 @@
+import type { ContainerLogStreamHandle } from "@lunora/config";
+import { discoverContainerInfo, streamContainerLogs } from "@lunora/config";
+import type { Plugin } from "vite";
+
+import { lunoraLine } from "./log";
+import type { ResolvedLunoraPluginOptions } from "./types";
+
+/**
+ * Dev-only plugin that tails the local dev containers' own stdout/stderr in the
+ * Vite terminal.
+ *
+ * `@cloudflare/vite-plugin` builds and runs each declared container locally via
+ * Docker (image `cloudflare-dev/&lt;class>:&lt;id>`) but only forwards the *worker's*
+ * console — the container process's own output is otherwise invisible. This
+ * plugin attaches to those Docker log streams (via `@lunora/config`'s
+ * `streamContainerLogs`, which lazy-loads `dockerode`) and prints each line
+ * through Vite's logger, branded and tagged `container:&lt;name>`.
+ *
+ * A no-op when the project declares no containers (the common case): discovery
+ * returns an empty list, so `dockerode` is never imported and no Docker work
+ * starts. Set `LUNORA_CONTAINER_LOGS=0` to opt out. A missing/stopped Docker
+ * engine degrades to a single warning rather than breaking dev.
+ */
+const containerLogsPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
+    let handle: ContainerLogStreamHandle | undefined;
+
+    return {
+        apply: "serve",
+        configureServer(server) {
+            if (handle || process.env.LUNORA_CONTAINER_LOGS === "0") {
+                return;
+            }
+
+            const discovery = discoverContainerInfo(options.projectRoot, options.schemaDir);
+            const containers = discovery.containers.map((container) => {
+                return { className: container.className, exportName: container.exportName };
+            });
+
+            if (containers.length === 0) {
+                return;
+            }
+
+            const { logger } = server.config;
+
+            handle = streamContainerLogs({
+                containers,
+                onLine: (line) => {
+                    const text = lunoraLine(`container:${line.name} ${line.text}`);
+
+                    if (line.level === "error") {
+                        logger.warn(text);
+                    } else {
+                        logger.info(text);
+                    }
+                },
+                onUnavailable: (message) => {
+                    logger.warn(lunoraLine(`container: Docker engine unreachable — container logs unavailable (${message})`));
+                },
+            });
+
+            // Detach on shutdown so the Docker poll loop doesn't outlive the server.
+            server.httpServer?.once("close", () => {
+                handle?.close();
+                handle = undefined;
+            });
+        },
+        name: "lunora:container-logs",
+    };
+};
+
+export default containerLogsPlugin;

--- a/packages/vite/src/container-logs-plugin.ts
+++ b/packages/vite/src/container-logs-plugin.ts
@@ -24,8 +24,20 @@ import type { ResolvedLunoraPluginOptions } from "./types";
 const containerLogsPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
     let handle: ContainerLogStreamHandle | undefined;
 
+    // Idempotent — safe to call from more than one lifecycle hook.
+    const closeHandle = (): void => {
+        handle?.close();
+        handle = undefined;
+    };
+
     return {
         apply: "serve",
+        // Fires on `server.close()` for both the normal and middleware-mode dev
+        // servers, so the Docker poll loop is torn down even when there is no
+        // `httpServer` to listen on (middleware mode).
+        buildEnd() {
+            closeHandle();
+        },
         configureServer(server) {
             if (handle || process.env.LUNORA_CONTAINER_LOGS === "0") {
                 return;
@@ -58,11 +70,10 @@ const containerLogsPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
                 },
             });
 
-            // Detach on shutdown so the Docker poll loop doesn't outlive the server.
-            server.httpServer?.once("close", () => {
-                handle?.close();
-                handle = undefined;
-            });
+            // Normal (non-middleware) dev server: detach the moment the HTTP
+            // server closes. In middleware mode `httpServer` is null, so the
+            // `buildEnd` hook above is the teardown path instead.
+            server.httpServer?.once("close", closeHandle);
         },
         name: "lunora:container-logs",
     };

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -4,6 +4,7 @@ import type { Plugin } from "vite";
 
 import agentRulesHintPlugin from "./agent-rules-hint-plugin";
 import codegenPlugin from "./codegen-plugin";
+import containerLogsPlugin from "./container-logs-plugin";
 import devVariablesPlugin from "./dev-variables-plugin";
 import { createCommandProbe, withDevWorkerEnv } from "./dev-worker-env";
 import { frameworkComposePlugin } from "./framework-compose-plugin";
@@ -95,6 +96,7 @@ const lunora = (options?: LunoraPluginOptions): LunoraPlugins => {
         devVariablesPlugin(resolved),
         codegenPlugin(resolved),
         logStreamPlugin(),
+        containerLogsPlugin(resolved),
         agentRulesHintPlugin(resolved),
     ];
 
@@ -136,6 +138,7 @@ const lunora = (options?: LunoraPluginOptions): LunoraPlugins => {
 const VERSION = "0.0.0";
 
 export { default as codegenPlugin } from "./codegen-plugin";
+export { default as containerLogsPlugin } from "./container-logs-plugin";
 export type { ReconcileResult } from "./cron-sync";
 export { reconcileWranglerCrons } from "./cron-sync";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -96,7 +96,6 @@ const lunora = (options?: LunoraPluginOptions): LunoraPlugins => {
         devVariablesPlugin(resolved),
         codegenPlugin(resolved),
         logStreamPlugin(),
-        containerLogsPlugin(resolved),
         agentRulesHintPlugin(resolved),
     ];
 
@@ -113,6 +112,11 @@ const lunora = (options?: LunoraPluginOptions): LunoraPlugins => {
     }
 
     if (resolved.cloudflare !== false) {
+        // Only the Cloudflare plugin builds + runs the dev containers, so tail
+        // their logs only when it's active — the BYO (`cloudflare: false`) path
+        // never starts containers, so Docker polling would be pointless.
+        plugins.push(containerLogsPlugin(resolved));
+
         // Honor remote-binding dev (`LUNORA_REMOTE` / `lunora.json` `remote`) on
         // the `vite dev` path too, exactly like `lunora dev`: materialize a temp
         // wrangler config with `"remote": true` on each eligible binding and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,6 +674,7 @@ overrides:
   tmp@<0.2.6: ^0.2.6
   tmp@<=0.2.3: ^0.2.4
   undici@<6.27.0: ^6.27.0
+  uuid@<11.1.0: ^11.1.0
 
 packageExtensionsChecksum: sha256-EChhAQXD/a53igqWJYuXGGZ5U8gMFGk0wOiVhLZA3W4=
 
@@ -18550,9 +18551,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validate-html-nesting@1.2.4:
@@ -29049,7 +29049,7 @@ snapshots:
       docker-modem: 5.0.7
       protobufjs: 7.6.4
       tar-fs: 2.1.5
-      uuid: 10.0.0
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -36619,7 +36619,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
+  uuid@11.1.1: {}
 
   validate-html-nesting@1.2.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ catalogs:
       specifier: 4.1.9
       version: 4.1.9
   tooling:
+    dockerode:
+      specifier: ^4.0.12
+      version: 4.0.12
     ts-morph:
       specifier: ^28.0.0
       version: 28.0.0
@@ -302,6 +305,9 @@ catalogs:
     '@standard-schema/spec':
       specifier: 1.1.0
       version: 1.1.0
+    '@types/dockerode':
+      specifier: ^3.3.47
+      version: 3.3.47
     '@types/node':
       specifier: 25.9.3
       version: 25.9.3
@@ -735,7 +741,7 @@ importers:
         version: 4.0.0-alpha.14
       '@visulima/vis':
         specifier: catalog:prod
-        version: 1.0.0-alpha.43(@shikijs/langs@4.2.0)(@shikijs/themes@4.2.0)(cfonts@3.3.1)(marked@15.0.12)(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)(shiki@4.2.0)(ws@8.21.0)
+        version: 1.0.0-alpha.43(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@shikijs/langs@4.2.0)(@shikijs/themes@4.2.0)(cfonts@3.3.1)(marked@15.0.12)(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)(shiki@4.2.0)(ws@8.21.0)
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
         version: 9.3.1
@@ -1866,6 +1872,9 @@ importers:
       '@visulima/colorize':
         specifier: 2.0.0-alpha.14
         version: 2.0.0-alpha.14
+      dockerode:
+        specifier: catalog:tooling
+        version: 4.0.12
       es-module-lexer:
         specifier: catalog:vite
         version: 2.1.0
@@ -1876,6 +1885,9 @@ importers:
         specifier: catalog:tooling
         version: 28.0.0
     devDependencies:
+      '@types/dockerode':
+        specifier: catalog:types
+        version: 3.3.47
       '@types/node':
         specifier: catalog:types
         version: 25.9.3
@@ -3704,6 +3716,9 @@ packages:
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
   '@base-ui/react@1.6.0':
     resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
     engines: {node: '>=14.0.0'}
@@ -4811,6 +4826,20 @@ packages:
       tailwindcss:
         optional: true
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
 
@@ -5272,6 +5301,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -6960,6 +6992,33 @@ packages:
 
   '@posthog/types@1.390.0':
     resolution: {integrity: sha512-zMjK6nrUWhAlL8ECrM4WldvgawqdoAE5B0ys7eA0lCoWuyzfFoSyh6zYtEuBSDRyN7fQLSfNCK+mQH4ngOl7Zw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -9227,6 +9286,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.47':
+    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -9281,6 +9346,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
@@ -9305,6 +9373,9 @@ packages:
 
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
@@ -10980,6 +11051,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
@@ -11163,6 +11237,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -11322,6 +11399,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
@@ -11450,6 +11531,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -11811,6 +11895,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -12269,6 +12357,14 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
+    engines: {node: '>= 8.0'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -13375,6 +13471,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -14788,6 +14887,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.capitalize@4.2.1:
     resolution: {integrity: sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==}
 
@@ -15241,6 +15343,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdist@2.4.1:
     resolution: {integrity: sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==}
     hasBin: true
@@ -15349,6 +15454,9 @@ packages:
   named-placeholders@1.1.6:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
+
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -16620,6 +16728,10 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -17444,6 +17556,9 @@ packages:
   spdx-satisfies@5.0.1:
     resolution: {integrity: sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@1.0.0:
     resolution: {integrity: sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==}
 
@@ -17459,6 +17574,10 @@ packages:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
@@ -17767,6 +17886,13 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
@@ -18032,6 +18158,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   twoslash-protocol@0.3.8:
     resolution: {integrity: sha512-HmvAHoiEviK8LqvAQyc9/irkdvwTUiR1fHmNwH/0gq8EHxyBt4PWVPixjEXg6wJu1u6yBrILEWXGK9Kw58/8yQ==}
 
@@ -18141,6 +18270,9 @@ packages:
 
   unctx@2.5.0:
     resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -18417,6 +18549,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
@@ -19870,6 +20007,8 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.0
 
+  '@balena/dockerignore@1.0.2': {}
+
   '@base-ui/react@1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -20915,6 +21054,25 @@ snapshots:
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.4
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.4
+      yargs: 17.7.2
+
   '@hexagon/base64@1.1.28': {}
 
   '@hono/node-server@1.19.14(hono@4.12.26)':
@@ -21276,6 +21434,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -23045,6 +23205,26 @@ snapshots:
       '@posthog/types': 1.390.0
 
   '@posthog/types@1.390.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -25529,6 +25709,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 25.9.3
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.47':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 25.9.3
+      '@types/ssh2': 1.15.5
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -25585,6 +25776,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
@@ -25606,6 +25801,10 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/retry@0.12.2': {}
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/stats.js@0.17.4': {}
 
@@ -26553,10 +26752,11 @@ snapshots:
   '@visulima/secret-scanner-binding-win32-x64-msvc@1.0.0-alpha.7':
     optional: true
 
-  '@visulima/secret-scanner@1.0.0-alpha.7(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)':
+  '@visulima/secret-scanner@1.0.0-alpha.7(@grpc/grpc-js@1.14.4)(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)':
     dependencies:
       ignore: 7.0.5
     optionalDependencies:
+      '@grpc/grpc-js': 1.14.4
       '@visulima/secret-scanner-binding-darwin-arm64': 1.0.0-alpha.7
       '@visulima/secret-scanner-binding-darwin-x64': 1.0.0-alpha.7
       '@visulima/secret-scanner-binding-linux-arm64-gnu': 1.0.0-alpha.7
@@ -26608,13 +26808,15 @@ snapshots:
   '@visulima/task-runner-binding-win32-x64-msvc@1.0.0-alpha.24':
     optional: true
 
-  '@visulima/task-runner@1.0.0-alpha.24':
+  '@visulima/task-runner@1.0.0-alpha.24(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)':
     dependencies:
       '@lydell/node-pty': 1.2.0-beta.12
       '@visulima/humanizer': 3.0.0-alpha.15
       '@visulima/path': 3.0.0-alpha.13
       nanotar: 0.3.0
     optionalDependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.1
       '@visulima/task-runner-binding-darwin-arm64': 1.0.0-alpha.24
       '@visulima/task-runner-binding-darwin-x64': 1.0.0-alpha.24
       '@visulima/task-runner-binding-linux-arm64-gnu': 1.0.0-alpha.24
@@ -26730,13 +26932,13 @@ snapshots:
   '@visulima/vis-binding-win32-x64-msvc@1.0.0-alpha.43':
     optional: true
 
-  '@visulima/vis@1.0.0-alpha.43(@shikijs/langs@4.2.0)(@shikijs/themes@4.2.0)(cfonts@3.3.1)(marked@15.0.12)(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)(shiki@4.2.0)(ws@8.21.0)':
+  '@visulima/vis@1.0.0-alpha.43(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)(@shikijs/langs@4.2.0)(@shikijs/themes@4.2.0)(cfonts@3.3.1)(marked@15.0.12)(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)(shiki@4.2.0)(ws@8.21.0)':
     dependencies:
       '@visulima/error': 6.0.0-alpha.34
-      '@visulima/secret-scanner': 1.0.0-alpha.7(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)
+      '@visulima/secret-scanner': 1.0.0-alpha.7(@grpc/grpc-js@1.14.4)(mysql2@3.22.5(@types/node@25.9.3))(pg@8.21.0)
       '@visulima/source-map': 3.0.0-alpha.12
       '@visulima/tabular': 4.0.0-alpha.14
-      '@visulima/task-runner': 1.0.0-alpha.24
+      '@visulima/task-runner': 1.0.0-alpha.24(@grpc/grpc-js@1.14.4)(@grpc/proto-loader@0.8.1)
       '@visulima/tui': 1.0.0-alpha.26(@shikijs/langs@4.2.0)(@shikijs/themes@4.2.0)(@visulima/tabular@4.0.0-alpha.14)(cfonts@3.3.1)(marked@15.0.12)(react-reconciler@0.33.0(react@19.2.7))(react@19.2.7)(shiki@4.2.0)(ws@8.21.0)
       module-replacements: 2.11.0
       module-replacements-codemods: 2.0.1
@@ -27439,6 +27641,10 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   asn1js@3.0.10:
     dependencies:
       pvtsutils: 1.3.6
@@ -27709,6 +27915,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.32: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   before-after-hook@4.0.0: {}
 
   better-ajv-errors@1.2.0(ajv@8.20.0):
@@ -27892,6 +28102,9 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buildcheck@0.0.7:
+    optional: true
+
   builtin-modules@3.3.0: {}
 
   builtin-modules@5.2.0: {}
@@ -28009,6 +28222,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   chownr@3.0.0: {}
 
@@ -28345,6 +28560,12 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -28810,6 +29031,27 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.12:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.6.4
+      tar-fs: 2.1.5
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   doctrine@2.1.0:
     dependencies:
@@ -30183,6 +30425,8 @@ snapshots:
       react: 19.2.7
     optionalDependencies:
       typescript: 6.0.3
+
+  fs-constants@1.0.0: {}
 
   fs-extra@11.3.5:
     dependencies:
@@ -31667,6 +31911,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.capitalize@4.2.1: {}
 
   lodash.escaperegexp@4.1.2: {}
@@ -32390,6 +32636,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mkdirp-classic@0.5.3: {}
+
   mkdist@2.4.1(typescript@6.0.3)(vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.38)(esbuild@0.28.1)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       autoprefixer: 10.5.0(postcss@8.5.15)
@@ -32491,6 +32739,9 @@ snapshots:
   named-placeholders@1.1.6:
     dependencies:
       lru.min: 1.1.4
+
+  nan@2.28.0:
+    optional: true
 
   nanoid@3.3.12: {}
 
@@ -34028,6 +34279,20 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.9.3
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -35299,6 +35564,8 @@ snapshots:
       spdx-expression-parse: 3.0.1
       spdx-ranges: 2.1.1
 
+  split-ca@1.0.1: {}
+
   split2@1.0.0:
     dependencies:
       through2: 2.0.5
@@ -35308,6 +35575,14 @@ snapshots:
   sql-escaper@1.3.3: {}
 
   srvx@0.11.16: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
 
   stable-hash-x@0.2.0: {}
 
@@ -35631,6 +35906,21 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.2.0:
     dependencies:
       b4a: 1.8.1
@@ -35881,6 +36171,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@0.14.5: {}
+
   twoslash-protocol@0.3.8: {}
 
   twoslash@0.3.8(typescript@6.0.3):
@@ -36023,6 +36315,8 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
       unplugin: 2.3.11
+
+  undici-types@5.26.5: {}
 
   undici-types@7.24.6: {}
 
@@ -36324,6 +36618,8 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   validate-html-nesting@1.2.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,11 @@ overrides:
   tmp@<0.2.6: ^0.2.6
   tmp@<=0.2.3: ^0.2.4
   undici@<6.27.0: ^6.27.0
+  # dockerode pulls uuid@10, flagged by GHSA-w5hq-g745-h8pq (missing buffer
+  # bounds check in v3/v5/v6 when `buf` is passed). dockerode only calls
+  # `uuid.v4()`, so it's not exploitable here, but bump the whole tree to the
+  # patched line to clear the advisory; v11 keeps the named `v4` export.
+  uuid@<11.1.0: ^11.1.0
 
 catalogs:
   ai:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -153,6 +153,7 @@ catalogs:
     typescript: 6.0.3
   types:
     "@standard-schema/spec": 1.1.0
+    "@types/dockerode": ^3.3.47
     "@types/node": 25.9.3
   cloudflare:
     "@cloudflare/containers": ^0.3.7
@@ -167,6 +168,7 @@ catalogs:
     "@playwright/test": ^1.61.0
     playwright: ^1.61.0
   tooling:
+    dockerode: ^4.0.12
     ts-morph: ^28.0.0
   vite:
     # Exact-pinned (no caret). 1.40.0 regressed the dev runner — `getWorkerEntryExportTypes`
@@ -392,11 +394,14 @@ peerDependencyRules:
 allowBuilds:
   '@parcel/watcher': true
   core-js: false
+  cpu-features: false
   esbuild: true
   msgpackr-extract: true
   msw: false
+  protobufjs: false
   rs-module-lexer: true
   sharp: true
+  ssh2: false
   unrs-resolver: true
   vue-demi: false
   workerd: true


### PR DESCRIPTION
## What

Running `lunora dev` (CLI) or `vite dev` now tails each running dev **container's own stdout/stderr** into the dev terminal, alongside the existing wrangler output. Previously wrangler built and ran each declared container locally but only forwarded the *worker's* console — the container process's own logs were invisible.

## How

New `@lunora/config` module **`streamContainerLogs`**:

- Lazy-loads **`dockerode`** (the user-chosen Docker client) only when the project actually declares containers — zero cost and no import for the common no-container case.
- Polls `listContainers({status:["running"]})` on a fixed interval (in-flight guarded), matches running `cloudflare-dev/<class>:<build>` images to declared containers by lowercased class name, and attaches to each log stream via `modem.demuxStream` into line-buffered writables (stdout → `info`, stderr → `error`), tagged by the container's **export name**.
- Reconciles attach/detach every tick; tears every stream down on `close()`.
- A missing/stopped Docker engine degrades to a **single** `onUnavailable` warning rather than breaking dev.
- Opt out with `LUNORA_CONTAINER_LOGS=0`.

Wiring:
- **`@lunora/cli`** `dev` handler — starts streaming after the worker spawns (best-effort; a Docker hiccup can never break dev), tagged `[container:<name>]`, torn down on exit.
- **`@lunora/vite`** — new serve-only `containerLogsPlugin`, registered after `logStreamPlugin`, closed on dev-server `close`.
- `pnpm-workspace.yaml` — `dockerode` (`tooling` catalog) + `@types/dockerode` (`types` catalog); the unused native build scripts (`cpu-features`/`protobufjs`/`ssh2`) are disabled since only the Unix-socket path is used.

## Tests

6 unit tests in `@lunora/config` over a hand-driven fake Docker (stdout/stderr tagging, multi-frame line buffering + CR stripping, non-declared-image filtering, single unavailable warning, stream teardown on close). eslint / tsc / prettier green across `@lunora/config`, `@lunora/cli`, `@lunora/vite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `lunora dev` and Vite dev mode can now stream local Docker container logs directly into the console.
  * Log lines are labeled by container name, with errors highlighted separately.

* **Bug Fixes**
  * Docker/unavailable-container issues no longer stop dev startup.
  * Container log streaming now shuts down cleanly when dev servers exit.
  * You can disable container log streaming with `LUNORA_CONTAINER_LOGS=0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->