### PR TITLE
refactor(vite): adopt Vite 8 environment API, scope worker virtual to non-client env

### DIFF
--- a/packages/vite/__tests__/codegen-plugin.test.ts
+++ b/packages/vite/__tests__/codegen-plugin.test.ts
@@ -195,10 +195,14 @@ describe("codegen-plugin", () => {
             send,
             server: {
                 config: { logger: { error: vi.fn<() => void>(), info: vi.fn<() => void>(), warn: vi.fn<() => void>() } },
-                environments: undefined,
+                // Vite 8 always exposes per-environment module graphs; codegen
+                // invalidates the generated dir across all of them.
+                environments: {
+                    client: { moduleGraph: { idToModuleMap: new Map(), invalidateModule: vi.fn<() => void>() } },
+                    worker: { moduleGraph: { idToModuleMap: new Map(), invalidateModule: vi.fn<() => void>() } },
+                },
                 hot: { send },
                 httpServer: undefined,
-                moduleGraph: { idToModuleMap: new Map(), invalidateModule: vi.fn<() => void>() },
                 watcher: { add: vi.fn<() => void>(), off: vi.fn<() => void>(), on: vi.fn<() => void>() },
                 ws: { send: vi.fn<() => void>() },
             } as unknown as import("vite").ViteDevServer,

--- a/packages/vite/__tests__/framework-compose-plugin.test.ts
+++ b/packages/vite/__tests__/framework-compose-plugin.test.ts
@@ -53,12 +53,17 @@ const callResolveId = (plugin: Plugin, id: string): unknown => {
     return run?.call({} as never, id, undefined, {} as never);
 };
 
-/** Call a plugin's `load` hook regardless of whether it is a fn or `{ handler }`. */
-const callLoad = (plugin: Plugin, id: string): unknown => {
+/**
+ * Call a plugin's `load` hook regardless of whether it is a fn or `{ handler }`.
+ * Vite 8 always runs hooks within an environment context; the worker virtual is
+ * emitted in every non-"client" environment, so the harness defaults to `"ssr"`
+ * (the real-entry path) and callers pass an explicit name when they care.
+ */
+const callLoad = (plugin: Plugin, id: string, environment = "ssr"): unknown => {
     const hook = plugin.load;
     const run = typeof hook === "function" ? hook : hook?.handler;
 
-    return run?.call({} as never, id, undefined as never);
+    return run?.call({ environment: { name: environment } } as never, id, undefined as never);
 };
 
 describe("framework-compose-plugin", () => {
@@ -117,6 +122,23 @@ describe("framework-compose-plugin", () => {
             expect(code).toContain('"/workspace/app/lunora/_generated/functions"');
             expect(code).toContain("createShardDO()");
             expect(code).toContain("shardDO: env.SHARD");
+        });
+
+        it("emits a worker-free stub in the client environment but the real entry in the worker environment", () => {
+            expect.hasAssertions();
+
+            const plugin = frameworkComposePlugin(baseOptions(), context("react-router", "A"));
+
+            // Browser environment: a stub with none of the worker-only runtime, so
+            // an accidental client import can't pull worker code into the bundle.
+            const clientSource = callLoad(plugin, RESOLVED_LUNORA_WORKER_ID, "client") as string;
+
+            expect(clientSource).not.toContain("composeWorker(");
+            expect(clientSource).not.toContain("createShardDO");
+
+            // Worker environment (named after the worker, not "client"): the real
+            // composed entry.
+            expect(callLoad(plugin, RESOLVED_LUNORA_WORKER_ID, "my-worker")).toContain("composeWorker(");
         });
 
         it("honours a custom generatedDir in the emitted imports", () => {

--- a/packages/vite/src/codegen-plugin.ts
+++ b/packages/vite/src/codegen-plugin.ts
@@ -271,39 +271,19 @@ const codegenPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
             // wedge the loop), and on server close.
             let cachedProject: Project | undefined;
 
-            // Invalidate generated modules across every module graph so the dev
-            // server picks up new types/values. Vite 6's environment API (used by
-            // `@cloudflare/vite-plugin` for the worker/SSR environment) keeps
-            // per-environment graphs that the legacy `server.moduleGraph` doesn't
-            // cover, so walk those too when present.
-            type ModuleGraphLike = {
-                idToModuleMap: Map<string, { id: string | null }>;
-                invalidateModule: (module: { id: string | null }) => void;
-            };
-
+            // Invalidate generated modules across every environment's module graph
+            // so the dev server picks up new types/values. `@cloudflare/vite-plugin`
+            // runs the worker (and SSR) in their own Vite environments, each with
+            // its own graph the client graph doesn't cover — `server.environments`
+            // is always present on Vite 8 (the plugin's peer), so walk them all.
             const invalidateGenerated = (): void => {
-                // `environments` is absent on Vite < 6 / partial mocks; the cast
-                // through `unknown` keeps the runtime guard meaningful.
-                const environments = server.environments as unknown as Record<string, { moduleGraph?: ModuleGraphLike }> | undefined;
-                const graphs: ModuleGraphLike[] = [];
+                for (const environment of Object.values(server.environments)) {
+                    const graph = environment.moduleGraph;
 
-                if (environments !== undefined) {
-                    for (const environment of Object.values(environments)) {
-                        if (environment.moduleGraph !== undefined) {
-                            graphs.push(environment.moduleGraph);
-                        }
-                    }
-                }
-
-                if (graphs.length === 0) {
-                    graphs.push(server.moduleGraph as unknown as ModuleGraphLike);
-                }
-
-                for (const graph of graphs) {
                     for (const moduleEntry of graph.idToModuleMap.values()) {
                         if (moduleEntry.id && isInside(moduleEntry.id, absoluteGeneratedDirectory)) {
-                            // Invalidate via the owning graph so per-environment
-                            // graphs are handled correctly.
+                            // Invalidate via the owning environment graph so each
+                            // environment re-pulls the regenerated module.
                             graph.invalidateModule(moduleEntry);
                         }
                     }

--- a/packages/vite/src/framework-compose-plugin.ts
+++ b/packages/vite/src/framework-compose-plugin.ts
@@ -23,6 +23,17 @@ const LUNORA_WORKER_VIRTUAL_ID: string = "virtual:lunora/worker";
 const RESOLVED_VIRTUAL_PREFIX = "\0";
 const RESOLVED_LUNORA_WORKER_ID: string = `${RESOLVED_VIRTUAL_PREFIX}${LUNORA_WORKER_VIRTUAL_ID}`;
 
+/**
+ * Stub emitted for the worker virtual in the *client* (browser) environment. The
+ * composed entry pulls in worker-only runtime — `composeWorker`, `createShardDO`,
+ * the framework's server handler — none of which belongs in a browser chunk. The
+ * client never imports `virtual:lunora/worker` in practice, so this only hardens
+ * against an accidental import leaking worker code into the client bundle.
+ */
+const CLIENT_WORKER_STUB = `// @lunora/vite — the composed worker entry is worker-only and unavailable in the client environment.
+export default {};
+`;
+
 /** Strip a single trailing slash from a dir so the emitted import has exactly one separator. */
 const TRAILING_SLASH = /\/$/;
 
@@ -214,6 +225,15 @@ export const frameworkComposePlugin = (options: ResolvedLunoraPluginOptions, con
     return {
         load(id) {
             if (id === RESOLVED_LUNORA_WORKER_ID && isWorkerVirtualActive(context) && context.framework !== undefined) {
+                // `@cloudflare/vite-plugin` names the browser environment "client"
+                // and the worker environment after the worker; emit the stub there
+                // and the real entry everywhere else (worker/SSR). Vite 8 always
+                // runs hooks within an environment context, so `this.environment`
+                // is guaranteed present here.
+                if (this.environment.name === "client") {
+                    return CLIENT_WORKER_STUB;
+                }
+
                 // `_generated/containers.ts` exists only when the project declares
                 // containers; codegen has already run by load time, so this fs
                 // check decides whether the composed entry re-exports them.


### PR DESCRIPTION
## What

Two focused, Vite-8-only cleanups in `@lunora/vite`, surfaced while evaluating whether Vite's Environment API could improve the plugin. The plugin already consumes the Environment API transitively (via `@cloudflare/vite-plugin`, which owns the workerd environment), so this is incremental hardening rather than a migration.

### 1. Drop the Vite-<6 module-graph fallback (`codegen-plugin.ts`)
`invalidateGenerated` reflectively read `server.environments` through `as unknown as` casts and fell back to the legacy `server.moduleGraph`. The package's peer dep is `vite: ^8.0.16`, where `server.environments` is always present and each `DevEnvironment.moduleGraph` is non-optional — so it now iterates the typed API directly and deletes the `ModuleGraphLike` shim, the casts, and the dead fallback branch.

### 2. Scope the composed worker virtual to non-client environments (`framework-compose-plugin.ts`)
The `load` hook for `virtual:lunora/worker` now returns a worker-free stub in the `client` environment and the real composed entry everywhere else. This hardens against worker-only runtime (`composeWorker`, `createShardDO`, the framework SSR handler) ever being bundled into a browser chunk.

`@cloudflare/vite-plugin@1.42.0` **reserves** the name `client` for the browser environment (`createEnvironmentNameValidator` throws on it) and names the worker/SSR environment after the worker. Cloudflare class-A composition runs SSR *inside* the worker, so the SSR/worker environment is never `client` and still receives the real entry.

## Why it's safe
- `this.environment` and `DevEnvironment.moduleGraph` are non-optional in the Vite 8 type surface; the `load` hook always runs within an environment context.
- The client never imports `virtual:lunora/worker` in practice (it's only ever the wrangler `main`), so the stub is strictly defensive.
- No behavior change for `cloudflare: false` (BYO) or class-C SPA projects.

## Testing
- `tsc --noEmit`, ESLint, and Prettier all clean.
- Full `@lunora/vite` suite: **126/126 passing**, including a new test asserting the client-stub vs worker-entry split and an updated codegen mock matching the per-environment-graph contract.

## Review
Audited by both thermo-nuclear passes (branch audit + code quality): no bug/security/breakage findings (every risk verified against `@cloudflare/vite-plugin` internals and the Vite 8 types), and all four code-quality polish nits applied (template-literal stub, parameterized `callLoad` helper, trimmed duplicate comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)