### PR TITLE
feat: D1-backed global-shape poll tier (Phase 8)

### DIFF
--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -17,7 +17,7 @@ import {
     refreshCodegenProject,
     runCodegen,
 } from "../src/index";
-import type { FunctionIR, SchemaIR } from "../src/ir";
+import type { FunctionIR, SchemaIR, ShapeIR } from "../src/ir";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureRoot = join(here, "fixtures", "simple");
@@ -1354,6 +1354,36 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             expect(output).toContain("config.hyperdriveGlobal?.(env, { identity, userId }) ?? globalDbStub");
             expect(output).toContain("hyperdriveGlobal?: (env: Record<string, unknown>");
             expect(output).not.toContain("config.d1?.(env");
+        });
+
+        const settingsShape: ShapeIR = { exportName: "allSettings", filePath: "shapes", table: "settings" };
+
+        it("emits the global-shape poll override when a project has shapes AND a `.global()` table", () => {
+            expect.assertions(3);
+
+            const output = emitShard({ schema: globalSchema("d1"), shapes: [settingsShape] });
+
+            // resolveShape flags a `.global()`-table shape so the base serves it via the poll path.
+            expect(output).toContain('const isGlobal = (schema as unknown as SchemaLike).tables[shape.table]?.shardMode?.kind === "global"');
+            // The DO reads the global membership by draining the global backend's findMany.
+            expect(output).toContain("protected override async readGlobalShapeRows");
+            expect(output).toContain("await globalDb.findMany(resolved.table, { cursor, where: resolved.effectiveWhere })");
+        });
+
+        it("does not emit readGlobalShapeRows when the project has shapes but no `.global()` table", () => {
+            expect.assertions(1);
+
+            const output = emitShard({
+                schema: {
+                    tables: [
+                        { indexes: [], name: "messages", rankIndexes: [], relations: [], searchIndexes: [], shape: {}, shardMode: "root", vectorIndexes: [] },
+                    ],
+                    vectorIndexes: [],
+                },
+                shapes: [{ exportName: "msgs", filePath: "shapes", table: "messages" }],
+            });
+
+            expect(output).not.toContain("protected override async readGlobalShapeRows");
         });
     });
 

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -2730,7 +2730,7 @@ const emitShard = ({
     // project, so its `shard.ts` is byte-identical.
     const shapeResolveOverride = hasShapes
         ? `
-        protected override resolveShape(name: string, args: Record<string, unknown>, identity?: { identity?: Record<string, unknown>; userId?: string }): { columns?: readonly string[]; effectiveWhere?: WhereInput; table: string } | undefined {
+        protected override resolveShape(name: string, args: Record<string, unknown>, identity?: { identity?: Record<string, unknown>; userId?: string }): { columns?: readonly string[]; effectiveWhere?: WhereInput; global?: boolean; table: string } | undefined {
             const shape = LUNORA_SHAPES[name];
 
             if (!shape) {
@@ -2752,7 +2752,12 @@ const emitShard = ({
             // known. Remedy: denormalize, or move the joined table to \`.global()\`.
             assertShapeShardable(effectiveWhere, schema as unknown as SchemaLike, shape.table);
 
-            return { columns: shape.columns, effectiveWhere, table: shape.table };
+            // A \`.global()\` table lives in D1 (no per-DO op-log): flag it so the
+            // base serves it through the latency-tiered poll path (\`readGlobalShapeRows\`)
+            // instead of the CDC poke path.
+            const isGlobal = (schema as unknown as SchemaLike).tables[shape.table]?.shardMode?.kind === "global";
+
+            return { columns: shape.columns, effectiveWhere, global: isGlobal, table: shape.table };
         }
 `
         : "";
@@ -2989,6 +2994,41 @@ const vectorsStub: VectorSearchLike = {
     const globalDatabaseLine = hasGlobalTables
         ? `            const globalDb: DatabaseWriterLike = ${globalDatabaseThunk}?.(env, { identity, userId }) ?? globalDbStub;\n`
         : "";
+
+    // Local-first sync engine, global tier: when a project has shapes AND
+    // `.global()` tables, the DO serves a `.global()`-table shape's seed/poll
+    // rows by draining the global backend's `findMany` under the socket's
+    // verified identity — the same identity-scoped read the poke-live path uses,
+    // just against D1/Hyperdrive instead of this DO's op-log. Emitted only when
+    // both features are present so a shape-free or global-free `shard.ts` stays
+    // byte-identical.
+    const globalShapeReaderOverride =
+        hasShapes && hasGlobalTables
+            ? `
+        protected override async readGlobalShapeRows(resolved: { columns?: readonly string[]; effectiveWhere?: WhereInput; global?: boolean; table: string }, identity?: { identity?: Record<string, unknown>; userId?: string }): Promise<Array<{ doc: Record<string, unknown>; id: string }>> {
+            const env = this.env as Record<string, unknown>;
+            const globalDb: DatabaseWriterLike = ${globalDatabaseThunk}?.(env, identity) ?? globalDbStub;
+            const rows: Array<{ doc: Record<string, unknown>; id: string }> = [];
+
+            let cursor: null | string = null;
+
+            // Drain every page of the global membership so the seed/diff sees the
+            // full rowset (D1 \`findMany\` is paginated).
+            do {
+                // eslint-disable-next-line no-await-in-loop -- sequential page drain to assemble the full membership
+                const page = await globalDb.findMany(resolved.table, { cursor, where: resolved.effectiveWhere });
+
+                for (const doc of page.page) {
+                    rows.push({ doc, id: String((doc as { _id?: unknown })._id) });
+                }
+
+                cursor = page.isDone ? null : page.continueCursor;
+            } while (cursor !== null);
+
+            return rows;
+        }
+`
+            : "";
 
     const facadeBlock = hasTables
         ? `\n            const facade = db as unknown as Record<string, ReturnType<typeof bindTableFacade>>;
@@ -3233,7 +3273,7 @@ ${relationFanout.override}
                 iterator: (signal) => (registered.handler as (context: unknown, args: Record<string, unknown>, signal: AbortSignal) => AsyncIterable<unknown>)(this.buildCtx({ functionPath }), args, signal),
             };
         }
-${customMutatorOverride}${shapeResolveOverride}
+${customMutatorOverride}${shapeResolveOverride}${globalShapeReaderOverride}
         protected override lifecycleHookPaths(event: "connect" | "disconnect"): readonly string[] {
             return LUNORA_LIFECYCLE_HOOKS[event];
         }

--- a/packages/do/__tests__/shard-do.global-shape.test.ts
+++ b/packages/do/__tests__/shard-do.global-shape.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import type { SocketAttachment } from "../src/types";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The `.global()`-table shape tier. A `.global()` table lives in D1, which has
+ * no per-DO op-log, so a global shape can't be poke-live: the DO seeds its
+ * membership from the global backend once on subscribe, then on each alarm tick
+ * re-reads the full membership and pokes only the diff against a per-socket
+ * snapshot.
+ *
+ * The base `ShardDO` has no global backend (`readGlobalShapeRows` → `[]`), so the
+ * test subclass overrides it with an in-memory reader (standing in for D1) and
+ * `resolveShape` to mark the shape `global`. Driving `alarm()` directly exercises
+ * the poll/diff loop the real runtime invokes when the poll alarm fires.
+ */
+
+interface ShapeRow {
+    doc: Record<string, unknown>;
+    id: string;
+}
+
+interface FakeWebSocket {
+    attachment: SocketAttachment | undefined;
+    close: () => void;
+    deserializeAttachment: () => unknown;
+    send: (data: string) => void;
+    sent: string[];
+    serializeAttachment: (value: unknown) => void;
+}
+
+const createFakeWebSocket = (): FakeWebSocket => {
+    return {
+        attachment: { subs: {} },
+        close() {
+            /* no-op */
+        },
+        deserializeAttachment() {
+            return this.attachment;
+        },
+        send(data: string) {
+            this.sent.push(data);
+        },
+        sent: [],
+        serializeAttachment(value: unknown) {
+            this.attachment = value as SocketAttachment | undefined;
+        },
+    };
+};
+
+/** A shard whose only shape is a `.global()`-table shape served from an in-memory reader. */
+class GlobalShapeShard extends ShardDO {
+    /** The stand-in for the D1 membership; mutate it then drive `alarm()`. */
+    public rows: ShapeRow[] = [];
+
+    // eslint-disable-next-line class-methods-use-this -- this shard exercises only the shape/alarm path; RPC is unused.
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve({ ok: true });
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test stub override: resolves by `name` alone.
+    protected override resolveShape(name: string): { effectiveWhere?: Record<string, unknown>; global?: boolean; table: string } | undefined {
+        if (name !== "globalThings") {
+            return undefined;
+        }
+
+        return { effectiveWhere: {}, global: true, table: "things" };
+    }
+
+    protected override readGlobalShapeRows(): Promise<ShapeRow[]> {
+        return Promise.resolve(
+            this.rows.map((row) => {
+                return { doc: { ...row.doc }, id: row.id };
+            }),
+        );
+    }
+}
+
+let harness: ReturnType<typeof createSqliteExec>;
+const alarmBox: { scheduled: null | number } = { scheduled: null };
+
+const makeState = (sockets: FakeWebSocket[]): ShardDOState => {
+    return {
+        acceptWebSocket(ws) {
+            sockets.push(ws as unknown as FakeWebSocket);
+        },
+        getWebSockets() {
+            return sockets as unknown as WebSocket[];
+        },
+        storage: {
+            deleteAlarm() {
+                alarmBox.scheduled = null;
+
+                return Promise.resolve();
+            },
+            getAlarm() {
+                return Promise.resolve(alarmBox.scheduled);
+            },
+            setAlarm(scheduledTime) {
+                alarmBox.scheduled = typeof scheduledTime === "number" ? scheduledTime : scheduledTime.getTime();
+
+                return Promise.resolve();
+            },
+            sql: harness.sql as unknown as ShardDOState["storage"]["sql"],
+        },
+    };
+};
+
+const subscribeShape = async (shard: ShardDO, ws: FakeWebSocket): Promise<void> => {
+    await shard.webSocketMessage(ws as unknown as WebSocket, JSON.stringify({ id: "g1", shape: { name: "globalThings" }, type: "shape_subscribe" }));
+};
+
+/** Collect the row-ops across every `pokePart` frame the socket received. */
+const pokeOps = (ws: FakeWebSocket): { key: string; op: string; value?: Record<string, unknown> }[] =>
+    ws.sent
+        .map((raw) => JSON.parse(raw) as { rowsPatch?: { key: string; op: string; value?: Record<string, unknown> }[]; type: string })
+        .filter((frame) => frame.type === "pokePart")
+        .flatMap((frame) => frame.rowsPatch ?? []);
+
+const frameTypes = (ws: FakeWebSocket): string[] => ws.sent.map((raw) => (JSON.parse(raw) as { type: string }).type);
+
+describe("shardDO global-shape poll tier", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+        alarmBox.scheduled = null;
+    });
+
+    it("seeds the current global membership as an insert-poke and arms the alarm", async () => {
+        expect.assertions(4);
+
+        const sockets: FakeWebSocket[] = [];
+        const shard = new GlobalShapeShard(makeState(sockets), {});
+        const ws = createFakeWebSocket();
+        sockets.push(ws);
+
+        shard.rows = [
+            { doc: { _id: "t1", label: "a" }, id: "t1" },
+            { doc: { _id: "t2", label: "b" }, id: "t2" },
+        ];
+
+        await subscribeShape(shard, ws);
+
+        expect(frameTypes(ws)).toStrictEqual(["ack", "pokeStart", "pokePart", "pokeEnd"]);
+
+        const ops = pokeOps(ws);
+
+        expect(ops).toHaveLength(2);
+        expect(ops).toStrictEqual([
+            { key: "t1", op: "insert", table: "things", value: expect.objectContaining({ _id: "t1", label: "a" }) },
+            { key: "t2", op: "insert", table: "things", value: expect.objectContaining({ _id: "t2", label: "b" }) },
+        ]);
+        // The poll alarm is armed so the runtime will call `alarm()` to refresh.
+        expect(alarmBox.scheduled).not.toBeNull();
+    });
+
+    it("pokes only the diff (insert / update / delete) on an alarm tick", async () => {
+        expect.assertions(2);
+
+        const sockets: FakeWebSocket[] = [];
+        const shard = new GlobalShapeShard(makeState(sockets), {});
+        const ws = createFakeWebSocket();
+        sockets.push(ws);
+
+        shard.rows = [
+            { doc: { _id: "t1", label: "a" }, id: "t1" },
+            { doc: { _id: "t2", label: "b" }, id: "t2" },
+        ];
+        await subscribeShape(shard, ws);
+        ws.sent.length = 0;
+
+        // t1 changes, t2 vanishes, t3 joins.
+        shard.rows = [
+            { doc: { _id: "t1", label: "a2" }, id: "t1" },
+            { doc: { _id: "t3", label: "c" }, id: "t3" },
+        ];
+
+        await shard.alarm();
+
+        expect(frameTypes(ws)).toStrictEqual(["pokeStart", "pokePart", "pokeEnd"]);
+        expect(pokeOps(ws)).toStrictEqual([
+            { key: "t1", op: "update", table: "things", value: expect.objectContaining({ label: "a2" }) },
+            { key: "t3", op: "insert", table: "things", value: expect.objectContaining({ _id: "t3", label: "c" }) },
+            { key: "t2", op: "delete", table: "things" },
+        ]);
+    });
+
+    it("sends no poke on an alarm tick when membership is unchanged", async () => {
+        expect.assertions(1);
+
+        const sockets: FakeWebSocket[] = [];
+        const shard = new GlobalShapeShard(makeState(sockets), {});
+        const ws = createFakeWebSocket();
+        sockets.push(ws);
+
+        shard.rows = [{ doc: { _id: "t1", label: "a" }, id: "t1" }];
+        await subscribeShape(shard, ws);
+        ws.sent.length = 0;
+
+        await shard.alarm();
+
+        expect(ws.sent).toStrictEqual([]);
+    });
+
+    it("re-arms the alarm while a global shape stays subscribed", async () => {
+        expect.assertions(1);
+
+        const sockets: FakeWebSocket[] = [];
+        const shard = new GlobalShapeShard(makeState(sockets), {});
+        const ws = createFakeWebSocket();
+        sockets.push(ws);
+
+        shard.rows = [{ doc: { _id: "t1" }, id: "t1" }];
+        await subscribeShape(shard, ws);
+        alarmBox.scheduled = null; // clear the seed-time arm
+
+        await shard.alarm();
+
+        // Still one global subscriber ⇒ the alarm is re-armed for the next tick.
+        expect(alarmBox.scheduled).not.toBeNull();
+    });
+
+    it("does not re-arm the alarm once the global shape is unsubscribed", async () => {
+        expect.assertions(2);
+
+        const sockets: FakeWebSocket[] = [];
+        const shard = new GlobalShapeShard(makeState(sockets), {});
+        const ws = createFakeWebSocket();
+        sockets.push(ws);
+
+        shard.rows = [{ doc: { _id: "t1" }, id: "t1" }];
+        await subscribeShape(shard, ws);
+        ws.sent.length = 0;
+
+        await shard.webSocketMessage(ws as unknown as WebSocket, JSON.stringify({ id: "g1", type: "shape_unsubscribe" }));
+        alarmBox.scheduled = null;
+
+        await shard.alarm();
+
+        // No global subscribers remain ⇒ the alarm is not re-armed and the DO idles.
+        expect(alarmBox.scheduled).toBeNull();
+        expect(pokeOps(ws)).toStrictEqual([]);
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -23,6 +23,7 @@ import {
     trimIdempotent,
     writeIdempotent,
 } from "./ctx-db";
+import type { ShapeRow } from "./ctx-db-shapes";
 import type { MigrationDirection, MigrationRunResult } from "./data-migration";
 import { DATA_MIGRATION_STATE_TABLE, readMigrationStatus } from "./data-migration";
 import type { DependencyTracker } from "./dependency-tracker";
@@ -159,12 +160,32 @@ interface ShardDOState {
      */
     setWebSocketAutoResponse?: (pair: WebSocketRequestResponsePair) => void;
     storage: {
+        /**
+         * Cancel any pending alarm. Optional: present on the real
+         * `DurableObjectState.storage`, absent in the unit harness.
+         */
+        deleteAlarm?: () => Promise<void>;
+
+        /**
+         * The currently-armed alarm time (ms epoch) or `null`. Used by the
+         * global-shape poll loop to avoid double-arming. Optional: present on
+         * the real runtime, absent in the unit harness.
+         */
+        getAlarm?: () => Promise<null | number>;
         /** Native PITR (≤30 days): bookmark for a past `time`. Absent in local dev. */
         getBookmarkForTime?: (time: Date | number) => Promise<string>;
         /** Native PITR: bookmark for the object's current state. Absent in local dev. */
         getCurrentBookmark?: () => Promise<string>;
         /** Native PITR: arm a restore to `bookmark` on next restart; returns the undo bookmark. */
         onNextSessionRestoreBookmark?: (bookmark: string) => Promise<string>;
+
+        /**
+         * Arm the DO's single alarm to fire at `scheduledTime` (ms epoch),
+         * waking {@link ShardDO.alarm}. Used by the global-shape poll loop.
+         * Optional: present on the real runtime, absent in the unit harness
+         * (where the poll loop degrades to seed-only).
+         */
+        setAlarm?: (scheduledTime: Date | number) => Promise<void>;
         sql: {
             [key: string]: unknown;
 
@@ -226,6 +247,17 @@ interface SubscriptionOutcome {
 interface ResolvedShape {
     columns?: ReadonlyArray<string>;
     effectiveWhere?: WhereInput;
+
+    /**
+     * `true` when the shape's table is `.global()` (lives in D1, not this DO's
+     * SQLite). A global shape has **no per-DO op-log** to diff, so it is served
+     * by the **latency-tiered poll path** ({@link ShardDO.seedGlobalShape} +
+     * {@link ShardDO.refreshGlobalShape}) instead of the CDC poke path — seeded
+     * from {@link ShardDO.readGlobalShapeRows} and refreshed on an alarm tick.
+     * The codegen subclass sets it from the schema's `shardMode`; absent ⇒ a
+     * shard-local (poke-live) shape.
+     */
+    global?: boolean;
     table: string;
 }
 
@@ -1480,6 +1512,16 @@ abstract class ShardDO {
     protected static readonly MAX_SUBSCRIPTIONS_PER_SOCKET = 32;
 
     /**
+     * Poll interval (ms) for `.global()`-table shapes. A global table lives in
+     * D1 with no per-DO op-log, so its shapes can't be poke-live; the DO re-reads
+     * each subscribed global shape's membership from D1 on an alarm every
+     * `GLOBAL_SHAPE_POLL_INTERVAL_MS` and pokes only the diff. This is the
+     * latency floor for a global-shape update — deliberately coarse (seconds, not
+     * the sub-millisecond poke-live path) since the D1 read fans out per tick.
+     */
+    protected static readonly GLOBAL_SHAPE_POLL_INTERVAL_MS = 2000;
+
+    /**
      * Per-socket whisper-topic cap. Topic membership rides the same hibernation
      * attachment as `subs`, so bound it for the same reason — a runaway
      * `whisper_subscribe` loop must not wedge the attachment past the runtime's
@@ -1681,6 +1723,24 @@ abstract class ShardDO {
      * `sinceCheckpoint`.
      */
     private readonly shapeMemos = new WeakMap<WebSocket, Map<string, ShapeMemo>>();
+
+    /**
+     * Per-socket, per-**global**-shape membership snapshot: maps each global
+     * shape's subscription id to a `key → projected-value JSON` map of the rows
+     * last poked to that socket. A `.global()` (D1) table has no op-log to diff,
+     * so {@link ShardDO.refreshGlobalShape} re-reads the full membership on each
+     * alarm tick and diffs it against this snapshot to compute the poke. Parallel
+     * to {@link ShardDO.shapeMemos} (the cursor baseline for poke-live shapes);
+     * in-memory only — a cold snapshot on a reconnected socket re-seeds full.
+     */
+    private readonly globalShapeSnapshots = new WeakMap<WebSocket, Map<string, Map<string, string>>>();
+
+    /**
+     * Whether a global-shape poll alarm is currently armed. Guards
+     * {@link ShardDO.scheduleGlobalPoll} from re-arming on every seed; reset in
+     * {@link ShardDO.alarm} before the poll so a still-subscribed shape re-arms.
+     */
+    private globalPollScheduled = false;
 
     /** Monotonic per-DO poke id source; correlates a poke's `pokeStart`/`pokePart`/`pokeEnd` frames. */
     private pokeSequence = 0;
@@ -2280,6 +2340,7 @@ abstract class ShardDO {
         // bounce. Cheap to recompute on the next subscribe.
         this.subMemos.delete(ws);
         this.shapeMemos.delete(ws);
+        this.globalShapeSnapshots.delete(ws);
 
         // Clear the attachment so a future reconnection starts clean.
         (ws as HibernatableWebSocket).serializeAttachment?.(undefined);
@@ -2289,6 +2350,24 @@ abstract class ShardDO {
     // eslint-disable-next-line class-methods-use-this -- Workers hibernation handler: the platform invokes it on the instance; the signature must stay an instance method
     public webSocketError(_ws: WebSocket, _error: unknown): void {
         // Subclasses can override with proper logging. Avoid throwing.
+    }
+
+    /**
+     * Durable Object alarm handler — the heartbeat for `.global()`-table shapes.
+     * The runtime wakes this when the poll alarm armed by `scheduleGlobalPoll`
+     * fires; it refreshes every subscribed global shape (diff-poke from the global
+     * backend) and re-arms while any remain. With no global subscribers left, the
+     * alarm is not re-armed and the DO goes idle. A base-only / global-free DO
+     * never arms it, so this stays dormant there.
+     */
+    public async alarm(): Promise<void> {
+        this.globalPollScheduled = false;
+
+        const remaining = await this.pollGlobalShapes();
+
+        if (remaining > 0) {
+            await this.scheduleGlobalPoll();
+        }
     }
 
     /** Subclasses implement function dispatch. */
@@ -3448,6 +3527,7 @@ abstract class ShardDO {
         }
 
         this.shapeMemos.get(ws)?.delete(subId);
+        this.globalShapeSnapshots.get(ws)?.delete(subId);
     }
 
     /**
@@ -3562,6 +3642,27 @@ abstract class ShardDO {
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to dispatch via the generated shape registry
     protected resolveShape(_name: string, _args: Record<string, unknown>, _identity?: SubscriptionIdentity): ResolvedShape | undefined {
         return undefined;
+    }
+
+    /**
+     * Read the FULL current membership of a `.global()`-table shape from its D1
+     * (or Hyperdrive) backend — the seed/poll source for the latency-tiered
+     * global shape path. A `.global()` table lives in another store with no
+     * per-DO op-log, so this is the only way to learn its rows from inside the
+     * shard DO; {@link ShardDO.seedGlobalShape} calls it once on subscribe and
+     * {@link ShardDO.refreshGlobalShape} on every alarm tick, diffing the result
+     * against the per-socket snapshot to compute the poke.
+     *
+     * The base class has no global backend, so it returns `[]` (a base-only DO,
+     * or a project with no global tables, never resolves a global shape). The
+     * codegen subclass overrides it to drain `globalDb.findMany(table, { where:
+     * effectiveWhere })` under the socket's verified `identity` — the same
+     * unforgeable value `resolveShape` composed the RLS predicate with, so the
+     * D1 read is identity-scoped exactly like the poke-live path.
+     */
+    // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this to read the global (D1) backend; the base has none
+    protected readGlobalShapeRows(_resolved: ResolvedShape, _identity?: SubscriptionIdentity): Promise<ShapeRow[]> {
+        return Promise.resolve([]);
     }
 
     /**
@@ -5640,9 +5741,18 @@ abstract class ShardDO {
      */
     private async seedShapeSubscription(ws: WebSocket, subId: string, shape: ShapeSubscriptionQuery): Promise<void> {
         const attachment = this.readAttachment(ws);
-        const resolved = this.resolveShape(shape.name, shape.args ?? {}, { identity: attachment.identity, userId: attachment.userId });
+        const identity: SubscriptionIdentity = { identity: attachment.identity, userId: attachment.userId };
+        const resolved = this.resolveShape(shape.name, shape.args ?? {}, identity);
 
         if (!resolved) {
+            return;
+        }
+
+        // A `.global()`-table shape has no op-log to resume/diff: seed it from D1
+        // and let the alarm poll loop drive updates (latency-tiered, not poke-live).
+        if (resolved.global) {
+            await this.seedGlobalShape(ws, subId, resolved, identity);
+
             return;
         }
 
@@ -5709,7 +5819,10 @@ abstract class ShardDO {
 
                 // Unresolvable now (revoked policy / dropped shape): leave the memo
                 // so a later flush retries rather than silently advancing past it.
-                if (!resolved || !changed.has(resolved.table)) {
+                // A `.global()` shape is driven by the alarm poll loop, not this
+                // op-log flush (its table can't appear in this DO's `changed` set
+                // anyway), so it is always skipped here.
+                if (!resolved || resolved.global || !changed.has(resolved.table)) {
                     continue;
                 }
 
@@ -5835,6 +5948,159 @@ abstract class ShardDO {
                 value: projectColumns(row.doc, resolved.columns),
             };
         });
+    }
+
+    /**
+     * Seed a `.global()`-table shape: read its full membership from D1, ship it
+     * as one insert-poke, record the membership snapshot the alarm poll loop will
+     * diff against, and arm the poll alarm. A global shape has no op-log cursor,
+     * so the poke is stamped at this DO's current cursor (informational only) and
+     * carries no resume base — a reconnect always re-seeds full.
+     */
+    private async seedGlobalShape(ws: WebSocket, subId: string, resolved: ResolvedShape, identity: SubscriptionIdentity): Promise<void> {
+        const rows = await this.readGlobalShapeRows(resolved, identity);
+        const snapshot = new Map<string, string>();
+        const rowsPatch: ShapeRowOp[] = [];
+
+        for (const { doc, id } of rows) {
+            const value = projectColumns(doc, resolved.columns);
+
+            snapshot.set(id, JSON.stringify(value));
+            rowsPatch.push({ key: id, op: "insert", table: resolved.table, value });
+        }
+
+        this.recordGlobalSnapshot(ws, subId, snapshot);
+
+        await awaitWsDrain(ws);
+        this.sendPoke(ws, [{ rowsPatch, shapeId: subId }], this.currentCdcCursor() ?? 0, this.currentCdcEpoch(), undefined);
+        await this.scheduleGlobalPoll();
+    }
+
+    /**
+     * Re-read a global shape's membership from D1 and poke only the diff against
+     * the socket's last snapshot: a new key → `insert`, a changed projected value
+     * → `update`, a vanished key → `delete`. The snapshot advances to the fresh
+     * membership even when the diff is empty, so the next tick compares from here.
+     * No frame is sent when nothing changed (the common steady-state tick).
+     */
+    private async refreshGlobalShape(ws: WebSocket, subId: string, resolved: ResolvedShape, identity: SubscriptionIdentity): Promise<void> {
+        const rows = await this.readGlobalShapeRows(resolved, identity);
+        const previous = this.globalShapeSnapshots.get(ws)?.get(subId) ?? new Map<string, string>();
+        const next = new Map<string, string>();
+        const rowsPatch: ShapeRowOp[] = [];
+
+        for (const { doc, id } of rows) {
+            const value = projectColumns(doc, resolved.columns);
+            const json = JSON.stringify(value);
+
+            next.set(id, json);
+
+            const before = previous.get(id);
+
+            if (before === undefined) {
+                rowsPatch.push({ key: id, op: "insert", table: resolved.table, value });
+            } else if (before !== json) {
+                rowsPatch.push({ key: id, op: "update", table: resolved.table, value });
+            }
+        }
+
+        for (const id of previous.keys()) {
+            if (!next.has(id)) {
+                rowsPatch.push({ key: id, op: "delete", table: resolved.table });
+            }
+        }
+
+        this.recordGlobalSnapshot(ws, subId, next);
+
+        if (rowsPatch.length === 0) {
+            return;
+        }
+
+        await awaitWsDrain(ws);
+        this.sendPoke(ws, [{ rowsPatch, shapeId: subId }], this.currentCdcCursor() ?? 0, this.currentCdcEpoch(), undefined);
+    }
+
+    /** Record a socket's latest global-shape membership snapshot (creating the per-socket map lazily). */
+    private recordGlobalSnapshot(ws: WebSocket, subId: string, snapshot: Map<string, string>): void {
+        let snapshots = this.globalShapeSnapshots.get(ws);
+
+        if (!snapshots) {
+            snapshots = new Map<string, Map<string, string>>();
+            this.globalShapeSnapshots.set(ws, snapshots);
+        }
+
+        snapshots.set(subId, snapshot);
+    }
+
+    /**
+     * Arm the poll alarm for `.global()` shapes if one isn't already pending.
+     * Idempotent — every global-shape seed calls it, but only the first arms the
+     * alarm. Degrades to a no-op when the runtime exposes no `setAlarm` (the unit
+     * harness): a global shape is then seed-only, which the poll-loop tests assert
+     * by driving {@link ShardDO.alarm} directly.
+     */
+    private async scheduleGlobalPoll(): Promise<void> {
+        if (this.globalPollScheduled) {
+            return;
+        }
+
+        const { setAlarm } = this.state.storage;
+
+        if (!setAlarm) {
+            return;
+        }
+
+        this.globalPollScheduled = true;
+
+        try {
+            await setAlarm.call(this.state.storage, Date.now() + ShardDO.GLOBAL_SHAPE_POLL_INTERVAL_MS);
+        } catch {
+            // A failed arm clears the flag so a later seed/tick retries.
+            this.globalPollScheduled = false;
+        }
+    }
+
+    /**
+     * Refresh every `.global()`-table shape held across all live sockets, one
+     * diff-poke per (socket, shape). Returns the number of global shapes still
+     * subscribed so {@link ShardDO.alarm} knows whether to re-arm. Expired sockets
+     * are dropped in passing (mirrors {@link ShardDO.pokeShapeSubscribers}).
+     */
+    private async pollGlobalShapes(): Promise<number> {
+        const sockets = [...this.state.getWebSockets()];
+        let remaining = 0;
+
+        for (const ws of sockets) {
+            if (this.isSocketExpired(ws)) {
+                this.dropExpiredSocket(ws);
+
+                continue;
+            }
+
+            const attachment = this.readAttachment(ws);
+            const { shapes } = attachment;
+
+            if (!shapes) {
+                continue;
+            }
+
+            const identity: SubscriptionIdentity = { identity: attachment.identity, userId: attachment.userId };
+
+            for (const [subId, shape] of Object.entries(shapes)) {
+                const resolved = this.resolveShape(shape.name, shape.args ?? {}, identity);
+
+                if (!resolved?.global) {
+                    continue;
+                }
+
+                remaining += 1;
+
+                // eslint-disable-next-line no-await-in-loop -- per-socket D1 reads are intentionally serialized to bound concurrent global reads per tick
+                await this.refreshGlobalShape(ws, subId, resolved, identity);
+            }
+        }
+
+        return remaining;
     }
 
     /** Send one poke (`pokeStart` → `pokePart` per shape → `pokeEnd`) to a socket. All parts apply atomically at `pokeEnd`. */


### PR DESCRIPTION
Closes the last deferred gap of the Zero-class local-first sync engine (PR #37): **Phase 8's `.global()`-table shape tier**. A `.global()` table lives in D1, which has no per-DO op-log, so a shape over it cannot be poke-live. This PR serves it through a **latency-tiered poll loop** instead.

Stacked on `feat/local-first-sync-engine` (PR #37) because the shape infra it builds on lives only there. Retarget to `alpha` once #37 merges.

## How it works

- **Seed** — on `shape_subscribe`, the DO reads the shape's full membership from the global backend and ships it as one insert-poke, recording a per-socket membership snapshot.
- **Poll** — seeding arms a Durable Object **alarm** (`GLOBAL_SHAPE_POLL_INTERVAL_MS`). Each tick re-reads the membership and pokes only the **diff** (insert / update / delete) against the snapshot, then re-arms while any global shape stays subscribed. No diff → no frame.
- **Identity-scoped reads** — the DO drains `globalDb.findMany(table, { where: effectiveWhere })` under the socket's verified identity, the same `config.d1` / `config.hyperdriveGlobal` thunk the global-table write path already uses, so reads compose with RLS exactly like the poke-live path.

## Changes

- **`@lunora/do`** — base-class machinery: `readGlobalShapeRows` hook (base returns `[]`), `seedGlobalShape` / `refreshGlobalShape` / `pollGlobalShapes` / `scheduleGlobalPoll`, the public `alarm()` handler, `ResolvedShape.global` flag, routing in `seedShapeSubscription`, a guard in `pokeShapeSubscribers`, snapshot cleanup on `webSocketClose` + `shapeUnsubscribe`, and `setAlarm`/`getAlarm`/`deleteAlarm` on the structural storage interface.
- **`@lunora/codegen`** — `resolveShape` flags a `.global()`-table shape; a `readGlobalShapeRows` override is emitted only when a project has **both** shapes and a `.global()` table — so shape-free / global-free `shard.ts` stays byte-identical.

## Tests

- `@lunora/do`: `shard-do.global-shape.test.ts` — seed insert-poke + alarm arm, diff poke (insert/update/delete) on a tick, no-poke on unchanged membership, re-arm while subscribed, no re-arm after unsubscribe (5 tests).
- `@lunora/codegen`: emit-assertion tests for the override (emitted with shapes+global, absent without global).
- Gates green: `@lunora/do` (885) + `@lunora/codegen` (430) test, `lint:types`, `eslint`, `prettier`. Byte-identical golden snapshot holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014J7gaGqkxiJ6sNYWnzXR5R