### PR TITLE
feat(vite): error-overlay solution finders

### DIFF
--- a/packages/cli/__tests__/commands/verify.test.ts
+++ b/packages/cli/__tests__/commands/verify.test.ts
@@ -127,6 +127,23 @@ describe("lunora verify", () => {
             expect(result.errors.some((error) => error.includes("codegen failed"))).toBe(true);
         });
 
+        it("prints the matched Lunora fix under a recognized codegen error", async () => {
+            expect.assertions(3);
+
+            writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+            // Valid TypeScript with no `defineSchema()` call → codegen throws the
+            // recognized "defineSchema() not found" error, which carries a fix hint.
+            writeFileSync(join(workdir, "lunora", "schema.ts"), "export const notASchema = 1;", "utf8");
+            const { logger, recorded } = recordingLogger();
+
+            const result = await runVerifyCommand({ cwd: workdir, logger });
+
+            expect(result.code).toBe(1);
+            expect(result.errors.some((error) => error.includes("codegen failed"))).toBe(true);
+            // The fix hint (solution header) is rendered alongside the error bullet.
+            expect(recorded.errors.join("\n")).toContain("No Lunora schema found");
+        });
+
         it("returns 1 when wrangler.jsonc is missing", async () => {
             expect.assertions(3);
 

--- a/packages/cli/__tests__/util/codegen-error.test.ts
+++ b/packages/cli/__tests__/util/codegen-error.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { renderCodegenFailure, renderCodegenHint } from "../../src/util/codegen-error";
+
+describe("renderCodegenFailure", () => {
+    it("renders the failure message with the matched Lunora fix as a hint, sans stack", () => {
+        expect.assertions(4);
+
+        const output = renderCodegenFailure(new Error("defineSchema() not found in lunora/schema.ts"), "startup");
+
+        // The failure line carries the reason and the original message.
+        expect(output).toContain("codegen failed (startup): defineSchema() not found");
+        // The recognized error contributes its solution header + a body fragment
+        // as the rendered hint (Markdown emphasis flattened for the terminal).
+        expect(output).toContain("No Lunora schema found");
+        expect(output).toContain("vis generate lunora-table --name=messages");
+        // The internal codegen stack is suppressed — no frame leaks through.
+        expect(output).not.toContain("codegen-error");
+    });
+
+    it("omits the reason tag when none is given", () => {
+        expect.assertions(2);
+
+        const output = renderCodegenFailure(new Error("defineSchema() not found in lunora/schema.ts"));
+
+        // `lunora prepare` has no distinct trigger — the failure line is unparenthesized.
+        expect(output).toContain("codegen failed: defineSchema() not found");
+        expect(output).toContain("No Lunora schema found");
+    });
+
+    it("renders only the failure for an unrecognized error, with no hint", () => {
+        expect.assertions(2);
+
+        const output = renderCodegenFailure(new Error("TypeError: boom is not a function"), "change: x.ts");
+
+        expect(output).toContain("codegen failed (change: x.ts): TypeError: boom is not a function");
+        expect(output).not.toContain("No Lunora schema found");
+    });
+
+    it("coerces a non-Error throw to a string without crashing", () => {
+        expect.assertions(1);
+
+        expect(renderCodegenFailure("raw string failure", "startup")).toContain("raw string failure");
+    });
+});
+
+describe("renderCodegenHint", () => {
+    it("renders the matched fix alone (no failure line), sans stack", () => {
+        expect.assertions(3);
+
+        const output = renderCodegenHint("defineSchema() not found in lunora/schema.ts");
+
+        expect(output).toBeDefined();
+        // Only the fix — the header + a body fragment — with no "codegen failed" line.
+        expect(output).toContain("No Lunora schema found");
+        expect(output).not.toContain("codegen failed");
+    });
+
+    it("returns undefined for an unrecognized message", () => {
+        expect.assertions(1);
+
+        expect(renderCodegenHint("TypeError: boom is not a function")).toBeUndefined();
+    });
+});

--- a/packages/cli/__tests__/util/codegen-error.test.ts
+++ b/packages/cli/__tests__/util/codegen-error.test.ts
@@ -13,7 +13,7 @@ describe("renderCodegenFailure", () => {
         // The recognized error contributes its solution header + a body fragment
         // as the rendered hint (Markdown emphasis flattened for the terminal).
         expect(output).toContain("No Lunora schema found");
-        expect(output).toContain("vis generate lunora-table --name=messages");
+        expect(output).toContain("lunora init");
         // The internal codegen stack is suppressed — no frame leaks through.
         expect(output).not.toContain("codegen-error");
     });

--- a/packages/cli/__tests__/util/codegen-watch.test.ts
+++ b/packages/cli/__tests__/util/codegen-watch.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { startCodegenWatch } from "../../src/util/codegen-watch";
+import { renderCodegenFailure, startCodegenWatch } from "../../src/util/codegen-watch";
 import type { Logger } from "../../src/util/logger";
 
 const silentLogger = (): { logger: Logger; warns: string[] } => {
@@ -20,6 +20,38 @@ const silentLogger = (): { logger: Logger; warns: string[] } => {
         warns,
     };
 };
+
+describe("renderCodegenFailure", () => {
+    it("renders the failure message with the matched Lunora fix as a hint, sans stack", () => {
+        expect.assertions(4);
+
+        const output = renderCodegenFailure(new Error("defineSchema() not found in lunora/schema.ts"), "startup");
+
+        // The failure line carries the reason and the original message.
+        expect(output).toContain("codegen failed (startup): defineSchema() not found");
+        // The recognized error contributes its solution header + a body fragment
+        // as the rendered hint (Markdown emphasis flattened for the terminal).
+        expect(output).toContain("No Lunora schema found");
+        expect(output).toContain("vis generate lunora-table --name=messages");
+        // The internal codegen-watch stack is suppressed — no frame leaks through.
+        expect(output).not.toContain("codegen-watch");
+    });
+
+    it("renders only the failure for an unrecognized error, with no hint", () => {
+        expect.assertions(2);
+
+        const output = renderCodegenFailure(new Error("TypeError: boom is not a function"), "change: x.ts");
+
+        expect(output).toContain("codegen failed (change: x.ts): TypeError: boom is not a function");
+        expect(output).not.toContain("No Lunora schema found");
+    });
+
+    it("coerces a non-Error throw to a string without crashing", () => {
+        expect.assertions(1);
+
+        expect(renderCodegenFailure("raw string failure", "startup")).toContain("raw string failure");
+    });
+});
 
 describe("startCodegenWatch", () => {
     describe("watchAvailable flag — degraded path (non-existent directory)", () => {

--- a/packages/cli/__tests__/util/codegen-watch.test.ts
+++ b/packages/cli/__tests__/util/codegen-watch.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { renderCodegenFailure, startCodegenWatch } from "../../src/util/codegen-watch";
+import { startCodegenWatch } from "../../src/util/codegen-watch";
 import type { Logger } from "../../src/util/logger";
 
 const silentLogger = (): { logger: Logger; warns: string[] } => {
@@ -20,38 +20,6 @@ const silentLogger = (): { logger: Logger; warns: string[] } => {
         warns,
     };
 };
-
-describe("renderCodegenFailure", () => {
-    it("renders the failure message with the matched Lunora fix as a hint, sans stack", () => {
-        expect.assertions(4);
-
-        const output = renderCodegenFailure(new Error("defineSchema() not found in lunora/schema.ts"), "startup");
-
-        // The failure line carries the reason and the original message.
-        expect(output).toContain("codegen failed (startup): defineSchema() not found");
-        // The recognized error contributes its solution header + a body fragment
-        // as the rendered hint (Markdown emphasis flattened for the terminal).
-        expect(output).toContain("No Lunora schema found");
-        expect(output).toContain("vis generate lunora-table --name=messages");
-        // The internal codegen-watch stack is suppressed — no frame leaks through.
-        expect(output).not.toContain("codegen-watch");
-    });
-
-    it("renders only the failure for an unrecognized error, with no hint", () => {
-        expect.assertions(2);
-
-        const output = renderCodegenFailure(new Error("TypeError: boom is not a function"), "change: x.ts");
-
-        expect(output).toContain("codegen failed (change: x.ts): TypeError: boom is not a function");
-        expect(output).not.toContain("No Lunora schema found");
-    });
-
-    it("coerces a non-Error throw to a string without crashing", () => {
-        expect.assertions(1);
-
-        expect(renderCodegenFailure("raw string failure", "startup")).toContain("raw string failure");
-    });
-});
 
 describe("startCodegenWatch", () => {
     describe("watchAvailable flag — degraded path (non-existent directory)", () => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,6 +73,7 @@
         "@lunora/d1": "1.0.0-alpha.7",
         "@lunora/seed": "1.0.0-alpha.5",
         "@visulima/cerebro": "3.0.0-alpha.32",
+        "@visulima/error": "6.0.0-alpha.34",
         "@visulima/fs": "5.0.0-alpha.32",
         "@visulima/pail": "4.0.0-alpha.22",
         "@visulima/path": "3.0.0-alpha.13",

--- a/packages/cli/src/commands/prepare/handler.ts
+++ b/packages/cli/src/commands/prepare/handler.ts
@@ -10,6 +10,7 @@ import { inferLunoraBindings, reconcileWranglerBindings } from "@lunora/config";
 
 import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
+import { renderCodegenFailure } from "../../util/codegen-error";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
 import type { Logger } from "../../util/logger";
@@ -84,7 +85,10 @@ const runPrepareCommand = async (options: PrepareCommandOptions): Promise<Prepar
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
 
-        options.logger.error(`codegen failed: ${message}`);
+        // Render the failure plus any matched Lunora fix (same hint the Vite
+        // overlay and `lunora dev` show); the returned `error` stays the plain
+        // machine-readable string for `--format json` and callers.
+        options.logger.error(renderCodegenFailure(error));
 
         return {
             code: 1,

--- a/packages/cli/src/commands/verify/handler.ts
+++ b/packages/cli/src/commands/verify/handler.ts
@@ -5,6 +5,7 @@ import { runCodegen } from "@lunora/codegen";
 
 import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
+import { renderCodegenHint } from "../../util/codegen-error";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
 import type { Logger } from "../../util/logger";
@@ -75,6 +76,14 @@ const reportVerifyResult = (logger: Logger, errors: string[], warnings: string[]
 
         for (const error of errors) {
             logger.error(`  - ${error}`);
+
+            // Surface the actionable Lunora fix (the same hint the Vite overlay
+            // and `lunora dev` show) directly under a recognized codegen error.
+            const hint = renderCodegenHint(error);
+
+            if (hint !== undefined) {
+                logger.error(hint);
+            }
         }
 
         return { code: 1, errors, warnings, wranglerPath };

--- a/packages/cli/src/util/codegen-error.ts
+++ b/packages/cli/src/util/codegen-error.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared terminal rendering for codegen failures across the CLI's three
+ * surfaces — the `lunora dev` watch loop, `lunora prepare`, and `lunora verify`.
+ * Each matches the thrown error's message against `@lunora/codegen`'s shared
+ * solution table and renders the actionable fix through `@visulima/error` (the
+ * same renderer cerebro uses for thrown CLI errors), so the terminal fix and
+ * the Vite overlay's solution panel stay in lockstep.
+ */
+import type { LunoraSolution } from "@lunora/codegen";
+import { findLunoraSolution } from "@lunora/codegen";
+import { renderError, VisulimaError } from "@visulima/error";
+
+/**
+ * Flatten a Lunora solution's Markdown body into plain terminal text: drop
+ * code-fence markers and strip inline `**bold**` / `` `code` `` emphasis. The
+ * Markdown is authored for the Vite overlay's browser renderer; `renderError`
+ * lays the text out and colors it for the terminal, so here we only flatten the
+ * content it can't render.
+ */
+const flattenSolutionBody = (solution: LunoraSolution): string =>
+    solution.body
+        .split("\n")
+        .filter((line) => !line.startsWith("```"))
+        .join("\n")
+        .replaceAll(/\*\*(.+?)\*\*/gu, "$1")
+        .replaceAll(/`([^`]+)`/gu, "$1");
+
+/** Shared `renderError` options that suppress the (uninformative) codegen stack. */
+const NO_STACK = { filterStacktrace: () => false, hideErrorCodeView: true } as const;
+
+/**
+ * Render a failed codegen run as a single block: the failure line plus, when the
+ * message is recognized, the matched Lunora fix as the error's `hint`. Used where
+ * the failure is the only thing being reported (the `lunora dev` watch loop and
+ * `lunora prepare`). `reason` tags the failure with its trigger (e.g. `startup`,
+ * `change: schema.ts`); omit it when there is no distinct trigger. The internal
+ * stack is suppressed — the message and the fix are what help.
+ */
+const renderCodegenFailure = (error: unknown, reason?: string): string => {
+    const message = error instanceof Error ? error.message : String(error);
+    const solution = findLunoraSolution(message);
+
+    const rendered = new VisulimaError({
+        hint: solution ? [solution.header, "", flattenSolutionBody(solution)] : undefined,
+        message: reason === undefined ? `codegen failed: ${message}` : `codegen failed (${reason}): ${message}`,
+        name: "CodegenError",
+    });
+
+    rendered.stack = "";
+
+    return renderError(rendered, NO_STACK);
+};
+
+/**
+ * Render *only* the matched Lunora fix for a codegen-error message, or
+ * `undefined` when the message isn't recognized. Used where the failure itself
+ * is already reported separately (e.g. `lunora verify`, which collects the error
+ * string for its `--format json` output) and only the fix needs surfacing.
+ */
+const renderCodegenHint = (message: string): string | undefined => {
+    const solution = findLunoraSolution(message);
+
+    if (solution === undefined) {
+        return undefined;
+    }
+
+    const rendered = new VisulimaError({
+        hint: [flattenSolutionBody(solution)],
+        message: solution.header,
+        name: "Hint",
+    });
+
+    rendered.stack = "";
+
+    return renderError(rendered, NO_STACK);
+};
+
+export { renderCodegenFailure, renderCodegenHint };

--- a/packages/cli/src/util/codegen-watch.ts
+++ b/packages/cli/src/util/codegen-watch.ts
@@ -8,8 +8,9 @@ import type { FSWatcher } from "node:fs";
 import { existsSync, watch } from "node:fs";
 import { join } from "node:path";
 
-import type { CodegenOptions } from "@lunora/codegen";
+import type { CodegenOptions, LunoraSolution } from "@lunora/codegen";
 import { findLunoraSolution, runCodegen } from "@lunora/codegen";
+import { renderError, VisulimaError } from "@visulima/error";
 
 import type { Logger } from "./logger";
 
@@ -19,37 +20,45 @@ const DEFAULT_DEBOUNCE_MS = 100;
 const PATH_SEGMENT_SEPARATOR = /[/\\]/u;
 
 /**
- * Render a solution's Markdown body to plain terminal text: drop code-fence
- * markers (keep the fenced code) and strip `**bold**` / `` `code` `` emphasis.
- * The Vite error overlay renders the same Markdown in the browser; the CLI has
- * no Markdown renderer, so it shows a lightly de-marked version.
+ * Adapt a Lunora solution's Markdown body into an `@visulima/error` hint — a
+ * list of plain-text blocks with code-fence markers and inline `**bold**` /
+ * `` `code` `` emphasis stripped. The Markdown is authored for the Vite
+ * overlay's browser renderer; `renderError` (below) lays the hint out and
+ * colors it for the terminal, so here we only flatten content it can't render.
  */
-const toTerminalText = (markdown: string): string =>
-    markdown
+const solutionToHint = (solution: LunoraSolution): string[] => {
+    const body = solution.body
         .split("\n")
         .filter((line) => !line.startsWith("```"))
         .join("\n")
         .replaceAll(/\*\*(.+?)\*\*/gu, "$1")
         .replaceAll(/`([^`]+)`/gu, "$1");
 
+    return [solution.header, "", body];
+};
+
 /**
- * Print the Lunora fix hint for a recognized codegen error, mirroring the Vite
- * overlay's solution panel on the non-Vite `lunora dev` path. No-op when the
- * message isn't one Lunora recognizes — the bare `logger.error` already stands.
+ * Render a failed codegen run for the terminal through `@visulima/error` — the
+ * same renderer cerebro uses for thrown CLI errors — attaching the matched
+ * Lunora fix as the error's `hint` (the overlay shows the same fix as a solution
+ * panel). The internal stack is suppressed: in a watch loop the codegen call
+ * site is noise; the message plus an actionable hint is what helps.
  */
-const printSolutionHint = (logger: Logger, message: string): void => {
+const renderCodegenFailure = (error: unknown, reason: string): string => {
+    const message = error instanceof Error ? error.message : String(error);
     const solution = findLunoraSolution(message);
 
-    if (!solution) {
-        return;
-    }
+    const rendered = new VisulimaError({
+        hint: solution ? solutionToHint(solution) : undefined,
+        message: `codegen failed (${reason}): ${message}`,
+        name: "CodegenError",
+    });
 
-    logger.info("");
-    logger.info(`  → ${solution.header}`);
+    // No useful frames for a dev watch loop — drop the stack so the output is
+    // just the failure line and the fix hint.
+    rendered.stack = "";
 
-    for (const line of toTerminalText(solution.body).split("\n")) {
-        logger.info(line === "" ? "" : `    ${line}`);
-    }
+    return renderError(rendered, { filterStacktrace: () => false, hideErrorCodeView: true });
 };
 
 /** Run codegen once, logging success or surfacing a parse/emit error without throwing. */
@@ -59,10 +68,7 @@ const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenO
 
         logger.success(`codegen: wrote ${lunoraDirectory}/_generated (${reason})`);
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-
-        logger.error(`codegen failed (${reason}): ${message}`);
-        printSolutionHint(logger, message);
+        logger.error(renderCodegenFailure(error, reason));
     }
 };
 
@@ -164,3 +170,5 @@ export interface CodegenWatcherHandle {
      */
     watchAvailable: boolean;
 }
+
+export { renderCodegenFailure };

--- a/packages/cli/src/util/codegen-watch.ts
+++ b/packages/cli/src/util/codegen-watch.ts
@@ -9,7 +9,7 @@ import { existsSync, watch } from "node:fs";
 import { join } from "node:path";
 
 import type { CodegenOptions } from "@lunora/codegen";
-import { runCodegen } from "@lunora/codegen";
+import { findLunoraSolution, runCodegen } from "@lunora/codegen";
 
 import type { Logger } from "./logger";
 
@@ -18,6 +18,40 @@ const DEFAULT_DEBOUNCE_MS = 100;
 /** Splits a watch filename into path segments to detect `_generated` writes. */
 const PATH_SEGMENT_SEPARATOR = /[/\\]/u;
 
+/**
+ * Render a solution's Markdown body to plain terminal text: drop code-fence
+ * markers (keep the fenced code) and strip `**bold**` / `` `code` `` emphasis.
+ * The Vite error overlay renders the same Markdown in the browser; the CLI has
+ * no Markdown renderer, so it shows a lightly de-marked version.
+ */
+const toTerminalText = (markdown: string): string =>
+    markdown
+        .split("\n")
+        .filter((line) => !line.startsWith("```"))
+        .join("\n")
+        .replaceAll(/\*\*(.+?)\*\*/gu, "$1")
+        .replaceAll(/`([^`]+)`/gu, "$1");
+
+/**
+ * Print the Lunora fix hint for a recognized codegen error, mirroring the Vite
+ * overlay's solution panel on the non-Vite `lunora dev` path. No-op when the
+ * message isn't one Lunora recognizes — the bare `logger.error` already stands.
+ */
+const printSolutionHint = (logger: Logger, message: string): void => {
+    const solution = findLunoraSolution(message);
+
+    if (!solution) {
+        return;
+    }
+
+    logger.info("");
+    logger.info(`  → ${solution.header}`);
+
+    for (const line of toTerminalText(solution.body).split("\n")) {
+        logger.info(line === "" ? "" : `    ${line}`);
+    }
+};
+
 /** Run codegen once, logging success or surfacing a parse/emit error without throwing. */
 const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenOptions["apiSpec"], logger: Logger, reason: string): void => {
     try {
@@ -25,7 +59,10 @@ const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenO
 
         logger.success(`codegen: wrote ${lunoraDirectory}/_generated (${reason})`);
     } catch (error: unknown) {
-        logger.error(`codegen failed (${reason}): ${error instanceof Error ? error.message : String(error)}`);
+        const message = error instanceof Error ? error.message : String(error);
+
+        logger.error(`codegen failed (${reason}): ${message}`);
+        printSolutionHint(logger, message);
     }
 };
 

--- a/packages/cli/src/util/codegen-watch.ts
+++ b/packages/cli/src/util/codegen-watch.ts
@@ -8,58 +8,16 @@ import type { FSWatcher } from "node:fs";
 import { existsSync, watch } from "node:fs";
 import { join } from "node:path";
 
-import type { CodegenOptions, LunoraSolution } from "@lunora/codegen";
-import { findLunoraSolution, runCodegen } from "@lunora/codegen";
-import { renderError, VisulimaError } from "@visulima/error";
+import type { CodegenOptions } from "@lunora/codegen";
+import { runCodegen } from "@lunora/codegen";
 
+import { renderCodegenFailure } from "./codegen-error";
 import type { Logger } from "./logger";
 
 const DEFAULT_DEBOUNCE_MS = 100;
 
 /** Splits a watch filename into path segments to detect `_generated` writes. */
 const PATH_SEGMENT_SEPARATOR = /[/\\]/u;
-
-/**
- * Adapt a Lunora solution's Markdown body into an `@visulima/error` hint — a
- * list of plain-text blocks with code-fence markers and inline `**bold**` /
- * `` `code` `` emphasis stripped. The Markdown is authored for the Vite
- * overlay's browser renderer; `renderError` (below) lays the hint out and
- * colors it for the terminal, so here we only flatten content it can't render.
- */
-const solutionToHint = (solution: LunoraSolution): string[] => {
-    const body = solution.body
-        .split("\n")
-        .filter((line) => !line.startsWith("```"))
-        .join("\n")
-        .replaceAll(/\*\*(.+?)\*\*/gu, "$1")
-        .replaceAll(/`([^`]+)`/gu, "$1");
-
-    return [solution.header, "", body];
-};
-
-/**
- * Render a failed codegen run for the terminal through `@visulima/error` — the
- * same renderer cerebro uses for thrown CLI errors — attaching the matched
- * Lunora fix as the error's `hint` (the overlay shows the same fix as a solution
- * panel). The internal stack is suppressed: in a watch loop the codegen call
- * site is noise; the message plus an actionable hint is what helps.
- */
-const renderCodegenFailure = (error: unknown, reason: string): string => {
-    const message = error instanceof Error ? error.message : String(error);
-    const solution = findLunoraSolution(message);
-
-    const rendered = new VisulimaError({
-        hint: solution ? solutionToHint(solution) : undefined,
-        message: `codegen failed (${reason}): ${message}`,
-        name: "CodegenError",
-    });
-
-    // No useful frames for a dev watch loop — drop the stack so the output is
-    // just the failure line and the fix hint.
-    rendered.stack = "";
-
-    return renderError(rendered, { filterStacktrace: () => false, hideErrorCodeView: true });
-};
 
 /** Run codegen once, logging success or surfacing a parse/emit error without throwing. */
 const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenOptions["apiSpec"], logger: Logger, reason: string): void => {
@@ -170,5 +128,3 @@ export interface CodegenWatcherHandle {
      */
     watchAvailable: boolean;
 }
-
-export { renderCodegenFailure };

--- a/packages/codegen/__tests__/solutions.test.ts
+++ b/packages/codegen/__tests__/solutions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { findLunoraSolution, LUNORA_SOLUTION_RULES } from "../src/solutions";
+
+/**
+ * Real messages Lunora throws, captured from the source. Consumers (the Vite
+ * overlay, the `lunora dev` CLI) match on the message text alone, so these are
+ * the exact strings the rules must recognize.
+ */
+const LUNORA_MESSAGES = {
+    duplicate: 'defineSchema(...).extend(...): table "todos" already exists — another extension with the same key already contributed it.',
+    exportGap: "[lunora] 1 declared binding is not exported by your worker entry — `wrangler deploy` will fail.",
+    jurisdiction: 'unknown jurisdiction "moon" — expected "eu", "us", or "fedramp"',
+    notObjectLiteral: "defineSchema() expects an object literal",
+    occ: 'optimistic concurrency conflict on "todos" — the row changed during this mutation; refetch and retry',
+    reserved: 'table name "insert" is reserved — it collides with a `ctx.db` member (one of "insert", "patch"). Rename the table.',
+    schemaMissing: "defineSchema() not found in /app/lunora/schema.ts",
+    uniqueLiteral: '`unique` must be a literal `true` or `false`, got "someFlag"',
+    uniqueRuntime: 'unique constraint violation on "todos"',
+} as const;
+
+const expectedId: Record<keyof typeof LUNORA_MESSAGES, string> = {
+    duplicate: "lunora-table-duplicate",
+    exportGap: "lunora-worker-entry-export-gap",
+    jurisdiction: "lunora-jurisdiction",
+    notObjectLiteral: "lunora-schema-not-object-literal",
+    occ: "lunora-runtime-occ",
+    reserved: "lunora-table-reserved",
+    schemaMissing: "lunora-schema-missing",
+    uniqueLiteral: "lunora-unique-literal",
+    uniqueRuntime: "lunora-runtime-unique",
+};
+
+describe("findLunoraSolution", () => {
+    it.each(Object.entries(LUNORA_MESSAGES))("matches exactly one rule for the %s error", (key, message) => {
+        expect.assertions(4);
+
+        // Each real message must match exactly one rule — this guards the loose
+        // `includes(...)` matchers against silently co-matching a second rule
+        // (where ordering, not the predicate, would decide the winner).
+        const allMatches = LUNORA_SOLUTION_RULES.filter((rule) => rule.test(message));
+
+        expect(allMatches).toHaveLength(1);
+        expect(allMatches[0]?.id).toBe(expectedId[key as keyof typeof LUNORA_MESSAGES]);
+
+        const solution = findLunoraSolution(message);
+
+        expect(solution?.id).toBe(expectedId[key as keyof typeof LUNORA_MESSAGES]);
+        expect(typeof solution?.body).toBe("string");
+    });
+
+    it("returns undefined for unrelated and empty messages", () => {
+        expect.assertions(2);
+
+        expect(findLunoraSolution("TypeError: x is not a function")).toBeUndefined();
+        expect(findLunoraSolution("")).toBeUndefined();
+    });
+
+    it("keeps every rule id unique", () => {
+        expect.assertions(1);
+
+        const ids = LUNORA_SOLUTION_RULES.map((rule) => rule.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+});

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -85,6 +85,8 @@ export {
 } from "./schema-drift";
 export { schemaFromIr } from "./schema-from-ir";
 export { LUNORA_ERROR_CODES, validatorIrToJsonSchema } from "./schema-ir";
+export type { LunoraSolution, LunoraSolutionRule } from "./solutions";
+export { findLunoraSolution, LUNORA_SOLUTION_RULES } from "./solutions";
 export type { Finding } from "@lunora/advisor";
 
 export const VERSION = "0.0.0";

--- a/packages/codegen/src/solutions.ts
+++ b/packages/codegen/src/solutions.ts
@@ -56,7 +56,7 @@ export const LUNORA_SOLUTION_RULES: ReadonlyArray<LunoraSolutionRule> = [
             "});",
             "```",
             "",
-            "Or scaffold a table with `vis generate lunora-table --name=messages`.",
+            "Or run `lunora init` to scaffold Lunora (a sample `lunora/schema.ts` included) into your app.",
         ].join("\n"),
         header: "No Lunora schema found",
         id: "lunora-schema-missing",

--- a/packages/codegen/src/solutions.ts
+++ b/packages/codegen/src/solutions.ts
@@ -1,0 +1,179 @@
+/**
+ * Lunora-specific error→solution hints. A small rule table mapping the exact
+ * messages Lunora throws — codegen/schema diagnostics, worker-entry export gaps,
+ * and the runtime data-layer conflicts — to an actionable fix.
+ *
+ * This table is the single source of truth shared by every consumer that wants
+ * to turn a raw Lunora error into a fix hint: the Vite error overlay
+ * (`@lunora/vite`) renders the Markdown in the browser, and the standalone
+ * `lunora dev` CLI prints it to the terminal. It lives in `@lunora/codegen`
+ * because codegen owns most of the throw sites, so the hints stay next to the
+ * code that produces the messages.
+ *
+ * Matching is on the **message text**. By the time a diagnostic reaches a
+ * consumer it has often been flattened to a plain `{ message }` (the overlay
+ * pushes codegen errors through `server.hot.send` with `name === "Error"`), so
+ * the class identity is gone and the message is the only stable signal.
+ *
+ * Bodies are Markdown — the overlay renders them; the CLI prints them (lightly
+ * de-marked) as-is.
+ */
+
+/** A resolved hint for a recognized Lunora error. */
+export interface LunoraSolution {
+    /** Markdown body shown under the header. */
+    body: string;
+    /** Short header for the solution. */
+    header: string;
+    /** Stable id (used in DEBUG logs and tests). */
+    id: string;
+}
+
+/** A single error→solution rule: a {@link LunoraSolution} plus its matcher. */
+export interface LunoraSolutionRule extends LunoraSolution {
+    /** True when this rule recognizes the error message. */
+    test: (message: string) => boolean;
+}
+
+/**
+ * The rules, ordered most- to least-specific: the dev-time codegen/schema rules
+ * come first because they're the errors a developer hits while editing
+ * `lunora/`, then the runtime data-layer conflicts that surface from the worker.
+ * The first matching rule (in array order) wins.
+ */
+export const LUNORA_SOLUTION_RULES: ReadonlyArray<LunoraSolutionRule> = [
+    {
+        body: [
+            "Lunora codegen couldn't find a schema to generate from.",
+            "",
+            "Create `lunora/schema.ts` exporting a `defineSchema(...)` call:",
+            "",
+            "```ts",
+            'import { defineSchema, defineTable, v } from "@lunora/server";',
+            "",
+            "export default defineSchema({",
+            "  messages: defineTable({ body: v.string() }),",
+            "});",
+            "```",
+            "",
+            "Or scaffold a table with `vis generate lunora-table --name=messages`.",
+        ].join("\n"),
+        header: "No Lunora schema found",
+        id: "lunora-schema-missing",
+        test: (message) => message.includes("defineSchema() not found") || message.includes("schema.ts not found at"),
+    },
+    {
+        body: [
+            "`defineSchema(...)` must be called with an **inline object literal** mapping table names to `defineTable(...)`:",
+            "",
+            "```ts",
+            "export default defineSchema({",
+            "  todos: defineTable({ title: v.string(), done: v.boolean() }),",
+            "});",
+            "```",
+            "",
+            "Codegen reads the schema statically, so it can't follow a variable or a spread — pass the object literal directly.",
+        ].join("\n"),
+        header: "`defineSchema()` needs an inline object literal",
+        id: "lunora-schema-not-object-literal",
+        test: (message) => message.includes("defineSchema() expects an object literal"),
+    },
+    {
+        body: [
+            "This table name collides with a built-in `ctx.db` member, so the generated client can't expose it.",
+            "",
+            "Rename the table to anything that isn't a reserved name (the error lists them) — e.g. `userAccounts` instead of `insert`.",
+        ].join("\n"),
+        header: "Table name is reserved",
+        id: "lunora-table-reserved",
+        test: (message) => message.includes("is reserved") && message.includes("ctx.db"),
+    },
+    {
+        body: [
+            "Two tables resolve to the same name — usually a base table and a schema **extension** both defining it.",
+            "",
+            "Rename one of them, or drop the duplicate from the extension. Each table name must be unique across `defineSchema(...)` and every `.extend(...)`.",
+        ].join("\n"),
+        header: "Duplicate table name",
+        id: "lunora-table-duplicate",
+        // Anchor on `.extend(` — the only Lunora throw for this is
+        // `defineSchema(...).extend(...): table "x" already exists …`. Matching a
+        // bare "already exists"/"extension" pair would false-positive on
+        // unrelated forwarded errors (e.g. a "file already exists" + "extension").
+        test: (message) => message.includes("already exists") && message.includes(".extend("),
+    },
+    {
+        body: [
+            '`.jurisdiction(...)` accepts only a **string literal** of `"eu"`, `"us"`, or `"fedramp"`:',
+            "",
+            "```ts",
+            'defineSchema({ /* … */ }).jurisdiction("eu");',
+            "```",
+        ].join("\n"),
+        header: "Invalid `.jurisdiction(...)` value",
+        id: "lunora-jurisdiction",
+        test: (message) => message.includes("unknown jurisdiction") || (message.includes("jurisdiction") && message.includes('"eu", "us", or "fedramp"')),
+    },
+    {
+        body: [
+            "The `unique` flag on an index must be a **literal** `true` or `false`, not a computed value — codegen needs to read it statically:",
+            "",
+            "```ts",
+            'defineTable({ email: v.string() }).index("by_email", ["email"], { unique: true });',
+            "```",
+        ].join("\n"),
+        header: "`unique` must be a literal",
+        id: "lunora-unique-literal",
+        test: (message) => message.includes("must be a literal") && message.includes("unique"),
+    },
+    {
+        body: [
+            "A declared container/workflow class isn't re-exported by your worker entry, so `wrangler deploy` would reject it.",
+            "",
+            "Add the generated re-export shown in the error to your worker entry (e.g. `src/index.ts`):",
+            "",
+            "```ts",
+            'export * from "./lunora/_generated/containers";',
+            "```",
+        ].join("\n"),
+        header: "Binding not exported by your worker entry",
+        id: "lunora-worker-entry-export-gap",
+        test: (message) => message.includes("not exported by your worker entry"),
+    },
+    {
+        body: [
+            "A row with the same value already exists in a `unique` index.",
+            "",
+            "- If you meant to upsert, use `ctx.db.<table>().upsert(...)` (or `.patch(...)` an existing row) instead of `.insert(...)`.",
+            '- Otherwise pick a value that isn\'t already taken, and consider surfacing a friendly "already exists" message to the user.',
+        ].join("\n"),
+        header: "Unique constraint violation",
+        id: "lunora-runtime-unique",
+        test: (message) => message.includes("unique constraint violation on"),
+    },
+    {
+        body: [
+            "Another write changed this row while your mutation was running (optimistic concurrency conflict).",
+            "",
+            "Re-read the row and retry the mutation with the fresh value. Lunora serializes a DO's mutations, so a persistent conflict usually means the handler conflicts **with itself** (e.g. a trigger or cascade touching the same row) — split that work rather than adding a retry loop.",
+        ].join("\n"),
+        header: "Optimistic concurrency conflict",
+        id: "lunora-runtime-occ",
+        test: (message) => message.includes("optimistic concurrency conflict"),
+    },
+];
+
+/**
+ * Find the first Lunora solution whose rule matches `message`, or `undefined`
+ * if none recognize it. Consumers turn the returned Markdown into their own
+ * presentation (overlay panel, terminal hint, …).
+ */
+export const findLunoraSolution = (message: string): LunoraSolution | undefined => {
+    for (const rule of LUNORA_SOLUTION_RULES) {
+        if (rule.test(message)) {
+            return { body: rule.body, header: rule.header, id: rule.id };
+        }
+    }
+
+    return undefined;
+};

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -80,6 +80,21 @@ lunora({
 
 `lunora()` returns a flat `Plugin[]`; Vite flattens nested plugin arrays, so `plugins: [lunora()]` works without spreading.
 
+### Error overlay
+
+The overlay surfaces dev-time failures in the browser. Lunora ships **solution finders** that turn the common ones — missing/invalid `defineSchema`, reserved or duplicate table names, a bad `.jurisdiction(...)`, a non-literal `unique`, a binding that isn't re-exported by your worker entry, and runtime unique-constraint / optimistic-concurrency conflicts — into an actionable fix hint right in the overlay.
+
+`overlay` also accepts an options object forwarded to [`@visulima/vite-overlay`](https://www.npmjs.com/package/@visulima/vite-overlay), so you can add your own finders alongside Lunora's:
+
+```ts
+lunora({
+    overlay: {
+        // your finders run alongside Lunora's; either side can win per error via `priority`
+        solutionFinders: [myCustomFinder],
+    },
+});
+```
+
 > This README covers the basics. For the full API, options, and guides, see the **[documentation](https://lunora.sh/docs/packages/vite)**.
 
 ## Related

--- a/packages/vite/__tests__/index.test.ts
+++ b/packages/vite/__tests__/index.test.ts
@@ -133,5 +133,14 @@ describe("index", () => {
             expect(defaulted === false ? undefined : defaulted.forwardedConsoleMethods).toStrictEqual(["error", "warn"]);
             expect(overridden === false ? undefined : overridden.forwardedConsoleMethods).toStrictEqual(["error"]);
         });
+
+        it("keeps the default when the user explicitly passes an undefined forwardedConsoleMethods", () => {
+            expect.assertions(1);
+
+            // An explicit `undefined` must not erase the default via the spread.
+            const resolved = resolveOverlayOption({ forwardedConsoleMethods: undefined });
+
+            expect(resolved === false ? undefined : resolved.forwardedConsoleMethods).toStrictEqual(["error", "warn"]);
+        });
     });
 });

--- a/packages/vite/__tests__/index.test.ts
+++ b/packages/vite/__tests__/index.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { lunora } from "../src/index";
+import { lunora, resolveOverlayOption } from "../src/index";
+import { lunoraSolutionFinder } from "../src/solution-finders";
 
 let workdir: string;
 
@@ -88,6 +89,49 @@ describe("index", () => {
             const minimal = lunora({ cloudflare: false, overlay: false, projectRoot: workdir, validateWrangler: false });
 
             expect(plugins.length).toBeGreaterThan(minimal.length);
+        });
+    });
+
+    describe("resolveOverlayOption", () => {
+        const userFinder = { handle: async () => undefined, name: "user", priority: 100 };
+
+        it("returns false when overlay is disabled", () => {
+            expect.assertions(1);
+
+            expect(resolveOverlayOption(false)).toBe(false);
+        });
+
+        it("injects Lunora's finders for the default (true/undefined) overlay", () => {
+            expect.assertions(2);
+
+            for (const overlay of [true, undefined] as const) {
+                const resolved = resolveOverlayOption(overlay);
+
+                expect(resolved === false ? [] : resolved.solutionFinders).toContain(lunoraSolutionFinder);
+            }
+        });
+
+        it("prepends Lunora's finders before a user's, keeping both", () => {
+            expect.assertions(3);
+
+            const resolved = resolveOverlayOption({ solutionFinders: [userFinder] });
+            const finders = resolved === false ? [] : (resolved.solutionFinders ?? []);
+
+            expect(finders).toHaveLength(2);
+            // Lunora is first, so at an equal priority it wins the overlay's stable
+            // sort — a user must use a strictly higher priority to outrank it.
+            expect(finders[0]).toBe(lunoraSolutionFinder);
+            expect(finders[1]).toBe(userFinder);
+        });
+
+        it("defaults forwardedConsoleMethods but lets a partial user object override it", () => {
+            expect.assertions(2);
+
+            const defaulted = resolveOverlayOption({ solutionFinders: [] });
+            const overridden = resolveOverlayOption({ forwardedConsoleMethods: ["error"] });
+
+            expect(defaulted === false ? undefined : defaulted.forwardedConsoleMethods).toStrictEqual(["error", "warn"]);
+            expect(overridden === false ? undefined : overridden.forwardedConsoleMethods).toStrictEqual(["error"]);
         });
     });
 });

--- a/packages/vite/__tests__/solution-finders.test.ts
+++ b/packages/vite/__tests__/solution-finders.test.ts
@@ -1,11 +1,14 @@
+import { findLunoraSolution } from "@lunora/codegen";
 import { describe, expect, it } from "vitest";
 
-import { LUNORA_SOLUTION_RULES, lunoraSolutionFinder, lunoraSolutionFinders } from "../src/solution-finders";
+import { lunoraSolutionFinder, lunoraSolutionFinders } from "../src/solution-finders";
 
 /**
  * Real messages Lunora throws, captured from the source. Codegen/schema
  * failures reach the overlay's finders with `name === "Error"` (pushed through
- * `server.hot.send`), so every rule must match on the message text alone.
+ * `server.hot.send`), so the finder must recognize them on the message text
+ * alone. The exact id each message maps to is asserted in `@lunora/codegen`'s
+ * `solutions` test — here we only check the overlay finder delegates correctly.
  */
 const CODEGEN_MESSAGES = {
     duplicate: 'defineSchema(...).extend(...): table "todos" already exists — another extension with the same key already contributed it.',
@@ -19,18 +22,6 @@ const CODEGEN_MESSAGES = {
     uniqueRuntime: 'unique constraint violation on "todos"',
 } as const;
 
-const expectedId: Record<keyof typeof CODEGEN_MESSAGES, string> = {
-    duplicate: "lunora-table-duplicate",
-    exportGap: "lunora-worker-entry-export-gap",
-    jurisdiction: "lunora-jurisdiction",
-    notObjectLiteral: "lunora-schema-not-object-literal",
-    occ: "lunora-runtime-occ",
-    reserved: "lunora-table-reserved",
-    schemaMissing: "lunora-schema-missing",
-    uniqueLiteral: "lunora-unique-literal",
-    uniqueRuntime: "lunora-runtime-unique",
-};
-
 describe("lunoraSolutionFinder", () => {
     it("exposes a single finder with a high priority and a stable name", () => {
         expect.assertions(3);
@@ -40,21 +31,16 @@ describe("lunoraSolutionFinder", () => {
         expect(lunoraSolutionFinder.priority).toBeGreaterThanOrEqual(100);
     });
 
-    it.each(Object.entries(CODEGEN_MESSAGES))("returns a solution for the %s error", async (key, message) => {
-        expect.assertions(4);
+    it.each(Object.entries(CODEGEN_MESSAGES))("returns the codegen solution for the %s error", async (_key, message) => {
+        expect.assertions(2);
 
-        // Each real message must match exactly one rule — this guards the loose
-        // `includes(...)` matchers against silently co-matching a second rule
-        // (where ordering, not the predicate, would decide the winner).
-        const allMatches = LUNORA_SOLUTION_RULES.filter((rule) => rule.test(message));
-
-        expect(allMatches).toHaveLength(1);
-        expect(allMatches[0]?.id).toBe(expectedId[key as keyof typeof CODEGEN_MESSAGES]);
-
+        // The finder is a thin wrapper over `@lunora/codegen`'s shared table: it
+        // must surface exactly that table's `{ header, body }` for the message.
+        const expected = findLunoraSolution(message);
         const solution = await lunoraSolutionFinder.handle({ message, name: "Error" }, { file: "", line: 0 });
 
-        expect(solution?.header).not.toBe("");
-        expect(typeof solution?.body).toBe("string");
+        expect(solution?.header).toBe(expected?.header);
+        expect(solution?.body).toBe(expected?.body);
     });
 
     it("defers (returns undefined) for unrelated errors", async () => {
@@ -68,13 +54,5 @@ describe("lunoraSolutionFinder", () => {
         const empty = await lunoraSolutionFinder.handle({ message: "", name: "Error" }, { file: "", line: 0 });
 
         expect(empty).toBeUndefined();
-    });
-
-    it("keeps every rule id unique", () => {
-        expect.assertions(1);
-
-        const ids = LUNORA_SOLUTION_RULES.map((rule) => rule.id);
-
-        expect(new Set(ids).size).toBe(ids.length);
     });
 });

--- a/packages/vite/__tests__/solution-finders.test.ts
+++ b/packages/vite/__tests__/solution-finders.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { LUNORA_SOLUTION_RULES, lunoraSolutionFinder, lunoraSolutionFinders } from "../src/solution-finders";
+
+/**
+ * Real messages Lunora throws, captured from the source. Codegen/schema
+ * failures reach the overlay's finders with `name === "Error"` (pushed through
+ * `server.hot.send`), so every rule must match on the message text alone.
+ */
+const CODEGEN_MESSAGES = {
+    duplicate: 'defineSchema(...).extend(...): table "todos" already exists — another extension with the same key already contributed it.',
+    exportGap: "[lunora] 1 declared binding is not exported by your worker entry — `wrangler deploy` will fail.",
+    jurisdiction: 'unknown jurisdiction "moon" — expected "eu", "us", or "fedramp"',
+    notObjectLiteral: "defineSchema() expects an object literal",
+    occ: 'optimistic concurrency conflict on "todos" — the row changed during this mutation; refetch and retry',
+    reserved: 'table name "insert" is reserved — it collides with a `ctx.db` member (one of "insert", "patch"). Rename the table.',
+    schemaMissing: "defineSchema() not found in /app/lunora/schema.ts",
+    uniqueLiteral: '`unique` must be a literal `true` or `false`, got "someFlag"',
+    uniqueRuntime: 'unique constraint violation on "todos"',
+} as const;
+
+const expectedId: Record<keyof typeof CODEGEN_MESSAGES, string> = {
+    duplicate: "lunora-table-duplicate",
+    exportGap: "lunora-worker-entry-export-gap",
+    jurisdiction: "lunora-jurisdiction",
+    notObjectLiteral: "lunora-schema-not-object-literal",
+    occ: "lunora-runtime-occ",
+    reserved: "lunora-table-reserved",
+    schemaMissing: "lunora-schema-missing",
+    uniqueLiteral: "lunora-unique-literal",
+    uniqueRuntime: "lunora-runtime-unique",
+};
+
+describe("lunoraSolutionFinder", () => {
+    it("exposes a single finder with a high priority and a stable name", () => {
+        expect.assertions(3);
+
+        expect(lunoraSolutionFinders).toHaveLength(1);
+        expect(lunoraSolutionFinder.name).toBe("lunora");
+        expect(lunoraSolutionFinder.priority).toBeGreaterThanOrEqual(100);
+    });
+
+    it.each(Object.entries(CODEGEN_MESSAGES))("returns a solution for the %s error", async (key, message) => {
+        expect.assertions(4);
+
+        // Each real message must match exactly one rule — this guards the loose
+        // `includes(...)` matchers against silently co-matching a second rule
+        // (where ordering, not the predicate, would decide the winner).
+        const allMatches = LUNORA_SOLUTION_RULES.filter((rule) => rule.test(message));
+
+        expect(allMatches).toHaveLength(1);
+        expect(allMatches[0]?.id).toBe(expectedId[key as keyof typeof CODEGEN_MESSAGES]);
+
+        const solution = await lunoraSolutionFinder.handle({ message, name: "Error" }, { file: "", line: 0 });
+
+        expect(solution?.header).not.toBe("");
+        expect(typeof solution?.body).toBe("string");
+    });
+
+    it("defers (returns undefined) for unrelated errors", async () => {
+        expect.assertions(2);
+
+        const generic = await lunoraSolutionFinder.handle({ message: "TypeError: x is not a function", name: "TypeError" }, { file: "a.ts", line: 1 });
+
+        expect(generic).toBeUndefined();
+
+        // A missing/blank message must never throw and must defer.
+        const empty = await lunoraSolutionFinder.handle({ message: "", name: "Error" }, { file: "", line: 0 });
+
+        expect(empty).toBeUndefined();
+    });
+
+    it("keeps every rule id unique", () => {
+        expect.assertions(1);
+
+        const ids = LUNORA_SOLUTION_RULES.map((rule) => rule.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+});

--- a/packages/vite/docs/index.mdx
+++ b/packages/vite/docs/index.mdx
@@ -20,16 +20,16 @@ export default defineConfig({
 
 ## Options
 
-| Option             | Default               | Purpose                                                                        |
-| ------------------ | --------------------- | ------------------------------------------------------------------------------ |
-| `schemaDir`        | `"lunora"`            | Directory containing `schema.ts` + function files                              |
-| `generatedDir`     | `"lunora/_generated"` | Where to emit `api.ts`, `server.ts`, `dataModel.ts`                            |
-| `apiSpec`          | `"openapi"`           | API spec emitted into `_generated/`: `"openapi"`/`"openrpc"`/`"both"`/`"none"` |
-| `studio`           | `true`                | Serve the Lunora studio at `/__lunora` during dev, or `false` to skip          |
-| `cloudflare`       | `true`                | Pass options to `@cloudflare/vite-plugin`, or `false` to skip                  |
-| `overlay`          | `true`                | Inject `@visulima/vite-overlay` for runtime errors, or `false` to skip         |
-| `validateWrangler` | `true`                | Cross-check `wrangler.jsonc` bindings against the schema                       |
-| `projectRoot`      | `process.cwd()`       | Override for monorepo setups                                                   |
+| Option             | Default               | Purpose                                                                                              |
+| ------------------ | --------------------- | ---------------------------------------------------------------------------------------------------- |
+| `schemaDir`        | `"lunora"`            | Directory containing `schema.ts` + function files                                                    |
+| `generatedDir`     | `"lunora/_generated"` | Where to emit `api.ts`, `server.ts`, `dataModel.ts`                                                  |
+| `apiSpec`          | `"openapi"`           | API spec emitted into `_generated/`: `"openapi"`/`"openrpc"`/`"both"`/`"none"`                       |
+| `studio`           | `true`                | Serve the Lunora studio at `/__lunora` during dev, or `false` to skip                                |
+| `cloudflare`       | `true`                | Pass options to `@cloudflare/vite-plugin`, or `false` to skip                                        |
+| `overlay`          | `true`                | Inject `@visulima/vite-overlay` for runtime errors; `false` to skip, or an options object to forward |
+| `validateWrangler` | `true`                | Cross-check `wrangler.jsonc` bindings against the schema                                             |
+| `projectRoot`      | `process.cwd()`       | Override for monorepo setups                                                                         |
 
 ## Codegen lifecycle
 
@@ -49,6 +49,34 @@ bindings as Vite errors before they explode at deploy.
 During dev the plugin mounts the Lunora studio at `/__lunora` so you can browse
 your schema, data, logs, and advisors without leaving the dev server. Set
 `studio: false` to turn it off.
+
+## Error overlay
+
+The plugin injects [`@visulima/vite-overlay`](https://www.npmjs.com/package/@visulima/vite-overlay)
+so runtime and codegen failures show up in the browser instead of only the
+terminal. On top of it Lunora registers **solution finders** that recognise
+framework-specific failures and render an actionable fix hint in the overlay:
+
+- a missing or non-object-literal `defineSchema(...)`
+- a reserved or duplicate table name
+- an invalid `.jurisdiction(...)` value
+- a non-literal `unique` index flag
+- a container/workflow class that isn't re-exported by your worker entry
+- runtime unique-constraint and optimistic-concurrency (`ConflictError`) conflicts
+
+Pass an options object to forward overlay configuration — including your own
+`solutionFinders`, which run alongside Lunora's (each error resolves to the
+highest-`priority` finder that recognises it):
+
+```ts
+lunora({
+    overlay: {
+        solutionFinders: [myCustomFinder],
+    },
+});
+```
+
+Set `overlay: false` to disable it entirely.
 
 ## See also
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -36,8 +36,10 @@ const resolveOverlayOption = (overlay: LunoraPluginOptions["overlay"]): false | 
     const userOverlay = overlay === true || overlay === undefined ? {} : overlay;
 
     return {
-        forwardedConsoleMethods: ["error", "warn"],
         ...userOverlay,
+        // After the spread + nullish-coalesce so an explicit `undefined` from the
+        // user doesn't erase Lunora's default (the spread would otherwise win).
+        forwardedConsoleMethods: userOverlay.forwardedConsoleMethods ?? ["error", "warn"],
         solutionFinders: [...lunoraSolutionFinders, ...(userOverlay.solutionFinders ?? [])],
     };
 };

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -11,10 +11,36 @@ import { frameworkComposePlugin } from "./framework-compose-plugin";
 import { createPluginContext, frameworkDetectPlugin } from "./framework-detect-plugin";
 import logStreamPlugin from "./log-stream-plugin";
 import { planViteRemoteBindings, remoteBindingsCleanupPlugin, withRemoteBindings } from "./remote-bindings-plugin";
+import { lunoraSolutionFinders } from "./solution-finders";
 import { studioPlugin } from "./studio-plugin";
 import type { CloudflarePluginOptions, LunoraPluginOptions, LunoraPlugins, OverlayPluginOptions, ResolvedLunoraPluginOptions } from "./types";
 import { withWorkerStartupHint } from "./worker-startup-hint";
 import { wranglerValidatorPlugin } from "./wrangler-validator-plugin";
+
+/**
+ * Resolve the `overlay` toggle into the overlay plugin's options — or `false` to
+ * skip it. Lunora's solution finders are **prepended** so they run before the
+ * overlay's built-ins; a user's own finders are appended and can still win per
+ * error via a strictly higher `priority` (equal priority keeps Lunora first,
+ * since the overlay sorts stably). Lunora also forwards both `error` AND `warn`
+ * console calls by default (the overlay's own default is `["error"]` only) so
+ * Lunora's branded `warn` advisories surface in the browser too — the user can
+ * override `forwardedConsoleMethods`.
+ */
+// eslint-disable-next-line sonarjs/function-return-type -- returns the overlay options object, or false to skip; the union mirrors the resolved overlay field.
+const resolveOverlayOption = (overlay: LunoraPluginOptions["overlay"]): false | OverlayPluginOptions => {
+    if (overlay === false) {
+        return false;
+    }
+
+    const userOverlay = overlay === true || overlay === undefined ? {} : overlay;
+
+    return {
+        forwardedConsoleMethods: ["error", "warn"],
+        ...userOverlay,
+        solutionFinders: [...lunoraSolutionFinders, ...(userOverlay.solutionFinders ?? [])],
+    };
+};
 
 const resolveOptions = (options: LunoraPluginOptions | undefined): ResolvedLunoraPluginOptions => {
     const input = options ?? {};
@@ -32,26 +58,12 @@ const resolveOptions = (options: LunoraPluginOptions | undefined): ResolvedLunor
         cloudflareOption = input.cloudflare;
     }
 
-    // Forward both `error` AND `warn` console calls to the dev error overlay by
-    // default (the overlay plugin's own default is `["error"]` only) — surfacing
-    // Lunora's branded `warn` advisories in the browser too. User-overridable.
-    const overlayDefaults = { forwardedConsoleMethods: ["error", "warn"] } satisfies Partial<OverlayPluginOptions>;
-    let overlayOption: false | OverlayPluginOptions;
-
-    if (input.overlay === false) {
-        overlayOption = false;
-    } else if (input.overlay === true || input.overlay === undefined) {
-        overlayOption = { ...overlayDefaults };
-    } else {
-        overlayOption = { ...overlayDefaults, ...input.overlay };
-    }
-
     return {
         apiSpec: input.apiSpec ?? "openapi",
         cloudflare: cloudflareOption,
         studio: input.studio ?? true,
         generatedDir: input.generatedDir ?? `${schemaDirectory}/_generated`,
-        overlay: overlayOption,
+        overlay: resolveOverlayOption(input.overlay),
         projectRoot: input.projectRoot ?? process.cwd(),
         schemaDir: schemaDirectory,
         validateWrangler: input.validateWrangler ?? true,
@@ -163,8 +175,10 @@ export { buildWorkerEntrySource, CLASS_A_WIRING, frameworkComposePlugin, isAutoC
 export { default as logStreamPlugin } from "./log-stream-plugin";
 export type { PlanViteRemoteOptions, ViteRemotePlan } from "./remote-bindings-plugin";
 export { planViteRemoteBindings, remoteBindingsCleanupPlugin, withRemoteBindings } from "./remote-bindings-plugin";
+export type { LunoraSolutionRule, Solution, SolutionFinder } from "./solution-finders";
+export { LUNORA_SOLUTION_RULES, lunoraSolutionFinder, lunoraSolutionFinders } from "./solution-finders";
 export { buildStudioUrl, STUDIO_PATH, studioPlugin } from "./studio-plugin";
 export type { CloudflarePluginOptions, LunoraPluginOptions, LunoraPlugins, OverlayPluginOptions, ResolvedLunoraPluginOptions } from "./types";
 export { augmentWorkerStartupError, isWorkerEntryEvalError, withWorkerStartupHint, WORKER_STARTUP_HINT } from "./worker-startup-hint";
 export { wranglerValidatorPlugin } from "./wrangler-validator-plugin";
-export { lunora, VERSION };
+export { lunora, resolveOverlayOption, VERSION };

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -175,8 +175,11 @@ export { buildWorkerEntrySource, CLASS_A_WIRING, frameworkComposePlugin, isAutoC
 export { default as logStreamPlugin } from "./log-stream-plugin";
 export type { PlanViteRemoteOptions, ViteRemotePlan } from "./remote-bindings-plugin";
 export { planViteRemoteBindings, remoteBindingsCleanupPlugin, withRemoteBindings } from "./remote-bindings-plugin";
-export type { LunoraSolutionRule, Solution, SolutionFinder } from "./solution-finders";
-export { LUNORA_SOLUTION_RULES, lunoraSolutionFinder, lunoraSolutionFinders } from "./solution-finders";
+// The error→solution rule table itself lives in `@lunora/codegen` (shared with
+// the standalone `lunora dev` CLI); `@lunora/vite` only wraps it as an overlay
+// finder. Import `findLunoraSolution` / `LUNORA_SOLUTION_RULES` from `@lunora/codegen`.
+export type { Solution, SolutionFinder } from "./solution-finders";
+export { lunoraSolutionFinder, lunoraSolutionFinders } from "./solution-finders";
 export { buildStudioUrl, STUDIO_PATH, studioPlugin } from "./studio-plugin";
 export type { CloudflarePluginOptions, LunoraPluginOptions, LunoraPlugins, OverlayPluginOptions, ResolvedLunoraPluginOptions } from "./types";
 export { augmentWorkerStartupError, isWorkerEntryEvalError, withWorkerStartupHint, WORKER_STARTUP_HINT } from "./worker-startup-hint";

--- a/packages/vite/src/solution-finders.ts
+++ b/packages/vite/src/solution-finders.ts
@@ -1,0 +1,214 @@
+import type { OverlayPluginOptions } from "./types";
+
+/**
+ * A `@visulima/vite-overlay` solution finder. Derived from the overlay's own
+ * options type so the shape can't drift from the installed package. The overlay
+ * runs every finder it's given (custom finders first, then its built-ins),
+ * sorted by `priority` descending, and shows the first non-`undefined` result.
+ *
+ * Note: this type (and {@link Solution}) is re-exported from `@lunora/vite` and
+ * intentionally tracks the installed `@visulima/vite-overlay` — if a future
+ * overlay release changes the finder contract, that surfaces here as a compile
+ * error rather than a silent drift.
+ */
+type SolutionFinder = NonNullable<OverlayPluginOptions["solutionFinders"]>[number];
+
+/** What a finder may return: a Markdown-rendered `{ header?, body }`, or `undefined` to defer. */
+type Solution = NonNullable<Awaited<ReturnType<SolutionFinder["handle"]>>>;
+
+/**
+ * The normalized error a finder receives. The overlay invokes finders
+ * **server-side** with a flattened object — not the original `Error` — so the
+ * class identity is gone by the time we see it (`error instanceof X` never
+ * works here). Codegen/schema failures, which Lunora pushes through
+ * `server.hot.send({ type: "error", … })`, arrive with `name === "Error"`, so
+ * the class name is useless for matching: **every rule matches on `message`**,
+ * the one field that carries the full text on both the codegen-push and the
+ * forwarded-runtime paths. `message` is typed `unknown` because the overlay's
+ * own contract passes the error as `any`.
+ */
+interface NormalizedError {
+    message?: unknown;
+}
+
+/**
+ * A single Lunora error→solution rule. `test` runs against the error message;
+ * the first matching rule (in array order) wins, since the rules are evaluated
+ * by one finder that returns on first hit.
+ */
+interface LunoraSolutionRule {
+    /** Markdown body shown under the header. */
+    body: string;
+    /** Short Markdown header for the solution panel. */
+    header: string;
+    /** Stable id (used as the finder name in DEBUG logs and in tests). */
+    id: string;
+    /** True when this rule recognizes the error. */
+    test: (message: string) => boolean;
+}
+
+/**
+ * Lunora-specific error solutions for the dev error overlay. Ordered most- to
+ * least-specific; the dev-time codegen/schema rules come first because they're
+ * the errors a developer hits while editing `lunora/`, then the runtime
+ * data-layer conflicts that surface from the worker.
+ *
+ * Bodies are Markdown — the overlay parses `header`/`body` through its Markdown
+ * renderer before injecting them.
+ */
+const LUNORA_SOLUTION_RULES: ReadonlyArray<LunoraSolutionRule> = [
+    {
+        body: [
+            "Lunora codegen couldn't find a schema to generate from.",
+            "",
+            "Create `lunora/schema.ts` exporting a `defineSchema(...)` call:",
+            "",
+            "```ts",
+            'import { defineSchema, defineTable, v } from "@lunora/server";',
+            "",
+            "export default defineSchema({",
+            "  messages: defineTable({ body: v.string() }),",
+            "});",
+            "```",
+            "",
+            "Or scaffold a table with `vis generate lunora-table --name=messages`.",
+        ].join("\n"),
+        header: "No Lunora schema found",
+        id: "lunora-schema-missing",
+        test: (message) => message.includes("defineSchema() not found") || message.includes("schema.ts not found at"),
+    },
+    {
+        body: [
+            "`defineSchema(...)` must be called with an **inline object literal** mapping table names to `defineTable(...)`:",
+            "",
+            "```ts",
+            "export default defineSchema({",
+            "  todos: defineTable({ title: v.string(), done: v.boolean() }),",
+            "});",
+            "```",
+            "",
+            "Codegen reads the schema statically, so it can't follow a variable or a spread — pass the object literal directly.",
+        ].join("\n"),
+        header: "`defineSchema()` needs an inline object literal",
+        id: "lunora-schema-not-object-literal",
+        test: (message) => message.includes("defineSchema() expects an object literal"),
+    },
+    {
+        body: [
+            "This table name collides with a built-in `ctx.db` member, so the generated client can't expose it.",
+            "",
+            "Rename the table to anything that isn't a reserved name (the error lists them) — e.g. `userAccounts` instead of `insert`.",
+        ].join("\n"),
+        header: "Table name is reserved",
+        id: "lunora-table-reserved",
+        test: (message) => message.includes("is reserved") && message.includes("ctx.db"),
+    },
+    {
+        body: [
+            "Two tables resolve to the same name — usually a base table and a schema **extension** both defining it.",
+            "",
+            "Rename one of them, or drop the duplicate from the extension. Each table name must be unique across `defineSchema(...)` and every `.extend(...)`.",
+        ].join("\n"),
+        header: "Duplicate table name",
+        id: "lunora-table-duplicate",
+        // Anchor on `.extend(` — the only Lunora throw for this is
+        // `defineSchema(...).extend(...): table "x" already exists …`. Matching a
+        // bare "already exists"/"extension" pair would false-positive on
+        // unrelated forwarded errors (e.g. a "file already exists" + "extension").
+        test: (message) => message.includes("already exists") && message.includes(".extend("),
+    },
+    {
+        body: [
+            '`.jurisdiction(...)` accepts only a **string literal** of `"eu"`, `"us"`, or `"fedramp"`:',
+            "",
+            "```ts",
+            'defineSchema({ /* … */ }).jurisdiction("eu");',
+            "```",
+        ].join("\n"),
+        header: "Invalid `.jurisdiction(...)` value",
+        id: "lunora-jurisdiction",
+        test: (message) => message.includes("unknown jurisdiction") || (message.includes("jurisdiction") && message.includes('"eu", "us", or "fedramp"')),
+    },
+    {
+        body: [
+            "The `unique` flag on an index must be a **literal** `true` or `false`, not a computed value — codegen needs to read it statically:",
+            "",
+            "```ts",
+            'defineTable({ email: v.string() }).index("by_email", ["email"], { unique: true });',
+            "```",
+        ].join("\n"),
+        header: "`unique` must be a literal",
+        id: "lunora-unique-literal",
+        test: (message) => message.includes("must be a literal") && message.includes("unique"),
+    },
+    {
+        body: [
+            "A declared container/workflow class isn't re-exported by your worker entry, so `wrangler deploy` would reject it.",
+            "",
+            "Add the generated re-export shown in the error to your worker entry (e.g. `src/index.ts`):",
+            "",
+            "```ts",
+            'export * from "./lunora/_generated/containers";',
+            "```",
+        ].join("\n"),
+        header: "Binding not exported by your worker entry",
+        id: "lunora-worker-entry-export-gap",
+        test: (message) => message.includes("not exported by your worker entry"),
+    },
+    {
+        body: [
+            "A row with the same value already exists in a `unique` index.",
+            "",
+            "- If you meant to upsert, use `ctx.db.<table>().upsert(...)` (or `.patch(...)` an existing row) instead of `.insert(...)`.",
+            '- Otherwise pick a value that isn\'t already taken, and consider surfacing a friendly "already exists" message to the user.',
+        ].join("\n"),
+        header: "Unique constraint violation",
+        id: "lunora-runtime-unique",
+        test: (message) => message.includes("unique constraint violation on"),
+    },
+    {
+        body: [
+            "Another write changed this row while your mutation was running (optimistic concurrency conflict).",
+            "",
+            "Re-read the row and retry the mutation with the fresh value. Lunora serializes a DO's mutations, so a persistent conflict usually means the handler conflicts **with itself** (e.g. a trigger or cascade touching the same row) — split that work rather than adding a retry loop.",
+        ].join("\n"),
+        header: "Optimistic concurrency conflict",
+        id: "lunora-runtime-occ",
+        test: (message) => message.includes("optimistic concurrency conflict"),
+    },
+];
+
+/**
+ * Lunora's solution finder for the dev error overlay. A single finder that
+ * walks {@link LUNORA_SOLUTION_RULES} and returns the first match — so one
+ * `priority` slot covers every Lunora rule and the overlay's built-in finders
+ * still run for anything we don't recognize (we return `undefined`).
+ *
+ * Priority is high so a Lunora-specific hint wins over the overlay's generic
+ * finder for the same error; a user's own finder can still outrank it with a
+ * higher `priority`.
+ */
+const lunoraSolutionFinder: SolutionFinder = {
+    // Synchronous body wrapped in `Promise.resolve` rather than `async`: the
+    // overlay's `handle` contract is promise-returning, but `require-await` is on
+    // for src and there's nothing to await here.
+    handle: (error: NormalizedError): Promise<Solution | undefined> => {
+        const message = typeof error.message === "string" ? error.message : "";
+
+        for (const rule of LUNORA_SOLUTION_RULES) {
+            if (rule.test(message)) {
+                return Promise.resolve({ body: rule.body, header: rule.header });
+            }
+        }
+
+        return Promise.resolve(undefined);
+    },
+    name: "lunora",
+    priority: 100,
+};
+
+/** The finders Lunora injects into the overlay by default. */
+const lunoraSolutionFinders: ReadonlyArray<SolutionFinder> = [lunoraSolutionFinder];
+
+export type { LunoraSolutionRule, Solution, SolutionFinder };
+export { LUNORA_SOLUTION_RULES, lunoraSolutionFinder, lunoraSolutionFinders };

--- a/packages/vite/src/solution-finders.ts
+++ b/packages/vite/src/solution-finders.ts
@@ -1,3 +1,5 @@
+import { findLunoraSolution } from "@lunora/codegen";
+
 import type { OverlayPluginOptions } from "./types";
 
 /**
@@ -22,167 +24,21 @@ type Solution = NonNullable<Awaited<ReturnType<SolutionFinder["handle"]>>>;
  * class identity is gone by the time we see it (`error instanceof X` never
  * works here). Codegen/schema failures, which Lunora pushes through
  * `server.hot.send({ type: "error", … })`, arrive with `name === "Error"`, so
- * the class name is useless for matching: **every rule matches on `message`**,
- * the one field that carries the full text on both the codegen-push and the
- * forwarded-runtime paths. `message` is typed `unknown` because the overlay's
- * own contract passes the error as `any`.
+ * the class name is useless for matching: we match on the `message` text via
+ * `@lunora/codegen`'s shared {@link findLunoraSolution} table. `message` is
+ * typed `unknown` because the overlay's own contract passes the error as `any`.
  */
 interface NormalizedError {
     message?: unknown;
 }
 
 /**
- * A single Lunora error→solution rule. `test` runs against the error message;
- * the first matching rule (in array order) wins, since the rules are evaluated
- * by one finder that returns on first hit.
- */
-interface LunoraSolutionRule {
-    /** Markdown body shown under the header. */
-    body: string;
-    /** Short Markdown header for the solution panel. */
-    header: string;
-    /** Stable id (used as the finder name in DEBUG logs and in tests). */
-    id: string;
-    /** True when this rule recognizes the error. */
-    test: (message: string) => boolean;
-}
-
-/**
- * Lunora-specific error solutions for the dev error overlay. Ordered most- to
- * least-specific; the dev-time codegen/schema rules come first because they're
- * the errors a developer hits while editing `lunora/`, then the runtime
- * data-layer conflicts that surface from the worker.
- *
- * Bodies are Markdown — the overlay parses `header`/`body` through its Markdown
- * renderer before injecting them.
- */
-const LUNORA_SOLUTION_RULES: ReadonlyArray<LunoraSolutionRule> = [
-    {
-        body: [
-            "Lunora codegen couldn't find a schema to generate from.",
-            "",
-            "Create `lunora/schema.ts` exporting a `defineSchema(...)` call:",
-            "",
-            "```ts",
-            'import { defineSchema, defineTable, v } from "@lunora/server";',
-            "",
-            "export default defineSchema({",
-            "  messages: defineTable({ body: v.string() }),",
-            "});",
-            "```",
-            "",
-            "Or scaffold a table with `vis generate lunora-table --name=messages`.",
-        ].join("\n"),
-        header: "No Lunora schema found",
-        id: "lunora-schema-missing",
-        test: (message) => message.includes("defineSchema() not found") || message.includes("schema.ts not found at"),
-    },
-    {
-        body: [
-            "`defineSchema(...)` must be called with an **inline object literal** mapping table names to `defineTable(...)`:",
-            "",
-            "```ts",
-            "export default defineSchema({",
-            "  todos: defineTable({ title: v.string(), done: v.boolean() }),",
-            "});",
-            "```",
-            "",
-            "Codegen reads the schema statically, so it can't follow a variable or a spread — pass the object literal directly.",
-        ].join("\n"),
-        header: "`defineSchema()` needs an inline object literal",
-        id: "lunora-schema-not-object-literal",
-        test: (message) => message.includes("defineSchema() expects an object literal"),
-    },
-    {
-        body: [
-            "This table name collides with a built-in `ctx.db` member, so the generated client can't expose it.",
-            "",
-            "Rename the table to anything that isn't a reserved name (the error lists them) — e.g. `userAccounts` instead of `insert`.",
-        ].join("\n"),
-        header: "Table name is reserved",
-        id: "lunora-table-reserved",
-        test: (message) => message.includes("is reserved") && message.includes("ctx.db"),
-    },
-    {
-        body: [
-            "Two tables resolve to the same name — usually a base table and a schema **extension** both defining it.",
-            "",
-            "Rename one of them, or drop the duplicate from the extension. Each table name must be unique across `defineSchema(...)` and every `.extend(...)`.",
-        ].join("\n"),
-        header: "Duplicate table name",
-        id: "lunora-table-duplicate",
-        // Anchor on `.extend(` — the only Lunora throw for this is
-        // `defineSchema(...).extend(...): table "x" already exists …`. Matching a
-        // bare "already exists"/"extension" pair would false-positive on
-        // unrelated forwarded errors (e.g. a "file already exists" + "extension").
-        test: (message) => message.includes("already exists") && message.includes(".extend("),
-    },
-    {
-        body: [
-            '`.jurisdiction(...)` accepts only a **string literal** of `"eu"`, `"us"`, or `"fedramp"`:',
-            "",
-            "```ts",
-            'defineSchema({ /* … */ }).jurisdiction("eu");',
-            "```",
-        ].join("\n"),
-        header: "Invalid `.jurisdiction(...)` value",
-        id: "lunora-jurisdiction",
-        test: (message) => message.includes("unknown jurisdiction") || (message.includes("jurisdiction") && message.includes('"eu", "us", or "fedramp"')),
-    },
-    {
-        body: [
-            "The `unique` flag on an index must be a **literal** `true` or `false`, not a computed value — codegen needs to read it statically:",
-            "",
-            "```ts",
-            'defineTable({ email: v.string() }).index("by_email", ["email"], { unique: true });',
-            "```",
-        ].join("\n"),
-        header: "`unique` must be a literal",
-        id: "lunora-unique-literal",
-        test: (message) => message.includes("must be a literal") && message.includes("unique"),
-    },
-    {
-        body: [
-            "A declared container/workflow class isn't re-exported by your worker entry, so `wrangler deploy` would reject it.",
-            "",
-            "Add the generated re-export shown in the error to your worker entry (e.g. `src/index.ts`):",
-            "",
-            "```ts",
-            'export * from "./lunora/_generated/containers";',
-            "```",
-        ].join("\n"),
-        header: "Binding not exported by your worker entry",
-        id: "lunora-worker-entry-export-gap",
-        test: (message) => message.includes("not exported by your worker entry"),
-    },
-    {
-        body: [
-            "A row with the same value already exists in a `unique` index.",
-            "",
-            "- If you meant to upsert, use `ctx.db.<table>().upsert(...)` (or `.patch(...)` an existing row) instead of `.insert(...)`.",
-            '- Otherwise pick a value that isn\'t already taken, and consider surfacing a friendly "already exists" message to the user.',
-        ].join("\n"),
-        header: "Unique constraint violation",
-        id: "lunora-runtime-unique",
-        test: (message) => message.includes("unique constraint violation on"),
-    },
-    {
-        body: [
-            "Another write changed this row while your mutation was running (optimistic concurrency conflict).",
-            "",
-            "Re-read the row and retry the mutation with the fresh value. Lunora serializes a DO's mutations, so a persistent conflict usually means the handler conflicts **with itself** (e.g. a trigger or cascade touching the same row) — split that work rather than adding a retry loop.",
-        ].join("\n"),
-        header: "Optimistic concurrency conflict",
-        id: "lunora-runtime-occ",
-        test: (message) => message.includes("optimistic concurrency conflict"),
-    },
-];
-
-/**
  * Lunora's solution finder for the dev error overlay. A single finder that
- * walks {@link LUNORA_SOLUTION_RULES} and returns the first match — so one
- * `priority` slot covers every Lunora rule and the overlay's built-in finders
- * still run for anything we don't recognize (we return `undefined`).
+ * delegates to `@lunora/codegen`'s shared rule table (the same table the
+ * standalone `lunora dev` CLI prints to the terminal) and returns the first
+ * match — so one `priority` slot covers every Lunora rule and the overlay's
+ * built-in finders still run for anything we don't recognize (we return
+ * `undefined`).
  *
  * Priority is high so a Lunora-specific hint wins over the overlay's generic
  * finder for the same error; a user's own finder can still outrank it with a
@@ -194,14 +50,9 @@ const lunoraSolutionFinder: SolutionFinder = {
     // for src and there's nothing to await here.
     handle: (error: NormalizedError): Promise<Solution | undefined> => {
         const message = typeof error.message === "string" ? error.message : "";
+        const solution = findLunoraSolution(message);
 
-        for (const rule of LUNORA_SOLUTION_RULES) {
-            if (rule.test(message)) {
-                return Promise.resolve({ body: rule.body, header: rule.header });
-            }
-        }
-
-        return Promise.resolve(undefined);
+        return Promise.resolve(solution ? { body: solution.body, header: solution.header } : undefined);
     },
     name: "lunora",
     priority: 100,
@@ -210,5 +61,5 @@ const lunoraSolutionFinder: SolutionFinder = {
 /** The finders Lunora injects into the overlay by default. */
 const lunoraSolutionFinders: ReadonlyArray<SolutionFinder> = [lunoraSolutionFinder];
 
-export type { LunoraSolutionRule, Solution, SolutionFinder };
-export { LUNORA_SOLUTION_RULES, lunoraSolutionFinder, lunoraSolutionFinders };
+export type { Solution, SolutionFinder };
+export { lunoraSolutionFinder, lunoraSolutionFinders };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1688,6 +1688,9 @@ importers:
       '@visulima/cerebro':
         specifier: 3.0.0-alpha.32
         version: 3.0.0-alpha.32(@bomb.sh/tab@0.0.16(cac@6.7.14)(citty@0.2.2))(@visulima/pail@4.0.0-alpha.22(@opentelemetry/api@1.9.1)(@visulima/redact@3.0.0-alpha.14)(express@5.2.1)(hono@4.12.26)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)))(github-slugger@2.0.0)
+      '@visulima/error':
+        specifier: 6.0.0-alpha.34
+        version: 6.0.0-alpha.34
       '@visulima/fs':
         specifier: 5.0.0-alpha.32
         version: 5.0.0-alpha.32(ini@7.0.0)(json5@2.2.3)(jsonc-parser@3.3.1)(smol-toml@1.6.1)(yaml@2.9.0)


### PR DESCRIPTION
## What

Registers a Lunora-specific **solution-finder set** into the dev error overlay (`@visulima/vite-overlay`), so framework-specific failures render an actionable fix hint in the browser instead of a bare stack trace.

A single finder (`priority: 100`) walks an ordered rule table and returns the first match, leaving the overlay's built-in finders live for anything it doesn't recognise. Finders run **server-side** over a flattened error, and codegen/schema diagnostics arrive with `name === "Error"`, so every rule matches on the **message text**.

Recognised errors:
- missing / non-object-literal `defineSchema(...)`
- reserved or duplicate table names
- invalid `.jurisdiction(...)` value
- non-literal `unique` index flag
- container/workflow class not re-exported by the worker entry
- runtime unique-constraint and optimistic-concurrency (`ConflictError`) conflicts

## How

- `packages/vite/src/solution-finders.ts` (new) — the rule table + single finder. Bodies are static Markdown (no error text interpolated → no injection surface).
- `packages/vite/src/index.ts` — the overlay merge is extracted into a testable `resolveOverlayOption()`: Lunora's finders are **prepended** (a user's own finders are kept and can outrank via a strictly higher `priority`; equal priority keeps Lunora first via the overlay's stable sort), and `forwardedConsoleMethods` still defaults to `["error","warn"]`.
- Docs/README updated with the recognised errors and the custom-`solutionFinders` example.

## Review

Authored, then run through both thermo-nuclear review passes (branch audit + code quality). Verdict: no high/critical/medium findings. All low/minor findings fixed in this branch — tightened the duplicate-table matcher to anchor on `.extend(`, dropped a dead `name` field, documented the overlay type-derivation coupling, and added exactly-one-match + merge tests.

## Test plan

- `pnpm --filter "@lunora/vite" exec vitest run` — 20/20 pass (`solution-finders.test.ts` + `index.test.ts`)
- `pnpm --filter "@lunora/vite" run lint:types` — clean
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development error overlay that shows actionable hints for common setup and runtime issues.
  * Expanded overlay configuration: it can be fully disabled, accept forwarded console methods, and be customized with additional solution finders (using priority to determine precedence).
  * Enhanced codegen watch output with more structured, hint-based terminal errors (instead of a simple one-line message).
* **Documentation**
  * Updated the Vite plugin README and docs with a new **“Error overlay”** section, including configuration details and customization examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->