### PR TITLE
fix(studio): stop infinite render loops in admin panels

### DIFF
--- a/packages/studio/src/features/advisors/insights-panel.tsx
+++ b/packages/studio/src/features/advisors/insights-panel.tsx
@@ -161,6 +161,42 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
     // override lets tests drive a skewed distribution without a worker.
     const fanShardTraffic = loadShardTraffic ?? ((table: string): Promise<ShardTrafficResult> => client.shardTraffic(table));
 
+    // Fan the cross-shard traffic feed out so the hot_shard lint can see
+    // cross-shard skew — the one input a single shard's snapshot can't supply.
+    // Off the metrics hot path and best-effort: a rejection (older worker / no
+    // admin token) leaves hot_shard dormant rather than blanking the panel.
+    // Driven by any one table's live shard set — a DO holds every table, so each
+    // shard's getMetrics request total is the same regardless of which table
+    // seeds the fan-out; we dedupe by shardKey to be safe.
+    const loadShardTrafficFeed = async (tableNames: ReadonlyArray<string>): Promise<void> => {
+        // The fan-out needs ANY live table to enumerate the shard set; with no
+        // tables there's nothing to seed it, so skip the call entirely rather
+        // than POST an empty `table` the worker rejects with a 400.
+        const seedTable = tableNames[0];
+
+        if (seedTable === undefined || seedTable === "") {
+            setShardTraffic(null);
+
+            return;
+        }
+
+        try {
+            const traffic = await fanShardTraffic(seedTable);
+            const byShard = new Map<string, AdvisorShardTraffic>();
+
+            for (const entry of traffic.shards) {
+                if (!byShard.has(entry.shardKey)) {
+                    byShard.set(entry.shardKey, { requests: entry.requests, shardKey: entry.shardKey });
+                }
+            }
+
+            setShardTraffic([...byShard.values()]);
+        } catch {
+            // shard-traffic endpoint unavailable — leave hot_shard dormant.
+            setShardTraffic(null);
+        }
+    };
+
     const refresh = async (shard: string): Promise<void> => {
         const [snapshot, stats, advisorySnapshot] = await Promise.allSettled([
             client.query(GET_METRICS, {}, callOptions(shard)) as Promise<MetricsSnapshot>,
@@ -221,29 +257,7 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
             setDeclaredIndexes(null);
         }
 
-        // Fan the cross-shard traffic feed out so the hot_shard lint can see
-        // cross-shard skew — the one input a single shard's snapshot can't
-        // supply. Off the metrics hot path and best-effort: a rejection (older
-        // worker / no admin token) leaves hot_shard dormant rather than
-        // blanking the panel. Driven by any one table's live shard set — a DO
-        // holds every table, so each shard's getMetrics request total is the
-        // same regardless of which table seeds the fan-out; we dedupe by
-        // shardKey to be safe.
-        try {
-            const traffic = await fanShardTraffic(tableNames[0] ?? "");
-            const byShard = new Map<string, AdvisorShardTraffic>();
-
-            for (const entry of traffic.shards) {
-                if (!byShard.has(entry.shardKey)) {
-                    byShard.set(entry.shardKey, { requests: entry.requests, shardKey: entry.shardKey });
-                }
-            }
-
-            setShardTraffic([...byShard.values()]);
-        } catch {
-            // shard-traffic endpoint unavailable — leave hot_shard dormant.
-            setShardTraffic(null);
-        }
+        await loadShardTrafficFeed(tableNames);
     };
 
     // Drive the initial load and re-load whenever `shardKey` changes (debounced),

--- a/packages/studio/src/features/advisors/rls-panel.tsx
+++ b/packages/studio/src/features/advisors/rls-panel.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
@@ -68,7 +68,7 @@ const RlsPanel = (): ReactElement => {
     const [data, setData] = useState<RlsPoliciesResult | null>(null);
     const [error, setError] = useState<null | string>(null);
 
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         try {
             // Deployment-wide metadata (root shard), so no shard selector is needed.
             const result = (await client.query(RLS_POLICIES, {}, callOptions(""))) as RlsPoliciesResult;
@@ -83,7 +83,7 @@ const RlsPanel = (): ReactElement => {
         } catch (error_: unknown) {
             setError(errorMessage(error_));
         }
-    };
+    }, [client]);
 
     useEffect(() => {
         fireAndForget(refresh());

--- a/packages/studio/src/features/advisors/security-advisor-panel.tsx
+++ b/packages/studio/src/features/advisors/security-advisor-panel.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { TFunction } from "../../i18n/i18n-context";
 import { useT } from "../../i18n/i18n-context";
@@ -84,7 +84,7 @@ const SecurityAdvisorPanel = (): ReactElement => {
     const [findings, setFindings] = useState<SecurityFinding[] | null>(null);
     const [error, setError] = useState<null | string>(null);
 
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         try {
             const result = (await client.query(GET_SECURITY_AUDIT, {}, callOptions(""))) as SecurityAuditResult;
 
@@ -95,7 +95,7 @@ const SecurityAdvisorPanel = (): ReactElement => {
         } catch (error_: unknown) {
             setError(errorMessage(error_));
         }
-    };
+    }, [client]);
 
     useEffect(() => {
         fireAndForget(refresh());

--- a/packages/studio/src/features/analytics/analytics-panel.tsx
+++ b/packages/studio/src/features/analytics/analytics-panel.tsx
@@ -1,7 +1,7 @@
 import type { AnalyticsSqlResult } from "@lunora/bindings/analytics";
 import { createAnalyticsSqlClient } from "@lunora/bindings/analytics";
 import type { ReactElement } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Card } from "../../components/ui/card";
 import { EmptyState } from "../../components/ui/empty-state";
@@ -175,40 +175,43 @@ export const AnalyticsPanel = ({ config, dataset = DEFAULT_DATASET, runQuery }: 
         return (sql: string) => client.query(sql);
     }, [config, runQuery]);
 
-    const load = async (token: { cancelled: boolean }): Promise<void> => {
-        if (run === null) {
-            return;
-        }
-
-        for (const panel of PANEL_QUERIES) {
-            if (token.cancelled) {
+    const load = useCallback(
+        async (token: { cancelled: boolean }): Promise<void> => {
+            if (run === null) {
                 return;
             }
 
-            setStates((current) => {
-                return { ...current, [panel.key]: { error: null, loading: true, result: null } };
-            });
-
-            try {
-                // eslint-disable-next-line no-await-in-loop -- panels run sequentially to stay under the SQL API's per-token rate limit.
-                const result = await run(panel.sql(dataset));
-
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `cancelled` is flipped by the effect's cleanup during the await, so TS's narrowing from the loop-top guard is stale.
-                if (!token.cancelled) {
-                    setStates((current) => {
-                        return { ...current, [panel.key]: { error: null, loading: false, result } };
-                    });
+            for (const panel of PANEL_QUERIES) {
+                if (token.cancelled) {
+                    return;
                 }
-            } catch (error_) {
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `cancelled` is flipped by the effect's cleanup during the await, so TS's narrowing from the loop-top guard is stale.
-                if (!token.cancelled) {
-                    setStates((current) => {
-                        return { ...current, [panel.key]: { error: errorMessage(error_), loading: false, result: null } };
-                    });
+
+                setStates((current) => {
+                    return { ...current, [panel.key]: { error: null, loading: true, result: null } };
+                });
+
+                try {
+                    // eslint-disable-next-line no-await-in-loop -- panels run sequentially to stay under the SQL API's per-token rate limit.
+                    const result = await run(panel.sql(dataset));
+
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `cancelled` is flipped by the effect's cleanup during the await, so TS's narrowing from the loop-top guard is stale.
+                    if (!token.cancelled) {
+                        setStates((current) => {
+                            return { ...current, [panel.key]: { error: null, loading: false, result } };
+                        });
+                    }
+                } catch (error_) {
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `cancelled` is flipped by the effect's cleanup during the await, so TS's narrowing from the loop-top guard is stale.
+                    if (!token.cancelled) {
+                        setStates((current) => {
+                            return { ...current, [panel.key]: { error: errorMessage(error_), loading: false, result: null } };
+                        });
+                    }
                 }
             }
-        }
-    };
+        },
+        [run, dataset],
+    );
 
     useEffect(() => {
         const token = { cancelled: false };

--- a/packages/studio/src/features/auth/users-panel.tsx
+++ b/packages/studio/src/features/auth/users-panel.tsx
@@ -1,7 +1,7 @@
 import type { AuthUser } from "@lunora/client";
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -47,7 +47,7 @@ export const UsersPanel = ({ pageSize = DEFAULT_PAGE_SIZE }: UsersPanelProps = {
     const [createOpen, setCreateOpen] = useState<boolean>(false);
     const { capabilities } = useAuthCapabilities();
 
-    const fetchUsers = async (): Promise<void> => {
+    const fetchUsers = useCallback(async (): Promise<void> => {
         setUsersError(null);
 
         const trimmedSearch = debouncedSearch.trim();
@@ -66,7 +66,7 @@ export const UsersPanel = ({ pageSize = DEFAULT_PAGE_SIZE }: UsersPanelProps = {
             setUsers(null);
             setUsersError(errorMessage(error_));
         }
-    };
+    }, [client, debouncedSearch, roleFilter, pageSize]);
 
     // Post-mutation refetch callback for the detail drawer / create dialog.
     const reloadUsers = (): void => {

--- a/packages/studio/src/features/data/hooks/use-mask-policies.ts
+++ b/packages/studio/src/features/data/hooks/use-mask-policies.ts
@@ -1,5 +1,5 @@
 import { useLunora } from "@lunora/react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { MaskColumnMetadata, MaskPoliciesResult } from "../../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../../lib/admin";
@@ -26,7 +26,7 @@ const useMaskPolicies = (): ReadonlyArray<MaskColumnMetadata> => {
     const client = useLunora();
     const [columns, setColumns] = useState<ReadonlyArray<MaskColumnMetadata>>(NO_COLUMNS);
 
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         try {
             const result = (await client.query(MASK_POLICIES, {}, callOptions(""))) as MaskPoliciesResult;
 
@@ -34,7 +34,7 @@ const useMaskPolicies = (): ReadonlyArray<MaskColumnMetadata> => {
         } catch {
             setColumns(NO_COLUMNS);
         }
-    };
+    }, [client]);
 
     useEffect(() => {
         fireAndForget(refresh());

--- a/packages/studio/src/features/logs/mail-panel.tsx
+++ b/packages/studio/src/features/logs/mail-panel.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { ChangeEvent, MouseEvent, ReactElement } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -100,7 +100,7 @@ const MailPanel = ({ limit = 100 }: MailPanelProps): ReactElement => {
     const [tab, setTab] = useState<PreviewTab>("html");
     const [filter, setFilter] = useState<string>("");
 
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         setError(null);
 
         try {
@@ -111,7 +111,7 @@ const MailPanel = ({ limit = 100 }: MailPanelProps): ReactElement => {
             setEntries([]);
             setError(errorMessage(error_));
         }
-    };
+    }, [client, limit]);
 
     const clearInbox = async (): Promise<void> => {
         setError(null);

--- a/packages/studio/src/features/payments/payments-panel.tsx
+++ b/packages/studio/src/features/payments/payments-panel.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
@@ -87,7 +87,7 @@ const PaymentsPanel = ({ limit = 100 }: PaymentsPanelProps): ReactElement => {
     const [events, setEvents] = useState<Row[]>([]);
     const [error, setError] = useState<null | string>(null);
 
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         setError(null);
 
         try {
@@ -100,7 +100,7 @@ const PaymentsPanel = ({ limit = 100 }: PaymentsPanelProps): ReactElement => {
             setEvents([]);
             setError(errorMessage(error_));
         }
-    };
+    }, [client, limit]);
 
     useEffect(() => {
         fireAndForget(refresh());

--- a/packages/studio/src/features/permissions/permissions-matrix.tsx
+++ b/packages/studio/src/features/permissions/permissions-matrix.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { LiveError } from "../../components/live-status";
 import { Badge } from "../../components/ui/badge";
@@ -141,7 +141,7 @@ export const PermissionsMatrix = ({ onProbe }: PermissionsMatrixProps = {}): Rea
     // One-shot load for the supporting metadata (masks + advisories). The policy
     // list is the live channel below; masks and advisories only change on codegen,
     // and a stale read here merely under-/over-flags a cell until the next mount.
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         const queryRls = client.query(RLS_POLICIES, {}, callOptions("")) as Promise<RlsPoliciesResult>;
         const queryMasks = client.query(MASK_POLICIES, {}, callOptions("")) as Promise<MaskPoliciesResult>;
         const queryAdvisories = client.query(GET_ADVISORIES, {}, callOptions("")) as Promise<AdvisoriesResult>;
@@ -164,7 +164,7 @@ export const PermissionsMatrix = ({ onProbe }: PermissionsMatrixProps = {}): Rea
         } catch (error_: unknown) {
             setError(errorMessage(error_));
         }
-    };
+    }, [client]);
 
     useEffect(() => {
         fireAndForget(refresh());

--- a/packages/studio/src/features/storage/storage-rules-panel.tsx
+++ b/packages/studio/src/features/storage/storage-rules-panel.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
@@ -46,7 +46,7 @@ export const StorageRulesPanel = (): ReactElement => {
     const [data, setData] = useState<StorageRulesResult | null>(null);
     const [error, setError] = useState<null | string>(null);
 
-    const refresh = async (): Promise<void> => {
+    const refresh = useCallback(async (): Promise<void> => {
         try {
             const result = (await client.query(STORAGE_RULES, {}, callOptions(""))) as StorageRulesResult;
 
@@ -55,7 +55,7 @@ export const StorageRulesPanel = (): ReactElement => {
         } catch (error_: unknown) {
             setError(errorMessage(error_));
         }
-    };
+    }, [client]);
 
     useEffect(() => {
         fireAndForget(refresh());


### PR DESCRIPTION
## Problem

Opening `/__lunora/data` (and several other studio pages) appeared to "fail to connect" and spun in a loop. The real cause was an **infinite React render loop**, not a network failure.

Nine panels fetched inside a `useEffect` whose only dependency was an async function recreated on every render:

```js
const refresh = async () => { … setColumns(result.columns) … };  // new identity each render
useEffect(() => { fireAndForget(refresh()); }, [refresh]);        // dep changes every render
```

Each fetch set state to a fresh array/object → re-render → new `refresh` → effect re-fires → fetch again. It hammered `/_lunora/rpc` until Chrome exhausted its socket pool (`ERR_INSUFFICIENT_RESOURCES`). A single `/__lunora/data` load issued **~12,000 requests / 4,203 console errors**.

## Fix

Memoize each fetch with `useCallback` (deps: the stable `client` plus the panel's own inputs) so the effect's dependency is stable and the load runs once per real input change.

Affected panels: `data/use-mask-policies`, `advisors/{security,rls}`, `permissions-matrix`, `storage-rules`, `logs/mail`, `payments`, `analytics`, `auth/users`.

Also:
- Guard `insights-panel`'s shard-traffic fan-out so it isn't POSTed with an empty `table` (the worker rightly 400s that), and extract the fan-out into a helper to stay under the complexity gate.

## Verification

Drove all **31 studio routes** with Playwright:
- One `/__lunora/data` load: **4,203 console errors → 0**.
- Full sweep now yields only benign, by-design endpoint degradations (single-DO `shard-traffic` 400 is intentional + has a server test; workflows `501`; a WS teardown race).
- `tsc --noEmit` clean; ESLint clean on all changed files.

## Follow-up

A full TanStack Query migration of the studio (the QueryClient is already provided by `LunoraProvider`) will land next to prevent this bug class structurally and dedupe shared admin reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across several Studio panels by stabilizing refresh behavior, reducing unnecessary re-renders and repeated data loads.
  * Made cross-shard traffic loading more resilient by avoiding empty lookups, deduplicating shard entries, and treating load failures as no-data instead of errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->