### PR TITLE
refactor: hoist ExecutionContextLike into shared/

### DIFF
--- a/apps/playground/lunora/inbound.ts
+++ b/apps/playground/lunora/inbound.ts
@@ -52,11 +52,10 @@ export const onEmail = mutation
     });
 
 /** Most-recently-received inbox messages, newest first via the `by_received` index. */
-export const list = query.input({ limit: v.optional(v.number()) }).query(
-    async ({ args, ctx }): Promise<Doc<"inbox">[]> =>
-        ctx.db
-            .query("inbox")
-            .withIndex("by_received")
-            .order("desc")
-            .take(args.limit ?? 50),
+export const list = query.input({ limit: v.optional(v.number()) }).query(async ({ args, ctx }): Promise<Doc<"inbox">[]> =>
+    ctx.db
+        .query("inbox")
+        .withIndex("by_received")
+        .order("desc")
+        .take(args.limit ?? 50),
 );

--- a/apps/playground/lunora/messages.ts
+++ b/apps/playground/lunora/messages.ts
@@ -15,12 +15,11 @@ const limits = { send: { kind: "token bucket", period: 60_000, rate: 30 } } sati
  * schema means the runtime routes this query to exactly the channel's DO —
  * no fan-out, full real-time subscriptions.
  */
-export const list = query.input({ channelId: v.id("channels"), limit: v.optional(v.number()) }).query(
-    async ({ args, ctx }): Promise<Doc<"messages">[]> =>
-        ctx.db
-            .query("messages")
-            .withIndex("by_channel_created", (q) => q.eq("channelId", args.channelId))
-            .take(args.limit ?? 50),
+export const list = query.input({ channelId: v.id("channels"), limit: v.optional(v.number()) }).query(async ({ args, ctx }): Promise<Doc<"messages">[]> =>
+    ctx.db
+        .query("messages")
+        .withIndex("by_channel_created", (q) => q.eq("channelId", args.channelId))
+        .take(args.limit ?? 50),
 );
 
 /**

--- a/examples/payment-demo/lunora/billing.ts
+++ b/examples/payment-demo/lunora/billing.ts
@@ -48,8 +48,8 @@ export const apiCallsRemaining = action.action(async ({ ctx }): Promise<{ allowe
 });
 
 /** Open the Stripe billing portal for the demo reference (customer derived from the store). */
-export const portal = action.action(
-    async ({ ctx }): Promise<{ url: string }> => ctx.payments.createPortalSession(DEMO_REFERENCE, "https://example.com/account"),
+export const portal = action.action(async ({ ctx }): Promise<{ url: string }> =>
+    ctx.payments.createPortalSession(DEMO_REFERENCE, "https://example.com/account"),
 );
 
 /** Reactive read of the webhook-synced subscriptions for the demo reference. */

--- a/packages/bindings/__tests__/vectors/create-vectors.test.ts
+++ b/packages/bindings/__tests__/vectors/create-vectors.test.ts
@@ -15,11 +15,10 @@ const fakeIndex = (overrides: Partial<VectorizeIndexLike> = {}): VectorizeIndexL
         deleteByIds: vi.fn<VectorizeIndexLike["deleteByIds"]>(async (ids: ReadonlyArray<string>): Promise<VectorizeDeleteMutation> => {
             return { count: ids.length, mutationId: `delete-${String(ids.length)}` };
         }),
-        getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(
-            async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
-                ids.map((id) => {
-                    return { id, values: [0, 0, 0] };
-                }),
+        getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+            ids.map((id) => {
+                return { id, values: [0, 0, 0] };
+            }),
         ),
         insert: vi.fn<VectorizeIndexLike["insert"]>(async (vectors): Promise<VectorizeUpsertMutation> => {
             return { mutationId: `insert-${String(vectors.length)}` };

--- a/packages/bindings/__tests__/vectors/ctx.test.ts
+++ b/packages/bindings/__tests__/vectors/ctx.test.ts
@@ -10,11 +10,10 @@ const fakeIndex = (overrides: Partial<VectorizeIndexLike> = {}): VectorizeIndexL
         deleteByIds: vi.fn<VectorizeIndexLike["deleteByIds"]>(async (ids: ReadonlyArray<string>): Promise<VectorizeDeleteMutation> => {
             return { count: ids.length, mutationId: `delete-${String(ids.length)}` };
         }),
-        getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(
-            async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
-                ids.map((id) => {
-                    return { id, metadata: { k: id }, values: [1, 2] };
-                }),
+        getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+            ids.map((id) => {
+                return { id, metadata: { k: id }, values: [1, 2] };
+            }),
         ),
         insert: vi.fn<VectorizeIndexLike["insert"]>(async (vectors): Promise<VectorizeUpsertMutation> => {
             return { mutationId: `insert-${String(vectors.length)}` };

--- a/packages/cli/src/util/insert-schema-extension.ts
+++ b/packages/cli/src/util/insert-schema-extension.ts
@@ -20,8 +20,7 @@ import type { CallExpression, Node as TsNode } from "ts-morph";
 import { Node, Project, SyntaxKind } from "ts-morph";
 
 type InsertSchemaExtensionResult =
-    | { ok: true; text: string }
-    | { ok: false; reason: "already-applied" | "invalid-identifier" | "no-define-schema" | "non-object-argument" };
+    { ok: true; text: string } | { ok: false; reason: "already-applied" | "invalid-identifier" | "no-define-schema" | "non-object-argument" };
 
 /**
  * A valid JavaScript identifier. The item key is spliced into `schema.ts` as a

--- a/packages/cli/src/util/wrangler-secrets.ts
+++ b/packages/cli/src/util/wrangler-secrets.ts
@@ -7,8 +7,14 @@
  * reconcile against and `env diff` needs to compare. The command runner is
  * injectable so tests can stub the wrangler invocation.
  */
-import type { ExecFileException } from "node:child_process";
 import { execFile } from "node:child_process";
+
+/**
+ * The shape of an `execFile` callback error we care about. `@types/node`'s
+ * `ExecFileException` covers this but is now deprecated; we only read `code`
+ * (a number, or an `errno` string like `ENOENT`), so type it structurally.
+ */
+type ExecFileError = Error & { code?: number | string | null };
 
 interface SecretListRunnerResult {
     code: number;
@@ -39,7 +45,7 @@ interface ListRemoteSecretsResult {
 }
 
 /** Map an execFile error to an exit code (0 on success, the child's code, else 1). */
-const execCode = (error: ExecFileException | null): number => {
+const execCode = (error: ExecFileError | null): number => {
     if (!error) {
         return 0;
     }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -399,13 +399,7 @@ export interface ServerWhisperMessage {
 }
 
 export type ServerMessage =
-    | ServerAckMessage
-    | ServerChunkMessage
-    | ServerCompleteMessage
-    | ServerDataMessage
-    | ServerErrorMessage
-    | ServerResumeMessage
-    | ServerWhisperMessage;
+    ServerAckMessage | ServerChunkMessage | ServerCompleteMessage | ServerDataMessage | ServerErrorMessage | ServerResumeMessage | ServerWhisperMessage;
 
 /**
  * The authenticated user as exposed client-side, mirroring better-auth's

--- a/packages/config/src/schema-edit/parse.ts
+++ b/packages/config/src/schema-edit/parse.ts
@@ -47,8 +47,7 @@ interface SchemaTable {
 
 /** Result of parsing a schema source string. */
 type ParseSchemaResult =
-    | { ok: false; reason: "aliased-define-schema" | "no-define-schema" | "non-object-argument" }
-    | { ok: true; tables: ReadonlyArray<SchemaTable> };
+    { ok: false; reason: "aliased-define-schema" | "no-define-schema" | "non-object-argument" } | { ok: true; tables: ReadonlyArray<SchemaTable> };
 
 const OPTIONAL_VALIDATOR_PATTERN = /^v\s*\.\s*optional\s*\(/u;
 const SHARD_BY_PATTERN = /\.shardBy\(\s*["']([^"']+)["']\s*\)/u;

--- a/packages/db/docs/index.mdx
+++ b/packages/db/docs/index.mdx
@@ -113,7 +113,7 @@ function Chat({ channelId }: { channelId: Id<"channels"> }) {
 
     const send = (text: string) => db.actions.messages({ channelId, text, userId: me });
 
-    return /* … */;
+    return; /* … */
 }
 ```
 

--- a/packages/nuxt/__tests__/h3-request.test.ts
+++ b/packages/nuxt/__tests__/h3-request.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveWebRequest } from "../src/runtime/h3-request";
+
+// `resolveWebRequest` is the one piece of the `/_lunora/**` Nitro handler that
+// changes shape across the widened `h3: "^1.0.0 || ^2.0.0"` peer range, so it is
+// the thing the new v2 support actually has to get right. v1 exposes
+// `toWebRequest(event)`; v2 removed it and carries the web `Request` as
+// `event.req`. Driving both stubs here exercises the v2 path deterministically
+// without installing a second h3 major or booting Nitro — a CI matrix over the
+// installed h3 version could not reach the branch that no real fixture hits.
+describe("resolveWebRequest across the h3 v1 → v2 seam", () => {
+    it("calls toWebRequest(event) under h3 v1", () => {
+        const request = new Request("https://app.test/_lunora/rpc", { method: "POST" });
+        const toWebRequest = vi.fn(() => request);
+        const event = { context: {} };
+
+        expect(resolveWebRequest({ toWebRequest }, event)).toBe(request);
+        expect(toWebRequest).toHaveBeenCalledWith(event);
+    });
+
+    it("reads event.req when h3 v2 dropped toWebRequest", () => {
+        const request = new Request("https://app.test/_lunora/ws");
+
+        // v2: `toWebRequest` is absent, so the namespace reads back `undefined`
+        // (a real ESM namespace returns undefined for a missing export, not a throw).
+        expect(resolveWebRequest({}, { req: request })).toBe(request);
+    });
+});

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -78,7 +78,7 @@
         "vitest": "catalog:test"
     },
     "peerDependencies": {
-        "h3": "^1.0.0",
+        "h3": "^1.0.0 || ^2.0.0",
         "nuxt": "^4.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -73,7 +73,7 @@
         "@types/node": "catalog:types",
         "@vitest/coverage-v8": "catalog:test",
         "fallow": "catalog:lint",
-        "h3": "^2.0.0",
+        "h3": "^1.0.0",
         "typescript": "catalog:tsc",
         "vitest": "catalog:test"
     },

--- a/packages/nuxt/src/runtime/cloudflare.ts
+++ b/packages/nuxt/src/runtime/cloudflare.ts
@@ -18,12 +18,7 @@
  * so this seam stays pure (no Nitro types needed) and unit-testable with a plain
  * object — a real `H3Event` is still assignable here.
  */
-
-/** Cloudflare `ExecutionContext` subset Lunora uses (`waitUntil` / `passThroughOnException`). */
-interface ExecutionContextLike {
-    passThroughOnException?: () => void;
-    waitUntil?: (promise: Promise<unknown>) => void;
-}
+import type { ExecutionContextLike } from "../../../../shared/execution-context";
 
 /** The `{ env, context|ctx }` payload Nitro attaches for the Cloudflare runtime. */
 interface CloudflareEventBag {
@@ -70,5 +65,7 @@ const resolveCloudflare = (event: H3EventLike): ResolvedCloudflare => {
     return {};
 };
 
-export type { ExecutionContextLike, H3EventLike, ResolvedCloudflare };
+export type { H3EventLike, ResolvedCloudflare };
 export { resolveCloudflare };
+
+export { type ExecutionContextLike } from "../../../../shared/execution-context";

--- a/packages/nuxt/src/runtime/h3-request.ts
+++ b/packages/nuxt/src/runtime/h3-request.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve the inbound web `Request` from an H3 event across the h3 v1 → v2 break.
+ *
+ * v1 exposes `toWebRequest(event)`; the v2 web-standards rewrite removed it and
+ * carries the web `Request` directly as `event.req`. The `@lunora/nuxt` seam
+ * supports both (peer range `h3: "^1.0.0 || ^2.0.0"`), so we feature-detect
+ * `toWebRequest` at runtime rather than importing it statically — a named
+ * `import { toWebRequest }` would throw at module-eval under v2 (missing export).
+ *
+ * Kept as a pure helper (the `h3` namespace + event in, a `Request` out) so both
+ * branches are unit-tested without booting Nitro or installing a second h3 major.
+ */
+// `toWebRequest` is typed `unknown` (not a call signature) so the real `h3`
+// namespace — whose `toWebRequest` takes a narrow `H3Event` — stays assignable
+// under `strictFunctionTypes`; we re-narrow it to a `Request` factory at the call.
+interface H3RequestNamespace {
+    toWebRequest?: unknown;
+}
+
+const resolveWebRequest = (h3: H3RequestNamespace, event: unknown): Request =>
+    typeof h3.toWebRequest === "function"
+        ? (h3.toWebRequest as (event: unknown) => Request)(event) // h3 v1
+        : (event as { req: Request }).req; // h3 v2 — `event.req` is the web Request
+
+export type { H3RequestNamespace };
+export { resolveWebRequest };

--- a/packages/nuxt/src/runtime/handler.ts
+++ b/packages/nuxt/src/runtime/handler.ts
@@ -15,7 +15,8 @@
  * boot required. The thin H3 adapter that reads `env`/`ctx` off the event and
  * the raw `Request`/`Response` lives in the `[...].ts` route module.
  */
-import type { ExecutionContextLike } from "./cloudflare";
+import type { ExecutionContextLike } from "../../../../shared/execution-context";
+import { NOOP_EXECUTION_CONTEXT } from "../../../../shared/execution-context";
 
 /**
  * Structural view of the Lunora worker the route delegates to — just the
@@ -26,12 +27,6 @@ import type { ExecutionContextLike } from "./cloudflare";
 interface LunoraWorkerLike {
     fetch: (request: Request, env: unknown, context: ExecutionContextLike) => Promise<Response> | Response;
 }
-
-/** A no-op `ExecutionContext` used when the Cloudflare runtime didn't supply one (so `worker.fetch` always gets a valid 3rd arg). */
-const NOOP_EXECUTION_CONTEXT: ExecutionContextLike = {
-    passThroughOnException: () => {},
-    waitUntil: () => {},
-};
 
 /**
  * Forward one inbound request to the Lunora worker. `env` must be the Cloudflare
@@ -62,4 +57,6 @@ const delegateToLunora = async (
 };
 
 export type { LunoraWorkerLike };
-export { delegateToLunora, NOOP_EXECUTION_CONTEXT };
+export { delegateToLunora };
+
+export { NOOP_EXECUTION_CONTEXT } from "../../../../shared/execution-context";

--- a/packages/nuxt/src/runtime/server/lunora.ts
+++ b/packages/nuxt/src/runtime/server/lunora.ts
@@ -17,7 +17,7 @@
  * v1 → v2 break: v1 exposes `toWebRequest(event)`, while the v2 web-standards
  * rewrite removed it and carries the web `Request` directly as `event.req`. A
  * static `import { toWebRequest }` would throw at module-eval under v2 (missing
- * named export), so we feature-detect it at runtime instead.
+ * named export), so `resolveWebRequest` feature-detects it at runtime instead.
  */
 // eslint-disable-next-line import/no-namespace -- a namespace import is required to feature-detect `toWebRequest`, which v2 removed (a static named import would throw at module-eval).
 import * as h3 from "h3";
@@ -28,6 +28,7 @@ import * as h3 from "h3";
 import lunoraApp from "#lunora/app";
 
 import { resolveCloudflare } from "../cloudflare";
+import { resolveWebRequest } from "../h3-request";
 import { delegateToLunora } from "../handler";
 
 /**
@@ -39,10 +40,7 @@ import { delegateToLunora } from "../handler";
  */
 export default h3.defineEventHandler(async (event) => {
     const { ctx, env } = resolveCloudflare(event as never);
-    const request =
-        typeof h3.toWebRequest === "function"
-            ? h3.toWebRequest(event) // h3 v1
-            : (event as unknown as { req: Request }).req; // h3 v2 — `event.req` is the web Request
+    const request = resolveWebRequest(h3, event);
 
     return delegateToLunora(lunoraApp, request, env, ctx);
 });

--- a/packages/nuxt/src/runtime/server/lunora.ts
+++ b/packages/nuxt/src/runtime/server/lunora.ts
@@ -12,10 +12,15 @@
  * entrypoint via the project's `exports.cloudflare.ts`, so one deploy carries
  * both the SSR handler and the Durable Object class.
  *
- * This file is only ever bundled by Nitro; `h3`'s `defineEventHandler` and
- * `toWebRequest` are its sole framework imports.
+ * This file is only ever bundled by Nitro; `h3`'s `defineEventHandler` is its
+ * sole framework entry. We use a namespace import so the seam spans the h3
+ * v1 → v2 break: v1 exposes `toWebRequest(event)`, while the v2 web-standards
+ * rewrite removed it and carries the web `Request` directly as `event.req`. A
+ * static `import { toWebRequest }` would throw at module-eval under v2 (missing
+ * named export), so we feature-detect it at runtime instead.
  */
-import { defineEventHandler, toWebRequest } from "h3";
+// eslint-disable-next-line import/no-namespace -- a namespace import is required to feature-detect `toWebRequest`, which v2 removed (a static named import would throw at module-eval).
+import * as h3 from "h3";
 
 // `#lunora/app` is a virtual specifier the @lunora/nuxt module registers
 // (nuxt.options.alias + nitro virtual). Its default export is the project's
@@ -32,9 +37,12 @@ import { delegateToLunora } from "../handler";
  * off the event, and return the worker's `Response` verbatim (H3 streams it,
  * including a `101 Switching Protocols` upgrade with its `webSocket`).
  */
-export default defineEventHandler(async (event) => {
+export default h3.defineEventHandler(async (event) => {
     const { ctx, env } = resolveCloudflare(event as never);
-    const request = toWebRequest(event);
+    const request =
+        typeof h3.toWebRequest === "function"
+            ? h3.toWebRequest(event) // h3 v1
+            : (event as unknown as { req: Request }).req; // h3 v2 — `event.req` is the web Request
 
     return delegateToLunora(lunoraApp, request, env, ctx);
 });

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -1,10 +1,13 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["node"]
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): `lint:types`
+        // is `tsc --noEmit` and the real build is packem (driven by package.json
+        // exports), so neither is load-bearing here. A set `rootDir` would raise
+        // TS6059 for the inlined `../../../../shared/execution-context` import (a file
+        // outside this package, bundled in at build time). See shared/execution-context.ts.
     },
     "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -1,3 +1,5 @@
+import type { ExecutionContextLike } from "../../../shared/execution-context";
+import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
 import type { AuthAdmin, AuthIntrospector } from "./auth-admin-routes";
 import { buildAuthAdminRoutes } from "./auth-admin-routes";
 import { MAX_BODY_BYTES, readBodyBytesWithLimit, readBodyTextWithLimit, readJsonBodyWithLimit } from "./body-readers";
@@ -38,11 +40,6 @@ interface RpcEnvelope {
     fanOut?: FanOutSpec;
     functionPath: string;
     shardKey?: string;
-}
-
-interface ExecutionContextLike {
-    passThroughOnException: () => void;
-    waitUntil: (promise: Promise<unknown>) => void;
 }
 
 type Route = (request: Request, env: unknown, context: ExecutionContextLike) => Promise<Response> | Response;
@@ -2122,7 +2119,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             const sinkContext: ObservabilitySinkContext | undefined = context
                 ? {
                       waitUntil: (promise) => {
-                          context.waitUntil(promise);
+                          context.waitUntil?.(promise);
                       },
                   }
                 : undefined;
@@ -2510,7 +2507,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         const basePath = options.authBasePath ?? DEFAULT_AUTH_BASE_PATH;
 
         if (isAuthAttemptPath(url.pathname, basePath)) {
-            context.waitUntil(recordAuthAttempt(env, authResponse.status >= 400 ? "fail" : "ok"));
+            context.waitUntil?.(recordAuthAttempt(env, authResponse.status >= 400 ? "fail" : "ok"));
         }
 
         return authResponse;
@@ -2640,7 +2637,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     return {
         async fetch(request, env, context) {
             if (options.passThroughOnException) {
-                context.passThroughOnException();
+                context.passThroughOnException?.();
             }
 
             // Resolve env-driven security knobs before the preflight/CSRF guards
@@ -2816,16 +2813,6 @@ const withFrameworkWorker = (host: FrameworkHostHandler, optionsInput: Framework
 type LunoraHandlerOptions = ((env: unknown) => FrameworkWorkerOptions) | Partial<FrameworkWorkerOptions>;
 
 /**
- * No-op `ExecutionContext` used when the host runtime didn't supply one (a
- * non-Cloudflare preview, or a unit test), so the worker's `fetch` always
- * receives a valid third argument.
- */
-const NOOP_EXECUTION_CONTEXT: ExecutionContextLike = {
-    passThroughOnException: () => {},
-    waitUntil: () => {},
-};
-
-/**
  * Resolve per-request Lunora worker options. A factory is called with the
  * request `env`; a partial object has its `shardDO` defaulted to `env.SHARD` so
  * the common case needs no configuration. Throws a clear error when no shard
@@ -2889,7 +2876,7 @@ const createLunoraHandler =
 /** Re-exported helper so callers can roundtrip envelopes in tests. */
 const defineRpcEnvelope = (envelope: RpcEnvelope): RpcEnvelope => envelope;
 
-export { composeWorker, createLunoraHandler, createWorker, defineRpcEnvelope, NOOP_EXECUTION_CONTEXT, resolveLunoraOptions, withFrameworkWorker };
+export { composeWorker, createLunoraHandler, createWorker, defineRpcEnvelope, resolveLunoraOptions, withFrameworkWorker };
 export type {
     AdminTableResolver,
     BackupManifest,
@@ -2897,7 +2884,6 @@ export type {
     CronHandler,
     CronJobDispatch,
     CronJobInfo,
-    ExecutionContextLike,
     FrameworkHostHandler,
     FrameworkWorkerOptions,
     FrameworkWorkerOptionsInput,
@@ -2934,6 +2920,7 @@ export type {
     WorkerOptions,
 };
 
+export { type ExecutionContextLike, NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
 export type {
     AuthAdmin,
     AuthCapabilities,

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,10 +1,13 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types", "node"]
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): `lint:types`
+        // is `tsc --noEmit` and the real build is packem (driven by package.json
+        // exports), so neither is load-bearing here. A set `rootDir` would raise
+        // TS6059 for the inlined `../../../shared/execution-context` import (a file
+        // outside this package, bundled in at build time). See shared/execution-context.ts.
     },
     "include": ["src/**/*", "__tests__/**/*", "__bench__/**/*"]
 }

--- a/packages/studio/src/lib/policy-scaffold.ts
+++ b/packages/studio/src/lib/policy-scaffold.ts
@@ -54,9 +54,7 @@ const FAILURE_MESSAGES: Readonly<Record<string, string>> = {
 
 /** Outcome of a scaffold/wire apply, normalising every host response. */
 type PolicyScaffoldResult =
-    | { diagnostics: ReadonlyArray<string>; kind: "ok"; label: string }
-    | { kind: "error"; message: string }
-    | { kind: "needs-manual-edit"; message: string };
+    { diagnostics: ReadonlyArray<string>; kind: "ok"; label: string } | { kind: "error"; message: string } | { kind: "needs-manual-edit"; message: string };
 
 /** Apply a scaffolder request through the dev host, normalising every outcome. */
 const applyPolicyScaffold = async (request: PolicyScaffoldRequest): Promise<PolicyScaffoldResult> => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2295,8 +2295,8 @@ importers:
         specifier: catalog:lint
         version: 2.102.0
       h3:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^1.0.0
+        version: 1.15.11
       typescript:
         specifier: catalog:tsc
         version: 6.0.3
@@ -13898,10 +13898,6 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
-
-  h3@2.0.0:
-    resolution: {integrity: sha512-3INyyEir2VkWXD3auY+uUL/mqrgYX5ejRdUjtjyd4AOZcoijIyvf6PkBPsn+NFGE5rks2nCcMIOLZGTxpp/A7w==}
-    deprecated: please use 1.x or beta
 
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
@@ -30850,8 +30846,6 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
-
-  h3@2.0.0: {}
 
   h3@2.0.1-rc.20:
     dependencies:

--- a/shared/execution-context.ts
+++ b/shared/execution-context.ts
@@ -1,0 +1,36 @@
+/**
+ * The subset of the Cloudflare `ExecutionContext` the Lunora worker entry and
+ * the framework mount seams rely on — `waitUntil` for fire-and-forget work that
+ * must outlive the response, and `passThroughOnException` for the top-level
+ * error posture.
+ *
+ * It is deliberately **not** a package. `@lunora/runtime` is the leaf server
+ * runtime and `@lunora/nuxt` is a framework integration that intentionally does
+ * not depend on `@lunora/runtime`'s worker types, yet both need this exact
+ * shape: the runtime to build/forward the worker `fetch`, Nuxt to forward an
+ * inbound request to the user's composed worker. Each imports this file by
+ * relative path and the bundler (packem/rollup) inlines it: no runtime
+ * dependency edge is created, the helper is duplicated only in emitted output,
+ * never in source. One source of truth, zero deps. See AGENTS.md → "Top-level
+ * `shared/` — bundler-inlined source".
+ *
+ * Both methods are **optional**: a real Cloudflare `ExecutionContext` always
+ * supplies them, but a host that mounts Lunora as a sub-handler (Nitro/H3, a
+ * non-Cloudflare preview, a unit test) may hand over a partial context or none
+ * at all. Callers therefore invoke them defensively (`ctx.waitUntil?.(…)`) or
+ * fall back to {@link NOOP_EXECUTION_CONTEXT}.
+ */
+export interface ExecutionContextLike {
+    passThroughOnException?: () => void;
+    waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/**
+ * No-op `ExecutionContext` used when the host runtime didn't supply one (a
+ * non-Cloudflare preview, or a unit test), so the worker's `fetch` always
+ * receives a valid third argument.
+ */
+export const NOOP_EXECUTION_CONTEXT: ExecutionContextLike = {
+    passThroughOnException: () => {},
+    waitUntil: () => {},
+};


### PR DESCRIPTION
## What

Deduplicates the `ExecutionContextLike` type + `NOOP_EXECUTION_CONTEXT` constant that were declared independently in `@lunora/runtime` (`create-worker.ts`) and `@lunora/nuxt` (`runtime/cloudflare.ts`, `runtime/handler.ts`), and fixes a pre-existing broken `h3` devDep that was failing `@lunora/nuxt`'s typecheck.

### Background

This follows the `createLunoraHandler` work (5473874d). The goal was to "extract the Nuxt seam to use `createLunoraHandler`". On investigation that turned out to be the wrong shape: the generated `defineApp().build()` resolves `shardDO` per request and fans in **all** the user's options — auth lazy-init, `security` posture, and the storage/scheduler/vector/auth **admin routes** that live under `/_lunora/admin/*`. A bare `createLunoraHandler({ shardDO })` carries none of that, so building from options would regress the studio/admin plane. The Nuxt seam correctly keeps forwarding to the user's composed `#lunora/app`; the only genuine duplication was the two tiny zero-dep primitives — now hoisted into the repo-root `shared/` folder (bundler-inlined, **no new runtime dependency edge**, same pattern as `shared/stable-key`).

## Commits

1. **`fix(nuxt): pin h3 devDep off deprecated 2.0.0 stub`** — `h3@2.0.0` on npm is a deprecated empty tombstone (no code, no types; the registry marks it *"please use 1.x or beta"*), so the `^2.0.0` devDep made `@lunora/nuxt`'s `tsc --noEmit` fail to resolve `h3` in `server/lunora.ts`. Aligned the devDep with the existing `^1.0.0` peerDep — the v1 API (`defineEventHandler`, `toWebRequest`) the seam actually uses.
2. **`refactor: hoist ExecutionContextLike into shared/`** — moved both primitives into `shared/execution-context.ts`. The shared type uses **optional** methods (the honest superset: a host mounting Lunora as a sub-handler may not supply a full `ExecutionContext`), so the runtime now invokes them defensively (`ctx.waitUntil?.(…)`). Behavior is unchanged — every caller still passes a real ctx or `NOOP`. Dropped `outDir`/`rootDir` from the runtime + nuxt tsconfigs (a set `rootDir` raises TS6059 on the inlined import), matching the existing `shared/` consumers.

## Verification

- `@lunora/runtime` `tsc --noEmit` — clean
- `@lunora/nuxt` `tsc --noEmit` — clean (h3 resolution fixed)
- `@lunora/runtime` full suite — **420/420** passing
- `@lunora/nuxt` — **7/7** passing
- ESLint + Prettier clean (pre-commit hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker execution handling so optional context methods (e.g., `waitUntil`, pass-through, exception behavior) no longer cause runtime failures.
  * Improved request forwarding compatibility across H3 versions when building the forwarded Web `Request`.
* **Refactor**
  * Consolidated shared execution-context definitions across runtime packages for consistent exports and behavior.
* **Chores**
  * Updated `h3` version range in the Nuxt package to match peer expectations.
  * Adjusted TypeScript configs to align with the current build/type-check flow.
* **Documentation**
  * Updated the Quick start sample formatting in the DB docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->