### PR TITLE
fix(studio): stop data-tab render-loop hang

### DIFF
--- a/packages/studio/scripts/build-standalone.mjs
+++ b/packages/studio/scripts/build-standalone.mjs
@@ -50,6 +50,11 @@ const baseOptions = {
     bundle: true,
     format: "esm",
     minify: true,
+    // `minify` mangles top-level function/class names, but some bundled deps
+    // (e.g. `@floating-ui/react`, TanStack Router) branch on `Function.name` at
+    // runtime — mangling flips those guards into a render loop that hangs the
+    // data tab. `keepNames` restores the original `.name` after minification.
+    keepNames: true,
     // The studio is a browser SPA.
     platform: "browser",
     target: ["es2022"],

--- a/packages/vite/__tests__/studio-plugin.test.ts
+++ b/packages/vite/__tests__/studio-plugin.test.ts
@@ -173,6 +173,33 @@ describe("studioPlugin", () => {
         expect(next).not.toHaveBeenCalled();
     });
 
+    it("serves studio assets with revalidation headers and honours a matching ETag", () => {
+        const middleware = installMiddleware("localhost");
+        const next = vi.fn<() => void>();
+        const { response } = makeResponse();
+
+        middleware({ url: `${STUDIO_PATH}/studio.js` }, response, next);
+
+        // No built studio (501) → no asset bytes to cache; skip.
+        if (response.statusCode !== 200) {
+            return;
+        }
+
+        const headers = Object.fromEntries((response.setHeader as ReturnType<typeof vi.fn>).mock.calls as [string, string][]);
+
+        // Unhashed URL → revalidate every load so a rebuild is never shadowed.
+        expect(headers["Cache-Control"]).toBe("no-cache");
+        expect(headers.ETag).toMatch(/^W\/"js-/);
+
+        const second = makeResponse();
+
+        middleware({ headers: { "if-none-match": headers.ETag }, url: `${STUDIO_PATH}/studio.js` } as { url?: string }, second.response, next);
+
+        expect(second.response.statusCode).toBe(304);
+        expect(second.end).toHaveBeenCalledWith();
+        expect(next).not.toHaveBeenCalled();
+    });
+
     it("returns 403 on a non-loopback bind", () => {
         expect.assertions(3);
 

--- a/packages/vite/src/studio-plugin.ts
+++ b/packages/vite/src/studio-plugin.ts
@@ -252,9 +252,14 @@ const createStudioHandler = (
     const projectRoot = server.config.root ?? process.cwd();
 
     // Serve a static studio asset (script/styles), re-reading from disk when a
-    // mid-session `@lunora/studio` rebuild changes the bytes. Returns `true` once
-    // it has written a response so the caller can stop dispatching.
-    const serveStaticAsset = (pathname: string, response: ServerResponse): void => {
+    // mid-session `@lunora/studio` rebuild changes the bytes.
+    //
+    // The assets sit at stable, unhashed URLs, so the browser would heuristically
+    // cache them and shadow a picked-up rebuild until a hard-reload (this once
+    // masked a fixed render loop behind a stale bundle). Send `no-cache` + a
+    // stamp-derived `ETag` so the browser must revalidate: unchanged assets cost
+    // a cheap `304`, a rebuild is always fetched fresh.
+    const serveStaticAsset = (pathname: string, request: IncomingMessage, response: ServerResponse): void => {
         const stamp = studioAssetsStamp();
 
         if (assets === undefined || stamp !== assetsStamp) {
@@ -271,6 +276,22 @@ const createStudioHandler = (
         }
 
         const isScript = pathname === STUDIO_SCRIPT_PATH;
+        const assetKind = isScript ? "js" : "css";
+        const etag = stamp === undefined ? undefined : `W/"${assetKind}-${String(stamp)}"`;
+
+        response.setHeader("Cache-Control", "no-cache");
+
+        if (etag !== undefined) {
+            response.setHeader("ETag", etag);
+
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `headers` is typed required but partial/mocked requests omit it
+            if (headerValue(request.headers?.["if-none-match"]) === etag.toLowerCase()) {
+                response.statusCode = 304;
+                response.end();
+
+                return;
+            }
+        }
 
         sendOk(response, isScript ? assets.script : assets.styles, isScript ? "text/javascript; charset=utf-8" : "text/css; charset=utf-8");
     };
@@ -335,7 +356,7 @@ const createStudioHandler = (
         // SPA route and gets the history fallback (the document) below, so a hard
         // load of a deep link like `/__lunora/data` boots the router there.
         if (pathname === STUDIO_SCRIPT_PATH || pathname === STUDIO_STYLE_PATH) {
-            serveStaticAsset(pathname, response);
+            serveStaticAsset(pathname, request, response);
 
             return;
         }


### PR DESCRIPTION
Follow-up to #48 (already merged). This change was made after #48 merged, so it never landed on `alpha`.

## What
Stop the data-tab render-loop hang in the studio:
- **`build-standalone.mjs`**: set `keepNames: true` so minification doesn't mangle `Function.name` — some bundled deps (`@floating-ui/react`, TanStack Router) branch on it at runtime, and mangling flips those guards into a render loop that hangs the data tab.
- **`studio-plugin.ts`**: serve studio assets with `no-cache` + a stamp-derived `ETag` so a picked-up `@lunora/studio` rebuild is never shadowed by a stale browser copy (which previously masked the fixed render loop behind a cached bundle); honour a matching `If-None-Match` with a bodyless `304`.
- **`studio-plugin.test.ts`**: regression test for the revalidation headers + ETag `304` round-trip.

## Validation
- Rebased cleanly onto current `alpha`.
- Build ✅, typecheck (vite + studio) ✅, ESLint ✅ (no errors), vite tests ✅ 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGzpcgGkQSQpbCd1nJLpTx