### PR TITLE
fix(lfse): wave-4 hardening (redact RPC errors, keyed fan-out, restart-safe diff-emit)

### DIFF
--- a/packages/db/__tests__/internals.test.ts
+++ b/packages/db/__tests__/internals.test.ts
@@ -108,9 +108,8 @@ const recordingWriter = (): { ops: ({ key: string; type: "delete" } | { type: "i
 
 describe(makeDiffEmit, () => {
     it("emits only the rows that changed between snapshots", () => {
-        const synced = new Map<string, Row>();
         const { ops, writer } = recordingWriter();
-        const emit = makeDiffEmit(synced, writer);
+        const emit = makeDiffEmit(writer);
 
         // First snapshot: two inserts.
         emit(
@@ -127,7 +126,6 @@ describe(makeDiffEmit, () => {
             { type: "insert", value: { _id: "a", text: "1" } },
             { type: "insert", value: { _id: "b", text: "2" } },
         ]);
-        expect(synced.size).toBe(2);
 
         // Second snapshot: `a` changed, `b` removed, `c` added.
         ops.length = 0;
@@ -149,9 +147,8 @@ describe(makeDiffEmit, () => {
     });
 
     it("writes nothing when the snapshot is unchanged", () => {
-        const synced = new Map<string, Row>();
         const { ops, writer } = recordingWriter();
-        const emit = makeDiffEmit(synced, writer);
+        const emit = makeDiffEmit(writer);
         const snapshot = (): Map<string, Row> => toMap([{ _id: "a", text: "1" }] satisfies Row[], (r) => r._id);
 
         emit(snapshot());
@@ -159,6 +156,43 @@ describe(makeDiffEmit, () => {
         emit(snapshot());
 
         expect(ops).toStrictEqual([]);
+    });
+
+    it("re-inserts every row when sync restarts into a fresh writer", () => {
+        // TanStack DB clears a collection's data on GC teardown (`state.cleanup()`
+        // → `syncedData.clear()`) and re-invokes the `sync` closure on restart, so
+        // each `makeDiffEmit` must start from an empty base and re-insert every
+        // row into the emptied collection — never carry a stale base that would
+        // suppress the re-inserts (or churn unchanged rows as spurious updates).
+        const snapshot = (): Map<string, Row> =>
+            toMap(
+                [
+                    { _id: "a", text: "1" },
+                    { _id: "b", text: "2" },
+                ] satisfies Row[],
+                (r) => r._id,
+            );
+
+        const first = recordingWriter();
+        const emitBeforeRestart = makeDiffEmit(first.writer);
+
+        emitBeforeRestart(snapshot());
+
+        expect(first.ops).toStrictEqual([
+            { type: "insert", value: { _id: "a", text: "1" } },
+            { type: "insert", value: { _id: "b", text: "2" } },
+        ]);
+
+        // Restart: a brand-new emit over a brand-new (empty) writer, same rows.
+        const second = recordingWriter();
+        const emitAfterRestart = makeDiffEmit(second.writer);
+
+        emitAfterRestart(snapshot());
+
+        expect(second.ops).toStrictEqual([
+            { type: "insert", value: { _id: "a", text: "1" } },
+            { type: "insert", value: { _id: "b", text: "2" } },
+        ]);
     });
 });
 

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -150,7 +150,6 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
 
     const getKey = options.getKey ?? ((row: TRow) => row._id);
     const checkpoints = createCheckpointRegistry();
-    const synced = new Map<string, TRow>();
 
     // Mutable sync handles, populated when TanStack calls the `sync` closure and
     // driven by `scope(...)` from outside it.
@@ -204,7 +203,10 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
         id: options.id ?? options.list?.__lunoraRef ?? `shape:${options.shape?.name ?? ""}`,
         sync: {
             sync: (writer) => {
-                emit = makeDiffEmit<TRow>(synced, writer);
+                // A fresh diff base per sync start: TanStack clears the
+                // collection's data on GC teardown, so a restarted `sync` must
+                // re-insert every row rather than diff against a stale snapshot.
+                emit = makeDiffEmit<TRow>(writer);
 
                 // Surface a subscription error and move the collection out of
                 // `loading`, so a rejected subscription never hangs it forever.

--- a/packages/db/src/internals.ts
+++ b/packages/db/src/internals.ts
@@ -141,41 +141,58 @@ export const toMap = <T extends object>(rows: ReadonlyArray<T>, getKey: (row: T)
  * Build an `emit(next)` that diffs a desired keyed snapshot into a collection's
  * sync channel — only changed rows are written, so a reconnect snapshot or a
  * scope change never churns the synced view out from under a pending optimistic
- * row. The last-synced base is tracked in `synced`.
+ * row.
+ *
+ * The last-synced base is owned here, as each row's serialized form keyed by id.
+ * Keeping it internal (rather than accepting it as a parameter) is what makes the
+ * diff restart-safe: TanStack DB re-invokes a collection's `sync` closure after a
+ * GC teardown, and that teardown clears the collection's data (`state.cleanup()`
+ * → `syncedData.clear()`). A fresh `emit` therefore starts from an empty base and
+ * re-inserts every row into the emptied collection, instead of diffing against a
+ * stale prior snapshot and skipping the re-inserts. The serialized base also can
+ * never drift from the row set it describes — there is no second map to keep in
+ * lockstep.
  *
  * Change detection compares rows by `JSON.stringify`, which is key-order
- * sensitive — safe here because `synced` only ever holds server snapshots, whose
+ * sensitive — safe here because the base only ever holds server snapshots, whose
  * column order is stable across reconnects (same query projection). A sync source
  * with unstable key ordering would need a structural compare instead.
  */
-export const makeDiffEmit =
-    <T extends object>(synced: Map<string, T>, writer: SyncWriter<T>) =>
-    (next: Map<string, T>): void => {
+export const makeDiffEmit = <T extends object>(writer: SyncWriter<T>) => {
+    // Last-emitted base: each row's serialized form keyed by id. Reassigned (not
+    // mutated) each emit so the comparison never sees a half-updated map.
+    let syncedJson = new Map<string, string>();
+
+    return (next: Map<string, T>): void => {
         writer.begin();
 
-        for (const [key, value] of next) {
-            const previous = synced.get(key);
+        const nextJson = new Map<string, string>();
 
-            if (previous === undefined) {
+        for (const [key, value] of next) {
+            const valueJson = JSON.stringify(value);
+
+            nextJson.set(key, valueJson);
+
+            const previousJson = syncedJson.get(key);
+
+            if (previousJson === undefined) {
                 writer.write({ type: "insert", value });
-            } else if (JSON.stringify(previous) !== JSON.stringify(value)) {
+            } else if (previousJson !== valueJson) {
                 writer.write({ type: "update", value });
             }
         }
 
-        for (const key of synced.keys()) {
+        for (const key of syncedJson.keys()) {
             if (!next.has(key)) {
                 writer.write({ key, type: "delete" });
             }
         }
 
         writer.commit();
-        synced.clear();
 
-        for (const [key, value] of next) {
-            synced.set(key, value);
-        }
+        syncedJson = nextJson;
     };
+};
 
 /**
  * Run a Lunora mutation under the outbox's retry policy.


### PR DESCRIPTION
Three hardening followups to the local-first sync engine (stacked on `lfse-followups`, the followup branch for #37). Surfaced by a two-pass thermo review; the one finding (066) is fixed.

## Commits

### `security(do)`: redact unhandled error messages in `errorToResponse`
`ShardDO`'s RPC error path no longer echoes arbitrary `error.message` to clients — it logs the error server-side and returns a static `{ code: "RPC_FAILED", message: "internal error" }`, mirroring `@lunora/runtime`'s `toErrorResponse`. **Reviewed clean** by both passes.

### `perf(client)`: key optimistic fan-out by subscription key
Replaces an O(n) scan over `this.subscriptions.all()` (matching fn/shardKey/argsKey on every optimistic write) with an O(1) `SubscriptionRegistry.key(...)` lookup. Behavior-preserving — the registry already dedups one state per key. **Reviewed clean** by both passes.

### `perf(db)`: cache diff-emit row serialization, restart-safe
`makeDiffEmit` caches each synced row's JSON so an unchanged snapshot re-diffs without re-serializing.

**Fix applied (the one review finding, MEDIUM, confirmed by both passes):** the original split — a caller-owned, restart-persistent `synced` map plus a closure-private JSON cache — desynced when TanStack DB restarts a collection's sync closure. On GC teardown TanStack clears the collection's data (`state.cleanup()` → `syncedData.clear()`) and re-invokes `sync`; the stale `synced` then suppressed the required re-inserts (and churned unchanged rows as spurious updates). The base is now a single internally-owned `key→json` map — fresh per `sync` start, restart-safe by construction, no lockstep invariant. Verified against the TanStack DB 0.6.12 source (`state.js:929 cleanup()`). Adds a sync-restart regression test.

## Verification
- `@lunora/db`: 34 tests pass (incl. new restart regression), typecheck + ESLint clean
- `@lunora/client`: 262 tests pass
- `@lunora/do` + `@lunora/client` + `@lunora/db`: build + typecheck clean, 0 ESLint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)