### PR TITLE
fix: redact RPC error messages + key optimistic fan-out

### DIFF
--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -1490,6 +1490,88 @@ describe("lunoraClient", () => {
             expect(received).toEqual([0, 1, 2]);
         });
 
+        it("optimistic update only applies to the subscription matching (fn, args, shardKey) — different args are not mutated", async () => {
+            expect.assertions(2);
+
+            // Two subscriptions to the same function with different args.
+            // A mutation optimistic-targeting args {id:1} must not touch args {id:2}.
+            const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ error: { code: "BOOM", message: "fail" } }, { status: 500 }));
+            const client = new LunoraClient({
+                fetch: fetchMock,
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const receivedA: unknown[] = [];
+            const receivedB: unknown[] = [];
+
+            client.subscribe(fnRef("counter:get"), { id: 1 }, (d) => receivedA.push(d));
+            client.subscribe(fnRef("counter:get"), { id: 2 }, (d) => receivedB.push(d));
+            const socket = latestSocket();
+
+            socket.open();
+
+            const subAId = wireFrames(socket)[0].id as string;
+            const subBId = wireFrames(socket)[1].id as string;
+
+            socket.receive({ delta: 10, id: subAId, type: "delta" });
+            socket.receive({ delta: 20, id: subBId, type: "delta" });
+
+            // Mutation targets {id:1} only.
+            await client
+                .mutation(
+                    fnRef("counter:get"),
+                    { id: 1 },
+                    {
+                        optimistic: (current) => (typeof current === "number" ? current + 1 : 1),
+                    },
+                )
+                .catch(() => undefined);
+
+            // Only the matching subscription (id:1) received the optimistic bump + rollback.
+            expect(receivedA).toEqual([10, 11, 10]);
+            expect(receivedB).toEqual([20]);
+        });
+
+        it("optimistic update only applies to the subscription matching (fn, args, shardKey) — different shardKey is not mutated", async () => {
+            expect.assertions(1);
+
+            // A subscription on shardKey "room-1"; a mutation targeting shardKey
+            // "room-2" (different shard) must not touch it.
+            const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ error: { code: "BOOM", message: "fail" } }, { status: 500 }));
+            const client = new LunoraClient({
+                fetch: fetchMock,
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const received: unknown[] = [];
+
+            client.subscribe(fnRef("counter:get"), {}, (d) => received.push(d), { shardKey: "room-1" });
+            const socket = latestSocket();
+
+            socket.open();
+
+            const subId = firstSub(socket).id as string;
+
+            socket.receive({ delta: 10, id: subId, type: "delta" });
+
+            // Mutation targets shardKey "room-2" — no match for the room-1 subscription.
+            await client
+                .mutation(
+                    fnRef("counter:get"),
+                    {},
+                    {
+                        optimistic: (current) => (typeof current === "number" ? current + 1 : 1),
+                        shardKey: "room-2",
+                    },
+                )
+                .catch(() => undefined);
+
+            // The room-1 subscription must not have been touched.
+            expect(received).toEqual([10]);
+        });
+
         it("setQuery on an unsubscribed query is a no-op", async () => {
             expect.assertions(2);
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -2242,13 +2242,10 @@ class LunoraClient {
             return optimisticRollbacks;
         }
 
-        const mutationArgsKey = stableStringify(argsRecord);
+        const matchKey = SubscriptionRegistry.key(functionRef, argsRecord, mutationShardKey);
+        const state = this.subscriptions.get(matchKey);
 
-        for (const state of this.subscriptions.all()) {
-            if (state.fn.__lunoraRef !== functionRef || state.shardKey !== mutationShardKey || state.argsKey !== mutationArgsKey) {
-                continue;
-            }
-
+        if (state) {
             const rollback = applyOptimisticToState(state, optimistic);
 
             if (rollback) {

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -218,7 +218,7 @@ describe("shardDO", () => {
         expect(response.status).toBe(400);
     });
 
-    it("returns 500 with mapped error when handleRpc throws", async () => {
+    it("returns 500 with RPC_FAILED and generic message when handleRpc throws", async () => {
         expect.assertions(2);
 
         shard.rpcResult = undefined;
@@ -236,7 +236,32 @@ describe("shardDO", () => {
         const response = await failing.fetch(request);
 
         expect(response.status).toBe(500);
-        await expect(response.json()).resolves.toMatchObject({ error: { code: "RPC_FAILED", message: "boom" } });
+        await expect(response.json()).resolves.toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
+    });
+
+    it("does not echo raw error.message to clients on unhandled handler throw (redaction regression)", async () => {
+        expect.assertions(3);
+
+        const sensitiveMessage = "table users column secret_token does not exist";
+        const failing = new TestShard(state, {});
+
+        failing.handleRpc = async () => {
+            throw new Error(sensitiveMessage);
+        };
+
+        const request = new Request("https://shard.internal/rpc", {
+            body: JSON.stringify({ args: {}, functionPath: "fail" }),
+            method: "POST",
+        });
+
+        const response = await failing.fetch(request);
+        const rawBody = await response.text();
+
+        expect(response.status).toBe(500);
+        // Sensitive throw text must NOT appear anywhere in the response body.
+        expect(rawBody).not.toContain(sensitiveMessage);
+        // Generic redacted message must be returned instead.
+        expect(JSON.parse(rawBody)).toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
     });
 
     it("subscribe updates attachment registry and acks", async () => {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -3718,9 +3718,14 @@ abstract class ShardDO {
             return jsonResponse({ error: { code: lunoraError.code ?? "INTERNAL", message: lunoraError.message ?? "internal error" } }, status);
         }
 
-        const message = error instanceof Error ? error.message : "unknown error";
+        // Do NOT echo arbitrary error.message values to clients — an unhandled
+        // throw may carry SQL fragments, file paths, or internal identifiers. Log
+        // the raw error server-side and return a generic message (mirrors
+        // `@lunora/runtime`'s `toErrorResponse`).
+        // eslint-disable-next-line no-console -- server-side diagnostic for an unhandled handler error
+        console.error("[@lunora/do] unhandled RPC error:", error);
 
-        return jsonResponse({ error: { code: "RPC_FAILED", message } }, 500);
+        return jsonResponse({ error: { code: "RPC_FAILED", message: "internal error" } }, 500);
     }
 
     /**


### PR DESCRIPTION
Two hardening followups that are independent of the local-first sync engine and apply cleanly to `alpha`. Cherry-picked from the wave-4 hardening batch; the third commit (066, restart-safe diff-emit) targets `@lunora/db`'s collection layer which doesn't exist on `alpha` yet, so it stays on #54.

### `security(do)`: redact unhandled error messages in `errorToResponse`
`ShardDO`'s catch-all RPC error path no longer echoes arbitrary `error.message` to clients — an unhandled throw may carry SQL fragments, file paths, or internal identifiers. It now logs the raw error server-side and returns a static `{ code: "RPC_FAILED", message: "internal error" }`, mirroring `@lunora/runtime`'s `toErrorResponse`. The typed branches (Conflict / Validation / Lunora errors) are unchanged — those messages are intentional client contract.

### `perf(client)`: key optimistic fan-out by subscription key
Replaces an O(n) scan over `this.subscriptions.all()` (re-matching fn/shardKey/argsKey on every optimistic write) with an O(1) `SubscriptionRegistry.key(...)` + `.get(...)` lookup. Behavior-preserving — the registry already keeps exactly one state per key.

## Verification (on the `alpha` base)
- `@lunora/do` + `@lunora/client`: build + typecheck clean, 0 ESLint errors
- `@lunora/client`: 250 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)