### PR TITLE
security(do): redact unhandled RPC error messages on the lfse line

### DIFF
--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -218,7 +218,7 @@ describe("shardDO", () => {
         expect(response.status).toBe(400);
     });
 
-    it("returns 500 with mapped error when handleRpc throws", async () => {
+    it("returns 500 with RPC_FAILED and generic message when handleRpc throws", async () => {
         expect.assertions(2);
 
         shard.rpcResult = undefined;
@@ -236,7 +236,32 @@ describe("shardDO", () => {
         const response = await failing.fetch(request);
 
         expect(response.status).toBe(500);
-        await expect(response.json()).resolves.toMatchObject({ error: { code: "RPC_FAILED", message: "boom" } });
+        await expect(response.json()).resolves.toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
+    });
+
+    it("does not echo raw error.message to clients on unhandled handler throw (redaction regression)", async () => {
+        expect.assertions(3);
+
+        const sensitiveMessage = "table users column secret_token does not exist";
+        const failing = new TestShard(state, {});
+
+        failing.handleRpc = async () => {
+            throw new Error(sensitiveMessage);
+        };
+
+        const request = new Request("https://shard.internal/rpc", {
+            body: JSON.stringify({ args: {}, functionPath: "fail" }),
+            method: "POST",
+        });
+
+        const response = await failing.fetch(request);
+        const rawBody = await response.text();
+
+        expect(response.status).toBe(500);
+        // Sensitive throw text must NOT appear anywhere in the response body.
+        expect(rawBody).not.toContain(sensitiveMessage);
+        // Generic redacted message must be returned instead.
+        expect(JSON.parse(rawBody)).toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
     });
 
     it("subscribe updates attachment registry and acks", async () => {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -4287,9 +4287,14 @@ abstract class ShardDO {
             return jsonResponse({ error: { code: lunoraError.code ?? "INTERNAL", message: lunoraError.message ?? "internal error" } }, status);
         }
 
-        const message = error instanceof Error ? error.message : "unknown error";
+        // Do NOT echo arbitrary error.message values to clients — an unhandled
+        // throw may carry SQL fragments, file paths, or internal identifiers. Log
+        // the raw error server-side and return a generic message (mirrors
+        // `@lunora/runtime`'s `toErrorResponse`).
+        // eslint-disable-next-line no-console -- server-side diagnostic for an unhandled handler error
+        console.error("[@lunora/do] unhandled RPC error:", error);
 
-        return jsonResponse({ error: { code: "RPC_FAILED", message } }, 500);
+        return jsonResponse({ error: { code: "RPC_FAILED", message: "internal error" } }, 500);
     }
 
     /**


### PR DESCRIPTION
## What

Brings the `errorToResponse` redaction to the `lfse-followups` integration line. The generic `RPC_FAILED` 500 path in `@lunora/do`'s `ShardDO.errorToResponse` echoed the raw `error.message` to clients — an unhandled throw can carry SQL fragments, file paths, or internal identifiers (Sensitive Information Disclosure).

Now it logs the raw error server-side (`console.error`) and returns a generic `{ code: "RPC_FAILED", message: "internal error" }`, mirroring `@lunora/runtime`'s `toErrorResponse`, which already redacts.

## Why a separate PR

The identical fix is already queued for `alpha` in #56 (`security/redact-rpc-errors-alpha`, open + mergeable). The `lfse-followups` line is a separate stack that still ships the leak until it next syncs from alpha, so this closes the gap on the active line now. Cherry-picked from the same commit, so the content is identical and will reconcile cleanly when the lines converge.

## Verification

- `@lunora/do` build + `shard-do.test.ts` (56 tests, incl. a new redaction-regression test asserting a sensitive message is not echoed) ✅
- types + eslint + prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)