### PR TITLE
perf(client): keyed optimistic subscription fan-out

### DIFF
--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -1616,6 +1616,41 @@ describe("lunoraClient", () => {
             expect(received).toEqual([0]);
             expect(result).toEqual({ ok: true });
         });
+
+        it("optimistic update is scoped to the matching (fn, args) pair and does not touch subscriptions with different args", async () => {
+            // This test locks in the keyed-lookup invariant: an optimistic transform
+            // applied to (fn, { room: "a" }) must NOT bleed into the subscription
+            // for (fn, { room: "b" }) even though both watch the same function.
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: { ok: true } }));
+            const client = new LunoraClient({
+                fetch: fetchMock,
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const aReceived: unknown[] = [];
+            const bReceived: unknown[] = [];
+
+            client.subscribe(fnRef("c:get"), { room: "a" }, (d) => aReceived.push(d));
+            client.subscribe(fnRef("c:get"), { room: "b" }, (d) => bReceived.push(d));
+            const socket = latestSocket();
+
+            socket.open();
+
+            const aId = firstSub(socket).id as string;
+            const bId = wireFrames(socket)[1].id as string;
+
+            socket.receive({ delta: 10, id: aId, type: "delta" });
+            socket.receive({ delta: 20, id: bId, type: "delta" });
+
+            // Mutation targets { room: "a" } only — subscription B must be unchanged.
+            await client.mutation(fnRef("c:get"), { room: "a" }, { optimistic: (c) => (typeof c === "number" ? c + 1 : 1) });
+
+            expect(aReceived).toEqual([10, 11]);
+            expect(bReceived).toEqual([20]);
+        });
     });
 
     // --- Scheduler admin --------------------------------------------------------

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -2537,11 +2537,18 @@ class LunoraClient {
     }
 
     /**
-     * Apply an optimistic update to every subscription that matches the
-     * mutation's function ref, shard key, and args, returning the rollback
-     * callbacks to invoke if the mutation later fails. Scoping to the same
-     * (fn, shardKey, args) keeps one user's mutation from clobbering another
-     * subscriber's value on the same function (e.g. two users on different rooms).
+     * Apply an optimistic update to the subscription that matches the mutation's
+     * `(functionRef, args, shardKey)` triple, returning the rollback callbacks to
+     * invoke if the mutation later fails.
+     *
+     * The registry is already indexed by exactly this triple via
+     * `SubscriptionRegistry.key`, so at most one subscription can match. A direct
+     * O(1) keyed lookup replaces the former O(N) linear scan over all subscriptions.
+     *
+     * `shardKey` normalization: both `undefined` and `""` map to the empty string
+     * inside `SubscriptionRegistry.key` (via `?? ""`), so a mutation fired without
+     * a shardKey correctly matches a subscription registered without one regardless
+     * of whether the caller passed `undefined` or omitted the field.
      */
     private applyOptimisticUpdates(
         functionRef: string,
@@ -2555,13 +2562,13 @@ class LunoraClient {
             return optimisticRollbacks;
         }
 
-        const mutationArgsKey = stableStringify(argsRecord);
+        // Build the same composite key the registry used when the subscription was
+        // registered so we can retrieve the matching state in O(1) instead of
+        // scanning all subscriptions.
+        const matchKey = SubscriptionRegistry.key(functionRef, argsRecord, mutationShardKey);
+        const state = this.subscriptions.get(matchKey);
 
-        for (const state of this.subscriptions.all()) {
-            if (state.fn.__lunoraRef !== functionRef || state.shardKey !== mutationShardKey || state.argsKey !== mutationArgsKey) {
-                continue;
-            }
-
+        if (state) {
             const rollback = applyOptimisticToState(state, optimistic);
 
             if (rollback) {


### PR DESCRIPTION
**Plan 065** (perf, P1). Replaces the triple-match optimistic subscription fan-out loop with a keyed lookup.

- Tech-lead review: ✅ APPROVED — behavior-preserving, tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JGzpcgGkQSQpbCd1nJLpTx
