### PR TITLE
perf(db): cache synced-row JSON in diff-emit

### DIFF
--- a/packages/db/__tests__/internals.test.ts
+++ b/packages/db/__tests__/internals.test.ts
@@ -108,9 +108,10 @@ const recordingWriter = (): { ops: ({ key: string; type: "delete" } | { type: "i
 
 describe(makeDiffEmit, () => {
     it("emits only the rows that changed between snapshots", () => {
-        const synced = new Map<string, Row>();
+        // syncedJson is the single Map<string, string> cache owned at the caller level.
+        const syncedJson = new Map<string, string>();
         const { ops, writer } = recordingWriter();
-        const emit = makeDiffEmit(synced, writer);
+        const emit = makeDiffEmit(syncedJson, writer);
 
         // First snapshot: two inserts.
         emit(
@@ -127,7 +128,7 @@ describe(makeDiffEmit, () => {
             { type: "insert", value: { _id: "a", text: "1" } },
             { type: "insert", value: { _id: "b", text: "2" } },
         ]);
-        expect(synced.size).toBe(2);
+        expect(syncedJson.size).toBe(2);
 
         // Second snapshot: `a` changed, `b` removed, `c` added.
         ops.length = 0;
@@ -149,9 +150,9 @@ describe(makeDiffEmit, () => {
     });
 
     it("writes nothing when the snapshot is unchanged", () => {
-        const synced = new Map<string, Row>();
+        const syncedJson = new Map<string, string>();
         const { ops, writer } = recordingWriter();
-        const emit = makeDiffEmit(synced, writer);
+        const emit = makeDiffEmit(syncedJson, writer);
         const snapshot = (): Map<string, Row> => toMap([{ _id: "a", text: "1" }] satisfies Row[], (r) => r._id);
 
         emit(snapshot());
@@ -159,6 +160,70 @@ describe(makeDiffEmit, () => {
         emit(snapshot());
 
         expect(ops).toStrictEqual([]);
+    });
+
+    it("does not emit spurious updates for unchanged rows after a sync restart", () => {
+        // Simulates the sync-restart path in collection-options: syncedJson is
+        // owned at the outer closure level and shared across makeDiffEmit calls.
+        // A new `emit` closure (representing a sync.sync restart) must receive
+        // the same syncedJson reference so already-committed rows are seen as
+        // known, not inserted/updated anew.
+        const syncedJson = new Map<string, string>();
+        const { ops: ops1, writer: writer1 } = recordingWriter();
+
+        // First sync session: two rows arrive.
+        const emit1 = makeDiffEmit(syncedJson, writer1);
+        emit1(
+            toMap(
+                [
+                    { _id: "a", text: "hello" },
+                    { _id: "b", text: "world" },
+                ] satisfies Row[],
+                (r) => r._id,
+            ),
+        );
+
+        expect(ops1).toStrictEqual([
+            { type: "insert", value: { _id: "a", text: "hello" } },
+            { type: "insert", value: { _id: "b", text: "world" } },
+        ]);
+        expect(syncedJson.size).toBe(2);
+
+        // Sync restart: a new writer (and therefore a new emit closure) is created,
+        // but the same syncedJson is passed — the committed state must be preserved.
+        const { ops: ops2, writer: writer2 } = recordingWriter();
+        const emit2 = makeDiffEmit(syncedJson, writer2);
+
+        // Server re-delivers the same rows (identical snapshot after reconnect).
+        // No writes should be emitted — they are NOT new or changed.
+        emit2(
+            toMap(
+                [
+                    { _id: "a", text: "hello" },
+                    { _id: "b", text: "world" },
+                ] satisfies Row[],
+                (r) => r._id,
+            ),
+        );
+
+        expect(ops2).toStrictEqual([]);
+    });
+
+    it("correctly detects a change on the first emit after a sync restart", () => {
+        // After restart, a row whose value actually changed must still emit "update".
+        const syncedJson = new Map<string, string>();
+        const { writer: writer1 } = recordingWriter();
+        const emit1 = makeDiffEmit(syncedJson, writer1);
+
+        emit1(toMap([{ _id: "a", text: "v1" }] satisfies Row[], (r) => r._id));
+
+        // Restart with a new writer/closure, same syncedJson.
+        const { ops: ops2, writer: writer2 } = recordingWriter();
+        const emit2 = makeDiffEmit(syncedJson, writer2);
+
+        emit2(toMap([{ _id: "a", text: "v2" }] satisfies Row[], (r) => r._id));
+
+        expect(ops2).toStrictEqual([{ type: "update", value: { _id: "a", text: "v2" } }]);
     });
 });
 

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -150,7 +150,11 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
 
     const getKey = options.getKey ?? ((row: TRow) => row._id);
     const checkpoints = createCheckpointRegistry();
-    const synced = new Map<string, TRow>();
+    // JSON-serialized form of each last-synced row, keyed by row id.
+    // Owned here (outside sync.sync) so it persists correctly across sync
+    // restarts — a new makeDiffEmit closure on restart receives the same
+    // reference and starts from the committed synced state.
+    const syncedJson = new Map<string, string>();
 
     // Mutable sync handles, populated when TanStack calls the `sync` closure and
     // driven by `scope(...)` from outside it.
@@ -204,7 +208,7 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
         id: options.id ?? options.list?.__lunoraRef ?? `shape:${options.shape?.name ?? ""}`,
         sync: {
             sync: (writer) => {
-                emit = makeDiffEmit<TRow>(synced, writer);
+                emit = makeDiffEmit<TRow>(syncedJson, writer);
 
                 // Surface a subscription error and move the collection out of
                 // `loading`, so a rejected subscription never hangs it forever.

--- a/packages/db/src/internals.ts
+++ b/packages/db/src/internals.ts
@@ -141,39 +141,61 @@ export const toMap = <T extends object>(rows: ReadonlyArray<T>, getKey: (row: T)
  * Build an `emit(next)` that diffs a desired keyed snapshot into a collection's
  * sync channel — only changed rows are written, so a reconnect snapshot or a
  * scope change never churns the synced view out from under a pending optimistic
- * row. The last-synced base is tracked in `synced`.
+ * row. The last-synced base is tracked in `syncedJson`.
  *
  * Change detection compares rows by `JSON.stringify`, which is key-order
- * sensitive — safe here because `synced` only ever holds server snapshots, whose
- * column order is stable across reconnects (same query projection). A sync source
- * with unstable key ordering would need a structural compare instead.
+ * sensitive — safe here because server snapshots have stable column order
+ * across reconnects (same query projection). A sync source with unstable key
+ * ordering would need a structural compare instead.
+ *
+ * `syncedJson` holds the JSON-serialized form of each last-synced row, keyed
+ * by row id. It is the **sole** synced-state map — no parallel row-object map
+ * is kept. Each incoming value is serialized exactly once per tick (for both
+ * comparison and cache update), so the previous value is never re-serialized.
+ *
+ * Lifecycle: `syncedJson` must be owned by the caller at the same scope as any
+ * other per-collection state (e.g. outside the `sync.sync` callback), so the
+ * cache persists correctly across sync restarts. A new `makeDiffEmit` closure
+ * created on restart receives the same map reference and starts from the
+ * committed synced state — no spurious diffs on reconnect.
  */
 export const makeDiffEmit =
-    <T extends object>(synced: Map<string, T>, writer: SyncWriter<T>) =>
+    <T extends object>(syncedJson: Map<string, string>, writer: SyncWriter<T>) =>
     (next: Map<string, T>): void => {
         writer.begin();
 
-        for (const [key, value] of next) {
-            const previous = synced.get(key);
+        // Serialize each incoming row once; the string is used for both the
+        // change comparison and to repopulate the cache after commit.
+        const nextJson = new Map<string, string>();
 
-            if (previous === undefined) {
+        for (const [key, value] of next) {
+            const valueJson = JSON.stringify(value);
+
+            nextJson.set(key, valueJson);
+
+            if (!syncedJson.has(key)) {
                 writer.write({ type: "insert", value });
-            } else if (JSON.stringify(previous) !== JSON.stringify(value)) {
+            } else if (syncedJson.get(key) !== valueJson) {
                 writer.write({ type: "update", value });
             }
+            // Unchanged row: no write. The cached string equality check replaces
+            // the previous JSON.stringify(previous) call, halving serialization work.
         }
 
-        for (const key of synced.keys()) {
+        for (const key of syncedJson.keys()) {
             if (!next.has(key)) {
                 writer.write({ key, type: "delete" });
             }
         }
 
         writer.commit();
-        synced.clear();
 
-        for (const [key, value] of next) {
-            synced.set(key, value);
+        // Replace the JSON cache atomically with the new snapshot.
+        // All valueJson strings were already computed above — no extra serialization.
+        syncedJson.clear();
+
+        for (const [key, valueJson] of nextJson) {
+            syncedJson.set(key, valueJson);
         }
     };
 


### PR DESCRIPTION
**Plan 066** (perf, P1). Caches the synced-row JSON in `@lunora/db`'s diff-emit so rows aren't re-serialized per diff.

- Tech-lead review: ✅ APPROVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JGzpcgGkQSQpbCd1nJLpTx
