### PR TITLE
perf(do): grouped relation count (kill N+1 in resolveCounts)

### DIFF
--- a/packages/do/__tests__/ctx-db.relations.test.ts
+++ b/packages/do/__tests__/ctx-db.relations.test.ts
@@ -205,6 +205,146 @@ describe("ctx-db relations", () => {
             expect(page[0]!["reactions"]).toBeUndefined();
         });
 
+        it("_count excludes rows hidden by a flat-column read policy (grouped WHERE ANDs the policy)", async () => {
+            // The grouped-count WHERE must AND policyWhere so a _count can never reveal
+            // child rows the caller couldn't read.
+            expect.assertions(2);
+
+            const writer = makeWriter(schema);
+
+            await seed(writer);
+
+            // Policy: only "👍" reactions are visible.
+            const { page } = await writer.findMany("messages", {
+                orderBy: [{ _id: "asc" }],
+                relationBaseWhere: (table) => (table === "reactions" ? { emoji: "👍" } : undefined),
+                with: { _count: { reactions: true } },
+            });
+
+            // m1 has r1 (👍) + r2 (🎉); policy hides r2 → count is 1.
+            // m2 has r3 (🔥); policy hides it → count is 0.
+            expect((page[0]!["_count"] as Record<string, number>)["reactions"]).toBe(1);
+            expect((page[1]!["_count"] as Record<string, number>)["reactions"]).toBe(0);
+        });
+
+        it("_count with a relation-predicate read policy returns correct counts (not zeroed)", async () => {
+            // CORRECTNESS FIX: policyWhere from relationBaseWhere may be a relation
+            // predicate (e.g. {author:{is:{name:"Ada"}}}). Without resolveAggregateRelations
+            // the predicate is compiled as scalar equality → always false → every _count = 0.
+            // This test FAILS without the fix and passes with it.
+            expect.assertions(2);
+
+            // Extend the schema: reactions gain a userId FK + relation to users.
+            const extSchema: SchemaLike = {
+                tables: {
+                    messages: {
+                        indexes: [{ fields: ["authorId"], name: "by_author" }],
+                        relationMap: {
+                            reactions: { field: "messageId", kind: "many", references: "_id", table: "reactions" },
+                        },
+                        shape: { authorId: { kind: "string" }, body: { kind: "string" } },
+                    },
+                    reactions: {
+                        indexes: [
+                            { fields: ["messageId"], name: "by_message" },
+                            { fields: ["userId"], name: "by_user" },
+                        ],
+                        relationMap: {
+                            author: { field: "userId", kind: "one", references: "_id", table: "users" },
+                        },
+                        shape: { emoji: { kind: "string" }, messageId: { kind: "string" }, userId: { kind: "string" } },
+                    },
+                    users: { indexes: [], shape: { name: { kind: "string" } } },
+                },
+            };
+
+            const writer = makeWriter(extSchema);
+
+            await writer.insert("users", { _id: "u1", name: "Ada" }, { allowExplicitId: true });
+            await writer.insert("users", { _id: "u2", name: "Bot" }, { allowExplicitId: true });
+            await writer.insert("messages", { _id: "m1", authorId: "u1", body: "hi" }, { allowExplicitId: true });
+            await writer.insert("messages", { _id: "m2", authorId: "u2", body: "hey" }, { allowExplicitId: true });
+            // m1: r1 by Ada (✓), r2 by Bot (✗ under policy)
+            // m2: r3 by Ada (✓)
+            await writer.insert("reactions", { _id: "r1", emoji: "👍", messageId: "m1", userId: "u1" }, { allowExplicitId: true });
+            await writer.insert("reactions", { _id: "r2", emoji: "🎉", messageId: "m1", userId: "u2" }, { allowExplicitId: true });
+            await writer.insert("reactions", { _id: "r3", emoji: "🔥", messageId: "m2", userId: "u1" }, { allowExplicitId: true });
+
+            // RLS: only reactions whose author is "Ada" are visible.
+            // This is a RELATION predicate on reactions: {author:{is:{name:"Ada"}}}.
+            const { page } = await writer.findMany("messages", {
+                orderBy: [{ _id: "asc" }],
+                relationBaseWhere: (table) => (table === "reactions" ? { author: { is: { name: "Ada" } } } : undefined),
+                with: { _count: { reactions: true } },
+            });
+
+            // Without the fix, both would be 0 (relation predicate compiled as scalar → no match).
+            // With the fix: m1 → 1 (r1 by Ada), m2 → 1 (r3 by Ada).
+            expect((page[0]!["_count"] as Record<string, number>)["reactions"]).toBe(1);
+            expect((page[1]!["_count"] as Record<string, number>)["reactions"]).toBe(1);
+        });
+
+        it("_count works with numeric FK values (SQL→JS key-equality invariant)", async () => {
+            // The grouped path reads the FK back from SQL and uses Map.get (JS SameValueZero).
+            // Numeric FKs stored in the JSON blob are returned as JS numbers by json_extract;
+            // as long as the parent field is also a number, the lookup succeeds.
+            expect.assertions(2);
+
+            const numSchema: SchemaLike = {
+                tables: {
+                    ratings: {
+                        indexes: [{ fields: ["score"], name: "by_score" }],
+                        relationMap: {
+                            reviews: { field: "ratingScore", kind: "many", references: "score", table: "reviews" },
+                        },
+                        shape: { score: { kind: "number" } },
+                    },
+                    reviews: {
+                        indexes: [{ fields: ["ratingScore"], name: "by_rating" }],
+                        shape: { ratingScore: { kind: "number" }, text: { kind: "string" } },
+                    },
+                },
+            };
+
+            const writer = makeWriter(numSchema);
+
+            // Insert parents with a numeric `score` field (not _id).
+            await writer.insert("ratings", { _id: "rat1", score: 5 }, { allowExplicitId: true });
+            await writer.insert("ratings", { _id: "rat2", score: 3 }, { allowExplicitId: true });
+            // Insert children with a numeric FK `ratingScore`.
+            await writer.insert("reviews", { _id: "rev1", ratingScore: 5, text: "great" }, { allowExplicitId: true });
+            await writer.insert("reviews", { _id: "rev2", ratingScore: 5, text: "also great" }, { allowExplicitId: true });
+            await writer.insert("reviews", { _id: "rev3", ratingScore: 3, text: "ok" }, { allowExplicitId: true });
+
+            const { page } = await writer.findMany("ratings", {
+                orderBy: [{ score: "desc" }],
+                with: { _count: { reviews: true } },
+            });
+
+            // score=5 → 2 reviews, score=3 → 1 review.
+            // If the SQL→JS type invariant is broken (e.g. Map.get("5") on a number key),
+            // both would return 0.
+            expect((page[0]!["_count"] as Record<string, number>)["reviews"]).toBe(2);
+            expect((page[1]!["_count"] as Record<string, number>)["reviews"]).toBe(1);
+        });
+
+        it("_count is 0 when the parent FK is null (one relation)", async () => {
+            // For a `one` relation the FK is ON the parent. When it is null/absent,
+            // _count must return 0 without issuing any query.
+            expect.assertions(1);
+
+            const writer = makeWriter(schema);
+
+            // Insert a message with no authorId (the FK for the `author` one-relation).
+            await writer.insert("messages", { _id: "m_null", body: "orphan" }, { allowExplicitId: true });
+
+            // `author` is a `one` relation: parentField = messages.authorId.
+            // authorId is null/absent → parentValue is null → _count.author must be 0.
+            const { page } = await writer.findMany("messages", { where: { _id: "m_null" }, with: { _count: { author: true } } });
+
+            expect((page[0]!["_count"] as Record<string, number>)["author"]).toBe(0);
+        });
+
         it("throws on an unknown relation name", async () => {
             expect.assertions(1);
 
@@ -387,12 +527,12 @@ describe("ctx-db relations", () => {
             const parents = [{ _id: "g1", ownerId: "l1" }];
 
             await resolveWith({
-                counter: async () => 0,
                 fetcher: async (table) => {
                     fetchedTables.push(table);
 
                     return { continueCursor: null, isDone: true, page: [{ _id: "l1", name: "Local One" }] };
                 },
+                groupedCounter: async () => new Map(),
                 parents,
                 schema: reverseSchema,
                 tableName: "globals",

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -75,7 +75,7 @@ import type { ReactiveCache } from "./reactive-cache";
 import type { RelationExistsMarker } from "./relation-predicates";
 import { assertFlatPredicate as assertFlatRelationPredicate, resolveRelationPredicates } from "./relation-predicates";
 import type { RelationDefinitionLike } from "./relations";
-import { applyOnDelete, resolveWith, runRowValidators } from "./relations";
+import { applyOnDelete, fanOutScalarCounts, resolveWith, runRowValidators } from "./relations";
 import { guardWriter } from "./rls-guard";
 import { buildFtsMatch, ftsTableName, scoreDocument, stringifySearchText, tokenizeSearch } from "./search-text";
 import type { SystemDatabaseReader, SystemReaderSchedulerLike, SystemReaderStorageLike } from "./system-reader";
@@ -1683,15 +1683,12 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
     const globalFallback = (): DatabaseWriterLike | undefined => globalDb;
 
     /**
-     * Backend-routed `fetcher`/`counter` pair handed to {@link resolveWith} so a
-     * shard-local parent's `with` can load a global (D1) child in one bounded
-     * `IN (...)` read. The unsupported direction (global parent → shard-local
-     * child) is rejected upstream in `resolveWith`'s `requireRelation`.
+     * Backend-routed `fetcher`/`groupedCounter` pair handed to {@link resolveWith}
+     * so a shard-local parent's `with` can load a global (D1) child in one bounded
+     * `IN (...)` read and count children in one grouped query.
      */
     const relationFetcher = (relationTable: string, relationArgs: QueryArgs): Promise<QueryPage> =>
         routeBackend(relationTable, "relation load").findMany(relationTable, relationArgs);
-    const relationCounter = (relationTable: string, relationWhere?: WhereInput): Promise<number> =>
-        routeBackend(relationTable, "relation load").count(relationTable, relationWhere);
 
     /**
      * Child reader for relation-predicate semijoin resolution. A local child
@@ -1751,6 +1748,83 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             schema,
             tableName: predicateTable,
         });
+
+    /**
+     * Grouped aggregate counter for `_count` relation loading. For shard-local
+     * children, runs a single `SELECT :whereField AS __fk__, COUNT(*) … GROUP BY
+     * :whereField` against this DO's SQLite and returns all per-parent tallies in
+     * one query. For global (D1) children, fans out parallel scalar `count()`
+     * calls — one per distinct FK value — through the `globalDb` writer, since
+     * the `DatabaseWriterLike` interface doesn't expose a grouped-count method.
+     *
+     * CORRECTNESS: `policyWhere` (the child table's RLS read filter) may contain
+     * Prisma-style relation predicates (e.g. `{author:{is:W}}`). These must be
+     * resolved via `resolveAggregateRelations` BEFORE `compileWhereSql` is called;
+     * otherwise the relation node is treated as scalar equality and never matches,
+     * making every `_count` return 0. The cross-backend (fan-out) path routes
+     * through the full `count()` method, which already resolves relation predicates
+     * internally, so only the local grouped path needs this step.
+     */
+    const relationGroupedCounter = async (
+        relationTable: string,
+        whereField: string,
+        values: unknown[],
+        policyWhere?: WhereInput,
+    ): Promise<Map<unknown, number>> => {
+        const globalWriter = globalWriterFor(relationTable, "relation grouped count");
+
+        if (globalWriter) {
+            // Global (D1) child: parallel scalar counts through the D1 writer.
+            // The D1 writer's count() already resolves relation predicates internally.
+            // Stamp a scan dependency: any row in the child table can shift a count.
+            onRead(relationTable, SCAN_DEP);
+
+            return fanOutScalarCounts((t, w) => globalWriter.count(t, w), relationTable, whereField, values, policyWhere);
+        }
+
+        // Shard-local child: one grouped SQL query.
+        const definition = schema.tables[relationTable];
+
+        if (!definition) {
+            throw new Error(`unknown table: ${relationTable}`);
+        }
+
+        // Register a scan dependency — any insert/delete in the child table can
+        // shift a count, so invalidate the same way the scalar count path did.
+        onRead(relationTable, SCAN_DEP);
+
+        // Build WHERE: whereField IN (values) [AND policyWhere] [AND softDeleteScope].
+        // Then resolve any relation predicates in the combined WHERE before compiling
+        // to SQL. Without resolution, a relation predicate in policyWhere (e.g.
+        // {author:{is:W}}) is compiled as scalar equality and never matches, causing
+        // every _count to silently return 0 (fail-closed but wrong).
+        const softScope = softDeleteScope(definition.softDeleteMode, undefined);
+        const inFilter: WhereInput = { [whereField]: { in: values } };
+        const combined = mergeWhere(mergeWhere(inFilter, policyWhere), softScope);
+        // resolveAggregateRelations rewrites relation-crossing predicates (e.g.
+        // {author:{is:W}}) into flat IN clauses before SQL compilation — same path
+        // count() / findMany() use. Pass `undefined` for relationBaseWhere (consistent
+        // with how the scalar counter was called: no nested policy threading).
+        const resolvedCombined = await resolveAggregateRelations(combined, relationTable, undefined);
+        const whereCondition = compileWhereSql(resolvedCombined, doWhereSqlStrategy);
+
+        // `jsonPathSql` maps `_id` → `id` (physical column) and user fields to
+        // `json_extract(__doc__, '$.field')`, matching how WHERE compiles the
+        // same field — so GROUP BY and WHERE are consistent.
+        const fieldSql = jsonPathSql(whereField);
+
+        let query = dsql`SELECT ${fieldSql} AS __fk__, COUNT(*) AS count FROM ${dsql.identifier(relationTable)}`;
+
+        if (whereCondition) {
+            query = dsql`${query} WHERE ${whereCondition}`;
+        }
+
+        query = dsql`${query} GROUP BY ${fieldSql}`;
+
+        const rows = runDrizzle<{ __fk__: unknown; count: number }>(sql, query).toArray();
+
+        return new Map(rows.map((row) => [row["__fk__"], row.count]));
+    };
 
     let triggerDepth = 0;
 
@@ -2395,7 +2469,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             if (limit === undefined) {
                 if (args.with) {
                     await resolveWith({
-                        counter: relationCounter,
+                        groupedCounter: relationGroupedCounter,
                         fetcher: relationFetcher,
                         parents: docs,
                         relationBaseWhere: args.relationBaseWhere,
@@ -2415,8 +2489,8 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
 
             if (args.with) {
                 await resolveWith({
-                    counter: relationCounter,
                     fetcher: relationFetcher,
+                    groupedCounter: relationGroupedCounter,
                     parents: page,
                     relationBaseWhere: args.relationBaseWhere,
                     schema,

--- a/packages/do/src/index.ts
+++ b/packages/do/src/index.ts
@@ -188,7 +188,7 @@ export {
     resolveRelationPredicates,
 } from "./relation-predicates";
 export type { ApplyOnDeleteOptions, NestedWith, OnDeleteActionLike, RelationDefinitionLike, ResolveWithOptions, WithInput } from "./relations";
-export { applyOnDelete, resolveWith, runRowValidators } from "./relations";
+export { applyOnDelete, fanOutScalarCounts, resolveWith, runRowValidators } from "./relations";
 export type { LogEventInput } from "./request-log";
 export { guardWriter, RLS_UNWRAP_SYMBOL, RlsRequiredError } from "./rls-guard";
 export { buildFtsMatch, ftsTableName, scoreDocument, stringifySearchText, tokenizeSearch } from "./search-text";

--- a/packages/do/src/relations.ts
+++ b/packages/do/src/relations.ts
@@ -5,25 +5,26 @@
  * key — never an N+1. `resolveWith` takes a page of already-fetched parent
  * rows and, for each requested relation, issues a single `IN (...)` query
  * against the target table, then attaches the loaded rows back onto each
- * parent in place. `_count` aggregation is the one exception: it issues one
- * `count` per *distinct* parent FK value (no single GROUP BY yet), since the
- * injected `counter` returns a scalar rather than grouped tallies.
+ * parent in place. `_count` aggregation follows the same batching discipline:
+ * a single `GROUP BY :fk … WHERE :fk IN (...)` returns every per-parent
+ * tally in one round-trip via the injected `groupedCounter`.
  *
- * The fetcher/counter are injected (the DO passes its `writer.findMany` /
- * `writer.count`, D1 passes its async twins), so the same helper serves both
- * dialects. Nested `with` recurses for free: the injected fetcher re-enters
- * its own `findMany`, which calls `resolveWith` again on the child page.
+ * The fetcher/groupedCounter are injected (the DO passes its `writer.findMany`
+ * and a grouped-count helper over the local SQLite, D1 passes its async twins),
+ * so the same helper serves both dialects. Nested `with` recurses for free:
+ * the injected fetcher re-enters its own `findMany`, which calls `resolveWith`
+ * again on the child page.
  *
  * Cross-backend scope: BOTH directions are supported, and routing is the
- * injected `fetcher`/`counter`'s job — `resolveWith` itself is backend-agnostic.
- * Forward (shard-local parent → global D1 child) is a single bounded `IN (...)`
- * read routed to the D1 writer. Reverse (global D1 parent → shard-local child):
- * the child's rows span every shard DO, so the D1 ctx-db routes the child's
- * read/count to an injected cross-shard reader built on the Query Coordinator's
- * RLS-correct `fanOut` (identity forwarded → RLS per shard). When that
- * capability isn't wired the injected fetcher throws a clear "not supported"
- * error, so the loader never pre-rejects the direction itself. Same-backend
- * relations route straight back to the local writer.
+ * injected `fetcher`/`groupedCounter`'s job — `resolveWith` itself is
+ * backend-agnostic. Forward (shard-local parent → global D1 child) is a
+ * single bounded `IN (...)` read routed to the D1 writer. Reverse (global D1
+ * parent → shard-local child): the child's rows span every shard DO, so the
+ * D1 ctx-db routes the child's read/count to an injected cross-shard reader
+ * built on the Query Coordinator's RLS-correct `fanOut` (identity forwarded →
+ * RLS per shard). When that capability isn't wired the injected fetcher throws
+ * a clear "not supported" error, so the loader never pre-rejects the direction
+ * itself. Same-backend relations route straight back to the local writer.
  *
  * Ordering caveat (reverse direction only): a `many` relation with `orderBy` +
  * `limit` whose children span MULTIPLE shards is grouped correctly but globally
@@ -84,8 +85,18 @@ interface WithInput {
 }
 
 interface ResolveWithOptions {
-    counter: (tableName: string, where?: WhereInput) => Promise<number>;
     fetcher: (tableName: string, args: QueryArgs) => Promise<QueryPage>;
+
+    /**
+     * Grouped aggregate: for every FK value in `values`, return the count of
+     * child rows in `tableName` whose `whereField` equals that value,
+     * optionally AND-ing in `policyWhere` (the child table's RLS read filter).
+     * Returns a `Map` keyed by FK value with the per-group count — missing
+     * keys (groups with zero children) are not included; callers default to 0.
+     * A single `GROUP BY :whereField … WHERE :whereField IN (values)` query
+     * replaces the former one-query-per-distinct-value loop.
+     */
+    groupedCounter: (tableName: string, whereField: string, values: unknown[], policyWhere?: WhereInput) => Promise<Map<unknown, number>>;
     parents: Record<string, unknown>[];
 
     /**
@@ -98,6 +109,33 @@ interface ResolveWithOptions {
     tableName: string;
     with: WithInput;
 }
+
+/**
+ * Cross-backend fan-out for grouped `_count` on backends whose `groupedCounter`
+ * must fall back to scalar calls (e.g. a DO's global-D1 child or the sql-store's
+ * cross-shard reverse direction). Issues one `counter(table, where)` per FK
+ * value in parallel and collects the results into a Map.
+ *
+ * Used by both the DO and sql-store `relationGroupedCounter` implementations so
+ * the parallel fan-out logic isn't duplicated.
+ */
+const fanOutScalarCounts = async (
+    counter: (tableName: string, where?: WhereInput) => Promise<number>,
+    tableName: string,
+    whereField: string,
+    values: unknown[],
+    policyWhere: WhereInput | undefined,
+): Promise<Map<unknown, number>> => {
+    const pairs = await Promise.all(
+        values.map(async (value) => {
+            const countWhere: WhereInput = policyWhere ? { AND: [{ [whereField]: value }, policyWhere] } : { [whereField]: value };
+
+            return [value, await counter(tableName, countWhere)] as const;
+        }),
+    );
+
+    return new Map(pairs);
+};
 
 /** Distinct, non-nullish values of `field` across `rows`, preserving first-seen order. */
 const distinctValues = (rows: Record<string, unknown>[], field: string): unknown[] => {
@@ -120,7 +158,7 @@ const distinctValues = (rows: Record<string, unknown>[], field: string): unknown
  * `Doc[]`, `_count` → merged into `parent._count`.
  */
 const resolveWith = async (options: ResolveWithOptions): Promise<void> => {
-    const { counter, fetcher, parents, relationBaseWhere, schema, tableName, with: withInput } = options;
+    const { groupedCounter, fetcher, parents, relationBaseWhere, schema, tableName, with: withInput } = options;
 
     if (parents.length === 0) {
         return;
@@ -239,25 +277,28 @@ const resolveWith = async (options: ResolveWithOptions): Promise<void> => {
             // `one`: count target rows the parent's FK points at (0 or 1).
             const [whereField, parentField] = relation.kind === "many" ? [relation.field, relation.references] : [relation.references, relation.field];
 
-            // One count per *distinct* parent value (deduped), so repeated FKs
-            // across the page collapse to a single aggregate query each.
-            const countByValue = new Map<unknown, number>();
-
-            // RLS: AND the child table's read policy into the count so a
-            // `_count` can't reveal rows the caller couldn't read.
+            // RLS: AND the child table's read policy into the grouped count so
+            // a `_count` can never reveal rows the caller couldn't read.
             const policyWhere = relationBaseWhere?.(relation.table);
 
-            for (const value of distinctValues(parents, parentField)) {
-                const countWhere: WhereInput = policyWhere ? { AND: [{ [whereField]: value }, policyWhere] } : { [whereField]: value };
+            // Collect the distinct parent values we need counts for; skip the
+            // query entirely when the page is empty or all FKs are null.
+            const values = distinctValues(parents, parentField);
 
-                // eslint-disable-next-line no-await-in-loop -- one aggregate query per distinct FK value; sequential keeps the count fan-out bounded
-                countByValue.set(value, await counter(relation.table, countWhere));
-            }
+            // Single grouped query: GROUP BY <whereField> WHERE <whereField> IN (values).
+            // All per-parent tallies come back in one round-trip. The outer loop
+            // is per-relation (sequential over relations, not per value); each
+            // iteration issues exactly one async call.
+            // eslint-disable-next-line no-await-in-loop -- one grouped query per relation; collapses D per-value queries into 1
+            const countByValue = values.length === 0 ? new Map<unknown, number>() : await groupedCounter(relation.table, whereField, values, policyWhere);
 
             for (const parent of parents) {
                 const counts = (parent["_count"] as Record<string, number> | undefined) ?? {};
                 const parentValue = parent[parentField];
 
+                // JS SameValueZero Map lookup: safe for string ids; numeric FK
+                // values must arrive from SQL as the same JS type as parent[parentField]
+                // (the SQL→JS key-equality invariant introduced by the grouped path).
                 counts[name] = parentValue === null || parentValue === undefined ? 0 : (countByValue.get(parentValue) ?? 0);
                 parent["_count"] = counts;
             }
@@ -427,5 +468,5 @@ const runRowValidators = (definition: TableDefinitionLike, document: Record<stri
     }
 };
 
-export { applyOnDelete, distinctValues, resolveWith, runRowValidators };
+export { applyOnDelete, distinctValues, fanOutScalarCounts, resolveWith, runRowValidators };
 export type { ApplyOnDeleteOptions, NestedWith, OnDeleteActionLike, RelationDefinitionLike, ResolveWithOptions, WithInput };

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -55,6 +55,7 @@ import {
     encodeAggregateKey,
     encodeCursor,
     encodePartitionKey,
+    fanOutScalarCounts,
     foldAggregateTally,
     ftsTableName,
     hasTrigger,
@@ -2620,12 +2621,81 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             // as the top-level `relationPredicateFetcher`; aliased here for the
             // nested `with` load.
             const relationFetcher = relationPredicateFetcher;
-            const relationCounter: DatabaseWriterLike["count"] = (childTable, where) => {
-                if (!isShardLocalTarget(childTable)) {
-                    return writer.count(childTable, where);
+
+            /**
+             * Grouped aggregate counter for `_count` relation loading. For
+             * local D1 children, issues one `SELECT :whereField AS __fk__,
+             * COUNT(*) … GROUP BY :whereField` and returns all tallies in a
+             * single round-trip. For shard-local (cross-shard reverse
+             * direction), fans out parallel scalar `crossShardCounter` calls
+             * since the coordinator interface doesn't expose grouped counts.
+             *
+             * CORRECTNESS: `policyWhere` may contain relation predicates (e.g.
+             * `{author:{is:W}}`). These are resolved via `resolveAggregateRelations`
+             * BEFORE `compileWhereSql` so they are rewritten into flat IN clauses
+             * rather than compiled raw as scalar equality (which never matches).
+             * The cross-shard fan-out path routes through `crossShardCounter`,
+             * which uses the full `count()` method and resolves predicates
+             * internally — so only the local D1 path needs this step.
+             */
+            const relationGroupedCounter = async (
+                childTable: string,
+                whereField: string,
+                values: unknown[],
+                policyWhere?: WhereInput,
+            ): Promise<Map<unknown, number>> => {
+                if (isShardLocalTarget(childTable)) {
+                    // Cross-shard reverse direction: parallel scalar counts per FK value.
+                    if (!crossShardCounter) {
+                        return crossBackendUnsupported(childTable);
+                    }
+
+                    return fanOutScalarCounts(crossShardCounter, childTable, whereField, values, policyWhere);
                 }
 
-                return crossShardCounter ? crossShardCounter(childTable, where) : crossBackendUnsupported(childTable);
+                // Local D1 child: one grouped SQL query.
+                const childDefinition = schema.tables[childTable];
+
+                if (!childDefinition) {
+                    throw new Error(`unknown table: ${childTable}`);
+                }
+
+                // Build WHERE: whereField IN (values) [AND policyWhere] [AND softDeleteScope].
+                // Then resolve any relation predicates before SQL compilation — without
+                // this, a relation predicate in policyWhere is compiled as scalar equality
+                // and silently returns 0 for every group (fail-closed but wrong).
+                const softScope = softDeleteScope(childDefinition.softDeleteMode, undefined);
+                const inFilter: WhereInput = { [whereField]: { in: values } };
+                const combined = mergeWhere(mergeWhere(inFilter, policyWhere), softScope);
+                // resolveAggregateRelations rewrites relation-crossing predicates (e.g.
+                // {author:{is:W}}) into flat IN clauses — consistent with count() /
+                // findMany(). Pass `undefined` for relationBaseWhere (no nested policy
+                // threading, matching what the old scalar counter did).
+                const resolvedCombined = await resolveAggregateRelations(combined, childTable, undefined);
+                const whereCondition = compileWhereSql(resolvedCombined, whereSqlStrategy);
+
+                // `physicalColumn` maps `_id`/`id` → `id`; all other fields are themselves.
+                const fieldRef = columnRefSql(whereField);
+
+                let groupQuery = sql`SELECT ${fieldRef} AS __fk__, COUNT(*) AS count FROM ${sql.identifier(childTable)}`;
+
+                if (whereCondition) {
+                    groupQuery = sql`${groupQuery} WHERE ${whereCondition}`;
+                }
+
+                groupQuery = sql`${groupQuery} GROUP BY ${fieldRef}`;
+
+                const groupRows = await queryAll(exec, dialect, groupQuery);
+                const result = new Map<unknown, number>();
+
+                for (const row of groupRows) {
+                    // JS SameValueZero Map lookup: safe for string ids; numeric FK
+                    // values must arrive from SQL as the same JS type as parent[parentField]
+                    // (the SQL→JS key-equality invariant introduced by the grouped path).
+                    result.set(row["__fk__"], Number(row["count"] ?? 0));
+                }
+
+                return result;
             };
 
             // RLS (3.2) / aggregates (3.1) inject `baseWhere` we AND-merge
@@ -2677,7 +2747,14 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
 
             if (limit === undefined) {
                 if (args.with) {
-                    await resolveWith({ counter: relationCounter, fetcher: relationFetcher, parents: documents, schema, tableName, with: args.with });
+                    await resolveWith({
+                        fetcher: relationFetcher,
+                        groupedCounter: relationGroupedCounter,
+                        parents: documents,
+                        schema,
+                        tableName,
+                        with: args.with,
+                    });
                 }
 
                 // eslint-disable-next-line unicorn/no-null -- findMany's public return uses `continueCursor: string | null`; an unpaged result has no cursor.
@@ -2689,7 +2766,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             const last = page.at(-1);
 
             if (args.with) {
-                await resolveWith({ counter: relationCounter, fetcher: relationFetcher, parents: page, schema, tableName, with: args.with });
+                await resolveWith({ fetcher: relationFetcher, groupedCounter: relationGroupedCounter, parents: page, schema, tableName, with: args.with });
             }
 
             return {


### PR DESCRIPTION
**Plan 067** (perf, P2). Kills the N+1 in `resolveCounts` by issuing one grouped relation-count query per relation instead of one scalar count per parent.

- Tech-lead review: ✅ APPROVED — RLS/soft-delete parity verified across backends. Cross-backend (global D1 / cross-shard) paths stay parallel-scalar; only shard-local paths get the N+1→1 win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JGzpcgGkQSQpbCd1nJLpTx
