### PR TITLE
perf(do): share op-log read across shape pokes in one flush

### DIFF
--- a/packages/do/__tests__/shard-do.shape-poke.test.ts
+++ b/packages/do/__tests__/shard-do.shape-poke.test.ts
@@ -251,4 +251,43 @@ describe("shardDO shape poke protocol (dispatch path)", () => {
         expect(pokeOps(a)).toStrictEqual([{ key: "m1", op: "insert", table: "messages", value: expect.objectContaining({ _id: "m1" }) }]);
         expect(b.sent).toStrictEqual([]);
     });
+
+    it("shares the op drain across shapes but keeps membership probes isolated", async () => {
+        expect.assertions(4);
+
+        // Two sockets subscribed to differently-predicated shapes on the same table,
+        // both starting at memo cursor 0. In each flush, both shapes share the same
+        // collapseOpRange result (same table + sinceSeq); only the per-shape
+        // selectShapeMemberIds call separates which rows each subscriber receives.
+        const sockets: FakeWebSocket[] = [];
+        const shard = new ShapePokeShard(makeState(sockets), {});
+        const a = createFakeWebSocket();
+        const b = createFakeWebSocket();
+        sockets.push(a, b);
+
+        // Subscribe a → c1, b → c2. Both seeds are empty; both memos start at 0.
+        await subscribeShape(shard, a, "c1");
+        await shard.webSocketMessage(
+            b as unknown as WebSocket,
+            JSON.stringify({ id: "s1", shape: { args: { channelId: "c2" }, name: "messagesByChannel" }, type: "shape_subscribe" }),
+        );
+        a.sent.length = 0;
+        b.sent.length = 0;
+
+        // Flush 1 — write m1 into c1. Both shapes drain the same op range (messages,
+        // sinceSeq=0); only a's c1 membership probe matches.
+        await shard.fetch(write("messages:send", { _id: "m1", channelId: "c1", text: "hi" }));
+
+        expect(pokeOps(a)).toStrictEqual([{ key: "m1", op: "insert", table: "messages", value: expect.objectContaining({ _id: "m1" }) }]);
+        expect(b.sent).toStrictEqual([]);
+
+        a.sent.length = 0;
+
+        // Flush 2 — write m2 into c2. Both shapes drain the op range (messages,
+        // sinceSeq=1); only b's c2 membership probe matches.
+        await shard.fetch(write("messages:send", { _id: "m2", channelId: "c2", text: "hey" }));
+
+        expect(a.sent).toStrictEqual([]);
+        expect(pokeOps(b)).toStrictEqual([{ key: "m2", op: "insert", table: "messages", value: expect.objectContaining({ _id: "m2" }) }]);
+    });
 });

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -6004,6 +6004,12 @@ abstract class ShardDO {
         const checkpoint = frameCursor ?? this.currentCdcCursor() ?? 0;
         const sql = this.sql as SqlExec;
 
+        // Per-flush op-range cache: keyed by `${table}:${sinceSeq}`.
+        // Shapes that share the same (table, memoCursor) in one flush reuse the
+        // already-drained collapsed range and pay only the per-shape membership
+        // probe. Created fresh each call so a later flush never reuses stale data.
+        const opRangeCache = new Map<string, Map<string, CdcChange>>();
+
         const pokeOne = (ws: WebSocket): void => {
             if (this.isSocketExpired(ws)) {
                 this.dropExpiredSocket(ws);
@@ -6041,7 +6047,7 @@ abstract class ShardDO {
                     }
 
                     const memoCursor = this.shapeMemos.get(ws)?.get(subId)?.cursor ?? 0;
-                    const rowsPatch = this.buildShapeDiff(sql, resolved, memoCursor, checkpoint);
+                    const rowsPatch = this.buildShapeDiff(sql, resolved, memoCursor, checkpoint, opRangeCache);
 
                     if (rowsPatch.length > 0) {
                         parts.push({ rowsPatch, shapeId: subId });
@@ -6099,18 +6105,16 @@ abstract class ShardDO {
     }
 
     /**
-     * Build the row-ops for a shape over the op range `(sinceSeq, upTo]`. Reads
-     * the changelog (drained across pages), collapses to the latest op per row,
-     * then runs ONE membership probe ({@link selectShapeMemberIds}) over the
-     * changed ids: a row still in the set → upsert with its post-image doc
-     * (projected to the shape's columns); a row that left the set, or any delete,
-     * → `delete(key)` (a delete carries no post-image, so membership is
-     * unknowable from the op alone — the client no-ops an unknown key).
+     * Drain and collapse the CDC op-log for `table` over `(sinceSeq, upTo]`.
+     * Returns a map from row-id to its latest {@link CdcChange} across all pages
+     * in the range. The result is shareable across multiple shapes that resolve
+     * the same `(table, sinceSeq)` in one flush — the per-shape membership probe
+     * ({@link buildShapeDiff}) is NOT shared.
      */
-    // eslint-disable-next-line class-methods-use-this -- a pure op-page→membership-diff transform that reads only its args; kept a private method to sit beside the shape-poke pipeline it belongs to.
-    private buildShapeDiff(sql: SqlExec, resolved: ResolvedShape, sinceSeq: number, upTo: number): ShapeRowOp[] {
+    // eslint-disable-next-line class-methods-use-this -- stateless drain helper; kept beside the poke pipeline it belongs to.
+    private collapseOpRange(sql: SqlExec, table: string, sinceSeq: number, upTo: number): Map<string, CdcChange> {
         const latest = new Map<string, CdcChange>();
-        const tables = new Set([resolved.table]);
+        const tables = new Set([table]);
         let from = sinceSeq;
 
         // Drain the op range so a flush larger than one CDC page is fully covered.
@@ -6126,6 +6130,48 @@ abstract class ShardDO {
             }
 
             from = cursor;
+        }
+
+        return latest;
+    }
+
+    /**
+     * Build the row-ops for a shape over the op range `(sinceSeq, upTo]`. Reads
+     * the changelog (drained across pages via {@link collapseOpRange}), collapses
+     * to the latest op per row, then runs ONE membership probe
+     * ({@link selectShapeMemberIds}) over the changed ids: a row still in the set
+     * → upsert with its post-image doc (projected to the shape's columns); a row
+     * that left the set, or any delete, → `delete(key)` (a delete carries no
+     * post-image, so membership is unknowable from the op alone — the client
+     * no-ops an unknown key).
+     *
+     * `opRangeCache`, when provided, is a per-flush cache keyed by
+     * `${table}:${sinceSeq}`. A cache hit reuses the already-drained collapsed
+     * range so multiple shapes sharing the same `(table, memoCursor)` in one
+     * flush each pay only the per-shape membership probe — not the op-read.
+     * Callers that do not share a flush (e.g. the seed path) omit the cache.
+     */
+    private buildShapeDiff(
+        sql: SqlExec,
+        resolved: ResolvedShape,
+        sinceSeq: number,
+        upTo: number,
+        opRangeCache?: Map<string, Map<string, CdcChange>>,
+    ): ShapeRowOp[] {
+        const cacheKey = `${resolved.table}:${String(sinceSeq)}`;
+        let latest: Map<string, CdcChange>;
+
+        if (opRangeCache === undefined) {
+            latest = this.collapseOpRange(sql, resolved.table, sinceSeq, upTo);
+        } else {
+            const cached = opRangeCache.get(cacheKey);
+
+            if (cached === undefined) {
+                latest = this.collapseOpRange(sql, resolved.table, sinceSeq, upTo);
+                opRangeCache.set(cacheKey, latest);
+            } else {
+                latest = cached;
+            }
         }
 
         if (latest.size === 0) {


### PR DESCRIPTION
**Plan 072** (perf, P2). Shares the op-log read across shape pokes in one flush: extracts `collapseOpRange` and adds a per-flush `(table, sinceSeq)` cache so every shape resolving the same range reuses the collapsed op map. The per-shape membership probe stays per-shape.

- Tech-lead review: ✅ APPROVED — full do suite 908 green incl. the 070 matrix.
- **Stacked on `advisor/070`** (this PR targets that branch so the diff is 072-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JGzpcgGkQSQpbCd1nJLpTx
