### PR TITLE
perf(do): dedup identity-independent reactive query runs across sockets

### DIFF
--- a/packages/do/__tests__/subscription-refresh.integration.test.ts
+++ b/packages/do/__tests__/subscription-refresh.integration.test.ts
@@ -23,8 +23,9 @@
  * exercisable through the existing protected `executeSubscription`, `recordChangedTable`,
  * `webSocketMessage`, and `fetch` seams exposed by ShardDO.
  */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ADMIN_FUNCTIONS } from "../src/introspect";
 import type { ShardDOState, SubscriptionOutcome } from "../src/shard-do";
 import { ShardDO } from "../src/shard-do";
 import type { SocketAttachment, SubscriptionEnvelope } from "../src/types";
@@ -760,5 +761,171 @@ describe("shardDO: mutation → subscription-refresh pipeline", () => {
 
         // The socket still converged on the latest value (a frame was delivered).
         expect(subFrames(ws, "sub-A").length).toBeGreaterThan(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // Case 10 — ADMIN-READ DEDUP (positive, plan 073)
+    //
+    // Admin reads (`__lunora_admin__:*`) are identity-independent: the same
+    // `(functionPath, args)` always returns the same result regardless of which
+    // socket issued it.  `refreshSubscriptions` now holds a per-flush Promise
+    // cache (`adminFlushCache`) keyed by `reactiveCacheKey(functionPath, args,
+    // null)`.  The first worker creates the Promise synchronously and stores it;
+    // every subsequent worker awaits the SAME Promise.  N admin sockets subscribed
+    // to the same query therefore trigger exactly ONE `executeAdminSubscription`
+    // call per flush, not N.
+    //
+    // `pushSubscriptionData` still runs per socket so each socket receives its own
+    // (potentially different memo-type) frame — this test confirms both sockets
+    // do receive a frame after the write.
+    //
+    // Spy note: `executeAdminSubscription` is private (TypeScript compile-time
+    // only); we cast to `unknown` first to reach it without TS errors.
+    // -------------------------------------------------------------------------
+    it("admin-read dedup: N admin sockets on the same query share one handler run per flush", async () => {
+        expect.assertions(4);
+
+        const shard = new SubscriptionRefreshShard(state, {});
+
+        type HasExecuteAdminSub = { executeAdminSubscription: (path: string, args: Record<string, unknown>) => unknown };
+        const spy = vi.spyOn(shard as unknown as HasExecuteAdminSub, "executeAdminSubscription");
+
+        const wsA = createFakeWebSocket();
+        const wsB = createFakeWebSocket();
+
+        // Admin sockets are distinguished by `admin: true` in the attachment;
+        // the subscribe path rejects `__lunora_admin__:*` paths on non-admin sockets.
+        shard.registerSocket(wsA, { admin: true, subs: {} });
+        shard.registerSocket(wsB, { admin: true, subs: {} });
+
+        // Subscribe both sockets to the same admin query.
+        // `getMetrics` returns an in-memory request counter that increments on
+        // every `fetch` call, so the result is guaranteed to change after a write
+        // and `pushSubscriptionData`'s JSON-memo suppression will not silence it.
+        await shard.driveMessage(wsA, { id: "admin-A", query: { args: {}, functionPath: ADMIN_FUNCTIONS.getMetrics }, type: "subscribe" });
+        await shard.driveMessage(wsB, { id: "admin-B", query: { args: {}, functionPath: ADMIN_FUNCTIONS.getMetrics }, type: "subscribe" });
+
+        // Both seeds ran independently (seed path does not use the flush cache).
+        const callsAfterSeed = spy.mock.calls.length;
+
+        expect(callsAfterSeed).toBe(2); // one seed call per socket
+
+        // Trigger a write flush.  The `getMetrics` result changes because every
+        // `fetch` call increments `this.metrics.requests`, so both sockets receive
+        // a new frame (the JSON memo differs from the seed value).
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        // DEDUP: only ONE additional `executeAdminSubscription` call was made
+        // during the refresh — the second socket reused the cached Promise.
+        const callsDuringRefresh = spy.mock.calls.length - callsAfterSeed;
+
+        expect(callsDuringRefresh).toBe(1);
+
+        // Both sockets received an updated frame (the metrics value changed).
+        expect(subFrames(wsA, "admin-A").length).toBeGreaterThan(1);
+        expect(subFrames(wsB, "admin-B").length).toBeGreaterThan(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // Case 11 — RLS NO-SHARE / SECURITY (negative, plan 073)
+    //
+    // Identity-DEPENDENT user queries must NEVER be deduplicated.  Two sockets
+    // with different `userId` values subscribed to the same `(functionPath, args)`
+    // must each receive rows filtered to their own identity; no cross-identity
+    // data may appear on either socket.
+    //
+    // The handler must run once PER SOCKET (not once per flush), and the result
+    // pushed to each socket must reflect that socket's identity.
+    //
+    // Guard sanity-check (done once, then reverted, noted in the plan report):
+    // temporarily forcing `isAdmin = true` for ALL queries in `refreshSubscriptions`
+    // makes this test fail — one user's RLS-filtered rows reach the other user's
+    // socket — proving the guard reliably detects cross-identity leakage.
+    // -------------------------------------------------------------------------
+    it("rls no-share: identity-dependent queries run once per socket and never share results across identities", async () => {
+        expect.assertions(6);
+
+        // A shard whose `executeSubscription` filters rows by the caller's userId,
+        // simulating an RLS-scoped query (`ctx.auth.userId === row.ownerId`).
+        class RlsRefreshShard extends SubscriptionRefreshShard {
+            protected override executeSubscription(
+                functionPath: string,
+                _args: Record<string, unknown>,
+                identity?: { userId?: string },
+            ): Promise<SubscriptionOutcome | null> {
+                this.execCounts.set(functionPath, (this.execCounts.get(functionPath) ?? 0) + 1);
+
+                const base = this.outcomes.get(functionPath);
+
+                if (!base) {
+                    return Promise.resolve(null);
+                }
+
+                // Simulate RLS: only return rows that belong to the calling user.
+                const userId = identity?.userId;
+                const allRows = base.result as { ownerId: string; text: string }[];
+                const filtered = allRows.filter((r) => r.ownerId === userId);
+
+                return Promise.resolve({ result: filtered, tables: new Set(base.tables) });
+            }
+        }
+
+        const shard = new RlsRefreshShard(state, {});
+
+        const wsA = createFakeWebSocket();
+        const wsB = createFakeWebSocket();
+
+        // Socket A → user-1, Socket B → user-2.
+        shard.registerSocket(wsA, { subs: {}, userId: "user-1" });
+        shard.registerSocket(wsB, { subs: {}, userId: "user-2" });
+
+        // Shared base data; RLS filters it to each user's own rows.
+        shard.outcomes.set("messages:list", {
+            result: [
+                { ownerId: "user-1", text: "private to user-1" },
+                { ownerId: "user-2", text: "private to user-2" },
+            ],
+            tables: new Set(["messages"]),
+        });
+
+        await subscribeSocket(shard, wsA, "sub-A", "messages:list");
+        await subscribeSocket(shard, wsB, "sub-B", "messages:list");
+
+        // Each socket's seed was identity-scoped.
+        expect(dataFrames(wsA, "sub-A").at(-1)).toEqual([{ ownerId: "user-1", text: "private to user-1" }]);
+        expect(dataFrames(wsB, "sub-B").at(-1)).toEqual([{ ownerId: "user-2", text: "private to user-2" }]);
+
+        // Mutate: add a new row owned by user-1 so the refresh yields different
+        // data for user-1 (new frame) while user-2's result is unchanged (memo
+        // suppression, no new frame — the last delivered frame is still user-2's row).
+        shard.outcomes.set("messages:list", {
+            result: [
+                { ownerId: "user-1", text: "private to user-1" },
+                { ownerId: "user-1", text: "new row for user-1 only" },
+                { ownerId: "user-2", text: "private to user-2" },
+            ],
+            tables: new Set(["messages"]),
+        });
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        // user-1 received an updated frame carrying the new row.
+        expect(dataFrames(wsA, "sub-A").at(-1)).toEqual([
+            { ownerId: "user-1", text: "private to user-1" },
+            { ownerId: "user-1", text: "new row for user-1 only" },
+        ]);
+
+        // user-2's result did NOT change — memo suppression, no second data frame.
+        // The last delivered value is still user-2's own row (no cross-identity data).
+        expect(dataFrames(wsB, "sub-B").at(-1)).toEqual([{ ownerId: "user-2", text: "private to user-2" }]);
+
+        // No cross-identity data appeared on either socket:
+        // wsA never received user-2's row, wsB never received user-1's rows.
+        const allSentA = wsA.sent.map((line) => JSON.parse(line) as { data?: unknown; type: string });
+        const allSentB = wsB.sent.map((line) => JSON.parse(line) as { data?: unknown; type: string });
+
+        expect(allSentA.every((frame) => !JSON.stringify(frame.data ?? "").includes("user-2"))).toBe(true);
+        expect(allSentB.every((frame) => !JSON.stringify(frame.data ?? "").includes("user-1"))).toBe(true);
     });
 });

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -5634,6 +5634,51 @@ abstract class ShardDO {
     }
 
     /**
+     * Resolve one subscription's outcome, deduplicating admin reads within a
+     * single flush via `adminFlushCache`.
+     *
+     * **Security boundary** — this cache is populated ONLY when `isAdmin` is
+     * `true`, i.e. only for admin-prefixed function paths that route through
+     * {@link executeAdminSubscription} → raw SQLite introspection. Those reads
+     * never consult `ctx.auth` / RLS and are therefore identity-independent: the
+     * same `(functionPath, args)` always returns the same result for every socket
+     * in the same flush. Every other query (user queries and flag reads) passes
+     * `isAdmin = false` and is handled per-socket with the socket's own verified
+     * identity. The predicate must NEVER be `true` for any query that reads
+     * identity — doing so would push one user's cached rows to another user's
+     * socket.
+     *
+     * **Concurrency model** — the Promise is created synchronously (before any
+     * `await`) and stored in `adminFlushCache` before the call site awaits it.
+     * Concurrent workers that reach the same cache key after the first worker has
+     * stored the Promise therefore retrieve and await the SAME Promise rather than
+     * re-executing the handler: one execution per unique `(functionPath, args)`
+     * pair per flush.
+     */
+    private resolveOutcomeOrCache(
+        functionPath: string,
+        args: Record<string, unknown>,
+        isAdmin: boolean,
+        identity: { identity?: Record<string, unknown>; userId?: string },
+        adminFlushCache: Map<string, Promise<SubscriptionOutcome | null>>,
+    ): Promise<SubscriptionOutcome | null> {
+        if (!isAdmin) {
+            return this.resolveReactiveOutcome(functionPath, args, isAdmin, identity);
+        }
+
+        // eslint-disable-next-line unicorn/no-null -- reactiveCacheKey's identity arg is `null | string`; null is the documented "anonymous caller" discriminator, correct for admin reads that have no real identity
+        const cacheKey = reactiveCacheKey(functionPath, args, null);
+        let cached = adminFlushCache.get(cacheKey);
+
+        if (cached === undefined) {
+            cached = this.resolveReactiveOutcome(functionPath, args, isAdmin, identity);
+            adminFlushCache.set(cacheKey, cached);
+        }
+
+        return cached;
+    }
+
+    /**
      * For every live subscription whose query reads one of `changed`, re-run
      * the query and push a fresh `{ type: "data" }` frame when the result
      * differs from the last one sent. Subscriptions with no `functionPath`
@@ -5697,6 +5742,13 @@ abstract class ShardDO {
         const frameCursor = this.currentCdcCursor();
         const frameEpoch = this.currentCdcEpoch();
 
+        // Per-flush Promise cache for identity-independent (admin) query outcomes.
+        // Created fresh each call — never persisted — so a later flush never reuses
+        // stale data. See {@link ShardDO.resolveOutcomeOrCache} for the security
+        // boundary: this map is populated ONLY for admin reads, never for
+        // identity-dependent user queries or flag reads.
+        const adminFlushCache = new Map<string, Promise<SubscriptionOutcome | null>>();
+
         const refreshOne = async (ws: WebSocket): Promise<void> => {
             // Enforce token-expiry on the OUTBOUND path: a lapsed socket must not
             // keep receiving its user's live (RLS/`ctx.auth`-scoped) data. This is
@@ -5737,10 +5789,16 @@ abstract class ShardDO {
                     // scoped live query would evaluate anonymous and return zero rows.
                     // (Admin + reserved flag reads ignore the identity payload.)
                     // eslint-disable-next-line no-await-in-loop -- subscriptions on a socket re-run sequentially; each shares the single SQLite handle
-                    const outcome = await this.resolveReactiveOutcome(functionPath, query.args ?? {}, isAdmin, {
-                        identity: attachment.identity,
-                        userId: attachment.userId,
-                    });
+                    const outcome = await this.resolveOutcomeOrCache(
+                        functionPath,
+                        query.args ?? {},
+                        isAdmin,
+                        {
+                            identity: attachment.identity,
+                            userId: attachment.userId,
+                        },
+                        adminFlushCache,
+                    );
 
                     if (!outcome) {
                         continue;


### PR DESCRIPTION
**Plan 073** (perf, P2). Dedups identity-independent reactive query runs across sockets in one flush — the handler executes once per flush for admin/reserved reads instead of once per socket. Per-socket push still runs.

**Security boundary:** the identity-independence signal is `isAdmin` (`ADMIN_FUNCTION_PREFIX`) **only** — `FLAGS_FUNCTION_PREFIX` is explicitly excluded and all user queries are treated identity-dependent. The per-identity path is byte-for-byte unchanged.

- Tech-lead review: ✅ APPROVED — verified the predicate can never be true for an identity-reading query; includes a leak-detecting test (Case 11) and a forced-predicate sanity-check.
- **Stacked on `advisor/072`** (this PR targets that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JGzpcgGkQSQpbCd1nJLpTx
