### PR TITLE
fix(do): wave-4 shard-do hardening (redact errors, settled frame, dedup, op-range cache, socket-pool)

### DIFF
--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -456,6 +456,110 @@ describe("lunoraClient", () => {
             expect(last).toEqual({ id: sub.id, type: "unsubscribe" });
         });
 
+        it("forwards a settled frame's watermark to onCheckpoint without firing the data callback", () => {
+            expect.assertions(3);
+
+            const client = new LunoraClient({
+                clientId: "client-A",
+                fetch: vi.fn<typeof fetch>(),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const received: unknown[] = [];
+            const checkpoints: { checkpoint?: number; mutationId?: number }[] = [];
+
+            client.subscribe(fnRef("messages:list"), {}, (d) => received.push(d), {
+                onCheckpoint: (watermark) => checkpoints.push(watermark),
+            });
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            const sub = firstSub(socket);
+
+            socket.receive({ id: sub.id, type: "ack" });
+            // A write touched the read tables but the result was byte-identical, so
+            // the server sent a `settled` frame instead of a data frame.
+            socket.receive({ cursor: 12, epoch: "e1", id: sub.id, lastMutationId: 5, type: "settled" });
+
+            // No value changed — the data callback must not fire...
+            expect(received).toEqual([]);
+            // ...but the echoed watermark + advanced cursor reach onCheckpoint so a
+            // @lunora/db list overlay can drop.
+            expect(checkpoints).toEqual([{ checkpoint: 12, mutationId: 5 }]);
+
+            // An older client (or one with no settled support) safely ignores an
+            // unknown frame — the default switch arm is a no-op.
+            expect(() => socket.receive({ id: sub.id, type: "totally-unknown-frame" })).not.toThrow();
+
+            client.close();
+        });
+
+        it("ignores a settled frame for an unknown subscription id", () => {
+            expect.assertions(1);
+
+            const client = new LunoraClient({
+                clientId: "client-A",
+                fetch: vi.fn<typeof fetch>(),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            client.subscribe(fnRef("messages:list"), {}, () => undefined);
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            expect(() => socket.receive({ cursor: 1, id: "sub_does_not_exist", type: "settled" })).not.toThrow();
+
+            client.close();
+        });
+
+        it("fans a settled frame out to every subscriber sharing the same subscription state", () => {
+            // Regression: SubscriptionState is shared across subscribers to the same
+            // (fn, args, shardKey). A second subscriber (e.g. a @lunora/db collection)
+            // that joins AFTER a plain useQuery must still receive `settled` fan-out —
+            // a single onCheckpoint slot would only ever notify the state's creator.
+            expect.assertions(2);
+
+            const client = new LunoraClient({
+                clientId: "client-A",
+                fetch: vi.fn<typeof fetch>(),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const first: { checkpoint?: number; mutationId?: number }[] = [];
+            const second: { checkpoint?: number; mutationId?: number }[] = [];
+
+            // First subscriber CREATES the shared state...
+            client.subscribe(fnRef("messages:list"), {}, () => undefined, {
+                onCheckpoint: (watermark) => first.push(watermark),
+            });
+            // ...second subscriber JOINS the existing state (same fn + args).
+            client.subscribe(fnRef("messages:list"), {}, () => undefined, {
+                onCheckpoint: (watermark) => second.push(watermark),
+            });
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            const sub = firstSub(socket);
+
+            socket.receive({ id: sub.id, type: "ack" });
+            socket.receive({ cursor: 7, epoch: "e1", id: sub.id, lastMutationId: 3, type: "settled" });
+
+            // BOTH checkpoint callbacks fire, not just the creator's.
+            expect(first).toEqual([{ checkpoint: 7, mutationId: 3 }]);
+            expect(second).toEqual([{ checkpoint: 7, mutationId: 3 }]);
+
+            client.close();
+        });
+
         it("announces every socket with a context-less connect envelope before resubscribing", () => {
             expect.assertions(3);
 

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -492,7 +492,9 @@ describe("lunoraClient", () => {
 
             // An older client (or one with no settled support) safely ignores an
             // unknown frame — the default switch arm is a no-op.
-            expect(() => socket.receive({ id: sub.id, type: "totally-unknown-frame" })).not.toThrow();
+            expect(() => {
+                socket.receive({ id: sub.id, type: "totally-unknown-frame" });
+            }).not.toThrow();
 
             client.close();
         });
@@ -513,7 +515,9 @@ describe("lunoraClient", () => {
 
             socket.open();
 
-            expect(() => socket.receive({ cursor: 1, id: "sub_does_not_exist", type: "settled" })).not.toThrow();
+            expect(() => {
+                socket.receive({ cursor: 1, id: "sub_does_not_exist", type: "settled" });
+            }).not.toThrow();
 
             client.close();
         });

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -3558,6 +3558,7 @@ class LunoraClient {
      * client must re-render changed, but the resume position may have moved".
      */
     private ackAndAdvanceCursor(state: SubscriptionState, cursor: number | undefined, epoch: string | undefined): void {
+        /* eslint-disable no-param-reassign -- advance the shared subscription state in place (same pattern as the optimistic-update path above) */
         state.acked = true;
 
         if ((cursor !== undefined && cursor !== state.serverCursor) || (epoch !== undefined && epoch !== state.serverEpoch)) {
@@ -3571,6 +3572,7 @@ class LunoraClient {
 
             this.persistQueryValue(state);
         }
+        /* eslint-enable no-param-reassign */
     }
 
     /**

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -47,6 +47,7 @@ import type {
     ServerPokePartMessage,
     ServerPokeStartMessage,
     ServerResumeMessage,
+    ServerSettledMessage,
     ServerWhisperMessage,
     ShardTrafficResult,
     StorageListPage,
@@ -2013,7 +2014,7 @@ class LunoraClient {
         function_: F,
         args: ArgsOf<F>,
         callback: (data: ReturnOf<F>) => void,
-        options: { onError?: SubscriptionErrorCallback; shardKey?: string } = {},
+        options: { onCheckpoint?: (watermark: SyncWatermark) => void; onError?: SubscriptionErrorCallback; shardKey?: string } = {},
     ): Unsubscribe {
         if (this.closed) {
             throw new Error("LunoraClient is closed");
@@ -2037,6 +2038,7 @@ class LunoraClient {
                 args: argsRecord,
                 argsKey,
                 callbacks: new Set<SubscriptionCallback>(),
+                checkpointCallbacks: new Set(),
                 errorCallbacks: new Set<SubscriptionErrorCallback>(),
                 fn: function_,
                 id,
@@ -2053,6 +2055,14 @@ class LunoraClient {
 
         if (errorCallback) {
             state.errorCallbacks.add(errorCallback);
+        }
+
+        // Register this subscriber's checkpoint callback on the SHARED state, so a
+        // `@lunora/db` collection still receives `settled` fan-out even when it
+        // joins a query a plain `useQuery` opened first (the state already existed
+        // above). One slot would drop every subscriber but the state's creator.
+        if (options.onCheckpoint) {
+            state.checkpointCallbacks.add(options.onCheckpoint);
         }
 
         // Replay last value to new subscriber synchronously if available.
@@ -2074,6 +2084,10 @@ class LunoraClient {
 
             if (errorCallback) {
                 subscriptionState.errorCallbacks.delete(errorCallback);
+            }
+
+            if (options.onCheckpoint) {
+                subscriptionState.checkpointCallbacks.delete(options.onCheckpoint);
             }
 
             if (subscriptionState.callbacks.size === 0) {
@@ -3274,6 +3288,11 @@ class LunoraClient {
 
                 break;
             }
+            case "settled": {
+                this.handleSettledMessage(message);
+
+                break;
+            }
             case "whisper": {
                 this.dispatchWhisper(message, shardKey);
 
@@ -3497,15 +3516,57 @@ class LunoraClient {
             return;
         }
 
+        this.ackAndAdvanceCursor(state, message.cursor, message.epoch);
+    }
+
+    /**
+     * Handle a `settled` frame: a write touched one of this subscription's read
+     * tables but produced a byte-identical result, so the server suppressed the
+     * data frame. Like {@link handleResumeMessage} the value didn't change — we
+     * advance the resume position and re-persist — but we ALSO surface the echoed
+     * custom-mutator watermark via `onCheckpoint` so a `@lunora/db` list
+     * collection drops the optimistic overlay for the confirmed write (otherwise
+     * its checkpoint gate, fed only by data frames, would hang forever). Sent
+     * only to custom-mutator clients; plain `useQuery` subscribers leave
+     * `onCheckpoint` unset and this is a near no-op.
+     */
+    private handleSettledMessage(message: ServerSettledMessage): void {
+        const state = this.subscriptions.getById(message.id);
+
+        if (!state) {
+            return;
+        }
+
+        this.ackAndAdvanceCursor(state, message.cursor, message.epoch);
+
+        if (message.lastMutationId !== undefined) {
+            state.lastMutationId = message.lastMutationId;
+        }
+
+        // Fan out to every registered subscriber (shared state — see
+        // SubscriptionState.checkpointCallbacks). A snapshot isn't needed: a
+        // checkpoint callback never (un)subscribes to this same state mid-flush.
+        for (const onCheckpoint of state.checkpointCallbacks) {
+            onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
+        }
+    }
+
+    /**
+     * Mark `state` acked and, when the frame carries a newer cursor/epoch than
+     * the cached position, advance the resume watermark and re-persist. Shared by
+     * the `resume` and `settled` frame handlers — both acknowledge "nothing the
+     * client must re-render changed, but the resume position may have moved".
+     */
+    private ackAndAdvanceCursor(state: SubscriptionState, cursor: number | undefined, epoch: string | undefined): void {
         state.acked = true;
 
-        if ((message.cursor !== undefined && message.cursor !== state.serverCursor) || (message.epoch !== undefined && message.epoch !== state.serverEpoch)) {
-            if (message.cursor !== undefined) {
-                state.serverCursor = message.cursor;
+        if ((cursor !== undefined && cursor !== state.serverCursor) || (epoch !== undefined && epoch !== state.serverEpoch)) {
+            if (cursor !== undefined) {
+                state.serverCursor = cursor;
             }
 
-            if (message.epoch !== undefined) {
-                state.serverEpoch = message.epoch;
+            if (epoch !== undefined) {
+                state.serverEpoch = epoch;
             }
 
             this.persistQueryValue(state);

--- a/packages/client/src/subscription.ts
+++ b/packages/client/src/subscription.ts
@@ -23,20 +23,6 @@ export interface SubscriptionState {
      */
     readonly argsKey: string;
     readonly callbacks: Set<SubscriptionCallback>;
-    /** Notified when the server rejects this subscription (e.g. admin auth). */
-    readonly errorCallbacks: Set<SubscriptionErrorCallback>;
-    readonly fn: FunctionReference;
-    readonly id: string;
-
-    /**
-     * The highest custom-mutator `mutationId` from this client the server has
-     * applied, captured from the last `settled` frame (the suppressed-list-frame
-     * watermark). Forwarded to {@link SubscriptionState.checkpointCallbacks}.
-     * Absent until a `settled` frame arrives.
-     */
-    lastMutationId?: number;
-    /** Last known value, used to short-circuit `useQuery`-style consumers. */
-    lastValue: unknown;
 
     /**
      * Notified when a `settled` frame advances this subscription's watermark — a
@@ -52,6 +38,22 @@ export interface SubscriptionState {
      * `useQuery` consumers register nothing, leaving the set empty.
      */
     readonly checkpointCallbacks: Set<(watermark: { checkpoint?: number; mutationId?: number }) => void>;
+    /** Notified when the server rejects this subscription (e.g. admin auth). */
+    readonly errorCallbacks: Set<SubscriptionErrorCallback>;
+    readonly fn: FunctionReference;
+
+    readonly id: string;
+
+    /**
+     * The highest custom-mutator `mutationId` from this client the server has
+     * applied, captured from the last `settled` frame (the suppressed-list-frame
+     * watermark). Forwarded to {@link SubscriptionState.checkpointCallbacks}.
+     * Absent until a `settled` frame arrives.
+     */
+    lastMutationId?: number;
+
+    /** Last known value, used to short-circuit `useQuery`-style consumers. */
+    lastValue: unknown;
 
     /**
      * The `__cdc_log` high-watermark (`cursor`) the `lastValue` reflects,

--- a/packages/client/src/subscription.ts
+++ b/packages/client/src/subscription.ts
@@ -27,8 +27,31 @@ export interface SubscriptionState {
     readonly errorCallbacks: Set<SubscriptionErrorCallback>;
     readonly fn: FunctionReference;
     readonly id: string;
+
+    /**
+     * The highest custom-mutator `mutationId` from this client the server has
+     * applied, captured from the last `settled` frame (the suppressed-list-frame
+     * watermark). Forwarded to {@link SubscriptionState.checkpointCallbacks}.
+     * Absent until a `settled` frame arrives.
+     */
+    lastMutationId?: number;
     /** Last known value, used to short-circuit `useQuery`-style consumers. */
     lastValue: unknown;
+
+    /**
+     * Notified when a `settled` frame advances this subscription's watermark — a
+     * write touched the subscription's tables but the result was byte-identical,
+     * so the server suppressed the data frame. A `@lunora/db` list collection
+     * uses this to drop the optimistic overlay for the confirmed write.
+     *
+     * A SET (not a single slot) because `SubscriptionState` is SHARED across
+     * every subscriber to the same `(fn, args, shardKey)`: a `@lunora/db`
+     * collection may subscribe to a query a plain `useQuery` already opened, so
+     * each subscriber registers its own callback (mirroring `callbacks` /
+     * `errorCallbacks`) and a `settled` frame fans out to all of them. Plain
+     * `useQuery` consumers register nothing, leaving the set empty.
+     */
+    readonly checkpointCallbacks: Set<(watermark: { checkpoint?: number; mutationId?: number }) => void>;
 
     /**
      * The `__cdc_log` high-watermark (`cursor`) the `lastValue` reflects,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -514,6 +514,7 @@ export interface ServerSettledMessage {
     /** The CDC epoch this settled frame's cursor belongs to (see {@link CachedQuery.serverEpoch}). */
     epoch?: string;
     id: string;
+
     /**
      * The highest custom-mutator `mutationId` from this client the server has
      * now applied (the per-client `__client_watermark`). Forwarded to a

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -483,14 +483,6 @@ export interface ServerDataMessage {
     /** The CDC epoch this frame's cursor belongs to (see {@link CachedQuery.serverEpoch}). */
     epoch?: string;
     id: string;
-
-    /**
-     * The highest custom-mutator `mutationId` from this client the server has
-     * now applied (the per-client `__client_watermark`). Echoed so the client's
-     * outbox can drop confirmed pending mutations and let TanStack DB collapse
-     * the matching optimistic overlay. Absent on shards without custom mutators.
-     */
-    lastMutationId?: number;
     type: "data" | "delta";
 }
 
@@ -505,9 +497,31 @@ export interface ServerResumeMessage {
     /** The CDC epoch this resume's cursor belongs to (see {@link CachedQuery.serverEpoch}). */
     epoch?: string;
     id: string;
-    /** Per-client custom-mutator watermark (see {@link ServerDataMessage.lastMutationId}). */
-    lastMutationId?: number;
     type: "resume";
+}
+
+/**
+ * Settled acknowledgement for a **list** subscription: a write touched one of
+ * the subscription's read tables but produced a byte-identical result, so the
+ * server suppressed the data frame. Sent ONLY to a `@lunora/db` custom-mutator
+ * client (one that announced a `clientId`, hence has a server-side
+ * `__client_watermark`) so its optimistic list overlay drops even when no data
+ * frame arrives. Plain `useQuery` subscribers never receive it, and an older
+ * client safely ignores the unknown frame.
+ */
+export interface ServerSettledMessage {
+    cursor?: number;
+    /** The CDC epoch this settled frame's cursor belongs to (see {@link CachedQuery.serverEpoch}). */
+    epoch?: string;
+    id: string;
+    /**
+     * The highest custom-mutator `mutationId` from this client the server has
+     * now applied (the per-client `__client_watermark`). Forwarded to a
+     * collection's `onCheckpoint` so it can drop the overlay for the confirmed
+     * write whose result didn't change this list.
+     */
+    lastMutationId?: number;
+    type: "settled";
 }
 
 export interface ServerErrorMessage {
@@ -584,7 +598,7 @@ export interface ServerPokeStartMessage {
 
 /** One shape's slice of an in-flight poke: the row-ops to apply for `shapeId`. */
 export interface ServerPokePartMessage {
-    /** Per-client custom-mutator watermark carried with this slice (see {@link ServerDataMessage.lastMutationId}). */
+    /** Per-client custom-mutator watermark carried with this slice (see {@link ServerSettledMessage.lastMutationId}). */
     lastMutationId?: number;
     pokeId: string;
     /** Ordered row-level changes for this shape, applied in sequence at `pokeEnd`. */
@@ -619,6 +633,7 @@ export type ServerMessage =
     | ServerPokePartMessage
     | ServerPokeStartMessage
     | ServerResumeMessage
+    | ServerSettledMessage
     | ServerWhisperMessage;
 
 /**

--- a/packages/db/__tests__/collection-options.test.ts
+++ b/packages/db/__tests__/collection-options.test.ts
@@ -19,6 +19,7 @@ interface ShapeSubscribeCall {
 const makeClient = () => {
     const shapeSubscribes: ShapeSubscribeCall[] = [];
     const client = {
+        confirmedMutationWatermark: vi.fn<() => number>(() => 0),
         subscribe: vi.fn<(...arguments_: unknown[]) => () => void>(),
         subscribeShape: vi.fn<
             (
@@ -220,6 +221,62 @@ describe("lunoraCollectionOptions (shape source)", () => {
 
         // The next poke syncs the write's watermark → the overlay drop unblocks.
         call?.onCheckpoint?.({ checkpoint: 9, mutationId: 4 });
+        await pending;
+
+        expect(order).toStrictEqual(["dropped"]);
+    });
+});
+
+/**
+ * The full-table `list` sync source. A `list` collection live-syncs through
+ * `client.subscribe`; a write that touches the read tables but produces a
+ * byte-identical result emits no data frame (server-side frame suppression), so
+ * the server's `settled` frame drives `onCheckpoint` to drop the optimistic
+ * overlay — without it, a custom-mutator overlay would hang forever.
+ */
+describe("lunoraCollectionOptions (list source)", () => {
+    const subscribeOptionsFrom = (client: never): { onCheckpoint?: (watermark: { checkpoint?: number; mutationId?: number }) => void } => {
+        const subscribeMock = (client as unknown as { subscribe: ReturnType<typeof vi.fn> }).subscribe;
+
+        return (subscribeMock.mock.calls[0]?.[3] ?? {}) as { onCheckpoint?: (watermark: { checkpoint?: number; mutationId?: number }) => void };
+    };
+
+    it("wires an onCheckpoint into the list subscription", async () => {
+        const { client } = makeClient();
+
+        const options = lunoraCollectionOptions({ client, list: ref("messages:list") });
+        const collection = createCollection(options.config);
+
+        collection.subscribeChanges(() => {});
+        await flush();
+
+        expect((client as unknown as { subscribe: ReturnType<typeof vi.fn> }).subscribe).toHaveBeenCalledTimes(1);
+        expect(subscribeOptionsFrom(client).onCheckpoint).toBeTypeOf("function");
+    });
+
+    it("drops a stuck overlay when a settled frame's onCheckpoint advances the watermark", async () => {
+        const { client } = makeClient();
+
+        const options = lunoraCollectionOptions({ client, list: ref("messages:list") });
+        const collection = createCollection(options.config);
+
+        collection.subscribeChanges(() => {});
+        await flush();
+
+        const { onCheckpoint } = subscribeOptionsFrom(client);
+        const order: string[] = [];
+
+        // A confirmed write at seq 7 whose authoritative result did not change the
+        // list. No data frame arrives — only the suppressed-frame `settled`
+        // watermark, forwarded here.
+        const pending = options.checkpoints.awaitMutationId(7).then(() => order.push("dropped"));
+
+        onCheckpoint?.({ checkpoint: 3, mutationId: 6 });
+        await Promise.resolve();
+
+        expect(order).toStrictEqual([]);
+
+        onCheckpoint?.({ checkpoint: 4, mutationId: 7 });
         await pending;
 
         expect(order).toStrictEqual(["dropped"]);

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -172,31 +172,37 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
             emit?.(toMap(data as TRow[], getKey));
             onReady?.();
 
-            // The shape path resolves the registry from the poke `checkpoint`
-            // (below). A `list` frame carries no per-frame watermark, so advance
-            // from the client's server-confirmed custom-mutator watermark (the
-            // push-ack stream) as synced rows land — a `bindMutators` optimistic
-            // overlay then drops exactly when the server rows arrive instead of
-            // `awaitMutationId` hanging forever after the write is accepted.
+            // The shape path resolves the registry from the poke `checkpoint`,
+            // and the list path resolves it from the `onCheckpoint` watermark a
+            // `settled` frame forwards (both wired below). A `list` *data* frame
+            // carries no per-frame watermark, so advance from the client's
+            // server-confirmed custom-mutator watermark (the push-ack stream) as
+            // synced rows land — a `bindMutators` optimistic overlay then drops
+            // exactly when the server rows arrive instead of `awaitMutationId`
+            // hanging forever after the write is accepted.
             if (options.shape === undefined) {
                 checkpoints.resolve({ mutationId: options.client.confirmedMutationWatermark() });
             }
         };
         const onError = (error: SubscriptionError): void => onErrorHandler?.(error);
 
+        // Advance the registry as the source syncs, so a mutator runtime can drop
+        // optimistic overlays once the server's rows (or a `settled` no-change
+        // acknowledgement) have landed. Both paths forward the same watermark
+        // shape, so the handler is identical.
+        const onCheckpoint = (watermark: { checkpoint?: number; mutationId?: number }): void => {
+            checkpoints.resolve(watermark);
+        };
+
         if (options.shape !== undefined) {
             return options.client.subscribeShape({ args, name: options.shape.name }, onRows, {
-                // Advance the registry as the shape syncs, so a mutator runtime can
-                // drop optimistic overlays once the server's rows have landed.
-                onCheckpoint: (watermark) => {
-                    checkpoints.resolve(watermark);
-                },
+                onCheckpoint,
                 onError,
                 shardKey: options.shape.shardKey,
             });
         }
 
-        return options.client.subscribe(options.list as FunctionReference, args, onRows, { onError });
+        return options.client.subscribe(options.list as FunctionReference, args, onRows, { onCheckpoint, onError });
     };
 
     const config: CollectionConfig<TRow, string> = {

--- a/packages/do/__tests__/shard-do.reactive-dedup.test.ts
+++ b/packages/do/__tests__/shard-do.reactive-dedup.test.ts
@@ -11,12 +11,9 @@
  * The SECURITY boundary is `isIdentityIndependent`: an RLS / `ctx.auth` / flag
  * read evaluates under the socket's own verified identity and MUST NOT be
  * shared, or one identity's rows leak to another. These tests lock in:
- *   1. POSITIVE — an identity-independent query runs once for N sockets.
- *   2. NEGATIVE — an identity-dependent query runs once PER socket, each under
- *      its own identity (no cross-identity leak).
- *   3. SANITY — forcing the predicate true on an identity-dependent query
- *      reintroduces the leak (1 run, the second socket served the first's
- *      identity), proving the predicate is load-bearing.
+ * 1. POSITIVE — an identity-independent query runs once for N sockets.
+ * 2. NEGATIVE — an identity-dependent query runs once PER socket, each under its own identity (no cross-identity leak).
+ * 3. SANITY — forcing the predicate true on an identity-dependent query reintroduces the leak (1 run, the second socket served the first's identity), proving the predicate is load-bearing.
  */
 import { describe, expect, it } from "vitest";
 
@@ -74,7 +71,7 @@ const createFakeState = (): ShardDOState & { sockets: FakeWebSocket[] } => {
                 },
             },
         },
-    } as unknown as ShardDOState & { sockets: FakeWebSocket[] };
+    };
 };
 
 interface IdentityArg {
@@ -92,10 +89,10 @@ interface IdentityArg {
 class DedupShard extends ShardDO {
     public readonly runs: { functionPath: string; userId: string }[] = [];
 
-    private counter = 0;
-
     /** `functionPaths` forced identity-independent on top of the admin default. */
     public forcedIndependent = new Set<string>();
+
+    private counter = 0;
 
     public override handleRpc(): Promise<unknown> {
         this.recordChangedTable("messages");
@@ -147,7 +144,9 @@ const lastOwner = (ws: FakeWebSocket, subId: string): string | undefined => {
     return frames.at(-1)?.data?.owner;
 };
 
-const attachmentFor = (userId: string): SocketAttachment => ({ identity: { userId }, subs: {}, userId }) as SocketAttachment;
+const attachmentFor = (userId: string): SocketAttachment => {
+    return { identity: { userId }, subs: {}, userId };
+};
 
 describe("shardDO reactive dedup (identity-independent runs)", () => {
     it("positive: an identity-independent query runs ONCE for N sockets in a flush", async () => {

--- a/packages/do/__tests__/shard-do.reactive-dedup.test.ts
+++ b/packages/do/__tests__/shard-do.reactive-dedup.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Cross-socket dedup of identity-INDEPENDENT reactive query runs
+ * (`resolveReactiveOutcomeDeduped`).
+ *
+ * Within a single `refreshSubscriptions` flush, N sockets subscribed to the
+ * SAME `(functionPath, args)` re-run the query N times (the Case-6 fan-out
+ * characterization in the integration suite). When the read is
+ * identity-INDEPENDENT — admin/reserved introspection, whose result cannot vary
+ * by the caller — the run is shared across sockets, collapsing N runs to ONE.
+ *
+ * The SECURITY boundary is `isIdentityIndependent`: an RLS / `ctx.auth` / flag
+ * read evaluates under the socket's own verified identity and MUST NOT be
+ * shared, or one identity's rows leak to another. These tests lock in:
+ *   1. POSITIVE — an identity-independent query runs once for N sockets.
+ *   2. NEGATIVE — an identity-dependent query runs once PER socket, each under
+ *      its own identity (no cross-identity leak).
+ *   3. SANITY — forcing the predicate true on an identity-dependent query
+ *      reintroduces the leak (1 run, the second socket served the first's
+ *      identity), proving the predicate is load-bearing.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ShardDOState, SubscriptionOutcome } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import type { SocketAttachment, SubscriptionEnvelope } from "../src/types";
+
+interface FakeWebSocket {
+    attachment: SocketAttachment | undefined;
+    close: () => void;
+    closed: boolean;
+    deserializeAttachment: () => unknown;
+    send: (data: string) => void;
+    sent: string[];
+    serializeAttachment: (value: unknown) => void;
+}
+
+const createFakeWebSocket = (): FakeWebSocket => {
+    return {
+        attachment: undefined,
+        close() {
+            this.closed = true;
+        },
+        closed: false,
+        deserializeAttachment() {
+            return this.attachment;
+        },
+        send(data: string) {
+            this.sent.push(data);
+        },
+        sent: [],
+        serializeAttachment(value: unknown) {
+            this.attachment = value as SocketAttachment | undefined;
+        },
+    };
+};
+
+// Omits `waitUntil` so `flushChangedTables` awaits `refreshSubscriptions`
+// synchronously, making the per-flush run count deterministic.
+const createFakeState = (): ShardDOState & { sockets: FakeWebSocket[] } => {
+    const sockets: FakeWebSocket[] = [];
+
+    return {
+        acceptWebSocket(ws: WebSocket) {
+            sockets.push(ws as unknown as FakeWebSocket);
+        },
+        getWebSockets() {
+            return sockets as unknown as WebSocket[];
+        },
+        sockets,
+        storage: {
+            sql: {
+                exec() {
+                    return { one: () => undefined, toArray: () => [], [Symbol.iterator]: Array.prototype[Symbol.iterator].bind([]) };
+                },
+            },
+        },
+    } as unknown as ShardDOState & { sockets: FakeWebSocket[] };
+};
+
+interface IdentityArg {
+    identity?: Record<string, unknown>;
+    userId?: string;
+}
+
+/**
+ * Records every subscription run with the identity it ran under, and returns a
+ * result tagged by that identity plus a global counter — so a leak (one
+ * identity's value delivered to another) is directly observable, and every run
+ * yields a byte-distinct object result (forcing a full `data` frame, never the
+ * suppression path).
+ */
+class DedupShard extends ShardDO {
+    public readonly runs: { functionPath: string; userId: string }[] = [];
+
+    private counter = 0;
+
+    /** `functionPaths` forced identity-independent on top of the admin default. */
+    public forcedIndependent = new Set<string>();
+
+    public override handleRpc(): Promise<unknown> {
+        this.recordChangedTable("messages");
+
+        return Promise.resolve({ ok: true });
+    }
+
+    public registerSocket(ws: FakeWebSocket, attachment: SocketAttachment): void {
+        this.state.acceptWebSocket(ws as unknown as WebSocket);
+        ws.serializeAttachment(attachment);
+    }
+
+    public driveSubscribe(ws: FakeWebSocket, subId: string, functionPath: string): Promise<void> {
+        const envelope: SubscriptionEnvelope = { id: subId, query: { args: {}, functionPath }, type: "subscribe" };
+
+        return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
+    }
+
+    public writeRpc(): Promise<Response> {
+        return this.fetch(
+            new Request("https://shard.internal/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "mutation:write" }),
+                headers: { "content-type": "application/json" },
+                method: "POST",
+            }),
+        );
+    }
+
+    protected override executeSubscription(functionPath: string, _args: Record<string, unknown>, identity?: IdentityArg): Promise<SubscriptionOutcome | null> {
+        const userId = identity?.userId ?? "anon";
+
+        this.runs.push({ functionPath, userId });
+        this.counter += 1;
+
+        return Promise.resolve({ result: { n: this.counter, owner: userId }, tables: new Set(["messages"]) });
+    }
+
+    protected override isIdentityIndependent(functionPath: string): boolean {
+        return this.forcedIndependent.has(functionPath) || super.isIdentityIndependent(functionPath);
+    }
+}
+
+/** The `owner` of the most recent `{type:"data"}` frame for `subId`. */
+const lastOwner = (ws: FakeWebSocket, subId: string): string | undefined => {
+    const frames = ws.sent
+        .map((line) => JSON.parse(line) as { data?: { owner?: string }; id: string; type: string })
+        .filter((frame) => frame.type === "data" && frame.id === subId);
+
+    return frames.at(-1)?.data?.owner;
+};
+
+const attachmentFor = (userId: string): SocketAttachment => ({ identity: { userId }, subs: {}, userId }) as SocketAttachment;
+
+describe("shardDO reactive dedup (identity-independent runs)", () => {
+    it("positive: an identity-independent query runs ONCE for N sockets in a flush", async () => {
+        expect.assertions(3);
+
+        const shard = new DedupShard(createFakeState(), {});
+
+        shard.forcedIndependent.add("shared:list");
+
+        const sockets: FakeWebSocket[] = [];
+
+        for (let index = 0; index < 3; index += 1) {
+            const ws = createFakeWebSocket();
+
+            shard.registerSocket(ws, attachmentFor(`user-${String(index)}`));
+            // eslint-disable-next-line no-await-in-loop -- sequential seed keeps run ordering deterministic
+            await shard.driveSubscribe(ws, `sub-${String(index)}`, "shared:list");
+            sockets.push(ws);
+        }
+
+        // Three seeds, one run each (seeding does not dedup).
+        expect(shard.runs.filter((r) => r.functionPath === "shared:list")).toHaveLength(3);
+
+        const runsAfterSeed = shard.runs.length;
+
+        // One write touching "messages" → all three subs intersect and refresh.
+        await shard.writeRpc();
+
+        // The shared identity-independent run executed exactly once this flush…
+        expect(shard.runs.length - runsAfterSeed).toBe(1);
+        // …yet every socket still received its own refreshed frame.
+        expect(sockets.every((ws, index) => lastOwner(ws, `sub-${String(index)}`) !== undefined)).toBe(true);
+    });
+
+    it("negative: an identity-dependent query runs once PER socket under its own identity (no leak)", async () => {
+        expect.assertions(4);
+
+        const shard = new DedupShard(createFakeState(), {});
+
+        const wsA = createFakeWebSocket();
+        const wsB = createFakeWebSocket();
+
+        shard.registerSocket(wsA, attachmentFor("user-A"));
+        shard.registerSocket(wsB, attachmentFor("user-B"));
+
+        await shard.driveSubscribe(wsA, "sub-A", "messages:list");
+        await shard.driveSubscribe(wsB, "sub-B", "messages:list");
+
+        const runsAfterSeed = shard.runs.length;
+
+        await shard.writeRpc();
+
+        const refreshRuns = shard.runs.slice(runsAfterSeed);
+
+        // No dedup: the query ran once per socket…
+        expect(refreshRuns).toHaveLength(2);
+        // …each under its OWN identity…
+        expect(new Set(refreshRuns.map((r) => r.userId))).toStrictEqual(new Set(["user-A", "user-B"]));
+        // …and each socket received only its own identity's rows (no cross leak).
+        expect(lastOwner(wsA, "sub-A")).toBe("user-A");
+        expect(lastOwner(wsB, "sub-B")).toBe("user-B");
+    });
+
+    it("sanity: forcing the predicate true on an identity-dependent query reintroduces the leak", async () => {
+        expect.assertions(3);
+
+        const shard = new DedupShard(createFakeState(), {});
+
+        // Deliberately misclassify an RLS query as identity-independent.
+        shard.forcedIndependent.add("messages:list");
+
+        const wsA = createFakeWebSocket();
+        const wsB = createFakeWebSocket();
+
+        shard.registerSocket(wsA, attachmentFor("user-A"));
+        shard.registerSocket(wsB, attachmentFor("user-B"));
+
+        await shard.driveSubscribe(wsA, "sub-A", "messages:list");
+        await shard.driveSubscribe(wsB, "sub-B", "messages:list");
+
+        const runsAfterSeed = shard.runs.length;
+
+        await shard.writeRpc();
+
+        // Dedup wrongly kicked in: a single run this flush…
+        expect(shard.runs.length - runsAfterSeed).toBe(1);
+
+        // …whose identity is served to BOTH sockets — user-B is leaked user-A's
+        // data. This is exactly what the real predicate prevents.
+        const ownerA = lastOwner(wsA, "sub-A");
+        const ownerB = lastOwner(wsB, "sub-B");
+
+        expect(ownerA).toBe(ownerB);
+        expect(ownerB).toBe("user-A");
+    });
+});

--- a/packages/do/__tests__/shard-do.shape-poke.test.ts
+++ b/packages/do/__tests__/shard-do.shape-poke.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { DatabaseWriterLike } from "../src/ctx-db";
+import type { CdcChange, DatabaseWriterLike, SqlExec } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
 import type { ShardDOState } from "../src/shard-do";
 import { ShardDO } from "../src/shard-do";
@@ -103,6 +103,21 @@ class ShapePokeShard extends ShardDO {
         });
 
         return this.writer;
+    }
+}
+
+/**
+ * {@link ShapePokeShard} that counts every `__cdc_log` page read backing a shape
+ * diff, so a test can prove the flush-local op-range cache collapses N
+ * same-range shape diffs to ONE changelog drain.
+ */
+class CountingShapePokeShard extends ShapePokeShard {
+    public cdcPageReads = 0;
+
+    protected override readShapeCdcPage(sql: SqlExec, sinceSeq: number, tables: ReadonlySet<string>): { changes: CdcChange[]; cursor: number } {
+        this.cdcPageReads += 1;
+
+        return super.readShapeCdcPage(sql, sinceSeq, tables);
     }
 }
 
@@ -250,5 +265,50 @@ describe("shardDO shape poke protocol (dispatch path)", () => {
         // Only the c1 subscriber is poked.
         expect(pokeOps(a)).toStrictEqual([{ key: "m1", op: "insert", table: "messages", value: expect.objectContaining({ _id: "m1" }) }]);
         expect(b.sent).toStrictEqual([]);
+    });
+
+    it("shares one op-log drain across same-range shape diffs in a flush (op-range cache)", async () => {
+        expect.assertions(3);
+
+        // Run the SAME single write against a shard holding `socketCount` shapes
+        // on the identical (table, range), counting only the page reads the write
+        // flush performs.
+        const measure = async (socketCount: number): Promise<{ reads: number; sockets: FakeWebSocket[] }> => {
+            harness = createSqliteExec();
+            runShardMigrations(harness.sql, messagesSchema, { cdc: true });
+
+            const sockets: FakeWebSocket[] = [];
+            const shard = new CountingShapePokeShard(makeState(sockets), {});
+
+            // Every socket subscribes to the SAME shape (c1) before any write, so
+            // each shape memo records the same seed cursor → an identical diff
+            // range `(memoCursor, checkpoint]` for all of them on the write flush.
+            for (let index = 0; index < socketCount; index += 1) {
+                const ws = createFakeWebSocket();
+
+                sockets.push(ws);
+                // eslint-disable-next-line no-await-in-loop -- sequential subscribe keeps seed cursors identical
+                await subscribeShape(shard, ws, "c1");
+            }
+
+            shard.cdcPageReads = 0;
+            await shard.fetch(write("messages:send", { _id: "m1", channelId: "c1", text: "hi" }));
+
+            return { reads: shard.cdcPageReads, sockets };
+        };
+
+        const one = await measure(1);
+        const three = await measure(3);
+
+        // A single shape diff drains the op range with at least one page read.
+        expect(one.reads).toBeGreaterThan(0);
+
+        // Three sockets on the identical (table, range) share that ONE drain — the
+        // flush-local cache collapses the extra two, so the page-read count is
+        // unchanged (pre-cache this would have been 3x).
+        expect(three.reads).toBe(one.reads);
+
+        // Correctness is intact: every subscriber still received the insert poke.
+        expect(three.sockets.every((ws) => pokeOps(ws).some((op) => op.key === "m1" && op.op === "insert"))).toBe(true);
     });
 });

--- a/packages/do/__tests__/shard-do.stream.test.ts
+++ b/packages/do/__tests__/shard-do.stream.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ShardDOState } from "../src/shard-do";
 import { ShardDO } from "../src/shard-do";
@@ -284,5 +284,38 @@ describe("shardDO streaming queries", () => {
         expect((errorFrame?.error as { code?: string; message?: string })?.code).toBe("FORBIDDEN");
         expect((errorFrame?.error as { code?: string; message?: string })?.message).toBe("kaboom");
         expect(frames.filter((f) => f.type === "complete")).toHaveLength(0);
+    });
+
+    it("redacts a bare (codeless) handler throw from the stream error frame", async () => {
+        expect.assertions(4);
+
+        const shard = new StreamShard(state, {});
+        const sensitive = "SELECT secret_token FROM users WHERE id = 42";
+
+        shard.registered.set("metrics:leak", async function* leakGen() {
+            yield 1;
+            // A plain Error with no `code` is the generic catch-all — its message
+            // may carry SQL / internal identifiers and must be redacted.
+            throw new Error(sensitive);
+        });
+
+        const ws = createFakeWebSocket();
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        shard.registerSocket(ws, { subs: {} });
+        await shard.driveMessage(ws, { id: "stream_7", query: { functionPath: "metrics:leak" }, type: "stream" });
+        await waitForTerminator(ws);
+
+        const frames = parseFrames(ws);
+        const errorFrame = frames.find((f) => f.type === "error");
+
+        expect(errorFrame).toBeDefined();
+        // The raw message must not leak; the code falls back to the generic code.
+        expect((errorFrame?.error as { code?: string; message?: string })?.code).toBe("INTERNAL_SERVER_ERROR");
+        expect((errorFrame?.error as { code?: string; message?: string })?.message).toBe("internal error");
+        // ...but it is logged server-side for diagnosis.
+        expect(errorSpy).toHaveBeenCalled();
+
+        errorSpy.mockRestore();
     });
 });

--- a/packages/do/__tests__/shard-do.stream.test.ts
+++ b/packages/do/__tests__/shard-do.stream.test.ts
@@ -314,7 +314,7 @@ describe("shardDO streaming queries", () => {
         expect((errorFrame?.error as { code?: string; message?: string })?.code).toBe("INTERNAL_SERVER_ERROR");
         expect((errorFrame?.error as { code?: string; message?: string })?.message).toBe("internal error");
         // ...but it is logged server-side for diagnosis.
-        expect(errorSpy).toHaveBeenCalledWith();
+        expect(errorSpy).toHaveBeenCalledWith("[@lunora/do] unhandled stream error:", expect.anything());
 
         errorSpy.mockRestore();
     });

--- a/packages/do/__tests__/shard-do.stream.test.ts
+++ b/packages/do/__tests__/shard-do.stream.test.ts
@@ -314,7 +314,7 @@ describe("shardDO streaming queries", () => {
         expect((errorFrame?.error as { code?: string; message?: string })?.code).toBe("INTERNAL_SERVER_ERROR");
         expect((errorFrame?.error as { code?: string; message?: string })?.message).toBe("internal error");
         // ...but it is logged server-side for diagnosis.
-        expect(errorSpy).toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith();
 
         errorSpy.mockRestore();
     });

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -248,7 +248,7 @@ describe("shardDO", () => {
         expect(text).not.toContain(sensitive);
         expect(JSON.parse(text)).toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
         // ...but it is logged server-side for diagnosis.
-        expect(errorSpy).toHaveBeenCalledWith();
+        expect(errorSpy).toHaveBeenCalledWith("[@lunora/do] unhandled RPC error:", expect.anything());
 
         errorSpy.mockRestore();
     });

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -218,15 +218,20 @@ describe("shardDO", () => {
         expect(response.status).toBe(400);
     });
 
-    it("returns 500 with mapped error when handleRpc throws", async () => {
-        expect.assertions(2);
+    it("returns 500 with a redacted message when handleRpc throws", async () => {
+        expect.assertions(4);
 
         shard.rpcResult = undefined;
         const failing = new TestShard(state, {});
+        const sensitive = "table users column secret_token does not exist";
 
         failing.handleRpc = async () => {
-            throw new Error("boom");
+            throw new Error(sensitive);
         };
+
+        // The unhandled throw is logged server-side; the client must only see a
+        // generic message. Silence + capture the diagnostic.
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
         const request = new Request("https://shard.internal/rpc", {
             body: JSON.stringify({ args: {}, functionPath: "fail" }),
@@ -236,7 +241,16 @@ describe("shardDO", () => {
         const response = await failing.fetch(request);
 
         expect(response.status).toBe(500);
-        await expect(response.json()).resolves.toMatchObject({ error: { code: "RPC_FAILED", message: "boom" } });
+
+        const text = await response.text();
+
+        // The raw thrown message must never reach the client.
+        expect(text).not.toContain(sensitive);
+        expect(JSON.parse(text)).toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
+        // ...but it is logged server-side for diagnosis.
+        expect(errorSpy).toHaveBeenCalled();
+
+        errorSpy.mockRestore();
     });
 
     it("subscribe updates attachment registry and acks", async () => {

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -248,7 +248,7 @@ describe("shardDO", () => {
         expect(text).not.toContain(sensitive);
         expect(JSON.parse(text)).toMatchObject({ error: { code: "RPC_FAILED", message: "internal error" } });
         // ...but it is logged server-side for diagnosis.
-        expect(errorSpy).toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith();
 
         errorSpy.mockRestore();
     });

--- a/packages/do/__tests__/socket-pool.test.ts
+++ b/packages/do/__tests__/socket-pool.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { runSocketPool } from "../src/socket-pool";
+
+/** A deferred whose `resolve` is callable from outside the executor. */
+const defer = (): { promise: Promise<void>; resolve: () => void } => {
+    let resolve: () => void = () => {};
+    const promise = new Promise<void>((r) => {
+        resolve = r;
+    });
+
+    return { promise, resolve };
+};
+
+describe(runSocketPool, () => {
+    it("visits every item exactly once", async () => {
+        expect.assertions(2);
+
+        const items = Array.from({ length: 25 }, (_, index) => index);
+        const visits: number[] = [];
+
+        await runSocketPool(items, (item) => {
+            visits.push(item);
+
+            return Promise.resolve();
+        });
+
+        expect(visits).toHaveLength(items.length);
+        expect([...visits].sort((a, b) => a - b)).toStrictEqual(items);
+    });
+
+    it("never runs more than `concurrency` workers at once", async () => {
+        expect.assertions(2);
+
+        const items = Array.from({ length: 20 }, (_, index) => index);
+        const gates = items.map(() => defer());
+
+        let active = 0;
+        let peak = 0;
+
+        const run = runSocketPool(
+            items,
+            async (item) => {
+                active += 1;
+                peak = Math.max(peak, active);
+                await gates[item]?.promise;
+                active -= 1;
+            },
+            4,
+        );
+
+        // Let the workers ramp up, then release the gates in waves.
+        for (const gate of gates) {
+            await Promise.resolve();
+            gate.resolve();
+        }
+
+        await run;
+
+        // At most 4 in flight at any moment, and the pool actually parallelized.
+        expect(peak).toBeLessThanOrEqual(4);
+        expect(peak).toBe(4);
+    });
+
+    it("no-ops on an empty list and caps workers at the item count", async () => {
+        expect.assertions(2);
+
+        const empty: number[] = [];
+        let calls = 0;
+
+        await runSocketPool(empty, () => {
+            calls += 1;
+
+            return Promise.resolve();
+        });
+
+        expect(calls).toBe(0);
+
+        // Fewer items than the default concurrency: every item still runs once.
+        const visits: number[] = [];
+
+        await runSocketPool([1, 2], (item) => {
+            visits.push(item);
+
+            return Promise.resolve();
+        });
+
+        expect(visits.sort((a, b) => a - b)).toStrictEqual([1, 2]);
+    });
+});

--- a/packages/do/__tests__/socket-pool.test.ts
+++ b/packages/do/__tests__/socket-pool.test.ts
@@ -88,4 +88,25 @@ describe(runSocketPool, () => {
 
         expect(visits.toSorted((a, b) => a - b)).toStrictEqual([1, 2]);
     });
+
+    it("contains a per-item failure so the remaining items still run", async () => {
+        expect.assertions(2);
+
+        const items = [0, 1, 2, 3, 4];
+        const visited: number[] = [];
+
+        // Item 2 rejects; the pool must swallow it and keep draining the rest.
+        await runSocketPool(
+            items,
+            (item) => {
+                visited.push(item);
+
+                return item === 2 ? Promise.reject(new Error("boom")) : Promise.resolve();
+            },
+            1,
+        );
+
+        expect(visited.toSorted((a, b) => a - b)).toStrictEqual(items);
+        expect(visited).toContain(4);
+    });
 });

--- a/packages/do/__tests__/socket-pool.test.ts
+++ b/packages/do/__tests__/socket-pool.test.ts
@@ -4,12 +4,12 @@ import { runSocketPool } from "../src/socket-pool";
 
 /** A deferred whose `resolve` is callable from outside the executor. */
 const defer = (): { promise: Promise<void>; resolve: () => void } => {
-    let resolve: () => void = () => {};
-    const promise = new Promise<void>((r) => {
-        resolve = r;
+    let resolveFn: () => void = () => {};
+    const promise = new Promise<void>((resolve) => {
+        resolveFn = resolve;
     });
 
-    return { promise, resolve };
+    return { promise, resolve: resolveFn };
 };
 
 describe(runSocketPool, () => {
@@ -26,7 +26,7 @@ describe(runSocketPool, () => {
         });
 
         expect(visits).toHaveLength(items.length);
-        expect([...visits].sort((a, b) => a - b)).toStrictEqual(items);
+        expect(visits.toSorted((a, b) => a - b)).toStrictEqual(items);
     });
 
     it("never runs more than `concurrency` workers at once", async () => {
@@ -51,6 +51,7 @@ describe(runSocketPool, () => {
 
         // Let the workers ramp up, then release the gates in waves.
         for (const gate of gates) {
+            // eslint-disable-next-line no-await-in-loop -- intentionally yield a microtask between gate releases so workers ramp up before draining
             await Promise.resolve();
             gate.resolve();
         }
@@ -85,6 +86,6 @@ describe(runSocketPool, () => {
             return Promise.resolve();
         });
 
-        expect(visits.sort((a, b) => a - b)).toStrictEqual([1, 2]);
+        expect(visits.toSorted((a, b) => a - b)).toStrictEqual([1, 2]);
     });
 });

--- a/packages/do/__tests__/subscription-refresh.integration.test.ts
+++ b/packages/do/__tests__/subscription-refresh.integration.test.ts
@@ -170,6 +170,12 @@ const subFrames = (ws: FakeWebSocket, subId: string): { id: string; type: string
         .map((line) => JSON.parse(line) as { id: string; type: string })
         .filter((frame) => (frame.type === "data" || frame.type === "delta") && frame.id === subId);
 
+/** `{type:"settled"}` frames for a given subId — the suppressed-list watermark frame. */
+const settledFrames = (ws: FakeWebSocket, subId: string): { id: string; lastMutationId?: number; type: string }[] =>
+    ws.sent
+        .map((line) => JSON.parse(line) as { id: string; lastMutationId?: number; type: string })
+        .filter((frame) => frame.type === "settled" && frame.id === subId);
+
 /** Only `{type:"data"}` frames for a given subId — used to read the most recent full snapshot. */
 const dataFrames = (ws: FakeWebSocket, subId: string): unknown[] =>
     ws.sent
@@ -251,6 +257,54 @@ describe("shardDO: mutation → subscription-refresh pipeline", () => {
         // Socket B must NOT have received any additional frame — memo skip.
         // "settings" was not in the changed set, so the subscription is skipped entirely.
         expect(subFrames(wsB, "sub-B")).toHaveLength(1); // only the seed; no refresh
+    });
+
+    // -------------------------------------------------------------------------
+    // SETTLED FRAME — suppressed-list watermark for custom-mutator clients.
+    //
+    // A write touches a subscribed table but the query re-runs to a byte-identical
+    // result, so `pushSubscriptionData` suppresses the data/delta frame. For a
+    // `@lunora/db` custom-mutator client (one that announced a `clientId`), that
+    // silence would otherwise strand its optimistic overlay forever. The server
+    // emits a lightweight `settled` frame carrying the client's watermark so the
+    // overlay drops; a plain `useQuery` client (no `clientId`) gets nothing.
+    // -------------------------------------------------------------------------
+    it("settled frame: a no-change refresh emits a settled frame only to a clientId socket", async () => {
+        expect.assertions(6);
+
+        const shard = new SubscriptionRefreshShard(state, {});
+
+        // Socket A announced a clientId (a custom-mutator @lunora/db client).
+        const wsA = createFakeWebSocket();
+
+        shard.registerSocket(wsA, { clientId: "client-A", subs: {}, userId: "" });
+
+        // Socket B is a plain useQuery client — no clientId.
+        const wsB = createFakeWebSocket();
+
+        shard.registerSocket(wsB);
+
+        const stableOutcome = { result: [{ _id: "m1", text: "hello" }], tables: new Set(["messages"]) };
+
+        shard.outcomes.set("messages:list", stableOutcome);
+        await subscribeSocket(shard, wsA, "sub-A", "messages:list");
+        await subscribeSocket(shard, wsB, "sub-B", "messages:list");
+
+        // Both seeded with a data frame, neither has a settled frame yet.
+        expect(subFrames(wsA, "sub-A")).toHaveLength(1);
+        expect(subFrames(wsB, "sub-B")).toHaveLength(1);
+        expect(settledFrames(wsA, "sub-A")).toHaveLength(0);
+
+        // A write touches "messages" but the query re-runs to the SAME result, so
+        // both subscriptions hit the byte-identical suppression branch.
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        // No new data/delta frame on either socket (result unchanged).
+        expect(subFrames(wsA, "sub-A")).toHaveLength(1);
+        // Socket A (clientId) received a settled watermark frame; socket B did not.
+        expect(settledFrames(wsA, "sub-A")).toHaveLength(1);
+        expect(settledFrames(wsB, "sub-B")).toHaveLength(0);
     });
 
     // -------------------------------------------------------------------------

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -5494,13 +5494,13 @@ abstract class ShardDO {
      * different identity, so this predicate gates {@link resolveReactiveOutcomeDeduped}
      * shut for them.
      */
-    // eslint-disable-next-line class-methods-use-this -- a pure predicate over the function path; a method so the security boundary lives in one named place (and tests can probe it)
+    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/member-ordering -- pure predicate over the function path; a protected method so the security boundary lives in one named place (and tests can probe it), co-located with the reactive dedup it gates rather than hoisted away from its only caller
     protected isIdentityIndependent(functionPath: string): boolean {
         return functionPath.startsWith(ADMIN_FUNCTION_PREFIX);
     }
 
     /**
-     * {@link resolveReactiveOutcome} with flush-local memoization across sockets.
+     * Memoizing wrapper over {@link resolveReactiveOutcome}: flush-local sharing across sockets.
      * Within a single {@link refreshSubscriptions} pass, N sockets subscribed to
      * the SAME identity-independent `(functionPath, args)` re-run the query N
      * times today (see the Case-6 fan-out characterization). When the read is
@@ -5571,7 +5571,7 @@ abstract class ShardDO {
      * 4. On normal completion send `{type:"complete"}`; on throw send
      * `{type:"error"}`. Either way drop the controller.
      */
-
+    // eslint-disable-next-line sonarjs/cognitive-complexity -- the stream lifecycle (ack → chunk pump → complete/error) plus the structured-vs-redacted error branch is the wire protocol and reads clearer inline than split across helpers sharing the controller + socket
     private async handleStream(ws: WebSocket, id: string, functionPath: string, args: Record<string, unknown>): Promise<void> {
         const iterable = this.executeStream(functionPath, args);
 
@@ -5646,7 +5646,8 @@ abstract class ShardDO {
                 console.error("[@lunora/do] unhandled stream error:", error);
             }
 
-            const message = isStructured ? (error instanceof Error ? error.message : String(error)) : "internal error";
+            const rawMessage = error instanceof Error ? error.message : String(error);
+            const message = isStructured ? rawMessage : "internal error";
 
             ws.send(
                 JSON.stringify({
@@ -6316,7 +6317,7 @@ abstract class ShardDO {
      * changelog read that {@link readShapeOpRange} memoizes per flush, and gives
      * tests a point to count the reads the op-range cache collapses.
      */
-    // eslint-disable-next-line class-methods-use-this -- thin pass-through seam over the module-level reader; a method so the op-range cache + tests share one read point
+    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/member-ordering -- thin pass-through seam over the module-level reader; a protected method so the op-range cache + tests share one read point, co-located with the poke path it serves rather than hoisted away from its only caller
     protected readShapeCdcPage(sql: SqlExec, sinceSeq: number, tables: ReadonlySet<string>): { changes: CdcChange[]; cursor: number } {
         return readCdcChanges(sql, { sinceSeq, tables });
     }

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -5479,6 +5479,70 @@ abstract class ShardDO {
     }
 
     /**
+     * SECURITY BOUNDARY for cross-socket reactive dedup. A read is
+     * identity-INDEPENDENT only when its result cannot vary by the caller's
+     * verified identity — i.e. the admin/reserved introspection reads, which
+     * route to {@link executeAdminSubscription} and ignore the
+     * {@link SubscriptionIdentity} entirely.
+     *
+     * Everything else is identity-DEPENDENT and must NEVER be shared across
+     * sockets: a user query may be `rls()` / `ctx.auth`-scoped (different rows
+     * per identity), and a flag read ({@link FLAGS_FUNCTION_PREFIX}) evaluates
+     * the provider with the subscriber's identity (per-user targeting). Sharing
+     * one socket's result with another would leak one identity's rows/flags to a
+     * different identity, so this predicate gates {@link resolveReactiveOutcomeDeduped}
+     * shut for them.
+     */
+    // eslint-disable-next-line class-methods-use-this -- a pure predicate over the function path; a method so the security boundary lives in one named place (and tests can probe it)
+    protected isIdentityIndependent(functionPath: string): boolean {
+        return functionPath.startsWith(ADMIN_FUNCTION_PREFIX);
+    }
+
+    /**
+     * {@link resolveReactiveOutcome} with flush-local memoization across sockets.
+     * Within a single {@link refreshSubscriptions} pass, N sockets subscribed to
+     * the SAME identity-independent `(functionPath, args)` re-run the query N
+     * times today (see the Case-6 fan-out characterization). When the read is
+     * identity-independent (admin/reserved — see {@link isIdentityIndependent})
+     * its result is the same for every socket, so the first run is cached (by its
+     * in-flight Promise, since the bounded worker pool runs sockets in parallel)
+     * and shared with the rest — collapsing N runs to ONE.
+     *
+     * Identity-DEPENDENT reads are passed straight through, UNCACHED: each socket
+     * must evaluate under its own by-value identity (RLS / `ctx.auth` / per-user
+     * flags), so they never share a result. The `cache` is created fresh per
+     * flush by the caller, so a result is never reused across passes (it would go
+     * stale after the next write).
+     */
+    private resolveReactiveOutcomeDeduped(
+        functionPath: string,
+        args: Record<string, unknown>,
+        isAdmin: boolean,
+        identity: SubscriptionIdentity,
+        cache: Map<string, Promise<SubscriptionOutcome | null>>,
+    ): Promise<SubscriptionOutcome | null> {
+        if (!this.isIdentityIndependent(functionPath)) {
+            return this.resolveReactiveOutcome(functionPath, args, isAdmin, identity);
+        }
+
+        // Identity is irrelevant for these reads, so the null-identity key is
+        // identical across every sharing socket.
+        // eslint-disable-next-line unicorn/no-null -- reactiveCacheKey's identity arg is `null | string`; null = the identity-independent bucket
+        const key = reactiveCacheKey(functionPath, args, null);
+        const cached = cache.get(key);
+
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const pending = this.resolveReactiveOutcome(functionPath, args, isAdmin, identity);
+
+        cache.set(key, pending);
+
+        return pending;
+    }
+
+    /**
      * Constant-time bearer check against `env.LUNORA_ADMIN_TOKEN`. Returns
      * `false` (closed) when the token is unset so admin introspection is
      * opt-in rather than exposed by default.
@@ -5773,6 +5837,13 @@ abstract class ShardDO {
         const frameCursor = this.currentCdcCursor();
         const frameEpoch = this.currentCdcEpoch();
 
+        // Flush-local dedup of identity-INDEPENDENT reactive runs: N sockets on
+        // the same admin/reserved `(functionPath, args)` share ONE query run this
+        // pass instead of re-running it per socket. Created fresh per flush so a
+        // result is never reused across writes; identity-dependent reads bypass it
+        // entirely (see resolveReactiveOutcomeDeduped).
+        const reactiveRunCache = new Map<string, Promise<SubscriptionOutcome | null>>();
+
         const refreshOne = async (ws: WebSocket): Promise<void> => {
             // Enforce token-expiry on the OUTBOUND path: a lapsed socket must not
             // keep receiving its user's live (RLS/`ctx.auth`-scoped) data. This is
@@ -5813,10 +5884,13 @@ abstract class ShardDO {
                     // scoped live query would evaluate anonymous and return zero rows.
                     // (Admin + reserved flag reads ignore the identity payload.)
                     // eslint-disable-next-line no-await-in-loop -- subscriptions on a socket re-run sequentially; each shares the single SQLite handle
-                    const outcome = await this.resolveReactiveOutcome(functionPath, query.args ?? {}, isAdmin, {
-                        identity: attachment.identity,
-                        userId: attachment.userId,
-                    });
+                    const outcome = await this.resolveReactiveOutcomeDeduped(
+                        functionPath,
+                        query.args ?? {},
+                        isAdmin,
+                        { identity: attachment.identity, userId: attachment.userId },
+                        reactiveRunCache,
+                    );
 
                     if (!outcome) {
                         continue;

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -6710,6 +6710,23 @@ abstract class ShardDO {
         if (existing?.lastJson === json) {
             existing.tables = outcome.tables;
 
+            // The result is byte-identical to the last frame, so no data/delta
+            // frame goes out (frame suppression). For a `@lunora/db`
+            // custom-mutator client (one that announced a `clientId`, hence has a
+            // client watermark), a confirmed write whose authoritative result did
+            // NOT change this list would otherwise leave its optimistic overlay
+            // stuck forever — with no frame, the client's checkpoint gate never
+            // advances. Emit a lightweight `settled` frame (carrying the same
+            // cursor/epoch as the data path) so the client drops the overlay
+            // without a visible change. Plain `useQuery` subscribers (no
+            // `clientId`, no watermark) never receive it, and an old client
+            // ignores the unknown frame.
+            const settledWatermark = this.socketClientWatermark(ws);
+
+            if (settledWatermark !== undefined) {
+                trySendFrame(ws, `{"type":"settled","id":${JSON.stringify(subId)},"lastMutationId":${String(settledWatermark)}${cursorSuffix}}`);
+            }
+
             return;
         }
 

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -4346,9 +4346,14 @@ abstract class ShardDO {
             return jsonResponse({ error: { code: lunoraError.code ?? "INTERNAL", message: lunoraError.message ?? "internal error" } }, status);
         }
 
-        const message = error instanceof Error ? error.message : "unknown error";
+        // Do NOT echo arbitrary error.message values to clients — an unhandled
+        // throw may carry SQL fragments, file paths, or internal identifiers. Log
+        // the raw error server-side and return a generic message (mirrors
+        // `@lunora/runtime`'s `toErrorResponse`).
+        // eslint-disable-next-line no-console -- server-side diagnostic for an unhandled handler error
+        console.error("[@lunora/do] unhandled RPC error:", error);
 
-        return jsonResponse({ error: { code: "RPC_FAILED", message } }, 500);
+        return jsonResponse({ error: { code: "RPC_FAILED", message: "internal error" } }, 500);
     }
 
     /**
@@ -5564,11 +5569,23 @@ abstract class ShardDO {
             }
         } catch (error: unknown) {
             const { code } = error as { code?: string };
-            const message = error instanceof Error ? error.message : String(error);
+            // A structured error (one carrying its own `code`, e.g. a thrown
+            // `LunoraError`) keeps its intentional, developer-facing message. A
+            // bare/unexpected throw is the generic catch-all: log the raw error
+            // server-side and send a redacted message so SQL fragments, file
+            // paths, or internal identifiers never reach the client.
+            const isStructured = typeof code === "string";
+
+            if (!isStructured) {
+                // eslint-disable-next-line no-console -- server-side diagnostic for an unhandled stream error
+                console.error("[@lunora/do] unhandled stream error:", error);
+            }
+
+            const message = isStructured ? (error instanceof Error ? error.message : String(error)) : "internal error";
 
             ws.send(
                 JSON.stringify({
-                    error: { code: typeof code === "string" ? code : "INTERNAL_SERVER_ERROR", message },
+                    error: { code: isStructured ? code : "INTERNAL_SERVER_ERROR", message },
                     id,
                     type: "error",
                 }),

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -6176,6 +6176,12 @@ abstract class ShardDO {
         const checkpoint = frameCursor ?? this.currentCdcCursor() ?? 0;
         const sql = this.sql as SqlExec;
 
+        // Flush-local op-range cache: every shape over the same `(table, sinceSeq,
+        // upTo)` reads the identical changelog slice, so they share ONE drain this
+        // flush instead of re-scanning the op-log per shape/socket. Created fresh
+        // per flush so a slice is never reused across writes (it would go stale).
+        const opRangeCache = new Map<string, Map<string, CdcChange>>();
+
         const pokeOne = async (ws: WebSocket): Promise<void> => {
             if (this.isSocketExpired(ws)) {
                 this.dropExpiredSocket(ws);
@@ -6191,7 +6197,7 @@ abstract class ShardDO {
             }
 
             const identity: SubscriptionIdentity = { identity: attachment.identity, userId: attachment.userId };
-            const { emptyAdvanced, partAdvanced, parts } = this.collectShapePokeParts(ws, shapes, identity, changed, checkpoint, sql);
+            const { emptyAdvanced, partAdvanced, parts } = this.collectShapePokeParts(ws, shapes, identity, changed, checkpoint, sql, opRangeCache);
 
             // Empty-diff shapes advance regardless (nothing to deliver for them),
             // so the next flush doesn't re-scan the same op range.
@@ -6252,6 +6258,7 @@ abstract class ShardDO {
         changed: Set<string>,
         checkpoint: number,
         sql: SqlExec,
+        opRangeCache: Map<string, Map<string, CdcChange>>,
     ): { emptyAdvanced: string[]; partAdvanced: string[]; parts: ShapePokePart[] } {
         const parts: ShapePokePart[] = [];
         const emptyAdvanced: string[] = [];
@@ -6266,7 +6273,7 @@ abstract class ShardDO {
                 }
 
                 const memoCursor = this.shapeMemos.get(ws)?.get(subId)?.cursor ?? 0;
-                const rowsPatch = this.buildShapeDiff(sql, resolved, memoCursor, checkpoint);
+                const rowsPatch = this.buildShapeDiff(sql, resolved, memoCursor, checkpoint, opRangeCache);
 
                 if (rowsPatch.length > 0) {
                     parts.push({ rowsPatch, shapeId: subId });
@@ -6283,23 +6290,30 @@ abstract class ShardDO {
     }
 
     /**
-     * Build the row-ops for a shape over the op range `(sinceSeq, upTo]`. Reads
-     * the changelog (drained across pages), collapses to the latest op per row,
-     * then runs ONE membership probe ({@link selectShapeMemberIds}) over the
-     * changed ids: a row still in the set → upsert with its post-image doc
-     * (projected to the shape's columns); a row that left the set, or any delete,
-     * → `delete(key)` (a delete carries no post-image, so membership is
-     * unknowable from the op alone — the client no-ops an unknown key).
+     * Drain the op-log range `(sinceSeq, upTo]` for `table` into the latest op per
+     * row id (collapsing multiple ops on the same row to the newest). Within one
+     * flush, every shape over the SAME `(table, sinceSeq, upTo)` reads the
+     * identical changelog slice, so the drained map is memoized in the
+     * caller-supplied `cache` (created fresh per flush) — N shapes on a table
+     * share ONE changelog drain instead of re-scanning it per shape. The
+     * per-shape membership probe still runs per shape (its predicate is
+     * identity/args-specific), so only the shared op read is collapsed.
      */
-    // eslint-disable-next-line class-methods-use-this -- a pure op-page→membership-diff transform that reads only its args; kept a private method to sit beside the shape-poke pipeline it belongs to.
-    private buildShapeDiff(sql: SqlExec, resolved: ResolvedShape, sinceSeq: number, upTo: number): ShapeRowOp[] {
+    private readShapeOpRange(sql: SqlExec, table: string, sinceSeq: number, upTo: number, cache?: Map<string, Map<string, CdcChange>>): Map<string, CdcChange> {
+        const key = `${table} ${String(sinceSeq)} ${String(upTo)}`;
+        const cached = cache?.get(key);
+
+        if (cached !== undefined) {
+            return cached;
+        }
+
         const latest = new Map<string, CdcChange>();
-        const tables = new Set([resolved.table]);
+        const tables = new Set([table]);
         let from = sinceSeq;
 
         // Drain the op range so a flush larger than one CDC page is fully covered.
         for (;;) {
-            const { changes, cursor } = readCdcChanges(sql, { sinceSeq: from, tables });
+            const { changes, cursor } = this.readShapeCdcPage(sql, from, tables);
 
             for (const change of changes) {
                 latest.set(change.id, change);
@@ -6311,6 +6325,41 @@ abstract class ShardDO {
 
             from = cursor;
         }
+
+        cache?.set(key, latest);
+
+        return latest;
+    }
+
+    /**
+     * Read one page of the `__cdc_log` for a shape diff (table-scoped). A thin
+     * protected seam over {@link readCdcChanges}: it isolates the single
+     * changelog read that {@link readShapeOpRange} memoizes per flush, and gives
+     * tests a point to count the reads the op-range cache collapses.
+     */
+    // eslint-disable-next-line class-methods-use-this -- thin pass-through seam over the module-level reader; a method so the op-range cache + tests share one read point
+    protected readShapeCdcPage(sql: SqlExec, sinceSeq: number, tables: ReadonlySet<string>): { changes: CdcChange[]; cursor: number } {
+        return readCdcChanges(sql, { sinceSeq, tables });
+    }
+
+    /**
+     * Build the row-ops for a shape over the op range `(sinceSeq, upTo]`. Reads
+     * the changelog (drained across pages via {@link readShapeOpRange}, shared
+     * across same-range shapes in a flush), collapses to the latest op per row,
+     * then runs ONE membership probe ({@link selectShapeMemberIds}) over the
+     * changed ids: a row still in the set → upsert with its post-image doc
+     * (projected to the shape's columns); a row that left the set, or any delete,
+     * → `delete(key)` (a delete carries no post-image, so membership is
+     * unknowable from the op alone — the client no-ops an unknown key).
+     */
+    private buildShapeDiff(
+        sql: SqlExec,
+        resolved: ResolvedShape,
+        sinceSeq: number,
+        upTo: number,
+        opRangeCache?: Map<string, Map<string, CdcChange>>,
+    ): ShapeRowOp[] {
+        const latest = this.readShapeOpRange(sql, resolved.table, sinceSeq, upTo, opRangeCache);
 
         if (latest.size === 0) {
             return [];

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -92,6 +92,7 @@ import { buildSecurityAudit } from "./security-audit";
 import { buildSettings, isDevEnvironment } from "./settings";
 import type { ShapePokePart, ShapeRowOp } from "./shape-global-diff";
 import { buildPokeFrames, diffGlobalMembership, projectColumns } from "./shape-global-diff";
+import { runSocketPool } from "./socket-pool";
 import { runReadonlySql } from "./sql-console";
 import { findDanglingReferences } from "./storage-correlation";
 import { sendDeltaFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
@@ -5916,26 +5917,10 @@ abstract class ShardDO {
             }
         };
 
-        // Bounded fan-out: at most 8 sockets refresh in parallel. Larger
-        // batches don't help (subscription handlers spend their time on
-        // SQLite, which is single-threaded inside the DO) and risk
-        // exhausting the I/O budget.
-        const concurrency = 8;
-        let cursor = 0;
-        const worker = async (): Promise<void> => {
-            let socket = sockets[cursor];
-
-            cursor += 1;
-
-            while (socket !== undefined) {
-                // eslint-disable-next-line no-await-in-loop -- each worker drains the shared cursor sequentially; parallelism comes from running `concurrency` workers
-                await refreshOne(socket);
-                socket = sockets[cursor];
-                cursor += 1;
-            }
-        };
-
-        await Promise.all(Array.from({ length: Math.min(concurrency, sockets.length) }, () => worker()));
+        // Bounded fan-out (default 8 in flight): each worker drains its sockets
+        // one at a time so the per-subscription `awaitWsDrain` gate above paces a
+        // slow consumer. See {@link runSocketPool}.
+        await runSocketPool(sockets, refreshOne);
     }
 
     /**
@@ -6196,50 +6181,44 @@ abstract class ShardDO {
                 return;
             }
 
-            const identity: SubscriptionIdentity = { identity: attachment.identity, userId: attachment.userId };
-            const { emptyAdvanced, partAdvanced, parts } = this.collectShapePokeParts(ws, shapes, identity, changed, checkpoint, sql, opRangeCache);
+            try {
+                const identity: SubscriptionIdentity = { identity: attachment.identity, userId: attachment.userId };
+                const { emptyAdvanced, partAdvanced, parts } = this.collectShapePokeParts(ws, shapes, identity, changed, checkpoint, sql, opRangeCache);
 
-            // Empty-diff shapes advance regardless (nothing to deliver for them),
-            // so the next flush doesn't re-scan the same op range.
-            for (const subId of emptyAdvanced) {
-                this.recordShapeMemo(ws, subId, checkpoint);
-            }
+                // Empty-diff shapes advance regardless (nothing to deliver for them),
+                // so the next flush doesn't re-scan the same op range.
+                for (const subId of emptyAdvanced) {
+                    this.recordShapeMemo(ws, subId, checkpoint);
+                }
 
-            // Await drain before the (potentially large) poke so a slow consumer
-            // can't grow this socket's outbound buffer without bound — the same
-            // backpressure the seed/refresh paths apply. Part-bearing shapes
-            // advance only after the poke lands; a failed send leaves their memos
-            // so the next flush re-emits the rows.
-            if (parts.length > 0) {
-                await awaitWsDrain(ws);
+                // Await drain before the (potentially large) poke so a slow consumer
+                // can't grow this socket's outbound buffer without bound — the same
+                // backpressure the seed/refresh paths apply. Part-bearing shapes
+                // advance only after the poke lands; a failed send leaves their memos
+                // so the next flush re-emits the rows.
+                if (parts.length > 0) {
+                    await awaitWsDrain(ws);
 
-                if (this.sendPoke(ws, parts, checkpoint, frameEpoch, undefined)) {
-                    for (const subId of partAdvanced) {
-                        this.recordShapeMemo(ws, subId, checkpoint);
+                    if (this.sendPoke(ws, parts, checkpoint, frameEpoch, undefined)) {
+                        for (const subId of partAdvanced) {
+                            this.recordShapeMemo(ws, subId, checkpoint);
+                        }
                     }
                 }
-            }
-        };
-
-        const concurrency = 8;
-        let index = 0;
-        const worker = async (): Promise<void> => {
-            let socket = sockets[index];
-
-            index += 1;
-
-            while (socket !== undefined) {
-                // eslint-disable-next-line no-await-in-loop -- serialize this worker's sockets so the per-send drain gate actually applies backpressure
-                await pokeOne(socket);
-                socket = sockets[index];
-                index += 1;
+            } catch {
+                // A throwing socket (e.g. awaitWsDrain/sendPoke rejecting on a dead
+                // connection) must not abort the poke fan-out to its siblings — the
+                // bounded pool runs sockets in parallel and one bad socket would
+                // otherwise reject the whole Promise.all. Memos are left untouched,
+                // so the next flush re-pokes this socket. Mirrors refreshSubscriptions.
+                /* poke error contained to this socket */
             }
         };
 
         // Bounded fan-out matching `refreshSubscriptions`: each worker drains its
-        // sockets one at a time so the per-send `awaitWsDrain` gate above can
-        // apply backpressure on a slow consumer.
-        await Promise.all(Array.from({ length: Math.min(concurrency, sockets.length) }, () => worker()));
+        // sockets one at a time so the per-send `awaitWsDrain` gate above applies
+        // backpressure on a slow consumer. See {@link runSocketPool}.
+        await runSocketPool(sockets, pokeOne);
     }
 
     /**

--- a/packages/do/src/socket-pool.ts
+++ b/packages/do/src/socket-pool.ts
@@ -9,18 +9,13 @@
  * single, shared loop.
  *
  * Semantics:
- * - Each item is visited EXACTLY once: `concurrency` workers pull from a shared
- *   cursor, so no item is processed twice and none is skipped.
- * - At most `concurrency` (default 8) `processOne` calls are in flight at once.
- *   Larger batches don't help the subscription paths — their handlers spend
- *   their time on the DO's single-threaded SQLite — and risk exhausting the
- *   I/O budget.
- * - Within a worker, items run one at a time (awaited), so a `processOne` that
- *   awaits `awaitWsDrain` before each `ws.send` genuinely paces that socket.
- * - `undefined` is the past-the-end sentinel (an out-of-range index), so callers
- *   must not pass an array containing `undefined` items.
+ * - Each item is visited EXACTLY once: `concurrency` workers pull from a shared cursor, so no item is processed twice and none is skipped.
+ * - At most `concurrency` (default 8) `processOne` calls are in flight at once. Larger batches don't help the subscription paths (their handlers spend their time on the DO's single-threaded SQLite) and risk exhausting the I/O budget.
+ * - Within a worker, items run one at a time (awaited), so a `processOne` that awaits `awaitWsDrain` before each `ws.send` genuinely paces that socket.
+ * - `undefined` is the past-the-end sentinel (an out-of-range index), so callers must not pass an array containing `undefined` items.
  */
-export const runSocketPool = async <T>(items: readonly T[], processOne: (item: T) => Promise<void>, concurrency = 8): Promise<void> => {
+// eslint-disable-next-line import/prefer-default-export -- named export: import sites stay uniform (`import { runSocketPool }`), per the repo's no-default-mixing convention
+export const runSocketPool = async <T>(items: ReadonlyArray<T>, processOne: (item: T) => Promise<void>, concurrency = 8): Promise<void> => {
     let cursor = 0;
 
     const worker = async (): Promise<void> => {

--- a/packages/do/src/socket-pool.ts
+++ b/packages/do/src/socket-pool.ts
@@ -24,8 +24,17 @@ export const runSocketPool = async <T>(items: ReadonlyArray<T>, processOne: (ite
         cursor += 1;
 
         while (item !== undefined) {
-            // eslint-disable-next-line no-await-in-loop -- each worker drains its picks sequentially; parallelism comes from running `concurrency` workers
-            await processOne(item);
+            try {
+                // eslint-disable-next-line no-await-in-loop -- each worker drains its picks sequentially; parallelism comes from running `concurrency` workers
+                await processOne(item);
+            } catch {
+                // Contain a per-item failure so one rejecting item never aborts the
+                // pool — the other workers keep draining. Callers that need retry or
+                // diagnostics handle it inside `processOne` (the refresh/poke paths
+                // leave their memos so the next flush retries); this is the safety
+                // net that makes the contract hold regardless of the caller.
+            }
+
             item = items[cursor];
             cursor += 1;
         }

--- a/packages/do/src/socket-pool.ts
+++ b/packages/do/src/socket-pool.ts
@@ -1,0 +1,40 @@
+/**
+ * Bounded fan-out helper for the ShardDO write-flush paths.
+ *
+ * `refreshSubscriptions` (per-socket query re-run) and `pokeShapeSubscribers`
+ * (per-socket shape diff) both fan one write out to every live socket, and both
+ * want the SAME shape: cap how many sockets are processed in parallel, but drain
+ * each worker's picks sequentially so a per-send `awaitWsDrain` gate inside
+ * `processOne` still applies backpressure to a slow consumer. This is that
+ * single, shared loop.
+ *
+ * Semantics:
+ * - Each item is visited EXACTLY once: `concurrency` workers pull from a shared
+ *   cursor, so no item is processed twice and none is skipped.
+ * - At most `concurrency` (default 8) `processOne` calls are in flight at once.
+ *   Larger batches don't help the subscription paths — their handlers spend
+ *   their time on the DO's single-threaded SQLite — and risk exhausting the
+ *   I/O budget.
+ * - Within a worker, items run one at a time (awaited), so a `processOne` that
+ *   awaits `awaitWsDrain` before each `ws.send` genuinely paces that socket.
+ * - `undefined` is the past-the-end sentinel (an out-of-range index), so callers
+ *   must not pass an array containing `undefined` items.
+ */
+export const runSocketPool = async <T>(items: readonly T[], processOne: (item: T) => Promise<void>, concurrency = 8): Promise<void> => {
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+        let item = items[cursor];
+
+        cursor += 1;
+
+        while (item !== undefined) {
+            // eslint-disable-next-line no-await-in-loop -- each worker drains its picks sequentially; parallelism comes from running `concurrency` workers
+            await processOne(item);
+            item = items[cursor];
+            cursor += 1;
+        }
+    };
+
+    await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+};


### PR DESCRIPTION
Re-execution of the Wave-4 shard-do plans **onto current `alpha`**, as one coupled stack (all five edit the same `packages/do/src/shard-do.ts` regions sequentially, so they can't be independent PRs). Each carries its thermo-nuclear review fixes folded in. Tech-lead reviewed; all 6 gates green locally (`@lunora/do` 910 + `@lunora/client` 262 + `@lunora/db` 35 tests; types clean).

**Commits (merge with a merge-commit to preserve all five for semantic-release):**

1. `fix(do): redact raw error messages from rpc/ws error frames` (plan 064) — `errorToResponse` RPC_FAILED fall-through + `handleStream` catch-all log server-side and return generic `"internal error"`; coded/structured errors keep their messages.
2. `fix(do,client,db): emit settled frame to drop stale list overlays` (plan 068) — DO emits a `settled` frame on the byte-identical suppression path, gated on `socketClientWatermark(ws) !== undefined` (clientId only). Client parses via shared `ackAndAdvanceCursor`; `@lunora/db` wires `onCheckpoint` on the list path. Dead `lastMutationId` removed from Data/Resume messages.
3. `perf(do): dedup identity-independent reactive query runs` (plan 073) — flush-local memo collapses N identical admin/reserved reactive runs to one. `isIdentityIndependent` is `ADMIN_FUNCTION_PREFIX`-only (security boundary); RLS/`ctx.auth`/per-user-flag reads bypass the cache. Negative + force-override sanity tests.
4. `perf(do): share op-log read across shape pokes in a flush` (plan 072) — flush-local `(table,sinceSeq,upTo)` cache shares one `__cdc_log` drain across same-range shape diffs; read-counter test.
5. `refactor(do): extract bounded socket-pool fan-out helper` (plan 074) — extracts the duplicated bounded loop into `runSocketPool`; behavior-preserving; dedicated test.

Supersedes #58, #62, #66, #67, #68 (stale pre-divergence executions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint notifications for subscriptions, helping clients react when writes are confirmed.
  * Improved subscription handling for settled updates so the app can recognize confirmed changes even when no new data is returned.
  * Increased concurrent socket processing for faster handling of multiple tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->