### PR TITLE
ci(lint): serialize typecheck steps to fix dist-clean race

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,13 +85,15 @@
 
     # tsc over the affected graph plus the registry typecheck, split from eslint
     # into its own required check. registry/ isn't a vis project; it imports
-    # @lunora/* and is typechecked against the full built dist. Both tsc
-    # invocations read the built dist without mutating it, so they run
-    # concurrently via the `parallel:` step group.
+    # @lunora/* and is typechecked against the full built dist.
     #
-    # NOTE: lint:affected:types is a `vis affected` invocation; lint:types:registry
-    # is a plain tsc. If the .vis/ cache lock ever surfaces as flaky errors, make
-    # these sequential steps instead of a parallel group.
+    # These run SEQUENTIALLY, not in a parallel group: `lint:types:registry`
+    # begins with `build:packages` (a full `vis run build`), which packem starts
+    # by *cleaning* each package's `dist/`. Run concurrently with `lint:affected:types`,
+    # that clean window races the affected typecheck's tsc as it reads a dependency's
+    # dist — intermittently dropping a freshly-removed declaration (e.g.
+    # `@lunora/auth/dist/plugins-client.d.ts`) and failing with TS2307 on an
+    # affected example. Serializing removes the concurrent reader during the rebuild.
     "types":
         "name": "Lint (types)"
         "if": "needs.files-changed.outputs.frontend_lintable == 'true'"
@@ -123,12 +125,13 @@
             - "name": "Build affected packages"
               "run": "pnpm run build:affected:packages"
 
-            - "parallel":
-                  - "name": "Typecheck"
-                    "run": "pnpm run lint:affected:types"
+            - "name": "Typecheck"
+              "run": "pnpm run lint:affected:types"
 
-                  - "name": "Typecheck registry items"
-                    "run": "pnpm run lint:types:registry"
+            # Sequential (not parallel) with the step above: its `build:packages`
+            # rebuild cleans each package's dist, which races a concurrent tsc read.
+            - "name": "Typecheck registry items"
+              "run": "pnpm run lint:types:registry"
 
     # fallow codebase-intelligence over the affected graph. `health` is a report
     # (prints each project's score, exits 0) — it surfaces dead code / dupes /


### PR DESCRIPTION
## Problem

The **Lint (types)** job intermittently fails with `TS2307: Cannot find module '@lunora/auth/plugins/client'` on `lunora-example-auth-playground` (and cascades to other examples), even though the code resolves fine locally and the type-check passes on retry.

## Root cause

The job runs two steps in a `parallel:` group:
- `lint:affected:types` — tsc over the affected graph, reading dependencies' built `dist/`
- `lint:types:registry` — which **begins with `build:packages`** (a full `vis run build`)

packem **cleans each package's `dist/`** at the start of a build. Running concurrently, the registry step's rebuild of `@lunora/auth` clears its `dist/` (removing `plugins-client.d.ts`) in the exact window the affected typecheck's tsc reads it → TS2307. It's a race, hence intermittent.

## Fix

Serialize the two steps (no `parallel:`), so no tsc reads a `dist/` while a build is cleaning it. This is the escape hatch the job's own comment already prescribed: *"If the .vis/ cache lock ever surfaces as flaky errors, make these sequential steps instead of a parallel group."*

No code changes; CI-only. `test.yml`'s separate `parallel:` group (independent steps that don't rebuild) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the type-check workflow to run the two validation steps one after the other instead of at the same time.
  * This reduces intermittent build and type-check failures caused by overlapping cleanup and rebuild activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->