### PR TITLE
feat(do): plan 075 Phase 1 — fan-out observability

### DIFF
--- a/packages/do/__bench__/fanout-whisper.bench.ts
+++ b/packages/do/__bench__/fanout-whisper.bench.ts
@@ -1,0 +1,112 @@
+import { beforeAll, bench, describe } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+/**
+ * Whisper fan-out cost vs subscriber count — the regression guard for plan 075's
+ * O(subscribers) per-flush fan-out (the cost the auto-elastic relay tier targets,
+ * and that `getFanoutMetrics` surfaces).
+ *
+ * Each iteration drives ONE real `broadcastWhisper` through the public
+ * `webSocketMessage` path: the owner scans every connected socket, reads its
+ * hibernation attachment, and sends the one shared frame to topic members. The
+ * bench measures that loop at a small and a large subscriber count so a
+ * regression (e.g. building the frame per-socket, or an O(N²) membership check)
+ * shows up as a super-linear jump between the two.
+ *
+ * Harness notes. `getWebSockets()` returns ONLY the N topic members, so the
+ * fan-out iterates exactly N — the senders live in a separate pool (they need no
+ * membership and `broadcastWhisper` reads the sender only via the `sender`
+ * argument), keeping the iterated count equal to N rather than N + senders.
+ * Senders rotate through a large pool so no single sender exceeds the per-socket
+ * whisper token bucket (`WHISPER_RATE_BURST`), which would otherwise make a
+ * measured call early-return instead of fanning out. `send` is a no-op counter,
+ * so the member sockets don't accumulate frames across iterations (the cost under
+ * test is the owner's loop, not client recv).
+ */
+
+const TOPIC = "bench-topic";
+const ENVELOPE = JSON.stringify({ data: { x: 1, y: 2 }, topic: TOPIC, type: "whisper" });
+const SENDER_POOL = 16_384;
+
+class FakeSocket {
+    public sent = 0;
+
+    private attachment: unknown;
+
+    public constructor(initial?: unknown) {
+        this.attachment = initial;
+    }
+
+    public deserializeAttachment(): unknown {
+        return this.attachment;
+    }
+
+    public send(_data: string): void {
+        this.sent += 1;
+    }
+
+    public serializeAttachment(value: unknown): void {
+        this.attachment = value;
+    }
+}
+
+class WhisperBenchShard extends ShardDO {
+    // eslint-disable-next-line class-methods-use-this -- abstract stub; the whisper path never dispatches an RPC
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve({});
+    }
+}
+
+interface FanoutRig {
+    next: () => WebSocket;
+    shard: WhisperBenchShard;
+}
+
+const buildRig = (n: number): FanoutRig => {
+    const members: FakeSocket[] = [];
+    for (let index = 0; index < n; index += 1) {
+        members.push(new FakeSocket({ subs: {}, whispers: [TOPIC] }));
+    }
+
+    const senders: FakeSocket[] = [];
+    for (let index = 0; index < SENDER_POOL; index += 1) {
+        senders.push(new FakeSocket({ subs: {} }));
+    }
+
+    const state = {
+        acceptWebSocket() {},
+        getWebSockets: () => members,
+        storage: { sql: {} },
+    } as unknown as ShardDOState;
+
+    let cursor = 0;
+    const next = (): WebSocket => {
+        const sender = senders[cursor % SENDER_POOL];
+        cursor += 1;
+
+        return sender as unknown as WebSocket;
+    };
+
+    return { next, shard: new WhisperBenchShard(state, {}) };
+};
+
+const defineFanoutBench = (n: number): void => {
+    describe(`whisper fan-out — ${String(n)} subscribers`, () => {
+        let rig: FanoutRig;
+
+        // CodSpeed's instrumented runner honors beforeAll but not module-top-level
+        // state, so the rig is built here.
+        beforeAll(() => {
+            rig = buildRig(n);
+        });
+
+        bench(`broadcastWhisper to ${String(n)} members`, async () => {
+            await rig.shard.webSocketMessage(rig.next(), ENVELOPE);
+        });
+    });
+};
+
+defineFanoutBench(128);
+defineFanoutBench(1024);

--- a/packages/do/__tests__/introspect.test.ts
+++ b/packages/do/__tests__/introspect.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { facetColumn, findStorageReferences, listTables, readTablePage, selectMatchingIds, summarizeSubscriptions } from "../src/introspect";
+import {
+    createFanoutCounters,
+    facetColumn,
+    findStorageReferences,
+    listTables,
+    readTablePage,
+    recordFanoutPass,
+    selectMatchingIds,
+    summarizeFanoutTopics,
+    summarizeSubscriptions,
+} from "../src/introspect";
 import createSqliteExec from "./_helpers/node-sqlite";
 
 describe("introspect", () => {
@@ -597,6 +607,100 @@ describe("introspect", () => {
                 totalConnections: 1,
                 totalSubscriptions: 0,
             });
+        });
+    });
+
+    describe("summarizeFanoutTopics", () => {
+        it("returns an empty result with zeroed peak for no sockets", () => {
+            expect.assertions(1);
+
+            expect(summarizeFanoutTopics([])).toEqual({ peakSubscribers: 0, topics: [], totalConnections: 0 });
+        });
+
+        it("counts shapes by name and whispers by topic, busiest first", () => {
+            expect.assertions(1);
+
+            const result = summarizeFanoutTopics([
+                { shapes: { "s-1": { name: "roomMessages" } }, whispers: ["cursor:general"] },
+                { shapes: { "s-2": { name: "roomMessages" } }, whispers: ["cursor:general"] },
+                { shapes: { "s-3": { name: "roomMessages" }, "s-4": { name: "roster" } } },
+                { whispers: ["cursor:general", "typing:42"] },
+            ]);
+
+            // roomMessages: 3 sockets, cursor:general: 3 sockets, roster: 1, typing:42: 1.
+            expect(result).toEqual({
+                peakSubscribers: 3,
+                topics: [
+                    { kind: "whisper", subscribers: 3, topic: "cursor:general" },
+                    { kind: "shape", subscribers: 3, topic: "roomMessages" },
+                    { kind: "shape", subscribers: 1, topic: "roster" },
+                    { kind: "whisper", subscribers: 1, topic: "typing:42" },
+                ],
+                totalConnections: 4,
+            });
+        });
+
+        it("falls back to a sentinel name for a shape with no registered name", () => {
+            expect.assertions(1);
+
+            expect(summarizeFanoutTopics([{ shapes: { "s-1": {} } }])).toEqual({
+                peakSubscribers: 1,
+                topics: [{ kind: "shape", subscribers: 1, topic: "(unknown shape)" }],
+                totalConnections: 1,
+            });
+        });
+
+        it("caps the returned topics at the supplied limit while peak still reflects the busiest", () => {
+            expect.assertions(3);
+
+            // "a" is joined by both sockets; "b"/"c" by one each. A limit of 2 keeps
+            // only the two busiest, but the peak still reflects the global maximum.
+            const result = summarizeFanoutTopics([{ whispers: ["a", "b", "c"] }, { whispers: ["a"] }], 2);
+
+            expect(result.topics).toHaveLength(2);
+            expect(result.topics[0]).toEqual({ kind: "whisper", subscribers: 2, topic: "a" });
+            expect(result.peakSubscribers).toBe(2);
+        });
+    });
+
+    describe("recordFanoutPass / createFanoutCounters", () => {
+        it("starts every counter at zero", () => {
+            expect.assertions(1);
+
+            expect(createFanoutCounters()).toEqual({
+                maxMs: 0,
+                passes: 0,
+                peakSocketsIterated: 0,
+                socketsDelivered: 0,
+                socketsIterated: 0,
+                totalMs: 0,
+            });
+        });
+
+        it("accumulates totals and lifts the peak-width and slowest-pass high-water marks", () => {
+            expect.assertions(2);
+
+            let counters = createFanoutCounters();
+
+            counters = recordFanoutPass(counters, 10, 4, 3);
+            counters = recordFanoutPass(counters, 25, 25, 1);
+            counters = recordFanoutPass(counters, 7, 0, 12);
+
+            expect(counters).toEqual({
+                maxMs: 12,
+                passes: 3,
+                peakSocketsIterated: 25,
+                socketsDelivered: 29,
+                socketsIterated: 42,
+                totalMs: 16,
+            });
+
+            // Pure: a single pass returns a fresh object and never mutates its input.
+            const base = createFanoutCounters();
+
+            recordFanoutPass(base, 5, 5, 5);
+
+            expect(base).toEqual(createFanoutCounters());
         });
     });
 });

--- a/packages/do/__tests__/shard-do.admin-subscription.test.ts
+++ b/packages/do/__tests__/shard-do.admin-subscription.test.ts
@@ -147,6 +147,40 @@ describe("shardDO admin subscriptions", () => {
         expect(dataEnvelopes(ws).at(-1)?.data).toMatchObject({ requests: 0, shard: "shard-a" });
     });
 
+    it("seeds getFanoutMetrics with per-topic subscriber counts folded from every socket", async () => {
+        expect.assertions(4);
+
+        const shard = new AdminSubShard(state, { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+        const admin = createFakeWebSocket();
+        const member1 = createFakeWebSocket();
+        const member2 = createFakeWebSocket();
+
+        // Two members share a shape and a whisper topic; the admin socket watches
+        // neither, so it contributes to the connection count but no topic.
+        shard.registerSocket(admin, { admin: true, subs: {} });
+        shard.registerSocket(member1, { shapes: { s1: { name: "roomMessages" } }, subs: {}, whispers: ["cursor:room"] });
+        shard.registerSocket(member2, { shapes: { s2: { name: "roomMessages" } }, subs: {}, whispers: ["cursor:room"] });
+
+        await shard.driveMessage(admin, adminSub("sub-1", ADMIN_FUNCTIONS.getFanoutMetrics));
+
+        const seeded = dataEnvelopes(admin).at(-1)?.data as {
+            peakSubscribers: number;
+            shapePoke: { passes: number };
+            topics: { kind: string; subscribers: number; topic: string }[];
+            totalConnections: number;
+        };
+
+        expect(seeded.totalConnections).toBe(3);
+        expect(seeded.peakSubscribers).toBe(2);
+        // Both topics have 2 subscribers; ties break by topic name (cursor:room < roomMessages).
+        expect(seeded.topics).toEqual([
+            { kind: "whisper", subscribers: 2, topic: "cursor:room" },
+            { kind: "shape", subscribers: 2, topic: "roomMessages" },
+        ]);
+        // No poke/broadcast has run in this test, so the running counters are zero.
+        expect(seeded.shapePoke.passes).toBe(0);
+    });
+
     it("re-runs a readTablePage subscription only when its own table is written", async () => {
         expect.assertions(3);
 

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -5,7 +5,16 @@ import type { DatabaseWriterLike, SchemaLike, SqlExec } from "../src/ctx-db";
 import { applyCdcChanges, createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
 import type { DataMigrationLike, MigrationRunResult } from "../src/data-migration";
 import { runDataMigration } from "../src/data-migration";
-import type { AdvisoryFinding, FlagEvaluation, FlagsResult, QueueMetadata, StudioFeaturesResult } from "../src/introspect";
+import type {
+    AdvisoryFinding,
+    FanoutMetricsResult,
+    FanoutPathCounters,
+    FanoutTopicStat,
+    FlagEvaluation,
+    FlagsResult,
+    QueueMetadata,
+    StudioFeaturesResult,
+} from "../src/introspect";
 import { ADMIN_FUNCTIONS } from "../src/introspect";
 import type { RankIndexDefinitionLike, ShardRankPageResult } from "../src/rank";
 import { rankKeyFromDoc } from "../src/rank";
@@ -61,6 +70,25 @@ const FLAG_EVALUATION_KEY_GUARD: KeysMatch<keyof FlagEvaluation, (typeof FLAG_EV
 const FLAGS_RESULT_KEYS = ["configured", "flags"] as const;
 
 const FLAGS_RESULT_KEY_GUARD: KeysMatch<keyof FlagsResult, (typeof FLAGS_RESULT_KEYS)[number]> = true;
+
+/**
+ * Canonical key sets of the `getFanoutMetrics` wire shapes (plan 075 Phase 1),
+ * duplicated by `@lunora/studio`'s hand mirror the same way as the types above.
+ * Forces both packages' copies of the fan-out observability payload to move
+ * together — adding or dropping a counter/topic field fails the build rather than
+ * silently shipping a missing studio cell.
+ */
+const FANOUT_TOPIC_STAT_KEYS = ["kind", "subscribers", "topic"] as const;
+
+const FANOUT_TOPIC_STAT_KEY_GUARD: KeysMatch<keyof FanoutTopicStat, (typeof FANOUT_TOPIC_STAT_KEYS)[number]> = true;
+
+const FANOUT_PATH_COUNTERS_KEYS = ["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"] as const;
+
+const FANOUT_PATH_COUNTERS_KEY_GUARD: KeysMatch<keyof FanoutPathCounters, (typeof FANOUT_PATH_COUNTERS_KEYS)[number]> = true;
+
+const FANOUT_METRICS_RESULT_KEYS = ["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"] as const;
+
+const FANOUT_METRICS_RESULT_KEY_GUARD: KeysMatch<keyof FanoutMetricsResult, (typeof FANOUT_METRICS_RESULT_KEYS)[number]> = true;
 
 /**
  * A real-SQLite-backed ShardDO whose `handleRpc` throws — proving the admin
@@ -442,6 +470,17 @@ describe("shardDO admin introspection", () => {
         expect([...FLAG_EVALUATION_KEYS]).toStrictEqual(["errorCode", "key", "reason", "type", "value", "variant"]);
         expect(FLAGS_RESULT_KEY_GUARD).toBe(true);
         expect([...FLAGS_RESULT_KEYS]).toStrictEqual(["configured", "flags"]);
+    });
+
+    it("keeps the getFanoutMetrics wire shapes in lockstep with the studio's hand-mirror", () => {
+        expect.assertions(6);
+
+        expect(FANOUT_TOPIC_STAT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_TOPIC_STAT_KEYS]).toStrictEqual(["kind", "subscribers", "topic"]);
+        expect(FANOUT_PATH_COUNTERS_KEY_GUARD).toBe(true);
+        expect([...FANOUT_PATH_COUNTERS_KEYS]).toStrictEqual(["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"]);
+        expect(FANOUT_METRICS_RESULT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual(["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"]);
     });
 
     it("serves declared-workflow metadata from the codegen-overridden hook", async () => {

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -59,6 +59,7 @@ const ADMIN_FUNCTIONS = {
     getAuditLog: "__lunora_admin__:getAuditLog",
     getAuthMetrics: "__lunora_admin__:getAuthMetrics",
     getCapturedMail: "__lunora_admin__:getCapturedMail",
+    getFanoutMetrics: "__lunora_admin__:getFanoutMetrics",
     getFunctionStats: "__lunora_admin__:getFunctionStats",
     listSubscriptions: "__lunora_admin__:listSubscriptions",
     listTableIndexes: "__lunora_admin__:listTableIndexes",
@@ -1292,17 +1293,178 @@ const summarizeSubscriptions = (attachments: SocketAttachmentLike[]): Subscripti
     return { connections, totalConnections: connections.length, totalSubscriptions };
 };
 
+/**
+ * One topic or shape with the number of sockets currently subscribed to it, as
+ * surfaced by `__lunora_admin__:getFanoutMetrics`. `subscribers` is the fan-out
+ * **width** one poke/broadcast incurs for this topic — the O(subscribers) cost
+ * the auto-elastic relay tier (plan 075) targets — so a single hot topic is
+ * visible here long before it becomes a bottleneck.
+ */
+interface FanoutTopicStat {
+    /** `"shape"` = a reactive-query shape (poked from SQLite); `"whisper"` = an ephemeral whisper topic. */
+    kind: "shape" | "whisper";
+    /** Connected sockets currently subscribed — the fan-out width one flush/broadcast incurs for this topic. */
+    subscribers: number;
+    /** The shape name (the `defineShape` export) or the whisper topic string. */
+    topic: string;
+}
+
+/**
+ * Running fan-out counters for one delivery path (the reactive shape poke or the
+ * whisper broadcast) since this DO instance woke. In-memory and reset on
+ * hibernation/restart — the same "since this instance woke" granularity as
+ * `getMetrics`/`getFunctionStats`.
+ *
+ * `socketsIterated` is the O(subscribers) loop cost the relay tier targets;
+ * `socketsDelivered` is how many of those iterated sockets actually received a
+ * frame (the rest were visited but had no matching shape, or were the whisper
+ * sender). `totalMs`/`maxMs` are **coarse** wall-clock for the asynchronous
+ * shape-poke path only: a Durable Object's clock advances only across I/O, so
+ * treat them as directional, not exact. They stay `0` for the synchronous
+ * whisper path, which performs no awaited I/O to time.
+ */
+interface FanoutPathCounters {
+    /** Coarse slowest single pass, in ms (shape-poke path only; `0` for whisper). */
+    maxMs: number;
+    /** Fan-out passes that ran (shape-poke flushes / whisper broadcasts). */
+    passes: number;
+    /** Widest single pass — the most sockets iterated in one flush/broadcast. */
+    peakSocketsIterated: number;
+    /** Sockets that actually received a frame, summed across every pass. */
+    socketsDelivered: number;
+    /** Sockets visited, summed across every pass — the O(subscribers) iteration cost. */
+    socketsIterated: number;
+    /** Coarse summed wall-clock across every pass, in ms (shape-poke path only; `0` for whisper). */
+    totalMs: number;
+}
+
+/**
+ * Payload of a `__lunora_admin__:getFanoutMetrics` call: the current per-topic
+ * subscriber counts plus the running fan-out counters for each delivery path.
+ * The point-in-time `topics`/`peakSubscribers`/`totalConnections` are derived
+ * live from `getWebSockets()` + each socket's attachment; the `shapePoke`/
+ * `whisper` counters are the in-memory running tallies (reset on hibernation).
+ * Feeds the Studio fan-out observability panel — the "you can see it scale"
+ * half of plan 075 Phase 1, before any topology change exists.
+ */
+interface FanoutMetricsResult {
+    /** Highest current subscriber count across all topics/shapes — the widest single fan-out right now. */
+    peakSubscribers: number;
+    /** Running reactive-shape-poke fan-out counters since this instance woke. */
+    shapePoke: FanoutPathCounters;
+    /** Epoch-ms this instance began collecting (shared with `getMetrics`/`getFunctionStats`). */
+    sinceMs: number;
+    /** Hottest topics/shapes by current subscriber count, busiest first (capped at {@link DEFAULT_FANOUT_TOPIC_LIMIT}). */
+    topics: FanoutTopicStat[];
+    /** Live socket count on this shard. */
+    totalConnections: number;
+    /** Running whisper-broadcast fan-out counters since this instance woke. */
+    whisper: FanoutPathCounters;
+}
+
+/**
+ * One socket's attachment as seen by {@link summarizeFanoutTopics} — the subset
+ * of `./types`' `SocketAttachment` the fan-out summary reads (live `shapes` keyed
+ * by subscription id, and the joined whisper `topics`). Narrowed so the summary
+ * stays a pure, harness-testable function with no dependency on the DO runtime.
+ */
+interface FanoutAttachmentLike {
+    shapes?: Record<string, { name?: string }>;
+    whispers?: string[];
+}
+
+/** Default cap on the number of hot topics {@link summarizeFanoutTopics} returns, so a deployment with thousands of distinct shapes can't return an unbounded list. */
+const DEFAULT_FANOUT_TOPIC_LIMIT = 20;
+
+/** A freshly-zeroed {@link FanoutPathCounters}, for a DO instance waking up. */
+const createFanoutCounters = (): FanoutPathCounters => {
+    return { maxMs: 0, passes: 0, peakSocketsIterated: 0, socketsDelivered: 0, socketsIterated: 0, totalMs: 0 };
+};
+
+/**
+ * Fold one fan-out pass into a running {@link FanoutPathCounters}, returning the
+ * updated counters: bump the pass count, add the iterated/delivered socket
+ * totals, and lift the peak-width and slowest-pass high-water marks. Pure (a new
+ * object, no mutation) so it stays trivially testable; the caller swaps the
+ * stored counters for the result. `ms` is `0` for the synchronous whisper path
+ * (nothing awaited to time).
+ */
+const recordFanoutPass = (counters: FanoutPathCounters, iterated: number, delivered: number, ms: number): FanoutPathCounters => {
+    return {
+        maxMs: Math.max(counters.maxMs, ms),
+        passes: counters.passes + 1,
+        peakSocketsIterated: Math.max(counters.peakSocketsIterated, iterated),
+        socketsDelivered: counters.socketsDelivered + delivered,
+        socketsIterated: counters.socketsIterated + iterated,
+        totalMs: counters.totalMs + ms,
+    };
+};
+
+/**
+ * Fold a per-socket list of attachments into the point-in-time half of a
+ * {@link FanoutMetricsResult}: current subscriber count per shape (grouped by
+ * `defineShape` name) and per whisper topic, the busiest `limit` of them, the
+ * peak width across all of them, and the live socket count. Pure — the DO method
+ * feeds it `getWebSockets().map(readAttachment)` and merges in the running
+ * counters.
+ */
+const summarizeFanoutTopics = (
+    attachments: FanoutAttachmentLike[],
+    limit = DEFAULT_FANOUT_TOPIC_LIMIT,
+): { peakSubscribers: number; topics: FanoutTopicStat[]; totalConnections: number } => {
+    const shapeCounts = new Map<string, number>();
+    const whisperCounts = new Map<string, number>();
+
+    for (const attachment of attachments) {
+        for (const shape of Object.values(attachment.shapes ?? {})) {
+            const key = shape.name ?? "(unknown shape)";
+
+            shapeCounts.set(key, (shapeCounts.get(key) ?? 0) + 1);
+        }
+
+        for (const topic of attachment.whispers ?? []) {
+            whisperCounts.set(topic, (whisperCounts.get(topic) ?? 0) + 1);
+        }
+    }
+
+    const topics: FanoutTopicStat[] = [
+        ...[...shapeCounts].map(([topic, subscribers]): FanoutTopicStat => {
+            return { kind: "shape", subscribers, topic };
+        }),
+        ...[...whisperCounts].map(([topic, subscribers]): FanoutTopicStat => {
+            return { kind: "whisper", subscribers, topic };
+        }),
+    ];
+
+    // Busiest first; ties broken by name so the order is stable across reads.
+    topics.sort((a, b) => b.subscribers - a.subscribers || a.topic.localeCompare(b.topic));
+
+    let peakSubscribers = 0;
+
+    for (const topic of topics) {
+        if (topic.subscribers > peakSubscribers) {
+            peakSubscribers = topic.subscribers;
+        }
+    }
+
+    return { peakSubscribers, topics: topics.slice(0, limit), totalConnections: attachments.length };
+};
+
 export {
     ADMIN_FUNCTION_PREFIX,
     ADMIN_FUNCTIONS,
+    createFanoutCounters,
+    DEFAULT_FANOUT_TOPIC_LIMIT,
     facetColumn,
     findStorageReferences,
     FLAGS_FUNCTION_PREFIX,
     listTables,
     MAX_PAGE_SIZE,
     readTablePage,
+    recordFanoutPass,
     RELATION_FUNCTION_PREFIX,
     selectMatchingIds,
+    summarizeFanoutTopics,
     summarizeSubscriptions,
 };
 export type {
@@ -1315,6 +1477,9 @@ export type {
     FacetColumnOptions,
     FacetColumnResult,
     FacetValue,
+    FanoutMetricsResult,
+    FanoutPathCounters,
+    FanoutTopicStat,
     FilterClause,
     FilterOperator,
     FlagEvaluation,

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -1330,7 +1330,14 @@ interface FanoutPathCounters {
     passes: number;
     /** Widest single pass — the most sockets iterated in one flush/broadcast. */
     peakSocketsIterated: number;
-    /** Sockets that actually received a frame, summed across every pass. */
+
+    /**
+     * Sockets a frame was sent to, summed across every pass. The shape-poke path
+     * counts only confirmed sends (`sendPoke` returned `true`); the whisper path
+     * counts matched receivers (the best-effort `trySendFrame` may silently no-op
+     * on a socket that closed between the snapshot and the send), so it can very
+     * marginally over-count in that near-impossible race.
+     */
     socketsDelivered: number;
     /** Sockets visited, summed across every pass — the O(subscribers) iteration cost. */
     socketsIterated: number;
@@ -1439,13 +1446,9 @@ const summarizeFanoutTopics = (
     // Busiest first; ties broken by name so the order is stable across reads.
     topics.sort((a, b) => b.subscribers - a.subscribers || a.topic.localeCompare(b.topic));
 
-    let peakSubscribers = 0;
-
-    for (const topic of topics) {
-        if (topic.subscribers > peakSubscribers) {
-            peakSubscribers = topic.subscribers;
-        }
-    }
+    // The peak is the head of the busiest-first list — and it is the FULL list,
+    // so the global max survives the `slice(0, limit)` truncation below.
+    const peakSubscribers = topics[0]?.subscribers ?? 0;
 
     return { peakSubscribers, topics: topics.slice(0, limit), totalConnections: attachments.length };
 };

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -47,6 +47,7 @@ import type {
     AuditLogResult,
     ColumnMeta,
     CreateWorkflowInstanceResult,
+    FanoutMetricsResult,
     FilterClause,
     FilterOperator,
     FlagsResult,
@@ -66,14 +67,17 @@ import type {
 import {
     ADMIN_FUNCTION_PREFIX,
     ADMIN_FUNCTIONS,
+    createFanoutCounters,
     facetColumn,
     findStorageReferences,
     FLAGS_FUNCTION_PREFIX,
     listTables,
     MAX_PAGE_SIZE,
     readTablePage,
+    recordFanoutPass,
     RELATION_FUNCTION_PREFIX,
     selectMatchingIds,
+    summarizeFanoutTopics,
     summarizeSubscriptions,
 } from "./introspect";
 import type { LogEntry } from "./log-buffer";
@@ -1765,6 +1769,19 @@ abstract class ShardDO {
      * (durable aggregation would be a separate, heavier feature).
      */
     private readonly metrics = { errors: 0, requests: 0, sinceMs: Date.now() };
+
+    /**
+     * Running fan-out cost counters surfaced by the
+     * `__lunora_admin__:getFanoutMetrics` RPC — one tally for the reactive
+     * shape-poke path (`pokeShapeSubscribers`) and one for the whisper broadcast
+     * path (`broadcastWhisper`). Each pass records the sockets it iterated (the
+     * O(subscribers) cost) and delivered to. In-memory and reset on
+     * hibernation/restart, sharing `metrics.sinceMs` as the "since this instance
+     * woke" epoch. This is the observability half of plan 075's auto-elastic
+     * relay tier (Phase 1): measure the per-flush fan-out cost so the promotion
+     * threshold is grounded in real numbers, with no behavior change.
+     */
+    private readonly fanout = { shapePoke: createFanoutCounters(), whisper: createFanoutCounters() };
 
     /**
      * Declared indexes (`table:index`) a query has exercised since this instance
@@ -5207,6 +5224,13 @@ abstract class ShardDO {
             return this.collectSubscriptions();
         }
 
+        if (functionPath === ADMIN_FUNCTIONS.getFanoutMetrics) {
+            // Per-topic subscriber counts + running fan-out cost counters (plan
+            // 075 Phase 1 observability). Deployment-wide live state, so it carries
+            // the wildcard like the other read-only admin reads.
+            return this.collectFanoutMetrics();
+        }
+
         if (functionPath === ADMIN_FUNCTIONS.getLogs) {
             return { entries: this.logs.entries() };
         }
@@ -5287,6 +5311,21 @@ abstract class ShardDO {
      */
     private collectSubscriptions(): SubscriptionsResult {
         return summarizeSubscriptions(this.state.getWebSockets().map((ws) => this.readAttachment(ws)));
+    }
+
+    /**
+     * Assemble the `__lunora_admin__:getFanoutMetrics` payload for the Studio
+     * fan-out observability panel (plan 075 Phase 1). The point-in-time topic
+     * subscriber counts are folded live from each socket's attachment via
+     * {@link summarizeFanoutTopics}; the running per-path cost counters are the
+     * in-memory {@link ShardDO.fanout} tallies, sharing `metrics.sinceMs` as the
+     * "since this instance woke" epoch. Read-only: touches no SQLite and mutates
+     * no socket state.
+     */
+    private collectFanoutMetrics(): FanoutMetricsResult {
+        const summary = summarizeFanoutTopics(this.state.getWebSockets().map((ws) => this.readAttachment(ws)));
+
+        return { ...summary, shapePoke: this.fanout.shapePoke, sinceMs: this.metrics.sinceMs, whisper: this.fanout.whisper };
     }
 
     /** Resolve a `getAuditLog` admin read, parsing the optional `limit`/`sinceSeq` cursor args and ensuring the reserved table first. */
@@ -6185,6 +6224,11 @@ abstract class ShardDO {
         // per flush so a slice is never reused across writes (it would go stale).
         const opRangeCache = new Map<string, Map<string, CdcChange>>();
 
+        // Observability (plan 075 Phase 1): count sockets this flush actually
+        // poked so `getFanoutMetrics` can report the delivered-vs-iterated split.
+        // Pure measurement — it never alters which sockets are poked.
+        let delivered = 0;
+
         const pokeOne = async (ws: WebSocket): Promise<void> => {
             if (this.isSocketExpired(ws)) {
                 this.dropExpiredSocket(ws);
@@ -6218,6 +6262,8 @@ abstract class ShardDO {
                     await awaitWsDrain(ws);
 
                     if (this.sendPoke(ws, parts, checkpoint, frameEpoch, undefined)) {
+                        delivered += 1;
+
                         for (const subId of partAdvanced) {
                             this.recordShapeMemo(ws, subId, checkpoint);
                         }
@@ -6236,7 +6282,16 @@ abstract class ShardDO {
         // Bounded fan-out matching `refreshSubscriptions`: each worker drains its
         // sockets one at a time so the per-send `awaitWsDrain` gate above applies
         // backpressure on a slow consumer. See {@link runSocketPool}.
+        const startMs = Date.now();
+
         await runSocketPool(sockets, pokeOne);
+
+        // Record the fan-out cost of this flush (plan 075 Phase 1). `startMs` wraps
+        // the whole pool, so the elapsed time captures the awaited drain/send I/O
+        // across every socket; it is coarse (a DO clock advances only on I/O) but
+        // the socket counts are exact. Recorded even for a zero-delivery flush so
+        // the iterated-vs-delivered ratio reflects wasted work honestly.
+        this.fanout.shapePoke = recordFanoutPass(this.fanout.shapePoke, sockets.length, delivered, Date.now() - startMs);
     }
 
     /**
@@ -7166,14 +7221,27 @@ abstract class ShardDO {
         const fromSuffix = from === undefined ? "" : `,"from":${JSON.stringify(from)}`;
         const frame = `{"type":"whisper","topic":${JSON.stringify(topic)},"data":${dataJson}${fromSuffix}}`;
 
+        // Observability (plan 075 Phase 1): tally the sockets scanned vs. actually
+        // delivered to so `getFanoutMetrics` shows the whisper fan-out width. Pure
+        // counting — it never changes who receives the whisper.
+        let scanned = 0;
+        let delivered = 0;
+
         for (const ws of this.state.getWebSockets()) {
+            scanned += 1;
+
             if (ws === sender || this.readAttachment(ws).whispers?.includes(topic) !== true) {
                 continue;
             }
 
             // Best-effort fan-out; a closed socket is simply skipped.
             trySendFrame(ws, frame);
+            delivered += 1;
         }
+
+        // The broadcast is synchronous (no awaited I/O), so no wall-clock is
+        // captured (`0` ms); the scanned/delivered socket counts are exact.
+        this.fanout.whisper = recordFanoutPass(this.fanout.whisper, scanned, delivered, 0);
     }
 
     // eslint-disable-next-line class-methods-use-this -- cohesive DO instance method grouped with the hibernation/attachment helpers; reads only the socket

--- a/packages/studio/__tests__/app/studio.test.tsx
+++ b/packages/studio/__tests__/app/studio.test.tsx
@@ -3,7 +3,15 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { Studio } from "../../src/app/studio";
-import type { FlagEvaluation, FlagsResult, QueueMetadata, StudioFeaturesResult } from "../../src/lib/admin";
+import type {
+    FanoutMetricsResult,
+    FanoutPathCounters,
+    FanoutTopicStat,
+    FlagEvaluation,
+    FlagsResult,
+    QueueMetadata,
+    StudioFeaturesResult,
+} from "../../src/lib/admin";
 import { ADMIN_FUNCTIONS } from "../../src/lib/admin";
 import type { MockClientHooks } from "../mock-client";
 import { createMockClient } from "../mock-client";
@@ -99,6 +107,26 @@ const FLAG_EVALUATION_KEY_GUARD: KeysMatch<keyof FlagEvaluation, (typeof FLAG_EV
 const FLAGS_RESULT_KEYS = ["configured", "flags"] as const;
 
 const FLAGS_RESULT_KEY_GUARD: KeysMatch<keyof FlagsResult, (typeof FLAGS_RESULT_KEYS)[number]> = true;
+
+/**
+ * Canonical key sets of the `getFanoutMetrics` wire shapes (plan 075 Phase 1) —
+ * hand-mirrored from `@lunora/do` the same way as the types above, with the
+ * matching guards living in `@lunora/do`'s `shard-do.admin.test.ts`. The fan-out
+ * panel reads these fields off the wire, so a dropped field would surface as a
+ * silent `undefined` cell rather than a type error; these guards fail the build
+ * on drift.
+ */
+const FANOUT_TOPIC_STAT_KEYS = ["kind", "subscribers", "topic"] as const;
+
+const FANOUT_TOPIC_STAT_KEY_GUARD: KeysMatch<keyof FanoutTopicStat, (typeof FANOUT_TOPIC_STAT_KEYS)[number]> = true;
+
+const FANOUT_PATH_COUNTERS_KEYS = ["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"] as const;
+
+const FANOUT_PATH_COUNTERS_KEY_GUARD: KeysMatch<keyof FanoutPathCounters, (typeof FANOUT_PATH_COUNTERS_KEYS)[number]> = true;
+
+const FANOUT_METRICS_RESULT_KEYS = ["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"] as const;
+
+const FANOUT_METRICS_RESULT_KEY_GUARD: KeysMatch<keyof FanoutMetricsResult, (typeof FANOUT_METRICS_RESULT_KEYS)[number]> = true;
 
 describe("studio", () => {
     it("renders every domain's sub-pages at once in the grouped sidebar", async () => {
@@ -228,5 +256,16 @@ describe("studio", () => {
         expect([...FLAG_EVALUATION_KEYS]).toStrictEqual(["errorCode", "key", "reason", "type", "value", "variant"]);
         expect(FLAGS_RESULT_KEY_GUARD).toBe(true);
         expect([...FLAGS_RESULT_KEYS]).toStrictEqual(["configured", "flags"]);
+    });
+
+    it("keeps the studio's getFanoutMetrics mirror in lockstep with @lunora/do's contract", () => {
+        expect.assertions(6);
+
+        expect(FANOUT_TOPIC_STAT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_TOPIC_STAT_KEYS]).toStrictEqual(["kind", "subscribers", "topic"]);
+        expect(FANOUT_PATH_COUNTERS_KEY_GUARD).toBe(true);
+        expect([...FANOUT_PATH_COUNTERS_KEYS]).toStrictEqual(["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"]);
+        expect(FANOUT_METRICS_RESULT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual(["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"]);
     });
 });

--- a/packages/studio/src/app/studio.tsx
+++ b/packages/studio/src/app/studio.tsx
@@ -66,6 +66,7 @@ import { PaymentsPanel } from "../features/payments/payments-panel";
 import { PermissionsPanel } from "../features/permissions/permissions-panel";
 import QueuesPanel from "../features/queues/queues-panel";
 import DashboardsPanel from "../features/reports/dashboards-panel";
+import FanoutPanel from "../features/reports/fanout-panel";
 import { HealthPanel } from "../features/reports/health-panel";
 import { MetricsPanel } from "../features/reports/metrics-panel";
 import { SchemaViewer } from "../features/schema/schema-viewer";
@@ -96,6 +97,7 @@ type StudioTab =
     | "data"
     | "drains"
     | "export"
+    | "fanout"
     | "files"
     | "flags"
     | "functions"
@@ -267,6 +269,9 @@ const TAB_ICONS: Record<StudioTab, ReactNode> = {
         <path d="M5 6c0-1.4 3.1-2.5 7-2.5s7 1.1 7 2.5-3.1 2.5-7 2.5S5 7.4 5 6Zm0 0v12c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5V6M5 12c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5" />
     ),
     export: <path d="M12 3v11m0 0 4-4m-4 4-4-4M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />,
+    fanout: (
+        <path d="M12 5a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm-7 16a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm14 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4ZM12 7v3.5M12 10.5 6 17m6-6.5 6 6.5" />
+    ),
     files: <path d="M4 7a2 2 0 0 1 2-2h3l2 2.5h7a2 2 0 0 1 2 2V18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7Z" />,
     flags: <path d="M6 21V4m0 0h11l-2 3 2 3H6" />,
     functions: <path d="m9 8-4 4 4 4m6-8 4 4-4 4" />,
@@ -314,7 +319,7 @@ const NAV_GROUPS: readonly [NavGroup, ...NavGroup[]] = [
     { key: "functions", tabs: ["functions", "api", "workflows", "queues"] },
     { key: "auth", tabs: ["users", "organizations", "authSessions", "authConfig"] },
     { key: "storage", tabs: ["files", "storageRules"] },
-    { key: "observability", tabs: ["logs", "audit", "realtime", "metrics", "analytics", "health"] },
+    { key: "observability", tabs: ["logs", "audit", "realtime", "fanout", "metrics", "analytics", "health"] },
     { key: "advisors", tabs: ["security", "rls", "permissions", "insights"] },
     { key: "operations", tabs: ["schedule", "mail", "drains", "payments", "flags"] },
     { key: "settings", tabs: ["settings"] },
@@ -729,6 +734,7 @@ const StudioLayout = (): ReactElement => {
         data: t("Data"),
         drains: t("Log drains"),
         export: t("Export / Import"),
+        fanout: t("Fan-out"),
         files: t("Files"),
         flags: t("Flags"),
         functions: t("Functions"),
@@ -780,6 +786,7 @@ const StudioLayout = (): ReactElement => {
         data: t("Browse and edit rows across your shard and global tables."),
         drains: t("Forward logs to Logpush, Tail Workers, or a webhook collector."),
         export: t("Export a shard to NDJSON, or import rows from it."),
+        fanout: t("Realtime fan-out cost and per-topic subscriber counts for this shard."),
         files: t("Browse objects in your R2 storage buckets."),
         flags: t("Inspect feature flags and their live evaluation under a targeting context."),
         functions: t("Run registered queries, mutations, and actions."),
@@ -998,6 +1005,7 @@ const buildRouter = ({
         data: <TableEditor editable={dataEditable} initialShardKey={initialShardKey} />,
         drains: <LogDrainsPanel />,
         export: <ExportImportPanel initialShardKey={initialShardKey} />,
+        fanout: <FanoutPanel initialShardKey={initialShardKey} />,
         files: <FileBrowser />,
         flags: <FlagsPanel initialShardKey={initialShardKey} />,
         functions: (

--- a/packages/studio/src/features/reports/fanout-panel.tsx
+++ b/packages/studio/src/features/reports/fanout-panel.tsx
@@ -1,0 +1,186 @@
+import type { ReactElement, ReactNode } from "react";
+import { useState } from "react";
+
+import { ShardInput } from "../../components/shard-input";
+import { Badge } from "../../components/ui/badge";
+import { Card } from "../../components/ui/card";
+import { EmptyState } from "../../components/ui/empty-state";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { useAdminQuery } from "../../hooks/use-admin-query";
+import { useAutoRefresh } from "../../hooks/use-auto-refresh";
+import useDebounced from "../../hooks/use-debounced";
+import type { TFunction } from "../../i18n/i18n-context";
+import { useT } from "../../i18n/i18n-context";
+import type { FanoutMetricsResult, FanoutPathCounters } from "../../lib/admin";
+import { ADMIN_FUNCTIONS } from "../../lib/admin";
+
+interface FanoutPanelProps {
+    /** Shard key the panel reports on. Defaults to the root shard. */
+    readonly initialShardKey?: string;
+}
+
+/** Format a coarse millisecond duration for a stat card. */
+const formatMs = (ms: number): string => `${ms.toString()} ms`;
+
+/** True once a result has loaded and the shard has no connections and has run no fan-out passes yet. */
+const isFanoutIdle = (result: FanoutMetricsResult): boolean => result.totalConnections === 0 && result.shapePoke.passes === 0 && result.whisper.passes === 0;
+
+/** One labelled fan-out counter as a compact KPI card (the metrics panel's stat-card anatomy). */
+const StatCard = ({ label, testId, value }: { label: string; testId?: string; value: ReactNode }): ReactElement => (
+    <Card className="gap-0 py-0">
+        <div className="flex flex-col gap-2.5 p-4">
+            <span className="font-mono text-[11px] tracking-wide text-muted-foreground uppercase">{label}</span>
+            <span className="truncate text-2xl font-semibold tabular-nums text-foreground" data-testid={testId}>
+                {value}
+            </span>
+        </div>
+    </Card>
+);
+
+/**
+ * The running counters for one delivery path as a titled grid of stat cards.
+ * `includeTiming` is `false` for the whisper path (a synchronous broadcast
+ * captures no wall-clock — a DO clock advances only on awaited I/O — so the
+ * `0`ms timing fields would mislead and are omitted rather than shown).
+ */
+const PathCounters = ({
+    counters,
+    includeTiming,
+    prefix,
+    t,
+    title,
+}: {
+    counters: FanoutPathCounters;
+    includeTiming: boolean;
+    prefix: string;
+    t: TFunction;
+    title: string;
+}): ReactElement => (
+    <section className="flex flex-col gap-2" data-testid={`${prefix}-section`}>
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid={`${prefix}-stats`}>
+            <StatCard label={t("Passes")} testId={`${prefix}-passes`} value={counters.passes} />
+            <StatCard label={t("Sockets iterated")} testId={`${prefix}-iterated`} value={counters.socketsIterated} />
+            <StatCard label={t("Delivered")} testId={`${prefix}-delivered`} value={counters.socketsDelivered} />
+            <StatCard label={t("Peak width")} testId={`${prefix}-peak`} value={counters.peakSocketsIterated} />
+            {includeTiming && <StatCard label={t("Total time")} testId={`${prefix}-total-ms`} value={formatMs(counters.totalMs)} />}
+            {includeTiming && <StatCard label={t("Max time")} testId={`${prefix}-max-ms`} value={formatMs(counters.maxMs)} />}
+        </dl>
+    </section>
+);
+
+/**
+ * Fan-out observability for one shard (plan 075 Phase 1): the current
+ * per-topic/shape subscriber counts and the running per-flush fan-out cost of
+ * the reactive shape-poke and whisper-broadcast paths. Reads the
+ * `__lunora_admin__:getFanoutMetrics` RPC via {@link useAdminQuery} (gated by the
+ * server's `LUNORA_ADMIN_TOKEN`).
+ *
+ * This makes the O(subscribers) fan-out cost visible — the "you can see it
+ * scale" half of the auto-elastic relay tier, before any topology change exists.
+ * Subscriber counts are a point-in-time read (no write-flush fires on a
+ * connect/disconnect) and the cost counters reset when the DO hibernates, so the
+ * panel polls on a fixed interval to stay current without a manual refresh.
+ */
+const FanoutPanel = ({ initialShardKey }: FanoutPanelProps): ReactElement => {
+    const t = useT();
+
+    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+
+    // Re-read on the debounced shard key so typing a shard applies once it settles
+    // without querying a half-typed value.
+    const debouncedShard = useDebounced(shardKey.trim(), 400);
+
+    const {
+        data: result,
+        error,
+        refetch,
+    } = useAdminQuery<FanoutMetricsResult>(ADMIN_FUNCTIONS.getFanoutMetrics, {}, { keepPreviousData: true, shardKey: debouncedShard });
+
+    // Point-in-time DO read — poll to keep the snapshot current without a manual refresh.
+    useAutoRefresh(refetch, true);
+
+    const isIdle = result !== undefined && isFanoutIdle(result);
+
+    return (
+        <div className="flex flex-col gap-4" data-testid="fanout-panel">
+            <div className="flex flex-wrap items-center gap-2">
+                <ShardInput onChange={setShardKey} testId="fanout-shard-input" value={shardKey} />
+                {result !== undefined && (
+                    <div className="ml-auto flex items-center gap-2 text-sm text-muted-foreground" data-testid="fanout-count">
+                        <Badge variant="secondary">{t("{count} connections", { count: result.totalConnections })}</Badge>
+                        <Badge variant="secondary">{t("peak {count} subscribers", { count: result.peakSubscribers })}</Badge>
+                    </div>
+                )}
+            </div>
+
+            {error !== null && (
+                <p className="text-sm text-destructive" data-testid="fanout-error" role="alert">
+                    {error}
+                </p>
+            )}
+
+            {error === null && isIdle && (
+                <EmptyState
+                    description={t("Realtime fan-out cost and per-topic subscriber counts for this shard.")}
+                    icon={
+                        <svg
+                            aria-hidden="true"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.6}
+                            viewBox="0 0 24 24"
+                        >
+                            <path d="M4 12h4l3 7 4-14 3 7h2" />
+                        </svg>
+                    }
+                    testId="fanout-empty"
+                    title={t("No fan-out activity yet.")}
+                />
+            )}
+
+            {error === null && result !== undefined && !isIdle && (
+                <>
+                    {result.topics.length > 0 && (
+                        <section className="flex flex-col gap-2" data-testid="fanout-topics-section">
+                            <h3 className="text-sm font-medium text-foreground">{t("Hot topics")}</h3>
+                            <Card className="overflow-hidden py-0">
+                                <Table data-testid="fanout-topics-table">
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>{t("Topic")}</TableHead>
+                                            <TableHead>{t("Kind")}</TableHead>
+                                            <TableHead className="text-right">{t("Subscribers")}</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {result.topics.map((topic) => (
+                                            <TableRow data-testid="fanout-topic-row" key={`${topic.kind}:${topic.topic}`}>
+                                                <TableCell className="font-mono text-xs">{topic.topic}</TableCell>
+                                                <TableCell>
+                                                    <Badge variant="outline">{topic.kind}</Badge>
+                                                </TableCell>
+                                                <TableCell className="text-right font-medium tabular-nums">{topic.subscribers}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </Card>
+                        </section>
+                    )}
+
+                    <section className="flex flex-col gap-3" data-testid="fanout-cost">
+                        <h2 className="text-sm font-medium text-muted-foreground">{t("Fan-out cost since this instance woke")}</h2>
+                        <PathCounters counters={result.shapePoke} includeTiming prefix="fanout-poke" t={t} title={t("Shape pokes")} />
+                        <PathCounters counters={result.whisper} includeTiming={false} prefix="fanout-whisper" t={t} title={t("Whisper broadcasts")} />
+                    </section>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default FanoutPanel;
+export type { FanoutPanelProps };

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -39,6 +39,7 @@ export const ADMIN_FUNCTIONS = {
     getAuditLog: "__lunora_admin__:getAuditLog",
     getAuthMetrics: "__lunora_admin__:getAuthMetrics",
     getCapturedMail: "__lunora_admin__:getCapturedMail",
+    getFanoutMetrics: "__lunora_admin__:getFanoutMetrics",
     getFunctionStats: "__lunora_admin__:getFunctionStats",
     listFlags: "__lunora_admin__:listFlags",
     listQueues: "__lunora_admin__:listQueues",
@@ -682,6 +683,53 @@ export interface SubscriptionsResult {
     connections: SubscriptionConnection[];
     totalConnections: number;
     totalSubscriptions: number;
+}
+
+/**
+ * One topic or shape with its current subscriber count, returned by
+ * `__lunora_admin__:getFanoutMetrics` and mirroring `@lunora/do`'s
+ * `FanoutTopicStat`. `subscribers` is the fan-out width one poke/broadcast incurs
+ * for this topic — the signal the auto-elastic relay tier (plan 075) watches.
+ */
+export interface FanoutTopicStat {
+    /** `"shape"` = a reactive-query shape; `"whisper"` = an ephemeral whisper topic. */
+    kind: "shape" | "whisper";
+    /** Connected sockets currently subscribed — the fan-out width for this topic. */
+    subscribers: number;
+    /** The shape name or the whisper topic string. */
+    topic: string;
+}
+
+/**
+ * Running fan-out counters for one delivery path since the DO instance woke,
+ * mirroring `@lunora/do`'s `FanoutPathCounters`. `socketsIterated` is the
+ * O(subscribers) loop cost; `socketsDelivered` is how many of those received a
+ * frame. `totalMs`/`maxMs` are **coarse** (a DO clock advances only on I/O) and
+ * populated only for the asynchronous shape-poke path — they stay `0` for the
+ * synchronous whisper broadcast.
+ */
+export interface FanoutPathCounters {
+    maxMs: number;
+    passes: number;
+    peakSocketsIterated: number;
+    socketsDelivered: number;
+    socketsIterated: number;
+    totalMs: number;
+}
+
+/**
+ * Payload of a `__lunora_admin__:getFanoutMetrics` call, mirroring `@lunora/do`'s
+ * `FanoutMetricsResult`: the current per-topic subscriber counts (derived live
+ * from the shard's sockets) plus the running per-path fan-out cost counters
+ * (in-memory, reset on hibernation). Feeds the Studio fan-out observability panel.
+ */
+export interface FanoutMetricsResult {
+    peakSubscribers: number;
+    shapePoke: FanoutPathCounters;
+    sinceMs: number;
+    topics: FanoutTopicStat[];
+    totalConnections: number;
+    whisper: FanoutPathCounters;
 }
 
 /** Outcome of one dispatch in the request log, mirroring `@lunora/do`'s `RequestOutcome`. */

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -995,6 +995,23 @@ const MESSAGE_IDS = [
     "Light theme",
     "System theme",
     "Integrity",
+    // Fan-out observability panel (plan 075 Phase 1).
+    "Fan-out",
+    "Realtime fan-out cost and per-topic subscriber counts for this shard.",
+    "No fan-out activity yet.",
+    "peak {count} subscribers",
+    "Hot topics",
+    "Topic",
+    "Kind",
+    "Subscribers",
+    "Fan-out cost since this instance woke",
+    "Shape pokes",
+    "Whisper broadcasts",
+    "Passes",
+    "Sockets iterated",
+    "Delivered",
+    "Peak width",
+    "Max time",
 ] as const;
 
 /** A known studio message id — one of the entries in {@link MESSAGE_IDS}. */

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -130,8 +130,11 @@ checkpoint)` (≈6111) drains the op range from the owner's SQLite and probes
 3. **RLS-uniform gate signal.** Reuse plan 073's identity-independence
    determination as the _necessary_ condition for promoting a **reactive shape**.
    Confirm: is 073's signal available at the granularity this needs (per shape,
-   at runtime)? If not, what is the minimal extension? whisper/presence are
-   uniform by construction and need no per-shape proof.
+   at runtime)? If not, what is the minimal extension? `whisper` topics are
+   uniform by construction (opaque payload, no per-identity result) and need no
+   per-shape proof; presence (`usePresence`) is **not** uniform-by-construction —
+   it is a reactive query (`listPresent`) and goes through this gate like any
+   shape.
 4. **Resume across a shifting topology.** How does a client that reconnects onto a
    _different_ relay resume correctly from its `(sinceSeq, sinceEpoch)`? Proposal:
    relays are stateless re-broadcasters; the **owner remains the checkpoint
@@ -156,7 +159,7 @@ file (or a sibling design doc). **Maintainer sign-off required before Phase 1.**
 Deliverable: a measured T_up from a fan-out micro-benchmark on `ShardDO`
 (subscribers vs per-flush CPU), not a guessed constant.
 
-### Phase 1 — Observability only (ship first, low risk)
+### Phase 1 — Observability only (ship first, low risk) — **SHIPPED**
 
 Instrument the owner: per-topic/shape **subscriber count + per-flush fan-out
 cost**, surfaced in Studio (Advisors/metrics). No behavior change. This proves
@@ -166,14 +169,32 @@ the DX before any topology change exists. Gate behind a flag if needed.
 **Verify**: metrics appear in Studio for a synthetic high-subscriber topic;
 `pnpm --filter "@lunora/do" run test` green; no change to poke output.
 
-### Phase 2 — whisper/presence relay (the natural first adopter)
+> **Shipped.** `ShardDO.pokeShapeSubscribers` + `broadcastWhisper` record
+> per-pass fan-out counters (in-memory, hibernation-reset, shared `sinceMs`);
+> the `__lunora_admin__:getFanoutMetrics` read folds live per-topic subscriber
+> counts via `summarizeFanoutTopics`; a Studio "Fan-out" page (Observability)
+> renders hot topics + per-path cost. Pure measurement — no change to which
+> sockets are poked or who receives a whisper. Counting is always-on (integer
+> increments are negligible); no env flag was needed. Coarse `totalMs`/`maxMs`
+> are captured for the async poke path only (a DO clock advances only on I/O)
+> and omitted for the synchronous whisper path; socket-count width is the exact,
+> reliable cost signal. The full `@lunora/do` suite is green and the wire shapes
+> carry key drift-guards on both the `@lunora/do` and `@lunora/studio` sides.
 
-Relay-scale **whisper topics** (and `usePresence`, which rides whisper-like
-ephemeral fan-out) only — payloads are already opaque and topic-uniform, so no
-owner/relay _data_ split is required, and there is no RLS-uniform proof to
-compute. Owner multicasts the opaque whisper frame to relays; relays fan out to
-their attached sockets. New connections to a hot topic route to a relay via the
-runtime hop.
+### Phase 2 — whisper relay (the natural first adopter)
+
+Relay-scale **whisper topics** only — their payload is already opaque and
+topic-uniform, so no owner/relay _data_ split is required and there is no
+RLS-uniform proof to compute. Owner multicasts the opaque whisper frame to
+relays; relays fan out to their attached sockets. New connections to a hot topic
+route to a relay via the runtime hop.
+
+> **`usePresence` is _not_ in this phase.** Despite being "ephemeral awareness",
+> presence is implemented as a `heartbeat` **mutation** + a `listPresent`
+> **reactive query** over a presence table (`definePresence`,
+> `packages/server/src/presence.ts` — "Live queries (subscriptions) drive
+> `listPresent`"). It flows through the reactive-shape path, **not** `whisper`,
+> so it is handled in Phase 3 as an RLS-uniform reactive shape, not here.
 
 **Verify**: a topic above T_up serves identical whisper delivery to subscribers
 whether they land on the owner or a relay; sender still never receives its own
@@ -187,6 +208,12 @@ Extend relay-scaling to **reactive query shapes that pass the RLS-uniform gate**
 op-range), then multicasts the opaque delta frame to relays. Resume goes through
 the owner per Decision 4. Non-uniform shapes are **never** promoted and keep
 today's owner-served path byte-for-byte.
+
+`usePresence`'s `listPresent` is the canonical first target here: it is typically
+room-public (so it passes the RLS-uniform gate) and is the highest-fan-out
+reactive query in practice — every member of a large room subscribes to the same
+present-list. Treating it as a reactive shape (not an opaque whisper) is what
+makes its delta correct for every subscriber.
 
 **Verify**: an RLS-uniform public shape with subscribers across owner+relays
 produces byte-identical deltas to today's single-DO path (reuse plan 070's
@@ -251,8 +278,9 @@ Stop and report back if:
 
 - **The RLS-uniform gate is the correctness boundary.** A reactive shape is
   promotable ONLY if its poke is identity-independent (plan 073's signal). Never
-  multicast one delta across an identity boundary. whisper/presence are uniform
-  by construction; reactive shapes must prove it.
+  multicast one delta across an identity boundary. Only `whisper` topics are
+  uniform by construction; every reactive shape — including presence's
+  `listPresent` — must pass the gate.
 - **The owner stays the checkpoint authority.** Relays are stateless
   re-broadcasters. All resume/ordering truth lives at the owner so a client can
   reconnect onto any relay and still resume from its checkpoint.

--- a/plans/README.md
+++ b/plans/README.md
@@ -211,9 +211,9 @@ partysync). Two genuine gaps surfaced; one is filed as a design spike here. The
 other (Yjs/CRDT collaborative editing via `y-partyserver`) is tracked separately
 as a prospective `@lunora/collab` package and is **not** in this directory yet.
 
-| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                            |
-| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ------------------------------------------------- |
-| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | TODO (design spike — Phase 0 sign-off gates code) |
+| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                                                 |
+| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ---------------------------------------------------------------------- |
+| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | Phase 1 (observability) SHIPPED — Phases 2–4 gated on Phase 0 sign-off |
 
 ### Notes
 
@@ -221,8 +221,9 @@ as a prospective `@lunora/collab` package and is **not** in this directory yet.
   thinking about it" principle: not a user-facing pub/sub primitive but an
   **automatic internal elasticity** of the subscription transport. Depends on
   plans **072 + 073** (the "compute once" op-range and the identity-independence
-  signal its RLS-uniform gate reuses). Phased: observability → whisper/presence
-  relay → RLS-uniform reactive-shape relay → collapse/ceiling. Start only if the
+  signal its RLS-uniform gate reuses). Phased: observability → whisper relay →
+  RLS-uniform reactive-shape relay (incl. `usePresence`'s `listPresent`, which is
+  a reactive query, not whisper) → collapse/ceiling. Start only if the
   live-broadcast / massive-public-room segment is an explicit product goal.
 - **CRDT / collaborative editing** — the other PartyKit gap (`y-partyserver`).
   Reuse, don't rebuild: `y-partyserver` is ISC and solves Yjs document


### PR DESCRIPTION
## What

Implements **Plan 075 Phase 1** (observability only) — the "you can see it scale" half of the auto-elastic fan-out relay tier, with **no behavior change**. Plus carries the stranded presence-phasing doc correction (see below).

## Why

Plan 075's relay tier promotes a topic/shape once its per-flush fan-out cost (O(subscribers)) becomes the bottleneck. Phase 0 needs that threshold grounded in **real numbers**, and the DX goal is that Studio *shows* a topic getting hot. Phase 1 makes the cost measurable before any topology change exists. Phases 2–4 (the transport/RLS rewrite) stay gated on Phase 0 sign-off.

Builds on plans **072** (shared op-range) and **073** (identity-independent runs), now landed on alpha.

## Changes

**`@lunora/do`**
- `pokeShapeSubscribers` + `broadcastWhisper` record per-pass fan-out counters: passes, sockets iterated, sockets delivered, peak width, and — for the async poke path only — coarse wall-time. In-memory, reset on hibernation, sharing `metrics.sinceMs`.
- New `__lunora_admin__:getFanoutMetrics` read folds **live per-topic/shape subscriber counts** from socket attachments (`summarizeFanoutTopics`) and returns them with the running counters.
- `recordFanoutPass` is pure (returns updated counters); instrumentation never changes which sockets are poked or who receives a whisper.

**`@lunora/studio`**
- A new **Fan-out** page under Observability (modeled on the subscriptions panel): hot topics by subscriber count + per-path cost cards.
- Wire types hand-mirrored in `lib/admin.ts`, with key **drift-guards on both the `@lunora/do` and `@lunora/studio` sides**.

**Design notes**
- Counting is **always-on** — integer increments are negligible; no env flag needed. The admin read is already `LUNORA_ADMIN_TOKEN`-gated.
- Socket-count **width** is the exact, reliable cost signal (the plan's O(subscribers) model). `totalMs`/`maxMs` are **coarse** (a DO clock advances only on I/O) and captured for the async poke path only — omitted for the synchronous whisper broadcast rather than shown as a misleading `0`.

## Tests & verification

- Pure `summarizeFanoutTopics` / `recordFanoutPass` unit cases + an end-to-end `getFanoutMetrics` admin-read assertion folding real socket attachments.
- Wire-shape drift guards (compile-time + runtime) on both packages.
- Full `@lunora/do` suite green (**938 passed**); `@lunora/do` + `@lunora/studio` typecheck clean (the 6 remaining studio `tsc` errors are pre-existing auth-panel baseline, confirmed against pristine alpha); ESLint clean on all changed files (one pre-existing `tabLabel` react-hooks warning, not introduced here).
- Studio jsdom component tests aren't run here (sandbox limitation); the panel is verified via typecheck + lint and the server contract via the DO integration test.

## Docs

- Carries the **presence-phasing correction** (originally #55, stranded on the diverged `lfse-followups` base): `usePresence` is a `listPresent` reactive query, so it belongs in Phase 3 (RLS-uniform), not Phase 2 (whisper). All touch points reconciled.
- Marks plan 075 **Phase 1 SHIPPED** in the plan + README status row.

Supersedes #55 (whose base branch diverged from alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NXayJPpMpVhqzEd4dLEx4