### PR TITLE
feat(do): plan 075 Phase 2 — whisper relay (WIP)

### DIFF
--- a/packages/do/__tests__/relay.test.ts
+++ b/packages/do/__tests__/relay.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor } from "../src/relay";
+
+describe("relay promotion reducer", () => {
+    const thresholds = { tDown: 4000, tUp: 8000 };
+
+    it("promotes an owned key at or above tUp, holds below", () => {
+        expect.assertions(3);
+
+        expect(nextPromotionState("owned", 7999, thresholds)).toBe("owned");
+        expect(nextPromotionState("owned", 8000, thresholds)).toBe("promoted");
+        expect(nextPromotionState("owned", 50_000, thresholds)).toBe("promoted");
+    });
+
+    it("collapses a promoted key only below tDown, holds at or above", () => {
+        expect.assertions(3);
+
+        expect(nextPromotionState("promoted", 4000, thresholds)).toBe("promoted");
+        expect(nextPromotionState("promoted", 3999, thresholds)).toBe("owned");
+        expect(nextPromotionState("promoted", 0, thresholds)).toBe("owned");
+    });
+
+    it("holds the current state across the hysteresis band (no flap)", () => {
+        expect.assertions(2);
+
+        // A count of 6000 sits between tDown and tUp: whichever state we're in stays.
+        expect(nextPromotionState("owned", 6000, thresholds)).toBe("owned");
+        expect(nextPromotionState("promoted", 6000, thresholds)).toBe("promoted");
+    });
+
+    it("defaults to the 8000/4000 thresholds", () => {
+        expect.assertions(3);
+
+        expect(DEFAULT_PROMOTION_THRESHOLDS).toStrictEqual({ tDown: 4000, tUp: 8000 });
+        expect(nextPromotionState("owned", 8000)).toBe("promoted");
+        expect(nextPromotionState("promoted", 3999)).toBe("owned");
+    });
+
+    it("rejects an empty or inverted hysteresis band", () => {
+        expect.assertions(2);
+
+        expect(() => nextPromotionState("owned", 1, { tDown: 8000, tUp: 8000 })).toThrow(/tDown/);
+        expect(() => nextPromotionState("owned", 1, { tDown: 9000, tUp: 8000 })).toThrow(/must be < tUp/);
+    });
+});
+
+describe("relayCountFor", () => {
+    it("needs no relays at or below one DO's capacity", () => {
+        expect.assertions(2);
+
+        expect(relayCountFor(8000, 8000, 8)).toBe(0);
+        expect(relayCountFor(1, 8000, 8)).toBe(0);
+    });
+
+    it("sizes the relay set to the overflow above one DO's capacity", () => {
+        expect.assertions(3);
+
+        expect(relayCountFor(16_000, 8000, 8)).toBe(1); // 8k overflow → 1 relay
+        expect(relayCountFor(24_001, 8000, 8)).toBe(3); // 16,001 overflow → ceil(16001/8000)=3
+        expect(relayCountFor(40_000, 8000, 8)).toBe(4); // 32k overflow → 4 relays
+    });
+
+    it("never exceeds the max-relays cost ceiling", () => {
+        expect.assertions(1);
+
+        // A viral key: overflow would want many relays, but the cap holds.
+        expect(relayCountFor(10_000_000, 8000, 8)).toBe(8);
+    });
+
+    it("returns zero for a non-positive capacity rather than dividing by zero", () => {
+        expect.assertions(1);
+
+        expect(relayCountFor(10_000, 0, 8)).toBe(0);
+    });
+});

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -1,0 +1,110 @@
+/**
+ * Auto-elastic fan-out relay tier — promotion state machine + internal owner↔relay
+ * frame protocol (plan 075 Phase 2).
+ *
+ * A hot fan-out key (a shard whose subscriber count makes one isolate's per-flush
+ * fan-out the bottleneck — see the measured curve in
+ * `plans/075-phase0-relay-protocol-design.md` § 7) is **promoted**: the runtime
+ * routes _new_ connections to relay DOs, the owner computes each delta once and
+ * forwards an opaque frame to its relays, and each relay re-broadcasts to its
+ * attached sockets. This module is the pure, owner-side decision layer; the
+ * transport that consumes it lives in `shard-do.ts` (relay mode) and the runtime
+ * (endpoint selection at the WS upgrade hop).
+ *
+ * Everything here is internal: the {@link OwnerRelayFrame} types are NOT part of
+ * the public client protocol (the app never sees them — the relay tier is
+ * invisible runtime elasticity).
+ */
+
+/** Whether a fan-out key is owner-served (the default) or has been promoted to a relay set. */
+type PromotionState = "owned" | "promoted";
+
+/**
+ * Subscriber-count thresholds governing promotion, with hysteresis. `tDown` must
+ * be strictly below `tUp`: the band between them holds the current state so a key
+ * hovering near the threshold can't flap between owner-served and promoted.
+ */
+interface PromotionThresholds {
+    /** Collapse back to owner-served below this live-subscriber count (must be `< tUp`). */
+    tDown: number;
+    /** Promote to a relay set at or above this live-subscriber count. */
+    tUp: number;
+}
+
+/**
+ * Default promotion thresholds. `tUp = 8,000` is where the measured fan-out curve
+ * (~10–15 µs/socket end-to-end in workerd, ~120 ms per flush at 8k) makes per-flush
+ * fan-out the bottleneck well within a single DO's ~32k connection cap; `tDown` is
+ * half that, the anti-flap band. Both are tunable per deployment against the
+ * Phase-1 `getFanoutMetrics` readout — never silently hardcoded into the hot path.
+ */
+const DEFAULT_PROMOTION_THRESHOLDS: PromotionThresholds = { tDown: 4000, tUp: 8000 };
+
+/**
+ * Pure promotion reducer: the next {@link PromotionState} given the current state
+ * and the live subscriber count, under the hysteresis band. `owned` promotes at
+ * `>= tUp`; `promoted` collapses at `< tDown`; in between, the state is unchanged.
+ * @throws if `tDown >= tUp` (the band would be empty or inverted — a config error).
+ */
+const nextPromotionState = (current: PromotionState, subscribers: number, thresholds: PromotionThresholds = DEFAULT_PROMOTION_THRESHOLDS): PromotionState => {
+    if (thresholds.tDown >= thresholds.tUp) {
+        throw new Error(`invalid promotion thresholds: tDown (${String(thresholds.tDown)}) must be < tUp (${String(thresholds.tUp)})`);
+    }
+
+    if (current === "owned") {
+        return subscribers >= thresholds.tUp ? "promoted" : "owned";
+    }
+
+    return subscribers < thresholds.tDown ? "owned" : "promoted";
+};
+
+/**
+ * How many relays a promoted key needs to serve `subscribers` connections, given
+ * each relay's capacity, capped at `maxRelays` (the cost ceiling — a viral key can
+ * never silently spawn unbounded DOs; the runtime surfaces the cap in Studio when
+ * approached). The owner keeps serving its own share, so this sizes the _relay_
+ * set for the overflow above one DO's capacity.
+ * @returns the relay count in `[0, maxRelays]`
+ */
+const relayCountFor = (subscribers: number, perRelayCapacity: number, maxRelays: number): number => {
+    if (subscribers <= perRelayCapacity || perRelayCapacity <= 0) {
+        return 0;
+    }
+
+    const overflow = subscribers - perRelayCapacity;
+    const needed = Math.ceil(overflow / perRelayCapacity);
+
+    return Math.min(needed, Math.max(0, maxRelays));
+};
+
+/** A relay announces (on first attach) that it is serving a fan-out key for the owner. */
+interface RelayAttach {
+    relayId: string;
+    type: "relay_attach";
+}
+
+/** A relay announces it has drained to zero sockets and is detaching from the key. */
+interface RelayDetach {
+    relayId: string;
+    type: "relay_detach";
+}
+
+/**
+ * The owner forwards one **opaque, already-serialized** frame for a relay to
+ * re-broadcast verbatim to its attached sockets. `frame` is the exact wire string
+ * the owner would have sent its own sockets (a whisper frame in Phase 2); the relay
+ * never parses or re-derives it. `cursor`/`epoch` accompany reactive-shape frames
+ * (Phase 3) so a relay can stamp the checkpoint; absent for ephemeral whisper.
+ */
+interface RelayFrame {
+    cursor?: number;
+    epoch?: string;
+    frame: string;
+    type: "relay_frame";
+}
+
+/** Internal owner↔relay control frames (plan 075). NOT the public client protocol — the app never sees these. */
+type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame;
+
+export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
+export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame };


### PR DESCRIPTION
**Draft — Phase 2 (whisper relay), built incrementally.** Stacked on #73 (Phase 1) and #74 (Phase 0 design, signed off).

Phase 2 is XL/HIGH-risk (it touches the subscription transport), so it lands as reviewable slices rather than one drop.

## Slice 1 — foundation (this commit)

The pure, owner-side decision layer + the internal owner↔relay frame protocol:
- `nextPromotionState` — hysteresis reducer (`owned ⇄ promoted`) keyed on live subscriber count vs `T_up`/`T_down`; the band holds state so a key near the threshold can't flap. Default `8,000/4,000` from the §7 measured curve.
- `relayCountFor` — sizes the relay set to the overflow above one DO's capacity, hard-capped at `maxRelays` (the cost ceiling).
- `OwnerRelayFrame` types — the internal `relay_attach`/`relay_detach`/`relay_frame` protocol (opaque owner-serialized re-broadcast). **Not** the public client protocol.

Granularity-agnostic, consumer-free by design. 9 tests; types/eslint/prettier clean.

## Design refinement vs Phase 0 §2

The §2 "route a new connection to a relay **by topic** at the WS upgrade hop" doesn't hold for whisper — a socket connects first, then joins a topic via `whisper_subscribe`, so the topic is unknown at upgrade. Resolution: relay at **shard granularity** (the upgrade already routes by `?shard=`, and "one giant public room = one shard" is the canonical case). Per-topic relay is a later refinement. Will fold this into the Phase 0 doc.

## Remaining slices

- **Slice 2** — relay-mode `ShardDO` + the owner↔relay whisper hub (DO-to-DO link; owner forwards opaque frames, relays re-broadcast). Node-tested in isolation.
- **Slice 3** — runtime upgrade-hop endpoint selection (owner vs relay) + the promotion-state lookup/registry, invisible to the client.
- **Slice 4** — collapse below `T_down`, the `maxRelays` ceiling + Studio/advisor surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NXayJPpMpVhqzEd4dLEx4