### PR TITLE
feat(do): auto-elastic fan-out relay tier for hot shards

### DIFF
--- a/packages/do/__bench__/fanout-whisper.bench.ts
+++ b/packages/do/__bench__/fanout-whisper.bench.ts
@@ -1,0 +1,112 @@
+import { beforeAll, bench, describe } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+/**
+ * Whisper fan-out cost vs subscriber count — the regression guard for plan 075's
+ * O(subscribers) per-flush fan-out (the cost the auto-elastic relay tier targets,
+ * and that `getFanoutMetrics` surfaces).
+ *
+ * Each iteration drives ONE real `broadcastWhisper` through the public
+ * `webSocketMessage` path: the owner scans every connected socket, reads its
+ * hibernation attachment, and sends the one shared frame to topic members. The
+ * bench measures that loop at a small and a large subscriber count so a
+ * regression (e.g. building the frame per-socket, or an O(N²) membership check)
+ * shows up as a super-linear jump between the two.
+ *
+ * Harness notes. `getWebSockets()` returns ONLY the N topic members, so the
+ * fan-out iterates exactly N — the senders live in a separate pool (they need no
+ * membership and `broadcastWhisper` reads the sender only via the `sender`
+ * argument), keeping the iterated count equal to N rather than N + senders.
+ * Senders rotate through a large pool so no single sender exceeds the per-socket
+ * whisper token bucket (`WHISPER_RATE_BURST`), which would otherwise make a
+ * measured call early-return instead of fanning out. `send` is a no-op counter,
+ * so the member sockets don't accumulate frames across iterations (the cost under
+ * test is the owner's loop, not client recv).
+ */
+
+const TOPIC = "bench-topic";
+const ENVELOPE = JSON.stringify({ data: { x: 1, y: 2 }, topic: TOPIC, type: "whisper" });
+const SENDER_POOL = 16_384;
+
+class FakeSocket {
+    public sent = 0;
+
+    private attachment: unknown;
+
+    public constructor(initial?: unknown) {
+        this.attachment = initial;
+    }
+
+    public deserializeAttachment(): unknown {
+        return this.attachment;
+    }
+
+    public send(_data: string): void {
+        this.sent += 1;
+    }
+
+    public serializeAttachment(value: unknown): void {
+        this.attachment = value;
+    }
+}
+
+class WhisperBenchShard extends ShardDO {
+    // eslint-disable-next-line class-methods-use-this -- abstract stub; the whisper path never dispatches an RPC
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve({});
+    }
+}
+
+interface FanoutRig {
+    next: () => WebSocket;
+    shard: WhisperBenchShard;
+}
+
+const buildRig = (n: number): FanoutRig => {
+    const members: FakeSocket[] = [];
+    for (let index = 0; index < n; index += 1) {
+        members.push(new FakeSocket({ subs: {}, whispers: [TOPIC] }));
+    }
+
+    const senders: FakeSocket[] = [];
+    for (let index = 0; index < SENDER_POOL; index += 1) {
+        senders.push(new FakeSocket({ subs: {} }));
+    }
+
+    const state = {
+        acceptWebSocket() {},
+        getWebSockets: () => members,
+        storage: { sql: {} },
+    } as unknown as ShardDOState;
+
+    let cursor = 0;
+    const next = (): WebSocket => {
+        const sender = senders[cursor % SENDER_POOL];
+        cursor += 1;
+
+        return sender as unknown as WebSocket;
+    };
+
+    return { next, shard: new WhisperBenchShard(state, {}) };
+};
+
+const defineFanoutBench = (n: number): void => {
+    describe(`whisper fan-out — ${String(n)} subscribers`, () => {
+        let rig: FanoutRig;
+
+        // CodSpeed's instrumented runner honors beforeAll but not module-top-level
+        // state, so the rig is built here.
+        beforeAll(() => {
+            rig = buildRig(n);
+        });
+
+        bench(`broadcastWhisper to ${String(n)} members`, async () => {
+            await rig.shard.webSocketMessage(rig.next(), ENVELOPE);
+        });
+    });
+};
+
+defineFanoutBench(128);
+defineFanoutBench(1024);

--- a/packages/do/__tests__/introspect.test.ts
+++ b/packages/do/__tests__/introspect.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { facetColumn, findStorageReferences, listTables, readTablePage, selectMatchingIds, summarizeSubscriptions } from "../src/introspect";
+import {
+    createFanoutCounters,
+    facetColumn,
+    findStorageReferences,
+    listTables,
+    readTablePage,
+    recordFanoutPass,
+    selectMatchingIds,
+    summarizeFanoutTopics,
+    summarizeSubscriptions,
+} from "../src/introspect";
 import createSqliteExec from "./_helpers/node-sqlite";
 
 describe("introspect", () => {
@@ -597,6 +607,100 @@ describe("introspect", () => {
                 totalConnections: 1,
                 totalSubscriptions: 0,
             });
+        });
+    });
+
+    describe("summarizeFanoutTopics", () => {
+        it("returns an empty result with zeroed peak for no sockets", () => {
+            expect.assertions(1);
+
+            expect(summarizeFanoutTopics([])).toEqual({ peakSubscribers: 0, topics: [], totalConnections: 0 });
+        });
+
+        it("counts shapes by name and whispers by topic, busiest first", () => {
+            expect.assertions(1);
+
+            const result = summarizeFanoutTopics([
+                { shapes: { "s-1": { name: "roomMessages" } }, whispers: ["cursor:general"] },
+                { shapes: { "s-2": { name: "roomMessages" } }, whispers: ["cursor:general"] },
+                { shapes: { "s-3": { name: "roomMessages" }, "s-4": { name: "roster" } } },
+                { whispers: ["cursor:general", "typing:42"] },
+            ]);
+
+            // roomMessages: 3 sockets, cursor:general: 3 sockets, roster: 1, typing:42: 1.
+            expect(result).toEqual({
+                peakSubscribers: 3,
+                topics: [
+                    { kind: "whisper", subscribers: 3, topic: "cursor:general" },
+                    { kind: "shape", subscribers: 3, topic: "roomMessages" },
+                    { kind: "shape", subscribers: 1, topic: "roster" },
+                    { kind: "whisper", subscribers: 1, topic: "typing:42" },
+                ],
+                totalConnections: 4,
+            });
+        });
+
+        it("falls back to a sentinel name for a shape with no registered name", () => {
+            expect.assertions(1);
+
+            expect(summarizeFanoutTopics([{ shapes: { "s-1": {} } }])).toEqual({
+                peakSubscribers: 1,
+                topics: [{ kind: "shape", subscribers: 1, topic: "(unknown shape)" }],
+                totalConnections: 1,
+            });
+        });
+
+        it("caps the returned topics at the supplied limit while peak still reflects the busiest", () => {
+            expect.assertions(3);
+
+            // "a" is joined by both sockets; "b"/"c" by one each. A limit of 2 keeps
+            // only the two busiest, but the peak still reflects the global maximum.
+            const result = summarizeFanoutTopics([{ whispers: ["a", "b", "c"] }, { whispers: ["a"] }], 2);
+
+            expect(result.topics).toHaveLength(2);
+            expect(result.topics[0]).toEqual({ kind: "whisper", subscribers: 2, topic: "a" });
+            expect(result.peakSubscribers).toBe(2);
+        });
+    });
+
+    describe("recordFanoutPass / createFanoutCounters", () => {
+        it("starts every counter at zero", () => {
+            expect.assertions(1);
+
+            expect(createFanoutCounters()).toEqual({
+                maxMs: 0,
+                passes: 0,
+                peakSocketsIterated: 0,
+                socketsDelivered: 0,
+                socketsIterated: 0,
+                totalMs: 0,
+            });
+        });
+
+        it("accumulates totals and lifts the peak-width and slowest-pass high-water marks", () => {
+            expect.assertions(2);
+
+            let counters = createFanoutCounters();
+
+            counters = recordFanoutPass(counters, 10, 4, 3);
+            counters = recordFanoutPass(counters, 25, 25, 1);
+            counters = recordFanoutPass(counters, 7, 0, 12);
+
+            expect(counters).toEqual({
+                maxMs: 12,
+                passes: 3,
+                peakSocketsIterated: 25,
+                socketsDelivered: 29,
+                socketsIterated: 42,
+                totalMs: 16,
+            });
+
+            // Pure: a single pass returns a fresh object and never mutates its input.
+            const base = createFanoutCounters();
+
+            recordFanoutPass(base, 5, 5, 5);
+
+            expect(base).toEqual(createFanoutCounters());
         });
     });
 });

--- a/packages/do/__tests__/relay-set.test.ts
+++ b/packages/do/__tests__/relay-set.test.ts
@@ -82,3 +82,51 @@ describe("owner relay-set persistence", () => {
         expect(response.status).toBe(400);
     });
 });
+
+describe("owner promotion probe (/_lunora/route)", () => {
+    let database: ReturnType<typeof createSqliteExec>;
+
+    beforeEach(() => {
+        database = createSqliteExec();
+    });
+
+    afterEach(() => {
+        database.close();
+    });
+
+    const probe = async (name: string, socketCount: number, env: Record<string, string>): Promise<number> => {
+        const state = {
+            acceptWebSocket() {},
+            getWebSockets: () => Array.from({ length: socketCount }, () => ({}) as WebSocket),
+            id: { name },
+            storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+        } as unknown as ShardDOState;
+        const shard = new RelaySetShard(state, env);
+        const response = await shard.fetch(new Request("https://shard.internal/_lunora/route", { method: "GET" }));
+        const body: { relayCount: number } = await response.json();
+
+        return body.relayCount;
+    };
+
+    const ENV = { LUNORA_MAX_RELAYS: "8", LUNORA_RELAY_FAN: "2", LUNORA_RELAY_THRESHOLD: "3" };
+
+    it("keeps an owner un-promoted below the threshold and promotes at/above it", async () => {
+        expect.assertions(3);
+
+        await expect(probe("room-1", 2, ENV)).resolves.toBe(0); // below threshold → owner-served
+        await expect(probe("room-1", 3, ENV)).resolves.toBe(2); // at threshold → fan of 2
+        await expect(probe("room-1", 9000, ENV)).resolves.toBe(2); // well above → still the configured fan
+    });
+
+    it("caps the fan at LUNORA_MAX_RELAYS", async () => {
+        expect.assertions(1);
+
+        await expect(probe("room-1", 5, { LUNORA_MAX_RELAYS: "3", LUNORA_RELAY_FAN: "100", LUNORA_RELAY_THRESHOLD: "1" })).resolves.toBe(3);
+    });
+
+    it("never promotes a relay-role DO (flat single tier)", async () => {
+        expect.assertions(1);
+
+        await expect(probe("room-1::relay::0", 9000, ENV)).resolves.toBe(0);
+    });
+});

--- a/packages/do/__tests__/relay-set.test.ts
+++ b/packages/do/__tests__/relay-set.test.ts
@@ -130,3 +130,58 @@ describe("owner promotion probe (/_lunora/route)", () => {
         await expect(probe("room-1::relay::0", 9000, ENV)).resolves.toBe(0);
     });
 });
+
+describe("relay collapse (detach on drain)", () => {
+    let database: ReturnType<typeof createSqliteExec>;
+
+    beforeEach(() => {
+        database = createSqliteExec();
+    });
+
+    afterEach(() => {
+        database.close();
+    });
+
+    it("a drained relay detaches from its owner, and re-arms to re-attach", async () => {
+        expect.assertions(2);
+
+        // Capture the owner↔relay control messages the relay POSTs to siblings.
+        const posts: { body: { relayIndex?: number; type: string }; name: string }[] = [];
+        const namespace = {
+            // `postRelayMessage` calls `stub.fetch(url, init)` (the DO-stub form workerd
+            // accepts), so the body arrives as `init.body`, not a Request.
+            get: (id: { __name: string }) => {
+                return {
+                    fetch: (_input: string, init: { body: string }) => {
+                        posts.push({ body: JSON.parse(init.body) as { type: string }, name: id.__name });
+
+                        return Promise.resolve(new Response(null, { status: 204 }));
+                    },
+                };
+            },
+            idFromName: (name: string) => {
+                return { __name: name };
+            },
+        };
+
+        const state = {
+            acceptWebSocket() {},
+            getWebSockets: () => [] as WebSocket[],
+            id: { name: "room-1::relay::0" },
+            storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+        } as unknown as ShardDOState;
+
+        const shard = new RelaySetShard(state, { SHARD: namespace });
+
+        // Teach the relay its namespace binding via any forwarded request.
+        await shard.fetch(new Request("https://shard.internal/_lunora/route", { headers: { "x-lunora-shard-binding": "SHARD" }, method: "GET" }));
+
+        // The relay's last socket closes → it detaches from the owner.
+        await shard.webSocketClose({} as WebSocket, 1000, "", true);
+
+        const detach = posts.find((post) => post.body.type === "relay_detach");
+
+        expect(detach).toStrictEqual({ body: { relayIndex: 0, type: "relay_detach" }, name: "room-1" });
+        expect(detach?.name).toBe("room-1"); // forwarded to the owner, not a relay
+    });
+});

--- a/packages/do/__tests__/relay-set.test.ts
+++ b/packages/do/__tests__/relay-set.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The owner's relay set (plan 075 Phase 2) is the `__lunora_relays` SQLite table,
+ * driven by the internal `/_lunora/relay` `relay_attach`/`relay_detach` control
+ * messages and read synchronously on the whisper-forward hot path. This exercises
+ * that persistence directly in Node (the cross-DO fan-out it drives is covered by
+ * the workerd e2e).
+ */
+class RelaySetShard extends ShardDO {
+    // eslint-disable-next-line class-methods-use-this -- abstract stub; the relay-set control path never dispatches an RPC
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve({});
+    }
+}
+
+describe("owner relay-set persistence", () => {
+    let database: ReturnType<typeof createSqliteExec>;
+    let shard: RelaySetShard;
+
+    beforeEach(() => {
+        database = createSqliteExec();
+        const state = {
+            acceptWebSocket() {},
+            getWebSockets: () => [],
+            id: { name: "room-1" },
+            storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+        } as unknown as ShardDOState;
+
+        shard = new RelaySetShard(state, {});
+    });
+
+    afterEach(() => {
+        database.close();
+    });
+
+    const post = (body: Record<string, unknown>): Promise<Response> =>
+        shard.fetch(
+            new Request("https://shard.internal/_lunora/relay", {
+                body: JSON.stringify(body),
+                headers: { "content-type": "application/json" },
+                method: "POST",
+            }),
+        );
+
+    const relayIndices = (): number[] =>
+        (database.sql.exec("SELECT idx FROM __lunora_relays ORDER BY idx").toArray() as { idx: bigint | number }[]).map((row) => Number(row.idx));
+
+    it("records attached relays (idempotently) and drops detached ones", async () => {
+        expect.assertions(4);
+
+        const attached = await post({ relayIndex: 0, type: "relay_attach" });
+
+        expect(attached.status).toBe(204);
+
+        await post({ relayIndex: 2, type: "relay_attach" });
+        await post({ relayIndex: 0, type: "relay_attach" }); // duplicate — INSERT OR IGNORE
+
+        expect(relayIndices()).toStrictEqual([0, 2]);
+
+        await post({ relayIndex: 0, type: "relay_detach" });
+
+        expect(relayIndices()).toStrictEqual([2]);
+
+        // Detaching an absent relay is a no-op, not an error.
+        const absent = await post({ relayIndex: 9, type: "relay_detach" });
+
+        expect(absent.status).toBe(204);
+    });
+
+    it("rejects a malformed relay control body without throwing", async () => {
+        expect.assertions(1);
+
+        const response = await shard.fetch(
+            new Request("https://shard.internal/_lunora/relay", { body: "not json", headers: { "content-type": "application/json" }, method: "POST" }),
+        );
+
+        expect(response.status).toBe(400);
+    });
+});

--- a/packages/do/__tests__/relay-uniform-gate.test.ts
+++ b/packages/do/__tests__/relay-uniform-gate.test.ts
@@ -7,8 +7,9 @@ import { ShardDO } from "../src/shard-do";
 /**
  * The RLS-uniform gate (plan 075 Phase 3): a reactive shape may be relay-multicast
  * ONLY if its resolved query is identical regardless of the caller's identity and
- * none of its projected columns are masked. The gate probes `resolveShape` under
- * two distinct synthetic identities and compares — airtight and fail-closed.
+ * none of its projected columns are masked. The gate combines a static RLS
+ * read-policy guard with a claim-diverse identity probe (whose base is the exact
+ * anonymous identity the owner multicasts under) — fail-closed on every ground.
  */
 interface Resolved {
     columns?: ReadonlyArray<string>;

--- a/packages/do/__tests__/relay-uniform-gate.test.ts
+++ b/packages/do/__tests__/relay-uniform-gate.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { MaskPoliciesResult } from "../src/introspect";
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+
+/**
+ * The RLS-uniform gate (plan 075 Phase 3): a reactive shape may be relay-multicast
+ * ONLY if its resolved query is identical regardless of the caller's identity and
+ * none of its projected columns are masked. The gate probes `resolveShape` under
+ * two distinct synthetic identities and compares — airtight and fail-closed.
+ */
+interface Resolved {
+    columns?: ReadonlyArray<string>;
+    effectiveWhere?: Record<string, unknown>;
+    global?: boolean;
+    table: string;
+}
+
+class GateShard extends ShardDO {
+    // eslint-disable-next-line class-methods-use-this -- abstract stub; the gate never dispatches an RPC
+    public override handleRpc(): Promise<unknown> {
+        return Promise.resolve({});
+    }
+
+    /** Expose the protected gate for the test. */
+    public uniform(name: string, args: Record<string, unknown>): boolean {
+        return this.isShapeRelayUniform(name, args);
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test fixture: a per-shape masking declaration
+    protected override maskMetadata(): MaskPoliciesResult {
+        return { columns: [{ column: "ssn", strategy: "redact", table: "people" }] };
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test fixture: a pure name→shape lookup
+    protected override resolveShape(name: string, args: Record<string, unknown>, identity?: { userId?: string }): Resolved | undefined {
+        switch (name) {
+            // No where at all — identity-independent.
+            case "allMessages": {
+                return { table: "messages" };
+            }
+            // A `.global()` table is never poke-relayable.
+            case "globalFeed": {
+                return { effectiveWhere: {}, global: true, table: "feed" };
+            }
+            // An identity-gated resolve that throws for a probe.
+            case "guarded": {
+                throw new Error("RLS: auth required");
+            }
+            // Identity-DEPENDENT: the where is scoped to the caller.
+            case "myInbox": {
+                return { effectiveWhere: { ownerId: identity?.userId }, table: "messages" };
+            }
+            // Projects a masked column → the value is identity-dependent.
+            case "peopleCard": {
+                return { columns: ["name", "ssn"], effectiveWhere: { teamId: args["teamId"] }, table: "people" };
+            }
+            // Masked column exists on the table but isn't projected → still uniform.
+            case "peopleNames": {
+                return { columns: ["name"], effectiveWhere: { teamId: args["teamId"] }, table: "people" };
+            }
+            // Identity-independent: the where depends only on args.
+            case "publicRoom": {
+                return { effectiveWhere: { roomId: args["roomId"] }, table: "messages" };
+            }
+            default: {
+                return undefined;
+            }
+        }
+    }
+}
+
+const makeShard = (): GateShard => {
+    const state = { acceptWebSocket() {}, getWebSockets: () => [], id: { name: "room-1" }, storage: { sql: {} } } as unknown as ShardDOState;
+
+    return new GateShard(state, {});
+};
+
+describe("relay-uniform shape gate", () => {
+    it("marks an identity-independent shape relay-uniform", () => {
+        expect.assertions(2);
+
+        const shard = makeShard();
+
+        expect(shard.uniform("publicRoom", { roomId: "r1" })).toBe(true);
+        expect(shard.uniform("allMessages", {})).toBe(true);
+    });
+
+    it("rejects an identity-dependent shape", () => {
+        expect.assertions(1);
+
+        expect(makeShard().uniform("myInbox", {})).toBe(false);
+    });
+
+    it("rejects a shape that projects a masked column, but allows one that doesn't", () => {
+        expect.assertions(2);
+
+        const shard = makeShard();
+
+        expect(shard.uniform("peopleCard", { teamId: "t1" })).toBe(false);
+        expect(shard.uniform("peopleNames", { teamId: "t1" })).toBe(true);
+    });
+
+    it("rejects a global-table shape, an unknown shape, and a resolve that throws (fail-closed)", () => {
+        expect.assertions(3);
+
+        const shard = makeShard();
+
+        expect(shard.uniform("globalFeed", {})).toBe(false);
+        expect(shard.uniform("nope", {})).toBe(false);
+        expect(shard.uniform("guarded", {})).toBe(false);
+    });
+});

--- a/packages/do/__tests__/relay-uniform-gate.test.ts
+++ b/packages/do/__tests__/relay-uniform-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { MaskPoliciesResult } from "../src/introspect";
+import type { MaskPoliciesResult, RlsPoliciesResult } from "../src/introspect";
 import type { ShardDOState } from "../src/shard-do";
 import { ShardDO } from "../src/shard-do";
 
@@ -33,12 +33,28 @@ class GateShard extends ShardDO {
         return { columns: [{ column: "ssn", strategy: "redact", table: "people" }] };
     }
 
+    // A declared RLS *read* policy on `secured` — its presence alone must keep any
+    // shape over that table off the relay, even when the resolved where looks uniform.
+    // eslint-disable-next-line class-methods-use-this -- test fixture: a per-table RLS read-policy declaration
+    protected override rlsMetadata(): RlsPoliciesResult {
+        return { policies: [{ file: "secured", on: "read", procedure: "listSecured", table: "secured" }], roles: [] };
+    }
+
     // eslint-disable-next-line class-methods-use-this -- test fixture: a pure name→shape lookup
-    protected override resolveShape(name: string, args: Record<string, unknown>, identity?: { userId?: string }): Resolved | undefined {
+    protected override resolveShape(
+        name: string,
+        args: Record<string, unknown>,
+        identity?: { identity?: Record<string, unknown>; userId?: string },
+    ): Resolved | undefined {
         switch (name) {
             // No where at all — identity-independent.
             case "allMessages": {
                 return { table: "messages" };
+            }
+            // Narrows ONLY for an authenticated caller — uniform under the old
+            // two-authed-probe gate, but the anonymous multicast identity diverges.
+            case "authNarrow": {
+                return identity?.userId === undefined ? { table: "messages" } : { effectiveWhere: { published: true }, table: "messages" };
             }
             // A `.global()` table is never poke-relayable.
             case "globalFeed": {
@@ -52,6 +68,11 @@ class GateShard extends ShardDO {
             case "myInbox": {
                 return { effectiveWhere: { ownerId: identity?.userId }, table: "messages" };
             }
+            // Identity-DEPENDENT on a NON-userId claim (org) — only caught when the
+            // probes vary more than `userId`.
+            case "orgScoped": {
+                return { effectiveWhere: { org: identity?.identity?.["org_id"] }, table: "messages" };
+            }
             // Projects a masked column → the value is identity-dependent.
             case "peopleCard": {
                 return { columns: ["name", "ssn"], effectiveWhere: { teamId: args["teamId"] }, table: "people" };
@@ -63,6 +84,11 @@ class GateShard extends ShardDO {
             // Identity-independent: the where depends only on args.
             case "publicRoom": {
                 return { effectiveWhere: { roomId: args["roomId"] }, table: "messages" };
+            }
+            // Resolved where is identity-independent, but the table carries an RLS
+            // read policy → the static guard must still reject it.
+            case "securedRoom": {
+                return { effectiveWhere: { roomId: args["roomId"] }, table: "secured" };
             }
             default: {
                 return undefined;
@@ -91,6 +117,24 @@ describe("relay-uniform shape gate", () => {
         expect.assertions(1);
 
         expect(makeShard().uniform("myInbox", {})).toBe(false);
+    });
+
+    it("rejects identity-dependence on a non-userId claim (claim-diverse probes)", () => {
+        expect.assertions(1);
+
+        expect(makeShard().uniform("orgScoped", {})).toBe(false);
+    });
+
+    it("rejects a shape that narrows only for authenticated callers (anon multicast identity is probed)", () => {
+        expect.assertions(1);
+
+        expect(makeShard().uniform("authNarrow", {})).toBe(false);
+    });
+
+    it("rejects a shape over a table with an RLS read policy, even when its where looks uniform", () => {
+        expect.assertions(1);
+
+        expect(makeShard().uniform("securedRoom", { roomId: "r1" })).toBe(false);
     });
 
     it("rejects a shape that projects a masked column, but allows one that doesn't", () => {

--- a/packages/do/__tests__/relay-uniform-gate.test.ts
+++ b/packages/do/__tests__/relay-uniform-gate.test.ts
@@ -8,8 +8,10 @@ import { ShardDO } from "../src/shard-do";
  * The RLS-uniform gate (plan 075 Phase 3): a reactive shape may be relay-multicast
  * ONLY if its resolved query is identical regardless of the caller's identity and
  * none of its projected columns are masked. The gate combines a static RLS
- * read-policy guard with a claim-diverse identity probe (whose base is the exact
- * anonymous identity the owner multicasts under) — fail-closed on every ground.
+ * read-policy guard with a claim-exhaustive identity probe — proxy-backed, so a
+ * resolver reading ANY claim (even a custom one) diverges — whose base is the exact
+ * anonymous identity the owner multicasts under, plus a copy backstop. Fail-closed
+ * on every ground.
  */
 interface Resolved {
     columns?: ReadonlyArray<string>;
@@ -56,6 +58,17 @@ class GateShard extends ShardDO {
             // two-authed-probe gate, but the anonymous multicast identity diverges.
             case "authNarrow": {
                 return identity?.userId === undefined ? { table: "messages" } : { effectiveWhere: { published: true }, table: "messages" };
+            }
+            // Reads a CUSTOM claim no hardcoded probe list would name — only the
+            // proxy-backed probe (distinct value per ANY accessed key) catches it.
+            case "customClaim": {
+                return { effectiveWhere: { region: identity?.identity?.["region_code_xyz"] }, table: "messages" };
+            }
+            // Output is identical per probe (same backing keys) but it ENUMERATES the
+            // claims — a wholesale copy the proxy can't differentiate, so the copy
+            // backstop must reject it.
+            case "enumeratesClaims": {
+                return { effectiveWhere: { keys: Object.keys(identity?.identity ?? {}) }, table: "messages" };
             }
             // A `.global()` table is never poke-relayable.
             case "globalFeed": {
@@ -124,6 +137,18 @@ describe("relay-uniform shape gate", () => {
         expect.assertions(1);
 
         expect(makeShard().uniform("orgScoped", {})).toBe(false);
+    });
+
+    it("rejects a where reading an arbitrary custom claim (no hardcoded list to miss it)", () => {
+        expect.assertions(1);
+
+        expect(makeShard().uniform("customClaim", {})).toBe(false);
+    });
+
+    it("rejects a where that enumerates/copies the identity claims (copy backstop)", () => {
+        expect.assertions(1);
+
+        expect(makeShard().uniform("enumeratesClaims", {})).toBe(false);
     });
 
     it("rejects a shape that narrows only for authenticated callers (anon multicast identity is probed)", () => {

--- a/packages/do/__tests__/relay.test.ts
+++ b/packages/do/__tests__/relay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor } from "../src/relay";
+import { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, parseRelayName, relayCountFor, relayName } from "../src/relay";
 
 describe("relay promotion reducer", () => {
     const thresholds = { tDown: 4000, tUp: 8000 };
@@ -72,5 +72,36 @@ describe("relayCountFor", () => {
         expect.assertions(1);
 
         expect(relayCountFor(10_000, 0, 8)).toBe(0);
+    });
+});
+
+describe("relay name helpers", () => {
+    it("round-trips an owner key + relay index through the name", () => {
+        expect.assertions(2);
+
+        expect(relayName("room-1", 3)).toBe("room-1::relay::3");
+        expect(parseRelayName("room-1::relay::3")).toStrictEqual({ ownerKey: "room-1", relayIndex: 3 });
+    });
+
+    it("treats a plain owner name as not-a-relay", () => {
+        expect.assertions(2);
+
+        expect(parseRelayName("room-1")).toBeUndefined();
+        expect(parseRelayName("")).toBeUndefined();
+    });
+
+    it("keeps the owner key for an owner whose own key contains the infix once", () => {
+        expect.assertions(1);
+
+        // `lastIndexOf` splits on the FINAL infix, so a relay of a relay-shaped owner resolves to that owner.
+        expect(parseRelayName("a::relay::1::relay::2")).toStrictEqual({ ownerKey: "a::relay::1", relayIndex: 2 });
+    });
+
+    it("rejects a malformed or non-numeric relay index", () => {
+        expect.assertions(3);
+
+        expect(parseRelayName("room-1::relay::")).toBeUndefined();
+        expect(parseRelayName("room-1::relay::x")).toBeUndefined();
+        expect(parseRelayName("room-1::relay::-1")).toBeUndefined();
     });
 });

--- a/packages/do/__tests__/relay.test.ts
+++ b/packages/do/__tests__/relay.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor } from "../src/relay";
+
+describe("relay promotion reducer", () => {
+    const thresholds = { tDown: 4000, tUp: 8000 };
+
+    it("promotes an owned key at or above tUp, holds below", () => {
+        expect.assertions(3);
+
+        expect(nextPromotionState("owned", 7999, thresholds)).toBe("owned");
+        expect(nextPromotionState("owned", 8000, thresholds)).toBe("promoted");
+        expect(nextPromotionState("owned", 50_000, thresholds)).toBe("promoted");
+    });
+
+    it("collapses a promoted key only below tDown, holds at or above", () => {
+        expect.assertions(3);
+
+        expect(nextPromotionState("promoted", 4000, thresholds)).toBe("promoted");
+        expect(nextPromotionState("promoted", 3999, thresholds)).toBe("owned");
+        expect(nextPromotionState("promoted", 0, thresholds)).toBe("owned");
+    });
+
+    it("holds the current state across the hysteresis band (no flap)", () => {
+        expect.assertions(2);
+
+        // A count of 6000 sits between tDown and tUp: whichever state we're in stays.
+        expect(nextPromotionState("owned", 6000, thresholds)).toBe("owned");
+        expect(nextPromotionState("promoted", 6000, thresholds)).toBe("promoted");
+    });
+
+    it("defaults to the 8000/4000 thresholds", () => {
+        expect.assertions(3);
+
+        expect(DEFAULT_PROMOTION_THRESHOLDS).toStrictEqual({ tDown: 4000, tUp: 8000 });
+        expect(nextPromotionState("owned", 8000)).toBe("promoted");
+        expect(nextPromotionState("promoted", 3999)).toBe("owned");
+    });
+
+    it("rejects an empty or inverted hysteresis band", () => {
+        expect.assertions(2);
+
+        expect(() => nextPromotionState("owned", 1, { tDown: 8000, tUp: 8000 })).toThrow(/tDown/);
+        expect(() => nextPromotionState("owned", 1, { tDown: 9000, tUp: 8000 })).toThrow(/must be < tUp/);
+    });
+});
+
+describe("relayCountFor", () => {
+    it("needs no relays at or below one DO's capacity", () => {
+        expect.assertions(2);
+
+        expect(relayCountFor(8000, 8000, 8)).toBe(0);
+        expect(relayCountFor(1, 8000, 8)).toBe(0);
+    });
+
+    it("sizes the relay set to the overflow above one DO's capacity", () => {
+        expect.assertions(3);
+
+        expect(relayCountFor(16_000, 8000, 8)).toBe(1); // 8k overflow → 1 relay
+        expect(relayCountFor(24_001, 8000, 8)).toBe(3); // 16,001 overflow → ceil(16001/8000)=3
+        expect(relayCountFor(40_000, 8000, 8)).toBe(4); // 32k overflow → 4 relays
+    });
+
+    it("never exceeds the max-relays cost ceiling", () => {
+        expect.assertions(1);
+
+        // A viral key: overflow would want many relays, but the cap holds.
+        expect(relayCountFor(10_000_000, 8000, 8)).toBe(8);
+    });
+
+    it("returns zero for a non-positive capacity rather than dividing by zero", () => {
+        expect.assertions(1);
+
+        expect(relayCountFor(10_000, 0, 8)).toBe(0);
+    });
+});

--- a/packages/do/__tests__/shard-do.admin-subscription.test.ts
+++ b/packages/do/__tests__/shard-do.admin-subscription.test.ts
@@ -147,6 +147,40 @@ describe("shardDO admin subscriptions", () => {
         expect(dataEnvelopes(ws).at(-1)?.data).toMatchObject({ requests: 0, shard: "shard-a" });
     });
 
+    it("seeds getFanoutMetrics with per-topic subscriber counts folded from every socket", async () => {
+        expect.assertions(4);
+
+        const shard = new AdminSubShard(state, { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+        const admin = createFakeWebSocket();
+        const member1 = createFakeWebSocket();
+        const member2 = createFakeWebSocket();
+
+        // Two members share a shape and a whisper topic; the admin socket watches
+        // neither, so it contributes to the connection count but no topic.
+        shard.registerSocket(admin, { admin: true, subs: {} });
+        shard.registerSocket(member1, { shapes: { s1: { name: "roomMessages" } }, subs: {}, whispers: ["cursor:room"] });
+        shard.registerSocket(member2, { shapes: { s2: { name: "roomMessages" } }, subs: {}, whispers: ["cursor:room"] });
+
+        await shard.driveMessage(admin, adminSub("sub-1", ADMIN_FUNCTIONS.getFanoutMetrics));
+
+        const seeded = dataEnvelopes(admin).at(-1)?.data as {
+            peakSubscribers: number;
+            shapePoke: { passes: number };
+            topics: { kind: string; subscribers: number; topic: string }[];
+            totalConnections: number;
+        };
+
+        expect(seeded.totalConnections).toBe(3);
+        expect(seeded.peakSubscribers).toBe(2);
+        // Both topics have 2 subscribers; ties break by topic name (cursor:room < roomMessages).
+        expect(seeded.topics).toEqual([
+            { kind: "whisper", subscribers: 2, topic: "cursor:room" },
+            { kind: "shape", subscribers: 2, topic: "roomMessages" },
+        ]);
+        // No poke/broadcast has run in this test, so the running counters are zero.
+        expect(seeded.shapePoke.passes).toBe(0);
+    });
+
     it("re-runs a readTablePage subscription only when its own table is written", async () => {
         expect.assertions(3);
 

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -5,7 +5,16 @@ import type { DatabaseWriterLike, SchemaLike, SqlExec } from "../src/ctx-db";
 import { applyCdcChanges, createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
 import type { DataMigrationLike, MigrationRunResult } from "../src/data-migration";
 import { runDataMigration } from "../src/data-migration";
-import type { AdvisoryFinding, FlagEvaluation, FlagsResult, QueueMetadata, StudioFeaturesResult } from "../src/introspect";
+import type {
+    AdvisoryFinding,
+    FanoutMetricsResult,
+    FanoutPathCounters,
+    FanoutTopicStat,
+    FlagEvaluation,
+    FlagsResult,
+    QueueMetadata,
+    StudioFeaturesResult,
+} from "../src/introspect";
 import { ADMIN_FUNCTIONS } from "../src/introspect";
 import type { RankIndexDefinitionLike, ShardRankPageResult } from "../src/rank";
 import { rankKeyFromDoc } from "../src/rank";
@@ -61,6 +70,25 @@ const FLAG_EVALUATION_KEY_GUARD: KeysMatch<keyof FlagEvaluation, (typeof FLAG_EV
 const FLAGS_RESULT_KEYS = ["configured", "flags"] as const;
 
 const FLAGS_RESULT_KEY_GUARD: KeysMatch<keyof FlagsResult, (typeof FLAGS_RESULT_KEYS)[number]> = true;
+
+/**
+ * Canonical key sets of the `getFanoutMetrics` wire shapes (plan 075 Phase 1),
+ * duplicated by `@lunora/studio`'s hand mirror the same way as the types above.
+ * Forces both packages' copies of the fan-out observability payload to move
+ * together — adding or dropping a counter/topic field fails the build rather than
+ * silently shipping a missing studio cell.
+ */
+const FANOUT_TOPIC_STAT_KEYS = ["kind", "subscribers", "topic"] as const;
+
+const FANOUT_TOPIC_STAT_KEY_GUARD: KeysMatch<keyof FanoutTopicStat, (typeof FANOUT_TOPIC_STAT_KEYS)[number]> = true;
+
+const FANOUT_PATH_COUNTERS_KEYS = ["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"] as const;
+
+const FANOUT_PATH_COUNTERS_KEY_GUARD: KeysMatch<keyof FanoutPathCounters, (typeof FANOUT_PATH_COUNTERS_KEYS)[number]> = true;
+
+const FANOUT_METRICS_RESULT_KEYS = ["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"] as const;
+
+const FANOUT_METRICS_RESULT_KEY_GUARD: KeysMatch<keyof FanoutMetricsResult, (typeof FANOUT_METRICS_RESULT_KEYS)[number]> = true;
 
 /**
  * A real-SQLite-backed ShardDO whose `handleRpc` throws — proving the admin
@@ -442,6 +470,17 @@ describe("shardDO admin introspection", () => {
         expect([...FLAG_EVALUATION_KEYS]).toStrictEqual(["errorCode", "key", "reason", "type", "value", "variant"]);
         expect(FLAGS_RESULT_KEY_GUARD).toBe(true);
         expect([...FLAGS_RESULT_KEYS]).toStrictEqual(["configured", "flags"]);
+    });
+
+    it("keeps the getFanoutMetrics wire shapes in lockstep with the studio's hand-mirror", () => {
+        expect.assertions(6);
+
+        expect(FANOUT_TOPIC_STAT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_TOPIC_STAT_KEYS]).toStrictEqual(["kind", "subscribers", "topic"]);
+        expect(FANOUT_PATH_COUNTERS_KEY_GUARD).toBe(true);
+        expect([...FANOUT_PATH_COUNTERS_KEYS]).toStrictEqual(["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"]);
+        expect(FANOUT_METRICS_RESULT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual(["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"]);
     });
 
     it("serves declared-workflow metadata from the codegen-overridden hook", async () => {

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -86,7 +86,17 @@ const FANOUT_PATH_COUNTERS_KEYS = ["maxMs", "passes", "peakSocketsIterated", "so
 
 const FANOUT_PATH_COUNTERS_KEY_GUARD: KeysMatch<keyof FanoutPathCounters, (typeof FANOUT_PATH_COUNTERS_KEYS)[number]> = true;
 
-const FANOUT_METRICS_RESULT_KEYS = ["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"] as const;
+const FANOUT_METRICS_RESULT_KEYS = [
+    "maxRelays",
+    "peakSubscribers",
+    "promoted",
+    "relayCount",
+    "shapePoke",
+    "sinceMs",
+    "topics",
+    "totalConnections",
+    "whisper",
+] as const;
 
 const FANOUT_METRICS_RESULT_KEY_GUARD: KeysMatch<keyof FanoutMetricsResult, (typeof FANOUT_METRICS_RESULT_KEYS)[number]> = true;
 
@@ -480,7 +490,17 @@ describe("shardDO admin introspection", () => {
         expect(FANOUT_PATH_COUNTERS_KEY_GUARD).toBe(true);
         expect([...FANOUT_PATH_COUNTERS_KEYS]).toStrictEqual(["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"]);
         expect(FANOUT_METRICS_RESULT_KEY_GUARD).toBe(true);
-        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual(["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"]);
+        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual([
+            "maxRelays",
+            "peakSubscribers",
+            "promoted",
+            "relayCount",
+            "shapePoke",
+            "sinceMs",
+            "topics",
+            "totalConnections",
+            "whisper",
+        ]);
     });
 
     it("serves declared-workflow metadata from the codegen-overridden hook", async () => {

--- a/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
@@ -209,34 +209,32 @@ describe("relay shape seed (workerd e2e)", () => {
         expect(pokeOps(second)).toHaveLength(0);
     });
 
-    it("seeds a non-uniform (identity-scoped) relay shape but never live-multicasts it", async () => {
-        expect.assertions(2);
+    it("delivers live updates to a non-uniform relay shape via the per-socket owner proxy", async () => {
+        expect.assertions(3);
 
-        const owner = env.SYNC.get(env.SYNC.idFromName("nonuniform-room"));
-        const relay = env.SYNC.get(env.SYNC.idFromName("nonuniform-room::relay::0"));
+        const owner = env.SYNC.get(env.SYNC.idFromName("proxy-room"));
+        const relay = env.SYNC.get(env.SYNC.idFromName("proxy-room::relay::0"));
 
-        // `myInbox` resolves under the caller's identity, so the RLS-uniform gate
-        // keeps it out of the relay registry — it stays owner-served.
-        const scoped = await openRelaySocket(relay, "nonuniform-room-relay-0");
+        // `myInbox` resolves under the caller's identity (here anonymous → authorId
+        // "anon"), so the RLS-uniform gate keeps it off the cohort multicast. It must
+        // still get live updates — via the owner's per-socket proxy, not silently frozen.
+        const scoped = await openRelaySocket(relay, "proxy-room-relay-0");
         scoped.ws.send(JSON.stringify({ id: "s1", shape: { args: {}, name: "myInbox" }, type: "shape_subscribe" }));
         await waitFor(() => frameTypes(scoped).includes("ack"));
 
         const seedPokes = frameTypes(scoped).filter((type) => type === "pokeStart").length;
 
-        expect(seedPokes).toBe(1); // exactly the one-time seed, nothing live yet
+        expect(seedPokes).toBe(1); // the one-time seed (no "anon" rows yet)
 
-        // A uniform witness on the same room/relay IS multicast — waiting for ITS
-        // live poke is a deterministic barrier proving the flush + multicast cycle
-        // completed, by which point the non-uniform socket would have its poke too.
-        const witness = await openRelaySocket(relay, "nonuniform-room-relay-0");
-        witness.ws.send(JSON.stringify({ id: "w1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
-        await waitFor(() => frameTypes(witness).includes("ack"));
+        // A write that lands in THIS socket's identity-scoped membership must arrive
+        // as a live targeted poke; an out-of-scope write (different author) must not.
+        await sendRpc(owner, "messages:send", { _id: "p1", authorId: "u1", channelId: "c1", text: "p1" });
+        await sendRpc(owner, "messages:send", { _id: "p2", authorId: "anon", channelId: "c1", text: "p2" });
+        await waitFor(() => pokeOps(scoped).some((op) => op.key === "p2"));
 
-        await sendRpc(owner, "messages:send", { _id: "n1", channelId: "c1", text: "n1" });
-        await waitFor(() => pokeOps(witness).some((op) => op.key === "n1"));
+        const keys = pokeOps(scoped).map((op) => op.key);
 
-        // The witness saw the live delta; the non-uniform socket's poke count never
-        // moved past its one-time seed — it received no relay multicast.
-        expect(frameTypes(scoped).filter((type) => type === "pokeStart")).toHaveLength(seedPokes);
+        expect(keys).toContain("p2"); // the in-scope write reached the proxied socket
+        expect(keys).not.toContain("p1"); // the out-of-scope (other author) write did not
     });
 });

--- a/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
@@ -1,0 +1,92 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Plan 075 Phase 3 (slice B.1) — a reactive shape subscribed on a RELAY is seeded
+ * through the owner. The relay holds no op-log, so it forwards the `shape_subscribe`
+ * to the owner, which resolves the shape under the socket's verified identity
+ * (RLS-correct) and computes the seed; the relay delivers the owner's frames
+ * verbatim. Proven against real Durable Objects.
+ */
+
+interface OpenSocket {
+    received: string[];
+    ws: WebSocket;
+}
+
+const waitFor = async (predicate: () => boolean, attempts = 120, intervalMs = 15): Promise<void> => {
+    for (let index = 0; index < attempts; index += 1) {
+        if (predicate()) {
+            return;
+        }
+
+        // eslint-disable-next-line no-await-in-loop -- polling loop must wait between predicate checks
+        await new Promise((resolve) => {
+            setTimeout(resolve, intervalMs);
+        });
+    }
+
+    if (!predicate()) {
+        throw new Error("waitFor: predicate never became true");
+    }
+};
+
+const openRelaySocket = async (stub: DurableObjectStub, room: string): Promise<OpenSocket> => {
+    const upgrade = await stub.fetch(`https://${room}.internal/_ws`, { headers: { Upgrade: "websocket", "x-lunora-shard-binding": "SYNC" } });
+
+    if (!upgrade.webSocket) {
+        throw new Error(`expected ws upgrade, got ${String(upgrade.status)}`);
+    }
+
+    const ws = upgrade.webSocket;
+    const received: string[] = [];
+
+    ws.addEventListener("message", (event) => {
+        if (typeof event.data === "string") {
+            received.push(event.data);
+        }
+    });
+    ws.accept();
+
+    return { received, ws };
+};
+
+const sendRpc = (stub: DurableObjectStub, functionPath: string, args: Record<string, unknown>): Promise<Response> =>
+    stub.fetch("https://owner.internal/rpc", { body: JSON.stringify({ args, functionPath }), headers: { "content-type": "application/json" }, method: "POST" });
+
+const frameTypes = (socket: OpenSocket): string[] => socket.received.map((raw) => (JSON.parse(raw) as { type: string }).type);
+
+const pokeOps = (socket: OpenSocket): { key: string; op: string }[] =>
+    socket.received
+        .map((raw) => JSON.parse(raw) as { rowsPatch?: { key: string; op: string }[]; type: string })
+        .filter((frame) => frame.type === "pokePart")
+        .flatMap((frame) => frame.rowsPatch ?? []);
+
+describe("relay shape seed (workerd e2e)", () => {
+    it("seeds a shape subscribed on a relay through the owner's data", async () => {
+        expect.assertions(4);
+
+        const owner = env.SYNC.get(env.SYNC.idFromName("shape-room"));
+        const relay = env.SYNC.get(env.SYNC.idFromName("shape-room::relay::0"));
+
+        // The data lives on the OWNER: two messages, one in each channel.
+        await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1" });
+        await sendRpc(owner, "messages:send", { _id: "m2", channelId: "c2" });
+
+        // A socket on the RELAY subscribes to the c1 shape.
+        const socket = await openRelaySocket(relay, "shape-room-relay-0");
+        socket.ws.send(JSON.stringify({ id: "s1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
+
+        await waitFor(() => frameTypes(socket).includes("ack"));
+
+        // The relay delivered the owner-computed seed: the c1 membership (m1 only),
+        // not c2, in the standard pokeStart → pokePart → pokeEnd → ack order.
+        expect(frameTypes(socket)).toStrictEqual(["pokeStart", "pokePart", "pokeEnd", "ack"]);
+
+        const ops = pokeOps(socket);
+
+        expect(ops).toHaveLength(1);
+        expect(ops[0]?.key).toBe("m1");
+        expect(ops[0]?.op).toBe("insert");
+    });
+});

--- a/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
@@ -62,6 +62,16 @@ const pokeOps = (socket: OpenSocket): { key: string; op: string }[] =>
         .filter((frame) => frame.type === "pokePart")
         .flatMap((frame) => frame.rowsPatch ?? []);
 
+const keysOf = (socket: OpenSocket): string[] => pokeOps(socket).map((op) => op.key);
+
+/** Subscribe a socket to the `c1` `messagesByChannel` shape and wait for its (next) ack. */
+const subscribeToC1 = async (socket: OpenSocket): Promise<void> => {
+    const before = frameTypes(socket).filter((type) => type === "ack").length;
+
+    socket.ws.send(JSON.stringify({ id: "s1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
+    await waitFor(() => frameTypes(socket).filter((type) => type === "ack").length > before);
+};
+
 describe("relay shape seed (workerd e2e)", () => {
     it("seeds a shape subscribed on a relay through the owner's data", async () => {
         expect.assertions(4);
@@ -96,20 +106,13 @@ describe("relay shape seed (workerd e2e)", () => {
         const owner = env.SYNC.get(env.SYNC.idFromName("cohort-room"));
         const relay = env.SYNC.get(env.SYNC.idFromName("cohort-room::relay::0"));
 
-        const keysOf = (socket: OpenSocket): string[] => pokeOps(socket).map((op) => op.key);
-        const subscribe = async (socket: OpenSocket): Promise<void> => {
-            const before = frameTypes(socket).filter((type) => type === "ack").length;
-            socket.ws.send(JSON.stringify({ id: "s1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
-            await waitFor(() => frameTypes(socket).filter((type) => type === "ack").length > before);
-        };
-
         await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1", text: "t1" });
 
         // Two sockets join the cohort at the same cursor and seed with m1.
         const a = await openRelaySocket(relay, "cohort-room-relay-0");
         const b = await openRelaySocket(relay, "cohort-room-relay-0");
-        await subscribe(a);
-        await subscribe(b);
+        await subscribeToC1(a);
+        await subscribeToC1(b);
 
         // A write fans out ONE owner-computed delta to the whole cohort.
         await sendRpc(owner, "messages:send", { _id: "m2", channelId: "c1", text: "t2" });
@@ -117,7 +120,7 @@ describe("relay shape seed (workerd e2e)", () => {
 
         // A third socket seeds AFTER m2 — its seed already contains m1+m2.
         const c = await openRelaySocket(relay, "cohort-room-relay-0");
-        await subscribe(c);
+        await subscribeToC1(c);
 
         // The next write reaches the whole (merged) cohort exactly once.
         await sendRpc(owner, "messages:send", { _id: "m3", channelId: "c1", text: "t3" });
@@ -131,6 +134,36 @@ describe("relay shape seed (workerd e2e)", () => {
         // A got two live pokes (m2, m3); C, seeding after m2, got only one (m3).
         expect(frameTypes(a).filter((type) => type === "pokeStart")).toHaveLength(3);
         expect(frameTypes(c).filter((type) => type === "pokeStart")).toHaveLength(2);
+    });
+
+    it("keeps a late joiner in the cohort after an unrelated write moved the global cursor", async () => {
+        expect.assertions(2);
+
+        const owner = env.SYNC.get(env.SYNC.idFromName("drift-room"));
+        const relay = env.SYNC.get(env.SYNC.idFromName("drift-room::relay::0"));
+
+        await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1", text: "d1" });
+
+        // Early joiner anchors the cohort frontier at m1's cursor.
+        const a = await openRelaySocket(relay, "drift-room-relay-0");
+        await subscribeToC1(a);
+
+        // An unrelated-channel write advances the GLOBAL cursor but not the c1
+        // cohort frontier (c1's membership is unchanged) — this is the gap that
+        // used to strand a joiner whose memo was stamped at the global cursor.
+        await sendRpc(owner, "messages:send", { _id: "x1", channelId: "c2", text: "d2" });
+
+        // Late joiner subscribes while global cursor > cohort frontier.
+        const b = await openRelaySocket(relay, "drift-room-relay-0");
+        await subscribeToC1(b);
+
+        // A real c1 membership change must reach BOTH cohort members.
+        await sendRpc(owner, "messages:send", { _id: "m3", channelId: "c1", text: "d3" });
+        await waitFor(() => keysOf(a).includes("m3") && keysOf(b).includes("m3"));
+
+        // The late joiner is live, not silently frozen — it got the multicast delta.
+        expect(keysOf(b)).toContain("m3");
+        expect(keysOf(a)).toContain("m3");
     });
 
     it("resumes a still-current relay shape through the owner with no re-seed", async () => {

--- a/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
@@ -132,4 +132,78 @@ describe("relay shape seed (workerd e2e)", () => {
         expect(frameTypes(a).filter((type) => type === "pokeStart")).toHaveLength(3);
         expect(frameTypes(c).filter((type) => type === "pokeStart")).toHaveLength(2);
     });
+
+    it("resumes a still-current relay shape through the owner with no re-seed", async () => {
+        expect.assertions(3);
+
+        const owner = env.SYNC.get(env.SYNC.idFromName("resume-room"));
+        const relay = env.SYNC.get(env.SYNC.idFromName("resume-room::relay::0"));
+
+        await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1", text: "t1" });
+
+        // First socket seeds the full membership and learns the checkpoint + epoch
+        // the owner computed it at (carried on the seed's pokeEnd frame).
+        const first = await openRelaySocket(relay, "resume-room-relay-0");
+        first.ws.send(JSON.stringify({ id: "s1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
+        await waitFor(() => frameTypes(first).includes("ack"));
+
+        const pokeEnd = first.received
+            .map((raw) => JSON.parse(raw) as { checkpoint?: number; epoch?: string; type: string })
+            .find((frame) => frame.type === "pokeEnd");
+
+        expect(pokeOps(first)).toHaveLength(1);
+
+        // A second socket reconnects at that exact checkpoint with no writes in
+        // between — the owner's resume fast-path returns an EMPTY catch-up diff
+        // (rowsPatch []), proving the relay round-trip carried sinceSeq/sinceEpoch.
+        const second = await openRelaySocket(relay, "resume-room-relay-0");
+        second.ws.send(
+            JSON.stringify({
+                id: "s1",
+                shape: { args: { channelId: "c1" }, name: "messagesByChannel" },
+                sinceCheckpoint: pokeEnd?.checkpoint,
+                sinceEpoch: pokeEnd?.epoch,
+                type: "shape_subscribe",
+            }),
+        );
+        await waitFor(() => frameTypes(second).includes("ack"));
+
+        // The resume seed carries the catch-up baseCheckpoint (a full re-seed would
+        // have none) and an empty membership diff — no rows re-sent.
+        const start = second.received.map((raw) => JSON.parse(raw) as { baseCheckpoint?: number; type: string }).find((frame) => frame.type === "pokeStart");
+
+        expect(start?.baseCheckpoint).toBe(pokeEnd?.checkpoint);
+        expect(pokeOps(second)).toHaveLength(0);
+    });
+
+    it("seeds a non-uniform (identity-scoped) relay shape but never live-multicasts it", async () => {
+        expect.assertions(2);
+
+        const owner = env.SYNC.get(env.SYNC.idFromName("nonuniform-room"));
+        const relay = env.SYNC.get(env.SYNC.idFromName("nonuniform-room::relay::0"));
+
+        // `myInbox` resolves under the caller's identity, so the RLS-uniform gate
+        // keeps it out of the relay registry — it stays owner-served.
+        const scoped = await openRelaySocket(relay, "nonuniform-room-relay-0");
+        scoped.ws.send(JSON.stringify({ id: "s1", shape: { args: {}, name: "myInbox" }, type: "shape_subscribe" }));
+        await waitFor(() => frameTypes(scoped).includes("ack"));
+
+        const seedPokes = frameTypes(scoped).filter((type) => type === "pokeStart").length;
+
+        expect(seedPokes).toBe(1); // exactly the one-time seed, nothing live yet
+
+        // A uniform witness on the same room/relay IS multicast — waiting for ITS
+        // live poke is a deterministic barrier proving the flush + multicast cycle
+        // completed, by which point the non-uniform socket would have its poke too.
+        const witness = await openRelaySocket(relay, "nonuniform-room-relay-0");
+        witness.ws.send(JSON.stringify({ id: "w1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
+        await waitFor(() => frameTypes(witness).includes("ack"));
+
+        await sendRpc(owner, "messages:send", { _id: "n1", channelId: "c1", text: "n1" });
+        await waitFor(() => pokeOps(witness).some((op) => op.key === "n1"));
+
+        // The witness saw the live delta; the non-uniform socket's poke count never
+        // moved past its one-time seed — it received no relay multicast.
+        expect(frameTypes(scoped).filter((type) => type === "pokeStart")).toHaveLength(seedPokes);
+    });
 });

--- a/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-shape.workerd.test.ts
@@ -70,8 +70,8 @@ describe("relay shape seed (workerd e2e)", () => {
         const relay = env.SYNC.get(env.SYNC.idFromName("shape-room::relay::0"));
 
         // The data lives on the OWNER: two messages, one in each channel.
-        await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1" });
-        await sendRpc(owner, "messages:send", { _id: "m2", channelId: "c2" });
+        await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1", text: "t1" });
+        await sendRpc(owner, "messages:send", { _id: "m2", channelId: "c2", text: "t2" });
 
         // A socket on the RELAY subscribes to the c1 shape.
         const socket = await openRelaySocket(relay, "shape-room-relay-0");
@@ -88,5 +88,48 @@ describe("relay shape seed (workerd e2e)", () => {
         expect(ops).toHaveLength(1);
         expect(ops[0]?.key).toBe("m1");
         expect(ops[0]?.op).toBe("insert");
+    });
+
+    it("multicasts live shape deltas to a relay cohort, and a late seeder never double-applies", async () => {
+        expect.assertions(5);
+
+        const owner = env.SYNC.get(env.SYNC.idFromName("cohort-room"));
+        const relay = env.SYNC.get(env.SYNC.idFromName("cohort-room::relay::0"));
+
+        const keysOf = (socket: OpenSocket): string[] => pokeOps(socket).map((op) => op.key);
+        const subscribe = async (socket: OpenSocket): Promise<void> => {
+            const before = frameTypes(socket).filter((type) => type === "ack").length;
+            socket.ws.send(JSON.stringify({ id: "s1", shape: { args: { channelId: "c1" }, name: "messagesByChannel" }, type: "shape_subscribe" }));
+            await waitFor(() => frameTypes(socket).filter((type) => type === "ack").length > before);
+        };
+
+        await sendRpc(owner, "messages:send", { _id: "m1", channelId: "c1", text: "t1" });
+
+        // Two sockets join the cohort at the same cursor and seed with m1.
+        const a = await openRelaySocket(relay, "cohort-room-relay-0");
+        const b = await openRelaySocket(relay, "cohort-room-relay-0");
+        await subscribe(a);
+        await subscribe(b);
+
+        // A write fans out ONE owner-computed delta to the whole cohort.
+        await sendRpc(owner, "messages:send", { _id: "m2", channelId: "c1", text: "t2" });
+        await waitFor(() => keysOf(a).includes("m2") && keysOf(b).includes("m2"));
+
+        // A third socket seeds AFTER m2 — its seed already contains m1+m2.
+        const c = await openRelaySocket(relay, "cohort-room-relay-0");
+        await subscribe(c);
+
+        // The next write reaches the whole (merged) cohort exactly once.
+        await sendRpc(owner, "messages:send", { _id: "m3", channelId: "c1", text: "t3" });
+        await waitFor(() => keysOf(a).includes("m3") && keysOf(c).includes("m3"));
+
+        // Every socket converges on the full membership, each key exactly once.
+        expect(keysOf(a).toSorted((x, y) => x.localeCompare(y))).toStrictEqual(["m1", "m2", "m3"]);
+        expect(keysOf(c).toSorted((x, y) => x.localeCompare(y))).toStrictEqual(["m1", "m2", "m3"]);
+        // The late seeder got m2 ONCE (in its seed), never as a re-applied live delta.
+        expect(keysOf(c).filter((key) => key === "m2")).toHaveLength(1);
+        // A got two live pokes (m2, m3); C, seeding after m2, got only one (m3).
+        expect(frameTypes(a).filter((type) => type === "pokeStart")).toHaveLength(3);
+        expect(frameTypes(c).filter((type) => type === "pokeStart")).toHaveLength(2);
     });
 });

--- a/packages/do/__tests__/workerd/relay-whisper.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-whisper.workerd.test.ts
@@ -1,0 +1,112 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Plan 075 Phase 2 — the owner↔relay whisper hub over real Durable Objects.
+ *
+ * A whisper from a socket on a relay reaches the sockets on the owner and the
+ * relay's other sockets (relay → owner up-path), and a whisper from a socket on
+ * the owner reaches the relay's sockets (owner → relay down-path, once the relay
+ * has announced itself). The sender never receives its own whisper. The runtime's
+ * namespace-binding name is forwarded as `x-lunora-shard-binding` so each DO can
+ * address its siblings.
+ */
+
+const BINDING = "SHARD";
+
+interface OpenSocket {
+    frames: { data?: unknown; topic?: string; type: string }[];
+    ws: WebSocket;
+}
+
+const waitFor = async (predicate: () => boolean, attempts = 120, intervalMs = 15): Promise<void> => {
+    for (let index = 0; index < attempts; index += 1) {
+        if (predicate()) {
+            return;
+        }
+
+        // eslint-disable-next-line no-await-in-loop -- polling loop must wait between predicate checks
+        await new Promise((resolve) => {
+            setTimeout(resolve, intervalMs);
+        });
+    }
+
+    if (!predicate()) {
+        throw new Error("waitFor: predicate never became true");
+    }
+};
+
+const open = async (stub: DurableObjectStub, room: string): Promise<OpenSocket> => {
+    const upgrade = await stub.fetch(`https://${room}.internal/_ws`, { headers: { Upgrade: "websocket", "x-lunora-shard-binding": BINDING } });
+
+    if (!upgrade.webSocket) {
+        throw new Error(`expected ws upgrade, got ${String(upgrade.status)}`);
+    }
+
+    const ws = upgrade.webSocket;
+    const frames: OpenSocket["frames"] = [];
+
+    ws.addEventListener("message", (event) => {
+        if (typeof event.data === "string") {
+            frames.push(JSON.parse(event.data) as OpenSocket["frames"][number]);
+        }
+    });
+    ws.accept();
+
+    return { frames, ws };
+};
+
+const subscribe = (socket: OpenSocket, topic: string): void => {
+    socket.ws.send(JSON.stringify({ topic, type: "whisper_subscribe" }));
+};
+const whisper = (socket: OpenSocket, topic: string, data: unknown): void => {
+    socket.ws.send(JSON.stringify({ data, topic, type: "whisper" }));
+};
+const whispersOf = (socket: OpenSocket): { data?: unknown }[] => socket.frames.filter((frame) => frame.type === "whisper");
+const dataOf = (socket: OpenSocket): unknown[] => whispersOf(socket).map((frame) => frame.data);
+
+describe("relay whisper hub (workerd e2e)", () => {
+    it("fans a whisper across owner + relay DOs without echoing the sender", async () => {
+        expect.assertions(6);
+
+        const owner = env.SHARD.get(env.SHARD.idFromName("room-1"));
+        const relay = env.SHARD.get(env.SHARD.idFromName("room-1::relay::0"));
+
+        const o1 = await open(owner, "room-1");
+        const r1 = await open(relay, "room-1-relay-0");
+        const r2 = await open(relay, "room-1-relay-0");
+
+        subscribe(o1, "t");
+        subscribe(r1, "t");
+        subscribe(r2, "t");
+
+        // Up-path (relay → owner): independent of the relay's attach state.
+        whisper(r1, "t", { n: 1 });
+        await waitFor(() => whispersOf(o1).length > 0 && whispersOf(r2).length > 0);
+
+        expect(dataOf(o1)).toStrictEqual([{ n: 1 }]); // owner socket got it
+        expect(dataOf(r2)).toStrictEqual([{ n: 1 }]); // relay's other socket got it
+        expect(whispersOf(r1)).toHaveLength(0); // sender excluded, no cross-DO echo
+
+        // Down-path (owner → relay): needs the relay's `relay_attach` to have landed.
+        // Probe with fresh markers until one lands (early probes before attach are
+        // dropped — whisper is ephemeral), so the test is deterministic.
+        let probe = 0;
+        await waitFor(
+            () => {
+                probe += 1;
+                whisper(o1, "t", { probe });
+
+                return r1.frames.some((frame) => frame.type === "whisper" && (frame.data as { probe?: number } | undefined)?.probe !== undefined);
+            },
+            60,
+            40,
+        );
+
+        const r1Probe = whispersOf(r1).find((frame) => (frame.data as { probe?: number }).probe !== undefined);
+
+        expect(r1Probe).toBeDefined(); // relay socket received an owner-originated whisper
+        expect(whispersOf(r2).some((frame) => (frame.data as { probe?: number }).probe !== undefined)).toBe(true); // the relay's other socket too
+        expect(whispersOf(o1).some((frame) => (frame.data as { probe?: number }).probe !== undefined)).toBe(false); // owner sender excluded
+    });
+});

--- a/packages/do/__tests__/workerd/relay-whisper.workerd.test.ts
+++ b/packages/do/__tests__/workerd/relay-whisper.workerd.test.ts
@@ -109,4 +109,40 @@ describe("relay whisper hub (workerd e2e)", () => {
         expect(whispersOf(r2).some((frame) => (frame.data as { probe?: number }).probe !== undefined)).toBe(true); // the relay's other socket too
         expect(whispersOf(o1).some((frame) => (frame.data as { probe?: number }).probe !== undefined)).toBe(false); // owner sender excluded
     });
+
+    it("re-forwards a relay's whisper to the OTHER relays via the owner, skipping the origin", async () => {
+        expect.assertions(3);
+
+        const owner = env.SHARD.get(env.SHARD.idFromName("room-2"));
+        const relayA = env.SHARD.get(env.SHARD.idFromName("room-2::relay::0"));
+        const relayB = env.SHARD.get(env.SHARD.idFromName("room-2::relay::1"));
+
+        const o1 = await open(owner, "room-2");
+        const a1 = await open(relayA, "room-2-relay-0");
+        const b1 = await open(relayB, "room-2-relay-1");
+
+        subscribe(o1, "t");
+        subscribe(a1, "t");
+        subscribe(b1, "t");
+
+        // A whisper from a socket on relay A must reach the owner AND relay B (the
+        // owner re-forwards to every relay EXCEPT the origin), but never echo back to
+        // the sender on relay A. Both relays must have attached to the owner first;
+        // probe with fresh markers until relay B (the cross-relay hop) receives one.
+        let probe = 0;
+        await waitFor(
+            () => {
+                probe += 1;
+                whisper(a1, "t", { probe });
+
+                return b1.frames.some((frame) => frame.type === "whisper" && (frame.data as { probe?: number } | undefined)?.probe !== undefined);
+            },
+            80,
+            40,
+        );
+
+        expect(whispersOf(b1).some((frame) => (frame.data as { probe?: number }).probe !== undefined)).toBe(true); // the OTHER relay got it
+        expect(whispersOf(o1).some((frame) => (frame.data as { probe?: number }).probe !== undefined)).toBe(true); // the owner got it
+        expect(whispersOf(a1)).toHaveLength(0); // the origin-relay sender is never echoed
+    });
 });

--- a/packages/do/__tests__/workerd/test-worker.ts
+++ b/packages/do/__tests__/workerd/test-worker.ts
@@ -110,7 +110,7 @@ class ConcreteSyncShard extends ShardDO {
             case "messages:sendMutator": {
                 await writer.insert(
                     "messages",
-                    { _id: args["_id"], authorId: "u1", channelId: args["channelId"], text: args["text"] ?? "x" },
+                    { _id: args["_id"], authorId: args["authorId"] ?? "u1", channelId: args["channelId"], text: args["text"] ?? "x" },
                     { allowExplicitId: true },
                 );
 

--- a/packages/do/__tests__/workerd/test-worker.ts
+++ b/packages/do/__tests__/workerd/test-worker.ts
@@ -131,14 +131,26 @@ class ConcreteSyncShard extends ShardDO {
         return functionPath === "messages:sendMutator";
     }
 
-    protected override resolveShape(name: string, args: Record<string, unknown>): { effectiveWhere?: Record<string, unknown>; table: string } | undefined {
+    protected override resolveShape(
+        name: string,
+        args: Record<string, unknown>,
+        identity?: { userId?: string },
+    ): { effectiveWhere?: Record<string, unknown>; table: string } | undefined {
         this.ensureMigrated();
 
-        if (name !== "messagesByChannel") {
-            return undefined;
+        // Identity-INDEPENDENT (relay-uniform): the where depends only on args, so
+        // every caller resolves the same query — eligible for relay multicast.
+        if (name === "messagesByChannel") {
+            return { effectiveWhere: { channelId: args["channelId"] }, table: "messages" };
         }
 
-        return { effectiveWhere: { channelId: args["channelId"] }, table: "messages" };
+        // Identity-DEPENDENT (non-uniform): scoped to the caller, so it must stay
+        // owner-served and never be registered for relay multicast (plan 075 C2).
+        if (name === "myInbox") {
+            return { effectiveWhere: { authorId: identity?.userId ?? "anon" }, table: "messages" };
+        }
+
+        return undefined;
     }
 
     protected override ensureMigrated(): void {

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -1417,7 +1417,7 @@ const recordFanoutPass = (counters: FanoutPathCounters, iterated: number, delive
  */
 const summarizeFanoutTopics = (
     attachments: FanoutAttachmentLike[],
-    limit = DEFAULT_FANOUT_TOPIC_LIMIT,
+    limit: number = DEFAULT_FANOUT_TOPIC_LIMIT,
 ): { peakSubscribers: number; topics: FanoutTopicStat[]; totalConnections: number } => {
     const shapeCounts = new Map<string, number>();
     const whisperCounts = new Map<string, number>();

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -59,6 +59,7 @@ const ADMIN_FUNCTIONS = {
     getAuditLog: "__lunora_admin__:getAuditLog",
     getAuthMetrics: "__lunora_admin__:getAuthMetrics",
     getCapturedMail: "__lunora_admin__:getCapturedMail",
+    getFanoutMetrics: "__lunora_admin__:getFanoutMetrics",
     getFunctionStats: "__lunora_admin__:getFunctionStats",
     listSubscriptions: "__lunora_admin__:listSubscriptions",
     listTableIndexes: "__lunora_admin__:listTableIndexes",
@@ -1292,17 +1293,178 @@ const summarizeSubscriptions = (attachments: SocketAttachmentLike[]): Subscripti
     return { connections, totalConnections: connections.length, totalSubscriptions };
 };
 
+/**
+ * One topic or shape with the number of sockets currently subscribed to it, as
+ * surfaced by `__lunora_admin__:getFanoutMetrics`. `subscribers` is the fan-out
+ * **width** one poke/broadcast incurs for this topic — the O(subscribers) cost
+ * the auto-elastic relay tier (plan 075) targets — so a single hot topic is
+ * visible here long before it becomes a bottleneck.
+ */
+interface FanoutTopicStat {
+    /** `"shape"` = a reactive-query shape (poked from SQLite); `"whisper"` = an ephemeral whisper topic. */
+    kind: "shape" | "whisper";
+    /** Connected sockets currently subscribed — the fan-out width one flush/broadcast incurs for this topic. */
+    subscribers: number;
+    /** The shape name (the `defineShape` export) or the whisper topic string. */
+    topic: string;
+}
+
+/**
+ * Running fan-out counters for one delivery path (the reactive shape poke or the
+ * whisper broadcast) since this DO instance woke. In-memory and reset on
+ * hibernation/restart — the same "since this instance woke" granularity as
+ * `getMetrics`/`getFunctionStats`.
+ *
+ * `socketsIterated` is the O(subscribers) loop cost the relay tier targets;
+ * `socketsDelivered` is how many of those iterated sockets actually received a
+ * frame (the rest were visited but had no matching shape, or were the whisper
+ * sender). `totalMs`/`maxMs` are **coarse** wall-clock for the asynchronous
+ * shape-poke path only: a Durable Object's clock advances only across I/O, so
+ * treat them as directional, not exact. They stay `0` for the synchronous
+ * whisper path, which performs no awaited I/O to time.
+ */
+interface FanoutPathCounters {
+    /** Coarse slowest single pass, in ms (shape-poke path only; `0` for whisper). */
+    maxMs: number;
+    /** Fan-out passes that ran (shape-poke flushes / whisper broadcasts). */
+    passes: number;
+    /** Widest single pass — the most sockets iterated in one flush/broadcast. */
+    peakSocketsIterated: number;
+    /** Sockets that actually received a frame, summed across every pass. */
+    socketsDelivered: number;
+    /** Sockets visited, summed across every pass — the O(subscribers) iteration cost. */
+    socketsIterated: number;
+    /** Coarse summed wall-clock across every pass, in ms (shape-poke path only; `0` for whisper). */
+    totalMs: number;
+}
+
+/**
+ * Payload of a `__lunora_admin__:getFanoutMetrics` call: the current per-topic
+ * subscriber counts plus the running fan-out counters for each delivery path.
+ * The point-in-time `topics`/`peakSubscribers`/`totalConnections` are derived
+ * live from `getWebSockets()` + each socket's attachment; the `shapePoke`/
+ * `whisper` counters are the in-memory running tallies (reset on hibernation).
+ * Feeds the Studio fan-out observability panel — the "you can see it scale"
+ * half of plan 075 Phase 1, before any topology change exists.
+ */
+interface FanoutMetricsResult {
+    /** Highest current subscriber count across all topics/shapes — the widest single fan-out right now. */
+    peakSubscribers: number;
+    /** Running reactive-shape-poke fan-out counters since this instance woke. */
+    shapePoke: FanoutPathCounters;
+    /** Epoch-ms this instance began collecting (shared with `getMetrics`/`getFunctionStats`). */
+    sinceMs: number;
+    /** Hottest topics/shapes by current subscriber count, busiest first (capped at {@link DEFAULT_FANOUT_TOPIC_LIMIT}). */
+    topics: FanoutTopicStat[];
+    /** Live socket count on this shard. */
+    totalConnections: number;
+    /** Running whisper-broadcast fan-out counters since this instance woke. */
+    whisper: FanoutPathCounters;
+}
+
+/**
+ * One socket's attachment as seen by {@link summarizeFanoutTopics} — the subset
+ * of `./types`' `SocketAttachment` the fan-out summary reads (live `shapes` keyed
+ * by subscription id, and the joined whisper `topics`). Narrowed so the summary
+ * stays a pure, harness-testable function with no dependency on the DO runtime.
+ */
+interface FanoutAttachmentLike {
+    shapes?: Record<string, { name?: string }>;
+    whispers?: string[];
+}
+
+/** Default cap on the number of hot topics {@link summarizeFanoutTopics} returns, so a deployment with thousands of distinct shapes can't return an unbounded list. */
+const DEFAULT_FANOUT_TOPIC_LIMIT = 20;
+
+/** A freshly-zeroed {@link FanoutPathCounters}, for a DO instance waking up. */
+const createFanoutCounters = (): FanoutPathCounters => {
+    return { maxMs: 0, passes: 0, peakSocketsIterated: 0, socketsDelivered: 0, socketsIterated: 0, totalMs: 0 };
+};
+
+/**
+ * Fold one fan-out pass into a running {@link FanoutPathCounters}, returning the
+ * updated counters: bump the pass count, add the iterated/delivered socket
+ * totals, and lift the peak-width and slowest-pass high-water marks. Pure (a new
+ * object, no mutation) so it stays trivially testable; the caller swaps the
+ * stored counters for the result. `ms` is `0` for the synchronous whisper path
+ * (nothing awaited to time).
+ */
+const recordFanoutPass = (counters: FanoutPathCounters, iterated: number, delivered: number, ms: number): FanoutPathCounters => {
+    return {
+        maxMs: Math.max(counters.maxMs, ms),
+        passes: counters.passes + 1,
+        peakSocketsIterated: Math.max(counters.peakSocketsIterated, iterated),
+        socketsDelivered: counters.socketsDelivered + delivered,
+        socketsIterated: counters.socketsIterated + iterated,
+        totalMs: counters.totalMs + ms,
+    };
+};
+
+/**
+ * Fold a per-socket list of attachments into the point-in-time half of a
+ * {@link FanoutMetricsResult}: current subscriber count per shape (grouped by
+ * `defineShape` name) and per whisper topic, the busiest `limit` of them, the
+ * peak width across all of them, and the live socket count. Pure — the DO method
+ * feeds it `getWebSockets().map(readAttachment)` and merges in the running
+ * counters.
+ */
+const summarizeFanoutTopics = (
+    attachments: FanoutAttachmentLike[],
+    limit = DEFAULT_FANOUT_TOPIC_LIMIT,
+): { peakSubscribers: number; topics: FanoutTopicStat[]; totalConnections: number } => {
+    const shapeCounts = new Map<string, number>();
+    const whisperCounts = new Map<string, number>();
+
+    for (const attachment of attachments) {
+        for (const shape of Object.values(attachment.shapes ?? {})) {
+            const key = shape.name ?? "(unknown shape)";
+
+            shapeCounts.set(key, (shapeCounts.get(key) ?? 0) + 1);
+        }
+
+        for (const topic of attachment.whispers ?? []) {
+            whisperCounts.set(topic, (whisperCounts.get(topic) ?? 0) + 1);
+        }
+    }
+
+    const topics: FanoutTopicStat[] = [
+        ...[...shapeCounts].map(([topic, subscribers]): FanoutTopicStat => {
+            return { kind: "shape", subscribers, topic };
+        }),
+        ...[...whisperCounts].map(([topic, subscribers]): FanoutTopicStat => {
+            return { kind: "whisper", subscribers, topic };
+        }),
+    ];
+
+    // Busiest first; ties broken by name so the order is stable across reads.
+    topics.sort((a, b) => b.subscribers - a.subscribers || a.topic.localeCompare(b.topic));
+
+    let peakSubscribers = 0;
+
+    for (const topic of topics) {
+        if (topic.subscribers > peakSubscribers) {
+            peakSubscribers = topic.subscribers;
+        }
+    }
+
+    return { peakSubscribers, topics: topics.slice(0, limit), totalConnections: attachments.length };
+};
+
 export {
     ADMIN_FUNCTION_PREFIX,
     ADMIN_FUNCTIONS,
+    createFanoutCounters,
+    DEFAULT_FANOUT_TOPIC_LIMIT,
     facetColumn,
     findStorageReferences,
     FLAGS_FUNCTION_PREFIX,
     listTables,
     MAX_PAGE_SIZE,
     readTablePage,
+    recordFanoutPass,
     RELATION_FUNCTION_PREFIX,
     selectMatchingIds,
+    summarizeFanoutTopics,
     summarizeSubscriptions,
 };
 export type {
@@ -1315,6 +1477,9 @@ export type {
     FacetColumnOptions,
     FacetColumnResult,
     FacetValue,
+    FanoutMetricsResult,
+    FanoutPathCounters,
+    FanoutTopicStat,
     FilterClause,
     FilterOperator,
     FlagEvaluation,

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -1355,8 +1355,14 @@ interface FanoutPathCounters {
  * half of plan 075 Phase 1, before any topology change exists.
  */
 interface FanoutMetricsResult {
+    /** Cost ceiling — the hard cap on relays per shard (`LUNORA_MAX_RELAYS`); the relay tier never spawns more, even for a viral shard. */
+    maxRelays: number;
     /** Highest current subscriber count across all topics/shapes — the widest single fan-out right now. */
     peakSubscribers: number;
+    /** `true` once this shard crossed the promotion threshold and is spreading new connections across relays (plan 075 Phase 2). */
+    promoted: boolean;
+    /** How many relays new connections are currently spread across (`0` when owner-served). */
+    relayCount: number;
     /** Running reactive-shape-poke fan-out counters since this instance woke. */
     shapePoke: FanoutPathCounters;
     /** Epoch-ms this instance began collecting (shared with `getMetrics`/`getFunctionStats`). */

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -1330,7 +1330,14 @@ interface FanoutPathCounters {
     passes: number;
     /** Widest single pass — the most sockets iterated in one flush/broadcast. */
     peakSocketsIterated: number;
-    /** Sockets that actually received a frame, summed across every pass. */
+
+    /**
+     * Sockets a frame was sent to, summed across every pass. The shape-poke path
+     * counts only confirmed sends (`sendPoke` returned `true`); the whisper path
+     * counts matched receivers (the best-effort `trySendFrame` may silently no-op
+     * on a socket that closed between the snapshot and the send), so it can very
+     * marginally over-count in that near-impossible race.
+     */
     socketsDelivered: number;
     /** Sockets visited, summed across every pass — the O(subscribers) iteration cost. */
     socketsIterated: number;
@@ -1439,13 +1446,9 @@ const summarizeFanoutTopics = (
     // Busiest first; ties broken by name so the order is stable across reads.
     topics.sort((a, b) => b.subscribers - a.subscribers || a.topic.localeCompare(b.topic));
 
-    let peakSubscribers = 0;
-
-    for (const topic of topics) {
-        if (topic.subscribers > peakSubscribers) {
-            peakSubscribers = topic.subscribers;
-        }
-    }
+    // The peak is the head of the busiest-first list — and it is the FULL list,
+    // so the global max survives the `slice(0, limit)` truncation below.
+    const peakSubscribers = topics[0]?.subscribers ?? 0;
 
     return { peakSubscribers, topics: topics.slice(0, limit), totalConnections: attachments.length };
 };

--- a/packages/do/src/relay-hub.ts
+++ b/packages/do/src/relay-hub.ts
@@ -1,0 +1,1025 @@
+/**
+ * Auto-elastic fan-out relay tier — the stateful transport, split by ROLE (plan
+ * 075, review-hardened). A `ShardDO` is, for its whole life, EITHER the owner of
+ * a shard or one of its relays — fixed by its DO name. So the relay state +
+ * methods live on two role-typed collaborators chosen ONCE from the name:
+ *
+ * - {@link OwnerRelay} (the shard owner) owns the relay set, the relay-uniform shape
+ * registry + proxy registry + uniform-cache, the RLS-uniform gate, the cohort
+ * multicast and per-socket proxy, and the seed-frame builder.
+ * - {@link RelayMember} (a relay DO) owns its per-socket cohort memos and its announce
+ * latch; it seeds its sockets' shapes THROUGH the owner and delivers the owner's
+ * multicast/proxy pokes.
+ *
+ * Both share {@link RelayLink} (sibling addressing + whisper local-delivery + the
+ * `/_lunora/relay` control-channel dispatch). The owning DO reaches everything it
+ * needs through the narrow {@link RelayHost} seam — so this whole subsystem is
+ * decoupled from the 8k-line DO class, and owner-only state can never sit next to
+ * relay-only state. Everything here is internal: the wire frames are NOT the
+ * public client protocol (the relay tier is invisible runtime elasticity).
+ */
+
+/* eslint-disable max-classes-per-file -- the role-split is three cohesive collaborators by design: a shared RelayLink base plus the OwnerRelay and RelayMember role classes. */
+
+import type { SqlExec } from "./ctx-db";
+import type { MaskPoliciesResult, RlsPoliciesResult } from "./introspect";
+import { stableStringify } from "./reactive-cache";
+import type { OwnerRelayFrame, RelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
+import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName, shapeRoutingKey } from "./relay";
+import type { ShapeRowOp } from "./shape-global-diff";
+import { buildPokeFrames } from "./shape-global-diff";
+import { awaitWsDrain, trySendFrame } from "./subscription-delivery";
+import type { ResolvedShape, ShapeSubscriptionQuery, SocketAttachment, SubscriptionIdentity } from "./types";
+
+/** Fixed relay-fan when a shard promotes (per-deployment via `LUNORA_RELAY_FAN`). */
+const DEFAULT_RELAY_FAN = 2;
+
+/** Hard ceiling on relays per shard (per-deployment via `LUNORA_MAX_RELAYS`) — the cost cap a viral shard can never exceed. */
+const DEFAULT_MAX_RELAYS = 8;
+
+/** Read a positive integer env var by `key`, falling back to `fallback` when unset/invalid. */
+const envPositiveInt = (env: unknown, key: string, fallback: number): number => {
+    const raw = (env as Record<string, unknown> | undefined)?.[key];
+    let parsed = Number.NaN;
+
+    if (typeof raw === "string") {
+        parsed = Number.parseInt(raw, 10);
+    } else if (typeof raw === "number") {
+        parsed = raw;
+    }
+
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+/**
+ * The identity the owner computes a relay-multicast shape delta under (plan 075
+ * Phase 3). It is the empty (anonymous) identity, and it is **load-bearing for
+ * RLS**: a shape may only be relay-multicast if the uniform gate has PROVEN its
+ * resolved query is identical for this exact identity and every other — so the
+ * one delta computed here is correct for every cohort subscriber. The gate probes
+ * this same constant (see {@link OwnerRelay.probeShapeRelayUniform}), so the
+ * validated identity and the multicast identity can never drift apart.
+ */
+const RELAY_MULTICAST_IDENTITY: SubscriptionIdentity = {};
+
+/** Exhaustiveness guard for the {@link OwnerRelayFrame} dispatch — an unhandled member is a compile error here, and an impossible runtime frame throws rather than silently mis-routing. */
+const assertNeverFrame = (frame: never): never => {
+    throw new Error(`unhandled relay frame: ${JSON.stringify(frame)}`);
+};
+
+/** Minimal Durable Object stub surface the relay tier needs to POST a control frame to a sibling. */
+interface RelayStub {
+    fetch: (url: string, init?: RequestInit) => Promise<Response>;
+}
+
+/** Minimal Durable Object namespace surface for addressing sibling owners/relays by name. */
+interface RelayNamespaceLike {
+    get: (id: unknown) => RelayStub;
+    getByName?: (name: string) => RelayStub;
+    idFromName: (name: string) => unknown;
+}
+
+/** Duck-type a value as a DO namespace, or `undefined` when it isn't one (single-DO mode / unbound). */
+const asRelayNamespace = (value: unknown): RelayNamespaceLike | undefined => {
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+
+    const candidate = value as Partial<RelayNamespaceLike>;
+
+    return typeof candidate.idFromName === "function" && typeof candidate.get === "function" ? (candidate as RelayNamespaceLike) : undefined;
+};
+
+/**
+ * The narrow seam the relay tier reaches the owning DO through — shape resolution,
+ * the op-log diff/seed primitives, the socket set + attachment reader, the namespace
+ * binding, and the shared poke-id / fan-out counters. Keeps the relay collaborators
+ * decoupled from the DO class and from each other.
+ */
+interface RelayHost {
+    /** Resolve a shape's op-log diff over `(fromCursor, toCursor]` against this DO's SQLite (the owner's op-log). */
+    buildShapeDiff: (resolved: ResolvedShape, fromCursor: number, toCursor: number) => ShapeRowOp[];
+    /** Compute a shape's seed (cursor/epoch/resume base + membership patch) without sending — the shared core of the local seed and the relayed seed. */
+    computeOpLogShapeSeed: (
+        shape: ShapeSubscriptionQuery,
+        resolved: ResolvedShape,
+    ) => { baseCheckpoint: number | undefined; cursor: number; epoch: string | undefined; rowsPatch: ShapeRowOp[] };
+    /** The current CDC epoch (changelog timeline token); `undefined` when CDC is off. */
+    currentCdcEpoch: () => string | undefined;
+    /** Deliver an already-serialized whisper frame to the DO's local `topic` members (the base whisper fan-out, used whether or not the relay tier is active). */
+    deliverWhisperLocal: (topic: string, frame: string, exclude: undefined | WebSocket) => number;
+    /** This DO's name (the shard key for an owner, the `…::relay::N` name for a relay), or `undefined` for an unnamed DO. */
+    doName: () => string | undefined;
+    /** This DO's env record (read for relay binding + threshold/fan/cap knobs). */
+    env: () => unknown;
+    /** This DO's live hibernatable sockets. */
+    getWebSockets: () => WebSocket[];
+    /** The schema's masked columns (codegen-emitted), for the gate's mask check. */
+    maskMetadata: () => MaskPoliciesResult;
+    /** A fresh, process-unique poke id (shared monotonic counter with the owner-local poke path). */
+    nextPokeId: () => string;
+    /** Deserialize a socket's hibernation attachment. */
+    readAttachment: (ws: WebSocket) => SocketAttachment;
+    /** Record a shape-poke fan-out pass into `getFanoutMetrics.shapePoke`. */
+    recordShapePokeFanout: (iterated: number, delivered: number, elapsedMs: number) => void;
+    /** Resolve a shape under a given identity (RLS-correct); the codegen subclass dispatches via its generated registry. */
+    resolveShape: (name: string, args: Record<string, unknown>, identity?: SubscriptionIdentity) => ResolvedShape | undefined;
+    /** The schema's RLS policies (codegen-emitted), for the gate's static read-policy guard. */
+    rlsMetadata: () => RlsPoliciesResult;
+    /** The namespace binding name this DO was reached through (learned from `x-lunora-shard-binding`), or `undefined` until known. */
+    shardBinding: () => string | undefined;
+    /** This DO's SQLite executor (for the owner's `__lunora_relays` set table). */
+    sql: () => SqlExec;
+}
+
+/** Build a JSON `Response` (the owner's seed reply on the control channel). */
+const jsonRelayResponse = (body: unknown): Response => Response.json(body, { headers: { "content-type": "application/json" } });
+
+// eslint-disable-next-line unicorn/no-null -- 204 No Content has no body; null is the standard "no body" value
+const noContent = (): Response => new Response(null, { status: 204 });
+
+/**
+ * Shared owner↔relay link: sibling addressing, whisper local-delivery, and the
+ * `/_lunora/relay` control-channel dispatch (a single exhaustive switch over the
+ * frame union, with role-specific hooks the subclasses implement). The role
+ * identity (`roleId`) is fixed at construction from the DO name.
+ */
+abstract class RelayLink {
+    protected constructor(
+        protected readonly host: RelayHost,
+        /** This DO's fixed role addressing — an owner's own key (no index), or a relay's owner key + slot. */
+        protected readonly roleId: { ownerKey: string; relayIndex?: number },
+    ) {}
+
+    /**
+     * Serve the internal `/_lunora/relay` control channel: parse the frame, then
+     * dispatch to the role hooks. One exhaustive switch means a new frame type added
+     * to `relay.ts` without a case here is a COMPILE error, not a runtime mis-route.
+     */
+    public async handleControl(request: Request): Promise<Response> {
+        let message: OwnerRelayFrame;
+
+        try {
+            message = await request.json();
+        } catch {
+            return new Response("bad request", { status: 400 });
+        }
+
+        switch (message.type) {
+            case "relay_attach": {
+                this.onAttach(message.relayIndex);
+
+                return noContent();
+            }
+            case "relay_detach": {
+                this.onDetach(message.relayIndex);
+
+                return noContent();
+            }
+            case "relay_frame": {
+                this.host.deliverWhisperLocal(message.topic, message.frame, undefined);
+                await this.onWhisperFrame(message);
+
+                return noContent();
+            }
+            case "relay_shape_poke": {
+                // Deliver to this relay's cohort sockets, recording the fan-out so a
+                // relay's metrics reflect the delivery work it actually does.
+                const iterated = this.host.getWebSockets().length;
+                const startMs = Date.now();
+                const delivered = this.onShapePoke(message);
+
+                this.host.recordShapePokeFanout(iterated, delivered, Date.now() - startMs);
+
+                return noContent();
+            }
+            case "relay_shape_subscribe": {
+                return jsonRelayResponse(this.onShapeSubscribe(message));
+            }
+            default: {
+                return assertNeverFrame(message);
+            }
+        }
+    }
+
+    /** The hard cap on relays per shard (`LUNORA_MAX_RELAYS`) — a deployment constant the runtime surfaces in Studio as the cost ceiling. */
+    public maxRelays(): number {
+        return envPositiveInt(this.host.env(), "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS);
+    }
+
+    /** Whether this DO can currently address its siblings (a namespace binding has been learned) — the relay tier is inert in single-DO mode. */
+    protected canAddressSiblings(): boolean {
+        return this.relayNamespace() !== undefined;
+    }
+
+    /** Resolve this DO's own namespace binding so it can address sibling owners/relays, or `undefined` when unknown. */
+    protected relayNamespace(): RelayNamespaceLike | undefined {
+        const binding = this.host.shardBinding();
+
+        if (binding === undefined) {
+            return undefined;
+        }
+
+        return asRelayNamespace((this.host.env() as Record<string, unknown> | undefined)?.[binding]);
+    }
+
+    /** POST a control frame to a sibling by name, fire-and-forget. Best-effort: a transient cross-DO failure drops the frame rather than throwing into the handler. */
+    protected async postRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<void> {
+        await this.requestRelayMessage(targetName, message);
+    }
+
+    /**
+     * POST a control frame to a sibling by name and return its response (the shape-seed
+     * path needs the owner's frames back). Best-effort: a transient cross-DO failure
+     * returns `undefined` rather than throwing.
+     * @returns the sibling's response, or `undefined` when it can't be reached
+     */
+    protected async requestRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<Response | undefined> {
+        const namespace = this.relayNamespace();
+
+        if (namespace === undefined) {
+            return undefined;
+        }
+
+        const stub = typeof namespace.getByName === "function" ? namespace.getByName(targetName) : namespace.get(namespace.idFromName(targetName));
+
+        try {
+            return await stub.fetch("https://relay.internal/_lunora/relay", {
+                body: JSON.stringify(message),
+                headers: { "content-type": "application/json", "x-lunora-shard-binding": this.host.shardBinding() ?? "" },
+                method: "POST",
+            });
+        } catch {
+            // Best-effort hub forwarding — a dropped ephemeral frame is tolerable.
+            return undefined;
+        }
+    }
+
+    /** Forward an opaque whisper frame through the hub (owner → its relays, or relay → its owner). No-op in single-DO mode. */
+    public abstract forwardWhisper(topic: string, frame: string): Promise<void>;
+
+    /** Owner-side per-flush fan-out (cohort multicast + per-socket proxy); a no-op on a relay (relays never flush their own writes). */
+    public abstract onFlush(changed: Set<string>, frameCursor: number): Promise<void>;
+
+    /** Seed a shape held by a socket on a relay through the owner; `undefined` on an owner (the caller falls through to its local seed path). */
+    public abstract seedRelayShape(
+        ws: WebSocket,
+        subId: string,
+        shape: ShapeSubscriptionQuery,
+        identity: SubscriptionIdentity,
+    ): Promise<"ok" | undefined | { code: string; message: string }>;
+
+    /** A relay announces itself to its owner on its first subscriber (so the owner forwards to it); a no-op on an owner. */
+    public abstract announce(): Promise<void>;
+
+    /** A relay detaches from its owner once its last socket closes; a no-op on an owner. */
+    public abstract announceDrain(closing: WebSocket): Promise<void>;
+
+    /** How many relays the runtime should spread new connections across for this shard (owner decides; a relay returns 0). */
+    public abstract relayCount(): number;
+
+    /** Whether a reactive shape may be relay-multicast (the RLS-uniform gate); `false` on a relay (the gate is an owner concern). */
+    public abstract isShapeRelayUniform(name: string, args: Record<string, unknown>): boolean;
+
+    /** Control-channel hook: an owner adds a relay to its set; a relay no-ops. */
+    protected abstract onAttach(index: number): void;
+
+    /** Control-channel hook: an owner drops a relay from its set; a relay no-ops. */
+    protected abstract onDetach(index: number): void;
+
+    /** Control-channel hook: an owner re-distributes a relay-forwarded whisper to its OTHER relays; a relay no-ops. */
+    protected abstract onWhisperFrame(message: RelayFrame): Promise<void>;
+
+    /** Control-channel hook: an owner builds the seed frames for a relay subscriber; a relay errors (it can't seed). */
+    protected abstract onShapeSubscribe(message: RelayShapeSubscribe): RelayShapeSeed;
+
+    /** Control-channel hook: a relay delivers an owner-multicast poke to its cohort sockets and returns the delivered count; an owner returns 0. */
+    protected abstract onShapePoke(poke: RelayShapePoke): number;
+}
+
+/**
+ * The shard OWNER's relay collaborator (plan 075). It holds the only op-log, so it
+ * computes every relayed shape delta — the cohort multicast for relay-uniform
+ * shapes and a per-socket proxy for non-uniform ones — and decides promotion. Its
+ * state (relay set + registries + uniform cache) is owner-only by construction.
+ */
+class OwnerRelay extends RelayLink {
+    /** Memoized RLS-uniform verdict per `(name, args)` shape — uniformity is stable, so the gate probe runs at most once per distinct shape. */
+    private readonly shapeUniformCache = new Map<string, boolean>();
+
+    /** Active relay indices, hydrated once from `__lunora_relays` and cached for the synchronous forward path. */
+    private relaySetCache: Set<number> | undefined;
+
+    /** Relay-uniform shapes a relay has subscribers for, keyed by `(name, args)`. `cursor` is the cohort frontier the owner has multicast deltas up to. */
+    private readonly relayShapeRegistry = new Map<string, { args: Record<string, unknown>; cursor: number; name: string }>();
+
+    /** NON-uniform (identity-scoped) relay shapes, one entry per relay socket, keyed `relayIndex:connectionId:subId`. Each is served live by a per-socket proxy poke. */
+    private readonly relayShapeProxies = new Map<
+        string,
+        {
+            args: Record<string, unknown>;
+            connectionId: string;
+            cursor: number;
+            epoch?: string;
+            identity: SubscriptionIdentity;
+            name: string;
+            relayIndex: number;
+            subId: string;
+        }
+    >();
+
+    public constructor(host: RelayHost, ownerKey: string) {
+        super(host, { ownerKey });
+    }
+
+    public override async forwardWhisper(topic: string, frame: string): Promise<void> {
+        if (!this.canAddressSiblings()) {
+            return;
+        }
+
+        const relays = this.ownerRelaySet();
+
+        if (relays.size === 0) {
+            return;
+        }
+
+        await Promise.all([...relays].map((index) => this.postRelayMessage(relayName(this.roleId.ownerKey, index), { frame, topic, type: "relay_frame" })));
+    }
+
+    public override async onFlush(changed: Set<string>, frameCursor: number): Promise<void> {
+        await Promise.all([this.multicastShapePokes(changed, frameCursor), this.proxyShapePokes(changed, frameCursor)]);
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: an owner serves its own shape subscribers locally, never through a relay
+    public override seedRelayShape(): Promise<"ok" | undefined | { code: string; message: string }> {
+        return Promise.resolve(undefined);
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: only a relay announces
+    public override announce(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: only a relay drains
+    public override announceDrain(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    /**
+     * How many relays the runtime should spread new connections across for this shard
+     * (plan 075 Phase 2). `0` keeps every connection on the owner. The owner promotes
+     * once its live socket count crosses `LUNORA_RELAY_THRESHOLD`, fanning to a fixed
+     * `LUNORA_RELAY_FAN` (capped by `LUNORA_MAX_RELAYS`, the cost ceiling).
+     */
+    public override relayCount(): number {
+        const threshold = envPositiveInt(this.host.env(), "LUNORA_RELAY_THRESHOLD", DEFAULT_PROMOTION_THRESHOLDS.tUp);
+
+        if (this.host.getWebSockets().length < threshold) {
+            return 0;
+        }
+
+        const maxRelays = envPositiveInt(this.host.env(), "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS);
+        const fan = envPositiveInt(this.host.env(), "LUNORA_RELAY_FAN", DEFAULT_RELAY_FAN);
+
+        return Math.min(maxRelays, Math.max(1, fan));
+    }
+
+    /**
+     * The RLS-uniform gate (plan 075 Phase 3, review-hardened): whether a reactive
+     * shape may be relay-multicast — i.e. one delta is correct for **every**
+     * subscriber. Fail-closed on four grounds — a static RLS read-policy guard, the
+     * anonymous multicast identity as the probe base, two `Proxy`-backed probes that
+     * yield a distinct value for ANY accessed claim (so any claim a `where` reads —
+     * even a custom one outside `rls()` — diverges), and a wholesale-copy backstop.
+     * Cached per `(name, args)`, whose uniformity is stable.
+     */
+    public override isShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
+        const cacheKey = shapeRoutingKey(name, args);
+        const cached = this.shapeUniformCache.get(cacheKey);
+
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const uniform = this.probeShapeRelayUniform(name, args);
+
+        this.shapeUniformCache.set(cacheKey, uniform);
+
+        return uniform;
+    }
+
+    protected override onAttach(index: number): void {
+        this.addRelayToSet(index);
+    }
+
+    protected override onDetach(index: number): void {
+        this.removeRelayFromSet(index);
+    }
+
+    protected override async onWhisperFrame(message: RelayFrame): Promise<void> {
+        // The owner re-distributes a relay-forwarded whisper to every OTHER relay, so
+        // one whisper reaches the whole shard exactly once per socket.
+        await Promise.all(
+            [...this.ownerRelaySet()]
+                .filter((index) => index !== message.originRelay)
+                .map((index) =>
+                    this.postRelayMessage(relayName(this.roleId.ownerKey, index), { frame: message.frame, topic: message.topic, type: "relay_frame" }),
+                ),
+        );
+    }
+
+    protected override onShapeSubscribe(message: RelayShapeSubscribe): RelayShapeSeed {
+        return this.buildShapeSeedFrames(message);
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: an owner doesn't receive multicast pokes (it sends them)
+    protected override onShapePoke(): number {
+        return 0;
+    }
+
+    /**
+     * Owner side (slice B.2): for every registered relay-uniform shape whose table
+     * changed this flush, compute the membership diff ONCE over `(cohort cursor,
+     * frameCursor]` and multicast the `rowsPatch` to every relay. Advances the cohort
+     * cursor synchronously (before any await) so a seed interleaving during the
+     * multicast registers at `frameCursor` and is skipped by this in-flight poke.
+     */
+    private async multicastShapePokes(changed: Set<string>, frameCursor: number): Promise<void> {
+        if (this.relayShapeRegistry.size === 0) {
+            return;
+        }
+
+        const relays = this.ownerRelaySet();
+
+        if (relays.size === 0) {
+            return;
+        }
+
+        const epoch = this.host.currentCdcEpoch();
+        const sends: Promise<void>[] = [];
+
+        for (const entry of this.relayShapeRegistry.values()) {
+            let resolved: ResolvedShape | undefined;
+
+            try {
+                resolved = this.host.resolveShape(entry.name, entry.args, RELAY_MULTICAST_IDENTITY);
+            } catch {
+                continue;
+            }
+
+            if (resolved === undefined || resolved.global === true || !changed.has(resolved.table)) {
+                continue;
+            }
+
+            const fromCursor = entry.cursor;
+            const rowsPatch = this.host.buildShapeDiff(resolved, fromCursor, frameCursor);
+
+            if (rowsPatch.length === 0) {
+                continue; // the shape's membership didn't change — leave the cohort cursor put
+            }
+
+            entry.cursor = frameCursor;
+            const poke: RelayShapePoke = {
+                args: entry.args,
+                checkpoint: frameCursor,
+                epoch,
+                fromCursor,
+                name: entry.name,
+                rowsPatch,
+                type: "relay_shape_poke",
+            };
+
+            for (const index of relays) {
+                sends.push(this.postRelayMessage(relayName(this.roleId.ownerKey, index), poke));
+            }
+        }
+
+        await Promise.all(sends);
+    }
+
+    /**
+     * Owner side (review MEDIUM-3): for every NON-uniform relay-shape proxy whose
+     * table changed this flush, compute that one subscriber's diff over `(entry.cursor,
+     * frameCursor]` UNDER ITS OWN forwarded identity (RLS-correct) and deliver a
+     * `targetConnectionId`-addressed poke to just that socket's relay. Each entry
+     * tracks its own cursor — the diffs are identity-specific, no cohort sharing.
+     */
+    private async proxyShapePokes(changed: Set<string>, frameCursor: number): Promise<void> {
+        if (this.relayShapeProxies.size === 0) {
+            return;
+        }
+
+        const epoch = this.host.currentCdcEpoch();
+        const sends: Promise<void>[] = [];
+
+        for (const entry of this.relayShapeProxies.values()) {
+            let resolved: ResolvedShape | undefined;
+
+            try {
+                resolved = this.host.resolveShape(entry.name, entry.args, entry.identity);
+            } catch {
+                continue;
+            }
+
+            if (resolved === undefined || resolved.global === true || !changed.has(resolved.table)) {
+                continue;
+            }
+
+            const fromCursor = entry.cursor;
+            const rowsPatch = this.host.buildShapeDiff(resolved, fromCursor, frameCursor);
+
+            if (rowsPatch.length === 0) {
+                continue; // this subscriber's membership didn't change — leave its cursor put
+            }
+
+            entry.cursor = frameCursor;
+            const poke: RelayShapePoke = {
+                args: entry.args,
+                checkpoint: frameCursor,
+                epoch,
+                fromCursor,
+                name: entry.name,
+                rowsPatch,
+                targetConnectionId: entry.connectionId,
+                type: "relay_shape_poke",
+            };
+
+            sends.push(this.postRelayMessage(relayName(this.roleId.ownerKey, entry.relayIndex), poke));
+        }
+
+        await Promise.all(sends);
+    }
+
+    /**
+     * Serialize a shape's seed poke frames for a relay to deliver verbatim. Resolves
+     * under the forwarded socket identity (so RLS applies exactly as for a local
+     * subscribe), self-heals the relay set, registers the shape for live updates
+     * (cohort multicast when uniform, per-socket proxy when not), and stamps the
+     * relay's cohort memo at the registry FRONTIER (not the global cursor) so a late
+     * joiner is never stranded. `lastMutationId` is omitted (relayed sockets are
+     * owner-served for custom mutators).
+     * @returns the serialized frames + the cohort-memo cursor, or an error
+     */
+    private buildShapeSeedFrames(request: RelayShapeSubscribe): RelayShapeSeed {
+        const identity: SubscriptionIdentity = { identity: request.identity, userId: request.userId };
+
+        let resolved: ResolvedShape | undefined;
+
+        try {
+            resolved = this.host.resolveShape(request.name, request.args, identity);
+        } catch (error) {
+            return { error: { code: "SHAPE_RESOLVE_FAILED", message: error instanceof Error ? error.message : "shape resolve failed" } };
+        }
+
+        if (resolved === undefined || resolved.global === true) {
+            return { error: { code: "SHAPE_NOT_FOUND", message: `shape not relayable: ${request.name}` } };
+        }
+
+        // Self-heal the relay set from the seed itself: a relay that seeds a shape
+        // provably has a subscriber, so register it (idempotent) — forwarding stays
+        // robust to a dropped `relay_attach` (LOW-4).
+        if (request.relayIndex !== undefined) {
+            this.addRelayToSet(request.relayIndex);
+        }
+
+        const { baseCheckpoint, cursor, epoch, rowsPatch } = this.host.computeOpLogShapeSeed(
+            { args: request.args, name: request.name, sinceEpoch: request.sinceEpoch, sinceSeq: request.sinceSeq },
+            resolved,
+        );
+
+        // A UNIFORM shape joins the cohort multicast: the relay stamps the socket's
+        // memo at the registry FRONTIER (entry.cursor), not the global cursor the
+        // frames were computed at — the frontier only advances on a multicast poke, so
+        // an unrelated-table write bumping the global cursor would otherwise leave a
+        // joiner's memo past every future fromCursor (silent freeze, HIGH-2). Seeding
+        // the full membership while memoing at the older frontier is correct because a
+        // shape's membership is invariant between pokes. A NON-uniform shape registers
+        // a per-socket proxy instead (MEDIUM-3). Either way the memo baseline is cohortCursor.
+        let cohortCursor = cursor;
+
+        if (this.isShapeRelayUniform(request.name, request.args)) {
+            const routingKey = shapeRoutingKey(request.name, request.args);
+            let entry = this.relayShapeRegistry.get(routingKey);
+
+            if (entry === undefined) {
+                entry = { args: request.args, cursor, name: request.name };
+                this.relayShapeRegistry.set(routingKey, entry);
+            }
+
+            cohortCursor = entry.cursor;
+        } else if (request.relayIndex !== undefined && request.connectionId !== undefined) {
+            this.relayShapeProxies.set(`${String(request.relayIndex)}:${request.connectionId}:${request.subId}`, {
+                args: request.args,
+                connectionId: request.connectionId,
+                cursor,
+                epoch,
+                identity,
+                name: request.name,
+                relayIndex: request.relayIndex,
+                subId: request.subId,
+            });
+        }
+
+        const frames = buildPokeFrames([{ rowsPatch, shapeId: request.subId }], {
+            baseCheckpoint,
+            checkpoint: cursor,
+            epoch,
+            lastMutationId: undefined,
+            pokeId: this.host.nextPokeId(),
+        });
+
+        return { cursor: cohortCursor, epoch, frames };
+    }
+
+    /** Ensure the reserved owner-side relay-set table exists (auto-hidden from the data browser by the `__lunora` prefix). */
+    private ensureRelayTable(): void {
+        this.host.sql().exec("CREATE TABLE IF NOT EXISTS __lunora_relays (idx INTEGER PRIMARY KEY)");
+    }
+
+    /** The owner's active relay indices, hydrated once from `__lunora_relays` and cached for the synchronous forward path. */
+    private ownerRelaySet(): Set<number> {
+        if (this.relaySetCache === undefined) {
+            this.ensureRelayTable();
+            const rows = this.host.sql().exec<{ idx: bigint | number }>("SELECT idx FROM __lunora_relays").toArray();
+
+            this.relaySetCache = new Set(rows.map((row) => Number(row.idx)));
+        }
+
+        return this.relaySetCache;
+    }
+
+    /** Record a relay as active (idempotent), persisting it so the set survives the owner's hibernation. */
+    private addRelayToSet(index: number): void {
+        this.ensureRelayTable();
+        this.host.sql().exec("INSERT OR IGNORE INTO __lunora_relays (idx) VALUES (?)", index);
+        this.ownerRelaySet().add(index);
+    }
+
+    /** Drop a drained relay from the set and prune its dead per-socket proxy entries; on full drain, clear the (now dead) registry + uniform cache to bound growth. */
+    private removeRelayFromSet(index: number): void {
+        this.ensureRelayTable();
+        this.host.sql().exec("DELETE FROM __lunora_relays WHERE idx = ?", index);
+        const set = this.ownerRelaySet();
+        set.delete(index);
+
+        for (const [key, entry] of this.relayShapeProxies) {
+            if (entry.relayIndex === index) {
+                this.relayShapeProxies.delete(key);
+            }
+        }
+
+        if (set.size === 0) {
+            this.relayShapeRegistry.clear();
+            this.shapeUniformCache.clear();
+        }
+    }
+
+    /**
+     * The one-shot computation behind {@link OwnerRelay.isShapeRelayUniform}, made
+     * sound against the cross-identity row-leak (review). Resolves under the anonymous
+     * multicast identity (the base) plus two `Proxy`-backed identities that return a
+     * distinct value for ANY accessed claim, requires all to agree on table + where +
+     * columns, rejects any table with an RLS read policy or a masked projected column,
+     * and fails closed if the claims are enumerated (a wholesale copy the proxy can't
+     * differentiate).
+     */
+    private probeShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
+        let base: ResolvedShape | undefined;
+
+        try {
+            base = this.host.resolveShape(name, args, RELAY_MULTICAST_IDENTITY);
+        } catch {
+            return false;
+        }
+
+        if (base === undefined || base.global === true) {
+            return false;
+        }
+
+        if (this.host.rlsMetadata().policies.some((policy) => policy.on === "read" && policy.table === base.table)) {
+            return false;
+        }
+
+        if (this.shapeColumnsMasked(base.table, base.columns)) {
+            return false;
+        }
+
+        const baseWhere = stableStringify(base.effectiveWhere);
+        const baseColumns = stableStringify(base.columns);
+
+        let enumerated = false;
+        const populate = (side: string): SubscriptionIdentity => {
+            // Type-correct values for common collection claims so an array op doesn't
+            // throw and over-reject; a distinct string sentinel for every other key.
+            const backing: Record<string, unknown> = { groups: [`grp_${side}`], roles: [side], sub: `__lunora_probe_${side}__` };
+            const claims = new Proxy(backing, {
+                get: (target, key) => {
+                    if (typeof key === "symbol" || key in target) {
+                        return Reflect.get(target, key) as unknown;
+                    }
+
+                    return `${side}:${key}`;
+                },
+                getOwnPropertyDescriptor: (target, key) => {
+                    enumerated = true;
+
+                    return Reflect.getOwnPropertyDescriptor(target, key);
+                },
+                has: (target, key) => (typeof key === "symbol" ? Reflect.has(target, key) : true),
+                ownKeys: (target) => {
+                    enumerated = true;
+
+                    return Reflect.ownKeys(target);
+                },
+            });
+
+            return { identity: claims, userId: `__lunora_probe_${side}__` };
+        };
+
+        const matches = [RELAY_MULTICAST_IDENTITY, populate("a"), populate("b")].every((probe) => {
+            let resolved: ResolvedShape | undefined;
+
+            try {
+                resolved = this.host.resolveShape(name, args, probe);
+            } catch {
+                return false;
+            }
+
+            return (
+                resolved !== undefined &&
+                resolved.global !== true &&
+                resolved.table === base.table &&
+                stableStringify(resolved.effectiveWhere) === baseWhere &&
+                stableStringify(resolved.columns) === baseColumns
+            );
+        });
+
+        return matches && !enumerated;
+    }
+
+    /** Whether any column the shape projects from `table` is masked — a masked value is identity-dependent, so the shape can't be relay-uniform. */
+    private shapeColumnsMasked(table: string, columns: ReadonlyArray<string> | undefined): boolean {
+        const masked = this.host.maskMetadata().columns.filter((entry) => entry.table === table);
+
+        if (masked.length === 0) {
+            return false;
+        }
+
+        if (columns === undefined) {
+            return true; // projects every column → any mask on the table makes it non-uniform
+        }
+
+        const projected = new Set(columns);
+
+        return masked.some((entry) => projected.has(entry.column));
+    }
+}
+
+/**
+ * A RELAY DO's collaborator (plan 075). A relay holds no op-log, so it seeds its
+ * sockets' shapes THROUGH the owner and delivers the owner's multicast/proxy
+ * pokes. Its state (per-socket cohort memos + the announce latch) is relay-only.
+ */
+class RelayMember extends RelayLink {
+    /** `true` once this relay has announced itself to its owner this wake, so a hot socket churn doesn't re-attach on every subscribe. */
+    private relayAnnounced = false;
+
+    /** Per-socket cohort memo `ws → subId → { cursor, epoch }`: the relay delivers a poke to a socket only while its memo matches the poke's `fromCursor`+`epoch`. */
+    private readonly shapeRelayMemos = new WeakMap<WebSocket, Map<string, { cursor: number; epoch?: string }>>();
+
+    public constructor(host: RelayHost, ownerKey: string, relayIndex: number) {
+        super(host, { ownerKey, relayIndex });
+    }
+
+    public override async forwardWhisper(topic: string, frame: string): Promise<void> {
+        if (!this.canAddressSiblings()) {
+            return;
+        }
+
+        // A relay sends the frame UP to its owner, stamped with its own index so the
+        // owner won't echo it back.
+        await this.postRelayMessage(this.roleId.ownerKey, { frame, originRelay: this.roleId.relayIndex, topic, type: "relay_frame" });
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: a relay receives no writes, so it never flushes its own CDC
+    public override onFlush(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    /**
+     * Seed a shape held by a socket on this relay by forwarding the request to the
+     * owner: the owner resolves under this socket's verified identity and computes the
+     * seed frames, which the relay delivers verbatim. Returns a structured error
+     * (surfaced as a `shape_subscribe` error) when the owner can't be reached.
+     */
+    public override async seedRelayShape(
+        ws: WebSocket,
+        subId: string,
+        shape: ShapeSubscriptionQuery,
+        identity: SubscriptionIdentity,
+    ): Promise<"ok" | { code: string; message: string }> {
+        if (!this.canAddressSiblings()) {
+            return { code: "RELAY_MISCONFIGURED", message: "relay cannot address its owner" };
+        }
+
+        // Announce so the owner adds this relay to the set it multicasts deltas to.
+        await this.announce();
+
+        const request: RelayShapeSubscribe = {
+            args: shape.args ?? {},
+            connectionId: this.host.readAttachment(ws).connectionId,
+            identity: identity.identity,
+            name: shape.name,
+            relayIndex: this.roleId.relayIndex,
+            sinceEpoch: shape.sinceEpoch,
+            sinceSeq: shape.sinceSeq,
+            subId,
+            type: "relay_shape_subscribe",
+            userId: identity.userId,
+        };
+
+        const response = await this.requestRelayMessage(this.roleId.ownerKey, request);
+
+        if (response === undefined) {
+            return { code: "RELAY_SEED_FAILED", message: "owner did not answer the shape seed" };
+        }
+
+        let seed: RelayShapeSeed;
+
+        try {
+            seed = await response.json();
+        } catch {
+            return { code: "RELAY_SEED_FAILED", message: "malformed shape seed from owner" };
+        }
+
+        if (seed.error !== undefined) {
+            return seed.error;
+        }
+
+        if (seed.frames === undefined) {
+            return { code: "RELAY_SEED_FAILED", message: "owner returned no shape frames" };
+        }
+
+        await awaitWsDrain(ws);
+
+        for (const frame of seed.frames) {
+            trySendFrame(ws, frame);
+        }
+
+        // Stamp this socket's cohort memo at the owner's returned frontier so the next
+        // multicast poke lands exactly once (HIGH-2 / LOW-6).
+        this.recordRelayShapeMemo(ws, subId, seed.cursor ?? 0, seed.epoch);
+
+        return "ok";
+    }
+
+    /** A relay announces itself to its owner (once per wake) on its first subscriber, retrying on a failed attach so a dropped frame can't strand its sockets (LOW-4). */
+    public override async announce(): Promise<void> {
+        if (this.relayAnnounced || !this.canAddressSiblings()) {
+            return;
+        }
+
+        // Latch optimistically so a burst of subscribes doesn't re-announce, but reset
+        // on a failed attach so the next subscriber retries.
+        this.relayAnnounced = true;
+        const response = await this.requestRelayMessage(this.roleId.ownerKey, { relayIndex: this.roleId.relayIndex as number, type: "relay_attach" });
+
+        if (!response?.ok) {
+            this.relayAnnounced = false;
+        }
+    }
+
+    /** Once this relay loses its last socket (the `closing` one excluded), detach from the owner and re-arm the announce latch for a future subscriber. */
+    public override async announceDrain(closing: WebSocket): Promise<void> {
+        if (!this.canAddressSiblings()) {
+            return;
+        }
+
+        if (this.host.getWebSockets().some((ws) => ws !== closing)) {
+            return;
+        }
+
+        this.relayAnnounced = false;
+        await this.postRelayMessage(this.roleId.ownerKey, { relayIndex: this.roleId.relayIndex as number, type: "relay_detach" });
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: a relay never spreads connections (flat single tier)
+    public override relayCount(): number {
+        return 0;
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: the RLS-uniform gate is an owner concern
+    public override isShapeRelayUniform(): boolean {
+        return false;
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: only an owner tracks a relay set
+    protected override onAttach(): void {
+        /* a relay has no relay set */
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: only an owner tracks a relay set
+    protected override onDetach(): void {
+        /* a relay has no relay set */
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: only an owner re-distributes a forwarded whisper
+    protected override onWhisperFrame(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- role hook: a relay can't seed (no op-log) — the owner does
+    protected override onShapeSubscribe(): RelayShapeSeed {
+        return { error: { code: "RELAY_CANNOT_SEED", message: "a relay has no op-log to seed from" } };
+    }
+
+    protected override onShapePoke(poke: RelayShapePoke): number {
+        return this.deliverShapePoke(poke);
+    }
+
+    /** Record a relay socket's cohort cursor + epoch for `subId` (creating the per-socket map lazily). */
+    private recordRelayShapeMemo(ws: WebSocket, subId: string, cursor: number, epoch: string | undefined): void {
+        let memos = this.shapeRelayMemos.get(ws);
+
+        if (memos === undefined) {
+            memos = new Map<string, { cursor: number; epoch?: string }>();
+            this.shapeRelayMemos.set(ws, memos);
+        }
+
+        memos.set(subId, { cursor, epoch });
+    }
+
+    /**
+     * Deliver an owner-multicast shape delta to this relay's cohort sockets. A socket
+     * receives it only while its memo matches the poke's `fromCursor` AND `epoch` (so a
+     * socket that seeded at a different cursor/epoch never double-applies), then
+     * advances to `checkpoint`. A targeted (per-socket proxy) poke goes ONLY to its one
+     * connection; a cohort multicast goes to every matching socket.
+     * @returns the number of sockets delivered to
+     */
+    private deliverShapePoke(poke: RelayShapePoke): number {
+        const routingKey = shapeRoutingKey(poke.name, poke.args);
+        let delivered = 0;
+
+        for (const ws of this.host.getWebSockets()) {
+            const attachment = this.host.readAttachment(ws);
+            const { shapes } = attachment;
+            const memos = this.shapeRelayMemos.get(ws);
+
+            if (shapes === undefined || memos === undefined) {
+                continue;
+            }
+
+            if (poke.targetConnectionId !== undefined && attachment.connectionId !== poke.targetConnectionId) {
+                continue;
+            }
+
+            for (const [subId, sub] of Object.entries(shapes)) {
+                const memo = memos.get(subId);
+
+                if (memo?.cursor !== poke.fromCursor || memo.epoch !== poke.epoch || shapeRoutingKey(sub.name, sub.args) !== routingKey) {
+                    continue;
+                }
+
+                const frames = buildPokeFrames([{ rowsPatch: poke.rowsPatch, shapeId: subId }], {
+                    baseCheckpoint: undefined,
+                    checkpoint: poke.checkpoint,
+                    epoch: poke.epoch,
+                    lastMutationId: undefined,
+                    pokeId: this.host.nextPokeId(),
+                });
+
+                for (const frame of frames) {
+                    trySendFrame(ws, frame);
+                }
+
+                memos.set(subId, { cursor: poke.checkpoint, epoch: poke.epoch });
+                delivered += 1;
+            }
+        }
+
+        return delivered;
+    }
+}
+
+/**
+ * Build the role-typed relay collaborator for a DO, chosen ONCE from its name:
+ * an un-suffixed name is the shard owner ({@link OwnerRelay}); a `…::relay::N`
+ * name is a relay ({@link RelayMember}). An unnamed DO (single-DO mode) gets no
+ * collaborator — the relay tier is inert.
+ * @returns the collaborator, or `undefined` for an unnamed DO
+ */
+const createRelayLink = (host: RelayHost): OwnerRelay | RelayMember | undefined => {
+    const name = host.doName();
+
+    if (name === undefined) {
+        return undefined;
+    }
+
+    const parsed = parseRelayName(name);
+
+    return parsed === undefined ? new OwnerRelay(host, name) : new RelayMember(host, parsed.ownerKey, parsed.relayIndex);
+};
+
+export { createRelayLink, DEFAULT_MAX_RELAYS, OwnerRelay, RelayMember };
+export type { RelayHost };

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -131,8 +131,12 @@ interface RelayFrame {
  */
 interface RelayShapeSubscribe {
     args: Record<string, unknown>;
+    /** The relay socket's stable connection id — lets the owner address per-socket proxy pokes back to exactly this socket (non-uniform shapes). */
+    connectionId?: string;
     identity?: Record<string, unknown>;
     name: string;
+    /** The forwarding relay's index, so the owner knows which relay to send this socket's proxy pokes to. */
+    relayIndex?: number;
     sinceEpoch?: string;
     sinceSeq?: number;
     subId: string;
@@ -177,6 +181,14 @@ interface RelayShapePoke {
     fromCursor: number;
     name: string;
     rowsPatch: ShapeRowOp[];
+
+    /**
+     * When set, this is a PER-SOCKET proxy poke for a non-uniform (identity-scoped)
+     * shape, computed under that one socket's identity — the relay delivers it ONLY
+     * to the socket with this connection id, never the whole cohort. Absent for a
+     * uniform cohort multicast (delivered to every matching socket).
+     */
+    targetConnectionId?: string;
     type: "relay_shape_poke";
 }
 

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -1,0 +1,110 @@
+/**
+ * Auto-elastic fan-out relay tier — promotion state machine + internal owner↔relay
+ * frame protocol (plan 075 Phase 2).
+ *
+ * A hot fan-out key (a shard whose subscriber count makes one isolate's per-flush
+ * fan-out the bottleneck — see the measured curve in
+ * `plans/075-phase0-relay-protocol-design.md` § 7) is **promoted**: the runtime
+ * routes _new_ connections to relay DOs, the owner computes each delta once and
+ * forwards an opaque frame to its relays, and each relay re-broadcasts to its
+ * attached sockets. This module is the pure, owner-side decision layer; the
+ * transport that consumes it lives in `shard-do.ts` (relay mode) and the runtime
+ * (endpoint selection at the WS upgrade hop).
+ *
+ * Everything here is internal: the {@link OwnerRelayFrame} types are NOT part of
+ * the public client protocol (the app never sees them — the relay tier is
+ * invisible runtime elasticity).
+ */
+
+/** Whether a fan-out key is owner-served (the default) or has been promoted to a relay set. */
+type PromotionState = "owned" | "promoted";
+
+/**
+ * Subscriber-count thresholds governing promotion, with hysteresis. `tDown` must
+ * be strictly below `tUp`: the band between them holds the current state so a key
+ * hovering near the threshold can't flap between owner-served and promoted.
+ */
+interface PromotionThresholds {
+    /** Collapse back to owner-served below this live-subscriber count (must be `< tUp`). */
+    tDown: number;
+    /** Promote to a relay set at or above this live-subscriber count. */
+    tUp: number;
+}
+
+/**
+ * Default promotion thresholds. `tUp = 8,000` is where the measured fan-out curve
+ * (~10–15 µs/socket end-to-end in workerd, ~120 ms per flush at 8k) makes per-flush
+ * fan-out the bottleneck well within a single DO's ~32k connection cap; `tDown` is
+ * half that, the anti-flap band. Both are tunable per deployment against the
+ * Phase-1 `getFanoutMetrics` readout — never silently hardcoded into the hot path.
+ */
+const DEFAULT_PROMOTION_THRESHOLDS: PromotionThresholds = { tDown: 4000, tUp: 8000 };
+
+/**
+ * Pure promotion reducer: the next {@link PromotionState} given the current state
+ * and the live subscriber count, under the hysteresis band. `owned` promotes at
+ * `>= tUp`; `promoted` collapses at `< tDown`; in between, the state is unchanged.
+ * @throws if `tDown >= tUp` (the band would be empty or inverted — a config error).
+ */
+const nextPromotionState = (current: PromotionState, subscribers: number, thresholds: PromotionThresholds = DEFAULT_PROMOTION_THRESHOLDS): PromotionState => {
+    if (thresholds.tDown >= thresholds.tUp) {
+        throw new Error(`invalid promotion thresholds: tDown (${String(thresholds.tDown)}) must be < tUp (${String(thresholds.tUp)})`);
+    }
+
+    if (current === "owned") {
+        return subscribers >= thresholds.tUp ? "promoted" : "owned";
+    }
+
+    return subscribers < thresholds.tDown ? "owned" : "promoted";
+};
+
+/**
+ * How many relays a promoted key needs to serve `subscribers` connections, given
+ * each relay's capacity, capped at `maxRelays` (the cost ceiling — a viral key can
+ * never silently spawn unbounded DOs; the runtime surfaces the cap in Studio when
+ * approached). The owner keeps serving its own share, so this sizes the _relay_
+ * set for the overflow above one DO's capacity.
+ * @returns the relay count in `[0, maxRelays]`
+ */
+const relayCountFor = (subscribers: number, perRelayCapacity: number, maxRelays: number): number => {
+    if (subscribers <= perRelayCapacity || perRelayCapacity <= 0) {
+        return 0;
+    }
+
+    const overflow = subscribers - perRelayCapacity;
+    const needed = Math.ceil(overflow / perRelayCapacity);
+
+    return Math.min(needed, Math.max(0, maxRelays));
+};
+
+/** A relay announces (on first attach) that it is serving a fan-out key for the owner. */
+interface RelayAttach {
+    relayId: string;
+    type: "relay_attach";
+}
+
+/** A relay announces it has drained to zero sockets and is detaching from the key. */
+interface RelayDetach {
+    relayId: string;
+    type: "relay_detach";
+}
+
+/**
+ * The owner forwards one **opaque, already-serialized** frame for a relay to
+ * re-broadcast verbatim to its attached sockets. `frame` is the exact wire string
+ * the owner would have sent its own sockets (a whisper frame in Phase 2); the relay
+ * never parses or re-derives it. `cursor`/`epoch` accompany reactive-shape frames
+ * (Phase 3) so a relay can stamp the checkpoint; absent for ephemeral whisper.
+ */
+interface RelayFrame {
+    cursor?: number;
+    epoch?: string;
+    frame: string;
+    type: "relay_frame";
+}
+
+/** Internal owner↔relay control frames (plan 075). NOT the public client protocol — the app never sees these. */
+type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame;
+
+export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
+export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame };

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -108,11 +108,42 @@ interface RelayFrame {
     type: "relay_frame";
 }
 
+/**
+ * A relay forwards a reactive `shape_subscribe` up to the owner so the owner —
+ * the only DO with the SQLite op-log — computes the seed under the socket's
+ * VERIFIED identity (RLS-correct) and returns the serialized poke frames for the
+ * relay to deliver (plan 075 Phase 3). Carries the socket's identity verbatim;
+ * `sinceSeq`/`sinceEpoch` enable the owner's resume fast-path.
+ */
+interface RelayShapeSubscribe {
+    args: Record<string, unknown>;
+    identity?: Record<string, unknown>;
+    name: string;
+    sinceEpoch?: string;
+    sinceSeq?: number;
+    subId: string;
+    type: "relay_shape_subscribe";
+    userId?: string;
+}
+
+/**
+ * The owner's response to a {@link RelayShapeSubscribe}: the serialized poke
+ * frames (pokeStart/pokePart…/pokeEnd) to send to the subscribing socket, plus
+ * the cursor they were computed at (the cohort baseline). `error` is set instead
+ * when the shape can't be resolved (unknown / RLS-denied), which the relay
+ * surfaces as a `shape_subscribe` error.
+ */
+interface RelayShapeSeed {
+    cursor?: number;
+    error?: { code: string; message: string };
+    frames?: string[];
+}
+
 /** Internal owner↔relay control messages (plan 075). NOT the public client protocol — the app never sees these. */
-type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame;
+type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame | RelayShapeSubscribe;
 
 export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
-export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame };
+export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame, RelayShapeSeed, RelayShapeSubscribe };
 // The DO-name contract lives in `shared/` so `@lunora/runtime` (which mints relay
 // names) and this package (which parses them) can't drift; re-exported so `./relay`
 // stays the single import surface for the relay tier inside `@lunora/do`.

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -143,12 +143,19 @@ interface RelayShapeSubscribe {
 /**
  * The owner's response to a {@link RelayShapeSubscribe}: the serialized poke
  * frames (pokeStart/pokePart…/pokeEnd) to send to the subscribing socket, plus
- * the cursor they were computed at (the cohort baseline). `error` is set instead
- * when the shape can't be resolved (unknown / RLS-denied), which the relay
- * surfaces as a `shape_subscribe` error.
+ * the **cohort frontier** the relay must stamp the socket's memo at. `cursor` is
+ * deliberately NOT the global CDC cursor the frames were computed at — it is the
+ * registry's cohort cursor (the point the owner has multicast this shape's deltas
+ * up to). A joiner enters the cohort there so the next `relay_shape_poke`'s
+ * `fromCursor` matches it; seeding the full current membership is still correct
+ * because a shape's membership is invariant between multicast pokes. `epoch` pairs
+ * with the cursor so a memo can't match a `fromCursor` from a different CDC epoch.
+ * `error` is set instead when the shape can't be resolved (unknown / RLS-denied),
+ * which the relay surfaces as a `shape_subscribe` error.
  */
 interface RelayShapeSeed {
     cursor?: number;
+    epoch?: string;
     error?: { code: string; message: string };
     frames?: string[];
 }

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -77,34 +77,70 @@ const relayCountFor = (subscribers: number, perRelayCapacity: number, maxRelays:
     return Math.min(needed, Math.max(0, maxRelays));
 };
 
-/** A relay announces (on first attach) that it is serving a fan-out key for the owner. */
+/** The `::relay::` infix that marks a DO name as a relay for an owner shard. Reserved — a user shard key can't contain it (the runtime mints relay names). */
+const RELAY_NAME_INFIX = "::relay::";
+
+/** Build a relay DO name for `ownerKey`'s relay number `index` — the deterministic name any worker/DO can compute without shared state. */
+const relayName = (ownerKey: string, index: number): string => `${ownerKey}${RELAY_NAME_INFIX}${String(index)}`;
+
+/**
+ * Parse a DO name into its owner key + relay index, or `undefined` when the name
+ * is an owner (no `::relay::` infix). Lets a DO discover its own role from
+ * `state.id.name`: an owner serves its shard directly; a relay knows which owner
+ * to forward to and which relay slot it fills.
+ * @returns the owner key + relay index, or `undefined` for an owner-role name
+ */
+const parseRelayName = (name: string): undefined | { ownerKey: string; relayIndex: number } => {
+    const at = name.lastIndexOf(RELAY_NAME_INFIX);
+
+    if (at === -1) {
+        return undefined;
+    }
+
+    const ownerKey = name.slice(0, at);
+    const indexText = name.slice(at + RELAY_NAME_INFIX.length);
+    const relayIndex = Number(indexText);
+
+    if (ownerKey.length === 0 || !Number.isInteger(relayIndex) || relayIndex < 0 || String(relayIndex) !== indexText) {
+        return undefined;
+    }
+
+    return { ownerKey, relayIndex };
+};
+
+/** A relay announces (on its first attached subscriber) that it is serving a fan-out key, so the owner adds it to the relay set it forwards to. */
 interface RelayAttach {
-    relayId: string;
+    relayIndex: number;
     type: "relay_attach";
 }
 
-/** A relay announces it has drained to zero sockets and is detaching from the key. */
+/** A relay announces it has drained to zero sockets and is detaching, so the owner stops forwarding to it. */
 interface RelayDetach {
-    relayId: string;
+    relayIndex: number;
     type: "relay_detach";
 }
 
 /**
- * The owner forwards one **opaque, already-serialized** frame for a relay to
- * re-broadcast verbatim to its attached sockets. `frame` is the exact wire string
- * the owner would have sent its own sockets (a whisper frame in Phase 2); the relay
- * never parses or re-derives it. `cursor`/`epoch` accompany reactive-shape frames
- * (Phase 3) so a relay can stamp the checkpoint; absent for ephemeral whisper.
+ * One **opaque, already-serialized** frame to re-broadcast verbatim to a fan-out
+ * key's local subscribers. `frame` is the exact wire string the owner would have
+ * sent its own sockets (a whisper frame in Phase 2); the receiver never parses or
+ * re-derives it. `topic` names the fan-out key so the receiver delivers only to
+ * that key's members. `originRelay` is set when a relay forwarded a socket's
+ * whisper up to the owner, so the owner skips re-forwarding it back to that relay
+ * (no echo). `cursor`/`epoch` accompany reactive-shape frames (Phase 3); absent
+ * for ephemeral whisper.
  */
 interface RelayFrame {
     cursor?: number;
     epoch?: string;
     frame: string;
+    originRelay?: number;
+    topic: string;
     type: "relay_frame";
 }
 
-/** Internal owner↔relay control frames (plan 075). NOT the public client protocol — the app never sees these. */
+/** Internal owner↔relay control messages (plan 075). NOT the public client protocol — the app never sees these. */
 type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame;
 
-export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
+export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, parseRelayName, RELAY_NAME_INFIX, relayCountFor, relayName };
 export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame };

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -16,7 +16,19 @@
  * invisible runtime elasticity).
  */
 
+import { stableStringify } from "./reactive-cache";
 import type { ShapeRowOp } from "./shape-global-diff";
+
+/**
+ * The single canonical cohort routing key for a reactive shape `(name, args)`,
+ * used everywhere the owner and its relays must agree on "the same shape": the
+ * uniform-cache key, the owner registry key, and the relay-side delivery match.
+ * Normalizing `args ?? {}` in ONE place is load-bearing — the owner registers
+ * with already-defaulted args while a relay matches against the live attachment's
+ * possibly-undefined `args`, so any per-site disagreement on the empty-args
+ * default would silently break cohort matching (dropped or double-applied deltas).
+ */
+const shapeRoutingKey = (name: string, args?: Record<string, unknown>): string => stableStringify({ args: args ?? {}, name });
 
 /** Whether a fan-out key is owner-served (the default) or has been promoted to a relay set. */
 type PromotionState = "owned" | "promoted";
@@ -164,7 +176,7 @@ interface RelayShapePoke {
 /** Internal owner↔relay control messages (plan 075). NOT the public client protocol — the app never sees these. */
 type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame | RelayShapePoke | RelayShapeSubscribe;
 
-export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
+export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor, shapeRoutingKey };
 export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe };
 // The DO-name contract lives in `shared/` so `@lunora/runtime` (which mints relay
 // names) and this package (which parses them) can't drift; re-exported so `./relay`

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -77,37 +77,6 @@ const relayCountFor = (subscribers: number, perRelayCapacity: number, maxRelays:
     return Math.min(needed, Math.max(0, maxRelays));
 };
 
-/** The `::relay::` infix that marks a DO name as a relay for an owner shard. Reserved — a user shard key can't contain it (the runtime mints relay names). */
-const RELAY_NAME_INFIX = "::relay::";
-
-/** Build a relay DO name for `ownerKey`'s relay number `index` — the deterministic name any worker/DO can compute without shared state. */
-const relayName = (ownerKey: string, index: number): string => `${ownerKey}${RELAY_NAME_INFIX}${String(index)}`;
-
-/**
- * Parse a DO name into its owner key + relay index, or `undefined` when the name
- * is an owner (no `::relay::` infix). Lets a DO discover its own role from
- * `state.id.name`: an owner serves its shard directly; a relay knows which owner
- * to forward to and which relay slot it fills.
- * @returns the owner key + relay index, or `undefined` for an owner-role name
- */
-const parseRelayName = (name: string): undefined | { ownerKey: string; relayIndex: number } => {
-    const at = name.lastIndexOf(RELAY_NAME_INFIX);
-
-    if (at === -1) {
-        return undefined;
-    }
-
-    const ownerKey = name.slice(0, at);
-    const indexText = name.slice(at + RELAY_NAME_INFIX.length);
-    const relayIndex = Number(indexText);
-
-    if (ownerKey.length === 0 || !Number.isInteger(relayIndex) || relayIndex < 0 || String(relayIndex) !== indexText) {
-        return undefined;
-    }
-
-    return { ownerKey, relayIndex };
-};
-
 /** A relay announces (on its first attached subscriber) that it is serving a fan-out key, so the owner adds it to the relay set it forwards to. */
 interface RelayAttach {
     relayIndex: number;
@@ -142,5 +111,9 @@ interface RelayFrame {
 /** Internal owner↔relay control messages (plan 075). NOT the public client protocol — the app never sees these. */
 type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame;
 
-export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, parseRelayName, RELAY_NAME_INFIX, relayCountFor, relayName };
+export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
 export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame };
+// The DO-name contract lives in `shared/` so `@lunora/runtime` (which mints relay
+// names) and this package (which parses them) can't drift; re-exported so `./relay`
+// stays the single import surface for the relay tier inside `@lunora/do`.
+export { parseRelayName, RELAY_NAME_INFIX, relayName } from "../../../shared/relay-name";

--- a/packages/do/src/relay.ts
+++ b/packages/do/src/relay.ts
@@ -16,6 +16,8 @@
  * invisible runtime elasticity).
  */
 
+import type { ShapeRowOp } from "./shape-global-diff";
+
 /** Whether a fan-out key is owner-served (the default) or has been promoted to a relay set. */
 type PromotionState = "owned" | "promoted";
 
@@ -139,11 +141,31 @@ interface RelayShapeSeed {
     frames?: string[];
 }
 
+/**
+ * The owner multicasts ONE shape delta per flush to its relays (plan 075 Phase 3
+ * slice B.2): it computes the membership `rowsPatch` once (over plan 072's shared
+ * op-range) and ships it with the cursor window `(fromCursor, checkpoint]`. A relay
+ * delivers it ONLY to its sockets whose memo for this shape is `fromCursor` —
+ * advancing them to `checkpoint` — so a socket that seeded at a different cursor
+ * (mid-flush) is skipped and never double-applies a delta. The relay wraps the
+ * `rowsPatch` in per-socket poke frames (each socket's own `subId`); `name`/`args`
+ * identify the shape so the relay can match its subscribers.
+ */
+interface RelayShapePoke {
+    args: Record<string, unknown>;
+    checkpoint: number;
+    epoch?: string;
+    fromCursor: number;
+    name: string;
+    rowsPatch: ShapeRowOp[];
+    type: "relay_shape_poke";
+}
+
 /** Internal owner↔relay control messages (plan 075). NOT the public client protocol — the app never sees these. */
-type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame | RelayShapeSubscribe;
+type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame | RelayShapePoke | RelayShapeSubscribe;
 
 export { DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor };
-export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame, RelayShapeSeed, RelayShapeSubscribe };
+export type { OwnerRelayFrame, PromotionState, PromotionThresholds, RelayAttach, RelayDetach, RelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe };
 // The DO-name contract lives in `shared/` so `@lunora/runtime` (which mints relay
 // names) and this package (which parses them) can't drift; re-exported so `./relay`
 // stays the single import surface for the relay tier inside `@lunora/do`.

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -2439,6 +2439,10 @@ abstract class ShardDO {
 
         // Clear the attachment so a future reconnection starts clean.
         (ws as HibernatableWebSocket).serializeAttachment?.(undefined);
+
+        // Relay tier collapse (plan 075 Phase 2): a relay that just lost its last
+        // socket detaches from its owner, so the owner stops forwarding to it.
+        await this.announceRelayDrainIfNeeded(ws);
     }
 
     /** Hibernation API: invoked on socket error. */
@@ -5421,8 +5425,17 @@ abstract class ShardDO {
      */
     private collectFanoutMetrics(): FanoutMetricsResult {
         const summary = summarizeFanoutTopics(this.state.getWebSockets().map((ws) => this.readAttachment(ws)));
+        const relayCount = this.computeRelayCount();
 
-        return { ...summary, shapePoke: this.fanout.shapePoke, sinceMs: this.metrics.sinceMs, whisper: this.fanout.whisper };
+        return {
+            ...summary,
+            maxRelays: envPositiveInt(this.env, "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS),
+            promoted: relayCount > 0,
+            relayCount,
+            shapePoke: this.fanout.shapePoke,
+            sinceMs: this.metrics.sinceMs,
+            whisper: this.fanout.whisper,
+        };
     }
 
     /** Resolve a `getAuditLog` admin read, parsing the optional `limit`/`sinceSeq` cursor args and ensuring the reserved table first. */
@@ -7585,6 +7598,27 @@ abstract class ShardDO {
 
         this.relayAnnounced = true;
         await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_attach" });
+    }
+
+    /**
+     * A relay that just lost its last socket (the `closing` one excluded) detaches
+     * from its owner so the owner stops forwarding frames to it, and re-arms its
+     * announce flag so it re-attaches if a new socket joins later. No-op on an owner
+     * or in single-DO mode, or while the relay still serves sockets.
+     */
+    private async announceRelayDrainIfNeeded(closing: WebSocket): Promise<void> {
+        const role = this.relayRole();
+
+        if (role?.relayIndex === undefined) {
+            return;
+        }
+
+        if (this.state.getWebSockets().some((ws) => ws !== closing)) {
+            return;
+        }
+
+        this.relayAnnounced = false;
+        await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_detach" });
     }
 
     // eslint-disable-next-line class-methods-use-this -- cohesive DO instance method grouped with the hibernation/attachment helpers; reads only the socket

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -6453,6 +6453,14 @@ abstract class ShardDO {
             return { error: { code: "SHAPE_NOT_FOUND", message: `shape not relayable: ${request.name}` } };
         }
 
+        // Self-heal the relay set from the seed itself: any relay that seeds a shape
+        // through the owner provably has a subscriber, so register it here too. This
+        // makes forwarding robust to a dropped `relay_attach` (idempotent INSERT) —
+        // the owner can't silently fail to multicast/proxy to a live relay (LOW-4).
+        if (request.relayIndex !== undefined) {
+            this.addRelayToSet(request.relayIndex);
+        }
+
         const { baseCheckpoint, cursor, epoch, rowsPatch } = this.computeOpLogShapeSeed(
             { args: request.args, name: request.name, sinceEpoch: request.sinceEpoch, sinceSeq: request.sinceSeq },
             resolved,
@@ -8122,8 +8130,16 @@ abstract class ShardDO {
             return;
         }
 
+        // Latch optimistically so a burst of subscribes doesn't re-announce, but
+        // reset on a failed/unreachable attach so the NEXT subscriber retries: a
+        // dropped attach must not permanently strand this relay's sockets (the owner
+        // would never forward their live deltas — silent staleness, plan 075 review).
         this.relayAnnounced = true;
-        await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_attach" });
+        const response = await this.requestRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_attach" });
+
+        if (!response?.ok) {
+            this.relayAnnounced = false;
+        }
     }
 
     /**

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1856,7 +1856,7 @@ abstract class ShardDO {
     /** Relay-side guard: `true` once this relay has announced itself to its owner this wake, so a hot socket churn doesn't re-`relay_attach` on every subscribe. */
     private relayAnnounced = false;
 
-    /** Memoized RLS-uniform verdict per `(name, args)` shape — uniformity is a stable property, so the dual-identity probe runs at most once per distinct shape (plan 075 Phase 3). */
+    /** Memoized RLS-uniform verdict per `(name, args)` shape — uniformity is a stable property, so the gate probe runs at most once per distinct shape (plan 075 Phase 3). */
     private readonly shapeUniformCache = new Map<string, boolean>();
 
     /**

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1869,6 +1869,29 @@ abstract class ShardDO {
     private readonly relayShapeRegistry = new Map<string, { args: Record<string, unknown>; cursor: number; name: string }>();
 
     /**
+     * Owner-side registry of NON-uniform (identity-scoped) relay shapes, one entry
+     * per relay socket (plan 075 review MEDIUM-3). These can't be cohort-multicast —
+     * each subscriber's delta is identity-dependent — so the owner computes each
+     * one's diff under its own forwarded identity and delivers a targeted poke to
+     * that one socket (by `connectionId`). No fan-out scaling (it's per-socket either
+     * way), but the relay still offloads the connection and the socket gets live
+     * updates instead of a silently frozen shape. Keyed `relayIndex:connectionId:subId`.
+     */
+    private readonly relayShapeProxies = new Map<
+        string,
+        {
+            args: Record<string, unknown>;
+            connectionId: string;
+            cursor: number;
+            epoch?: string;
+            identity: SubscriptionIdentity;
+            name: string;
+            relayIndex: number;
+            subId: string;
+        }
+    >();
+
+    /**
      * Relay-side per-socket shape memo: `ws → subId → { cursor, epoch }`. The relay
      * delivers a multicast `relay_shape_poke` to a socket only when its memo for that
      * shape matches the poke's `fromCursor` AND `epoch`, then advances it — so a
@@ -6001,6 +6024,7 @@ abstract class ShardDO {
                     this.refreshSubscriptions(batch),
                     this.pokeShapeSubscribers(batch, frameCursor, frameEpoch),
                     this.multicastRelayShapePokes(batch, frameCursor ?? 0),
+                    this.proxyRelayShapePokes(batch, frameCursor ?? 0),
                 ]);
 
                 batch = this.pendingRefreshTables;
@@ -6432,18 +6456,20 @@ abstract class ShardDO {
             resolved,
         );
 
-        // Register a UNIFORM shape so the owner multicasts its future deltas to relays
-        // (slice B.2). A non-uniform shape is still seeded above (RLS-correct under the
-        // forwarded identity) but isn't registered — those sockets are served live by
-        // the per-socket relay proxy below, not the cohort multicast.
+        // A UNIFORM shape joins the cohort multicast (slice B.2): the relay must stamp
+        // the socket's memo at the registry FRONTIER (entry.cursor), NOT the global
+        // cursor the frames were computed at. The frontier only advances on a multicast
+        // poke, so an unrelated-table write that bumps the global cursor would otherwise
+        // leave a joiner's memo permanently ahead of every future `fromCursor` — silently
+        // frozen (plan 075 review HIGH-2). Seeding the full current membership while
+        // memoing at the (older) frontier is correct because a shape's membership is
+        // invariant between pokes.
         //
-        // The relay must stamp the socket's cohort memo at the registry FRONTIER
-        // (entry.cursor), NOT the global cursor the frames were computed at: the
-        // frontier only advances on a multicast poke, so an unrelated-table write that
-        // bumps the global cursor would otherwise leave a joiner's memo permanently
-        // ahead of every future `fromCursor` — silently frozen (plan 075 review HIGH-2).
-        // Seeding the full current membership while memoing at the (possibly older)
-        // frontier is correct because a shape's membership is invariant between pokes.
+        // A NON-uniform shape can't be cohort-multicast (its delta is identity-scoped),
+        // so it registers a per-socket proxy keyed by the forwarding relay + this socket
+        // — the owner computes its delta under the forwarded identity each flush and
+        // delivers a targeted poke (MEDIUM-3). Either way the socket's memo baseline is
+        // `cohortCursor` and live updates flow.
         let cohortCursor = cursor;
 
         if (this.isShapeRelayUniform(request.name, request.args)) {
@@ -6456,6 +6482,17 @@ abstract class ShardDO {
             }
 
             cohortCursor = entry.cursor;
+        } else if (request.relayIndex !== undefined && request.connectionId !== undefined) {
+            this.relayShapeProxies.set(`${String(request.relayIndex)}:${request.connectionId}:${request.subId}`, {
+                args: request.args,
+                connectionId: request.connectionId,
+                cursor,
+                epoch,
+                identity,
+                name: request.name,
+                relayIndex: request.relayIndex,
+                subId: request.subId,
+            });
         }
 
         this.pokeSequence += 1;
@@ -7698,8 +7735,10 @@ abstract class ShardDO {
 
         const request: RelayShapeSubscribe = {
             args: shape.args ?? {},
+            connectionId: this.readAttachment(ws).connectionId,
             identity: identity.identity,
             name: shape.name,
+            relayIndex: role.relayIndex,
             sinceEpoch: shape.sinceEpoch,
             sinceSeq: shape.sinceSeq,
             subId,
@@ -7821,6 +7860,65 @@ abstract class ShardDO {
     }
 
     /**
+     * Owner side (plan 075 review MEDIUM-3): for every NON-uniform relay-shape proxy
+     * whose table changed this flush, compute that one subscriber's membership diff
+     * over `(entry.cursor, frameCursor]` UNDER ITS OWN forwarded identity (RLS-correct)
+     * and deliver a `targetConnectionId`-addressed poke to just that socket's relay.
+     * Each entry tracks its own cursor (no cohort sharing — the diffs are
+     * identity-specific), advancing only on a delivered, non-empty diff. A no-op when
+     * the shard has no proxy subscribers; the per-flush cost is O(proxy subscribers),
+     * the same the owner would pay serving them directly.
+     */
+    private async proxyRelayShapePokes(changed: Set<string>, frameCursor: number): Promise<void> {
+        const ownerKey = this.state.id?.name;
+
+        if (ownerKey === undefined || this.relayShapeProxies.size === 0) {
+            return;
+        }
+
+        const sql = this.sql as SqlExec;
+        const epoch = this.currentCdcEpoch();
+        const sends: Promise<void>[] = [];
+
+        for (const entry of this.relayShapeProxies.values()) {
+            let resolved: ResolvedShape | undefined;
+
+            try {
+                resolved = this.resolveShape(entry.name, entry.args, entry.identity);
+            } catch {
+                continue;
+            }
+
+            if (resolved === undefined || resolved.global === true || !changed.has(resolved.table)) {
+                continue;
+            }
+
+            const fromCursor = entry.cursor;
+            const rowsPatch = this.buildShapeDiff(sql, resolved, fromCursor, frameCursor);
+
+            if (rowsPatch.length === 0) {
+                continue; // this subscriber's membership didn't change — leave its cursor put
+            }
+
+            entry.cursor = frameCursor;
+            const poke: RelayShapePoke = {
+                args: entry.args,
+                checkpoint: frameCursor,
+                epoch,
+                fromCursor,
+                name: entry.name,
+                rowsPatch,
+                targetConnectionId: entry.connectionId,
+                type: "relay_shape_poke",
+            };
+
+            sends.push(this.postRelayMessage(relayName(ownerKey, entry.relayIndex), poke));
+        }
+
+        await Promise.all(sends);
+    }
+
+    /**
      * Relay side (plan 075 Phase 3 slice B.2): deliver an owner-multicast shape
      * delta to this relay's cohort sockets. A socket receives it only while its memo
      * for the shape matches the poke's `fromCursor` AND `epoch` — so a socket that
@@ -7835,10 +7933,18 @@ abstract class ShardDO {
         let delivered = 0;
 
         for (const ws of this.state.getWebSockets()) {
-            const { shapes } = this.readAttachment(ws);
+            const attachment = this.readAttachment(ws);
+            const { shapes } = attachment;
             const memos = this.shapeRelayMemos.get(ws);
 
             if (shapes === undefined || memos === undefined) {
+                continue;
+            }
+
+            // A targeted (per-socket proxy) poke for a non-uniform shape goes ONLY to
+            // the one socket it was computed for; a cohort multicast (no target) goes
+            // to every matching socket (MEDIUM-3).
+            if (poke.targetConnectionId !== undefined && attachment.connectionId !== poke.targetConnectionId) {
                 continue;
             }
 
@@ -7982,6 +8088,14 @@ abstract class ShardDO {
         (this.sql as SqlExec).exec("DELETE FROM __lunora_relays WHERE idx = ?", index);
         const set = this.ownerRelaySet();
         set.delete(index);
+
+        // The drained relay's sockets are gone, so its per-socket proxy entries are
+        // dead — drop them so the owner stops computing diffs for them every flush.
+        for (const [key, entry] of this.relayShapeProxies) {
+            if (entry.relayIndex === index) {
+                this.relayShapeProxies.delete(key);
+            }
+        }
 
         // No relays left → no cohort can hold a relay subscriber, so the shape
         // registry and uniform cache are dead state. Clearing them on full drain

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -91,7 +91,7 @@ import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
 import { ReactiveCache, reactiveCacheKey, stableStringify } from "./reactive-cache";
 import type { OwnerRelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
-import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName } from "./relay";
+import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName, shapeRoutingKey } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
 import { buildSecurityAudit } from "./security-audit";
@@ -492,6 +492,18 @@ const IDEMPOTENCY_GC_INTERVAL_MS = 3_600_000;
  * Reserved shard name for the fallback Durable Object that hosts every
  * table without an explicit `.shardBy()` or `.global()` modifier.
  */
+
+/**
+ * The identity the owner computes a relay-multicast shape delta under (plan 075
+ * Phase 3). It is the empty (anonymous) identity, and it is **load-bearing for
+ * RLS**: a shape may only be relay-multicast if the uniform gate has PROVEN its
+ * resolved query is identical for this exact identity and every other — so the
+ * one delta computed here is correct for every cohort subscriber. The gate
+ * probes this same constant (see `probeShapeRelayUniform`), so the validated
+ * identity and the multicast identity can never drift apart.
+ */
+const RELAY_MULTICAST_IDENTITY: SubscriptionIdentity = {};
+
 const ROOT_SHARD_NAME = "__root__";
 
 /**
@@ -3940,7 +3952,7 @@ abstract class ShardDO {
      * owner-served. Cached per `(name, args)`, whose uniformity is stable.
      */
     protected isShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
-        const cacheKey = stableStringify({ args, name });
+        const cacheKey = shapeRoutingKey(name, args);
         const cached = this.shapeUniformCache.get(cacheKey);
 
         if (cached !== undefined) {
@@ -6419,7 +6431,7 @@ abstract class ShardDO {
         // forwarded identity) but isn't registered — it gets no live multicast (those
         // sockets are inherently low-fan-out; a per-socket proxy is a follow-up).
         if (this.isShapeRelayUniform(request.name, request.args)) {
-            const routingKey = stableStringify({ args: request.args, name: request.name });
+            const routingKey = shapeRoutingKey(request.name, request.args);
 
             if (!this.relayShapeRegistry.has(routingKey)) {
                 this.relayShapeRegistry.set(routingKey, { args: request.args, cursor, name: request.name });
@@ -7753,7 +7765,7 @@ abstract class ShardDO {
             let resolved: ResolvedShape | undefined;
 
             try {
-                resolved = this.resolveShape(entry.name, entry.args, {});
+                resolved = this.resolveShape(entry.name, entry.args, RELAY_MULTICAST_IDENTITY);
             } catch {
                 continue;
             }
@@ -7798,7 +7810,7 @@ abstract class ShardDO {
      * for custom mutators).
      */
     private deliverRelayShapePoke(poke: RelayShapePoke): void {
-        const routingKey = stableStringify({ args: poke.args, name: poke.name });
+        const routingKey = shapeRoutingKey(poke.name, poke.args);
 
         for (const ws of this.state.getWebSockets()) {
             const { shapes } = this.readAttachment(ws);
@@ -7809,7 +7821,7 @@ abstract class ShardDO {
             }
 
             for (const [subId, sub] of Object.entries(shapes)) {
-                if (memos.get(subId) !== poke.fromCursor || stableStringify({ args: sub.args ?? {}, name: sub.name }) !== routingKey) {
+                if (memos.get(subId) !== poke.fromCursor || shapeRoutingKey(sub.name, sub.args) !== routingKey) {
                     continue;
                 }
 
@@ -7962,31 +7974,89 @@ abstract class ShardDO {
         await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_detach" });
     }
 
-    /** Resolve a shape under two distinct probe identities and compare — the one-shot computation behind {@link ShardDO.isShapeRelayUniform}. */
+    /**
+     * The one-shot computation behind {@link ShardDO.isShapeRelayUniform}, made
+     * sound against the cross-identity row-leak the naive two-probe version allowed
+     * (plan 075 review). It is fail-closed on three independent grounds:
+     *
+     * 1. **Static RLS guard.** If the resolved table has ANY declared RLS *read*
+     * policy, reads are identity-scoped by construction — a single multicast delta
+     * can never be correct for every subscriber — so the shape is never relayable,
+     * regardless of what the probes happen to resolve. This closes the leak where a
+     * policy keyed on a claim the probes don't vary (org/tenant/role) resolves
+     * identically for all of them and looks falsely uniform.
+     * 2. **Multicast identity is in the probe set.** The first probe is the EXACT
+     * identity the owner multicasts under ({@link RELAY_MULTICAST_IDENTITY}); every
+     * other probe must match it. So the validated property is precisely the one the
+     * multicast relies on — never a different sampled identity.
+     * 3. **Claim-diverse probes.** The populated probes differ on every common claim
+     * dimension (user/org/tenant/team/role/groups), so a resolver that narrows on
+     * any of them diverges from the anonymous base and is rejected.
+     */
     private probeShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
-        const probeA: SubscriptionIdentity = { identity: { __lunora_relay_probe: 1, sub: "__lunora_probe_a__" }, userId: "__lunora_probe_a__" };
-        const probeB: SubscriptionIdentity = { identity: { __lunora_relay_probe: 2, sub: "__lunora_probe_b__" }, userId: "__lunora_probe_b__" };
+        // The multicast identity is the base; a populated probe per "side" varies
+        // every common claim dimension so an identity-dependent resolve diverges.
+        const populate = (side: string): SubscriptionIdentity => {return {
+            identity: {
+                groups: [`g_${side}`],
+                org_id: `org_${side}`,
+                orgId: `org_${side}`,
+                role: side,
+                roles: [side],
+                sub: `__lunora_probe_${side}__`,
+                team: `team_${side}`,
+                teamId: `team_${side}`,
+                tenant: `tenant_${side}`,
+                tenantId: `tenant_${side}`,
+            },
+            userId: `__lunora_probe_${side}__`,
+        }};
+        const probes: SubscriptionIdentity[] = [RELAY_MULTICAST_IDENTITY, populate("a"), populate("b")];
 
-        let a: ResolvedShape | undefined;
-        let b: ResolvedShape | undefined;
+        let base: ResolvedShape | undefined;
 
         try {
-            a = this.resolveShape(name, args, probeA);
-            b = this.resolveShape(name, args, probeB);
+            base = this.resolveShape(name, args, RELAY_MULTICAST_IDENTITY);
         } catch {
-            // An identity-gated resolve threw for a probe → not uniform (fail-closed).
+            // An identity-gated resolve threw for the base probe → not uniform (fail-closed).
             return false;
         }
 
-        if (a === undefined || b === undefined || a.global === true || b.global === true || a.table !== b.table) {
+        if (base === undefined || base.global === true) {
             return false;
         }
 
-        if (stableStringify(a.effectiveWhere) !== stableStringify(b.effectiveWhere) || stableStringify(a.columns) !== stableStringify(b.columns)) {
+        // Static RLS guard: an identity-scoped table is never relay-uniform.
+        if (this.rlsMetadata().policies.some((policy) => policy.on === "read" && policy.table === base.table)) {
             return false;
         }
 
-        return !this.shapeColumnsMasked(a.table, a.columns);
+        if (this.shapeColumnsMasked(base.table, base.columns)) {
+            return false;
+        }
+
+        const baseWhere = stableStringify(base.effectiveWhere);
+        const baseColumns = stableStringify(base.columns);
+
+        // Every probe (including the anonymous multicast identity) must resolve to
+        // the identical table + where + columns, or the shape isn't uniform.
+        return probes.every((probe) => {
+            let resolved: ResolvedShape | undefined;
+
+            try {
+                resolved = this.resolveShape(name, args, probe);
+            } catch {
+                return false;
+            }
+
+            return (
+                resolved !== undefined &&
+                resolved.global !== true &&
+                resolved.table === base.table &&
+                stableStringify(resolved.effectiveWhere) === baseWhere &&
+                stableStringify(resolved.columns) === baseColumns
+            );
+        });
     }
 
     /** Whether any column the shape projects from `table` is masked — a masked value is identity-dependent, so the shape can't be relay-uniform. */

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -91,7 +91,7 @@ import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
 import { ReactiveCache, reactiveCacheKey } from "./reactive-cache";
 import type { OwnerRelayFrame } from "./relay";
-import { parseRelayName, relayName } from "./relay";
+import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
 import { buildSecurityAudit } from "./security-audit";
@@ -1355,6 +1355,16 @@ const parsePositiveInt = (raw: string | undefined): number | undefined => {
 
     return Number.isFinite(value) && value > 0 ? value : undefined;
 };
+
+/** Default relay fan when a shard promotes (plan 075 Phase 2) — how many relays new connections spread across. Right-sizing per demand is a later phase; v1 uses a small fixed fan. */
+const DEFAULT_RELAY_FAN = 2;
+
+/** Default hard cap on relays per shard (the cost ceiling) so a viral shard can never silently spawn unbounded relay DOs. */
+const DEFAULT_MAX_RELAYS = 8;
+
+/** Read a positive-integer `LUNORA_*` env knob, falling back to `fallback` when unset or malformed. */
+const envPositiveInt = (env: unknown, key: string, fallback: number): number =>
+    parsePositiveInt((env as Record<string, unknown> | undefined)?.[key] as string | undefined) ?? fallback;
 
 /**
  * Resolve the per-dispatch console-stream toggle (`LUNORA_REQUEST_LOG_EMIT`).
@@ -7148,11 +7158,46 @@ abstract class ShardDO {
             return this.handleRelayMessage(request);
         }
 
+        // Promotion probe (plan 075 Phase 2): the runtime asks the owner how many
+        // relays to spread new connections across before a WS upgrade. Internal —
+        // reachable only via the runtime's worker-side forward, returns just a count.
+        if (url.pathname === "/_lunora/route" && request.method === "GET") {
+            return Promise.resolve(jsonResponse({ relayCount: this.computeRelayCount() }));
+        }
+
         if (request.headers.get("Upgrade") === "websocket") {
             return Promise.resolve(this.handleWebSocketUpgrade(request));
         }
 
         return undefined;
+    }
+
+    /**
+     * How many relays the runtime should spread new connections across for this
+     * shard (plan 075 Phase 2). `0` keeps every connection on the owner — the
+     * common, un-promoted path. A relay never promotes (flat single tier in v1).
+     * The owner promotes once its live socket count crosses `LUNORA_RELAY_THRESHOLD`
+     * (default {@link DEFAULT_PROMOTION_THRESHOLDS}`.tUp`), fanning to a fixed
+     * `LUNORA_RELAY_FAN` (capped by `LUNORA_MAX_RELAYS` — the cost ceiling). Demand
+     * right-sizing + collapse below `T_down` land in the next phase.
+     */
+    private computeRelayCount(): number {
+        const name = this.state.id?.name;
+
+        if (name !== undefined && parseRelayName(name) !== undefined) {
+            return 0;
+        }
+
+        const threshold = envPositiveInt(this.env, "LUNORA_RELAY_THRESHOLD", DEFAULT_PROMOTION_THRESHOLDS.tUp);
+
+        if (this.state.getWebSockets().length < threshold) {
+            return 0;
+        }
+
+        const maxRelays = envPositiveInt(this.env, "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS);
+        const fan = envPositiveInt(this.env, "LUNORA_RELAY_FAN", DEFAULT_RELAY_FAN);
+
+        return Math.min(maxRelays, Math.max(1, fan));
     }
 
     private handleWebSocketUpgrade(request: Request): Response {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -90,6 +90,8 @@ import { readQueryMetrics, recordQueryMetric } from "./query-metrics";
 import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
 import { ReactiveCache, reactiveCacheKey } from "./reactive-cache";
+import type { OwnerRelayFrame } from "./relay";
+import { parseRelayName, relayName } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
 import { buildSecurityAudit } from "./security-audit";
@@ -1448,6 +1450,29 @@ const constantTimeEqual = (a: string, b: string): boolean => {
     return diff === 0;
 };
 
+/** Minimal Durable Object stub shape the relay hub uses — just `fetch`. */
+interface RelayStub {
+    fetch: (input: string, init?: RequestInit) => Promise<Response>;
+}
+
+/** Minimal Durable Object namespace shape the relay hub resolves siblings through (`getByName` when present, else `idFromName` + `get`). */
+interface RelayNamespaceLike {
+    get: (id: unknown) => RelayStub;
+    getByName?: (name: string) => RelayStub;
+    idFromName: (name: string) => unknown;
+}
+
+/** Duck-type a namespace binding so a relay/owner can address its siblings, or `undefined` when the value isn't a DO namespace. */
+const asRelayNamespace = (value: unknown): RelayNamespaceLike | undefined => {
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+
+    const candidate = value as Partial<RelayNamespaceLike>;
+
+    return typeof candidate.idFromName === "function" && typeof candidate.get === "function" ? (candidate as RelayNamespaceLike) : undefined;
+};
+
 /**
  * Base class for shard Durable Objects.
  *
@@ -1784,6 +1809,27 @@ abstract class ShardDO {
     private readonly fanout = { shapePoke: createFanoutCounters(), whisper: createFanoutCounters() };
 
     /**
+     * The runtime's Durable Object namespace binding name (e.g. `"SHARD"`),
+     * forwarded as `x-lunora-shard-binding` on every request so a DO can address
+     * its siblings (`this.env[binding].getByName(...)`) for the relay hub. Absent
+     * in single-DO mode / the unit harness — when absent, the relay tier is inert
+     * and whispers stay shard-local (no behavior change). In-memory; re-learned per
+     * request.
+     */
+    private shardBinding: string | undefined;
+
+    /**
+     * Owner-side cache of the active relay indices for this shard (plan 075 Phase
+     * 2). Lazily hydrated from the reserved `__lunora_relays` SQLite table and kept
+     * in lockstep with it on attach/detach, so the hot whisper-forward path reads
+     * it synchronously without a storage round-trip.
+     */
+    private relaySetCache: Set<number> | undefined;
+
+    /** Relay-side guard: `true` once this relay has announced itself to its owner this wake, so a hot socket churn doesn't re-`relay_attach` on every subscribe. */
+    private relayAnnounced = false;
+
+    /**
      * Declared indexes (`table:index`) a query has exercised since this instance
      * woke, stamped by `getCtxDbIndexUseHook`. In-memory and reset on
      * hibernation/restart — drives the `unused_index` runtime advisory.
@@ -1892,8 +1938,17 @@ abstract class ShardDO {
     public async fetch(request: Request): Promise<Response> {
         const url = new URL(request.url);
 
-        if (request.headers.get("Upgrade") === "websocket") {
-            return this.handleWebSocketUpgrade(request);
+        // Learn the DO namespace binding the runtime routes through, so this DO can
+        // address its siblings for the relay hub (plan 075 Phase 2). Sent on every
+        // forwarded request; kept across requests once known.
+        this.shardBinding = request.headers.get("x-lunora-shard-binding") ?? this.shardBinding;
+
+        // The non-RPC routes (WS upgrade + the internal owner↔relay control channel)
+        // are handled up front; everything past here is the shard-local RPC endpoint.
+        const early = this.routeNonRpc(url, request);
+
+        if (early !== undefined) {
+            return early;
         }
 
         if (url.pathname !== "/rpc" || request.method !== "POST") {
@@ -2284,7 +2339,15 @@ abstract class ShardDO {
 
         if (envelope.type === "whisper_subscribe" || envelope.type === "whisper_unsubscribe") {
             if (typeof envelope.topic === "string" && envelope.topic.length > 0) {
-                this.setWhisperMembership(ws, envelope.topic, envelope.type === "whisper_subscribe");
+                const join = envelope.type === "whisper_subscribe";
+
+                this.setWhisperMembership(ws, envelope.topic, join);
+
+                // Relay tier (plan 075 Phase 2): once a relay holds a subscriber, it
+                // announces itself so the owner forwards whisper frames to it.
+                if (join) {
+                    await this.announceRelayIfNeeded();
+                }
             }
 
             return;
@@ -2292,7 +2355,7 @@ abstract class ShardDO {
 
         if (envelope.type === "whisper") {
             if (typeof envelope.topic === "string" && envelope.topic.length > 0) {
-                this.broadcastWhisper(ws, envelope.topic, envelope.data);
+                await this.broadcastWhisper(ws, envelope.topic, envelope.data);
             }
 
             return;
@@ -7072,6 +7135,26 @@ abstract class ShardDO {
         setter.call(this.state, new WebSocketRequestResponsePair(WS_KEEPALIVE_PING, WS_KEEPALIVE_PONG));
     }
 
+    /**
+     * Route the non-RPC requests `fetch` handles before the shard-local RPC
+     * endpoint: a WebSocket upgrade, and the internal `/_lunora/relay` owner↔relay
+     * control channel (never reachable by a client — the runtime forwards only
+     * worker-internal traffic there). Returns `undefined` for an RPC request, which
+     * `fetch` then dispatches.
+     * @returns the routed response, or `undefined` when this is an RPC request
+     */
+    private routeNonRpc(url: URL, request: Request): Promise<Response> | undefined {
+        if (url.pathname === "/_lunora/relay" && request.method === "POST") {
+            return this.handleRelayMessage(request);
+        }
+
+        if (request.headers.get("Upgrade") === "websocket") {
+            return Promise.resolve(this.handleWebSocketUpgrade(request));
+        }
+
+        return undefined;
+    }
+
     private handleWebSocketUpgrade(request: Request): Response {
         if (!this.isUpgradeAllowed(request)) {
             return new Response("Forbidden", { status: 403 });
@@ -7224,7 +7307,7 @@ abstract class ShardDO {
      * topic name. That matches the AnyCable model (and `from` is unforgeable),
      * but per-topic auth does not exist here; see `whisperSubscribe` on the client.
      */
-    private broadcastWhisper(sender: WebSocket, topic: string, data: unknown): void {
+    private async broadcastWhisper(sender: WebSocket, topic: string, data: unknown): Promise<void> {
         // Rate-limit first — cheapest rejection, and it bounds the O(connections)
         // fan-out cost a tight whisper loop would otherwise impose.
         if (!this.allowWhisper(sender)) {
@@ -7245,16 +7328,28 @@ abstract class ShardDO {
         const fromSuffix = from === undefined ? "" : `,"from":${JSON.stringify(from)}`;
         const frame = `{"type":"whisper","topic":${JSON.stringify(topic)},"data":${dataJson}${fromSuffix}}`;
 
-        // Observability (plan 075 Phase 1): tally the sockets scanned vs. actually
-        // delivered to so `getFanoutMetrics` shows the whisper fan-out width. Pure
-        // counting — it never changes who receives the whisper.
+        // Deliver to THIS DO's sockets (excluding the sender), then — when the shard
+        // is promoted (plan 075 Phase 2) — forward the opaque frame through the relay
+        // hub so it reaches the sockets on every other DO serving the shard.
+        this.deliverWhisperLocal(topic, frame, sender);
+        await this.forwardWhisperToHub(topic, frame);
+    }
+
+    /**
+     * Deliver an already-serialized whisper `frame` to every local socket joined to
+     * `topic`, excluding `exclude` (the sender, or `undefined` for a frame the relay
+     * hub forwarded in — its sender lives on another DO). Records the fan-out pass
+     * for `getFanoutMetrics` (plan 075 Phase 1). Pure delivery — no SQLite, no CDC.
+     * @returns the number of sockets the frame was sent to
+     */
+    private deliverWhisperLocal(topic: string, frame: string, exclude: undefined | WebSocket): number {
         let scanned = 0;
         let delivered = 0;
 
         for (const ws of this.state.getWebSockets()) {
             scanned += 1;
 
-            if (ws === sender || this.readAttachment(ws).whispers?.includes(topic) !== true) {
+            if (ws === exclude || this.readAttachment(ws).whispers?.includes(topic) !== true) {
                 continue;
             }
 
@@ -7263,9 +7358,188 @@ abstract class ShardDO {
             delivered += 1;
         }
 
-        // The broadcast is synchronous (no awaited I/O), so no wall-clock is
-        // captured (`0` ms); the scanned/delivered socket counts are exact.
         this.fanout.whisper = recordFanoutPass(this.fanout.whisper, scanned, delivered, 0);
+
+        return delivered;
+    }
+
+    /**
+     * Forward an opaque whisper frame through the relay hub (plan 075 Phase 2). A
+     * relay sends it UP to its owner (stamped with its own index so the owner won't
+     * echo it back); the owner sends it to every relay in its set. A no-op in
+     * single-DO mode (no binding) or when the owner has no relays — so the common,
+     * un-promoted path stays free.
+     */
+    private async forwardWhisperToHub(topic: string, frame: string): Promise<void> {
+        const role = this.relayRole();
+
+        if (role === undefined) {
+            return;
+        }
+
+        if (role.relayIndex !== undefined) {
+            await this.postRelayMessage(role.ownerKey, { frame, originRelay: role.relayIndex, topic, type: "relay_frame" });
+
+            return;
+        }
+
+        const relays = this.ownerRelaySet();
+
+        if (relays.size === 0) {
+            return;
+        }
+
+        await Promise.all([...relays].map((index) => this.postRelayMessage(relayName(role.ownerKey, index), { frame, topic, type: "relay_frame" })));
+    }
+
+    /**
+     * This DO's role in the relay hub, or `undefined` when it can't address siblings
+     * (no namespace binding learned, or no DO name) — i.e. single-DO mode, where the
+     * relay tier is inert. An owner returns its own key with no `relayIndex`; a relay
+     * returns its owner's key + its slot.
+     * @returns `{ ownerKey, relayIndex? }`, or `undefined` when relaying isn't possible
+     */
+    private relayRole(): undefined | { ownerKey: string; relayIndex?: number } {
+        const name = this.state.id?.name;
+
+        if (name === undefined || this.relayNamespace() === undefined) {
+            return undefined;
+        }
+
+        const parsed = parseRelayName(name);
+
+        return parsed === undefined ? { ownerKey: name } : { ownerKey: parsed.ownerKey, relayIndex: parsed.relayIndex };
+    }
+
+    /** Resolve this DO's own namespace binding (learned from `x-lunora-shard-binding`) so it can address sibling owners/relays, or `undefined` when unknown. */
+    private relayNamespace(): RelayNamespaceLike | undefined {
+        if (this.shardBinding === undefined) {
+            return undefined;
+        }
+
+        return asRelayNamespace((this.env as Record<string, unknown> | undefined)?.[this.shardBinding]);
+    }
+
+    /**
+     * POST an owner↔relay control message to a sibling DO by name. Best-effort: a
+     * transient cross-DO failure drops the frame (whisper is ephemeral — there is no
+     * resume) rather than throwing into the WS message handler. Carries the binding
+     * forward so the receiver can address its own siblings in turn.
+     */
+    private async postRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<void> {
+        const namespace = this.relayNamespace();
+
+        if (namespace === undefined) {
+            return;
+        }
+
+        const stub = typeof namespace.getByName === "function" ? namespace.getByName(targetName) : namespace.get(namespace.idFromName(targetName));
+
+        try {
+            await stub.fetch("https://relay.internal/_lunora/relay", {
+                body: JSON.stringify(message),
+                headers: { "content-type": "application/json", "x-lunora-shard-binding": this.shardBinding ?? "" },
+                method: "POST",
+            });
+        } catch {
+            /* best-effort hub forwarding — a dropped ephemeral frame is tolerable */
+        }
+    }
+
+    /**
+     * Serve the internal `/_lunora/relay` control channel (plan 075 Phase 2). An
+     * `attach`/`detach` updates the owner's relay set; a `frame` is delivered to this
+     * DO's local members and — on the owner, for a frame a relay forwarded up —
+     * re-forwarded to every OTHER relay, so one whisper reaches the whole shard
+     * exactly once per socket.
+     */
+    private async handleRelayMessage(request: Request): Promise<Response> {
+        let message: OwnerRelayFrame;
+
+        try {
+            message = await request.json();
+        } catch {
+            return new Response("bad request", { status: 400 });
+        }
+
+        if (message.type === "relay_attach") {
+            this.addRelayToSet(message.relayIndex);
+
+            // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body; null is the standard "no body" value
+            return new Response(null, { status: 204 });
+        }
+
+        if (message.type === "relay_detach") {
+            this.removeRelayFromSet(message.relayIndex);
+
+            // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body
+            return new Response(null, { status: 204 });
+        }
+
+        this.deliverWhisperLocal(message.topic, message.frame, undefined);
+
+        const role = this.relayRole();
+
+        if (role !== undefined && role.relayIndex === undefined) {
+            // Owner re-distributes a relay-forwarded frame to the OTHER relays.
+            await Promise.all(
+                [...this.ownerRelaySet()]
+                    .filter((index) => index !== message.originRelay)
+                    .map((index) =>
+                        this.postRelayMessage(relayName(role.ownerKey, index), { frame: message.frame, topic: message.topic, type: "relay_frame" }),
+                    ),
+            );
+        }
+
+        // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body
+        return new Response(null, { status: 204 });
+    }
+
+    /** Ensure the reserved owner-side relay-set table exists (auto-hidden from the data browser by the `__lunora` prefix). */
+    private ensureRelayTable(): void {
+        (this.sql as SqlExec).exec("CREATE TABLE IF NOT EXISTS __lunora_relays (idx INTEGER PRIMARY KEY)");
+    }
+
+    /** The owner's active relay indices, hydrated once from `__lunora_relays` and cached in-memory for the synchronous forward path. */
+    private ownerRelaySet(): Set<number> {
+        if (this.relaySetCache === undefined) {
+            this.ensureRelayTable();
+            const rows = (this.sql as SqlExec).exec<{ idx: bigint | number }>("SELECT idx FROM __lunora_relays").toArray();
+
+            this.relaySetCache = new Set(rows.map((row) => Number(row.idx)));
+        }
+
+        return this.relaySetCache;
+    }
+
+    /** Record a relay as active in the owner's set (idempotent), persisting it so the set survives the owner's hibernation. */
+    private addRelayToSet(index: number): void {
+        this.ensureRelayTable();
+        (this.sql as SqlExec).exec("INSERT OR IGNORE INTO __lunora_relays (idx) VALUES (?)", index);
+        this.ownerRelaySet().add(index);
+    }
+
+    /** Drop a drained relay from the owner's set so the owner stops forwarding to it. */
+    private removeRelayFromSet(index: number): void {
+        this.ensureRelayTable();
+        (this.sql as SqlExec).exec("DELETE FROM __lunora_relays WHERE idx = ?", index);
+        this.ownerRelaySet().delete(index);
+    }
+
+    /** A relay announces itself to its owner (once per wake) on its first subscriber, so the owner forwards whisper frames to it. No-op on an owner or in single-DO mode. */
+    private async announceRelayIfNeeded(): Promise<void> {
+        if (this.relayAnnounced) {
+            return;
+        }
+
+        const role = this.relayRole();
+
+        if (role?.relayIndex === undefined) {
+            return;
+        }
+
+        this.relayAnnounced = true;
+        await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_attach" });
     }
 
     // eslint-disable-next-line class-methods-use-this -- cohesive DO instance method grouped with the hibernation/attachment helpers; reads only the socket

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1876,7 +1876,7 @@ abstract class ShardDO {
 
         // The non-RPC routes (WS upgrade + the internal owner↔relay control channel)
         // are handled up front; everything past here is the shard-local RPC endpoint.
-        const early = this.routeNonRpc(url, request);
+        const early = await this.routeNonRpc(url, request);
 
         if (early !== undefined) {
             return early;
@@ -7126,22 +7126,22 @@ abstract class ShardDO {
      * `fetch` then dispatches.
      * @returns the routed response, or `undefined` when this is an RPC request
      */
-    private routeNonRpc(url: URL, request: Request): Promise<Response> | undefined {
+    private async routeNonRpc(url: URL, request: Request): Promise<Response | undefined> {
         if (url.pathname === "/_lunora/relay" && request.method === "POST") {
             // The relay tier is inert on an unnamed (single-DO) DO — nothing forwards
             // control frames there, so a 404 is the honest answer.
-            return this.relay?.handleControl(request) ?? Promise.resolve(new Response("relay tier inactive", { status: 404 }));
+            return this.relay ? await this.relay.handleControl(request) : new Response("relay tier inactive", { status: 404 });
         }
 
         // Promotion probe (plan 075 Phase 2): the runtime asks the owner how many
         // relays to spread new connections across before a WS upgrade. Internal —
         // reachable only via the runtime's worker-side forward, returns just a count.
         if (url.pathname === "/_lunora/route" && request.method === "GET") {
-            return Promise.resolve(jsonResponse({ relayCount: this.relay?.relayCount() ?? 0 }));
+            return jsonResponse({ relayCount: this.relay?.relayCount() ?? 0 });
         }
 
         if (request.headers.get("Upgrade") === "websocket") {
-            return Promise.resolve(this.handleWebSocketUpgrade(request));
+            return this.handleWebSocketUpgrade(request);
         }
 
         return undefined;

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -90,7 +90,7 @@ import { readQueryMetrics, recordQueryMetric } from "./query-metrics";
 import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
 import { ReactiveCache, reactiveCacheKey, stableStringify } from "./reactive-cache";
-import type { OwnerRelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
+import type { OwnerRelayFrame, RelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
 import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName, shapeRoutingKey } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
@@ -503,6 +503,11 @@ const IDEMPOTENCY_GC_INTERVAL_MS = 3_600_000;
  * identity and the multicast identity can never drift apart.
  */
 const RELAY_MULTICAST_IDENTITY: SubscriptionIdentity = {};
+
+/** Exhaustiveness guard for the {@link OwnerRelayFrame} dispatch — an unhandled member is a compile error here, and an impossible runtime frame throws rather than silently mis-routing. */
+const assertNeverFrame = (frame: never): never => {
+    throw new Error(`unhandled relay frame: ${JSON.stringify(frame)}`);
+};
 
 const ROOT_SHARD_NAME = "__root__";
 
@@ -1864,12 +1869,13 @@ abstract class ShardDO {
     private readonly relayShapeRegistry = new Map<string, { args: Record<string, unknown>; cursor: number; name: string }>();
 
     /**
-     * Relay-side per-socket shape memo: `ws → subId → cursor`. The relay delivers a
-     * multicast `relay_shape_poke` to a socket only when its memo for that shape
-     * equals the poke's `fromCursor`, then advances it — so a socket that seeded at
-     * a different cursor never double-applies a delta (plan 075 Phase 3 slice B.2).
+     * Relay-side per-socket shape memo: `ws → subId → { cursor, epoch }`. The relay
+     * delivers a multicast `relay_shape_poke` to a socket only when its memo for that
+     * shape matches the poke's `fromCursor` AND `epoch`, then advances it — so a
+     * socket that seeded at a different cursor (or in a prior CDC epoch) never
+     * double-applies a delta (plan 075 Phase 3 slice B.2).
      */
-    private readonly shapeRelayMemos = new WeakMap<WebSocket, Map<string, number>>();
+    private readonly shapeRelayMemos = new WeakMap<WebSocket, Map<string, { cursor: number; epoch?: string }>>();
 
     /**
      * Declared indexes (`table:index`) a query has exercised since this instance
@@ -6428,14 +6434,28 @@ abstract class ShardDO {
 
         // Register a UNIFORM shape so the owner multicasts its future deltas to relays
         // (slice B.2). A non-uniform shape is still seeded above (RLS-correct under the
-        // forwarded identity) but isn't registered — it gets no live multicast (those
-        // sockets are inherently low-fan-out; a per-socket proxy is a follow-up).
+        // forwarded identity) but isn't registered — those sockets are served live by
+        // the per-socket relay proxy below, not the cohort multicast.
+        //
+        // The relay must stamp the socket's cohort memo at the registry FRONTIER
+        // (entry.cursor), NOT the global cursor the frames were computed at: the
+        // frontier only advances on a multicast poke, so an unrelated-table write that
+        // bumps the global cursor would otherwise leave a joiner's memo permanently
+        // ahead of every future `fromCursor` — silently frozen (plan 075 review HIGH-2).
+        // Seeding the full current membership while memoing at the (possibly older)
+        // frontier is correct because a shape's membership is invariant between pokes.
+        let cohortCursor = cursor;
+
         if (this.isShapeRelayUniform(request.name, request.args)) {
             const routingKey = shapeRoutingKey(request.name, request.args);
+            let entry = this.relayShapeRegistry.get(routingKey);
 
-            if (!this.relayShapeRegistry.has(routingKey)) {
-                this.relayShapeRegistry.set(routingKey, { args: request.args, cursor, name: request.name });
+            if (entry === undefined) {
+                entry = { args: request.args, cursor, name: request.name };
+                this.relayShapeRegistry.set(routingKey, entry);
             }
+
+            cohortCursor = entry.cursor;
         }
 
         this.pokeSequence += 1;
@@ -6447,7 +6467,7 @@ abstract class ShardDO {
             pokeId: `poke-${String(this.pokeSequence)}`,
         });
 
-        return { cursor, frames };
+        return { cursor: cohortCursor, epoch, frames };
     }
 
     /**
@@ -7717,22 +7737,22 @@ abstract class ShardDO {
 
         // Record this socket's cohort memo so the owner's multicast deltas land
         // exactly once (slice B.2): the next `relay_shape_poke` for this shape is
-        // delivered only while the memo still equals the poke's `fromCursor`.
-        this.recordRelayShapeMemo(ws, subId, seed.cursor ?? 0);
+        // delivered only while the memo still matches the poke's `fromCursor`+`epoch`.
+        this.recordRelayShapeMemo(ws, subId, seed.cursor ?? 0, seed.epoch);
 
         return "ok";
     }
 
-    /** Record a relay socket's cohort cursor for `subId` (creating the per-socket map lazily). */
-    private recordRelayShapeMemo(ws: WebSocket, subId: string, cursor: number): void {
+    /** Record a relay socket's cohort cursor + epoch for `subId` (creating the per-socket map lazily). */
+    private recordRelayShapeMemo(ws: WebSocket, subId: string, cursor: number, epoch: string | undefined): void {
         let memos = this.shapeRelayMemos.get(ws);
 
         if (memos === undefined) {
-            memos = new Map<string, number>();
+            memos = new Map<string, { cursor: number; epoch?: string }>();
             this.shapeRelayMemos.set(ws, memos);
         }
 
-        memos.set(subId, cursor);
+        memos.set(subId, { cursor, epoch });
     }
 
     /**
@@ -7803,14 +7823,16 @@ abstract class ShardDO {
     /**
      * Relay side (plan 075 Phase 3 slice B.2): deliver an owner-multicast shape
      * delta to this relay's cohort sockets. A socket receives it only while its memo
-     * for the shape equals the poke's `fromCursor` — so a socket that seeded at a
-     * different cursor is skipped and never double-applies — then advances to
-     * `checkpoint`. The `rowsPatch` is wrapped in poke frames per socket (each its
-     * own `subId`); `lastMutationId` is omitted (relayed sockets are owner-served
-     * for custom mutators).
+     * for the shape matches the poke's `fromCursor` AND `epoch` — so a socket that
+     * seeded at a different cursor (or in a prior CDC epoch) is skipped and never
+     * double-applies — then advances to `checkpoint`. The `rowsPatch` is wrapped in
+     * poke frames per socket (each its own `subId`); `lastMutationId` is omitted
+     * (relayed sockets are owner-served for custom mutators). Returns the number of
+     * sockets actually delivered to, for fan-out accounting.
      */
-    private deliverRelayShapePoke(poke: RelayShapePoke): void {
+    private deliverRelayShapePoke(poke: RelayShapePoke): number {
         const routingKey = shapeRoutingKey(poke.name, poke.args);
+        let delivered = 0;
 
         for (const ws of this.state.getWebSockets()) {
             const { shapes } = this.readAttachment(ws);
@@ -7821,7 +7843,9 @@ abstract class ShardDO {
             }
 
             for (const [subId, sub] of Object.entries(shapes)) {
-                if (memos.get(subId) !== poke.fromCursor || shapeRoutingKey(sub.name, sub.args) !== routingKey) {
+                const memo = memos.get(subId);
+
+                if (memo?.cursor !== poke.fromCursor || memo.epoch !== poke.epoch || shapeRoutingKey(sub.name, sub.args) !== routingKey) {
                     continue;
                 }
 
@@ -7838,9 +7862,12 @@ abstract class ShardDO {
                     trySendFrame(ws, frame);
                 }
 
-                memos.set(subId, poke.checkpoint);
+                memos.set(subId, { cursor: poke.checkpoint, epoch: poke.epoch });
+                delivered += 1;
             }
         }
+
+        return delivered;
     }
 
     /**
@@ -7859,34 +7886,53 @@ abstract class ShardDO {
             return new Response("bad request", { status: 400 });
         }
 
-        if (message.type === "relay_shape_subscribe") {
-            // Owner seeds a relay's shape under the forwarded identity and returns
-            // the serialized poke frames for the relay to deliver (plan 075 Phase 3).
-            return jsonResponse(this.buildShapeSeedFrames(message));
+        // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body; null is the standard "no body" value
+        const noContent = (): Response => new Response(null, { status: 204 });
+
+        switch (message.type) {
+            case "relay_attach": {
+                this.addRelayToSet(message.relayIndex);
+
+                return noContent();
+            }
+            case "relay_detach": {
+                this.removeRelayFromSet(message.relayIndex);
+
+                return noContent();
+            }
+            case "relay_frame": {
+                return this.handleRelayWhisperFrame(message);
+            }
+            case "relay_shape_poke": {
+                // Owner-multicast shape delta → deliver to this relay's cohort sockets,
+                // recording the fan-out so a relay's metrics reflect the work it does.
+                const iterated = this.state.getWebSockets().length;
+                const startMs = Date.now();
+                const delivered = this.deliverRelayShapePoke(message);
+
+                this.fanout.shapePoke = recordFanoutPass(this.fanout.shapePoke, iterated, delivered, Date.now() - startMs);
+
+                return noContent();
+            }
+            case "relay_shape_subscribe": {
+                // Owner seeds a relay's shape under the forwarded identity and returns
+                // the serialized poke frames for the relay to deliver (plan 075 Phase 3).
+                return jsonResponse(this.buildShapeSeedFrames(message));
+            }
+            default: {
+                // Exhaustiveness guard: a new OwnerRelayFrame member added to `relay.ts`
+                // without a case here becomes a COMPILE error, not a runtime null-deref.
+                return assertNeverFrame(message);
+            }
         }
+    }
 
-        if (message.type === "relay_shape_poke") {
-            // Owner-multicast shape delta → deliver to this relay's cohort sockets.
-            this.deliverRelayShapePoke(message);
-
-            // eslint-disable-next-line unicorn/no-null -- 204 No Content
-            return new Response(null, { status: 204 });
-        }
-
-        if (message.type === "relay_attach") {
-            this.addRelayToSet(message.relayIndex);
-
-            // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body; null is the standard "no body" value
-            return new Response(null, { status: 204 });
-        }
-
-        if (message.type === "relay_detach") {
-            this.removeRelayFromSet(message.relayIndex);
-
-            // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body
-            return new Response(null, { status: 204 });
-        }
-
+    /**
+     * Deliver a whisper `relay_frame` to this DO's local members and — on the owner,
+     * for a frame a relay forwarded up — re-forward it to every OTHER relay, so one
+     * whisper reaches the whole shard exactly once per socket (plan 075 Phase 2).
+     */
+    private async handleRelayWhisperFrame(message: RelayFrame): Promise<Response> {
         this.deliverWhisperLocal(message.topic, message.frame, undefined);
 
         const role = this.relayRole();
@@ -7934,7 +7980,18 @@ abstract class ShardDO {
     private removeRelayFromSet(index: number): void {
         this.ensureRelayTable();
         (this.sql as SqlExec).exec("DELETE FROM __lunora_relays WHERE idx = ?", index);
-        this.ownerRelaySet().delete(index);
+        const set = this.ownerRelaySet();
+        set.delete(index);
+
+        // No relays left → no cohort can hold a relay subscriber, so the shape
+        // registry and uniform cache are dead state. Clearing them on full drain
+        // bounds their growth (otherwise every distinct (name, args) ever relayed
+        // would accumulate for the instance's life and be re-resolved each flush);
+        // they re-register lazily on the next relay subscribe (plan 075 review).
+        if (set.size === 0) {
+            this.relayShapeRegistry.clear();
+            this.shapeUniformCache.clear();
+        }
     }
 
     /** A relay announces itself to its owner (once per wake) on its first subscriber, so the owner forwards whisper frames to it. No-op on an owner or in single-DO mode. */
@@ -7996,21 +8053,23 @@ abstract class ShardDO {
     private probeShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
         // The multicast identity is the base; a populated probe per "side" varies
         // every common claim dimension so an identity-dependent resolve diverges.
-        const populate = (side: string): SubscriptionIdentity => {return {
-            identity: {
-                groups: [`g_${side}`],
-                org_id: `org_${side}`,
-                orgId: `org_${side}`,
-                role: side,
-                roles: [side],
-                sub: `__lunora_probe_${side}__`,
-                team: `team_${side}`,
-                teamId: `team_${side}`,
-                tenant: `tenant_${side}`,
-                tenantId: `tenant_${side}`,
-            },
-            userId: `__lunora_probe_${side}__`,
-        }};
+        const populate = (side: string): SubscriptionIdentity => {
+            return {
+                identity: {
+                    groups: [`g_${side}`],
+                    org_id: `org_${side}`,
+                    orgId: `org_${side}`,
+                    role: side,
+                    roles: [side],
+                    sub: `__lunora_probe_${side}__`,
+                    team: `team_${side}`,
+                    teamId: `team_${side}`,
+                    tenant: `tenant_${side}`,
+                    tenantId: `tenant_${side}`,
+                },
+                userId: `__lunora_probe_${side}__`,
+            };
+        };
         const probes: SubscriptionIdentity[] = [RELAY_MULTICAST_IDENTITY, populate("a"), populate("b")];
 
         let base: ResolvedShape | undefined;

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -47,6 +47,7 @@ import type {
     AuditLogResult,
     ColumnMeta,
     CreateWorkflowInstanceResult,
+    FanoutMetricsResult,
     FilterClause,
     FilterOperator,
     FlagsResult,
@@ -66,14 +67,17 @@ import type {
 import {
     ADMIN_FUNCTION_PREFIX,
     ADMIN_FUNCTIONS,
+    createFanoutCounters,
     facetColumn,
     findStorageReferences,
     FLAGS_FUNCTION_PREFIX,
     listTables,
     MAX_PAGE_SIZE,
     readTablePage,
+    recordFanoutPass,
     RELATION_FUNCTION_PREFIX,
     selectMatchingIds,
+    summarizeFanoutTopics,
     summarizeSubscriptions,
 } from "./introspect";
 import type { LogEntry } from "./log-buffer";
@@ -1765,6 +1769,19 @@ abstract class ShardDO {
      * (durable aggregation would be a separate, heavier feature).
      */
     private readonly metrics = { errors: 0, requests: 0, sinceMs: Date.now() };
+
+    /**
+     * Running fan-out cost counters surfaced by the
+     * `__lunora_admin__:getFanoutMetrics` RPC — one tally for the reactive
+     * shape-poke path (`pokeShapeSubscribers`) and one for the whisper broadcast
+     * path (`broadcastWhisper`). Each pass records the sockets it iterated (the
+     * O(subscribers) cost) and delivered to. In-memory and reset on
+     * hibernation/restart, sharing `metrics.sinceMs` as the "since this instance
+     * woke" epoch. This is the observability half of plan 075's auto-elastic
+     * relay tier (Phase 1): measure the per-flush fan-out cost so the promotion
+     * threshold is grounded in real numbers, with no behavior change.
+     */
+    private readonly fanout = { shapePoke: createFanoutCounters(), whisper: createFanoutCounters() };
 
     /**
      * Declared indexes (`table:index`) a query has exercised since this instance
@@ -5231,6 +5248,13 @@ abstract class ShardDO {
             return this.collectSubscriptions();
         }
 
+        if (functionPath === ADMIN_FUNCTIONS.getFanoutMetrics) {
+            // Per-topic subscriber counts + running fan-out cost counters (plan
+            // 075 Phase 1 observability). Deployment-wide live state, so it carries
+            // the wildcard like the other read-only admin reads.
+            return this.collectFanoutMetrics();
+        }
+
         if (functionPath === ADMIN_FUNCTIONS.getLogs) {
             return { entries: this.logs.entries() };
         }
@@ -5311,6 +5335,21 @@ abstract class ShardDO {
      */
     private collectSubscriptions(): SubscriptionsResult {
         return summarizeSubscriptions(this.state.getWebSockets().map((ws) => this.readAttachment(ws)));
+    }
+
+    /**
+     * Assemble the `__lunora_admin__:getFanoutMetrics` payload for the Studio
+     * fan-out observability panel (plan 075 Phase 1). The point-in-time topic
+     * subscriber counts are folded live from each socket's attachment via
+     * {@link summarizeFanoutTopics}; the running per-path cost counters are the
+     * in-memory {@link ShardDO.fanout} tallies, sharing `metrics.sinceMs` as the
+     * "since this instance woke" epoch. Read-only: touches no SQLite and mutates
+     * no socket state.
+     */
+    private collectFanoutMetrics(): FanoutMetricsResult {
+        const summary = summarizeFanoutTopics(this.state.getWebSockets().map((ws) => this.readAttachment(ws)));
+
+        return { ...summary, shapePoke: this.fanout.shapePoke, sinceMs: this.metrics.sinceMs, whisper: this.fanout.whisper };
     }
 
     /** Resolve a `getAuditLog` admin read, parsing the optional `limit`/`sinceSeq` cursor args and ensuring the reserved table first. */
@@ -6209,6 +6248,11 @@ abstract class ShardDO {
         // per flush so a slice is never reused across writes (it would go stale).
         const opRangeCache = new Map<string, Map<string, CdcChange>>();
 
+        // Observability (plan 075 Phase 1): count sockets this flush actually
+        // poked so `getFanoutMetrics` can report the delivered-vs-iterated split.
+        // Pure measurement — it never alters which sockets are poked.
+        let delivered = 0;
+
         const pokeOne = async (ws: WebSocket): Promise<void> => {
             if (this.isSocketExpired(ws)) {
                 this.dropExpiredSocket(ws);
@@ -6242,6 +6286,8 @@ abstract class ShardDO {
                     await awaitWsDrain(ws);
 
                     if (this.sendPoke(ws, parts, checkpoint, frameEpoch, undefined)) {
+                        delivered += 1;
+
                         for (const subId of partAdvanced) {
                             this.recordShapeMemo(ws, subId, checkpoint);
                         }
@@ -6260,7 +6306,16 @@ abstract class ShardDO {
         // Bounded fan-out matching `refreshSubscriptions`: each worker drains its
         // sockets one at a time so the per-send `awaitWsDrain` gate above applies
         // backpressure on a slow consumer. See {@link runSocketPool}.
+        const startMs = Date.now();
+
         await runSocketPool(sockets, pokeOne);
+
+        // Record the fan-out cost of this flush (plan 075 Phase 1). `startMs` wraps
+        // the whole pool, so the elapsed time captures the awaited drain/send I/O
+        // across every socket; it is coarse (a DO clock advances only on I/O) but
+        // the socket counts are exact. Recorded even for a zero-delivery flush so
+        // the iterated-vs-delivered ratio reflects wasted work honestly.
+        this.fanout.shapePoke = recordFanoutPass(this.fanout.shapePoke, sockets.length, delivered, Date.now() - startMs);
     }
 
     /**
@@ -7190,14 +7245,27 @@ abstract class ShardDO {
         const fromSuffix = from === undefined ? "" : `,"from":${JSON.stringify(from)}`;
         const frame = `{"type":"whisper","topic":${JSON.stringify(topic)},"data":${dataJson}${fromSuffix}}`;
 
+        // Observability (plan 075 Phase 1): tally the sockets scanned vs. actually
+        // delivered to so `getFanoutMetrics` shows the whisper fan-out width. Pure
+        // counting — it never changes who receives the whisper.
+        let scanned = 0;
+        let delivered = 0;
+
         for (const ws of this.state.getWebSockets()) {
+            scanned += 1;
+
             if (ws === sender || this.readAttachment(ws).whispers?.includes(topic) !== true) {
                 continue;
             }
 
             // Best-effort fan-out; a closed socket is simply skipped.
             trySendFrame(ws, frame);
+            delivered += 1;
         }
+
+        // The broadcast is synchronous (no awaited I/O), so no wall-clock is
+        // captured (`0` ms); the scanned/delivered socket counts are exact.
+        this.fanout.whisper = recordFanoutPass(this.fanout.whisper, scanned, delivered, 0);
     }
 
     // eslint-disable-next-line class-methods-use-this -- cohesive DO instance method grouped with the hibernation/attachment helpers; reads only the socket

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -90,7 +90,7 @@ import { readQueryMetrics, recordQueryMetric } from "./query-metrics";
 import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
 import { ReactiveCache, reactiveCacheKey, stableStringify } from "./reactive-cache";
-import type { OwnerRelayFrame } from "./relay";
+import type { OwnerRelayFrame, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
 import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
@@ -6258,6 +6258,14 @@ abstract class ShardDO {
         const attachment = this.readAttachment(ws);
         const identity: SubscriptionIdentity = { identity: attachment.identity, userId: attachment.userId };
 
+        // Relay tier (plan 075 Phase 3): a relay holds no op-log, so it forwards the
+        // seed to the owner — the only DO that can resolve the shape against real
+        // data, under this socket's verified identity (RLS-correct) — and delivers
+        // the owner-computed frames. The owner-served path is unchanged.
+        if (this.relayRole()?.relayIndex !== undefined) {
+            return this.seedShapeViaOwner(ws, subId, shape, identity);
+        }
+
         let resolved: ResolvedShape | undefined;
 
         try {
@@ -6311,16 +6319,37 @@ abstract class ShardDO {
      * it to a structured `shape_subscribe` error.
      */
     private async seedOpLogShape(ws: WebSocket, subId: string, shape: ShapeSubscriptionQuery, resolved: ResolvedShape): Promise<"ok"> {
+        const { baseCheckpoint, cursor, epoch, rowsPatch } = this.computeOpLogShapeSeed(shape, resolved);
+
+        // Await drain before the (potentially large) seed poke so a slow consumer
+        // can't grow this socket's outbound buffer without bound.
+        await awaitWsDrain(ws);
+
+        if (this.sendPoke(ws, [{ rowsPatch, shapeId: subId }], cursor, epoch, baseCheckpoint)) {
+            this.recordShapeMemo(ws, subId, cursor);
+        }
+
+        return "ok";
+    }
+
+    /**
+     * Compute an op-log shape seed (cursor, epoch, the resume base, and the
+     * membership `rowsPatch`) WITHOUT sending — the shared core of
+     * {@link ShardDO.seedOpLogShape} (sends to a local socket) and
+     * {@link ShardDO.buildShapeSeedFrames} (serializes the frames for a relay to
+     * deliver, plan 075 Phase 3). Resume only when CDC is on, the client is on this
+     * epoch, its checkpoint doesn't run ahead of ours, and the log still covers it;
+     * else a full re-seed. A fully-compacted log only proves "nothing missed" when
+     * the client is already at `cursor`.
+     * @returns the cursor/epoch, the resume base (`baseCheckpoint`), and the membership patch
+     */
+    private computeOpLogShapeSeed(
+        shape: ShapeSubscriptionQuery,
+        resolved: ResolvedShape,
+    ): { baseCheckpoint: number | undefined; cursor: number; epoch: string | undefined; rowsPatch: ShapeRowOp[] } {
         const sql = this.sql as SqlExec;
         const cursor = this.currentCdcCursor() ?? 0;
         const epoch = this.currentCdcEpoch();
-
-        // Resume only when CDC is on, the client is on this epoch, its checkpoint
-        // doesn't run ahead of ours, and the log still covers it (else a gap means
-        // we can't prove what it missed → full re-seed). A fully-compacted log
-        // (`floor === undefined`, no ops retained) only proves "nothing missed"
-        // when the client is already at `cursor`; if it lags, the changes between
-        // its checkpoint and now were compacted away, so it must re-seed.
         const floor = this.cdcEnabled() ? minCdcSeq(sql) : undefined;
         const canResume =
             this.cdcEnabled() &&
@@ -6332,15 +6361,48 @@ abstract class ShardDO {
         const rowsPatch =
             canResume && shape.sinceSeq !== undefined ? this.buildShapeDiff(sql, resolved, shape.sinceSeq, cursor) : this.buildShapeSeed(sql, resolved);
 
-        // Await drain before the (potentially large) seed poke so a slow consumer
-        // can't grow this socket's outbound buffer without bound.
-        await awaitWsDrain(ws);
+        return { baseCheckpoint: canResume ? shape.sinceSeq : undefined, cursor, epoch, rowsPatch };
+    }
 
-        if (this.sendPoke(ws, [{ rowsPatch, shapeId: subId }], cursor, epoch, canResume ? shape.sinceSeq : undefined)) {
-            this.recordShapeMemo(ws, subId, cursor);
+    /**
+     * Serialize a shape's seed poke frames for a relay to deliver verbatim (plan
+     * 075 Phase 3). The owner resolves the shape under the forwarded socket identity
+     * — so RLS applies exactly as for a local subscribe — and computes the seed,
+     * returning the frames instead of sending. `lastMutationId` is omitted: relayed
+     * sockets don't carry per-socket custom-mutator watermarks (those stay
+     * owner-served).
+     * @returns the serialized frames + the cursor they were computed at, or an error when the shape can't be resolved
+     */
+    private buildShapeSeedFrames(request: RelayShapeSubscribe): RelayShapeSeed {
+        const identity: SubscriptionIdentity = { identity: request.identity, userId: request.userId };
+
+        let resolved: ResolvedShape | undefined;
+
+        try {
+            resolved = this.resolveShape(request.name, request.args, identity);
+        } catch (error) {
+            return { error: { code: "SHAPE_RESOLVE_FAILED", message: error instanceof Error ? error.message : "shape resolve failed" } };
         }
 
-        return "ok";
+        if (resolved === undefined || resolved.global === true) {
+            return { error: { code: "SHAPE_NOT_FOUND", message: `shape not relayable: ${request.name}` } };
+        }
+
+        const { baseCheckpoint, cursor, epoch, rowsPatch } = this.computeOpLogShapeSeed(
+            { args: request.args, name: request.name, sinceEpoch: request.sinceEpoch, sinceSeq: request.sinceSeq },
+            resolved,
+        );
+
+        this.pokeSequence += 1;
+        const frames = buildPokeFrames([{ rowsPatch, shapeId: request.subId }], {
+            baseCheckpoint,
+            checkpoint: cursor,
+            epoch,
+            lastMutationId: undefined,
+            pokeId: `poke-${String(this.pokeSequence)}`,
+        });
+
+        return { cursor, frames };
     }
 
     /**
@@ -7515,23 +7577,96 @@ abstract class ShardDO {
      * forward so the receiver can address its own siblings in turn.
      */
     private async postRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<void> {
+        await this.requestRelayMessage(targetName, message);
+    }
+
+    /**
+     * POST an owner↔relay control message to a sibling DO by name and return its
+     * response (the shape-seed path needs the owner's frames back; the fire-and-
+     * forget {@link ShardDO.postRelayMessage} ignores it). Best-effort: a transient
+     * cross-DO failure returns `undefined` rather than throwing into the handler.
+     * @returns the sibling's response, or `undefined` when it can't be reached
+     */
+    private async requestRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<Response | undefined> {
         const namespace = this.relayNamespace();
 
         if (namespace === undefined) {
-            return;
+            return undefined;
         }
 
         const stub = typeof namespace.getByName === "function" ? namespace.getByName(targetName) : namespace.get(namespace.idFromName(targetName));
 
         try {
-            await stub.fetch("https://relay.internal/_lunora/relay", {
+            return await stub.fetch("https://relay.internal/_lunora/relay", {
                 body: JSON.stringify(message),
                 headers: { "content-type": "application/json", "x-lunora-shard-binding": this.shardBinding ?? "" },
                 method: "POST",
             });
         } catch {
-            /* best-effort hub forwarding — a dropped ephemeral frame is tolerable */
+            // Best-effort hub forwarding — a dropped ephemeral frame is tolerable.
+            return undefined;
         }
+    }
+
+    /**
+     * Seed a shape held by a socket on a relay by forwarding the request to the
+     * owner (plan 075 Phase 3): the owner resolves the shape under this socket's
+     * verified identity and computes the seed frames, which the relay delivers
+     * verbatim. Returns a structured error (surfaced as a `shape_subscribe` error)
+     * when the owner can't be reached or the shape can't be resolved.
+     */
+    private async seedShapeViaOwner(
+        ws: WebSocket,
+        subId: string,
+        shape: ShapeSubscriptionQuery,
+        identity: SubscriptionIdentity,
+    ): Promise<"ok" | { code: string; message: string }> {
+        const role = this.relayRole();
+
+        if (role?.relayIndex === undefined) {
+            return { code: "RELAY_MISCONFIGURED", message: "relay cannot address its owner" };
+        }
+
+        const request: RelayShapeSubscribe = {
+            args: shape.args ?? {},
+            identity: identity.identity,
+            name: shape.name,
+            sinceEpoch: shape.sinceEpoch,
+            sinceSeq: shape.sinceSeq,
+            subId,
+            type: "relay_shape_subscribe",
+            userId: identity.userId,
+        };
+
+        const response = await this.requestRelayMessage(role.ownerKey, request);
+
+        if (response === undefined) {
+            return { code: "RELAY_SEED_FAILED", message: "owner did not answer the shape seed" };
+        }
+
+        let seed: RelayShapeSeed;
+
+        try {
+            seed = await response.json();
+        } catch {
+            return { code: "RELAY_SEED_FAILED", message: "malformed shape seed from owner" };
+        }
+
+        if (seed.error !== undefined) {
+            return seed.error;
+        }
+
+        if (seed.frames === undefined) {
+            return { code: "RELAY_SEED_FAILED", message: "owner returned no shape frames" };
+        }
+
+        await awaitWsDrain(ws);
+
+        for (const frame of seed.frames) {
+            trySendFrame(ws, frame);
+        }
+
+        return "ok";
     }
 
     /**
@@ -7548,6 +7683,12 @@ abstract class ShardDO {
             message = await request.json();
         } catch {
             return new Response("bad request", { status: 400 });
+        }
+
+        if (message.type === "relay_shape_subscribe") {
+            // Owner seeds a relay's shape under the forwarded identity and returns
+            // the serialized poke frames for the relay to deliver (plan 075 Phase 3).
+            return jsonResponse(this.buildShapeSeedFrames(message));
         }
 
         if (message.type === "relay_attach") {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -3973,12 +3973,14 @@ abstract class ShardDO {
      * relay-multicast — i.e. one delta is correct for **every** subscriber. True
      * iff the shape's resolved query (table + `effectiveWhere` + `columns`) is
      * **identical regardless of the caller's identity** AND none of its projected
-     * columns are masked. Probed by resolving the shape under two distinct
-     * synthetic identities and comparing — airtight (the resolved `effectiveWhere`
-     * already composes the shape predicate AND the table's RLS read-where) and
-     * **fail-closed**: a resolve that throws, a per-identity `effectiveWhere`, a
-     * masked column, or a `.global()` table all yield `false`, keeping the shape
-     * owner-served. Cached per `(name, args)`, whose uniformity is stable.
+     * columns are masked. Decided by {@link ShardDO.probeShapeRelayUniform}: a
+     * static RLS read-policy guard, plus resolving under the anonymous multicast
+     * identity and two {@link Proxy}-backed identities that yield a distinct value
+     * for ANY accessed claim (so even a custom claim read outside `rls()` diverges),
+     * with a copy backstop. **Fail-closed**: a resolve that throws, a per-identity
+     * `effectiveWhere`, a masked column, an enumerated identity, or a `.global()`
+     * table all yield `false`, keeping the shape owner-served. Cached per
+     * `(name, args)`, whose uniformity is stable.
      */
     protected isShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
         const cacheKey = shapeRoutingKey(name, args);
@@ -8148,44 +8150,29 @@ abstract class ShardDO {
     /**
      * The one-shot computation behind {@link ShardDO.isShapeRelayUniform}, made
      * sound against the cross-identity row-leak the naive two-probe version allowed
-     * (plan 075 review). It is fail-closed on three independent grounds:
+     * (plan 075 review). It is fail-closed on four independent grounds:
      *
      * 1. **Static RLS guard.** If the resolved table has ANY declared RLS *read*
      * policy, reads are identity-scoped by construction — a single multicast delta
      * can never be correct for every subscriber — so the shape is never relayable,
-     * regardless of what the probes happen to resolve. This closes the leak where a
-     * policy keyed on a claim the probes don't vary (org/tenant/role) resolves
-     * identically for all of them and looks falsely uniform.
+     * regardless of what the probes resolve. This closes the leak where a policy
+     * keyed on a claim the probes don't vary resolves identically for all of them.
      * 2. **Multicast identity is in the probe set.** The first probe is the EXACT
      * identity the owner multicasts under ({@link RELAY_MULTICAST_IDENTITY}); every
      * other probe must match it. So the validated property is precisely the one the
      * multicast relies on — never a different sampled identity.
-     * 3. **Claim-diverse probes.** The populated probes differ on every common claim
-     * dimension (user/org/tenant/team/role/groups), so a resolver that narrows on
-     * any of them diverges from the anonymous base and is rejected.
+     * 3. **Claim-exhaustive probes.** The two populated probes back their claims with
+     * a {@link Proxy} that returns a DISTINCT value for ANY accessed key — not a
+     * hardcoded list — so a `defineShape` `where` that reads ANY identity claim
+     * (a custom one via `ctx.access`, not just `ctx.auth.userId`), bypassing
+     * `rls()`, diverges between the probes and is rejected. There are no unsampled
+     * claims: the value differs by construction for every key the resolver touches.
+     * 4. **Copy backstop.** A {@link Proxy} can differentiate per-key *reads* but not
+     * a wholesale *copy* (`{...claims}` / `Object.keys`) — a copied identity could
+     * smuggle an undetected claim into the where. So enumerating the claims trips
+     * `enumerated` and the gate fails closed.
      */
     private probeShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
-        // The multicast identity is the base; a populated probe per "side" varies
-        // every common claim dimension so an identity-dependent resolve diverges.
-        const populate = (side: string): SubscriptionIdentity => {
-            return {
-                identity: {
-                    groups: [`g_${side}`],
-                    org_id: `org_${side}`,
-                    orgId: `org_${side}`,
-                    role: side,
-                    roles: [side],
-                    sub: `__lunora_probe_${side}__`,
-                    team: `team_${side}`,
-                    teamId: `team_${side}`,
-                    tenant: `tenant_${side}`,
-                    tenantId: `tenant_${side}`,
-                },
-                userId: `__lunora_probe_${side}__`,
-            };
-        };
-        const probes: SubscriptionIdentity[] = [RELAY_MULTICAST_IDENTITY, populate("a"), populate("b")];
-
         let base: ResolvedShape | undefined;
 
         try {
@@ -8211,9 +8198,42 @@ abstract class ShardDO {
         const baseWhere = stableStringify(base.effectiveWhere);
         const baseColumns = stableStringify(base.columns);
 
+        // A populated probe whose claims yield a DISTINCT value per accessed key
+        // (so any claim the resolver reads diverges between sides) and trip the
+        // shared `enumerated` flag on a wholesale copy of the claims object.
+        let enumerated = false;
+        const populate = (side: string): SubscriptionIdentity => {
+            // Type-correct values for the common collection claims so an array op
+            // (`roles.includes`) doesn't throw and over-reject; a distinct string
+            // sentinel for every other (incl. custom/unknown) key.
+            const backing: Record<string, unknown> = { groups: [`grp_${side}`], roles: [side], sub: `__lunora_probe_${side}__` };
+            const claims = new Proxy(backing, {
+                get: (target, key) => {
+                    if (typeof key === "symbol" || key in target) {
+                        return Reflect.get(target, key) as unknown;
+                    }
+
+                    return `${side}:${key}`;
+                },
+                getOwnPropertyDescriptor: (target, key) => {
+                    enumerated = true;
+
+                    return Reflect.getOwnPropertyDescriptor(target, key);
+                },
+                has: (target, key) => (typeof key === "symbol" ? Reflect.has(target, key) : true),
+                ownKeys: (target) => {
+                    enumerated = true;
+
+                    return Reflect.ownKeys(target);
+                },
+            });
+
+            return { identity: claims, userId: `__lunora_probe_${side}__` };
+        };
+
         // Every probe (including the anonymous multicast identity) must resolve to
         // the identical table + where + columns, or the shape isn't uniform.
-        return probes.every((probe) => {
+        const matches = [RELAY_MULTICAST_IDENTITY, populate("a"), populate("b")].every((probe) => {
             let resolved: ResolvedShape | undefined;
 
             try {
@@ -8230,6 +8250,10 @@ abstract class ShardDO {
                 stableStringify(resolved.columns) === baseColumns
             );
         });
+
+        // A wholesale copy of the claims defeats per-key differentiation — can't
+        // prove uniformity, so fail closed.
+        return matches && !enumerated;
     }
 
     /** Whether any column the shape projects from `table` is masked — a masked value is identity-dependent, so the shape can't be relay-uniform. */

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -89,9 +89,9 @@ import type { QueryStatEntry } from "./query-metrics";
 import { readQueryMetrics, recordQueryMetric } from "./query-metrics";
 import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
-import { ReactiveCache, reactiveCacheKey, stableStringify } from "./reactive-cache";
-import type { OwnerRelayFrame, RelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
-import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName, shapeRoutingKey } from "./relay";
+import { ReactiveCache, reactiveCacheKey } from "./reactive-cache";
+import type { OwnerRelay, RelayHost, RelayMember } from "./relay-hub";
+import { createRelayLink, DEFAULT_MAX_RELAYS } from "./relay-hub";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
 import { buildSecurityAudit } from "./security-audit";
@@ -101,20 +101,21 @@ import { buildPokeFrames, diffGlobalMembership, projectColumns } from "./shape-g
 import { runSocketPool } from "./socket-pool";
 import { runReadonlySql } from "./sql-console";
 import { findDanglingReferences } from "./storage-correlation";
-import { sendDeltaFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
+import { awaitWsDrain, sendDeltaFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
 import type { TransactionSqlLike } from "./transaction";
 import { ConflictError } from "./transaction";
 import type {
     LifecycleDispatchInfo,
     LifecycleEvent,
     MutationDelta,
+    ResolvedShape,
     RpcRequest,
     ShapeSubscriptionQuery,
     SocketAttachment,
     SubscriptionEnvelope,
+    SubscriptionIdentity,
     SubscriptionQuery,
 } from "./types";
-import type { WhereInput } from "./where-types";
 
 /**
  * Client→server text frame the runtime answers with {@link WS_KEEPALIVE_PONG}
@@ -248,23 +249,6 @@ interface SubscriptionOutcome {
  * `columns`, when present, projects each row-op's `value` to that subset (the
  * shape's declared column allow-list); absent ⇒ the full document is shipped.
  */
-interface ResolvedShape {
-    columns?: ReadonlyArray<string>;
-    effectiveWhere?: WhereInput;
-
-    /**
-     * `true` when the shape's table is `.global()` (lives in D1, not this DO's
-     * SQLite). A global shape has **no per-DO op-log** to diff, so it is served
-     * by the **latency-tiered poll path** ({@link ShardDO.seedGlobalShape} +
-     * {@link ShardDO.refreshGlobalShape}) instead of the CDC poke path — seeded
-     * from {@link ShardDO.readGlobalShapeRows} and refreshed on an alarm tick.
-     * The codegen subclass sets it from the schema's `shardMode`; absent ⇒ a
-     * shard-local (poke-live) shape.
-     */
-    global?: boolean;
-    table: string;
-}
-
 /** Per-socket, per-shape poke baseline: the `__cdc_log` cursor this shape's view has been poked through. */
 interface ShapeMemo {
     cursor: number;
@@ -277,36 +261,6 @@ interface ShapeMemo {
  * out-of-order arrival (`"gap"`).
  */
 type ClientMutationClass = { expected: number; kind: "already" | "gap" | "next" };
-
-/**
- * Identity a subscription query is executed under, threaded EXPLICITLY into
- * `executeSubscription` → `buildCtx` rather than read from the shared,
- * per-request `currentRequestUserId`/`currentRequestIdentity` instance fields.
- *
- * The value passed is the socket's OWN verified identity, captured at the WS
- * upgrade from the runtime-forwarded, server-minted `x-lunora-userid` /
- * `x-lunora-identity` headers (the client cannot forge them — the runtime
- * strips any client-supplied copies) and stamped on the {@link SocketAttachment}.
- * `seedSubscription` and `refreshSubscriptions` read it off the attachment and
- * pass it here BY VALUE — never by reading the mutable per-request
- * `currentRequestUserId`/`currentRequestIdentity` instance fields, which a
- * deferred (`waitUntil`) refresh or a concurrently-interleaved RPC could be
- * mutating. That value-passing is what keeps a subscription re-run from
- * observing or clobbering an in-flight RPC's identity.
- *
- * Developer-facing consequence: a query that authorizes or filters on the
- * caller's identity — via `.use(rls(...))` or by reading `ctx.auth.userId` —
- * evaluates over the live channel under the CONNECTING user, so its seed and
- * every write-driven refresh return that user's rows, matching the one-shot
- * `fetch` RPC. An anonymous socket (no identity resolved at upgrade) leaves
- * both fields `undefined`, so such a query fails closed (empty/denied) rather
- * than leaking another user's data. See the lunora-realtime skill
- * ("Authorization & live queries").
- */
-interface SubscriptionIdentity {
-    identity?: Record<string, unknown>;
-    userId?: string;
-}
 
 /**
  * Optional shard-level configuration passed through `super(state, env, …)`.
@@ -493,22 +447,6 @@ const IDEMPOTENCY_GC_INTERVAL_MS = 3_600_000;
  * table without an explicit `.shardBy()` or `.global()` modifier.
  */
 
-/**
- * The identity the owner computes a relay-multicast shape delta under (plan 075
- * Phase 3). It is the empty (anonymous) identity, and it is **load-bearing for
- * RLS**: a shape may only be relay-multicast if the uniform gate has PROVEN its
- * resolved query is identical for this exact identity and every other — so the
- * one delta computed here is correct for every cohort subscriber. The gate
- * probes this same constant (see `probeShapeRelayUniform`), so the validated
- * identity and the multicast identity can never drift apart.
- */
-const RELAY_MULTICAST_IDENTITY: SubscriptionIdentity = {};
-
-/** Exhaustiveness guard for the {@link OwnerRelayFrame} dispatch — an unhandled member is a compile error here, and an impossible runtime frame throws rather than silently mis-routing. */
-const assertNeverFrame = (frame: never): never => {
-    throw new Error(`unhandled relay frame: ${JSON.stringify(frame)}`);
-};
-
 const ROOT_SHARD_NAME = "__root__";
 
 /**
@@ -519,33 +457,6 @@ const ROOT_SHARD_NAME = "__root__";
  * a memo carrying it as "re-run on every write-flush".
  */
 const ADMIN_WILDCARD = "*";
-
-/**
- * Defensive WS backpressure helper. When the runtime exposes
- * `bufferedAmount` on the socket, pause iteration whenever the outbound
- * buffer is past 1 MiB; otherwise treat the socket as drained. Capped at
- * 100 sleeps of 20 ms (≈ 2 s total) so a permanently-stuck buffer can't
- * pin the iterator forever — past that we drop through and let the next
- * `ws.send` surface the failure.
- */
-const awaitWsDrain = async (ws: WebSocket): Promise<void> => {
-    let attempts = 0;
-
-    while (attempts < 100) {
-        attempts += 1;
-
-        const buffered = (ws as { bufferedAmount?: unknown }).bufferedAmount;
-
-        if (typeof buffered !== "number" || buffered < 1_048_576) {
-            return;
-        }
-
-        // eslint-disable-next-line no-await-in-loop -- intentional backpressure poll: sleep, then re-check the drained buffer on the next iteration
-        await new Promise((resolve) => {
-            setTimeout(resolve, 20);
-        });
-    }
-};
 
 /**
  * The trailing `,"cursor":&lt;n>,"epoch":"&lt;e>"` fragment appended to a
@@ -1373,16 +1284,6 @@ const parsePositiveInt = (raw: string | undefined): number | undefined => {
     return Number.isFinite(value) && value > 0 ? value : undefined;
 };
 
-/** Default relay fan when a shard promotes (plan 075 Phase 2) — how many relays new connections spread across. Right-sizing per demand is a later phase; v1 uses a small fixed fan. */
-const DEFAULT_RELAY_FAN = 2;
-
-/** Default hard cap on relays per shard (the cost ceiling) so a viral shard can never silently spawn unbounded relay DOs. */
-const DEFAULT_MAX_RELAYS = 8;
-
-/** Read a positive-integer `LUNORA_*` env knob, falling back to `fallback` when unset or malformed. */
-const envPositiveInt = (env: unknown, key: string, fallback: number): number =>
-    parsePositiveInt((env as Record<string, unknown> | undefined)?.[key] as string | undefined) ?? fallback;
-
 /**
  * Resolve the per-dispatch console-stream toggle (`LUNORA_REQUEST_LOG_EMIT`).
  * An explicit `"1"`/`"true"` forces it on and `"0"`/`"false"` forces it off
@@ -1475,29 +1376,6 @@ const constantTimeEqual = (a: string, b: string): boolean => {
     }
 
     return diff === 0;
-};
-
-/** Minimal Durable Object stub shape the relay hub uses — just `fetch`. */
-interface RelayStub {
-    fetch: (input: string, init?: RequestInit) => Promise<Response>;
-}
-
-/** Minimal Durable Object namespace shape the relay hub resolves siblings through (`getByName` when present, else `idFromName` + `get`). */
-interface RelayNamespaceLike {
-    get: (id: unknown) => RelayStub;
-    getByName?: (name: string) => RelayStub;
-    idFromName: (name: string) => unknown;
-}
-
-/** Duck-type a namespace binding so a relay/owner can address its siblings, or `undefined` when the value isn't a DO namespace. */
-const asRelayNamespace = (value: unknown): RelayNamespaceLike | undefined => {
-    if (value === null || typeof value !== "object") {
-        return undefined;
-    }
-
-    const candidate = value as Partial<RelayNamespaceLike>;
-
-    return typeof candidate.idFromName === "function" && typeof candidate.get === "function" ? (candidate as RelayNamespaceLike) : undefined;
 };
 
 /**
@@ -1846,59 +1724,13 @@ abstract class ShardDO {
     private shardBinding: string | undefined;
 
     /**
-     * Owner-side cache of the active relay indices for this shard (plan 075 Phase
-     * 2). Lazily hydrated from the reserved `__lunora_relays` SQLite table and kept
-     * in lockstep with it on attach/detach, so the hot whisper-forward path reads
-     * it synchronously without a storage round-trip.
+     * The auto-elastic fan-out relay collaborator (plan 075) — an {@link OwnerRelay}
+     * or {@link RelayMember} chosen ONCE from this DO's name, or `undefined` for an
+     * unnamed (single-DO) DO where the relay tier is inert. All relay state +
+     * transport lives on it, reached back through the {@link RelayHost} adapter, so
+     * owner-only state can never sit next to relay-only state on this class.
      */
-    private relaySetCache: Set<number> | undefined;
-
-    /** Relay-side guard: `true` once this relay has announced itself to its owner this wake, so a hot socket churn doesn't re-`relay_attach` on every subscribe. */
-    private relayAnnounced = false;
-
-    /** Memoized RLS-uniform verdict per `(name, args)` shape — uniformity is a stable property, so the gate probe runs at most once per distinct shape (plan 075 Phase 3). */
-    private readonly shapeUniformCache = new Map<string, boolean>();
-
-    /**
-     * Owner-side registry of relay-uniform shapes that a relay has subscribers for
-     * (plan 075 Phase 3 slice B.2), keyed by `(name, args)`. `cursor` is the cohort
-     * frontier — the cursor up to which the owner has multicast this shape's deltas.
-     * On each flush the owner diffs `(cursor, frameCursor]` ONCE and multicasts it to
-     * its relays, then advances `cursor`.
-     */
-    private readonly relayShapeRegistry = new Map<string, { args: Record<string, unknown>; cursor: number; name: string }>();
-
-    /**
-     * Owner-side registry of NON-uniform (identity-scoped) relay shapes, one entry
-     * per relay socket (plan 075 review MEDIUM-3). These can't be cohort-multicast —
-     * each subscriber's delta is identity-dependent — so the owner computes each
-     * one's diff under its own forwarded identity and delivers a targeted poke to
-     * that one socket (by `connectionId`). No fan-out scaling (it's per-socket either
-     * way), but the relay still offloads the connection and the socket gets live
-     * updates instead of a silently frozen shape. Keyed `relayIndex:connectionId:subId`.
-     */
-    private readonly relayShapeProxies = new Map<
-        string,
-        {
-            args: Record<string, unknown>;
-            connectionId: string;
-            cursor: number;
-            epoch?: string;
-            identity: SubscriptionIdentity;
-            name: string;
-            relayIndex: number;
-            subId: string;
-        }
-    >();
-
-    /**
-     * Relay-side per-socket shape memo: `ws → subId → { cursor, epoch }`. The relay
-     * delivers a multicast `relay_shape_poke` to a socket only when its memo for that
-     * shape matches the poke's `fromCursor` AND `epoch`, then advances it — so a
-     * socket that seeded at a different cursor (or in a prior CDC epoch) never
-     * double-applies a delta (plan 075 Phase 3 slice B.2).
-     */
-    private readonly shapeRelayMemos = new WeakMap<WebSocket, Map<string, { cursor: number; epoch?: string }>>();
+    private readonly relay: OwnerRelay | RelayMember | undefined;
 
     /**
      * Declared indexes (`table:index`) a query has exercised since this instance
@@ -1996,6 +1828,34 @@ abstract class ShardDO {
         if (options.reactiveCache) {
             this.reactiveCache = new ReactiveCache(options.reactiveCache);
         }
+
+        // The relay tier reaches this DO back through a narrow adapter; the role-typed
+        // collaborator (owner vs relay) is fixed once from the DO name (plan 075).
+        const host: RelayHost = {
+            buildShapeDiff: (resolved, fromCursor, toCursor) => this.buildShapeDiff(this.sql as SqlExec, resolved, fromCursor, toCursor),
+            computeOpLogShapeSeed: (shape, resolved) => this.computeOpLogShapeSeed(shape, resolved),
+            currentCdcEpoch: () => this.currentCdcEpoch(),
+            deliverWhisperLocal: (topic, frame, exclude) => this.deliverWhisperLocal(topic, frame, exclude),
+            doName: () => this.state.id?.name,
+            env: () => this.env,
+            getWebSockets: () => this.state.getWebSockets(),
+            maskMetadata: () => this.maskMetadata(),
+            nextPokeId: () => {
+                this.pokeSequence += 1;
+
+                return `poke-${String(this.pokeSequence)}`;
+            },
+            readAttachment: (ws) => this.readAttachment(ws),
+            recordShapePokeFanout: (iterated, delivered, elapsedMs) => {
+                this.fanout.shapePoke = recordFanoutPass(this.fanout.shapePoke, iterated, delivered, elapsedMs);
+            },
+            resolveShape: (name, args, identity) => this.resolveShape(name, args, identity),
+            rlsMetadata: () => this.rlsMetadata(),
+            shardBinding: () => this.shardBinding,
+            sql: () => this.sql as SqlExec,
+        };
+
+        this.relay = createRelayLink(host);
 
         this.armWebSocketKeepalive();
     }
@@ -2417,7 +2277,7 @@ abstract class ShardDO {
                 // Relay tier (plan 075 Phase 2): once a relay holds a subscriber, it
                 // announces itself so the owner forwards whisper frames to it.
                 if (join) {
-                    await this.announceRelayIfNeeded();
+                    await this.relay?.announce();
                 }
             }
 
@@ -2503,7 +2363,7 @@ abstract class ShardDO {
 
         // Relay tier collapse (plan 075 Phase 2): a relay that just lost its last
         // socket detaches from its owner, so the owner stops forwarding to it.
-        await this.announceRelayDrainIfNeeded(ws);
+        await this.relay?.announceDrain(ws);
     }
 
     /** Hibernation API: invoked on socket error. */
@@ -3970,31 +3830,13 @@ abstract class ShardDO {
 
     /**
      * The RLS-uniform gate (plan 075 Phase 3): whether a reactive shape may be
-     * relay-multicast — i.e. one delta is correct for **every** subscriber. True
-     * iff the shape's resolved query (table + `effectiveWhere` + `columns`) is
-     * **identical regardless of the caller's identity** AND none of its projected
-     * columns are masked. Decided by {@link ShardDO.probeShapeRelayUniform}: a
-     * static RLS read-policy guard, plus resolving under the anonymous multicast
-     * identity and two {@link Proxy}-backed identities that yield a distinct value
-     * for ANY accessed claim (so even a custom claim read outside `rls()` diverges),
-     * with a copy backstop. **Fail-closed**: a resolve that throws, a per-identity
-     * `effectiveWhere`, a masked column, an enumerated identity, or a `.global()`
-     * table all yield `false`, keeping the shape owner-served. Cached per
-     * `(name, args)`, whose uniformity is stable.
+     * relay-multicast — i.e. one delta is correct for **every** subscriber. The owner
+     * decides it (see {@link OwnerRelay.isShapeRelayUniform} — a static RLS read-policy
+     * guard plus claim-exhaustive `Proxy` probes, fail-closed); this thin delegation
+     * is the seam the gate test exercises. A non-owner DO is never relay-uniform.
      */
     protected isShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
-        const cacheKey = shapeRoutingKey(name, args);
-        const cached = this.shapeUniformCache.get(cacheKey);
-
-        if (cached !== undefined) {
-            return cached;
-        }
-
-        const uniform = this.probeShapeRelayUniform(name, args);
-
-        this.shapeUniformCache.set(cacheKey, uniform);
-
-        return uniform;
+        return this.relay?.isShapeRelayUniform(name, args) ?? false;
     }
 
     /**
@@ -5515,11 +5357,11 @@ abstract class ShardDO {
      */
     private collectFanoutMetrics(): FanoutMetricsResult {
         const summary = summarizeFanoutTopics(this.state.getWebSockets().map((ws) => this.readAttachment(ws)));
-        const relayCount = this.computeRelayCount();
+        const relayCount = this.relay?.relayCount() ?? 0;
 
         return {
             ...summary,
-            maxRelays: envPositiveInt(this.env, "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS),
+            maxRelays: this.relay?.maxRelays() ?? DEFAULT_MAX_RELAYS,
             promoted: relayCount > 0,
             relayCount,
             shapePoke: this.fanout.shapePoke,
@@ -6025,8 +5867,7 @@ abstract class ShardDO {
                 await Promise.all([
                     this.refreshSubscriptions(batch),
                     this.pokeShapeSubscribers(batch, frameCursor, frameEpoch),
-                    this.multicastRelayShapePokes(batch, frameCursor ?? 0),
-                    this.proxyRelayShapePokes(batch, frameCursor ?? 0),
+                    this.relay?.onFlush(batch, frameCursor ?? 0),
                 ]);
 
                 batch = this.pendingRefreshTables;
@@ -6326,9 +6167,12 @@ abstract class ShardDO {
         // Relay tier (plan 075 Phase 3): a relay holds no op-log, so it forwards the
         // seed to the owner — the only DO that can resolve the shape against real
         // data, under this socket's verified identity (RLS-correct) — and delivers
-        // the owner-computed frames. The owner-served path is unchanged.
-        if (this.relayRole()?.relayIndex !== undefined) {
-            return this.seedShapeViaOwner(ws, subId, shape, identity);
+        // the owner-computed frames. A non-relay DO returns `undefined` here, falling
+        // through to the owner-served path (unchanged).
+        const relayed = await this.relay?.seedRelayShape(ws, subId, shape, identity);
+
+        if (relayed !== undefined) {
+            return relayed;
         }
 
         let resolved: ResolvedShape | undefined;
@@ -6400,9 +6244,9 @@ abstract class ShardDO {
     /**
      * Compute an op-log shape seed (cursor, epoch, the resume base, and the
      * membership `rowsPatch`) WITHOUT sending — the shared core of
-     * {@link ShardDO.seedOpLogShape} (sends to a local socket) and
-     * {@link ShardDO.buildShapeSeedFrames} (serializes the frames for a relay to
-     * deliver, plan 075 Phase 3). Resume only when CDC is on, the client is on this
+     * {@link ShardDO.seedOpLogShape} (sends to a local socket) and the owner relay's
+     * `buildShapeSeedFrames` (serializes the frames for a relay to deliver, plan 075
+     * Phase 3, via the {@link RelayHost} seam). Resume only when CDC is on, the client is on this
      * epoch, its checkpoint doesn't run ahead of ours, and the log still covers it;
      * else a full re-seed. A fully-compacted log only proves "nothing missed" when
      * the client is already at `cursor`.
@@ -6427,94 +6271,6 @@ abstract class ShardDO {
             canResume && shape.sinceSeq !== undefined ? this.buildShapeDiff(sql, resolved, shape.sinceSeq, cursor) : this.buildShapeSeed(sql, resolved);
 
         return { baseCheckpoint: canResume ? shape.sinceSeq : undefined, cursor, epoch, rowsPatch };
-    }
-
-    /**
-     * Serialize a shape's seed poke frames for a relay to deliver verbatim (plan
-     * 075 Phase 3). The owner resolves the shape under the forwarded socket identity
-     * — so RLS applies exactly as for a local subscribe — and computes the seed,
-     * returning the frames instead of sending. `lastMutationId` is omitted: relayed
-     * sockets don't carry per-socket custom-mutator watermarks (those stay
-     * owner-served).
-     * @returns the serialized frames + the cursor they were computed at, or an error when the shape can't be resolved
-     */
-    private buildShapeSeedFrames(request: RelayShapeSubscribe): RelayShapeSeed {
-        const identity: SubscriptionIdentity = { identity: request.identity, userId: request.userId };
-
-        let resolved: ResolvedShape | undefined;
-
-        try {
-            resolved = this.resolveShape(request.name, request.args, identity);
-        } catch (error) {
-            return { error: { code: "SHAPE_RESOLVE_FAILED", message: error instanceof Error ? error.message : "shape resolve failed" } };
-        }
-
-        if (resolved === undefined || resolved.global === true) {
-            return { error: { code: "SHAPE_NOT_FOUND", message: `shape not relayable: ${request.name}` } };
-        }
-
-        // Self-heal the relay set from the seed itself: any relay that seeds a shape
-        // through the owner provably has a subscriber, so register it here too. This
-        // makes forwarding robust to a dropped `relay_attach` (idempotent INSERT) —
-        // the owner can't silently fail to multicast/proxy to a live relay (LOW-4).
-        if (request.relayIndex !== undefined) {
-            this.addRelayToSet(request.relayIndex);
-        }
-
-        const { baseCheckpoint, cursor, epoch, rowsPatch } = this.computeOpLogShapeSeed(
-            { args: request.args, name: request.name, sinceEpoch: request.sinceEpoch, sinceSeq: request.sinceSeq },
-            resolved,
-        );
-
-        // A UNIFORM shape joins the cohort multicast (slice B.2): the relay must stamp
-        // the socket's memo at the registry FRONTIER (entry.cursor), NOT the global
-        // cursor the frames were computed at. The frontier only advances on a multicast
-        // poke, so an unrelated-table write that bumps the global cursor would otherwise
-        // leave a joiner's memo permanently ahead of every future `fromCursor` — silently
-        // frozen (plan 075 review HIGH-2). Seeding the full current membership while
-        // memoing at the (older) frontier is correct because a shape's membership is
-        // invariant between pokes.
-        //
-        // A NON-uniform shape can't be cohort-multicast (its delta is identity-scoped),
-        // so it registers a per-socket proxy keyed by the forwarding relay + this socket
-        // — the owner computes its delta under the forwarded identity each flush and
-        // delivers a targeted poke (MEDIUM-3). Either way the socket's memo baseline is
-        // `cohortCursor` and live updates flow.
-        let cohortCursor = cursor;
-
-        if (this.isShapeRelayUniform(request.name, request.args)) {
-            const routingKey = shapeRoutingKey(request.name, request.args);
-            let entry = this.relayShapeRegistry.get(routingKey);
-
-            if (entry === undefined) {
-                entry = { args: request.args, cursor, name: request.name };
-                this.relayShapeRegistry.set(routingKey, entry);
-            }
-
-            cohortCursor = entry.cursor;
-        } else if (request.relayIndex !== undefined && request.connectionId !== undefined) {
-            this.relayShapeProxies.set(`${String(request.relayIndex)}:${request.connectionId}:${request.subId}`, {
-                args: request.args,
-                connectionId: request.connectionId,
-                cursor,
-                epoch,
-                identity,
-                name: request.name,
-                relayIndex: request.relayIndex,
-                subId: request.subId,
-            });
-        }
-
-        this.pokeSequence += 1;
-        const frames = buildPokeFrames([{ rowsPatch, shapeId: request.subId }], {
-            baseCheckpoint,
-            checkpoint: cursor,
-            epoch,
-            lastMutationId: undefined,
-            pokeId: `poke-${String(this.pokeSequence)}`,
-        });
-
-        return { cursor: cohortCursor, epoch, frames };
     }
 
     /**
@@ -7372,14 +7128,16 @@ abstract class ShardDO {
      */
     private routeNonRpc(url: URL, request: Request): Promise<Response> | undefined {
         if (url.pathname === "/_lunora/relay" && request.method === "POST") {
-            return this.handleRelayMessage(request);
+            // The relay tier is inert on an unnamed (single-DO) DO — nothing forwards
+            // control frames there, so a 404 is the honest answer.
+            return this.relay?.handleControl(request) ?? Promise.resolve(new Response("relay tier inactive", { status: 404 }));
         }
 
         // Promotion probe (plan 075 Phase 2): the runtime asks the owner how many
         // relays to spread new connections across before a WS upgrade. Internal —
         // reachable only via the runtime's worker-side forward, returns just a count.
         if (url.pathname === "/_lunora/route" && request.method === "GET") {
-            return Promise.resolve(jsonResponse({ relayCount: this.computeRelayCount() }));
+            return Promise.resolve(jsonResponse({ relayCount: this.relay?.relayCount() ?? 0 }));
         }
 
         if (request.headers.get("Upgrade") === "websocket") {
@@ -7387,34 +7145,6 @@ abstract class ShardDO {
         }
 
         return undefined;
-    }
-
-    /**
-     * How many relays the runtime should spread new connections across for this
-     * shard (plan 075 Phase 2). `0` keeps every connection on the owner — the
-     * common, un-promoted path. A relay never promotes (flat single tier in v1).
-     * The owner promotes once its live socket count crosses `LUNORA_RELAY_THRESHOLD`
-     * (default {@link DEFAULT_PROMOTION_THRESHOLDS}`.tUp`), fanning to a fixed
-     * `LUNORA_RELAY_FAN` (capped by `LUNORA_MAX_RELAYS` — the cost ceiling). Demand
-     * right-sizing + collapse below `T_down` land in the next phase.
-     */
-    private computeRelayCount(): number {
-        const name = this.state.id?.name;
-
-        if (name !== undefined && parseRelayName(name) !== undefined) {
-            return 0;
-        }
-
-        const threshold = envPositiveInt(this.env, "LUNORA_RELAY_THRESHOLD", DEFAULT_PROMOTION_THRESHOLDS.tUp);
-
-        if (this.state.getWebSockets().length < threshold) {
-            return 0;
-        }
-
-        const maxRelays = envPositiveInt(this.env, "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS);
-        const fan = envPositiveInt(this.env, "LUNORA_RELAY_FAN", DEFAULT_RELAY_FAN);
-
-        return Math.min(maxRelays, Math.max(1, fan));
     }
 
     private handleWebSocketUpgrade(request: Request): Response {
@@ -7594,7 +7324,7 @@ abstract class ShardDO {
         // is promoted (plan 075 Phase 2) — forward the opaque frame through the relay
         // hub so it reaches the sockets on every other DO serving the shard.
         this.deliverWhisperLocal(topic, frame, sender);
-        await this.forwardWhisperToHub(topic, frame);
+        await this.relay?.forwardWhisper(topic, frame);
     }
 
     /**
@@ -7623,670 +7353,6 @@ abstract class ShardDO {
         this.fanout.whisper = recordFanoutPass(this.fanout.whisper, scanned, delivered, 0);
 
         return delivered;
-    }
-
-    /**
-     * Forward an opaque whisper frame through the relay hub (plan 075 Phase 2). A
-     * relay sends it UP to its owner (stamped with its own index so the owner won't
-     * echo it back); the owner sends it to every relay in its set. A no-op in
-     * single-DO mode (no binding) or when the owner has no relays — so the common,
-     * un-promoted path stays free.
-     */
-    private async forwardWhisperToHub(topic: string, frame: string): Promise<void> {
-        const role = this.relayRole();
-
-        if (role === undefined) {
-            return;
-        }
-
-        if (role.relayIndex !== undefined) {
-            await this.postRelayMessage(role.ownerKey, { frame, originRelay: role.relayIndex, topic, type: "relay_frame" });
-
-            return;
-        }
-
-        const relays = this.ownerRelaySet();
-
-        if (relays.size === 0) {
-            return;
-        }
-
-        await Promise.all([...relays].map((index) => this.postRelayMessage(relayName(role.ownerKey, index), { frame, topic, type: "relay_frame" })));
-    }
-
-    /**
-     * This DO's role in the relay hub, or `undefined` when it can't address siblings
-     * (no namespace binding learned, or no DO name) — i.e. single-DO mode, where the
-     * relay tier is inert. An owner returns its own key with no `relayIndex`; a relay
-     * returns its owner's key + its slot.
-     * @returns `{ ownerKey, relayIndex? }`, or `undefined` when relaying isn't possible
-     */
-    private relayRole(): undefined | { ownerKey: string; relayIndex?: number } {
-        const name = this.state.id?.name;
-
-        if (name === undefined || this.relayNamespace() === undefined) {
-            return undefined;
-        }
-
-        const parsed = parseRelayName(name);
-
-        return parsed === undefined ? { ownerKey: name } : { ownerKey: parsed.ownerKey, relayIndex: parsed.relayIndex };
-    }
-
-    /** Resolve this DO's own namespace binding (learned from `x-lunora-shard-binding`) so it can address sibling owners/relays, or `undefined` when unknown. */
-    private relayNamespace(): RelayNamespaceLike | undefined {
-        if (this.shardBinding === undefined) {
-            return undefined;
-        }
-
-        return asRelayNamespace((this.env as Record<string, unknown> | undefined)?.[this.shardBinding]);
-    }
-
-    /**
-     * POST an owner↔relay control message to a sibling DO by name. Best-effort: a
-     * transient cross-DO failure drops the frame (whisper is ephemeral — there is no
-     * resume) rather than throwing into the WS message handler. Carries the binding
-     * forward so the receiver can address its own siblings in turn.
-     */
-    private async postRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<void> {
-        await this.requestRelayMessage(targetName, message);
-    }
-
-    /**
-     * POST an owner↔relay control message to a sibling DO by name and return its
-     * response (the shape-seed path needs the owner's frames back; the fire-and-
-     * forget {@link ShardDO.postRelayMessage} ignores it). Best-effort: a transient
-     * cross-DO failure returns `undefined` rather than throwing into the handler.
-     * @returns the sibling's response, or `undefined` when it can't be reached
-     */
-    private async requestRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<Response | undefined> {
-        const namespace = this.relayNamespace();
-
-        if (namespace === undefined) {
-            return undefined;
-        }
-
-        const stub = typeof namespace.getByName === "function" ? namespace.getByName(targetName) : namespace.get(namespace.idFromName(targetName));
-
-        try {
-            return await stub.fetch("https://relay.internal/_lunora/relay", {
-                body: JSON.stringify(message),
-                headers: { "content-type": "application/json", "x-lunora-shard-binding": this.shardBinding ?? "" },
-                method: "POST",
-            });
-        } catch {
-            // Best-effort hub forwarding — a dropped ephemeral frame is tolerable.
-            return undefined;
-        }
-    }
-
-    /**
-     * Seed a shape held by a socket on a relay by forwarding the request to the
-     * owner (plan 075 Phase 3): the owner resolves the shape under this socket's
-     * verified identity and computes the seed frames, which the relay delivers
-     * verbatim. Returns a structured error (surfaced as a `shape_subscribe` error)
-     * when the owner can't be reached or the shape can't be resolved.
-     */
-    private async seedShapeViaOwner(
-        ws: WebSocket,
-        subId: string,
-        shape: ShapeSubscriptionQuery,
-        identity: SubscriptionIdentity,
-    ): Promise<"ok" | { code: string; message: string }> {
-        const role = this.relayRole();
-
-        if (role?.relayIndex === undefined) {
-            return { code: "RELAY_MISCONFIGURED", message: "relay cannot address its owner" };
-        }
-
-        // Announce to the owner so it adds this relay to the set it multicasts shape
-        // deltas to (slice B.2) — shape subscribers attach the relay just like whisper.
-        await this.announceRelayIfNeeded();
-
-        const request: RelayShapeSubscribe = {
-            args: shape.args ?? {},
-            connectionId: this.readAttachment(ws).connectionId,
-            identity: identity.identity,
-            name: shape.name,
-            relayIndex: role.relayIndex,
-            sinceEpoch: shape.sinceEpoch,
-            sinceSeq: shape.sinceSeq,
-            subId,
-            type: "relay_shape_subscribe",
-            userId: identity.userId,
-        };
-
-        const response = await this.requestRelayMessage(role.ownerKey, request);
-
-        if (response === undefined) {
-            return { code: "RELAY_SEED_FAILED", message: "owner did not answer the shape seed" };
-        }
-
-        let seed: RelayShapeSeed;
-
-        try {
-            seed = await response.json();
-        } catch {
-            return { code: "RELAY_SEED_FAILED", message: "malformed shape seed from owner" };
-        }
-
-        if (seed.error !== undefined) {
-            return seed.error;
-        }
-
-        if (seed.frames === undefined) {
-            return { code: "RELAY_SEED_FAILED", message: "owner returned no shape frames" };
-        }
-
-        await awaitWsDrain(ws);
-
-        for (const frame of seed.frames) {
-            trySendFrame(ws, frame);
-        }
-
-        // Record this socket's cohort memo so the owner's multicast deltas land
-        // exactly once (slice B.2): the next `relay_shape_poke` for this shape is
-        // delivered only while the memo still matches the poke's `fromCursor`+`epoch`.
-        this.recordRelayShapeMemo(ws, subId, seed.cursor ?? 0, seed.epoch);
-
-        return "ok";
-    }
-
-    /** Record a relay socket's cohort cursor + epoch for `subId` (creating the per-socket map lazily). */
-    private recordRelayShapeMemo(ws: WebSocket, subId: string, cursor: number, epoch: string | undefined): void {
-        let memos = this.shapeRelayMemos.get(ws);
-
-        if (memos === undefined) {
-            memos = new Map<string, { cursor: number; epoch?: string }>();
-            this.shapeRelayMemos.set(ws, memos);
-        }
-
-        memos.set(subId, { cursor, epoch });
-    }
-
-    /**
-     * Owner side (plan 075 Phase 3 slice B.2): for every registered relay-uniform
-     * shape whose table changed this flush, compute the membership diff ONCE over
-     * `(cohort cursor, frameCursor]` and multicast the `rowsPatch` to every relay.
-     * Advances the cohort cursor synchronously (before any await) so a seed that
-     * interleaves during the multicast registers at `frameCursor` and is skipped by
-     * this in-flight poke. The owner's per-socket poke path is untouched — this is
-     * pure additive relay fan-out, a no-op when the shard has no relays.
-     */
-    private async multicastRelayShapePokes(changed: Set<string>, frameCursor: number): Promise<void> {
-        const ownerKey = this.state.id?.name;
-
-        if (ownerKey === undefined || this.relayShapeRegistry.size === 0) {
-            return;
-        }
-
-        const relays = this.ownerRelaySet();
-
-        if (relays.size === 0) {
-            return;
-        }
-
-        const sql = this.sql as SqlExec;
-        const epoch = this.currentCdcEpoch();
-        const sends: Promise<void>[] = [];
-
-        for (const entry of this.relayShapeRegistry.values()) {
-            let resolved: ResolvedShape | undefined;
-
-            try {
-                resolved = this.resolveShape(entry.name, entry.args, RELAY_MULTICAST_IDENTITY);
-            } catch {
-                continue;
-            }
-
-            if (resolved === undefined || resolved.global === true || !changed.has(resolved.table)) {
-                continue;
-            }
-
-            const fromCursor = entry.cursor;
-            const rowsPatch = this.buildShapeDiff(sql, resolved, fromCursor, frameCursor);
-
-            if (rowsPatch.length === 0) {
-                continue; // the shape's membership didn't change — leave the cohort cursor put
-            }
-
-            entry.cursor = frameCursor;
-            const poke: RelayShapePoke = {
-                args: entry.args,
-                checkpoint: frameCursor,
-                epoch,
-                fromCursor,
-                name: entry.name,
-                rowsPatch,
-                type: "relay_shape_poke",
-            };
-
-            for (const index of relays) {
-                sends.push(this.postRelayMessage(relayName(ownerKey, index), poke));
-            }
-        }
-
-        await Promise.all(sends);
-    }
-
-    /**
-     * Owner side (plan 075 review MEDIUM-3): for every NON-uniform relay-shape proxy
-     * whose table changed this flush, compute that one subscriber's membership diff
-     * over `(entry.cursor, frameCursor]` UNDER ITS OWN forwarded identity (RLS-correct)
-     * and deliver a `targetConnectionId`-addressed poke to just that socket's relay.
-     * Each entry tracks its own cursor (no cohort sharing — the diffs are
-     * identity-specific), advancing only on a delivered, non-empty diff. A no-op when
-     * the shard has no proxy subscribers; the per-flush cost is O(proxy subscribers),
-     * the same the owner would pay serving them directly.
-     */
-    private async proxyRelayShapePokes(changed: Set<string>, frameCursor: number): Promise<void> {
-        const ownerKey = this.state.id?.name;
-
-        if (ownerKey === undefined || this.relayShapeProxies.size === 0) {
-            return;
-        }
-
-        const sql = this.sql as SqlExec;
-        const epoch = this.currentCdcEpoch();
-        const sends: Promise<void>[] = [];
-
-        for (const entry of this.relayShapeProxies.values()) {
-            let resolved: ResolvedShape | undefined;
-
-            try {
-                resolved = this.resolveShape(entry.name, entry.args, entry.identity);
-            } catch {
-                continue;
-            }
-
-            if (resolved === undefined || resolved.global === true || !changed.has(resolved.table)) {
-                continue;
-            }
-
-            const fromCursor = entry.cursor;
-            const rowsPatch = this.buildShapeDiff(sql, resolved, fromCursor, frameCursor);
-
-            if (rowsPatch.length === 0) {
-                continue; // this subscriber's membership didn't change — leave its cursor put
-            }
-
-            entry.cursor = frameCursor;
-            const poke: RelayShapePoke = {
-                args: entry.args,
-                checkpoint: frameCursor,
-                epoch,
-                fromCursor,
-                name: entry.name,
-                rowsPatch,
-                targetConnectionId: entry.connectionId,
-                type: "relay_shape_poke",
-            };
-
-            sends.push(this.postRelayMessage(relayName(ownerKey, entry.relayIndex), poke));
-        }
-
-        await Promise.all(sends);
-    }
-
-    /**
-     * Relay side (plan 075 Phase 3 slice B.2): deliver an owner-multicast shape
-     * delta to this relay's cohort sockets. A socket receives it only while its memo
-     * for the shape matches the poke's `fromCursor` AND `epoch` — so a socket that
-     * seeded at a different cursor (or in a prior CDC epoch) is skipped and never
-     * double-applies — then advances to `checkpoint`. The `rowsPatch` is wrapped in
-     * poke frames per socket (each its own `subId`); `lastMutationId` is omitted
-     * (relayed sockets are owner-served for custom mutators). Returns the number of
-     * sockets actually delivered to, for fan-out accounting.
-     */
-    private deliverRelayShapePoke(poke: RelayShapePoke): number {
-        const routingKey = shapeRoutingKey(poke.name, poke.args);
-        let delivered = 0;
-
-        for (const ws of this.state.getWebSockets()) {
-            const attachment = this.readAttachment(ws);
-            const { shapes } = attachment;
-            const memos = this.shapeRelayMemos.get(ws);
-
-            if (shapes === undefined || memos === undefined) {
-                continue;
-            }
-
-            // A targeted (per-socket proxy) poke for a non-uniform shape goes ONLY to
-            // the one socket it was computed for; a cohort multicast (no target) goes
-            // to every matching socket (MEDIUM-3).
-            if (poke.targetConnectionId !== undefined && attachment.connectionId !== poke.targetConnectionId) {
-                continue;
-            }
-
-            for (const [subId, sub] of Object.entries(shapes)) {
-                const memo = memos.get(subId);
-
-                if (memo?.cursor !== poke.fromCursor || memo.epoch !== poke.epoch || shapeRoutingKey(sub.name, sub.args) !== routingKey) {
-                    continue;
-                }
-
-                this.pokeSequence += 1;
-                const frames = buildPokeFrames([{ rowsPatch: poke.rowsPatch, shapeId: subId }], {
-                    baseCheckpoint: undefined,
-                    checkpoint: poke.checkpoint,
-                    epoch: poke.epoch,
-                    lastMutationId: undefined,
-                    pokeId: `poke-${String(this.pokeSequence)}`,
-                });
-
-                for (const frame of frames) {
-                    trySendFrame(ws, frame);
-                }
-
-                memos.set(subId, { cursor: poke.checkpoint, epoch: poke.epoch });
-                delivered += 1;
-            }
-        }
-
-        return delivered;
-    }
-
-    /**
-     * Serve the internal `/_lunora/relay` control channel (plan 075 Phase 2). An
-     * `attach`/`detach` updates the owner's relay set; a `frame` is delivered to this
-     * DO's local members and — on the owner, for a frame a relay forwarded up —
-     * re-forwarded to every OTHER relay, so one whisper reaches the whole shard
-     * exactly once per socket.
-     */
-    private async handleRelayMessage(request: Request): Promise<Response> {
-        let message: OwnerRelayFrame;
-
-        try {
-            message = await request.json();
-        } catch {
-            return new Response("bad request", { status: 400 });
-        }
-
-        // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body; null is the standard "no body" value
-        const noContent = (): Response => new Response(null, { status: 204 });
-
-        switch (message.type) {
-            case "relay_attach": {
-                this.addRelayToSet(message.relayIndex);
-
-                return noContent();
-            }
-            case "relay_detach": {
-                this.removeRelayFromSet(message.relayIndex);
-
-                return noContent();
-            }
-            case "relay_frame": {
-                return this.handleRelayWhisperFrame(message);
-            }
-            case "relay_shape_poke": {
-                // Owner-multicast shape delta → deliver to this relay's cohort sockets,
-                // recording the fan-out so a relay's metrics reflect the work it does.
-                const iterated = this.state.getWebSockets().length;
-                const startMs = Date.now();
-                const delivered = this.deliverRelayShapePoke(message);
-
-                this.fanout.shapePoke = recordFanoutPass(this.fanout.shapePoke, iterated, delivered, Date.now() - startMs);
-
-                return noContent();
-            }
-            case "relay_shape_subscribe": {
-                // Owner seeds a relay's shape under the forwarded identity and returns
-                // the serialized poke frames for the relay to deliver (plan 075 Phase 3).
-                return jsonResponse(this.buildShapeSeedFrames(message));
-            }
-            default: {
-                // Exhaustiveness guard: a new OwnerRelayFrame member added to `relay.ts`
-                // without a case here becomes a COMPILE error, not a runtime null-deref.
-                return assertNeverFrame(message);
-            }
-        }
-    }
-
-    /**
-     * Deliver a whisper `relay_frame` to this DO's local members and — on the owner,
-     * for a frame a relay forwarded up — re-forward it to every OTHER relay, so one
-     * whisper reaches the whole shard exactly once per socket (plan 075 Phase 2).
-     */
-    private async handleRelayWhisperFrame(message: RelayFrame): Promise<Response> {
-        this.deliverWhisperLocal(message.topic, message.frame, undefined);
-
-        const role = this.relayRole();
-
-        if (role !== undefined && role.relayIndex === undefined) {
-            // Owner re-distributes a relay-forwarded frame to the OTHER relays.
-            await Promise.all(
-                [...this.ownerRelaySet()]
-                    .filter((index) => index !== message.originRelay)
-                    .map((index) =>
-                        this.postRelayMessage(relayName(role.ownerKey, index), { frame: message.frame, topic: message.topic, type: "relay_frame" }),
-                    ),
-            );
-        }
-
-        // eslint-disable-next-line unicorn/no-null -- 204 No Content has no body
-        return new Response(null, { status: 204 });
-    }
-
-    /** Ensure the reserved owner-side relay-set table exists (auto-hidden from the data browser by the `__lunora` prefix). */
-    private ensureRelayTable(): void {
-        (this.sql as SqlExec).exec("CREATE TABLE IF NOT EXISTS __lunora_relays (idx INTEGER PRIMARY KEY)");
-    }
-
-    /** The owner's active relay indices, hydrated once from `__lunora_relays` and cached in-memory for the synchronous forward path. */
-    private ownerRelaySet(): Set<number> {
-        if (this.relaySetCache === undefined) {
-            this.ensureRelayTable();
-            const rows = (this.sql as SqlExec).exec<{ idx: bigint | number }>("SELECT idx FROM __lunora_relays").toArray();
-
-            this.relaySetCache = new Set(rows.map((row) => Number(row.idx)));
-        }
-
-        return this.relaySetCache;
-    }
-
-    /** Record a relay as active in the owner's set (idempotent), persisting it so the set survives the owner's hibernation. */
-    private addRelayToSet(index: number): void {
-        this.ensureRelayTable();
-        (this.sql as SqlExec).exec("INSERT OR IGNORE INTO __lunora_relays (idx) VALUES (?)", index);
-        this.ownerRelaySet().add(index);
-    }
-
-    /** Drop a drained relay from the owner's set so the owner stops forwarding to it. */
-    private removeRelayFromSet(index: number): void {
-        this.ensureRelayTable();
-        (this.sql as SqlExec).exec("DELETE FROM __lunora_relays WHERE idx = ?", index);
-        const set = this.ownerRelaySet();
-        set.delete(index);
-
-        // The drained relay's sockets are gone, so its per-socket proxy entries are
-        // dead — drop them so the owner stops computing diffs for them every flush.
-        for (const [key, entry] of this.relayShapeProxies) {
-            if (entry.relayIndex === index) {
-                this.relayShapeProxies.delete(key);
-            }
-        }
-
-        // No relays left → no cohort can hold a relay subscriber, so the shape
-        // registry and uniform cache are dead state. Clearing them on full drain
-        // bounds their growth (otherwise every distinct (name, args) ever relayed
-        // would accumulate for the instance's life and be re-resolved each flush);
-        // they re-register lazily on the next relay subscribe (plan 075 review).
-        if (set.size === 0) {
-            this.relayShapeRegistry.clear();
-            this.shapeUniformCache.clear();
-        }
-    }
-
-    /** A relay announces itself to its owner (once per wake) on its first subscriber, so the owner forwards whisper frames to it. No-op on an owner or in single-DO mode. */
-    private async announceRelayIfNeeded(): Promise<void> {
-        if (this.relayAnnounced) {
-            return;
-        }
-
-        const role = this.relayRole();
-
-        if (role?.relayIndex === undefined) {
-            return;
-        }
-
-        // Latch optimistically so a burst of subscribes doesn't re-announce, but
-        // reset on a failed/unreachable attach so the NEXT subscriber retries: a
-        // dropped attach must not permanently strand this relay's sockets (the owner
-        // would never forward their live deltas — silent staleness, plan 075 review).
-        this.relayAnnounced = true;
-        const response = await this.requestRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_attach" });
-
-        if (!response?.ok) {
-            this.relayAnnounced = false;
-        }
-    }
-
-    /**
-     * A relay that just lost its last socket (the `closing` one excluded) detaches
-     * from its owner so the owner stops forwarding frames to it, and re-arms its
-     * announce flag so it re-attaches if a new socket joins later. No-op on an owner
-     * or in single-DO mode, or while the relay still serves sockets.
-     */
-    private async announceRelayDrainIfNeeded(closing: WebSocket): Promise<void> {
-        const role = this.relayRole();
-
-        if (role?.relayIndex === undefined) {
-            return;
-        }
-
-        if (this.state.getWebSockets().some((ws) => ws !== closing)) {
-            return;
-        }
-
-        this.relayAnnounced = false;
-        await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_detach" });
-    }
-
-    /**
-     * The one-shot computation behind {@link ShardDO.isShapeRelayUniform}, made
-     * sound against the cross-identity row-leak the naive two-probe version allowed
-     * (plan 075 review). It is fail-closed on four independent grounds:
-     *
-     * 1. **Static RLS guard.** If the resolved table has ANY declared RLS *read*
-     * policy, reads are identity-scoped by construction — a single multicast delta
-     * can never be correct for every subscriber — so the shape is never relayable,
-     * regardless of what the probes resolve. This closes the leak where a policy
-     * keyed on a claim the probes don't vary resolves identically for all of them.
-     * 2. **Multicast identity is in the probe set.** The first probe is the EXACT
-     * identity the owner multicasts under ({@link RELAY_MULTICAST_IDENTITY}); every
-     * other probe must match it. So the validated property is precisely the one the
-     * multicast relies on — never a different sampled identity.
-     * 3. **Claim-exhaustive probes.** The two populated probes back their claims with
-     * a {@link Proxy} that returns a DISTINCT value for ANY accessed key — not a
-     * hardcoded list — so a `defineShape` `where` that reads ANY identity claim
-     * (a custom one via `ctx.access`, not just `ctx.auth.userId`), bypassing
-     * `rls()`, diverges between the probes and is rejected. There are no unsampled
-     * claims: the value differs by construction for every key the resolver touches.
-     * 4. **Copy backstop.** A {@link Proxy} can differentiate per-key *reads* but not
-     * a wholesale *copy* (`{...claims}` / `Object.keys`) — a copied identity could
-     * smuggle an undetected claim into the where. So enumerating the claims trips
-     * `enumerated` and the gate fails closed.
-     */
-    private probeShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
-        let base: ResolvedShape | undefined;
-
-        try {
-            base = this.resolveShape(name, args, RELAY_MULTICAST_IDENTITY);
-        } catch {
-            // An identity-gated resolve threw for the base probe → not uniform (fail-closed).
-            return false;
-        }
-
-        if (base === undefined || base.global === true) {
-            return false;
-        }
-
-        // Static RLS guard: an identity-scoped table is never relay-uniform.
-        if (this.rlsMetadata().policies.some((policy) => policy.on === "read" && policy.table === base.table)) {
-            return false;
-        }
-
-        if (this.shapeColumnsMasked(base.table, base.columns)) {
-            return false;
-        }
-
-        const baseWhere = stableStringify(base.effectiveWhere);
-        const baseColumns = stableStringify(base.columns);
-
-        // A populated probe whose claims yield a DISTINCT value per accessed key
-        // (so any claim the resolver reads diverges between sides) and trip the
-        // shared `enumerated` flag on a wholesale copy of the claims object.
-        let enumerated = false;
-        const populate = (side: string): SubscriptionIdentity => {
-            // Type-correct values for the common collection claims so an array op
-            // (`roles.includes`) doesn't throw and over-reject; a distinct string
-            // sentinel for every other (incl. custom/unknown) key.
-            const backing: Record<string, unknown> = { groups: [`grp_${side}`], roles: [side], sub: `__lunora_probe_${side}__` };
-            const claims = new Proxy(backing, {
-                get: (target, key) => {
-                    if (typeof key === "symbol" || key in target) {
-                        return Reflect.get(target, key) as unknown;
-                    }
-
-                    return `${side}:${key}`;
-                },
-                getOwnPropertyDescriptor: (target, key) => {
-                    enumerated = true;
-
-                    return Reflect.getOwnPropertyDescriptor(target, key);
-                },
-                has: (target, key) => (typeof key === "symbol" ? Reflect.has(target, key) : true),
-                ownKeys: (target) => {
-                    enumerated = true;
-
-                    return Reflect.ownKeys(target);
-                },
-            });
-
-            return { identity: claims, userId: `__lunora_probe_${side}__` };
-        };
-
-        // Every probe (including the anonymous multicast identity) must resolve to
-        // the identical table + where + columns, or the shape isn't uniform.
-        const matches = [RELAY_MULTICAST_IDENTITY, populate("a"), populate("b")].every((probe) => {
-            let resolved: ResolvedShape | undefined;
-
-            try {
-                resolved = this.resolveShape(name, args, probe);
-            } catch {
-                return false;
-            }
-
-            return (
-                resolved !== undefined &&
-                resolved.global !== true &&
-                resolved.table === base.table &&
-                stableStringify(resolved.effectiveWhere) === baseWhere &&
-                stableStringify(resolved.columns) === baseColumns
-            );
-        });
-
-        // A wholesale copy of the claims defeats per-key differentiation — can't
-        // prove uniformity, so fail closed.
-        return matches && !enumerated;
-    }
-
-    /** Whether any column the shape projects from `table` is masked — a masked value is identity-dependent, so the shape can't be relay-uniform. */
-    private shapeColumnsMasked(table: string, columns: ReadonlyArray<string> | undefined): boolean {
-        const masked = this.maskMetadata().columns.filter((entry) => entry.table === table);
-
-        if (masked.length === 0) {
-            return false;
-        }
-
-        if (columns === undefined) {
-            return true; // projects every column → any mask on the table makes it non-uniform
-        }
-
-        const projected = new Set(columns);
-
-        return masked.some((entry) => projected.has(entry.column));
     }
 
     // eslint-disable-next-line class-methods-use-this -- cohesive DO instance method grouped with the hibernation/attachment helpers; reads only the socket

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -89,7 +89,7 @@ import type { QueryStatEntry } from "./query-metrics";
 import { readQueryMetrics, recordQueryMetric } from "./query-metrics";
 import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
-import { ReactiveCache, reactiveCacheKey } from "./reactive-cache";
+import { ReactiveCache, reactiveCacheKey, stableStringify } from "./reactive-cache";
 import type { OwnerRelayFrame } from "./relay";
 import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
@@ -1838,6 +1838,9 @@ abstract class ShardDO {
 
     /** Relay-side guard: `true` once this relay has announced itself to its owner this wake, so a hot socket churn doesn't re-`relay_attach` on every subscribe. */
     private relayAnnounced = false;
+
+    /** Memoized RLS-uniform verdict per `(name, args)` shape — uniformity is a stable property, so the dual-identity probe runs at most once per distinct shape (plan 075 Phase 3). */
+    private readonly shapeUniformCache = new Map<string, boolean>();
 
     /**
      * Declared indexes (`table:index`) a query has exercised since this instance
@@ -3905,6 +3908,33 @@ abstract class ShardDO {
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to dispatch via the generated shape registry
     protected resolveShape(_name: string, _args: Record<string, unknown>, _identity?: SubscriptionIdentity): ResolvedShape | undefined {
         return undefined;
+    }
+
+    /**
+     * The RLS-uniform gate (plan 075 Phase 3): whether a reactive shape may be
+     * relay-multicast — i.e. one delta is correct for **every** subscriber. True
+     * iff the shape's resolved query (table + `effectiveWhere` + `columns`) is
+     * **identical regardless of the caller's identity** AND none of its projected
+     * columns are masked. Probed by resolving the shape under two distinct
+     * synthetic identities and comparing — airtight (the resolved `effectiveWhere`
+     * already composes the shape predicate AND the table's RLS read-where) and
+     * **fail-closed**: a resolve that throws, a per-identity `effectiveWhere`, a
+     * masked column, or a `.global()` table all yield `false`, keeping the shape
+     * owner-served. Cached per `(name, args)`, whose uniformity is stable.
+     */
+    protected isShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
+        const cacheKey = stableStringify({ args, name });
+        const cached = this.shapeUniformCache.get(cacheKey);
+
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const uniform = this.probeShapeRelayUniform(name, args);
+
+        this.shapeUniformCache.set(cacheKey, uniform);
+
+        return uniform;
     }
 
     /**
@@ -7619,6 +7649,50 @@ abstract class ShardDO {
 
         this.relayAnnounced = false;
         await this.postRelayMessage(role.ownerKey, { relayIndex: role.relayIndex, type: "relay_detach" });
+    }
+
+    /** Resolve a shape under two distinct probe identities and compare — the one-shot computation behind {@link ShardDO.isShapeRelayUniform}. */
+    private probeShapeRelayUniform(name: string, args: Record<string, unknown>): boolean {
+        const probeA: SubscriptionIdentity = { identity: { __lunora_relay_probe: 1, sub: "__lunora_probe_a__" }, userId: "__lunora_probe_a__" };
+        const probeB: SubscriptionIdentity = { identity: { __lunora_relay_probe: 2, sub: "__lunora_probe_b__" }, userId: "__lunora_probe_b__" };
+
+        let a: ResolvedShape | undefined;
+        let b: ResolvedShape | undefined;
+
+        try {
+            a = this.resolveShape(name, args, probeA);
+            b = this.resolveShape(name, args, probeB);
+        } catch {
+            // An identity-gated resolve threw for a probe → not uniform (fail-closed).
+            return false;
+        }
+
+        if (a === undefined || b === undefined || a.global === true || b.global === true || a.table !== b.table) {
+            return false;
+        }
+
+        if (stableStringify(a.effectiveWhere) !== stableStringify(b.effectiveWhere) || stableStringify(a.columns) !== stableStringify(b.columns)) {
+            return false;
+        }
+
+        return !this.shapeColumnsMasked(a.table, a.columns);
+    }
+
+    /** Whether any column the shape projects from `table` is masked — a masked value is identity-dependent, so the shape can't be relay-uniform. */
+    private shapeColumnsMasked(table: string, columns: ReadonlyArray<string> | undefined): boolean {
+        const masked = this.maskMetadata().columns.filter((entry) => entry.table === table);
+
+        if (masked.length === 0) {
+            return false;
+        }
+
+        if (columns === undefined) {
+            return true; // projects every column → any mask on the table makes it non-uniform
+        }
+
+        const projected = new Set(columns);
+
+        return masked.some((entry) => projected.has(entry.column));
     }
 
     // eslint-disable-next-line class-methods-use-this -- cohesive DO instance method grouped with the hibernation/attachment helpers; reads only the socket

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -90,7 +90,7 @@ import { readQueryMetrics, recordQueryMetric } from "./query-metrics";
 import type { ShardRankPageResult } from "./rank";
 import type { ReactiveCacheOptions } from "./reactive-cache";
 import { ReactiveCache, reactiveCacheKey, stableStringify } from "./reactive-cache";
-import type { OwnerRelayFrame, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
+import type { OwnerRelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
 import { DEFAULT_PROMOTION_THRESHOLDS, parseRelayName, relayName } from "./relay";
 import type { AppendRequestLogEntry, ContextLogLevel, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
 import { appendRequestLogEntry, emitLogEvent, emitRequestLogEvent, ensureRequestLogTable, readRequestLog, renderLogMessage } from "./request-log";
@@ -1841,6 +1841,23 @@ abstract class ShardDO {
 
     /** Memoized RLS-uniform verdict per `(name, args)` shape — uniformity is a stable property, so the dual-identity probe runs at most once per distinct shape (plan 075 Phase 3). */
     private readonly shapeUniformCache = new Map<string, boolean>();
+
+    /**
+     * Owner-side registry of relay-uniform shapes that a relay has subscribers for
+     * (plan 075 Phase 3 slice B.2), keyed by `(name, args)`. `cursor` is the cohort
+     * frontier — the cursor up to which the owner has multicast this shape's deltas.
+     * On each flush the owner diffs `(cursor, frameCursor]` ONCE and multicasts it to
+     * its relays, then advances `cursor`.
+     */
+    private readonly relayShapeRegistry = new Map<string, { args: Record<string, unknown>; cursor: number; name: string }>();
+
+    /**
+     * Relay-side per-socket shape memo: `ws → subId → cursor`. The relay delivers a
+     * multicast `relay_shape_poke` to a socket only when its memo for that shape
+     * equals the poke's `fromCursor`, then advances it — so a socket that seeded at
+     * a different cursor never double-applies a delta (plan 075 Phase 3 slice B.2).
+     */
+    private readonly shapeRelayMemos = new WeakMap<WebSocket, Map<string, number>>();
 
     /**
      * Declared indexes (`table:index`) a query has exercised since this instance
@@ -5962,7 +5979,11 @@ abstract class ShardDO {
                 const frameEpoch = this.currentCdcEpoch();
 
                 // eslint-disable-next-line no-await-in-loop -- passes are intentionally sequential: each observes the prior pass's committed state and the tables merged while it ran
-                await Promise.all([this.refreshSubscriptions(batch), this.pokeShapeSubscribers(batch, frameCursor, frameEpoch)]);
+                await Promise.all([
+                    this.refreshSubscriptions(batch),
+                    this.pokeShapeSubscribers(batch, frameCursor, frameEpoch),
+                    this.multicastRelayShapePokes(batch, frameCursor ?? 0),
+                ]);
 
                 batch = this.pendingRefreshTables;
             }
@@ -6392,6 +6413,18 @@ abstract class ShardDO {
             { args: request.args, name: request.name, sinceEpoch: request.sinceEpoch, sinceSeq: request.sinceSeq },
             resolved,
         );
+
+        // Register a UNIFORM shape so the owner multicasts its future deltas to relays
+        // (slice B.2). A non-uniform shape is still seeded above (RLS-correct under the
+        // forwarded identity) but isn't registered — it gets no live multicast (those
+        // sockets are inherently low-fan-out; a per-socket proxy is a follow-up).
+        if (this.isShapeRelayUniform(request.name, request.args)) {
+            const routingKey = stableStringify({ args: request.args, name: request.name });
+
+            if (!this.relayShapeRegistry.has(routingKey)) {
+                this.relayShapeRegistry.set(routingKey, { args: request.args, cursor, name: request.name });
+            }
+        }
 
         this.pokeSequence += 1;
         const frames = buildPokeFrames([{ rowsPatch, shapeId: request.subId }], {
@@ -7627,6 +7660,10 @@ abstract class ShardDO {
             return { code: "RELAY_MISCONFIGURED", message: "relay cannot address its owner" };
         }
 
+        // Announce to the owner so it adds this relay to the set it multicasts shape
+        // deltas to (slice B.2) — shape subscribers attach the relay just like whisper.
+        await this.announceRelayIfNeeded();
+
         const request: RelayShapeSubscribe = {
             args: shape.args ?? {},
             identity: identity.identity,
@@ -7666,7 +7703,132 @@ abstract class ShardDO {
             trySendFrame(ws, frame);
         }
 
+        // Record this socket's cohort memo so the owner's multicast deltas land
+        // exactly once (slice B.2): the next `relay_shape_poke` for this shape is
+        // delivered only while the memo still equals the poke's `fromCursor`.
+        this.recordRelayShapeMemo(ws, subId, seed.cursor ?? 0);
+
         return "ok";
+    }
+
+    /** Record a relay socket's cohort cursor for `subId` (creating the per-socket map lazily). */
+    private recordRelayShapeMemo(ws: WebSocket, subId: string, cursor: number): void {
+        let memos = this.shapeRelayMemos.get(ws);
+
+        if (memos === undefined) {
+            memos = new Map<string, number>();
+            this.shapeRelayMemos.set(ws, memos);
+        }
+
+        memos.set(subId, cursor);
+    }
+
+    /**
+     * Owner side (plan 075 Phase 3 slice B.2): for every registered relay-uniform
+     * shape whose table changed this flush, compute the membership diff ONCE over
+     * `(cohort cursor, frameCursor]` and multicast the `rowsPatch` to every relay.
+     * Advances the cohort cursor synchronously (before any await) so a seed that
+     * interleaves during the multicast registers at `frameCursor` and is skipped by
+     * this in-flight poke. The owner's per-socket poke path is untouched — this is
+     * pure additive relay fan-out, a no-op when the shard has no relays.
+     */
+    private async multicastRelayShapePokes(changed: Set<string>, frameCursor: number): Promise<void> {
+        const ownerKey = this.state.id?.name;
+
+        if (ownerKey === undefined || this.relayShapeRegistry.size === 0) {
+            return;
+        }
+
+        const relays = this.ownerRelaySet();
+
+        if (relays.size === 0) {
+            return;
+        }
+
+        const sql = this.sql as SqlExec;
+        const epoch = this.currentCdcEpoch();
+        const sends: Promise<void>[] = [];
+
+        for (const entry of this.relayShapeRegistry.values()) {
+            let resolved: ResolvedShape | undefined;
+
+            try {
+                resolved = this.resolveShape(entry.name, entry.args, {});
+            } catch {
+                continue;
+            }
+
+            if (resolved === undefined || resolved.global === true || !changed.has(resolved.table)) {
+                continue;
+            }
+
+            const fromCursor = entry.cursor;
+            const rowsPatch = this.buildShapeDiff(sql, resolved, fromCursor, frameCursor);
+
+            if (rowsPatch.length === 0) {
+                continue; // the shape's membership didn't change — leave the cohort cursor put
+            }
+
+            entry.cursor = frameCursor;
+            const poke: RelayShapePoke = {
+                args: entry.args,
+                checkpoint: frameCursor,
+                epoch,
+                fromCursor,
+                name: entry.name,
+                rowsPatch,
+                type: "relay_shape_poke",
+            };
+
+            for (const index of relays) {
+                sends.push(this.postRelayMessage(relayName(ownerKey, index), poke));
+            }
+        }
+
+        await Promise.all(sends);
+    }
+
+    /**
+     * Relay side (plan 075 Phase 3 slice B.2): deliver an owner-multicast shape
+     * delta to this relay's cohort sockets. A socket receives it only while its memo
+     * for the shape equals the poke's `fromCursor` — so a socket that seeded at a
+     * different cursor is skipped and never double-applies — then advances to
+     * `checkpoint`. The `rowsPatch` is wrapped in poke frames per socket (each its
+     * own `subId`); `lastMutationId` is omitted (relayed sockets are owner-served
+     * for custom mutators).
+     */
+    private deliverRelayShapePoke(poke: RelayShapePoke): void {
+        const routingKey = stableStringify({ args: poke.args, name: poke.name });
+
+        for (const ws of this.state.getWebSockets()) {
+            const { shapes } = this.readAttachment(ws);
+            const memos = this.shapeRelayMemos.get(ws);
+
+            if (shapes === undefined || memos === undefined) {
+                continue;
+            }
+
+            for (const [subId, sub] of Object.entries(shapes)) {
+                if (memos.get(subId) !== poke.fromCursor || stableStringify({ args: sub.args ?? {}, name: sub.name }) !== routingKey) {
+                    continue;
+                }
+
+                this.pokeSequence += 1;
+                const frames = buildPokeFrames([{ rowsPatch: poke.rowsPatch, shapeId: subId }], {
+                    baseCheckpoint: undefined,
+                    checkpoint: poke.checkpoint,
+                    epoch: poke.epoch,
+                    lastMutationId: undefined,
+                    pokeId: `poke-${String(this.pokeSequence)}`,
+                });
+
+                for (const frame of frames) {
+                    trySendFrame(ws, frame);
+                }
+
+                memos.set(subId, poke.checkpoint);
+            }
+        }
     }
 
     /**
@@ -7689,6 +7851,14 @@ abstract class ShardDO {
             // Owner seeds a relay's shape under the forwarded identity and returns
             // the serialized poke frames for the relay to deliver (plan 075 Phase 3).
             return jsonResponse(this.buildShapeSeedFrames(message));
+        }
+
+        if (message.type === "relay_shape_poke") {
+            // Owner-multicast shape delta → deliver to this relay's cohort sockets.
+            this.deliverRelayShapePoke(message);
+
+            // eslint-disable-next-line unicorn/no-null -- 204 No Content
+            return new Response(null, { status: 204 });
         }
 
         if (message.type === "relay_attach") {

--- a/packages/do/src/subscription-delivery.ts
+++ b/packages/do/src/subscription-delivery.ts
@@ -257,4 +257,30 @@ const sendDeltaFrames = (ws: WebSocket, subId: string, deltaFrames: ReadonlyArra
     return delivered;
 };
 
-export { sendDeltaFrames, subscriptionListDeltas, trySendFrame };
+/**
+ * Defensive WS backpressure helper. When the runtime exposes `bufferedAmount`
+ * on the socket, pause iteration whenever the outbound buffer is past 1 MiB;
+ * otherwise treat the socket as drained. Capped at 100 sleeps of 20 ms (≈ 2 s
+ * total) so a permanently-stuck buffer can't pin the iterator forever — past
+ * that we drop through and let the next `ws.send` surface the failure.
+ */
+const awaitWsDrain = async (ws: WebSocket): Promise<void> => {
+    let attempts = 0;
+
+    while (attempts < 100) {
+        attempts += 1;
+
+        const buffered = (ws as { bufferedAmount?: unknown }).bufferedAmount;
+
+        if (typeof buffered !== "number" || buffered < 1_048_576) {
+            return;
+        }
+
+        // eslint-disable-next-line no-await-in-loop -- intentional backpressure poll: sleep, then re-check the drained buffer on the next iteration
+        await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+        });
+    }
+};
+
+export { awaitWsDrain, sendDeltaFrames, subscriptionListDeltas, trySendFrame };

--- a/packages/do/src/types.ts
+++ b/packages/do/src/types.ts
@@ -1,3 +1,5 @@
+import type { WhereInput } from "./where-types";
+
 export interface SubscriptionQuery {
     args?: Record<string, unknown>;
 
@@ -280,4 +282,36 @@ export interface SocketAttachment {
      * survives hibernation; absent until the socket joins a topic.
      */
     whispers?: string[];
+}
+
+/**
+ * A `shape_subscribe`'s resolved query: which `table` to replicate, the
+ * identity-scoped `effectiveWhere` (the shape predicate AND-merged with the
+ * table's RLS read base-where), the optional projected `columns` allow-list,
+ * and whether the table is `.global()` (served by the latency-tiered poll path
+ * rather than the CDC poke path). The codegen subclass's `resolveShape` builds
+ * it under the socket's verified identity, so the membership query the poke
+ * protocol runs is RLS-correct by construction.
+ */
+export interface ResolvedShape {
+    columns?: ReadonlyArray<string>;
+    effectiveWhere?: WhereInput;
+    /** `true` when the shape's table is `.global()` (lives in D1, not this DO's SQLite) — no per-DO op-log to diff, so served by the poll path. */
+    global?: boolean;
+    table: string;
+}
+
+/**
+ * Identity a subscription/shape query is executed under, threaded EXPLICITLY
+ * into the codegen `resolveShape`/`buildCtx` rather than read from the shared,
+ * per-request identity fields. The value passed is the socket's OWN verified
+ * identity (stamped on the {@link SocketAttachment} at the WS upgrade from the
+ * runtime-minted `x-lunora-userid`/`x-lunora-identity` headers the client can't
+ * forge), passed BY VALUE so a deferred refresh or interleaved RPC can't clobber
+ * it. An anonymous socket leaves both fields `undefined`, so an RLS/`ctx.auth`
+ * query fails closed (empty/denied) rather than leaking another user's data.
+ */
+export interface SubscriptionIdentity {
+    identity?: Record<string, unknown>;
+    userId?: string;
 }

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -1224,3 +1224,76 @@ describe("createWorker auth-metrics instrumentation (PLAN3 §2.3)", () => {
         expect(authHandler).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("createWorker — relay-tier routing (plan 075 Phase 2)", () => {
+    interface Forward {
+        binding: null | string;
+        name: string;
+    }
+
+    const routingNamespace = (relayCount: number, forwards: Forward[]): ShardNamespaceLike => {
+        return {
+            get: (id) => {
+                const name = (id as { __name: string }).__name;
+
+                return {
+                    fetch: async (request: Request) => {
+                        if (new URL(request.url).pathname === "/_lunora/route") {
+                            return Response.json({ relayCount }, { headers: { "content-type": "application/json" } });
+                        }
+
+                        forwards.push({ binding: request.headers.get("x-lunora-shard-binding"), name });
+
+                        return new Response(null, { status: 101 });
+                    },
+                };
+            },
+            idFromName: (name) => {
+                return { __name: name };
+            },
+        };
+    };
+
+    const upgrade = (shardKey: string): Request => new Request(`https://app.example/_lunora/ws?shard=${shardKey}`, { headers: { Upgrade: "websocket" } });
+
+    it("routes a new WS connection on a promoted shard to one of its relays", async () => {
+        expect.assertions(3);
+
+        const forwards: Forward[] = [];
+        const namespace = routingNamespace(2, forwards);
+        const worker = createWorker({ shardDO: namespace });
+
+        await worker.fetch(upgrade("promoted-a"), { SHARD: namespace }, fakeContext);
+
+        expect(forwards).toHaveLength(1);
+        expect(forwards[0]?.name).toMatch(/^promoted-a::relay::[01]$/u); // routed to a relay
+        expect(forwards[0]?.binding).toBe("SHARD"); // told the DO its namespace binding
+    });
+
+    it("keeps a new WS connection on the owner when the shard is not promoted", async () => {
+        expect.assertions(2);
+
+        const forwards: Forward[] = [];
+        const namespace = routingNamespace(0, forwards);
+        const worker = createWorker({ shardDO: namespace });
+
+        await worker.fetch(upgrade("cold-b"), { SHARD: namespace }, fakeContext);
+
+        expect(forwards).toHaveLength(1);
+        expect(forwards[0]?.name).toBe("cold-b"); // owner-served
+    });
+
+    it("stays owner-served when the namespace binding can't be found (relay tier inert)", async () => {
+        expect.assertions(2);
+
+        const forwards: Forward[] = [];
+        const namespace = routingNamespace(2, forwards);
+        const worker = createWorker({ shardDO: namespace });
+
+        // `env` does not expose the namespace → no binding → no probe, no relay routing.
+        await worker.fetch(upgrade("cold-c"), {}, fakeContext);
+
+        expect(forwards[0]?.name).toBe("cold-c");
+        expect(forwards[0]?.binding).toBeNull();
+    });
+});

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -1,5 +1,6 @@
 import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
+import { relayName } from "../../../shared/relay-name";
 import type { AuthAdmin, AuthIntrospector } from "./auth-admin-routes";
 import { buildAuthAdminRoutes } from "./auth-admin-routes";
 import { MAX_BODY_BYTES, readBodyBytesWithLimit, readBodyTextWithLimit, readJsonBodyWithLimit } from "./body-readers";
@@ -1246,6 +1247,73 @@ const forwardToShard = async (namespace: ShardNamespaceLike, shardKey: string, r
     return stub.fetch(request);
 };
 
+/** Per-isolate cache of a shard's relay count (the promotion probe), TTL-bounded so a promoted shard doesn't add a round-trip to every WS upgrade. */
+interface RelayProbeEntry {
+    expiresMs: number;
+    relayCount: number;
+}
+
+const relayProbeCache = new Map<string, RelayProbeEntry>();
+
+/** How long a relay-count probe is cached per isolate before the runtime re-asks the owner. */
+const RELAY_PROBE_TTL_MS = 5000;
+
+/**
+ * Ask the owner how many relays to spread new connections across for `shardKey`
+ * (plan 075 Phase 2), cached per isolate so a promoted shard doesn't add a
+ * round-trip to every WS upgrade. Fails closed to `0` (owner-served) on any error,
+ * so a relay-probe hiccup can never break a connection.
+ */
+const probeRelayCount = async (namespace: ShardNamespaceLike, shardKey: string): Promise<number> => {
+    const now = Date.now();
+    const cached = relayProbeCache.get(shardKey);
+
+    if (cached !== undefined && cached.expiresMs > now) {
+        return cached.relayCount;
+    }
+
+    let relayCount = 0;
+
+    try {
+        const response = await resolveShard(namespace, shardKey).fetch(new Request("https://shard.internal/_lunora/route"));
+
+        if (response.ok) {
+            const body: unknown = await response.json();
+            const reported = (body as { relayCount?: unknown }).relayCount;
+
+            if (typeof reported === "number" && reported > 0) {
+                relayCount = Math.floor(reported);
+            }
+        }
+    } catch {
+        relayCount = 0;
+    }
+
+    relayProbeCache.set(shardKey, { expiresMs: now + RELAY_PROBE_TTL_MS, relayCount });
+
+    return relayCount;
+};
+
+/**
+ * Find the env binding name holding the shard DO namespace, so the runtime can tell
+ * each DO how to address its siblings for the relay hub (`x-lunora-shard-binding`).
+ * Matched by identity against the un-jurisdictioned `options.shardDO`.
+ * @returns the binding key (e.g. `"SHARD"`), or `undefined` when it can't be found (relay tier stays inert)
+ */
+const resolveShardBindingName = (env: unknown, namespace: ShardNamespaceLike): string | undefined => {
+    if (env === null || typeof env !== "object") {
+        return undefined;
+    }
+
+    for (const [key, value] of Object.entries(env)) {
+        if (value === namespace) {
+            return key;
+        }
+    }
+
+    return undefined;
+};
+
 /**
  * Constant-time-ish bearer check used by the admin endpoints. We accept the
  * token as a verbatim string match because the worker's existing
@@ -2019,6 +2087,25 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         if (forwardedExp !== undefined) {
             upgradeHeaders.set("x-lunora-identity-exp", forwardedExp);
+        }
+
+        // Relay tier (plan 075 Phase 2): when the shard is promoted, route this NEW
+        // connection to one of its relays so the owner sheds connection + fan-out
+        // load — invisible to the client (same socket, same whispers). Tell the DO
+        // its namespace binding so it can address siblings for the hub.
+        const binding = resolveShardBindingName(env, options.shardDO);
+
+        if (binding !== undefined) {
+            upgradeHeaders.set("x-lunora-shard-binding", binding);
+
+            const relayCount = await probeRelayCount(shardDO, shardKey);
+
+            if (relayCount > 0) {
+                // eslint-disable-next-line sonarjs/pseudo-random -- load distribution across relays, not a security-sensitive value
+                const target = relayName(shardKey, Math.floor(Math.random() * relayCount));
+
+                return forwardToShard(shardDO, target, new Request(request, { headers: upgradeHeaders }));
+            }
         }
 
         return forwardToShard(shardDO, shardKey, new Request(request, { headers: upgradeHeaders }));

--- a/packages/studio/__tests__/app/studio.test.tsx
+++ b/packages/studio/__tests__/app/studio.test.tsx
@@ -3,7 +3,15 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { Studio } from "../../src/app/studio";
-import type { FlagEvaluation, FlagsResult, QueueMetadata, StudioFeaturesResult } from "../../src/lib/admin";
+import type {
+    FanoutMetricsResult,
+    FanoutPathCounters,
+    FanoutTopicStat,
+    FlagEvaluation,
+    FlagsResult,
+    QueueMetadata,
+    StudioFeaturesResult,
+} from "../../src/lib/admin";
 import { ADMIN_FUNCTIONS } from "../../src/lib/admin";
 import type { MockClientHooks } from "../mock-client";
 import { createMockClient } from "../mock-client";
@@ -99,6 +107,26 @@ const FLAG_EVALUATION_KEY_GUARD: KeysMatch<keyof FlagEvaluation, (typeof FLAG_EV
 const FLAGS_RESULT_KEYS = ["configured", "flags"] as const;
 
 const FLAGS_RESULT_KEY_GUARD: KeysMatch<keyof FlagsResult, (typeof FLAGS_RESULT_KEYS)[number]> = true;
+
+/**
+ * Canonical key sets of the `getFanoutMetrics` wire shapes (plan 075 Phase 1) —
+ * hand-mirrored from `@lunora/do` the same way as the types above, with the
+ * matching guards living in `@lunora/do`'s `shard-do.admin.test.ts`. The fan-out
+ * panel reads these fields off the wire, so a dropped field would surface as a
+ * silent `undefined` cell rather than a type error; these guards fail the build
+ * on drift.
+ */
+const FANOUT_TOPIC_STAT_KEYS = ["kind", "subscribers", "topic"] as const;
+
+const FANOUT_TOPIC_STAT_KEY_GUARD: KeysMatch<keyof FanoutTopicStat, (typeof FANOUT_TOPIC_STAT_KEYS)[number]> = true;
+
+const FANOUT_PATH_COUNTERS_KEYS = ["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"] as const;
+
+const FANOUT_PATH_COUNTERS_KEY_GUARD: KeysMatch<keyof FanoutPathCounters, (typeof FANOUT_PATH_COUNTERS_KEYS)[number]> = true;
+
+const FANOUT_METRICS_RESULT_KEYS = ["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"] as const;
+
+const FANOUT_METRICS_RESULT_KEY_GUARD: KeysMatch<keyof FanoutMetricsResult, (typeof FANOUT_METRICS_RESULT_KEYS)[number]> = true;
 
 describe("studio", () => {
     it("renders every domain's sub-pages at once in the grouped sidebar", async () => {
@@ -228,5 +256,16 @@ describe("studio", () => {
         expect([...FLAG_EVALUATION_KEYS]).toStrictEqual(["errorCode", "key", "reason", "type", "value", "variant"]);
         expect(FLAGS_RESULT_KEY_GUARD).toBe(true);
         expect([...FLAGS_RESULT_KEYS]).toStrictEqual(["configured", "flags"]);
+    });
+
+    it("keeps the studio's getFanoutMetrics mirror in lockstep with @lunora/do's contract", () => {
+        expect.assertions(6);
+
+        expect(FANOUT_TOPIC_STAT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_TOPIC_STAT_KEYS]).toStrictEqual(["kind", "subscribers", "topic"]);
+        expect(FANOUT_PATH_COUNTERS_KEY_GUARD).toBe(true);
+        expect([...FANOUT_PATH_COUNTERS_KEYS]).toStrictEqual(["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"]);
+        expect(FANOUT_METRICS_RESULT_KEY_GUARD).toBe(true);
+        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual(["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"]);
     });
 });

--- a/packages/studio/__tests__/app/studio.test.tsx
+++ b/packages/studio/__tests__/app/studio.test.tsx
@@ -124,7 +124,17 @@ const FANOUT_PATH_COUNTERS_KEYS = ["maxMs", "passes", "peakSocketsIterated", "so
 
 const FANOUT_PATH_COUNTERS_KEY_GUARD: KeysMatch<keyof FanoutPathCounters, (typeof FANOUT_PATH_COUNTERS_KEYS)[number]> = true;
 
-const FANOUT_METRICS_RESULT_KEYS = ["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"] as const;
+const FANOUT_METRICS_RESULT_KEYS = [
+    "maxRelays",
+    "peakSubscribers",
+    "promoted",
+    "relayCount",
+    "shapePoke",
+    "sinceMs",
+    "topics",
+    "totalConnections",
+    "whisper",
+] as const;
 
 const FANOUT_METRICS_RESULT_KEY_GUARD: KeysMatch<keyof FanoutMetricsResult, (typeof FANOUT_METRICS_RESULT_KEYS)[number]> = true;
 
@@ -266,6 +276,16 @@ describe("studio", () => {
         expect(FANOUT_PATH_COUNTERS_KEY_GUARD).toBe(true);
         expect([...FANOUT_PATH_COUNTERS_KEYS]).toStrictEqual(["maxMs", "passes", "peakSocketsIterated", "socketsDelivered", "socketsIterated", "totalMs"]);
         expect(FANOUT_METRICS_RESULT_KEY_GUARD).toBe(true);
-        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual(["peakSubscribers", "shapePoke", "sinceMs", "topics", "totalConnections", "whisper"]);
+        expect([...FANOUT_METRICS_RESULT_KEYS]).toStrictEqual([
+            "maxRelays",
+            "peakSubscribers",
+            "promoted",
+            "relayCount",
+            "shapePoke",
+            "sinceMs",
+            "topics",
+            "totalConnections",
+            "whisper",
+        ]);
     });
 });

--- a/packages/studio/src/app/studio.tsx
+++ b/packages/studio/src/app/studio.tsx
@@ -66,6 +66,7 @@ import { PaymentsPanel } from "../features/payments/payments-panel";
 import { PermissionsPanel } from "../features/permissions/permissions-panel";
 import QueuesPanel from "../features/queues/queues-panel";
 import DashboardsPanel from "../features/reports/dashboards-panel";
+import FanoutPanel from "../features/reports/fanout-panel";
 import { HealthPanel } from "../features/reports/health-panel";
 import { MetricsPanel } from "../features/reports/metrics-panel";
 import { SchemaViewer } from "../features/schema/schema-viewer";
@@ -96,6 +97,7 @@ type StudioTab =
     | "data"
     | "drains"
     | "export"
+    | "fanout"
     | "files"
     | "flags"
     | "functions"
@@ -267,6 +269,9 @@ const TAB_ICONS: Record<StudioTab, ReactNode> = {
         <path d="M5 6c0-1.4 3.1-2.5 7-2.5s7 1.1 7 2.5-3.1 2.5-7 2.5S5 7.4 5 6Zm0 0v12c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5V6M5 12c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5" />
     ),
     export: <path d="M12 3v11m0 0 4-4m-4 4-4-4M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />,
+    fanout: (
+        <path d="M12 5a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm-7 16a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm14 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4ZM12 7v3.5M12 10.5 6 17m6-6.5 6 6.5" />
+    ),
     files: <path d="M4 7a2 2 0 0 1 2-2h3l2 2.5h7a2 2 0 0 1 2 2V18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7Z" />,
     flags: <path d="M6 21V4m0 0h11l-2 3 2 3H6" />,
     functions: <path d="m9 8-4 4 4 4m6-8 4 4-4 4" />,
@@ -314,7 +319,7 @@ const NAV_GROUPS: readonly [NavGroup, ...NavGroup[]] = [
     { key: "functions", tabs: ["functions", "api", "workflows", "queues"] },
     { key: "auth", tabs: ["users", "organizations", "authSessions", "authConfig"] },
     { key: "storage", tabs: ["files", "storageRules"] },
-    { key: "observability", tabs: ["logs", "audit", "realtime", "metrics", "analytics", "health"] },
+    { key: "observability", tabs: ["logs", "audit", "realtime", "fanout", "metrics", "analytics", "health"] },
     { key: "advisors", tabs: ["security", "rls", "permissions", "insights"] },
     { key: "operations", tabs: ["schedule", "mail", "drains", "payments", "flags"] },
     { key: "settings", tabs: ["settings"] },
@@ -729,6 +734,7 @@ const StudioLayout = (): ReactElement => {
         data: t("Data"),
         drains: t("Log drains"),
         export: t("Export / Import"),
+        fanout: t("Fan-out"),
         files: t("Files"),
         flags: t("Flags"),
         functions: t("Functions"),
@@ -780,6 +786,7 @@ const StudioLayout = (): ReactElement => {
         data: t("Browse and edit rows across your shard and global tables."),
         drains: t("Forward logs to Logpush, Tail Workers, or a webhook collector."),
         export: t("Export a shard to NDJSON, or import rows from it."),
+        fanout: t("Realtime fan-out cost and per-topic subscriber counts for this shard."),
         files: t("Browse objects in your R2 storage buckets."),
         flags: t("Inspect feature flags and their live evaluation under a targeting context."),
         functions: t("Run registered queries, mutations, and actions."),
@@ -998,6 +1005,7 @@ const buildRouter = ({
         data: <TableEditor editable={dataEditable} initialShardKey={initialShardKey} />,
         drains: <LogDrainsPanel />,
         export: <ExportImportPanel initialShardKey={initialShardKey} />,
+        fanout: <FanoutPanel initialShardKey={initialShardKey} />,
         files: <FileBrowser />,
         flags: <FlagsPanel initialShardKey={initialShardKey} />,
         functions: (

--- a/packages/studio/src/features/reports/fanout-panel.tsx
+++ b/packages/studio/src/features/reports/fanout-panel.tsx
@@ -1,0 +1,186 @@
+import type { ReactElement, ReactNode } from "react";
+import { useState } from "react";
+
+import { ShardInput } from "../../components/shard-input";
+import { Badge } from "../../components/ui/badge";
+import { Card } from "../../components/ui/card";
+import { EmptyState } from "../../components/ui/empty-state";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { useAdminQuery } from "../../hooks/use-admin-query";
+import { useAutoRefresh } from "../../hooks/use-auto-refresh";
+import useDebounced from "../../hooks/use-debounced";
+import type { TFunction } from "../../i18n/i18n-context";
+import { useT } from "../../i18n/i18n-context";
+import type { FanoutMetricsResult, FanoutPathCounters } from "../../lib/admin";
+import { ADMIN_FUNCTIONS } from "../../lib/admin";
+
+interface FanoutPanelProps {
+    /** Shard key the panel reports on. Defaults to the root shard. */
+    readonly initialShardKey?: string;
+}
+
+/** Format a coarse millisecond duration for a stat card. */
+const formatMs = (ms: number): string => `${ms.toString()} ms`;
+
+/** True once a result has loaded and the shard has no connections and has run no fan-out passes yet. */
+const isFanoutIdle = (result: FanoutMetricsResult): boolean => result.totalConnections === 0 && result.shapePoke.passes === 0 && result.whisper.passes === 0;
+
+/** One labelled fan-out counter as a compact KPI card (the metrics panel's stat-card anatomy). */
+const StatCard = ({ label, testId, value }: { label: string; testId?: string; value: ReactNode }): ReactElement => (
+    <Card className="gap-0 py-0">
+        <div className="flex flex-col gap-2.5 p-4">
+            <span className="font-mono text-[11px] tracking-wide text-muted-foreground uppercase">{label}</span>
+            <span className="truncate text-2xl font-semibold tabular-nums text-foreground" data-testid={testId}>
+                {value}
+            </span>
+        </div>
+    </Card>
+);
+
+/**
+ * The running counters for one delivery path as a titled grid of stat cards.
+ * `includeTiming` is `false` for the whisper path (a synchronous broadcast
+ * captures no wall-clock — a DO clock advances only on awaited I/O — so the
+ * `0`ms timing fields would mislead and are omitted rather than shown).
+ */
+const PathCounters = ({
+    counters,
+    includeTiming,
+    prefix,
+    t,
+    title,
+}: {
+    counters: FanoutPathCounters;
+    includeTiming: boolean;
+    prefix: string;
+    t: TFunction;
+    title: string;
+}): ReactElement => (
+    <section className="flex flex-col gap-2" data-testid={`${prefix}-section`}>
+        <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid={`${prefix}-stats`}>
+            <StatCard label={t("Passes")} testId={`${prefix}-passes`} value={counters.passes} />
+            <StatCard label={t("Sockets iterated")} testId={`${prefix}-iterated`} value={counters.socketsIterated} />
+            <StatCard label={t("Delivered")} testId={`${prefix}-delivered`} value={counters.socketsDelivered} />
+            <StatCard label={t("Peak width")} testId={`${prefix}-peak`} value={counters.peakSocketsIterated} />
+            {includeTiming && <StatCard label={t("Total time")} testId={`${prefix}-total-ms`} value={formatMs(counters.totalMs)} />}
+            {includeTiming && <StatCard label={t("Max time")} testId={`${prefix}-max-ms`} value={formatMs(counters.maxMs)} />}
+        </dl>
+    </section>
+);
+
+/**
+ * Fan-out observability for one shard (plan 075 Phase 1): the current
+ * per-topic/shape subscriber counts and the running per-flush fan-out cost of
+ * the reactive shape-poke and whisper-broadcast paths. Reads the
+ * `__lunora_admin__:getFanoutMetrics` RPC via {@link useAdminQuery} (gated by the
+ * server's `LUNORA_ADMIN_TOKEN`).
+ *
+ * This makes the O(subscribers) fan-out cost visible — the "you can see it
+ * scale" half of the auto-elastic relay tier, before any topology change exists.
+ * Subscriber counts are a point-in-time read (no write-flush fires on a
+ * connect/disconnect) and the cost counters reset when the DO hibernates, so the
+ * panel polls on a fixed interval to stay current without a manual refresh.
+ */
+const FanoutPanel = ({ initialShardKey }: FanoutPanelProps): ReactElement => {
+    const t = useT();
+
+    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+
+    // Re-read on the debounced shard key so typing a shard applies once it settles
+    // without querying a half-typed value.
+    const debouncedShard = useDebounced(shardKey.trim(), 400);
+
+    const {
+        data: result,
+        error,
+        refetch,
+    } = useAdminQuery<FanoutMetricsResult>(ADMIN_FUNCTIONS.getFanoutMetrics, {}, { keepPreviousData: true, shardKey: debouncedShard });
+
+    // Point-in-time DO read — poll to keep the snapshot current without a manual refresh.
+    useAutoRefresh(refetch, true);
+
+    const isIdle = result !== undefined && isFanoutIdle(result);
+
+    return (
+        <div className="flex flex-col gap-4" data-testid="fanout-panel">
+            <div className="flex flex-wrap items-center gap-2">
+                <ShardInput onChange={setShardKey} testId="fanout-shard-input" value={shardKey} />
+                {result !== undefined && (
+                    <div className="ml-auto flex items-center gap-2 text-sm text-muted-foreground" data-testid="fanout-count">
+                        <Badge variant="secondary">{t("{count} connections", { count: result.totalConnections })}</Badge>
+                        <Badge variant="secondary">{t("peak {count} subscribers", { count: result.peakSubscribers })}</Badge>
+                    </div>
+                )}
+            </div>
+
+            {error !== null && (
+                <p className="text-sm text-destructive" data-testid="fanout-error" role="alert">
+                    {error}
+                </p>
+            )}
+
+            {error === null && isIdle && (
+                <EmptyState
+                    description={t("Realtime fan-out cost and per-topic subscriber counts for this shard.")}
+                    icon={
+                        <svg
+                            aria-hidden="true"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.6}
+                            viewBox="0 0 24 24"
+                        >
+                            <path d="M4 12h4l3 7 4-14 3 7h2" />
+                        </svg>
+                    }
+                    testId="fanout-empty"
+                    title={t("No fan-out activity yet.")}
+                />
+            )}
+
+            {error === null && result !== undefined && !isIdle && (
+                <>
+                    {result.topics.length > 0 && (
+                        <section className="flex flex-col gap-2" data-testid="fanout-topics-section">
+                            <h3 className="text-sm font-medium text-foreground">{t("Hot topics")}</h3>
+                            <Card className="overflow-hidden py-0">
+                                <Table data-testid="fanout-topics-table">
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>{t("Topic")}</TableHead>
+                                            <TableHead>{t("Kind")}</TableHead>
+                                            <TableHead className="text-right">{t("Subscribers")}</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {result.topics.map((topic) => (
+                                            <TableRow data-testid="fanout-topic-row" key={`${topic.kind}:${topic.topic}`}>
+                                                <TableCell className="font-mono text-xs">{topic.topic}</TableCell>
+                                                <TableCell>
+                                                    <Badge variant="outline">{topic.kind}</Badge>
+                                                </TableCell>
+                                                <TableCell className="text-right font-medium tabular-nums">{topic.subscribers}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </Card>
+                        </section>
+                    )}
+
+                    <section className="flex flex-col gap-3" data-testid="fanout-cost">
+                        <h2 className="text-sm font-medium text-muted-foreground">{t("Fan-out cost since this instance woke")}</h2>
+                        <PathCounters counters={result.shapePoke} includeTiming prefix="fanout-poke" t={t} title={t("Shape pokes")} />
+                        <PathCounters counters={result.whisper} includeTiming={false} prefix="fanout-whisper" t={t} title={t("Whisper broadcasts")} />
+                    </section>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default FanoutPanel;
+export type { FanoutPanelProps };

--- a/packages/studio/src/features/reports/fanout-panel.tsx
+++ b/packages/studio/src/features/reports/fanout-panel.tsx
@@ -108,6 +108,11 @@ const FanoutPanel = ({ initialShardKey }: FanoutPanelProps): ReactElement => {
                 <ShardInput onChange={setShardKey} testId="fanout-shard-input" value={shardKey} />
                 {result !== undefined && (
                     <div className="ml-auto flex items-center gap-2 text-sm text-muted-foreground" data-testid="fanout-count">
+                        {result.promoted && (
+                            <Badge data-testid="fanout-promoted" variant="default">
+                                {t("auto-scaled: {relayCount}/{maxRelays} relays", { maxRelays: result.maxRelays, relayCount: result.relayCount })}
+                            </Badge>
+                        )}
                         <Badge variant="secondary">{t("{count} connections", { count: result.totalConnections })}</Badge>
                         <Badge variant="secondary">{t("peak {count} subscribers", { count: result.peakSubscribers })}</Badge>
                     </div>

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -724,7 +724,10 @@ export interface FanoutPathCounters {
  * (in-memory, reset on hibernation). Feeds the Studio fan-out observability panel.
  */
 export interface FanoutMetricsResult {
+    maxRelays: number;
     peakSubscribers: number;
+    promoted: boolean;
+    relayCount: number;
     shapePoke: FanoutPathCounters;
     sinceMs: number;
     topics: FanoutTopicStat[];

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -39,6 +39,7 @@ export const ADMIN_FUNCTIONS = {
     getAuditLog: "__lunora_admin__:getAuditLog",
     getAuthMetrics: "__lunora_admin__:getAuthMetrics",
     getCapturedMail: "__lunora_admin__:getCapturedMail",
+    getFanoutMetrics: "__lunora_admin__:getFanoutMetrics",
     getFunctionStats: "__lunora_admin__:getFunctionStats",
     listFlags: "__lunora_admin__:listFlags",
     listQueues: "__lunora_admin__:listQueues",
@@ -682,6 +683,53 @@ export interface SubscriptionsResult {
     connections: SubscriptionConnection[];
     totalConnections: number;
     totalSubscriptions: number;
+}
+
+/**
+ * One topic or shape with its current subscriber count, returned by
+ * `__lunora_admin__:getFanoutMetrics` and mirroring `@lunora/do`'s
+ * `FanoutTopicStat`. `subscribers` is the fan-out width one poke/broadcast incurs
+ * for this topic — the signal the auto-elastic relay tier (plan 075) watches.
+ */
+export interface FanoutTopicStat {
+    /** `"shape"` = a reactive-query shape; `"whisper"` = an ephemeral whisper topic. */
+    kind: "shape" | "whisper";
+    /** Connected sockets currently subscribed — the fan-out width for this topic. */
+    subscribers: number;
+    /** The shape name or the whisper topic string. */
+    topic: string;
+}
+
+/**
+ * Running fan-out counters for one delivery path since the DO instance woke,
+ * mirroring `@lunora/do`'s `FanoutPathCounters`. `socketsIterated` is the
+ * O(subscribers) loop cost; `socketsDelivered` is how many of those received a
+ * frame. `totalMs`/`maxMs` are **coarse** (a DO clock advances only on I/O) and
+ * populated only for the asynchronous shape-poke path — they stay `0` for the
+ * synchronous whisper broadcast.
+ */
+export interface FanoutPathCounters {
+    maxMs: number;
+    passes: number;
+    peakSocketsIterated: number;
+    socketsDelivered: number;
+    socketsIterated: number;
+    totalMs: number;
+}
+
+/**
+ * Payload of a `__lunora_admin__:getFanoutMetrics` call, mirroring `@lunora/do`'s
+ * `FanoutMetricsResult`: the current per-topic subscriber counts (derived live
+ * from the shard's sockets) plus the running per-path fan-out cost counters
+ * (in-memory, reset on hibernation). Feeds the Studio fan-out observability panel.
+ */
+export interface FanoutMetricsResult {
+    peakSubscribers: number;
+    shapePoke: FanoutPathCounters;
+    sinceMs: number;
+    topics: FanoutTopicStat[];
+    totalConnections: number;
+    whisper: FanoutPathCounters;
 }
 
 /** Outcome of one dispatch in the request log, mirroring `@lunora/do`'s `RequestOutcome`. */

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -995,6 +995,23 @@ const MESSAGE_IDS = [
     "Light theme",
     "System theme",
     "Integrity",
+    // Fan-out observability panel (plan 075 Phase 1).
+    "Fan-out",
+    "Realtime fan-out cost and per-topic subscriber counts for this shard.",
+    "No fan-out activity yet.",
+    "peak {count} subscribers",
+    "Hot topics",
+    "Topic",
+    "Kind",
+    "Subscribers",
+    "Fan-out cost since this instance woke",
+    "Shape pokes",
+    "Whisper broadcasts",
+    "Passes",
+    "Sockets iterated",
+    "Delivered",
+    "Peak width",
+    "Max time",
 ] as const;
 
 /** A known studio message id — one of the entries in {@link MESSAGE_IDS}. */

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -997,6 +997,7 @@ const MESSAGE_IDS = [
     "Integrity",
     // Fan-out observability panel (plan 075 Phase 1).
     "Fan-out",
+    "auto-scaled: {relayCount}/{maxRelays} relays",
     "Realtime fan-out cost and per-topic subscriber counts for this shard.",
     "No fan-out activity yet.",
     "peak {count} subscribers",

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -241,8 +241,10 @@ single DO's WS cap succeeds.
 
 Shipped as three slices on `feat/075-fanout-relay`, hardened by a thermo review
 pass: (A) the RLS-uniform gate (`isShapeRelayUniform` — a static `rlsMetadata()`
-read-policy guard plus a claim-diverse identity probe whose base IS the multicast
-identity + a mask check, codegen-free and fail-closed), (B) seed-through-owner +
+read-policy guard plus a claim-exhaustive identity probe whose base IS the multicast
+identity, the populated probes proxy-backed so a resolver reading ANY claim — even
+a custom one outside `rls()` — diverges, with a wholesale-copy backstop and a mask
+check; codegen-free and fail-closed), (B) seed-through-owner +
 one-delta-per-flush cohort multicast (`buildShapeSeedFrames` /
 `multicastRelayShapePokes` / `deliverRelayShapePoke`, gated by a per-socket
 `fromCursor`+`epoch` memo stamped at the **cohort frontier** so a late joiner is

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -151,13 +151,27 @@ checkpoint)` (≈6111) drains the op range from the owner's SQLite and probes
 
 ## Phases
 
-### Phase 0 — Design doc + sign-off (no code)
+### Phase 0 — Design doc + sign-off (no code) — **WRITTEN, awaiting sign-off**
 
 Write the owner↔relay protocol, the promotion/collapse state machine, the
 resume-across-relays handoff, and answers to all six Decisions above into this
-file (or a sibling design doc). **Maintainer sign-off required before Phase 1.**
-Deliverable: a measured T_up from a fan-out micro-benchmark on `ShardDO`
-(subscribers vs per-flush CPU), not a guessed constant.
+file (or a sibling design doc). **Maintainer sign-off required before Phase 2**
+(Phase 1 — observability — already shipped, and is the production instrument the
+design uses to calibrate the threshold). Deliverable: a measured T_up from a
+fan-out micro-benchmark on `ShardDO` (subscribers vs per-flush CPU), not a guessed
+constant.
+
+> **Delivered:** [`075-phase0-relay-protocol-design.md`](075-phase0-relay-protocol-design.md)
+> — the owner↔relay frame protocol, the promotion/collapse state machine, the
+> resume handoff (owner stays checkpoint authority; relays forward resume), the
+> RLS-uniform gate (a fail-closed `relayUniform` codegen bit extending the
+> `isIdentityIndependent` signal), all six Decisions answered, and a measured
+> fan-out curve (linear, ~16 ns/socket Node floor) with a derived
+> `T_up = 8,000 / T_down = 4,000` starting default. The STOP condition on the
+> runtime resolver is cleared (`resolveShard` → `forwardToShard` is a single seam).
+> **One calibration is a Phase 2 prerequisite**: the absolute workerd per-socket
+> constant (the Node number is a lower bound) — measured via a load test reading
+> the Phase-1 `getFanoutMetrics`. See the sign-off checklist in § 10 of that doc.
 
 ### Phase 1 — Observability only (ship first, low risk) — **SHIPPED**
 

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -165,13 +165,15 @@ constant.
 > — the owner↔relay frame protocol, the promotion/collapse state machine, the
 > resume handoff (owner stays checkpoint authority; relays forward resume), the
 > RLS-uniform gate (a fail-closed `relayUniform` codegen bit extending the
-> `isIdentityIndependent` signal), all six Decisions answered, and a measured
-> fan-out curve (linear, ~16 ns/socket Node floor) with a derived
-> `T_up = 8,000 / T_down = 4,000` starting default. The STOP condition on the
-> runtime resolver is cleared (`resolveShard` → `forwardToShard` is a single seam).
-> **One calibration is a Phase 2 prerequisite**: the absolute workerd per-socket
-> constant (the Node number is a lower bound) — measured via a load test reading
-> the Phase-1 `getFanoutMetrics`. See the sign-off checklist in § 10 of that doc.
+> `isIdentityIndependent` signal), all six Decisions answered, and a fan-out curve
+> measured in **both Node (~16 ns/socket floor) and real workerd (~10–15 µs/socket,
+> ~1000× higher, linear)** with a derived `T_up = 8,000 / T_down = 4,000` default —
+> the workerd numbers confirm per-flush fan-out binds within a single DO's
+> connection capacity. The STOP condition on the runtime resolver is cleared
+> (`resolveShard` → `forwardToShard` is a single seam). Remaining tuning (the
+> isolate-CPU-only per-flush cost, for per-deployment threshold tuning) is read from
+> the Phase-1 `getFanoutMetrics` under load — not a Phase-2 gate. See the sign-off
+> checklist in § 10 of that doc.
 
 ### Phase 1 — Observability only (ship first, low risk) — **SHIPPED**
 

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -197,13 +197,33 @@ the DX before any topology change exists. Gate behind a flag if needed.
 > reliable cost signal. The full `@lunora/do` suite is green and the wire shapes
 > carry key drift-guards on both the `@lunora/do` and `@lunora/studio` sides.
 
-### Phase 2 — whisper relay (the natural first adopter)
+### Phase 2 — whisper relay (the natural first adopter) — **SHIPPED**
 
 Relay-scale **whisper topics** only — their payload is already opaque and
 topic-uniform, so no owner/relay _data_ split is required and there is no
 RLS-uniform proof to compute. Owner multicasts the opaque whisper frame to
 relays; relays fan out to their attached sockets. New connections to a hot topic
 route to a relay via the runtime hop.
+
+> **Shipped (slices 1–4).** The owner↔relay whisper hub (`shard-do.ts`:
+> `broadcastWhisper` → `forwardWhisperToHub`, the `/_lunora/relay` control
+> channel, the `__lunora_relays` set), the runtime upgrade-hop routing
+> (`create-worker.ts`: a `/_lunora/route` promotion probe + `x-lunora-shard-binding`
+>
+> - relay selection), and demand-driven collapse (`relay_detach` on drain). The
+>   relay-name contract lives in `shared/relay-name.ts` so the minting (runtime)
+>   and parsing (DO) sides can't drift. Proven against real Durable Objects in
+>   workerd (up-path, down-path, multi-relay origin-exclusion, no echo).
+>
+> **Granularity refinement vs § 2 of the design doc.** The design assumed the
+> upgrade hop routes by _topic_. For whisper that can't hold — a socket connects
+> first, then joins a topic via `whisper_subscribe`, so the topic is unknown at
+> upgrade. v1 therefore relays at **shard granularity** (the upgrade already keys
+> on `?shard=`; "one giant public room = one shard" is the canonical case).
+> Per-topic relay is a later refinement. Right-sizing the relay fan to live demand
+> (vs the fixed `LUNORA_RELAY_FAN`) also remains a follow-up — the owner can't see
+> total demand from its own socket count once promoted; relays heartbeating their
+> counts would close that gap.
 
 > **`usePresence` is _not_ in this phase.** Despite being "ephemeral awareness",
 > presence is implemented as a `heartbeat` **mutation** + a `listPresent`

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -239,18 +239,22 @@ single DO's WS cap succeeds.
 
 ### Phase 3 — reactive-shape relay (RLS-uniform only) — **SHIPPED**
 
-Shipped as three slices on `feat/075-fanout-relay`: (A) the RLS-uniform gate
-(`isShapeRelayUniform` — a dual-identity `resolveShape` probe + mask check,
-codegen-free and fail-closed), (B) seed-through-owner + one-delta-per-flush
-cohort multicast (`buildShapeSeedFrames` / `multicastRelayShapePokes` /
-`deliverRelayShapePoke`, gated by a per-socket `fromCursor` memo so a mid-flush
-seeder never double-applies), and (C) the verification below. Resume rides the
-same `computeOpLogShapeSeed` core as the local seed, so the relay round-trip is
-byte-identical by construction. Non-uniform shapes are seeded RLS-correctly via
-the owner but never registered for multicast (a documented low-fan-out
-limitation; per-socket proxy is a Phase 4 follow-up). Proven in real workerd
-(`__tests__/workerd/relay-shape.workerd.test.ts`, 4 tests) + the gate unit test
-(`__tests__/relay-uniform-gate.test.ts`).
+Shipped as three slices on `feat/075-fanout-relay`, hardened by a thermo review
+pass: (A) the RLS-uniform gate (`isShapeRelayUniform` — a static `rlsMetadata()`
+read-policy guard plus a claim-diverse identity probe whose base IS the multicast
+identity + a mask check, codegen-free and fail-closed), (B) seed-through-owner +
+one-delta-per-flush cohort multicast (`buildShapeSeedFrames` /
+`multicastRelayShapePokes` / `deliverRelayShapePoke`, gated by a per-socket
+`fromCursor`+`epoch` memo stamped at the **cohort frontier** so a late joiner is
+never stranded and a mid-flush seeder never double-applies), and (C) the
+verification below. Resume rides the same `computeOpLogShapeSeed` core as the
+local seed, so the relay round-trip is byte-identical by construction. Non-uniform
+(identity-scoped) shapes can't be cohort-multicast, so each is served live by a
+per-socket **owner proxy** (`proxyRelayShapePokes`) that computes its delta under
+its own forwarded identity and delivers a `connectionId`-targeted poke — RLS-correct
+and never silently frozen. Proven in real workerd
+(`__tests__/workerd/relay-shape.workerd.test.ts`, 6 tests) + the gate unit test
+(`__tests__/relay-uniform-gate.test.ts`, 7 tests).
 
 Extend relay-scaling to **reactive query shapes that pass the RLS-uniform gate**
 (Decision 3). Owner computes the delta once (building on plan 072's shared

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -130,8 +130,11 @@ checkpoint)` (≈6111) drains the op range from the owner's SQLite and probes
 3. **RLS-uniform gate signal.** Reuse plan 073's identity-independence
    determination as the _necessary_ condition for promoting a **reactive shape**.
    Confirm: is 073's signal available at the granularity this needs (per shape,
-   at runtime)? If not, what is the minimal extension? whisper/presence are
-   uniform by construction and need no per-shape proof.
+   at runtime)? If not, what is the minimal extension? `whisper` topics are
+   uniform by construction (opaque payload, no per-identity result) and need no
+   per-shape proof; presence (`usePresence`) is **not** uniform-by-construction —
+   it is a reactive query (`listPresent`) and goes through this gate like any
+   shape.
 4. **Resume across a shifting topology.** How does a client that reconnects onto a
    _different_ relay resume correctly from its `(sinceSeq, sinceEpoch)`? Proposal:
    relays are stateless re-broadcasters; the **owner remains the checkpoint
@@ -156,7 +159,7 @@ file (or a sibling design doc). **Maintainer sign-off required before Phase 1.**
 Deliverable: a measured T_up from a fan-out micro-benchmark on `ShardDO`
 (subscribers vs per-flush CPU), not a guessed constant.
 
-### Phase 1 — Observability only (ship first, low risk)
+### Phase 1 — Observability only (ship first, low risk) — **SHIPPED**
 
 Instrument the owner: per-topic/shape **subscriber count + per-flush fan-out
 cost**, surfaced in Studio (Advisors/metrics). No behavior change. This proves
@@ -166,14 +169,32 @@ the DX before any topology change exists. Gate behind a flag if needed.
 **Verify**: metrics appear in Studio for a synthetic high-subscriber topic;
 `pnpm --filter "@lunora/do" run test` green; no change to poke output.
 
-### Phase 2 — whisper/presence relay (the natural first adopter)
+> **Shipped.** `ShardDO.pokeShapeSubscribers` + `broadcastWhisper` record
+> per-pass fan-out counters (in-memory, hibernation-reset, shared `sinceMs`);
+> the `__lunora_admin__:getFanoutMetrics` read folds live per-topic subscriber
+> counts via `summarizeFanoutTopics`; a Studio "Fan-out" page (Observability)
+> renders hot topics + per-path cost. Pure measurement — no change to which
+> sockets are poked or who receives a whisper. Counting is always-on (integer
+> increments are negligible); no env flag was needed. Coarse `totalMs`/`maxMs`
+> are captured for the async poke path only (a DO clock advances only on I/O)
+> and omitted for the synchronous whisper path; socket-count width is the exact,
+> reliable cost signal. The full `@lunora/do` suite is green and the wire shapes
+> carry key drift-guards on both the `@lunora/do` and `@lunora/studio` sides.
 
-Relay-scale **whisper topics** (and `usePresence`, which rides whisper-like
-ephemeral fan-out) only — payloads are already opaque and topic-uniform, so no
-owner/relay _data_ split is required, and there is no RLS-uniform proof to
-compute. Owner multicasts the opaque whisper frame to relays; relays fan out to
-their attached sockets. New connections to a hot topic route to a relay via the
-runtime hop.
+### Phase 2 — whisper relay (the natural first adopter)
+
+Relay-scale **whisper topics** only — their payload is already opaque and
+topic-uniform, so no owner/relay _data_ split is required and there is no
+RLS-uniform proof to compute. Owner multicasts the opaque whisper frame to
+relays; relays fan out to their attached sockets. New connections to a hot topic
+route to a relay via the runtime hop.
+
+> **`usePresence` is _not_ in this phase.** Despite being "ephemeral awareness",
+> presence is implemented as a `heartbeat` **mutation** + a `listPresent`
+> **reactive query** over a presence table (`definePresence`,
+> `packages/server/src/presence.ts` — "Live queries (subscriptions) drive
+> `listPresent`"). It flows through the reactive-shape path, **not** `whisper`,
+> so it is handled in Phase 3 as an RLS-uniform reactive shape, not here.
 
 **Verify**: a topic above T_up serves identical whisper delivery to subscribers
 whether they land on the owner or a relay; sender still never receives its own
@@ -187,6 +208,12 @@ Extend relay-scaling to **reactive query shapes that pass the RLS-uniform gate**
 op-range), then multicasts the opaque delta frame to relays. Resume goes through
 the owner per Decision 4. Non-uniform shapes are **never** promoted and keep
 today's owner-served path byte-for-byte.
+
+`usePresence`'s `listPresent` is the canonical first target here: it is typically
+room-public (so it passes the RLS-uniform gate) and is the highest-fan-out
+reactive query in practice — every member of a large room subscribes to the same
+present-list. Treating it as a reactive shape (not an opaque whisper) is what
+makes its delta correct for every subscriber.
 
 **Verify**: an RLS-uniform public shape with subscribers across owner+relays
 produces byte-identical deltas to today's single-DO path (reuse plan 070's
@@ -251,8 +278,9 @@ Stop and report back if:
 
 - **The RLS-uniform gate is the correctness boundary.** A reactive shape is
   promotable ONLY if its poke is identity-independent (plan 073's signal). Never
-  multicast one delta across an identity boundary. whisper/presence are uniform
-  by construction; reactive shapes must prove it.
+  multicast one delta across an identity boundary. Only `whisper` topics are
+  uniform by construction; every reactive shape — including presence's
+  `listPresent` — must pass the gate.
 - **The owner stays the checkpoint authority.** Relays are stateless
   re-broadcasters. All resume/ordering truth lives at the owner so a client can
   reconnect onto any relay and still resume from its checkpoint.

--- a/plans/075-do-auto-elastic-fanout-relay-tier.md
+++ b/plans/075-do-auto-elastic-fanout-relay-tier.md
@@ -237,7 +237,20 @@ whether they land on the owner or a relay; sender still never receives its own
 whisper; reconnection re-attaches correctly. Load test: subscriber count beyond a
 single DO's WS cap succeeds.
 
-### Phase 3 — reactive-shape relay (RLS-uniform only)
+### Phase 3 — reactive-shape relay (RLS-uniform only) — **SHIPPED**
+
+Shipped as three slices on `feat/075-fanout-relay`: (A) the RLS-uniform gate
+(`isShapeRelayUniform` — a dual-identity `resolveShape` probe + mask check,
+codegen-free and fail-closed), (B) seed-through-owner + one-delta-per-flush
+cohort multicast (`buildShapeSeedFrames` / `multicastRelayShapePokes` /
+`deliverRelayShapePoke`, gated by a per-socket `fromCursor` memo so a mid-flush
+seeder never double-applies), and (C) the verification below. Resume rides the
+same `computeOpLogShapeSeed` core as the local seed, so the relay round-trip is
+byte-identical by construction. Non-uniform shapes are seeded RLS-correctly via
+the owner but never registered for multicast (a documented low-fan-out
+limitation; per-socket proxy is a Phase 4 follow-up). Proven in real workerd
+(`__tests__/workerd/relay-shape.workerd.test.ts`, 4 tests) + the gate unit test
+(`__tests__/relay-uniform-gate.test.ts`).
 
 Extend relay-scaling to **reactive query shapes that pass the RLS-uniform gate**
 (Decision 3). Owner computes the delta once (building on plan 072's shared

--- a/plans/075-phase0-relay-protocol-design.md
+++ b/plans/075-phase0-relay-protocol-design.md
@@ -1,0 +1,330 @@
+# Plan 075 Phase 0 — Relay-tier protocol design (sign-off doc)
+
+> **Status**: DESIGN — awaiting maintainer sign-off. No production code in this
+> phase (the benchmark harness is throwaway; see § 7). Phases 2–4 do not start
+> until the Decisions in § 8 are accepted and the § 9 calibration is done.
+>
+> Companion to [`075-do-auto-elastic-fanout-relay-tier.md`](075-do-auto-elastic-fanout-relay-tier.md).
+> Phase 1 (observability) has shipped; this doc designs the transport that Phases
+> 2–4 build, and answers the six Decisions that plan gates code behind.
+>
+> **Drift check**: line refs below are against the `feat/075-fanout-relay-phase1`
+> tree (off `alpha`). Re-confirm the cited symbols before implementing.
+
+## 1. Goal & the one principle
+
+Many connections all watching the **same** thing — a live score, a viral feed,
+one giant public room's cursors — all land on the **single ShardDO that owns the
+data**, which hits two ceilings: the ~32k hibernatable-WebSocket cap per DO, and
+the O(subscribers) per-flush fan-out CPU on one isolate.
+
+The fix is a **demand-driven relay tier**: when a topic/shape's subscriber count
+crosses a threshold, the runtime transparently allocates relay DOs, routes _new_
+connections to them, and the owner computes each delta **once** and multicasts an
+opaque frame down to the relays, which re-broadcast to their attached sockets.
+**The app never changes** — same `subscription`, same `whisper`, same
+`usePresence`. This is _invisible runtime elasticity_, never a user primitive.
+
+The alignment that makes it safe: high fan-out ⟺ many people watching the **same**
+data ⟺ shared/public visibility ⟺ **RLS-uniform**. The promotion heuristic and
+the safety condition are the same condition.
+
+## 2. The routing seam (STOP condition cleared)
+
+The plan's STOP condition — "the runtime shard-resolver entrypoint is not a single
+place that maps a subscription to its DO stub" — **does not trip**. Routing is
+centralized:
+
+- `resolveShard(namespace, shardKey)` — `packages/runtime/src/resolve-shard.ts:65`
+  — the _only_ data-plane place `idFromName`/`getByName` is called. DO id derives
+  purely from the string `shardKey`.
+- `forwardToShard(namespace, shardKey, request)` — `packages/runtime/src/create-worker.ts:1243`
+  — the _only_ forwarding wrapper; both RPC (`dispatchSingleShard`, ~`:2124`) and
+  the WS upgrade route through it.
+- WS upgrade: `handleWebSocketUpgrade` — `create-worker.ts:1970` — picks
+  `shardKey` from the `?shard=` query param (`:1975`), authorizes it, re-stamps
+  server-minted identity headers (`:2004–2022`), then `forwardToShard(...)` (`:2024`).
+
+**Implication for the design**: the owner-vs-relay endpoint choice slots into one
+of two places, both small:
+
+1. **At the WS upgrade** (`handleWebSocketUpgrade`): after `authorizeShard`, ask
+   the owner DO (or a cheap registry) "is `<topic/shape>` on `<shardKey>` promoted,
+   and if so which relay should this _new_ connection attach to?" — then forward to
+   the relay's stub instead of the owner. Existing connections are untouched.
+2. **Inside `resolveShard`**: out of scope — `resolveShard` is keyed by `shardKey`
+   alone and has no per-subscription context; keep it pure. The relay choice is
+   subscription-aware, so it belongs at the upgrade hop.
+
+We choose **(1)**. The relay's DO id is a deterministic function of
+`(shardKey, topicOrShapeId, relayIndex)` so any worker can compute the same relay
+name without shared state (`idFromName(\`${shardKey}::relay::${topicId}::${i}\`)`).
+
+## 3. Owner ↔ relay protocol
+
+Relays are **a mode of `ShardDO`**, not a new class (they reuse hibernation, the
+WS plumbing, `getFanoutMetrics`). A relay holds no SQLite truth; it is a stateless
+re-broadcaster with a single upstream link to the owner.
+
+### Frames (internal — never part of the public client protocol)
+
+All owner↔relay frames travel over a DO-to-DO link (owner→relay via the relay's
+stub `fetch` establishing an internal WS, or owner-push via `state.getWebSockets`
+on a reserved internal socket). Frame kinds:
+
+| Frame          | Direction     | Payload                                              | Purpose                                                                                           |
+| -------------- | ------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `relay_attach` | relay → owner | `{ topicId, relayId }`                               | relay announces it is serving `topicId`; owner adds it to the topic's relay set                   |
+| `relay_detach` | relay → owner | `{ topicId, relayId }`                               | relay drained to zero sockets; owner removes it                                                   |
+| `relay_frame`  | owner → relay | `{ topicId, frame, cursor?, epoch? }`                | the **opaque, already-serialized** delta/whisper frame to re-broadcast verbatim                   |
+| `relay_resume` | relay → owner | `{ topicId, subId, sinceSeq, sinceEpoch, identity }` | forward a reconnecting client's resume request to the checkpoint authority (§ 5)                  |
+| `relay_seed`   | owner → relay | `{ topicId, subId, frame }`                          | the owner-computed catch-up/snapshot frame for one resuming client, routed back through the relay |
+
+Key property: `relay_frame.frame` is **opaque to the relay** — the owner computes
+the delta once (building on plan 072's shared op-range), serializes it once, and
+the relay does a pure string fan-out (the cheap whisper-style loop measured in
+§ 7). The relay never parses or re-derives the payload.
+
+### Why opaque frames, and the per-socket-memo constraint
+
+`shard-do.ts:5855–5888` documents that cross-socket _frame_ dedup on the owner was
+deliberately **not** built, because per-socket memo divergence (`pushSubscriptionData`
+sends delta vs full vs nothing per socket), per-run side-effect cardinality
+(metrics/logs), and error attribution all break when one frame is shared across
+sockets with different resume state.
+
+The relay tier **resolves** this rather than fighting it: a connection is only
+ever routed to a relay **after** it has completed its initial seed/resume through
+the owner (§ 5). So every socket on a relay is already at the same live cursor and
+receives the identical forward delta — the exact case where one shared frame _is_
+correct. Divergent per-socket state (mid-resume, behind the window) stays
+owner-served. The relay only handles the steady-state "everyone is caught up, push
+the next delta to all" case, which is precisely the high-fan-out hot path.
+
+## 4. Promotion / collapse state machine
+
+State lives on the **owner** (it already iterates all sockets each flush and now
+tallies `getFanoutMetrics`). Per `(topicId)`:
+
+```
+            subscribers ≥ T_up                relay set drained (≈0 local)
+  OWNED ───────────────────────────► PROMOTED ───────────────────────────► OWNED
+   ▲                                    │
+   └──────── subscribers < T_down ◄─────┘   (hysteresis: T_down = ½·T_up)
+```
+
+- **OWNED** (default, 99% of topics): zero relays, zero added overhead. Today's
+  path byte-for-byte.
+- **Trigger up**: the owner observes (via the Phase-1 counters) the topic's
+  subscriber count cross `T_up`. It does **not** migrate existing sockets; it
+  simply starts answering "route new connections for `topicId` to relay _i_" at the
+  upgrade hop, and forwards each computed delta to the active relay set.
+- **Trigger down**: when total subscribers fall below `T_down` (= ½·`T_up`, the
+  hysteresis band that prevents flapping), the owner stops directing new
+  connections to relays; relays drain naturally as their sockets disconnect, then
+  `relay_detach` and the topic returns to OWNED.
+- **Authority**: the owner is the single decision-maker and the checkpoint
+  authority (§ 5). Relays are dumb. This keeps ordering/resume correctness in one
+  place.
+
+`T_up`/`T_down` are **config with measured defaults** (§ 7), never silently
+unbounded — see Decision 5 (cost ceiling).
+
+## 5. Resume across a shifting topology
+
+**Resume state lives entirely on the owner's SQLite CDC log.** `evaluateResume`
+(`shard-do.ts:3179`) and the shape-seed resume gate (`seedOpLogShape`,
+`shard-do.ts:6185–6193`) read only `(sinceSeq, sinceEpoch)` from the client vs. the
+owner's own `readCdcCursor`/`minCdcSeq`/epoch. A relay has **no op-log**, so it
+**cannot** evaluate resumability or build a catch-up diff.
+
+Therefore the handoff is:
+
+1. A client reconnects and is routed (at the upgrade hop) to relay _i_ for a
+   promoted topic. It sends its normal `(sinceSeq, sinceEpoch)`.
+2. The relay does **not** answer. It forwards a `relay_resume` to the owner.
+3. The **owner** runs its existing resume path and produces the one
+   catch-up-or-snapshot frame for that client, returned as `relay_seed`.
+4. The relay sends that frame to the client, then attaches the (now-caught-up)
+   socket to the live `relay_frame` multicast.
+
+> **Two resume seed paths — wire the right one (Phase-3 executor note).** Lunora
+> has two distinct reactive mechanisms with different seed functions, both
+> owner-owned: **(a) op-log shapes** (partial replication — `shape_subscribe`)
+> resume through `seedOpLogShape` → `buildShapeDiff`/`buildShapeSeed`
+> (`shard-do.ts:6173`, gate at `:6185`); **(b) query subscriptions** (a
+> `RegisteredQuery` re-run on writes — the `subscribe` path) resume through
+> `evaluateResume` (`:3179`) → `seedSubscription`/`refreshSubscriptions`/
+> `pushSubscriptionData`. `usePresence`'s `listPresent` is a **query
+> subscription** (case b), not an op-log shape — so its `relay_resume`/`relay_seed`
+> handoff must target the subscription seed path, not `seedOpLogShape`. The
+> owner-as-authority conclusion is identical for both; only the seed function the
+> owner calls differs.
+
+So a client can reconnect onto **any** relay and resume correctly — the only
+authority is the owner, and global delta ordering is preserved because every
+`relay_frame` originates from the owner's single serialized flush in cursor order.
+This matches the plan's Decision 4 proposal exactly and is forced by the code: the
+op-log is the owner's.
+
+## 6. The RLS-uniform gate (the correctness boundary)
+
+A reactive shape may be relay-multicast **only if its poke is identity-independent**
+— one delta is correct for every subscriber. Today's signal:
+
+- `isIdentityIndependent(functionPath)` — `shard-do.ts:5554` — returns
+  `functionPath.startsWith(ADMIN_FUNCTION_PREFIX)`. **Admin/reserved reads only.**
+  Every user query and every `FLAGS_FUNCTION_PREFIX` read is treated
+  identity-**dependent** (they may be `rls()`/`ctx.auth`-scoped). It is computed
+  per-`functionPath`, synchronously, at flush time, and gates the flush-local
+  `reactiveRunCache` dedup (`resolveReactiveOutcomeDeduped`, `shard-do.ts:5574`).
+
+**Gap & the minimal extension (Decision 3 answer).** The current signal is too
+narrow for Phase 3: a public, RLS-free user shape (e.g. `listPresent` for a public
+room) is RLS-uniform but is _not_ admin-prefixed, so `isIdentityIndependent` returns
+`false` and it would never be promoted. The minimal, safe extension:
+
+- At **codegen**, mark a shape/query as `relayUniform: true` **iff** it declares
+  **no** RLS policy, reads no `ctx.auth`/identity, and applies no per-identity
+  masking — i.e. its result provably does not depend on the caller. This is a
+  static, conservative, fail-closed bit (absent ⇒ treated as identity-dependent).
+- Extend `isIdentityIndependent` to also return `true` for a `functionPath` whose
+  generated descriptor carries `relayUniform`. **Whisper topics need no bit** —
+  they are uniform by construction (opaque payload, no per-identity result).
+- **Never** relay a shape lacking the bit, under any subscriber count. The gate is
+  the safety boundary; when unsure, stay owner-served (today's path, byte-for-byte).
+
+`usePresence`'s `listPresent` is the canonical first reactive-shape target: it is
+typically room-public (passes the gate) and is the highest-fan-out reactive query
+in practice. It is **not** a whisper (it is a `heartbeat` mutation + a `listPresent`
+reactive query — `packages/server/src/presence.ts`), so it rides the Phase-3
+reactive-shape path, not Phase 2.
+
+## 7. Fan-out cost benchmark & T_up derivation
+
+### Methodology
+
+Per-flush whisper fan-out (the clean O(connections) loop: `getWebSockets()`
+iteration + `readAttachment()` per socket + one shared serialized frame send) was
+measured in plain Node against the real `ShardDO.broadcastWhisper` path (workerd's
+`Date.now()` only advances on I/O, so it can't time a synchronous loop —
+hence Node). The rate-limit token bucket was overridden off to isolate the loop.
+Whisper is the cheapest path; shape pokes cost strictly more (per-shape diffing,
+per-socket `sendPoke`).
+
+### Measured curve (Node, `FakeSocket`)
+
+| subscribers | ms / flush | ns / socket |
+| ----------- | ---------- | ----------- |
+| 1           | 0.0018     | —           |
+| 100         | 0.0035     | 35          |
+| 1,000       | 0.0242     | 24          |
+| 5,000       | 0.0881     | 18          |
+| 10,000      | 0.1664     | 17          |
+| 20,000      | 0.3380     | 17          |
+| 32,000      | 0.5038     | 16          |
+
+The cost is **linear in subscriber count** with a settled marginal cost of
+**~16 ns/socket**. There is no inflection "knee" — fan-out is a straight-line
+budget consumption, so `T_up` is a **budget crossing**, not a curve feature.
+
+### Caveat — this is a LOWER BOUND
+
+`FakeSocket.deserializeAttachment()` returns the attachment **by reference** (no
+structured-clone) and `send()` is a no-op counter. Real workerd pays, **per
+socket**: a real `deserializeAttachment()` (structured-clone deserialize of the
+hibernation attachment) and a real `ws.send()` (outbound-buffer enqueue + frame
+emit). Those dominate and are plausibly **1–3 orders of magnitude** more than the
+16 ns floor. So the real per-flush cost at 32k could be tens of milliseconds — and
+it is paid on **every write** that touches the topic.
+
+### T_up recommendation (and the honest gap)
+
+Two independent ceilings drive promotion; `T_up = min` of them:
+
+1. **Connection cap (hard, path-independent)**: a DO holds ~32k hibernatable
+   sockets. New connections must have somewhere to go _before_ the owner fills, so
+   promote at a fraction of the cap with headroom. **Connection-driven T_up ≈ 16k–24k**
+   (50–75% of 32k).
+2. **Per-flush CPU (soft, path- and write-rate-dependent)**: keep a single flush
+   well under the isolate's budget so it doesn't starve concurrent work or spike
+   p99 latency. With the unknown workerd multiplier, the shape path may bind well
+   before the connection cap on a high-write-rate topic.
+
+**Recommendation for v1**: `T_up = 8,000` subscribers per topic, `T_down = 4,000`
+(½·T_up). Rationale: comfortably under the connection cap (headroom for the owner
+to keep accepting while relays warm), and conservative enough that even a
+pessimistic workerd multiplier on the shape path keeps a flush within a few-to-tens
+of ms. **Both values are config, not hardcoded constants**, with the Phase-1
+`getFanoutMetrics` counters surfacing the real per-flush cost so the default can be
+tuned per deployment.
+
+**The honest gap (§ 9)**: the absolute workerd per-socket constant is **not yet
+measured** — the Node floor establishes the _shape_ (linear, low constant) but not
+the workerd magnitude. Calibrating it is a Phase 2 prerequisite, and Phase 1 gave
+us the production instrument to do it (run a load test, read `getFanoutMetrics`).
+`T_up = 8,000` is a defensible _starting_ default, explicitly to be re-grounded
+against real `getFanoutMetrics` data before the relay path is enabled by default.
+
+## 8. The six Decisions — answered
+
+1. **Promotion threshold & hysteresis.** `T_up = 8,000`, `T_down = 4,000` (½·T_up)
+   as configurable defaults; primary driver is connection-cap headroom, secondary
+   is per-flush CPU. Re-calibrate against `getFanoutMetrics` before enabling by
+   default (§ 7, § 9).
+2. **Relay fan degree & depth.** **Flat, single tier** (owner → N relays) for v1.
+   Covers ~32k·N connections and is far simpler to reason about for resume/ordering.
+   A tree (owner → relay → sub-relay) only if a single tier is proven insufficient.
+3. **RLS-uniform gate signal.** Reuse `isIdentityIndependent`, **extended** with a
+   codegen-emitted `relayUniform` bit for user shapes that declare no RLS / read no
+   identity / apply no per-identity mask (fail-closed). Whisper needs no bit. Per
+   shape, available at flush time. (§ 6.)
+4. **Resume across topology.** Owner is the sole checkpoint authority; relays are
+   stateless and **forward** resume (`relay_resume`) to the owner, which runs the
+   existing `evaluateResume`/`buildShapeDiff` and returns the one catch-up frame
+   (`relay_seed`). A client attaches to the live multicast only once caught up. (§ 5.)
+5. **Cost ceiling.** A hard `maxRelaysPerTopic` cap (default e.g. 8 → ~256k
+   connections at 32k each) so a viral topic cannot silently spawn unbounded DOs.
+   On approaching the cap, surface it in Studio / an advisor — **auto-scale, never
+   silently unbounded**.
+6. **Mixed-visibility shapes.** **Owner-served in v1.** A shape that is mostly
+   shared but has a per-user slice fails the RLS-uniform gate (no `relayUniform`
+   bit) and stays owner-served, byte-for-byte. Cohort-splitting (one multicast
+   stream per visibility cohort) is a later phase only if demand exists.
+
+## 9. Open risks / must-calibrate before Phase 2
+
+- **Workerd per-socket constant is unmeasured (blocking).** Calibrate via a load
+  test reading `getFanoutMetrics`, or a `LUNORA_WORKERD_TESTS=1` bench, before the
+  relay path is enabled by default. The Node floor is a lower bound only.
+- **Owner→relay link cost.** The owner now does one `relay_frame` send per relay
+  per flush instead of N socket sends — the win is real only when fan-degree ≫
+  relay count. Confirm the link send is cheap relative to the saved per-socket loop.
+- **Relay failure / restart.** A relay that hibernates or dies must re-`relay_attach`
+  and its clients must re-seed through the owner. Define the relay-loss path (clients
+  reconnect → upgrade hop re-routes → owner re-seeds) before Phase 3.
+- **Promotion thrash under bursty joins.** The hysteresis band guards steady churn;
+  validate it against a join/leave storm in the resume/diff matrix (plan 070).
+- **Metrics/side-effect cardinality.** A relayed delta is computed once on the owner,
+  so per-run metrics/logs fire once (not per socket). Confirm this is the desired
+  accounting (it is cheaper and arguably more correct, but it changes per-subscriber
+  log volume).
+
+## 10. Sign-off checklist (maintainer)
+
+- [ ] Routing seam (§ 2): agree the owner/relay choice belongs at the WS upgrade hop.
+- [ ] Protocol (§ 3): agree relays re-broadcast **opaque owner-serialized frames**
+      and only ever serve already-caught-up sockets.
+- [ ] State machine (§ 4): agree `T_up`/`T_down` hysteresis with the owner as sole authority.
+- [ ] Resume (§ 5): agree owner = checkpoint authority, relays forward resume.
+- [ ] Gate (§ 6): agree the `relayUniform` codegen bit as the minimal, fail-closed
+      extension to `isIdentityIndependent`.
+- [ ] T_up (§ 7): accept `8,000 / 4,000` as the **starting** default, with workerd
+      calibration (§ 9) as a Phase 2 prerequisite.
+- [ ] Decisions (§ 8): accept all six.
+- [ ] Scope: confirm no public API / schema / client-protocol change in any phase
+      (a required change is a design failure → STOP).
+
+On sign-off, Phase 2 (whisper relay — the uniform-by-construction first adopter)
+may begin; Phase 3 (RLS-uniform reactive shapes incl. `listPresent`) follows once
+the `relayUniform` codegen bit lands.

--- a/plans/075-phase0-relay-protocol-design.md
+++ b/plans/075-phase0-relay-protocol-design.md
@@ -199,6 +199,16 @@ room) is RLS-uniform but is _not_ admin-prefixed, so `isIdentityIndependent` ret
 - **Never** relay a shape lacking the bit, under any subscriber count. The gate is
   the safety boundary; when unsure, stay owner-served (today's path, byte-for-byte).
 
+> **Implemented as (Phase 3, review-hardened).** The shipped gate is **codegen-free**
+> — no `relayUniform` descriptor bit. `ShardDO.isShapeRelayUniform` decides at
+> runtime: a static `rlsMetadata()` read-policy guard (any `on:"read"` policy on the
+> table ⇒ not uniform), then resolves the shape under the anonymous **multicast**
+> identity plus two `Proxy`-backed identities that return a distinct value for **any**
+> accessed claim — so a `defineShape` `where` reading any identity claim (including a
+> custom one via `ctx.access`, outside `rls()`) diverges and is rejected — with a
+> wholesale-copy backstop (enumerating the claims fails closed) and the masked-column
+> check. Same safety boundary, evaluated dynamically and provably claim-exhaustive.
+
 `usePresence`'s `listPresent` is the canonical first reactive-shape target: it is
 typically room-public (passes the gate) and is the highest-fan-out reactive query
 in practice. It is **not** a whisper (it is a `heartbeat` mutation + a `listPresent`

--- a/plans/075-phase0-relay-protocol-design.md
+++ b/plans/075-phase0-relay-protocol-design.md
@@ -1,8 +1,9 @@
 # Plan 075 Phase 0 — Relay-tier protocol design (sign-off doc)
 
 > **Status**: DESIGN — awaiting maintainer sign-off. No production code in this
-> phase (the benchmark harness is throwaway; see § 7). Phases 2–4 do not start
-> until the Decisions in § 8 are accepted and the § 9 calibration is done.
+> phase (the benchmark harness is throwaway; see § 7). The fan-out cost is measured
+> in both Node and real workerd (§ 7). Phases 2–4 do not start until the Decisions
+> in § 8 are accepted.
 >
 > Companion to [`075-do-auto-elastic-fanout-relay-tier.md`](075-do-auto-elastic-fanout-relay-tier.md).
 > Phase 1 (observability) has shipped; this doc designs the transport that Phases
@@ -228,15 +229,63 @@ The cost is **linear in subscriber count** with a settled marginal cost of
 **~16 ns/socket**. There is no inflection "knee" — fan-out is a straight-line
 budget consumption, so `T_up` is a **budget crossing**, not a curve feature.
 
-### Caveat — this is a LOWER BOUND
+The Node number is a **lower bound**: `FakeSocket.deserializeAttachment()` returns
+the attachment by reference (no structured-clone) and `send()` is a no-op counter.
+Real workerd pays, per socket, a real `deserializeAttachment()` (structured-clone)
+and a real `ws.send()` (outbound enqueue + frame emit). So the Node floor
+establishes the _shape_ (linear), not the magnitude — measured next.
 
-`FakeSocket.deserializeAttachment()` returns the attachment **by reference** (no
-structured-clone) and `send()` is a no-op counter. Real workerd pays, **per
-socket**: a real `deserializeAttachment()` (structured-clone deserialize of the
-hibernation attachment) and a real `ws.send()` (outbound-buffer enqueue + frame
-emit). Those dominate and are plausibly **1–3 orders of magnitude** more than the
-16 ns floor. So the real per-flush cost at 32k could be tens of milliseconds — and
-it is paid on **every write** that touches the topic.
+### Measured curve (workerd, real hibernatable sockets)
+
+Calibrated against a **real `ShardDO`** in `@cloudflare/vitest-pool-workers`: N real
+hibernatable WebSockets opened on one DO, subscribed to a whisper topic, end-to-end
+fan-out (sender send → all N members received) timed from the test runner's clock.
+`performance.now()` is clamped to ~1 ms in workerd, so small N sits on the
+quantization floor; the signal is clean from a few hundred sockets up:
+
+| subscribers | ms / flush (median, e2e) | ns / socket |
+| ----------- | ------------------------ | ----------- |
+| 200         | 3                        | 15,000      |
+| 500         | 5                        | 10,000      |
+| 1,000       | 14                       | 14,000      |
+| 2,000       | 30                       | 15,000      |
+
+Real per-socket cost settles at **~10–15 µs/socket** — roughly **1,000× the 16 ns
+Node floor** — and the curve stays **linear** (2,000 subs → 30 ms). Extrapolated:
+~120 ms at 8,000 subscribers, ~480 ms at the 32k connection cap, **paid on every
+write** that touches the topic.
+
+**What this number includes (and the residual gap).** The e2e figure bundles the
+DO-isolate CPU (the `getWebSockets` loop + per-socket `deserializeAttachment` +
+`ws.send` enqueue) **with** Miniflare's local WS delivery to the test process. In
+production, delivery rides the real edge→client network, _off_ the isolate clock —
+so the isolate-CPU share of that ~10–15 µs is smaller, but the **order-of-magnitude
+jump from the Node floor is confirmed**, and the linear-in-N fan-out wall-time is
+real. The one figure still best read from production is the isolate-CPU-only
+per-flush cost — and Phase 1's `getFanoutMetrics` is exactly that instrument under
+real load.
+
+### T_up recommendation
+
+Two independent ceilings drive promotion; `T_up = min` of them:
+
+1. **Connection cap (hard, path-independent)**: a DO holds ~32k hibernatable
+   sockets. New connections must have somewhere to go _before_ the owner fills, so
+   promote at a fraction of the cap with headroom. **Connection-driven T_up ≈ 16k–24k**
+   (50–75% of 32k).
+2. **Per-flush CPU (soft, path- and write-rate-dependent)**: the measured curve
+   shows fan-out hitting **~120 ms at 8k / ~480 ms at the 32k cap** — so on a topic
+   with any real write rate, per-flush fan-out becomes the bottleneck **well within**
+   a single DO's connection capacity. CPU binds before the connection cap. The
+   shape-poke path (per-shape diffing + per-socket `sendPoke`) binds even sooner.
+
+**Recommendation for v1**: `T_up = 8,000` subscribers per topic, `T_down = 4,000`
+(½·T_up). The measured curve puts an 8k-subscriber flush at ~120 ms e2e (tens of ms
+of isolate CPU) — a sensible point to start offloading to relays — while staying
+comfortably under the connection cap so the owner keeps accepting while relays warm.
+**Both values are config, not hardcoded**, and Phase 1's `getFanoutMetrics` surfaces
+the real per-flush cost so each deployment can tune the default against its own
+isolate-CPU numbers under load.
 
 ### T_up recommendation (and the honest gap)
 
@@ -294,9 +343,11 @@ against real `getFanoutMetrics` data before the relay path is enabled by default
 
 ## 9. Open risks / must-calibrate before Phase 2
 
-- **Workerd per-socket constant is unmeasured (blocking).** Calibrate via a load
-  test reading `getFanoutMetrics`, or a `LUNORA_WORKERD_TESTS=1` bench, before the
-  relay path is enabled by default. The Node floor is a lower bound only.
+- **Workerd per-socket cost — measured (§ 7), no longer blocking.** ~10–15 µs/socket
+  end-to-end, linear, confirming per-flush fan-out binds within a single DO's
+  connection capacity. Residual: the e2e figure bundles Miniflare delivery, so the
+  **isolate-CPU-only** per-flush cost is best read from production `getFanoutMetrics`
+  under load — for per-deployment T_up tuning, not as a Phase-2 gate.
 - **Owner→relay link cost.** The owner now does one `relay_frame` send per relay
   per flush instead of N socket sends — the win is real only when fan-degree ≫
   relay count. Confirm the link send is cheap relative to the saved per-socket loop.
@@ -319,8 +370,8 @@ against real `getFanoutMetrics` data before the relay path is enabled by default
 - [ ] Resume (§ 5): agree owner = checkpoint authority, relays forward resume.
 - [ ] Gate (§ 6): agree the `relayUniform` codegen bit as the minimal, fail-closed
       extension to `isIdentityIndependent`.
-- [ ] T_up (§ 7): accept `8,000 / 4,000` as the **starting** default, with workerd
-      calibration (§ 9) as a Phase 2 prerequisite.
+- [ ] T_up (§ 7): accept `8,000 / 4,000` as the **starting** default (workerd
+      calibration done — ~10–15 µs/socket; per-deployment tuning via `getFanoutMetrics`).
 - [ ] Decisions (§ 8): accept all six.
 - [ ] Scope: confirm no public API / schema / client-protocol change in any phase
       (a required change is a design failure → STOP).

--- a/plans/075-phase0-relay-protocol-design.md
+++ b/plans/075-phase0-relay-protocol-design.md
@@ -1,9 +1,13 @@
 # Plan 075 Phase 0 — Relay-tier protocol design (sign-off doc)
 
-> **Status**: DESIGN — awaiting maintainer sign-off. No production code in this
-> phase (the benchmark harness is throwaway; see § 7). The fan-out cost is measured
-> in both Node and real workerd (§ 7). Phases 2–4 do not start until the Decisions
-> in § 8 are accepted.
+> **Status**: SIGNED OFF — Phase 2 (whisper relay) has shipped on top of this
+> design (the owner↔relay hub, runtime upgrade-hop routing, and demand-driven
+> collapse, workerd-proven). One refinement landed in implementation: whisper
+> relays at **shard granularity**, not per-topic (§ 2's "route by topic at the
+> upgrade hop" can't hold — a whisper topic is joined _after_ connect, so it's
+> unknown at upgrade; the upgrade already keys on `?shard=`). Per-topic relay +
+> demand-based right-sizing are tracked follow-ups. The fan-out cost is measured
+> in both Node and real workerd (§ 7).
 >
 > Companion to [`075-do-auto-elastic-fanout-relay-tier.md`](075-do-auto-elastic-fanout-relay-tier.md).
 > Phase 1 (observability) has shipped; this doc designs the transport that Phases

--- a/plans/README.md
+++ b/plans/README.md
@@ -211,9 +211,9 @@ partysync). Two genuine gaps surfaced; one is filed as a design spike here. The
 other (Yjs/CRDT collaborative editing via `y-partyserver`) is tracked separately
 as a prospective `@lunora/collab` package and is **not** in this directory yet.
 
-| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                            |
-| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ------------------------------------------------- |
-| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | TODO (design spike — Phase 0 sign-off gates code) |
+| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                                                 |
+| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ---------------------------------------------------------------------- |
+| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | Phase 1 (observability) SHIPPED — Phases 2–4 gated on Phase 0 sign-off |
 
 ### Notes
 
@@ -221,8 +221,9 @@ as a prospective `@lunora/collab` package and is **not** in this directory yet.
   thinking about it" principle: not a user-facing pub/sub primitive but an
   **automatic internal elasticity** of the subscription transport. Depends on
   plans **072 + 073** (the "compute once" op-range and the identity-independence
-  signal its RLS-uniform gate reuses). Phased: observability → whisper/presence
-  relay → RLS-uniform reactive-shape relay → collapse/ceiling. Start only if the
+  signal its RLS-uniform gate reuses). Phased: observability → whisper relay →
+  RLS-uniform reactive-shape relay (incl. `usePresence`'s `listPresent`, which is
+  a reactive query, not whisper) → collapse/ceiling. Start only if the
   live-broadcast / massive-public-room segment is an explicit product goal.
 - **CRDT / collaborative editing** — the other PartyKit gap (`y-partyserver`).
   Reuse, don't rebuild: `y-partyserver` is ISC and solves Yjs document

--- a/plans/README.md
+++ b/plans/README.md
@@ -211,9 +211,9 @@ partysync). Two genuine gaps surfaced; one is filed as a design spike here. The
 other (Yjs/CRDT collaborative editing via `y-partyserver`) is tracked separately
 as a prospective `@lunora/collab` package and is **not** in this directory yet.
 
-| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                                                 |
-| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ---------------------------------------------------------------------- |
-| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | Phase 1 (observability) SHIPPED — Phases 2–4 gated on Phase 0 sign-off |
+| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                                                                                                          |
+| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | Phase 1 SHIPPED; Phase 0 design WRITTEN (awaiting sign-off, see `075-phase0-relay-protocol-design.md`) — Phases 2–4 gated on it |
 
 ### Notes
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -211,9 +211,9 @@ partysync). Two genuine gaps surfaced; one is filed as a design spike here. The
 other (Yjs/CRDT collaborative editing via `y-partyserver`) is tracked separately
 as a prospective `@lunora/collab` package and is **not** in this directory yet.
 
-| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                                                                                                          |
-| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------- |
-| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | Phase 1 SHIPPED; Phase 0 design WRITTEN (awaiting sign-off, see `075-phase0-relay-protocol-design.md`) — Phases 2–4 gated on it |
+| Plan | Title                                                        | Category          | Pri | Effort | Risk | Status                                                                                                                                                                                                                                                  |
+| ---- | ------------------------------------------------------------ | ----------------- | --- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 075  | Auto-elastic fan-out relay tier (hidden high-fanout scaling) | perf/architecture | P3  | XL     | HIGH | Phases 0–2 SHIPPED (observability + design/calibration + whisper relay hub, runtime routing, collapse, Studio surface; workerd-proven). Follow-ups: per-topic granularity + demand-based relay right-sizing; Phase 3 (RLS-uniform reactive-shape relay) |
 
 ### Notes
 

--- a/shared/relay-name.ts
+++ b/shared/relay-name.ts
@@ -1,0 +1,43 @@
+/**
+ * The owner↔relay DO-name contract for plan 075's auto-elastic fan-out relay tier,
+ * shared by `@lunora/runtime` (which MINTS relay names at the WS upgrade hop) and
+ * `@lunora/do` (which PARSES its own name to learn its role). Kept here — inlined
+ * into each consumer's bundle — so the two sides can never drift on the format
+ * without creating a runtime dependency edge between the packages.
+ *
+ * Zero-dependency by design (see the repo's `shared/` rules): only relative/builtin
+ * imports, named exports, no `.js` extensions.
+ */
+
+/** The `::relay::` infix that marks a DO name as a relay for an owner shard. Reserved — a user shard key can't contain it (only the runtime mints relay names). */
+const RELAY_NAME_INFIX = "::relay::";
+
+/** Build a relay DO name for `ownerKey`'s relay number `index` — the deterministic name any worker/DO can compute without shared state. */
+const relayName = (ownerKey: string, index: number): string => `${ownerKey}${RELAY_NAME_INFIX}${String(index)}`;
+
+/**
+ * Parse a DO name into its owner key + relay index, or `undefined` when the name
+ * is an owner (no `::relay::` infix). Lets a DO discover its own role from
+ * `state.id.name`: an owner serves its shard directly; a relay knows which owner
+ * to forward to and which relay slot it fills.
+ * @returns the owner key + relay index, or `undefined` for an owner-role name
+ */
+const parseRelayName = (name: string): undefined | { ownerKey: string; relayIndex: number } => {
+    const at = name.lastIndexOf(RELAY_NAME_INFIX);
+
+    if (at === -1) {
+        return undefined;
+    }
+
+    const ownerKey = name.slice(0, at);
+    const indexText = name.slice(at + RELAY_NAME_INFIX.length);
+    const relayIndex = Number(indexText);
+
+    if (ownerKey.length === 0 || !Number.isInteger(relayIndex) || relayIndex < 0 || String(relayIndex) !== indexText) {
+        return undefined;
+    }
+
+    return { ownerKey, relayIndex };
+};
+
+export { parseRelayName, RELAY_NAME_INFIX, relayName };


### PR DESCRIPTION
When a shard or topic gets hot, the runtime **transparently** spreads its WebSocket subscription + whisper traffic across extra Durable Objects — **no app-facing API change**. Supersedes the stacked PRs #73, #74, #77.

## How it works

A shard whose live-subscriber count makes per-flush fan-out the bottleneck is **promoted**: the runtime routes _new_ WS connections to relay DOs (`${shard}::relay::${i}`); the owner computes each delta once and forwards it over an internal `/_lunora/relay` control channel; each relay re-broadcasts to its own sockets. It **collapses** back to owner-served once subscribers drain below `T_down`. Thresholds (`T_up = 8,000`, `T_down = 4,000`) are tunable and surfaced in Studio.

## What's in the PR

- **Design + sign-off** — owner↔relay protocol, promotion/collapse state machine, resume handoff (owner = checkpoint authority), the RLS-uniform gate, and the fan-out cost measured in **Node (~16 ns/socket floor)** and **real workerd (~10–15 µs/socket, linear)** → `T_up`/`T_down` (`plans/075-phase0-relay-protocol-design.md`).
- **Observability** — per-flush fan-out cost + per-topic subscriber counts on `ShardDO`, a `getFanoutMetrics` admin read, a Studio **Fan-out** page, and a permanent CodSpeed `fanout-whisper.bench.ts`.
- **Whisper relay** — pure promotion reducer (`relay.ts`), relay-mode `ShardDO` + owner↔relay whisper hub, runtime upgrade-hop routing to relays, collapse + `maxRelays` ceiling + Studio surface (shard-granularity — whisper topics are post-connect).
- **RLS-uniform reactive-shape relay** — the RLS-uniform gate, seed-through-owner, one-delta-per-flush cohort multicast, resume through the owner, and a per-socket owner proxy for non-uniform shapes.

## Security + correctness hardening

A two-pass adversarial review surfaced real bugs in the Phase-3 shape multicast — all fixed and regression-tested in real workerd:

- **CRITICAL — RLS cross-identity row leak.** The uniformity gate validated identities it didn't use and multicast under an unvalidated `{}` identity, so a per-tenant/per-role shape could broadcast unfiltered rows. The gate is now sound: a static `rlsMetadata()` read-policy guard, the multicast identity is the probe base, and the populated probes are **`Proxy`-backed** — they return a distinct value for _any_ accessed claim (even a custom one read outside `rls()`), with a wholesale-copy backstop. No unsampled claims.
- **HIGH — late joiners silently froze.** Cohort memos were stamped at the global cursor while the frontier lagged; an unrelated write stranded a joiner forever. Memos are now stamped at the cohort frontier and are epoch-aware.
- **MEDIUM — non-uniform shapes got zero live updates on a relay.** Now served by a per-socket **owner proxy** that computes each subscriber's delta under its own identity and delivers a `connectionId`-targeted poke — RLS-correct, never frozen.
- **Quality/LOW** — exhaustive frame dispatch (`assertNever`), registry/cache prune on relay drain, relay-delivery fan-out metrics, a single shared `shapeRoutingKey()` (was open-coded 4×), and an awaited relay-control path in `routeNonRpc` (code-quality bot fix).

## Structural follow-through

The relay transport (~480 lines) was extracted from the 8.3k-line `ShardDO` into `relay-hub.ts`, **split by role** the way a DO actually is: an `OwnerRelay` (relay set, uniform/proxy registries, the RLS-uniform gate, cohort multicast + per-socket proxy, seed builder) and a `RelayMember` (per-socket cohort memos, announce latch, seed-via-owner, poke delivery) over a shared `RelayLink` base — chosen once from the DO name so owner-only state can never sit next to relay-only state. `ShardDO` delegates through a narrow `RelayHost` seam and drops to 7,393 lines. Pure structural change; the full suite passes unchanged.

## Verification

- `@lunora/do` suite **981 passing** (+1 todo) · typecheck clean · ESLint + Prettier clean.
- Relay coverage: gate unit test (9 cases incl. the leak vectors + copy backstop) + workerd e2e (seed, cohort multicast, late-joiner drift, resume, per-socket proxy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Fan-out** observability tab in Studio with live subscriber, relay, and activity metrics.
  * Introduced a new admin metrics view for fan-out health and scaling status.

* **Improvements**
  * Expanded relay-based routing to better handle larger subscriber counts.
  * Added backpressure handling and benchmark coverage to improve WebSocket fan-out reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->