### PR TITLE
feat(client): harden offline handling (identity, multi-tab, versioning, sync status)

### DIFF
--- a/apps/docs/src/content/docs/concepts/offline-first.mdx
+++ b/apps/docs/src/content/docs/concepts/offline-first.mdx
@@ -67,11 +67,60 @@ Each cached query stores `{ identity, value, serverCursor, ts }`, keyed by
 entries evicted first) and written with a short debounce as values advance, so a
 chatty subscription doesn't thrash the disk.
 
-The `identity` field is a fingerprint of the auth token at write time. On boot
-the client only hydrates entries whose identity matches the **current** token.
+The `identity` field is a fingerprint of the auth identity at write time. On boot
+the client only hydrates entries whose identity matches the **current** one.
 A signed-out cache never leaks into a new session, and an identity change clears
 the cache outright. The offline outbox is gated by the same rule, so queued
 writes are never replayed under a different user.
+
+By default the fingerprint is a hash of the bearer token — which means a **token
+refresh** (same user, new JWT) reads as an identity change and would discard
+queued writes. Pass a stable subject (the user id) so a refresh during an offline
+window keeps them:
+
+```ts
+client.setAuthToken(accessToken, user.id); // identity keyed on user.id, not the token bytes
+```
+
+A real user switch (different subject) still drops the previous user's queued
+writes. Omit the second argument to keep the legacy token-hash behaviour.
+
+## Surviving a breaking deploy
+
+Set `persistenceVersion` to invalidate persisted writes and cached reads across a
+breaking change to a function signature or query shape. Bump it on deploy; on the
+next boot, any persisted write or cached read stamped with a different version is
+dropped (and purged) instead of replayed/hydrated against the new schema:
+
+```ts
+new LunoraClient({ url, persistence: createIndexedDbPersistence(), persistenceVersion: "2024-06-30" });
+```
+
+Omit it to disable version gating (records are never invalidated by version).
+
+## Multiple tabs
+
+The durable outbox is shared across a profile's tabs. To avoid every tab
+re-queuing and replaying the same persisted writes on reconnect, the standalone
+client elects a single **leader** (via the Web Locks API) that owns hydration;
+when the leader tab closes, another takes over. Server-side idempotency keeps
+replays exactly-once regardless, so this is an efficiency guard, not a
+correctness one. (Where Web Locks are unavailable — React Native, SSR — a single
+context hydrates directly.) Apps with heavy multi-tab offline use should prefer
+[`@lunora/db`](/docs/packages/db) collections, whose outbox is fully
+leader-coordinated.
+
+## Sync status
+
+Beyond connection status, surface how many writes are waiting to sync:
+
+```ts
+client.pendingCount(); // number of queued offline writes not yet sent
+const off = client.onPendingChange((n) => setBadge(n === 0 ? "Synced" : `Syncing ${n}…`));
+```
+
+A `@lunora/db` app reads `db.pendingCount()` (its writes ride the unified outbox,
+not the built-in queue).
 
 ## Connection status UI
 

--- a/apps/docs/src/content/docs/concepts/offline-first.mdx
+++ b/apps/docs/src/content/docs/concepts/offline-first.mdx
@@ -82,8 +82,15 @@ window keeps them:
 client.setAuthToken(accessToken, user.id); // identity keyed on user.id, not the token bytes
 ```
 
-A real user switch (different subject) still drops the previous user's queued
-writes. Omit the second argument to keep the legacy token-hash behaviour.
+The subject is **sticky**: a later `setAuthToken(refreshedToken)` that omits it
+keeps the established subject, and establishing the subject for the first time on
+an unchanged token (e.g. the user id resolves a tick after the token was set)
+re-stamps in-flight queued writes rather than dropping them. A real user switch
+(the token _and_ subject both change) still drops the previous user's writes; pass
+`null` to clear the subject on an explicit sign-out. Prefer passing a stable id
+consistently — avoid a `user?.id` that's transiently `undefined` across a reload
+boundary, since a value queued under the token-hash and replayed under the subject
+after a reload can still mismatch.
 
 ## Surviving a breaking deploy
 
@@ -97,6 +104,11 @@ new LunoraClient({ url, persistence: createIndexedDbPersistence(), persistenceVe
 ```
 
 Omit it to disable version gating (records are never invalidated by version).
+**Adopting it is itself an invalidation event:** records written before you set
+`persistenceVersion` carry no version, so the first boot after enabling it purges
+all currently-queued offline writes (and cached reads). Enable it on a build where
+that clean slate is acceptable — typically the same breaking deploy you're
+protecting against — not purely speculatively.
 
 ## Multiple tabs
 
@@ -106,9 +118,14 @@ client elects a single **leader** (via the Web Locks API) that owns hydration;
 when the leader tab closes, another takes over. Server-side idempotency keeps
 replays exactly-once regardless, so this is an efficiency guard, not a
 correctness one. (Where Web Locks are unavailable — React Native, SSR — a single
-context hydrates directly.) Apps with heavy multi-tab offline use should prefer
-[`@lunora/db`](/docs/packages/db) collections, whose outbox is fully
-leader-coordinated.
+context hydrates directly.) One trade-off: because only the leader hydrates the
+_pre-existing_ persisted queue, writes left over from a prior session can sit until
+the leader flushes them — so if the leader is a backgrounded/offline tab while a
+foreground tab is online, those carried-over writes wait for the leader (the writes
+stay durable and replay exactly-once; only their latency is affected). New writes
+made in any tab flush over that tab's own socket. Apps with heavy multi-tab offline
+use should prefer [`@lunora/db`](/docs/packages/db) collections, whose outbox is
+fully leader-coordinated.
 
 ## Sync status
 

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -1499,6 +1499,45 @@ describe("lunoraClient", () => {
             vi.useRealTimers();
         });
 
+        it("re-stamps queued writes when the subject is established later on the same token (no drop)", async () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: { ok: true } }));
+            const client = new LunoraClient({
+                fetch: fetchMock,
+                heartbeatIntervalMs: 0,
+                reconnect: { initialDelayMs: 10, jitter: false, maxDelayMs: 10 },
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            // The common React pattern: token set before the user id is known
+            // (`user?.id` is transiently undefined), so identity is the token hash.
+            client.setAuthToken("token-1");
+
+            client.subscribe(fnRef("posts:list"), {}, () => undefined);
+            latestSocket().open();
+            latestSocket().triggerClose();
+
+            const pending = client.mutation(fnRef("posts:create"), { title: "queued" });
+
+            // The user id resolves a tick later — SAME token, just a stabler label.
+            // The in-flight write must be re-stamped, not dropped.
+            client.setAuthToken("token-1", "user-1");
+
+            await vi.advanceTimersByTimeAsync(20);
+            latestSocket().open();
+            await vi.runAllTimersAsync();
+
+            await expect(pending).resolves.toEqual({ ok: true });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            client.close();
+            vi.useRealTimers();
+        });
+
         it("pendingCount and onPendingChange track queued writes draining on reconnect", async () => {
             expect.assertions(4);
 

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -1459,6 +1459,89 @@ describe("lunoraClient", () => {
 
             client.close();
         });
+
+        it("a same-subject token refresh during the offline window keeps the queued writes", async () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: { ok: true } }));
+            const client = new LunoraClient({
+                fetch: fetchMock,
+                heartbeatIntervalMs: 0,
+                reconnect: { initialDelayMs: 10, jitter: false, maxDelayMs: 10 },
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            // Same user (subject "user-1"), initial access token.
+            client.setAuthToken("token-v1", "user-1");
+
+            client.subscribe(fnRef("posts:list"), {}, () => undefined);
+            latestSocket().open();
+            latestSocket().triggerClose();
+
+            const pending = client.mutation(fnRef("posts:create"), { title: "queued" });
+
+            // The access token is refreshed (new JWT) for the SAME user before flush.
+            client.setAuthToken("token-v2", "user-1");
+
+            // Reconnect and flush.
+            await vi.advanceTimersByTimeAsync(20);
+            latestSocket().open();
+            await vi.runAllTimersAsync();
+
+            // The write survives the refresh (identity keyed on subject, not token).
+            await expect(pending).resolves.toEqual({ ok: true });
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            client.close();
+            vi.useRealTimers();
+        });
+
+        it("pendingCount and onPendingChange track queued writes draining on reconnect", async () => {
+            expect.assertions(4);
+
+            vi.useFakeTimers();
+
+            const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: { ok: true } }));
+            const client = new LunoraClient({
+                fetch: fetchMock,
+                heartbeatIntervalMs: 0,
+                reconnect: { initialDelayMs: 10, jitter: false, maxDelayMs: 10 },
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const counts: number[] = [];
+
+            client.onPendingChange((n) => counts.push(n));
+
+            // Fires immediately with the current (0) count.
+            expect(client.pendingCount()).toBe(0);
+
+            client.subscribe(fnRef("posts:list"), {}, () => undefined);
+            latestSocket().open();
+            latestSocket().triggerClose();
+
+            // Two writes queue offline → pending count climbs.
+            client.mutation(fnRef("posts:create"), { title: "a" }).catch(() => undefined);
+            client.mutation(fnRef("posts:create"), { title: "b" }).catch(() => undefined);
+
+            expect(client.pendingCount()).toBe(2);
+
+            // Reconnect → flush drains the queue.
+            await vi.advanceTimersByTimeAsync(20);
+            latestSocket().open();
+            await vi.runAllTimersAsync();
+
+            expect(client.pendingCount()).toBe(0);
+            // The observer saw the climb to 2 and the drain back to 0.
+            expect(counts).toEqual(expect.arrayContaining([0, 1, 2, 0]));
+
+            client.close();
+            vi.useRealTimers();
+        });
     });
 
     // --- Optimistic updates -----------------------------------------------------

--- a/packages/client/__tests__/offline-lifecycle.test.ts
+++ b/packages/client/__tests__/offline-lifecycle.test.ts
@@ -564,4 +564,43 @@ describe("offline lifecycle (e2e)", () => {
 
         client.close();
     });
+
+    it("9. drops and purges a persisted write whose schema version no longer matches", async () => {
+        expect.assertions(2);
+
+        vi.useFakeTimers();
+
+        const storage = createFakeAsyncStorage();
+
+        // A durable write left by an OLDER app version (stamped "v1").
+        await createAsyncStoragePersistence({ storage }).append({
+            args: { title: "old-build" },
+            functionPath: "posts:create",
+            id: "m1",
+            identity: null,
+            version: "v1",
+        });
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: { id: "m1" } }));
+
+        // The new build runs persistenceVersion "v2".
+        const client = new LunoraClient({
+            fetch: fetchMock,
+            heartbeatIntervalMs: 0,
+            persistence: createAsyncStoragePersistence({ storage }),
+            persistenceVersion: "v2",
+            reconnect: { initialDelayMs: 10, jitter: false, maxDelayMs: 10 },
+            url: "https://app.example",
+            WebSocket: createMockWebSocket(),
+        });
+
+        await vi.runAllTimersAsync();
+
+        // The stale-version write is NOT replayed against the new schema...
+        expect(fetchMock).not.toHaveBeenCalled();
+        // ...and is purged from durable storage.
+        await expect(createAsyncStoragePersistence({ storage }).load()).resolves.toEqual([]);
+
+        client.close();
+    });
 });

--- a/packages/client/__tests__/offline-queue.test.ts
+++ b/packages/client/__tests__/offline-queue.test.ts
@@ -57,7 +57,7 @@ describe("offlineQueue", () => {
         expect.assertions(4);
 
         const onEvict = vi.fn<(entry: { functionPath: string; liveAwaiter?: boolean }, error: Error & { code?: string }) => void>();
-        const queue = new OfflineQueue({ maxItems: 1 }, undefined, onEvict);
+        const queue = new OfflineQueue({ maxItems: 1 }, { onEvict });
 
         // A hydrated-style entry (no live awaiter) is evicted by a newer write.
         queue.enqueue({ args: {}, functionPath: "old", liveAwaiter: false, reject: () => undefined, resolve: () => undefined });
@@ -76,7 +76,7 @@ describe("offlineQueue", () => {
         expect.assertions(3);
 
         const persistence = createInMemoryPersistence();
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         queue.enqueue({ args: {}, functionPath: "a", reject: () => undefined, resolve: () => undefined });
         queue.enqueue({ args: {}, functionPath: "b", reject: () => undefined, resolve: () => undefined });
@@ -120,7 +120,7 @@ describe("offlineQueue — persistence", () => {
         expect.assertions(4);
 
         const persistence = createInMemoryPersistence();
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         queue.enqueue({ args: { title: "hi" }, functionPath: "posts:create", reject: () => undefined, resolve: () => undefined, shardKey: "room-1" });
 
@@ -141,7 +141,7 @@ describe("offlineQueue — persistence", () => {
 
         const persistence = createInMemoryPersistence();
         const append = vi.spyOn(persistence, "append");
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         queue.enqueue({ args: {}, functionPath: "posts:create", identity: "1:abc", reject: () => undefined, resolve: () => undefined });
 
@@ -156,7 +156,7 @@ describe("offlineQueue — persistence", () => {
 
         await persistence.append({ args: {}, functionPath: "a", identity: "1:abc", id: "1" });
 
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         await queue.hydrate();
 
@@ -172,7 +172,7 @@ describe("offlineQueue — persistence", () => {
 
         await persistence.append({ args: {}, functionPath: "a", id: "1" });
 
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         await queue.hydrate();
 
@@ -185,7 +185,7 @@ describe("offlineQueue — persistence", () => {
         expect.assertions(1);
 
         const persistence = createInMemoryPersistence();
-        const queue = new OfflineQueue({ maxItems: 1 }, persistence);
+        const queue = new OfflineQueue({ maxItems: 1 }, { persistence });
 
         queue.enqueue({ args: {}, functionPath: "old", reject: () => undefined, resolve: () => undefined });
         queue.enqueue({ args: {}, functionPath: "new", reject: () => undefined, resolve: () => undefined });
@@ -204,7 +204,7 @@ describe("offlineQueue — persistence", () => {
         await persistence.append({ args: {}, functionPath: "b", id: "2", shardKey: "room-2" });
         await persistence.append({ args: {}, functionPath: "c", id: "3", shardKey: "room-1" });
 
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
         const shardKeys = await queue.hydrate();
 
         expect(queue.size).toBe(3);
@@ -222,7 +222,7 @@ describe("offlineQueue — persistence", () => {
 
         await persistence.append({ args: {}, functionPath: "a", id: "1" });
 
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         await queue.hydrate();
         // A second hydrate (or one after the live enqueue assigned the same id)
@@ -239,7 +239,7 @@ describe("offlineQueue — persistence", () => {
 
         await persistence.append({ args: {}, functionPath: "a", id: "1" });
 
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         await queue.hydrate();
 
@@ -255,7 +255,7 @@ describe("offlineQueue — persistence", () => {
         expect.assertions(2);
 
         const persistence = createInMemoryPersistence();
-        const queue = new OfflineQueue({}, persistence);
+        const queue = new OfflineQueue({}, { persistence });
 
         queue.enqueue({ args: {}, functionPath: "a", reject: () => undefined, resolve: () => undefined });
         queue.clear();
@@ -275,7 +275,7 @@ describe("offlineQueue — persistence error reporting", () => {
             append: () => Promise.reject(appendError),
         };
         const handler = vi.fn<(context: PersistenceErrorContext) => void>();
-        const queue = new OfflineQueue({ onPersistenceError: handler }, faultyPersistence);
+        const queue = new OfflineQueue({ onPersistenceError: handler }, { persistence: faultyPersistence });
 
         queue.enqueue({ args: {}, functionPath: "posts:create", reject: () => undefined, resolve: () => undefined });
 
@@ -295,7 +295,7 @@ describe("offlineQueue — persistence error reporting", () => {
             append: () => Promise.reject(new Error("quota")),
         };
         const handler = vi.fn<(context: PersistenceErrorContext) => void>();
-        const queue = new OfflineQueue({ onPersistenceError: handler }, faultyPersistence);
+        const queue = new OfflineQueue({ onPersistenceError: handler }, { persistence: faultyPersistence });
 
         queue.enqueue({ args: {}, functionPath: "posts:create", reject: () => undefined, resolve: () => undefined });
 
@@ -316,7 +316,7 @@ describe("offlineQueue — persistence error reporting", () => {
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
         try {
-            const queue = new OfflineQueue({}, faultyPersistence);
+            const queue = new OfflineQueue({}, { persistence: faultyPersistence });
 
             queue.enqueue({ args: {}, functionPath: "posts:create", reject: () => undefined, resolve: () => undefined });
 
@@ -334,7 +334,7 @@ describe("offlineQueue — persistence error reporting", () => {
 
         const persistence = createInMemoryPersistence();
         const handler = vi.fn<(context: PersistenceErrorContext) => void>();
-        const queue = new OfflineQueue({ onPersistenceError: handler }, persistence);
+        const queue = new OfflineQueue({ onPersistenceError: handler }, { persistence });
 
         queue.enqueue({ args: {}, functionPath: "posts:create", reject: () => undefined, resolve: () => undefined });
 
@@ -352,7 +352,7 @@ describe("offlineQueue — persistence error reporting", () => {
             remove: () => Promise.reject(removeError),
         };
         const handler = vi.fn<(context: PersistenceErrorContext) => void>();
-        const queue = new OfflineQueue({ maxItems: 1, onPersistenceError: handler }, faultyPersistence);
+        const queue = new OfflineQueue({ maxItems: 1, onPersistenceError: handler }, { persistence: faultyPersistence });
 
         queue.enqueue({ args: {}, functionPath: "old", reject: () => undefined, resolve: () => undefined });
         queue.enqueue({ args: {}, functionPath: "new", reject: () => undefined, resolve: () => undefined });

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -8,6 +8,7 @@ import type { QueuedMutation } from "./offline-queue";
 import { nextId, OfflineQueue, reportPersistenceError } from "./offline-queue";
 import type { OptimisticLayerHandle } from "./optimistic-layers";
 import { applyOptimisticLayer, dropConfirmedLayers, foldOptimistic, notifySubscription } from "./optimistic-layers";
+import isStaleVersion from "./persisted-version";
 import { queryCacheKey } from "./query-cache";
 import type { ReconnectCalculator } from "./reconnect";
 import { createReconnect } from "./reconnect";
@@ -655,17 +656,16 @@ class LunoraClient {
         this.persistenceVersion = options.persistenceVersion;
         this.queryCache = options.queryCache === false ? undefined : options.queryCache;
         this.onPersistenceError = options.offlineQueue?.onPersistenceError;
-        this.offlineQueue = new OfflineQueue(
-            options.offlineQueue,
-            options.persistence,
-            (entry, error) => {
+        this.offlineQueue = new OfflineQueue(options.offlineQueue, {
+            onEvict: (entry, error) => {
                 this.emitItemSettled(entry, "rejected", error);
             },
-            (size) => {
+            onSizeChange: (size) => {
                 this.pendingChangeListeners.emit(size);
             },
-            options.persistenceVersion,
-        );
+            persistence: options.persistence,
+            version: options.persistenceVersion,
+        });
         this.outbox = options.outbox;
         // A db app persists a stable id alongside the outbox and passes it in; the
         // standalone client gets an ephemeral per-session id, fine because it only
@@ -700,11 +700,16 @@ class LunoraClient {
      * sync across all mounted instances.
      *
      * Pass a STABLE `subject` (the user id) to key the offline-queue identity on
-     * it instead of the token bytes. Without it, a token *refresh* (same user,
-     * new JWT) reads as an identity change and discards queued offline writes —
-     * pass `subject` so a refresh during an offline window keeps them. A real user
-     * switch (different `subject`) still drops them. Omit `subject` to keep the
-     * legacy token-hash behaviour.
+     * it instead of the token bytes, so a token *refresh* (same user, new JWT)
+     * doesn't read as an identity change and discard queued writes. The subject is
+     * **sticky**: a later call that omits it (or passes `undefined`) keeps the
+     * established subject — so `setAuthToken(refreshedToken)` after a prior
+     * `setAuthToken(token, user.id)` retains the identity. Pass `null` to clear it
+     * (an explicit sign-out). Establishing the subject for the first time on an
+     * UNCHANGED token (e.g. the user id resolves a tick after the token was set)
+     * re-stamps any in-flight queued writes rather than dropping them — same
+     * credential, just a more stable label. A real user switch (the token AND
+     * subject both change) still drops the previous user's writes.
      *
      * Does NOT update the WebSocket auth — the WS token is fixed at upgrade
      * time and lives in the URL. To refresh live WS auth, call
@@ -719,14 +724,26 @@ class LunoraClient {
         const previousIdentity = this.identityFingerprint();
 
         this.authToken = token;
-        this.authSubject = subject;
+        // Sticky: only an explicit value (incl. `null` = sign-out) changes the
+        // subject; omitting it keeps the established one.
+        if (subject !== undefined) {
+            this.authSubject = subject;
+        }
 
-        if (this.identityFingerprint() !== previousIdentity) {
-            // Identity changed — drain and reject any in-memory offline writes
-            // queued under the previous identity so they can never replay as the
-            // new user. (Flush also re-checks each item's stamp; this is the eager
-            // path so a switch doesn't leave another user's writes lingering.)
-            this.rejectQueuedForIdentityChange();
+        const newIdentity = this.identityFingerprint();
+
+        if (newIdentity !== previousIdentity) {
+            if (tokenChanged) {
+                // A genuine credential change — drain and reject any in-memory
+                // offline writes queued under the previous identity so they can
+                // never replay as the new user. (Flush also re-checks each stamp.)
+                this.rejectQueuedForIdentityChange();
+            } else {
+                // The token is unchanged (same credential) — the identity label
+                // just got more stable (a subject resolved). Migrate queued writes
+                // to the new fingerprint instead of dropping them.
+                this.restampQueuedIdentity(previousIdentity, newIdentity);
+            }
         }
 
         // Notify token listeners only on an actual token change (useAuth refetch).
@@ -2514,22 +2531,28 @@ class LunoraClient {
      * browsers, SSR) — single-context there, so no coordination is needed.
      */
     private hydrateAsOutboxLeader(): void {
+        const hydrate = (): void => {
+            this.hydratePersistedQueue().catch(() => undefined);
+        };
         // eslint-disable-next-line n/no-unsupported-features/node-builtins -- browser-only API; the `!locks` branch is the React Native / older-browser / SSR fallback
         const locks = (globalThis as { navigator?: { locks?: LockManager } }).navigator?.locks;
 
         if (!locks) {
-            this.hydratePersistedQueue().catch(() => undefined);
+            // No Web Locks (React Native / older browser / SSR) — single context,
+            // no coordination needed.
+            hydrate();
 
             return;
         }
 
         locks
+            // Lock request rejected/aborted → fall back to direct hydration.
             .request(`lunora:outbox-leader:${this.url}`, () => {
                 // Leadership acquired. Hydrate once, then hold the lock (an
                 // unresolved promise) until close() releases it — at which point
                 // the next tab waiting on the lock becomes leader.
                 if (!this.closed) {
-                    this.hydratePersistedQueue().catch(() => undefined);
+                    hydrate();
                 }
 
                 return new Promise<void>((resolve) => {
@@ -2542,11 +2565,7 @@ class LunoraClient {
                     this.outboxLeaderRelease = resolve;
                 });
             })
-            .catch(() => {
-                // Lock request failed/aborted — fall back to direct hydration so a
-                // single tab still replays its writes.
-                this.hydratePersistedQueue().catch(() => undefined);
-            });
+            .catch(hydrate);
     }
 
     /**
@@ -2567,7 +2586,7 @@ class LunoraClient {
             for (const { key, ...entry } of entries) {
                 // Version gate: a value persisted under a different app/schema
                 // version is dropped and purged rather than hydrated.
-                if (this.persistenceVersion !== undefined && entry.version !== this.persistenceVersion) {
+                if (isStaleVersion(this.persistenceVersion, entry.version)) {
                     this.queryCache.remove(key).catch(() => undefined);
 
                     continue;
@@ -3858,8 +3877,10 @@ class LunoraClient {
         // identity — so a same-user token refresh keeps the same fingerprint and
         // doesn't discard queued writes. `null` subject = explicitly signed out.
         if (this.authSubject !== undefined) {
+            // `subj:` is a distinct namespace from the token-hash format
+            // (`<len>:<hash>`) so a subject can never alias a token fingerprint.
             // eslint-disable-next-line unicorn/no-null -- signed-out identity sentinel, distinct from undefined
-            return this.authSubject === null ? null : `s:${this.authSubject}`;
+            return this.authSubject === null ? null : `subj:${this.authSubject}`;
         }
 
         const token = this.authToken;
@@ -3906,6 +3927,22 @@ class LunoraClient {
         }
 
         this.clearQueryCacheForIdentityChange();
+    }
+
+    /**
+     * Migrate every live identity stamp from `from` to `to` — used when the auth
+     * identity label changes but the underlying credential (token) does NOT, e.g.
+     * the user id resolves a tick after the token was set. The in-memory
+     * `queuedIdentities` map is the flush-time source of truth, so re-stamping it
+     * keeps the in-flight writes replayable under the new (more stable) identity
+     * instead of the flush guard discarding them as a mismatch.
+     */
+    private restampQueuedIdentity(from: string | null, to: string | null): void {
+        for (const [id, stamp] of this.queuedIdentities) {
+            if (stamp === from) {
+                this.queuedIdentities.set(id, to);
+            }
+        }
     }
 
     /**

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -511,6 +511,12 @@ class LunoraClient {
 
     private readonly persistence: PersistenceAdapter | undefined;
 
+    /** App/schema version stamped on persisted writes + cached reads; mismatches are purged. */
+    private readonly persistenceVersion: string | undefined;
+
+    /** Releases the multi-tab outbox-leader Web Lock on close (see `hydrateAsOutboxLeader`). */
+    private outboxLeaderRelease: (() => void) | undefined;
+
     /** Durable read cache (Pillar 2); `undefined` when `queryCache` is omitted or `false`. */
     private readonly queryCache: QueryCacheAdapter | undefined;
 
@@ -567,6 +573,15 @@ class LunoraClient {
     private authToken: string | null = null;
 
     /**
+     * Optional STABLE identity subject (a user id), the basis of the offline-queue
+     * identity stamp when supplied. Keeps a same-user token *refresh* from looking
+     * like an identity change (which would discard queued writes). `undefined` =
+     * not supplied, so identity falls back to a hash of the raw token. See
+     * `setAuthToken` / `identityFingerprint`.
+     */
+    private authSubject: string | null | undefined = undefined;
+
+    /**
      * Identity stamp recorded against each queued offline mutation, keyed by
      * the queue-assigned mutation id. Captured at enqueue from the auth token
      * in effect at the time, and re-checked at flush so a queued write can
@@ -588,6 +603,9 @@ class LunoraClient {
 
     /** Subscribers to offline-queued mutation verdicts (see `onMutationSettled`). */
     private readonly mutationSettledListeners = new Listeners<MutationSettledEvent>();
+
+    /** Subscribers to the offline-queue pending-count (see `onPendingChange`). */
+    private readonly pendingChangeListeners = new Listeners<number>();
 
     /**
      * Whisper-topic handlers, keyed by `connectionKey(shardKey)` → topic → set
@@ -634,11 +652,20 @@ class LunoraClient {
         this.connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
         this.defaultConnectionContext = options.connectionContext;
         this.persistence = options.persistence;
+        this.persistenceVersion = options.persistenceVersion;
         this.queryCache = options.queryCache === false ? undefined : options.queryCache;
         this.onPersistenceError = options.offlineQueue?.onPersistenceError;
-        this.offlineQueue = new OfflineQueue(options.offlineQueue, options.persistence, (entry, error) => {
-            this.emitItemSettled(entry, "rejected", error);
-        });
+        this.offlineQueue = new OfflineQueue(
+            options.offlineQueue,
+            options.persistence,
+            (entry, error) => {
+                this.emitItemSettled(entry, "rejected", error);
+            },
+            (size) => {
+                this.pendingChangeListeners.emit(size);
+            },
+            options.persistenceVersion,
+        );
         this.outbox = options.outbox;
         // A db app persists a stable id alongside the outbox and passes it in; the
         // standalone client gets an ephemeral per-session id, fine because it only
@@ -648,9 +675,10 @@ class LunoraClient {
         if (this.persistence) {
             // Deferred to a microtask so the constructor itself stays
             // synchronous; hydration then opens sockets for any restored writes
-            // so they flush once the WS connects.
+            // so they flush once the WS connects. Gated behind a Web Lock so only
+            // ONE tab re-queues the shared durable writes (see the method).
             queueMicrotask((): void => {
-                this.hydratePersistedQueue().catch(() => undefined);
+                this.hydrateAsOutboxLeader();
             });
         }
 
@@ -671,25 +699,40 @@ class LunoraClient {
      * {@link onAuthTokenChange} listeners so React hooks like `useAuth` stay in
      * sync across all mounted instances.
      *
+     * Pass a STABLE `subject` (the user id) to key the offline-queue identity on
+     * it instead of the token bytes. Without it, a token *refresh* (same user,
+     * new JWT) reads as an identity change and discards queued offline writes —
+     * pass `subject` so a refresh during an offline window keeps them. A real user
+     * switch (different `subject`) still drops them. Omit `subject` to keep the
+     * legacy token-hash behaviour.
+     *
      * Does NOT update the WebSocket auth — the WS token is fixed at upgrade
      * time and lives in the URL. To refresh live WS auth, call
      * {@link setWsToken} explicitly, which closes existing shard sockets to
      * force a reconnect with the new credential.
      */
-    public setAuthToken(token: string | null): void {
-        if (this.authToken === token) {
-            return;
-        }
+    public setAuthToken(token: string | null, subject?: string | null): void {
+        const tokenChanged = this.authToken !== token;
+        // Compare the IDENTITY (subject when supplied, else token hash), not the
+        // raw token, so a same-subject refresh doesn't trip the identity-change
+        // drain. Capture the old fingerprint before mutating the inputs.
+        const previousIdentity = this.identityFingerprint();
 
         this.authToken = token;
+        this.authSubject = subject;
 
-        // Identity changed — drain and reject any in-memory offline writes
-        // queued under the previous identity so they can never replay as the
-        // new user. (Flush also re-checks each item's stamp; this is the eager
-        // path so a token swap doesn't leave another user's writes lingering.)
-        this.rejectQueuedForIdentityChange();
+        if (this.identityFingerprint() !== previousIdentity) {
+            // Identity changed — drain and reject any in-memory offline writes
+            // queued under the previous identity so they can never replay as the
+            // new user. (Flush also re-checks each item's stamp; this is the eager
+            // path so a switch doesn't leave another user's writes lingering.)
+            this.rejectQueuedForIdentityChange();
+        }
 
-        this.authTokenListeners.emit(token);
+        // Notify token listeners only on an actual token change (useAuth refetch).
+        if (tokenChanged) {
+            this.authTokenListeners.emit(token);
+        }
     }
 
     public getAuthToken(): string | null {
@@ -1076,6 +1119,30 @@ class LunoraClient {
         const unsubscribe = this.statusListeners.add(listener);
 
         listener(this.computeStatus());
+
+        return unsubscribe;
+    }
+
+    /**
+     * Number of offline writes waiting in the built-in queue to be sent — the
+     * depth for a "N changes waiting to sync" indicator. Counts writes that are
+     * queued (offline / mid-reconnect), not ones already in flight on the wire.
+     * A `@lunora/db` app whose writes ride the unified outbox should read
+     * `LunoraDb.pendingCount()` instead (this counts only the built-in queue).
+     */
+    public pendingCount(): number {
+        return this.offlineQueue.size;
+    }
+
+    /**
+     * Subscribe to changes in {@link pendingCount}. Invokes `listener` immediately
+     * with the current count, then whenever the queue depth changes (a write is
+     * enqueued, flushed, or discarded). Returns an unsubscribe function.
+     */
+    public onPendingChange(listener: (pending: number) => void): Unsubscribe {
+        const unsubscribe = this.pendingChangeListeners.add(listener);
+
+        listener(this.offlineQueue.size);
 
         return unsubscribe;
     }
@@ -2246,6 +2313,10 @@ class LunoraClient {
     public close(): void {
         this.closed = true;
 
+        // Release multi-tab outbox leadership so another tab can take over.
+        this.outboxLeaderRelease?.();
+        this.outboxLeaderRelease = undefined;
+
         // Fail any in-flight streams so consumers see a deterministic
         // termination instead of an iterator that hangs forever after the
         // underlying socket goes away.
@@ -2302,6 +2373,7 @@ class LunoraClient {
         this.statusListeners.clear();
         this.tokenExpiredListeners.clear();
         this.mutationSettledListeners.clear();
+        this.pendingChangeListeners.clear();
         this.whisperHandlers.clear();
 
         // Shape subscriptions retain user row/error callbacks and replicated
@@ -2432,6 +2504,52 @@ class LunoraClient {
     }
 
     /**
+     * Re-queue the durable offline writes — but only as the multi-tab LEADER. The
+     * persisted queue is shared across a profile's tabs; without coordination
+     * every tab would re-queue and replay the same writes (correct only because
+     * the server dedups by idempotency key, but wasteful + racy). A Web Lock makes
+     * exactly one tab hydrate; it holds the lock for its lifetime, so when it
+     * closes another tab acquires the lock and takes over. Falls back to
+     * unconditional hydration where Web Locks are unavailable (React Native, older
+     * browsers, SSR) — single-context there, so no coordination is needed.
+     */
+    private hydrateAsOutboxLeader(): void {
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- browser-only API; the `!locks` branch is the React Native / older-browser / SSR fallback
+        const locks = (globalThis as { navigator?: { locks?: LockManager } }).navigator?.locks;
+
+        if (!locks) {
+            this.hydratePersistedQueue().catch(() => undefined);
+
+            return;
+        }
+
+        locks
+            .request(`lunora:outbox-leader:${this.url}`, () => {
+                // Leadership acquired. Hydrate once, then hold the lock (an
+                // unresolved promise) until close() releases it — at which point
+                // the next tab waiting on the lock becomes leader.
+                if (!this.closed) {
+                    this.hydratePersistedQueue().catch(() => undefined);
+                }
+
+                return new Promise<void>((resolve) => {
+                    if (this.closed) {
+                        resolve();
+
+                        return;
+                    }
+
+                    this.outboxLeaderRelease = resolve;
+                });
+            })
+            .catch(() => {
+                // Lock request failed/aborted — fall back to direct hydration so a
+                // single tab still replays its writes.
+                this.hydratePersistedQueue().catch(() => undefined);
+            });
+    }
+
+    /**
      * Load every cached query into {@link hydratedQueryCache} so the next
      * `subscribe()` for each key seeds its initial value off disk. A
      * subscription created before this resolves simply misses the cache (it
@@ -2447,6 +2565,14 @@ class LunoraClient {
             const entries = await this.queryCache.load();
 
             for (const { key, ...entry } of entries) {
+                // Version gate: a value persisted under a different app/schema
+                // version is dropped and purged rather than hydrated.
+                if (this.persistenceVersion !== undefined && entry.version !== this.persistenceVersion) {
+                    this.queryCache.remove(key).catch(() => undefined);
+
+                    continue;
+                }
+
                 this.hydratedQueryCache.set(key, entry);
             }
         } catch {
@@ -2500,6 +2626,7 @@ class LunoraClient {
             ts: Date.now(),
             value: authoritative,
             ...(state.serverEpoch === undefined ? {} : { serverEpoch: state.serverEpoch }),
+            ...(this.persistenceVersion === undefined ? {} : { version: this.persistenceVersion }),
         });
 
         this.cacheFlushTimer ??= setTimeout(() => {
@@ -3727,6 +3854,14 @@ class LunoraClient {
     // which means "not stamped / hydrated"); the two must not be conflated.
 
     private identityFingerprint(): string | null {
+        // A stable subject (user id), when supplied to `setAuthToken`, is the
+        // identity — so a same-user token refresh keeps the same fingerprint and
+        // doesn't discard queued writes. `null` subject = explicitly signed out.
+        if (this.authSubject !== undefined) {
+            // eslint-disable-next-line unicorn/no-null -- signed-out identity sentinel, distinct from undefined
+            return this.authSubject === null ? null : `s:${this.authSubject}`;
+        }
+
         const token = this.authToken;
 
         if (token === null) {

--- a/packages/client/src/offline-queue.ts
+++ b/packages/client/src/offline-queue.ts
@@ -1,3 +1,4 @@
+import isStaleVersion from "./persisted-version";
 import type { OfflineQueueOptions, PersistenceAdapter, PersistenceErrorContext, PersistenceOperation } from "./types";
 
 interface QueuedMutation<T = unknown> {
@@ -41,6 +42,18 @@ interface QueuedMutation<T = unknown> {
  * record). The `error` carries the `OFFLINE_QUEUE_OVERFLOW` code.
  */
 type EvictHandler = (entry: QueuedMutation, error: Error & { code?: string }) => void;
+
+/** Injected dependencies for {@link OfflineQueue} (kept off the user-facing {@link OfflineQueueOptions}). */
+interface OfflineQueueDeps {
+    /** Invoked when an entry is discarded on capacity overflow (carries `OFFLINE_QUEUE_OVERFLOW`). */
+    onEvict?: EvictHandler;
+    /** Invoked with the new depth after any size change (drives the client's pending-sync count). */
+    onSizeChange?: (size: number) => void;
+    /** Durable store; when present, writes are mirrored and restored across reloads. */
+    persistence?: PersistenceAdapter;
+    /** App/schema version stamped on persisted writes; mismatched records are purged on hydrate. */
+    version?: string;
+}
 
 let idCounter = 0;
 
@@ -120,20 +133,14 @@ class OfflineQueue {
 
     private readonly items: QueuedMutation[] = [];
 
-    public constructor(
-        options: OfflineQueueOptions = {},
-        persistence?: PersistenceAdapter,
-        onEvict?: EvictHandler,
-        onSizeChange?: (size: number) => void,
-        version?: string,
-    ) {
+    public constructor(options: OfflineQueueOptions = {}, deps: OfflineQueueDeps = {}) {
         this.maxItems = options.maxItems ?? 1000;
         this.queueBeforeFirstConnect = options.queueBeforeFirstConnect ?? false;
         this.onPersistenceError = options.onPersistenceError;
-        this.persistence = persistence;
-        this.onEvict = onEvict;
-        this.onSizeChange = onSizeChange;
-        this.version = version;
+        this.persistence = deps.persistence;
+        this.onEvict = deps.onEvict;
+        this.onSizeChange = deps.onSizeChange;
+        this.version = deps.version;
     }
 
     public get size(): number {
@@ -206,7 +213,7 @@ class OfflineQueue {
 
             // Version gate: a write persisted by a different app/schema version is
             // dropped and purged rather than replayed against the current schema.
-            if (this.version !== undefined && mutation.version !== this.version) {
+            if (isStaleVersion(this.version, mutation.version)) {
                 this.persistence.remove(mutation.id).catch((error: unknown) => {
                     reportPersistenceError(this.onPersistenceError, "remove", error, mutation.id);
                 });

--- a/packages/client/src/offline-queue.ts
+++ b/packages/client/src/offline-queue.ts
@@ -113,14 +113,27 @@ class OfflineQueue {
 
     private readonly onEvict: EvictHandler | undefined;
 
+    private readonly onSizeChange: ((size: number) => void) | undefined;
+
+    /** App/schema version stamped on persisted writes; mismatched records are purged on hydrate. */
+    private readonly version: string | undefined;
+
     private readonly items: QueuedMutation[] = [];
 
-    public constructor(options: OfflineQueueOptions = {}, persistence?: PersistenceAdapter, onEvict?: EvictHandler) {
+    public constructor(
+        options: OfflineQueueOptions = {},
+        persistence?: PersistenceAdapter,
+        onEvict?: EvictHandler,
+        onSizeChange?: (size: number) => void,
+        version?: string,
+    ) {
         this.maxItems = options.maxItems ?? 1000;
         this.queueBeforeFirstConnect = options.queueBeforeFirstConnect ?? false;
         this.onPersistenceError = options.onPersistenceError;
         this.persistence = persistence;
         this.onEvict = onEvict;
+        this.onSizeChange = onSizeChange;
+        this.version = version;
     }
 
     public get size(): number {
@@ -134,7 +147,14 @@ class OfflineQueue {
         this.items.push(item);
 
         this.persistence
-            ?.append({ args: item.args, functionPath: item.functionPath, id: item.id, identity: item.identity, shardKey: item.shardKey })
+            ?.append({
+                args: item.args,
+                functionPath: item.functionPath,
+                id: item.id,
+                identity: item.identity,
+                shardKey: item.shardKey,
+                ...(this.version === undefined ? {} : { version: this.version }),
+            })
             .catch((error: unknown) => {
                 reportPersistenceError(this.onPersistenceError, "append", error, item.id);
             });
@@ -159,6 +179,8 @@ class OfflineQueue {
                 this.onEvict?.(dropped, error);
             }
         }
+
+        this.notifySize();
     }
 
     /**
@@ -182,6 +204,16 @@ class OfflineQueue {
                 continue;
             }
 
+            // Version gate: a write persisted by a different app/schema version is
+            // dropped and purged rather than replayed against the current schema.
+            if (this.version !== undefined && mutation.version !== this.version) {
+                this.persistence.remove(mutation.id).catch((error: unknown) => {
+                    reportPersistenceError(this.onPersistenceError, "remove", error, mutation.id);
+                });
+
+                continue;
+            }
+
             this.items.push({
                 args: mutation.args,
                 functionPath: mutation.functionPath,
@@ -193,6 +225,8 @@ class OfflineQueue {
             });
             shardKeys.add(mutation.shardKey);
         }
+
+        this.notifySize();
 
         return [...shardKeys];
     }
@@ -208,6 +242,7 @@ class OfflineQueue {
             const drained = [...this.items];
 
             this.items.length = 0;
+            this.notifySize();
 
             return drained;
         }
@@ -221,6 +256,7 @@ class OfflineQueue {
 
         this.items.length = 0;
         this.items.push(...kept);
+        this.notifySize();
 
         return drained;
     }
@@ -237,6 +273,7 @@ class OfflineQueue {
         }
 
         this.items.unshift(...items);
+        this.notifySize();
     }
 
     public clear(): void {
@@ -253,6 +290,12 @@ class OfflineQueue {
         }
 
         this.items.length = 0;
+        this.notifySize();
+    }
+
+    /** Notify the size observer (the client's pending-sync count) after any change. */
+    private notifySize(): void {
+        this.onSizeChange?.(this.items.length);
     }
 }
 

--- a/packages/client/src/persisted-version.ts
+++ b/packages/client/src/persisted-version.ts
@@ -1,0 +1,14 @@
+/**
+ * The single definition of the persisted-data version gate, shared by the
+ * offline-write queue and the read cache so the two can't diverge.
+ *
+ * A persisted record is stale (drop + purge it on hydrate) when version gating is
+ * ON — `current` is set via `LunoraClientOptions.persistenceVersion` — and the
+ * record's `stamped` version differs. With no `current` version configured,
+ * gating is off and nothing is stale. A record stamped under an OLDER scheme
+ * (legacy `undefined`) is stale once gating is on, so adopting `persistenceVersion`
+ * starts from a clean slate.
+ */
+const isStaleVersion = (current: string | undefined, stamped: string | undefined): boolean => current !== undefined && stamped !== current;
+
+export default isStaleVersion;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -107,6 +107,15 @@ export interface PersistedMutation {
      */
     identity?: string | null;
     shardKey?: string;
+
+    /**
+     * App/schema version stamped at enqueue (from `LunoraClientOptions.persistenceVersion`).
+     * On hydrate, a record whose `version` doesn't match the current one is dropped
+     * and purged rather than replayed — so a write persisted by an older deploy
+     * (with a now-changed function signature) can't replay against the new schema.
+     * Absent when no `persistenceVersion` is configured (no version gating).
+     */
+    version?: string;
 }
 
 /**
@@ -199,6 +208,14 @@ export interface CachedQuery {
 
     /** The full query result last seen from the server. */
     value: unknown;
+
+    /**
+     * App/schema version stamped when persisted (from `LunoraClientOptions.persistenceVersion`).
+     * A cached value whose `version` doesn't match the current one is not hydrated —
+     * so a result of a now-changed shape from an older deploy can't render. Absent
+     * when no `persistenceVersion` is configured (no version gating).
+     */
+    version?: string;
 }
 
 /**
@@ -280,6 +297,16 @@ export interface LunoraClientOptions {
     outbox?: OutboxSink;
     /** Durable store for the offline mutation queue; omit to keep it in memory. */
     persistence?: PersistenceAdapter;
+
+    /**
+     * App/schema version stamped onto every persisted queued write and cached
+     * read. Bump it on a breaking change to a function signature or query shape:
+     * on the next boot, persisted writes / cached reads stamped with a different
+     * version are dropped (and purged) rather than replayed / hydrated against the
+     * new schema. Omit to disable version gating (records are never invalidated by
+     * version).
+     */
+    persistenceVersion?: string;
 
     /**
      * Durable store for the read cache (Pillar 2). When supplied, query results

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -305,6 +305,12 @@ export interface LunoraClientOptions {
      * version are dropped (and purged) rather than replayed / hydrated against the
      * new schema. Omit to disable version gating (records are never invalidated by
      * version).
+     *
+     * **Adoption is itself an invalidation event:** records written before you set
+     * `persistenceVersion` carry no version, so the first boot after enabling it
+     * purges all currently-queued offline writes (and cached reads) as stale. Adopt
+     * it on a build where that clean slate is acceptable — typically the same
+     * breaking deploy you're protecting against — not purely speculatively.
      */
     persistenceVersion?: string;
 

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -151,6 +151,13 @@ export interface LunoraDb<D extends Record<string, AnyDef>> {
     collections: { [K in keyof D]: Collection<RowOf<D[K]>, string> };
     /** The shared offline executor (the outbox). */
     executor: OfflineExecutor;
+
+    /**
+     * Number of writes still pending in the durable outbox — the depth for a
+     * "N changes waiting to sync" indicator. A convenience over reaching through
+     * `executor.getPendingCount()`.
+     */
+    pendingCount: () => number;
     /** Re-point a `scopeBy` collection's subscription (omit `args` to detach) — present for scoped collections. */
     scope: { [K in keyof D]: D[K] extends { scopeBy: string } ? (args?: Record<string, unknown>) => void : never };
 }
@@ -304,5 +311,5 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
         };
     }
 
-    return { actions, collections, executor, scope } as unknown as LunoraDb<D>;
+    return { actions, collections, executor, pendingCount: () => executor.getPendingCount(), scope } as unknown as LunoraDb<D>;
 };

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -155,7 +155,10 @@ export interface LunoraDb<D extends Record<string, AnyDef>> {
     /**
      * Number of writes still pending in the durable outbox — the depth for a
      * "N changes waiting to sync" indicator. A convenience over reaching through
-     * `executor.getPendingCount()`.
+     * `executor.getPendingCount()`. **Pull-only** (the underlying TanStack
+     * executor exposes no change subscription): read it after a `db.actions.*`
+     * call and on connection-status changes, or poll. The standalone
+     * `LunoraClient` exposes the reactive `onPendingChange` for its built-in queue.
      */
     pendingCount: () => number;
     /** Re-point a `scopeBy` collection's subscription (omit `args` to detach) — present for scoped collections. */


### PR DESCRIPTION
Follow-up to the merged offline-rejection work (#72). An audit against RxDB / PowerSync / TanStack DB surfaced four real gaps in offline write handling — one a data-loss bug. This fixes all four.

## 1. Token refresh no longer discards queued writes (data-loss fix) 🔴
The offline-queue identity fingerprint was a hash of the **raw JWT**, so a same-user token *refresh* during an offline window read as an identity change and dropped/un-persisted every queued write (on both the standalone queue and `@lunora/db`).

`setAuthToken(token, subject?)` now keys identity on a stable `subject` (the user id) when supplied:
```ts
client.setAuthToken(accessToken, user.id); // refresh keeps queued writes; real user switch still drops them
```
Falls back to the token hash when no subject is given (back-compat).

## 2. Multi-tab leader election (standalone queue)
The durable queue is shared across a profile's tabs; previously **every** tab re-queued and replayed the same persisted writes on reconnect (correct only via server idempotency, but wasteful/racy). The standalone client now gates hydration behind a **Web Lock** so one leader tab owns it; another takes over when the leader closes. Falls back to direct hydration where Web Locks are unavailable (RN/SSR). (`@lunora/db` was already leader-coordinated.)

## 3. Persisted-data versioning
`persistenceVersion` stamps queued writes + cached reads; on boot, records with a mismatched version are dropped and purged rather than replayed/hydrated against a changed schema.

## 4. Sync-status surface
`client.pendingCount()` / `client.onPendingChange()` and `db.pendingCount()` for a "syncing N changes…" indicator.

## Verification
`@lunora/client` 280 tests (new: token-refresh-survives, version-gate, pending-count), `@lunora/db` 39, type-checks + ESLint + Prettier green. Docs updated (offline-first concept: identity/subject, versioning, multi-tab, sync status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-tab coordination for durable offline writes so only one tab hydrates while others synchronize.
  * Added pending write depth via `pendingCount()` plus `onPendingChange` notifications for sync-status UI.
  * Added `persistenceVersion` support to automatically invalidate persisted queued writes and cached query results after breaking changes.
* **Bug Fixes**
  * Token refreshes now preserve queued offline writes when the signed-in identity hasn’t changed; signing out clears them.
* **Documentation**
  * Updated offline-first guidance for identity persistence and versioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->