### PR TITLE
feat(client): durable offline stores on by default

### DIFF
--- a/packages/client/__tests__/resolve-durable-defaults.test.ts
+++ b/packages/client/__tests__/resolve-durable-defaults.test.ts
@@ -1,0 +1,101 @@
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolvePersistenceAdapter } from "../src/persistence";
+import { resolveQueryCacheAdapter } from "../src/query-cache";
+import type { PersistenceAdapter, QueryCacheAdapter } from "../src/types";
+
+/**
+ * Install a fake `indexedDB` global for the duration of a probe and restore the
+ * previous value afterwards, so the auto-probe branch can be exercised in the
+ * Node test environment (which has no `indexedDB`).
+ */
+const withGlobalIndexedDb = <T>(run: () => T): T => {
+    const previous = (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+
+    (globalThis as { indexedDB?: IDBFactory }).indexedDB = new IDBFactory();
+
+    try {
+        return run();
+    } finally {
+        (globalThis as { indexedDB?: IDBFactory }).indexedDB = previous;
+    }
+};
+
+afterEach(() => {
+    // Guard against a leaked global if an assertion threw inside the probe.
+    delete (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+});
+
+describe("resolvePersistenceAdapter", () => {
+    const explicit: PersistenceAdapter = {
+        append: () => Promise.resolve(),
+        clear: () => Promise.resolve(),
+        load: () => Promise.resolve([]),
+        remove: () => Promise.resolve(),
+    };
+
+    it("returns an explicit adapter unchanged", () => {
+        expect(resolvePersistenceAdapter(explicit)).toBe(explicit);
+    });
+
+    it("opts out on `false`", () => {
+        expect(resolvePersistenceAdapter(false)).toBeUndefined();
+    });
+
+    it("stays in memory when no IndexedDB is available", () => {
+        // Node test env: no `indexedDB` global.
+        expect(resolvePersistenceAdapter(undefined)).toBeUndefined();
+    });
+
+    it("auto-probes a durable IndexedDB store by default when available", () => {
+        withGlobalIndexedDb(() => {
+            const resolved = resolvePersistenceAdapter(undefined);
+
+            expect(resolved).toBeDefined();
+            expect(typeof resolved?.append).toBe("function");
+        });
+    });
+
+    it("suppresses the auto-default when an outbox owns the write path", () => {
+        withGlobalIndexedDb(() => {
+            expect(resolvePersistenceAdapter(undefined, false)).toBeUndefined();
+        });
+    });
+
+    it("still honours an explicit adapter even when the auto-default is suppressed", () => {
+        withGlobalIndexedDb(() => {
+            expect(resolvePersistenceAdapter(explicit, false)).toBe(explicit);
+        });
+    });
+});
+
+describe("resolveQueryCacheAdapter", () => {
+    const explicit: QueryCacheAdapter = {
+        clear: () => Promise.resolve(),
+        load: () => Promise.resolve([]),
+        put: () => Promise.resolve(),
+        remove: () => Promise.resolve(),
+    };
+
+    it("returns an explicit adapter unchanged", () => {
+        expect(resolveQueryCacheAdapter(explicit)).toBe(explicit);
+    });
+
+    it("opts out on `false`", () => {
+        expect(resolveQueryCacheAdapter(false)).toBeUndefined();
+    });
+
+    it("stays in memory when no IndexedDB is available", () => {
+        expect(resolveQueryCacheAdapter(undefined)).toBeUndefined();
+    });
+
+    it("auto-probes a durable IndexedDB store by default when available", () => {
+        withGlobalIndexedDb(() => {
+            const resolved = resolveQueryCacheAdapter(undefined);
+
+            expect(resolved).toBeDefined();
+            expect(typeof resolved?.put).toBe("function");
+        });
+    });
+});

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -9,7 +9,8 @@ import { nextId, OfflineQueue, reportPersistenceError } from "./offline-queue";
 import type { OptimisticLayerHandle } from "./optimistic-layers";
 import { applyOptimisticLayer, dropConfirmedLayers, foldOptimistic, notifySubscription } from "./optimistic-layers";
 import isStaleVersion from "./persisted-version";
-import { queryCacheKey } from "./query-cache";
+import { resolvePersistenceAdapter } from "./persistence";
+import { queryCacheKey, resolveQueryCacheAdapter } from "./query-cache";
 import type { ReconnectCalculator } from "./reconnect";
 import { createReconnect } from "./reconnect";
 import type { StreamHandle, StreamIterable } from "./stream";
@@ -652,9 +653,14 @@ class LunoraClient {
         this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
         this.connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
         this.defaultConnectionContext = options.connectionContext;
-        this.persistence = options.persistence;
+        // Auto-probe durable stores: an omitted option defaults to IndexedDB when
+        // the environment supports it (browsers), so the bare client is local-first
+        // out of the box; `false` opts out, an explicit adapter is used as-is. The
+        // write-queue auto-default is suppressed when an outbox (the `@lunora/db`
+        // path) owns the durable write path, so we never persist a second copy.
+        this.persistence = resolvePersistenceAdapter(options.persistence, options.outbox === undefined);
         this.persistenceVersion = options.persistenceVersion;
-        this.queryCache = options.queryCache === false ? undefined : options.queryCache;
+        this.queryCache = resolveQueryCacheAdapter(options.queryCache);
         this.onPersistenceError = options.offlineQueue?.onPersistenceError;
         this.offlineQueue = new OfflineQueue(options.offlineQueue, {
             onEvict: (entry, error) => {
@@ -663,7 +669,7 @@ class LunoraClient {
             onSizeChange: (size) => {
                 this.pendingChangeListeners.emit(size);
             },
-            persistence: options.persistence,
+            persistence: this.persistence,
             version: options.persistenceVersion,
         });
         this.outbox = options.outbox;

--- a/packages/client/src/persistence.ts
+++ b/packages/client/src/persistence.ts
@@ -153,5 +153,39 @@ const createIndexedDbPersistence = (options: IndexedDbPersistenceOptions = {}): 
     };
 };
 
-export { createIndexedDbPersistence, createInMemoryPersistence };
+/**
+ * Resolve the effective offline-queue persistence from the user option,
+ * defaulting to a durable IndexedDB store when the environment supports one.
+ *
+ * An explicit adapter is used as-is; `false` opts out (the caller keeps an
+ * in-memory queue, lost on reload); `undefined` (the default) auto-probes
+ * IndexedDB when the global is present (browsers) and `autoProbe` is set,
+ * otherwise `undefined` — so SSR/Node/React-Native keep today's in-memory
+ * behaviour and only environments that can persist do.
+ *
+ * `autoProbe` is `false` when the `@lunora/db` outbox is wired: that sink is the
+ * single durable write path, so the built-in queue must stay in memory rather
+ * than persist a second, never-flushed copy. An explicit adapter is still
+ * honoured (the caller asked for it); only the implicit default is suppressed.
+ *
+ * The IndexedDB adapter opens its connection lazily, so constructing it here is
+ * cheap and never throws (the `indexedDB` global is verified present first).
+ */
+const resolvePersistenceAdapter = (option: false | PersistenceAdapter | undefined, autoProbe = true): PersistenceAdapter | undefined => {
+    if (option === false) {
+        return undefined;
+    }
+
+    if (option) {
+        return option;
+    }
+
+    if (!autoProbe || typeof indexedDB === "undefined") {
+        return undefined;
+    }
+
+    return createIndexedDbPersistence();
+};
+
+export { createIndexedDbPersistence, createInMemoryPersistence, resolvePersistenceAdapter };
 export type { IndexedDbPersistenceOptions };

--- a/packages/client/src/query-cache.ts
+++ b/packages/client/src/query-cache.ts
@@ -222,5 +222,30 @@ const createIndexedDbQueryCache = (options: IndexedDbQueryCacheOptions = {}): Qu
     };
 };
 
-export { createIndexedDbQueryCache, createInMemoryQueryCache, queryCacheKey };
+/**
+ * Resolve the effective read-cache from the user option, defaulting to a durable
+ * IndexedDB store when the environment supports one. Same tri-state semantics as
+ * `resolvePersistenceAdapter` in `./persistence`:
+ *
+ * - an explicit adapter is used as-is;
+ * - `false` opts out — reads stay in memory only;
+ * - `undefined` (the default) auto-probes IndexedDB (browsers), else `undefined`.
+ */
+const resolveQueryCacheAdapter = (option: false | QueryCacheAdapter | undefined): QueryCacheAdapter | undefined => {
+    if (option === false) {
+        return undefined;
+    }
+
+    if (option) {
+        return option;
+    }
+
+    if (typeof indexedDB === "undefined") {
+        return undefined;
+    }
+
+    return createIndexedDbQueryCache();
+};
+
+export { createIndexedDbQueryCache, createInMemoryQueryCache, queryCacheKey, resolveQueryCacheAdapter };
 export type { IndexedDbQueryCacheOptions };

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -295,8 +295,17 @@ export interface LunoraClientOptions {
      * standalone client, which keeps using {@link LunoraClientOptions.persistence}.
      */
     outbox?: OutboxSink;
-    /** Durable store for the offline mutation queue; omit to keep it in memory. */
-    persistence?: PersistenceAdapter;
+
+    /**
+     * Durable store for the offline mutation queue. Tri-state — an explicit
+     * {@link PersistenceAdapter} is used as-is; `false` opts out (the queue stays
+     * in memory, lost on reload); omitted (the default) auto-probes a durable
+     * IndexedDB store when the `indexedDB` global is present (browsers), otherwise
+     * in-memory, so SSR/Node/React-Native keep the in-memory behaviour and only
+     * environments that can persist do. Pass `createAsyncStoragePersistence()` on
+     * React Native.
+     */
+    persistence?: false | PersistenceAdapter;
 
     /**
      * App/schema version stamped onto every persisted queued write and cached
@@ -315,11 +324,13 @@ export interface LunoraClientOptions {
     persistenceVersion?: string;
 
     /**
-     * Durable store for the read cache (Pillar 2). When supplied, query results
+     * Durable store for the read cache (Pillar 2). When active, query results
      * are persisted as their subscriptions advance and hydrated on construction
      * so a reload renders cached data before the socket reconnects, then resumes
-     * the live subscription from the persisted cursor. Omit (or pass `false`) to
-     * keep reads in memory only — the default, unchanged behaviour.
+     * the live subscription from the persisted cursor. Tri-state — an explicit
+     * {@link QueryCacheAdapter} is used as-is; `false` opts out (reads stay in
+     * memory only); omitted (the default) auto-probes IndexedDB exactly like
+     * {@link LunoraClientOptions.persistence}.
      */
     queryCache?: QueryCacheAdapter | false;
     reconnect?: ReconnectOptions;


### PR DESCRIPTION
## What

Makes the bare `@lunora/client` local-first **out of the box**. Previously the offline write queue and read cache lived in memory unless the consumer explicitly wired `persistence` / `queryCache` adapters — so a reload lost queued writes and cached reads, and "local-first" only really held for the `@lunora/db` path.

## How

- New `resolvePersistenceAdapter(option, autoProbe)` and `resolveQueryCacheAdapter(option)` with tri-state semantics:
  - explicit adapter → used as-is
  - `false` → opt out (in-memory, lost on reload)
  - **omitted (default) → auto-probe IndexedDB** and use it when the global is present (browsers), else in-memory
- SSR / Node / React-Native (`typeof indexedDB === "undefined"`) → falls back to in-memory, exactly today's behavior. RN users still pass `createAsyncStoragePersistence()` explicitly.
- The **write-queue** auto-default is suppressed when an `outbox` (the `@lunora/db` path) owns the durable write path, so a db app never persists a second, never-flushed copy.
- `persistence` option gains a `false` opt-out (matching `queryCache`).

## Tests

- `packages/client/__tests__/resolve-durable-defaults.test.ts` — auto-probe on/off, `false` opt-out, outbox suppression, explicit-adapter passthrough.
- Verified locally: `@lunora/client` 279 pass · `@lunora/db` 37 pass · `@lunora/react` 98 pass · `tsc --noEmit` clean · 0 ESLint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic offline storage and read-cache setup when supported by the browser.
  * You can now explicitly disable durable persistence or the query cache while keeping the app functional.

* **Bug Fixes**
  * Improved handling of offline writes when an outbox is managing durable updates.
  * Read and write caching now follows clearer enable/disable behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->