### PR TITLE
fix: found improvments

### DIFF
--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -435,6 +435,23 @@ describe("lunora init", () => {
             expect(existsSync(join(workdir, "   "))).toBe(false);
         });
 
+        it("trims a whitespace-padded name so the target dir is not whitespace-padded", async () => {
+            expect.assertions(3);
+
+            const result = await runInitCommand({
+                cwd: workdir,
+                from: templatesRoot,
+                logger: silentLogger(),
+                name: "  padded-app  ",
+                templateType: "tanstack-start-react",
+            });
+
+            expect(result.code).toBe(0);
+            // The trimmed name is used for the target dir — no whitespace-padded folder.
+            expect(existsSync(join(workdir, "padded-app", "package.json"))).toBe(true);
+            expect(existsSync(join(workdir, "  padded-app  "))).toBe(false);
+        });
+
         it("--from with missing template reports a helpful error", async () => {
             expect.assertions(2);
 

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -398,6 +398,43 @@ describe("lunora init", () => {
             expect(errors.join("\n")).toContain("not empty");
         });
 
+        it("refuses an empty project name", async () => {
+            expect.assertions(3);
+
+            const errors: string[] = [];
+
+            const result = await runInitCommand({
+                cwd: workdir,
+                from: templatesRoot,
+                logger: { ...silentLogger(), error: (message) => errors.push(message) },
+                name: "",
+                templateType: "tanstack-start-react",
+            });
+
+            expect(result.code).toBe(1);
+            expect(errors.join("\n")).toContain("refusing an empty project name");
+            // cwd itself must not have been scaffolded into (e.g. no package.json dropped in workdir)
+            expect(existsSync(join(workdir, "package.json"))).toBe(false);
+        });
+
+        it("refuses a whitespace-only project name", async () => {
+            expect.assertions(3);
+
+            const errors: string[] = [];
+
+            const result = await runInitCommand({
+                cwd: workdir,
+                from: templatesRoot,
+                logger: { ...silentLogger(), error: (message) => errors.push(message) },
+                name: "   ",
+                templateType: "tanstack-start-react",
+            });
+
+            expect(result.code).toBe(1);
+            expect(errors.join("\n")).toContain("refusing an empty project name");
+            expect(existsSync(join(workdir, "   "))).toBe(false);
+        });
+
         it("--from with missing template reports a helpful error", async () => {
             expect.assertions(2);
 

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -1383,6 +1383,17 @@ const scaffoldNewProject = async (
     const name = options.name ?? (await tuiText(COPY.name, { badge: BADGES.dir, default: suggestedName, placeholder: suggestedName }));
     const choice = await resolveScaffoldChoice(options);
 
+    // Guard against an empty / whitespace-only name: `options.name ?? …` only
+    // falls back on null/undefined, so an explicit `--name ""` (or a
+    // whitespace-only name) passes straight through. `resolve(cwd, "")`
+    // resolves to cwd itself, and `resolve(cwd, "   ")` creates a confusing
+    // whitespace-named directory — reject both up front.
+    if (name.trim().length === 0) {
+        options.logger.error(`init: refusing an empty project name — pass a directory name (e.g. \`lunora init my-app\`).`);
+
+        return { code: 1, files: [], target: "" };
+    }
+
     // Guard the project name against path traversal: it becomes a directory
     // under cwd, so a name containing separators or `..` could scaffold outside
     // the intended parent. Mirrors the `--source` `isSafeSource` gate.

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -1380,7 +1380,7 @@ const scaffoldNewProject = async (
     // generated per run so an empty submit lands on something nicer than a static
     // placeholder (create-astro does the same).
     const suggestedName = generateProjectName();
-    const name = options.name ?? (await tuiText(COPY.name, { badge: BADGES.dir, default: suggestedName, placeholder: suggestedName }));
+    const rawName = options.name ?? (await tuiText(COPY.name, { badge: BADGES.dir, default: suggestedName, placeholder: suggestedName }));
     const choice = await resolveScaffoldChoice(options);
 
     // Guard against an empty / whitespace-only name: `options.name ?? …` only
@@ -1388,7 +1388,9 @@ const scaffoldNewProject = async (
     // whitespace-only name) passes straight through. `resolve(cwd, "")`
     // resolves to cwd itself, and `resolve(cwd, "   ")` creates a confusing
     // whitespace-named directory — reject both up front.
-    if (name.trim().length === 0) {
+    const name = rawName.trim();
+
+    if (name.length === 0) {
         options.logger.error(`init: refusing an empty project name — pass a directory name (e.g. \`lunora init my-app\`).`);
 
         return { code: 1, files: [], target: "" };

--- a/packages/client/__tests__/offline-queue.test.ts
+++ b/packages/client/__tests__/offline-queue.test.ts
@@ -366,4 +366,22 @@ describe("offlineQueue — persistence error reporting", () => {
         expect(removeCalls).toHaveLength(1);
         expect(removeCalls[0]?.[0]?.error).toBe(removeError);
     });
+
+    it("hydrate load failure invokes handler with operation 'load' and rejects", async () => {
+        expect.assertions(4);
+
+        const loadError = new Error("indexeddb unavailable");
+        const faultyPersistence = {
+            ...createInMemoryPersistence(),
+            load: () => Promise.reject(loadError),
+        };
+        const handler = vi.fn<(context: PersistenceErrorContext) => void>();
+        const queue = new OfflineQueue({ onPersistenceError: handler }, { persistence: faultyPersistence });
+
+        await expect(queue.hydrate()).rejects.toBe(loadError);
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler.mock.calls[0]?.[0]?.operation).toBe("load");
+        expect(handler.mock.calls[0]?.[0]?.error).toBe(loadError);
+    });
 });

--- a/packages/client/__tests__/persistence-query-cache-coexistence.test.ts
+++ b/packages/client/__tests__/persistence-query-cache-coexistence.test.ts
@@ -1,0 +1,79 @@
+import { IDBFactory } from "fake-indexeddb";
+import { describe, expect, it } from "vitest";
+
+import { createIndexedDbPersistence } from "../src/persistence";
+import { createIndexedDbQueryCache, queryCacheKey } from "../src/query-cache";
+import type { PersistedMutation } from "../src/types";
+
+const mutation = (id: string): PersistedMutation => {
+    return { args: { id }, functionPath: "posts:create", id };
+};
+
+/**
+ * Regression: the offline outbox and the read cache must open DISTINCT IndexedDB
+ * databases. They used to share the `lunora` database at mismatched schema
+ * versions (outbox v1, query-cache v2); IndexedDB's version is a property of the
+ * database, not the store, so once both were enabled by default the lower-version
+ * open threw `VersionError: The requested version (1) is less than the existing
+ * version (2)`. In a browser that surfaced as a Vite runtime-error overlay that
+ * blocked every interaction (all e2e specs timed out clicking through it).
+ *
+ * These cases would have thrown against the old shared-database code and pass now
+ * that each adapter owns its own database.
+ */
+describe("offline outbox + query cache coexistence (shared IDBFactory)", () => {
+    it("both adapters open on one factory without a VersionError, regardless of open order", async () => {
+        expect.assertions(2);
+
+        const indexedDB = new IDBFactory();
+
+        // Open the query cache FIRST so its database reaches its own version before
+        // the outbox opens — the exact ordering that tripped `VersionError` when the
+        // two shared the `lunora` database.
+        const queryCache = createIndexedDbQueryCache({ indexedDB });
+
+        await queryCache.put(queryCacheKey("messages:list", "{}"), { identity: "u1", ts: 1, value: { count: 1 } });
+
+        const outbox = createIndexedDbPersistence({ indexedDB });
+
+        await outbox.append(mutation("a"));
+
+        await expect(outbox.load()).resolves.toHaveLength(1);
+        await expect(queryCache.load()).resolves.toHaveLength(1);
+    });
+
+    it("survives a reload boundary — fresh adapters on the same factory re-open cleanly", async () => {
+        expect.assertions(2);
+
+        const indexedDB = new IDBFactory();
+
+        // Session 1: both databases created.
+        await createIndexedDbQueryCache({ indexedDB }).put(queryCacheKey("messages:list", "{}"), { identity: "u1", ts: 1, value: { count: 1 } });
+        await createIndexedDbPersistence({ indexedDB }).append(mutation("a"));
+
+        // Session 2 (reload): brand-new adapter instances re-open the existing
+        // databases. The outbox re-opening its DB must not collide with whatever
+        // version the query cache left behind.
+        const outbox = createIndexedDbPersistence({ indexedDB });
+        const queryCache = createIndexedDbQueryCache({ indexedDB });
+
+        await expect(outbox.load()).resolves.toHaveLength(1);
+        await expect(queryCache.load()).resolves.toHaveLength(1);
+    });
+
+    it("keeps the outbox and read cache in separate databases", async () => {
+        expect.assertions(3);
+
+        const indexedDB = new IDBFactory();
+
+        await createIndexedDbPersistence({ indexedDB }).append(mutation("a"));
+        await createIndexedDbQueryCache({ indexedDB }).put(queryCacheKey("messages:list", "{}"), { identity: "u1", ts: 1, value: { count: 1 } });
+
+        const databases = await indexedDB.databases();
+        const names = databases.map((database) => database.name);
+
+        expect(names).toContain("lunora");
+        expect(names).toContain("lunora-query-cache");
+        expect(names).toHaveLength(2);
+    });
+});

--- a/packages/client/__tests__/persistence-query-cache-coexistence.test.ts
+++ b/packages/client/__tests__/persistence-query-cache-coexistence.test.ts
@@ -11,7 +11,7 @@ const mutation = (id: string): PersistedMutation => {
 
 /**
  * Regression: the offline outbox and the read cache must open DISTINCT IndexedDB
- * databases. They used to share the `lunora` database at mismatched schema
+ * databases. They used to share one `lunora` database at mismatched schema
  * versions (outbox v1, query-cache v2); IndexedDB's version is a property of the
  * database, not the store, so once both were enabled by default the lower-version
  * open threw `VersionError: The requested version (1) is less than the existing
@@ -29,7 +29,7 @@ describe("offline outbox + query cache coexistence (shared IDBFactory)", () => {
 
         // Open the query cache FIRST so its database reaches its own version before
         // the outbox opens — the exact ordering that tripped `VersionError` when the
-        // two shared the `lunora` database.
+        // two shared one `lunora` database.
         const queryCache = createIndexedDbQueryCache({ indexedDB });
 
         await queryCache.put(queryCacheKey("messages:list", "{}"), { identity: "u1", ts: 1, value: { count: 1 } });
@@ -72,7 +72,7 @@ describe("offline outbox + query cache coexistence (shared IDBFactory)", () => {
         const databases = await indexedDB.databases();
         const names = databases.map((database) => database.name);
 
-        expect(names).toContain("lunora");
+        expect(names).toContain("lunora-outbox");
         expect(names).toContain("lunora-query-cache");
         expect(names).toHaveLength(2);
     });

--- a/packages/client/src/offline-queue.ts
+++ b/packages/client/src/offline-queue.ts
@@ -1,5 +1,5 @@
 import isStaleVersion from "./persisted-version";
-import type { OfflineQueueOptions, PersistenceAdapter, PersistenceErrorContext, PersistenceOperation } from "./types";
+import type { OfflineQueueOptions, PersistedMutation, PersistenceAdapter, PersistenceErrorContext, PersistenceOperation } from "./types";
 
 interface QueuedMutation<T = unknown> {
     readonly args: Record<string, unknown>;
@@ -203,7 +203,15 @@ class OfflineQueue {
             return [];
         }
 
-        const persisted = await this.persistence.load();
+        let persisted: PersistedMutation[];
+
+        try {
+            persisted = await this.persistence.load();
+        } catch (error) {
+            reportPersistenceError(this.onPersistenceError, "load", error);
+            throw error;
+        }
+
         const shardKeys = new Set<string | undefined>();
 
         for (const mutation of persisted) {

--- a/packages/client/src/persistence.ts
+++ b/packages/client/src/persistence.ts
@@ -48,6 +48,11 @@ interface IndexedDbPersistenceOptions {
     storeName?: string;
 }
 
+// The offline outbox owns the `lunora` database outright (schema v1). The read
+// cache lives in its OWN `lunora-query-cache` database — do NOT co-locate the two
+// stores here: IndexedDB's version is per-database, so sharing one DB forces the
+// two independently-toggleable adapters to keep a single version constant in sync
+// (they didn't, which threw `VersionError` once both were enabled by default).
 const DEFAULT_DATABASE = "lunora";
 const DEFAULT_STORE = "offline-mutations";
 /** Secondary index on the mutation id — the store's primary key is an autoincrement seq that preserves FIFO order. */

--- a/packages/client/src/persistence.ts
+++ b/packages/client/src/persistence.ts
@@ -40,7 +40,7 @@ const createInMemoryPersistence = (): PersistenceAdapter => {
 
 // eslint-disable-next-line unicorn/prevent-abbreviations -- public exported type name; renaming breaks @lunora/client consumers
 interface IndexedDbPersistenceOptions {
-    /** Database name; defaults to `"lunora"`. */
+    /** Database name; defaults to `"lunora-outbox"` (its own DB, separate from the read cache). */
     databaseName?: string;
     /** Injectable `IDBFactory` (e.g. `fake-indexeddb` in tests); defaults to the global `indexedDB`. */
     indexedDB?: IDBFactory;
@@ -48,12 +48,13 @@ interface IndexedDbPersistenceOptions {
     storeName?: string;
 }
 
-// The offline outbox owns the `lunora` database outright (schema v1). The read
-// cache lives in its OWN `lunora-query-cache` database — do NOT co-locate the two
-// stores here: IndexedDB's version is per-database, so sharing one DB forces the
-// two independently-toggleable adapters to keep a single version constant in sync
-// (they didn't, which threw `VersionError` once both were enabled by default).
-const DEFAULT_DATABASE = "lunora";
+// The offline outbox owns the `lunora-outbox` database outright (schema v1). The
+// read cache lives in its OWN `lunora-query-cache` database — do NOT co-locate the
+// two stores in one DB: IndexedDB's version is per-database, so sharing one DB
+// forces the two independently-toggleable adapters to keep a single version
+// constant in sync (they didn't, which threw `VersionError` once both were enabled
+// by default).
+const DEFAULT_DATABASE = "lunora-outbox";
 const DEFAULT_STORE = "offline-mutations";
 /** Secondary index on the mutation id — the store's primary key is an autoincrement seq that preserves FIFO order. */
 const ID_INDEX = "by_id";

--- a/packages/client/src/query-cache.ts
+++ b/packages/client/src/query-cache.ts
@@ -88,7 +88,7 @@ const TS_INDEX = "by_ts";
  * Schema version for the read-cache database. The query cache owns its own
  * database ({@link DEFAULT_DATABASE}) so its schema evolves independently of the
  * offline-mutation outbox — the two adapters are toggled independently and never
- * share a version namespace. (They previously shared the `lunora` database at
+ * share a version namespace. (They previously shared one `lunora` database at
  * mismatched versions — 1 for the outbox, 2 here — which threw
  * `VersionError: The requested version (1) is less than the existing version (2)`
  * once both were enabled: IndexedDB's version is a property of the database, not
@@ -114,7 +114,7 @@ const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
  * reuse one connection.
  *
  * The store lives in its own `lunora-query-cache` database — deliberately
- * separate from the offline-mutation outbox's `lunora` database so the two
+ * separate from the offline-mutation outbox's `lunora-outbox` database so the two
  * independently-toggleable adapters never share (and drift on) a schema version.
  * Throws eagerly if no `IDBFactory` is available — callers in non-browser
  * environments should use {@link createInMemoryQueryCache}.

--- a/packages/client/src/query-cache.ts
+++ b/packages/client/src/query-cache.ts
@@ -69,7 +69,7 @@ const createInMemoryQueryCache = (options: { maxEntries?: number } = {}): QueryC
 
 // eslint-disable-next-line unicorn/prevent-abbreviations -- public exported type name; renaming breaks @lunora/client consumers
 interface IndexedDbQueryCacheOptions {
-    /** Database name; defaults to `"lunora"` (shared with the offline-mutation store). */
+    /** Database name; defaults to `"lunora-query-cache"` (its own DB, separate from the offline outbox). */
     databaseName?: string;
     /** Injectable `IDBFactory` (e.g. `fake-indexeddb` in tests); defaults to the global `indexedDB`. */
     indexedDB?: IDBFactory;
@@ -79,16 +79,22 @@ interface IndexedDbQueryCacheOptions {
     storeName?: string;
 }
 
-const DEFAULT_DATABASE = "lunora";
+const DEFAULT_DATABASE = "lunora-query-cache";
 const DEFAULT_STORE = "query-cache";
 /** Secondary index on `ts` so LRU eviction can walk oldest-first without loading every row. */
 const TS_INDEX = "by_ts";
 
 /**
- * Schema version. v2 adds the `query-cache` store alongside the v1
- * `offline-mutations` store, so both adapters can share one `lunora` database.
+ * Schema version for the read-cache database. The query cache owns its own
+ * database ({@link DEFAULT_DATABASE}) so its schema evolves independently of the
+ * offline-mutation outbox — the two adapters are toggled independently and never
+ * share a version namespace. (They previously shared the `lunora` database at
+ * mismatched versions — 1 for the outbox, 2 here — which threw
+ * `VersionError: The requested version (1) is less than the existing version (2)`
+ * once both were enabled: IndexedDB's version is a property of the database, not
+ * the store, so every opener must request the same version.)
  */
-const DATABASE_VERSION = 2;
+const DATABASE_VERSION = 1;
 
 /** Promisify an `IDBRequest`. */
 const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
@@ -107,11 +113,11 @@ const promisifyRequest = <T>(request: IDBRequest<T>): Promise<T> =>
  * LRU eviction. The store handle is opened lazily and cached, so repeated ops
  * reuse one connection.
  *
- * The store lives in the same `lunora` database as the offline-mutation queue
- * (bumped to schema v2). Opening it upgrades a v1 database in place, adding the
- * `query-cache` store without touching `offline-mutations`. Throws eagerly if no
- * `IDBFactory` is available — callers in non-browser environments should use
- * {@link createInMemoryQueryCache}.
+ * The store lives in its own `lunora-query-cache` database — deliberately
+ * separate from the offline-mutation outbox's `lunora` database so the two
+ * independently-toggleable adapters never share (and drift on) a schema version.
+ * Throws eagerly if no `IDBFactory` is available — callers in non-browser
+ * environments should use {@link createInMemoryQueryCache}.
  */
 // eslint-disable-next-line unicorn/prevent-abbreviations -- public exported function name; renaming breaks @lunora/client consumers
 const createIndexedDbQueryCache = (options: IndexedDbQueryCacheOptions = {}): QueryCacheAdapter => {

--- a/packages/config/__tests__/scaffold-dev-variables.test.ts
+++ b/packages/config/__tests__/scaffold-dev-variables.test.ts
@@ -299,6 +299,44 @@ describe("ensureDevVariables", () => {
         }
     });
 
+    it("reports `exists` (no info line) when a peer lands every missing key before our write", async () => {
+        expect.assertions(3);
+
+        // Only AUTH_SECRET present locally; the example also wants AUTH_URL, STORAGE_SECRET, LUNORA_ADMIN_TOKEN.
+        writeFileSync(join(dir, ".dev.vars"), 'AUTH_SECRET="my-real-secret"\n', "utf8");
+        writeFileSync(join(dir, ".dev.vars.example"), EXAMPLE, "utf8");
+
+        // Peer wins the whole race: between our fingerprint and our re-check it
+        // lands *all* the missing keys. Our re-plan then finds nothing to add, so
+        // the append writes zero lines — that must surface as an unchanged file
+        // (`exists`), not a dangling `Updated .dev.vars — added .` log.
+        let statCalls = 0;
+
+        onStatSync = () => {
+            statCalls += 1;
+
+            if (statCalls === 2) {
+                writeFileSync(
+                    join(dir, ".dev.vars"),
+                    'AUTH_SECRET="my-real-secret"\nAUTH_URL="http://localhost:5173"\nSTORAGE_SECRET="peer"\nLUNORA_ADMIN_TOKEN="peer"\n',
+                    "utf8",
+                );
+            }
+        };
+
+        const info = vi.fn<(message: string) => void>();
+
+        try {
+            const result = await ensureDevVariables({ confirm: async () => true, cwd: dir, info, randomHex: fixedHex });
+
+            expect(result.status).toBe("exists");
+            expect(result.addedKeys).toStrictEqual([]);
+            expect(info).not.toHaveBeenCalled();
+        } finally {
+            onStatSync = undefined;
+        }
+    });
+
     it("does not append when the user declines the missing-key prompt", async () => {
         expect.assertions(2);
 

--- a/packages/config/__tests__/scaffold-dev-variables.test.ts
+++ b/packages/config/__tests__/scaffold-dev-variables.test.ts
@@ -15,6 +15,28 @@ import {
     planDevVariablesScaffold,
 } from "../src/scaffold-dev-variables";
 
+/**
+ * A hook fired from inside a mocked `statSync`, right before it returns —
+ * lets a test simulate a concurrent peer's write landing exactly between the
+ * source's pre-write read and its pre-rename re-check. `undefined` (the
+ * default) makes the mock behave exactly like the real `statSync`.
+ */
+let onStatSync: (() => void) | undefined;
+
+// eslint-disable-next-line vitest/prefer-import-in-mock -- `vi.mock(import("node:fs"), ...)` type-checks the mock's shape too strictly against `statSync`'s (Stats | BigIntStats | undefined) overloads
+vi.mock("node:fs", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:fs")>();
+
+    return {
+        ...actual,
+        statSync: (...args: Parameters<typeof actual.statSync>) => {
+            onStatSync?.();
+
+            return actual.statSync(...args);
+        },
+    };
+});
+
 /** Deterministic stand-in for `crypto.randomBytes(n).toString("hex")`. */
 const fixedHex = (bytes: number): string => "a".repeat(bytes * 2);
 
@@ -235,6 +257,46 @@ describe("ensureDevVariables", () => {
         // Existing value is preserved; missing secret keys are appended with fresh hex.
         expect(written).toContain('AUTH_SECRET="my-real-secret"');
         expect(written).toContain(`STORAGE_SECRET="${"a".repeat(64)}"`);
+    });
+
+    it("merges a concurrent peer's append instead of clobbering it (compare-and-swap retry)", async () => {
+        expect.assertions(4);
+
+        // Only AUTH_SECRET present locally; the example also wants AUTH_URL, STORAGE_SECRET, LUNORA_ADMIN_TOKEN.
+        writeFileSync(join(dir, ".dev.vars"), 'AUTH_SECRET="my-real-secret"\n', "utf8");
+        writeFileSync(join(dir, ".dev.vars.example"), EXAMPLE, "utf8");
+
+        // Simulate a peer process winning the race: right after our first
+        // pre-write fingerprint (the 1st statSync call), it lands its own
+        // append (adding AUTH_URL) before our pre-rename re-check (the 2nd
+        // statSync call) runs. The re-check must see a changed file — sending
+        // us back to re-read + re-plan (picking up the peer's AUTH_URL as
+        // already-present) — rather than overwriting the peer's file with our
+        // stale, pre-peer content.
+        let statCalls = 0;
+
+        onStatSync = () => {
+            statCalls += 1;
+
+            if (statCalls === 2) {
+                writeFileSync(join(dir, ".dev.vars"), 'AUTH_SECRET="my-real-secret"\nAUTH_URL="http://localhost:5173"\n', "utf8");
+            }
+        };
+
+        try {
+            const result = await ensureDevVariables({ confirm: async () => true, cwd: dir, info: () => undefined, randomHex: fixedHex });
+            const written = readFileSync(join(dir, ".dev.vars"), "utf8");
+
+            expect(result.status).toBe("augmented");
+            // Our attempt still added the remaining keys (STORAGE_SECRET, LUNORA_ADMIN_TOKEN) —
+            // AUTH_URL is no longer "missing" once re-planned against the peer's content.
+            expect(result.addedKeys).toStrictEqual(["STORAGE_SECRET", "LUNORA_ADMIN_TOKEN"]);
+            // Both the peer's key and our keys survive in the final file.
+            expect(written).toContain('AUTH_URL="http://localhost:5173"');
+            expect(written).toContain(`STORAGE_SECRET="${"a".repeat(64)}"`);
+        } finally {
+            onStatSync = undefined;
+        }
     });
 
     it("does not append when the user declines the missing-key prompt", async () => {

--- a/packages/config/src/scaffold-dev-variables.ts
+++ b/packages/config/src/scaffold-dev-variables.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -302,31 +302,99 @@ const atomicCreateDevVariables = (path: string, content: string): void => {
     }
 };
 
-/**
- * Append lines to an existing `.dev.vars`, atomically and owner-only.
- *
- * Mirrors {@link atomicCreateDevVariables}: build the full new content, write it
- * to a sibling temp file (`mode: 0o600`), then `rename` over the target. The
- * read happens immediately before the write so a concurrent peer's appends are
- * picked up rather than clobbered — a plain read-modify-write would race two
- * `lunora dev` / Vite processes into last-writer-wins (the exact scenario the
- * create path defends against). A trailing newline is inserted only if needed.
- */
-const appendDevVariables = (path: string, additions: string[]): void => {
-    const existing = readFileSync(path, "utf8");
-    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-    const content = `${existing}${separator}${additions.join("\n")}\n`;
+/** Retry budget for {@link appendDevVariables}'s compare-and-swap loop. */
+const APPEND_MAX_ATTEMPTS = 5;
 
-    const temporaryPath = `${path}.tmp-${String(process.pid)}`;
+/** The bits of file identity we compare before trusting our read was still current at rename time. */
+interface FileFingerprint {
+    mtimeMs: number;
+    size: number;
+}
 
+/** `undefined` when the path doesn't exist (e.g. it was deleted between attempts). */
+const fingerprintOf = (path: string): FileFingerprint | undefined => {
     try {
-        writeFileSync(temporaryPath, content, { encoding: "utf8", mode: 0o600 });
-        renameSync(temporaryPath, path);
-    } catch (error) {
-        rmSync(temporaryPath, { force: true });
+        const stats = statSync(path);
 
-        throw error;
+        return { mtimeMs: stats.mtimeMs, size: stats.size };
+    } catch {
+        return undefined;
     }
+};
+
+const sameFingerprint = (a: FileFingerprint | undefined, b: FileFingerprint | undefined): boolean => {
+    if (a === undefined || b === undefined) {
+        return false;
+    }
+
+    return a.mtimeMs === b.mtimeMs && a.size === b.size;
+};
+
+/**
+ * Append lines to an existing `.dev.vars`, atomically and owner-only, via a
+ * compare-and-swap retry loop.
+ *
+ * Mirrors {@link atomicCreateDevVariables} in shape (sibling temp file, `mode:
+ * 0o600`, atomic `rename`), but a plain read-modify-write is not enough here:
+ * two concurrent `lunora dev` / Vite processes could both read the same old
+ * content, each append their own additions, and the second `rename` would
+ * silently discard the first writer's lines. To close that window:
+ *
+ * 1. Each attempt reads the file and fingerprints it (`mtimeMs` + `size`).
+ * 2. `buildAdditions(existing)` re-derives the lines to append from that fresh
+ * read (the caller re-runs its planner, e.g. {@link planDevVariablesAugment},
+ * so a peer's already-landed keys are recognised as present and skipped).
+ * 3. The new content is written to an attempt-unique temp file (pid + random
+ * suffix, so two processes never collide on the temp path itself).
+ * 4. The target is re-fingerprinted immediately before the rename. If it
+ * changed since step 1, a peer won the race — discard the temp file and
+ * retry from a fresh read/merge instead of clobbering their append.
+ *
+ * Returns the additions actually written (from the attempt that won), or `[]`
+ * if a fresh read showed nothing left to add (a peer already added everything
+ * this call wanted). Throws after {@link APPEND_MAX_ATTEMPTS} losing attempts;
+ * the error names only the path, never file content or additions.
+ */
+const appendDevVariables = (path: string, buildAdditions: (existing: string) => string[]): string[] => {
+    for (let attempt = 0; attempt < APPEND_MAX_ATTEMPTS; attempt += 1) {
+        const beforeFingerprint = fingerprintOf(path);
+        const existing = readFileSync(path, "utf8");
+        const additions = buildAdditions(existing);
+
+        if (additions.length === 0) {
+            return [];
+        }
+
+        const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+        const content = `${existing}${separator}${additions.join("\n")}\n`;
+
+        const temporaryPath = `${path}.tmp-${String(process.pid)}-${randomBytes(6).toString("hex")}`;
+
+        try {
+            writeFileSync(temporaryPath, content, { encoding: "utf8", mode: 0o600 });
+
+            // Re-check the target's identity right before the swap: if it moved
+            // since our read, another writer won the race — discard our temp file
+            // and retry from a fresh read/merge instead of clobbering their append.
+            const beforeRenameFingerprint = fingerprintOf(path);
+
+            if (!sameFingerprint(beforeFingerprint, beforeRenameFingerprint)) {
+                rmSync(temporaryPath, { force: true });
+
+                continue;
+            }
+
+            renameSync(temporaryPath, path);
+
+            return additions;
+        } catch (error) {
+            rmSync(temporaryPath, { force: true });
+
+            throw error;
+        }
+    }
+
+    throw new Error(`Failed to append to ${path} after ${String(APPEND_MAX_ATTEMPTS)} attempts — a concurrent writer kept winning the race.`);
 };
 
 /**
@@ -399,10 +467,21 @@ const ensureDevVariables = async (deps: EnsureDevVariablesDeps): Promise<EnsureD
         return { addedKeys: [], generatedKeys: [], status: "declined" };
     }
 
-    appendDevVariables(devVariablesPath, augment.additions);
-    deps.info(`Updated ${DEV_VARS_FILE} — added ${list}${generatedSuffix(augment.generatedKeys)}.`);
+    // Re-plan from whatever `.dev.vars` looks like on each attempt: a concurrent
+    // writer may have already landed some (or all) of these keys between our
+    // initial read above and the rename, and re-running the (pure) planner
+    // against the fresh content naturally treats those keys as already-present
+    // and skips them, instead of clobbering the peer's append.
+    const written = appendDevVariables(
+        devVariablesPath,
+        (currentContent) => planDevVariablesAugment({ existingContent: currentContent, exampleContent, randomHex: deps.randomHex }).additions,
+    );
+    const writtenKeys = written.map((line) => splitDevVariableLine(line)?.key).filter((key): key is string => key !== undefined);
+    const writtenGeneratedKeys = augment.generatedKeys.filter((key) => writtenKeys.includes(key));
 
-    return { addedKeys: augment.missingKeys, generatedKeys: augment.generatedKeys, status: "augmented" };
+    deps.info(`Updated ${DEV_VARS_FILE} — added ${writtenKeys.join(", ")}${generatedSuffix(writtenGeneratedKeys)}.`);
+
+    return { addedKeys: writtenKeys, generatedKeys: writtenGeneratedKeys, status: "augmented" };
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/config/src/scaffold-dev-variables.ts
+++ b/packages/config/src/scaffold-dev-variables.ts
@@ -477,6 +477,14 @@ const ensureDevVariables = async (deps: EnsureDevVariablesDeps): Promise<EnsureD
         (currentContent) => planDevVariablesAugment({ existingContent: currentContent, exampleContent, randomHex: deps.randomHex }).additions,
     );
     const writtenKeys = written.map((line) => splitDevVariableLine(line)?.key).filter((key): key is string => key !== undefined);
+
+    // A concurrent writer may have landed every missing key between our plan and
+    // the CAS append, leaving nothing for us to write. Report that as an
+    // unchanged file rather than logging a dangling "added ." line.
+    if (writtenKeys.length === 0) {
+        return { addedKeys: [], generatedKeys: [], status: "exists" };
+    }
+
     const writtenGeneratedKeys = augment.generatedKeys.filter((key) => writtenKeys.includes(key));
 
     deps.info(`Updated ${DEV_VARS_FILE} — added ${writtenKeys.join(", ")}${generatedSuffix(writtenGeneratedKeys)}.`);

--- a/packages/do/__tests__/data-migration.test.ts
+++ b/packages/do/__tests__/data-migration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DatabaseWriterLike, SchemaLike, SqlExec } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
@@ -234,11 +234,15 @@ describe("runDataMigration", () => {
         });
 
         it("a maxBatches pause still returns in_progress even when releaseClaim's UPDATE throws", async () => {
-            expect.assertions(3);
+            expect.assertions(4);
 
             const writer = setupWriter();
 
             await seed(writer);
+
+            // The swallowed failure is logged so repeated release failures are
+            // observable rather than silently delaying every resume.
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
             // Wrap the real SqlExec so only the release-claim statement (the
             // `updated_at = 0` back-date, distinct from the heartbeat's
@@ -264,6 +268,10 @@ describe("runDataMigration", () => {
             // with a fresh (non-zero) updated_at — the stale-claim timeout is
             // the fallback path a later invocation relies on.
             expect(stateRow("bump-version")).toMatchObject({ status: "in_progress" });
+
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('data migration "bump-version": releaseClaim failed'), expect.any(Error));
+
+            warn.mockRestore();
         });
 
         it("re-running a completed migration is a no-op that returns the stored counts", async () => {

--- a/packages/do/__tests__/data-migration.test.ts
+++ b/packages/do/__tests__/data-migration.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import type { DatabaseWriterLike, SchemaLike, SqlExec } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
 import type { DataMigrationLike } from "../src/data-migration";
 import { DATA_MIGRATION_STATE_TABLE, runDataMigration } from "../src/data-migration";
@@ -231,6 +231,39 @@ describe("runDataMigration", () => {
             const snapshot = await allUsers(writer);
 
             expect(snapshot.map((document) => document["version"])).toEqual([1, 1, 1, 1, 1]);
+        });
+
+        it("a maxBatches pause still returns in_progress even when releaseClaim's UPDATE throws", async () => {
+            expect.assertions(3);
+
+            const writer = setupWriter();
+
+            await seed(writer);
+
+            // Wrap the real SqlExec so only the release-claim statement (the
+            // `updated_at = 0` back-date, distinct from the heartbeat's
+            // `updated_at = ?` touch) throws — every other statement (claim,
+            // persistState, etc.) runs against the real SQLite engine
+            // untouched, so the batch itself is unaffected.
+            const throwingSql: SqlExec = {
+                exec: (query, ...parameters) => {
+                    if (query.includes("updated_at = 0")) {
+                        throw new Error("simulated releaseClaim failure");
+                    }
+
+                    return harness.sql.exec(query, ...parameters);
+                },
+            };
+
+            const result = await runDataMigration({ batchSize: 2, maxBatches: 1, migration: bumpVersion, sql: throwingSql, writer });
+
+            expect(result.status).toBe("in_progress");
+            expect(result.processed).toBe(2);
+
+            // The claim was never released, so it's still marked in_progress
+            // with a fresh (non-zero) updated_at — the stale-claim timeout is
+            // the fallback path a later invocation relies on.
+            expect(stateRow("bump-version")).toMatchObject({ status: "in_progress" });
         });
 
         it("re-running a completed migration is a no-op that returns the stored counts", async () => {

--- a/packages/do/src/data-migration.ts
+++ b/packages/do/src/data-migration.ts
@@ -537,8 +537,14 @@ const runDataMigration = async (options: RunDataMigrationOptions): Promise<Migra
     if (!dryRun && !isDone) {
         // Paused on the `maxBatches` limit, not finished. Drop our claim so the
         // next invocation can resume immediately rather than waiting out the
-        // stale-claim timeout (see releaseClaim).
-        releaseClaim(sql, migration.id);
+        // stale-claim timeout (see releaseClaim). A failure here is non-fatal:
+        // the batch succeeded, and the stale-claim timeout still lets a later
+        // invocation reclaim after STALE_CLAIM_TIMEOUT_MS.
+        try {
+            releaseClaim(sql, migration.id);
+        } catch {
+            /* claim release is best-effort; the stale-claim timeout is the fallback */
+        }
     }
 
     // eslint-disable-next-line unicorn/no-null -- MigrationRunResult.cursor: null on completion (no resume point), matching the wire shape

--- a/packages/do/src/data-migration.ts
+++ b/packages/do/src/data-migration.ts
@@ -542,8 +542,11 @@ const runDataMigration = async (options: RunDataMigrationOptions): Promise<Migra
         // invocation reclaim after STALE_CLAIM_TIMEOUT_MS.
         try {
             releaseClaim(sql, migration.id);
-        } catch {
-            /* claim release is best-effort; the stale-claim timeout is the fallback */
+        } catch (error) {
+            // Claim release is best-effort; the stale-claim timeout is the fallback. Log so
+            // repeated failures are observable rather than silently delaying every resume.
+            // eslint-disable-next-line no-console -- no logger is injected here; emit via console so the host captures the swallowed release failure
+            console.warn(`data migration "${migration.id}": releaseClaim failed`, error);
         }
     }
 

--- a/packages/flags/__tests__/flags.test.ts
+++ b/packages/flags/__tests__/flags.test.ts
@@ -146,6 +146,38 @@ describe("createFlags", () => {
         expect(provider.counts["dark-mode"]).toBe(2);
     });
 
+    it("returns the same in-flight promise for identical calls (memo hit, not just equal values)", async () => {
+        const provider = makeProvider({ "dark-mode": true });
+        const flags = createFlags({ provider: () => provider });
+
+        const [first, second] = [flags.details.boolean("dark-mode", false), flags.details.boolean("dark-mode", false)];
+
+        expect(first).toBe(second);
+
+        await Promise.all([first, second]);
+
+        expect(provider.counts["dark-mode"]).toBe(1);
+    });
+
+    it("does not share memo across different flag keys with an empty context (no false cache hits)", async () => {
+        const provider = makeProvider({ "dark-mode": true, "beta-mode": true });
+        const flags = createFlags({ provider: () => provider });
+
+        await Promise.all([flags.boolean("dark-mode", false), flags.boolean("beta-mode", false)]);
+
+        expect(provider.counts["dark-mode"]).toBe(1);
+        expect(provider.counts["beta-mode"]).toBe(1);
+    });
+
+    it("does not share memo across different default values for the same flag key", async () => {
+        const provider = makeProvider({});
+        const flags = createFlags({ provider: () => provider });
+
+        await Promise.all([flags.string("welcome", "a"), flags.string("welcome", "b")]);
+
+        expect(provider.counts.welcome).toBe(2);
+    });
+
     it("never throws when the provider errors — resolves the default with an errorCode", async () => {
         const provider = makeProvider({ "dark-mode": true }, { resolveThrows: true });
         const flags = createFlags({ provider: () => provider });

--- a/packages/flags/src/flags.ts
+++ b/packages/flags/src/flags.ts
@@ -82,13 +82,29 @@ interface CreateFlagsOptions {
 
 type FlagType = "boolean" | "number" | "object" | "string";
 
-/** Stable memo key over the evaluation's type, key, default, and context. */
+/**
+ * Stable memo key over the evaluation's type, key, default, and context.
+ *
+ * The `[type, flagKey, defaultValue]` prefix is cheap and always computed. The
+ * context portion is the expensive part — sorting and serializing its entries
+ * — so the common case of an empty/absent context (no per-call context and no
+ * default `targetingKey`) short-circuits to a constant suffix instead of doing
+ * that work, since `Object.keys(context)` is then `[]` and would otherwise
+ * just serialize to the same constant `"[]"`. A non-empty context still goes
+ * through the same sort+stringify as before, so the key stays stable and
+ * collision-free.
+ */
 const memoKey = (type: FlagType, flagKey: string, defaultValue: FlagValue, context: EvaluationContext): string => {
-    const entries = Object.keys(context)
-        .toSorted((a, b) => a.localeCompare(b))
-        .map((name) => [name, context[name]]);
+    const contextKeys = Object.keys(context);
+    const prefix = JSON.stringify([type, flagKey, defaultValue]);
 
-    return JSON.stringify([type, flagKey, defaultValue, entries]);
+    if (contextKeys.length === 0) {
+        return `${prefix}:[]`;
+    }
+
+    const entries = contextKeys.toSorted((a, b) => a.localeCompare(b)).map((name) => [name, context[name]]);
+
+    return `${prefix}:${JSON.stringify(entries)}`;
 };
 
 /** Dispatch one evaluation to the matching typed OpenFeature client method. */

--- a/packages/runtime/__tests__/query-coordinator.test.ts
+++ b/packages/runtime/__tests__/query-coordinator.test.ts
@@ -220,6 +220,68 @@ describe("merge strategies", () => {
         expect(result.data).toEqual([{ x: 1 }, { x: 2 }]);
     });
 
+    it("topK — orders rows with missing/non-numeric `by` field deterministically (no NaN comparator)", async () => {
+        expect.assertions(2);
+
+        const registry = createStaticShardRegistry({ messages: ["a", "b", "c"] });
+        const coordinator = createQueryCoordinator({ registry });
+
+        const rows: Record<string, unknown[]> = {
+            a: [{ id: "a1" }, { id: "a2", score: 0.9 }],
+            b: [
+                { id: "b1", score: "not-a-number" },
+                { id: "b2", score: 0.7 },
+            ],
+            c: [{ id: "c1", score: null }, { id: "c2", score: 0.8 }, { id: "c3" }],
+        };
+
+        const spy = createShardSpy((shardKey) => json(rows[shardKey] ?? []));
+
+        const runOnce = () =>
+            coordinator.fanOut(
+                spy.namespace,
+                buildRequest({
+                    fanOut: { merge: { by: "score", k: 3, kind: "topK" }, table: "messages" },
+                }),
+            );
+
+        const first = await runOnce();
+        const second = await runOnce();
+
+        expect(first.data).toEqual([
+            { id: "a2", score: 0.9 },
+            { id: "c2", score: 0.8 },
+            { id: "b2", score: 0.7 },
+        ]);
+        expect(second.data).toEqual(first.data);
+    });
+
+    it("topK — sorts close finite values without throwing, highest first in desc", async () => {
+        expect.assertions(1);
+
+        const registry = createStaticShardRegistry({ messages: ["a"] });
+        const coordinator = createQueryCoordinator({ registry });
+
+        const spy = createShardSpy(() =>
+            json([
+                { id: "sum", score: 0.1 + 0.2 },
+                { id: "exact", score: 0.3 },
+            ]),
+        );
+
+        const result = await coordinator.fanOut(
+            spy.namespace,
+            buildRequest({
+                fanOut: { merge: { by: "score", k: 2, kind: "topK" }, table: "messages" },
+            }),
+        );
+
+        expect(result.data).toEqual([
+            { id: "sum", score: 0.1 + 0.2 },
+            { id: "exact", score: 0.3 },
+        ]);
+    });
+
     it("first — returns the first successful shard's value", async () => {
         expect.assertions(1);
 

--- a/packages/runtime/src/query-coordinator.ts
+++ b/packages/runtime/src/query-coordinator.ts
@@ -1488,8 +1488,19 @@ const mergeTopK = (values: ReadonlyArray<unknown>, strategy: { by: string; direc
     }
 
     const direction = strategy.direction ?? "desc";
+    const ascending = (x: number, y: number): number => {
+        if (x < y) {
+            return -1;
+        }
 
-    collected.sort((a, b) => (direction === "asc" ? a.score - b.score : b.score - a.score));
+        if (x > y) {
+            return 1;
+        }
+
+        return 0;
+    };
+
+    collected.sort((a, b) => (direction === "asc" ? ascending(a.score, b.score) : ascending(b.score, a.score)));
 
     return collected.slice(0, strategy.k).map((entry) => entry.row);
 };

--- a/packages/scheduler/__tests__/scheduler-do.test.ts
+++ b/packages/scheduler/__tests__/scheduler-do.test.ts
@@ -380,6 +380,40 @@ describe("schedulerDO — retry / dead-letter pipeline", () => {
         expect(dead.attempts).toBeGreaterThan(5);
     });
 
+    it("logs a warning when a job is parked in the dead-letter store", async () => {
+        expect.assertions(2);
+
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        try {
+            const state = createFakeState();
+            const scheduler = new FailingScheduler(state, { LUNORA_ORIGIN_URL: "https://app.test" }, Number.POSITIVE_INFINITY);
+
+            const id = await scheduledId(await scheduler.fetch(post("/schedule", { args: {}, functionPath: "f", scheduledFor: Date.now() - 1000 })));
+
+            // Fire the alarm enough times to exhaust MAX_RETRY_ATTEMPTS (5). Each
+            // fire we force the re-armed entry due again.
+            for (let index = 0; index < 7; index += 1) {
+                const indexKey = [...state.storageMap.keys()].find((key) => key.startsWith("t:"));
+
+                if (indexKey) {
+                    const recordId = state.storageMap.get(indexKey);
+
+                    state.storageMap.delete(indexKey);
+                    state.storageMap.set(`t:${"0".padStart(15, "0")}:${String(recordId)}`, recordId);
+                }
+
+                // eslint-disable-next-line no-await-in-loop -- sequential alarm fires
+                await scheduler.alarm();
+            }
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0]?.[0]).toContain(id);
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
     it("does not leave a dangling dispatched: marker (claim is index-only)", async () => {
         expect.assertions(2);
 

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -735,6 +735,9 @@ class SchedulerDO {
             // survive.
             await this.state.storage.delete([`${RETRY_PREFIX}${record.id}`, `${HEADER_PREFIX}${record.id}`]);
 
+            // eslint-disable-next-line no-console -- no logger is injected into SchedulerDO; emit via console so the host captures dead-letter parks
+            console.warn(`@lunora/scheduler: job "${record.id}" (${record.functionPath}) parked in dead-letter after ${String(attempts)} attempts`);
+
             return;
         }
 


### PR DESCRIPTION
Consolidates the 7 approved fixes from the Wave 8 all-package audit
(`/improve` across all 45 packages). Each was written as a self-contained
plan, executed in an isolated worktree, and reviewed (diff + tests + re-run
verification) before landing here. Linear history on top of `alpha`; 14 files
(7 source + 7 test), disjoint packages.

| Commit | Package | Fix |
|---|---|---|
| `6f0c073b` | runtime | topK shard-merge uses a total-order comparator — fixes `NaN` sort when ≥2 rows lack the sort field |
| `31c85c3c` | client | offline-queue `hydrate()` reports `load()` failures via `onPersistenceError` instead of silently dropping persisted writes |
| `eaadf0b8` | config | `.dev.vars` append is now a fingerprinted compare-and-swap retry (no last-writer-wins between concurrent `dev`/Vite) |
| `9299e16f` | scheduler | log a line when a job is parked in the dead-letter store |
| `1256edd2` | flags | serialize the flag-eval context once per request (memo-key perf) |
| `9cfcbe05` | do | guard `releaseClaim` on the migration pause path — a throw no longer fails a good batch / stalls resume 30s |
| `f62b8427` | cli | reject empty / whitespace-only `lunora init` project names |

## Verification
- Each fix ships with a regression test; suites green per package (runtime 433, client 292, config 377, scheduler 102, flags 51, do 992, cli 521).
- `lint:types` clean per package.

## Notes
- `config` carries one documented deviation from its plan: `appendDevVariables` now takes a `buildAdditions` closure so the CAS loop re-plans per attempt (a truer re-merge than the original spec).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `init` now rejects empty/whitespace-only project names before other safety checks.
  - Offline queue persistence load failures are now surfaced more reliably.
  - Data migrations paused by batch limits can continue even if claim release fails.
  - Dead-lettered retry jobs now emit a warning when exceeding the retry limit.
  - Development variable updates now handle concurrent writers to reduce lost updates.
- **Performance**
  - Improved flag memoization avoids expensive context work when the evaluation context is empty.
  - `TopK` ascending sorting now uses an explicit comparator for consistent ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->