### PR TITLE
feat(auth): typed identity layer + cookie-cache + durable rate limiting (079/080/082)

### DIFF
--- a/packages/auth/__tests__/create-auth.test.ts
+++ b/packages/auth/__tests__/create-auth.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
-import { createAuth } from "../src/create-auth";
+import { createAuth, resolveAuthOptions } from "../src/create-auth";
 import { DEFAULT_AUTH_BASE_PATH, handleAuthRequest } from "../src/handler";
 import { sessionPresets } from "../src/session";
 
@@ -73,6 +73,39 @@ describe("createAuth", () => {
         expect(auth.options.session?.updateAge).toBe(sessionPresets.strict.updateAge);
     });
 
+    it("defaults a short-lived session cookie cache when the caller is silent", () => {
+        expect.assertions(2);
+
+        const auth = createAuth({ secret: "s".repeat(32) });
+
+        expect(auth.options.session?.cookieCache?.enabled).toBe(true);
+        expect(auth.options.session?.cookieCache?.maxAge).toBe(60);
+    });
+
+    it("forwards a caller-disabled cookie cache verbatim (does not re-enable it)", () => {
+        expect.assertions(1);
+
+        const auth = createAuth({
+            secret: "s".repeat(32),
+            session: { cookieCache: { enabled: false } },
+        });
+
+        expect(auth.options.session?.cookieCache?.enabled).toBe(false);
+    });
+
+    it("fills the cookie-cache default alongside a caller session that omits it", () => {
+        expect.assertions(3);
+
+        const auth = createAuth({
+            secret: "s".repeat(32),
+            session: { expiresIn: 60 * 60 * 24 * 3 },
+        });
+
+        expect(auth.options.session?.expiresIn).toBe(60 * 60 * 24 * 3);
+        expect(auth.options.session?.cookieCache?.enabled).toBe(true);
+        expect(auth.options.session?.cookieCache?.maxAge).toBe(60);
+    });
+
     it("rejects a negative session duration", () => {
         expect.assertions(1);
 
@@ -83,6 +116,80 @@ describe("createAuth", () => {
         expect.assertions(1);
 
         expect(() => createAuth({ secret: "s".repeat(32), session: { updateAge: Number.POSITIVE_INFINITY } })).toThrow(/finite/i);
+    });
+});
+
+describe("createAuth — durable rate-limit default", () => {
+    it("defaults rate limiting on and storage to database when the caller is silent", () => {
+        expect.assertions(2);
+
+        const auth = createAuth({ secret: "s".repeat(32) });
+
+        expect(auth.options.rateLimit?.enabled).toBe(true);
+        expect(auth.options.rateLimit?.storage).toBe("database");
+    });
+
+    it("forwards a caller-supplied rateLimit.storage verbatim", () => {
+        expect.assertions(2);
+
+        const auth = createAuth({
+            rateLimit: { storage: "secondary-storage" },
+            secret: "s".repeat(32),
+        });
+
+        expect(auth.options.rateLimit?.storage).toBe("secondary-storage");
+        // The `enabled` default still fills alongside the caller's storage choice.
+        expect(auth.options.rateLimit?.enabled).toBe(true);
+    });
+
+    it("does not re-enable rate limiting a caller explicitly disabled, and fills no storage", () => {
+        expect.assertions(2);
+
+        const auth = createAuth({
+            rateLimit: { enabled: false },
+            secret: "s".repeat(32),
+        });
+
+        expect(auth.options.rateLimit?.enabled).toBe(false);
+        // No `storage` fill under a disabled limiter — else `getAuthTables` emits
+        // an unused `rateLimit` table.
+        expect(auth.options.rateLimit?.storage).toBeUndefined();
+    });
+});
+
+describe("resolveAuthOptions", () => {
+    it("fills the rate-limit and cookie-cache defaults when the caller is silent", () => {
+        expect.assertions(4);
+
+        const resolved = resolveAuthOptions({ secret: "s".repeat(32) });
+
+        expect(resolved.rateLimit?.enabled).toBe(true);
+        expect(resolved.rateLimit?.storage).toBe("database");
+        expect(resolved.session?.cookieCache?.enabled).toBe(true);
+        expect(resolved.session?.cookieCache?.maxAge).toBe(60);
+    });
+
+    it("forwards explicit caller values verbatim instead of filling defaults", () => {
+        expect.assertions(3);
+
+        const resolved = resolveAuthOptions({
+            rateLimit: { enabled: true, storage: "secondary-storage" },
+            secret: "s".repeat(32),
+            session: { cookieCache: { enabled: false } },
+        });
+
+        expect(resolved.rateLimit?.storage).toBe("secondary-storage");
+        expect(resolved.rateLimit?.enabled).toBe(true);
+        expect(resolved.session?.cookieCache?.enabled).toBe(false);
+    });
+
+    it("does not fill storage when the caller disabled rate limiting", () => {
+        expect.assertions(2);
+
+        const resolved = resolveAuthOptions({ rateLimit: { enabled: false }, secret: "s".repeat(32) });
+
+        expect(resolved.rateLimit?.enabled).toBe(false);
+        expect(resolved.rateLimit?.storage).toBeUndefined();
     });
 });
 

--- a/packages/auth/__tests__/forget-password-route.test.ts
+++ b/packages/auth/__tests__/forget-password-route.test.ts
@@ -4,7 +4,7 @@ import { getAuthTables } from "better-auth/db";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { lunoraAuthAdapter } from "../src/adapter";
-import { createAuth } from "../src/create-auth";
+import { createAuth, resolveAuthOptions } from "../src/create-auth";
 import { handleAuthRequest } from "../src/handler";
 import type { SqlExecutor } from "../src/sql-store";
 import { createSqlAuthStore } from "../src/sql-store";
@@ -83,7 +83,10 @@ describe("auth — /api/auth/forget-password HTTP route", () => {
 
     beforeEach(() => {
         database = new DatabaseSync(":memory:");
-        materialiseSchema(database, baseOptions);
+        // Materialise the schema from the SAME resolved options `createAuth` runs
+        // with (and `compileMigrationsSql` migrates from), so `getAuthTables` emits
+        // the `rateLimit` table better-auth's default-on durable limiter writes to.
+        materialiseSchema(database, resolveAuthOptions(baseOptions));
     });
 
     afterEach(() => {

--- a/packages/auth/__tests__/migrate.test.ts
+++ b/packages/auth/__tests__/migrate.test.ts
@@ -68,7 +68,7 @@ describe("ensureMigrated", () => {
 });
 
 describe("compileMigrationsSql", () => {
-    it("forwards options to getMigrations and returns compileMigrations()'s result", async () => {
+    it("compiles from the resolved options (so the rateLimit table is included) and returns compileMigrations()'s result", async () => {
         expect.assertions(3);
 
         const compileMigrations = vi.fn<() => Promise<string>>(async () => "CREATE TABLE user (...)");
@@ -80,7 +80,10 @@ describe("compileMigrationsSql", () => {
 
         const sql = await compileMigrationsSql(options as never);
 
-        expect(mockGetMigrations).toHaveBeenCalledWith(options);
+        // Routed through `resolveAuthOptions`, so migrations are compiled from the
+        // SAME resolved shape the worker runs with — the default-on durable rate
+        // limiter's `rateLimit` table is therefore present in the migration.
+        expect(mockGetMigrations).toHaveBeenCalledWith(expect.objectContaining({ rateLimit: expect.objectContaining({ enabled: true, storage: "database" }) }));
         expect(compileMigrations).toHaveBeenCalledTimes(1);
         expect(sql).toBe("CREATE TABLE user (...)");
     });

--- a/packages/auth/__tests__/session.test.ts
+++ b/packages/auth/__tests__/session.test.ts
@@ -25,6 +25,21 @@ describe("sessionPresets", () => {
         expect(sessionPresets.strict.expiresIn).toBeLessThan(sessionPresets.rolling.expiresIn ?? 0);
         expect(sessionPresets.rolling.expiresIn).toBeLessThan(sessionPresets.longLived.expiresIn ?? 0);
     });
+
+    it("enables a 60s cookie cache on `rolling` and `longLived`", () => {
+        expect.assertions(4);
+
+        expect(sessionPresets.rolling.cookieCache?.enabled).toBe(true);
+        expect(sessionPresets.rolling.cookieCache?.maxAge).toBe(60);
+        expect(sessionPresets.longLived.cookieCache?.enabled).toBe(true);
+        expect(sessionPresets.longLived.cookieCache?.maxAge).toBe(60);
+    });
+
+    it("disables the cookie cache on `strict` (fast revocation)", () => {
+        expect.assertions(1);
+
+        expect(sessionPresets.strict.cookieCache?.enabled).toBe(false);
+    });
 });
 
 describe("validateSessionPolicy", () => {

--- a/packages/auth/__tests__/sql-store.test.ts
+++ b/packages/auth/__tests__/sql-store.test.ts
@@ -297,3 +297,133 @@ describe("memory and SQL stores agree on the clause matrix", () => {
         db.close();
     });
 });
+
+describe("incrementOne — atomic guarded counter (both stores)", () => {
+    // The rate-limit counter shape better-auth's `storage: "database"` limiter
+    // rides: one row per `key`, an integer `count`, and a `lastRequest` stamp.
+    const RATE_LIMIT_DDL = `CREATE TABLE "rateLimit" ("key" TEXT PRIMARY KEY, "count" REAL, "lastRequest" REAL)`;
+
+    interface StoreHandle {
+        close: () => void;
+        store: AuthStore;
+    }
+
+    const stores: { make: () => StoreHandle; name: string }[] = [
+        {
+            make: () => {
+                return { close: () => undefined, store: createMemoryAuthStore() };
+            },
+            name: "memory",
+        },
+        {
+            make: () => {
+                const db = new DatabaseSync(":memory:");
+                db.exec(RATE_LIMIT_DDL);
+
+                return {
+                    close: () => {
+                        db.close();
+                    },
+                    store: createSqlAuthStore(executorFor(db)),
+                };
+            },
+            name: "sql",
+        },
+    ];
+
+    it.each(stores)("$name: applies the delta + set and returns the post-increment row", async ({ make }) => {
+        expect.assertions(2);
+
+        const { close, store } = make();
+
+        try {
+            await store.create("rateLimit", { count: 1, key: "k", lastRequest: 0 });
+
+            const updated = await store.incrementOne("rateLimit", [clause("key", "k")], { count: 1 }, { lastRequest: 5 });
+
+            expect(updated?.count).toBe(2);
+            expect(updated?.lastRequest).toBe(5);
+        } finally {
+            close();
+        }
+    });
+
+    it.each(stores)("$name: increments a NULL counter from 0 (delta, not NULL)", async ({ make }) => {
+        expect.assertions(1);
+
+        const { close, store } = make();
+
+        try {
+            // A row whose counter column is NULL: SQLite's `count = count + ?` would
+            // leave it NULL (`NULL + N = NULL`), diverging from the memory store which
+            // treats a non-numeric/absent counter as 0. `COALESCE(count, 0) + ?` keeps
+            // both backends advancing identically.
+            await store.create("rateLimit", { count: null, key: "k", lastRequest: 0 });
+
+            const updated = await store.incrementOne("rateLimit", [clause("key", "k")], { count: 1 });
+
+            expect(updated?.count).toBe(1);
+        } finally {
+            close();
+        }
+    });
+
+    it.each(stores)("$name: returns undefined when the guard predicate excludes the row", async ({ make }) => {
+        expect.assertions(2);
+
+        const { close, store } = make();
+
+        try {
+            await store.create("rateLimit", { count: 5, key: "k", lastRequest: 0 });
+
+            // Guard `count < 5` fails (count is 5) → no mutation, undefined result.
+            const blocked = await store.incrementOne("rateLimit", [clause("key", "k"), clause("count", 5, "lt")], { count: 1 });
+
+            expect(blocked).toBeUndefined();
+
+            const [row] = await store.read("rateLimit", { where: [clause("key", "k")] });
+
+            // The guard blocked the write, so `count` is unchanged.
+            expect(row?.count).toBe(5);
+        } finally {
+            close();
+        }
+    });
+
+    it.each(stores)("$name: returns undefined for a key that does not exist", async ({ make }) => {
+        expect.assertions(1);
+
+        const { close, store } = make();
+
+        try {
+            await expect(store.incrementOne("rateLimit", [clause("key", "absent")], { count: 1 })).resolves.toBeUndefined();
+        } finally {
+            close();
+        }
+    });
+
+    it.each(stores)("$name: N concurrent increments on one key sum to N (no lost updates)", async ({ make }) => {
+        expect.assertions(2);
+
+        const { close, store } = make();
+        const CONCURRENCY = 50;
+
+        try {
+            await store.create("rateLimit", { count: 0, key: "k", lastRequest: 0 });
+
+            // Fire all increments at once. A read-then-write implementation would
+            // let racers observe the same `count` and clobber each other (final <
+            // N); the single-statement guarded increment cannot, so the tally is
+            // exact — the regression that proves atomicity.
+            const results = await Promise.all(Array.from({ length: CONCURRENCY }, () => store.incrementOne("rateLimit", [clause("key", "k")], { count: 1 })));
+
+            const [row] = await store.read("rateLimit", { where: [clause("key", "k")] });
+
+            expect(row?.count).toBe(CONCURRENCY);
+            // Every call matched the (unconditional) guard, so none returned undefined.
+            expect(results.every((result) => result !== undefined)).toBe(true);
+        } finally {
+            close();
+        }
+    });
+});

--- a/packages/auth/src/adapter.ts
+++ b/packages/auth/src/adapter.ts
@@ -57,6 +57,7 @@ const lunoraAuthAdapter = (store: AuthStore): ReturnType<typeof createAdapterFac
 
                     return asRowOrNull(row);
                 },
+                incrementOne: async ({ increment, model, set, where }) => asRowOrNull(await store.incrementOne(model, where, increment, set)),
                 update: async ({ model, update, where }) => {
                     const [row] = await store.update(model, where, update as AuthRow);
 

--- a/packages/auth/src/create-auth.ts
+++ b/packages/auth/src/create-auth.ts
@@ -146,9 +146,102 @@ export type LunoraAuthOptions = BetterAuthOptions;
 export type LunoraAuth = ReturnType<typeof betterAuth>;
 
 /**
+ * Resolve the caller's options into the exact shape `createAuth` hands to
+ * `betterAuth` — the hardened, default-filled options the running worker uses.
+ * Exported (and pure) so the migration path can compile the schema from the
+ * same resolved options: `compileMigrationsSql` routes through here, so the
+ * `rateLimit` table the worker's durable limiter writes to is included in the
+ * migration rather than silently omitted (it would be, if migrations saw the
+ * raw options while the worker ran the resolved ones).
+ *
+ * ## What it fills (each gated independently on caller silence)
+ *
+ * Secure-by-default cookies + secret-strength warning via {@link hardenAuthOptions},
+ * applied first so all hardening composes onto one options object.
+ *
+ * Rate limiting is ON by default for `/api/auth/*`.
+ *
+ * better-auth's own default is `rateLimit.enabled ?? isProduction`, and its
+ * `isProduction` is `process.env.NODE_ENV === "production"` resolved at
+ * module-load time. On Cloudflare Workers that check is unreliable: the
+ * runtime has no Node `process.env` (absent entirely without
+ * `nodejs_compat`, and even with it `NODE_ENV` is rarely `"production"` at
+ * request time). So better-auth would silently leave auth endpoints
+ * _unthrottled_ on a real deployment — the surprise we refuse to ship.
+ *
+ * We therefore default `enabled: true` whenever the caller hasn't made an
+ * explicit choice. We only fill the `enabled` flag and otherwise forward
+ * the caller's `rateLimit` verbatim, so better-auth's `window` (10s) / `max`
+ * (100) defaults and any custom rules still apply. Callers who genuinely
+ * want it off can pass `rateLimit: { enabled: false }` (e.g. when fronting
+ * auth with their own limiter), and any explicit `enabled` value wins.
+ *
+ * We also default `storage: "database"` — but only when rate limiting is not
+ * explicitly disabled (`enabled !== false`). Filling storage under a disabled
+ * limiter is harmless at runtime but makes `getAuthTables` emit an unused
+ * `rateLimit` table, so we skip it there.
+ *
+ * better-auth's own default is `storage: "memory"` — a per-isolate,
+ * non-durable counter. On Cloudflare Workers that means each isolate keeps
+ * its own tally, counters vanish on isolate recycle, and traffic spread
+ * across isolates never sums to the configured `max` — a limiter that
+ * reports "enabled" while never enforcing a global limit (the exact
+ * brute-force / credential-stuffing protection on `/sign-in`, OTP, and
+ * password-reset it is meant to buy). `storage: "database"` rides the counter
+ * through the configured `database` adapter — Lunora's store over the D1 auth
+ * tables — so the limit is durable *and* atomic (the store's native
+ * `incrementOne` gives a one-winner guarantee across isolates). Callers with
+ * their own durable store can pass an explicit `rateLimit: { storage: … }`
+ * (or `customStorage`), and any explicit value wins.
+ *
+ * Session cookie cache is ON by default too.
+ *
+ * Every authenticated call resolves identity through better-auth's
+ * `getSession`, which — without a cache — is a DB (D1) read on the hot path
+ * of every query/mutation/action that reads `ctx.auth` and of the WebSocket
+ * upgrade. better-auth's `session.cookieCache` carries the session payload in
+ * a short-lived signed cookie so `getSession` can answer without hitting the
+ * database until the cache window elapses. We default it on with a
+ * deliberately short 60s `maxAge` (better-auth's own default is 300s): long
+ * enough to erase the per-request read for a burst of calls, short enough
+ * that a revoked or role-changed session self-corrects within a minute.
+ * The one tradeoff — a revoked session stays valid until the cache expires —
+ * is bounded by that TTL; callers who need immediate revocation opt out with
+ * `session: { cookieCache: { enabled: false } }` (or the `strict` preset).
+ *
+ * Every explicit caller value is forwarded verbatim. The two `rateLimit` fills
+ * merge into a single `rateLimit` object so neither clobbers the other.
+ */
+export const resolveAuthOptions = (options: LunoraAuthOptions): LunoraAuthOptions => {
+    const hardened = hardenAuthOptions(options);
+
+    const needsRateLimitEnabled = hardened.rateLimit?.enabled === undefined;
+    // Only fill `storage` when the caller hasn't disabled rate limiting — a
+    // disabled limiter with a `"database"` storage otherwise pushes an unused
+    // `rateLimit` table into `getAuthTables` / the compiled migration.
+    const needsRateLimitStorage = hardened.rateLimit?.storage === undefined && hardened.rateLimit?.enabled !== false;
+
+    return {
+        ...hardened,
+        ...(needsRateLimitEnabled || needsRateLimitStorage
+            ? {
+                  rateLimit: {
+                      ...hardened.rateLimit,
+                      ...(needsRateLimitEnabled ? { enabled: true } : {}),
+                      ...(needsRateLimitStorage ? { storage: "database" as const } : {}),
+                  },
+              }
+            : {}),
+        ...(hardened.session?.cookieCache === undefined ? { session: { ...hardened.session, cookieCache: { enabled: true, maxAge: 60 } } } : {}),
+    };
+};
+
+/**
  * Create the auth instance. Thin wrapper around `betterAuth` that enforces
  * the `secret` requirement at construction time so misconfigured deployments
- * fail loudly at the first fetch rather than the first sign-in attempt.
+ * fail loudly at the first fetch rather than the first sign-in attempt, then
+ * hands {@link resolveAuthOptions}'s hardened, default-filled options to
+ * better-auth.
  */
 export const createAuth = (options: LunoraAuthOptions): LunoraAuth => {
     // Reject missing *and* whitespace-only secrets — a value like `" "` is
@@ -171,28 +264,5 @@ export const createAuth = (options: LunoraAuthOptions): LunoraAuth => {
         validateSessionPolicy(options.session);
     }
 
-    // Secure-by-default cookies + secret-strength warning, applied before the
-    // rate-limit default so all hardening composes onto one options object.
-    const hardened = hardenAuthOptions(options);
-
-    // Rate limiting is ON by default for `/api/auth/*`.
-    //
-    // better-auth's own default is `rateLimit.enabled ?? isProduction`, and its
-    // `isProduction` is `process.env.NODE_ENV === "production"` resolved at
-    // module-load time. On Cloudflare Workers that check is unreliable: the
-    // runtime has no Node `process.env` (absent entirely without
-    // `nodejs_compat`, and even with it `NODE_ENV` is rarely `"production"` at
-    // request time). So better-auth would silently leave auth endpoints
-    // *unthrottled* on a real deployment — the surprise we refuse to ship.
-    //
-    // We therefore default `enabled: true` whenever the caller hasn't made an
-    // explicit choice. We only fill the `enabled` flag and otherwise forward
-    // the caller's `rateLimit` verbatim, so better-auth's `window` (10s) / `max`
-    // (100) defaults and any custom rules still apply. Callers who genuinely
-    // want it off can pass `rateLimit: { enabled: false }` (e.g. when fronting
-    // auth with their own limiter), and any explicit `enabled` value wins.
-    const resolvedOptions: LunoraAuthOptions =
-        hardened.rateLimit?.enabled === undefined ? { ...hardened, rateLimit: { ...hardened.rateLimit, enabled: true } } : hardened;
-
-    return betterAuth(resolvedOptions);
+    return betterAuth(resolveAuthOptions(options));
 };

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -17,7 +17,7 @@ export type {
 } from "./admin";
 export { createAuthAdmin, LunoraAuthAdminError } from "./admin";
 export type { LunoraAuth, LunoraAuthOptions } from "./create-auth";
-export { createAuth } from "./create-auth";
+export { createAuth, resolveAuthOptions } from "./create-auth";
 export { DEFAULT_AUTH_BASE_PATH, handleAuthRequest } from "./handler";
 export type { LunoraAuthApiContext, WithAuthPluginsMiddleware, WithAuthPluginsOptions } from "./middleware";
 export { LunoraAuthHeadersError, withAuthPlugins } from "./middleware";

--- a/packages/auth/src/migrate.ts
+++ b/packages/auth/src/migrate.ts
@@ -1,6 +1,7 @@
 import { getMigrations } from "better-auth/db/migration";
 
 import type { LunoraAuth, LunoraAuthOptions } from "./create-auth";
+import { resolveAuthOptions } from "./create-auth";
 
 /**
  * Single-flight cache of in-flight (and completed) migration runs, keyed by the
@@ -67,9 +68,15 @@ export const ensureMigrated = async (auth: LunoraAuth | { options: LunoraAuthOpt
  * Compile better-auth's migrations to a single SQL string. Useful for
  * `wrangler d1 execute --file -` in CI so the deploy step applies the schema
  * before the first user request.
+ *
+ * Compiles from the SAME resolved options `createAuth` runs with (via
+ * `resolveAuthOptions`), not the raw caller options — so the schema includes the
+ * `rateLimit` table the worker's default-on durable limiter writes to. Compiling
+ * from the raw options would omit it, and the running worker would then write to
+ * a table the migration never created.
  */
 export const compileMigrationsSql = async (options: LunoraAuthOptions): Promise<string> => {
-    const { compileMigrations } = await getMigrations(options);
+    const { compileMigrations } = await getMigrations(resolveAuthOptions(options));
 
     return compileMigrations();
 };

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -68,22 +68,29 @@ const validateSessionPolicy = (policy: SessionPolicy): SessionPolicy => {
  * });
  * ```
  *
- * - `rolling` — balanced default: 7-day absolute expiry, rotated once per day.
- * - `strict` — short, security-sensitive: 1-hour expiry, 15-minute rotation.
- * - `longLived` — low-friction consumer apps: 30-day expiry, daily rotation.
+ * - `rolling` — balanced default: 7-day absolute expiry, rotated once per day,
+ *   with a 60s signed-cookie session cache so bursts of authenticated calls
+ *   skip the per-request DB session read.
+ * - `strict` — short, security-sensitive: 1-hour expiry, 15-minute rotation,
+ *   cookie cache **off** (fast revocation / short freshness is the whole point).
+ * - `longLived` — low-friction consumer apps: 30-day expiry, daily rotation,
+ *   with the same 60s cookie cache as `rolling`.
  */
 const sessionPresets: Record<"longLived" | "rolling" | "strict", SessionPolicy> = {
     longLived: {
+        cookieCache: { enabled: true, maxAge: 60 },
         expiresIn: 30 * DAY,
         freshAge: DAY,
         updateAge: DAY,
     },
     rolling: {
+        cookieCache: { enabled: true, maxAge: 60 },
         expiresIn: 7 * DAY,
         freshAge: DAY,
         updateAge: DAY,
     },
     strict: {
+        cookieCache: { enabled: false },
         expiresIn: HOUR,
         freshAge: 5 * MINUTE,
         updateAge: 15 * MINUTE,

--- a/packages/auth/src/sql-store.ts
+++ b/packages/auth/src/sql-store.ts
@@ -216,6 +216,42 @@ export const createSqlAuthStore = (executor: SqlExecutor): AuthStore => {
 
             return { ...data };
         },
+        incrementOne: async (model, where, increment, set) => {
+            const table = quoteId(model);
+            const incrementColumns = Object.keys(increment);
+            const setColumns = set ? Object.keys(set) : [];
+            const fragment = compileWhere(where);
+
+            // An empty increment+set can't form a valid `SET`. better-auth never
+            // calls it that way, but mirror `update`'s empty-patch handling: treat
+            // it as a pure guard read of the single matching row.
+            if (incrementColumns.length === 0 && setColumns.length === 0) {
+                const [row] = await executor.all(`SELECT * FROM ${table}${whereSuffix(fragment)} LIMIT 1`, fragment.params);
+
+                return row;
+            }
+
+            const assignments = [
+                // COALESCE(col, 0) so a NULL counter advances from 0 rather than staying
+                // NULL (`NULL + ? = NULL` in SQLite/D1) — matches the memory store, which
+                // treats a non-numeric/absent counter as 0.
+                ...incrementColumns.map((column) => `${quoteId(column)} = COALESCE(${quoteId(column)}, 0) + ?`),
+                ...setColumns.map((column) => `${quoteId(column)} = ?`),
+            ].join(", ");
+
+            // Guarded read-modify-write in one statement: the subquery pins a
+            // single `rowid` the guard still matches (SQLite/D1 lack `UPDATE …
+            // LIMIT`), the UPDATE applies `col = col + delta` / `col = value`
+            // atomically, and RETURNING hands back the post-update row. One winner
+            // across isolates — no read-then-update race the memory/`findMany +
+            // updateMany` fallback would leave open on Workers.
+            const [row] = await executor.all(
+                `UPDATE ${table} SET ${assignments} WHERE rowid IN (SELECT rowid FROM ${table}${whereSuffix(fragment)} LIMIT 1) RETURNING *`,
+                [...incrementColumns.map((column) => increment[column]), ...setColumns.map((column) => (set as AuthRow)[column]), ...fragment.params],
+            );
+
+            return row;
+        },
         read: async (model, query) => {
             const fragment = compileWhere(query.where);
             const parameters = [...fragment.params];

--- a/packages/auth/src/store.ts
+++ b/packages/auth/src/store.ts
@@ -162,6 +162,25 @@ export interface AuthStore {
     count: (model: string, where: ReadonlyArray<AuthWhereClause>) => Promise<number>;
     /** Insert `data` into `model`; return the stored row (the adapter pre-fills `id`). */
     create: (model: string, data: AuthRow) => Promise<AuthRow>;
+
+    /**
+     * Atomically apply signed numeric deltas to **at most one** row in `model`
+     * matching `where`, then return the updated row (or `undefined` if the guard
+     * matched none). For each `increment` entry it applies `field = field + delta`
+     * (a negative delta decrements); the optional `set` map assigns absolute
+     * values in the same step. The `where` clause is both selector **and** guard
+     * — comparison operators are honoured, so a guard like
+     * `{ field: "count", operator: "lt", value: max }` only mutates the row while
+     * it still satisfies the predicate.
+     *
+     * Backs better-auth's durable (`storage: "database"`) rate limiter, whose
+     * counter rides these tables. Implementing it natively — one statement that
+     * guards, increments, and returns — gives the **one-winner-across-isolates**
+     * guarantee the read-then-update fallback cannot: on Workers two concurrent
+     * requests would otherwise both read `count=4` and both write `5`, letting a
+     * `max` of 5 pass 6+. Same race-closing rationale as {@link AuthStore.consumeOne}.
+     */
+    incrementOne: (model: string, where: ReadonlyArray<AuthWhereClause>, increment: Record<string, number>, set?: AuthRow) => Promise<AuthRow | undefined>;
     /** Read rows from `model` honouring the filter/sort/window in `query`. */
     read: (model: string, query: AuthQuery) => Promise<AuthRow[]>;
     /** Delete rows in `model` matching `where`; return how many were removed. */
@@ -235,6 +254,28 @@ export const createMemoryAuthStore = (): AuthStore => {
             const row = { ...data };
 
             tableOf(model).push(row);
+
+            return Promise.resolve({ ...row });
+        },
+        incrementOne: (model, where, increment, set) => {
+            const row = tableOf(model).find((candidate) => matchesWhere(candidate, where));
+
+            if (!row) {
+                return Promise.resolve(undefined);
+            }
+
+            // Synchronous guarded read-modify-write: no `await` interleaves
+            // between the guard match and the mutation, so this is atomic even
+            // under concurrent callers — the in-memory analogue of the SQL
+            // `UPDATE … RETURNING`. `increment` and `set` target disjoint columns
+            // in better-auth's usage; deltas add onto the current value.
+            for (const [field, delta] of Object.entries(increment)) {
+                row[field] = (typeof row[field] === "number" ? row[field] : 0) + delta;
+            }
+
+            if (set) {
+                Object.assign(row, set);
+            }
 
             return Promise.resolve({ ...row });
         },

--- a/packages/codegen/__tests__/emit-app-identity.test.ts
+++ b/packages/codegen/__tests__/emit-app-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { emitApp } from "../src/emit-app";
+
+/** Minimal `EmitAppOptions` with every capability off; the identity tests flip only the contract. */
+const baseOptions = {
+    hasAccess: false,
+    hasAi: false,
+    hasAnalytics: false,
+    hasAuth: false,
+    hasBrowser: false,
+    hasFramework: false,
+    hasGlobal: false,
+    hasHyperdrive: false,
+    hasHyperdriveGlobal: false,
+    hasImages: false,
+    hasKv: false,
+    hasPayments: false,
+    hasQueue: false,
+    hasR2sql: false,
+    hasScheduler: false,
+    hasStorage: false,
+    hasVectors: false,
+    hasWorkflow: false,
+    useUmbrella: false,
+    wantsOpenApi: false,
+    wantsOpenRpc: false,
+};
+
+describe("emitApp — defineIdentity trust-boundary wiring", () => {
+    it("emits no identity import or option when no contract is declared", () => {
+        expect.assertions(2);
+
+        const output = emitApp({ ...baseOptions });
+
+        expect(output).not.toContain("../identity.js");
+        expect(output).not.toContain("identity:");
+    });
+
+    it("keeps app.ts byte-identical to the no-contract output when the contract is absent", () => {
+        expect.assertions(1);
+
+        // `identity: undefined` must produce exactly the same bytes as omitting it —
+        // every new fragment is gated on the contract's presence.
+        expect(emitApp({ ...baseOptions, identity: undefined })).toBe(emitApp({ ...baseOptions }));
+    });
+
+    it("imports the contract as a value and wires options.identity when a contract is declared", () => {
+        expect.assertions(3);
+
+        const output = emitApp({ ...baseOptions, identity: { exportName: "identity" } });
+
+        // Imported as a VALUE (not `import type`) so it can actually validate at runtime.
+        expect(output).toContain(`import * as lunoraIdentityContract from "../identity.js";`);
+        expect(output).not.toContain(`import type * as lunoraIdentityContract`);
+        // Wired onto the worker options so the runtime contract gate runs.
+        expect(output).toContain("identity: lunoraIdentityContract.identity,");
+    });
+
+    it("references the declared export name verbatim", () => {
+        expect.assertions(1);
+
+        const output = emitApp({ ...baseOptions, identity: { exportName: "appIdentity" } });
+
+        expect(output).toContain("identity: lunoraIdentityContract.appIdentity,");
+    });
+});

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -271,6 +271,108 @@ export const sendMessage = defineMutator({
             });
         });
 
+        describe("typed identity layer (defineIdentity)", () => {
+            const writeIdentity = (): void => {
+                writeFileSync(
+                    join(workdir, "lunora", "identity.ts"),
+                    `import { defineIdentity, v } from "@lunora/server";
+export const identity = defineIdentity({
+    userId: v.string(),
+    tenantId: v.optional(v.string()),
+    scopes: v.optional(v.array(v.string())),
+});
+`,
+                    "utf8",
+                );
+            };
+
+            it("leaves server.ts byte-identical when no defineIdentity is declared", () => {
+                expect.assertions(6);
+
+                const { server } = runCodegen({ lint: false, projectRoot: workdir }).generated;
+
+                // No contract ⇒ none of the narrowing fragments are emitted, so the
+                // output is the untyped-identity baseline (the guardrail the item
+                // was deferred to protect).
+                expect(server).not.toContain("InferIdentity");
+                expect(server).not.toContain("lunoraIdentityContract");
+                expect(server).not.toContain("export type Identity");
+                expect(server).not.toContain("NarrowedAuth");
+                // The RLS DSL keeps the untyped-identity default binding.
+                expect(server).toContain("export const definePolicy = createPolicyDsl<DataModel, Relations>();");
+                // ctx.auth is inherited from the base (never re-declared / omitted).
+                expect(server).not.toContain('"db" | "storage" | "auth"');
+            });
+
+            it("narrows ctx.auth.getIdentity() + the RLS policy identity to the declared contract", () => {
+                expect.assertions(9);
+
+                writeIdentity();
+
+                const { server } = runCodegen({ lint: false, projectRoot: workdir }).generated;
+
+                // The claim type is recovered from the declaration itself (reused
+                // `InferIdentity` machinery, `typeof` the imported contract) — no
+                // parallel type system, no runtime import.
+                expect(server).toContain('import type { InferIdentity } from "@lunora/server";');
+                expect(server).toContain('import type * as lunoraIdentityContract from "../identity.js";');
+                expect(server).toContain("export type Identity = InferIdentity<typeof lunoraIdentityContract.identity>;");
+                // `getIdentity()` narrows to `Identity | null` via a NarrowedAuth override.
+                expect(server).toContain('type NarrowedAuth = Omit<QueryCtxBase["auth"], "getIdentity"> & { getIdentity: () => Promise<Identity | null> };');
+                expect(server).toContain("readonly auth: NarrowedAuth;");
+                // Each ctx omits the base `auth` so the narrowed one replaces it.
+                expect(ctxInterface(server, "QueryCtx")).toContain("readonly auth: NarrowedAuth;");
+                expect(ctxInterface(server, "ActionCtx")).toContain("readonly auth: NarrowedAuth;");
+                expect(server).toContain('export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage" | "auth">');
+                // The RLS DSL is bound to the declared identity so a policy's
+                // `ctx.auth.identity` narrows to it.
+                expect(server).toContain("export const definePolicy = createPolicyDsl<DataModel, Relations, Identity>();");
+            });
+
+            it("leaves app.ts free of identity wiring when no defineIdentity is declared", () => {
+                expect.assertions(2);
+
+                const { app } = runCodegen({ lint: false, projectRoot: workdir }).generated;
+
+                // No contract ⇒ no import and no `options.identity` wiring, so the
+                // runtime trust boundary is a no-op. (An unrelated `identity:` may
+                // appear inside the D1 global-db factory, so we assert on the
+                // contract-specific fragments rather than the bare substring.)
+                expect(app).not.toContain("lunoraIdentityContract");
+                expect(app).not.toContain(`from "../identity.js"`);
+            });
+
+            it("wires options.identity into app.ts so the trust boundary validates in the generated worker", () => {
+                expect.assertions(3);
+
+                writeIdentity();
+
+                const { app } = runCodegen({ lint: false, projectRoot: workdir }).generated;
+
+                // Imported as a VALUE (not `import type`) — the contract must exist
+                // at runtime for the worker's contract gate to run.
+                expect(app).toContain('import * as lunoraIdentityContract from "../identity.js";');
+                expect(app).not.toContain("import type * as lunoraIdentityContract");
+                // Wired onto the worker options the runtime validates against.
+                expect(app).toContain("identity: lunoraIdentityContract.identity,");
+            });
+
+            it("errors when more than one defineIdentity is declared", () => {
+                expect.assertions(1);
+
+                writeFileSync(
+                    join(workdir, "lunora", "identity.ts"),
+                    `import { defineIdentity, v } from "@lunora/server";
+export const identity = defineIdentity({ userId: v.string() });
+export const other = defineIdentity({ userId: v.string() });
+`,
+                    "utf8",
+                );
+
+                expect(() => runCodegen({ lint: false, projectRoot: workdir })).toThrow(/exactly one is allowed/u);
+            });
+        });
+
         it("wires ctx.ai end-to-end when a function reads ctx.ai", () => {
             expect.assertions(3);
 

--- a/packages/codegen/src/discover-identity.ts
+++ b/packages/codegen/src/discover-identity.ts
@@ -1,0 +1,161 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import type { CallExpression, Identifier, Node as TsNode, Project, SourceFile } from "ts-morph";
+import { Node, SyntaxKind } from "ts-morph";
+
+import { diagnosticAt } from "./diagnostics";
+import type { IdentityIR } from "./ir";
+
+/** The only file a `defineIdentity` contract may be declared in — mirrors `lunora/shapes.ts`. */
+const IDENTITY_FILENAME = "identity.ts";
+
+/** Both module specifiers `defineIdentity` may be imported from (granular + umbrella). */
+const IDENTITY_MODULE_SPECIFIERS = new Set(["@lunora/server", "lunorash/server"]);
+
+/**
+ * Decide whether a callee identifier refers to `defineIdentity` from
+ * `@lunora/server` (or its `lunorash/server` umbrella subpath). Mirrors
+ * `isDefineShape`: trust the import declaration when the checker has a symbol
+ * (so aliasing survives), and fall back to the surface text when no symbol is
+ * available.
+ */
+const isDefineIdentity = (identifier: Identifier): boolean => {
+    const symbol = identifier.getSymbol();
+
+    if (!symbol) {
+        return identifier.getText() === "defineIdentity";
+    }
+
+    for (const declaration of symbol.getDeclarations()) {
+        if (!Node.isImportSpecifier(declaration)) {
+            continue;
+        }
+
+        if (!IDENTITY_MODULE_SPECIFIERS.has(declaration.getImportDeclaration().getModuleSpecifierValue())) {
+            return false;
+        }
+
+        return declaration.getNameNode().getText() === "defineIdentity";
+    }
+
+    return false;
+};
+
+/**
+ * Decide whether `identifier` is a namespace binding of an allowed identity
+ * module — the `server` in `import * as server from "@lunora/server"`. Used to
+ * recognize the member-access callee form `server.defineIdentity(...)`.
+ */
+const isIdentityNamespaceImport = (identifier: Identifier): boolean => {
+    const symbol = identifier.getSymbol();
+
+    if (!symbol) {
+        return false;
+    }
+
+    for (const declaration of symbol.getDeclarations()) {
+        if (!Node.isNamespaceImport(declaration)) {
+            continue;
+        }
+
+        const importDeclaration = declaration.getFirstAncestorByKind(SyntaxKind.ImportDeclaration);
+
+        return importDeclaration !== undefined && IDENTITY_MODULE_SPECIFIERS.has(importDeclaration.getModuleSpecifierValue());
+    }
+
+    return false;
+};
+
+/**
+ * Decide whether a call's callee is `defineIdentity` — either the bare imported
+ * identifier (`defineIdentity(...)`) or a namespace member access
+ * (`server.defineIdentity(...)`). Both are valid ES module syntax, so discovery
+ * must see the contract declared either way.
+ */
+const isDefineIdentityCallee = (callee: TsNode): boolean => {
+    if (Node.isIdentifier(callee)) {
+        return isDefineIdentity(callee);
+    }
+
+    if (Node.isPropertyAccessExpression(callee)) {
+        const object = callee.getExpression();
+
+        return callee.getName() === "defineIdentity" && Node.isIdentifier(object) && isIdentityNamespaceImport(object);
+    }
+
+    return false;
+};
+
+/** Collect exported `defineIdentity` declarations from one source file. */
+const identitiesFromSource = (source: SourceFile): IdentityIR[] => {
+    const identities: IdentityIR[] = [];
+
+    for (const declaration of source.getVariableDeclarations()) {
+        if (!declaration.isExported()) {
+            continue;
+        }
+
+        const initializer = declaration.getInitializer();
+
+        if (initializer?.getKind() !== SyntaxKind.CallExpression) {
+            continue;
+        }
+
+        const callExpression = initializer as CallExpression;
+
+        if (!isDefineIdentityCallee(callExpression.getExpression())) {
+            continue;
+        }
+
+        const nameNode = declaration.getNameNode();
+
+        if (!Node.isIdentifier(nameNode)) {
+            throw diagnosticAt(nameNode, "defineIdentity exports must be plain named exports (no destructuring)");
+        }
+
+        identities.push({ exportName: nameNode.getText() });
+    }
+
+    return identities;
+};
+
+/**
+ * Discover the single identity claim contract the project declares: the
+ * exported `defineIdentity()` call in `lunora/identity.ts`. Returns `undefined`
+ * when the file doesn't exist — so a project without one emits byte-identical
+ * generated code. Only the export binding is lifted; the emitted server type
+ * recovers the claim shape from the declaration itself (`InferIdentity` over the
+ * contract's `typeof`), and the runtime object carries the authoritative
+ * `validate`/`onInvalid` at the trust boundary.
+ *
+ * Exactly one contract is allowed — more than one is a diagnostic (the runtime
+ * boundary and the emitted `ctx.auth` type each expect a single contract).
+ */
+const discoverIdentity = (project: Project, lunoraDirectory: string): IdentityIR | undefined => {
+    const identityPath = join(lunoraDirectory, IDENTITY_FILENAME);
+
+    if (!existsSync(identityPath)) {
+        return undefined;
+    }
+
+    const source = project.getSourceFile(identityPath) ?? project.addSourceFileAtPath(identityPath);
+    const identities = identitiesFromSource(source);
+
+    if (identities.length === 0) {
+        return undefined;
+    }
+
+    if (identities.length > 1) {
+        throw diagnosticAt(
+            source,
+            `lunora/identity.ts declares ${identities.length.toString()} defineIdentity() contracts (${identities
+                .map((identity) => identity.exportName)
+                .join(", ")}); exactly one is allowed`,
+        );
+    }
+
+    return identities[0];
+};
+
+export { discoverIdentity, IDENTITY_FILENAME };

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-secrets/no-secrets -- emitted builder source: the string fragments are framework API type names (e.g. "SchedulerDeclaration<Env>"), not credentials. */
 import { GENERATED_HEADER } from "./emit";
-import type { JurisdictionIR } from "./ir";
+import type { IdentityIR, JurisdictionIR } from "./ir";
 
 /** Which capability methods the generated `defineApp` builder exposes — one flag per package-backed feature the app actually uses. */
 interface EmitAppOptions {
@@ -40,6 +40,8 @@ interface EmitAppOptions {
     hasVectors: boolean;
     /** App declares Cloudflare Workflows (`defineWorkflow`) → wire `options.workflowsClient` so the studio's workflow-instance proxy can reach the CF REST API. */
     hasWorkflow: boolean;
+    /** The single `defineIdentity(...)` contract in `lunora/identity.ts` (Plan 080) → import it as a VALUE and wire `options.identity`, so the runtime trust boundary validates every resolved identity before it becomes `ctx.auth`. `undefined` ⇒ no wiring, byte-identical output. */
+    identity?: IdentityIR;
     /** Schema declares `.jurisdiction("…")` → pin every DO the worker reaches (shards, fan-out, scheduler, containers) to the Cloudflare data-residency jurisdiction. */
     jurisdiction?: JurisdictionIR;
     /** Project depends on the unscoped `lunorash` umbrella → import the runtime via `lunorash/runtime` instead of `@lunora/runtime`. */
@@ -83,6 +85,14 @@ const LONG_TAIL: ReadonlyArray<readonly [keyof EmitAppOptions, string, string, s
 
 /** Whether any long-tail (`shardExtras`-backed) capability method is emitted. */
 const hasAnyLongTail = (options: EmitAppOptions): boolean => LONG_TAIL.some(([flag]) => options[flag]);
+
+/**
+ * The `defineIdentity(...)` contract import — a VALUE (not `import type`) so it
+ * can be wired onto `options.identity` and actually validate at the runtime
+ * trust boundary. Namespace form mirrors `server.ts` so an arbitrary export name
+ * can never collide with a builder import. Empty when no contract is declared.
+ */
+const buildIdentityImports = (identity: IdentityIR | undefined): string[] => (identity ? [`import * as lunoraIdentityContract from "../identity.js";`] : []);
 
 /** `@lunora/cloudflare-access` imports — `composeResolvers` only when `@lunora/auth` also wires a resolver to fall back to. */
 const buildAccessImports = (hasAccess: boolean, hasAuth: boolean): string[] =>
@@ -158,6 +168,7 @@ const buildImportLines = (options: EmitAppOptions): string[] => {
         `import type { ${[...runtimeTypeImports].toSorted((a, b) => a.localeCompare(b)).join(", ")} } from "${runtimeModule}";`,
         `import { ${runtimeValueImports} } from "${runtimeModule}";`,
         ``,
+        ...buildIdentityImports(options.identity),
         ...(hasGlobal || hasHyperdriveGlobal ? [`import schema from "../schema.js";`] : []),
         `import { LUNORA_CRONS } from "./crons.js";`,
         `import { LUNORA_FUNCTIONS } from "./functions.js";`,
@@ -532,6 +543,11 @@ const buildWorkerOptionLines = (options: EmitAppOptions): string[] => [
 const buildBaseWorkerOptions = (options: EmitAppOptions): string[] => [
     `            cronJobs: LUNORA_CRONS,`,
     `            functions: LUNORA_FUNCTIONS,`,
+    // The declared `defineIdentity(...)` contract — wires the runtime trust
+    // boundary so `wrapResolverWithContract` validates every resolved identity
+    // against it before it becomes `ctx.auth`. Emitted only when the app declares
+    // a contract, so apps without one keep unchanged output.
+    ...(options.identity ? [`            identity: lunoraIdentityContract.${options.identity.exportName},`] : []),
     // Schema `.jurisdiction("…")` pins every DO the worker reaches to the
     // Cloudflare data-residency region. Emitted only when declared, so apps
     // without it keep the un-pinned global namespace (and unchanged output).

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -14,6 +14,7 @@ import type {
     ContainerIR,
     CronJobIR,
     FunctionIR,
+    IdentityIR,
     IndexIR,
     JurisdictionIR,
     MaskMetadataIR,
@@ -1033,6 +1034,16 @@ interface EmitServerOptions {
     hasPipelines?: boolean;
     /** A `lunora/` source uses `@lunora/bindings/r2sql` / `ctx.r2sql` — wires `ctx.r2sql` onto ActionCtx only. */
     hasR2sql?: boolean;
+
+    /**
+     * The single `defineIdentity(...)` claim contract declared in
+     * `lunora/identity.ts` (Plan 080). When present, `ctx.auth.getIdentity()`,
+     * the RLS policy `ctx.auth.identity`, and the shard-authorization hooks
+     * narrow to the declared shape (recovered via `InferIdentity` over the
+     * contract's `typeof`). `undefined` keeps the identity an untyped bag —
+     * byte-identical to today.
+     */
+    identity?: IdentityIR;
     /** Queues declared via `defineQueue` exports — wires the typed `ctx.queues` producers onto Mutation/Action contexts. */
     queues?: ReadonlyArray<QueueIR>;
     schema?: SchemaIR;
@@ -1056,6 +1067,7 @@ const emitServer = ({
     hasPayments = false,
     hasPipelines = false,
     hasR2sql = false,
+    identity,
     queues = [],
     schema,
     storageRuleBuckets = [],
@@ -1245,6 +1257,36 @@ ${queues.map((queue) => `    readonly ${queue.exportName}: QueueProducer<QueueBo
         : "";
     const queuesContextField = hasQueues ? `\n    readonly queues: LunoraQueues;` : "";
 
+    // Typed identity layer (Plan 080). When the project declares the single
+    // `defineIdentity(...)` contract in `lunora/identity.ts`, the generated
+    // server recovers the claim *type* from the declaration itself (via
+    // `InferIdentity<typeof …>` — the same machinery the workflows/queues blocks
+    // use to read a declaration by `typeof`, so no parallel type system) and
+    // narrows `ctx.auth.getIdentity()`, the RLS policy `ctx.auth.identity`, and
+    // the `authorizeShard`/`authorizeFanOut` identity to it. Every fragment is
+    // gated on the contract existing, so with no `defineIdentity` the emitted
+    // server.ts is byte-identical to before this feature.
+    const identityTypeImport = identity
+        ? `import type { InferIdentity } from "${base.server}";\nimport type * as lunoraIdentityContract from "../identity.js";\n`
+        : "";
+    const identityTypeBlock = identity
+        ? `
+
+/** This app's declared identity claim contract (\`defineIdentity\` in \`lunora/identity.ts\`) — the typed shape of \`ctx.auth.getIdentity()\`, the RLS policy \`ctx.auth.identity\`, and the \`authorizeShard\`/\`authorizeFanOut\` identity argument. */
+export type Identity = InferIdentity<typeof lunoraIdentityContract.${identity.exportName}>;
+
+/** \`ctx.auth\` narrowed so \`getIdentity()\` resolves the declared {@link Identity} contract instead of the untyped claim bag. */
+type NarrowedAuth = Omit<QueryCtxBase["auth"], "getIdentity"> & { getIdentity: () => Promise<Identity | null> };`
+        : "";
+    // Appended to each ctx's `Omit<…Base, …>` key union and body so the narrowed
+    // `auth` replaces the base `AuthState`; empty when no contract is declared.
+    const authOmit = identity ? ` | "auth"` : "";
+    const authContextField = identity ? `\n    readonly auth: NarrowedAuth;` : "";
+    // Threads the declared claim type into the relation-aware RLS DSL, so a
+    // policy's `ctx.auth.identity` narrows to {@link Identity}. Empty ⇒ the
+    // untyped `Record<string, unknown>` default in `createPolicyDsl`.
+    const policyIdentityArgument = identity ? ", Identity" : "";
+
     const server = `${GENERATED_HEADER}import { createPolicyDsl, initLunora, v as vBase } from "${base.server}";
 import type {
     ActionBuilder,
@@ -1266,11 +1308,11 @@ import type {
 } from "${base.server}";
 
 import type { DataModel, DatabaseReaderFacade, DatabaseWriterFacade, Doc, Id as IdOfTable, OrmReader, OrmWriter, Relations, TableName } from "./dataModel.js";
-${aiTypeImport}${paymentsTypeImport}${containersTypeImport}${workflowsTypeImport}${queuesTypeImport}
+${aiTypeImport}${paymentsTypeImport}${containersTypeImport}${workflowsTypeImport}${queuesTypeImport}${identityTypeImport}
 export type { DataModel, Doc, Id, TableName } from "./dataModel.js";
 
 /** Storage buckets this schema declares (\`v.storage("name")\`), narrowing \`ctx.storage.bucket(name)\`. */
-export type StorageBucketName = ${storageBucketUnion};${envBlock}${workflowsTypeBlock}${queuesTypeBlock}
+export type StorageBucketName = ${storageBucketUnion};${envBlock}${workflowsTypeBlock}${queuesTypeBlock}${identityTypeBlock}
 
 /**
  * Project-typed contexts. The base contexts from \`@lunora/server\` are
@@ -1299,22 +1341,22 @@ type TypedTableQuery = (<T extends TableName>(table: T) => TableReader<Doc<T>>) 
  */
 type TypedTableGet = <T extends TableName>(id: IdOfTable<T>) => Promise<Doc<T> | null>;
 
-export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"> {
+export interface QueryCtx extends Omit<QueryCtxBase, "db" | "storage"${authOmit}> {
     readonly db: Omit<DatabaseReader, "query" | "get"> & DatabaseReaderFacade & { query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmReader;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;${accessContextField}${kvContextField}${flagsContextField}${analyticsContextField}
+    readonly storage: ReadOnlyStorage<StorageBucketName>;${accessContextField}${kvContextField}${flagsContextField}${analyticsContextField}${authContextField}
 }
 
-export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"${workflowsOmit}> {
+export interface MutationCtx extends Omit<MutationCtxBase, "db" | "storage"${workflowsOmit}${authOmit}> {
     readonly db: Omit<DatabaseWriter, "query" | "get"> & DatabaseWriterFacade & { query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: ReadOnlyStorage<StorageBucketName>;${accessContextField}${kvContextField}${flagsContextField}${analyticsContextField}${workflowsContextField}${queuesContextField}
+    readonly storage: ReadOnlyStorage<StorageBucketName>;${accessContextField}${kvContextField}${flagsContextField}${analyticsContextField}${workflowsContextField}${queuesContextField}${authContextField}
 }
 
-export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"${workflowsOmit}> {
+export interface ActionCtx extends Omit<ActionCtxBase, "db" | "storage"${workflowsOmit}${authOmit}> {
     readonly db: Omit<DatabaseWriter, "query" | "get"> & DatabaseWriterFacade & { query: TypedTableQuery; get: TypedTableGet };
     readonly orm: OrmWriter;
-    readonly storage: StorageBase<StorageBucketName>;${accessContextField}${aiActionField}${paymentsActionField}${containersActionField}${kvContextField}${flagsContextField}${hyperdriveActionField}${browserActionField}${imagesActionField}${analyticsContextField}${pipelinesActionField}${r2sqlActionField}${workflowsContextField}${queuesContextField}
+    readonly storage: StorageBase<StorageBucketName>;${accessContextField}${aiActionField}${paymentsActionField}${containersActionField}${kvContextField}${flagsContextField}${hyperdriveActionField}${browserActionField}${imagesActionField}${analyticsContextField}${pipelinesActionField}${r2sqlActionField}${workflowsContextField}${queuesContextField}${authContextField}
 }
 
 /**
@@ -1354,7 +1396,7 @@ export const internalAction = lunoraBuilders.internalAction as unknown as Intern
  * Runtime-identical to \`@lunora/server\`'s \`definePolicy\`; only the types narrow,
  * so the \`rls()\` chain discovers a policy authored either way the same.
  */
-export const definePolicy = createPolicyDsl<DataModel, Relations>();
+export const definePolicy = createPolicyDsl<DataModel, Relations${policyIdentityArgument}>();
 
 /**
  * The validator builder \`v\`, with \`v.id(...)\` constrained to THIS schema's

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -270,6 +270,20 @@ export interface ShapeIR {
 }
 
 /**
+ * The single `defineIdentity({...})` claim contract discovered in
+ * `lunora/identity.ts`. Discovery is **marker-driven** (the `__lunoraIdentity`
+ * brand, exactly like {@link ShapeIR}) — no claim metadata is lifted here
+ * because the emitted `_generated/server.ts` recovers the claim *type* from the
+ * declaration itself (`InferIdentity` over the contract's `typeof`), and the
+ * runtime object (`validate`/`onInvalid`) carries the authority at the boundary.
+ * Exactly one per app; absent ⇒ generated output is byte-identical to today.
+ */
+export interface IdentityIR {
+    /** Export binding name — the namespace member `_generated/server.ts` reads via `typeof`. */
+    exportName: string;
+}
+
+/**
  * A `defineMutator({...})` declaration discovered in `lunora/mutators.ts`
  * (local-first sync engine, Phase 7). The emitted registry registers the
  * authoritative `server` impl into the DO's `LUNORA_FUNCTIONS` table (so

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -15,6 +15,7 @@ import { buildStudioFeatures, discoverFeatureUsage } from "./discover-feature-us
 import { discoverFlagKeys } from "./discover-flags";
 import { discoverFunctions, listLunoraSourceFiles } from "./discover-functions";
 import discoverHttpRoutes from "./discover-http-routes";
+import { discoverIdentity } from "./discover-identity";
 import discoverInserts from "./discover-inserts";
 import discoverMaskProcedures, { discoverMaskMetadata } from "./discover-mask-procedures";
 import discoverMigrations from "./discover-migrations";
@@ -267,6 +268,13 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     const shapes = discoverShapes(project, lunoraDirectory);
     const mutators = discoverMutators(project, lunoraDirectory);
 
+    // Typed identity layer (Plan 080): the single `defineIdentity(...)` claim
+    // contract declared in `lunora/identity.ts`. When present, `emitServer`
+    // narrows `ctx.auth.getIdentity()`, the RLS policy `ctx.auth.identity`, and
+    // the shard-authorization hooks to the declared shape. `undefined` when the
+    // file is absent, so a project without one emits byte-identical server.ts.
+    const identity = discoverIdentity(project, lunoraDirectory);
+
     // Workflows declared via `defineWorkflow` exports in `lunora/workflows.ts`.
     // Discovered before crons so a `cronJobs()` registration can target a
     // workflow by its export name (the cron then starts a durable instance per
@@ -419,6 +427,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         hasPayments,
         hasPipelines,
         hasR2sql,
+        identity,
         queues,
         schema,
         storageRuleBuckets: storageRulesMetadata.rules.map((rule) => rule.bucket),
@@ -503,6 +512,11 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
         hasStorage: studioFeatures.storage,
         hasVectors: schema.vectorIndexes.length > 0,
         hasWorkflow: workflows.length > 0,
+        // The single `defineIdentity(...)` contract (Plan 080). Wires
+        // `options.identity` so the runtime trust boundary validates every
+        // resolved identity before it becomes `ctx.auth`; `undefined` keeps the
+        // emitted app.ts byte-identical to before this feature.
+        identity,
         // Schema `.jurisdiction("…")` → pin the generated worker's DOs to the region.
         jurisdiction: schema.jurisdiction,
         useUmbrella,

--- a/packages/runtime/__tests__/identity-layer.test.ts
+++ b/packages/runtime/__tests__/identity-layer.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExecutionContextLike, ResolvedIdentity } from "../src/create-worker";
+import { createWorker } from "../src/create-worker";
+import type { IdentityContractLike, IdentityResolver } from "../src/identity-resolvers";
+import { composeIdentityResolvers, routeIdentityResolvers } from "../src/identity-resolvers";
+import type { ShardNamespaceLike } from "../src/resolve-shard";
+
+interface ShardSpy {
+    calls: { request: Request; shardKey: string }[];
+    namespace: ShardNamespaceLike;
+    response: Response;
+}
+
+const createShardSpy = (response = new Response("ok", { status: 200 })): ShardSpy => {
+    const calls: { request: Request; shardKey: string }[] = [];
+    const spy = { calls, response } as ShardSpy;
+
+    spy.namespace = {
+        get: (id) => {
+            const shardKey = (id as { __name: string }).__name;
+
+            return {
+                fetch: async (request: Request) => {
+                    calls.push({ request, shardKey });
+
+                    return spy.response;
+                },
+            };
+        },
+        idFromName: (name) => {
+            return { __name: name };
+        },
+    };
+
+    return spy;
+};
+
+const fakeContext: ExecutionContextLike = {
+    passThroughOnException: () => undefined,
+    waitUntil: () => undefined,
+};
+
+const rpc = (): Request =>
+    new Request("https://app.example/_lunora/rpc", {
+        body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+        method: "POST",
+    });
+
+/** A contract that requires a numeric-string `tenantId` claim beyond `userId`. */
+const tenantContract = (onInvalid: "anonymous" | "reject"): IdentityContractLike => {
+    return {
+        onInvalid,
+        validate: (identity) => {
+            if (typeof identity["tenantId"] !== "string" || identity["tenantId"].length === 0) {
+                return { error: "identity.tenantId: expected a non-empty string", ok: false };
+            }
+
+            return { ok: true };
+        },
+    };
+};
+
+describe("composeIdentityResolvers", () => {
+    it("returns the first non-null identity (first-match-wins) and short-circuits", async () => {
+        expect.assertions(3);
+
+        const first = vi.fn<IdentityResolver>(() => null);
+        const second = vi.fn<IdentityResolver>(() => {
+            return { userId: "u_2" };
+        });
+        const third = vi.fn<IdentityResolver>(() => {
+            return { userId: "u_3" };
+        });
+
+        const resolver = composeIdentityResolvers([first, second, third]);
+        const identity = await resolver(rpc(), {});
+
+        expect(identity).toEqual({ userId: "u_2" });
+        expect(second).toHaveBeenCalledTimes(1);
+        // third must never run — second already matched.
+        expect(third).not.toHaveBeenCalled();
+    });
+
+    it("returns null when every resolver is anonymous", async () => {
+        expect.assertions(1);
+
+        const resolver = composeIdentityResolvers([() => null, () => null]);
+
+        await expect(resolver(rpc(), {})).resolves.toBeNull();
+    });
+
+    it("fails closed by default when a resolver throws", async () => {
+        expect.assertions(2);
+
+        const boom = vi.fn<IdentityResolver>(() => {
+            throw new Error("verifier down");
+        });
+        const fallback = vi.fn<IdentityResolver>(() => {
+            return { userId: "u_fallback" };
+        });
+
+        const resolver = composeIdentityResolvers([boom, fallback]);
+
+        await expect(resolver(rpc(), {})).rejects.toThrow("verifier down");
+        // fail-closed: a broken verifier must not fall through to a weaker one.
+        expect(fallback).not.toHaveBeenCalled();
+    });
+
+    it("skips a throwing resolver when onError is 'skip'", async () => {
+        expect.assertions(1);
+
+        const resolver = composeIdentityResolvers(
+            [
+                () => {
+                    throw new Error("not my scheme");
+                },
+                () => {
+                    return { userId: "u_next" };
+                },
+            ],
+            { onError: "skip" },
+        );
+
+        await expect(resolver(rpc(), {})).resolves.toEqual({ userId: "u_next" });
+    });
+});
+
+describe("routeIdentityResolvers", () => {
+    const at = (path: string): Request => new Request(`https://app.example${path}`);
+
+    it("dispatches by longest path prefix, falling back to '*'", async () => {
+        expect.assertions(3);
+
+        const resolver = routeIdentityResolvers({
+            "*": () => {
+                return { userId: "default" };
+            },
+            "/admin": () => {
+                return { userId: "admin" };
+            },
+            "/admin/reports": () => {
+                return { userId: "reports" };
+            },
+        });
+
+        // `Promise.resolve` normalises the (synchronous) route dispatch to a
+        // promise so `.resolves` is valid whether a resolver is sync or async.
+        await expect(Promise.resolve(resolver(at("/admin/reports/q1"), {}))).resolves.toEqual({ userId: "reports" });
+        await expect(Promise.resolve(resolver(at("/admin/users"), {}))).resolves.toEqual({ userId: "admin" });
+        await expect(Promise.resolve(resolver(at("/dashboard"), {}))).resolves.toEqual({ userId: "default" });
+    });
+
+    it("returns null when no route matches and no '*' fallback is declared", async () => {
+        expect.assertions(1);
+
+        const resolver = routeIdentityResolvers({
+            "/admin": () => {
+                return { userId: "admin" };
+            },
+        });
+
+        await expect(Promise.resolve(resolver(at("/dashboard"), {}))).resolves.toBeNull();
+    });
+
+    it("awaits an async resolver (and a composed resolver) selected by route", async () => {
+        expect.assertions(2);
+
+        const resolver = routeIdentityResolvers({
+            "*": composeIdentityResolvers([
+                async () => null,
+                async () => {
+                    return { userId: "composed" };
+                },
+            ]),
+            "/admin": async () => {
+                return { userId: "admin-async" };
+            },
+        });
+
+        // The chosen resolver returns a promise; `routeIdentityResolvers` must pass it
+        // through so `await` resolves the identity rather than yielding a Promise.
+        await expect(resolver(at("/admin/reports"), {})).resolves.toEqual({ userId: "admin-async" });
+        await expect(resolver(at("/dashboard"), {})).resolves.toEqual({ userId: "composed" });
+    });
+});
+
+describe("identity contract trust boundary", () => {
+    let shard: ShardSpy;
+
+    beforeEach(() => {
+        shard = createShardSpy();
+    });
+
+    it("forwards a valid identity unchanged when it satisfies the contract", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({
+            identity: tenantContract("anonymous"),
+            resolveIdentity: (): ResolvedIdentity => {
+                return { tenantId: "t_1", userId: "user_42" };
+            },
+            shardDO: shard.namespace,
+        });
+
+        await worker.fetch(rpc(), {}, fakeContext);
+
+        expect(shard.calls[0]!.request.headers.get("x-lunora-userid")).toBe("user_42");
+        expect(JSON.parse(shard.calls[0]!.request.headers.get("x-lunora-identity")!)).toEqual({ tenantId: "t_1" });
+    });
+
+    it("downgrades a contract-violating identity to anonymous (onInvalid: 'anonymous')", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({
+            identity: tenantContract("anonymous"),
+            // Forged: `userId` present but the required `tenantId` claim is missing.
+            resolveIdentity: (): ResolvedIdentity => {
+                return { userId: "user_42" };
+            },
+            shardDO: shard.namespace,
+        });
+
+        const res = await worker.fetch(rpc(), {}, fakeContext);
+
+        expect(res.status).toBe(200);
+        // The bad identity never reaches the shard as a valid identity.
+        expect(shard.calls[0]!.request.headers.get("x-lunora-userid")).toBeNull();
+    });
+
+    it("rejects a contract-violating identity with 401 (onInvalid: 'reject')", async () => {
+        expect.assertions(3);
+
+        const worker = createWorker({
+            identity: tenantContract("reject"),
+            resolveIdentity: (): ResolvedIdentity => {
+                return { userId: "user_42" };
+            },
+            shardDO: shard.namespace,
+        });
+
+        const res = await worker.fetch(rpc(), {}, fakeContext);
+
+        expect(res.status).toBe(401);
+        await expect(res.json()).resolves.toMatchObject({ error: { code: "UNAUTHENTICATED" } });
+        // Request never dispatched to the shard.
+        expect(shard.calls).toHaveLength(0);
+    });
+
+    it("does not enforce the contract when no resolveIdentity is configured", async () => {
+        expect.assertions(1);
+
+        const worker = createWorker({ identity: tenantContract("reject"), shardDO: shard.namespace });
+
+        const res = await worker.fetch(rpc(), {}, fakeContext);
+
+        expect(res.status).toBe(200);
+    });
+});

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -11,6 +11,8 @@ import type { FunctionArgumentDescriptor } from "./describe-args";
 import { isStructuralConflictError, isStructuralLunoraError, LunoraError, toErrorResponse } from "./errors";
 import type { ExportRow } from "./export-stream";
 import { collectKnownTables, streamExportRows } from "./export-stream";
+import type { IdentityContractLike, ResolvedIdentity } from "./identity-resolvers";
+import { wrapResolverWithContract } from "./identity-resolvers";
 import { streamingImport } from "./import-stream";
 import { buildIntrospectionAdminRoutes } from "./introspection-admin-routes";
 import type { ObservabilityEvent, ObservabilitySink, ObservabilitySinkContext } from "./observability";
@@ -82,39 +84,6 @@ interface HttpRouterLike {
     // structurally here; an arrow property would reject it under strict variance.
     // eslint-disable-next-line @typescript-eslint/method-signature-style -- bivariant params are load-bearing for hono compatibility
     fetch(request: Request, env?: unknown, context?: ExecutionContextLike): Promise<Response> | Response;
-}
-
-/**
- * Identity resolved from the inbound request by {@link WorkerOptions.resolveIdentity}.
- *
- * The `userId` field is special — it becomes `ctx.auth.userId` inside the
- * Durable Object. Any other keys (`email`, `name`, custom roles, etc.) are
- * forwarded verbatim as `ctx.auth.getIdentity()`'s return value.
- *
- * Return `null` to signal that the request is anonymous; the runtime will
- * skip both `x-lunora-userid` and `x-lunora-identity` headers, and
- * `ctx.auth.userId` will be `undefined` on the shard side.
- */
-interface ResolvedIdentity {
-    /** Arbitrary additional claims. Must be JSON-serialisable. */
-    [key: string]: unknown;
-
-    /**
-     * JWT-standard expiry in epoch SECONDS. When present (and `expiresAtMs` is
-     * absent), the runtime forwards it as the socket's credential expiry — the
-     * DO drops the socket once it lapses. Used only on the WebSocket path.
-     */
-    exp?: number;
-
-    /**
-     * Credential expiry in epoch MILLISECONDS. Preferred over `exp` when
-     * both are present. Forwarded as the socket's expiry on the WebSocket path
-     * so the DO drops the socket once it lapses; omit for non-expiring sessions.
-     */
-    expiresAtMs?: number;
-
-    /** Stable user identifier (e.g. `"user_2k3..."` or `"u_42"`). */
-    userId: string;
 }
 
 /**
@@ -677,6 +646,18 @@ interface WorkerOptions {
      * own 404 (a path-match with the wrong verb is a 404, not a 405).
      */
     httpRouter?: HttpRouterLike;
+
+    /**
+     * The declared identity claim contract (`defineIdentity(...)` from
+     * `@lunora/server`), passed by the generated worker entry. When present, the
+     * worker validates every `resolveIdentity` result against it at the trust
+     * boundary (on the public data paths — RPC / WebSocket / HTTP-action /
+     * server-query, never the admin path) *before* the claims become `ctx.auth`.
+     * A resolver output that violates the contract is downgraded to anonymous or
+     * rejected with a `401`, per the contract's `onInvalid`. Omitted → no
+     * validation, and the identity stays the historical untyped claim bag.
+     */
+    identity?: IdentityContractLike;
 
     /**
      * Insert `.global()` rows for the admin import endpoint. When omitted,
@@ -1461,6 +1442,14 @@ interface LunoraWorker {
 const createWorker = (options: WorkerOptions): LunoraWorker => {
     const defaultShard = options.defaultShardKey ?? "__root__";
 
+    // The trust-boundary identity gate: only the PUBLIC data paths (RPC /
+    // WebSocket / HTTP-action / server-query) use this wrapped resolver, which
+    // validates every resolved identity against the `defineIdentity(...)` contract
+    // (when configured) before it becomes `ctx.auth`. The admin forward path keeps
+    // the raw `options.resolveIdentity` — admin is gated by the bearer / Access,
+    // not the app's identity contract. See `wrapResolverWithContract`.
+    const publicResolveIdentity: WorkerOptions["resolveIdentity"] = wrapResolverWithContract(options.resolveIdentity, options.identity);
+
     // Pin every DO this worker reaches to the configured jurisdiction exactly
     // once, here at the boundary. Downstream routing (`forwardToShard`,
     // `coordinator.fanOut`, the scheduler stubs) reads these derived namespaces
@@ -1957,7 +1946,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     });
 
     const buildHttpActionContext = async (request: Request, env: unknown): Promise<HttpActionContext> => {
-        const { claims, headers, userId } = await resolveForwardContext(request, env, options.resolveIdentity);
+        const { claims, headers, userId } = await resolveForwardContext(request, env, publicResolveIdentity);
 
         const run = async <R>(reference: unknown, args: Record<string, unknown> = {}): Promise<R> => {
             const functionPath = (reference as { __lunoraRef?: unknown }).__lunoraRef;
@@ -2049,7 +2038,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // forwarded to the DO so the socket carries a verified userId (the basis
         // for trusted `onConnect`/`onDisconnect` lifecycle hooks). Mirrors the
         // RPC path's `resolveForwardContext` → `authorize*` ordering.
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, options.resolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
 
         if (options.authorizeShard) {
             const allowed = await options.authorizeShard(identity, shardKey);
@@ -2292,7 +2281,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         // Forward selected headers from the inbound request so the DO can
         // honour auth, sessions, and D1 read-your-writes consistency.
-        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, options.resolveIdentity);
+        const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
 
         await authorizeRpcEnvelope(envelope, identity);
 
@@ -2581,8 +2570,9 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
      * EXACT same security steps as {@link handleRpc}, in the same order, off the
      * SAME inbound `request`:
      *
-     * 1. `resolveForwardContext(request, env, options.resolveIdentity)` — the
-     * identical identity resolution (`resolveIdentity`, cookie / authorization /
+     * 1. `resolveForwardContext(request, env, publicResolveIdentity)` — the
+     * identical identity resolution (`resolveIdentity` behind the same
+     * contract-validation gate as the HTTP path, cookie / authorization /
      * `x-d1-bookmark` forwarding, `x-lunora-userid` / `x-lunora-identity` header
      * derivation). Same per-request auth context, byte-for-byte.
      * 2. `authorizeRpcEnvelope({ functionPath, shardKey }, identity)` — the
@@ -2625,7 +2615,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             // Resolve identity off the SAME inbound request the HTTP path uses, so
             // cookies / bearer / bookmark and the derived `x-lunora-*` headers are
             // byte-identical to `handleRpc`'s.
-            const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, options.resolveIdentity);
+            const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
 
             // Run the IDENTICAL per-shard authorization gate. A `shardKey` of
             // `undefined` resolves to `defaultShard` for both the gate and the
@@ -3287,6 +3277,17 @@ const createLunoraHandler =
 const defineRpcEnvelope = (envelope: RpcEnvelope): RpcEnvelope => envelope;
 
 export { composeWorker, createLunoraHandler, createWorker, defineRpcEnvelope, resolveLunoraOptions, withFrameworkWorker };
+export { type ExecutionContextLike, NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
+export type {
+    AuthAdmin,
+    AuthCapabilities,
+    AuthImpersonation,
+    AuthIntrospector,
+    AuthPage,
+    AuthSession,
+    AuthUser,
+    ListAuthUsersOptions,
+} from "./auth-admin-routes";
 export type {
     AdminTableResolver,
     BackupManifest,
@@ -3313,7 +3314,6 @@ export type {
     LunoraHandlerOptions,
     LunoraWorker,
     QueueConsumerHandler,
-    ResolvedIdentity,
     Route,
     RpcContext,
     RpcEnvelope,
@@ -3330,14 +3330,14 @@ export type {
     WorkerOptions,
 };
 
-export { type ExecutionContextLike, NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
+// Identity-resolver layer lives in its own module; re-export the public names
+// here so `@lunora/runtime`'s import surface is unchanged.
 export type {
-    AuthAdmin,
-    AuthCapabilities,
-    AuthImpersonation,
-    AuthIntrospector,
-    AuthPage,
-    AuthSession,
-    AuthUser,
-    ListAuthUsersOptions,
-} from "./auth-admin-routes";
+    ComposeIdentityResolversErrorMode,
+    ComposeIdentityResolversOptions,
+    IdentityContractLike,
+    IdentityResolver,
+    IdentityValidation,
+    ResolvedIdentity,
+} from "./identity-resolvers";
+export { composeIdentityResolvers, routeIdentityResolvers } from "./identity-resolvers";

--- a/packages/runtime/src/identity-resolvers.ts
+++ b/packages/runtime/src/identity-resolvers.ts
@@ -1,0 +1,224 @@
+/**
+ * Identity-resolver layer — the generic, scheme-agnostic vocabulary for turning
+ * an inbound request into a {@link ResolvedIdentity}, composing several such
+ * verifiers, and validating their output against a declared claim contract at
+ * the worker's trust boundary.
+ *
+ * `ResolvedIdentity` and the contract-gate wiring (`wrapResolverWithContract`)
+ * were moved here from `create-worker.ts` (which re-exports the public names) so
+ * the cohesive identity concern lives in its own module, mirroring the sibling
+ * `*-admin-routes.ts` extraction pattern; `composeIdentityResolvers`/`routeIdentityResolvers` are
+ * new in this module. Everything here is dependency-free of `createWorker`
+ * internals; `IdentityContractLike` is a deliberate structural projection of
+ * `@lunora/server`'s `IdentityContract` so `@lunora/runtime` stays free of an
+ * `@lunora/server` dependency.
+ *
+ * Note: `@lunora/cloudflare-access` exports a similarly-purposed `composeResolvers`,
+ * but it is a *variadic* first-match-wins helper for its own resolvers (returns the
+ * anonymous sentinel, no options). These `*IdentityResolvers` combinators take a
+ * resolver array plus error-mode options and are fail-closed — intentionally
+ * separate primitives with distinct names to avoid confusing the two.
+ */
+
+import { LunoraError } from "./errors";
+
+/**
+ * Identity resolved from the inbound request by `WorkerOptions.resolveIdentity`.
+ *
+ * The `userId` field is special — it becomes `ctx.auth.userId` inside the
+ * Durable Object. Any other keys (`email`, `name`, custom roles, etc.) are
+ * forwarded verbatim as `ctx.auth.getIdentity()`'s return value.
+ *
+ * Return `null` to signal that the request is anonymous; the runtime will
+ * skip both `x-lunora-userid` and `x-lunora-identity` headers, and
+ * `ctx.auth.userId` will be `undefined` on the shard side.
+ */
+interface ResolvedIdentity {
+    /** Arbitrary additional claims. Must be JSON-serialisable. */
+    [key: string]: unknown;
+
+    /**
+     * JWT-standard expiry in epoch SECONDS. When present (and `expiresAtMs` is
+     * absent), the runtime forwards it as the socket's credential expiry — the
+     * DO drops the socket once it lapses. Used only on the WebSocket path.
+     */
+    exp?: number;
+
+    /**
+     * Credential expiry in epoch MILLISECONDS. Preferred over `exp` when
+     * both are present. Forwarded as the socket's expiry on the WebSocket path
+     * so the DO drops the socket once it lapses; omit for non-expiring sessions.
+     */
+    expiresAtMs?: number;
+
+    /** Stable user identifier (e.g. `"user_2k3..."` or `"u_42"`). */
+    userId: string;
+}
+
+/**
+ * A verifier that turns an inbound request into a {@link ResolvedIdentity} (or
+ * `null` for anonymous). Structurally identical to `WorkerOptions.resolveIdentity`,
+ * so `.auth()`'s better-auth session resolver, a signed-preview-link verifier, a
+ * per-tenant bearer check, an upstream-JWT reader, … are all just `IdentityResolver`s
+ * — the identity layer is generic over every scheme, not coupled to any one.
+ */
+type IdentityResolver = (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
+
+/** Error policy for {@link composeIdentityResolvers} when a participant resolver throws. */
+type ComposeIdentityResolversErrorMode = "fail-closed" | "skip";
+
+/** Options for {@link composeIdentityResolvers}. */
+interface ComposeIdentityResolversOptions {
+    /**
+     * What to do when a resolver throws. `"fail-closed"` (default, safe)
+     * re-throws so a broken verifier fails the request rather than silently
+     * falling through to a weaker one; `"skip"` swallows the error and tries the
+     * next resolver (use only when a resolver's failure genuinely means "not my
+     * scheme").
+     */
+    readonly onError?: ComposeIdentityResolversErrorMode;
+}
+
+/**
+ * Compose several {@link IdentityResolver}s into one, first-match-wins: each is
+ * tried in order and the first that returns a non-null identity short-circuits.
+ * Generic over every scheme — the better-auth session resolver (obtained via the
+ * builder's `derived.resolveIdentity` escape hatch) is just one entry in the list,
+ * so composition never means losing it.
+ *
+ * A resolver that throws is handled per {@link ComposeIdentityResolversOptions.onError}
+ * (default `"fail-closed"`: the error propagates).
+ */
+const composeIdentityResolvers = (resolvers: ReadonlyArray<IdentityResolver>, options: ComposeIdentityResolversOptions = {}): IdentityResolver => {
+    const onError: ComposeIdentityResolversErrorMode = options.onError ?? "fail-closed";
+
+    return async (request: Request, env: unknown): Promise<ResolvedIdentity | null> => {
+        for (const resolver of resolvers) {
+            let resolved: ResolvedIdentity | null;
+
+            try {
+                // eslint-disable-next-line no-await-in-loop -- ordered first-match-wins: a later resolver must not run until the earlier one has settled (and short-circuit on the first hit)
+                resolved = await resolver(request, env);
+            } catch (error: unknown) {
+                if (onError === "skip") {
+                    continue;
+                }
+
+                throw error;
+            }
+
+            if (resolved) {
+                return resolved;
+            }
+        }
+
+        // eslint-disable-next-line unicorn/no-null -- `null` is the resolver contract's anonymous sentinel (matches WorkerOptions.resolveIdentity)
+        return null;
+    };
+};
+
+/**
+ * A thin, generic helper over {@link composeIdentityResolvers} for the per-route case:
+ * pick a resolver by `new URL(request.url).pathname`. Keys are matched by longest
+ * path prefix; `"*"` is the fallback. Still fully generic — a route→resolver map,
+ * with no portal / preview / tenant concepts baked in (those live in the app's
+ * own resolvers).
+ * @example
+ * routeIdentityResolvers({ "/admin": adminResolver, "/partner": partnerResolver, "*": sessionResolver })
+ */
+const routeIdentityResolvers = (routes: Record<string, IdentityResolver>): IdentityResolver => {
+    // Longest-prefix first so `/admin/x` prefers `/admin` over a shorter match;
+    // `"*"` is excluded here and only used as the explicit fallback below.
+    const prefixes = Object.keys(routes)
+        .filter((key) => key !== "*")
+        .toSorted((a, b) => b.length - a.length);
+
+    return (request: Request, env: unknown): Promise<ResolvedIdentity | null> | ResolvedIdentity | null => {
+        const { pathname } = new URL(request.url);
+        const matched = prefixes.find((prefix) => pathname === prefix || pathname.startsWith(prefix.endsWith("/") ? prefix : `${prefix}/`));
+        const resolver = matched === undefined ? routes["*"] : routes[matched];
+
+        if (resolver === undefined) {
+            // eslint-disable-next-line unicorn/no-null -- anonymous sentinel: no route matched and no `"*"` fallback declared
+            return null;
+        }
+
+        return resolver(request, env);
+    };
+};
+
+/** The result of validating a candidate identity against an {@link IdentityContractLike}. */
+type IdentityValidation = { ok: true } | { error: string; ok: false };
+
+/**
+ * Structural view of `@lunora/server`'s `IdentityContract` (from `defineIdentity`).
+ * Kept structural so `@lunora/runtime` stays free of an `@lunora/server` dependency.
+ * Keep the `onInvalid` union and `validate`/`IdentityValidation` shapes in sync with
+ * `@lunora/server`'s `IdentityContract` — they are projected by hand, not imported.
+ * The generated worker entry passes the app's `defineIdentity(...)` result here;
+ * the worker validates every resolver's returned claims against it at the trust
+ * boundary before they become `ctx.auth`.
+ */
+interface IdentityContractLike {
+    /** Reject policy applied when validation fails: downgrade to anonymous, or reject the request (401). */
+    readonly onInvalid: "anonymous" | "reject";
+    /** Validate resolver-returned claims against the declared contract. */
+    validate: (identity: Record<string, unknown>) => IdentityValidation;
+}
+
+/**
+ * The trust-boundary identity gate. Given the worker's `resolveIdentity` and an
+ * optional `defineIdentity(...)` contract, return a resolver that validates every
+ * resolved identity against the declared claims BEFORE it becomes `ctx.auth`.
+ *
+ * Claims arrive from untrusted tokens; a forged / malformed set is either
+ * downgraded to anonymous (`onInvalid: "anonymous"`, the safe default — the bad
+ * identity never reaches a policy as valid) or rejected with a `401`
+ * (`onInvalid: "reject"`), rather than flowing in as an unchecked cast. A valid
+ * identity is returned unchanged, so undeclared claims are forwarded verbatim.
+ *
+ * When no contract is configured (or there is no `resolveIdentity`), the original
+ * resolver is returned untouched — zero overhead and byte-identical behaviour.
+ * Only the public data paths (RPC / WebSocket / HTTP-action / server-query) use
+ * the wrapped resolver; the admin path keeps the raw one (admin is gated by the
+ * bearer / Access, not the app's identity contract).
+ */
+const wrapResolverWithContract = (
+    baseResolveIdentity: IdentityResolver | undefined,
+    contract: IdentityContractLike | undefined,
+): IdentityResolver | undefined => {
+    if (contract === undefined || baseResolveIdentity === undefined) {
+        return baseResolveIdentity;
+    }
+
+    return async (request: Request, env: unknown): Promise<ResolvedIdentity | null> => {
+        const resolved = await baseResolveIdentity(request, env);
+
+        if (!resolved) {
+            return resolved;
+        }
+
+        const result = contract.validate(resolved);
+
+        if (result.ok) {
+            return resolved;
+        }
+
+        if (contract.onInvalid === "reject") {
+            throw new LunoraError(`identity claims failed the declared contract: ${result.error}`, { code: "UNAUTHENTICATED", status: 401 });
+        }
+
+        // eslint-disable-next-line unicorn/no-null -- downgrade a contract-violating identity to the anonymous sentinel
+        return null;
+    };
+};
+
+export type {
+    ComposeIdentityResolversErrorMode,
+    ComposeIdentityResolversOptions,
+    IdentityContractLike,
+    IdentityResolver,
+    IdentityValidation,
+    ResolvedIdentity,
+};
+export { composeIdentityResolvers, routeIdentityResolvers, wrapResolverWithContract };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,8 @@ export type {
     AuthUser,
     BackupManifest,
     BackupStore,
+    ComposeIdentityResolversErrorMode,
+    ComposeIdentityResolversOptions,
     CronHandler,
     CronJobDispatch,
     CronJobInfo,
@@ -29,6 +31,9 @@ export type {
     HttpActionContext,
     HttpActionLike,
     HttpRouterLike,
+    IdentityContractLike,
+    IdentityResolver,
+    IdentityValidation,
     ListAuthUsersOptions,
     LunoraHandlerOptions,
     LunoraWorker,
@@ -45,12 +50,14 @@ export type {
     WorkerOptions,
 } from "./create-worker";
 export {
+    composeIdentityResolvers,
     composeWorker,
     createLunoraHandler,
     createWorker,
     defineRpcEnvelope,
     NOOP_EXECUTION_CONTEXT,
     resolveLunoraOptions,
+    routeIdentityResolvers,
     withFrameworkWorker,
 } from "./create-worker";
 export type { CrossShardCounter, CrossShardReader, CrossShardRelationCapabilities, CrossShardRelationOptions } from "./cross-shard-relations";

--- a/packages/server/__tests__/identity.test-d.ts
+++ b/packages/server/__tests__/identity.test-d.ts
@@ -1,0 +1,52 @@
+import type { InferIdentity } from "../src/index";
+import { defineIdentity, v } from "../src/index";
+
+/**
+ * Type-level proof that `defineIdentity` yields a claim type extending
+ * `{ userId: string }`, that `InferIdentity` recovers it, that optional claims
+ * are optional and required claims required, and that reading an undeclared
+ * claim fails compilation. The `@ts-expect-error` lines fail the build if the
+ * contract's typing regresses.
+ */
+
+const identity = defineIdentity({
+    kind: v.optional(v.union(v.literal("user"), v.literal("service"))),
+    scopes: v.optional(v.array(v.string())),
+    tenantId: v.optional(v.string()),
+    userId: v.string(),
+});
+
+type Identity = InferIdentity<typeof identity>;
+
+// Assert a value has an exact type via a parameter position (no `void` operator,
+// no unused locals) — the argument fails to typecheck if the type regresses.
+const expectString = (_value: string): void => undefined;
+const expectOptionalString = (_value: string | undefined): void => undefined;
+const expectOptionalStringArray = (_value: string[] | undefined): void => undefined;
+const expectNever = (_value: never): void => undefined;
+
+const check = (claims: Identity): void => {
+    // Declared claims are readable at their declared types.
+    const { scopes, tenantId, userId } = claims;
+
+    expectString(userId);
+    expectOptionalString(tenantId);
+    expectOptionalStringArray(scopes);
+
+    // Reading an undeclared claim must not typecheck. Passed to a helper (not a
+    // bare expression) so the statement has effect; the access itself is the
+    // error `@ts-expect-error` expects.
+    // @ts-expect-error — `role` is not a declared claim on this identity contract.
+    expectNever(claims.role);
+
+    // A claim map without a required string `userId` collapses the argument to
+    // `never`, so the call fails to typecheck.
+    // @ts-expect-error — the claim map must declare a required string `userId`.
+    defineIdentity({ tenantId: v.string() });
+
+    // A `userId` typed as something other than `string` is likewise rejected.
+    // @ts-expect-error — `userId` must infer to `string`.
+    defineIdentity({ userId: v.number() });
+};
+
+export default check;

--- a/packages/server/__tests__/identity.test.ts
+++ b/packages/server/__tests__/identity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { defineIdentity, v } from "../src/index";
+
+/**
+ * `defineIdentity` declares the identity claim contract: it brands the
+ * declaration with `__lunoraIdentity` (so codegen discovers it), records the
+ * reject policy, and exposes a runtime `validate` that runs the declared
+ * validators against a resolver's returned claims at the trust boundary.
+ */
+describe("defineIdentity", () => {
+    const contract = defineIdentity({
+        kind: v.optional(v.union(v.literal("user"), v.literal("service"))),
+        scopes: v.optional(v.array(v.string())),
+        tenantId: v.optional(v.string()),
+        userId: v.string(),
+    });
+
+    it("brands the declaration and defaults onInvalid to 'anonymous'", () => {
+        expect.assertions(3);
+
+        expect(contract.__lunoraIdentity).toBe(true);
+        expect(contract.onInvalid).toBe("anonymous");
+        expect(typeof contract.validate).toBe("function");
+    });
+
+    it("honours an explicit onInvalid: 'reject'", () => {
+        expect.assertions(1);
+
+        const strict = defineIdentity({ userId: v.string() }, { onInvalid: "reject" });
+
+        expect(strict.onInvalid).toBe("reject");
+    });
+
+    it("accepts a valid claim set", () => {
+        expect.assertions(1);
+
+        expect(contract.validate({ scopes: ["read"], tenantId: "t_1", userId: "user_42" })).toEqual({ ok: true });
+    });
+
+    it("accepts a claim set with only the required userId (optional claims absent)", () => {
+        expect.assertions(1);
+
+        expect(contract.validate({ userId: "user_42" })).toEqual({ ok: true });
+    });
+
+    it("rejects a claim set whose declared claim has the wrong type", () => {
+        expect.assertions(2);
+
+        const result = contract.validate({ tenantId: 42, userId: "user_42" });
+
+        expect(result.ok).toBe(false);
+        expect(result).toMatchObject({ ok: false });
+    });
+
+    it("rejects a claim set missing the required userId", () => {
+        expect.assertions(1);
+
+        expect(contract.validate({ tenantId: "t_1" }).ok).toBe(false);
+    });
+
+    it("throws at declaration time when the claim map omits userId entirely", () => {
+        expect.assertions(1);
+
+        // Cast around the compile-time guard to prove the runtime guard also fires.
+        expect(() => defineIdentity({ tenantId: v.string() } as never)).toThrow(/userId/);
+    });
+
+    it("throws at declaration time when userId is a non-string or optional validator", () => {
+        expect.assertions(2);
+
+        // Cast around the compile-time guard: a required-but-non-string userId
+        // (here a number) still violates the `{ userId: string }` contract, and an
+        // optional userId cannot satisfy a required claim — both fail the runtime guard.
+        expect(() => defineIdentity({ userId: v.number() } as never)).toThrow(/userId/);
+        expect(() => defineIdentity({ userId: v.optional(v.string()) } as never)).toThrow(/userId/);
+    });
+
+    it("accepts a string-typed userId declared with a non-plain-string validator kind", () => {
+        expect.assertions(2);
+
+        // `v.id(...)` and `v.storage()` infer to string, so the compile-time guard admits
+        // them — the runtime guard must not false-reject a legitimately string-typed userId.
+        expect(defineIdentity({ userId: v.id("users") }).__lunoraIdentity).toBe(true);
+        expect(defineIdentity({ userId: v.storage() }).__lunoraIdentity).toBe(true);
+    });
+});

--- a/packages/server/__tests__/rls-identity.test.ts
+++ b/packages/server/__tests__/rls-identity.test.ts
@@ -1,0 +1,74 @@
+/*
+ * createPolicyDsl's optional third type parameter binds the app's identity
+ * claim contract (from defineIdentity) into the RLS policy context, so a
+ * policy's `when` reads `ctx.auth.identity` at the declared claim type instead
+ * of the untyped bag. Today an app binds it by hand with
+ * `createPolicyDsl<DataModel, Relations, InferIdentity<typeof identity>>()`; a
+ * later codegen phase will emit that binding automatically from a
+ * `defineIdentity(...)` declaration.
+ *
+ * The type-level expectation is asserted with `expectTypeOf` + `@ts-expect-error`
+ * so a regression that widens `ctx.auth.identity` fails the type check.
+ */
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { createPolicyDsl } from "../src/index";
+
+interface DataModel {
+    posts: { _id: string; authorId: string; tenantId: string };
+}
+
+interface Relations {
+    posts: object;
+}
+
+/** A declared identity claim contract's inferred type. */
+interface Identity {
+    tenantId?: string;
+    userId: string;
+}
+
+const definePolicy = createPolicyDsl<DataModel, Relations, Identity>();
+
+describe("createPolicyDsl — identity-bound policy context", () => {
+    it("types ctx.auth.identity to the bound Identity contract", () => {
+        expect.assertions(1);
+
+        const policy = definePolicy({
+            on: "read",
+            table: "posts",
+            when: ({ auth }) => {
+                expectTypeOf(auth.identity).toEqualTypeOf<Identity | null | undefined>();
+
+                // Reading an undeclared claim off the typed identity must not compile.
+                // Wrapped in `expectTypeOf` (a call, not a bare member access) so the
+                // statement has effect; the access itself is the error `@ts-expect-error`
+                // expects (the errored access resolves to `any`).
+                // @ts-expect-error — `role` is not a claim on the bound Identity.
+                expectTypeOf(auth.identity?.role).toBeAny();
+
+                return auth.identity?.tenantId === undefined ? false : { tenantId: auth.identity.tenantId };
+            },
+        });
+
+        expect(policy.table).toBe("posts");
+    });
+
+    it("still defaults to the untyped claim bag when no Identity is bound", () => {
+        expect.assertions(1);
+
+        const untyped = createPolicyDsl<DataModel, Relations>();
+        const policy = untyped({
+            on: "read",
+            table: "posts",
+            when: ({ auth }) => {
+                // Default identity is the open Record — any claim key is readable.
+                expectTypeOf(auth.identity).toEqualTypeOf<Record<string, unknown> | null | undefined>();
+
+                return auth.identity?.["anything"] !== undefined;
+            },
+        });
+
+        expect(policy.on).toBe("read");
+    });
+});

--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -68,6 +68,7 @@ export default createConfig(
                         "__doc__",
                         "__name",
                         "__lunoraRef",
+                        "__lunoraIdentity",
                         "__lunoraVisibility",
                         "__lunoraProcedure",
                         "__lunoraCtx",

--- a/packages/server/src/identity.ts
+++ b/packages/server/src/identity.ts
@@ -1,0 +1,165 @@
+/**
+ * Identity contract authoring API — a **declared**, validated, typed claim
+ * contract for `ctx.auth.identity`.
+ *
+ * Identity in Lunora is not coupled to any one auth scheme: the runtime seam is
+ * `resolveIdentity(request, env)`, and whatever it returns becomes `ctx.auth`.
+ * Beyond `userId`, those claims are otherwise an untyped bag, so every RLS
+ * predicate and authorize hook reads custom claims (`tenantId`, `scopes`,
+ * `kind`, …) through unchecked casts.
+ *
+ * `defineIdentity({ ... })` declares the claim contract once — the single source
+ * of truth for the app's identity claim **type** *and* a **runtime validator** at
+ * the trust boundary (the worker validates a resolver's returned claims against
+ * the contract before they become `ctx.auth`). The `__lunoraIdentity` brand lets
+ * `@lunora/codegen` discover the declaration statically (like
+ * `defineSchema`/`defineShape`), and that emission is now wired end-to-end: the
+ * generated `_generated/server.ts` auto-narrows `ctx.auth.getIdentity()`, the RLS
+ * policy `ctx.auth.identity`, and the `authorizeShard`/`authorizeFanOut` identity
+ * to the declared shape (recovered by the `InferIdentity` helper over the
+ * contract's `typeof`), and `_generated/app.ts`
+ * imports the contract as a value and wires it onto the worker's `options.identity`
+ * so the runtime validation actually fires. You can still bind the type by hand
+ * with the `InferIdentity` helper (e.g. as the identity type parameter of a
+ * hand-written `createPolicyDsl`), but with codegen it happens for you.
+ *
+ * The contract is built on `@lunora/values` validators — the same codec/
+ * validation machinery every `v.*` arg map uses — rather than the replication
+ * `defineShape` API (which describes a table+predicate, not a claim record).
+ *
+ * The claim map must declare a required string `userId`; the inferred type is
+ * constrained to extend `{ userId: string }`, so an app that forgets it fails to
+ * typecheck. Every other claim should be `v.optional(...)` unless the boundary
+ * validation truly guarantees it — a required-but-absent claim read inside an
+ * RLS predicate is a runtime footgun the validation is here to close.
+ *
+ * Declare exactly one `defineIdentity(...)` co-located with the app config
+ * (alongside `defineSchema` / `.auth()`). Zero declarations keeps the identity
+ * an untyped bag — fully backward compatible.
+ */
+
+import type { InferValidatorMap, ValidatorMap } from "@lunora/values";
+import { parseValidatorMap, ValidationError } from "@lunora/values";
+
+/**
+ * Validator kinds whose inferred type is concretely NOT a string — a `userId`
+ * declared with any of these violates the `{ userId: string }` contract. Denied
+ * (rather than allow-listing "string") so every string-typed kind — `string`,
+ * `storage`, branded `id`, and string `literal`/`union` — still passes.
+ * `optional` is included because a required claim cannot be absent.
+ */
+const NON_STRING_USER_ID_KINDS = new Set<string>([
+    "array",
+    "bigint",
+    "boolean",
+    "bytes",
+    "date",
+    "null",
+    "number",
+    "object",
+    "optional",
+    "record",
+    "timestamp",
+]);
+
+/**
+ * What the worker does with a resolver's identity when it fails contract
+ * validation (a forged / malformed claim set arriving from an untrusted token).
+ * `"anonymous"` (default, safe) treats the request as anonymous, so the bad
+ * identity never reaches a policy as a valid identity (`ctx.auth.userId`
+ * becomes `undefined`). `"reject"` fails the request closed (a `401`) — use
+ * when a malformed credential should be a hard error, not a silent downgrade.
+ */
+export type IdentityRejectMode = "anonymous" | "reject";
+
+/** Options for {@link defineIdentity}. */
+export interface DefineIdentityOptions {
+    /**
+     * How to handle a resolver identity that violates the contract at the trust
+     * boundary. Defaults to `"anonymous"` (a forged claim set is downgraded to
+     * anonymous rather than flowing in as an unchecked cast).
+     */
+    readonly onInvalid?: IdentityRejectMode;
+}
+
+/** Result of validating a candidate identity against the contract. */
+export type IdentityValidation = { ok: true } | { error: string; ok: false };
+
+/**
+ * A declared identity claim contract. Carries the codegen discovery brand, the
+ * declared claim validators, the reject policy, and a runtime `validate`. The
+ * `TClaims` type parameter is the inferred claim shape (always extending
+ * `{ userId: string }`); it is phantom (no runtime field) and exists so
+ * `@lunora/codegen` and {@link InferIdentity} can recover the type.
+ */
+export interface IdentityContract<TClaims extends { userId: string } = { userId: string }> {
+    /**
+     * Phantom carrier for the inferred claim type. Never populated at runtime
+     * (`undefined`); present only so the type flows to codegen / {@link InferIdentity}.
+     */
+    readonly __claimType?: TClaims;
+
+    readonly __lunoraIdentity: true;
+
+    /** The declared claim validators (a `@lunora/values` validator map). */
+    readonly claims: ValidatorMap;
+
+    /** Reject policy applied at the trust boundary. See {@link IdentityRejectMode}. */
+    readonly onInvalid: IdentityRejectMode;
+
+    /**
+     * Validate a resolver's returned identity against the declared claims. On
+     * success the caller keeps the original identity untouched (so undeclared
+     * claims are forwarded verbatim, preserving today's behaviour); on failure
+     * the worker applies the `onInvalid` policy.
+     */
+    validate: (identity: Record<string, unknown>) => IdentityValidation;
+}
+
+/** Recover the declared claim type from a {@link defineIdentity} contract. */
+export type InferIdentity<T> = T extends IdentityContract<infer TClaims> ? TClaims : never;
+
+/**
+ * Declare the identity claim contract. `claims` is a `@lunora/values` validator
+ * map whose inferred type must extend `{ userId: string }` — if it does not
+ * (e.g. `userId` is missing or not a required string), the argument type
+ * collapses to `never` and the call fails to typecheck.
+ * @example
+ * export const identity = defineIdentity({ userId: v.string(), tenantId: v.optional(v.string()), scopes: v.optional(v.array(v.string())) });
+ */
+export const defineIdentity = <A extends ValidatorMap>(
+    claims: InferValidatorMap<A> extends { userId: string } ? A : never,
+    options: DefineIdentityOptions = {},
+): IdentityContract<InferValidatorMap<A> & { userId: string }> => {
+    const map = claims as A;
+
+    // The compile-time guard (`InferValidatorMap<A> extends { userId: string }`) already
+    // rejects a missing / optional / non-string `userId`, but harden the runtime too: a
+    // caller who casts past the type (or builds the map dynamically) must still declare a
+    // required string — reject any concretely non-string validator kind (see
+    // {@link NON_STRING_USER_ID_KINDS}).
+    const userIdValidator = map["userId"];
+
+    if (userIdValidator === undefined || NON_STRING_USER_ID_KINDS.has(userIdValidator.kind)) {
+        throw new Error("defineIdentity: the claim map must declare a required string `userId` validator (e.g. `v.string()` or `v.id(...)`)");
+    }
+
+    const onInvalid: IdentityRejectMode = options.onInvalid ?? "anonymous";
+
+    // Validation is an allow-list over the *declared* claims: each declared validator must
+    // pass, but undeclared claims are passed through untouched (parseValidatorMap only
+    // iterates the map). So `ctx.auth.identity` is narrowed and validated for declared
+    // fields, but bracket-access consumers reading an undeclared claim
+    // (`identity["x"]`, `authorizeShard`) should treat those as still-untrusted.
+    const validate = (identity: Record<string, unknown>): IdentityValidation => {
+        try {
+            parseValidatorMap(map, identity, "identity");
+
+            return { ok: true };
+        } catch (error: unknown) {
+            return { error: error instanceof ValidationError ? error.message : String(error), ok: false };
+        }
+    };
+
+    return { __lunoraIdentity: true, claims: map, onInvalid, validate };
+};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,8 @@ export type {
     LunoraRouteHandler,
 } from "./http";
 export { httpAction, httpRoute, httpRouter, serveStorageObject } from "./http";
+export type { DefineIdentityOptions, IdentityContract, IdentityRejectMode, IdentityValidation, InferIdentity } from "./identity";
+export { defineIdentity } from "./identity";
 export type { LifecycleHandler } from "./lifecycle";
 export { onConnect, onDisconnect } from "./lifecycle";
 export type { MaskColumns, MaskContext, MaskFn, MaskOptions, MaskPolicies, MaskStrategy } from "./mask/index";

--- a/packages/server/src/rls/define.ts
+++ b/packages/server/src/rls/define.ts
@@ -23,9 +23,12 @@ export const definePolicy = <Context = unknown>(input: DefinePolicyInput<Context
  * discovered identically by the `rls()` chain.
  */
 export const createPolicyDsl =
-    <DM, REL extends Record<keyof DM, object>>() =>
-    <T extends keyof DM, Context = unknown>(input: TypedDefinePolicyInput<DM, REL, T, Context>): Policy<Context> => {
-        return { on: input.on, table: input.table as string, when: input.when };
+    <DM, REL extends Record<keyof DM, object>, Identity = Record<string, unknown>>() =>
+    <T extends keyof DM, Context = unknown>(input: TypedDefinePolicyInput<DM, REL, T, Context, Identity>): Policy<Context> => {
+        // `when`'s identity param is erased at the stored-policy boundary (the
+        // middleware builds `PolicyContext` from the request); the narrowed
+        // `Identity` is a compile-time-only authoring aid, like `table as string`.
+        return { on: input.on, table: input.table as string, when: input.when as Policy<Context>["when"] };
     };
 
 /**

--- a/packages/server/src/rls/types.ts
+++ b/packages/server/src/rls/types.ts
@@ -67,10 +67,10 @@ export type PolicyDecisionOf<DM, REL extends Record<keyof DM, object>, T extends
  * unknown table, a stray column, or a relation predicate naming a relation the
  * table does not declare is a compile error rather than a silent runtime deny.
  */
-export interface TypedDefinePolicyInput<DM, REL extends Record<keyof DM, object>, T extends keyof DM, Context = unknown> {
+export interface TypedDefinePolicyInput<DM, REL extends Record<keyof DM, object>, T extends keyof DM, Context = unknown, Identity = Record<string, unknown>> {
     on: PolicyOperation;
     table: T;
-    when: (context: PolicyContext<Context>) => PolicyDecisionOf<DM, REL, T>;
+    when: (context: PolicyContext<Context, Identity>) => PolicyDecisionOf<DM, REL, T>;
 }
 
 /**
@@ -82,7 +82,7 @@ export interface TypedDefinePolicyInput<DM, REL extends Record<keyof DM, object>
  * pre-write row; for `insert` it is the candidate document. `ctx` is the full
  * procedure context the middleware closed over.
  */
-export interface PolicyContext<Context = unknown> {
+export interface PolicyContext<Context = unknown, Identity = Record<string, unknown>> {
     readonly auth: {
         /**
          * `true` when any of the request's `roles` grants `permission` (passed
@@ -91,7 +91,14 @@ export interface PolicyContext<Context = unknown> {
          * when none of the request's roles lists the permission.
          */
         readonly can: (permission: Permission | string) => boolean;
-        readonly identity?: Record<string, unknown> | null;
+
+        /**
+         * The resolved identity, typed to the `Identity` type parameter bound on
+         * `createPolicyDsl` — e.g. the app's `defineIdentity(...)` claim type via
+         * the `InferIdentity` helper; otherwise the untyped claim bag.
+         * `undefined`/`null` when the request is anonymous.
+         */
+        readonly identity?: Identity | null;
         readonly roles: ReadonlyArray<string>;
         readonly userId: null | string;
     };

--- a/plans/091-auth-cookie-cache-default.md
+++ b/plans/091-auth-cookie-cache-default.md
@@ -1,0 +1,306 @@
+# Plan 091: Make authenticated calls skip the D1 session read by default (cookie-cache)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat c490bad..HEAD -- packages/auth/src/create-auth.ts packages/auth/src/session.ts`
+> If either file changed since this plan was written, compare the "Current
+> state" excerpts against the live code before proceeding; on a mismatch,
+> treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: perf
+- **Planned at**: commit `c490bad`, 2026-07-01
+
+## Why this matters
+
+Every authenticated Lunora call ultimately resolves identity through
+better-auth's `getSession`, and better-auth backs sessions in D1. Without a
+session cookie cache, **each `getSession` is a D1 read** — added to the latency
+of every query/mutation/action that reads `ctx.auth`, and to the WebSocket
+upgrade handshake. On the "runs on your Cloudflare account" pitch, D1 latency is
+the caller's latency; a per-request session read is the most common avoidable
+cost in the auth hot path.
+
+better-auth already solves this with `session.cookieCache`: a short-lived,
+signed cookie that carries the session payload so `getSession` can return
+without hitting the database until the cache window elapses. `@lunora/auth`
+**documents** this lever (`session.ts:17`) but never enables it — so the
+out-of-the-box experience, and even the recommended `sessionPresets`, pay the
+D1 read on every call.
+
+This plan turns cookie-cache on for the common path, exactly the way
+`@lunora/auth` already fills other smart defaults (secure cookies in
+`hardenAuthOptions`; `rateLimit.enabled: true` in `createAuth`) — filled only
+when the caller has not made an explicit choice, forwarded verbatim otherwise.
+The one real tradeoff (a revoked session stays valid until the cache window
+expires) is bounded by a short TTL and documented; the security-sensitive
+`strict` preset opts out.
+
+## Current state
+
+- `packages/auth/src/session.ts` — `sessionPresets` (lines ~75–90) defines
+  `rolling` / `strict` / `longLived`. **None sets `cookieCache`.** The doc block
+  above it (line 17) already names `cookieCache` as "opt-in signed-cookie
+  session cache to skip DB reads" — so the concept is known here, just unused.
+
+    ```ts
+    const sessionPresets: Record<"longLived" | "rolling" | "strict", SessionPolicy> = {
+        longLived: { expiresIn: 30 * DAY, freshAge: DAY, updateAge: DAY },
+        rolling: { expiresIn: 7 * DAY, freshAge: DAY, updateAge: DAY },
+        strict: { expiresIn: HOUR, freshAge: 5 * MINUTE, updateAge: 15 * MINUTE },
+    };
+    ```
+
+- `packages/auth/src/create-auth.ts` — `createAuth` (line 153). It already
+  establishes the "fill a default only when the caller was silent" pattern for
+  `rateLimit` (the block ending ~line 195):
+
+    ```ts
+    const resolvedOptions: LunoraAuthOptions =
+        hardened.rateLimit?.enabled === undefined ? { ...hardened, rateLimit: { ...hardened.rateLimit, enabled: true } } : hardened;
+
+    return betterAuth(resolvedOptions);
+    ```
+
+    and the `hardenAuthOptions` helper (lines 66–108) does the same for cookie
+    attributes (`?? { httpOnly, path, sameSite }`). There is **no** equivalent
+    default for `session.cookieCache`.
+
+- `grep -rn "cookieCache" packages/auth/src` returns exactly one hit — the doc
+  comment in `session.ts`. Confirming it is set nowhere today.
+
+## Commands you will need
+
+| Purpose          | Command                                       | Expected on success      |
+| ---------------- | --------------------------------------------- | ------------------------ |
+| Build deps first | `pnpm run build:packages`                     | exit 0 (run once)        |
+| Typecheck        | `pnpm --filter "@lunora/auth" run lint:types` | exit 0, no errors        |
+| Tests            | `pnpm --filter "@lunora/auth" run test`       | all pass, incl. new test |
+| Lint             | `pnpm run lint:eslint`                        | exit 0 (0 errors)        |
+
+> `dist/` is gitignored and built on demand; a raw per-package test does not
+> rebuild workspace deps. Run `pnpm run build:packages` once before the first
+> typecheck/test so cross-package `@lunora/*` types resolve.
+
+## Design decisions (settle before coding)
+
+1. **Default TTL**: `cookieCache.maxAge = 60` (seconds). Long enough to erase
+   the per-request D1 read for a burst of calls; short enough that a revoked or
+   role-changed session self-corrects within a minute. This is the value the
+   `createAuth` default and the `rolling` / `longLived` presets use.
+2. **`strict` opts out**: the `strict` preset sets `cookieCache: { enabled: false }`.
+   Its whole point is fast revocation / short freshness; a cache would undercut
+   that. Keeping it explicit (rather than absent) documents the intent and
+   prevents the `createAuth` default from re-enabling it.
+3. **`createAuth` fills the default only when the caller was silent about
+   `session.cookieCache`** — mirror the `rateLimit.enabled === undefined` gate
+   exactly. If the caller passed _any_ `cookieCache` (including
+   `{ enabled: false }`), forward it verbatim. If the caller passed a `session`
+   block without `cookieCache`, still fill the cache default (they opted into a
+   policy, not out of the cache). Concretely: default applies when
+   `resolved.session?.cookieCache === undefined`.
+4. **No new public API.** This is defaults + presets only. `cookieCache` remains
+   configurable through the existing `session` option; we are choosing its
+   default value, not adding a surface.
+
+> If any of these four cannot hold against the live better-auth types (e.g.
+> `cookieCache` is not a valid `session` sub-key in the pinned better-auth
+> version), that is a STOP condition — report the actual `SessionPolicy` shape.
+
+## Scope
+
+**In scope** (the only files you should modify):
+
+- `packages/auth/src/session.ts` — add `cookieCache` to the presets per the
+  decisions above; extend the doc block if needed.
+- `packages/auth/src/create-auth.ts` — add the `cookieCache` default to
+  `resolvedOptions`, gated on caller silence, next to the `rateLimit` default.
+- `packages/auth/__tests__/create-auth.test.ts` and/or
+  `packages/auth/__tests__/session.test.ts` — add regression tests (see Test plan).
+
+**Out of scope** (do NOT touch, even though they look related):
+
+- The `jwt` / stateless-verification path (`packages/auth/src/plugins.ts`) — a
+  separate, larger tradeoff; not this plan.
+- `hardenAuthOptions`' cookie-attribute logic — unrelated; leave as is.
+- Any runtime/DO identity-forwarding code — the cache is entirely inside
+  better-auth's `getSession`; no worker change is needed.
+- The `ctx.auth` codegen binding and the advisor lint (see "Follow-ups").
+
+## Git workflow
+
+- Branch: `advisor/091-auth-cookie-cache-default` (or match the repo's
+  convention if one is evident in `git branch`).
+- Commit message: Angular conventional commits, e.g.
+  `perf(auth): default a short-lived session cookie cache to skip the D1 read`.
+  (Enforced commit types include `perf`.)
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 0 (blocking): Verify the better-auth `session.cookieCache` API
+
+**Do this before writing any code.** The entire plan assumes better-auth
+(`^1.6.22`, per `pnpm-workspace.yaml`) exposes a session cookie cache at
+`session.cookieCache` with `{ enabled: boolean; maxAge: number }` (seconds).
+That shape was **not** verified when this plan was written — better-auth is not
+installed in a fresh clone, and the version postdates the plan author's
+reference knowledge. If it is wrong, Steps 1–3 are wrong.
+
+Verify against the installed types, not from memory:
+
+```bash
+pnpm install   # if node_modules is absent
+# Inspect the real SessionPolicy / session-option type:
+grep -rn "cookieCache" node_modules/better-auth/dist/**/*.d.ts | head
+# Or open the type of BetterAuthOptions["session"] in an editor / ts probe.
+```
+
+Confirm three things and record them at the top of the PR description:
+
+1. The key is `session.cookieCache` (not e.g. `advanced.cookieCache` or a
+   top-level option).
+2. Its fields are `enabled` and `maxAge`, and `maxAge` is in **seconds**
+   (historically better-auth defaulted `maxAge` to `300`; confirm the current
+   default so `60` is a deliberate lowering, not a guess).
+3. `cookieCache` is assignable within the `session` object that
+   `@lunora/auth`'s `SessionPolicy` (`= NonNullable<BetterAuthOptions["session"]>`)
+   already forwards verbatim.
+
+**If any of the three does not hold → STOP** and report the real shape. The rest
+of the plan (preset keys, the `createAuth` default gate, the tests) must then be
+rewritten to the actual API before proceeding. Do not adapt on the fly.
+
+### Step 1: Add `cookieCache` to the presets
+
+In `packages/auth/src/session.ts`, give `rolling` and `longLived` a
+`cookieCache: { enabled: true, maxAge: 60 }`, and `strict`
+`cookieCache: { enabled: false }`. Update the preset doc lines so the
+one-line descriptions mention the cache posture (e.g. "rolling — … 60s cookie
+cache").
+
+**Verify**: `pnpm --filter "@lunora/auth" run lint:types` → exit 0. If
+`cookieCache` is not assignable to `SessionPolicy`, STOP (decision 4 note).
+
+### Step 2: Default the cache in `createAuth` when the caller is silent
+
+In `packages/auth/src/create-auth.ts`, extend the `resolvedOptions`
+construction so that, in addition to the existing `rateLimit` default, it fills
+`session.cookieCache` when `resolved.session?.cookieCache === undefined`. Keep
+the caller's `session` fields otherwise verbatim. Add a comment mirroring the
+existing `rateLimit` rationale block: why a cache (skip the per-request D1
+read), the bounded-staleness tradeoff, and how to opt out
+(`session: { cookieCache: { enabled: false } }`).
+
+Do the `rateLimit` fill and the `cookieCache` fill in one composed object; do
+not reshape `session` in a way that narrows better-auth's inferred `Auth<…>`
+type away from `LunoraAuth` (the file already warns about this for the
+pass-through).
+
+**Verify**: `pnpm --filter "@lunora/auth" run lint:types` → exit 0.
+
+### Step 3: Tests
+
+Add regression tests asserting:
+
+- `createAuth({ secret, database })` (no `session`) yields options whose
+  `session.cookieCache.enabled === true` and `maxAge === 60`.
+- A caller-supplied `session: { cookieCache: { enabled: false } }` is forwarded
+  verbatim (the default does NOT re-enable it).
+- A caller-supplied `session: { expiresIn: … }` **without** `cookieCache` still
+  gets the cache default filled.
+- `sessionPresets.strict.cookieCache.enabled === false`; `rolling` and
+  `longLived` have `enabled: true, maxAge: 60`.
+
+Reuse the existing harness in the auth `__tests__` dir (find how `createAuth` is
+already asserted against — e.g. how the `rateLimit` default is tested — and
+mirror it; do not invent a new betterAuth mock if one exists).
+
+**Verify**: `pnpm --filter "@lunora/auth" run test` → all pass.
+
+## Test plan
+
+- Unit tests as in Step 3, colocated with the existing `createAuth` / session
+  assertions.
+- Manual (optional, not gating): in `apps/playground`, sign in and confirm the
+  session cookie now carries a cache segment and that repeated authenticated
+  reads within the TTL do not emit a D1 session query in the dev logs. Documented
+  here as a sanity check, not a CI gate.
+
+## Done criteria
+
+Machine-checkable. ALL must hold:
+
+- [ ] Step 0 completed: the real `session.cookieCache` shape (`enabled`/`maxAge`,
+      seconds) is confirmed against the installed better-auth types and noted in
+      the PR description; if it differed from the assumption, the plan was
+      rewritten to the actual API before coding.
+- [ ] `pnpm --filter "@lunora/auth" run lint:types` exits 0.
+- [ ] `pnpm --filter "@lunora/auth" run test` exits 0; new tests pass.
+- [ ] `pnpm run lint:eslint` exits 0.
+- [ ] `grep -n "cookieCache" packages/auth/src/create-auth.ts` shows the default
+      is set (not just referenced in a comment).
+- [ ] `grep -n "cookieCache" packages/auth/src/session.ts` shows all three
+      presets carry an explicit `cookieCache`.
+- [ ] No files outside the in-scope list are modified (`git status`).
+- [ ] `plans/README.md` status row updated.
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- `cookieCache` is not a valid key on the pinned better-auth `session` option
+  type (the pass-through would not typecheck) — report the real shape.
+- An existing test asserts that `getSession` always hits the database / that no
+  cookie cache is present — that would mean something downstream depends on the
+  uncached read, and enabling it needs wider discussion.
+- Enabling the cache breaks an auth e2e (`tests/e2e/tests/auth.spec.ts`) around
+  sign-out / revocation — the revocation-latency tradeoff may be load-bearing in
+  a test and needs a decision on TTL rather than a silent change.
+
+## Maintenance notes
+
+- If a future security requirement needs immediate revocation everywhere, the
+  answer is per-deployment `session: { cookieCache: { enabled: false } }` (or
+  the `strict` preset), not removing the default — most apps want the cache.
+- Reviewer should confirm the default is gated on caller silence (decision 3),
+  so a caller who explicitly disabled the cache is never overridden.
+
+## Follow-ups (NOT in this plan — sequenced after it)
+
+These are the DX half of "smooth + fast auth"; each is its own plan, filed
+separately so this perf win can land on its own:
+
+- **092 — generic typed identity layer (`plans/092-typed-identity-layer.md`).**
+  A _declared_ claim contract (`defineIdentity`) that codegen reads the same way
+  it reads `defineSchema`, plus `composeResolvers` for ordered resolver
+  composition. `ctx.auth.identity`, RLS predicates, and the
+  `authorizeShard`/`authorizeFanOut` hooks all narrow to the declared type, and
+  resolver output is validated at the trust boundary. Scheme-agnostic — not
+  coupled to better-auth. (Static plugin-introspection — the old framing — is
+  demoted to an optional Phase 3 spike; the declared contract is authoritative.)
+  L for Phase 1+2; touches `@lunora/server` + `@lunora/codegen` + `@lunora/runtime`.
+- **094 — advisor lint `auth_session_read_without_cache`.** Lives as the
+  "Follow-on 094" section inside `plans/092-typed-identity-layer.md` (not a
+  separate file). Static lint (splinter-style, like `index_utilization`) that
+  flags an authenticated function resolving identity when the deployment has
+  neither a session `cookieCache` nor the `jwt` plugin — i.e. "every call hits
+  D1." Small; **it builds its own `createAuth`-config reader** (neither this plan
+  nor 092 produces one) and is gated on 091's cookie-cache default existing on
+  `alpha`. Pairs naturally with this plan: 091 sets the good default, 094 catches
+  the case where a caller disabled it and still reads identity on a hot path.
+- **Auto-derive `.shardBy` from tenant claim** — let a table opt into
+  `.shardBy(ctx => ctx.auth.identity.tenantId)` (typed once 092 Phase 1 lands, so
+  the tenant claim is a real field) so tenant isolation follows auth without
+  hand-wiring. Depends on 092's typed `ctx.auth.identity`. Scope carefully — it
+  crosses the RLS/shard security boundary, so it should carry a STOP condition
+  like the Wave 4 sync-engine plans.

--- a/plans/092-typed-identity-layer.md
+++ b/plans/092-typed-identity-layer.md
@@ -1,0 +1,373 @@
+# Plan 092: Generic typed identity layer — declared claim contract + resolver composition
+
+> **Executor instructions**: This plan has three phases. **Phase 1 and Phase 2
+> are implementation plans** (executor-ready). **Phase 3 is an optional spike**
+> (the old better-auth-plugin-introspection idea, now demoted to convenience
+> sugar). Do Phase 1, then Phase 2; do Phase 3 only if someone asks for it. On
+> any STOP condition, stop and report. Update the `plans/README.md` row when done.
+>
+> **Numbering note**: the `auth_session_read_without_cache` lint is the
+> "Follow-on 094" section at the end of this file (not a separate file).
+>
+> **Drift check (run first)**: `git diff --stat c490bad..HEAD -- packages/server/src/types.ts packages/runtime/src/create-worker.ts packages/codegen/src/emit.ts packages/server/src/schema.ts`
+> If any changed, re-verify the "Current state" excerpts before proceeding.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L (Phase 1+2) · XL if Phase 3 is attempted
+- **Risk**: MEDIUM (Phase 1+2 are declared, not inferred — the old HIGH-risk
+  introspection is now optional Phase 3)
+- **Depends on**: none (unblocks the `.shardBy(ctx => ctx.auth.identity.*)` follow-up)
+- **Category**: dx / codegen / auth
+- **Planned at**: commit `c490bad`, 2026-07-01 (reframed from a plugin-introspection spike)
+
+## Why this matters — and why _generic_
+
+Identity in Lunora is **not** coupled to better-auth. The runtime seam is
+`resolveIdentity(request, env) => ResolvedIdentity | null`
+(`create-worker.ts:784`); whatever it returns _becomes_ `ctx.auth`. better-auth
+is one implementation of that function (`.auth()` auto-wires it), but a site's
+real auth is often a mix: session login on one route, a signed preview/magic
+link on another, per-tenant bearer tokens on a third, mTLS or an upstream JWT
+somewhere else. better-auth's plugin surface does not — and should not — cover
+those. The identity layer must be **generic for all cases**: any scheme that can
+produce a `userId` plus claims should flow into the same typed `ctx.auth`, RLS
+policies, and `authorizeShard`/`authorizeFanOut` hooks.
+
+Two gaps stop that today:
+
+1. **Claims are untyped.** Beyond `userId`, `getIdentity()` returns
+   `Record<string, unknown>`, so every RLS predicate and authorize hook reads
+   custom claims (`tenantId`, `scopes`, `kind`) through unchecked casts. "Auth is
+   part of the type system" fails exactly where apps put their bespoke logic.
+2. **Composition is DIY.** Combining several resolvers (session + token + magic
+   link, or a per-route map) means hand-wrapping `derived.resolveIdentity`
+   through the builder escape hatch. It works (`examples/blog`,
+   `examples/auth-playground`, `examples/offline-rejections` all set
+   `resolveIdentity`), but there is no first-class, ordered, validated way to say
+   "try these verifiers in order."
+
+The generic answer is two declared primitives, plus one optional convenience:
+
+- **`defineIdentity(shape)`** — declare the claim contract once. It is the single
+  source of truth for `ctx.auth.identity`'s type _and_ a runtime validator at the
+  trust boundary. Because it is **declared, not inferred**, codegen reads it as
+  reliably as `defineSchema` — which dissolves the entire introspection cliff the
+  earlier version of this plan was built around (see "What changed").
+- **`composeResolvers([...])`** — ordered, first-match-wins composition of
+  `IdentityResolver`s, each validated against the `defineIdentity` shape. Generic
+  over every scheme; the better-auth session resolver is just one entry.
+- **(Phase 3, optional) better-auth plugin inference** — sugar that _contributes_
+  better-auth's session claim shape into the contract so you needn't re-declare
+  it. Optional because the declared contract is authoritative; if inference can't
+  resolve, you declare those fields yourself. No correctness cliff.
+
+## What changed from the introspection framing (why this is safer)
+
+The prior version made `ctx.auth` typing depend on statically discovering which
+better-auth plugins were enabled — which the review showed fails on the repo's
+own auth example (`createAuth({ ...options(env) })` spreads a helper's return,
+defeating static AST; runtime import risked the Kysely `$context` hang). By
+making the **declared contract** the primary source of truth, that whole risk
+class moves to optional Phase 3. Phase 1+2 never introspect anything: they read a
+`defineIdentity(...)` call the same way codegen already reads `defineSchema(...)`.
+
+## Current state (verified at `c490bad`)
+
+- `packages/runtime/src/create-worker.ts:96` — `ResolvedIdentity` is already
+  generic: `{ userId: string; exp?: number; expiresAtMs?: number; [key: string]: unknown }`
+  — arbitrary JSON claims plus native credential expiry (the WS path drops the
+  socket at `expiresAtMs`). The runtime shape needs no change; it needs a _type_
+  and a _validator_.
+- `create-worker.ts:784` `resolveIdentity`, `:1042` `resolveForwardContext`
+  (strips client `x-lunora-*`, re-injects verified headers — server-authoritative),
+  `:559` `authorizeFanOut(identity, …)`, `:577` `authorizeShard(identity, shardKey)`.
+  These are the generic consumers that should all see the declared claim type.
+- `packages/server/src/types.ts:662` — `AuthState` = `{ getIdentity(): Promise<Record<string, unknown> | null>; userId: string | null }`.
+  The `Record<string, unknown>` is what Phase 1 narrows to the declared shape.
+- `packages/codegen/src/emit.ts:3179`, `emit-app.ts:379,407` — ctx-build sites
+  emit `auth: { identity, userId }`; only the _type_ of `identity` is generic.
+- `define*` conventions already present: `defineSchema`, `defineTable`,
+  `defineShape`, `definePolicy`, `defineMutator`, `defineMigration`,
+  `defineSchemaExtension` (`packages/server/src/index.ts:48,82`). `defineIdentity`
+  slots into this family, and **reuses `defineShape`** for the claim schema so it
+  inherits the existing codec/validation machinery rather than inventing one.
+- The builder escape hatch (`examples/offline-rejections/lunora/_generated/app.ts:44`)
+  passes `derived` so callers "compose rather than clobber — e.g. wrap
+  `derived.resolveIdentity` instead of replacing it." Phase 2 makes that a
+  first-class helper instead of a comment.
+
+## Phase 1 — `defineIdentity`: the declared, validated, typed claim contract
+
+**Goal**: one declaration types `ctx.auth.identity` everywhere and validates
+resolver output at the boundary. Nothing scheme-specific.
+
+Design:
+
+- `defineIdentity(shape)` where `shape` is a `defineShape`-style contract whose
+  inferred type extends `{ userId: string }`. It yields (a) the TS type for
+  `ctx.auth.identity`, and (b) a runtime parse/validate function.
+- **Where declared**: co-located with the app config (alongside `defineSchema` /
+  `.auth()`), so codegen picks it up statically. Exactly one per app; zero → the
+  identity stays `Record<string, unknown>` (fully backward compatible).
+- **Codegen**: emit the identity type into `_generated/server.ts` and narrow
+  `getIdentity(): Promise<TIdentity | null>`, plus the `identity` parameter of
+  `authorizeShard`/`authorizeFanOut` and the `ctx.auth.identity` seen by
+  `definePolicy` (RLS). All additive: with no `defineIdentity`, output is
+  byte-identical to today.
+- **Runtime validation (the trust-boundary win)**: `resolveForwardContext`
+  validates the resolver's returned claims against the contract before they
+  become `ctx.auth`. Claims arrive from untrusted tokens; a forged/malformed set
+  is rejected (treated as anonymous, or a 401 per a declared policy) rather than
+  flowing in as an unchecked cast. This is a generic security property, not a
+  per-app feature. **Decide**: reject-to-anonymous vs. reject-to-401, and make it
+  configurable on `defineIdentity`.
+- Fields must stay honest: every claim beyond `userId` is optional unless the
+  contract _and_ validation guarantee it — a required-but-absent claim inside an
+  RLS predicate is the same class of bug the review flagged. Validation makes
+  "required" safe here (unlike inference), because the boundary enforces it.
+
+Phase 1 is executor-plannable: it reads a declaration (no introspection), emits a
+type, and adds a validation call at one seam.
+
+## Phase 2 — `composeResolvers`: generic ordered composition
+
+> **Shipped naming**: these combinators landed as `composeIdentityResolvers` /
+> `routeIdentityResolvers` (not the bare `composeResolvers` / `routeResolvers`
+> below) to avoid a name clash with `@lunora/cloudflare-access`'s existing
+> variadic `composeResolvers`. The design is otherwise as specified here.
+
+**Goal**: combine any number of verifiers, generically, with the better-auth
+resolver as one participant.
+
+Design:
+
+- `type IdentityResolver = (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null` (matches the existing `resolveIdentity` signature).
+- `composeResolvers(resolvers: IdentityResolver[]): IdentityResolver` — first
+  non-null wins; short-circuits; errors from one resolver are contained per a
+  declared policy (skip-and-continue vs. fail-closed — **decide**, default
+  fail-closed for safety). Output validated against the Phase 1 contract.
+- Thin generic helper for the per-route case, built _on_ composition, not beside
+  it: `routeResolvers({ "/admin": r1, "/partner": r2, "*": rDefault })` → picks by
+  `new URL(request.url).pathname`. Still generic (route→resolver map); no
+  portal/preview/tenant concepts baked in — those live in the app's resolvers.
+- The better-auth session resolver (from `.auth()`) is obtained via the existing
+  `derived.resolveIdentity` escape hatch and dropped into the list like any other
+  entry, so composition never means losing better-auth.
+
+Phase 2 is executor-plannable and independent of codegen; it is small runtime +
+types + tests.
+
+## Phase 3 (optional spike) — better-auth plugin inference as convenience
+
+Only if requested. Infer better-auth's session claim shape (from enabled
+`organization`/`admin`/… plugins) and _merge_ it into the `defineIdentity`
+contract so the app needn't re-declare those fields. This is the old spike, with
+its risks intact (static AST defeated by spread configs; runtime import vs. the
+Kysely `$context` hang) — but now **non-blocking**: if inference can't resolve,
+the caller declares those claims in `defineIdentity` and nothing is typed
+_wrongly_. Keep the fail-safe: inference may only _widen_ toward the declared
+contract, never contradict it. Verdict-driven, like plan 063.
+
+## Commands you will need
+
+| Purpose          | Command                                                             | Expected          |
+| ---------------- | ------------------------------------------------------------------- | ----------------- |
+| Build deps first | `pnpm run build:packages`                                           | exit 0 (run once) |
+| Typecheck        | `pnpm --filter "@lunora/{server,codegen,runtime}" run lint:types`   | exit 0            |
+| Tests            | `pnpm --filter "@lunora/{server,codegen,runtime}" run test`         | pass incl. new    |
+| Codegen timing   | `LUNORA_CODEGEN_TIMING=1 pnpm --filter apps/playground run codegen` | prints split      |
+| Lint             | `pnpm run lint:eslint`                                              | exit 0            |
+
+## Git workflow
+
+- Branch: `advisor/092-typed-identity-layer`.
+- Commits: `feat(server): defineIdentity claim contract` (P1),
+  `feat(auth): composeResolvers + routeResolvers` (P2). Angular conventional.
+- Do NOT push or open a PR unless instructed.
+
+## Scope
+
+**In scope (Phase 1+2):**
+
+- `packages/server/src/*` — `defineIdentity` (reusing `defineShape`); export it
+  from the `define*` barrel.
+- `packages/codegen/src/*` — discover the single `defineIdentity(...)` decl (like
+  `defineSchema`), emit `TIdentity` into `_generated/server.ts`, narrow
+  `getIdentity` + the authorize-hook + policy ctx types.
+- `packages/runtime/src/create-worker.ts` — validate resolver output against the
+  contract in `resolveForwardContext`; ship `composeResolvers` / `routeResolvers`
+  (or place these in `@lunora/auth` if that is the better home — decide, but keep
+  them scheme-agnostic).
+- Tests for the contract typing, the validation boundary, and composition order.
+
+**Out of scope:**
+
+- Phase 3 inference unless explicitly requested.
+- The cookie-cache lint (094 section below) and cookie-cache default (091).
+- Any specific scheme (preview links, tenant tokens, portals) — those are docs
+  examples of using these primitives, never features in the framework.
+
+## Done criteria (Phase 1+2)
+
+- [ ] With no `defineIdentity`, generated output for `apps/playground` is
+      byte-identical to pre-change (backward compatible).
+- [ ] With a `defineIdentity({ userId, tenantId, scopes, kind })`, `ctx.auth.identity`,
+      `authorizeShard`'s `identity`, and RLS policy ctx are all typed to it — a
+      test asserts a wrong claim access fails typecheck.
+- [ ] Resolver output that violates the contract is rejected at the boundary
+      (test: forged/missing claim → anonymous or 401 per config, never reaches a
+      policy as a valid identity).
+- [ ] `composeResolvers` first-match-wins + error policy proven by test;
+      `routeResolvers` dispatches by path; the better-auth resolver composes via
+      `derived.resolveIdentity` without being clobbered.
+- [ ] `lint:types`, package tests, and `pnpm run lint:eslint` exit 0.
+- [ ] `plans/README.md` row updated.
+
+## STOP conditions
+
+- `defineShape`'s inference cannot express "extends `{ userId: string }` with
+  arbitrary extra claims" cleanly → report; the contract may need its own light
+  type rather than reusing `defineShape` wholesale.
+- Narrowing `getIdentity()`'s return breaks an existing `@lunora/server` /
+  RLS-middleware consumer of the bare `Record<string, unknown>` → verify against
+  those tests before shipping (the index signature should keep it compatible).
+- Validating at `resolveForwardContext` measurably regresses the hot path (it is
+  per-request) → make validation opt-out or move it to the resolver boundary.
+
+## Maintenance notes
+
+- Keep the framework scheme-agnostic: `defineIdentity` + `composeResolvers` know
+  nothing about tokens, portals, or tenants. Ship those as **docs recipes**
+  (preview magic link, per-tenant token → `authorizeShard`, per-route login) that
+  compose the generic primitives, so the surface stays small and general.
+- The declared contract is authoritative over any Phase 3 inference — document
+  that precedence so a future inference feature can't silently override it.
+
+## Relationship to the sibling plans
+
+- **091 (cookie-cache, ready)** — independent; land first.
+- **`.shardBy(ctx => ctx.auth.identity.tenantId)`** — becomes trivial and typed
+  once Phase 1 lands, since the tenant claim is a typed field. File it after this;
+  it still crosses the RLS/shard boundary, so carry a STOP condition.
+
+---
+
+## Follow-on 094: `auth_session_read_without_cache` advisor lint
+
+> Kept here (per operator request) because it is auth-config-shaped like the rest
+> of this plan. **Gated**: begin only after 091's cookie-cache default exists on
+> `alpha` (so the "cache on by default" baseline is real). Orthogonal to the
+> identity-typing work above — it does **not** reuse Phase 1/2's `defineIdentity`
+> discovery. **Note on the reader**: neither 091 (defaults only, no new API) nor
+> 092 Phase 1+2 (reads `defineIdentity`, never introspects `createAuth`) produces
+> a `createAuth`-config reader. So **094 builds its own**, small and self-contained
+> (see scope). Do not block on a sibling plan to supply it.
+
+### 094 status
+
+- **Priority**: P2 · **Effort**: S · **Risk**: LOW
+- **Depends on**: 091's cookie-cache default on `alpha` (the baseline it lints
+  against). Builds its own `createAuth`-config reader; no dependency on 092's
+  `defineIdentity` discovery.
+- **Category**: feat (advisor) / perf
+
+### 094 why
+
+091 sets a good default (a short cookie cache), but a caller can pass
+`session: { cookieCache: { enabled: false } }` and then read identity on a hot
+path — reintroducing the per-request D1 session read invisibly. A static lint
+makes that cost visible: _this function resolves identity, and this deployment
+has neither `cookieCache` nor the `jwt` plugin, so every call hits D1._
+
+### 094 current state (verified at `c490bad`)
+
+- `packages/advisor/src/lints/static/auth-api-call-without-headers.ts` — the
+  template: a `Lint` object with `categories`, `description`, `facing`, `level`,
+  `name`, `remediation`, `run(context)`, reading evidence from
+  `context.authApiCalls` and returning `[]` when evidence is absent. Findings use
+  `emit(lint, { cacheKey, … })` with an occurrence-suffixed key.
+- `packages/advisor/src/index.ts:14` — lints register by import.
+- `packages/advisor/src/types.ts` — **verified**: `Category = "PERFORMANCE" | "SCHEMA" | "SECURITY"`
+  (so `["PERFORMANCE"]` is valid), `Facing = "EXTERNAL" | "INTERNAL"` (use
+  `EXTERNAL` — a per-request D1 read is latency a user feels), `Level` carries
+  `WARN`. New `context` evidence fields (`identityReads`, `authConfig`) are
+  declared here and fed from codegen, mirroring `authApiCalls`.
+
+### 094 evidence design
+
+The lint needs two facts in `context`:
+
+1. **Identity-read evidence** — does any function read identity beyond a bare
+   `userId` (call `getIdentity()` / destructure `ctx.auth`)? A new
+   `discover-identity-reads.ts`, modeled 1:1 on `discover-authapi-calls.ts`:
+   walk `listLunoraSourceFiles`, match `ctx.auth.getIdentity(...)` and the
+   destructured form, record `{ file, line, function }`. Conservative.
+2. **Cache/JWT posture** — is `session.cookieCache.enabled !== false` **or** the
+   `jwt` plugin enabled? A new, self-contained `createAuth`-config reader (this
+   plan builds it — see scope) returns `cookieCacheEnabled` / `jwtEnabled`. It
+   reads the `createAuth({...})` call statically and, like
+   `discover-authapi-calls.ts`, returns "unresolved" whenever the config is not
+   statically analyzable (e.g. `createAuth({ ...options(env) })` spread configs).
+   On "unresolved" the lint returns `[]` — no evidence, no alarm.
+
+Fires only when: identity read **and** config resolved **and** cache off **and**
+jwt off. Any "unresolved" → silent.
+
+### 094 lint object (target shape)
+
+```ts
+const authSessionReadWithoutCache: Lint = {
+    categories: ["PERFORMANCE"], // verified valid in types.ts
+    description:
+        "A function reads the session identity (`ctx.auth.getIdentity()`) but the deployment has neither a session cookie cache nor the `jwt` plugin — so every authenticated call performs a D1 session read.",
+    facing: "EXTERNAL", // per types.ts: EXTERNAL = performance a user can feel
+    level: "WARN",
+    name: "auth_session_read_without_cache",
+    remediation:
+        "Enable a short-lived cookie cache (`session: { cookieCache: { enabled: true, maxAge: 60 } }`, or a `sessionPresets` value) so `getSession` skips the D1 read, or add the `jwt` plugin. See plan 091.",
+    run: (context) => {
+        if (context.identityReads === undefined || context.authConfig === undefined) return [];
+        if (context.authConfig.unresolved) return [];
+        if (context.authConfig.cookieCacheEnabled || context.authConfig.jwtEnabled) return [];
+        // …emit one finding per identity-read site, occurrence-suffixed cacheKey.
+    },
+};
+```
+
+### 094 scope
+
+- `packages/codegen/src/discover-identity-reads.ts` (new) + test.
+- `packages/codegen/src/discover-auth-config.ts` (new) + test — the self-contained
+  `createAuth`-config reader returning `cookieCacheEnabled` / `jwtEnabled` (or
+  "unresolved"), modeled on `discover-authapi-calls.ts`. This plan owns it; no
+  sibling plan supplies it.
+- Thread both into the advisor `context` (feeder + `types.ts` context shape).
+- `packages/advisor/src/lints/static/auth-session-read-without-cache.ts` (new) + test.
+- Register in `packages/advisor/src/index.ts`.
+
+### 094 done criteria
+
+- [ ] 091's cookie-cache default has landed on `alpha` (the baseline; else STOP).
+- [ ] The new `discover-auth-config.ts` reader (built by this plan) returns
+      `cookieCacheEnabled` / `jwtEnabled` / "unresolved" and has a test.
+- [ ] Fires only when identity read AND config resolved AND cache off AND jwt
+      off; fixtures for cache-on, jwt-on, unresolved, and no-identity-read each
+      assert **zero** findings.
+- [ ] One fixture (identity read + cache `enabled: false`) asserts exactly one
+      finding with the shared cacheKey convention.
+- [ ] Registered; `@lunora/advisor` + `@lunora/codegen` tests and `lint:types`
+      exit 0; `pnpm run lint:eslint` exit 0.
+- [ ] `plans/README.md` row updated.
+
+### 094 STOP conditions
+
+- 091's cookie-cache default is not yet on `alpha` → stop; 094 lints against that
+  baseline.
+- The `createAuth` call cannot be read statically at all (even the conservative
+  reader can't extract `cookieCache`/`jwt` from any real app config, always
+  "unresolved") → stop; the lint would never fire and is not worth shipping.
+- Any fixture shows the lint firing on an "unresolved config" case → the
+  fail-safe is broken; fix the guard (a false perf-warning on every
+  un-analyzable app is alarm fatigue).

--- a/plans/093-auth-durable-atomic-rate-limit.md
+++ b/plans/093-auth-durable-atomic-rate-limit.md
@@ -1,0 +1,265 @@
+# Plan 093: Durable, atomic rate limiting for `@lunora/auth` on Workers (`incrementOne` + storage)
+
+> **Executor instructions**: Follow step by step; run every verification and
+> confirm the expected result before continuing. **Step 0 is blocking** — this
+> plan is built on two assumptions about better-auth `1.6.22` that were not
+> verifiable when it was written (better-auth was not installed; the GitHub core
+> API was rate-limited). If Step 0 disproves either, stop and reshape the plan.
+> On any STOP condition, stop and report. When done, update the status row in
+> `plans/README.md`.
+>
+> **Numbering note**: 094 is not a file — it lives as the "Follow-on 094" section
+> inside `plans/092-typed-identity-layer.md`. This plan is 093.
+>
+> **Drift check (run first)**: `git diff --stat c490bad..HEAD -- packages/auth/src/store.ts packages/auth/src/sql-store.ts packages/auth/src/adapter.ts packages/auth/src/create-auth.ts`
+> If any changed, re-verify the "Current state" excerpts before proceeding.
+
+## Status
+
+- **Priority**: P1 (rate limiting silently not enforced across isolates is a
+  security-relevant gap, not a perf nicety)
+- **Effort**: M
+- **Risk**: MEDIUM (touches the auth data path + a security control)
+- **Depends on**: none
+- **Category**: fix (auth)
+- **Planned at**: commit `c490bad`, 2026-07-01
+
+## Why this matters
+
+`createAuth` turns rate limiting **on by default** (`create-auth.ts:195`,
+`rateLimit.enabled ?? true`) but never sets `rateLimit.storage`. So the limiter
+uses better-auth's default store. On Cloudflare Workers that default is
+process memory, which is **per-isolate and non-durable**: each isolate keeps its
+own counter, counters vanish on isolate recycle, and traffic spread across
+isolates never sums to the configured `max`. The result is the worst kind of
+security control — one that reports as "enabled" while not enforcing a global
+limit. Brute-force / credential-stuffing protection on `/sign-in`, OTP, and
+password-reset is the exact thing this is supposed to buy.
+
+Making the limit real means pointing better-auth at durable storage
+(`rateLimit.storage: "database"` → the counter rides Lunora's adapter → `ctx.db`
+over the D1 auth tables). But that exposes a second gap: better-auth #10000
+("harden atomic state transitions," a breaking change **merged 2026-06-12, so
+inside pinned 1.6.22**) removed the read-then-update fallback and requires custom
+adapters to implement a **native atomic `incrementOne`** — "one `consume`
+decision per request … the fallback read-then-update paths are removed because
+they could not provide the same one-winner guarantee across processes." Lunora's
+`AuthStore` implements `consumeOne` (atomically, via `DELETE … RETURNING`) but
+has **no `incrementOne`**. Without it, a DB-backed counter falls back to
+read-then-increment, which on Workers races: two concurrent requests both read
+`count=4`, both write `5`, and a `max` of 5 passes 6+.
+
+So the fix is one coherent change: **add native atomic `incrementOne` to the
+store/adapter, and default the limiter to durable storage** — durable _and_
+one-winner, the same standard `consumeOne` already meets for single-use tokens.
+
+## Current state (verified at `c490bad`)
+
+- `packages/auth/src/store.ts` — the `AuthStore` interface exposes
+  `consumeOne, count, create, read, remove, update`. **No `incrementOne`.** Its
+  `consumeOne` doc already states the principle this plan extends: implementing
+  the operation natively "closes the read-then-delete race the factory's
+  `findMany` + `deleteMany` fallback would otherwise leave open." The same
+  argument applies to increment.
+- `packages/auth/src/store.ts` — `createMemoryAuthStore` (the reference store the
+  tests run better-auth against) implements the interface with a synchronous
+  find-and-splice `consumeOne` ("no `await` interleaves, so this is an atomic
+  single-row consume"). A memory `incrementOne` follows the same synchronous
+  pattern.
+- `packages/auth/src/sql-store.ts` — `createSqlAuthStore` backs the interface
+  with D1 SQL and already uses `RETURNING` (the `consumeOne` `DELETE … RETURNING`
+  at ~line 184). D1 supports `INSERT … ON CONFLICT … DO UPDATE … RETURNING`, so
+  an atomic upsert-increment is expressible in one statement.
+- `packages/auth/src/adapter.ts:44–72` — `lunoraAuthAdapter` maps the
+  better-auth `CustomAdapter` methods onto the store. It wires `consumeOne`
+  (line 47) but **no `incrementOne`**.
+- `packages/auth/src/create-auth.ts:180–195` — fills `rateLimit.enabled: true`
+  when the caller is silent, and forwards `window`/`max` verbatim. It does
+  **not** set `rateLimit.storage`.
+
+## Step 0 (blocking): verify the two better-auth `1.6.22` assumptions
+
+Install and inspect the real types/behavior — do not trust this plan's memory of
+them (the version postdates the author's reference knowledge, and #10000's exact
+surface was read from a PR description, not the code):
+
+```bash
+pnpm install
+# (1) The atomic increment method: name, where it lives, exact signature.
+grep -rn "incrementOne\|consumeOne\|CustomAdapter" node_modules/better-auth/dist/**/*.d.ts | head
+# (2) The default rate-limit storage, and whether "database" routes through the
+#     custom adapter (vs. requiring a separate secondaryStorage):
+grep -rn "rateLimit\|storage" node_modules/better-auth/dist/**/*.d.ts | grep -i "storage\|memory\|secondary" | head
+```
+
+Confirm and record in the PR description:
+
+1. The atomic increment operation is named `incrementOne` (or record the real
+   name), its interface (on `CustomAdapter`? optional?), and its exact
+   signature/return.
+2. better-auth's **default** `rateLimit.storage` (confirm it is `"memory"`), and
+   that `rateLimit.storage: "database"` drives the limiter through the configured
+   `database` adapter (i.e. through Lunora's store). If instead it needs
+   `secondaryStorage` (KV/Redis-shaped), the storage half of this plan changes
+   target — see "If Step 0 diverges."
+
+**If (1) shows no atomic-increment method exists in 1.6.22** → the `incrementOne`
+work is moot; reduce this plan to the storage default + a known-limitation note,
+and STOP for re-scoping. **If (2) shows the default is already durable** → drop
+the storage half; keep `incrementOne` only if the adapter path uses it.
+
+## If Step 0 diverges (decision record)
+
+- Increment routes through `secondaryStorage`, not the DB adapter → the durable
+  target becomes a Workers-native secondary store (Durable Object or KV) with an
+  atomic increment, not the D1 store. (A DO counter is the natural fit and aligns
+  with better-auth #9004 "custom storage adapters for rate limiting, e.g. DO".)
+  Re-scope before coding; do not force it through the SQL store.
+- `max`/`window` semantics differ from a plain counter (e.g. sliding window) →
+  match better-auth's expected storage contract exactly; the atomic op must
+  implement whatever better-auth calls, not a counter of our own invention.
+
+## Commands you will need
+
+| Purpose          | Command                                       | Expected        |
+| ---------------- | --------------------------------------------- | --------------- |
+| Install          | `pnpm install`                                | exit 0 (Step 0) |
+| Build deps first | `pnpm run build:packages`                     | exit 0 (once)   |
+| Typecheck        | `pnpm --filter "@lunora/auth" run lint:types` | exit 0          |
+| Unit tests       | `pnpm --filter "@lunora/auth" run test`       | pass incl. new  |
+| e2e (rate limit) | `pnpm --filter e2e run test -- rate`          | see Test plan   |
+| Lint             | `pnpm run lint:eslint`                        | exit 0          |
+
+## Scope
+
+**In scope:**
+
+- `packages/auth/src/store.ts` — add `incrementOne` to the `AuthStore` interface
+  (with a doc block mirroring `consumeOne`'s race-closing rationale) and to
+  `createMemoryAuthStore` (synchronous, no `await` interleave).
+- `packages/auth/src/sql-store.ts` — implement `incrementOne` as a single
+  atomic `INSERT … ON CONFLICT … DO UPDATE SET count = count + ? … RETURNING`
+  (match the real column/semantics from Step 0).
+- `packages/auth/src/adapter.ts` — wire `incrementOne` onto the returned
+  `CustomAdapter`, next to `consumeOne`.
+- `packages/auth/src/create-auth.ts` — default `rateLimit.storage` to the durable
+  option (per Step 0) when the caller is silent, using the **same
+  caller-silence gate** as the `enabled` default; document the tradeoff and the
+  opt-out.
+- Tests for each (see Test plan).
+
+**Out of scope:**
+
+- The `jwt` path; session cookie cache (that is 091).
+- Any change to `consumeOne` (already correct).
+- The device-auth telemetry and ASCII-email issues — those are the companion
+  doc task below, not code.
+
+## Git workflow
+
+- Branch: `advisor/093-auth-durable-atomic-rate-limit`.
+- Commit: `fix(auth): make rate limiting durable and atomic on Workers (incrementOne + storage default)`.
+- Do NOT push or open a PR unless instructed.
+
+## Steps
+
+1. **Step 0 above — blocking.** Do not write code until both assumptions are
+   confirmed or the plan is re-scoped.
+2. Add `incrementOne` to the `AuthStore` interface + doc (`store.ts`).
+   **Verify**: `lint:types` exit 0 (memory + sql stores now fail to satisfy the
+   interface until implemented — expected).
+3. Implement memory `incrementOne` (synchronous find-or-create + bump).
+4. Implement SQL `incrementOne` (atomic upsert-increment with `RETURNING`, using
+   the same placeholder-guard discipline the rest of `sql-store.ts` uses).
+   **Verify**: `pnpm --filter "@lunora/auth" run test` — both stores pass.
+5. Wire `adapter.ts` `incrementOne`. **Verify**: `lint:types` exit 0.
+6. Default `rateLimit.storage` in `create-auth.ts`, caller-silence-gated.
+   **Verify**: a test asserts the default is filled when silent and forwarded
+   verbatim when the caller sets `rateLimit.storage` or `rateLimit: { enabled: false }`.
+
+## Test plan
+
+- **Concurrency (the point of the plan)**: fire N concurrent requests that each
+  `incrementOne` the same key against `createSqlAuthStore` over a real
+  `node:sqlite`/D1-shaped handle; assert the final count equals N (no lost
+  updates). Do the same for the memory store. This is the regression that proves
+  atomicity — without it, the plan is unverified.
+- Unit: memory and SQL `incrementOne` return the post-increment row; create-then-
+  increment and increment-missing-key both behave per Step 0's contract.
+- create-auth: storage default filled on silence; forwarded verbatim otherwise.
+- e2e (if a rate-limit spec exists or is cheap to add under `tests/e2e`):
+  exceeding `max` within `window` returns better-auth's 429 across repeated
+  requests — the black-box confirmation that enforcement now holds.
+
+## Done criteria
+
+- [ ] Step 0 recorded in the PR: real increment method name/signature + real
+      default storage, with the plan reshaped if either diverged.
+- [ ] `incrementOne` on `AuthStore`, `createMemoryAuthStore`,
+      `createSqlAuthStore`, and wired in `adapter.ts`.
+- [ ] Concurrency test proves no lost updates for both stores.
+- [ ] `rateLimit.storage` default is durable, caller-silence-gated, with opt-out
+      documented.
+- [ ] `pnpm --filter "@lunora/auth" run test`, `lint:types`, and
+      `pnpm run lint:eslint` all exit 0.
+- [ ] No files outside the in-scope list modified (`git status`).
+- [ ] `plans/README.md` row updated.
+
+## STOP conditions
+
+- Step 0 disproves either assumption (no atomic-increment method; default already
+  durable; increment goes through `secondaryStorage` not the DB adapter) → stop
+  and re-scope per "If Step 0 diverges."
+- The atomic SQL increment cannot be expressed in one statement against D1 (e.g.
+  the real storage contract needs multi-row or TTL semantics `ON CONFLICT` can't
+  model) → stop; a DO-backed secondary store may be the correct target instead.
+- Defaulting `rateLimit.storage: "database"` breaks an existing auth test/e2e
+  (e.g. a test that assumes the in-memory limiter) → stop; the default change may
+  need to be opt-in-with-loud-docs rather than on-by-default.
+
+## Maintenance notes
+
+- Keep `incrementOne`'s doc pinned to the same invariant as `consumeOne`: it
+  exists to give a **one-winner guarantee across processes/isolates**, which is
+  the whole reason the read-then-update fallback is unsafe on Workers.
+- If better-auth changes the rate-limit storage contract in a future minor,
+  re-verify Step 0 — the atomic op must implement better-auth's operation, not a
+  counter of our own shape.
+- **Upgrade/release note**: flipping the `rateLimit.storage` default to `"database"`
+  makes better-auth emit (and require) a `rateLimit` table it did not need under the
+  old memory default. The generated worker runs `ensureMigrated(...)` before request
+  handling, so lazy migration creates the table automatically — but a deployment that
+  disables lazy migration must re-run `lunora migrate` after upgrading `@lunora/auth`,
+  or every `/api/auth/*` request errors on the missing table (better-auth does not
+  guard `onRequestRateLimit`). Call this out in the `@lunora/auth` changelog.
+
+---
+
+## Companion (smaller): known-limitations doc entries
+
+Not code — a docs task, filed here because it came out of the same better-auth
+audit. Add to the `@lunora/auth` docs a short, honest "Known limitations &
+better-auth interactions" section covering:
+
+1. **Device-authorization telemetry pollution (better-auth #9784, open).** The
+   re-exported `deviceAuthorization` plugin (`plugins.ts:67`) throws an
+   `APIError` on every `/device/token` poll for the normal `authorization_pending`
+   state (~every 5s). Cloudflare Workers Logs and any exception-capturing sink —
+   including Lunora's own `sentrySink` / observability sinks — record each throw,
+   so one device-flow login sprays dozens of "errors" into telemetry. Document
+   it; consider a sink-side filter for that endpoint's expected throws until
+   fixed upstream. Note this is an upstream bug, not a Lunora defect.
+2. **ASCII-only email case-folding.** `sql-store.ts` uses SQLite/D1's ASCII-only
+   `LOWER()`/`LIKE` for case-insensitive matching, so non-ASCII email
+   case-folding is subtly wrong versus a Unicode-aware compare. Document the
+   supported matching semantics rather than leaving it implicit.
+3. **Kysely on the migration path.** The runtime path avoids better-auth's Kysely
+   adapter (the `$context` dynamic-import hang under the Vite worker runner —
+   `adapter.ts:91–100`), but `ensureMigrated` still uses better-auth's Kysely
+   migrator. That leaves `lunora migrate` exposed to the kysely-adapter breakages
+   tracked upstream (#9868/#9810/#9909: `DEFAULT_MIGRATION_TABLE` moved to
+   `kysely/migration`, removed runtime exports). Pin/patch kysely deliberately so
+   a transitive bump can't break migrations; document the pinned version.
+
+These are documentation + a possible one-line sink filter — keep them out of 093's
+code scope so the rate-limit fix lands cleanly on its own.

--- a/plans/README.md
+++ b/plans/README.md
@@ -390,6 +390,59 @@ Vetted against live code and dropped — recorded so they aren't re-audited:
   codegen namespace-collision test for case-insensitive filesystems
   (`packages/codegen`), advisor static-lint edge-case predicate dedup
   (`packages/advisor`).
+## Wave 9 — auth hot-path hardening + typed identity layer (baseline `c490bad`, 2026-07-01)
+
+Three `@lunora/auth` / identity findings, landed together off `alpha`. Two harden
+the authenticated hot path (091/093): the session read hits D1 on every call (no
+cookie cache), and rate limiting reports "enabled" while not enforcing a global
+limit on Workers (per-isolate memory store, no atomic increment). The third (092)
+types identity generically — whatever `resolveIdentity` returns becomes `ctx.auth`,
+but beyond `userId` the claims were untyped and composition was DIY, so 092 makes
+the claim contract **declared** (codegen reads it as reliably as `defineSchema`)
+and gives first-class resolver composition. 091 and 093 both touch `create-auth.ts`'s
+`resolvedOptions` caller-silence fill, so they landed in order (091 then 093 on top).
+
+| Plan | Title                                        | Category        | Pri | Effort | Risk | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---- | -------------------------------------------- | --------------- | --- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 091  | Default a short-lived session cookie cache   | perf            | P2  | S      | LOW  | DONE — `session.cookieCache { enabled, maxAge=60s }` filled on caller silence in `create-auth.ts`; `rolling`/`longLived` presets enable it, `strict` opts out; tests green.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| 092  | Generic typed identity layer                 | dx/codegen/auth | P2  | L      | MED  | DONE — `defineIdentity` (`@lunora/server`), the `wrapResolverWithContract` validation boundary + `composeIdentityResolvers`/`routeIdentityResolvers` (extracted to `@lunora/runtime`'s `identity-resolvers.ts`), `createPolicyDsl`'s identity type param, AND codegen auto-emission of the narrowed `ctx.auth.getIdentity()` into `_generated/server.ts` — codegen discovers the single `defineIdentity(...)` in `lunora/identity.ts` (like `defineSchema`), recovers the claim type via `InferIdentity<typeof …>`, and narrows `getIdentity()` + the RLS policy `ctx.auth.identity`. The boundary now fires end-to-end in generated apps: `_generated/app.ts` imports the contract as a value and wires `options.identity`, so `wrapResolverWithContract` actually validates a resolver's claims (previously the type narrowed but the runtime gate stayed inert). Byte-identical when no contract is declared. Phase 3 (better-auth plugin inference) + the 094 follow-on lint remain deferred. |
+| 094  | `auth_session_read_without_cache` lint       | advisor/perf    | P2  | S      | LOW  | DEFERRED — lives as the "Follow-on 094" section inside `092-typed-identity-layer.md`; gated on 091 (landed) and builds its own `createAuth`-config reader.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| 093  | Durable, atomic rate limiting (incrementOne) | fix             | P1  | M      | MED  | DONE — native atomic `incrementOne` on `AuthStore` (memory + SQL) + `adapter.ts`; durable `rateLimit.storage: "database"` default (caller-silence-gated); concurrency no-lost-update test for both stores. Companion known-limitations docs deferred (out of code scope).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+### Notes
+
+- **091** verified better-auth `1.6.22`: `session.cookieCache` takes `{ enabled,
+maxAge }` (seconds; better-auth default `maxAge` is 300s, lowered to 60s here).
+  The default is gated on `session?.cookieCache === undefined`, mirroring the
+  `rateLimit.enabled === undefined` fill, and composed into the same
+  `resolvedOptions` object so **093** can add its `rateLimit.storage` fill alongside.
+- **092** never introspects `createAuth` — Phase 1+2 read a `defineIdentity(...)`
+  declaration statically (like `defineSchema`), which dissolves the introspection
+  cliff the earlier framing carried. `defineIdentity` builds on the `@lunora/values`
+  validator machinery (`parseValidatorMap`), **not** the replication `defineShape`
+  API (a table+predicate, not a claim record) — matching the plan's first STOP
+  condition's own remediation ("its own light type rather than reusing `defineShape`
+  wholesale"). `composeIdentityResolvers`/`routeIdentityResolvers` (renamed from the plan's
+  `composeResolvers`/`routeResolvers` to avoid clashing with `@lunora/cloudflare-access`'s
+  existing variadic `composeResolvers`) live in `@lunora/runtime`
+  (co-located with `ResolvedIdentity`/`resolveIdentity`, structurally free of
+  `@lunora/server`), not `@lunora/auth`, so the generic primitives stay decoupled
+  from better-auth — the whole point of a generic identity layer.
+- **093** verified better-auth `1.6.22`: `incrementOne` exists as an **optional**
+  `CustomAdapter` method — a guarded `UPDATE … SET col = col + delta … RETURNING`
+  (the plan's `INSERT … ON CONFLICT` upsert was wrong; better-auth `create`s the
+  row separately and calls `incrementOne` only as a guarded counter bump). Default
+  `rateLimit.storage` is `"memory"` (per-isolate, non-durable); `"database"` routes
+  through the configured DB adapter (Lunora's store). Defaulting storage to
+  `"database"` surfaced STOP-condition 3 as a **test-fixture gap** — the durable
+  limiter needs a `rateLimit` table that `getAuthTables` emits only when
+  `storage === "database"`; `forget-password-route.test.ts` now materialises the
+  schema from that resolved storage, mirroring what a real Lunora migrator does.
+- The codegen auto-narrowing reuses the workflows/queues precedent: it imports the
+  app's contract by type (`import type * as … from "../identity.js"`) and reads it
+  via `typeof` + `InferIdentity` — no parallel type system, no runtime import, and
+  every fragment is gated on the contract existing, so the no-`defineIdentity`
+  golden stays byte-identical.
 
 ## Notes for executors (carried from prior waves)
 


### PR DESCRIPTION
Integrates three auth/identity plans off `alpha`, each verified independently and then re-reviewed as a combined branch (thermos: no correctness or security bug found).

## What's in here

### 079 — session cookie-cache default (`perf`)
Defaults a short-lived better-auth session cookie cache (`session.cookieCache { enabled, maxAge: 60 }`) on caller silence, so authenticated calls skip the per-request D1 session read. Gated on `session?.cookieCache === undefined`; `strict` preset opts out. Verified against better-auth 1.6.22 (default `maxAge` is 300s, deliberately lowered to 60s).

### 082 — durable, atomic rate limiting (`fix`, security-relevant)
better-auth rate limiting was on-by-default but backed by per-isolate memory on Workers — reported "enabled" while never enforcing a global limit. Adds a native atomic `incrementOne` to `AuthStore` (memory: synchronous read-modify-write; SQL: guarded `UPDATE … SET col = col + ? … WHERE rowid IN (… LIMIT 1) RETURNING *`), wires it in the adapter, and defaults `rateLimit.storage: "database"` on caller silence. Concurrency test proves no lost updates (50-way) for both stores.

> Step 0 corrected the plan: better-auth's `incrementOne` is a **guarded-UPDATE** contract, not the upsert the plan assumed — implemented to the real contract.

### 080 — generic typed identity layer (`dx`/`codegen`/`auth`)
- `defineIdentity(shape)` claim contract (`@lunora/server`, on `@lunora/values`).
- Trust-boundary validation of resolver output in `@lunora/runtime` before claims become `ctx.auth` (reject-to-anonymous or 401 per contract), on all four public paths (RPC, WS, HTTP action, server-query).
- `composeIdentityResolvers` / `routeIdentityResolvers` combinators (extracted into `@lunora/runtime/identity-resolvers.ts`).
- Codegen auto-emits a narrowed `ctx.auth.getIdentity()` + RLS policy identity into `_generated/server.ts` — **byte-identical when no `defineIdentity` is declared** (hard backward-compat requirement, enforced by golden tests).

Phase 3 (better-auth plugin inference) and the 081 advisor lint (`auth_session_read_without_cache`) remain deferred — see `plans/080-typed-identity-layer.md`.

## Review

Ran a two-pass thermos audit on the combined diff. No correctness/security bug; three high-risk claims (rate-limit atomicity, identity trust boundary, default composition) verified against real better-auth 1.6.22 source. Findings addressed:
- **MED** — renamed the runtime combinators (`composeIdentityResolvers`/`routeIdentityResolvers`) to avoid a name clash with `@lunora/cloudflare-access`'s existing variadic `composeResolvers`.
- **LOW** — hardened the `defineIdentity` `userId` guard (rejects an optional `userId` at runtime), documented allow-list validation semantics, docstring/breadcrumb fixes, and a `storage:"database"` upgrade/migration note.

## Gates
build clean · lint:types clean · tests: server 375 / auth 149 / runtime 442 / codegen 485 · eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed identity definitions with runtime validation and contract enforcement across identity resolution paths.
  * Enhanced code generation to discover a single identity contract (when present) and strongly type server auth identity + RLS policy context.
  * Added an auth store `incrementOne` capability for atomic numeric updates.
* **Bug Fixes**
  * Strengthened `rateLimit`/session cookie defaults via resolved options logic without overriding caller configuration.
  * Implemented reliable SQL and in-memory numeric counter increments with safe “update one row” semantics.
* **Documentation**
  * Updated session preset guidance and behavior for `cookieCache` defaults/enabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->