### PR TITLE
feat(cli): background dev mode + agent-aware dx

### DIFF
--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -216,6 +216,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": true,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -521,6 +521,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": true,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -167,6 +167,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -564,6 +564,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -343,6 +343,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -186,6 +186,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -1,0 +1,298 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DEV_LOG_FILE, readDevServerState, writeDevServerState } from "@lunora/config";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runDevBackground, runDevLogs, runDevStatus, runDevStop } from "../../src/commands/dev/lifecycle";
+import type { Logger } from "../../src/util/logger";
+
+interface RecordingLogger {
+    lines: { level: string; message: string }[];
+    logger: Logger;
+}
+
+const recordingLogger = (): RecordingLogger => {
+    const lines: { level: string; message: string }[] = [];
+    const push = (level: string) => (message: string) => lines.push({ level, message });
+
+    return {
+        lines,
+        logger: { error: push("error"), info: push("info"), success: push("success"), warn: push("warn") },
+    };
+};
+
+let workdir: string;
+
+describe("lunora dev lifecycle", () => {
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-cli-dev-lifecycle-"));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    describe("runDevStop", () => {
+        it("is idempotent: stopping with nothing running succeeds silently", async () => {
+            expect.assertions(2);
+
+            const { lines, logger } = recordingLogger();
+
+            const result = await runDevStop({ cwd: workdir, json: false, logger });
+
+            expect(result.code).toBe(0);
+            expect(lines.some((line) => line.message.includes("No dev server running"))).toBe(true);
+        });
+
+        it("sIGTERMs the recorded pid and clears the state record", async () => {
+            expect.assertions(4);
+
+            writeDevServerState(workdir, { mode: "cli", pid: 4242, url: "http://localhost:8787" });
+
+            const signals: { pid: number; signal: string }[] = [];
+            let dead = false;
+            const { lines, logger } = recordingLogger();
+
+            const result = await runDevStop({
+                alive: () => !dead,
+                cwd: workdir,
+                json: false,
+                logger,
+                pollIntervalMs: 1,
+                signal: (pid, signal) => {
+                    signals.push({ pid, signal });
+                    dead = true;
+                },
+            });
+
+            expect(result.code).toBe(0);
+            expect(signals).toStrictEqual([{ pid: 4242, signal: "SIGTERM" }]);
+            expect(readDevServerState(workdir)).toBeUndefined();
+            expect(lines.some((line) => line.message.includes("Stopped dev server (pid 4242)"))).toBe(true);
+        });
+
+        it("escalates to a process-group SIGKILL when SIGTERM stalls", async () => {
+            expect.assertions(2);
+
+            writeDevServerState(workdir, { mode: "cli", pid: 4242, url: "http://localhost:8787" });
+
+            const signals: { pid: number; signal: string }[] = [];
+
+            const result = await runDevStop({
+                alive: () => true,
+                cwd: workdir,
+                json: false,
+                logger: recordingLogger().logger,
+                pollIntervalMs: 1,
+                signal: (pid, signal) => {
+                    signals.push({ pid, signal });
+                },
+                stopGraceMs: 5,
+            });
+
+            expect(result.code).toBe(0);
+            // SIGTERM first, then the group SIGKILL (negative pid).
+            expect(signals).toStrictEqual([
+                { pid: 4242, signal: "SIGTERM" },
+                { pid: -4242, signal: "SIGKILL" },
+            ]);
+        });
+
+        it("clears a stale record (dead pid) without signalling anything", async () => {
+            expect.assertions(2);
+
+            writeDevServerState(workdir, { mode: "cli", pid: 4242, url: "http://localhost:8787" });
+
+            const signals: number[] = [];
+
+            await runDevStop({
+                alive: () => false,
+                cwd: workdir,
+                json: false,
+                logger: recordingLogger().logger,
+                signal: (pid) => {
+                    signals.push(pid);
+                },
+            });
+
+            expect(signals).toHaveLength(0);
+            expect(readDevServerState(workdir)).toBeUndefined();
+        });
+    });
+
+    describe("runDevStatus", () => {
+        it("reports not-running when there is no live record", () => {
+            expect.assertions(2);
+
+            const { lines, logger } = recordingLogger();
+
+            const result = runDevStatus({ cwd: workdir, json: false, logger });
+
+            expect(result.code).toBe(0);
+            expect(lines.some((line) => line.message.includes("No dev server running"))).toBe(true);
+        });
+
+        it("reports URL, pid, uptime, and background for a live record", () => {
+            expect.assertions(2);
+
+            const startedAt = new Date(Date.now() - 30_000).toISOString();
+
+            writeDevServerState(workdir, { background: true, mode: "cli", pid: process.pid, startedAt, url: "http://localhost:8787" });
+
+            const { lines, logger } = recordingLogger();
+
+            runDevStatus({ cwd: workdir, json: false, logger });
+
+            const banner = lines.find((line) => line.message.includes("Dev server running at http://localhost:8787"));
+
+            expect(banner?.message).toContain(`pid ${String(process.pid)}`);
+            expect(banner?.message).toContain("background");
+        });
+
+        it("prints a machine-readable document with --json", () => {
+            expect.assertions(2);
+
+            writeDevServerState(workdir, { mode: "vite", pid: process.pid, url: "http://localhost:5173" });
+
+            const chunks: string[] = [];
+            const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+                chunks.push(String(chunk));
+
+                return true;
+            });
+
+            runDevStatus({ cwd: workdir, json: true, logger: recordingLogger().logger });
+            stdoutSpy.mockRestore();
+
+            const parsed = JSON.parse(chunks.join("")) as { mode: string; running: boolean };
+
+            expect(parsed.running).toBe(true);
+            expect(parsed.mode).toBe("vite");
+        });
+    });
+
+    describe("runDevLogs", () => {
+        it("is forgiving when no log exists yet", () => {
+            expect.assertions(2);
+
+            const { lines, logger } = recordingLogger();
+
+            const result = runDevLogs({ cwd: workdir, logger });
+
+            expect(result.code).toBe(0);
+            expect(lines.some((line) => line.message.includes("No dev server logs"))).toBe(true);
+        });
+
+        it("prints the trailing lines of the capture log", () => {
+            expect.assertions(1);
+
+            const logPath = join(workdir, DEV_LOG_FILE);
+
+            mkdirSync(join(workdir, ".lunora"), { recursive: true });
+            writeFileSync(logPath, "one\ntwo\nthree\n", "utf8");
+
+            const chunks: string[] = [];
+            const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+                chunks.push(String(chunk));
+
+                return true;
+            });
+
+            runDevLogs({ cwd: workdir, lines: 2, logger: recordingLogger().logger });
+            stdoutSpy.mockRestore();
+
+            expect(chunks.join("")).toBe("two\nthree\n");
+        });
+    });
+
+    describe("runDevBackground", () => {
+        it("blocks until the state record + probe confirm readiness, then prints URL and pid", async () => {
+            expect.assertions(4);
+
+            const { lines, logger } = recordingLogger();
+
+            const result = await runDevBackground({
+                command: { args: ["dev"], command: "lunora" },
+                cwd: workdir,
+                json: false,
+                logger,
+                pollIntervalMs: 1,
+                probe: async () => true,
+                readyTimeoutMs: 2000,
+                spawnDetached: () => {
+                    // The "daemon" writes its state record shortly after spawn.
+                    setTimeout(() => {
+                        writeDevServerState(workdir, {
+                            background: true,
+                            mode: "cli",
+                            pid: process.ppid,
+                            studioUrl: "http://127.0.0.1:6173",
+                            url: "http://localhost:8787",
+                        });
+                    }, 5);
+
+                    return { exited: new Promise<number>(() => {}), pid: process.ppid };
+                },
+            });
+
+            expect(result.code).toBe(0);
+
+            const banner = lines.find((line) => line.message.includes("Dev server running at http://localhost:8787"));
+
+            expect(banner?.message).toContain(`pid ${String(process.ppid)}`);
+            expect(lines.some((line) => line.message.includes("lunora dev stop"))).toBe(true);
+            expect(lines.some((line) => line.message.includes("lunora dev logs"))).toBe(true);
+        });
+
+        it("surfaces the log tail and fails when the daemon dies before readiness", async () => {
+            expect.assertions(3);
+
+            mkdirSync(join(workdir, ".lunora"), { recursive: true });
+            writeFileSync(join(workdir, DEV_LOG_FILE), "Error: port already in use\n", "utf8");
+
+            const { lines, logger } = recordingLogger();
+
+            const result = await runDevBackground({
+                command: { args: ["dev"], command: "lunora" },
+                cwd: workdir,
+                json: false,
+                logger,
+                pollIntervalMs: 1,
+                probe: async () => false,
+                readyTimeoutMs: 2000,
+                spawnDetached: () => {
+                    return { exited: Promise.resolve(7), pid: 999_999 };
+                },
+            });
+
+            expect(result.code).toBe(7);
+            expect(lines.some((line) => line.level === "error" && line.message.includes("exited before becoming ready"))).toBe(true);
+            expect(lines.some((line) => line.message.includes("port already in use"))).toBe(true);
+        });
+
+        it("times out with an actionable hint when readiness is never confirmed", async () => {
+            expect.assertions(2);
+
+            const { lines, logger } = recordingLogger();
+
+            const result = await runDevBackground({
+                command: { args: ["dev"], command: "lunora" },
+                cwd: workdir,
+                json: false,
+                logger,
+                pollIntervalMs: 1,
+                probe: async () => false,
+                readyTimeoutMs: 25,
+                spawnDetached: () => {
+                    return { exited: new Promise<number>(() => {}), pid: 999_999 };
+                },
+            });
+
+            expect(result.code).toBe(1);
+            expect(lines.some((line) => line.level === "warn" && line.message.includes("lunora dev logs"))).toBe(true);
+        });
+    });
+});

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -325,6 +325,60 @@ describe("lunora dev lifecycle", () => {
     });
 
     describe("runDevBackground", () => {
+        it("spawns a real detached child through the default spawner (integration)", async () => {
+            expect.assertions(4);
+
+            const posix = process.platform !== "win32";
+
+            // No spawnDetached stub — the REAL default spawner runs. The child
+            // plays the daemon: logs a line, writes its own state record (as the
+            // wrangler daemon / vite plugin would), and stays alive past the wait.
+            const script = [
+                "const fs = require('node:fs');",
+                "console.log('child-alive');",
+                "fs.mkdirSync('.lunora', { recursive: true });",
+                "fs.writeFileSync('.lunora/dev.json', JSON.stringify({ mode: 'cli', pid: process.pid, startedAt: new Date().toISOString(), url: 'http://localhost:1' }));",
+                "setTimeout(() => {}, 30_000);",
+            ].join(" ");
+
+            const result = await runDevBackground({
+                command: { args: ["-e", script], command: process.execPath },
+                cwd: workdir,
+                json: false,
+                logger: recordingLogger().logger,
+                pollIntervalMs: 25,
+                probe: async () => true,
+                readyTimeoutMs: 15_000,
+            });
+
+            const state = readDevServerState(workdir);
+
+            try {
+                expect(result.code).toBe(0);
+                expect(state?.pid).toBeGreaterThan(0);
+
+                // The capture log received the child's stdout — created 0600 on
+                // POSIX (dev output can echo secrets).
+                const logPath = join(workdir, DEV_LOG_FILE);
+
+                expect(readFileSync(logPath, "utf8")).toContain("child-alive");
+
+                // eslint-disable-next-line no-bitwise -- extract the permission bits from st_mode
+                const mode = statSync(logPath).mode & 0o777;
+
+                // Windows has no POSIX permission bits — assert 0600 only there.
+                expect(posix ? mode : 0o600).toBe(0o600);
+            } finally {
+                if (state !== undefined) {
+                    try {
+                        process.kill(state.pid, "SIGKILL");
+                    } catch {
+                        /* already gone */
+                    }
+                }
+            }
+        }, 20_000);
+
         it("blocks until the state record + probe confirm readiness, then prints URL and pid", async () => {
             expect.assertions(4);
 

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { DEV_LOG_FILE, readDevServerState, writeDevServerState } from "@lunora/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { runDevBackground, runDevLogs, runDevStatus, runDevStop } from "../../src/commands/dev/lifecycle";
+import type { DevOptions } from "../../src/commands/dev/index";
+import { runDevBackground, runDevLogs, runDevStatus, runDevStop, startBackground } from "../../src/commands/dev/lifecycle";
 import type { Logger } from "../../src/util/logger";
 
 interface RecordingLogger {
@@ -151,6 +152,29 @@ describe("lunora dev lifecycle", () => {
             expect(signals).toHaveLength(0);
             expect(readDevServerState(workdir)).toBeUndefined();
         });
+
+        it("leaves a record another server claimed after the stale read", async () => {
+            expect.assertions(1);
+
+            writeDevServerState(workdir, { mode: "cli", pid: 4242, url: "http://localhost:8787" });
+
+            await runDevStop({
+                // The observed record is dead — but by clear time a NEW server
+                // has re-claimed the file. The pid-guarded clear must not
+                // delete that fresh record.
+                alive: () => {
+                    writeDevServerState(workdir, { mode: "cli", pid: 5353, url: "http://localhost:8788" });
+
+                    return false;
+                },
+                cwd: workdir,
+                json: false,
+                logger: recordingLogger().logger,
+                signal: () => {},
+            });
+
+            expect(readDevServerState(workdir)?.pid).toBe(5353);
+        });
     });
 
     describe("runDevStatus", () => {
@@ -238,6 +262,65 @@ describe("lunora dev lifecycle", () => {
             stdoutSpy.mockRestore();
 
             expect(chunks.join("")).toBe("two\nthree\n");
+        });
+    });
+
+    describe("startBackground", () => {
+        it("claims a provisional record, hands its pid to the child, and clears after", async () => {
+            expect.assertions(4);
+
+            let envSeen: Record<string, string | undefined> | undefined;
+            let pidDuringRun: number | undefined;
+
+            const result = await startBackground({
+                cwd: workdir,
+                jsonLogs: false,
+                logger: recordingLogger().logger,
+                options: {} as DevOptions,
+                remote: false,
+                run: (options) => {
+                    envSeen = options.env;
+                    // The provisional record is already claimed when the child spawns.
+                    pidDuringRun = readDevServerState(workdir)?.pid;
+
+                    return Promise.resolve({ code: 0 });
+                },
+            });
+
+            expect(result.code).toBe(0);
+            expect(pidDuringRun).toBe(process.pid);
+            expect(envSeen?.LUNORA_DEV_HANDOFF_PID).toBe(String(process.pid));
+            // No child superseded it, so the provisional record is gone.
+            expect(readDevServerState(workdir)).toBeUndefined();
+        });
+
+        it("loses the claim to a live incumbent and reports it without spawning", async () => {
+            expect.assertions(4);
+
+            // A live record owned by a different process (the runner's parent).
+            writeDevServerState(workdir, { mode: "cli", pid: process.ppid, url: "http://localhost:8787" });
+
+            let spawned = false;
+            const { lines, logger } = recordingLogger();
+
+            const result = await startBackground({
+                cwd: workdir,
+                jsonLogs: false,
+                logger,
+                options: {} as DevOptions,
+                remote: false,
+                run: () => {
+                    spawned = true;
+
+                    return Promise.resolve({ code: 0 });
+                },
+            });
+
+            expect(result.code).toBe(0);
+            expect(spawned).toBe(false);
+            expect(lines.some((line) => line.message.includes("already running"))).toBe(true);
+            // The incumbent's record is untouched.
+            expect(readDevServerState(workdir)?.pid).toBe(process.ppid);
         });
     });
 

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -74,10 +74,12 @@ describe("lunora dev lifecycle", () => {
             expect(lines.some((line) => line.message.includes("Stopped dev server (pid 4242)"))).toBe(true);
         });
 
-        it("escalates to a process-group SIGKILL when SIGTERM stalls", async () => {
+        it("escalates a BACKGROUND record to a process-group SIGKILL when SIGTERM stalls", async () => {
             expect.assertions(2);
 
-            writeDevServerState(workdir, { mode: "cli", pid: 4242, url: "http://localhost:8787" });
+            // Only a background (detached) record may be group-killed — its
+            // group holds nothing but our own children.
+            writeDevServerState(workdir, { background: true, mode: "cli", pid: 4242, url: "http://localhost:8787" });
 
             const signals: { pid: number; signal: string }[] = [];
 
@@ -94,10 +96,38 @@ describe("lunora dev lifecycle", () => {
             });
 
             expect(result.code).toBe(0);
-            // SIGTERM first, then the group SIGKILL (negative pid).
+            // SIGTERM first, then the group SIGKILL (negative pid — the pgid
+            // lookup on the fake pid fails and falls back to the recorded pid).
             expect(signals).toStrictEqual([
                 { pid: 4242, signal: "SIGTERM" },
                 { pid: -4242, signal: "SIGKILL" },
+            ]);
+        });
+
+        it("escalates a FOREGROUND record with a single-pid SIGKILL only", async () => {
+            expect.assertions(1);
+
+            // A foreground CLI may share its process group with the user's
+            // shell job — group-killing it could fell innocent processes.
+            writeDevServerState(workdir, { mode: "cli", pid: 4242, url: "http://localhost:8787" });
+
+            const signals: { pid: number; signal: string }[] = [];
+
+            await runDevStop({
+                alive: () => true,
+                cwd: workdir,
+                json: false,
+                logger: recordingLogger().logger,
+                pollIntervalMs: 1,
+                signal: (pid, signal) => {
+                    signals.push({ pid, signal });
+                },
+                stopGraceMs: 5,
+            });
+
+            expect(signals).toStrictEqual([
+                { pid: 4242, signal: "SIGTERM" },
+                { pid: 4242, signal: "SIGKILL" },
             ]);
         });
 
@@ -136,9 +166,11 @@ describe("lunora dev lifecycle", () => {
         });
 
         it("reports URL, pid, uptime, and background for a live record", () => {
-            expect.assertions(2);
+            expect.assertions(3);
 
-            const startedAt = new Date(Date.now() - 30_000).toISOString();
+            // `startedAt` must postdate this process's start — a record older
+            // than its own process reads as a recycled PID and is cleared.
+            const startedAt = new Date().toISOString();
 
             writeDevServerState(workdir, { background: true, mode: "cli", pid: process.pid, startedAt, url: "http://localhost:8787" });
 
@@ -149,6 +181,7 @@ describe("lunora dev lifecycle", () => {
             const banner = lines.find((line) => line.message.includes("Dev server running at http://localhost:8787"));
 
             expect(banner?.message).toContain(`pid ${String(process.pid)}`);
+            expect(banner?.message).toContain("uptime");
             expect(banner?.message).toContain("background");
         });
 

--- a/packages/cli/__tests__/commands/dev.test.ts
+++ b/packages/cli/__tests__/commands/dev.test.ts
@@ -2,10 +2,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { readDevServerState, writeDevServerState } from "@lunora/config";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { DevCommandOptions } from "../../src/commands/dev/handler";
-import { planDevCommand, runDevCommand } from "../../src/commands/dev/handler";
+import { detectDevFlavor, planDevCommand, runDevCommand } from "../../src/commands/dev/handler";
 import type { Logger } from "../../src/util/logger";
 
 const silentLogger = (): Logger => {
@@ -156,6 +157,75 @@ describe("lunora dev", () => {
             expect(plan.remote.enabled).toBe(true);
             expect(plan.remote.reason).toContain("no remote-eligible bindings");
             expect(plan.wrangler.args).not.toContain("--config");
+        });
+
+        it("plans `vite dev` for a project on @lunora/vite (flavor: vite)", () => {
+            expect.assertions(6);
+
+            writeFileSync(join(workdir, "package.json"), JSON.stringify({ devDependencies: { "@lunora/vite": "workspace:*" }, name: "app" }), "utf8");
+
+            expect(detectDevFlavor(workdir)).toBe("vite");
+
+            const plan = planDevCommand({ cwd: workdir, logger: silentLogger() });
+
+            expect(plan.flavor).toBe("vite");
+            expect(plan.wrangler.tag).toBe("vite");
+            expect(plan.wrangler.args.join(" ")).toContain("vite dev");
+            // The Vite plugin already runs studio + codegen inside the dev server.
+            expect(plan.studioEnabled).toBe(false);
+            expect(plan.codegenEnabled).toBe(false);
+        });
+
+        it("runs the project's dev script for the vite flavor (meta-framework CLIs)", () => {
+            expect.assertions(3);
+
+            // An Astro project: bare `vite dev` cannot boot it — the dev script
+            // (`astro dev`) is the source of truth for the dev server command.
+            writeFileSync(
+                join(workdir, "package.json"),
+                JSON.stringify({
+                    devDependencies: { "@lunora/vite": "workspace:*" },
+                    name: "app",
+                    packageManager: "pnpm@11.0.0",
+                    scripts: { dev: "astro dev" },
+                }),
+                "utf8",
+            );
+
+            const plan = planDevCommand({ cwd: workdir, logger: silentLogger() });
+
+            expect(plan.wrangler.tag).toBe("vite");
+            expect(plan.wrangler.command).toBe("pnpm");
+            expect(plan.wrangler.args).toStrictEqual(["run", "dev"]);
+        });
+
+        it("falls back to `vite dev` when the dev script would re-enter lunora", () => {
+            expect.assertions(1);
+
+            // `scripts.dev: "lunora dev"` + the vite flavor would spawn this CLI
+            // forever — the guard falls back to the direct vite exec instead.
+            writeFileSync(
+                join(workdir, "package.json"),
+                JSON.stringify({
+                    devDependencies: { "@lunora/vite": "workspace:*" },
+                    name: "app",
+                    scripts: { dev: "lunora dev" },
+                }),
+                "utf8",
+            );
+
+            const plan = planDevCommand({ cwd: workdir, logger: silentLogger() });
+
+            expect(plan.wrangler.args.join(" ")).toContain("vite dev");
+        });
+
+        it("forwards remote mode to the vite child as LUNORA_REMOTE env", () => {
+            expect.assertions(2);
+
+            const plan = planDevCommand({ cwd: workdir, flavor: "vite", logger: silentLogger(), remote: true });
+
+            expect(plan.wrangler.env).toStrictEqual({ LUNORA_REMOTE: "1" });
+            expect(plan.remote.enabled).toBe(true);
         });
 
         it("threads the materializer's cleanup disposer onto the remote plan", () => {
@@ -348,6 +418,76 @@ describe("lunora dev", () => {
 
             // The `finally` teardown ran the disposer despite the throw.
             expect(cleaned).toBe(true);
+        });
+
+        it("records the running server in .lunora/dev.json and clears it on exit", async () => {
+            expect.assertions(4);
+
+            let resolveExit: (code: number) => void = () => {};
+            const exited = new Promise<number>((resolve) => {
+                resolveExit = resolve;
+            });
+
+            const runPromise = runDevCommand({
+                cwd: workdir,
+                logger: silentLogger(),
+                startCodegen: () => {
+                    return { close: () => {}, watchAvailable: true };
+                },
+                startStudio: async () => {
+                    return { close: async () => {}, url: "http://127.0.0.1:6173" };
+                },
+                startWorker: () => {
+                    return { exited, kill: () => {} };
+                },
+            });
+
+            // Let startup complete (scaffold offer + spawn + state write).
+            await new Promise((resolve) => {
+                setTimeout(resolve, 25);
+            });
+
+            const state = readDevServerState(workdir);
+
+            expect(state?.pid).toBe(process.pid);
+            expect(state?.url).toBe("http://localhost:8787");
+            expect(state?.mode).toBe("cli");
+
+            resolveExit(0);
+            await runPromise;
+
+            // The record is cleared on shutdown.
+            expect(readDevServerState(workdir)).toBeUndefined();
+        });
+
+        it("reports an already-running dev server instead of double-starting (lockfile)", async () => {
+            expect.assertions(3);
+
+            // A live record owned by another process (the test runner's parent).
+            writeDevServerState(workdir, { mode: "cli", pid: process.ppid, url: "http://localhost:8787" });
+
+            let spawned = false;
+            const warns: string[] = [];
+            const logger: Logger = {
+                error: () => {},
+                info: () => {},
+                success: () => {},
+                warn: (message) => warns.push(message),
+            };
+
+            const result = await runDevCommand({
+                cwd: workdir,
+                logger,
+                startWorker: () => {
+                    spawned = true;
+
+                    return { exited: Promise.resolve(0), kill: () => {} };
+                },
+            });
+
+            expect(result.code).toBe(0);
+            expect(spawned).toBe(false);
+            expect(warns.some((line) => line.includes("already running"))).toBe(true);
         });
 
         it("logs an actionable .dev.vars hint when the scaffolder is declined non-interactively", async () => {

--- a/packages/cli/__tests__/commands/dev.test.ts
+++ b/packages/cli/__tests__/commands/dev.test.ts
@@ -460,6 +460,48 @@ describe("lunora dev", () => {
             expect(readDevServerState(workdir)).toBeUndefined();
         });
 
+        it("claims a provisional record for the vite flavor and hands off via env", async () => {
+            expect.assertions(4);
+
+            writeFileSync(join(workdir, "package.json"), JSON.stringify({ devDependencies: { "@lunora/vite": "workspace:*" }, name: "app" }), "utf8");
+
+            let resolveExit: (code: number) => void = () => {};
+            const exited = new Promise<number>((resolve) => {
+                resolveExit = resolve;
+            });
+            let childEnvironment: Record<string, string> | undefined;
+
+            const runPromise = runDevCommand({
+                cwd: workdir,
+                logger: silentLogger(),
+                startWorker: (descriptor) => {
+                    childEnvironment = descriptor.env ? { ...descriptor.env } : undefined;
+
+                    return { exited, kill: () => {} };
+                },
+            });
+
+            // Let startup complete (claim + scaffold offer + spawn).
+            await new Promise((resolve) => {
+                setTimeout(resolve, 25);
+            });
+
+            // The provisional record carries this CLI's pid until the vite
+            // dev-state plugin (in the child) supersedes it.
+            const state = readDevServerState(workdir);
+
+            expect(state?.pid).toBe(process.pid);
+            expect(state?.url).toBe("http://localhost:5173");
+            // The handoff env names the record the plugin may supersede.
+            expect(childEnvironment?.LUNORA_DEV_HANDOFF_PID).toBe(String(process.pid));
+
+            resolveExit(0);
+            await runPromise;
+
+            // The provisional record is cleared on shutdown.
+            expect(readDevServerState(workdir)).toBeUndefined();
+        });
+
         it("reports an already-running dev server instead of double-starting (lockfile)", async () => {
             expect.assertions(3);
 

--- a/packages/cli/__tests__/util/spawn.test.ts
+++ b/packages/cli/__tests__/util/spawn.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { spawnShellCompat } from "../../src/util/spawn";
+
+describe("spawnShellCompat", () => {
+    it("passes through untouched on POSIX", () => {
+        expect.assertions(1);
+
+        expect(spawnShellCompat("pnpm", ["run", "dev"], "linux")).toStrictEqual({ args: ["run", "dev"], command: "pnpm", shell: false });
+    });
+
+    it("enables the shell for package-manager shims on Windows", () => {
+        expect.assertions(1);
+
+        // pnpm/npx/yarn/bun are .cmd shims there — spawn() without a shell
+        // fails outright (EINVAL / ENOENT) and the child never gets a PID.
+        expect(spawnShellCompat("pnpm", ["run", "dev"], "win32")).toStrictEqual({ args: ["run", "dev"], command: "pnpm", shell: true });
+    });
+
+    it("never shells out for node itself, even on Windows", () => {
+        expect.assertions(1);
+
+        // process.execPath is a real executable; the daemon re-invocation
+        // must not pick up cmd.exe quoting semantics.
+        expect(spawnShellCompat(process.execPath, ["bin.mjs", "dev"], "win32")).toStrictEqual({
+            args: ["bin.mjs", "dev"],
+            command: process.execPath,
+            shell: false,
+        });
+    });
+
+    it("double-quotes whitespace-bearing arguments for cmd.exe", () => {
+        expect.assertions(1);
+
+        // With shell:true Node joins command + args verbatim — an unquoted
+        // spaced path (e.g. a --config temp file under "C:\Users\John Doe")
+        // would be re-split by cmd.exe.
+        expect(spawnShellCompat("pnpm", ["exec", "wrangler", "dev", "--config", String.raw`C:\Users\John Doe\app\w.jsonc`], "win32")).toStrictEqual({
+            args: ["exec", "wrangler", "dev", "--config", String.raw`"C:\Users\John Doe\app\w.jsonc"`],
+            command: "pnpm",
+            shell: true,
+        });
+    });
+});

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -105,12 +105,39 @@ Flags: `--provider <auth\|clerk\|auth0>`, `--yes`, `--from <dir>` (local registr
 
 Starts three concurrent processes: `wrangler dev` (Worker), the embedded
 Lunora studio, and codegen in watch mode. All three reload on file changes.
+In a project on `@lunora/vite` it spawns `vite dev` instead — the Vite plugin
+already runs the worker, studio, and codegen inside the Vite dev server.
 
 ```bash
 lunora dev                # default ports: studio 6173, worker 8787
 lunora dev --port 7000    # custom studio port
 lunora dev --no-studio    # Worker + codegen only
 ```
+
+#### Background mode (AI agents)
+
+`--background` starts the dev server as a managed detached process: the
+command blocks until the server accepts requests, prints the URL + PID, then
+returns. A state record at `.lunora/dev.json` acts as a lockfile — starting
+again while a server runs reports the existing instance instead of spawning a
+conflict, and `stop` / `status` / `logs` resolve the running instance from it.
+Every subcommand is idempotent: stopping when nothing runs succeeds silently.
+
+```bash
+lunora dev --background   # detach; blocks until ready, prints URL + PID
+lunora dev status         # URL, PID, uptime (add --json for a machine-readable doc)
+lunora dev logs           # captured output of a background run (--lines n, 0 = all)
+lunora dev stop           # SIGTERM, SIGKILL escalation after 10s; clears the record
+```
+
+When an AI coding agent is detected (Claude Code, Cursor, Codex, Gemini CLI,
+Cline, …) background mode and JSON logging turn on automatically — no flags
+needed in agent workflows. Set `LUNORA_AGENT_MODE=0` to opt out (or `=1` to
+force it). Agents can also poll `GET /_lunora/status` on the running worker —
+a public, secret-free health probe answering `{"ok":true}`.
+
+JSON log lines are available to everyone via `lunora dev --json` or
+`LUNORA_LOG_JSON=1`.
 
 ### `lunora deploy`
 

--- a/packages/cli/skills/lunora-quickstart/SKILL.md
+++ b/packages/cli/skills/lunora-quickstart/SKILL.md
@@ -31,9 +31,12 @@ Set up a working Lunora project as fast as possible.
    Lunora into the current project.
 4. Run `lunora codegen` to generate `lunora/_generated/` and typecheck the
    schema + functions. This is the agent's feedback loop.
-5. Start the dev loop with `lunora dev` (ask the user to run it locally, or
-   start it in the background for cloud/headless agents — it is long-running and
-   does not exit).
+5. Start the dev loop. As an agent, run `lunora dev --background` — it starts
+   the server as a managed detached process, blocks until it accepts requests,
+   prints the URL + PID, and returns (under a detected AI agent, plain
+   `lunora dev` does this automatically, with JSON logs). Never leave a bare
+   `lunora dev` running in your own shell — it is long-running and does not
+   exit.
 6. Verify a query/mutation round-trip works end to end.
 
 ## Path 1: New Project (Recommended)
@@ -87,7 +90,23 @@ not exit, so:
 
 - **Local development (user at the keyboard):** ask the user to run `lunora dev`
   in a terminal.
-- **Cloud or headless agents:** start `lunora dev` in the background.
+- **Agents:** run `lunora dev --background`. It detaches the server, waits until
+  it answers HTTP, prints `Dev server running at <url> (pid <n>)`, and exits —
+  no orphaned shell, no PID bookkeeping. When Lunora detects an AI agent
+  (Claude Code, Cursor, Codex, …), plain `lunora dev` flips into this mode
+  automatically with JSON logs; `LUNORA_AGENT_MODE=0` opts out.
+
+Manage the running server afterwards:
+
+```bash
+lunora dev status --json   # machine-readable: url, pid, uptime, logFile
+lunora dev logs --lines 50 # tail the captured output (.lunora/dev.log)
+lunora dev stop            # idempotent — succeeds even if nothing runs
+```
+
+A second `lunora dev` never double-starts: it reports the existing instance
+(`.lunora/dev.json` is the lockfile). Probe readiness or liveness at
+`GET /_lunora/status` (`{"ok":true}`).
 
 Vite serves on `http://localhost:5173` by default; the Worker is served on the
 same origin via `@cloudflare/vite-plugin`.
@@ -236,5 +255,6 @@ ids, `.dev.vars` secrets, and container exports.
 - [ ] New project: scaffolded with `lunora init --template <t>`.
 - [ ] Existing app: ran `lunora init --here` and wired `LunoraProvider`.
 - [ ] Ran `lunora codegen`: `lunora/_generated/` exists and typecheck is clean.
-- [ ] `lunora dev` is running — user terminal, or background for cloud agents.
+- [ ] Dev server is running — user terminal, or `lunora dev --background`
+      (check with `lunora dev status`).
 - [ ] Verified a query/mutation round-trip re-renders the client live.

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -1,12 +1,18 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import type { ContainerLogStreamHandle } from "@lunora/config";
 import {
     AGENT_RULES_HINT,
     claimAgentRulesHint,
+    clearDevServerState,
     detectAgentRules,
+    detectAiAgent,
     detectFramework,
+    DEV_DAEMON_ENV,
+    DEV_LOG_FILE_ENV,
     DEV_VARS_EXAMPLE_FILE,
     DEV_VARS_FILE,
     discoverContainerInfo,
@@ -18,9 +24,12 @@ import {
     isInteractive,
     materializeRemoteWranglerConfig,
     packageNamesFromBindings,
+    readLiveDevServerState,
+    readProjectDependencyNames,
     readProjectRemotePreference,
     resolveRemoteEnabled,
     streamContainerLogs,
+    writeDevServerState,
 } from "@lunora/config";
 
 import type { ApiSpec } from "../../util/api-spec";
@@ -29,20 +38,65 @@ import type { CodegenWatcherHandle } from "../../util/codegen-watch";
 import { startCodegenWatch } from "../../util/codegen-watch";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import type { PackageManager } from "../../util/detect-package-manager";
 import { detectPackageManager, execArgsFor, runScriptCommand } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
+import { forceJsonLogging } from "../../util/logger";
 import type { SpawnDescriptor } from "../../util/spawn";
 import type { StudioServerHandle } from "../../util/studio-server";
 import { startStudioServer } from "../../util/studio-server";
 import { createTuiConfirm } from "../../util/tui-prompts";
 import type { DevOptions } from "./index";
+import { runDevBackground, runDevLogs, runDevStatus, runDevStop } from "./lifecycle";
 
 /** Default port the embedded studio server listens on (the URL you open). */
 const DEFAULT_STUDIO_PORT = 6173;
 /** Default port `wrangler dev` serves the worker on. */
 const DEFAULT_WORKER_PORT = 8787;
+/** Default port Vite serves on — the state record carries the real resolved URL. */
+const DEFAULT_VITE_PORT = 5173;
 /** Grace period after the first SIGINT before we force-kill the worker. */
 const SIGINT_GRACE_MS = 5000;
+
+/**
+ * How the dev child runs. `wrangler` is the classic `lunora dev` stack
+ * (wrangler worker + embedded studio + codegen watch). `vite` is a project on
+ * `@lunora/vite`: the Vite plugin already runs the worker, studio, and codegen
+ * inside the Vite dev server, so `lunora dev` runs the project's own dev
+ * script and gets out of the way — that's what makes `--background` / `stop` /
+ * `status` / `logs` work uniformly for Vite projects too.
+ */
+type DevFlavor = "vite" | "wrangler";
+
+/** Detect the dev flavor: a declared `@lunora/vite` dependency means Vite owns the dev server. */
+const detectDevFlavor = (cwd: string): DevFlavor => (readProjectDependencyNames(cwd).has("@lunora/vite") ? "vite" : "wrangler");
+
+/**
+ * Resolve the child command for the vite flavor. The project's own `dev`
+ * script is the source of truth — for a meta-framework the dev server is the
+ * framework CLI (`astro dev`, `nuxt dev`, …), not bare `vite dev`, and every
+ * scaffolded template wires the right one into `scripts.dev`. Falls back to
+ * `vite dev` when there is no usable script, or when the script mentions
+ * `lunora` (it would re-enter this CLI and spawn itself forever).
+ */
+const resolveViteDevExec = (manager: PackageManager, cwd: string): { args: string[]; command: string } => {
+    let script: string | undefined;
+
+    try {
+        const raw = readFileSync(join(cwd, "package.json"), "utf8");
+
+        script = (JSON.parse(raw) as { scripts?: Record<string, string> }).scripts?.dev;
+    } catch {
+        // Missing / malformed package.json — fall through to the vite default.
+    }
+
+    if (script === undefined || script.trim() === "" || script.includes("lunora")) {
+        return execArgsFor(manager, "vite", ["dev"]);
+    }
+
+    // `<manager> run dev` is valid for npm, pnpm, yarn, and bun alike.
+    return { args: ["run", "dev"], command: manager };
+};
 
 /** A running worker child the orchestrator controls: send signals, await its exit. */
 interface WorkerProcess {
@@ -66,6 +120,8 @@ interface DevCommandOptions {
     ensureExample?: typeof ensureDevVarsExample;
     /** Injection seam for tests — defaults to the real empty-secret/admin-token filler. */
     fillSecrets?: typeof fillDevSecrets;
+    /** Dev flavor override (tests / callers that already detected it) — defaults to {@link detectDevFlavor}. */
+    flavor?: DevFlavor;
     logger: Logger;
     /** Injection seam for tests — defaults to the real remote-config materializer. */
     materializeRemote?: typeof materializeRemoteWranglerConfig;
@@ -103,13 +159,17 @@ interface DevRemotePlan {
 
 interface DevCommandPlan {
     codegenEnabled: boolean;
+    /** Which stack the child runs — see {@link DevFlavor}. */
+    flavor: DevFlavor;
 
     /**
-     * One-line redirect hint printed when a Vite/meta-framework is detected: in
-     * those projects the worker runs *inside* Vite, so the user should run their
-     * framework dev script for the full app. `undefined` for a standalone project
-     * (no framework) — `lunora dev` is the right command there. Purely
-     * informational: the wrangler spawn runs regardless.
+     * One-line redirect hint printed when a meta-framework is detected on the
+     * wrangler flavor: without `@lunora/vite` in the dependencies the worker
+     * still runs *inside* the framework's dev server, so the user should run
+     * their framework dev script for the full app. `undefined` for the vite
+     * flavor (`lunora dev` already runs the project's dev script there) and
+     * for a standalone project. Purely informational: the wrangler spawn runs
+     * regardless.
      */
     frameworkHint?: string;
     /** The remote-binding decision: which D1/KV/R2 bindings hit the deployed worker. */
@@ -118,7 +178,7 @@ interface DevCommandPlan {
     studioPort: number;
     workerOrigin: string;
     workerPort: number;
-    /** The single child process `lunora dev` spawns: `wrangler dev`. */
+    /** The single child process `lunora dev` spawns: `wrangler dev` (or `vite dev` for the vite flavor). */
     wrangler: SpawnDescriptor & { tag: string };
 }
 
@@ -153,24 +213,58 @@ const resolveRemotePlan = (options: DevCommandOptions, cwd: string): { args: str
 };
 
 /**
- * Plan `lunora dev`: it runs the worker via `wrangler dev` and nothing else as a
- * child process. Vite is intentionally NOT spawned — a project may not use Vite,
- * and when it does, the `@lunora/vite` plugin already runs the worker inside
- * Vite, so the user runs `vite` themselves. Pure + synchronous so it's unit-testable.
+ * Plan `lunora dev`. Wrangler flavor: the worker runs via `wrangler dev` and
+ * nothing else as a child process. Vite flavor (`@lunora/vite` declared): the
+ * plugin already runs the worker inside the Vite dev server, so the one child
+ * is the project's own dev script (`vite dev`, `astro dev`, …) and every CLI
+ * sibling is disabled. Pure + synchronous so it's unit-testable.
  */
 const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
     const cwd = options.cwd ?? process.cwd();
-    const workerPort = options.workerPort ?? DEFAULT_WORKER_PORT;
     const manager = detectPackageManager(cwd);
-    // In a Vite/meta-framework project the `@lunora/vite` plugin runs the worker
-    // inside Vite, so `lunora dev` (wrangler-only) gives just the worker — no
-    // frontend, no HMR. Detect the framework and surface a one-line redirect hint;
-    // the wrangler spawn still runs regardless (this is a hint, not a redirect).
+    const flavor = options.flavor ?? detectDevFlavor(cwd);
+
+    if (flavor === "vite") {
+        // `@lunora/vite` already runs the worker + studio + codegen (and remote
+        // bindings, dev vars, container logs) inside the Vite dev server — the
+        // CLI's own siblings would duplicate them, so they're all disabled and
+        // the one child is the project's own dev server. Remote mode is
+        // forwarded as env (`LUNORA_REMOTE=1`) for the plugin's remote-bindings
+        // handling; no temp wrangler config is materialized here. The Vite
+        // plugin writes the authoritative `.lunora/dev.json` (real resolved URL
+        // + Vite's PID) once the server listens; `workerOrigin` is only the
+        // pre-listen default.
+        const exec = resolveViteDevExec(manager, cwd);
+
+        return {
+            codegenEnabled: false,
+            flavor,
+            remote: { bindings: [], cleanup: () => {}, enabled: options.remote === true },
+            studioEnabled: false,
+            studioPort: options.port ?? DEFAULT_STUDIO_PORT,
+            workerOrigin: `http://localhost:${String(DEFAULT_VITE_PORT)}`,
+            workerPort: DEFAULT_VITE_PORT,
+            wrangler: {
+                args: exec.args,
+                command: exec.command,
+                cwd,
+                ...(options.remote === true ? { env: { LUNORA_REMOTE: "1" } } : {}),
+                tag: "vite",
+            },
+        };
+    }
+
+    // In a meta-framework project WITHOUT `@lunora/vite` (wrangler flavor, so
+    // the vite branch above didn't take it) the worker still runs inside the
+    // framework's dev server, so `lunora dev` (wrangler-only) gives just the
+    // worker — no frontend, no HMR. Surface a one-line redirect hint; the
+    // wrangler spawn still runs regardless (this is a hint, not a redirect).
     const detection = detectFramework(cwd);
     const frameworkHint =
         detection.framework === "none"
             ? undefined
             : `this project uses ${detection.framework} — the worker runs inside Vite there. run \`${runScriptCommand(manager, "dev")}\` for the full app (frontend + HMR); \`lunora dev\` starts only the worker.`;
+    const workerPort = options.workerPort ?? DEFAULT_WORKER_PORT;
     const remote = resolveRemotePlan(options, cwd);
     // `--var WORKER_ENV:development` flags the worker as a dev deployment so the
     // runtime streams every RPC dispatch summary to the terminal by default
@@ -183,6 +277,7 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
 
     return {
         codegenEnabled: options.codegen !== false,
+        flavor,
         frameworkHint,
         remote: remote.plan,
         studioEnabled: options.studio !== false,
@@ -264,7 +359,7 @@ const pipeChildOutput = (child: ChildProcess, tag: string, logger: Logger): void
 const defaultWorkerSpawner: WorkerSpawner = (descriptor, logger) => {
     const child = nodeSpawn(descriptor.command, [...descriptor.args], {
         cwd: descriptor.cwd ?? process.cwd(),
-        env: process.env,
+        env: descriptor.env ? { ...process.env, ...descriptor.env } : process.env,
         stdio: ["inherit", "pipe", "pipe"],
     });
 
@@ -460,6 +555,53 @@ const offerDevVariablesScaffold = async (options: DevCommandOptions, cwd: string
     }
 };
 
+/** Report an already-running dev server + the lifecycle hints (the idempotent-start path). */
+const reportExistingServer = (logger: Logger, existing: { pid: number; url: string }): void => {
+    logger.warn(`Dev server already running at ${existing.url} (pid ${String(existing.pid)})`);
+    logger.info("  Stop:   lunora dev stop");
+    logger.info("  Status: lunora dev status");
+    logger.info("  Logs:   lunora dev logs");
+};
+
+/**
+ * Wrangler-flavor extras once the worker child is spawned: write the
+ * `.lunora/dev.json` record (so `dev stop|status|logs` + the duplicate-start
+ * lock resolve this server), tail the dev containers' Docker logs, and print
+ * the banner. All skipped for the vite flavor, where `@lunora/vite`'s
+ * dev-state plugin writes the record itself (authoritative resolved URL +
+ * Vite's own PID) and the plugin stack owns container logs and the banner.
+ * Returns the container-log disposer for the caller's teardown set.
+ */
+const afterWorkerSpawn = (plan: DevCommandPlan, cwd: string, logger: Logger, studioUrl: string | undefined): ContainerLogStreamHandle | undefined => {
+    if (plan.flavor !== "wrangler") {
+        return undefined;
+    }
+
+    writeDevServerState(cwd, {
+        background: process.env[DEV_DAEMON_ENV] === "1",
+        logFile: process.env[DEV_LOG_FILE_ENV],
+        mode: "cli",
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        studioUrl,
+        url: plan.workerOrigin,
+    });
+
+    let containerLogs: ContainerLogStreamHandle | undefined;
+
+    // Tail the local dev containers' own stdout/stderr (no-op when the project
+    // declares none). Best-effort — a Docker hiccup must not break dev.
+    try {
+        containerLogs = startContainerLogStreaming(cwd, logger);
+    } catch {
+        /* never fatal */
+    }
+
+    printBanner(logger, plan, studioUrl);
+
+    return containerLogs;
+};
+
 /**
  * Start codegen watch + the studio server, spawn `wrangler dev`, print the
  * banner, and resolve when the worker exits or the user interrupts — tearing
@@ -475,9 +617,21 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
     const handles: Teardown = { remoteCleanup: plan.remote.cleanup };
 
     try {
+        // Lockfile check: a live `.lunora/dev.json` means a dev server is
+        // already running — report it and succeed (idempotent start) instead of
+        // spawning a conflicting sibling. A stale record (dead PID) was already
+        // cleared by the read.
+        const existing = readLiveDevServerState(cwd);
+
+        if (existing !== undefined && existing.pid !== process.pid) {
+            reportExistingServer(logger, existing);
+
+            return { code: 0, plan };
+        }
+
         await offerDevVariablesScaffold(options, cwd);
 
-        logger.info("starting wrangler dev + studio");
+        logger.info(plan.flavor === "vite" ? "starting vite dev (worker + studio + codegen run inside Vite via @lunora/vite)" : "starting wrangler dev + studio");
 
         if (plan.codegenEnabled) {
             handles.codegen = (options.startCodegen ?? startCodegenWatch)({ apiSpec: options.apiSpec, logger, projectRoot: cwd });
@@ -511,15 +665,7 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
 
         const worker = (options.startWorker ?? defaultWorkerSpawner)(plan.wrangler, logger);
 
-        // Tail the local dev containers' own stdout/stderr (no-op when the project
-        // declares none). Best-effort — a Docker hiccup must not break dev.
-        try {
-            handles.containerLogs = startContainerLogStreaming(cwd, logger);
-        } catch {
-            /* never fatal */
-        }
-
-        printBanner(logger, plan, studioUrl);
+        handles.containerLogs = afterWorkerSpawn(plan, cwd, logger, studioUrl);
         printAgentRulesHint(logger, cwd);
 
         let sigintCount = 0;
@@ -559,13 +705,141 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
     } finally {
         // Always shut the siblings down + unlink the remote temp config, whether
         // the worker exited cleanly, the user interrupted, or startup threw.
+        // The state record is only cleared while it still carries THIS process's
+        // PID (the guard makes the vite flavor — where Vite's plugin owns the
+        // record — and the already-running early return no-ops).
+        clearDevServerState(cwd, process.pid);
         await teardown(handles);
     }
 };
 
+/**
+ * Rebuild the argv a detached daemon `lunora dev` re-invocation needs, from the
+ * already-parsed options. `--background`/`--json` are deliberately NOT
+ * forwarded: the daemon must run the foreground path (its detachment marker is
+ * {@link DEV_DAEMON_ENV}), and JSON logging travels as `LUNORA_LOG_JSON=1` env.
+ */
+const daemonArguments = (options: DevOptions, remote: boolean): string[] => {
+    const args = ["dev"];
+
+    if (options.apiSpec !== undefined) {
+        args.push("--api-spec", options.apiSpec);
+    }
+
+    if (options.port !== undefined) {
+        args.push("--port", String(options.port));
+    }
+
+    if (options.workerPort !== undefined) {
+        args.push("--worker-port", String(options.workerPort));
+    }
+
+    if (options.codegen === false) {
+        args.push("--no-codegen");
+    }
+
+    if (options.studio === false) {
+        args.push("--no-studio");
+    }
+
+    if (remote) {
+        args.push("--remote");
+    }
+
+    return args;
+};
+
+/**
+ * Detach the dev server as a managed background process and block until it is
+ * ready: the project's dev script directly for a Vite project (its dev-state
+ * plugin writes the record), else this same CLI re-invoked as the daemon.
+ */
+const startBackground = (context: { cwd: string; jsonLogs: boolean; logger: Logger; options: DevOptions; remote: boolean }): Promise<{ code: number }> => {
+    const { cwd, jsonLogs, logger, options, remote } = context;
+
+    if (detectDevFlavor(cwd) === "vite") {
+        const exec = resolveViteDevExec(detectPackageManager(cwd), cwd);
+
+        return runDevBackground({
+            command: { args: exec.args, command: exec.command },
+            cwd,
+            ...(remote ? { env: { LUNORA_REMOTE: "1" } } : {}),
+            json: jsonLogs,
+            logger,
+        });
+    }
+
+    // Re-invoke this same CLI entry as the detached daemon.
+    return runDevBackground({
+        command: { args: [process.argv[1] ?? "lunora", ...daemonArguments(options, remote)], command: process.execPath },
+        cwd,
+        json: jsonLogs,
+        logger,
+    });
+};
+
 /** `lunora dev` handler (lazy-loaded via the command's `loader`). */
-const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(({ cwd, logger, options }) =>
-    runDevCommand({
+const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(async ({ argument, cwd, logger, options }) => {
+    const subcommand = argument[0];
+    const json = options.json === true;
+
+    if (subcommand === "stop") {
+        return runDevStop({ cwd, json, logger });
+    }
+
+    if (subcommand === "status") {
+        return runDevStatus({ cwd, json, logger });
+    }
+
+    if (subcommand === "logs") {
+        return runDevLogs({ cwd, lines: options.lines, logger });
+    }
+
+    if (subcommand !== undefined) {
+        logger.error(`dev: unknown subcommand "${subcommand}" — expected stop | status | logs (or no subcommand to start the dev server)`);
+
+        return { code: 1 };
+    }
+
+    // A daemon re-invocation IS the background server: it must run the plain
+    // foreground path below (and never re-detect an agent and recurse).
+    const isDaemon = process.env[DEV_DAEMON_ENV] === "1";
+    const agent = isDaemon ? undefined : detectAiAgent();
+    const jsonLogs = json || agent !== undefined;
+
+    if (jsonLogs) {
+        // Safe pre-first-log-line: the shared pail rebuilds with the JSON reporter.
+        forceJsonLogging();
+    }
+
+    if (agent !== undefined && options.background !== true) {
+        logger.info(`AI agent detected (${agent.name} via ${agent.variable}) — starting the dev server in background mode with JSON logs. Set LUNORA_AGENT_MODE=0 to opt out.`);
+    }
+
+    // Remote-binding mode obeys a clear precedence: an explicit `--remote`
+    // flag wins, then `LUNORA_REMOTE` in the environment, then the `remote`
+    // key in the project's `lunora.json` (a project default). See
+    // `resolveRemoteEnabled` in @lunora/config.
+    const remote = resolveRemoteEnabled({
+        configPreference: readProjectRemotePreference(cwd),
+        envValue: process.env["LUNORA_REMOTE"],
+        flag: options.remote,
+    });
+
+    if (!isDaemon && (options.background === true || agent !== undefined)) {
+        // Idempotent start: a live server means success, not a conflict.
+        const existing = readLiveDevServerState(cwd);
+
+        if (existing !== undefined) {
+            reportExistingServer(logger, existing);
+
+            return { code: 0 };
+        }
+
+        return startBackground({ cwd, jsonLogs, logger, options, remote });
+    }
+
+    return runDevCommand({
         apiSpec: parseApiSpec(options.apiSpec),
         // cerebro parses `--no-codegen`/`--no-studio` as the negation of the
         // `codegen`/`studio` booleans (runtime key drops the `no-` prefix), so a
@@ -574,20 +848,12 @@ const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(({ cwd, lo
         cwd,
         logger,
         port: options.port,
-        // Remote-binding mode obeys a clear precedence: an explicit `--remote`
-        // flag wins, then `LUNORA_REMOTE` in the environment, then the `remote`
-        // key in the project's `lunora.json` (a project default). See
-        // `resolveRemoteEnabled` in @lunora/config.
-        remote: resolveRemoteEnabled({
-            configPreference: readProjectRemotePreference(cwd),
-            envValue: process.env["LUNORA_REMOTE"],
-            flag: options.remote,
-        }),
+        remote,
         studio: options.studio === false ? false : undefined,
         workerPort: options.workerPort,
-    }),
-);
+    });
+});
 
 export { execute };
-export type { DevCommandOptions, DevCommandPlan, DevRemotePlan, WorkerProcess, WorkerSpawner };
-export { planDevCommand, resolveRemotePlan, runDevCommand };
+export type { DevCommandOptions, DevCommandPlan, DevFlavor, DevRemotePlan, WorkerProcess, WorkerSpawner };
+export { detectDevFlavor, planDevCommand, resolveRemotePlan, runDevCommand };

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -1,12 +1,11 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import type { ContainerLogStreamHandle } from "@lunora/config";
 import {
     AGENT_RULES_HINT,
     claimAgentRulesHint,
+    claimDevServerState,
     clearDevServerState,
     detectAgentRules,
     detectAiAgent,
@@ -25,11 +24,10 @@ import {
     materializeRemoteWranglerConfig,
     packageNamesFromBindings,
     readLiveDevServerState,
-    readProjectDependencyNames,
     readProjectRemotePreference,
     resolveRemoteEnabled,
     streamContainerLogs,
-    writeDevServerState,
+    updateDevServerState,
 } from "@lunora/config";
 
 import type { ApiSpec } from "../../util/api-spec";
@@ -38,7 +36,6 @@ import type { CodegenWatcherHandle } from "../../util/codegen-watch";
 import { startCodegenWatch } from "../../util/codegen-watch";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
-import type { PackageManager } from "../../util/detect-package-manager";
 import { detectPackageManager, execArgsFor, runScriptCommand } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { forceJsonLogging } from "../../util/logger";
@@ -47,7 +44,8 @@ import type { StudioServerHandle } from "../../util/studio-server";
 import { startStudioServer } from "../../util/studio-server";
 import { createTuiConfirm } from "../../util/tui-prompts";
 import type { DevOptions } from "./index";
-import { runDevBackground, runDevLogs, runDevStatus, runDevStop } from "./lifecycle";
+import type { DevFlavor } from "./lifecycle";
+import { detectDevFlavor, reportExistingServer, runLifecycleSubcommand, startBackground, viteDevCommand } from "./lifecycle";
 
 /** Default port the embedded studio server listens on (the URL you open). */
 const DEFAULT_STUDIO_PORT = 6173;
@@ -57,46 +55,6 @@ const DEFAULT_WORKER_PORT = 8787;
 const DEFAULT_VITE_PORT = 5173;
 /** Grace period after the first SIGINT before we force-kill the worker. */
 const SIGINT_GRACE_MS = 5000;
-
-/**
- * How the dev child runs. `wrangler` is the classic `lunora dev` stack
- * (wrangler worker + embedded studio + codegen watch). `vite` is a project on
- * `@lunora/vite`: the Vite plugin already runs the worker, studio, and codegen
- * inside the Vite dev server, so `lunora dev` runs the project's own dev
- * script and gets out of the way — that's what makes `--background` / `stop` /
- * `status` / `logs` work uniformly for Vite projects too.
- */
-type DevFlavor = "vite" | "wrangler";
-
-/** Detect the dev flavor: a declared `@lunora/vite` dependency means Vite owns the dev server. */
-const detectDevFlavor = (cwd: string): DevFlavor => (readProjectDependencyNames(cwd).has("@lunora/vite") ? "vite" : "wrangler");
-
-/**
- * Resolve the child command for the vite flavor. The project's own `dev`
- * script is the source of truth — for a meta-framework the dev server is the
- * framework CLI (`astro dev`, `nuxt dev`, …), not bare `vite dev`, and every
- * scaffolded template wires the right one into `scripts.dev`. Falls back to
- * `vite dev` when there is no usable script, or when the script mentions
- * `lunora` (it would re-enter this CLI and spawn itself forever).
- */
-const resolveViteDevExec = (manager: PackageManager, cwd: string): { args: string[]; command: string } => {
-    let script: string | undefined;
-
-    try {
-        const raw = readFileSync(join(cwd, "package.json"), "utf8");
-
-        script = (JSON.parse(raw) as { scripts?: Record<string, string> }).scripts?.dev;
-    } catch {
-        // Missing / malformed package.json — fall through to the vite default.
-    }
-
-    if (script === undefined || script.trim() === "" || script.includes("lunora")) {
-        return execArgsFor(manager, "vite", ["dev"]);
-    }
-
-    // `<manager> run dev` is valid for npm, pnpm, yarn, and bun alike.
-    return { args: ["run", "dev"], command: manager };
-};
 
 /** A running worker child the orchestrator controls: send signals, await its exit. */
 interface WorkerProcess {
@@ -234,7 +192,7 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
         // plugin writes the authoritative `.lunora/dev.json` (real resolved URL
         // + Vite's PID) once the server listens; `workerOrigin` is only the
         // pre-listen default.
-        const exec = resolveViteDevExec(manager, cwd);
+        const exec = viteDevCommand(cwd);
 
         return {
             codegenEnabled: false,
@@ -555,21 +513,11 @@ const offerDevVariablesScaffold = async (options: DevCommandOptions, cwd: string
     }
 };
 
-/** Report an already-running dev server + the lifecycle hints (the idempotent-start path). */
-const reportExistingServer = (logger: Logger, existing: { pid: number; url: string }): void => {
-    logger.warn(`Dev server already running at ${existing.url} (pid ${String(existing.pid)})`);
-    logger.info("  Stop:   lunora dev stop");
-    logger.info("  Status: lunora dev status");
-    logger.info("  Logs:   lunora dev logs");
-};
-
 /**
- * Wrangler-flavor extras once the worker child is spawned: write the
- * `.lunora/dev.json` record (so `dev stop|status|logs` + the duplicate-start
- * lock resolve this server), tail the dev containers' Docker logs, and print
- * the banner. All skipped for the vite flavor, where `@lunora/vite`'s
- * dev-state plugin writes the record itself (authoritative resolved URL +
- * Vite's own PID) and the plugin stack owns container logs and the banner.
+ * Wrangler-flavor extras once the worker child is spawned: tail the dev
+ * containers' Docker logs and print the banner. Skipped for the vite flavor,
+ * where the plugin stack owns both. (The `.lunora/dev.json` record is claimed
+ * earlier, before any sibling starts — see the claim in {@link runDevCommand}.)
  * Returns the container-log disposer for the caller's teardown set.
  */
 const afterWorkerSpawn = (plan: DevCommandPlan, cwd: string, logger: Logger, studioUrl: string | undefined): ContainerLogStreamHandle | undefined => {
@@ -577,15 +525,11 @@ const afterWorkerSpawn = (plan: DevCommandPlan, cwd: string, logger: Logger, stu
         return undefined;
     }
 
-    writeDevServerState(cwd, {
-        background: process.env[DEV_DAEMON_ENV] === "1",
-        logFile: process.env[DEV_LOG_FILE_ENV],
-        mode: "cli",
-        pid: process.pid,
-        startedAt: new Date().toISOString(),
-        studioUrl,
-        url: plan.workerOrigin,
-    });
+    // Backfill the studio URL onto the record claimed before the siblings
+    // started (it wasn't known at claim time).
+    if (studioUrl !== undefined) {
+        updateDevServerState(cwd, { studioUrl });
+    }
 
     let containerLogs: ContainerLogStreamHandle | undefined;
 
@@ -600,6 +544,30 @@ const afterWorkerSpawn = (plan: DevCommandPlan, cwd: string, logger: Logger, stu
     printBanner(logger, plan, studioUrl);
 
     return containerLogs;
+};
+
+/**
+ * Atomically claim `.lunora/dev.json` for a starting wrangler-flavor dev
+ * server (a no-op for the vite flavor, whose record `@lunora/vite`'s
+ * dev-state plugin claims itself once Vite listens). Closes the
+ * check-then-write race where two simultaneous starts both pass the
+ * read-based lock check. Returns the live incumbent when the claim is lost.
+ */
+const claimWranglerRecord = (plan: DevCommandPlan, cwd: string): { pid: number; url: string } | undefined => {
+    if (plan.flavor !== "wrangler") {
+        return undefined;
+    }
+
+    const claim = claimDevServerState(cwd, {
+        background: process.env[DEV_DAEMON_ENV] === "1",
+        logFile: process.env[DEV_LOG_FILE_ENV],
+        mode: "cli",
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        url: plan.workerOrigin,
+    });
+
+    return claim.ok ? undefined : claim.existing;
 };
 
 /**
@@ -629,9 +597,21 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             return { code: 0, plan };
         }
 
+        // Atomically claim the record before ANY sibling starts (see
+        // claimWranglerRecord); a lost claim means another start won the race.
+        const incumbent = claimWranglerRecord(plan, cwd);
+
+        if (incumbent !== undefined) {
+            reportExistingServer(logger, incumbent);
+
+            return { code: 0, plan };
+        }
+
         await offerDevVariablesScaffold(options, cwd);
 
-        logger.info(plan.flavor === "vite" ? "starting vite dev (worker + studio + codegen run inside Vite via @lunora/vite)" : "starting wrangler dev + studio");
+        logger.info(
+            plan.flavor === "vite" ? "starting vite dev (worker + studio + codegen run inside Vite via @lunora/vite)" : "starting wrangler dev + studio",
+        );
 
         if (plan.codegenEnabled) {
             handles.codegen = (options.startCodegen ?? startCodegenWatch)({ apiSpec: options.apiSpec, logger, projectRoot: cwd });
@@ -713,92 +693,16 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
     }
 };
 
-/**
- * Rebuild the argv a detached daemon `lunora dev` re-invocation needs, from the
- * already-parsed options. `--background`/`--json` are deliberately NOT
- * forwarded: the daemon must run the foreground path (its detachment marker is
- * {@link DEV_DAEMON_ENV}), and JSON logging travels as `LUNORA_LOG_JSON=1` env.
- */
-const daemonArguments = (options: DevOptions, remote: boolean): string[] => {
-    const args = ["dev"];
-
-    if (options.apiSpec !== undefined) {
-        args.push("--api-spec", options.apiSpec);
-    }
-
-    if (options.port !== undefined) {
-        args.push("--port", String(options.port));
-    }
-
-    if (options.workerPort !== undefined) {
-        args.push("--worker-port", String(options.workerPort));
-    }
-
-    if (options.codegen === false) {
-        args.push("--no-codegen");
-    }
-
-    if (options.studio === false) {
-        args.push("--no-studio");
-    }
-
-    if (remote) {
-        args.push("--remote");
-    }
-
-    return args;
-};
-
-/**
- * Detach the dev server as a managed background process and block until it is
- * ready: the project's dev script directly for a Vite project (its dev-state
- * plugin writes the record), else this same CLI re-invoked as the daemon.
- */
-const startBackground = (context: { cwd: string; jsonLogs: boolean; logger: Logger; options: DevOptions; remote: boolean }): Promise<{ code: number }> => {
-    const { cwd, jsonLogs, logger, options, remote } = context;
-
-    if (detectDevFlavor(cwd) === "vite") {
-        const exec = resolveViteDevExec(detectPackageManager(cwd), cwd);
-
-        return runDevBackground({
-            command: { args: exec.args, command: exec.command },
-            cwd,
-            ...(remote ? { env: { LUNORA_REMOTE: "1" } } : {}),
-            json: jsonLogs,
-            logger,
-        });
-    }
-
-    // Re-invoke this same CLI entry as the detached daemon.
-    return runDevBackground({
-        command: { args: [process.argv[1] ?? "lunora", ...daemonArguments(options, remote)], command: process.execPath },
-        cwd,
-        json: jsonLogs,
-        logger,
-    });
-};
-
 /** `lunora dev` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(async ({ argument, cwd, logger, options }) => {
-    const subcommand = argument[0];
     const json = options.json === true;
 
-    if (subcommand === "stop") {
-        return runDevStop({ cwd, json, logger });
-    }
+    // `stop` / `status` / `logs` route to their lifecycle commands; `undefined`
+    // means no subcommand — fall through to the start flow below.
+    const dispatched = runLifecycleSubcommand({ cwd, json, lines: options.lines, logger, subcommand: argument[0] });
 
-    if (subcommand === "status") {
-        return runDevStatus({ cwd, json, logger });
-    }
-
-    if (subcommand === "logs") {
-        return runDevLogs({ cwd, lines: options.lines, logger });
-    }
-
-    if (subcommand !== undefined) {
-        logger.error(`dev: unknown subcommand "${subcommand}" — expected stop | status | logs (or no subcommand to start the dev server)`);
-
-        return { code: 1 };
+    if (dispatched !== undefined) {
+        return dispatched;
     }
 
     // A daemon re-invocation IS the background server: it must run the plain
@@ -813,7 +717,9 @@ const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(async ({ a
     }
 
     if (agent !== undefined && options.background !== true) {
-        logger.info(`AI agent detected (${agent.name} via ${agent.variable}) — starting the dev server in background mode with JSON logs. Set LUNORA_AGENT_MODE=0 to opt out.`);
+        logger.info(
+            `AI agent detected (${agent.name} via ${agent.variable}) — starting the dev server in background mode with JSON logs. Set LUNORA_AGENT_MODE=0 to opt out.`,
+        );
     }
 
     // Remote-binding mode obeys a clear precedence: an explicit `--remote`
@@ -855,5 +761,9 @@ const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(async ({ a
 });
 
 export { execute };
-export type { DevCommandOptions, DevCommandPlan, DevFlavor, DevRemotePlan, WorkerProcess, WorkerSpawner };
-export { detectDevFlavor, planDevCommand, resolveRemotePlan, runDevCommand };
+export type { DevCommandOptions, DevCommandPlan, DevRemotePlan, WorkerProcess, WorkerSpawner };
+// `DevFlavor` / `detectDevFlavor` live in `./lifecycle`; re-exported here so the
+// planning surface (`planDevCommand` and friends) stays importable from one module.
+export type { DevFlavor } from "./lifecycle";
+export { detectDevFlavor } from "./lifecycle";
+export { planDevCommand, resolveRemotePlan, runDevCommand };

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -11,6 +11,7 @@ import {
     detectAiAgent,
     detectFramework,
     DEV_DAEMON_ENV,
+    DEV_HANDOFF_ENV,
     DEV_LOG_FILE_ENV,
     DEV_VARS_EXAMPLE_FILE,
     DEV_VARS_FILE,
@@ -40,6 +41,7 @@ import { detectPackageManager, execArgsFor, runScriptCommand } from "../../util/
 import type { Logger } from "../../util/logger";
 import { forceJsonLogging } from "../../util/logger";
 import type { SpawnDescriptor } from "../../util/spawn";
+import { spawnShellCompat } from "../../util/spawn";
 import type { StudioServerHandle } from "../../util/studio-server";
 import { startStudioServer } from "../../util/studio-server";
 import { createTuiConfirm } from "../../util/tui-prompts";
@@ -315,9 +317,13 @@ const pipeChildOutput = (child: ChildProcess, tag: string, logger: Logger): void
 
 /** Real worker spawner: runs the descriptor as a child and pipes its output through the logger. */
 const defaultWorkerSpawner: WorkerSpawner = (descriptor, logger) => {
-    const child = nodeSpawn(descriptor.command, [...descriptor.args], {
+    // Windows can't spawn the package-manager .cmd shims without a shell — see
+    // spawnShellCompat. POSIX passes through untouched.
+    const exec = spawnShellCompat(descriptor.command, descriptor.args);
+    const child = nodeSpawn(exec.command, exec.args, {
         cwd: descriptor.cwd ?? process.cwd(),
         env: descriptor.env ? { ...process.env, ...descriptor.env } : process.env,
+        shell: exec.shell,
         stdio: ["inherit", "pipe", "pipe"],
     });
 
@@ -547,25 +553,30 @@ const afterWorkerSpawn = (plan: DevCommandPlan, cwd: string, logger: Logger, stu
 };
 
 /**
- * Atomically claim `.lunora/dev.json` for a starting wrangler-flavor dev
- * server (a no-op for the vite flavor, whose record `@lunora/vite`'s
- * dev-state plugin claims itself once Vite listens). Closes the
+ * Atomically claim `.lunora/dev.json` for a starting dev server. Closes the
  * check-then-write race where two simultaneous starts both pass the
- * read-based lock check. Returns the live incumbent when the claim is lost.
+ * read-based lock check. For the wrangler flavor this record is final; for
+ * the vite flavor it is *provisional* — the pre-listen default URL under this
+ * CLI's PID — and `@lunora/vite`'s dev-state plugin supersedes it with the
+ * authoritative URL + Vite's PID (see {@link DEV_HANDOFF_ENV}). A daemon
+ * re-invocation likewise supersedes the provisional record its background
+ * parent claimed before spawning it. Returns the live incumbent on a lost
+ * claim.
  */
-const claimWranglerRecord = (plan: DevCommandPlan, cwd: string): { pid: number; url: string } | undefined => {
-    if (plan.flavor !== "wrangler") {
-        return undefined;
-    }
-
-    const claim = claimDevServerState(cwd, {
-        background: process.env[DEV_DAEMON_ENV] === "1",
-        logFile: process.env[DEV_LOG_FILE_ENV],
-        mode: "cli",
-        pid: process.pid,
-        startedAt: new Date().toISOString(),
-        url: plan.workerOrigin,
-    });
+const claimStartRecord = (plan: DevCommandPlan, cwd: string): { pid: number; url: string } | undefined => {
+    const handoffPid = Number(process.env[DEV_HANDOFF_ENV]);
+    const claim = claimDevServerState(
+        cwd,
+        {
+            background: process.env[DEV_DAEMON_ENV] === "1",
+            logFile: process.env[DEV_LOG_FILE_ENV],
+            mode: "cli",
+            pid: process.pid,
+            startedAt: new Date().toISOString(),
+            url: plan.workerOrigin,
+        },
+        Number.isInteger(handoffPid) && handoffPid > 0 ? { supersedePid: handoffPid } : undefined,
+    );
 
     return claim.ok ? undefined : claim.existing;
 };
@@ -598,13 +609,20 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         }
 
         // Atomically claim the record before ANY sibling starts (see
-        // claimWranglerRecord); a lost claim means another start won the race.
-        const incumbent = claimWranglerRecord(plan, cwd);
+        // claimStartRecord); a lost claim means another start won the race.
+        const incumbent = claimStartRecord(plan, cwd);
 
         if (incumbent !== undefined) {
             reportExistingServer(logger, incumbent);
 
             return { code: 0, plan };
+        }
+
+        if (plan.flavor === "vite") {
+            // Hand the provisional record down so the dev-state plugin inside
+            // the Vite child may supersede it (and only it) with the
+            // authoritative resolved URL + Vite's own PID.
+            plan.wrangler.env = { ...plan.wrangler.env, [DEV_HANDOFF_ENV]: String(process.pid) };
         }
 
         await offerDevVariablesScaffold(options, cwd);

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -3,9 +3,19 @@ import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/
 import { API_SPEC_HELP } from "../../util/api-spec";
 
 const devCommand: Command = {
+    argument: {
+        description: "Optional subcommand: stop (shut the running dev server down) | status (report it) | logs (print its captured output)",
+        name: "args",
+        type: String,
+    },
     description: "Run the dev stack: wrangler worker + studio + codegen watch",
     examples: [
         ["lunora dev", "Run the worker + studio + codegen watch"],
+        ["lunora dev --background", "Run detached: blocks until ready, prints URL + PID, then returns"],
+        ["lunora dev stop", "Stop the background/tracked dev server (idempotent)"],
+        ["lunora dev status", "Report the running dev server (URL, PID, uptime)"],
+        ["lunora dev logs", "Print the captured dev-server log (background runs)"],
+        ["lunora dev --json", "Machine-readable JSON log lines (also LUNORA_LOG_JSON=1)"],
         ["lunora dev --no-studio", "Skip the embedded studio server"],
         ["lunora dev --worker-port 8080", "Use a custom wrangler dev port"],
         ["lunora dev --remote", "Proxy D1/KV/R2 to the deployed worker (also LUNORA_REMOTE=1)"],
@@ -20,6 +30,13 @@ const devCommand: Command = {
         { description: `Which API spec(s) codegen emits: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
         { description: "Studio server port (default 6173)", name: "port", type: Number },
         { description: "wrangler dev port (default 8787)", name: "worker-port", type: Number },
+        {
+            description: "Run the dev server as a managed background process (auto-enabled when an AI agent is detected; LUNORA_AGENT_MODE=0 disables)",
+            name: "background",
+            type: Boolean,
+        },
+        { description: "Emit machine-readable JSON log lines (also LUNORA_LOG_JSON=1; auto-enabled for AI agents)", name: "json", type: Boolean },
+        { description: "How many trailing lines `lunora dev logs` prints (default 100, 0 = all)", name: "lines", type: Number },
         { description: "Don't start the embedded studio server", name: "no-studio", type: Boolean },
         { description: "Don't watch + regenerate codegen", name: "no-codegen", type: Boolean },
         { description: "Proxy D1/KV/R2 bindings to the deployed worker (or set LUNORA_REMOTE=1)", name: "remote", type: Boolean },
@@ -30,9 +47,12 @@ export { devCommand };
 
 export type DevOptions = CreateOptions<{
     "api-spec": string | undefined;
+    background: boolean | undefined;
     // The `--no-codegen` / `--no-studio` flags are declared as `no-*` options but
     // cerebro exposes them under the negated positive key at runtime.
     codegen: boolean | undefined;
+    json: boolean | undefined;
+    lines: number | undefined;
     port: number | undefined;
     remote: boolean | undefined;
     studio: boolean | undefined;

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -26,6 +26,8 @@ const devCommand: Command = {
             return { default: m.execute as CommandExecute<Toolbox> };
         }),
     name: "dev",
+    // KEEP IN SYNC with `daemonArguments` in `./lifecycle.ts`: a new flag that
+    // must reach a `--background` daemon has to be forwarded there explicitly.
     options: [
         { description: `Which API spec(s) codegen emits: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
         { description: "Studio server port (default 6173)", name: "port", type: Number },

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -12,15 +12,26 @@
  * reports the existing instance instead of spawning a conflict.
  */
 import type { ChildProcess } from "node:child_process";
-import { spawn as nodeSpawn } from "node:child_process";
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync } from "node:fs";
+import { spawn as nodeSpawn, spawnSync } from "node:child_process";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import type { DevServerState } from "@lunora/config";
-import { clearDevServerState, DEV_DAEMON_ENV, DEV_LOG_FILE, DEV_LOG_FILE_ENV, isProcessAlive, readDevServerState, readLiveDevServerState } from "@lunora/config";
+import {
+    clearDevServerState,
+    DEV_DAEMON_ENV,
+    DEV_LOG_FILE,
+    DEV_LOG_FILE_ENV,
+    isRecordedProcessCurrent,
+    readDevServerState,
+    readLiveDevServerState,
+    readProjectDependencyNames,
+} from "@lunora/config";
 
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { printJson } from "../../util/output-format";
+import type { DevOptions } from "./index";
 
 /** How long `--background` waits for the server to accept requests before giving up. */
 const DEFAULT_READY_TIMEOUT_MS = 120_000;
@@ -28,13 +39,59 @@ const DEFAULT_READY_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 250;
 /** Grace period `dev stop` allows for a clean SIGTERM shutdown before SIGKILL. */
 const STOP_GRACE_MS = 10_000;
-/** Trailing log lines `dev logs` prints by default (0 = all). */
+/** Trailing log lines `dev logs` prints by default (0 = all, within {@link LOG_TAIL_MAX_BYTES}). */
 const DEFAULT_LOG_LINES = 100;
 /** Log lines surfaced when a background start fails before becoming ready. */
 const FAILURE_LOG_TAIL_LINES = 40;
+/** Upper bound on how much of the capture log is read back — a long-lived run's log can grow unbounded. */
+const LOG_TAIL_MAX_BYTES = 256 * 1024;
 
 /** Env overriding {@link DEFAULT_READY_TIMEOUT_MS}. */
 const READY_TIMEOUT_ENV = "LUNORA_DEV_READY_TIMEOUT_MS";
+
+/**
+ * How the dev child runs. `wrangler` is the classic `lunora dev` stack
+ * (wrangler worker + embedded studio + codegen watch). `vite` is a project on
+ * `@lunora/vite`: the Vite plugin already runs the worker, studio, and codegen
+ * inside the Vite dev server, so `lunora dev` runs the project's own dev
+ * script and gets out of the way — that's what makes `--background` / `stop` /
+ * `status` / `logs` work uniformly for Vite projects too.
+ */
+type DevFlavor = "vite" | "wrangler";
+
+/** Detect the dev flavor: a declared `@lunora/vite` dependency means Vite owns the dev server. */
+const detectDevFlavor = (cwd: string): DevFlavor => (readProjectDependencyNames(cwd).has("@lunora/vite") ? "vite" : "wrangler");
+
+/**
+ * The dev-server exec for the vite flavor — shared by the foreground plan and
+ * the background detach so the two spawn sites can't drift. The project's own
+ * `dev` script is the source of truth: for a meta-framework the dev server is
+ * the framework CLI (`astro dev`, `nuxt dev`, …), not bare `vite dev`, and
+ * every scaffolded template wires the right one into `scripts.dev`. Falls back
+ * to `vite dev` when there is no usable script, or when the script mentions
+ * `lunora` (it would re-enter this CLI and spawn itself forever).
+ */
+const viteDevCommand = (cwd: string): { args: ReadonlyArray<string>; command: string } => {
+    const manager = detectPackageManager(cwd);
+    let script: string | undefined;
+
+    try {
+        const raw = readFileSync(join(cwd, "package.json"), "utf8");
+
+        script = (JSON.parse(raw) as { scripts?: Record<string, string> }).scripts?.dev;
+    } catch {
+        // Missing / malformed package.json — fall through to the vite default.
+    }
+
+    if (script === undefined || script.trim() === "" || script.includes("lunora")) {
+        const exec = execArgsFor(manager, "vite", ["dev"]);
+
+        return { args: exec.args, command: exec.command };
+    }
+
+    // `<manager> run dev` is valid for npm, pnpm, yarn, and bun alike.
+    return { args: ["run", "dev"], command: manager };
+};
 
 const sleep = (ms: number): Promise<void> =>
     new Promise((resolve) => {
@@ -68,17 +125,26 @@ interface DetachedChild {
 }
 
 /** Spawns the detached daemon process. Injectable so tests drive the orchestration without real processes. */
-type DetachedSpawner = (descriptor: { args: ReadonlyArray<string>; command: string; cwd: string; env: Readonly<Record<string, string | undefined>>; logPath: string }) => DetachedChild;
+type DetachedSpawner = (descriptor: {
+    args: ReadonlyArray<string>;
+    command: string;
+    cwd: string;
+    env: Readonly<Record<string, string | undefined>>;
+    logPath: string;
+}) => DetachedChild;
 
 /**
  * Real detached spawner: routes the child's stdout+stderr into the capture log
  * (truncating any previous run's log), detaches it into its own process group,
- * and unrefs so the parent can exit while the child lives on.
+ * and unrefs so the parent can exit while the child lives on. The log is
+ * created owner-only (0600): dev output routinely echoes `.dev.vars` secrets,
+ * tokens, and connection strings, which must not be world-readable on a
+ * multi-user machine.
  */
 const defaultDetachedSpawner: DetachedSpawner = (descriptor) => {
     mkdirSync(dirname(descriptor.logPath), { recursive: true });
 
-    const logFd = openSync(descriptor.logPath, "w");
+    const logFd = openSync(descriptor.logPath, "w", 0o600);
 
     let child: ChildProcess;
 
@@ -109,13 +175,41 @@ const defaultDetachedSpawner: DetachedSpawner = (descriptor) => {
     };
 };
 
-/** Read the last `count` lines of a log file (all lines when `count` &lt;= 0); `[]` when unreadable. */
-const readLogTail = (path: string, count: number): string[] => {
-    let text: string;
-
+/**
+ * Read the trailing window of a log file as text, capped at
+ * {@link LOG_TAIL_MAX_BYTES} so a giant long-running capture log is never
+ * slurped whole; `undefined` when unreadable. When capped, the first
+ * (likely partial) line of the window is dropped.
+ */
+const readLogWindow = (path: string): string | undefined => {
     try {
-        text = readFileSync(path, "utf8");
+        const { size } = statSync(path);
+
+        if (size <= LOG_TAIL_MAX_BYTES) {
+            return readFileSync(path, "utf8");
+        }
+
+        const fd = openSync(path, "r");
+
+        try {
+            const buffer = Buffer.alloc(LOG_TAIL_MAX_BYTES);
+            const read = readSync(fd, buffer, 0, LOG_TAIL_MAX_BYTES, size - LOG_TAIL_MAX_BYTES);
+            const text = buffer.toString("utf8", 0, read);
+
+            return text.slice(text.indexOf("\n") + 1);
+        } finally {
+            closeSync(fd);
+        }
     } catch {
+        return undefined;
+    }
+};
+
+/** Read the last `count` lines of a log file (all lines when `count` &lt;= 0, bounded by {@link LOG_TAIL_MAX_BYTES}); `[]` when unreadable. */
+const readLogTail = (path: string, count: number): string[] => {
+    const text = readLogWindow(path);
+
+    if (text === undefined) {
         return [];
     }
 
@@ -132,6 +226,19 @@ const readLogTail = (path: string, count: number): string[] => {
 /** The absolute capture-log path for a project, honouring the state record when present. */
 const resolveLogPath = (cwd: string, state: DevServerState | undefined): string => state?.logFile ?? join(cwd, DEV_LOG_FILE);
 
+/** Print the `stop` / `status` / `logs` hint triple shown after every start-adjacent report. */
+const printLifecycleHints = (logger: Logger): void => {
+    logger.info("  Stop:   lunora dev stop");
+    logger.info("  Status: lunora dev status");
+    logger.info("  Logs:   lunora dev logs");
+};
+
+/** Report an already-running dev server + the lifecycle hints (the idempotent-start path). */
+const reportExistingServer = (logger: Logger, existing: { pid: number; url: string }): void => {
+    logger.warn(`Dev server already running at ${existing.url} (pid ${String(existing.pid)})`);
+    printLifecycleHints(logger);
+};
+
 /** Print the ready banner both humans and agents read after a background start. */
 const printBackgroundBanner = (logger: Logger, state: DevServerState): void => {
     logger.success(`Dev server running at ${state.url} (pid ${String(state.pid)})`);
@@ -140,9 +247,7 @@ const printBackgroundBanner = (logger: Logger, state: DevServerState): void => {
         logger.info(`  Studio: ${state.studioUrl}`);
     }
 
-    logger.info("  Stop:   lunora dev stop");
-    logger.info("  Status: lunora dev status");
-    logger.info("  Logs:   lunora dev logs");
+    printLifecycleHints(logger);
 };
 
 interface BackgroundCommandOptions {
@@ -173,7 +278,13 @@ type ReadyOutcome = { exitCode: number; status: "exited" } | { state: DevServerS
  * keeps the three racing signals — record file, HTTP socket, process death —
  * in one legible loop.
  */
-const waitUntilReady = async (parameters: { child: DetachedChild; cwd: string; deadline: number; pollIntervalMs: number; probe: ReadinessProbe }): Promise<ReadyOutcome> => {
+const waitUntilReady = async (parameters: {
+    child: DetachedChild;
+    cwd: string;
+    deadline: number;
+    pollIntervalMs: number;
+    probe: ReadinessProbe;
+}): Promise<ReadyOutcome> => {
     const { child, cwd, deadline, pollIntervalMs, probe } = parameters;
     const exited = child.exited.then((code): { exitCode: number } => {
         return { exitCode: code };
@@ -274,8 +385,138 @@ const runDevBackground = async (options: BackgroundCommandOptions): Promise<{ co
     return { code: 1 };
 };
 
+/**
+ * Rebuild the argv a detached daemon `lunora dev` re-invocation needs, from the
+ * already-parsed options. `--background`/`--json` are deliberately NOT
+ * forwarded: the daemon must run the foreground path (its detachment marker is
+ * {@link DEV_DAEMON_ENV}), and JSON logging travels as `LUNORA_LOG_JSON=1` env.
+ *
+ * KEEP IN SYNC with the `dev` option table in `./index.ts`: any new flag that
+ * must reach the detached daemon has to be forwarded here explicitly, or a
+ * background start will silently drop it.
+ */
+const daemonArguments = (options: DevOptions, remote: boolean): string[] => {
+    const args = ["dev"];
+
+    if (options.apiSpec !== undefined) {
+        args.push("--api-spec", options.apiSpec);
+    }
+
+    if (options.port !== undefined) {
+        args.push("--port", String(options.port));
+    }
+
+    if (options.workerPort !== undefined) {
+        args.push("--worker-port", String(options.workerPort));
+    }
+
+    if (options.codegen === false) {
+        args.push("--no-codegen");
+    }
+
+    if (options.studio === false) {
+        args.push("--no-studio");
+    }
+
+    if (remote) {
+        args.push("--remote");
+    }
+
+    return args;
+};
+
+/**
+ * Detach the dev server as a managed background process and block until it is
+ * ready: the project's dev script directly for a Vite project (its dev-state
+ * plugin writes the record), else this same CLI re-invoked as the daemon.
+ */
+const startBackground = (context: { cwd: string; jsonLogs: boolean; logger: Logger; options: DevOptions; remote: boolean }): Promise<{ code: number }> => {
+    const { cwd, jsonLogs, logger, options, remote } = context;
+
+    if (detectDevFlavor(cwd) === "vite") {
+        return runDevBackground({
+            command: viteDevCommand(cwd),
+            cwd,
+            ...(remote ? { env: { LUNORA_REMOTE: "1" } } : {}),
+            json: jsonLogs,
+            logger,
+        });
+    }
+
+    // Re-invoke this same CLI entry as the detached daemon.
+    return runDevBackground({
+        command: { args: [process.argv[1] ?? "lunora", ...daemonArguments(options, remote)], command: process.execPath },
+        cwd,
+        json: jsonLogs,
+        logger,
+    });
+};
+
+/**
+ * Process-group id of `pid` via `ps` (POSIX only), or `undefined`. The
+ * recorded PID is not necessarily a group leader — a Vite background record
+ * holds Vite's PID while the detached group is led by the package-manager
+ * wrapper — so the group must be looked up, never assumed to equal the PID.
+ */
+const processGroupId = (pid: number): number | undefined => {
+    try {
+        // eslint-disable-next-line sonarjs/no-os-command-from-path -- `ps` must resolve from PATH (POSIX standard tool); args are fixed and no shell is involved
+        const result = spawnSync("ps", ["-o", "pgid=", "-p", String(pid)], { encoding: "utf8" });
+        const pgid = Number.parseInt(result.stdout.trim(), 10);
+
+        return Number.isInteger(pgid) && pgid > 0 ? pgid : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/** The signal seam `dev stop` drives — `process.kill` in production, recorded in tests. */
+type SignalFunction = (pid: number, signal: NodeJS.Signals) => void;
+
+/**
+ * Force-kill escalation after a stalled graceful shutdown, scoped by platform
+ * and by how the server was started.
+ *
+ * Windows has no POSIX process groups, so `taskkill /T /F` fells the whole
+ * child tree (wrangler/workerd/vite children would otherwise be orphaned
+ * holding the port). On POSIX, a BACKGROUND record was detached into its own
+ * process group containing only our children, so the group is killed
+ * (resolved via {@link processGroupId} — the recorded PID may not be its
+ * leader). A FOREGROUND record gets a single-PID kill only: the foreground
+ * CLI may share a process group with the user's shell job (no job control
+ * under `sh -c`), so a group kill could fell innocent processes.
+ */
+const forceKillRecordedServer = (state: DevServerState, signal: SignalFunction): void => {
+    if (process.platform === "win32") {
+        try {
+            // eslint-disable-next-line sonarjs/no-os-command-from-path -- `taskkill` must resolve from PATH (Windows system tool); args are fixed and no shell is involved
+            spawnSync("taskkill", ["/pid", String(state.pid), "/T", "/F"], { stdio: "ignore" });
+        } catch {
+            /* already gone */
+        }
+
+        return;
+    }
+
+    if (state.background === true) {
+        try {
+            signal(-(processGroupId(state.pid) ?? state.pid), "SIGKILL");
+
+            return;
+        } catch {
+            /* group gone or unkillable — fall through to the single PID */
+        }
+    }
+
+    try {
+        signal(state.pid, "SIGKILL");
+    } catch {
+        /* already gone */
+    }
+};
+
 interface StopCommandOptions {
-    /** Injection seam for tests — defaults to {@link isProcessAlive}. */
+    /** Injection seam for tests — defaults to {@link isRecordedProcessCurrent} against the record. */
     alive?: (pid: number) => boolean;
     cwd: string;
     json: boolean;
@@ -283,24 +524,28 @@ interface StopCommandOptions {
     /** Injection seam for tests — defaults to {@link POLL_INTERVAL_MS} / {@link STOP_GRACE_MS}. */
     pollIntervalMs?: number;
     /** Injection seam for tests — defaults to `process.kill`. */
-    signal?: (pid: number, signal: NodeJS.Signals) => void;
+    signal?: SignalFunction;
     stopGraceMs?: number;
 }
 
 /**
- * `lunora dev stop` — SIGTERM the recorded dev server, escalate to SIGKILL
- * after a grace period, and clear the state record. Idempotent: stopping when
- * nothing runs succeeds silently.
+ * `lunora dev stop` — SIGTERM the recorded dev server, escalate after a grace
+ * period (see {@link forceKillRecordedServer}), and clear the state record.
+ * Idempotent: stopping when nothing runs succeeds silently. The record's PID
+ * is verified to still be the process that wrote it (PID-reuse guard) before
+ * anything is signalled.
  */
 const runDevStop = async (options: StopCommandOptions): Promise<{ code: number }> => {
     const { cwd, logger } = options;
-    const alive = options.alive ?? isProcessAlive;
-    const signal = options.signal ?? ((pid: number, sig: NodeJS.Signals): void => {
-        process.kill(pid, sig);
-    });
+    const state = readDevServerState(cwd);
+    const alive = options.alive ?? ((pid: number): boolean => pid === state?.pid && isRecordedProcessCurrent(state));
+    const signal =
+        options.signal ??
+        ((pid: number, sig: NodeJS.Signals): void => {
+            process.kill(pid, sig);
+        });
     const pollInterval = options.pollIntervalMs ?? POLL_INTERVAL_MS;
     const grace = options.stopGraceMs ?? STOP_GRACE_MS;
-    const state = readDevServerState(cwd);
 
     if (state === undefined || !alive(state.pid)) {
         clearDevServerState(cwd);
@@ -328,18 +573,7 @@ const runDevStop = async (options: StopCommandOptions): Promise<{ code: number }
     }
 
     if (alive(state.pid)) {
-        // Graceful shutdown stalled — force-kill. Prefer the process GROUP
-        // (detached daemons lead their own group, taking wrangler/vite child
-        // processes down with them); fall back to the single PID.
-        try {
-            signal(-state.pid, "SIGKILL");
-        } catch {
-            try {
-                signal(state.pid, "SIGKILL");
-            } catch {
-                /* already gone */
-            }
-        }
+        forceKillRecordedServer(state, signal);
     }
 
     // The server clears its own record on clean shutdown; this covers the
@@ -423,7 +657,7 @@ const runDevStatus = (options: StatusCommandOptions): { code: number } => {
 
 interface LogsCommandOptions {
     cwd: string;
-    /** Trailing lines to print; 0 or negative = the whole log. */
+    /** Trailing lines to print; 0 or negative = the whole log (bounded by {@link LOG_TAIL_MAX_BYTES}). */
     lines?: number;
     logger: Logger;
 }
@@ -453,5 +687,60 @@ const runDevLogs = (options: LogsCommandOptions): { code: number } => {
     return { code: 0 };
 };
 
-export type { BackgroundCommandOptions, DetachedChild, DetachedSpawner, LogsCommandOptions, ReadinessProbe, StatusCommandOptions, StopCommandOptions };
-export { runDevBackground, runDevLogs, runDevStatus, runDevStop };
+/**
+ * Route a `lunora dev &lt;subcommand>` positional to its lifecycle command.
+ * Returns `undefined` when no subcommand was given (→ the caller runs the
+ * start path), a `{ code: 1 }` error for an unknown one.
+ */
+const runLifecycleSubcommand = (parameters: {
+    cwd: string;
+    json: boolean;
+    lines?: number;
+    logger: Logger;
+    subcommand: string | undefined;
+}): Promise<{ code: number }> | { code: number } | undefined => {
+    const { cwd, json, lines, logger, subcommand } = parameters;
+
+    if (subcommand === "stop") {
+        return runDevStop({ cwd, json, logger });
+    }
+
+    if (subcommand === "status") {
+        return runDevStatus({ cwd, json, logger });
+    }
+
+    if (subcommand === "logs") {
+        return runDevLogs({ cwd, lines, logger });
+    }
+
+    if (subcommand !== undefined) {
+        logger.error(`dev: unknown subcommand "${subcommand}" — expected stop | status | logs (or no subcommand to start the dev server)`);
+
+        return { code: 1 };
+    }
+
+    return undefined;
+};
+
+export type {
+    BackgroundCommandOptions,
+    DetachedChild,
+    DetachedSpawner,
+    DevFlavor,
+    LogsCommandOptions,
+    ReadinessProbe,
+    StatusCommandOptions,
+    StopCommandOptions,
+};
+export {
+    detectDevFlavor,
+    printLifecycleHints,
+    reportExistingServer,
+    runDevBackground,
+    runDevLogs,
+    runDevStatus,
+    runDevStop,
+    runLifecycleSubcommand,
+    startBackground,
+    viteDevCommand,
+};

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -18,8 +18,10 @@ import { dirname, join } from "node:path";
 
 import type { DevServerState } from "@lunora/config";
 import {
+    claimDevServerState,
     clearDevServerState,
     DEV_DAEMON_ENV,
+    DEV_HANDOFF_ENV,
     DEV_LOG_FILE,
     DEV_LOG_FILE_ENV,
     isRecordedProcessCurrent,
@@ -31,6 +33,7 @@ import {
 import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { printJson } from "../../util/output-format";
+import { spawnShellCompat } from "../../util/spawn";
 import type { DevOptions } from "./index";
 
 /** How long `--background` waits for the server to accept requests before giving up. */
@@ -148,12 +151,19 @@ const defaultDetachedSpawner: DetachedSpawner = (descriptor) => {
 
     let child: ChildProcess;
 
+    // Windows can't spawn the package-manager .cmd shims without a shell — see
+    // spawnShellCompat. windowsHide keeps the detached child from flashing a
+    // console window; both are no-ops on POSIX.
+    const exec = spawnShellCompat(descriptor.command, descriptor.args);
+
     try {
-        child = nodeSpawn(descriptor.command, [...descriptor.args], {
+        child = nodeSpawn(exec.command, exec.args, {
             cwd: descriptor.cwd,
             detached: true,
             env: descriptor.env,
+            shell: exec.shell,
             stdio: ["ignore", logFd, logFd],
+            windowsHide: true,
         });
     } finally {
         // The child holds its own copies of the fd; the parent's must not leak.
@@ -429,27 +439,73 @@ const daemonArguments = (options: DevOptions, remote: boolean): string[] => {
  * Detach the dev server as a managed background process and block until it is
  * ready: the project's dev script directly for a Vite project (its dev-state
  * plugin writes the record), else this same CLI re-invoked as the daemon.
+ *
+ * Before spawning, this parent atomically claims `.lunora/dev.json` as a
+ * provisional record under its own PID — closing the race where two
+ * simultaneous starts both pass the read-based lock check and spawn separate
+ * servers — and hands its PID down via {@link DEV_HANDOFF_ENV} so exactly one
+ * child (the vite dev-state plugin, or the wrangler daemon) supersedes the
+ * record with the authoritative URL + PID. The provisional record is cleared
+ * (PID-guarded) once the wait resolves; after a successful handoff the clear
+ * is a no-op because the record already carries the child's PID.
  */
-const startBackground = (context: { cwd: string; jsonLogs: boolean; logger: Logger; options: DevOptions; remote: boolean }): Promise<{ code: number }> => {
+const startBackground = async (context: {
+    cwd: string;
+    jsonLogs: boolean;
+    logger: Logger;
+    options: DevOptions;
+    remote: boolean;
+    /** Injection seam for tests — defaults to the real {@link runDevBackground}. */
+    run?: (options: BackgroundCommandOptions) => Promise<{ code: number }>;
+}): Promise<{ code: number }> => {
     const { cwd, jsonLogs, logger, options, remote } = context;
+    const run = context.run ?? runDevBackground;
+    const flavor = detectDevFlavor(cwd);
+    // Pre-listen default URL — cosmetic (shown only if a concurrent starter
+    // loses to this claim); the child's superseding record carries the real one.
+    const url = flavor === "vite" ? "http://localhost:5173" : `http://localhost:${String(options.workerPort ?? 8787)}`;
 
-    if (detectDevFlavor(cwd) === "vite") {
-        return runDevBackground({
-            command: viteDevCommand(cwd),
+    const claim = claimDevServerState(cwd, {
+        background: true,
+        mode: "cli",
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        url,
+    });
+
+    if (!claim.ok) {
+        if (claim.existing !== undefined) {
+            reportExistingServer(logger, claim.existing);
+        }
+
+        return { code: 0 };
+    }
+
+    const handoff = { [DEV_HANDOFF_ENV]: String(process.pid) };
+
+    try {
+        if (flavor === "vite") {
+            return await run({
+                command: viteDevCommand(cwd),
+                cwd,
+                env: { ...(remote ? { LUNORA_REMOTE: "1" } : {}), ...handoff },
+                json: jsonLogs,
+                logger,
+            });
+        }
+
+        // Re-invoke this same CLI entry as the detached daemon.
+        return await run({
+            command: { args: [process.argv[1] ?? "lunora", ...daemonArguments(options, remote)], command: process.execPath },
             cwd,
-            ...(remote ? { env: { LUNORA_REMOTE: "1" } } : {}),
+            env: handoff,
             json: jsonLogs,
             logger,
         });
+    } finally {
+        // Drop the provisional record unless a child already superseded it.
+        clearDevServerState(cwd, process.pid);
     }
-
-    // Re-invoke this same CLI entry as the detached daemon.
-    return runDevBackground({
-        command: { args: [process.argv[1] ?? "lunora", ...daemonArguments(options, remote)], command: process.execPath },
-        cwd,
-        json: jsonLogs,
-        logger,
-    });
 };
 
 /**
@@ -548,7 +604,13 @@ const runDevStop = async (options: StopCommandOptions): Promise<{ code: number }
     const grace = options.stopGraceMs ?? STOP_GRACE_MS;
 
     if (state === undefined || !alive(state.pid)) {
-        clearDevServerState(cwd);
+        // Drop the stale record — but only if it is still the one we read.
+        // Unguarded, this would race a concurrent `lunora dev` that claimed a
+        // fresh record between our read and this clear, orphaning that server
+        // from `stop`/`status`/`logs`.
+        if (state !== undefined) {
+            clearDevServerState(cwd, state.pid);
+        }
 
         if (options.json) {
             printJson({ running: false, stopped: false });

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -1,0 +1,457 @@
+/**
+ * `lunora dev` lifecycle subcommands and background mode.
+ *
+ * AI agents (and humans juggling terminals) struggle with a process that never
+ * exits: they start duplicate servers, lose PIDs, and leave zombies behind. So
+ * `lunora dev --background` starts the dev stack as a managed, detached
+ * process — it blocks until the server accepts requests, prints the URL + PID,
+ * and returns — while `.lunora/dev.json` (see `@lunora/config`'s
+ * `dev-server-state`) acts as the lockfile that `stop` / `status` / `logs`
+ * resolve the instance from. Every subcommand is idempotent and forgiving:
+ * stopping a stopped server succeeds silently, starting over a running one
+ * reports the existing instance instead of spawning a conflict.
+ */
+import type { ChildProcess } from "node:child_process";
+import { spawn as nodeSpawn } from "node:child_process";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import type { DevServerState } from "@lunora/config";
+import { clearDevServerState, DEV_DAEMON_ENV, DEV_LOG_FILE, DEV_LOG_FILE_ENV, isProcessAlive, readDevServerState, readLiveDevServerState } from "@lunora/config";
+
+import type { Logger } from "../../util/logger";
+import { printJson } from "../../util/output-format";
+
+/** How long `--background` waits for the server to accept requests before giving up. */
+const DEFAULT_READY_TIMEOUT_MS = 120_000;
+/** Poll cadence for readiness / process-death checks. */
+const POLL_INTERVAL_MS = 250;
+/** Grace period `dev stop` allows for a clean SIGTERM shutdown before SIGKILL. */
+const STOP_GRACE_MS = 10_000;
+/** Trailing log lines `dev logs` prints by default (0 = all). */
+const DEFAULT_LOG_LINES = 100;
+/** Log lines surfaced when a background start fails before becoming ready. */
+const FAILURE_LOG_TAIL_LINES = 40;
+
+/** Env overriding {@link DEFAULT_READY_TIMEOUT_MS}. */
+const READY_TIMEOUT_ENV = "LUNORA_DEV_READY_TIMEOUT_MS";
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+/**
+ * True when an HTTP server answers at `origin` — ANY response counts,
+ * including a 404. The probe targets `/_lunora/status` (the runtime's public
+ * health route), but an older runtime without that route still proves the
+ * server is up by answering at all; only a refused/failed connection is "not
+ * ready".
+ */
+const defaultProbe = async (origin: string): Promise<boolean> => {
+    try {
+        await fetch(new URL("/_lunora/status", origin), { signal: AbortSignal.timeout(1000) });
+
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/** Readiness probe seam — tests swap the real HTTP probe out. */
+type ReadinessProbe = (origin: string) => Promise<boolean>;
+
+/** A spawned detached child, narrowed to what the wait loop needs. */
+interface DetachedChild {
+    exited: Promise<number>;
+    pid: number | undefined;
+}
+
+/** Spawns the detached daemon process. Injectable so tests drive the orchestration without real processes. */
+type DetachedSpawner = (descriptor: { args: ReadonlyArray<string>; command: string; cwd: string; env: Readonly<Record<string, string | undefined>>; logPath: string }) => DetachedChild;
+
+/**
+ * Real detached spawner: routes the child's stdout+stderr into the capture log
+ * (truncating any previous run's log), detaches it into its own process group,
+ * and unrefs so the parent can exit while the child lives on.
+ */
+const defaultDetachedSpawner: DetachedSpawner = (descriptor) => {
+    mkdirSync(dirname(descriptor.logPath), { recursive: true });
+
+    const logFd = openSync(descriptor.logPath, "w");
+
+    let child: ChildProcess;
+
+    try {
+        child = nodeSpawn(descriptor.command, [...descriptor.args], {
+            cwd: descriptor.cwd,
+            detached: true,
+            env: descriptor.env,
+            stdio: ["ignore", logFd, logFd],
+        });
+    } finally {
+        // The child holds its own copies of the fd; the parent's must not leak.
+        closeSync(logFd);
+    }
+
+    child.unref();
+
+    return {
+        exited: new Promise<number>((resolve) => {
+            child.on("error", () => {
+                resolve(1);
+            });
+            child.on("exit", (code, signal) => {
+                resolve(code ?? (signal ? 1 : 0));
+            });
+        }),
+        pid: child.pid,
+    };
+};
+
+/** Read the last `count` lines of a log file (all lines when `count` &lt;= 0); `[]` when unreadable. */
+const readLogTail = (path: string, count: number): string[] => {
+    let text: string;
+
+    try {
+        text = readFileSync(path, "utf8");
+    } catch {
+        return [];
+    }
+
+    const lines = text.split("\n");
+
+    // A trailing newline yields one empty final element — not a real line.
+    if (lines.at(-1) === "") {
+        lines.pop();
+    }
+
+    return count > 0 ? lines.slice(-count) : lines;
+};
+
+/** The absolute capture-log path for a project, honouring the state record when present. */
+const resolveLogPath = (cwd: string, state: DevServerState | undefined): string => state?.logFile ?? join(cwd, DEV_LOG_FILE);
+
+/** Print the ready banner both humans and agents read after a background start. */
+const printBackgroundBanner = (logger: Logger, state: DevServerState): void => {
+    logger.success(`Dev server running at ${state.url} (pid ${String(state.pid)})`);
+
+    if (state.studioUrl !== undefined) {
+        logger.info(`  Studio: ${state.studioUrl}`);
+    }
+
+    logger.info("  Stop:   lunora dev stop");
+    logger.info("  Status: lunora dev status");
+    logger.info("  Logs:   lunora dev logs");
+};
+
+interface BackgroundCommandOptions {
+    /** The command to run detached (the daemon `lunora dev` or `vite dev`). */
+    command: { args: ReadonlyArray<string>; command: string };
+    cwd: string;
+    /** Extra env for the daemon beyond the detach/log/JSON plumbing. */
+    env?: Readonly<Record<string, string>>;
+    /** Whether the daemon should emit JSON log lines into the capture log. */
+    json: boolean;
+    logger: Logger;
+    /** Injection seam for tests — defaults to {@link POLL_INTERVAL_MS}. */
+    pollIntervalMs?: number;
+    /** Injection seam for tests — defaults to the real HTTP readiness probe. */
+    probe?: ReadinessProbe;
+    /** Injection seam for tests — defaults to env override or {@link DEFAULT_READY_TIMEOUT_MS}. */
+    readyTimeoutMs?: number;
+    /** Injection seam for tests — defaults to the real detached spawner. */
+    spawnDetached?: DetachedSpawner;
+}
+
+/** Outcome of the readiness wait: server ready (with its record), child death, or deadline. */
+type ReadyOutcome = { exitCode: number; status: "exited" } | { state: DevServerState; status: "ready" } | { status: "timeout" };
+
+/**
+ * Poll until the child's state record is live AND the server answers HTTP,
+ * the child dies, or the deadline passes. Polling (rather than event wiring)
+ * keeps the three racing signals — record file, HTTP socket, process death —
+ * in one legible loop.
+ */
+const waitUntilReady = async (parameters: { child: DetachedChild; cwd: string; deadline: number; pollIntervalMs: number; probe: ReadinessProbe }): Promise<ReadyOutcome> => {
+    const { child, cwd, deadline, pollIntervalMs, probe } = parameters;
+    const exited = child.exited.then((code): { exitCode: number } => {
+        return { exitCode: code };
+    });
+
+    while (Date.now() < deadline) {
+        const state = readLiveDevServerState(cwd);
+
+        // Wait for the record the child writes, then for the server to answer.
+        // Guard against reading a leftover record that predates this spawn: the
+        // recorded PID must be alive (readLive guarantees it) and must not be
+        // this parent process.
+        // eslint-disable-next-line no-await-in-loop -- readiness polling: each tick re-samples record + socket.
+        if (state !== undefined && state.pid !== process.pid && (await probe(state.url))) {
+            return { state, status: "ready" };
+        }
+
+        // Sleep one tick — but wake immediately (with the exit code) if the
+        // child dies first: a daemon dead before ready is a failed start.
+        // eslint-disable-next-line no-await-in-loop -- readiness polling; the race keeps child-death latency at zero.
+        const raced = await Promise.race([exited, sleep(pollIntervalMs)]);
+
+        if (raced !== undefined) {
+            return { ...raced, status: "exited" };
+        }
+    }
+
+    return { status: "timeout" };
+};
+
+/**
+ * Start the dev server as a managed background process: spawn detached with
+ * output captured to `.lunora/dev.log`, block until the server has written its
+ * state record AND accepts an HTTP request, print URL + PID, and return.
+ *
+ * The child — not this parent — writes `.lunora/dev.json` (the daemon `lunora
+ * dev` writes it once wrangler spawns; a Vite project's dev-state plugin writes
+ * it once Vite listens), so the record always carries the authoritative URL and
+ * the PID that `dev stop` must signal. This parent only passes the log path and
+ * detach marker down via env.
+ */
+const runDevBackground = async (options: BackgroundCommandOptions): Promise<{ code: number }> => {
+    const { cwd, logger } = options;
+    const logPath = resolveLogPath(cwd, undefined);
+    const environmentTimeout = Number(process.env[READY_TIMEOUT_ENV] ?? "");
+    const timeout = options.readyTimeoutMs ?? (Number.isFinite(environmentTimeout) && environmentTimeout > 0 ? environmentTimeout : DEFAULT_READY_TIMEOUT_MS);
+
+    const child = (options.spawnDetached ?? defaultDetachedSpawner)({
+        args: options.command.args,
+        command: options.command.command,
+        cwd,
+        env: {
+            ...process.env,
+            ...options.env,
+            [DEV_DAEMON_ENV]: "1",
+            [DEV_LOG_FILE_ENV]: logPath,
+            // The capture log is read back by `lunora dev logs` (and often an
+            // agent) — ANSI colour codes would only garble it.
+            ...(process.env.FORCE_COLOR === undefined ? { NO_COLOR: "1" } : {}),
+            ...(options.json ? { LUNORA_LOG_JSON: "1" } : {}),
+        },
+        logPath,
+    });
+
+    const outcome = await waitUntilReady({
+        child,
+        cwd,
+        deadline: Date.now() + timeout,
+        pollIntervalMs: options.pollIntervalMs ?? POLL_INTERVAL_MS,
+        probe: options.probe ?? defaultProbe,
+    });
+
+    if (outcome.status === "ready") {
+        printBackgroundBanner(logger, outcome.state);
+
+        return { code: 0 };
+    }
+
+    if (outcome.status === "exited") {
+        // Died before becoming ready — surface the log tail instead of leaving
+        // the user (or agent) to hunt for it.
+        logger.error(`dev server exited before becoming ready (exit code ${String(outcome.exitCode)}). Last output:`);
+
+        for (const line of readLogTail(logPath, FAILURE_LOG_TAIL_LINES)) {
+            logger.error(`  ${line}`);
+        }
+
+        clearDevServerState(cwd, child.pid);
+
+        return { code: outcome.exitCode === 0 ? 1 : outcome.exitCode };
+    }
+
+    logger.warn(
+        `dev server did not confirm ready within ${String(Math.round(timeout / 1000))}s — it may still be compiling. ` +
+            "Check `lunora dev status` and `lunora dev logs`; `lunora dev stop` shuts it down.",
+    );
+
+    return { code: 1 };
+};
+
+interface StopCommandOptions {
+    /** Injection seam for tests — defaults to {@link isProcessAlive}. */
+    alive?: (pid: number) => boolean;
+    cwd: string;
+    json: boolean;
+    logger: Logger;
+    /** Injection seam for tests — defaults to {@link POLL_INTERVAL_MS} / {@link STOP_GRACE_MS}. */
+    pollIntervalMs?: number;
+    /** Injection seam for tests — defaults to `process.kill`. */
+    signal?: (pid: number, signal: NodeJS.Signals) => void;
+    stopGraceMs?: number;
+}
+
+/**
+ * `lunora dev stop` — SIGTERM the recorded dev server, escalate to SIGKILL
+ * after a grace period, and clear the state record. Idempotent: stopping when
+ * nothing runs succeeds silently.
+ */
+const runDevStop = async (options: StopCommandOptions): Promise<{ code: number }> => {
+    const { cwd, logger } = options;
+    const alive = options.alive ?? isProcessAlive;
+    const signal = options.signal ?? ((pid: number, sig: NodeJS.Signals): void => {
+        process.kill(pid, sig);
+    });
+    const pollInterval = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+    const grace = options.stopGraceMs ?? STOP_GRACE_MS;
+    const state = readDevServerState(cwd);
+
+    if (state === undefined || !alive(state.pid)) {
+        clearDevServerState(cwd);
+
+        if (options.json) {
+            printJson({ running: false, stopped: false });
+        } else {
+            logger.info("No dev server running.");
+        }
+
+        return { code: 0 };
+    }
+
+    try {
+        signal(state.pid, "SIGTERM");
+    } catch {
+        /* died between the alive check and the signal — that's a stop */
+    }
+
+    const deadline = Date.now() + grace;
+
+    while (alive(state.pid) && Date.now() < deadline) {
+        // eslint-disable-next-line no-await-in-loop -- graceful-shutdown polling: re-check liveness each tick.
+        await sleep(pollInterval);
+    }
+
+    if (alive(state.pid)) {
+        // Graceful shutdown stalled — force-kill. Prefer the process GROUP
+        // (detached daemons lead their own group, taking wrangler/vite child
+        // processes down with them); fall back to the single PID.
+        try {
+            signal(-state.pid, "SIGKILL");
+        } catch {
+            try {
+                signal(state.pid, "SIGKILL");
+            } catch {
+                /* already gone */
+            }
+        }
+    }
+
+    // The server clears its own record on clean shutdown; this covers the
+    // SIGKILL path (and is a no-op when the record is already gone).
+    clearDevServerState(cwd, state.pid);
+
+    if (options.json) {
+        printJson({ pid: state.pid, stopped: true });
+    } else {
+        logger.success(`Stopped dev server (pid ${String(state.pid)}).`);
+    }
+
+    return { code: 0 };
+};
+
+interface StatusCommandOptions {
+    cwd: string;
+    json: boolean;
+    logger: Logger;
+    /** Injection seam for tests — defaults to `Date.now()`. */
+    now?: () => number;
+}
+
+/**
+ * `lunora dev status` — report the recorded dev server (URL, PID, uptime,
+ * background/foreground). A stale record (dead PID) reads as "not running" and
+ * is cleared. Always exits 0; agents branch on the JSON `running` field.
+ */
+const runDevStatus = (options: StatusCommandOptions): { code: number } => {
+    const { cwd, logger } = options;
+    const state = readLiveDevServerState(cwd);
+
+    if (state === undefined) {
+        if (options.json) {
+            printJson({ running: false });
+        } else {
+            logger.info("No dev server running.");
+        }
+
+        return { code: 0 };
+    }
+
+    const now = options.now ?? Date.now;
+    const startedAtMs = state.startedAt === undefined ? Number.NaN : Date.parse(state.startedAt);
+    const uptimeSeconds = Number.isFinite(startedAtMs) ? Math.max(0, Math.round((now() - startedAtMs) / 1000)) : undefined;
+
+    if (options.json) {
+        printJson({
+            background: state.background === true,
+            logFile: state.logFile,
+            mode: state.mode,
+            pid: state.pid,
+            running: true,
+            startedAt: state.startedAt,
+            studioUrl: state.studioUrl,
+            uptimeSeconds,
+            url: state.url,
+        });
+
+        return { code: 0 };
+    }
+
+    const details = [
+        `pid ${String(state.pid)}`,
+        ...(uptimeSeconds === undefined ? [] : [`uptime ${String(uptimeSeconds)}s`]),
+        state.background === true ? "background" : "foreground",
+    ];
+
+    logger.success(`Dev server running at ${state.url} (${details.join(", ")})`);
+
+    if (state.studioUrl !== undefined) {
+        logger.info(`  Studio: ${state.studioUrl}`);
+    }
+
+    if (state.logFile !== undefined) {
+        logger.info(`  Logs:   lunora dev logs (${state.logFile})`);
+    }
+
+    return { code: 0 };
+};
+
+interface LogsCommandOptions {
+    cwd: string;
+    /** Trailing lines to print; 0 or negative = the whole log. */
+    lines?: number;
+    logger: Logger;
+}
+
+/**
+ * `lunora dev logs` — print the captured dev-server output (background runs
+ * route stdout+stderr into `.lunora/dev.log`). Raw pass-through to stdout so
+ * JSON log lines stay parseable. Forgiving: no log yet is not an error.
+ */
+const runDevLogs = (options: LogsCommandOptions): { code: number } => {
+    const { cwd, logger } = options;
+    const state = readDevServerState(cwd);
+    const logPath = resolveLogPath(cwd, state);
+
+    if (!existsSync(logPath)) {
+        logger.info("No dev server logs found — output is captured when the server runs in background mode (`lunora dev --background`).");
+
+        return { code: 0 };
+    }
+
+    const tail = readLogTail(logPath, options.lines ?? DEFAULT_LOG_LINES);
+
+    if (tail.length > 0) {
+        process.stdout.write(`${tail.join("\n")}\n`);
+    }
+
+    return { code: 0 };
+};
+
+export type { BackgroundCommandOptions, DetachedChild, DetachedSpawner, LogsCommandOptions, ReadinessProbe, StatusCommandOptions, StopCommandOptions };
+export { runDevBackground, runDevLogs, runDevStatus, runDevStop };

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -82,14 +82,15 @@ const wantJson = (): boolean => {
     return flag === "1" || flag === "true";
 };
 
+/** Instantiate a reporter class through the local {@link PailReporterConstructor} typing (see its packaging-bug note). */
+const constructReporter = (Reporter: unknown): PailReporter => new (Reporter as PailReporterConstructor)();
+
 const buildReporters = (): PailReporter[] => {
     if (configuredReporters !== undefined && configuredReporters.length > 0) {
         return configuredReporters;
     }
 
-    const Reporter: PailReporterConstructor = (wantJson() ? JsonReporter : LunoraReporter) as PailReporterConstructor;
-
-    return [new Reporter()];
+    return [constructReporter(wantJson() ? JsonReporter : LunoraReporter)];
 };
 
 /**
@@ -115,8 +116,8 @@ const forceJsonLogging = (): void => {
  */
 const logHandlers = {
     compose: (...reporters: PailReporter[]): PailReporter[] => reporters,
-    console: (): PailReporter => new (LunoraReporter as PailReporterConstructor)(),
-    json: (): PailReporter => new (JsonReporter as PailReporterConstructor)(),
+    console: (): PailReporter => constructReporter(LunoraReporter),
+    json: (): PailReporter => constructReporter(JsonReporter),
 };
 
 /**

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -54,16 +54,78 @@ interface PailReporter {
 
 type PailReporterConstructor = new () => PailReporter;
 
+/**
+ * Lazily-constructed pail instance. Building it (plus its Pretty/Json reporter)
+ * is deferred until the first `createLogger()` / `getPail()` call so that merely
+ * importing this module stays side-effect-free (`package.json` declares
+ * `sideEffects:false`) — `lunora --help` / `-v` never pay the construction cost.
+ */
+let sharedPail: PailLogger | undefined;
+
+/**
+ * Programmatically forced JSON mode (`lunora dev --json` / agent auto-detect),
+ * OR-ed with the `LUNORA_LOG_JSON` env flag. Module-level because the pail
+ * instance is a lazily-built singleton.
+ */
+let jsonForced = false;
+
+/** Reporters installed via {@link configureLogHandlers}; `undefined` = default selection. */
+let configuredReporters: PailReporter[] | undefined;
+
 const wantJson = (): boolean => {
+    if (jsonForced) {
+        return true;
+    }
+
     const flag = process.env.LUNORA_LOG_JSON;
 
     return flag === "1" || flag === "true";
 };
 
-const buildReporter = (): PailReporter => {
+const buildReporters = (): PailReporter[] => {
+    if (configuredReporters !== undefined && configuredReporters.length > 0) {
+        return configuredReporters;
+    }
+
     const Reporter: PailReporterConstructor = (wantJson() ? JsonReporter : LunoraReporter) as PailReporterConstructor;
 
-    return new Reporter();
+    return [new Reporter()];
+};
+
+/**
+ * Switch every subsequent log line to machine-readable JSON (pail's
+ * `JsonReporter`), equivalent to `LUNORA_LOG_JSON=1`. Safe to call at any
+ * point: the shared pail is dropped so the next log call rebuilds it with the
+ * JSON reporter. Used by `lunora dev --json` and the AI-agent auto-detection.
+ */
+const forceJsonLogging = (): void => {
+    if (jsonForced) {
+        return;
+    }
+
+    jsonForced = true;
+    sharedPail = undefined;
+};
+
+/**
+ * Composable log handlers, mirroring the reporter primitives the logger is
+ * built from. `compose` maps directly onto pail's `reporters: [...]` array, so
+ * e.g. `configureLogHandlers(logHandlers.compose(logHandlers.console(), logHandlers.json()))`
+ * keeps human-readable output while also emitting structured JSON lines.
+ */
+const logHandlers = {
+    compose: (...reporters: PailReporter[]): PailReporter[] => reporters,
+    console: (): PailReporter => new (LunoraReporter as PailReporterConstructor)(),
+    json: (): PailReporter => new (JsonReporter as PailReporterConstructor)(),
+};
+
+/**
+ * Install a custom reporter set (see {@link logHandlers}). Replaces the
+ * default console-or-JSON selection; the shared pail is rebuilt on next use.
+ */
+const configureLogHandlers = (reporters: PailReporter | PailReporter[]): void => {
+    configuredReporters = Array.isArray(reporters) ? reporters : [reporters];
+    sharedPail = undefined;
 };
 
 /**
@@ -78,17 +140,9 @@ const STEP_LOG_TYPES = Object.fromEntries(STEP_BADGE_NAMES.map((name) => [name, 
     { label: string; logLevel: "informational" }
 >;
 
-/**
- * Lazily-constructed pail instance. Building it (plus its Pretty/Json reporter)
- * is deferred until the first `createLogger()` / `getPail()` call so that merely
- * importing this module stays side-effect-free (`package.json` declares
- * `sideEffects:false`) — `lunora --help` / `-v` never pay the construction cost.
- */
-let sharedPail: PailLogger | undefined;
-
 const getPail = (): PailLogger => {
     sharedPail ??= createPail({
-        reporters: [buildReporter()],
+        reporters: buildReporters(),
         scope: ["lunora"],
         stderr: process.stderr,
         stdout: process.stdout,
@@ -174,5 +228,5 @@ const logStep = (type: StepBadgeName, message: string): void => {
     (getPail() as unknown as Record<StepBadgeName, (message: string) => void>)[type](message);
 };
 
-export type { Logger };
-export { createLogger, createStderrLogger, getPail, logStep, pail };
+export type { Logger, PailReporter };
+export { configureLogHandlers, createLogger, createStderrLogger, forceJsonLogging, getPail, logHandlers, logStep, pail };

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -86,6 +86,13 @@ const wantJson = (): boolean => {
 const constructReporter = (Reporter: unknown): PailReporter => new (Reporter as PailReporterConstructor)();
 
 const buildReporters = (): PailReporter[] => {
+    // Forced JSON (`--json` / agent auto-detect) is a machine-readability
+    // contract — it must win even over an explicitly configured reporter set,
+    // or automation parsing stdout breaks.
+    if (jsonForced) {
+        return [constructReporter(JsonReporter)];
+    }
+
     if (configuredReporters !== undefined && configuredReporters.length > 0) {
         return configuredReporters;
     }

--- a/packages/cli/src/util/spawn.ts
+++ b/packages/cli/src/util/spawn.ts
@@ -1,5 +1,8 @@
 import { spawn as nodeSpawn } from "node:child_process";
 
+/** Matches any character that would make cmd.exe re-split an unquoted argument. */
+const NEEDS_CMD_QUOTING = /\s/;
+
 export interface SpawnDescriptor {
     args: ReadonlyArray<string>;
 
@@ -42,6 +45,32 @@ export interface SpawnResult {
  */
 export type Spawner = (descriptor: SpawnDescriptor) => Promise<SpawnResult>;
 
+/**
+ * Map a command + args onto what `child_process.spawn` can actually execute on
+ * this platform. On Windows the package-manager CLIs (`pnpm`, `npx`, `yarn`,
+ * `bun`) are `.cmd`/`.ps1` shims that `spawn()` cannot start without a shell —
+ * since Node's CVE-2024-27980 hardening the call fails outright (`EINVAL`, or
+ * `ENOENT` for the extensionless name) and the child never gets a PID. Node
+ * itself (`process.execPath`) is a real executable and needs no shell. With
+ * `shell: true` Node joins command + args verbatim for cmd.exe, so arguments
+ * containing whitespace (e.g. a `--config` temp path under a spaced user
+ * dir) are double-quoted here; everything else passes through untouched.
+ * POSIX platforms return the input unchanged.
+ */
+export const spawnShellCompat = (
+    command: string,
+    args: ReadonlyArray<string>,
+    platform: NodeJS.Platform = process.platform,
+): { args: string[]; command: string; shell: boolean } => {
+    if (platform !== "win32" || command === process.execPath) {
+        return { args: [...args], command, shell: false };
+    }
+
+    const quote = (value: string): string => (NEEDS_CMD_QUOTING.test(value) ? `"${value}"` : value);
+
+    return { args: args.map((argument) => quote(argument)), command: quote(command), shell: true };
+};
+
 export const defaultSpawner: Spawner = (descriptor) =>
     new Promise<SpawnResult>((resolve, reject) => {
         const hasInput = typeof descriptor.input === "string";
@@ -59,9 +88,11 @@ export const defaultSpawner: Spawner = (descriptor) =>
         } else if (descriptor.stdoutToStderr) {
             stdout = 2;
         }
-        const child = nodeSpawn(descriptor.command, [...descriptor.args], {
+        const exec = spawnShellCompat(descriptor.command, descriptor.args);
+        const child = nodeSpawn(exec.command, exec.args, {
             cwd: descriptor.cwd ?? process.cwd(),
             env: descriptor.env ? { ...process.env, ...descriptor.env } : process.env,
+            shell: exec.shell,
             stdio: [hasInput ? "pipe" : "inherit", stdout, "inherit"],
         });
 

--- a/packages/config/__tests__/agent-env.test.ts
+++ b/packages/config/__tests__/agent-env.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { detectAiAgent } from "../src/agent-env";
+
+describe("agent-env", () => {
+    it("returns undefined for a plain human environment", () => {
+        expect.assertions(1);
+
+        expect(detectAiAgent({ HOME: "/home/dev", TERM: "xterm-256color" })).toBeUndefined();
+    });
+
+    it("detects known agent markers", () => {
+        expect.assertions(3);
+
+        expect(detectAiAgent({ CLAUDECODE: "1" })?.name).toBe("Claude Code");
+        expect(detectAiAgent({ CURSOR_AGENT: "1" })?.name).toBe("Cursor agent");
+        expect(detectAiAgent({ GEMINI_CLI: "1" })?.name).toBe("Gemini CLI");
+    });
+
+    it("ignores empty or explicitly-disabled marker values", () => {
+        expect.assertions(2);
+
+        expect(detectAiAgent({ CLAUDECODE: "" })).toBeUndefined();
+        expect(detectAiAgent({ CLAUDECODE: "0" })).toBeUndefined();
+    });
+
+    it("lUNORA_AGENT_MODE forces the decision both ways", () => {
+        expect.assertions(2);
+
+        expect(detectAiAgent({ LUNORA_AGENT_MODE: "1" })?.variable).toBe("LUNORA_AGENT_MODE");
+        expect(detectAiAgent({ CLAUDECODE: "1", LUNORA_AGENT_MODE: "0" })).toBeUndefined();
+    });
+});

--- a/packages/config/__tests__/agent-env.test.ts
+++ b/packages/config/__tests__/agent-env.test.ts
@@ -30,4 +30,13 @@ describe("agent-env", () => {
         expect(detectAiAgent({ LUNORA_AGENT_MODE: "1" })?.variable).toBe("LUNORA_AGENT_MODE");
         expect(detectAiAgent({ CLAUDECODE: "1", LUNORA_AGENT_MODE: "0" })).toBeUndefined();
     });
+
+    it("lUNORA_AGENT_MODE disable is case-insensitive", () => {
+        expect.assertions(3);
+
+        // A human typing `False`/`FALSE` must not be flipped INTO agent mode.
+        expect(detectAiAgent({ CLAUDECODE: "1", LUNORA_AGENT_MODE: "False" })).toBeUndefined();
+        expect(detectAiAgent({ CLAUDECODE: "1", LUNORA_AGENT_MODE: "FALSE" })).toBeUndefined();
+        expect(detectAiAgent({ CLAUDECODE: "1", LUNORA_AGENT_MODE: " 0 " })).toBeUndefined();
+    });
 });

--- a/packages/config/__tests__/agent-env.test.ts
+++ b/packages/config/__tests__/agent-env.test.ts
@@ -13,7 +13,7 @@ describe("agent-env", () => {
         expect.assertions(3);
 
         expect(detectAiAgent({ CLAUDECODE: "1" })?.name).toBe("Claude Code");
-        expect(detectAiAgent({ CURSOR_AGENT: "1" })?.name).toBe("Cursor agent");
+        expect(detectAiAgent({ CURSOR_AGENT: "1" })?.name).toBe("Cursor Agent");
         expect(detectAiAgent({ GEMINI_CLI: "1" })?.name).toBe("Gemini CLI");
     });
 

--- a/packages/config/__tests__/dev-server-state.test.ts
+++ b/packages/config/__tests__/dev-server-state.test.ts
@@ -174,4 +174,25 @@ describe("dev-server-state", () => {
         expect(claim.ok).toBe(true);
         expect(readDevServerState(workdir)?.pid).toBe(process.pid);
     });
+
+    it("claimDevServerState supersedes exactly the named provisional record", () => {
+        expect.assertions(4);
+
+        // The parent CLI's provisional record (a live pid — use our own).
+        writeDevServerState(workdir, { mode: "cli", pid: process.pid, url: "http://localhost:5173" });
+
+        // The spawned server may replace the record it was handed (supersedePid).
+        const takeover = claimDevServerState(workdir, { mode: "vite", pid: 99_999, url: "http://localhost:5199" }, { supersedePid: process.pid });
+
+        expect(takeover.ok).toBe(true);
+        expect(readDevServerState(workdir)?.url).toBe("http://localhost:5199");
+
+        // A supersedePid that does NOT match the live record still loses.
+        writeDevServerState(workdir, { mode: "cli", pid: process.pid, url: "http://localhost:5173" });
+
+        const stranger = claimDevServerState(workdir, { mode: "vite", pid: 99_999, url: "http://localhost:5199" }, { supersedePid: 12_345 });
+
+        expect(stranger.ok).toBe(false);
+        expect(readDevServerState(workdir)?.url).toBe("http://localhost:5173");
+    });
 });

--- a/packages/config/__tests__/dev-server-state.test.ts
+++ b/packages/config/__tests__/dev-server-state.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    clearDevServerState,
+    DEV_STATE_DIR,
+    DEV_STATE_FILE,
+    isProcessAlive,
+    readDevServerState,
+    readLiveDevServerState,
+    updateDevServerState,
+    writeDevServerState,
+} from "../src/dev-server-state";
+
+/** A PID that is effectively never alive: beyond every platform's pid_max. */
+const DEAD_PID = 2 ** 30;
+
+describe("dev-server-state", () => {
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-dev-state-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("round-trips a written state, creating .lunora/ on demand", () => {
+        expect.assertions(2);
+
+        const path = writeDevServerState(workdir, {
+            background: true,
+            logFile: join(workdir, "dev.log"),
+            mode: "cli",
+            pid: 4321,
+            startedAt: "2026-01-01T00:00:00.000Z",
+            studioUrl: "http://127.0.0.1:6173",
+            url: "http://localhost:8787",
+        });
+
+        expect(path).toBe(join(workdir, DEV_STATE_FILE));
+        expect(readDevServerState(workdir)).toStrictEqual({
+            background: true,
+            logFile: join(workdir, "dev.log"),
+            mode: "cli",
+            pid: 4321,
+            startedAt: "2026-01-01T00:00:00.000Z",
+            studioUrl: "http://127.0.0.1:6173",
+            url: "http://localhost:8787",
+        });
+    });
+
+    it("returns undefined for a missing state file", () => {
+        expect.assertions(1);
+
+        expect(readDevServerState(workdir)).toBeUndefined();
+    });
+
+    it("returns undefined for malformed JSON or a record missing pid/url", () => {
+        expect.assertions(2);
+
+        writeDevServerState(workdir, { mode: "vite", pid: 1, url: "http://localhost:5173" });
+        writeFileSync(join(workdir, DEV_STATE_DIR, "dev.json"), "{ not json", "utf8");
+
+        expect(readDevServerState(workdir)).toBeUndefined();
+
+        writeFileSync(join(workdir, DEV_STATE_DIR, "dev.json"), JSON.stringify({ pid: 1 }), "utf8");
+
+        expect(readDevServerState(workdir)).toBeUndefined();
+    });
+
+    it("clearDevServerState is idempotent and honours expectedPid", () => {
+        expect.assertions(3);
+
+        writeDevServerState(workdir, { mode: "cli", pid: 111, url: "http://localhost:8787" });
+
+        // A stale server (pid 222) must not clobber the newer record (pid 111).
+        clearDevServerState(workdir, 222);
+
+        expect(readDevServerState(workdir)?.pid).toBe(111);
+
+        clearDevServerState(workdir, 111);
+
+        expect(readDevServerState(workdir)).toBeUndefined();
+
+        // Clearing again (nothing on disk) must not throw.
+        clearDevServerState(workdir);
+
+        expect(readDevServerState(workdir)).toBeUndefined();
+    });
+
+    it("updateDevServerState merges a patch into the existing record", () => {
+        expect.assertions(3);
+
+        expect(updateDevServerState(workdir, { background: true })).toBeUndefined();
+
+        writeDevServerState(workdir, { mode: "vite", pid: 7, url: "http://localhost:5173" });
+
+        const merged = updateDevServerState(workdir, { background: true, logFile: join(workdir, "dev.log") });
+
+        expect(merged?.background).toBe(true);
+        expect(readDevServerState(workdir)?.logFile).toBe(join(workdir, "dev.log"));
+    });
+
+    it("isProcessAlive: own pid is alive, an impossible pid is not", () => {
+        expect.assertions(3);
+
+        expect(isProcessAlive(process.pid)).toBe(true);
+        expect(isProcessAlive(DEAD_PID)).toBe(false);
+        expect(isProcessAlive(-1)).toBe(false);
+    });
+
+    it("readLiveDevServerState returns a live record and clears a stale one", () => {
+        expect.assertions(3);
+
+        writeDevServerState(workdir, { mode: "cli", pid: process.pid, url: "http://localhost:8787" });
+
+        expect(readLiveDevServerState(workdir)?.pid).toBe(process.pid);
+
+        writeDevServerState(workdir, { mode: "cli", pid: DEAD_PID, url: "http://localhost:8787" });
+
+        expect(readLiveDevServerState(workdir)).toBeUndefined();
+        // The stale record was removed on the spot.
+        expect(readDevServerState(workdir)).toBeUndefined();
+    });
+});

--- a/packages/config/__tests__/dev-server-state.test.ts
+++ b/packages/config/__tests__/dev-server-state.test.ts
@@ -5,10 +5,12 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+    claimDevServerState,
     clearDevServerState,
     DEV_STATE_DIR,
     DEV_STATE_FILE,
     isProcessAlive,
+    isRecordedProcessCurrent,
     readDevServerState,
     readLiveDevServerState,
     updateDevServerState,
@@ -126,5 +128,50 @@ describe("dev-server-state", () => {
         expect(readLiveDevServerState(workdir)).toBeUndefined();
         // The stale record was removed on the spot.
         expect(readDevServerState(workdir)).toBeUndefined();
+    });
+
+    it("treats a recycled PID as stale (record predates the process's start)", () => {
+        expect.assertions(2);
+
+        // A record claiming this very process started before 1970-01-02 can
+        // only be a recycled PID: this process verifiably started later. The
+        // start-time guard only runs where /proc exposes it (Linux) — on other
+        // platforms liveness alone decides, so assert conditionally.
+        const impossiblyOld = { mode: "cli" as const, pid: process.pid, startedAt: "1970-01-02T00:00:00.000Z", url: "http://localhost:8787" };
+        const expectStale = process.platform === "linux";
+
+        expect(isRecordedProcessCurrent(impossiblyOld)).toBe(!expectStale);
+
+        writeDevServerState(workdir, impossiblyOld);
+
+        expect(readLiveDevServerState(workdir)?.pid).toBe(expectStale ? undefined : process.pid);
+    });
+
+    it("claimDevServerState creates exclusively and reports a live incumbent", () => {
+        expect.assertions(5);
+
+        const first = claimDevServerState(workdir, { mode: "cli", pid: process.pid, url: "http://localhost:8787" });
+
+        expect(first.ok).toBe(true);
+        expect(readDevServerState(workdir)?.pid).toBe(process.pid);
+
+        // A second claimant loses to the live incumbent and gets its record.
+        const second = claimDevServerState(workdir, { mode: "vite", pid: DEAD_PID, url: "http://localhost:5173" });
+
+        expect(second.ok).toBe(false);
+        expect(second.existing?.pid).toBe(process.pid);
+        // The incumbent's record is untouched.
+        expect(readDevServerState(workdir)?.mode).toBe("cli");
+    });
+
+    it("claimDevServerState clears a stale incumbent and claims over it", () => {
+        expect.assertions(2);
+
+        writeDevServerState(workdir, { mode: "cli", pid: DEAD_PID, url: "http://localhost:8787" });
+
+        const claim = claimDevServerState(workdir, { mode: "vite", pid: process.pid, url: "http://localhost:5173" });
+
+        expect(claim.ok).toBe(true);
+        expect(readDevServerState(workdir)?.pid).toBe(process.pid);
     });
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -68,6 +68,7 @@
         "@lunora/container": "1.0.0-alpha.5",
         "@lunora/seed": "1.0.0-alpha.13",
         "@visulima/colorize": "2.0.0-alpha.14",
+        "@visulima/find-ai-runner": "1.0.0-alpha.9",
         "dockerode": "catalog:tooling",
         "es-module-lexer": "catalog:vite",
         "jsonc-parser": "catalog:vite",

--- a/packages/config/src/agent-env.ts
+++ b/packages/config/src/agent-env.ts
@@ -31,7 +31,10 @@ const AGENT_MODE_ENV = "LUNORA_AGENT_MODE";
 
 /**
  * Known agent markers, first match wins. Each is set by the agent harness in
- * the shells it spawns; none appear in interactive human terminals.
+ * the shells it spawns; none appear in interactive human terminals. The bar
+ * for adding an entry is high on purpose: a false positive silently detaches
+ * a human's `lunora dev` and switches it to JSON logs, which reads as "dev
+ * didn't start" — only markers verified to be agent-shell-only belong here.
  */
 const AGENT_ENV_MARKERS: ReadonlyArray<AgentDetection> = [
     { name: "Claude Code", variable: "CLAUDECODE" },
@@ -40,8 +43,6 @@ const AGENT_ENV_MARKERS: ReadonlyArray<AgentDetection> = [
     { name: "Codex", variable: "CODEX_SANDBOX" },
     { name: "Gemini CLI", variable: "GEMINI_CLI" },
     { name: "Cline", variable: "CLINE_ACTIVE" },
-    { name: "Replit agent", variable: "REPLIT_AGENT" },
-    { name: "Jules", variable: "JULES_AGENT" },
 ];
 
 /** True when the env value spells an explicit "off" (`0` / `false`). */

--- a/packages/config/src/agent-env.ts
+++ b/packages/config/src/agent-env.ts
@@ -1,0 +1,74 @@
+/**
+ * Detect whether the current process was spawned by an AI coding agent.
+ *
+ * Agents struggle with long-running processes: they shell out, wait for exit,
+ * and read output — but a dev server never exits. When an agent is detected,
+ * `lunora dev` flips into background mode (managed detached process, see
+ * `dev-server-state.ts`) and machine-readable JSON logging automatically, so
+ * agent workflows need no flags. Humans are unaffected: no marker, no change.
+ *
+ * Detection is by environment variable markers the agent harnesses themselves
+ * set in spawned shells. The table is deliberately conservative — a marker
+ * that also appears in interactive human terminals (or plain CI) must NOT be
+ * listed, because auto-backgrounding a human's `lunora dev` would be a nasty
+ * surprise. Setting the override env (see {@link AGENT_MODE_ENV}) to `1` or
+ * `0` forces the detection on or off.
+ */
+
+/** Minimal env shape — `process.env` structurally, injectable for tests. */
+type EnvLike = Readonly<Record<string, string | undefined>>;
+
+/** One detected agent: which tool, and which env var gave it away. */
+interface AgentDetection {
+    /** Human-readable agent name, for the "agent detected" log line. */
+    name: string;
+    /** The environment variable that matched. */
+    variable: string;
+}
+
+/** Env var that forces agent mode on (`1`/`true`) or off (`0`/`false`), overriding detection. */
+const AGENT_MODE_ENV = "LUNORA_AGENT_MODE";
+
+/**
+ * Known agent markers, first match wins. Each is set by the agent harness in
+ * the shells it spawns; none appear in interactive human terminals.
+ */
+const AGENT_ENV_MARKERS: ReadonlyArray<AgentDetection> = [
+    { name: "Claude Code", variable: "CLAUDECODE" },
+    { name: "Claude Code", variable: "CLAUDE_CODE" },
+    { name: "Cursor agent", variable: "CURSOR_AGENT" },
+    { name: "Codex", variable: "CODEX_SANDBOX" },
+    { name: "Gemini CLI", variable: "GEMINI_CLI" },
+    { name: "Cline", variable: "CLINE_ACTIVE" },
+    { name: "Replit agent", variable: "REPLIT_AGENT" },
+    { name: "Jules", variable: "JULES_AGENT" },
+];
+
+/** True when the env value spells an explicit "off" (`0` / `false`). */
+const isDisabled = (value: string): boolean => value === "0" || value === "false";
+
+/**
+ * Detect the AI agent driving this process, or `undefined` when none is.
+ * `LUNORA_AGENT_MODE` wins over the marker table in both directions.
+ * Pure — pass a custom `env` in tests.
+ */
+const detectAiAgent = (env: EnvLike = process.env): AgentDetection | undefined => {
+    const override = env[AGENT_MODE_ENV];
+
+    if (override !== undefined && override !== "") {
+        return isDisabled(override) ? undefined : { name: "agent (forced)", variable: AGENT_MODE_ENV };
+    }
+
+    for (const marker of AGENT_ENV_MARKERS) {
+        const value = env[marker.variable];
+
+        if (value !== undefined && value !== "" && !isDisabled(value)) {
+            return marker;
+        }
+    }
+
+    return undefined;
+};
+
+export type { AgentDetection };
+export { AGENT_MODE_ENV, detectAiAgent };

--- a/packages/config/src/agent-env.ts
+++ b/packages/config/src/agent-env.ts
@@ -32,8 +32,12 @@ interface AgentDetection {
 /** Env var that forces agent mode on (`1`/`true`) or off (`0`/`false`), overriding detection. */
 const AGENT_MODE_ENV = "LUNORA_AGENT_MODE";
 
-/** True when the env value spells an explicit "off" (`0` / `false`). */
-const isDisabled = (value: string): boolean => value === "0" || value === "false";
+/** True when the env value spells an explicit "off" (`0` / `false`, any casing). */
+const isDisabled = (value: string): boolean => {
+    const normalized = value.trim().toLowerCase();
+
+    return normalized === "0" || normalized === "false";
+};
 
 /**
  * Detect the AI agent driving this process, or `undefined` when none is.

--- a/packages/config/src/agent-env.ts
+++ b/packages/config/src/agent-env.ts
@@ -7,13 +7,16 @@
  * `dev-server-state.ts`) and machine-readable JSON logging automatically, so
  * agent workflows need no flags. Humans are unaffected: no marker, no change.
  *
- * Detection is by environment variable markers the agent harnesses themselves
- * set in spawned shells. The table is deliberately conservative — a marker
- * that also appears in interactive human terminals (or plain CI) must NOT be
- * listed, because auto-backgrounding a human's `lunora dev` would be a nasty
- * surprise. Setting the override env (see {@link AGENT_MODE_ENV}) to `1` or
- * `0` forces the detection on or off.
+ * The marker table itself lives in `@visulima/find-ai-runner`
+ * (`detectAiSession`), where it is maintained once for the whole ecosystem —
+ * every entry is sourced from a shipping implementation, and platform-only
+ * "ambient" markers (e.g. a Cursor editor terminal, where a human may be
+ * typing) are excluded by default, which is exactly the behavior-switch
+ * semantics Lunora needs. This module only layers Lunora's explicit override
+ * on top: setting {@link AGENT_MODE_ENV} to `1` or `0` forces the detection
+ * on or off.
  */
+import { detectAiSession } from "@visulima/find-ai-runner";
 
 /** Minimal env shape — `process.env` structurally, injectable for tests. */
 type EnvLike = Readonly<Record<string, string | undefined>>;
@@ -29,29 +32,13 @@ interface AgentDetection {
 /** Env var that forces agent mode on (`1`/`true`) or off (`0`/`false`), overriding detection. */
 const AGENT_MODE_ENV = "LUNORA_AGENT_MODE";
 
-/**
- * Known agent markers, first match wins. Each is set by the agent harness in
- * the shells it spawns; none appear in interactive human terminals. The bar
- * for adding an entry is high on purpose: a false positive silently detaches
- * a human's `lunora dev` and switches it to JSON logs, which reads as "dev
- * didn't start" — only markers verified to be agent-shell-only belong here.
- */
-const AGENT_ENV_MARKERS: ReadonlyArray<AgentDetection> = [
-    { name: "Claude Code", variable: "CLAUDECODE" },
-    { name: "Claude Code", variable: "CLAUDE_CODE" },
-    { name: "Cursor agent", variable: "CURSOR_AGENT" },
-    { name: "Codex", variable: "CODEX_SANDBOX" },
-    { name: "Gemini CLI", variable: "GEMINI_CLI" },
-    { name: "Cline", variable: "CLINE_ACTIVE" },
-];
-
 /** True when the env value spells an explicit "off" (`0` / `false`). */
 const isDisabled = (value: string): boolean => value === "0" || value === "false";
 
 /**
  * Detect the AI agent driving this process, or `undefined` when none is.
- * `LUNORA_AGENT_MODE` wins over the marker table in both directions.
- * Pure — pass a custom `env` in tests.
+ * `LUNORA_AGENT_MODE` wins over `@visulima/find-ai-runner`'s marker table in
+ * both directions. Pure — pass a custom `env` in tests.
  */
 const detectAiAgent = (env: EnvLike = process.env): AgentDetection | undefined => {
     const override = env[AGENT_MODE_ENV];
@@ -60,15 +47,9 @@ const detectAiAgent = (env: EnvLike = process.env): AgentDetection | undefined =
         return isDisabled(override) ? undefined : { name: "agent (forced)", variable: AGENT_MODE_ENV };
     }
 
-    for (const marker of AGENT_ENV_MARKERS) {
-        const value = env[marker.variable];
+    const session = detectAiSession(env);
 
-        if (value !== undefined && value !== "" && !isDisabled(value)) {
-            return marker;
-        }
-    }
-
-    return undefined;
+    return session === undefined ? undefined : { name: session.agent, variable: session.variable };
 };
 
 export type { AgentDetection };

--- a/packages/config/src/detect-framework.ts
+++ b/packages/config/src/detect-framework.ts
@@ -48,8 +48,13 @@ const FRAMEWORK_SIGNATURES: ReadonlyArray<{ class: FrameworkClass; dependency: s
 /** The standalone (class-C) result returned when no known framework is present or detection fails. */
 const STANDALONE: FrameworkDetection = { class: "C", framework: "none" };
 
-/** Read and parse the project `package.json`, returning its merged dependency name set (empty on any failure). */
-const readDependencyNames = (root: string): ReadonlySet<string> => {
+/**
+ * Read and parse the project `package.json`, returning its merged
+ * `dependencies` + `devDependencies` name set (empty on any failure). Public
+ * so sibling consumers (e.g. the CLI's Vite-project detection) share one
+ * best-effort reader instead of re-parsing `package.json` themselves.
+ */
+const readProjectDependencyNames = (root: string): ReadonlySet<string> => {
     const packageJsonPath = join(root, "package.json");
 
     if (!existsSync(packageJsonPath)) {
@@ -77,7 +82,7 @@ const readDependencyNames = (root: string): ReadonlySet<string> => {
  * SPA flow is preserved.
  */
 const detectFramework = (root: string): FrameworkDetection => {
-    const dependencies = readDependencyNames(root);
+    const dependencies = readProjectDependencyNames(root);
 
     if (dependencies.size === 0) {
         return STANDALONE;
@@ -93,4 +98,4 @@ const detectFramework = (root: string): FrameworkDetection => {
 };
 
 export type { DetectedFramework, FrameworkClass, FrameworkDetection };
-export { detectFramework };
+export { detectFramework, readProjectDependencyNames };

--- a/packages/config/src/dev-server-state.ts
+++ b/packages/config/src/dev-server-state.ts
@@ -41,6 +41,17 @@ const DEV_DAEMON_ENV = "LUNORA_DEV_DAEMON";
 /** Env carrying the capture-log path into the detached server, recorded in the state file. */
 const DEV_LOG_FILE_ENV = "LUNORA_DEV_LOG_FILE";
 
+/**
+ * Env carrying the PID of a parent that holds a *provisional* state record it
+ * expects the child dev server to supersede. The CLI claims `.lunora/dev.json`
+ * with its own PID before spawning the real server (closing the duplicate-start
+ * race for the vite flavor and the wrangler daemon), then hands its PID down
+ * via this variable; the child's claim (see {@link claimDevServerState}'s
+ * `supersedePid`) may replace exactly that record with the authoritative
+ * URL + PID.
+ */
+const DEV_HANDOFF_ENV = "LUNORA_DEV_HANDOFF_PID";
+
 /** How the recorded dev server runs. */
 type DevServerMode = "cli" | "vite";
 
@@ -302,8 +313,40 @@ interface ClaimDevServerStateResult {
  * server the claim fails with that record; a stale incumbent is cleared and
  * the claim retried. Still best-effort on I/O errors: an unwritable checkout
  * degrades to the plain (non-exclusive) write, never a crash.
+ *
+ * `supersedePid` names ONE live record this claim may replace instead of
+ * losing to: the provisional record a parent CLI wrote before spawning this
+ * server (handed down via {@link DEV_HANDOFF_ENV}). Any other live record
+ * still wins.
  */
-const claimDevServerState = (projectRoot: string, state: DevServerState): ClaimDevServerStateResult => {
+
+/**
+ * Resolve an exclusive-create conflict for {@link claimDevServerState}:
+ * someone holds the file. Live (and not us) → they won — unless it is the
+ * provisional record this claim was spawned to supersede. `undefined` means
+ * the incumbent was stale (readLive cleared it) and the exclusive create
+ * should be retried.
+ */
+const resolveClaimConflict = (projectRoot: string, state: DevServerState, supersedePid: number | undefined): ClaimDevServerStateResult | undefined => {
+    const existing = readLiveDevServerState(projectRoot);
+
+    if (existing === undefined) {
+        return undefined;
+    }
+
+    if (supersedePid !== undefined && existing.pid === supersedePid) {
+        return { ok: writeDevServerState(projectRoot, state) !== undefined };
+    }
+
+    if (existing.pid !== state.pid) {
+        return { existing, ok: false };
+    }
+
+    // Our own pid already owns the record (restart in-process) — refresh it.
+    return { ok: writeDevServerState(projectRoot, state) !== undefined };
+};
+
+const claimDevServerState = (projectRoot: string, state: DevServerState, options?: { supersedePid?: number }): ClaimDevServerStateResult => {
     const path = join(projectRoot, DEV_STATE_FILE);
     const payload = `${JSON.stringify(state, undefined, 2)}\n`;
 
@@ -320,17 +363,10 @@ const claimDevServerState = (projectRoot: string, state: DevServerState): ClaimD
                 return { ok: writeDevServerState(projectRoot, state) !== undefined };
             }
 
-            // Someone holds the file. Live (and not us) → they won. Stale →
-            // readLive cleared it; retry the exclusive create once.
-            const existing = readLiveDevServerState(projectRoot);
+            const resolved = resolveClaimConflict(projectRoot, state, options?.supersedePid);
 
-            if (existing !== undefined && existing.pid !== state.pid) {
-                return { existing, ok: false };
-            }
-
-            if (existing !== undefined) {
-                // Our own pid already owns the record (restart in-process) — refresh it.
-                return { ok: writeDevServerState(projectRoot, state) !== undefined };
+            if (resolved !== undefined) {
+                return resolved;
             }
         }
     }
@@ -343,6 +379,7 @@ export {
     claimDevServerState,
     clearDevServerState,
     DEV_DAEMON_ENV,
+    DEV_HANDOFF_ENV,
     DEV_LOG_FILE,
     DEV_LOG_FILE_ENV,
     DEV_STATE_DIR,

--- a/packages/config/src/dev-server-state.ts
+++ b/packages/config/src/dev-server-state.ts
@@ -72,9 +72,14 @@ const stringField = (record: Record<string, unknown>, key: string): string | und
 };
 
 /**
- * True when a process with `pid` is currently alive. Signal `0` performs the
- * existence check without delivering anything; `EPERM` means "alive but not
- * ours", so it still counts as running.
+ * True when a process with `pid` is currently alive AND signalable by this
+ * user. Signal `0` performs the existence check without delivering anything.
+ *
+ * `EPERM` ("alive but another user's process") deliberately counts as NOT
+ * alive here: every dev server this module tracks was spawned by the current
+ * user, so a PID we cannot signal is by definition a recycled PID — treating
+ * it as running would wedge the lockfile permanently and aim `dev stop`'s
+ * kill escalation at an innocent process.
  */
 const isProcessAlive = (pid: number): boolean => {
     if (!Number.isInteger(pid) || pid <= 0) {
@@ -85,9 +90,76 @@ const isProcessAlive = (pid: number): boolean => {
         process.kill(pid, 0);
 
         return true;
-    } catch (error: unknown) {
-        return (error as NodeJS.ErrnoException).code === "EPERM";
+    } catch {
+        return false;
     }
+};
+
+/** Tolerated skew between a process's start time and the record it wrote (spawn → listen → write can take seconds). */
+const START_TIME_SKEW_MS = 10_000;
+
+/**
+ * Kernel clock-tick rate backing `/proc/&lt;pid>/stat`'s `starttime` field.
+ * Linux fixes `USER_HZ` at 100 for userspace on every mainstream platform,
+ * independent of the kernel's internal HZ.
+ */
+const LINUX_CLOCK_TICKS_PER_SECOND = 100;
+
+/**
+ * Wall-clock start time of `pid` in epoch ms, or `undefined` where the
+ * platform doesn't expose it cheaply (non-Linux) or the read fails. Combines
+ * `/proc/&lt;pid>/stat` field 22 (`starttime`, in clock ticks since boot) with
+ * `/proc/stat`'s `btime` (boot time, epoch seconds).
+ */
+const processStartTimeMs = (pid: number): number | undefined => {
+    if (process.platform !== "linux") {
+        return undefined;
+    }
+
+    try {
+        const stat = readFileSync(`/proc/${String(pid)}/stat`, "utf8");
+        // The comm field is parenthesized and may itself contain spaces or
+        // parens — split after the LAST `)`, then `starttime` (field 22
+        // overall) is the 20th of the remaining space-separated fields.
+        const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+        const startTicks = Number(fields[19]);
+        const bootLine = readFileSync("/proc/stat", "utf8")
+            .split("\n")
+            .find((line) => line.startsWith("btime "));
+        const bootSeconds = Number(bootLine?.slice("btime ".length));
+
+        if (!Number.isFinite(startTicks) || !Number.isFinite(bootSeconds)) {
+            return undefined;
+        }
+
+        return bootSeconds * 1000 + (startTicks / LINUX_CLOCK_TICKS_PER_SECOND) * 1000;
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * True when the record's PID verifiably still refers to the dev server that
+ * wrote the record — not merely "some process exists with that number".
+ * Guards against PID reuse: a server process necessarily starts BEFORE its
+ * record is written, so a process that started after `startedAt` (+ skew) is
+ * a recycled PID wearing the corpse's number. The start-time check runs only
+ * where the platform exposes it (Linux); elsewhere liveness alone decides.
+ */
+const isRecordedProcessCurrent = (state: DevServerState): boolean => {
+    if (!isProcessAlive(state.pid)) {
+        return false;
+    }
+
+    const recordedAtMs = state.startedAt === undefined ? Number.NaN : Date.parse(state.startedAt);
+
+    if (Number.isNaN(recordedAtMs)) {
+        return true;
+    }
+
+    const actualStartMs = processStartTimeMs(state.pid);
+
+    return actualStartMs === undefined || actualStartMs <= recordedAtMs + START_TIME_SKEW_MS;
 };
 
 /**
@@ -193,8 +265,9 @@ const clearDevServerState = (projectRoot: string, expectedPid?: number): void =>
 
 /**
  * The state record of a dev server that is verifiably running right now, or
- * `undefined`. A record whose PID is dead is stale: it is cleared on the spot
- * so subsequent starts don't keep re-reading a corpse.
+ * `undefined`. A record whose PID is dead — or recycled onto a different
+ * process (see {@link isRecordedProcessCurrent}) — is stale: it is cleared on
+ * the spot so subsequent starts don't keep re-reading a corpse.
  */
 const readLiveDevServerState = (projectRoot: string): DevServerState | undefined => {
     const state = readDevServerState(projectRoot);
@@ -203,7 +276,7 @@ const readLiveDevServerState = (projectRoot: string): DevServerState | undefined
         return undefined;
     }
 
-    if (isProcessAlive(state.pid)) {
+    if (isRecordedProcessCurrent(state)) {
         return state;
     }
 
@@ -212,8 +285,62 @@ const readLiveDevServerState = (projectRoot: string): DevServerState | undefined
     return undefined;
 };
 
-export type { DevServerMode, DevServerState };
+/** Result of {@link claimDevServerState}: claimed, or lost to the live server already recorded. */
+interface ClaimDevServerStateResult {
+    /** The live record that won the race, when `ok` is `false`. */
+    existing?: DevServerState;
+    /** Whether this process now owns the record. */
+    ok: boolean;
+}
+
+/**
+ * Atomically claim `.lunora/dev.json` for a starting dev server. Unlike
+ * {@link writeDevServerState}, the create is exclusive (`wx`), which closes
+ * the check-then-write race where two near-simultaneous starts both read "no
+ * server", both spawn, and the second silently clobbers the first's record —
+ * leaving `dev stop` blind to the survivor. On losing the race to a LIVE
+ * server the claim fails with that record; a stale incumbent is cleared and
+ * the claim retried. Still best-effort on I/O errors: an unwritable checkout
+ * degrades to the plain (non-exclusive) write, never a crash.
+ */
+const claimDevServerState = (projectRoot: string, state: DevServerState): ClaimDevServerStateResult => {
+    const path = join(projectRoot, DEV_STATE_FILE);
+    const payload = `${JSON.stringify(state, undefined, 2)}\n`;
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+            mkdirSync(join(projectRoot, DEV_STATE_DIR), { recursive: true });
+            writeFileSync(path, payload, { encoding: "utf8", flag: "wx" });
+
+            return { ok: true };
+        } catch (error: unknown) {
+            if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+                // Permission/IO problem, not a race — fall back to the
+                // best-effort write so a read-only checkout behaves as before.
+                return { ok: writeDevServerState(projectRoot, state) !== undefined };
+            }
+
+            // Someone holds the file. Live (and not us) → they won. Stale →
+            // readLive cleared it; retry the exclusive create once.
+            const existing = readLiveDevServerState(projectRoot);
+
+            if (existing !== undefined && existing.pid !== state.pid) {
+                return { existing, ok: false };
+            }
+
+            if (existing !== undefined) {
+                // Our own pid already owns the record (restart in-process) — refresh it.
+                return { ok: writeDevServerState(projectRoot, state) !== undefined };
+            }
+        }
+    }
+
+    return { ok: writeDevServerState(projectRoot, state) !== undefined };
+};
+
+export type { ClaimDevServerStateResult, DevServerMode, DevServerState };
 export {
+    claimDevServerState,
     clearDevServerState,
     DEV_DAEMON_ENV,
     DEV_LOG_FILE,
@@ -221,6 +348,7 @@ export {
     DEV_STATE_DIR,
     DEV_STATE_FILE,
     isProcessAlive,
+    isRecordedProcessCurrent,
     readDevServerState,
     readLiveDevServerState,
     updateDevServerState,

--- a/packages/config/src/dev-server-state.ts
+++ b/packages/config/src/dev-server-state.ts
@@ -1,0 +1,228 @@
+/**
+ * `.lunora/dev.json` — the running dev server's state record.
+ *
+ * Written when a dev server starts (by `lunora dev` for the wrangler
+ * orchestration, or by `@lunora/vite`'s dev-state plugin when the project runs
+ * through Vite) and removed on shutdown. It doubles as a lockfile: a second
+ * `lunora dev` finds a live record and reports the existing instance instead of
+ * spawning a conflicting server, and `lunora dev stop|status|logs` resolve the
+ * running instance from it. This is what lets AI agents manage a long-running
+ * dev server without parsing terminal output or tracking PIDs themselves.
+ *
+ * Lives next to `.lunora/project.json` (see `linked-project.ts`) — per-checkout,
+ * machine-specific, gitignored by convention, and secret-free.
+ *
+ * Every read is best-effort: a missing file, malformed JSON, or unexpected
+ * shape collapses to `undefined`. A record whose PID is no longer alive is
+ * stale* — `readLiveDevServerState` clears it and reports "not running", so a
+ * crashed or SIGKILLed server never wedges the next start.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+import join from "./path";
+
+/** Directory holding per-checkout Lunora state (gitignored by convention). */
+const DEV_STATE_DIR = ".lunora";
+
+/** The dev-server state filename, relative to the project root. */
+const DEV_STATE_FILE: string = join(DEV_STATE_DIR, "dev.json");
+
+/** Log file a backgrounded dev server's output is captured to, relative to the project root. */
+const DEV_LOG_FILE: string = join(DEV_STATE_DIR, "dev.log");
+
+/**
+ * Marker env `lunora dev --background` sets on the detached server process
+ * (the daemon `lunora dev` or `vite dev`), so it records itself as
+ * `background: true` — and, for the CLI daemon, never re-detects an agent and
+ * recurses into background mode again.
+ */
+const DEV_DAEMON_ENV = "LUNORA_DEV_DAEMON";
+
+/** Env carrying the capture-log path into the detached server, recorded in the state file. */
+const DEV_LOG_FILE_ENV = "LUNORA_DEV_LOG_FILE";
+
+/** How the recorded dev server runs. */
+type DevServerMode = "cli" | "vite";
+
+/** The state record persisted to `.lunora/dev.json`. */
+interface DevServerState {
+    /** Whether the server was detached into the background (`lunora dev --background`). */
+    background?: boolean;
+    /** Absolute path of the log file capturing the server's output, when captured. */
+    logFile?: string;
+    /** `"cli"` for the `lunora dev` wrangler orchestration, `"vite"` for a Vite dev server. */
+    mode: DevServerMode;
+    /** PID of the process to signal for shutdown (the orchestrating CLI or the Vite process). */
+    pid: number;
+    /** ISO-8601 stamp written at startup, purely informational (drives `status` uptime). */
+    startedAt?: string;
+    /** The embedded studio server's URL, when it runs. */
+    studioUrl?: string;
+    /** The primary URL serving the worker/app. */
+    url: string;
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> => value !== null && typeof value === "object";
+
+/** Read a string field, returning `undefined` for absent/empty/non-string. */
+const stringField = (record: Record<string, unknown>, key: string): string | undefined => {
+    const value = record[key];
+
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+/**
+ * True when a process with `pid` is currently alive. Signal `0` performs the
+ * existence check without delivering anything; `EPERM` means "alive but not
+ * ours", so it still counts as running.
+ */
+const isProcessAlive = (pid: number): boolean => {
+    if (!Number.isInteger(pid) || pid <= 0) {
+        return false;
+    }
+
+    try {
+        process.kill(pid, 0);
+
+        return true;
+    } catch (error: unknown) {
+        return (error as NodeJS.ErrnoException).code === "EPERM";
+    }
+};
+
+/**
+ * Read the state record from `.lunora/dev.json`, or `undefined` when there is
+ * no usable record. Best-effort; performs NO liveness check — use
+ * {@link readLiveDevServerState} for "is a dev server actually running".
+ */
+const readDevServerState = (projectRoot: string): DevServerState | undefined => {
+    const path = join(projectRoot, DEV_STATE_FILE);
+
+    if (!existsSync(path)) {
+        return undefined;
+    }
+
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+        return undefined;
+    }
+
+    if (!isObject(parsed) || typeof parsed["pid"] !== "number") {
+        return undefined;
+    }
+
+    const url = stringField(parsed, "url");
+
+    if (url === undefined) {
+        return undefined;
+    }
+
+    return {
+        background: parsed["background"] === true,
+        logFile: stringField(parsed, "logFile"),
+        mode: parsed["mode"] === "vite" ? "vite" : "cli",
+        pid: parsed["pid"],
+        startedAt: stringField(parsed, "startedAt"),
+        studioUrl: stringField(parsed, "studioUrl"),
+        url,
+    };
+};
+
+/**
+ * Write the state record to `.lunora/dev.json`, creating the `.lunora/`
+ * directory when absent. Returns the absolute path written, or `undefined`
+ * when the write failed (state is convenience metadata — a read-only checkout
+ * must never crash dev startup).
+ */
+const writeDevServerState = (projectRoot: string, state: DevServerState): string | undefined => {
+    try {
+        mkdirSync(join(projectRoot, DEV_STATE_DIR), { recursive: true });
+
+        const path = join(projectRoot, DEV_STATE_FILE);
+
+        writeFileSync(path, `${JSON.stringify(state, undefined, 2)}\n`, "utf8");
+
+        return path;
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Merge `patch` into the existing state record, when one exists. Used by the
+ * CLI to stamp `background`/`logFile` onto the record the Vite plugin wrote.
+ * Returns the merged record, or `undefined` when there was nothing to update.
+ */
+const updateDevServerState = (projectRoot: string, patch: Partial<DevServerState>): DevServerState | undefined => {
+    const existing = readDevServerState(projectRoot);
+
+    if (existing === undefined) {
+        return undefined;
+    }
+
+    const merged = { ...existing, ...patch };
+
+    writeDevServerState(projectRoot, merged);
+
+    return merged;
+};
+
+/**
+ * Remove `.lunora/dev.json`. Idempotent and never throws. When `expectedPid`
+ * is given, the file is only removed while it still records that PID — so a
+ * shutting-down server can't clobber the record a newer server just wrote.
+ */
+const clearDevServerState = (projectRoot: string, expectedPid?: number): void => {
+    try {
+        if (expectedPid !== undefined) {
+            const current = readDevServerState(projectRoot);
+
+            if (current !== undefined && current.pid !== expectedPid) {
+                return;
+            }
+        }
+
+        rmSync(join(projectRoot, DEV_STATE_FILE), { force: true });
+    } catch {
+        /* best-effort */
+    }
+};
+
+/**
+ * The state record of a dev server that is verifiably running right now, or
+ * `undefined`. A record whose PID is dead is stale: it is cleared on the spot
+ * so subsequent starts don't keep re-reading a corpse.
+ */
+const readLiveDevServerState = (projectRoot: string): DevServerState | undefined => {
+    const state = readDevServerState(projectRoot);
+
+    if (state === undefined) {
+        return undefined;
+    }
+
+    if (isProcessAlive(state.pid)) {
+        return state;
+    }
+
+    clearDevServerState(projectRoot, state.pid);
+
+    return undefined;
+};
+
+export type { DevServerMode, DevServerState };
+export {
+    clearDevServerState,
+    DEV_DAEMON_ENV,
+    DEV_LOG_FILE,
+    DEV_LOG_FILE_ENV,
+    DEV_STATE_DIR,
+    DEV_STATE_FILE,
+    isProcessAlive,
+    readDevServerState,
+    readLiveDevServerState,
+    updateDevServerState,
+    writeDevServerState,
+};

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,5 @@
+export type { AgentDetection } from "./agent-env";
+export { AGENT_MODE_ENV, detectAiAgent } from "./agent-env";
 export type { AgentRulesStatus } from "./agent-rules";
 export {
     AGENT_RULES_DIR,
@@ -20,7 +22,21 @@ export type {
 } from "./container-logs";
 export { streamContainerLogs } from "./container-logs";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";
-export { detectFramework } from "./detect-framework";
+export { detectFramework, readProjectDependencyNames } from "./detect-framework";
+export type { DevServerMode, DevServerState } from "./dev-server-state";
+export {
+    clearDevServerState,
+    DEV_DAEMON_ENV,
+    DEV_LOG_FILE,
+    DEV_LOG_FILE_ENV,
+    DEV_STATE_DIR,
+    DEV_STATE_FILE,
+    isProcessAlive,
+    readDevServerState,
+    readLiveDevServerState,
+    updateDevServerState,
+    writeDevServerState,
+} from "./dev-server-state";
 export { DEV_VARS_EXAMPLE_FILE, DEV_VARS_FILE, DEV_VARS_KEY_PATTERN, parseDevVariableEntries } from "./dev-variables-format";
 export type { InferOptions, InferredBindings, InferredContainer, InferredWorkflow } from "./infer-bindings";
 export { inferLunoraBindings, packageNamesFromBindings } from "./infer-bindings";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -28,6 +28,7 @@ export {
     claimDevServerState,
     clearDevServerState,
     DEV_DAEMON_ENV,
+    DEV_HANDOFF_ENV,
     DEV_LOG_FILE,
     DEV_LOG_FILE_ENV,
     DEV_STATE_DIR,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,8 +23,9 @@ export type {
 export { streamContainerLogs } from "./container-logs";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";
 export { detectFramework, readProjectDependencyNames } from "./detect-framework";
-export type { DevServerMode, DevServerState } from "./dev-server-state";
+export type { ClaimDevServerStateResult, DevServerMode, DevServerState } from "./dev-server-state";
 export {
+    claimDevServerState,
     clearDevServerState,
     DEV_DAEMON_ENV,
     DEV_LOG_FILE,
@@ -32,6 +33,7 @@ export {
     DEV_STATE_DIR,
     DEV_STATE_FILE,
     isProcessAlive,
+    isRecordedProcessCurrent,
     readDevServerState,
     readLiveDevServerState,
     updateDevServerState,

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -60,6 +60,33 @@ describe("createWorker", () => {
         expect(res.status).toBe(404);
     });
 
+    it("answers GET /_lunora/status with an unauthenticated ok probe", async () => {
+        expect.assertions(4);
+
+        const worker = createWorker({ shardDO: shard.namespace });
+
+        const res = await worker.fetch(new Request("https://app.example/_lunora/status"), {}, fakeContext);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get("cache-control")).toBe("no-store");
+        // Bare ok — no framework name/version, so production deployments don't
+        // hand scanners a fingerprint.
+        await expect(res.json()).resolves.toStrictEqual({ ok: true });
+        // The probe never touches a shard.
+        expect(shard.calls).toHaveLength(0);
+    });
+
+    it("rejects non-GET/HEAD on /_lunora/status with 405", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({ shardDO: shard.namespace });
+
+        const res = await worker.fetch(new Request("https://app.example/_lunora/status", { method: "POST" }), {}, fakeContext);
+
+        expect(res.status).toBe(405);
+        expect(res.headers.get("allow")).toBe("GET, HEAD");
+    });
+
     it("forwards POST /_lunora/rpc to the default __root__ shard", async () => {
         expect.assertions(4);
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -917,6 +917,15 @@ const ADMIN_PATH_PREFIX = "/_lunora/admin/";
 /** The lone cross-shard admin route that sits outside {@link ADMIN_PATH_PREFIX}. */
 const MIGRATE_PATH = "/_lunora/migrate";
 
+/**
+ * Public, unauthenticated health probe (`GET /_lunora/status`). Dev tooling and
+ * AI agents poll it to confirm the worker is up and routing (the CLI's
+ * `lunora dev --background` blocks on it before detaching). Deliberately
+ * static and secret-free: it discloses nothing beyond "a Lunora worker answers
+ * here", which the 404 shape of every other route already reveals.
+ */
+const STATUS_PATH = "/_lunora/status";
+
 /** True for the admin routes the async `adminGate` may authorize — everything under `/_lunora/admin/` plus `/_lunora/migrate`. */
 const isAdminPath = (pathname: string): boolean => pathname.startsWith(ADMIN_PATH_PREFIX) || pathname === MIGRATE_PATH;
 // The cross-shard orchestration (`migrate` / `rank` / `rankpage` / `shard-traffic`)
@@ -3013,6 +3022,10 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     const customRoutes = options.routes !== undefined && Object.keys(options.routes).length > 0 ? options.routes : undefined;
 
     const internalRoutes: Record<string, InternalRoute> = {
+        [STATUS_PATH]: () =>
+            Response.json({ ok: true, service: "lunora", status: "ok" }, {
+                headers: { "cache-control": "no-store", "content-type": "application/json" },
+            }),
         [WS_PATH]: (request, env, url) => handleWebSocketUpgrade(request, env, url),
         [RPC_PATH]: (request, env, _url, context) => handleRpc(request, env, context),
         [RPC_BATCH_PATH]: (request, env, _url, context) => handleBatchRpc(request, env, context),

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -921,8 +921,9 @@ const MIGRATE_PATH = "/_lunora/migrate";
  * Public, unauthenticated health probe (`GET /_lunora/status`). Dev tooling and
  * AI agents poll it to confirm the worker is up and routing (the CLI's
  * `lunora dev --background` blocks on it before detaching). Deliberately
- * static and secret-free: it discloses nothing beyond "a Lunora worker answers
- * here", which the 404 shape of every other route already reveals.
+ * static and secret-free, and the body is a bare `{"ok":true}` — no framework
+ * name or version — so a production deployment doesn't hand scanners a
+ * stronger fingerprint than the path shape already implies.
  */
 const STATUS_PATH = "/_lunora/status";
 
@@ -3022,10 +3023,15 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     const customRoutes = options.routes !== undefined && Object.keys(options.routes).length > 0 ? options.routes : undefined;
 
     const internalRoutes: Record<string, InternalRoute> = {
-        [STATUS_PATH]: () =>
-            Response.json({ ok: true, service: "lunora", status: "ok" }, {
-                headers: { "cache-control": "no-store", "content-type": "application/json" },
-            }),
+        [STATUS_PATH]: (request) => {
+            // Health probes are reads; anything else on this path is a scanner
+            // or a mistake — refuse rather than answer 200 to arbitrary verbs.
+            if (request.method !== "GET" && request.method !== "HEAD") {
+                return new Response(undefined, { headers: { allow: "GET, HEAD" }, status: 405 });
+            }
+
+            return Response.json({ ok: true }, { headers: { "cache-control": "no-store" } });
+        },
         [WS_PATH]: (request, env, url) => handleWebSocketUpgrade(request, env, url),
         [RPC_PATH]: (request, env, _url, context) => handleRpc(request, env, context),
         [RPC_BATCH_PATH]: (request, env, _url, context) => handleBatchRpc(request, env, context),

--- a/packages/vite/__tests__/dev-state-plugin.test.ts
+++ b/packages/vite/__tests__/dev-state-plugin.test.ts
@@ -76,6 +76,7 @@ describe("devStatePlugin", () => {
     beforeEach(() => {
         workdir = mkdtempSync(join(tmpdir(), "lunora-vite-dev-state-"));
         vi.stubEnv("LUNORA_DEV_DAEMON", "");
+        vi.stubEnv("LUNORA_DEV_HANDOFF_PID", "");
         vi.stubEnv("LUNORA_DEV_LOG_FILE", "");
     });
 
@@ -163,5 +164,26 @@ describe("devStatePlugin", () => {
         mock.close();
 
         expect(readDevServerState(workdir)?.pid).toBe(process.ppid);
+    });
+
+    it("supersedes the parent CLI's provisional record named via LUNORA_DEV_HANDOFF_PID", () => {
+        expect.assertions(3);
+
+        // The parent CLI (posed by the test runner's live parent) claimed a
+        // provisional record before spawning Vite and handed its PID down.
+        writeDevServerState(workdir, { mode: "cli", pid: process.ppid, url: "http://localhost:5173" });
+        vi.stubEnv("LUNORA_DEV_HANDOFF_PID", String(process.ppid));
+
+        const mock = createMockServer();
+
+        configure(devStatePlugin(options(workdir)), mock.server);
+        mock.server.printUrls();
+
+        // The provisional record is replaced with the authoritative one.
+        const state = readDevServerState(workdir);
+
+        expect(state?.pid).toBe(process.pid);
+        expect(state?.mode).toBe("vite");
+        expect(mock.warnings).toHaveLength(0);
     });
 });

--- a/packages/vite/__tests__/dev-state-plugin.test.ts
+++ b/packages/vite/__tests__/dev-state-plugin.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readDevServerState, writeDevServerState } from "@lunora/config";
+import type { Plugin, ViteDevServer } from "vite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import devStatePlugin from "../src/dev-state-plugin";
+import type { ResolvedLunoraPluginOptions } from "../src/types";
+
+/** A controllable mock of the ViteDevServer subset the plugin touches. */
+interface MockServer {
+    close: () => void;
+    listen: () => void;
+    server: ViteDevServer;
+    warnings: string[];
+}
+
+const createMockServer = (url = "http://localhost:5173/"): MockServer => {
+    const listeners = new Map<string, (() => void)[]>();
+    const warnings: string[] = [];
+
+    const httpServer = {
+        address: () => {
+            return { address: "127.0.0.1", family: "IPv4", port: 5173 };
+        },
+        once: (event: string, callback: () => void) => {
+            listeners.set(event, [...(listeners.get(event) ?? []), callback]);
+        },
+    };
+
+    const server = {
+        config: {
+            logger: {
+                warn: (message: string) => {
+                    warnings.push(message);
+                },
+            },
+        },
+        httpServer,
+        printUrls: () => {},
+        resolvedUrls: { local: [url], network: [] },
+    } as unknown as ViteDevServer;
+
+    return {
+        close: () => {
+            for (const callback of listeners.get("close") ?? []) {
+                callback();
+            }
+        },
+        listen: () => {
+            for (const callback of listeners.get("listening") ?? []) {
+                callback();
+            }
+        },
+        server,
+        warnings,
+    };
+};
+
+/** Run the plugin's configureServer + its returned post hook against the mock. */
+const configure = (plugin: Plugin, server: ViteDevServer): void => {
+    const hook = plugin.configureServer;
+    const fn = typeof hook === "function" ? hook : hook?.handler;
+    const post = fn?.call(plugin as never, server) as (() => void) | undefined;
+
+    post?.();
+};
+
+const options = (root: string): ResolvedLunoraPluginOptions => ({ projectRoot: root }) as ResolvedLunoraPluginOptions;
+
+describe("devStatePlugin", () => {
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-vite-dev-state-"));
+        vi.stubEnv("LUNORA_DEV_DAEMON", "");
+        vi.stubEnv("LUNORA_DEV_LOG_FILE", "");
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("only applies in serve mode", () => {
+        expect.assertions(1);
+
+        expect(devStatePlugin(options(workdir)).apply).toBe("serve");
+    });
+
+    it("records the resolved URL + pid via the printUrls wrap and clears on close", () => {
+        expect.assertions(4);
+
+        const mock = createMockServer();
+
+        configure(devStatePlugin(options(workdir)), mock.server);
+
+        // The record is written when Vite prints its banner (printUrls).
+        mock.server.printUrls();
+
+        const state = readDevServerState(workdir);
+
+        expect(state?.mode).toBe("vite");
+        expect(state?.pid).toBe(process.pid);
+        // Trailing slash trimmed so consumers can append paths.
+        expect(state?.url).toBe("http://localhost:5173");
+
+        mock.close();
+
+        expect(readDevServerState(workdir)).toBeUndefined();
+    });
+
+    it("records the daemon marker + log file from the detach env", () => {
+        expect.assertions(2);
+
+        vi.stubEnv("LUNORA_DEV_DAEMON", "1");
+        vi.stubEnv("LUNORA_DEV_LOG_FILE", join(workdir, ".lunora", "dev.log"));
+
+        const mock = createMockServer();
+
+        configure(devStatePlugin(options(workdir)), mock.server);
+        mock.server.printUrls();
+
+        const state = readDevServerState(workdir);
+
+        expect(state?.background).toBe(true);
+        expect(state?.logFile).toBe(join(workdir, ".lunora", "dev.log"));
+    });
+
+    it("falls back to the listening event when printUrls never fires", async () => {
+        expect.assertions(1);
+
+        const mock = createMockServer();
+
+        configure(devStatePlugin(options(workdir)), mock.server);
+        mock.listen();
+
+        // The listening fallback records on a macrotask hop.
+        await new Promise((resolve) => {
+            setTimeout(resolve, 5);
+        });
+
+        expect(readDevServerState(workdir)?.mode).toBe("vite");
+    });
+
+    it("never clobbers another live server's record", () => {
+        expect.assertions(3);
+
+        // A record owned by a different, live process (the test runner's parent).
+        writeDevServerState(workdir, { mode: "cli", pid: process.ppid, url: "http://localhost:8787" });
+
+        const mock = createMockServer();
+
+        configure(devStatePlugin(options(workdir)), mock.server);
+        mock.server.printUrls();
+
+        expect(readDevServerState(workdir)?.pid).toBe(process.ppid);
+        expect(mock.warnings.some((line) => line.includes("already recorded"))).toBe(true);
+
+        // Close must not remove the other server's record either.
+        mock.close();
+
+        expect(readDevServerState(workdir)?.pid).toBe(process.ppid);
+    });
+});

--- a/packages/vite/__tests__/log-stream-plugin.test.ts
+++ b/packages/vite/__tests__/log-stream-plugin.test.ts
@@ -1,5 +1,5 @@
 import type { ViteDevServer } from "vite";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import logStreamPlugin from "../src/log-stream-plugin";
 
@@ -55,8 +55,38 @@ const captureStdout = (lines: string[], { tty = false }: { tty?: boolean } = {})
 const logLine = JSON.stringify({ function: "messages:list", level: "info", message: "hi", source: "lunora", type: "log" });
 
 describe("logStreamPlugin", () => {
+    // Pin both JSON-mode inputs: the suite itself often runs under an AI agent
+    // (CLAUDECODE etc.), which would legitimately flip the plugin into raw-JSON
+    // passthrough and skip the stream patch these tests exercise.
+    beforeEach(() => {
+        vi.stubEnv("LUNORA_AGENT_MODE", "0");
+        vi.stubEnv("LUNORA_LOG_JSON", "");
+    });
+
     afterEach(() => {
+        vi.unstubAllEnvs();
         vi.restoreAllMocks();
+    });
+
+    it("leaves the streams untouched in JSON mode (LUNORA_LOG_JSON=1)", () => {
+        expect.assertions(1);
+
+        vi.stubEnv("LUNORA_LOG_JSON", "1");
+
+        // Raw structured event passes through unformatted for machine consumers.
+        const received = captureStdout([`${logLine}\n`]);
+
+        expect(received.join("")).toBe(`${logLine}\n`);
+    });
+
+    it("passes raw JSON through when an AI agent drives the process", () => {
+        expect.assertions(1);
+
+        vi.stubEnv("LUNORA_AGENT_MODE", "1");
+
+        const received = captureStdout([`${logLine}\n`]);
+
+        expect(received.join("")).toBe(`${logLine}\n`);
     });
 
     it("only applies in serve mode", () => {

--- a/packages/vite/docs/index.mdx
+++ b/packages/vite/docs/index.mdx
@@ -78,6 +78,22 @@ lunora({
 
 Set `overlay: false` to disable it entirely.
 
+## Dev-server state & AI agents
+
+While `vite dev` runs, the plugin registers the server in `.lunora/dev.json`
+(URL, PID, start time — per-checkout, gitignored, secret-free) and removes the
+record on shutdown. That record is what lets `lunora dev status`, `lunora dev
+stop`, and `lunora dev logs` manage a Vite-based project, and what
+`lunora dev --background` blocks on before reporting the URL and PID — so an
+AI agent can start, health-check (`GET /_lunora/status` on the worker), and
+stop your dev server without parsing terminal output or leaking zombie
+processes.
+
+When an AI agent is detected (or `LUNORA_LOG_JSON=1` is set), the worker's
+structured log events pass through as raw single-line JSON instead of the
+pretty `[lunora]` terminal rendering, so machine consumers can parse them
+directly. Set `LUNORA_AGENT_MODE=0` to opt out of agent detection.
+
 ## See also
 
 - [@lunora/cli](/docs/packages/cli)

--- a/packages/vite/src/dev-state-plugin.ts
+++ b/packages/vite/src/dev-state-plugin.ts
@@ -13,9 +13,12 @@
  *
  * The detach plumbing arrives via env: `LUNORA_DEV_DAEMON=1` marks a
  * backgrounded run and `LUNORA_DEV_LOG_FILE` names the capture log, both
- * recorded so `status`/`logs` can report them.
+ * recorded so `status`/`logs` can report them. `LUNORA_DEV_HANDOFF_PID` names
+ * the parent CLI's provisional record this server may supersede — the CLI
+ * claims `.lunora/dev.json` before spawning Vite (closing the duplicate-start
+ * race) and this plugin replaces that record with the authoritative URL + PID.
  */
-import { claimDevServerState, clearDevServerState, DEV_DAEMON_ENV, DEV_LOG_FILE_ENV } from "@lunora/config";
+import { claimDevServerState, clearDevServerState, DEV_DAEMON_ENV, DEV_HANDOFF_ENV, DEV_LOG_FILE_ENV } from "@lunora/config";
 import type { Plugin, ViteDevServer } from "vite";
 
 import { lunoraLine } from "./log";
@@ -67,15 +70,22 @@ const devStatePlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
 
                 // Atomic exclusive claim: never clobber another live server's
                 // record (even in a start race) — surface it instead, so
-                // `lunora dev stop` keeps targeting the first server.
-                const claim = claimDevServerState(root, {
-                    background: process.env[DEV_DAEMON_ENV] === "1",
-                    logFile: process.env[DEV_LOG_FILE_ENV],
-                    mode: "vite",
-                    pid: process.pid,
-                    startedAt: new Date().toISOString(),
-                    url,
-                });
+                // `lunora dev stop` keeps targeting the first server. The one
+                // exception is the parent CLI's provisional record named via
+                // LUNORA_DEV_HANDOFF_PID, which exists to be superseded here.
+                const handoffPid = Number(process.env[DEV_HANDOFF_ENV]);
+                const claim = claimDevServerState(
+                    root,
+                    {
+                        background: process.env[DEV_DAEMON_ENV] === "1",
+                        logFile: process.env[DEV_LOG_FILE_ENV],
+                        mode: "vite",
+                        pid: process.pid,
+                        startedAt: new Date().toISOString(),
+                        url,
+                    },
+                    Number.isInteger(handoffPid) && handoffPid > 0 ? { supersedePid: handoffPid } : undefined,
+                );
 
                 if (!claim.ok) {
                     if (claim.existing !== undefined) {

--- a/packages/vite/src/dev-state-plugin.ts
+++ b/packages/vite/src/dev-state-plugin.ts
@@ -1,0 +1,125 @@
+/**
+ * Dev-only plugin that registers the running Vite dev server in
+ * `.lunora/dev.json` (see `@lunora/config`'s `dev-server-state`).
+ *
+ * The record is what makes a Vite-based Lunora project manageable without
+ * parsing terminal output: `lunora dev status|stop|logs` resolve the running
+ * instance from it, a second `lunora dev` reports the existing server instead
+ * of double-starting, and `lunora dev --background` (which detaches `vite dev`
+ * for AI-agent workflows) blocks on this record + an HTTP probe before
+ * reporting the URL and PID. The record carries the authoritative resolved
+ * local URL and THIS process's PID — signalling it shuts Vite (and the workerd
+ * runtime inside it) down cleanly.
+ *
+ * The detach plumbing arrives via env: `LUNORA_DEV_DAEMON=1` marks a
+ * backgrounded run and `LUNORA_DEV_LOG_FILE` names the capture log, both
+ * recorded so `status`/`logs` can report them.
+ */
+import { clearDevServerState, DEV_DAEMON_ENV, DEV_LOG_FILE_ENV, readLiveDevServerState, writeDevServerState } from "@lunora/config";
+import type { Plugin, ViteDevServer } from "vite";
+
+import { lunoraLine } from "./log";
+import type { ResolvedLunoraPluginOptions } from "./types";
+
+/** Trailing slash on Vite's resolved URL, trimmed so state consumers can append paths uniformly. */
+const TRAILING_SLASH = /\/$/;
+
+/**
+ * The dev server's local URL: Vite's resolved URL when already computed, else
+ * built from the live listening address (the `printUrls` wrap runs after
+ * `resolvedUrls` exists; the `listening` fallback may run just before).
+ */
+const resolveLocalUrl = (server: ViteDevServer): string | undefined => {
+    const resolved = server.resolvedUrls?.local[0];
+
+    if (resolved !== undefined) {
+        return resolved.replace(TRAILING_SLASH, "");
+    }
+
+    const address = server.httpServer?.address();
+
+    if (address !== null && typeof address === "object") {
+        return `http://localhost:${String(address.port)}`;
+    }
+
+    return undefined;
+};
+
+/** Vite plugin (serve-only) that writes the dev-server state record on listen and clears it on close. */
+const devStatePlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
+    let recorded = false;
+
+    return {
+        apply: "serve",
+        configureServer(server: ViteDevServer) {
+            const root = options.projectRoot;
+
+            const record = (): void => {
+                if (recorded) {
+                    return;
+                }
+
+                const url = resolveLocalUrl(server);
+
+                if (url === undefined) {
+                    return;
+                }
+
+                // Never clobber another live server's record — surface it instead,
+                // so `lunora dev stop` keeps targeting the first server.
+                const existing = readLiveDevServerState(root);
+
+                if (existing !== undefined && existing.pid !== process.pid) {
+                    server.config.logger.warn(
+                        lunoraLine(`another dev server is already recorded at ${existing.url} (pid ${String(existing.pid)}) — leaving .lunora/dev.json untouched`),
+                    );
+
+                    return;
+                }
+
+                recorded = true;
+                writeDevServerState(root, {
+                    background: process.env[DEV_DAEMON_ENV] === "1",
+                    logFile: process.env[DEV_LOG_FILE_ENV],
+                    mode: "vite",
+                    pid: process.pid,
+                    startedAt: new Date().toISOString(),
+                    url,
+                });
+            };
+
+            server.httpServer?.once("close", () => {
+                if (recorded) {
+                    clearDevServerState(root, process.pid);
+                    recorded = false;
+                }
+            });
+
+            // Returned hook runs after internal middlewares are installed.
+            return () => {
+                // Preferred: piggyback on Vite's startup banner (`printUrls` runs
+                // once `resolvedUrls` is populated, and again on the `u` shortcut).
+                if (typeof server.printUrls === "function") {
+                    const printUrls = server.printUrls.bind(server);
+
+                    // eslint-disable-next-line no-param-reassign -- intentionally wrap the live dev server's printUrls, mirroring studio-plugin's announce
+                    server.printUrls = (): void => {
+                        printUrls();
+                        record();
+                    };
+                }
+
+                // Fallback for middleware-mode / programmatic servers that never
+                // print a banner: record off the listening event. The macrotask
+                // hop lets Vite assign `resolvedUrls` first; `resolveLocalUrl`
+                // still works from the raw address if not.
+                server.httpServer?.once("listening", () => {
+                    setTimeout(record, 0);
+                });
+            };
+        },
+        name: "lunora:dev-state",
+    };
+};
+
+export default devStatePlugin;

--- a/packages/vite/src/dev-state-plugin.ts
+++ b/packages/vite/src/dev-state-plugin.ts
@@ -15,7 +15,7 @@
  * backgrounded run and `LUNORA_DEV_LOG_FILE` names the capture log, both
  * recorded so `status`/`logs` can report them.
  */
-import { clearDevServerState, DEV_DAEMON_ENV, DEV_LOG_FILE_ENV, readLiveDevServerState, writeDevServerState } from "@lunora/config";
+import { claimDevServerState, clearDevServerState, DEV_DAEMON_ENV, DEV_LOG_FILE_ENV } from "@lunora/config";
 import type { Plugin, ViteDevServer } from "vite";
 
 import { lunoraLine } from "./log";
@@ -65,20 +65,10 @@ const devStatePlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
                     return;
                 }
 
-                // Never clobber another live server's record — surface it instead,
-                // so `lunora dev stop` keeps targeting the first server.
-                const existing = readLiveDevServerState(root);
-
-                if (existing !== undefined && existing.pid !== process.pid) {
-                    server.config.logger.warn(
-                        lunoraLine(`another dev server is already recorded at ${existing.url} (pid ${String(existing.pid)}) — leaving .lunora/dev.json untouched`),
-                    );
-
-                    return;
-                }
-
-                recorded = true;
-                writeDevServerState(root, {
+                // Atomic exclusive claim: never clobber another live server's
+                // record (even in a start race) — surface it instead, so
+                // `lunora dev stop` keeps targeting the first server.
+                const claim = claimDevServerState(root, {
                     background: process.env[DEV_DAEMON_ENV] === "1",
                     logFile: process.env[DEV_LOG_FILE_ENV],
                     mode: "vite",
@@ -86,6 +76,20 @@ const devStatePlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
                     startedAt: new Date().toISOString(),
                     url,
                 });
+
+                if (!claim.ok) {
+                    if (claim.existing !== undefined) {
+                        server.config.logger.warn(
+                            lunoraLine(
+                                `another dev server is already recorded at ${claim.existing.url} (pid ${String(claim.existing.pid)}) — leaving .lunora/dev.json untouched`,
+                            ),
+                        );
+                    }
+
+                    return;
+                }
+
+                recorded = true;
             };
 
             server.httpServer?.once("close", () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -5,6 +5,7 @@ import type { Plugin } from "vite";
 import agentRulesHintPlugin from "./agent-rules-hint-plugin";
 import codegenPlugin from "./codegen-plugin";
 import containerLogsPlugin from "./container-logs-plugin";
+import devStatePlugin from "./dev-state-plugin";
 import devVariablesPlugin from "./dev-variables-plugin";
 import { createCommandProbe, withDevWorkerEnv } from "./dev-worker-env";
 import { frameworkComposePlugin } from "./framework-compose-plugin";
@@ -111,6 +112,9 @@ const lunora = (options?: LunoraPluginOptions): LunoraPlugins => {
         devVariablesPlugin(resolved),
         codegenPlugin(resolved),
         logStreamPlugin(),
+        // Registers the running dev server in `.lunora/dev.json` so
+        // `lunora dev --background|stop|status|logs` manage Vite projects too.
+        devStatePlugin(resolved),
         agentRulesHintPlugin(resolved),
     ];
 
@@ -162,6 +166,7 @@ export type { ReconcileResult } from "./cron-sync";
 export { reconcileWranglerCrons } from "./cron-sync";
 export type { DetectedFramework, FrameworkClass, FrameworkDetection } from "./detect-framework";
 export { detectFramework } from "./detect-framework";
+export { default as devStatePlugin } from "./dev-state-plugin";
 export { default as devVariablesPlugin } from "./dev-variables-plugin";
 export { createCommandProbe, DEV_WORKER_ENV_VALUE, DEV_WORKER_ENV_VAR, withDevWorkerEnv } from "./dev-worker-env";
 // Class-A composition surface. `LUNORA_WORKER_VIRTUAL_ID` is the virtual entry a

--- a/packages/vite/src/log-stream-plugin.ts
+++ b/packages/vite/src/log-stream-plugin.ts
@@ -1,4 +1,4 @@
-import { formatLunoraEvent, LUNORA_EVENT_SOURCE } from "@lunora/config";
+import { detectAiAgent, formatLunoraEvent, LUNORA_EVENT_SOURCE } from "@lunora/config";
 import type { Plugin } from "vite";
 
 /**
@@ -110,6 +110,27 @@ const patchStream = (stream: WritableLike): (() => void) => {
  * Patches `process.stdout`/`process.stderr` once the dev server is configured
  * and restores them when it closes.
  */
+
+/**
+ * True when the worker's structured JSON events should pass through RAW
+ * instead of being pretty-printed: an explicit `LUNORA_LOG_JSON=1|true`, or an
+ * AI agent driving the process (agents parse JSON; the decorated line only
+ * costs them tokens). `LUNORA_LOG_JSON=0` still opts out under an agent.
+ */
+const wantRawJsonLogs = (): boolean => {
+    const flag = process.env.LUNORA_LOG_JSON;
+
+    if (flag === "1" || flag === "true") {
+        return true;
+    }
+
+    if (flag === "0" || flag === "false") {
+        return false;
+    }
+
+    return detectAiAgent() !== undefined;
+};
+
 const logStreamPlugin = (): Plugin => {
     let restore: (() => void) | undefined;
 
@@ -117,6 +138,13 @@ const logStreamPlugin = (): Plugin => {
         apply: "serve",
         configureServer(server) {
             if (restore) {
+                return;
+            }
+
+            // JSON mode: leave the streams untouched — the runtime's structured
+            // events are already single-line JSON, which is exactly what a
+            // machine consumer wants on stdout.
+            if (wantRawJsonLogs()) {
                 return;
             }
 

--- a/packages/vite/src/log-stream-plugin.ts
+++ b/packages/vite/src/log-stream-plugin.ts
@@ -106,12 +106,6 @@ const patchStream = (stream: WritableLike): (() => void) => {
 };
 
 /**
- * Vite plugin (serve-only) that formats Lunora worker logs in the terminal.
- * Patches `process.stdout`/`process.stderr` once the dev server is configured
- * and restores them when it closes.
- */
-
-/**
  * True when the worker's structured JSON events should pass through RAW
  * instead of being pretty-printed: an explicit `LUNORA_LOG_JSON=1|true`, or an
  * AI agent driving the process (agents parse JSON; the decorated line only
@@ -131,6 +125,11 @@ const wantRawJsonLogs = (): boolean => {
     return detectAiAgent() !== undefined;
 };
 
+/**
+ * Vite plugin (serve-only) that formats Lunora worker logs in the terminal.
+ * Patches `process.stdout`/`process.stderr` once the dev server is configured
+ * and restores them when it closes.
+ */
 const logStreamPlugin = (): Plugin => {
     let restore: (() => void) | undefined;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1978,6 +1978,9 @@ importers:
       '@visulima/colorize':
         specifier: 2.0.0-alpha.14
         version: 2.0.0-alpha.14
+      '@visulima/find-ai-runner':
+        specifier: 1.0.0-alpha.9
+        version: 1.0.0-alpha.9
       dockerode:
         specifier: catalog:tooling
         version: 5.0.1
@@ -10067,6 +10070,11 @@ packages:
     peerDependenciesMeta:
       ai:
         optional: true
+
+  '@visulima/find-ai-runner@1.0.0-alpha.9':
+    resolution: {integrity: sha512-O7zIsOVCXLe4I6jBsqxqIF+F3trmtYB6BfLFpaiW/6fDYdJr2vXdYAdd44vuC6+G/ysOW/KrRvKJT4egRvFyDg==}
+    engines: {node: ^22.14.0 || >=24.10.0}
+    hasBin: true
 
   '@visulima/find-cache-dir@3.0.0-alpha.9':
     resolution: {integrity: sha512-fp4h/pUodZWV64gLLriyEi6iZpkOO3+TCQHore8PPJC9ldVUgvOfFQ2Vb+Y92cFBQ7h24lDpQa/Tgjxr0oNA0w==}
@@ -26606,6 +26614,8 @@ snapshots:
       - rrule
 
   '@visulima/error@6.0.0-alpha.34': {}
+
+  '@visulima/find-ai-runner@1.0.0-alpha.9': {}
 
   '@visulima/find-cache-dir@3.0.0-alpha.9': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -516,6 +516,7 @@ minimumReleaseAgeExclude:
   - '@visulima/vis-binding-win32-x64-msvc@1.0.0-alpha.43'
   - '@visulima/vis@1.0.0-alpha.43'
   - '@visulima/email@1.0.0-alpha.41'
+  - '@visulima/find-ai-runner@1.0.0-alpha.9'
   - esbuild@0.28.1
   - js-yaml@4.1.2
   - '@opentelemetry/core@2.8.0'


### PR DESCRIPTION
Astro-7-style agent ergonomics for `lunora dev`, for both the wrangler CLI stack and Vite projects.

## What

- **`lunora dev --background`** — runs the dev server as a managed detached process: blocks until the server accepts requests, prints `Dev server running at <url> (pid N)` plus stop/status/logs hints, then returns.
- **`.lunora/dev.json` state record as lockfile** — a second start reports the existing instance and exits 0 instead of spawning a conflict; claimed atomically (exclusive create) before any sibling starts.
- **`lunora dev stop | status | logs`** — idempotent and forgiving: stopping a stopped server succeeds silently; `status --json` gives agents a machine-readable document; `logs` prints the captured output (`--lines n`, 0 = all).
- **AI-agent auto-detection** — under Claude Code / Cursor / Codex / Gemini CLI / Cline, background mode and JSON logging enable automatically, no flags needed; `LUNORA_AGENT_MODE=1|0` overrides.
- **JSON logging** — `lunora dev --json` / `LUNORA_LOG_JSON=1` (pail `JsonReporter`), plus a composable `logHandlers` (`console`/`json`/`compose`) surface over pail's reporter array.
- **`GET /_lunora/status`** — public, secret-free health probe (`{"ok":true}`, GET/HEAD only) the readiness wait and agents poll.
- **Vite support** — `lunora dev` detects `@lunora/vite` projects and runs the project's own `dev` script (`vite dev`, `astro dev`, `nuxt dev`, …) instead of wrangler, falling back to `vite dev` when no usable script exists (or when the script would re-enter `lunora dev`); a new dev-state plugin registers any running Vite dev server in the state record (cleared on close, never clobbers a live record), and the log-stream plugin passes raw JSON worker events through in agent/JSON mode. Composes with alpha's Wave 11 framework redirect hint: the hint now fires only on the wrangler flavor (meta-framework without `@lunora/vite`), since the vite flavor runs the framework dev server itself.
- **Agent detection via `@visulima/find-ai-runner`** (third commit) — the hand-rolled marker table is replaced by [`@visulima/find-ai-runner@1.0.0-alpha.9`](https://github.com/visulima/visulima/pull/720)'s `detectAiSession` (markers maintained once for the ecosystem, sourced from shipping implementations; ambient platform markers excluded by default). Widens detection to GitHub Copilot CLI, opencode, Amp, Aider, Antigravity, Augment, Replit Agent, and the generic `AI_AGENT` convention; the Lunora-level `LUNORA_AGENT_MODE` override stays.

## Hardening (second commit, from a two-pass thermo review)

- PID-reuse guard: records are verified against the process's actual start time (`/proc` on Linux); `EPERM` counts as not-ours — a recycled PID can't wedge the lockfile or aim `dev stop` at an innocent process.
- Kill escalation scoped: process-group SIGKILL only for detached (background) records with the pgid resolved via `ps`; single-PID kill for foreground records; `taskkill /T /F` on Windows so the wrangler/workerd/vite child tree isn't orphaned.
- Capture log created `0600` (dev output can echo secrets); log reads bounded to the trailing 256 KiB.
- Status route answers GET/HEAD only and carries no framework fingerprint.
- Background orchestration consolidated into `lifecycle.ts`; unverified agent markers dropped.

## Testing

- 1,577 tests green across the four touched packages after the rebase onto `alpha` (config 396, cli 565, vite 152, runtime 464), including new coverage for the recycled-PID guard, atomic claim, foreground-vs-background escalation, the 405 path, and the vite-flavor dev-script spawn (meta-framework CLI + `lunora`-recursion fallback). `tsc` + ESLint clean.
- Live E2E on `apps/playground` (Vite flavor): background start → duplicate-start lock → `status --json` → health probe 200 → `logs` → `stop`, plus bare `lunora dev` under `CLAUDECODE=1` auto-detecting and backgrounding with JSON output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AhADYYkG7x9F77GHMw9Tw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `lunora dev` background mode with `status`, `stop`, and `logs` subcommands.
  * Added JSON log output and a health check endpoint for dev servers.
  * Improved support for Vite-based projects with automatic dev-server handling.

* **Bug Fixes**
  * Made dev server startup and shutdown more reliable and idempotent.
  * Added live process checks to reduce stale status and stop actions.
  * Improved log capture and recovery when background runs exit early.

* **Documentation**
  * Expanded `lunora dev` docs with background workflow, logging, and agent mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
