### PR TITLE
fix(server): close mask() value-oracle on index readers (plan 102)

### DIFF
--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -30,6 +30,21 @@ interface CapturedCall {
     tableOrId?: string;
 }
 
+/** Index-range builder passed to `.withIndex(name, q => …)` — mirrors `@lunora/do`'s `IndexRangeBuilderLike`. */
+interface FakeIndexBuilder {
+    eq: (field: string, value: unknown) => FakeIndexBuilder;
+    gt: (field: string, value: unknown) => FakeIndexBuilder;
+    gte: (field: string, value: unknown) => FakeIndexBuilder;
+    lt: (field: string, value: unknown) => FakeIndexBuilder;
+    lte: (field: string, value: unknown) => FakeIndexBuilder;
+}
+
+/** Search-filter builder passed to `.withSearchIndex(name, q => …)` — mirrors `@lunora/do`'s `SearchFilterBuilderLike`. */
+interface FakeSearchBuilder {
+    eq: (field: string, value: unknown) => FakeSearchBuilder;
+    search: (field: string, query: string) => FakeSearchBuilder;
+}
+
 interface FakeReader {
     collect: () => Promise<Record<string, unknown>[]>;
     filter: (predicate: (document: Record<string, unknown>) => boolean) => FakeReader;
@@ -38,8 +53,8 @@ interface FakeReader {
     paginate: () => Promise<{ continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] }>;
     take: (limit: number) => Promise<Record<string, unknown>[]>;
     unique: () => Promise<Record<string, unknown> | null>;
-    withIndex: (indexName?: string) => FakeReader;
-    withSearchIndex: () => FakeReader;
+    withIndex: (indexName?: string, range?: (q: FakeIndexBuilder) => FakeIndexBuilder) => FakeReader;
+    withSearchIndex: (indexName: string, search: (q: FakeSearchBuilder) => FakeSearchBuilder) => FakeReader;
 }
 
 interface FakeDatabase {
@@ -187,8 +202,32 @@ const enableQueryReader = (database: FakeDatabase, rows: (Record<string, unknown
             },
             take: async (limit) => list.slice(0, limit),
             unique: async () => list[0] ?? null,
-            withIndex: () => makeReader(list),
-            withSearchIndex: () => makeReader(list),
+            // Run the range callback against a chainable no-op builder — mirrors
+            // `@lunora/do`'s reader, and proves the mask guard's recorder pass is
+            // an EXTRA run the (pure) callback survives (the reader still runs it).
+            withIndex: (_indexName, range) => {
+                const builder: FakeIndexBuilder = {
+                    eq: () => builder,
+                    gt: () => builder,
+                    gte: () => builder,
+                    lt: () => builder,
+                    lte: () => builder,
+                };
+
+                range?.(builder);
+
+                return makeReader(list);
+            },
+            withSearchIndex: (_indexName, search) => {
+                const builder: FakeSearchBuilder = {
+                    eq: () => builder,
+                    search: () => builder,
+                };
+
+                search(builder);
+
+                return makeReader(list);
+            },
         };
     };
 
@@ -516,6 +555,84 @@ describe("mask — value oracle via filter/sort fails closed (regression)", () =
         await handler.handler(makeContext(database, "u1"), {});
 
         expect(database.calls.some((call) => call.method === "findMany")).toBe(true);
+    });
+});
+
+describe("mask — value oracle via index readers fails closed (regression)", () => {
+    it("withSearchIndex searching a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", email: "a@x.com", name: "Ann", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }))
+            // A search index over a masked column is the headline oracle: the
+            // matched (masked) row confirms the search term equals the hidden
+            // value. Must fail closed before the search ever runs.
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("users")
+                    .withSearchIndex("by_email", (q) => q.search("email", "a@x.com"))
+                    .first(),
+            );
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("withIndex ranging over a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", email: "a@x.com", name: "Ann", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }))
+            // An index equality/range over a masked column confirms / binary-
+            // searches the hidden value the same way a masked `where` does.
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("users")
+                    .withIndex("by_email", (q) => q.eq("email", "a@x.com"))
+                    .first(),
+            );
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("withIndex over a NON-masked column of a masked table still works and masks output (Strategy A)", async () => {
+        expect.assertions(4);
+
+        const seed = [
+            { _id: "u1", createdAt: 1, email: "a@x.com", name: "Ann", table: "users" },
+            { _id: "u2", createdAt: 2, email: "b@x.com", name: "Bo", table: "users" },
+        ];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }))
+            // Ranging over a NON-masked column is a legitimate index read: it must
+            // pass through (precise Strategy A), and the returned rows must still
+            // be masked on output.
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("users")
+                    .withIndex("by_created", (q) => q.gte("createdAt", 1))
+                    .collect(),
+            );
+
+        const rows = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0]?.["email"]).toBeNull();
+        expect(rows[1]?.["email"]).toBeNull();
+        expect(rows[0]?.["name"]).toBe("Ann");
     });
 });
 

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -221,6 +221,73 @@ const maskPage = <Context>(page: QueryPage, columns: MaskColumns<Context>, base:
 };
 
 /**
+ * SECURITY (value oracle on the index path): `withIndex` / `withSearchIndex`
+ * constrain WHICH rows are fetched by a caller-supplied range/search over a
+ * column. If that column is masked, a caller can
+ * `query(table).withIndex("by_ssn", q => q.eq("ssn", guess)).first()` — or the
+ * search-index twin `q => q.search("email", term)` — and confirm / binary-search
+ * the exact value the mask is meant to hide. It is the same oracle
+ * `assertWhereAllowed` (below) closes on the `where` path, reached instead
+ * through the index builder.
+ *
+ * Unlike `where` (a plain object walked by `collectWhereFields`), the
+ * range/search is a builder CALLBACK (`q => q.eq("ssn", x)`), so the referenced
+ * fields aren't statically inspectable. Run the callback once against a
+ * recording proxy: its blanket `get` trap turns EVERY property access into a
+ * method that captures its first positional argument — the field name is ALWAYS
+ * the first argument of every builder method (`eq`/`gt`/`gte`/`lt`/`lte` on the
+ * index range, `eq`/`search` on the search filter) — and returns a fresh
+ * recorder so the chain (`q.eq(...).gt(...)`) keeps recording. Recording through
+ * a blanket trap rather than a fixed method allow-list FAILS CLOSED: a
+ * field-naming method added to the builder later still records its field with no
+ * change here. Then reject if any recorded field is masked, mirroring
+ * `assertWhereAllowed`'s message.
+ *
+ * The callback runs twice — here on the recorder, then on the real builder in
+ * `reader.withIndex`/`withSearchIndex`. The builder callbacks are pure (they
+ * only push into a fresh per-call stage; see `@lunora/do`'s `createRangeBuilder`
+ * / `createSearchBuilder`), so the dry pass is side-effect free. `withIndex`'s
+ * `range` is optional (a bare index scan) — with no callback there is no field
+ * to record and nothing to reject.
+ */
+const assertIndexFieldsAllowed = <Context>(
+    builderCallback: ((q: unknown) => unknown) | undefined,
+    columns: MaskColumns<Context>,
+    tableName: string,
+    method: string,
+): void => {
+    if (typeof builderCallback !== "function") {
+        return;
+    }
+
+    const referenced = new Set<string>();
+
+    const makeRecorder = (): unknown =>
+        new Proxy(
+            {},
+            {
+                get:
+                    () =>
+                    (field: unknown): unknown => {
+                        if (typeof field === "string") {
+                            referenced.add(field);
+                        }
+
+                        return makeRecorder();
+                    },
+            },
+        );
+
+    builderCallback(makeRecorder());
+
+    for (const field of referenced) {
+        if (field in columns) {
+            throw new LunoraError("MASK_UNSUPPORTED", `${method}() filtering "${tableName}" by masked column "${field}" is not supported`);
+        }
+    }
+};
+
+/**
  * A value glued onto `ctx.db` is a per-table facade entry when it carries the
  * `findMany` + `withSearchIndex` accessor pair (mirrors RLS's check). Used to
  * find the entries that need re-binding through the masked writer.
@@ -246,7 +313,7 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
      * refinement (`filter` / `order` / `withIndex` / `withSearchIndex`) returns a
      * reader that is still masked.
      */
-    const wrapReader = (reader: TableReaderLike, columns: MaskColumns<Context>): TableReaderLike => {
+    const wrapReader = (reader: TableReaderLike, columns: MaskColumns<Context>, tableName: string): TableReaderLike => {
         return {
             collect: async () => {
                 const rows = await reader.collect();
@@ -262,6 +329,7 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
                 wrapReader(
                     reader.filter((document) => predicate(maskRow(document, columns, context))),
                     columns,
+                    tableName,
                 ),
             first: async () => {
                 const row = await reader.first();
@@ -269,7 +337,7 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
                 // eslint-disable-next-line unicorn/no-null -- mirrors the reader's `null` empty sentinel
                 return row ? maskRow(row, columns, context) : null;
             },
-            order: (direction) => wrapReader(reader.order(direction), columns),
+            order: (direction) => wrapReader(reader.order(direction), columns, tableName),
             paginate: async (options) => maskPage(await reader.paginate(options), columns, context),
             take: async (limit) => {
                 const rows = await reader.take(limit);
@@ -282,8 +350,21 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
                 // eslint-disable-next-line unicorn/no-null -- mirrors the reader's `null` empty sentinel
                 return row ? maskRow(row, columns, context) : null;
             },
-            withIndex: (indexName, range) => wrapReader(reader.withIndex(indexName, range), columns),
-            withSearchIndex: (indexName, search) => wrapReader(reader.withSearchIndex(indexName, search), columns),
+            // SECURITY (value oracle): reject before delegating when the range /
+            // search references a masked column — an index range or search term
+            // over a masked column is the same value oracle as a masked-column
+            // `where`, so it must fail closed (see `assertIndexFieldsAllowed`).
+            // Reads over NON-masked columns pass through and still mask output.
+            withIndex: (indexName, range) => {
+                assertIndexFieldsAllowed(range, columns, tableName, "withIndex");
+
+                return wrapReader(reader.withIndex(indexName, range), columns, tableName);
+            },
+            withSearchIndex: (indexName, search) => {
+                assertIndexFieldsAllowed(search, columns, tableName, "withSearchIndex");
+
+                return wrapReader(reader.withSearchIndex(indexName, search), columns, tableName);
+            },
         };
     };
 
@@ -475,7 +556,7 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
             const reader = base.query(tableName);
             const columns = perTable.get(tableName);
 
-            return columns ? wrapReader(reader, columns) : reader;
+            return columns ? wrapReader(reader, columns, tableName) : reader;
         },
 
         async rankPage(tableName, indexName, options) {


### PR DESCRIPTION
## The oracle

The `mask()` where-oracle remediation (`1246948c`) hardened
`where`/`count`/`aggregate`/`groupBy`/`.filter` against a value oracle — a
caller filtering by a masked column and binary-searching the exact hidden
value. But it did **not** cover the two index-reader entry points,
`withIndex` and `withSearchIndex`:

```ts
ctx.db.query("users").withIndex("by_email", q => q.eq("email", guess)).first()
ctx.db.query("users").withSearchIndex("by_email", q => q.search("email", term)).first()
```

still returned the matching (masked) row, confirming the value of a masked
column via the index range / search term. Same PII-confirmation leak, still
open on the index path. Search indexes on email/phone are common, so
`withSearchIndex` is the more plausible vector.

Precondition (bounds severity): the app must (a) `mask()` the table, (b) have
a normal/search index on the masked column, and (c) expose a query letting the
caller supply the range/search term — the same precondition the fixed `where`
oracle had.

## Strategy — A (precise)

Chosen **Strategy A**. The builder surface is small, well-defined, and safe to
proxy: `IndexRangeBuilder` (`eq`/`gt`/`gte`/`lt`/`lte`) and
`SearchFilterBuilder` (`eq`/`search`), each taking the field name as its
**first** argument, implemented as plain JS objects (not frozen host objects),
with pure callbacks that only push into a fresh per-call stage
(`@lunora/do`'s `createRangeBuilder`/`createSearchBuilder`).

`assertIndexFieldsAllowed` runs the range/search callback once against a
recording `Proxy` whose **blanket `get` trap** turns every property access into
a method that records its first positional argument, then rejects with
`MASK_UNSUPPORTED` if any recorded field is masked — mirroring
`assertWhereAllowed`'s message and fail-closed shape. The guard runs before
delegating to the real `reader.withIndex`/`withSearchIndex`.

Why the blanket trap (not a fixed `eq`/`gt`/… allow-list): it **fails closed**
against a field-naming method added to the builder later — an unknown method
still records its field with no change here. The field is always arg 0 of every
builder method, so recording arg 0 catches every field-naming method (and does
not over-reject on values that happen to equal a masked column name).

Legitimate index reads over **non-masked** columns of a masked table still work
and still mask output rows (Strategy A's whole point over the blunt reject).

## Tests (`packages/server/__tests__/mask.test.ts`)

New `describe("mask — value oracle via index readers fails closed")`:
1. `withSearchIndex` searching a masked `email` → throws `MASK_UNSUPPORTED` (headline oracle).
2. `withIndex` ranging over a masked `email` → throws `MASK_UNSUPPORTED`.
3. `withIndex` over a **non-masked** `createdAt` of a masked table → allowed, rows returned, output still masked (Strategy A discriminator).

The harness's fake reader now runs the builder callback against a chainable
no-op builder, so the mask guard's recorder pass is verified as an extra run the
(pure) callback survives. Existing `where`/`count`/`.filter` oracle tests and
the bare-`withIndex()` scan test are unchanged and still pass (387/387).

## Gates

`lint:types` + `test` (387 pass) + `lint:eslint` all exit 0.

## Regression note

None — Strategy A preserves index reads over non-masked columns (no blunt-reject
regression). Scope is limited to the mask middleware boundary; `@lunora/do`'s
index execution is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for masked columns by blocking index and search index conditions that reference hidden fields.
  * Requests that try to build search or index filters from masked data now fail with a clear error instead of exposing a value-based side channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->