### PR TITLE
docs(spikes): design + prototypes for Next.js, RAG, and durable-agent (plans 110, 111, 113)

### DIFF
--- a/plans/110-phase0-design.md
+++ b/plans/110-phase0-design.md
@@ -1,0 +1,287 @@
+# Plan 110 — Phase 0 design: `@lunora/next` composition adapter
+
+> **Spike outcome (TL;DR)**: OpenNext-on-Cloudflare **can** host `ShardDO` + the
+> WebSocket realtime plane alongside Next.js, matching Lunora's `/_lunora/*`
+> contract, **without a new architecture** — Next is a **class-B** framework and
+> reuses the shipped `withFrameworkWorker` composer at the OpenNext _custom-worker
+> boundary_. The WebSocket upgrade **must** live at that boundary, **not** in a
+> Next Route Handler. No STOP condition triggered. The remaining work is a normal
+> build plan plus the open decisions in §7.
+>
+> Prototype: `plans/proto/next/compose-next-worker.ts` (+ passing test). Ran
+> green in-sandbox (`9 passed`, shared run with 111/113).
+
+---
+
+## 1. Shared composition contract (from `@lunora/nuxt` + `@lunora/astro`)
+
+Every host integration mounts the **same** realtime plane. Extracted first-hand
+from the two shipped adapters and `@lunora/runtime`:
+
+### 1.1 The reserved paths (`/_lunora/*`)
+
+`packages/runtime/src/create-worker.ts:909-920` — Lunora owns these sub-paths; the
+host owns everything else:
+
+| Path                                              | Purpose                                                                          |
+| ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `POST /_lunora/rpc`                               | single RPC call (`RpcEnvelope`)                                                  |
+| `POST /_lunora/rpc-batch`                         | batched RPC                                                                      |
+| `/_lunora/ws`                                     | **WebSocket upgrade** → `101 Switching Protocols` (forwarded to `ShardDO.fetch`) |
+| `/_lunora/admin/*`                                | Studio admin plane (gated)                                                       |
+| `/_lunora/scheduler/dispatch`, `/_lunora/migrate` | scheduler + migrations                                                           |
+
+### 1.2 The single shared composer — `withFrameworkWorker`
+
+`packages/runtime/src/create-worker.ts:3285`. This is the **one** class-B seam
+behind `@lunora/svelte/worker`, `@lunora/vue/worker`, and `@lunora/astro`'s
+`withLunora` (`packages/astro/src/with-lunora.ts:45` re-exports it verbatim):
+
+```ts
+const withFrameworkWorker = (host: FrameworkHostHandler, optionsInput): LunoraWorker => {
+    const httpRouter = toHttpRouter(host); // host may be a bare fetch fn OR { fetch, scheduled }
+    const build = (options) => composeWorker({ ...options, httpRouter });
+    // reserves /_lunora/*, delegates everything else to `httpRouter` (the framework host)
+    // factory form rebuilds per request so per-request bindings (env.SHARD) wire in
+};
+```
+
+Key properties the contract guarantees (create-worker.ts:3264-3321):
+
+- **`host` shape**: `FrameworkHostHandler` = a bare `fetch` fn **or** a
+  `{ fetch, scheduled? }` object (create-worker.ts:3245). "Every class-B adapter
+  output (`@sveltejs/adapter-cloudflare`, Nitro's `cloudflare-module`,
+  `@astrojs/cloudflare`) is structurally one of these." **OpenNext's
+  `.open-next/worker.js` default export (`{ fetch }`) is exactly this shape.**
+- **Options factory**: `(env) => ({ shardDO: env.SHARD, ... })` — per-request,
+  because `env.SHARD` only exists at request time.
+- **WebSocket passthrough**: the `101` upgrade `Response` (carrying its
+  `webSocket`) is returned **verbatim** — the framework streams it unchanged
+  (create-worker.ts:3364-3366).
+- **`scheduled` preservation**: if Lunora configures no cron, the host's own
+  `scheduled` is preserved (so OpenNext's cache-purge cron, if any, survives).
+
+There is also `createLunoraHandler(options)` (create-worker.ts:3387) — the
+framework-neutral `(request, env, ctx) => Response` bridge for hosts that mount by
+**router path** rather than by wrapping a worker handler (Hono, h3, Elysia). Nuxt
+uses this style: its Nitro server route reconstructs a web `Request` and calls
+`delegateToLunora(lunoraApp, request, env, ctx)` (`packages/nuxt/src/runtime/handler.ts`,
+`.../server/lunora.ts`).
+
+### 1.3 Exporting `ShardDO`
+
+The `ShardDO` Durable Object class (`packages/do/src/index.ts:223`) **must be
+exported from the deployed worker's `main` entry** and bound in `wrangler.jsonc`.
+The adapters diverge only in _where_ that export lives:
+
+- **Nuxt**: a project-root `exports.cloudflare.ts` (`export { ShardDO } from "./lunora/server"`)
+  carried into the generated worker by Nitro's `cloudflare_module` hook
+  (`packages/nuxt/src/module.ts:73`).
+- **Astro**: the `src/worker.ts` custom entry (`main` in wrangler) that calls
+  `withLunora(...)` also re-exports `ShardDO` (`packages/astro/src/with-lunora.ts:28-37`).
+
+### 1.4 The class model (A/B/C)
+
+`packages/config/src/detect-framework.ts:10-46`:
+
+- **Class A** — Vite-native; **Lunora owns the worker entry** (`createWorker({ httpRouter })`).
+  TanStack Start, SolidStart, React Router.
+- **Class B** — framework owns its **own** Cloudflare adapter; Lunora **injects**
+  its composition into the framework's server entry via `withFrameworkWorker`.
+  **SvelteKit, Nuxt, Astro.**
+- **Class C** — non-CF / SSR-less; ship the client adapter + a standalone Lunora
+  worker (today's default).
+
+---
+
+## 2. Where Next.js falls: **class B**
+
+Next.js on Cloudflare deploys via **OpenNext** (`@opennextjs/cloudflare`), which
+**owns its own Cloudflare adapter** and emits its own Worker (`.open-next/worker.js`).
+That is the textbook class-B signature — identical to SvelteKit/Astro. The
+detection table (`FRAMEWORK_SIGNATURES`) should gain:
+
+```ts
+{ class: "B", dependency: "next", framework: "nextjs" },
+```
+
+(plus `nextjs → "@lunora/react"` in the CLI's `ADAPTER_BY_FRAMEWORK`).
+
+**Consequence**: Next needs **zero new runtime composition code**. The existing
+`withFrameworkWorker(openNextHandler, (env) => ({ shardDO: env.SHARD }))` composes
+Lunora with the OpenNext handler exactly as it does for Astro. `@lunora/next` is
+therefore a _thin_ package: framework detection entry, a `withLunora` alias (or
+just re-export `withFrameworkWorker`), and the template + docs for the OpenNext
+custom-worker wiring.
+
+---
+
+## 3. The chosen OpenNext seam — custom-worker boundary (decision)
+
+### 3.1 OpenNext's custom-worker mechanism
+
+OpenNext generates `.open-next/worker.js` whose default export is `{ fetch }`. Its
+documented **"Custom Worker"** how-to
+(<https://opennext.js.org/cloudflare/howtos/custom-worker>) is to import that
+handler, wrap it, and point wrangler's `main` at the custom file:
+
+```ts
+// src/worker.ts   (wrangler "main")
+// @ts-expect-error generated at build time by @opennextjs/cloudflare
+import { default as openNextHandler } from "./.open-next/worker.js";
+import { withFrameworkWorker } from "@lunora/runtime"; // via @lunora/next
+
+export default withFrameworkWorker(openNextHandler, (env) => ({ shardDO: env.SHARD }));
+
+// ShardDO must be exported from THIS worker entry (and bound in wrangler.jsonc):
+export { ShardDO } from "./lunora/server";
+```
+
+`wrangler.jsonc`:
+
+```jsonc
+{
+    "main": "src/worker.ts",
+    "compatibility_flags": ["nodejs_compat"],
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+}
+```
+
+### 3.2 Durable Object export — an established OpenNext pattern
+
+Re-exporting a DO class from the custom worker is **already** how OpenNext ships
+its own DO-backed cache/queue: when enabled you must re-export `DOQueueHandler`,
+`DOShardedTagCache`, `BucketCachePurge` from the worker
+(opennextjs-cloudflare **#502**). `ShardDO` sits right beside them:
+
+```ts
+// when OpenNext's DO cache/queue is enabled, alongside ShardDO:
+export { DOQueueHandler, DOShardedTagCache, BucketCachePurge } from "./.open-next/worker.js";
+```
+
+So the DO-export requirement is not a Lunora-specific hack — it is the normal
+OpenNext custom-worker story.
+
+### 3.3 Why the boundary and not a Next Route Handler
+
+A Next Route Handler (`app/_lunora/[...path]/route.ts`) **can** serve RPC (a plain
+`POST/GET → Response`). It **cannot** carry the WebSocket upgrade, and WS is
+Lunora's core realtime feature. Three independent reasons:
+
+1. **The `webSocket` field is non-standard.** A Cloudflare WS upgrade returns
+   `new Response(null, { status: 101, webSocket: client })`. `webSocket` is a
+   Workers-only Response extension. Next's `Response` abstraction has no concept
+   of it.
+2. **OpenNext's adapter round-trip strips it.** OpenNext converts the inbound
+   Cloudflare `Request` into a Next server request, runs Next, then reconstructs a
+   Cloudflare `Response` from Next's Web `Response`. Neither a `101` status switch
+   nor a `webSocket` field survives that reconstruction.
+3. **Route Handlers terminate on a response** and have no raw-socket access on
+   Workers. This is confirmed ecosystem-wide: Next ships no first-class WS server
+   (vercel/next.js#58698); on Cloudflare, WS upgrades are handled at the **Worker
+   fetch boundary** or forwarded to a **Durable Object**.
+
+At the custom-worker boundary, `withFrameworkWorker` intercepts `/_lunora/ws`
+_before_ OpenNext ever sees it; `createWorker` forwards it to `ShardDO.fetch`,
+which returns the `101` verbatim. **The boundary natively supports WS; the Route
+Handler cannot.** Since RPC and WS should share one mount, put **both** at the
+boundary. (An optional RPC-only Route Handler could exist for niche same-app edge
+cases, but the canonical, WS-capable mount is the boundary.)
+
+### 3.4 Prototype evidence
+
+`plans/proto/next/compose-next-worker.ts` models exactly this dispatch (a faithful,
+dependency-free stand-in for `withFrameworkWorker`, which needs workerd + a real DO
+namespace to boot). The test (`compose-next-worker.test.ts`, **ran green**) proves:
+
+- a non-`/_lunora` request delegates to the OpenNext handler;
+- `POST /_lunora/rpc` round-trips through Lunora without touching OpenNext;
+- `/_lunora/admin/*` reaches Lunora;
+- **a `/_lunora/ws` upgrade returns the `101` + its `webSocket` field verbatim** —
+  the load-bearing assertion, since that is precisely what a Route Handler +
+  OpenNext response adapter would strip.
+
+The real seam runs the identical logic via `withFrameworkWorker`, so the seam is
+proven at the composition level. What was _not_ runnable in-sandbox: a live
+workerd RPC round-trip through a real `ShardDO` (no workerd + Vectorize/DO binding
+here); that is a build-plan smoke test, not a spike blocker.
+
+---
+
+## 4. Dev-mode note
+
+OpenNext dev uses `initOpenNextCloudflareForDev()` in `next.config` so `next dev`
+sees the CF bindings. The realtime plane in dev has two options: (a) run under
+`wrangler dev` against the built custom worker (full WS parity), or (b) run
+`next dev` for the UI and point the Lunora client at a separate `wrangler dev`
+realtime worker. Recommend documenting (a) as the parity path and (b) as the
+fast-iteration path; finalize in the build plan (open question §7.6).
+
+---
+
+## 5. STOP-condition assessment
+
+| STOP condition (from the plan)                                                     | Triggered?                               | Evidence                                                                                                                   |
+| ---------------------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| OpenNext can't host DO + WS matching `/_lunora/*` without a different architecture | **No**                                   | Custom-worker boundary + `withFrameworkWorker` matches the contract exactly, same as Astro/Svelte (§3).                    |
+| WS subscription path has no viable home                                            | **No**                                   | The boundary returns the `101 + webSocket` verbatim; proven by prototype (§3.3-3.4).                                       |
+| Requires pinning an unstable/churning OpenNext API                                 | **Partial risk — flagged, not blocking** | The custom-worker import path (`./.open-next/worker.js`) and the DO re-export list are OpenNext-version-coupled; see §7.1. |
+
+No STOP. This is a green spike: the seam is proven and reuses shipped code.
+
+---
+
+## 6. `init` no-op — recommendation
+
+`packages/cli/src/commands/init/handler.ts:1348-1352` currently warns _"template
+'next' is not yet available"_ and exits 1. **Recommendation: leave the no-op in
+place until `templates/next` lands**, but improve the message to point at this
+design ("Next.js support is in progress — track plan 110; use `--vite react` today").
+Removing the branch before the template exists would let `lunora init -t next`
+scaffold a broken project (the plan's own maintenance note warns of this). Removal
+and the `templates/next` landing must be a single coordinated change in the build
+plan.
+
+---
+
+## 7. Open questions (maintainer decisions)
+
+1. **OpenNext version pinning.** The custom-worker import (`./.open-next/worker.js`)
+   and the DO re-export list (`DOQueueHandler`/`DOShardedTagCache`/`BucketCachePurge`)
+   are OpenNext-internal and move between releases. _Recommendation_: pin
+   `@opennextjs/cloudflare` to a tested minor in `templates/next`, add a
+   `@lunora/vite`/config check that verifies the custom worker still re-exports
+   `ShardDO`, and document a re-verification step (the plan's maintenance note).
+2. **Template authors the custom worker vs. codegen generates it.** _Recommendation_:
+   ship it as a **template file the user owns** (like Astro's `src/worker.ts`),
+   not generated — it is tiny, and users must edit it to add auth/crons. Revisit if
+   OpenNext churn makes a generated+validated file safer.
+3. **`@lunora/next` package surface for v1.** _Recommendation_: minimal —
+   detection entry (`next → class B`), a `withLunora` alias over
+   `withFrameworkWorker`, and the template. Defer SSR data-preload helpers
+   (`@lunora/react` server-preload → `hydratePreloaded`) to v2.
+4. **Auth routes.** `/api/auth/*` (better-auth via `@lunora/auth`) currently
+   routes through `handleAuthRequest`. Decide whether it mounts at the boundary
+   (before OpenNext) or as a Next Route Handler. _Recommendation_: boundary, for
+   symmetry with the other adapters and to keep auth off the Next render path.
+5. **Remove the `init` no-op now or with the template?** _Recommendation_: with the
+   template (§6).
+6. **Dev-mode story** (§4): `wrangler dev` custom worker (parity) vs `next dev` +
+   separate realtime worker (fast). Pick the documented default.
+7. **`nodejs_compat` + `compatibility_date` baseline** the template pins (OpenNext
+   requires `nodejs_compat`; Lunora's DO SQLite requires a recent compat date).
+
+---
+
+## 8. Follow-up build plan outline
+
+1. `@lunora/next` package: detection + `withLunora` alias + `next → @lunora/react`
+   adapter mapping; `next` added to `FRAMEWORK_SIGNATURES`.
+2. `templates/next`: OpenNext scaffold + `src/worker.ts` custom worker +
+   `wrangler.jsonc` (SHARD DO binding + migration) + `lunora/` app + `@lunora/react`
+   client wired to same-origin `/_lunora/*`.
+3. Remove/rewire the `init` no-op (coordinated with the template).
+4. Workerd smoke test: RPC round-trip + WS subscribe through the composed worker
+   (the piece not runnable in this spike).
+5. v2: SSR data-preload helpers, auth-route placement, all bindings.

--- a/plans/111-phase0-design.md
+++ b/plans/111-phase0-design.md
@@ -1,0 +1,257 @@
+# Plan 111 — Phase 0 design: first-class RAG helper (`ctx.ai.embed` + `ctx.vectors`)
+
+> **Spike outcome (TL;DR)**: The two primitives compose **cleanly** into an
+> index→retrieve helper with **no change** to `@lunora/ai` or
+> `@lunora/bindings/vectors` public surfaces — so **no STOP**. Recommended shape:
+> a `defineRag(config)` helper shipped as an **`@lunora/ai/rag` subpath** (a thin
+> library, _not_ a new binding or codegen-wired `ctx.rag`), callable as
+> `defineRag({...})(ctx).{index,retrieve}`. It respects the Vectorize `topK`
+> ceilings and the namespace/metadata constraints, and its `retrieve` return shape
+> is designed for the plan-113 agent memory step to consume directly.
+>
+> Prototype: `plans/proto/rag/rag.ts` (+ passing test over the **real**
+> `createVectors`). Ran green in-sandbox.
+
+---
+
+## 1. The two primitives, precisely (what the helper composes)
+
+### 1.1 Embedding — from `@lunora/ai`
+
+`ctx.ai` (`LunoraAi`, `packages/ai/src/types.ts:83-98`) exposes:
+
+```ts
+model: (model?: ModelInput) => LanguageModel;
+embeddingModel: (model?: EmbeddingModelInput) => EmbeddingModel; // string id → Workers AI; object → passthrough
+run: (model, inputs, options?) => Promise<unknown>;
+workersai: WorkersAiProviderLike;
+```
+
+**`ctx.ai` does NOT expose `embed` itself.** The actual embedding call is the AI
+SDK `embed`, **re-exported** from `@lunora/ai` (`packages/ai/src/index.ts:8`):
+
+```ts
+import { embed } from "@lunora/ai";
+const { embedding } = await embed({ model: ctx.ai.embeddingModel("@cf/baai/bge-base-en-v1.5"), value: text });
+// embedding: number[]
+```
+
+So the helper's embed seam is a **one-liner adapter**:
+
+```ts
+const embed = async (text: string): Promise<number[]> => (await aiEmbed({ model: ctx.ai.embeddingModel(cfg.embeddingModel), value: text })).embedding;
+```
+
+The embedding model is **provider-agnostic**: a string id resolves against Workers
+AI; an AI SDK `EmbeddingModel` (OpenAI, etc.) passes through (create-ai.ts:77-93).
+
+### 1.2 Vectorize — from `@lunora/bindings/vectors`
+
+`LunoraVectors` (`packages/bindings/src/vectors/types.ts:98-105`) — the helper only
+needs `upsertMany` (write) and `query` (read):
+
+```ts
+upsert     (indexName, { id, input, embed, metadata?, namespace? })      → VectorizeUpsertMutation
+upsertMany (indexName, ReadonlyArray<UpsertInput>)                       → VectorizeUpsertMutation   // ≤1000/batch
+query      (indexName, { input?, vector?, embed?, topK?, filter?,
+                         namespace?, returnMetadata?, returnValues? })   → VectorizeMatches
+```
+
+Crucially, `upsert`/`query` take the **`embed` function directly** on their input
+(`toVector` calls `input.embed(input.input)`, create-vectors.ts:25-33; `query`
+calls `input.embed(input.input)`, :107-111). The helper passes its §1.1 adapter
+straight into that slot — the two facades were **built to compose**.
+
+### 1.3 Constraints the helper MUST respect
+
+- **`topK` ceilings** (create-vectors.ts:37-96): `topK ∈ [1,100]`, lowered to
+  `[1,20]` when `returnValues: true` **or** `returnMetadata: "all"`. Violations
+  throw `RangeError` locally. Because the helper reads chunk text back from
+  metadata (§3.3), it queries with `returnMetadata: "all"` → **it must cap `topK`
+  at 20**.
+- **`upsertMany` batch ≤ 1000** and embedder fan-out is internally bounded to 8
+  (`UPSERT_EMBED_CONCURRENCY`, create-vectors.ts:67-81) — the helper must split
+  documents that chunk to >1000 pieces.
+- **Namespace = the tenant key.** Vectorize indexes are **account-global**
+  (`packages/bindings/src/vectors/context.ts:213-223`): a namespace-less upsert in
+  a multi-tenant/sharded app leaks vectors (ids/scores + metadata) cross-tenant.
+  The helper **must** thread `namespace` on **both** write and query. (The shipped
+  schema-driven sync hook emits a one-time dev warning on namespace-less sync; the
+  RAG helper should do the same or require an explicit `allowSharedNamespace`.)
+- **Metadata default `"indexed"`, not `"all"`** in the context bridge
+  (context.ts:99-104) so queries don't leak arbitrary stored fields — but the RAG
+  helper deliberately opts into `"all"` to retrieve chunk text (a documented
+  tradeoff; §3.3 discusses the DO-table alternative).
+
+---
+
+## 2. Placement recommendation: `@lunora/ai/rag` subpath, `defineRag`
+
+The plan lists three candidates. Assessment against the "scale invisibly" north
+star, the existing ctx-facade pattern, and the "keep it a thin composition"
+maintenance note:
+
+| Option                                           | Verdict                                                                                                                                                                                                                    |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **(a) new `@lunora/rag` package**                | Overweight. RAG adds **no** new binding, no runtime elasticity — it is pure glue over two facades. A package + release + `pnpm-workspace` override is disproportionate.                                                    |
+| **(c) `defineRag(...)` codegen-wired `ctx.rag`** | Premature. Wiring `ctx.rag` via codegen (like `defineSchema`/`defineFlags`) adds discovery + `_generated/*` surface for something that is a library call. Reserve as an _upgrade path_ if boilerplate proves painful (§6). |
+| **(b) `@lunora/ai/rag` subpath, `defineRag`** ✅ | **Recommended.** Lives next to `ctx.ai` (where embedding lives), ships in the package a RAG app already installs, adds no binding/codegen, stays a thin composition. `sideEffects:false` subpath keeps it tree-shakeable.  |
+
+**Why not a new `ctx.*` facade at all initially**: `ctx.ai` and `ctx.vectors` are
+_invisible_ bindings. RAG is a _pattern_ over them, not a new capability of the
+runtime. The north star favors not minting user-facing runtime surface unless it
+removes real complexity that a library cannot. `defineRag` removes the complexity
+(chunk→embed→upsert / embed→query→assemble) **as a library**, keeping the runtime
+surface unchanged. If real-world boilerplate (threading `ctx` + the embed adapter)
+proves annoying, graduate to `ctx.rag` in a follow-up — the API below is
+forward-compatible with that.
+
+---
+
+## 3. The API
+
+### 3.1 Declaration + binding
+
+```ts
+// lunora/rag.ts
+import { defineRag } from "@lunora/ai/rag";
+
+export const docs = defineRag({
+    index: "docs", // a ctx.vectors index binding key
+    embeddingModel: "@cf/baai/bge-base-en-v1.5", // declared ONCE → index + retrieve embed identically
+    chunkSize: 1000, // built-in fixed-window chunker (chars)
+    chunkOverlap: 200,
+    // chunk: (text) => string[]                     // optional override (token/sentence/semantic)
+    topK: 5, // default retrieval depth
+});
+```
+
+`defineRag(config)` returns a **per-request factory** `(ctx) => { index, retrieve }`.
+Binding `ctx` once reads well because both facades live on it:
+
+```ts
+// inside a mutation (write) or action/query (read):
+await docs(ctx).index({ id: doc._id, text: doc.body, metadata: { title: doc.title }, namespace: ctx.shardKey });
+const { context, chunks, sources } = await docs(ctx).retrieve(question, { topK: 5, namespace: ctx.shardKey });
+```
+
+In the real package, `ctx` supplies both `ctx.ai` and `ctx.vectors`; `defineRag`
+builds the §1.1 embed adapter internally. (The prototype's `RagCtx` passes the
+`embed` adapter explicitly to stay AI-SDK-free; the doc shows the real wiring.)
+
+### 3.2 Write side — `index({ id, text, metadata?, namespace? })`
+
+1. **Chunk** `text` via the built-in fixed-window splitter (default 1000 chars,
+   200 overlap) or the `chunk` override.
+2. **Embed + upsert** each chunk via `ctx.vectors.upsertMany(index, inputs)` — one
+   `embed` call per chunk (fan-out bounded to 8 internally).
+3. **Metadata schema linking chunk → source** (the helper owns these keys):
+    - vector `id` = `` `${sourceId}#${chunkIndex}` `` (deterministic).
+    - `metadata.__ragSource = sourceId`, `metadata.__ragChunk = chunkIndex`,
+      `metadata.__ragText = chunkText`, plus the caller's `metadata` spread in.
+    - `namespace` threaded through for tenant isolation.
+
+Returns `{ chunks: number }`.
+
+### 3.3 Read side — `retrieve(query, { topK?, filter?, namespace? })`
+
+1. **Embed** the query with the _same_ model (declared once → symmetric).
+2. **Query** `ctx.vectors.query(index, { input: query, embed, topK, filter,
+namespace, returnMetadata: "all" })` — capping `topK` at **20** (the ceiling
+   when full metadata is requested).
+3. **Assemble** the ranked result:
+
+```ts
+interface RetrieveResult {
+    chunks: { id; sourceId; chunkIndex; text; score; metadata? }[]; // best-first
+    context: string; // chunks joined under `[source:<id>#<n>]` headers — prompt-ready
+    sources: { id; metadata? }[]; // deduped, best-first
+}
+```
+
+The `context` string is drop-in for a prompt; `chunks` allow custom assembly;
+`sources` are deduped refs. **This shape is the plan-113 contract**: an agent's
+memory/retrieval step calls `docs(ctx).retrieve(userMsg)` and injects `.context`
+(and cites `.sources`).
+
+### 3.4 Storing chunk text — metadata vs DO table (design note)
+
+The prototype stores chunk text in vector metadata and reads it back with
+`returnMetadata: "all"` (topK ≤ 20, simple, self-contained). **For production the
+design recommends the alternative**: store chunk text in a Lunora **DO SQLite
+table** keyed by chunk id, query Vectorize with `returnMetadata: "none"` (topK ≤
+**100**), then hydrate text from the DB by id. Benefits: no Vectorize metadata-size
+pressure (~10 KiB/vector cap), higher `topK`, and it reuses the DO the app already
+has. This is an open question (§6.3) because it introduces a table the helper must
+own or the app must declare.
+
+---
+
+## 4. Prototype + test evidence
+
+`plans/proto/rag/rag.ts` implements `defineRag` exactly as §3. The test
+(`rag.test.ts`, **ran green**) drives it over the **real**
+`@lunora/bindings/vectors` `createVectors` (imported by source path) with:
+
+- an in-memory `VectorizeIndexLike` double (cosine similarity; honours `topK`,
+  `returnMetadata`, `namespace`), and
+- a deterministic token-bag embedder (similar text → similar vectors).
+
+Asserts: index→retrieve round-trips; chunk↔source metadata survives (id shape +
+user metadata preserved, internal keys stripped); ranking returns the right source;
+`context` + `sources` are well-formed; **namespace scopes retrieval** (tenant
+isolation); and the **real** `createVectors` throws when `topK: 50` is requested
+with `returnMetadata: "all"` (ceiling enforced live). What was mocked: the actual
+Workers AI embedder + a real Vectorize index (unreachable in-sandbox) — but the
+**composition logic and the real ceiling/validation code path run for real**.
+
+---
+
+## 5. STOP-condition assessment
+
+| STOP condition                                                                          | Triggered?                                                        | Notes                                                                                                                                                      |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Can't compose without changing `@lunora/ai` / `@lunora/bindings/vectors` public surface | **No**                                                            | `upsert`/`query` already accept an `embed` fn; `ctx.ai` already yields the model. Pure composition.                                                        |
+| Chunking/metadata opens a genuinely large product surface                               | **Partial → surfaced as open questions, not decided arbitrarily** | Chunking default is fixed-window + override hook; re-index/delete and text-storage location are real decisions (§6) — deliberately left to the maintainer. |
+
+No hard STOP. One **bounded gap** worth flagging (not a blocker): `LunoraVectors`
+has `deleteByIds` but no "delete by metadata filter" / "list ids by source", so
+**cleanly re-indexing a changed document** (deleting its old chunks) requires
+knowing the prior chunk ids. Deterministic ids + a stored chunk-count sidestep it
+(delete `${id}#0..n-1`), so it needs no surface change — but a future
+`vectors.deleteByFilter` would be cleaner (§6.4).
+
+---
+
+## 6. Open questions (maintainer decisions)
+
+1. **Placement — subpath vs `defineRag`-wired `ctx.rag`.** _Recommendation_:
+   `@lunora/ai/rag` subpath now (§2); graduate to codegen-wired `ctx.rag` only if
+   boilerplate warrants — the API is forward-compatible.
+2. **Default chunking strategy.** _Recommendation_: fixed-window chars (1000/200)
+   as the zero-config default + a `chunk` override; leave token-aware/semantic
+   chunkers to userland or a later `@lunora/ai/rag/chunkers` export.
+3. **Chunk-text storage: metadata vs DO table (§3.4).** _Recommendation_: DO table
+   for production (higher `topK`, no metadata bloat); who owns the table (helper
+   auto-declares vs app declares) is the sub-decision.
+4. **Re-index / delete-old-chunks (§5).** Deterministic-id delete now; consider a
+   `vectors.deleteByFilter` follow-up in `@lunora/bindings/vectors`.
+5. **Metadata schema ownership.** The helper owns `__ragSource/__ragChunk/__ragText`
+   — confirm the reserved-key convention (or a nested `__lunoraRag` object) so it
+   never collides with user metadata.
+6. **Tool integration for agents (ties to plan 113).** Should `retrieve` also be
+   exposable as an AI SDK `tool()` so an agent calls it as a function?
+   _Recommendation_: yes, ship a `docs(ctx).asTool()` in the 113 timeframe; the
+   `RetrieveResult` shape already fits.
+7. **Reranking scope.** Out of v1. Note as a future `retrieve({ rerank })` hook.
+8. **Embedding-model declaration site.** _Recommendation_: declared once on
+   `defineRag({ embeddingModel })` (as designed) so index + retrieve never drift;
+   allow a per-call override only for advanced cases.
+
+---
+
+## 7. Cross-plan note (for 113)
+
+Design `retrieve`'s return **for the agent consumer**: `{ context, chunks, sources }`
+lets an agent memory step inject `.context` and cite `.sources` with zero
+reshaping. Sequence **111 before any 113 build** (the plan's maintenance note).

--- a/plans/113-phase0-design.md
+++ b/plans/113-phase0-design.md
@@ -1,0 +1,291 @@
+# Plan 113 — Phase 0 design: durable AI-agent primitive (`defineAgent`)
+
+> **Spike outcome (TL;DR)**: Every part of a durable tool-loop maps onto a **shipped**
+> Lunora primitive — durable steps (`ctx.runStep` → native `step.do`), DO SQLite
+> thread tables, the WS `type:"stream"` transport, and (plan 111) `rag.retrieve`.
+> Replay-safety for **completed** steps is guaranteed by native `step.do`
+> memoization; a **failed/retried** side-effecting tool still needs an idempotency
+> key, which the deterministic step name provides. **No STOP** — but the honest
+> recommendation is **document-first / opt-in add-on, not a core primitive**,
+> because this is a _user-facing_ surface in tension with the "scale invisibly"
+> north star. That tension is the **top open question** for the maintainer (§7.1).
+>
+> PoC: `plans/proto/agent/agent-loop.ts` (+ passing test asserting thread ordering
+> **and** resume-doesn't-re-run-a-completed-tool). Ran green in-sandbox.
+
+---
+
+## 1. Machinery map — each loop part → a shipped primitive
+
+| Agent-loop part                                  | Reused Lunora primitive                                           | Reference                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------ | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LLM turn** (call model, get text or tool-call) | a **named durable step**                                          | `ctx.runStep(defineStep("llm:turn:N", …))` → `deps.step.do("llm:turn:N", cb)` — `packages/workflow/src/run-step.ts:130`; `define-step.ts:40`                                                                                                                                                   |
+| **Tool call** (execute a tool)                   | a **named durable step** (name = idempotency key)                 | same `ctx.runStep`; step name `tool:<name>:<callId>`                                                                                                                                                                                                                                           |
+| **Message persist** (user/assistant/tool rows)   | **DO SQLite table write**, idempotent by deterministic message id | `defineSchema` tables + `ctx.db`; shipped idempotency machinery `packages/do/src/ctx-db-idempotency.ts`                                                                                                                                                                                        |
+| **Stream deltas to client**                      | WS **`type:"stream"`** transport                                  | authored as a `query(...).stream()` async generator — `packages/server/src/builder/types.ts:67` (`RegisteredStream`); dispatched by `packages/do/src/shard-do.ts:2261` `handleStream`; consumed client-side via `createStream`/`StreamIterable` — `packages/client/src/lunora-client.ts:18-19` |
+| **Memory / RAG step**                            | `defineRag(...)(ctx).retrieve` (plan 111)                         | returns `{ context, chunks, sources }` — designed for this consumer                                                                                                                                                                                                                            |
+| **Loop orchestration** (durable, replayable)     | Cloudflare Workflows via `@lunora/workflow`                       | `defineWorkflow` + `createWorkflowContext` — `packages/workflow/src/index.ts`                                                                                                                                                                                                                  |
+| **Fan-out / parallel tools + saga rollback**     | shipped `branch`/`MAX_BRANCHES` + step `rollback`                 | `fan-out.ts`; `run-step.ts:113-128` (rollback wiring)                                                                                                                                                                                                                                          |
+| **Duplicate-step-name guard**                    | shipped workflow lint                                             | keep agent step names unique + deterministic                                                                                                                                                                                                                                                   |
+
+**Nothing new is required at the runtime layer.** The agent loop is an
+_assembly_ of these. That fact is the crux of the build-vs-document decision (§7.1).
+
+---
+
+## 2. Replay-safety / idempotency argument (the correctness core)
+
+### 2.1 What native `step.do` guarantees
+
+`run-step.ts:130` runs each step as `deps.step.do(step.name, callback, …)` —
+Cloudflare Workflows' native durable step. Its contract: **a step that has already
+completed is memoized by name; on a resume/replay the recorded output is returned
+WITHOUT re-invoking the callback.** So if the workflow crashes after a tool step
+committed, the resumed run **does not re-run that tool** — a card is charged once.
+
+Each LLM turn and each tool call is a **uniquely + deterministically named** step:
+
+- `llm:turn:<n>` — `n` is the loop turn index (deterministic across replays).
+- `tool:<name>:<callId>` — `callId` is the **provider's stable tool-call id** from
+  the LLM response (deterministic — it is itself replayed from the memoized
+  `llm:turn` output).
+
+Determinism of the **loop control** matters: which steps run is derived from
+**persisted step outputs** (the memoized `llm:turn` decisions), never from fresh
+`Date.now()`/`Math.random()` at the top level. Non-determinism _inside_ a step body
+is fine — the body's output is memoized. (Lunora already flags top-level
+non-determinism via the `nondeterministic_query_mutation` advisor lint.)
+
+The shipped **duplicate-step-name lint** is the guard that keeps names unique; the
+agent's naming scheme (`llm:turn:<n>`, `tool:<name>:<callId>`) is compatible with
+it.
+
+### 2.2 The nuance the design must NOT hide — retry ≠ replay
+
+`step.do` memoizes on **success**. A step whose body **fails mid-execution** (after
+a side effect, before the step records completion) is **retried at-least-once** —
+and re-run. So:
+
+- **Replay of a COMPLETED step** → safe (memoized). ✅
+- **Retry of a FAILED, side-effecting step** → the tool body must be **internally
+  idempotent**. This is _not_ a Lunora gap — it is the same at-least-once reality
+  in Temporal/Convex/every durable-execution engine. The standard answer is an
+  **idempotency key**, and the agent already has a perfect one: **the deterministic
+  step name** (`tool:<name>:<callId>`). The design hands that key to the tool
+  (e.g. as `ctx.idempotencyKey`) so a payment/side-effecting tool dedupes.
+
+**Therefore the STOP condition "the durable-step machinery can't guarantee tool
+idempotency across replays without changes to `@lunora/workflow`" does NOT
+trigger**: across _replays_ it is guaranteed by memoization; across _retries_ it is
+handled by the idempotency-key convention with zero engine change. The follow-up's
+first task is to **document + surface the idempotency key**, and optionally add a
+tiny `defineTool({ idempotent: true })` helper — a convenience, not a correctness
+prerequisite. This is open question §7.2.
+
+### 2.3 PoC evidence
+
+`plans/proto/agent/agent-loop.ts` models the loop and a faithful
+`DurableStepJournal` (an exact in-memory model of `step.do` memoization — a step
+name with a recorded output returns it without re-invoking `cb`, persisted across a
+resume by reusing the journal instance). The test (`agent-loop.test.ts`, **ran
+green**) asserts:
+
+- **(a) thread ordering**: messages persist as `user → assistant(tool_call) → tool
+→ assistant(final)` with monotonic `seq`, correct `toolCall`/`toolCallId`
+  correlation, and the tool ran exactly once.
+- **(b) resume safety**: a simulated crash **after** the tool step commits (before
+  turn-1's LLM call) is followed by a resume with the **same** journal + message
+  store; the resumed run serves `llm:turn:0` and `tool:getWeather:call_1` from the
+  journal — the tool's side-effect counter stays **1**, each step body was invoked
+  **exactly once** across crash+resume (`["llm:turn:0","tool:getWeather:call_1","llm:turn:1"]`),
+  and the final thread has no duplicated messages (idempotent upsert by message id).
+
+What was mocked: the LLM + the tool + Cloudflare Workflows itself (unreachable
+in-sandbox). The memoization contract modelled is the _documented_ `step.do`
+behavior that `run-step.ts:130` delegates to, so the replay-safety argument holds
+for the real machinery.
+
+---
+
+## 3. The API + thread schema
+
+### 3.1 `defineAgent`
+
+```ts
+// lunora/agents.ts
+import { defineAgent } from "@lunora/agent"; // recommended home — §7.1
+import { tool } from "@lunora/ai";
+import { docs } from "./rag"; // plan 111
+
+export const support = defineAgent({
+    model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", // string id or AI SDK model
+    thread: "supportThreads", // thread table name (see §3.3)
+    tools: {
+        getWeather: tool({/* AI SDK tool: description, inputSchema, execute */}),
+    },
+    memory: docs, // optional: a defineRag index → auto retrieval step (§4)
+    maxSteps: 8, // cost/step cap
+    // idempotentTools: ["charge"],   // §7.2
+});
+```
+
+### 3.2 Runtime surface — how an app invokes it
+
+The loop needs `ctx.runStep`, which only exists inside a **workflow run**. So
+`defineAgent` **compiles to a generated `defineWorkflow`** whose handler runs the
+loop. The app invokes it like any workflow producer:
+
+```ts
+// inside an action/mutation:
+const run = await ctx.agents.support.run(threadId, { message: input }); // → creates a workflow instance
+// stream deltas to the client with a paired streaming query (§4):
+// useStream(api.agents.support.stream, { threadId })
+```
+
+_Recommendation_: `ctx.agents.<name>.run(threadId, input)` (mirrors
+`ctx.workflows`/`ctx.queues` producer style) over a bare action, so the durable
+workflow instance + status are first-class. The streamed response is a **separate**
+`query(...).stream()` the client subscribes to by `threadId` (§4).
+
+### 3.3 Thread + message schema (`defineSchema` tables in the DO)
+
+```ts
+export default defineSchema({
+    agentThreads: defineTable({
+        agent: v.string(),
+        title: v.optional(v.string()),
+        createdAt: v.number(),
+        status: v.union(v.literal("idle"), v.literal("running"), v.literal("error")),
+    }).index("by_agent", ["agent"]),
+
+    agentMessages: defineTable({
+        threadId: v.id("agentThreads"),
+        seq: v.number(), // monotonic per-thread ordering
+        role: v.union(v.literal("user"), v.literal("assistant"), v.literal("tool"), v.literal("system")),
+        content: v.string(),
+        toolCall: v.optional(v.object({ id: v.string(), name: v.string(), args: v.any() })), // assistant → tool intent
+        toolCallId: v.optional(v.string()), // tool row → correlates to toolCall.id
+        stepName: v.optional(v.string()), // the durable step that produced it (audit/idempotency)
+        createdAt: v.number(),
+    }).index("by_thread", ["threadId", "seq"]),
+});
+```
+
+Message writes are **idempotent by a deterministic id** (`stepName` or
+`${threadId}:${role}:${turn}`) so a replay re-persist does not duplicate — the PoC
+proves this, and the shipped `ctx-db-idempotency.ts` provides the mechanism.
+
+---
+
+## 4. Streaming + memory integration
+
+- **Streaming**: author the agent's live response as a `query(...).stream()` async
+  generator (`RegisteredStream`, builder/types.ts:67) that yields token/tool-event
+  deltas; the DO's `handleStream` (shard-do.ts:2261) delivers them as
+  `ServerChunkMessage` frames over the existing WS `type:"stream"` transport; the
+  client consumes via `createStream`/`StreamIterable`. **No new transport.** The
+  stream reads from the persisted thread + in-flight step outputs, so a reconnect
+  resumes from the durable state.
+- **Memory/RAG (plan 111)**: `memory: docs` inserts a retrieval step at turn start
+  — `docs(ctx).retrieve(userMessage)` — and injects `.context` into the model
+  prompt (and can be exposed as an AI SDK `tool()` so the agent _chooses_ to
+  retrieve; plan 111 §6.6). `retrieve`'s `{ context, chunks, sources }` shape was
+  designed for exactly this.
+
+---
+
+## 5. STOP-condition assessment
+
+| STOP condition                                                                                            | Triggered?                                                 | Notes                                                                                                                               |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Durable-step machinery can't guarantee tool idempotency across replays without `@lunora/workflow` changes | **No**                                                     | Completed-step memoization is native (§2.1); retry needs an idempotency key = the deterministic step name, no engine change (§2.2). |
+| Design surface balloons (streaming + HITL + memory + cost caps each open sub-designs)                     | **Expected for XL → surfaced as open questions**           | §7 scopes them; recommend a phased build, not an attempt here.                                                                      |
+| "Scale invisibly" argues against a bespoke user-facing primitive                                          | **This is the real tension → §7.1, the TOP open question** | Honest outcome may be "document the composition; ship at most an opt-in add-on."                                                    |
+
+No hard STOP. The spike's job is to make the build-vs-document call _decidable_ — §7.
+
+---
+
+## 6. HITL, cost caps, cancellation (noted, not designed)
+
+- **Human-in-the-loop**: Cloudflare Workflows' `waitForEvent` pauses the run until
+  an external event (approval) arrives — a natural fit for a `pause`/`resume`
+  tool. Design in the build phase.
+- **Cost/step caps**: `maxSteps` (turns) + a token/$ budget checked between turns;
+  exceed → terminate with a persisted `status:"error"`.
+- **Cancellation**: the streaming query's `AbortSignal` + a workflow terminate.
+
+---
+
+## 7. Open questions (maintainer decisions)
+
+### 7.1 (TOP) Build a bespoke `defineAgent` primitive, or document the composition? — the "scale invisibly" tension
+
+This is a **user-facing primitive**, unlike the invisible runtime elasticity the
+north star prizes. §1 shows the loop is a _thin assembly_ of shipped primitives.
+That pulls two ways:
+
+- **Against building** (north-star-aligned): the composition is genuinely thin; a
+  bespoke primitive **locks in opinions prematurely** (thread schema, tool
+  protocol, streaming shape, HITL semantics) that are still moving industry-wide;
+  and it adds core user-facing surface that a good **recipe/example + a tiny
+  helper** could cover without commitment.
+- **For building** (parity/marketing): the assembled agent primitive is Convex's
+  **most-marketed differentiator** (`@convex-dev/agent`). "Build an agent on my
+  backend" is the current top AI use case; a first-class `defineAgent` is a
+  headline capability, and leaving it as docs concedes the comparison.
+
+**Recommendation (for the maintainer to ratify, not a unilateral decision)**:
+**document-first, then ship a MINIMAL `defineAgent` as an OPT-IN add-on package
+`@lunora/agent`, not in core `@lunora/ai`.** Concretely, phased:
+
+1. **Now**: a documented "durable agent" recipe/example composing
+   `@lunora/workflow` + `@lunora/ai` + `defineRag` (plan 111), plus a tiny
+   `runAgentLoop(...)` helper in `@lunora/ai` (the PoC, hardened). Zero new
+   user-facing primitive → keeps core invisible.
+2. **After the recipe validates demand**: graduate to `@lunora/agent`'s
+   `defineAgent` (§3) as an **opt-in add-on** (like `@lunora/auth`/`@lunora/mail`),
+   so the _core_ stays invisible while power users get the assembled primitive.
+
+Rationale: the add-on boundary is exactly how Lunora keeps its core small while
+still shipping big capabilities — building `defineAgent` as an _opt-in package_
+resolves the tension rather than compromising the core. **But the placement and the
+build-vs-document sequencing are the maintainer's call — this design is the
+artifact for that decision.**
+
+### 7.2 Idempotency-key convention for side-effecting tools (§2.2)
+
+_Recommendation_: pass the deterministic step name to the tool as
+`ctx.idempotencyKey`; optionally a `defineTool({ idempotent })` marker. Document
+loudly — a tool that runs twice on a _retry_ (not a replay) is the correctness
+cliff. No `@lunora/workflow` change required.
+
+### 7.3 Home: `@lunora/ai` vs new `@lunora/agent`
+
+_Recommendation_: new **`@lunora/agent`** opt-in package (§7.1) — keeps the loop's
+opinions out of the lean `@lunora/ai`.
+
+### 7.4 Memory/RAG integration shape
+
+_Recommendation_: `memory: <defineRag>` auto-injects a retrieval step **and**
+exposes `retrieve` as a `tool()` the agent may call (plan 111 §6.6). Sequence 111
+first.
+
+### 7.5 HITL via `waitForEvent` (§6) — in v1 or deferred? _Recommendation_: deferred to v2.
+
+### 7.6 Streaming transport details — token deltas + tool-call events over one
+
+`type:"stream"` query, keyed by `threadId`; confirm the delta envelope schema.
+
+### 7.7 Cost/step caps + cancellation (§6) — the default `maxSteps` and budget policy.
+
+---
+
+## 8. Cross-plan sequencing
+
+- **Sequence 111 (RAG) before any 113 build** — the agent memory step consumes
+  `defineRag(...).retrieve` (plan maintenance note).
+- Reuse the shipped **fan-out/saga** (plans 075/076) + the **duplicate-step-name
+  lint**; keep agent step names unique + deterministic (§2.1).
+- If built, this is the flagship Convex-parity AI feature — this design doc is the
+  decision artifact for build-vs-document (§7.1).

--- a/plans/proto/agent/agent-loop.test.ts
+++ b/plans/proto/agent/agent-loop.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Spike 113 PoC test. Asserts the two properties the plan requires:
+ *   (a) the message thread is persisted in order (user -> assistant tool-call ->
+ *       tool result -> final assistant), and
+ *   (b) on a simulated mid-loop crash + resume, the already-completed tool step is
+ *       NOT re-executed (no double side effect) and completed LLM turns are not
+ *       re-called.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { AgentDeps, LlmTurn, ThreadMessage } from "./agent-loop";
+import { DurableStepJournal, MessageStore, runAgent } from "./agent-loop";
+
+/** Build a mock LLM that returns one tool call on turn 0, then a final answer on turn 1. */
+const makeLlm = (): { fn: AgentDeps["llm"]; turns: number } => {
+    const state = { turns: 0 };
+
+    const fn = (): LlmTurn => {
+        const current = state.turns;
+
+        state.turns += 1;
+
+        if (current === 0) {
+            return { args: { city: "SF" }, id: "call_1", kind: "tool_call", name: "getWeather", text: "let me check the weather" };
+        }
+
+        return { kind: "final", text: "It is 21C and sunny in SF." };
+    };
+
+    return {
+        fn,
+        get turns() {
+            return state.turns;
+        },
+    };
+};
+
+/** Deterministic clock so `createdAt` is stable across the crash + resume. */
+const makeClock = () => {
+    let tick = 0;
+
+    return () => {
+        tick += 1;
+
+        return `2026-07-03T00:00:${String(tick).padStart(2, "0")}Z`;
+    };
+};
+
+describe("spike 113: durable single-tool agent loop", () => {
+    it("persists the thread in order across LLM -> tool -> LLM", async () => {
+        const llm = makeLlm();
+        const toolCalls: unknown[] = [];
+
+        const messages = await runAgent({
+            journal: new DurableStepJournal(),
+            llm: llm.fn,
+            messages: new MessageStore(),
+            now: makeClock(),
+            threadId: "t1",
+            tool: {
+                handler: (args) => {
+                    toolCalls.push(args);
+
+                    return "21C sunny";
+                },
+                name: "getWeather",
+            },
+            userInput: "what's the weather in SF?",
+        });
+
+        expect(messages.map((message: ThreadMessage) => message.role)).toEqual(["user", "assistant", "tool", "assistant"]);
+        expect(messages.map((message) => message.seq)).toEqual([0, 1, 2, 3]);
+        expect(messages[1].toolCall).toEqual({ args: { city: "SF" }, id: "call_1", name: "getWeather" });
+        expect(messages[2].toolCallId).toBe("call_1");
+        expect(messages[3].content).toContain("sunny");
+        expect(toolCalls).toHaveLength(1);
+    });
+
+    it("does not re-run a completed tool step on resume after a mid-loop crash", async () => {
+        // Shared, DURABLE state that survives the crash (the DO's SQLite + the
+        // Workflows step journal in the real design).
+        const journal = new DurableStepJournal();
+        const messages = new MessageStore();
+        const clock = makeClock();
+
+        const sideEffects = { count: 0 };
+        const llm = makeLlm();
+
+        const tool = {
+            handler: (): string => {
+                sideEffects.count += 1; // e.g. "charge the card" — must happen exactly once
+
+                return "21C sunny";
+            },
+            name: "getWeather",
+        };
+
+        // First attempt: crash right after the tool step commits, before turn 1's LLM call.
+        let crashed = false;
+
+        await expect(
+            runAgent({
+                checkpoint: (label) => {
+                    if (label === "after-tool:call_1") {
+                        crashed = true;
+
+                        throw new Error("SIMULATED_CRASH");
+                    }
+                },
+                journal,
+                llm: llm.fn,
+                messages,
+                now: clock,
+                threadId: "t1",
+                tool,
+                userInput: "what's the weather in SF?",
+            }),
+        ).rejects.toThrow("SIMULATED_CRASH");
+
+        expect(crashed).toBe(true);
+        expect(sideEffects.count).toBe(1); // tool ran once pre-crash
+        expect(journal.has("tool:getWeather:call_1")).toBe(true); // recorded in the journal
+        expect(journal.has("llm:turn:1")).toBe(false); // never reached
+
+        // RESUME: same journal + same message store, no checkpoint crash this time.
+        const invokedBeforeResume = [...journal.invoked];
+        const finalMessages = await runAgent({
+            journal,
+            llm: llm.fn,
+            messages,
+            now: clock,
+            threadId: "t1",
+            tool,
+            userInput: "what's the weather in SF?",
+        });
+
+        // (b) The tool did NOT run again — memoized by its step name.
+        expect(sideEffects.count).toBe(1);
+        // Each step body was invoked EXACTLY ONCE across the crash + resume: the two
+        // completed steps (llm:turn:0, tool:getWeather:call_1) ran pre-crash and were
+        // served from the journal on resume; only the new step (llm:turn:1) ran on resume.
+        expect(invokedBeforeResume).toEqual(["llm:turn:0", "tool:getWeather:call_1"]);
+        expect(journal.invoked).toEqual(["llm:turn:0", "tool:getWeather:call_1", "llm:turn:1"]);
+
+        // (a) The resumed thread is complete + in order, with no duplicated messages.
+        expect(finalMessages.map((message) => message.role)).toEqual(["user", "assistant", "tool", "assistant"]);
+        expect(finalMessages.map((message) => message.id)).toEqual(["t1:user:0", "t1:assistant:0", "t1:tool:call_1", "t1:assistant:1"]);
+        expect(finalMessages[3].content).toContain("sunny");
+    });
+});

--- a/plans/proto/agent/agent-loop.ts
+++ b/plans/proto/agent/agent-loop.ts
@@ -1,0 +1,191 @@
+/**
+ * Spike 113 proof-of-concept — a durable, replay-safe single-tool agent loop.
+ *
+ * Models the machinery Lunora already ships, so the loop is a *composition*, not a
+ * new engine:
+ *   - LLM turn  -> a named durable step  (real: `ctx.runStep(defineStep("llm:turn-N", ...))`
+ *                  -> `step.do("llm:turn-N", cb)`; packages/workflow/src/run-step.ts:130)
+ *   - tool call -> a named durable step  (real: `ctx.runStep(defineStep("tool:<name>:<callId>", ...))`)
+ *   - message persist -> a DO SQLite write, idempotent by a deterministic message id
+ *                  (real: `ctx.db` + the shipped ctx-db idempotency machinery)
+ *
+ * The replay-safety guarantee comes entirely from the native step memoization that
+ * Cloudflare Workflows provides and `run-step.ts` delegates to: `step.do(name, cb)`
+ * returns the persisted output of an ALREADY-COMPLETED step WITHOUT re-invoking `cb`.
+ * `DurableStepJournal` below is a faithful in-memory model of exactly that contract,
+ * so the PoC can assert "a completed tool step does not re-run on resume" without
+ * booting Cloudflare Workflows.
+ *
+ * IMPORTANT nuance the design doc expands on: memoization makes a COMPLETED step
+ * replay-safe. A step that FAILS mid-body is retried at-least-once, so a
+ * side-effecting tool (charge a card) must still be internally idempotent — the
+ * deterministic step name doubles as the idempotency key handed to the tool.
+ */
+
+/** A completed step's recorded output (mirrors Cloudflare Workflows' step journal). */
+interface JournalEntry {
+    output: unknown;
+}
+
+/**
+ * Faithful model of Cloudflare Workflows' `step.do(name, cb)` memoization:
+ * a step name that already has a recorded output returns it WITHOUT calling `cb`.
+ * Persisted across a resume by reusing the same journal instance.
+ */
+export class DurableStepJournal {
+    private readonly entries = new Map<string, JournalEntry>();
+
+    /** Names whose `cb` was actually invoked this process (for test assertions). */
+    public readonly invoked: string[] = [];
+
+    public async do<T>(name: string, callback: () => Promise<T> | T): Promise<T> {
+        const existing = this.entries.get(name);
+
+        if (existing) {
+            // Completed on a prior attempt/replay: return cached output, DO NOT re-run.
+            return existing.output as T;
+        }
+
+        this.invoked.push(name);
+
+        const output = await callback();
+
+        this.entries.set(name, { output });
+
+        return output;
+    }
+
+    public has(name: string): boolean {
+        return this.entries.has(name);
+    }
+}
+
+export type Role = "assistant" | "tool" | "user";
+
+export interface ThreadMessage {
+    /** Deterministic id -> idempotent across replays. */
+    id: string;
+    /** ISO timestamp (produced inside a step in the real design so replays are stable). */
+    createdAt: string;
+    content: string;
+    role: Role;
+    /** Present on an assistant message that requested a tool. */
+    toolCall?: { args: unknown; id: string; name: string };
+    /** Present on a tool message (correlates to the assistant `toolCall.id`). */
+    toolCallId?: string;
+    /** Monotonic per-thread sequence, assigned at persist time. */
+    seq: number;
+}
+
+/**
+ * Idempotent, ordered message store — models a DO SQLite thread table. Upsert by
+ * `id` so a replay that re-persists the same message does not duplicate it, and a
+ * monotonic `seq` gives a stable thread ordering.
+ */
+export class MessageStore {
+    private readonly byId = new Map<string, ThreadMessage>();
+
+    private nextSeq = 0;
+
+    public upsert(message: Omit<ThreadMessage, "seq"> & { seq?: number }): ThreadMessage {
+        const existing = this.byId.get(message.id);
+
+        if (existing) {
+            return existing;
+        }
+
+        const stored: ThreadMessage = { ...message, seq: this.nextSeq };
+
+        this.nextSeq += 1;
+        this.byId.set(message.id, stored);
+
+        return stored;
+    }
+
+    public list(): ThreadMessage[] {
+        return [...this.byId.values()].sort((a, b) => a.seq - b.seq);
+    }
+}
+
+/** What the (mocked) LLM returns for a turn: either a tool call or a final answer. */
+export type LlmTurn = { kind: "final"; text: string } | { args: unknown; id: string; kind: "tool_call"; name: string; text: string };
+
+export interface AgentDeps {
+    /** The durable-step journal (native `step.do` model). Reuse across a resume. */
+    journal: DurableStepJournal;
+    /** Mock LLM: given the running history, return this turn's action. */
+    llm: (history: ReadonlyArray<ThreadMessage>) => Promise<LlmTurn> | LlmTurn;
+    /** The message thread store (idempotent, ordered). */
+    messages: MessageStore;
+    /** Deterministic clock — a step body owns real time in the real design; injected here for stable tests. */
+    now: () => string;
+    /** Max LLM turns before bailing (cost/step cap — an open question in the design). */
+    maxTurns?: number;
+    /** Single tool for the PoC. Its step name (`tool:<name>:<callId>`) is its idempotency key. */
+    tool: { handler: (args: unknown) => Promise<string> | string; name: string };
+    /** Test hook: simulate a mid-loop crash at a labelled checkpoint. */
+    checkpoint?: (label: string) => void;
+    threadId: string;
+    userInput: string;
+}
+
+/**
+ * Run the durable single-tool agent loop. Each LLM turn and the tool call are
+ * named durable steps; message writes are idempotent. Safe to re-invoke with the
+ * same `journal` + `messages` after a crash — completed steps are not re-run.
+ */
+export const runAgent = async (deps: AgentDeps): Promise<ThreadMessage[]> => {
+    const maxTurns = deps.maxTurns ?? 8;
+
+    // Persist the user message once (idempotent by deterministic id).
+    deps.messages.upsert({ content: deps.userInput, createdAt: deps.now(), id: `${deps.threadId}:user:0`, role: "user" });
+
+    for (let turn = 0; turn < maxTurns; turn += 1) {
+        const history = deps.messages.list();
+
+        // LLM turn as a durable step: memoized by name, so a resume returns the
+        // recorded decision instead of paying for the model again.
+        const decision = await deps.journal.do<LlmTurn>(`llm:turn:${String(turn)}`, () => deps.llm(history));
+
+        if (decision.kind === "final") {
+            deps.messages.upsert({
+                content: decision.text,
+                createdAt: deps.now(),
+                id: `${deps.threadId}:assistant:${String(turn)}`,
+                role: "assistant",
+            });
+
+            return deps.messages.list();
+        }
+
+        // Persist the assistant's tool-call intent (idempotent).
+        deps.messages.upsert({
+            content: decision.text,
+            createdAt: deps.now(),
+            id: `${deps.threadId}:assistant:${String(turn)}`,
+            role: "assistant",
+            toolCall: { args: decision.args, id: decision.id, name: decision.name },
+        });
+
+        // Tool call as a durable step. The step name IS the idempotency key: on a
+        // resume the completed tool returns its recorded result and NEVER re-runs
+        // (no double-charge). `decision.id` is the provider's stable tool-call id.
+        const stepName = `tool:${decision.name}:${decision.id}`;
+        const toolResult = await deps.journal.do<string>(stepName, () => deps.tool.handler(decision.args));
+
+        deps.messages.upsert({
+            content: toolResult,
+            createdAt: deps.now(),
+            id: `${deps.threadId}:tool:${decision.id}`,
+            role: "tool",
+            toolCallId: decision.id,
+        });
+
+        // Injected crash point (test-only): a failure AFTER the tool step committed
+        // but BEFORE the next LLM turn. On resume the loop replays from the top and
+        // the tool step is served from the journal.
+        deps.checkpoint?.(`after-tool:${decision.id}`);
+    }
+
+    return deps.messages.list();
+};

--- a/plans/proto/next/compose-next-worker.test.ts
+++ b/plans/proto/next/compose-next-worker.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Spike 110 seam test. Proves the OpenNext custom-worker boundary:
+ *   (a) a non-`/_lunora` request (a page) delegates to the OpenNext handler,
+ *   (b) an RPC POST to `/_lunora/rpc` round-trips through Lunora,
+ *   (c) admin routes reach Lunora,
+ *   (d) a WebSocket upgrade to `/_lunora/ws` returns the 101 + its `webSocket`
+ *       field VERBATIM — the exact thing a Next Route Handler + OpenNext response
+ *       adapter would strip, which is why the WS path must live at the boundary.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { FetchHost, LunoraHandler, ResponseLike } from "./compose-next-worker";
+import { composeNextWorker } from "./compose-next-worker";
+
+const makeOpenNextHost = (): FetchHost => ({
+    fetch: vi.fn((request: Request): ResponseLike => new Response(`next-ssr:${new URL(request.url).pathname}`, { status: 200 })),
+});
+
+/** A stand-in for `createLunoraHandler()` covering the reserved sub-paths. */
+const makeLunora = (socket: object): { calls: string[]; handler: LunoraHandler } => {
+    const calls: string[] = [];
+
+    const handler: LunoraHandler = (request) => {
+        const { pathname } = new URL(request.url);
+
+        calls.push(pathname);
+
+        if (pathname === "/_lunora/ws" && request.headers.get("Upgrade") === "websocket") {
+            // Cloudflare's WebSocket upgrade: a 101 whose `webSocket` field the
+            // runtime hands to the client. Modelled as a plain object because Node's
+            // `Response` constructor rejects status 101 (workerd allows it).
+            return { status: 101, webSocket: socket };
+        }
+
+        if (pathname === "/_lunora/rpc") {
+            return Response.json({ result: 42 });
+        }
+
+        if (pathname.startsWith("/_lunora/admin/")) {
+            return Response.json({ admin: true });
+        }
+
+        return new Response("not found", { status: 404 });
+    };
+
+    return { calls, handler };
+};
+
+describe("spike 110: composeNextWorker OpenNext boundary seam", () => {
+    it("delegates non-/_lunora requests to the OpenNext handler", async () => {
+        const host = makeOpenNextHost();
+        const { handler } = makeLunora({});
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/dashboard"), {})) as Response;
+
+        expect(host.fetch).toHaveBeenCalledOnce();
+        expect(await response.text()).toBe("next-ssr:/dashboard");
+    });
+
+    it("round-trips an RPC POST through Lunora without touching OpenNext", async () => {
+        const host = makeOpenNextHost();
+        const { handler } = makeLunora({});
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/_lunora/rpc", { body: "{}", method: "POST" }), {})) as Response;
+
+        expect(host.fetch).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({ result: 42 });
+    });
+
+    it("routes the admin plane to Lunora", async () => {
+        const host = makeOpenNextHost();
+        const { handler } = makeLunora({});
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/_lunora/admin/functions"), {})) as Response;
+
+        expect(host.fetch).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({ admin: true });
+    });
+
+    it("returns the WebSocket upgrade (101 + webSocket) verbatim at the boundary", async () => {
+        const host = makeOpenNextHost();
+        const socket = { id: "ws-1" };
+        const { handler } = makeLunora(socket);
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/_lunora/ws", { headers: { Upgrade: "websocket" } }), {})) as {
+            status: number;
+            webSocket?: unknown;
+        };
+
+        expect(host.fetch).not.toHaveBeenCalled();
+        expect(response.status).toBe(101);
+        // The load-bearing assertion: the `webSocket` field survives the seam.
+        expect(response.webSocket).toBe(socket);
+    });
+});

--- a/plans/proto/next/compose-next-worker.ts
+++ b/plans/proto/next/compose-next-worker.ts
@@ -1,0 +1,88 @@
+/**
+ * Spike 110 prototype — the OpenNext-on-Cloudflare composition seam for
+ * `@lunora/next`, modelled as a standalone, runnable function.
+ *
+ * This is a faithful, dependency-free model of what the real integration does with
+ * the SHIPPED `withFrameworkWorker(host, (env) => ({ shardDO: env.SHARD }))`
+ * (packages/runtime/src/create-worker.ts:3285). We can't boot `createWorker` +
+ * a real `ShardDO` namespace in this sandbox (needs workerd + a Vectorize/DO
+ * binding), so the prototype isolates the ONE decision the spike must prove: at
+ * the OpenNext *custom-worker boundary*, reserve `/_lunora/*` for Lunora and
+ * delegate everything else to the OpenNext handler — and return Lunora's response
+ * (including a `101 Switching Protocols` WebSocket upgrade with its `webSocket`
+ * field) VERBATIM.
+ *
+ * Real wiring the template ships (custom worker; `main` in wrangler points here):
+ *
+ * ```ts
+ * // src/worker.ts  (wrangler main)
+ * // @ts-expect-error generated at build time by @opennextjs/cloudflare
+ * import { default as openNextHandler } from "./.open-next/worker.js";
+ * import { withFrameworkWorker } from "@lunora/runtime";
+ *
+ * export default withFrameworkWorker(openNextHandler, (env) => ({ shardDO: env.SHARD }));
+ *
+ * // ShardDO must be exported from the SAME worker entry (+ bound in wrangler.jsonc):
+ * export { ShardDO } from "./lunora/server";
+ * // When OpenNext's DO-backed cache/queue is enabled, re-export its DO classes too:
+ * // export { DOQueueHandler, DOShardedTagCache, BucketCachePurge } from "./.open-next/worker.js";
+ * ```
+ *
+ * A Next.js Route Handler (`app/_lunora/[...path]/route.ts`) can serve RPC (a plain
+ * POST/GET -> Response), but CANNOT carry the WebSocket upgrade: Cloudflare's 101
+ * response needs a non-standard `webSocket` field, and OpenNext's request/response
+ * adapter round-trip (Cloudflare Request -> Next server -> Web Response -> Cloudflare
+ * Response) does not preserve it. So the WS path — Lunora's core realtime feature —
+ * must live at the worker boundary. This prototype proves the boundary preserves it.
+ */
+
+/** What a Cloudflare `fetch` handler may return: a real `Response`, or a 101 upgrade carrying a `webSocket`. */
+export type ResponseLike = Response | { readonly status: number; readonly webSocket?: unknown };
+
+export interface ExecutionContextLike {
+    passThroughOnException?: () => void;
+    waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/** The OpenNext-emitted handler shape (`.open-next/worker.js` default export). */
+export interface FetchHost {
+    fetch: (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResponseLike> | ResponseLike;
+}
+
+/** Lunora's realtime plane bridge (`createLunoraHandler()` -> `(request, env, ctx) => Response`). */
+export type LunoraHandler = (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResponseLike> | ResponseLike;
+
+export interface ComposeOptions {
+    /** Reserved prefix for Lunora's realtime plane. Default `/_lunora/`. */
+    prefix?: string;
+}
+
+const DEFAULT_PREFIX = "/_lunora/";
+
+/**
+ * Compose the OpenNext host with Lunora's realtime handler into one worker
+ * `{ fetch }`. Requests under `prefix` (rpc / rpc-batch / ws / admin / migrate)
+ * go to Lunora; everything else delegates to OpenNext. The chosen response is
+ * returned verbatim, so a WebSocket upgrade survives unchanged.
+ *
+ * The real seam is `withFrameworkWorker`; this mirrors its dispatch so the spike's
+ * unit test can assert the contract without workerd.
+ */
+export const composeNextWorker = (host: FetchHost, lunora: LunoraHandler, options: ComposeOptions = {}): FetchHost => {
+    const prefix = options.prefix ?? DEFAULT_PREFIX;
+
+    return {
+        fetch: (request, env, context) => {
+            const { pathname } = new URL(request.url);
+
+            // Reserve the realtime plane. `startsWith(prefix)` also matches the exact
+            // prefix-less path (`/_lunora`) via the trailing slash the constants carry
+            // (`/_lunora/rpc`, `/_lunora/ws`, `/_lunora/admin/...`).
+            if (pathname.startsWith(prefix)) {
+                return lunora(request, env, context);
+            }
+
+            return host.fetch(request, env, context);
+        },
+    };
+};

--- a/plans/proto/rag/rag.test.ts
+++ b/plans/proto/rag/rag.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Spike 111 composition test. Drives `defineRag`'s index -> retrieve loop over the
+ * REAL `@lunora/bindings/vectors` `createVectors` (imported by source path) plus:
+ *   - an in-memory `VectorizeIndexLike` double (cosine similarity, honours topK,
+ *     returnMetadata, namespace) standing in for a Vectorize binding, and
+ *   - a deterministic token-bag `embed` (similar text -> similar vectors), standing
+ *     in for `ctx.ai.embeddingModel` + AI SDK `embed`.
+ *
+ * Asserts the chunk<->source metadata round-trips, retrieval ranks by similarity,
+ * the assembled context + source refs are well-formed, and the Vectorize topK
+ * ceiling (20 with returnMetadata:"all") is enforced by the real code.
+ */
+import { describe, expect, it } from "vitest";
+
+import createVectors from "../../../packages/bindings/src/vectors/create-vectors";
+import type {
+    VectorizeIndexLike,
+    VectorizeMatch,
+    VectorizeMatches,
+    VectorizeQueryOptions,
+    VectorizeVector,
+} from "../../../packages/bindings/src/vectors/types";
+import { defineRag } from "./rag";
+
+/** Deterministic 64-dim token-bag embedder: cosine similarity ~ token overlap. */
+const EMBED_DIMENSIONS = 64;
+
+const embedText = (text: string): ReadonlyArray<number> => {
+    const vector = Array.from({ length: EMBED_DIMENSIONS }, () => 0);
+
+    for (const token of text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean)) {
+        let hash = 0;
+
+        for (let index = 0; index < token.length; index += 1) {
+            hash = (hash * 31 + token.charCodeAt(index)) >>> 0;
+        }
+
+        vector[hash % EMBED_DIMENSIONS] += 1;
+    }
+
+    return vector;
+};
+
+const dot = (a: ReadonlyArray<number>, b: ReadonlyArray<number>): number => a.reduce((sum, value, index) => sum + value * b[index], 0);
+const norm = (a: ReadonlyArray<number>): number => Math.sqrt(dot(a, a)) || 1;
+const cosine = (a: ReadonlyArray<number>, b: ReadonlyArray<number>): number => dot(a, b) / (norm(a) * norm(b));
+
+/** Minimal in-memory Vectorize index double. */
+const createMemoryIndex = (): VectorizeIndexLike => {
+    const store = new Map<string, VectorizeVector>();
+
+    const upsert = async (vectors: ReadonlyArray<VectorizeVector>): Promise<{ mutationId: string }> => {
+        for (const vector of vectors) {
+            store.set(vector.id, vector);
+        }
+
+        return { mutationId: `m${String(store.size)}` };
+    };
+
+    const query = async (vector: ReadonlyArray<number>, options?: VectorizeQueryOptions): Promise<VectorizeMatches> => {
+        const namespace = options?.namespace;
+        const topK = options?.topK ?? 5;
+
+        const scored: VectorizeMatch[] = [...store.values()]
+            .filter((candidate) => namespace === undefined || candidate.namespace === namespace)
+            .map((candidate) => ({
+                id: candidate.id,
+                metadata: options?.returnMetadata === "none" ? undefined : candidate.metadata,
+                namespace: candidate.namespace,
+                score: cosine(vector, candidate.values),
+                values: options?.returnValues ? candidate.values : undefined,
+            }))
+            .sort((a, b) => b.score - a.score)
+            .slice(0, topK);
+
+        return { count: scored.length, matches: scored };
+    };
+
+    return {
+        deleteByIds: async (ids) => {
+            for (const id of ids) {
+                store.delete(id);
+            }
+
+            return { count: ids.length, mutationId: "d" };
+        },
+        getByIds: async (ids) => ids.map((id) => store.get(id)).filter((value): value is VectorizeVector => value !== undefined),
+        insert: upsert,
+        query,
+        upsert,
+    };
+};
+
+describe("spike 111: defineRag index -> retrieve composition", () => {
+    const buildCtx = () => {
+        const vectors = createVectors({ indexes: { docs: createMemoryIndex() } });
+
+        return { embed: async (text: string) => embedText(text), vectors };
+    };
+
+    it("indexes a document, then retrieves ranked chunks with assembled context + source refs", async () => {
+        const rag = defineRag({ chunkOverlap: 5, chunkSize: 40, index: "docs" })(buildCtx());
+
+        const durable = await rag.index({
+            id: "doc-durable",
+            metadata: { title: "Durable Objects" },
+            namespace: "tenant-1",
+            text: "Durable Objects give Cloudflare Workers stateful single-threaded actors with persistent storage and websockets.",
+        });
+        await rag.index({
+            id: "doc-vectorize",
+            metadata: { title: "Vectorize" },
+            namespace: "tenant-1",
+            text: "Vectorize is an account global vector database for similarity search over embeddings.",
+        });
+
+        expect(durable.chunks).toBeGreaterThan(1);
+
+        const result = await rag.retrieve("stateful durable objects websockets storage", { namespace: "tenant-1", topK: 3 });
+
+        // Best match is a chunk from the durable-objects document (highest token overlap).
+        expect(result.chunks.length).toBeGreaterThan(0);
+        expect(result.chunks[0].sourceId).toBe("doc-durable");
+        // chunk <-> source metadata round-trips (id shape + user metadata preserved, internal keys stripped).
+        expect(result.chunks[0].id).toMatch(/^doc-durable#\d+$/);
+        expect(result.chunks[0].metadata).toEqual({ title: "Durable Objects" });
+        expect(result.chunks[0].text.length).toBeGreaterThan(0);
+        // assembled context carries each chunk's text under a source-attribution header,
+        // and collectively covers the query's key terms across the winning document's chunks.
+        expect(result.context).toMatch(/\[source:doc-durable#\d+\]/);
+        expect(result.context.toLowerCase()).toContain("durable");
+        expect(result.context.toLowerCase()).toContain("stateful");
+        // deduped source refs, best-first.
+        expect(result.sources[0]).toEqual({ id: "doc-durable", metadata: { title: "Durable Objects" } });
+    });
+
+    it("scopes retrieval by namespace (tenant isolation)", async () => {
+        const rag = defineRag({ chunkSize: 200, index: "docs" })(buildCtx());
+
+        await rag.index({ id: "a", namespace: "tenant-1", text: "alpha widgets and gadgets" });
+        await rag.index({ id: "b", namespace: "tenant-2", text: "alpha widgets and gadgets" });
+
+        const result = await rag.retrieve("alpha widgets", { namespace: "tenant-1", topK: 10 });
+
+        expect(result.chunks.every((chunk) => chunk.sourceId === "a")).toBe(true);
+    });
+
+    it("enforces the Vectorize topK ceiling (<=20 with full metadata) via the real createVectors", async () => {
+        // The helper caps its OWN default topK, but a config asking for >20 must still be
+        // rejected by the real binding. Bypass the helper cap by calling the facade directly
+        // with the exact args the helper would pass, to prove the ceiling is live.
+        const ctx = buildCtx();
+
+        await expect(ctx.vectors.query("docs", { embed: ctx.embed, input: "q", returnMetadata: "all", topK: 50 })).rejects.toThrow(
+            /topK must be an integer in \[1, 20\]/,
+        );
+    });
+});

--- a/plans/proto/rag/rag.ts
+++ b/plans/proto/rag/rag.ts
@@ -1,0 +1,236 @@
+/**
+ * Spike 111 prototype — `defineRag`: a thin RAG helper composing the two existing
+ * facades (`ctx.ai` embeddings + `ctx.vectors` Vectorize) into an index -> retrieve
+ * loop. No new binding, no reimplemented embedding or vector query.
+ *
+ * `defineRag(config)` returns a per-request factory `rag(ctx)` that binds the two
+ * facades the app already has. In a real Lunora function:
+ *
+ * ```ts
+ * // lunora/rag.ts
+ * export const docs = defineRag({ index: "docs", embeddingModel: "@cf/baai/bge-base-en-v1.5" });
+ *
+ * // inside a mutation/action:
+ * import { embed } from "@lunora/ai";
+ * const r = docs({
+ *   vectors: ctx.vectors,
+ *   embed: async (text) => (await embed({ model: ctx.ai.embeddingModel("@cf/baai/bge-base-en-v1.5"), value: text })).embedding,
+ * });
+ * await r.index({ id: doc._id, text: doc.body, metadata: { title: doc.title }, namespace: ctx.shardKey });
+ * const { context, chunks, sources } = await r.retrieve("how do durable objects work?", { topK: 5, namespace: ctx.shardKey });
+ * ```
+ *
+ * The `embed` adapter is the seam to `ctx.ai`: `ctx.ai` exposes `embeddingModel(id)`
+ * (a resolved AI SDK model) but not `embed` itself — that is the AI SDK `embed`
+ * re-exported from `@lunora/ai`. The helper wires this adapter straight into
+ * `ctx.vectors.{upsert,query}`'s `embed` slot, so `createVectors` calls it per chunk.
+ */
+import type { LunoraVectors } from "../../../packages/bindings/src/vectors/types";
+
+/** The two facades the RAG helper binds — both already live on a Lunora `ctx`. */
+export interface RagCtx {
+    /** `(text) => vector`, adapting `ctx.ai`: `embed({ model: ctx.ai.embeddingModel(id), value: text }).embedding`. */
+    embed: (text: string) => Promise<ReadonlyArray<number>>;
+    /** The `@lunora/bindings/vectors` facade (`ctx.vectors`). */
+    vectors: LunoraVectors;
+}
+
+export interface RagConfig {
+    /** Optional custom chunker; overrides the built-in fixed-window splitter. */
+    chunk?: (text: string) => ReadonlyArray<string>;
+    /** Overlap (chars) between adjacent chunks. Default 200. */
+    chunkOverlap?: number;
+    /** Target chunk size (chars). Default 1000. */
+    chunkSize?: number;
+    /** Workers AI (or any AI SDK) embedding-model id, declared once so index + retrieve embed identically. */
+    embeddingModel?: string;
+    /** The Vectorize index name (a `ctx.vectors` binding key). */
+    index: string;
+    /** Default retrieval `topK`. Default 5. Capped by Vectorize (<=20 with full metadata). */
+    topK?: number;
+}
+
+export interface IndexInput {
+    /** Source document id — chunk ids derive from it as `${id}#${chunkIndex}`. */
+    id: string;
+    /** Arbitrary source metadata copied onto every chunk vector (e.g. title, url). */
+    metadata?: Record<string, unknown>;
+    /** Tenant/shard key. REQUIRED for multi-tenant apps — Vectorize is account-global. */
+    namespace?: string;
+    /** The document body to chunk + embed + upsert. */
+    text: string;
+}
+
+export interface RetrieveOptions {
+    filter?: Record<string, unknown>;
+    namespace?: string;
+    topK?: number;
+}
+
+export interface RetrievedChunk {
+    chunkIndex: number;
+    id: string;
+    metadata?: Record<string, unknown>;
+    score: number;
+    sourceId: string;
+    text: string;
+}
+
+/** The retrieve return shape — designed so a plan-113 agent memory step consumes it directly. */
+export interface RetrieveResult {
+    /** Ranked chunks (best first). */
+    chunks: ReadonlyArray<RetrievedChunk>;
+    /** Ready-to-inject assembled prompt context (chunks joined with source separators). */
+    context: string;
+    /** Deduped source references, in first-seen (best) order. */
+    sources: ReadonlyArray<{ id: string; metadata?: Record<string, unknown> }>;
+}
+
+export interface Rag {
+    index: (input: IndexInput) => Promise<{ chunks: number }>;
+    retrieve: (query: string, options?: RetrieveOptions) => Promise<RetrieveResult>;
+}
+
+const DEFAULT_CHUNK_SIZE = 1000;
+const DEFAULT_CHUNK_OVERLAP = 200;
+const DEFAULT_TOP_K = 5;
+
+/**
+ * Vectorize lowers the `topK` ceiling to 20 when a query asks for full metadata
+ * (`returnMetadata: "all"`). This prototype stores the chunk text in metadata and
+ * reads it back with `returnMetadata: "all"`, so it must honour the 20 ceiling —
+ * `createVectors` enforces it and throws on a violation.
+ */
+const MAX_TOP_K_FULL_METADATA = 20;
+
+/** Metadata key under which each chunk's text is stored on its vector. */
+const TEXT_KEY = "__ragText";
+/** Metadata key under which the owning source id is stored. */
+const SOURCE_KEY = "__ragSource";
+/** Metadata key under which the chunk index is stored. */
+const CHUNK_INDEX_KEY = "__ragChunk";
+
+/**
+ * Built-in fixed-window chunker: split into `size`-char windows overlapping by
+ * `overlap`. Deliberately simple + deterministic (a spike default); the real
+ * helper takes a `chunk` override for token/sentence/semantic strategies.
+ */
+const fixedWindowChunks = (text: string, size: number, overlap: number): ReadonlyArray<string> => {
+    const trimmed = text.trim();
+
+    if (trimmed.length === 0) {
+        return [];
+    }
+
+    if (trimmed.length <= size) {
+        return [trimmed];
+    }
+
+    const step = Math.max(1, size - overlap);
+    const chunks: string[] = [];
+
+    for (let start = 0; start < trimmed.length; start += step) {
+        chunks.push(trimmed.slice(start, start + size));
+
+        if (start + size >= trimmed.length) {
+            break;
+        }
+    }
+
+    return chunks;
+};
+
+/**
+ * Assemble ranked chunks into one prompt-ready context string, delimited by a
+ * source header so the model (and a human reader) can attribute each passage.
+ */
+const assembleContext = (chunks: ReadonlyArray<RetrievedChunk>): string =>
+    chunks.map((chunk) => `[source:${chunk.sourceId}#${String(chunk.chunkIndex)}]\n${chunk.text}`).join("\n\n");
+
+/**
+ * Declare a RAG index. Returns a factory that binds a request's `ctx` facades and
+ * exposes `{ index, retrieve }`. Pure composition — no I/O until a method runs.
+ */
+export const defineRag = (config: RagConfig): ((ctx: RagCtx) => Rag) => {
+    if (typeof config.index !== "string" || config.index.length === 0) {
+        throw new TypeError("defineRag: `index` must be a non-empty Vectorize index name");
+    }
+
+    const chunkSize = config.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    const chunkOverlap = config.chunkOverlap ?? DEFAULT_CHUNK_OVERLAP;
+    const defaultTopK = config.topK ?? DEFAULT_TOP_K;
+    const splitter = config.chunk ?? ((text: string) => fixedWindowChunks(text, chunkSize, chunkOverlap));
+
+    return (ctx: RagCtx): Rag => {
+        const index = async (input: IndexInput): Promise<{ chunks: number }> => {
+            const pieces = splitter(input.text);
+
+            if (pieces.length === 0) {
+                return { chunks: 0 };
+            }
+
+            // Compose the two facades: each chunk becomes an `UpsertInput` whose
+            // `embed` is the ctx.ai adapter and whose metadata links chunk -> source
+            // and carries the chunk text (so retrieve can reconstruct context).
+            const inputs = pieces.map((piece, chunkIndex) => ({
+                embed: ctx.embed,
+                id: `${input.id}#${String(chunkIndex)}`,
+                input: piece,
+                metadata: {
+                    ...input.metadata,
+                    [CHUNK_INDEX_KEY]: chunkIndex,
+                    [SOURCE_KEY]: input.id,
+                    [TEXT_KEY]: piece,
+                },
+                namespace: input.namespace,
+            }));
+
+            await ctx.vectors.upsertMany(config.index, inputs);
+
+            return { chunks: pieces.length };
+        };
+
+        const retrieve = async (query: string, options?: RetrieveOptions): Promise<RetrieveResult> => {
+            const topK = Math.min(options?.topK ?? defaultTopK, MAX_TOP_K_FULL_METADATA);
+
+            // Read side: embed the query (same adapter -> same model) and run the
+            // Vectorize query, asking for full metadata so we get the chunk text back.
+            const result = await ctx.vectors.query(config.index, {
+                embed: ctx.embed,
+                filter: options?.filter,
+                input: query,
+                namespace: options?.namespace,
+                returnMetadata: "all",
+                topK,
+            });
+
+            const chunks: RetrievedChunk[] = result.matches.map((match) => {
+                const metadata = match.metadata ?? {};
+                const { [CHUNK_INDEX_KEY]: rawIndex, [SOURCE_KEY]: rawSource, [TEXT_KEY]: rawText, ...userMetadata } = metadata;
+
+                return {
+                    chunkIndex: typeof rawIndex === "number" ? rawIndex : Number(rawIndex ?? 0),
+                    id: match.id,
+                    metadata: userMetadata,
+                    score: match.score,
+                    sourceId: typeof rawSource === "string" ? rawSource : String(rawSource ?? match.id),
+                    text: typeof rawText === "string" ? rawText : "",
+                };
+            });
+
+            const sources: { id: string; metadata?: Record<string, unknown> }[] = [];
+            const seen = new Set<string>();
+
+            for (const chunk of chunks) {
+                if (!seen.has(chunk.sourceId)) {
+                    seen.add(chunk.sourceId);
+                    sources.push({ id: chunk.sourceId, metadata: chunk.metadata });
+                }
+            }
+
+            return { chunks, context: assembleContext(chunks), sources };
+        };
+
+        return { index, retrieve };
+    };
+};

--- a/plans/proto/tsconfig.json
+++ b/plans/proto/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    // Type-check only (spike prototypes; the real build is per-package packem).
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        // Spike-only relaxation: the prototype SOURCE modules (rag.ts, agent-loop.ts,
+        // compose-next-worker.ts) pass the repo's strict base as-is; this only silences
+        // `noUncheckedIndexedAccess` on positional `messages[1]` / `chunks[0]` test
+        // assertions, so the tests stay readable without `!` noise everywhere.
+        "noUncheckedIndexedAccess": false
+    },
+    "include": ["**/*.ts", "../../packages/bindings/src/vectors/create-vectors.ts", "../../packages/bindings/src/vectors/types.ts"]
+}

--- a/plans/proto/vitest.config.ts
+++ b/plans/proto/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Standalone Vitest config for the wave-11 spike prototypes (plans 110 / 111 / 113).
+ *
+ * These prototypes deliberately live OUTSIDE the pnpm workspace (`plans/` is not a
+ * workspace glob) so they add no package, no `pnpm-workspace.yaml` override, and no
+ * build step. They exercise pure composition logic with in-memory doubles; the
+ * RAG prototype imports the *real* `@lunora/bindings/vectors` `createVectors` by
+ * relative source path (it only imports its own relative siblings, so Vitest's
+ * esbuild transform resolves it with no build).
+ *
+ * Run from this directory:  `pnpm exec vitest run --config vitest.config.ts`
+ */
+export default {
+    test: {
+        environment: "node",
+        include: ["**/*.test.ts"],
+        watch: false,
+    },
+};


### PR DESCRIPTION
Three Phase-0 design/spike deliverables (design doc + minimal, runnable prototype each). All prototype tests ran green in-sandbox (9 passed across the 3 modules) and typecheck clean. No plan STOP condition triggered; each doc ends with numbered maintainer open questions. `plans/README.md` intentionally untouched.

**110 — `@lunora/next` composition (`plans/110-phase0-design.md`).** Recommendation: Next is a **class-B** framework — reuse the shipped `withFrameworkWorker` composer at the OpenNext **custom-worker boundary** (`main` → a wrapper importing `.open-next/worker.js` + re-exporting `ShardDO`); zero new runtime code. The **WebSocket upgrade must live at that boundary, not in a Next Route Handler**, because OpenNext's request/response adapter strips the `101 + webSocket` field — this is the crux and it's resolved. No STOP. Prototype (`plans/proto/next`) models the seam and asserts RPC/admin route to Lunora and the WS 101+webSocket passes through verbatim. Key open questions: OpenNext version pinning (churn risk), whether to remove the `init` no-op now (recommend: with the template), v1 feature scope.

**111 — `ctx.rag` over `ai.embed` + `vectors` (`plans/111-phase0-design.md`).** Recommendation: a thin `defineRag(config)(ctx)` helper shipped as a **`@lunora/ai/rag` subpath** (not a new package, not a codegen-wired `ctx.rag` — respects "scale invisibly"). The two facades compose with **no public-surface change**. Respects the Vectorize `topK` ceilings (≤20 with full metadata) and namespace tenant-isolation; the `retrieve` → `{ context, chunks, sources }` return shape is designed for the plan-113 agent memory step. No STOP. Prototype (`plans/proto/rag`) runs index→retrieve over the **real** `createVectors` with a passing test (incl. the live topK-ceiling throw). Key open questions: chunk-text storage (metadata vs a DO table), re-index/delete-old-chunks gap, default chunking.

**113 — `defineAgent` durable tool-loop (`plans/113-phase0-design.md`).** Recommendation: the loop maps **entirely onto shipped primitives** (`ctx.runStep`/native `step.do`, DO SQLite thread tables, the WS `type:"stream"` transport, plan-111 `rag.retrieve`) — so the **top open question is build-vs-document** given the "scale invisibly" tension. Recommend **document-first, then an opt-in `@lunora/agent` add-on** (keep core invisible). Replay-safety: completed-step memoization is native; a retried side-effecting tool needs an idempotency key = the deterministic step name (no `@lunora/workflow` change) — so **no STOP**. PoC (`plans/proto/agent`) asserts thread ordering **and** resume-doesn't-re-run-a-completed-tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6