### PR TITLE
feat(studio): containers observability page (plan 112)

### DIFF
--- a/packages/codegen/__tests__/discover-feature-usage.test.ts
+++ b/packages/codegen/__tests__/discover-feature-usage.test.ts
@@ -15,6 +15,7 @@ const ALL_OFF: FeatureUsage = {
     ai: false,
     analytics: false,
     browser: false,
+    container: false,
     flags: false,
     hyperdrive: false,
     images: false,
@@ -30,6 +31,7 @@ const ALL_OFF: FeatureUsage = {
 };
 
 const NO_SIGNALS = {
+    containerCount: 0,
     cronCount: 0,
     dependencies: new Set<string>(),
     queueCount: 0,
@@ -204,6 +206,24 @@ describe("discover-feature-usage", () => {
         expect(discoverFeatureUsage(newProject(), workdir).storage).toBe(true);
     });
 
+    it("detects containers via either the `@lunora/container` import or a `ctx.containers` read", () => {
+        expect.assertions(2);
+
+        // `lunora/containers.ts` importing `defineContainer` from `@lunora/container`.
+        writeSource(
+            "containers.ts",
+            `import { defineContainer } from "@lunora/container";\nexport const transcoder = defineContainer({ image: "./Dockerfile" });`,
+        );
+        const viaImport = discoverFeatureUsage(newProject(), workdir);
+
+        rmSync(join(workdir, "containers.ts"));
+        writeSource("proxy.ts", `export const scale = async (ctx) => ctx.containers.get("transcoder");`);
+        const viaContext = discoverFeatureUsage(newProject(), workdir);
+
+        expect(viaImport.container).toBe(true);
+        expect(viaContext.container).toBe(true);
+    });
+
     it("detects scheduler via either the package import or `ctx.scheduler`", () => {
         expect.assertions(2);
 
@@ -235,6 +255,7 @@ describe("discover-feature-usage", () => {
             expect(buildStudioFeatures(ALL_OFF, NO_SIGNALS)).toStrictEqual({
                 analytics: false,
                 auth: false,
+                containers: false,
                 flags: false,
                 kv: false,
                 mail: false,
@@ -257,6 +278,7 @@ describe("discover-feature-usage", () => {
             expect.assertions(4);
 
             const result = buildStudioFeatures(ALL_OFF, {
+                containerCount: 0,
                 cronCount: 1,
                 dependencies: new Set<string>(),
                 queueCount: 0,
@@ -281,6 +303,14 @@ describe("discover-feature-usage", () => {
             const result = buildStudioFeatures(ALL_OFF, { ...NO_SIGNALS, dependencies: new Set(["@lunora/mail", "@lunora/payment"]) });
 
             expect(result).toMatchObject({ mail: true, payments: true });
+        });
+
+        it("shows the containers page from code usage, a declared container, or an @lunora/container dependency", () => {
+            expect.assertions(3);
+
+            expect(buildStudioFeatures({ ...ALL_OFF, container: true }, NO_SIGNALS).containers).toBe(true);
+            expect(buildStudioFeatures(ALL_OFF, { ...NO_SIGNALS, containerCount: 1 }).containers).toBe(true);
+            expect(buildStudioFeatures(ALL_OFF, { ...NO_SIGNALS, dependencies: new Set(["@lunora/container"]) }).containers).toBe(true);
         });
 
         it("shows the flags page from a ctx.flags read or an @lunora/flags dependency", () => {

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -192,6 +192,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -1456,6 +1456,7 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
                 studioFeatures: {
                     analytics: false,
                     auth: false,
+                    containers: false,
                     flags: false,
                     kv: false,
                     mail: false,

--- a/packages/codegen/src/discover-feature-usage.ts
+++ b/packages/codegen/src/discover-feature-usage.ts
@@ -29,6 +29,8 @@ interface FeatureUsage {
     analytics: boolean;
     /** A `lunora/` source imports `@lunora/browser` or reads `ctx.browser`. */
     browser: boolean;
+    /** A `lunora/` source imports `@lunora/container` (e.g. `defineContainer`) or reads `ctx.containers`. */
+    container: boolean;
     /** A `lunora/` source imports `@lunora/flags` or reads `ctx.flags`. */
     flags: boolean;
     /** A `lunora/` source imports `@lunora/hyperdrive` or reads `ctx.sql`. */
@@ -72,6 +74,10 @@ const PROBES: Record<keyof FeatureUsage, FeatureProbe> = {
     ai: { contextProperty: "ai", moduleSpecifier: "@lunora/ai" },
     analytics: { contextProperty: "analytics", moduleSpecifier: "@lunora/bindings/analytics" },
     browser: { contextProperty: "browser", moduleSpecifier: "@lunora/browser" },
+    // `lunora/containers.ts` imports `defineContainer` from `@lunora/container`,
+    // and handlers reach live instances via `ctx.containers` — either signals the
+    // app wires containers, so the studio should show the Containers page.
+    container: { contextProperty: "containers", moduleSpecifier: "@lunora/container" },
     flags: { contextProperty: "flags", moduleSpecifier: "@lunora/flags" },
     hyperdrive: { contextProperty: "sql", moduleSpecifier: "@lunora/hyperdrive" },
     images: { contextProperty: "images", moduleSpecifier: "@lunora/bindings/images" },
@@ -98,6 +104,8 @@ const PROBES: Record<keyof FeatureUsage, FeatureProbe> = {
  * (`src/server`), detected via the project's declared dependencies.
  */
 interface StudioFeatureSignals {
+    /** Number of declared containers — any `defineContainer` means the containers page is relevant. */
+    containerCount: number;
     /** Number of declared cron jobs — any cron means the scheduler page is relevant. */
     cronCount: number;
     /** The `@lunora/*` packages this app depends on (from its `package.json`). */
@@ -169,6 +177,7 @@ const discoverFeatureUsage = (project: Project, lunoraDirectory: string): Featur
         ai: false,
         analytics: false,
         browser: false,
+        container: false,
         flags: false,
         hyperdrive: false,
         images: false,
@@ -228,6 +237,7 @@ const buildStudioFeatures = (usage: FeatureUsage, signals: StudioFeatureSignals)
     return {
         analytics: usage.analytics || signals.dependencies.has("@lunora/bindings/analytics"),
         auth: signals.dependencies.has("@lunora/auth"),
+        containers: usage.container || signals.containerCount > 0 || signals.dependencies.has("@lunora/container"),
         flags: usage.flags || signals.dependencies.has("@lunora/flags"),
         kv: usage.kv || signals.dependencies.has("@lunora/bindings/kv"),
         mail: usage.mail || signals.dependencies.has("@lunora/mail"),

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -2916,6 +2916,7 @@ const emitShard = ({
     const studioFeaturesData: StudioFeaturesResult = studioFeatures ?? {
         analytics: false,
         auth: false,
+        containers: false,
         flags: false,
         kv: false,
         mail: false,

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -392,6 +392,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // studio hides only pages whose backing package the app genuinely never wires.
     const dependencies = discoverPackageDependencies(options.projectRoot);
     const studioFeatures = buildStudioFeatures(featureUsage, {
+        containerCount: containers.length,
         cronCount: crons.length,
         dependencies,
         queueCount: queues.length,

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -39,7 +39,20 @@ import createSqliteExec from "./_helpers/node-sqlite";
  * `StudioFeaturesResult` without updating this tuple — and there if the studio
  * copy drifts — forcing both packages to move together.
  */
-const STUDIO_FEATURE_KEYS = ["analytics", "auth", "flags", "kv", "mail", "payments", "queues", "scheduler", "storage", "vectors", "workflows"] as const;
+const STUDIO_FEATURE_KEYS = [
+    "analytics",
+    "auth",
+    "containers",
+    "flags",
+    "kv",
+    "mail",
+    "payments",
+    "queues",
+    "scheduler",
+    "storage",
+    "vectors",
+    "workflows",
+] as const;
 
 /** `true` only when `Keys` and `Canonical` are mutually assignable (the exact same key set). */
 type KeysMatch<Keys extends string, Canonical extends string> = [Keys] extends [Canonical] ? ([Canonical] extends [Keys] ? true : never) : never;
@@ -400,6 +413,7 @@ describe("shardDO admin introspection", () => {
             result: {
                 analytics: false,
                 auth: false,
+                containers: false,
                 flags: false,
                 kv: false,
                 mail: false,
@@ -418,6 +432,7 @@ describe("shardDO admin introspection", () => {
             protected override studioFeatures(): {
                 analytics: boolean;
                 auth: boolean;
+                containers: boolean;
                 flags: boolean;
                 kv: boolean;
                 mail: boolean;
@@ -431,6 +446,7 @@ describe("shardDO admin introspection", () => {
                 return {
                     analytics: false,
                     auth: false,
+                    containers: true,
                     flags: true,
                     kv: false,
                     mail: false,
@@ -451,6 +467,7 @@ describe("shardDO admin introspection", () => {
             result: {
                 analytics: false,
                 auth: false,
+                containers: true,
                 flags: true,
                 kv: false,
                 mail: false,
@@ -505,6 +522,7 @@ describe("shardDO admin introspection", () => {
         expect([...STUDIO_FEATURE_KEYS]).toStrictEqual([
             "analytics",
             "auth",
+            "containers",
             "flags",
             "kv",
             "mail",

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -407,6 +407,8 @@ interface StudioFeaturesResult {
     analytics: boolean;
     /** `@lunora/auth` is a declared dependency (backs the Users / Sessions / Organizations / Configuration pages). */
     auth: boolean;
+    /** `@lunora/container` / `ctx.containers` is used, the app declares containers, or it is a declared dependency. */
+    containers: boolean;
     /** `@lunora/flags` / `ctx.flags` is used, or it is a declared dependency. */
     flags: boolean;
     /** `@lunora/bindings/kv` / `ctx.kv` is used, or it is a declared dependency. */

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -2930,6 +2930,7 @@ abstract class ShardDO {
         return {
             analytics: false,
             auth: false,
+            containers: false,
             flags: false,
             kv: false,
             mail: false,

--- a/packages/studio/__tests__/app/studio.test.tsx
+++ b/packages/studio/__tests__/app/studio.test.tsx
@@ -41,6 +41,7 @@ const createClient = (features?: Partial<StudioFeaturesResult>): MockClientHooks
                 return {
                     analytics: true,
                     auth: true,
+                    containers: true,
                     flags: true,
                     kv: true,
                     mail: true,
@@ -85,7 +86,20 @@ const renderAndFind = async (testId: string): Promise<HTMLElement> => {
  * studio copy of the type drifts from this tuple — keeping both packages' copies
  * of the wire contract in lockstep.
  */
-const STUDIO_FEATURE_KEYS = ["analytics", "auth", "flags", "kv", "mail", "payments", "queues", "scheduler", "storage", "vectors", "workflows"] as const;
+const STUDIO_FEATURE_KEYS = [
+    "analytics",
+    "auth",
+    "containers",
+    "flags",
+    "kv",
+    "mail",
+    "payments",
+    "queues",
+    "scheduler",
+    "storage",
+    "vectors",
+    "workflows",
+] as const;
 
 /** `true` only when `Keys` and `Canonical` are mutually assignable (the exact same key set). */
 type KeysMatch<Keys extends string, Canonical extends string> = [Keys] extends [Canonical] ? ([Canonical] extends [Keys] ? true : never) : never;

--- a/packages/studio/__tests__/features/containers/fold-container-instances.test.ts
+++ b/packages/studio/__tests__/features/containers/fold-container-instances.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { foldContainerInstances, parseContainerMessage } from "../../../src/features/containers/fold-container-instances";
+import type { LogEntry } from "../../../src/lib/admin";
+
+/** Build a `container:&lt;name>` log entry the ShardDO emits for one lifecycle transition. */
+const containerEntry = (name: string, message: string, timestamp: number, level: LogEntry["level"] = "info"): LogEntry => {
+    return {
+        functionPath: `container:${name}`,
+        level,
+        message,
+        timestamp,
+    };
+};
+
+describe("parseContainerMessage", () => {
+    it("returns the bare event when there is no detail", () => {
+        expect.assertions(1);
+
+        expect(parseContainerMessage("start")).toStrictEqual({ event: "start" });
+    });
+
+    it("splits `<event>: <detail>` into the event token and trimmed detail", () => {
+        expect.assertions(2);
+
+        expect(parseContainerMessage("stop: hard timeout reached")).toStrictEqual({ detail: "hard timeout reached", event: "stop" });
+        expect(parseContainerMessage("error: boom")).toStrictEqual({ detail: "boom", event: "error" });
+    });
+
+    it("treats an empty detail as absent", () => {
+        expect.assertions(1);
+
+        expect(parseContainerMessage("stop: ")).toStrictEqual({ event: "stop" });
+    });
+});
+
+describe("foldContainerInstances", () => {
+    it("maps each lifecycle transition to its current state", () => {
+        expect.assertions(4);
+
+        const rows = foldContainerInstances([
+            containerEntry("a", "start", 10),
+            containerEntry("b", "sleep", 20),
+            containerEntry("c", "stop", 30),
+            containerEntry("d", "error: boom", 40, "error"),
+        ]);
+
+        expect(rows.find((row) => row.name === "a")?.state).toBe("running");
+        expect(rows.find((row) => row.name === "b")?.state).toBe("sleeping");
+        expect(rows.find((row) => row.name === "c")?.state).toBe("stopped");
+        expect(rows.find((row) => row.name === "d")?.state).toBe("error");
+    });
+
+    it("keeps only the most recent transition per container (instance up then down)", () => {
+        expect.assertions(3);
+
+        // Newest-first, as `getLogs` returns them: the stop (ts 200) wins over the start (ts 100).
+        const rows = foldContainerInstances([containerEntry("transcoder", "stop: exited", 200), containerEntry("transcoder", "start", 100)]);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.state).toBe("stopped");
+        expect(rows[0]?.detail).toBe("exited");
+    });
+
+    it("is order-independent — the greatest timestamp wins regardless of buffer order", () => {
+        expect.assertions(1);
+
+        const oldestLast = foldContainerInstances([containerEntry("x", "start", 100), containerEntry("x", "stop", 200)]);
+
+        expect(oldestLast[0]?.state).toBe("stopped");
+    });
+
+    it("ignores non-container log entries", () => {
+        expect.assertions(1);
+
+        const rows = foldContainerInstances([
+            { functionPath: "messages:list", level: "info", message: "ran", timestamp: 5 },
+            { level: "error", message: "boom", timestamp: 6 },
+            containerEntry("only", "start", 7),
+        ]);
+
+        expect(rows.map((row) => row.name)).toStrictEqual(["only"]);
+    });
+
+    it("carries the transition detail and severity, and sorts containers by name", () => {
+        expect.assertions(3);
+
+        const rows = foldContainerInstances([containerEntry("zeta", "start", 1), containerEntry("alpha", "error: crashed", 2, "error")]);
+
+        expect(rows.map((row) => row.name)).toStrictEqual(["alpha", "zeta"]);
+        expect(rows[0]?.detail).toBe("crashed");
+        expect(rows[0]?.level).toBe("error");
+    });
+
+    it("falls back to `unknown` for an unmapped transition token", () => {
+        expect.assertions(1);
+
+        expect(foldContainerInstances([containerEntry("weird", "teleport", 1)])[0]?.state).toBe("unknown");
+    });
+});

--- a/packages/studio/src/app/studio.tsx
+++ b/packages/studio/src/app/studio.tsx
@@ -84,6 +84,7 @@ const AuthConfigPanel = lazyNamed(() => import("../features/auth/auth-config-pan
 const AuthSessionsPanel = lazyNamed(() => import("../features/auth/auth-sessions-panel"), "AuthSessionsPanel");
 const OrganizationsPanel = lazyNamed(() => import("../features/auth/organizations-panel"), "OrganizationsPanel");
 const UsersPanel = lazyNamed(() => import("../features/auth/users-panel"), "UsersPanel");
+const ContainersPanel = lazyNamed(() => import("../features/containers/containers-panel"), "ContainersPanel");
 const TableEditor = lazyNamed(() => import("../features/data/table-editor"), "TableEditor");
 const ExportImportPanel = lazyNamed(() => import("../features/database/export-import"), "ExportImportPanel");
 const MigrationsPanel = lazyNamed(() => import("../features/database/migrations"), "MigrationsPanel");
@@ -127,6 +128,7 @@ type StudioTab =
     | "audit"
     | "authConfig"
     | "authSessions"
+    | "containers"
     | "dashboards"
     | "data"
     | "drains"
@@ -298,6 +300,7 @@ const TAB_ICONS: Record<StudioTab, ReactNode> = {
         <path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm7.4-3a7.4 7.4 0 0 0-.1-1.2l2-1.6-2-3.4-2.4 1a7.3 7.3 0 0 0-2-1.2l-.4-2.6h-3.6l-.4 2.6a7.3 7.3 0 0 0-2 1.2l-2.4-1-2 3.4 2 1.6a7.4 7.4 0 0 0 0 2.4l-2 1.6 2 3.4 2.4-1a7.3 7.3 0 0 0 2 1.2l.4 2.6h3.6l.4-2.6a7.3 7.3 0 0 0 2-1.2l2.4 1 2-3.4-2-1.6a7.4 7.4 0 0 0 .1-1.2Z" />
     ),
     authSessions: <path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0-13.5V12l4 2" />,
+    containers: <path d="M3 7.5 12 3l9 4.5v9L12 21l-9-4.5v-9Zm0 0 9 4.5m0 0 9-4.5m-9 4.5V21" />,
     dashboards: <path d="M4 5h7v6H4V5Zm9 0h7v4h-7V5ZM4 14h7v5H4v-5Zm9-1h7v6h-7v-6Z" />,
     drains: <path d="M5 5h14M7 5v6a5 5 0 0 0 10 0V5M10 16h4v3h-4zM12 19v2" />,
     data: (
@@ -352,7 +355,7 @@ type NavGroup = { readonly key: NavGroupKey; readonly tabs: ReadonlyArray<Studio
 const NAV_GROUPS: readonly [NavGroup, ...NavGroup[]] = [
     { key: "overview", tabs: ["home", "dashboards"] },
     { key: "database", tabs: ["data", "sql", "schema", "migrations", "vectors", "pitr", "export"] },
-    { key: "functions", tabs: ["functions", "api", "workflows", "queues"] },
+    { key: "functions", tabs: ["functions", "api", "workflows", "queues", "containers"] },
     { key: "auth", tabs: ["users", "organizations", "authSessions", "authConfig"] },
     { key: "storage", tabs: ["files", "storageRules", "kv"] },
     { key: "observability", tabs: ["logs", "audit", "realtime", "fanout", "metrics", "analytics", "health"] },
@@ -375,6 +378,7 @@ const TAB_FEATURE: Partial<Record<StudioTab, keyof StudioFeaturesResult>> = {
     analytics: "analytics",
     authConfig: "auth",
     authSessions: "auth",
+    containers: "containers",
     files: "storage",
     flags: "flags",
     kv: "kv",
@@ -420,6 +424,7 @@ const TABS = [
     "api",
     "workflows",
     "queues",
+    "containers",
     "schema",
     "migrations",
     "vectors",
@@ -790,6 +795,7 @@ const StudioLayout = (): ReactElement => {
             audit: t("Audit"),
             authConfig: t("Configuration"),
             authSessions: t("Sessions"),
+            containers: t("Containers"),
             dashboards: t("Dashboards"),
             data: t("Data"),
             drains: t("Log drains"),
@@ -844,6 +850,7 @@ const StudioLayout = (): ReactElement => {
         audit: t("A durable log of admin state-changing operations."),
         authConfig: t("Enabled plugins and session config (read-only)."),
         authSessions: t("Browse and revoke active sessions across all users."),
+        containers: t("Live Cloudflare Containers — current lifecycle state per container from the log stream."),
         dashboards: t("Chart widgets backed by saved read-only SQL queries."),
         data: t("Browse and edit rows across your shard and global tables."),
         drains: t("Forward logs to Logpush, Tail Workers, or a webhook collector."),
@@ -1054,6 +1061,7 @@ const buildRouter = ({
         audit: <AuditPanel initialShardKey={initialShardKey} />,
         authConfig: <AuthConfigPanel />,
         authSessions: <AuthSessionsPanel />,
+        containers: <ContainersPanel />,
         dashboards: <DashboardsPanel initialShardKey={initialShardKey} />,
         data: <TableEditor editable={dataEditable} initialShardKey={initialShardKey} />,
         drains: <LogDrainsPanel />,

--- a/packages/studio/src/features/containers/containers-panel.tsx
+++ b/packages/studio/src/features/containers/containers-panel.tsx
@@ -1,0 +1,127 @@
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+import { LiveError } from "../../components/live-status";
+import { Badge } from "../../components/ui/badge";
+import { Card, CardContent } from "../../components/ui/card";
+import { EmptyState } from "../../components/ui/empty-state";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
+import { useAdminQuery } from "../../hooks/use-admin-query";
+import { useT } from "../../i18n/i18n-context";
+import type { LogEntry } from "../../lib/admin";
+import { ADMIN_FUNCTIONS } from "../../lib/admin";
+import type { ContainerLifecycleState } from "./fold-container-instances";
+import { foldContainerInstances } from "./fold-container-instances";
+
+/** shadcn Badge variant per lifecycle state — running reads calm, error alarming. */
+type StateVariant = "destructive" | "info" | "outline" | "secondary" | "success";
+
+const STATE_VARIANT: Record<ContainerLifecycleState, StateVariant> = {
+    error: "destructive",
+    running: "success",
+    sleeping: "info",
+    stopped: "outline",
+    unknown: "secondary",
+};
+
+/**
+ * Coerce a (possibly partial or malformed) `getLogs` result into its `entries`
+ * array — a truncated payload, or a worker predating the field, yields `[]`
+ * rather than seeding the fold with `undefined`.
+ */
+const entriesOf = (result: unknown): LogEntry[] => {
+    const { entries } = (result ?? {}) as { entries?: unknown };
+
+    return Array.isArray(entries) ? (entries as LogEntry[]) : [];
+};
+
+/**
+ * The Containers observability page — a read-only view of the deployment's live
+ * Cloudflare Containers, folded from the lifecycle events `@lunora/container`
+ * pushes into the root shard's log buffer (the same stream the Logs panel
+ * reads). Per container it shows the current lifecycle state (running / sleeping
+ * / stopped / error), the last transition, and any detail (a stop reason / error
+ * message).
+ *
+ * Data-source note: the lifecycle envelope carries only `name` + transition +
+ * detail — `@lunora/do` folds the Container DO's push to `functionPath:
+ * "container:&lt;name>"`, dropping the per-instance id, and the envelope has no
+ * ports/health. So this is a per-container view, not per-instance, and it does
+ * not surface ports or health checks (those live in static `defineContainer`
+ * config, not the runtime stream). It streams live over the same admin WS the
+ * Logs panel uses.
+ */
+const ContainersPanel = (): ReactElement => {
+    const t = useT();
+
+    // Container lifecycle events are pushed to the ROOT shard's buffer
+    // (`reportContainerLifecycle` addresses `__root__`), so this reads the root
+    // shard (empty key) deployment-wide — no shard selector needed. Live so a
+    // start/stop/sleep/error updates the state without a manual refresh.
+    const { data, error, liveError } = useAdminQuery<{ entries?: unknown }>(ADMIN_FUNCTIONS.getLogs, {}, { live: true, shardKey: "" });
+
+    const loaded = data !== undefined;
+    const rows = useMemo(() => foldContainerInstances(entriesOf(data)), [data]);
+
+    return (
+        <div className="flex flex-col gap-6" data-testid="lunora-containers-panel">
+            {error !== null && (
+                <p className="text-sm text-destructive" data-testid="containers-error" role="alert">
+                    {error}
+                </p>
+            )}
+
+            <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm text-muted-foreground">
+                    {t(
+                        "Cloudflare Containers are observed from their lifecycle log stream. This shows the current state per container — ports and health checks aren't carried in that stream.",
+                    )}
+                </p>
+                <LiveError message={liveError} prefix="containers" />
+            </div>
+
+            {loaded && rows.length === 0 ? (
+                <EmptyState
+                    description={t(
+                        "No container lifecycle activity yet. Instances declared with defineContainer show up here once they start, sleep, stop, or error.",
+                    )}
+                    testId="containers-empty"
+                    title={t("No container activity")}
+                />
+            ) : (
+                <Card className="overflow-hidden py-0">
+                    <CardContent className="px-0">
+                        <Table data-testid="containers-table">
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>{t("Container")}</TableHead>
+                                    <TableHead>{t("State")}</TableHead>
+                                    <TableHead>{t("Last event")}</TableHead>
+                                    <TableHead>{t("Detail")}</TableHead>
+                                    <TableHead>{t("When")}</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {rows.map((row) => (
+                                    <TableRow data-testid={`containers-row-${row.name}`} key={row.name}>
+                                        <TableCell className="font-mono text-xs">{row.name}</TableCell>
+                                        <TableCell>
+                                            <Badge variant={STATE_VARIANT[row.state]}>{row.state}</Badge>
+                                        </TableCell>
+                                        <TableCell className="font-mono text-xs text-muted-foreground">{row.event}</TableCell>
+                                        <TableCell className="max-w-64 truncate text-xs text-muted-foreground" title={row.detail}>
+                                            {row.detail ?? "—"}
+                                        </TableCell>
+                                        <TableCell className="text-xs tabular-nums text-muted-foreground">{new Date(row.timestamp).toLocaleString()}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+};
+
+export { ContainersPanel };

--- a/packages/studio/src/features/containers/fold-container-instances.ts
+++ b/packages/studio/src/features/containers/fold-container-instances.ts
@@ -1,0 +1,110 @@
+import type { LogEntry, LogLevel } from "../../lib/admin";
+
+/**
+ * The current lifecycle state of a container, derived from the most recent
+ * lifecycle transition seen in the shard's log buffer. `unknown` covers a
+ * transition token the buffer folds but this view doesn't map.
+ */
+type ContainerLifecycleState = "error" | "running" | "sleeping" | "stopped" | "unknown";
+
+/** The `functionPath` prefix `@lunora/do` tags every container lifecycle log entry with. */
+const CONTAINER_LOG_PREFIX = "container:";
+
+/** Maps a raw lifecycle transition token (from the log message) to a current-state label. */
+const EVENT_STATE: Record<string, ContainerLifecycleState> = {
+    error: "error",
+    sleep: "sleeping",
+    start: "running",
+    stop: "stopped",
+};
+
+/**
+ * One container's current state, folded from its latest lifecycle transition.
+ *
+ * There is no per-instance id, port, or health signal in the log envelope:
+ * `@lunora/do` maps the Container DO's best-effort lifecycle push to
+ * `functionPath: "container:&lt;name>"` + a `&lt;event>` / `&lt;event>: &lt;detail>`
+ * message, dropping the instance id. So this view is per-container, not
+ * per-instance — the strongest signal the already-emitted data carries.
+ */
+interface ContainerInstanceRow {
+    /** Detail after the `&lt;event>:` marker (a stop reason / error message), when present. */
+    readonly detail?: string;
+    /** The raw lifecycle transition token that produced the current state (`start`/`stop`/`sleep`/`error`). */
+    readonly event: string;
+    /** Buffer severity of the last transition. */
+    readonly level: LogLevel;
+    /** The `lunora/containers.ts` export name. */
+    readonly name: string;
+    /** Current lifecycle state, derived from the last transition. */
+    readonly state: ContainerLifecycleState;
+    /** Epoch-ms of the last transition. */
+    readonly timestamp: number;
+}
+
+/**
+ * Split a folded container log message into its transition token + optional
+ * detail. `@lunora/do` writes `"&lt;event>"` or `"&lt;event>: &lt;detail>"` (e.g.
+ * `"stop: hard timeout reached"`), so the first `:` bounds the token.
+ */
+const parseContainerMessage = (message: string): { detail?: string; event: string } => {
+    const separator = message.indexOf(":");
+
+    if (separator === -1) {
+        return { event: message.trim() };
+    }
+
+    const detail = message.slice(separator + 1).trim();
+    const event = message.slice(0, separator).trim();
+
+    // Omit `detail` entirely (rather than setting it `undefined`) when empty, so
+    // the shape is `{ event }` for a detail-less transition.
+    return detail === "" ? { event } : { detail, event };
+};
+
+/**
+ * Reduce a shard's log entries (newest-first, as `getLogs` returns them) to the
+ * current state of each container — the panel's "current containers" view. Only
+ * `container:&lt;name>` entries are considered; for each container the entry with
+ * the greatest timestamp wins. Pure + order-independent, so it is unit-testable
+ * in isolation and stable regardless of the buffer's ordering.
+ */
+const foldContainerInstances = (entries: ReadonlyArray<LogEntry>): ContainerInstanceRow[] => {
+    const latest = new Map<string, ContainerInstanceRow>();
+
+    for (const entry of entries) {
+        const path = entry.functionPath ?? "";
+
+        if (!path.startsWith(CONTAINER_LOG_PREFIX)) {
+            continue;
+        }
+
+        const name = path.slice(CONTAINER_LOG_PREFIX.length);
+
+        if (name === "") {
+            continue;
+        }
+
+        const previous = latest.get(name);
+
+        if (previous !== undefined && previous.timestamp >= entry.timestamp) {
+            continue;
+        }
+
+        const { detail, event } = parseContainerMessage(entry.message);
+
+        latest.set(name, {
+            detail,
+            event,
+            level: entry.level,
+            name,
+            state: EVENT_STATE[event] ?? "unknown",
+            timestamp: entry.timestamp,
+        });
+    }
+
+    return [...latest.values()].toSorted((a, b) => a.name.localeCompare(b.name));
+};
+
+export { CONTAINER_LOG_PREFIX, foldContainerInstances, parseContainerMessage };
+export type { ContainerInstanceRow, ContainerLifecycleState };

--- a/packages/studio/src/hooks/use-studio-features.ts
+++ b/packages/studio/src/hooks/use-studio-features.ts
@@ -18,6 +18,7 @@ const STUDIO_FEATURES = adminRef(ADMIN_FUNCTIONS.studioFeatures);
 const DEFAULT_STUDIO_FEATURES: StudioFeaturesResult = {
     analytics: true,
     auth: true,
+    containers: true,
     flags: true,
     kv: true,
     mail: true,
@@ -41,6 +42,7 @@ const coerceFeatures = (raw: unknown): StudioFeaturesResult => {
     return {
         analytics: flag("analytics"),
         auth: flag("auth"),
+        containers: flag("containers"),
         flags: flag("flags"),
         kv: flag("kv"),
         mail: flag("mail"),

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -507,6 +507,7 @@ export interface StorageRulesResult {
 export interface StudioFeaturesResult {
     analytics: boolean;
     auth: boolean;
+    containers: boolean;
     flags: boolean;
     kv: boolean;
     mail: boolean;

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -1056,6 +1056,15 @@ const MESSAGE_IDS = [
     "Delivered",
     "Peak width",
     "Max time",
+    "Containers",
+    "Container",
+    "Last event",
+    "Detail",
+    "When",
+    "No container activity",
+    "Live Cloudflare Containers — current lifecycle state per container from the log stream.",
+    "Cloudflare Containers are observed from their lifecycle log stream. This shows the current state per container — ports and health checks aren't carried in that stream.",
+    "No container lifecycle activity yet. Instances declared with defineContainer show up here once they start, sleep, stop, or error.",
 ] as const;
 
 /** A known studio message id — one of the entries in {@link MESSAGE_IDS}. */


### PR DESCRIPTION
## Summary

Adds a read-only **Containers** observability page to the Lunora Studio, plus the codegen signal that gates it.

### Data source: Option A (fold lifecycle events) — why

The `@lunora/container` DO already best-effort-pushes each lifecycle transition (`start`/`sleep`/`stop`/`error`) into the **root shard's `LogBuffer`** via the reserved `recordContainerEvent` admin RPC; `@lunora/do` maps it to a `LogEntry` with `functionPath: "container:<name>"`. The panel reads that same buffer through the existing `getLogs` admin RPC (live) and folds it to a current-state view per container — **no new admin RPC and no container-runtime change**.

Option B (a `listContainers` RPC) was rejected: the ShardDO keeps no container-instance registry, so a live-instances snapshot with ports/health would require the ShardDO to track instance state on every event — more than a read.

**Gap (noted, per STOP condition #3):** the lifecycle envelope carries only name + transition + optional detail. `@lunora/do`'s mapping **drops the per-instance id**, and neither the envelope nor `@lunora/container`'s metadata (`labels`, `defaultPort`, `readyOn` are *static config*, not runtime signals) exposes live ports/health. So the panel is **per-container, not per-instance**, and does not show ports or health checks. The panel text states this explicitly.

### Codegen probe

- New `container` PROBE in `discover-feature-usage.ts` (import `@lunora/container` / read `ctx.containers`) + a `containerCount` signal, OR'd into a new `containers` flag in `buildStudioFeatures`.
- Extended the `StudioFeaturesResult` wire contract in `@lunora/do` (base hook returns `containers: false`; drift-guard tests + the studio hand-mirror updated in lockstep).
- **Golden impact:** the only change to a no-container app's generated output is the new `"containers": false` key in `LUNORA_STUDIO_FEATURES` — verified by the committed `simple` fixture snapshot.

### The panel

`packages/studio/src/features/containers/` — modeled on `QueuesPanel`. A pure, unit-tested reducer (`foldContainerInstances`) turns the log buffer into per-container rows: name, lifecycle state badge (running/sleeping/stopped/error), last event, detail, and time. Gated on the `containers` feature flag, wired into the **Functions** nav group. Registered **eagerly** (plan 107 studio code-split has not landed on this branch).

### Gate results

- `@lunora/codegen` `lint:types` ✅ · `test` ✅ (497 tests, goldens pass)
- `@lunora/studio` `lint:types` ✅ · `lint:eslint` ✅
- `@lunora/do` `lint:types` ✅ · studioFeatures admin tests ✅
- New reducer unit test (non-jsdom-dependent, 9 cases) ✅ — run in isolation to avoid the studio jsdom-suite hang.

### Conflict notes

- `packages/codegen/src/discover-feature-usage.ts` is also edited by the **perf PR (plan 106)** — rebase after it.
- `packages/studio/src/app/studio.tsx` is also edited by the **studio-split PR (plan 107)** — rebase after it (and convert the eager route registration to a lazy one if 107 has landed).

### Reviewer note

The studio jsdom sandbox can't render the panel here — **please manually smoke-test** in a dev studio against a container-using app: confirm instances render on lifecycle events and that the Containers tab hides for a non-container app.

Out of scope (optional follow-ups, noted in the plan): AI-usage and rate-limit panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Containers** section in Studio with navigation, routing, and localization support.
  * Introduced a live containers view that shows current container lifecycle activity in a table.
  * Expanded feature detection so Containers can be automatically recognized in supported apps.

* **Bug Fixes**
  * Improved default handling so the Containers view remains available when feature data is missing or incomplete.
  * Added safer handling for empty or unavailable container activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->