### PR TITLE
fix(cli): Wave 11 CLI/DX papercuts (plans 096–100)

### DIFF
--- a/examples/auth-playground/package.json
+++ b/examples/auth-playground/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "scripts": {
         "build": "vite build",
-        "codegen": "node node_modules/lunora/dist/bin.mjs codegen",
+        "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit"

--- a/examples/blog/package.json
+++ b/examples/blog/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "scripts": {
         "build": "vite build",
-        "codegen": "node node_modules/lunora/dist/bin.mjs codegen",
+        "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit"

--- a/examples/offline-rejections/package.json
+++ b/examples/offline-rejections/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "scripts": {
         "build": "vite build",
-        "codegen": "node node_modules/lunora/dist/bin.mjs codegen",
+        "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit"

--- a/examples/payment-demo/package.json
+++ b/examples/payment-demo/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "scripts": {
         "build": "vite build",
-        "codegen": "node node_modules/lunora/dist/bin.mjs codegen",
+        "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit"

--- a/examples/realtime-cursors/package.json
+++ b/examples/realtime-cursors/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "scripts": {
         "build": "vite build",
-        "codegen": "node node_modules/lunora/dist/bin.mjs codegen",
+        "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit"

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -7,7 +7,7 @@
     "sideEffects": false,
     "scripts": {
         "build": "vite build",
-        "codegen": "node node_modules/lunora/dist/bin.mjs codegen",
+        "codegen": "node node_modules/lunorash/dist/bin.mjs codegen",
         "deploy": "wrangler deploy",
         "dev": "vite",
         "lint:types": "tsc --noEmit"

--- a/packages/cli/__tests__/commands/analyze.test.ts
+++ b/packages/cli/__tests__/commands/analyze.test.ts
@@ -119,5 +119,20 @@ describe("lunora analyze", () => {
             expect(argv).toContain("--dry-run");
             expect(argv).toContain("--outdir");
         });
+
+        it("launches wrangler through npx when the project declares npm", async () => {
+            expect.assertions(2);
+
+            // `detectPackageManager` reads the nearest package.json's `packageManager`.
+            writeFileSync(join(workdir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+            const { logger } = recordingLogger();
+            // exit 1 short-circuits before we walk the (never-created) outdir.
+            const { calls, spawner } = createRecordingSpawner(1);
+
+            await runAnalyzeCommand({ cwd: workdir, logger, spawner });
+
+            expect(calls[0]?.descriptor.command).toBe("npx");
+            expect(calls[0]?.descriptor.args.slice(0, 3)).toStrictEqual(["--", "wrangler", "deploy"]);
+        });
     });
 });

--- a/packages/cli/__tests__/commands/containers.test.ts
+++ b/packages/cli/__tests__/commands/containers.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { runContainersCommand } from "../../src/commands/containers/handler";
@@ -11,6 +15,14 @@ const silentLogger = (): { errors: string[]; logger: Logger } => {
         errors,
         logger: { error: (message) => errors.push(message), info: () => {}, success: () => {}, warn: () => {} },
     };
+};
+
+/** A cwd whose nearest package.json declares npm, so `detectPackageManager` resolves npm. */
+const npmProjectCwd = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "lunora-cli-containers-npm-"));
+    writeFileSync(join(dir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+
+    return dir;
 };
 
 describe("lunora containers", () => {
@@ -43,6 +55,17 @@ describe("lunora containers", () => {
         await runContainersCommand({ argument: ["images", "list"], dockerAvailable: () => true, logger, spawner });
 
         expect(calls[0]?.descriptor.args).toEqual(["exec", "wrangler", "containers", "images", "list"]);
+    });
+
+    it("launches wrangler through npx when the project declares npm", async () => {
+        expect.assertions(1);
+
+        const { calls, spawner } = createRecordingSpawner();
+        const { logger } = silentLogger();
+
+        await runContainersCommand({ argument: ["images", "list"], cwd: npmProjectCwd(), dockerAvailable: () => true, logger, spawner });
+
+        expect(calls[0]?.descriptor).toMatchObject({ args: ["--", "wrangler", "containers", "images", "list"], command: "npx" });
     });
 
     it("rejects an unknown subcommand without spawning", async () => {

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -756,6 +756,39 @@ export const backfillNames = defineMigration({
                 expect(argv.some((line) => line.includes("wrangler deploy"))).toBe(true);
             });
 
+            it("launches wrangler through npx (secret-push + deploy) when the project declares npm", async () => {
+                expect.assertions(5);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+                // `detectPackageManager` reads the nearest package.json's `packageManager`.
+                writeFileSync(join(workdir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+
+                const { calls, spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({
+                    cwd: workdir,
+                    interactive: true,
+                    logger,
+                    secretConfirm: () => Promise.resolve(true),
+                    secretLister: () => Promise.resolve({ names: [], ok: true }),
+                    spawner,
+                });
+
+                expect(result.code).toBe(0);
+
+                // Every wrangler invocation now goes through `npx -- wrangler …`.
+                const secretPush = calls.find((call) => call.descriptor.args.includes("secret"));
+                const deploySpawn = calls.find((call) => call.descriptor.args.includes("deploy"));
+
+                // The secret value travels over stdin (`input`), never on argv.
+                expect(secretPush?.descriptor).toMatchObject({ args: ["--", "wrangler", "secret", "put", "LUNORA_ADMIN_TOKEN"], command: "npx" });
+                expect(typeof secretPush?.descriptor.input).toBe("string");
+                expect(secretPush?.descriptor.args).not.toContain(secretPush?.descriptor.input);
+
+                expect(deploySpawn?.descriptor).toMatchObject({ args: ["--", "wrangler", "deploy"], command: "npx" });
+            });
+
             it("aborts a non-interactive deploy when a required secret is missing on the target", async () => {
                 expect.assertions(3);
 

--- a/packages/cli/__tests__/commands/deployments.test.ts
+++ b/packages/cli/__tests__/commands/deployments.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { runDeploymentsCommand } from "../../src/commands/deployments/handler";
@@ -20,6 +24,14 @@ const silentLogger = (): { errors: string[]; logger: Logger } => {
 
 const argsOf = (calls: ReturnType<typeof createRecordingSpawner>["calls"]): string => calls[0]?.descriptor.args.join(" ") ?? "";
 
+/** A cwd whose nearest package.json declares npm, so `detectPackageManager` resolves npm. */
+const npmProjectCwd = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "lunora-cli-deployments-npm-"));
+    writeFileSync(join(dir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+
+    return dir;
+};
+
 describe("lunora deployments", () => {
     it("list spawns `wrangler deployments list` and forwards --json/--env", async () => {
         expect.assertions(3);
@@ -32,6 +44,18 @@ describe("lunora deployments", () => {
         expect(result.code).toBe(0);
         expect(argsOf(calls)).toContain("wrangler deployments list");
         expect(argsOf(calls)).toContain("--json");
+    });
+
+    it("launches wrangler through npx when the project declares npm", async () => {
+        expect.assertions(2);
+
+        const { calls, spawner } = createRecordingSpawner();
+        const { logger } = silentLogger();
+
+        await runDeploymentsCommand({ cwd: npmProjectCwd(), logger, spawner, subcommand: "list" });
+
+        expect(calls[0]?.descriptor.command).toBe("npx");
+        expect(calls[0]?.descriptor.args).toStrictEqual(["--", "wrangler", "deployments", "list"]);
     });
 
     it("inspect requires a version id", async () => {

--- a/packages/cli/__tests__/commands/dev.test.ts
+++ b/packages/cli/__tests__/commands/dev.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -39,6 +39,30 @@ describe("lunora dev", () => {
             expect(plan.wrangler.args.join(" ")).toContain("dev");
             expect(plan.wrangler.args.join(" ")).not.toContain("vite");
             expect(plan.studioEnabled).toBe(true);
+        });
+
+        it("adds a framework redirect hint (wrangler plan unchanged) in a Vite project", () => {
+            expect.assertions(4);
+
+            // A meta-framework project: `@lunora/vite` runs the worker inside Vite.
+            writeFileSync(join(workdir, "package.json"), JSON.stringify({ devDependencies: { "@react-router/dev": "^7.0.0" } }), "utf8");
+
+            const plan = planDevCommand({ cwd: workdir, logger: silentLogger() });
+
+            expect(plan.frameworkHint).toContain("react-router");
+            expect(plan.frameworkHint).toContain("lunora dev");
+            // The wrangler spawn is unchanged — the hint never replaces it.
+            expect(plan.wrangler.args.join(" ")).toContain("wrangler dev");
+            expect(plan.wrangler.tag).toBe("wrangler");
+        });
+
+        it("adds no hint for a standalone project (no framework)", () => {
+            expect.assertions(2);
+
+            const plan = planDevCommand({ cwd: workdir, logger: silentLogger() });
+
+            expect(plan.frameworkHint).toBeUndefined();
+            expect(plan.wrangler.args.join(" ")).toContain("wrangler dev");
         });
 
         it("flags the worker as a dev deployment via `--var WORKER_ENV:development`", () => {
@@ -192,6 +216,36 @@ describe("lunora dev", () => {
             expect(codegenClosed).toBe(true);
             expect(studioClosed).toBe(true);
             expect(result.plan.workerOrigin).toBe("http://localhost:8787");
+        });
+
+        it("logs the framework redirect hint but still spawns the worker", async () => {
+            expect.assertions(3);
+
+            writeFileSync(join(workdir, "package.json"), JSON.stringify({ dependencies: { nuxt: "^3.0.0" } }), "utf8");
+
+            const warnings: string[] = [];
+            let workerSpawned = false;
+
+            const result = await runDevCommand({
+                cwd: workdir,
+                logger: { ...silentLogger(), warn: (message) => warnings.push(message) },
+                startCodegen: () => {
+                    return { close: () => {}, watchAvailable: true };
+                },
+                startStudio: async () => {
+                    return { close: async () => {}, url: "http://127.0.0.1:6173" };
+                },
+                startWorker: () => {
+                    workerSpawned = true;
+
+                    return { exited: Promise.resolve(0), kill: () => {} };
+                },
+                studio: false,
+            });
+
+            expect(result.code).toBe(0);
+            expect(workerSpawned).toBe(true);
+            expect(warnings.some((line) => line.includes("nuxt") && line.includes("lunora dev"))).toBe(true);
         });
 
         it("fills empty .dev.vars secrets + the admin token before the worker boots", async () => {

--- a/packages/cli/__tests__/commands/env.test.ts
+++ b/packages/cli/__tests__/commands/env.test.ts
@@ -232,6 +232,26 @@ describe("lunora env", () => {
             expect(calls[0]?.descriptor.env).toBeUndefined();
         });
 
+        it("launches wrangler through npx when the project declares npm (secret stays on stdin)", async () => {
+            expect.assertions(4);
+
+            const { logger } = recordingLogger();
+
+            writeFileSync(join(workdir, ".dev.vars"), "FIRST=one\n", "utf8");
+            // `detectPackageManager` reads the nearest package.json's `packageManager`.
+            writeFileSync(join(workdir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+
+            const { calls, spawner } = createRecordingSpawner();
+
+            await runEnvCommand({ cwd: workdir, logger, spawner, subcommand: "push", yes: true });
+
+            expect(calls[0]?.descriptor.command).toBe("npx");
+            expect(calls[0]?.descriptor.args).toStrictEqual(["--", "wrangler", "secret", "put", "FIRST"]);
+            // The value still travels over stdin, never on argv.
+            expect(calls[0]?.descriptor.input).toBe("one");
+            expect(calls[0]?.descriptor.args).not.toContain("one");
+        });
+
         it("push --prod adds --env production", async () => {
             expect.assertions(2);
 

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -173,6 +173,28 @@ describe("lunora init", () => {
 
             expect(result.code).toBe(0);
             expect(calls).toHaveLength(0);
+        });
+
+        it("prints package-manager-neutral overlay next-steps for an npm project", async () => {
+            expect.assertions(3);
+
+            // An existing react-router project that declares npm; the overlay path
+            // (`--in-place`) must render its next-steps with the project's manager.
+            writeFileSync(
+                join(workdir, "package.json"),
+                JSON.stringify({ devDependencies: { "@react-router/dev": "^7.0.0" }, packageManager: "npm@10.9.0" }),
+                "utf8",
+            );
+            const infos: string[] = [];
+            const logger: Logger = { ...silentLogger(), info: (message) => infos.push(message) };
+
+            const result = await runInitCommand({ cwd: workdir, inPlace: true, logger });
+
+            const printed = infos.join("\n");
+
+            expect(result.code).toBe(0);
+            expect(printed).toContain("npm install @lunora/react");
+            expect(printed).not.toContain("pnpm add");
         });
 
         it("substitutes {{name}} placeholders", async () => {

--- a/packages/cli/__tests__/commands/logs.test.ts
+++ b/packages/cli/__tests__/commands/logs.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { runLogsCommand } from "../../src/commands/logs/handler";
@@ -18,6 +22,14 @@ const silentLogger = (): { errors: string[]; logger: Logger } => {
     };
 };
 
+/** A cwd whose nearest package.json declares npm, so `detectPackageManager` resolves npm. */
+const npmProjectCwd = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "lunora-cli-logs-npm-"));
+    writeFileSync(join(dir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+
+    return dir;
+};
+
 describe("lunora logs", () => {
     it("spawns `pnpm exec wrangler tail`", async () => {
         expect.assertions(3);
@@ -33,6 +45,18 @@ describe("lunora logs", () => {
         const args = calls[0]?.descriptor.args.join(" ") ?? "";
 
         expect(args).toContain("wrangler tail");
+    });
+
+    it("launches wrangler through npx when the project declares npm", async () => {
+        expect.assertions(2);
+
+        const { calls, spawner } = createRecordingSpawner();
+        const { logger } = silentLogger();
+
+        await runLogsCommand({ cwd: npmProjectCwd(), logger, spawner });
+
+        expect(calls[0]?.descriptor.command).toBe("npx");
+        expect(calls[0]?.descriptor.args).toStrictEqual(["--", "wrangler", "tail"]);
     });
 
     it("forwards worker name, --env, --format, --status, and --search", async () => {

--- a/packages/cli/__tests__/commands/verify.test.ts
+++ b/packages/cli/__tests__/commands/verify.test.ts
@@ -180,6 +180,26 @@ describe("lunora verify", () => {
             });
         });
 
+        it("routes tsc through npx when the project declares npm", async () => {
+            expect.assertions(2);
+
+            writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+            writeFileSync(join(workdir, "tsconfig.json"), TSCONFIG, "utf8");
+            // `detectPackageManager` reads the nearest package.json's `packageManager`.
+            writeFileSync(join(workdir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+            const { logger } = recordingLogger();
+            const { calls, spawner } = createRecordingSpawner(0);
+
+            await runVerifyCommand({ cwd: workdir, logger, spawner });
+
+            expect(calls).toHaveLength(1);
+            expect(calls[0]?.descriptor).toMatchObject({
+                args: ["--", "tsc", "--noEmit", "-p", "tsconfig.json"],
+                command: "npx",
+                cwd: workdir,
+            });
+        });
+
         it("returns 1 with a type-error message when tsc exits non-zero", async () => {
             expect.assertions(3);
 

--- a/packages/cli/__tests__/util/railpack.test.ts
+++ b/packages/cli/__tests__/util/railpack.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import type { Logger } from "../../src/util/logger";
@@ -11,6 +15,14 @@ const silentLogger = (): { errors: string[]; logger: Logger } => {
         errors,
         logger: { error: (message) => errors.push(message), info: () => {}, success: () => {}, warn: () => {} },
     };
+};
+
+/** A cwd whose nearest package.json declares npm, so `detectPackageManager` resolves npm. */
+const npmProjectCwd = (): string => {
+    const dir = mkdtempSync(join(tmpdir(), "lunora-cli-railpack-npm-"));
+    writeFileSync(join(dir, "package.json"), `{ "packageManager": "npm@10.9.0" }\n`, "utf8");
+
+    return dir;
 };
 
 describe(buildRailpackImages, () => {
@@ -47,6 +59,26 @@ describe(buildRailpackImages, () => {
         expect(calls).toHaveLength(4);
         expect(calls[0]?.descriptor).toMatchObject({ args: ["build", "./services/transcoder", "--name", "lunora-transcoder:build"], command: "railpack" });
         expect(calls[1]?.descriptor).toMatchObject({ args: ["exec", "wrangler", "containers", "push", "lunora-transcoder:build"], command: "pnpm" });
+    });
+
+    it("pushes through npx when the project declares npm (build stays on the railpack binary)", async () => {
+        expect.assertions(3);
+
+        const { calls, spawner } = createRecordingSpawner();
+        const { logger } = silentLogger();
+
+        const result = await buildRailpackImages({
+            cwd: npmProjectCwd(),
+            logger,
+            railpackAvailable: () => true,
+            spawner,
+            targets: [{ buildDir: "./services/transcoder", exportName: "transcoder" }],
+        });
+
+        expect(result.code).toBe(0);
+        // The Railpack build is its own binary — only the wrangler push routes through the manager.
+        expect(calls[0]?.descriptor).toMatchObject({ args: ["build", "./services/transcoder", "--name", "lunora-transcoder:build"], command: "railpack" });
+        expect(calls[1]?.descriptor).toMatchObject({ args: ["--", "wrangler", "containers", "push", "lunora-transcoder:build"], command: "npx" });
     });
 
     it("blocks when Railpack/BuildKit is unavailable, without spawning", async () => {

--- a/packages/cli/src/commands/analyze/handler.ts
+++ b/packages/cli/src/commands/analyze/handler.ts
@@ -4,6 +4,7 @@ import { join, relative } from "node:path";
 
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import type { SpawnDescriptor, Spawner } from "../../util/spawn";
 import { defaultSpawner } from "../../util/spawn";
@@ -131,9 +132,12 @@ const runAnalyzeCommand = async (options: AnalyzeCommandOptions): Promise<Analyz
     } else {
         outdir = mkdtempSync(join(tmpdir(), "lunora-analyze-"));
         temporary = true;
+
+        const exec = execArgsFor(detectPackageManager(cwd), "wrangler", ["deploy", "--dry-run", "--outdir", outdir]);
+
         descriptor = {
-            args: ["exec", "wrangler", "deploy", "--dry-run", "--outdir", outdir],
-            command: "pnpm",
+            args: exec.args,
+            command: exec.command,
             cwd,
         };
 

--- a/packages/cli/src/commands/containers/handler.ts
+++ b/packages/cli/src/commands/containers/handler.ts
@@ -1,5 +1,6 @@
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { DockerProbe } from "../../util/docker";
 import { isDockerAvailable } from "../../util/docker";
 import type { Logger } from "../../util/logger";
@@ -60,7 +61,7 @@ const runContainersCommand = async (options: ContainersCommandOptions): Promise<
         return { code: 1 };
     }
 
-    const args = ["exec", "wrangler", "containers", subcommand, ...rest];
+    const args = ["containers", subcommand, ...rest];
 
     if (options.tag !== undefined) {
         args.push("--tag", options.tag);
@@ -74,7 +75,9 @@ const runContainersCommand = async (options: ContainersCommandOptions): Promise<
         args.push("--env", options.env);
     }
 
-    const descriptor: SpawnDescriptor = { args, command: "pnpm", cwd: options.cwd ?? process.cwd() };
+    const cwd = options.cwd ?? process.cwd();
+    const exec = execArgsFor(detectPackageManager(cwd), "wrangler", args);
+    const descriptor: SpawnDescriptor = { args: exec.args, command: exec.command, cwd };
 
     options.logger.info(`running ${descriptor.command} ${descriptor.args.join(" ")}`);
 

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -26,6 +26,7 @@ import { autoLinkFromDeployOutput } from "../../util/auto-link";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
 import { renderDeploySummary } from "../../util/deploy-summary";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { DockerProbe } from "../../util/docker";
 import { isDockerAvailable } from "../../util/docker";
 import type { Logger } from "../../util/logger";
@@ -430,10 +431,11 @@ const resolveRequiredSecretKeys = async (cwd: string): Promise<string[]> => {
 const pushMintableSecrets = async (cwd: string, options: DeployCommandOptions, keys: ReadonlyArray<string>): Promise<boolean> => {
     const { logger } = options;
     const spawner = options.spawner ?? defaultSpawner;
+    const manager = detectPackageManager(cwd);
     const environmentFlag = options.env === undefined ? "" : ` --env ${options.env}`;
 
     for (const key of keys) {
-        const args = ["exec", "wrangler", "secret", "put", key];
+        const args = ["secret", "put", key];
 
         if (options.env !== undefined) {
             args.push("--env", options.env);
@@ -443,10 +445,12 @@ const pushMintableSecrets = async (cwd: string, options: DeployCommandOptions, k
             args.push("--temporary");
         }
 
+        const exec = execArgsFor(manager, "wrangler", args);
+
         // `wrangler secret put <name>` reads the value from stdin, so the generated
         // secret never lands on the command line, in env, or in shell history.
         // eslint-disable-next-line no-await-in-loop -- push sequentially so a failure aborts before the rest.
-        const pushResult = await spawner({ args, command: "pnpm", cwd, input: generateSecretValue() });
+        const pushResult = await spawner({ args: exec.args, command: exec.command, cwd, input: generateSecretValue() });
 
         if (pushResult.code !== 0) {
             logger.error(
@@ -822,14 +826,16 @@ const runPreDeployGates = async (cwd: string, options: DeployCommandOptions): Pr
 };
 
 /**
- * Assemble the `pnpm exec wrangler deploy …` argv: the class-B composed-entry
- * positional (when present), `--env`, and `--dry-run`. Extracted from
- * {@link executeDeploy} to keep its cognitive complexity within budget.
+ * Assemble the `wrangler deploy …` argv (the wrangler subcommand + flags): the
+ * class-B composed-entry positional (when present), `--env`, and `--dry-run`.
+ * The package-manager launcher (`pnpm exec` / `npx --` / …) is prepended by the
+ * caller via {@link execArgsFor}. Extracted from {@link executeDeploy} to keep
+ * its cognitive complexity within budget.
  */
 const buildWranglerDeployArgs = (cwd: string, options: DeployCommandOptions): string[] => {
     // `--preview` uploads a new Version (with a preview URL) instead of going
     // live, so production traffic is untouched.
-    const args = options.preview ? ["exec", "wrangler", "versions", "upload"] : ["exec", "wrangler", "deploy"];
+    const args = options.preview ? ["versions", "upload"] : ["deploy"];
 
     // Class-B composition: bundle the `src/worker.ts` wrapper (which the
     // framework's CF adapter can't clobber) instead of the adapter-owned `main`.
@@ -984,10 +990,11 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
     // existing links are never clobbered and subsequent deploys keep full TTY output.
     const shouldAutoLink = !isJsonFormat(options.format) && options.dryRun !== true && options.preview !== true && readLinkedProject(cwd) === undefined;
 
+    const exec = execArgsFor(detectPackageManager(cwd), "wrangler", buildWranglerDeployArgs(cwd, options));
     const descriptor: SpawnDescriptor = {
-        args: buildWranglerDeployArgs(cwd, options),
+        args: exec.args,
         captureStdout: shouldAutoLink,
-        command: "pnpm",
+        command: exec.command,
         cwd,
         // In `--format json` mode stdout is reserved for the single JSON document,
         // so route wrangler's progress + deployed-URL output to stderr instead.

--- a/packages/cli/src/commands/deployments/handler.ts
+++ b/packages/cli/src/commands/deployments/handler.ts
@@ -1,5 +1,6 @@
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import type { SpawnDescriptor, Spawner } from "../../util/spawn";
 import { defaultSpawner } from "../../util/spawn";
@@ -42,7 +43,7 @@ const withEnv = (args: string[], env: string | undefined): string[] => {
 
 /** Build the wrangler argv for `list`. */
 const buildListArgs = (options: DeploymentsCommandOptions): string[] => {
-    const args = withEnv(["exec", "wrangler", "deployments", "list"], options.env);
+    const args = withEnv(["deployments", "list"], options.env);
 
     if (options.json) {
         args.push("--json");
@@ -62,7 +63,7 @@ const buildArgs = (options: DeploymentsCommandOptions): { args?: string[]; error
                 return { error: "deployments inspect requires a version id. Usage: lunora deployments inspect <version-id>" };
             }
 
-            return { args: withEnv(["exec", "wrangler", "versions", "view", options.versionId], options.env) };
+            return { args: withEnv(["versions", "view", options.versionId], options.env) };
         }
         case "list": {
             return { args: buildListArgs(options) };
@@ -77,7 +78,7 @@ const buildArgs = (options: DeploymentsCommandOptions): { args?: string[]; error
             }
 
             // `versions deploy <id>@100%` makes one version fully live; `-y` accepts the prompts.
-            const args = withEnv(["exec", "wrangler", "versions", "deploy", `${options.versionId}@100%`, "--yes"], options.env);
+            const args = withEnv(["versions", "deploy", `${options.versionId}@100%`, "--yes"], options.env);
 
             if (options.message !== undefined) {
                 args.push("--message", options.message);
@@ -90,7 +91,7 @@ const buildArgs = (options: DeploymentsCommandOptions): { args?: string[]; error
                 return { error: "deployments rollback changes the live version. Re-run with --yes to confirm." };
             }
 
-            const args = withEnv(["exec", "wrangler", "rollback"], options.env);
+            const args = withEnv(["rollback"], options.env);
 
             if (options.versionId !== undefined) {
                 args.push(options.versionId);
@@ -119,7 +120,9 @@ const runDeploymentsCommand = async (options: DeploymentsCommandOptions): Promis
         return { code: 1, descriptor: undefined, error };
     }
 
-    const descriptor: SpawnDescriptor = { args, command: "pnpm", cwd: options.cwd ?? process.cwd() };
+    const cwd = options.cwd ?? process.cwd();
+    const exec = execArgsFor(detectPackageManager(cwd), "wrangler", args);
+    const descriptor: SpawnDescriptor = { args: exec.args, command: exec.command, cwd };
 
     options.logger.info(`${descriptor.command} ${descriptor.args.join(" ")}`);
 

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -6,6 +6,7 @@ import {
     AGENT_RULES_HINT,
     claimAgentRulesHint,
     detectAgentRules,
+    detectFramework,
     DEV_VARS_EXAMPLE_FILE,
     DEV_VARS_FILE,
     discoverContainerInfo,
@@ -28,6 +29,7 @@ import type { CodegenWatcherHandle } from "../../util/codegen-watch";
 import { startCodegenWatch } from "../../util/codegen-watch";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import type { PackageManager } from "../../util/detect-package-manager";
 import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import type { SpawnDescriptor } from "../../util/spawn";
@@ -102,6 +104,15 @@ interface DevRemotePlan {
 
 interface DevCommandPlan {
     codegenEnabled: boolean;
+
+    /**
+     * One-line redirect hint printed when a Vite/meta-framework is detected: in
+     * those projects the worker runs *inside* Vite, so the user should run their
+     * framework dev script for the full app. `undefined` for a standalone project
+     * (no framework) — `lunora dev` is the right command there. Purely
+     * informational: the wrangler spawn runs regardless.
+     */
+    frameworkHint?: string;
     /** The remote-binding decision: which D1/KV/R2 bindings hit the deployed worker. */
     remote: DevRemotePlan;
     studioEnabled: boolean;
@@ -142,6 +153,9 @@ const resolveRemotePlan = (options: DevCommandOptions, cwd: string): { args: str
     return { args: ["--config", result.configPath], plan: { bindings, cleanup, enabled: true } };
 };
 
+/** The dev-server script invocation for the framework redirect hint (`pnpm dev`, `npm run dev`, …). */
+const frameworkDevScript = (manager: PackageManager): string => (manager === "npm" || manager === "bun" ? `${manager} run dev` : `${manager} dev`);
+
 /**
  * Plan `lunora dev`: it runs the worker via `wrangler dev` and nothing else as a
  * child process. Vite is intentionally NOT spawned — a project may not use Vite,
@@ -152,6 +166,15 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
     const cwd = options.cwd ?? process.cwd();
     const workerPort = options.workerPort ?? DEFAULT_WORKER_PORT;
     const manager = detectPackageManager(cwd);
+    // In a Vite/meta-framework project the `@lunora/vite` plugin runs the worker
+    // inside Vite, so `lunora dev` (wrangler-only) gives just the worker — no
+    // frontend, no HMR. Detect the framework and surface a one-line redirect hint;
+    // the wrangler spawn still runs regardless (this is a hint, not a redirect).
+    const detection = detectFramework(cwd);
+    const frameworkHint =
+        detection.framework === "none"
+            ? undefined
+            : `this project uses ${detection.framework} — the worker runs inside Vite there. run \`${frameworkDevScript(manager)}\` for the full app (frontend + HMR); \`lunora dev\` starts only the worker.`;
     const remote = resolveRemotePlan(options, cwd);
     // `--var WORKER_ENV:development` flags the worker as a dev deployment so the
     // runtime streams every RPC dispatch summary to the terminal by default
@@ -164,6 +187,7 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
 
     return {
         codegenEnabled: options.codegen !== false,
+        frameworkHint,
         remote: remote.plan,
         studioEnabled: options.studio !== false,
         studioPort: options.port ?? DEFAULT_STUDIO_PORT,
@@ -481,6 +505,12 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             } catch (error: unknown) {
                 logger.warn(`studio server failed to start (${error instanceof Error ? error.message : String(error)}) — continuing without it`);
             }
+        }
+
+        // A Vite/meta-framework was detected: nudge the user to their framework
+        // dev script for the full app before wrangler starts (the worker still runs).
+        if (plan.frameworkHint !== undefined) {
+            logger.warn(plan.frameworkHint);
         }
 
         const worker = (options.startWorker ?? defaultWorkerSpawner)(plan.wrangler, logger);

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -29,8 +29,7 @@ import type { CodegenWatcherHandle } from "../../util/codegen-watch";
 import { startCodegenWatch } from "../../util/codegen-watch";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
-import type { PackageManager } from "../../util/detect-package-manager";
-import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
+import { detectPackageManager, execArgsFor, runScriptCommand } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import type { SpawnDescriptor } from "../../util/spawn";
 import type { StudioServerHandle } from "../../util/studio-server";
@@ -153,9 +152,6 @@ const resolveRemotePlan = (options: DevCommandOptions, cwd: string): { args: str
     return { args: ["--config", result.configPath], plan: { bindings, cleanup, enabled: true } };
 };
 
-/** The dev-server script invocation for the framework redirect hint (`pnpm dev`, `npm run dev`, …). */
-const frameworkDevScript = (manager: PackageManager): string => (manager === "npm" || manager === "bun" ? `${manager} run dev` : `${manager} dev`);
-
 /**
  * Plan `lunora dev`: it runs the worker via `wrangler dev` and nothing else as a
  * child process. Vite is intentionally NOT spawned — a project may not use Vite,
@@ -174,7 +170,7 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
     const frameworkHint =
         detection.framework === "none"
             ? undefined
-            : `this project uses ${detection.framework} — the worker runs inside Vite there. run \`${frameworkDevScript(manager)}\` for the full app (frontend + HMR); \`lunora dev\` starts only the worker.`;
+            : `this project uses ${detection.framework} — the worker runs inside Vite there. run \`${runScriptCommand(manager, "dev")}\` for the full app (frontend + HMR); \`lunora dev\` starts only the worker.`;
     const remote = resolveRemotePlan(options, cwd);
     // `--var WORKER_ENV:development` flags the worker as a dev deployment so the
     // runtime streams every RPC dispatch summary to the terminal by default

--- a/packages/cli/src/commands/env/handler.ts
+++ b/packages/cli/src/commands/env/handler.ts
@@ -16,6 +16,7 @@ import {
 
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import type { SpawnDescriptor, Spawner } from "../../util/spawn";
 import { defaultSpawner } from "../../util/spawn";
@@ -248,10 +249,12 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
     }
 
     const spawner = options.spawner ?? defaultSpawner;
+    const cwd = options.cwd ?? process.cwd();
+    const manager = detectPackageManager(cwd);
     const descriptors: SpawnDescriptor[] = [];
 
     for (const entry of map.values()) {
-        const args: string[] = ["exec", "wrangler", "secret", "put", entry.key];
+        const args: string[] = ["secret", "put", entry.key];
 
         if (options.prod) {
             args.push("--env", "production");
@@ -261,10 +264,11 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
             args.push("--temporary");
         }
 
+        const exec = execArgsFor(manager, "wrangler", args);
         const descriptor: SpawnDescriptor = {
-            args,
-            command: "pnpm",
-            cwd: options.cwd ?? process.cwd(),
+            args: exec.args,
+            command: exec.command,
+            cwd,
             // `wrangler secret put <name>` reads the value from stdin. We
             // pipe it through the spawner's `input` channel so the secret
             // never lands on the command line, in env, or in shell history.

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -14,7 +14,7 @@ import { defineHandler } from "../../util/command";
 import type { DetectedFramework, FrameworkDetection } from "../../util/detect-framework";
 import { detectFramework } from "../../util/detect-framework";
 import type { PackageManager, PackageManagerProbe } from "../../util/detect-package-manager";
-import { detectInstalledManagers, installArgsFor } from "../../util/detect-package-manager";
+import { detectInstalledManagers, detectPackageManager, installArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { patchViteConfig } from "../../util/patch-vite-config";
 import { PromptCancelledError } from "../../util/prompt-cancelled";
@@ -459,6 +459,14 @@ const runScriptCommand = (manager: PackageManager, script: string): string => {
 
     // pnpm / yarn run scripts by bare name.
     return `${manager} ${script}`;
+};
+
+/** The shell command that adds dependencies with `manager` (`pnpm add …`, `npm install …`, …). */
+const installCommand = (manager: PackageManager, packages: ReadonlyArray<string>): string => {
+    // npm spells "add a dependency" as `install`; pnpm/yarn/bun use `add`.
+    const verb = manager === "npm" ? "install" : "add";
+
+    return `${manager} ${verb} ${packages.join(" ")}`;
 };
 
 /**
@@ -1004,13 +1012,13 @@ const scaffoldLunoraDirectory = (cwd: string, logger: Logger): ReadonlyArray<str
  * composition is printed for the user to wire because it is framework-specific
  * and lives in files the CLI does not own.
  */
-const printFrameworkNextSteps = (detection: FrameworkDetection, logger: Logger): void => {
+const printFrameworkNextSteps = (detection: FrameworkDetection, manager: PackageManager, logger: Logger): void => {
     const { adapter, class: frameworkClass, framework } = detection;
 
     logger.info("");
     logger.info(`detected framework: ${framework} (class ${frameworkClass})`);
     logger.info("next steps:");
-    logger.info(`  1. install the adapter:  pnpm add ${adapter} @lunora/client @lunora/runtime @lunora/server`);
+    logger.info(`  1. install the adapter:  ${installCommand(manager, [adapter, "@lunora/client", "@lunora/runtime", "@lunora/server"])}`);
     logger.info("  2. run codegen:          lunora codegen");
 
     if (frameworkClass === "A") {
@@ -1097,7 +1105,9 @@ const runInPlaceInit = (cwd: string, logger: Logger): InitCommandResult => {
 
     const scaffolded = scaffoldLunoraDirectory(cwd, logger);
 
-    printFrameworkNextSteps(detection, logger);
+    // The overlay path patches an existing project, so honour its package
+    // manager (packageManager field / lockfile) rather than assuming pnpm.
+    printFrameworkNextSteps(detection, detectPackageManager(cwd), logger);
 
     return { code: 0, files: [...viteResult.files, ...scaffolded], target: cwd };
 };

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -14,7 +14,7 @@ import { defineHandler } from "../../util/command";
 import type { DetectedFramework, FrameworkDetection } from "../../util/detect-framework";
 import { detectFramework } from "../../util/detect-framework";
 import type { PackageManager, PackageManagerProbe } from "../../util/detect-package-manager";
-import { detectInstalledManagers, detectPackageManager, installArgsFor } from "../../util/detect-package-manager";
+import { detectInstalledManagers, detectPackageManager, installArgsFor, runScriptCommand } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { patchViteConfig } from "../../util/patch-vite-config";
 import { PromptCancelledError } from "../../util/prompt-cancelled";
@@ -445,20 +445,6 @@ const logScaffoldSuccess = (logger: Logger, written: ReadonlyArray<string>, targ
     }
 
     logger.success(`scaffolded ${String(written.length)} files into ${target}`);
-};
-
-/** The shell command that runs a project script with `manager` (`pnpm dev`, `npm run dev`, …). */
-const runScriptCommand = (manager: PackageManager, script: string): string => {
-    if (manager === "npm") {
-        return `npm run ${script}`;
-    }
-
-    if (manager === "bun") {
-        return `bun run ${script}`;
-    }
-
-    // pnpm / yarn run scripts by bare name.
-    return `${manager} ${script}`;
 };
 
 /** The shell command that adds dependencies with `manager` (`pnpm add …`, `npm install …`, …). */

--- a/packages/cli/src/commands/logs/handler.ts
+++ b/packages/cli/src/commands/logs/handler.ts
@@ -2,6 +2,7 @@ import { readLinkedProject } from "@lunora/config";
 
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import type { SpawnDescriptor, Spawner } from "../../util/spawn";
 import { defaultSpawner } from "../../util/spawn";
@@ -56,7 +57,7 @@ const runLogsCommand = async (options: LogsCommandOptions): Promise<LogsCommandR
         return { code: 1, descriptor: undefined, error: "invalid format" };
     }
 
-    const args = ["exec", "wrangler", "tail"];
+    const args = ["tail"];
 
     if (options.worker !== undefined) {
         args.push(options.worker);
@@ -86,9 +87,10 @@ const runLogsCommand = async (options: LogsCommandOptions): Promise<LogsCommandR
         args.push("--temporary");
     }
 
+    const exec = execArgsFor(detectPackageManager(cwd), "wrangler", args);
     const descriptor: SpawnDescriptor = {
-        args,
-        command: "pnpm",
+        args: exec.args,
+        command: exec.command,
         cwd,
     };
 

--- a/packages/cli/src/commands/verify/handler.ts
+++ b/packages/cli/src/commands/verify/handler.ts
@@ -8,6 +8,7 @@ import { parseApiSpec } from "../../util/api-spec";
 import { renderCodegenHint } from "../../util/codegen-error";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
 import { runSchemaDriftGate } from "../../util/schema-drift-gate";
@@ -50,7 +51,8 @@ const runTypecheckStep = async (cwd: string, spawner: Spawner): Promise<{ error?
         return { warning: "no tsconfig.json found — skipping TypeScript type-check" };
     }
 
-    const result = await spawner({ args: ["exec", "tsc", "--noEmit", "-p", "tsconfig.json"], command: "pnpm", cwd });
+    const exec = execArgsFor(detectPackageManager(cwd), "tsc", ["--noEmit", "-p", "tsconfig.json"]);
+    const result = await spawner({ args: exec.args, command: exec.command, cwd });
 
     return result.code === 0 ? {} : { error: `type errors: tsc --noEmit exited ${String(result.code)}` };
 };

--- a/packages/cli/src/util/detect-package-manager.ts
+++ b/packages/cli/src/util/detect-package-manager.ts
@@ -111,5 +111,19 @@ const execArgsFor = (manager: PackageManager, command: string, args: ReadonlyArr
     return { args: ["exec", command, ...args], command: "pnpm" };
 };
 
+/** The shell command that runs a project script with `manager` (`pnpm dev`, `npm run dev`, …). */
+const runScriptCommand = (manager: PackageManager, script: string): string => {
+    if (manager === "npm") {
+        return `npm run ${script}`;
+    }
+
+    if (manager === "bun") {
+        return `bun run ${script}`;
+    }
+
+    // pnpm / yarn run scripts by bare name.
+    return `${manager} ${script}`;
+};
+
 export type { PackageManager, PackageManagerProbe };
-export { detectInstalledManagers, detectPackageManager, execArgsFor, installArgsFor };
+export { detectInstalledManagers, detectPackageManager, execArgsFor, installArgsFor, runScriptCommand };

--- a/packages/cli/src/util/railpack.ts
+++ b/packages/cli/src/util/railpack.ts
@@ -1,5 +1,6 @@
 import { containerBuildTag } from "@lunora/container";
 
+import { detectPackageManager, execArgsFor } from "./detect-package-manager";
 import type { DockerProbe } from "./docker";
 import { isRailpackAvailable } from "./docker";
 import type { Logger } from "./logger";
@@ -68,7 +69,8 @@ const buildRailpackImages = async (options: RailpackBuildOptions): Promise<Railp
         const tag = containerBuildTag(target.exportName);
 
         const build: SpawnDescriptor = { args: ["build", target.buildDir, "--name", tag], command: "railpack", cwd: options.cwd };
-        const push: SpawnDescriptor = { args: ["exec", "wrangler", "containers", "push", tag], command: "pnpm", cwd: options.cwd };
+        const pushExec = execArgsFor(detectPackageManager(options.cwd), "wrangler", ["containers", "push", tag]);
+        const push: SpawnDescriptor = { args: pushExec.args, command: pushExec.command, cwd: options.cwd };
 
         options.logger.info(`railpack: building "${target.exportName}" → ${tag} from ${target.buildDir}`);
         // eslint-disable-next-line no-await-in-loop -- sequential: build must finish before push, and one target before the next

--- a/templates/analog/README.md
+++ b/templates/analog/README.md
@@ -85,9 +85,12 @@ ships `ShardDO` in the same `dist/analog/server/index.mjs` worker, and the
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev          # vite dev server (AnalogJS)
+<pm> install
+<pm> run dev               # vite dev server (AnalogJS)
 ```
 
 > **Cloudflare bindings in dev.** `/_lunora/**` needs the Cloudflare runtime

--- a/templates/astro/README.md
+++ b/templates/astro/README.md
@@ -10,9 +10,12 @@ loading flash.
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev
+<pm> install
+<pm> run dev
 ```
 
 ## Why an island adapter?

--- a/templates/nuxt/README.md
+++ b/templates/nuxt/README.md
@@ -53,8 +53,10 @@ deploy, a same-origin client.
 
 ## Develop
 
+Start the dev server with your package manager (`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm dev
+<pm> run dev
 ```
 
 `nuxt dev` serves the app and the `/_lunora/**` route together. Live queries

--- a/templates/react-router/README.md
+++ b/templates/react-router/README.md
@@ -9,12 +9,15 @@ Lunora `/_lunora/*` RPC layer behind the `virtual:lunora/worker` entry.
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev
+<pm> install
+<pm> run dev
 ```
 
-`pnpm dev` runs Vite with the `@cloudflare/vite-plugin`, so your React Router
+The dev server runs Vite with the `@cloudflare/vite-plugin`, so your React Router
 app and the Lunora worker share the same origin on the local dev server.
 
 ## Build

--- a/templates/react-router/package.json
+++ b/templates/react-router/package.json
@@ -12,7 +12,7 @@
         "preview": "vite preview",
         "codegen": "lunora codegen",
         "deploy": "react-router build && lunora deploy",
-        "typecheck": "react-router typegen && tsc"
+        "typecheck": "lunora codegen && react-router typegen && tsc"
     },
     "dependencies": {
         "@lunora/react": "^0.0.0",

--- a/templates/standalone/README.md
+++ b/templates/standalone/README.md
@@ -4,9 +4,12 @@ A standalone Lunora Worker app (no frontend).
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev
+<pm> install
+<pm> run dev
 ```
 
 Open <http://localhost:8787/> for the Lunora welcome page. All other routes

--- a/templates/sveltekit/README.md
+++ b/templates/sveltekit/README.md
@@ -9,9 +9,12 @@ server (read-your-writes SSR), the HTML ships with it, and on the client the
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev
+<pm> install
+<pm> run dev
 ```
 
 ## What's wired

--- a/templates/tanstack-start-react/README.md
+++ b/templates/tanstack-start-react/README.md
@@ -8,12 +8,15 @@ wired through `preloadQuery` so initial paint hydrates without a fetch.
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev
+<pm> install
+<pm> run dev
 ```
 
-`pnpm dev` runs the TanStack Start dev server alongside `wrangler dev` so
+The dev command runs the TanStack Start dev server alongside `wrangler dev` so
 your client and worker share the same origin.
 
 ## Build

--- a/templates/tanstack-start-solid/README.md
+++ b/templates/tanstack-start-solid/README.md
@@ -10,12 +10,15 @@ initial paint hydrates without a fetch and then goes live with no refetch.
 
 ## Develop
 
+Install dependencies and start the dev server with your package manager
+(`npm`, `pnpm`, `yarn`, or `bun`):
+
 ```bash
-pnpm install
-pnpm dev
+<pm> install
+<pm> run dev
 ```
 
-`pnpm dev` runs the TanStack Start dev server alongside `wrangler dev` so
+The dev command runs the TanStack Start dev server alongside `wrangler dev` so
 your client and worker share the same origin.
 
 ## Build


### PR DESCRIPTION
Wave 11 CLI/DX papercuts — five independent, low-risk fixes (plans 096–100). All gates green.

## 096 — route wrangler/tsc spawns through the detected package manager
Every command that spawned wrangler/tsc (deploy, env, logs, analyze, verify, containers, deployments, railpack push) hardcoded `command: "pnpm"` with `exec`-style args, so npm/yarn/bun users without pnpm on PATH hit `spawn pnpm ENOENT` on `lunora deploy` and friends. Each now routes through `execArgsFor(detectPackageManager(cwd), …)` — the same helper `dev` already used. The `wrangler secret put` stdin path is preserved (the value never reaches argv). Added an npm-path assertion per converted command.
- Gates: `lint:types` 0 · `test` 545 passing · `lint:eslint` 0.

## 097 — fix the broken `codegen` script path in all six examples
The umbrella package's npm name is `lunorash`, but the examples' `codegen` script pointed at `node_modules/lunora/dist/bin.mjs`, which doesn't exist (`Cannot find module`). Repointed to `node_modules/lunorash/dist/bin.mjs`.
- Decision: templates use bare `lunora codegen`, but that bin is **unlinked** in the monorepo examples (dist is built after install), so per the plan's STOP-condition fallback the explicit `lunorash` bin path is used. Smoke-tested `pnpm run codegen` in `examples/todo-app` — resolves + runs.

## 098 — run codegen before typecheck in react-router template
`typecheck` imported `#lunora/_generated` but never ran codegen, so a fresh scaffold failed before the first dev/build. Prefixed `lunora codegen &&`, matching `build`.

## 099 — package-manager-neutral init guidance
The framework-overlay next-steps hardcoded `pnpm add …` and the template READMEs hardcoded `pnpm install` / `pnpm dev`. Added an `installCommand(manager, pkgs)` helper and threaded the project's detected manager into the overlay; softened all eight template READMEs to a neutral form. Added an init overlay test (npm project → `npm install …`, never `pnpm add`).
- Gates: `lint:types` 0 · `test` passing · `lint:eslint` 0.

## 100 — `lunora dev` hints the framework dev script in a Vite project
In a Vite/meta-framework project `@lunora/vite` runs the worker inside Vite, so a bare `lunora dev` gives just the worker (no frontend/HMR). `planDevCommand` now detects the framework and adds a one-line `frameworkHint`; the runner logs it before spawning wrangler. Behavior is unchanged — wrangler still runs in every case; the hint is purely informational. Standalone projects get no hint.
- Commit type: used `feat(cli)` (`dx` is not in the enforced commitlint enum).

## Gate summary (final, whole @lunora/cli)
- `lint:types` → 0 · `test` → 57 files / 545 tests passing · `lint:eslint` → 0.
- No plans skipped or stopped. `plans/README.md` intentionally not touched (reviewer maintains the index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6