### PR TITLE
perf(studio): route-level code-splitting for on-demand panel loading (plan 107)

### DIFF
--- a/packages/cli/__tests__/util/studio-server.test.ts
+++ b/packages/cli/__tests__/util/studio-server.test.ts
@@ -137,4 +137,37 @@ describe("startStudioServer", () => {
             await studio.close();
         }
     });
+
+    it("serves standalone JS from the directory and rejects path traversal", async () => {
+        expect.assertions(5);
+
+        const port = await getFreePort();
+        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+        const loopbackHost = `127.0.0.1:${String(port)}`;
+
+        try {
+            const entry = await requestStudio(port, "/studio.js", loopbackHost);
+            // A `.js` request that escapes the standalone directory: the server takes
+            // the basename and the resolver rejects anything outside the dir.
+            const traversal = await requestStudio(port, "/../../../../../../etc/passwd.js", loopbackHost);
+            const unknownChunk = await requestStudio(port, "/chunk-DOESNOTEXIST0.js", loopbackHost);
+
+            // The entry is served from the standalone directory when the studio is
+            // built (200), or reports "not built" (501) — never a traversal leak.
+            expect([200, 501]).toContain(entry.statusCode);
+
+            // A traversal `.js` request must never be served: 404 when the studio is
+            // built (the file isn't in the dir), 501 when it isn't — never 200, and
+            // never the target file's contents.
+            expect([404, 501]).toContain(traversal.statusCode);
+            expect(traversal.body).not.toContain("root:");
+
+            // An unknown chunk resolves to 404 (built) / 501 (not) — never the SPA
+            // document, which would hand a module request an HTML body.
+            expect([404, 501]).toContain(unknownChunk.statusCode);
+            expect(unknownChunk.body).not.toContain("<!doctype html>");
+        } finally {
+            await studio.close();
+        }
+    });
 });

--- a/packages/cli/src/util/studio-server.ts
+++ b/packages/cli/src/util/studio-server.ts
@@ -20,9 +20,11 @@ import type { Duplex } from "node:stream";
 import { detectAgentRules } from "@lunora/config";
 import type { LocalEndpointHandler } from "@lunora/config/studio-host";
 import {
+    assetContentType,
     handlePolicyScaffoldRequest,
     handleSchemaEditRequest,
     handleSeedRequest,
+    isStandaloneModulePath,
     loadStudioAssets,
     POLICY_SCAFFOLD_ENDPOINT,
     readStandaloneAsset,
@@ -200,7 +202,7 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
         // code-split `chunk-*.js` siblings. Anything else is an SPA route and falls
         // through to the history fallback (the document) below.
         const isStyle = pathname === "/styles.css";
-        const isModule = pathname.endsWith(".js") || pathname.endsWith(".js.map");
+        const isModule = isStandaloneModulePath(pathname);
 
         if (!isStyle && !isModule) {
             return false;
@@ -245,7 +247,7 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
             return true;
         }
 
-        sendAsset(response, bytes, pathname.endsWith(".map") ? "application/json; charset=utf-8" : "text/javascript; charset=utf-8");
+        sendAsset(response, bytes, assetContentType(fileName));
 
         return true;
     };

--- a/packages/cli/src/util/studio-server.ts
+++ b/packages/cli/src/util/studio-server.ts
@@ -25,6 +25,7 @@ import {
     handleSeedRequest,
     loadStudioAssets,
     POLICY_SCAFFOLD_ENDPOINT,
+    readStandaloneAsset,
     renderStudioHtml,
     resolveAdminToken,
     SCHEMA_EDIT_ENDPOINT,
@@ -194,7 +195,14 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
     };
 
     const serveStaticAsset = (pathname: string, response: ServerResponse): boolean => {
-        if (pathname !== "/studio.js" && pathname !== "/styles.css") {
+        // Own the studio's static assets: `/styles.css`, plus every `.js` / `.js.map`
+        // under the standalone directory — the `studio.js` entry and its on-demand,
+        // code-split `chunk-*.js` siblings. Anything else is an SPA route and falls
+        // through to the history fallback (the document) below.
+        const isStyle = pathname === "/styles.css";
+        const isModule = pathname.endsWith(".js") || pathname.endsWith(".js.map");
+
+        if (!isStyle && !isModule) {
             return false;
         }
 
@@ -215,9 +223,29 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
             return true;
         }
 
-        const isScript = pathname === "/studio.js";
+        if (isStyle) {
+            sendAsset(response, assets.styles, "text/css; charset=utf-8");
 
-        sendAsset(response, isScript ? assets.script : assets.styles, isScript ? "text/javascript; charset=utf-8" : "text/css; charset=utf-8");
+            return true;
+        }
+
+        // `.js` / `.js.map`: serve the request's basename from the standalone dir.
+        // `readStandaloneAsset` is path-traversal-safe (lone filenames only), so a
+        // `/../../etc/passwd`-style request can't escape it; a name that doesn't
+        // resolve to a file in the directory answers 404 (never the SPA document,
+        // which would hand a module request an HTML body).
+        const fileName = pathname.slice(pathname.lastIndexOf("/") + 1);
+        const bytes = readStandaloneAsset(fileName, import.meta.url);
+
+        if (bytes === undefined) {
+            response.statusCode = 404;
+            response.setHeader("Content-Type", "text/plain");
+            response.end("Not found");
+
+            return true;
+        }
+
+        sendAsset(response, bytes, pathname.endsWith(".map") ? "application/json; charset=utf-8" : "text/javascript; charset=utf-8");
 
         return true;
     };

--- a/packages/config/__tests__/studio-host/assets.test.ts
+++ b/packages/config/__tests__/studio-host/assets.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveContainedFile } from "../../src/studio-host/assets";
+
+// A representative absolute standalone directory (as `@lunora/studio`'s
+// `dist/standalone` would resolve to). The guard is pure path math, so a fixed
+// root exercises it without touching the filesystem.
+const DIR = "/srv/app/node_modules/@lunora/studio/dist/standalone";
+
+describe("resolveContainedFile (studio standalone path-traversal guard)", () => {
+    it("resolves a plain entry / chunk / map filename to a direct child of the dir", () => {
+        expect.assertions(3);
+
+        expect(resolveContainedFile(DIR, "studio.js")).toBe(`${DIR}/studio.js`);
+        expect(resolveContainedFile(DIR, "chunk-FQKNJSRA.js")).toBe(`${DIR}/chunk-FQKNJSRA.js`);
+        expect(resolveContainedFile(DIR, "studio.js.map")).toBe(`${DIR}/studio.js.map`);
+    });
+
+    it("rejects traversal, absolute escapes, nested paths, and control chars", () => {
+        expect.assertions(11);
+
+        // Anything that could read outside the standalone directory must resolve
+        // to `undefined` (the host then answers 404) — never a path outside `DIR`.
+        const rejected = [
+            "",
+            ".",
+            "..",
+            "../styles.css",
+            "../../etc/passwd",
+            "../../../../../../etc/passwd",
+            "/etc/passwd",
+            "foo/bar.js",
+            String.raw`a\b.js`,
+            "sub/chunk.js",
+            "chunk\0.js",
+        ];
+
+        for (const name of rejected) {
+            expect(resolveContainedFile(DIR, name)).toBeUndefined();
+        }
+    });
+});

--- a/packages/config/__tests__/studio-host/assets.test.ts
+++ b/packages/config/__tests__/studio-host/assets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveContainedFile } from "../../src/studio-host/assets";
+import { assetContentType, isStandaloneModulePath, resolveContainedFile } from "../../src/studio-host/assets";
 
 // A representative absolute standalone directory (as `@lunora/studio`'s
 // `dist/standalone` would resolve to). The guard is pure path math, so a fixed
@@ -38,5 +38,29 @@ describe("resolveContainedFile (studio standalone path-traversal guard)", () => 
         for (const name of rejected) {
             expect(resolveContainedFile(DIR, name)).toBeUndefined();
         }
+    });
+});
+
+describe("isStandaloneModulePath", () => {
+    it("matches the studio.js entry, chunks, and their maps — not the stylesheet or SPA routes", () => {
+        expect.assertions(6);
+
+        expect(isStandaloneModulePath("/studio.js")).toBe(true);
+        expect(isStandaloneModulePath("/__lunora/chunk-FQKNJSRA.js")).toBe(true);
+        expect(isStandaloneModulePath("/studio.js.map")).toBe(true);
+        expect(isStandaloneModulePath("/styles.css")).toBe(false);
+        expect(isStandaloneModulePath("/__lunora/data")).toBe(false);
+        expect(isStandaloneModulePath("/")).toBe(false);
+    });
+});
+
+describe("assetContentType", () => {
+    it("maps each served extension to its Content-Type", () => {
+        expect.assertions(4);
+
+        expect(assetContentType("styles.css")).toBe("text/css; charset=utf-8");
+        expect(assetContentType("studio.js.map")).toBe("application/json; charset=utf-8");
+        expect(assetContentType("studio.js")).toBe("text/javascript; charset=utf-8");
+        expect(assetContentType("chunk-ABCD1234.js")).toBe("text/javascript; charset=utf-8");
     });
 });

--- a/packages/config/src/studio-host/assets.ts
+++ b/packages/config/src/studio-host/assets.ts
@@ -1,5 +1,6 @@
 import { readFileSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname, isAbsolute, join, normalize, relative } from "node:path";
 
 import type { StudioAssets, WarnLogger } from "./types";
 
@@ -45,6 +46,78 @@ export const studioAssetsStamp = (resolveFrom: string = import.meta.url): number
         const stylesMtime = statSync(require.resolve("@lunora/studio/styles.css")).mtimeMs;
 
         return Math.max(scriptMtime, stylesMtime);
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Absolute path of the built standalone directory — `@lunora/studio`'s
+ * `dist/standalone`, where the `studio.js` entry and its code-split `chunk-*.js`
+ * siblings live — or `undefined` when the studio isn't installed/built. The
+ * standalone bundle is emitted with esbuild `splitting`, so the hosts must serve
+ * the whole directory (not two fixed paths); this resolves its root.
+ */
+export const resolveStandaloneDirectory = (resolveFrom: string = import.meta.url): string | undefined => {
+    try {
+        return dirname(createRequire(resolveFrom).resolve("@lunora/studio/standalone/studio.js"));
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Resolve a plain filename to an absolute path that is a **direct child** of
+ * `directory`, or `undefined` when the name would escape it. Pure path math (no
+ * I/O): the path-traversal guard behind {@link readStandaloneAsset}, extracted so
+ * it can be unit-tested directly. Rejects empty names, `.`/`..`, path separators,
+ * NUL, and any resolved path that isn't a lone segment inside `directory` (a
+ * parent escape, an absolute path, or a nested subdirectory).
+ */
+export const resolveContainedFile = (directory: string, fileName: string): string | undefined => {
+    // A servable asset is a lone filename: reject separators, NUL, and the `.`/`..`
+    // segments up front (a bare `..` has no separator, so guard it explicitly).
+    if (fileName === "" || fileName === "." || fileName === ".." || fileName.includes("/") || fileName.includes("\\") || fileName.includes("\0")) {
+        return undefined;
+    }
+
+    const resolved = normalize(join(directory, fileName));
+    const relativePath = relative(directory, resolved);
+
+    // Belt-and-suspenders after resolving: the result must be a non-empty lone
+    // segment directly under `directory` — no parent escape, no absolute path, no
+    // nested separator.
+    if (relativePath === "" || relativePath.startsWith("..") || isAbsolute(relativePath) || relativePath.includes("/") || relativePath.includes("\\")) {
+        return undefined;
+    }
+
+    return resolved;
+};
+
+/**
+ * Read a single file from the standalone directory by its plain filename (the
+ * `studio.js` entry, a `chunk-*.js`, or a `.map`). **Path-traversal-safe** via
+ * {@link resolveContainedFile}: only a lone filename resolving to a direct child
+ * of the standalone directory is served — any separator, `..`, NUL, or absolute
+ * path is rejected — so a request like `../../etc/passwd` can never escape it.
+ * Returns the bytes, or `undefined` when the studio isn't built or the name
+ * doesn't resolve to a file inside the directory (the host answers that 404).
+ */
+export const readStandaloneAsset = (fileName: string, resolveFrom: string = import.meta.url): Buffer | undefined => {
+    const directory = resolveStandaloneDirectory(resolveFrom);
+
+    if (directory === undefined) {
+        return undefined;
+    }
+
+    const resolved = resolveContainedFile(directory, fileName);
+
+    if (resolved === undefined) {
+        return undefined;
+    }
+
+    try {
+        return readFileSync(resolved);
     } catch {
         return undefined;
     }

--- a/packages/config/src/studio-host/assets.ts
+++ b/packages/config/src/studio-host/assets.ts
@@ -15,7 +15,7 @@ import type { StudioAssets, WarnLogger } from "./types";
  * a host package (`@lunora/vite` / `@lunora/cli`) that has `@lunora/studio`
  * installed — node walks up from the host's `dist` to find it.
  */
-const loadStudioAssets = (logger?: WarnLogger, resolveFrom: string = import.meta.url): StudioAssets | undefined => {
+export const loadStudioAssets = (logger?: WarnLogger, resolveFrom: string = import.meta.url): StudioAssets | undefined => {
     try {
         const require = createRequire(resolveFrom);
 
@@ -123,4 +123,28 @@ export const readStandaloneAsset = (fileName: string, resolveFrom: string = impo
     }
 };
 
-export default loadStudioAssets;
+/**
+ * True when `pathname` addresses a standalone JS module — the `studio.js` entry
+ * or one of its code-split `chunk-*.js` siblings (and their `.map`s). Shared by
+ * the CLI and Vite hosts so both route the same request shapes to the directory
+ * server; the stylesheet is matched separately at each host's own style path.
+ */
+export const isStandaloneModulePath = (pathname: string): boolean => pathname.endsWith(".js") || pathname.endsWith(".js.map");
+
+/**
+ * Content-Type for a served standalone asset, by extension: `.css` → CSS,
+ * `.map` → JSON (a source map), everything else (the `.js` entry + chunks) →
+ * JavaScript. Shared by the CLI and Vite hosts so the MIME decision lives in one
+ * place.
+ */
+export const assetContentType = (fileName: string): string => {
+    if (fileName.endsWith(".css")) {
+        return "text/css; charset=utf-8";
+    }
+
+    if (fileName.endsWith(".map")) {
+        return "application/json; charset=utf-8";
+    }
+
+    return "text/javascript; charset=utf-8";
+};

--- a/packages/config/src/studio-host/index.ts
+++ b/packages/config/src/studio-host/index.ts
@@ -13,7 +13,7 @@
  * load the prebuilt asset bytes.
  */
 export { parseDevVariable, resolveAdminToken } from "./admin-token";
-export { default as loadStudioAssets, readStandaloneAsset, resolveStandaloneDirectory, studioAssetsStamp } from "./assets";
+export { assetContentType, isStandaloneModulePath, loadStudioAssets, readStandaloneAsset, resolveStandaloneDirectory, studioAssetsStamp } from "./assets";
 export type { PolicyScaffoldBody, PolicyScaffoldRequest, PolicyScaffoldResponse, WirePolicyEdit } from "./policy-scaffold-handler";
 export { handlePolicyScaffoldRequest, POLICY_SCAFFOLD_ENDPOINT } from "./policy-scaffold-handler";
 export { default as renderStudioHtml } from "./render-html";

--- a/packages/config/src/studio-host/index.ts
+++ b/packages/config/src/studio-host/index.ts
@@ -13,7 +13,7 @@
  * load the prebuilt asset bytes.
  */
 export { parseDevVariable, resolveAdminToken } from "./admin-token";
-export { default as loadStudioAssets, studioAssetsStamp } from "./assets";
+export { default as loadStudioAssets, readStandaloneAsset, resolveStandaloneDirectory, studioAssetsStamp } from "./assets";
 export type { PolicyScaffoldBody, PolicyScaffoldRequest, PolicyScaffoldResponse, WirePolicyEdit } from "./policy-scaffold-handler";
 export { handlePolicyScaffoldRequest, POLICY_SCAFFOLD_ENDPOINT } from "./policy-scaffold-handler";
 export { default as renderStudioHtml } from "./render-html";

--- a/packages/studio/scripts/build-standalone.mjs
+++ b/packages/studio/scripts/build-standalone.mjs
@@ -8,7 +8,7 @@
 // Run after `packem build`. packem's extension depends on its `runtime` setting
 // (`browser` → `.js`, `node` → `.mjs`), so detect whichever it produced rather
 // than hard-coding one.
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { build } from "esbuild";
@@ -72,9 +72,28 @@ const baseOptions = {
 const probe = await build({ ...baseOptions, define: { "process.env.NODE_ENV": '"production"' }, write: false });
 const nodeEnv = probe.outputFiles.some((file) => file.text.includes("jsxDEV")) ? "development" : "production";
 
+// esbuild appends to `outdir` without cleaning it, so stale (content-hashed)
+// chunks from a previous build would pile up beside the current ones. Wipe the
+// directory first so it holds exactly the entry + the chunks this build emits —
+// what the three static hosts serve.
+rmSync(join(process.cwd(), "dist/standalone"), { force: true, recursive: true });
+
 await build({
     ...baseOptions,
-    outfile: "dist/standalone/studio.js",
+    // Code-split output (not a single `outfile`): the route-level
+    // `React.lazy(() => import(...))` boundaries in `app/studio.tsx` (and Home's
+    // lazy `recharts` sparkline) become separate `chunk-*.js` files loaded on
+    // demand. `splitting` + `outdir` require the esm format (already set) and a
+    // directory; `entryNames: "studio"` keeps the entry at the `studio.js` name
+    // the HTML `scriptSrc` and the host resolvers hardcode, and the chunks live
+    // beside it, imported by relative path so the static hosts serve them from
+    // the standalone directory. Heavy deps (`@xyflow/react`, `recharts`) end up
+    // only in on-demand chunks, never in Home's first load.
+    outdir: "dist/standalone",
+    splitting: true,
+    entryNames: "studio",
+    chunkNames: "chunk-[hash]",
+    assetNames: "asset-[hash]",
     // React libraries gate dev-only warnings/checks (and the jsx vs jsxDEV
     // runtime) on this; match it to what the bundle graph actually needs.
     define: { "process.env.NODE_ENV": JSON.stringify(nodeEnv) },

--- a/packages/studio/src/app/studio.tsx
+++ b/packages/studio/src/app/studio.tsx
@@ -11,7 +11,7 @@ import {
     useRouterState,
     useSearch,
 } from "@tanstack/react-router";
-import type { ReactElement, ReactNode } from "react";
+import type { ComponentType, ReactElement, ReactNode } from "react";
 import { createContext, lazy, Suspense, use, useEffect, useMemo } from "react";
 
 import BrandMark from "../components/brand-mark";
@@ -61,160 +61,63 @@ import { CommandPalette, openCommandPalette } from "./command-palette";
 // other ~30 panels — they load only when their tab is visited. The `React.lazy`
 // identities live at module scope so they stay stable across router rebuilds;
 // the routed `<Outlet>` is wrapped in `<Suspense>` (see {@link StudioLayout}).
-// Named exports are unwrapped to the shape `React.lazy` expects (`{ default }`);
-// default-exporting panels pass straight through.
-const InsightsPanel = lazy(() =>
-    import("../features/advisors/insights-panel").then((m) => {
-        return { default: m.InsightsPanel };
-    }),
-);
+//
+// `React.lazy` wants a `{ default }` module; {@link lazyNamed} unwraps a named
+// export to that shape (preserving the component's props), so the many
+// named-export panels stay one-liners. Default-exporting panels pass straight to
+// `lazy`. The literal `import("…")` specifier MUST stay inline in the loader —
+// esbuild's code-splitting keys off the static string, so never hoist it to a
+// variable.
+const lazyNamed = <P, K extends string>(load: () => Promise<Record<K, ComponentType<P>>>, key: K) =>
+    lazy(() =>
+        load().then((loaded) => {
+            return { default: loaded[key] };
+        }),
+    );
+
+const InsightsPanel = lazyNamed(() => import("../features/advisors/insights-panel"), "InsightsPanel");
 const RlsPanel = lazy(() => import("../features/advisors/rls-panel"));
 const SecurityAdvisorPanel = lazy(() => import("../features/advisors/security-advisor-panel"));
-const AnalyticsPanel = lazy(() =>
-    import("../features/analytics/analytics-panel").then((m) => {
-        return { default: m.AnalyticsPanel };
-    }),
-);
+const AnalyticsPanel = lazyNamed(() => import("../features/analytics/analytics-panel"), "AnalyticsPanel");
 const ApiTab = lazy(() => import("../features/api/api-tab"));
-const AuthConfigPanel = lazy(() =>
-    import("../features/auth/auth-config-panel").then((m) => {
-        return { default: m.AuthConfigPanel };
-    }),
-);
-const AuthSessionsPanel = lazy(() =>
-    import("../features/auth/auth-sessions-panel").then((m) => {
-        return { default: m.AuthSessionsPanel };
-    }),
-);
-const OrganizationsPanel = lazy(() =>
-    import("../features/auth/organizations-panel").then((m) => {
-        return { default: m.OrganizationsPanel };
-    }),
-);
-const UsersPanel = lazy(() =>
-    import("../features/auth/users-panel").then((m) => {
-        return { default: m.UsersPanel };
-    }),
-);
-const TableEditor = lazy(() =>
-    import("../features/data/table-editor").then((m) => {
-        return { default: m.TableEditor };
-    }),
-);
-const ExportImportPanel = lazy(() =>
-    import("../features/database/export-import").then((m) => {
-        return { default: m.ExportImportPanel };
-    }),
-);
-const MigrationsPanel = lazy(() =>
-    import("../features/database/migrations").then((m) => {
-        return { default: m.MigrationsPanel };
-    }),
-);
-const PitrPanel = lazy(() =>
-    import("../features/database/pitr-panel").then((m) => {
-        return { default: m.PitrPanel };
-    }),
-);
-const FlagsPanel = lazy(() =>
-    import("../features/flags/flags-panel").then((m) => {
-        return { default: m.FlagsPanel };
-    }),
-);
-const FunctionRunner = lazy(() =>
-    import("../features/functions/function-runner").then((m) => {
-        return { default: m.FunctionRunner };
-    }),
-);
-const FunctionStatsPanel = lazy(() =>
-    import("../features/functions/function-stats").then((m) => {
-        return { default: m.FunctionStatsPanel };
-    }),
-);
-const AuditPanel = lazy(() =>
-    import("../features/logs/audit-panel").then((m) => {
-        return { default: m.AuditPanel };
-    }),
-);
-const LogDrainsPanel = lazy(() =>
-    import("../features/logs/log-drains-panel").then((m) => {
-        return { default: m.LogDrainsPanel };
-    }),
-);
+const AuthConfigPanel = lazyNamed(() => import("../features/auth/auth-config-panel"), "AuthConfigPanel");
+const AuthSessionsPanel = lazyNamed(() => import("../features/auth/auth-sessions-panel"), "AuthSessionsPanel");
+const OrganizationsPanel = lazyNamed(() => import("../features/auth/organizations-panel"), "OrganizationsPanel");
+const UsersPanel = lazyNamed(() => import("../features/auth/users-panel"), "UsersPanel");
+const TableEditor = lazyNamed(() => import("../features/data/table-editor"), "TableEditor");
+const ExportImportPanel = lazyNamed(() => import("../features/database/export-import"), "ExportImportPanel");
+const MigrationsPanel = lazyNamed(() => import("../features/database/migrations"), "MigrationsPanel");
+const PitrPanel = lazyNamed(() => import("../features/database/pitr-panel"), "PitrPanel");
+const FlagsPanel = lazyNamed(() => import("../features/flags/flags-panel"), "FlagsPanel");
+const FunctionRunner = lazyNamed(() => import("../features/functions/function-runner"), "FunctionRunner");
+const FunctionStatsPanel = lazyNamed(() => import("../features/functions/function-stats"), "FunctionStatsPanel");
+const AuditPanel = lazyNamed(() => import("../features/logs/audit-panel"), "AuditPanel");
+const LogDrainsPanel = lazyNamed(() => import("../features/logs/log-drains-panel"), "LogDrainsPanel");
+// `logs-panel` re-exports several types alongside the component, which trips the
+// generic prop inference in `lazyNamed` (it mis-infers the panel's props). The
+// explicit unwrap keeps `LogsPanel`'s exact props type.
 const LogsPanel = lazy(() =>
     import("../features/logs/logs-panel").then((m) => {
         return { default: m.LogsPanel };
     }),
 );
-const MailPanel = lazy(() =>
-    import("../features/logs/mail-panel").then((m) => {
-        return { default: m.MailPanel };
-    }),
-);
-const SchedulePanel = lazy(() =>
-    import("../features/logs/schedule-panel").then((m) => {
-        return { default: m.SchedulePanel };
-    }),
-);
+const MailPanel = lazyNamed(() => import("../features/logs/mail-panel"), "MailPanel");
+const SchedulePanel = lazyNamed(() => import("../features/logs/schedule-panel"), "SchedulePanel");
 const SubscriptionsPanel = lazy(() => import("../features/logs/subscriptions-panel"));
-const KvBrowser = lazy(() =>
-    import("../features/kv/kv-browser").then((m) => {
-        return { default: m.KvBrowser };
-    }),
-);
-const PaymentsPanel = lazy(() =>
-    import("../features/payments/payments-panel").then((m) => {
-        return { default: m.PaymentsPanel };
-    }),
-);
-const PermissionsPanel = lazy(() =>
-    import("../features/permissions/permissions-panel").then((m) => {
-        return { default: m.PermissionsPanel };
-    }),
-);
+const KvBrowser = lazyNamed(() => import("../features/kv/kv-browser"), "KvBrowser");
+const PaymentsPanel = lazyNamed(() => import("../features/payments/payments-panel"), "PaymentsPanel");
+const PermissionsPanel = lazyNamed(() => import("../features/permissions/permissions-panel"), "PermissionsPanel");
 const QueuesPanel = lazy(() => import("../features/queues/queues-panel"));
 const DashboardsPanel = lazy(() => import("../features/reports/dashboards-panel"));
 const FanoutPanel = lazy(() => import("../features/reports/fanout-panel"));
-const HealthPanel = lazy(() =>
-    import("../features/reports/health-panel").then((m) => {
-        return { default: m.HealthPanel };
-    }),
-);
-const MetricsPanel = lazy(() =>
-    import("../features/reports/metrics-panel").then((m) => {
-        return { default: m.MetricsPanel };
-    }),
-);
-const SchemaViewer = lazy(() =>
-    import("../features/schema/schema-viewer").then((m) => {
-        return { default: m.SchemaViewer };
-    }),
-);
-const SettingsPanel = lazy(() =>
-    import("../features/settings/settings-panel").then((m) => {
-        return { default: m.SettingsPanel };
-    }),
-);
-const SqlEditorPanel = lazy(() =>
-    import("../features/sql/sql-editor-panel").then((m) => {
-        return { default: m.SqlEditorPanel };
-    }),
-);
-const FileBrowser = lazy(() =>
-    import("../features/storage/file-browser").then((m) => {
-        return { default: m.FileBrowser };
-    }),
-);
-const StorageRulesPanel = lazy(() =>
-    import("../features/storage/storage-rules-panel").then((m) => {
-        return { default: m.StorageRulesPanel };
-    }),
-);
-const VectorBrowser = lazy(() =>
-    import("../features/vectors/vector-browser").then((m) => {
-        return { default: m.VectorBrowser };
-    }),
-);
+const HealthPanel = lazyNamed(() => import("../features/reports/health-panel"), "HealthPanel");
+const MetricsPanel = lazyNamed(() => import("../features/reports/metrics-panel"), "MetricsPanel");
+const SchemaViewer = lazyNamed(() => import("../features/schema/schema-viewer"), "SchemaViewer");
+const SettingsPanel = lazyNamed(() => import("../features/settings/settings-panel"), "SettingsPanel");
+const SqlEditorPanel = lazyNamed(() => import("../features/sql/sql-editor-panel"), "SqlEditorPanel");
+const FileBrowser = lazyNamed(() => import("../features/storage/file-browser"), "FileBrowser");
+const StorageRulesPanel = lazyNamed(() => import("../features/storage/storage-rules-panel"), "StorageRulesPanel");
+const VectorBrowser = lazyNamed(() => import("../features/vectors/vector-browser"), "VectorBrowser");
 const WorkflowsPanel = lazy(() => import("../features/workflows/workflows-panel"));
 
 /** Identifier for each built-in studio tab. */

--- a/packages/studio/src/app/studio.tsx
+++ b/packages/studio/src/app/studio.tsx
@@ -12,7 +12,7 @@ import {
     useSearch,
 } from "@tanstack/react-router";
 import type { ReactElement, ReactNode } from "react";
-import { createContext, use, useEffect, useMemo } from "react";
+import { createContext, lazy, Suspense, use, useEffect, useMemo } from "react";
 
 import BrandMark from "../components/brand-mark";
 import { ErrorBoundary } from "../components/error-boundary";
@@ -38,45 +38,12 @@ import {
     useSidebar,
 } from "../components/ui/sidebar";
 import { Skeleton } from "../components/ui/skeleton";
-import { InsightsPanel } from "../features/advisors/insights-panel";
-import RlsPanel from "../features/advisors/rls-panel";
-import SecurityAdvisorPanel from "../features/advisors/security-advisor-panel";
-import { AnalyticsPanel } from "../features/analytics/analytics-panel";
-import ApiTab from "../features/api/api-tab";
-import { AuthConfigPanel } from "../features/auth/auth-config-panel";
-import { AuthSessionsPanel } from "../features/auth/auth-sessions-panel";
-import { OrganizationsPanel } from "../features/auth/organizations-panel";
-import { UsersPanel } from "../features/auth/users-panel";
-import { TableEditor } from "../features/data/table-editor";
-import { ExportImportPanel } from "../features/database/export-import";
-import { MigrationsPanel } from "../features/database/migrations";
-import { PitrPanel } from "../features/database/pitr-panel";
-import { FlagsPanel } from "../features/flags/flags-panel";
-import { FunctionRunner } from "../features/functions/function-runner";
-import { FunctionStatsPanel } from "../features/functions/function-stats";
+// Home stays a static (eager) import so the landing route paints synchronously;
+// every other feature panel is a route-level `React.lazy` boundary defined below
+// so it — and its heavy deps (`@xyflow/react`, `recharts`, the SQL editor, the
+// data grid) — loads in its own on-demand `chunk-*.js`, not in Home's first load.
 import { HomePanel } from "../features/home/home-panel";
-import { KvBrowser } from "../features/kv/kv-browser";
-import { AuditPanel } from "../features/logs/audit-panel";
-import { LogDrainsPanel } from "../features/logs/log-drains-panel";
-import { LogsPanel } from "../features/logs/logs-panel";
-import { MailPanel } from "../features/logs/mail-panel";
 import type { SchedulePanelProps } from "../features/logs/schedule-panel";
-import { SchedulePanel } from "../features/logs/schedule-panel";
-import SubscriptionsPanel from "../features/logs/subscriptions-panel";
-import { PaymentsPanel } from "../features/payments/payments-panel";
-import { PermissionsPanel } from "../features/permissions/permissions-panel";
-import QueuesPanel from "../features/queues/queues-panel";
-import DashboardsPanel from "../features/reports/dashboards-panel";
-import FanoutPanel from "../features/reports/fanout-panel";
-import { HealthPanel } from "../features/reports/health-panel";
-import { MetricsPanel } from "../features/reports/metrics-panel";
-import { SchemaViewer } from "../features/schema/schema-viewer";
-import { SettingsPanel } from "../features/settings/settings-panel";
-import { SqlEditorPanel } from "../features/sql/sql-editor-panel";
-import { FileBrowser } from "../features/storage/file-browser";
-import { StorageRulesPanel } from "../features/storage/storage-rules-panel";
-import { VectorBrowser } from "../features/vectors/vector-browser";
-import WorkflowsPanel from "../features/workflows/workflows-panel";
 import useStudioFeatures from "../hooks/use-studio-features";
 import { useT } from "../i18n/i18n-context";
 import { StudioI18nProvider } from "../i18n/i18n-provider";
@@ -86,6 +53,169 @@ import { fireAndForget } from "../lib/internal";
 import type { FunctionDescriptor } from "../lib/types";
 import { cn } from "../lib/utils";
 import { CommandPalette, openCommandPalette } from "./command-palette";
+
+// Route-level lazy panels. Each becomes its own on-demand `chunk-*.js` under
+// `dist/standalone/` (esbuild `splitting` in `scripts/build-standalone.mjs`),
+// so a user landing on Home never downloads the SQL editor, the data grid, the
+// schema diagram (`@xyflow/react`), the reports charts (`recharts`), or the
+// other ~30 panels — they load only when their tab is visited. The `React.lazy`
+// identities live at module scope so they stay stable across router rebuilds;
+// the routed `<Outlet>` is wrapped in `<Suspense>` (see {@link StudioLayout}).
+// Named exports are unwrapped to the shape `React.lazy` expects (`{ default }`);
+// default-exporting panels pass straight through.
+const InsightsPanel = lazy(() =>
+    import("../features/advisors/insights-panel").then((m) => {
+        return { default: m.InsightsPanel };
+    }),
+);
+const RlsPanel = lazy(() => import("../features/advisors/rls-panel"));
+const SecurityAdvisorPanel = lazy(() => import("../features/advisors/security-advisor-panel"));
+const AnalyticsPanel = lazy(() =>
+    import("../features/analytics/analytics-panel").then((m) => {
+        return { default: m.AnalyticsPanel };
+    }),
+);
+const ApiTab = lazy(() => import("../features/api/api-tab"));
+const AuthConfigPanel = lazy(() =>
+    import("../features/auth/auth-config-panel").then((m) => {
+        return { default: m.AuthConfigPanel };
+    }),
+);
+const AuthSessionsPanel = lazy(() =>
+    import("../features/auth/auth-sessions-panel").then((m) => {
+        return { default: m.AuthSessionsPanel };
+    }),
+);
+const OrganizationsPanel = lazy(() =>
+    import("../features/auth/organizations-panel").then((m) => {
+        return { default: m.OrganizationsPanel };
+    }),
+);
+const UsersPanel = lazy(() =>
+    import("../features/auth/users-panel").then((m) => {
+        return { default: m.UsersPanel };
+    }),
+);
+const TableEditor = lazy(() =>
+    import("../features/data/table-editor").then((m) => {
+        return { default: m.TableEditor };
+    }),
+);
+const ExportImportPanel = lazy(() =>
+    import("../features/database/export-import").then((m) => {
+        return { default: m.ExportImportPanel };
+    }),
+);
+const MigrationsPanel = lazy(() =>
+    import("../features/database/migrations").then((m) => {
+        return { default: m.MigrationsPanel };
+    }),
+);
+const PitrPanel = lazy(() =>
+    import("../features/database/pitr-panel").then((m) => {
+        return { default: m.PitrPanel };
+    }),
+);
+const FlagsPanel = lazy(() =>
+    import("../features/flags/flags-panel").then((m) => {
+        return { default: m.FlagsPanel };
+    }),
+);
+const FunctionRunner = lazy(() =>
+    import("../features/functions/function-runner").then((m) => {
+        return { default: m.FunctionRunner };
+    }),
+);
+const FunctionStatsPanel = lazy(() =>
+    import("../features/functions/function-stats").then((m) => {
+        return { default: m.FunctionStatsPanel };
+    }),
+);
+const AuditPanel = lazy(() =>
+    import("../features/logs/audit-panel").then((m) => {
+        return { default: m.AuditPanel };
+    }),
+);
+const LogDrainsPanel = lazy(() =>
+    import("../features/logs/log-drains-panel").then((m) => {
+        return { default: m.LogDrainsPanel };
+    }),
+);
+const LogsPanel = lazy(() =>
+    import("../features/logs/logs-panel").then((m) => {
+        return { default: m.LogsPanel };
+    }),
+);
+const MailPanel = lazy(() =>
+    import("../features/logs/mail-panel").then((m) => {
+        return { default: m.MailPanel };
+    }),
+);
+const SchedulePanel = lazy(() =>
+    import("../features/logs/schedule-panel").then((m) => {
+        return { default: m.SchedulePanel };
+    }),
+);
+const SubscriptionsPanel = lazy(() => import("../features/logs/subscriptions-panel"));
+const KvBrowser = lazy(() =>
+    import("../features/kv/kv-browser").then((m) => {
+        return { default: m.KvBrowser };
+    }),
+);
+const PaymentsPanel = lazy(() =>
+    import("../features/payments/payments-panel").then((m) => {
+        return { default: m.PaymentsPanel };
+    }),
+);
+const PermissionsPanel = lazy(() =>
+    import("../features/permissions/permissions-panel").then((m) => {
+        return { default: m.PermissionsPanel };
+    }),
+);
+const QueuesPanel = lazy(() => import("../features/queues/queues-panel"));
+const DashboardsPanel = lazy(() => import("../features/reports/dashboards-panel"));
+const FanoutPanel = lazy(() => import("../features/reports/fanout-panel"));
+const HealthPanel = lazy(() =>
+    import("../features/reports/health-panel").then((m) => {
+        return { default: m.HealthPanel };
+    }),
+);
+const MetricsPanel = lazy(() =>
+    import("../features/reports/metrics-panel").then((m) => {
+        return { default: m.MetricsPanel };
+    }),
+);
+const SchemaViewer = lazy(() =>
+    import("../features/schema/schema-viewer").then((m) => {
+        return { default: m.SchemaViewer };
+    }),
+);
+const SettingsPanel = lazy(() =>
+    import("../features/settings/settings-panel").then((m) => {
+        return { default: m.SettingsPanel };
+    }),
+);
+const SqlEditorPanel = lazy(() =>
+    import("../features/sql/sql-editor-panel").then((m) => {
+        return { default: m.SqlEditorPanel };
+    }),
+);
+const FileBrowser = lazy(() =>
+    import("../features/storage/file-browser").then((m) => {
+        return { default: m.FileBrowser };
+    }),
+);
+const StorageRulesPanel = lazy(() =>
+    import("../features/storage/storage-rules-panel").then((m) => {
+        return { default: m.StorageRulesPanel };
+    }),
+);
+const VectorBrowser = lazy(() =>
+    import("../features/vectors/vector-browser").then((m) => {
+        return { default: m.VectorBrowser };
+    }),
+);
+const WorkflowsPanel = lazy(() => import("../features/workflows/workflows-panel"));
 
 /** Identifier for each built-in studio tab. */
 type StudioTab =
@@ -699,6 +829,22 @@ const StudioSidebar = ({ chrome, connected, current, groupLabel, groups, selectT
 };
 
 /**
+ * Skeleton shown while a route resolves — the brief first paint after mount, a
+ * lazy panel's chunk streaming in (the {@link Suspense} fallback below), and any
+ * future panel with a router loader — so the content area never flashes empty.
+ * Renders inside the layout's panel region during navigation.
+ */
+const RoutePending = (): ReactElement => (
+    <div className="flex flex-col gap-4" data-testid="dash-pending">
+        <div className="flex items-center gap-2">
+            <Skeleton className="h-8 w-40" />
+            <Skeleton className="h-8 w-24" />
+        </div>
+        <Skeleton className="h-72 w-full" />
+    </div>
+);
+
+/**
  * Persistent shell rendered by the router's root route: the grouped sidebar
  * ({@link StudioSidebar}) and the routed panel area (`&lt;Outlet />`). The active
  * tab is derived from the URL, so deep links and the browser back/forward
@@ -935,7 +1081,12 @@ const StudioLayout = (): ReactElement => {
                             label={tabLabel[current]}
                             retryLabel={t("Try again")}
                         >
-                            <Outlet />
+                            {/* Every routed panel except Home is a `React.lazy` boundary, so its
+                                chunk streams in behind this Suspense fallback; Home (the index
+                                route) is eager and paints without suspending. */}
+                            <Suspense fallback={<RoutePending />}>
+                                <Outlet />
+                            </Suspense>
                         </ErrorBoundary>
                     </div>
                 </div>
@@ -943,21 +1094,6 @@ const StudioLayout = (): ReactElement => {
         </SidebarProvider>
     );
 };
-
-/**
- * Skeleton shown while a route resolves — the brief first paint after mount and
- * any future panel with a router loader — so the content area never flashes
- * empty. Renders inside the layout's panel region during navigation.
- */
-const RoutePending = (): ReactElement => (
-    <div className="flex flex-col gap-4" data-testid="dash-pending">
-        <div className="flex items-center gap-2">
-            <Skeleton className="h-8 w-40" />
-            <Skeleton className="h-8 w-24" />
-        </div>
-        <Skeleton className="h-72 w-full" />
-    </div>
-);
 
 /**
  * Schema tab wrapper that lifts the optional `?table=&lt;name>` search param off

--- a/packages/studio/src/features/home/home-panel.tsx
+++ b/packages/studio/src/features/home/home-panel.tsx
@@ -1,8 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import type { ReactElement, ReactNode } from "react";
+import { lazy, Suspense } from "react";
 
-import { Bar, EvilBarChart } from "../../components/evilcharts/charts/bar-chart";
-import type { ChartConfig } from "../../components/evilcharts/ui/chart";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
 import { EmptyState } from "../../components/ui/empty-state";
@@ -14,6 +13,15 @@ import { fireAndForget, formatBytes } from "../../lib/internal";
 import { cn } from "../../lib/utils";
 import { deriveInsights } from "../advisors/derive-insights";
 import { BindingsOverview } from "./bindings-overview";
+
+// The stat-card sparkline is Home's only `recharts` consumer. Lazy-loading it
+// keeps the (heavy) chart engine out of the studio's entry bundle — Home's
+// structure paints immediately and each sparkline streams in on its own chunk.
+const Sparkline = lazy(() =>
+    import("./sparkline").then((m) => {
+        return { default: m.Sparkline };
+    }),
+);
 
 interface HomePanelProps {
     /** Shard key the health digest targets on first load. Defaults to the root shard. */
@@ -55,32 +63,6 @@ interface StatDelta {
     readonly positive: boolean;
     readonly text: string;
 }
-
-/** Series colour for the stat-card sparkline (the foreground var already flips per theme). */
-const SPARKLINE_CONFIG = { value: { colors: { dark: ["var(--foreground)"], light: ["var(--foreground)"] }, label: "" } } satisfies ChartConfig;
-
-/** A compact monochrome bar sparkline (evilcharts) drawn from a numeric series (oldest → newest). */
-const Sparkline = ({ data }: { readonly data: ReadonlyArray<number> }): ReactElement | null => {
-    const bars = data.slice(-16);
-
-    // A single point can't read as a trend (and renders as one fat block), so a
-    // sparkline only shows once there are at least a few buckets.
-    if (bars.length < 3) {
-        return null;
-    }
-
-    const rows = bars.map((value, index) => {
-        return { index, value };
-    });
-
-    return (
-        <div aria-hidden="true" className="h-8 w-28">
-            <EvilBarChart animationType="none" barCategoryGap={1} className="h-8 w-full" config={SPARKLINE_CONFIG} data={rows}>
-                <Bar dataKey="value" />
-            </EvilBarChart>
-        </div>
-    );
-};
 
 /** Sum a metrics-history field per minute bucket, oldest first — the series a sparkline draws. */
 const bucketSeries = (history: MetricsSnapshot["history"], field: "calls" | "errors"): number[] => {
@@ -148,7 +130,11 @@ const StatCard = ({
                         <span className="text-2xl font-semibold tabular-nums text-foreground">{value}</span>
                         {unit !== undefined && <span className="text-xs text-muted-foreground">{unit}</span>}
                     </span>
-                    {trend !== undefined && <Sparkline data={trend} />}
+                    {trend !== undefined && (
+                        <Suspense fallback={<div aria-hidden="true" className="h-8 w-28" />}>
+                            <Sparkline data={trend} />
+                        </Suspense>
+                    )}
                 </div>
             </div>
             {delta == null ? (

--- a/packages/studio/src/features/home/sparkline.tsx
+++ b/packages/studio/src/features/home/sparkline.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement } from "react";
+
+import { Bar, EvilBarChart } from "../../components/evilcharts/charts/bar-chart";
+import type { ChartConfig } from "../../components/evilcharts/ui/chart";
+
+/** Series colour for the stat-card sparkline (the foreground var already flips per theme). */
+const SPARKLINE_CONFIG = { value: { colors: { dark: ["var(--foreground)"], light: ["var(--foreground)"] }, label: "" } } satisfies ChartConfig;
+
+/**
+ * A compact monochrome bar sparkline (evilcharts) drawn from a numeric series
+ * (oldest → newest). Split into its own module so the Home panel can lazy-load
+ * it: `recharts` (the chart engine behind evilcharts) is the studio's heaviest
+ * client dep, and this is Home's only consumer of it, so deferring it keeps the
+ * chart engine off the studio's entry bundle — Home's structure paints first and
+ * each sparkline streams in on its own chunk.
+ */
+export const Sparkline = ({ data }: { readonly data: ReadonlyArray<number> }): ReactElement | null => {
+    const bars = data.slice(-16);
+
+    // A single point can't read as a trend (and renders as one fat block), so a
+    // sparkline only shows once there are at least a few buckets.
+    if (bars.length < 3) {
+        return null;
+    }
+
+    const rows = bars.map((value, index) => {
+        return { index, value };
+    });
+
+    return (
+        <div aria-hidden="true" className="h-8 w-28">
+            <EvilBarChart animationType="none" barCategoryGap={1} className="h-8 w-full" config={SPARKLINE_CONFIG} data={rows}>
+                <Bar dataKey="value" />
+            </EvilBarChart>
+        </div>
+    );
+};

--- a/packages/vite/__tests__/studio-plugin.test.ts
+++ b/packages/vite/__tests__/studio-plugin.test.ts
@@ -193,8 +193,10 @@ describe("studioPlugin", () => {
         const headers = Object.fromEntries((response.setHeader as ReturnType<typeof vi.fn>).mock.calls as [string, string][]);
 
         // Unhashed URL → revalidate every load so a rebuild is never shadowed.
+        // The ETag is keyed on the requested file (not just its kind) so each
+        // chunk revalidates independently — so `studio.js` yields `W/"studio.js-…"`.
         expect(headers["Cache-Control"]).toBe("no-cache");
-        expect(headers.ETag).toMatch(/^W\/"js-/);
+        expect(headers.ETag).toMatch(/^W\/"studio\.js-/);
 
         const second = makeResponse();
 

--- a/packages/vite/src/studio-plugin.ts
+++ b/packages/vite/src/studio-plugin.ts
@@ -14,6 +14,7 @@ import {
     handleSeedRequest,
     loadStudioAssets,
     POLICY_SCAFFOLD_ENDPOINT,
+    readStandaloneAsset,
     renderStudioHtml,
     resolveAdminToken,
     SCHEMA_EDIT_ENDPOINT,
@@ -251,14 +252,16 @@ const createStudioHandler = (
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime value can be undefined on a mocked server even though the type says string
     const projectRoot = server.config.root ?? process.cwd();
 
-    // Serve a static studio asset (script/styles), re-reading from disk when a
-    // mid-session `@lunora/studio` rebuild changes the bytes.
+    // Serve a static studio asset — the compiled stylesheet, the `studio.js`
+    // entry, or one of its on-demand `chunk-*.js` code-split siblings — re-reading
+    // from disk when a mid-session `@lunora/studio` rebuild changes the bytes.
     //
-    // The assets sit at stable, unhashed URLs, so the browser would heuristically
-    // cache them and shadow a picked-up rebuild until a hard-reload (this once
-    // masked a fixed render loop behind a stale bundle). Send `no-cache` + a
-    // stamp-derived `ETag` so the browser must revalidate: unchanged assets cost
-    // a cheap `304`, a rebuild is always fetched fresh.
+    // The entry + stylesheet sit at stable, unhashed URLs, so the browser would
+    // heuristically cache them and shadow a picked-up rebuild until a hard-reload
+    // (this once masked a fixed render loop behind a stale bundle). Send `no-cache`
+    // + a `${file}-${stamp}` ETag so the browser must revalidate: an unchanged
+    // asset costs a cheap `304`, a rebuild (new stamp, new chunk names) is always
+    // fetched fresh.
     const serveStaticAsset = (pathname: string, request: IncomingMessage, response: ServerResponse): void => {
         const stamp = studioAssetsStamp();
 
@@ -275,9 +278,11 @@ const createStudioHandler = (
             return;
         }
 
-        const isScript = pathname === STUDIO_SCRIPT_PATH;
-        const assetKind = isScript ? "js" : "css";
-        const etag = stamp === undefined ? undefined : `W/"${assetKind}-${String(stamp)}"`;
+        const isStyle = pathname === STUDIO_STYLE_PATH;
+        // Key the ETag on the requested file (not just its kind) so each chunk
+        // revalidates independently; the rebuild stamp busts them all at once.
+        const fileName = pathname.slice(pathname.lastIndexOf("/") + 1);
+        const etag = stamp === undefined ? undefined : `W/"${fileName}-${String(stamp)}"`;
 
         response.setHeader("Cache-Control", "no-cache");
 
@@ -293,7 +298,28 @@ const createStudioHandler = (
             }
         }
 
-        sendOk(response, isScript ? assets.script : assets.styles, isScript ? "text/javascript; charset=utf-8" : "text/css; charset=utf-8");
+        if (isStyle) {
+            sendOk(response, assets.styles, "text/css; charset=utf-8");
+
+            return;
+        }
+
+        // `.js` / `.js.map` under the mount: serve the request's basename from the
+        // standalone directory. `readStandaloneAsset` is path-traversal-safe (lone
+        // filenames only), so `/__lunora/../../etc/passwd` can't escape it; an
+        // unknown name answers 404 rather than the SPA document (which would hand a
+        // module request an HTML body).
+        const bytes = readStandaloneAsset(fileName);
+
+        if (bytes === undefined) {
+            response.statusCode = 404;
+            response.setHeader("Content-Type", "text/plain");
+            response.end("Not found");
+
+            return;
+        }
+
+        sendOk(response, bytes, pathname.endsWith(".map") ? "application/json; charset=utf-8" : "text/javascript; charset=utf-8");
     };
 
     return (request: IncomingMessage, response: ServerResponse, next: () => void): void => {
@@ -352,10 +378,13 @@ const createStudioHandler = (
             return;
         }
 
-        // Static assets are exact paths; every other route under the mount is an
-        // SPA route and gets the history fallback (the document) below, so a hard
-        // load of a deep link like `/__lunora/data` boots the router there.
-        if (pathname === STUDIO_SCRIPT_PATH || pathname === STUDIO_STYLE_PATH) {
+        // Static assets: the stylesheet plus every `.js` / `.js.map` under the
+        // mount — the `studio.js` entry and its code-split `chunk-*.js` siblings
+        // (an unknown module name 404s inside `serveStaticAsset`). Every other
+        // route under the mount is an SPA route and gets the history fallback (the
+        // document) below, so a hard load of a deep link like `/__lunora/data`
+        // boots the router there.
+        if (pathname === STUDIO_STYLE_PATH || pathname.endsWith(".js") || pathname.endsWith(".js.map")) {
             serveStaticAsset(pathname, request, response);
 
             return;

--- a/packages/vite/src/studio-plugin.ts
+++ b/packages/vite/src/studio-plugin.ts
@@ -9,9 +9,11 @@ import type { AddressInfo } from "node:net";
 import { detectAgentRules } from "@lunora/config";
 import type { LocalEndpointHandler, StudioAssets } from "@lunora/config/studio-host";
 import {
+    assetContentType,
     handlePolicyScaffoldRequest,
     handleSchemaEditRequest,
     handleSeedRequest,
+    isStandaloneModulePath,
     loadStudioAssets,
     POLICY_SCAFFOLD_ENDPOINT,
     readStandaloneAsset,
@@ -319,7 +321,7 @@ const createStudioHandler = (
             return;
         }
 
-        sendOk(response, bytes, pathname.endsWith(".map") ? "application/json; charset=utf-8" : "text/javascript; charset=utf-8");
+        sendOk(response, bytes, assetContentType(fileName));
     };
 
     return (request: IncomingMessage, response: ServerResponse, next: () => void): void => {
@@ -384,7 +386,7 @@ const createStudioHandler = (
         // route under the mount is an SPA route and gets the history fallback (the
         // document) below, so a hard load of a deep link like `/__lunora/data`
         // boots the router there.
-        if (pathname === STUDIO_STYLE_PATH || pathname.endsWith(".js") || pathname.endsWith(".js.map")) {
+        if (pathname === STUDIO_STYLE_PATH || isStandaloneModulePath(pathname)) {
             serveStaticAsset(pathname, request, response);
 
             return;


### PR DESCRIPTION
## What & why

The studio (the biggest package) was bundled by a hand-rolled esbuild script into a **single** `dist/standalone/studio.js` and served as one static asset. Every one of its ~35 feature panels was statically imported and eagerly instantiated (`component: () => panels[tab]`), so a user landing on **Home** downloaded and parsed the entire studio — the SQL editor, the data grid, the schema diagram (`@xyflow/react`), the reports charts (`recharts`), every panel — before first interaction, even though Home needs none of them.

This makes each panel and its heavy deps load **on demand**.

## What splits

- **Lazy boundaries** (`app/studio.tsx`): the eager panels element map becomes route-level `React.lazy(() => import(...))` components; the routed `<Outlet>` is wrapped in `<Suspense>`. **Home + the shell stay eager** (synchronous first paint, per the existing `indexRoute` comment).
- **Home's `recharts` leaf**: Home's only `recharts` consumer (the stat-card sparkline) was extracted into a lazily-loaded `home/sparkline.tsx`, so the chart engine leaves Home's first load too while Home's structure still paints immediately.

## esbuild + serving changes

- **`scripts/build-standalone.mjs`**: switched from a single `outfile` to `splitting: true` + `outdir`, with `entryNames: "studio"` so the entry stays `studio.js` (the HTML `scriptSrc` and the host resolvers hardcode it) and `chunk-*.js` siblings land beside it, imported by **relative** path. The outdir is wiped first so stale content-hashed chunks don't accumulate. The `dist/index.js` / `dist/mount.js` **library** outputs are untouched and still build.
- **Three hosts** now serve the standalone **directory** (entry + chunks + `.js.map`), not two fixed paths:
  - `@lunora/cli` `studio-server.ts`, `@lunora/vite` `studio-plugin.ts` (under `/__lunora`), and `@lunora/config` `studio-host/assets.ts` (`readStandaloneAsset` + `resolveStandaloneDirectory`).
  - `/styles.css` keeps its existing handling; the per-request freshness stamp / ETag is preserved; unknown or escaping names get a **404** (never the SPA document).

## Chunk inspection (verification)

Emitted `dist/standalone/`: `studio.js` entry (**~560kb**, down from a single ~2.5mb file) + **88** `chunk-*.js`, all ESM, entry references chunks by relative path only.

Static-import closure from the entry = **26 files** (the Home-path eager set). Heavy deps are outside it:
- `recharts` → only in `chunk-FQKNJSRA.js` (~474kb) — **not** in the Home-path set.
- `@xyflow/react` → only in `chunk-YTT6Z5ZY.js` (~228kb) — **not** in the Home-path set.

So Home's first load drops ~700kb of heavy deps; they load only when Schema / Reports (or Home's sparkline) are visited.

## Path-traversal safety

Each host resolves the request **basename** against the standalone dir and reads it through `readStandaloneAsset`, which is built on a pure `resolveContainedFile` guard: it rejects empty names, `.`/`..`, path separators, NUL, absolute paths, and anything that doesn't resolve to a direct child of the directory. Verified end-to-end: `studio.js` and a real `chunk-*.js` serve their bytes; `../styles.css`, `../../etc/passwd`, `..`, `/etc/passwd`, `sub/x.js`, and an unknown chunk all resolve to `undefined` → 404.

## Tests

- `@lunora/config`: a pure unit test for the traversal guard (`resolveContainedFile`).
- `@lunora/cli`: a `startStudioServer` case asserting a traversal `.js` request never leaks a file.

## Gates (all green)

`@lunora/studio` build (emits `studio.js` + `chunk-*.js`), `lint:types`, `lint:eslint`; `@lunora/cli` / `@lunora/vite` / `@lunora/config` `lint:types`; new config + cli tests pass. (The studio Vitest suite is not run — jsdom hangs in this sandbox.)

## Reviewer note — please smoke-test the dev studio

The sandbox can't run a live dev server, so **a reviewer must manually smoke-test the dev studio** (`lunora dev` and/or a plain `vite` with the plugin): open the Network tab, confirm Home does **not** fetch the schema-diagram / recharts chunks, and that navigating to Schema / Reports lazy-loads them with no 404s / white screen. "Chunks 404 in one host" is the most likely regression.

## Conflicts

Edits `packages/studio/src/app/studio.tsx`, which **plan 112 (studio-containers, separate branch)** also edits (adds a route) — **conflicts with the studio-containers PR on `studio.tsx`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio standalone now serves split JavaScript chunks and their source maps on-demand.
  * Home now lazy-loads its trend sparkline to improve perceived responsiveness.

* **Bug Fixes**
  * Missing standalone assets now return proper 404s (with safer path handling).
  * Static responses’ caching validation is more accurate per requested file.

* **Performance**
  * Studio UI now lazy-loads most panels behind a loading skeleton.
  * Standalone builds are cleaned before rebuilding to prevent stale output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->