### PR TITLE
fix(runtime): harden review findings from PR #92

### DIFF
--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -216,6 +216,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": true,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -521,6 +521,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": true,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -167,6 +167,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -564,6 +564,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -343,6 +343,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -186,6 +186,7 @@ const LUNORA_STORAGE_RULES: StorageRulesResult = {
 const LUNORA_STUDIO_FEATURES: StudioFeaturesResult = {
     "analytics": false,
     "auth": false,
+    "containers": false,
     "flags": false,
     "kv": false,
     "mail": false,

--- a/packages/auth/__tests__/create-auth.test.ts
+++ b/packages/auth/__tests__/create-auth.test.ts
@@ -235,6 +235,14 @@ describe("createAuth — secure-by-default hardening", () => {
         expect(auth.options.advanced?.useSecureCookies).toBe(false);
     });
 
+    it("treats the scheme case-insensitively (HTTP:// is still plain http)", () => {
+        expect.assertions(1);
+
+        const auth = createAuth({ baseURL: "HTTP://localhost:8787", secret: "s".repeat(32) });
+
+        expect(auth.options.advanced?.useSecureCookies).toBe(false);
+    });
+
     it("defaults useSecureCookies on when baseURL is unset (Workers serve HTTPS in prod)", () => {
         expect.assertions(1);
 

--- a/packages/auth/src/create-auth.ts
+++ b/packages/auth/src/create-auth.ts
@@ -58,7 +58,9 @@ const isHttpsBaseUrl = (baseURL: BetterAuthOptions["baseURL"]): boolean => {
  */
 const isExplicitHttpBaseUrl = (baseURL: BetterAuthOptions["baseURL"]): boolean => {
     if (typeof baseURL === "string") {
-        return baseURL.startsWith("http://");
+        // Scheme comparison is case-insensitive (RFC 3986): `HTTP://…` is
+        // still plain HTTP and must not slip through as "secure".
+        return baseURL.toLowerCase().startsWith("http://");
     }
 
     if (baseURL && typeof baseURL === "object") {
@@ -70,7 +72,7 @@ const isExplicitHttpBaseUrl = (baseURL: BetterAuthOptions["baseURL"]): boolean =
             return false;
         }
 
-        return typeof baseURL.fallback === "string" && baseURL.fallback.startsWith("http://");
+        return typeof baseURL.fallback === "string" && baseURL.fallback.toLowerCase().startsWith("http://");
     }
 
     return false;

--- a/packages/runtime/__tests__/auth-admin.test.ts
+++ b/packages/runtime/__tests__/auth-admin.test.ts
@@ -203,6 +203,39 @@ describe("createWorker — auth admin mutation endpoints", () => {
         expect(response.status).toBe(403);
     });
 
+    it("maps a known client-input code to its 4xx and an unmapped backend failure to 500", async () => {
+        expect.assertions(4);
+
+        const plane = authAdmin();
+        const banUser = vi.mocked(plane.banUser as NonNullable<AuthAdmin["banUser"]>);
+
+        banUser.mockImplementationOnce(async () => {
+            throw Object.assign(new Error("nope"), { code: "USER_NOT_FOUND" });
+        });
+        banUser.mockImplementationOnce(async () => {
+            throw Object.assign(new Error("driver exploded"), { code: "SQLITE_IOERR" });
+        });
+
+        const error = vi.spyOn(console, "error").mockImplementation(() => {});
+        const worker = createWorker({ adminToken: ADMIN_TOKEN, authAdmin: plane, shardDO: noopNamespace });
+
+        const notFound = await worker.fetch(post("https://app.example/_lunora/admin/auth/users/ban", { userId: "u1" }), {}, fakeContext);
+
+        expect(notFound.status).toBe(404);
+
+        // An unmapped code is a backend failure, not client input — it must
+        // read as a server incident (500), never a 400.
+        const backend = await worker.fetch(post("https://app.example/_lunora/admin/auth/users/ban", { userId: "u1" }), {}, fakeContext);
+        const body: { error: { code: string; message: string } } = await backend.json();
+
+        expect(backend.status).toBe(500);
+        expect(body.error.code).toBe("SQLITE_IOERR");
+        // The driver detail is logged server-side, never sent to the client.
+        expect(body.error.message).not.toContain("driver exploded");
+
+        error.mockRestore();
+    });
+
     it("reports AUTH_OP_NOT_SUPPORTED when the plane omits the mutation", async () => {
         expect.assertions(2);
 

--- a/packages/runtime/__tests__/security-headers.test.ts
+++ b/packages/runtime/__tests__/security-headers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { decorateResponse, enforceOrigin, handleCorsPreflight, resolveSecurity } from "../src/security-headers";
 
@@ -20,6 +20,25 @@ describe("resolveSecurity", () => {
         expect.hasAssertions();
 
         expect(() => resolveSecurity({ cors: { allowedOrigins: ["*"], allowCredentials: true } })).toThrow(/wildcard/i);
+    });
+
+    it("warns for a custom allowedOrigins predicate, with or without credentials", () => {
+        expect.assertions(3);
+
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        // The predicate feeds the CSRF/WS origin trust even without credentials.
+        resolveSecurity({ cors: { allowedOrigins: () => true } });
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("predicate"));
+
+        warn.mockClear();
+        resolveSecurity({ cors: { allowCredentials: true, allowedOrigins: () => true } });
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("allowCredentials"));
+        expect(warn).toHaveBeenCalledTimes(1);
+
+        warn.mockRestore();
     });
 
     it("allows a wildcard origin without credentials", () => {

--- a/packages/runtime/src/auth-admin-routes.ts
+++ b/packages/runtime/src/auth-admin-routes.ts
@@ -155,7 +155,7 @@ interface AuthRouteDescriptor {
 
 const AUTH_BASE = "/_lunora/admin/auth";
 
-/** HTTP status for an `authAdmin` error code; everything else falls back to 400. */
+/** HTTP status for a known client-input `authAdmin` error code; an unmapped code is a backend failure and reads 500. */
 const AUTH_ADMIN_ERROR_STATUS: Record<string, number> = {
     PASSWORD_TOO_LONG: 400,
     PASSWORD_TOO_SHORT: 400,
@@ -445,7 +445,10 @@ const buildAuthAdminRoutes = (deps: AuthAdminRouteDeps): Record<string, (request
             // eslint-disable-next-line no-console -- server-side diagnostic for a swallowed backend error
             console.error("[lunora] auth admin operation failed:", error);
 
-            throw new LunoraError("auth admin operation failed", { code, status: AUTH_ADMIN_ERROR_STATUS[code] ?? 400 });
+            // An unmapped code is an unexpected backend/DB failure, not client
+            // input — reporting it as 400 would hide operational incidents from
+            // admin tooling. Extend AUTH_ADMIN_ERROR_STATUS for new 4xx codes.
+            throw new LunoraError("auth admin operation failed", { code, status: AUTH_ADMIN_ERROR_STATUS[code] ?? 500 });
         }
     };
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -453,15 +453,19 @@ interface WorkerOptions {
     /**
      * Opt into an authorization-open posture for sharded and fan-out access.
      *
-     * By default (this flag unset/`false`) the runtime FAILS CLOSED: when
-     * neither {@link WorkerOptions.authorizeShard} nor {@link WorkerOptions.authorizeFanOut}
-     * is configured, naming a non-default shard (a potential cross-tenant hop)
-     * or sending a fan-out envelope is rejected with a `403`
-     * (`FORBIDDEN_SHARD`/`FORBIDDEN_FANOUT`). Set this to `true` to allow such
-     * requests from any caller (including unauthenticated ones) — appropriate
-     * only when every table is protected by per-row RLS. The runtime then emits
-     * a single `console.warn` so the open posture stays visible in logs. Has no
-     * effect once an `authorize*` callback is configured (those gate directly).
+     * By default (this flag unset/`false`) the runtime FAILS CLOSED per
+     * operation: naming a non-default shard (a potential cross-tenant hop) is
+     * rejected with a `403` (`FORBIDDEN_SHARD`) unless
+     * {@link WorkerOptions.authorizeShard} is configured, and a fan-out
+     * envelope is rejected (`FORBIDDEN_FANOUT`) unless
+     * {@link WorkerOptions.authorizeFanOut} is. Set this to `true` to allow
+     * such requests from any caller (including unauthenticated ones) —
+     * appropriate only when every table is protected by per-row RLS. The
+     * runtime then emits a single `console.warn` so the open posture stays
+     * visible in logs. The flag is consulted per operation: it has no effect
+     * on an operation whose own `authorize*` callback is configured (that
+     * callback gates directly), but configuring only one of the two callbacks
+     * does NOT cover the other operation.
      *
      * NOTE: this is a behaviour change from earlier alphas, where the same
      * situation was warn-once-then-allow. Apps that relied on client-chosen

--- a/packages/runtime/src/security-headers.ts
+++ b/packages/runtime/src/security-headers.ts
@@ -238,20 +238,20 @@ const resolveCors = (input: CorsOptions | false | undefined): ResolvedCors => {
         isAllowed = origins;
         isExplicitlyAllowed = origins;
 
-        // A predicate bypasses the array path's wildcard+credentials guard: if the
-        // predicate is over-broad (e.g. `() => true`, or a loose `endsWith`), it
-        // reflects any Origin *with* credentials — the exact "any site can read
-        // authed responses / forge state changes" combo the array path forbids at
-        // construction. We can't statically prove a predicate is safe, so warn
-        // loudly so an accidental `() => true` + credentials doesn't ship silently.
-        if (allowCredentials) {
-            // eslint-disable-next-line no-console -- surface a dangerous CORS combination at construction
-            console.warn(
-                "@lunora/runtime: security.cors combines a custom `allowedOrigins` predicate with `allowCredentials: true`. " +
-                    "Ensure the predicate matches ONLY trusted origins by exact equality — an over-broad predicate (e.g. `() => true`, " +
-                    "or `endsWith`/`includes` checks) reflects any origin with credentials, defeating the allowlist and the CSRF guard.",
-            );
-        }
+        // A predicate bypasses the array path's wildcard+credentials guard, and it
+        // is also assigned to `isExplicitlyAllowed` above — meaning the CSRF and
+        // WebSocket origin checks trust it even when CORS credentials are off. An
+        // over-broad predicate (e.g. `() => true`, or a loose `endsWith`) therefore
+        // admits cookie-bearing form posts and WS upgrades from any origin — and,
+        // with `allowCredentials: true`, additionally reflects any Origin with
+        // credentials (the exact combo the array path forbids at construction).
+        // We can't statically prove a predicate is safe, so warn loudly either way.
+        const credentialsNote = allowCredentials ? " AND reflects matching origins with credentials (`allowCredentials: true`)" : "";
+
+        // eslint-disable-next-line no-console -- surface a security-sensitive CORS configuration at construction
+        console.warn(
+            `@lunora/runtime: security.cors uses a custom \`allowedOrigins\` predicate. It is trusted by the CSRF and WebSocket origin checks${credentialsNote} — ensure it matches ONLY trusted origins by exact equality; an over-broad predicate (e.g. \`() => true\`, or \`endsWith\`/\`includes\` checks) defeats the allowlist.`,
+        );
     } else {
         const originsList = origins;
 


### PR DESCRIPTION
CodeRabbit's review of #92 surfaced four findings in files that PR no longer touches after its rebase — the code merged to `alpha` via #90. Fixed here directly against `alpha`:

- **@lunora/auth** — the secure-cookie default's scheme check is now case-insensitive: `HTTP://…` / `Http://…` are still plain HTTP and no longer slip through as "secure" (RFC 3986 schemes are case-insensitive). Test added.
- **@lunora/runtime (auth admin)** — an unmapped `authAdmin` error code now maps to **500** instead of 400: unknown backend/DB failures must read as server incidents, not client input. Known client-input codes keep their 4xx; the driver detail stays server-side. Test added covering both paths.
- **@lunora/runtime (CORS)** — the custom `allowedOrigins` predicate warning now fires with or without `allowCredentials`: the predicate is also assigned to `isExplicitlyAllowed`, so the CSRF and WebSocket origin checks trust it even when CORS credentials are off. The message calls out the credentials reflection only when it applies. Test added.
- **@lunora/runtime (docs)** — `allowUnauthenticatedShardAccess`'s doc now states the gate is per operation: configuring only `authorizeShard` or only `authorizeFanOut` does not cover the other operation (matches the actual `guardUnauthenticatedShardAccess` call sites).

A fifth finding (Stripe `payment_status` fail-closed) is already fixed on `alpha`.

Verified: auth 156 + runtime 464 tests green, `tsc` + ESLint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AhADYYkG7x9F77GHMw9Tw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mixed-case `HTTP://` base URLs so insecure URLs are recognized correctly.
  * Improved error handling for admin operations so unexpected backend errors return a server error instead of a client error.
  * Updated CORS warnings to show more consistently when using a custom allowed-origins rule.

* **Documentation**
  * Clarified security-related behavior for unauthenticated shard access and origin checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->