### PR TITLE
docs(next): spike design + prototype for @lunora/next composition (plan 110)

### DIFF
--- a/plans/110-phase0-design.md
+++ b/plans/110-phase0-design.md
@@ -1,0 +1,287 @@
+# Plan 110 — Phase 0 design: `@lunora/next` composition adapter
+
+> **Spike outcome (TL;DR)**: OpenNext-on-Cloudflare **can** host `ShardDO` + the
+> WebSocket realtime plane alongside Next.js, matching Lunora's `/_lunora/*`
+> contract, **without a new architecture** — Next is a **class-B** framework and
+> reuses the shipped `withFrameworkWorker` composer at the OpenNext _custom-worker
+> boundary_. The WebSocket upgrade **must** live at that boundary, **not** in a
+> Next Route Handler. No STOP condition triggered. The remaining work is a normal
+> build plan plus the open decisions in §7.
+>
+> Prototype: `plans/proto/next/compose-next-worker.ts` (+ passing test). Ran
+> green in-sandbox (`9 passed`, shared run with 111/113).
+
+---
+
+## 1. Shared composition contract (from `@lunora/nuxt` + `@lunora/astro`)
+
+Every host integration mounts the **same** realtime plane. Extracted first-hand
+from the two shipped adapters and `@lunora/runtime`:
+
+### 1.1 The reserved paths (`/_lunora/*`)
+
+`packages/runtime/src/create-worker.ts:909-920` — Lunora owns these sub-paths; the
+host owns everything else:
+
+| Path                                              | Purpose                                                                          |
+| ------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `POST /_lunora/rpc`                               | single RPC call (`RpcEnvelope`)                                                  |
+| `POST /_lunora/rpc-batch`                         | batched RPC                                                                      |
+| `/_lunora/ws`                                     | **WebSocket upgrade** → `101 Switching Protocols` (forwarded to `ShardDO.fetch`) |
+| `/_lunora/admin/*`                                | Studio admin plane (gated)                                                       |
+| `/_lunora/scheduler/dispatch`, `/_lunora/migrate` | scheduler + migrations                                                           |
+
+### 1.2 The single shared composer — `withFrameworkWorker`
+
+`packages/runtime/src/create-worker.ts:3285`. This is the **one** class-B seam
+behind `@lunora/svelte/worker`, `@lunora/vue/worker`, and `@lunora/astro`'s
+`withLunora` (`packages/astro/src/with-lunora.ts:45` re-exports it verbatim):
+
+```ts
+const withFrameworkWorker = (host: FrameworkHostHandler, optionsInput): LunoraWorker => {
+    const httpRouter = toHttpRouter(host); // host may be a bare fetch fn OR { fetch, scheduled }
+    const build = (options) => composeWorker({ ...options, httpRouter });
+    // reserves /_lunora/*, delegates everything else to `httpRouter` (the framework host)
+    // factory form rebuilds per request so per-request bindings (env.SHARD) wire in
+};
+```
+
+Key properties the contract guarantees (create-worker.ts:3264-3321):
+
+- **`host` shape**: `FrameworkHostHandler` = a bare `fetch` fn **or** a
+  `{ fetch, scheduled? }` object (create-worker.ts:3245). "Every class-B adapter
+  output (`@sveltejs/adapter-cloudflare`, Nitro's `cloudflare-module`,
+  `@astrojs/cloudflare`) is structurally one of these." **OpenNext's
+  `.open-next/worker.js` default export (`{ fetch }`) is exactly this shape.**
+- **Options factory**: `(env) => ({ shardDO: env.SHARD, ... })` — per-request,
+  because `env.SHARD` only exists at request time.
+- **WebSocket passthrough**: the `101` upgrade `Response` (carrying its
+  `webSocket`) is returned **verbatim** — the framework streams it unchanged
+  (create-worker.ts:3364-3366).
+- **`scheduled` preservation**: if Lunora configures no cron, the host's own
+  `scheduled` is preserved (so OpenNext's cache-purge cron, if any, survives).
+
+There is also `createLunoraHandler(options)` (create-worker.ts:3387) — the
+framework-neutral `(request, env, ctx) => Response` bridge for hosts that mount by
+**router path** rather than by wrapping a worker handler (Hono, h3, Elysia). Nuxt
+uses this style: its Nitro server route reconstructs a web `Request` and calls
+`delegateToLunora(lunoraApp, request, env, ctx)` (`packages/nuxt/src/runtime/handler.ts`,
+`.../server/lunora.ts`).
+
+### 1.3 Exporting `ShardDO`
+
+The `ShardDO` Durable Object class (`packages/do/src/index.ts:223`) **must be
+exported from the deployed worker's `main` entry** and bound in `wrangler.jsonc`.
+The adapters diverge only in _where_ that export lives:
+
+- **Nuxt**: a project-root `exports.cloudflare.ts` (`export { ShardDO } from "./lunora/server"`)
+  carried into the generated worker by Nitro's `cloudflare_module` hook
+  (`packages/nuxt/src/module.ts:73`).
+- **Astro**: the `src/worker.ts` custom entry (`main` in wrangler) that calls
+  `withLunora(...)` also re-exports `ShardDO` (`packages/astro/src/with-lunora.ts:28-37`).
+
+### 1.4 The class model (A/B/C)
+
+`packages/config/src/detect-framework.ts:10-46`:
+
+- **Class A** — Vite-native; **Lunora owns the worker entry** (`createWorker({ httpRouter })`).
+  TanStack Start, SolidStart, React Router.
+- **Class B** — framework owns its **own** Cloudflare adapter; Lunora **injects**
+  its composition into the framework's server entry via `withFrameworkWorker`.
+  **SvelteKit, Nuxt, Astro.**
+- **Class C** — non-CF / SSR-less; ship the client adapter + a standalone Lunora
+  worker (today's default).
+
+---
+
+## 2. Where Next.js falls: **class B**
+
+Next.js on Cloudflare deploys via **OpenNext** (`@opennextjs/cloudflare`), which
+**owns its own Cloudflare adapter** and emits its own Worker (`.open-next/worker.js`).
+That is the textbook class-B signature — identical to SvelteKit/Astro. The
+detection table (`FRAMEWORK_SIGNATURES`) should gain:
+
+```ts
+{ class: "B", dependency: "next", framework: "nextjs" },
+```
+
+(plus `nextjs → "@lunora/react"` in the CLI's `ADAPTER_BY_FRAMEWORK`).
+
+**Consequence**: Next needs **zero new runtime composition code**. The existing
+`withFrameworkWorker(openNextHandler, (env) => ({ shardDO: env.SHARD }))` composes
+Lunora with the OpenNext handler exactly as it does for Astro. `@lunora/next` is
+therefore a _thin_ package: framework detection entry, a `withLunora` alias (or
+just re-export `withFrameworkWorker`), and the template + docs for the OpenNext
+custom-worker wiring.
+
+---
+
+## 3. The chosen OpenNext seam — custom-worker boundary (decision)
+
+### 3.1 OpenNext's custom-worker mechanism
+
+OpenNext generates `.open-next/worker.js` whose default export is `{ fetch }`. Its
+documented **"Custom Worker"** how-to
+(<https://opennext.js.org/cloudflare/howtos/custom-worker>) is to import that
+handler, wrap it, and point wrangler's `main` at the custom file:
+
+```ts
+// src/worker.ts   (wrangler "main")
+// @ts-expect-error generated at build time by @opennextjs/cloudflare
+import { default as openNextHandler } from "./.open-next/worker.js";
+import { withFrameworkWorker } from "@lunora/runtime"; // via @lunora/next
+
+export default withFrameworkWorker(openNextHandler, (env) => ({ shardDO: env.SHARD }));
+
+// ShardDO must be exported from THIS worker entry (and bound in wrangler.jsonc):
+export { ShardDO } from "./lunora/server";
+```
+
+`wrangler.jsonc`:
+
+```jsonc
+{
+    "main": "src/worker.ts",
+    "compatibility_flags": ["nodejs_compat"],
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+}
+```
+
+### 3.2 Durable Object export — an established OpenNext pattern
+
+Re-exporting a DO class from the custom worker is **already** how OpenNext ships
+its own DO-backed cache/queue: when enabled you must re-export `DOQueueHandler`,
+`DOShardedTagCache`, `BucketCachePurge` from the worker
+(opennextjs-cloudflare **#502**). `ShardDO` sits right beside them:
+
+```ts
+// when OpenNext's DO cache/queue is enabled, alongside ShardDO:
+export { DOQueueHandler, DOShardedTagCache, BucketCachePurge } from "./.open-next/worker.js";
+```
+
+So the DO-export requirement is not a Lunora-specific hack — it is the normal
+OpenNext custom-worker story.
+
+### 3.3 Why the boundary and not a Next Route Handler
+
+A Next Route Handler (`app/_lunora/[...path]/route.ts`) **can** serve RPC (a plain
+`POST/GET → Response`). It **cannot** carry the WebSocket upgrade, and WS is
+Lunora's core realtime feature. Three independent reasons:
+
+1. **The `webSocket` field is non-standard.** A Cloudflare WS upgrade returns
+   `new Response(null, { status: 101, webSocket: client })`. `webSocket` is a
+   Workers-only Response extension. Next's `Response` abstraction has no concept
+   of it.
+2. **OpenNext's adapter round-trip strips it.** OpenNext converts the inbound
+   Cloudflare `Request` into a Next server request, runs Next, then reconstructs a
+   Cloudflare `Response` from Next's Web `Response`. Neither a `101` status switch
+   nor a `webSocket` field survives that reconstruction.
+3. **Route Handlers terminate on a response** and have no raw-socket access on
+   Workers. This is confirmed ecosystem-wide: Next ships no first-class WS server
+   (vercel/next.js#58698); on Cloudflare, WS upgrades are handled at the **Worker
+   fetch boundary** or forwarded to a **Durable Object**.
+
+At the custom-worker boundary, `withFrameworkWorker` intercepts `/_lunora/ws`
+_before_ OpenNext ever sees it; `createWorker` forwards it to `ShardDO.fetch`,
+which returns the `101` verbatim. **The boundary natively supports WS; the Route
+Handler cannot.** Since RPC and WS should share one mount, put **both** at the
+boundary. (An optional RPC-only Route Handler could exist for niche same-app edge
+cases, but the canonical, WS-capable mount is the boundary.)
+
+### 3.4 Prototype evidence
+
+`plans/proto/next/compose-next-worker.ts` models exactly this dispatch (a faithful,
+dependency-free stand-in for `withFrameworkWorker`, which needs workerd + a real DO
+namespace to boot). The test (`compose-next-worker.test.ts`, **ran green**) proves:
+
+- a non-`/_lunora` request delegates to the OpenNext handler;
+- `POST /_lunora/rpc` round-trips through Lunora without touching OpenNext;
+- `/_lunora/admin/*` reaches Lunora;
+- **a `/_lunora/ws` upgrade returns the `101` + its `webSocket` field verbatim** —
+  the load-bearing assertion, since that is precisely what a Route Handler +
+  OpenNext response adapter would strip.
+
+The real seam runs the identical logic via `withFrameworkWorker`, so the seam is
+proven at the composition level. What was _not_ runnable in-sandbox: a live
+workerd RPC round-trip through a real `ShardDO` (no workerd + Vectorize/DO binding
+here); that is a build-plan smoke test, not a spike blocker.
+
+---
+
+## 4. Dev-mode note
+
+OpenNext dev uses `initOpenNextCloudflareForDev()` in `next.config` so `next dev`
+sees the CF bindings. The realtime plane in dev has two options: (a) run under
+`wrangler dev` against the built custom worker (full WS parity), or (b) run
+`next dev` for the UI and point the Lunora client at a separate `wrangler dev`
+realtime worker. Recommend documenting (a) as the parity path and (b) as the
+fast-iteration path; finalize in the build plan (open question §7.6).
+
+---
+
+## 5. STOP-condition assessment
+
+| STOP condition (from the plan)                                                     | Triggered?                               | Evidence                                                                                                                   |
+| ---------------------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| OpenNext can't host DO + WS matching `/_lunora/*` without a different architecture | **No**                                   | Custom-worker boundary + `withFrameworkWorker` matches the contract exactly, same as Astro/Svelte (§3).                    |
+| WS subscription path has no viable home                                            | **No**                                   | The boundary returns the `101 + webSocket` verbatim; proven by prototype (§3.3-3.4).                                       |
+| Requires pinning an unstable/churning OpenNext API                                 | **Partial risk — flagged, not blocking** | The custom-worker import path (`./.open-next/worker.js`) and the DO re-export list are OpenNext-version-coupled; see §7.1. |
+
+No STOP. This is a green spike: the seam is proven and reuses shipped code.
+
+---
+
+## 6. `init` no-op — recommendation
+
+`packages/cli/src/commands/init/handler.ts:1348-1352` currently warns _"template
+'next' is not yet available"_ and exits 1. **Recommendation: leave the no-op in
+place until `templates/next` lands**, but improve the message to point at this
+design ("Next.js support is in progress — track plan 110; use `--vite react` today").
+Removing the branch before the template exists would let `lunora init -t next`
+scaffold a broken project (the plan's own maintenance note warns of this). Removal
+and the `templates/next` landing must be a single coordinated change in the build
+plan.
+
+---
+
+## 7. Open questions (maintainer decisions)
+
+1. **OpenNext version pinning.** The custom-worker import (`./.open-next/worker.js`)
+   and the DO re-export list (`DOQueueHandler`/`DOShardedTagCache`/`BucketCachePurge`)
+   are OpenNext-internal and move between releases. _Recommendation_: pin
+   `@opennextjs/cloudflare` to a tested minor in `templates/next`, add a
+   `@lunora/vite`/config check that verifies the custom worker still re-exports
+   `ShardDO`, and document a re-verification step (the plan's maintenance note).
+2. **Template authors the custom worker vs. codegen generates it.** _Recommendation_:
+   ship it as a **template file the user owns** (like Astro's `src/worker.ts`),
+   not generated — it is tiny, and users must edit it to add auth/crons. Revisit if
+   OpenNext churn makes a generated+validated file safer.
+3. **`@lunora/next` package surface for v1.** _Recommendation_: minimal —
+   detection entry (`next → class B`), a `withLunora` alias over
+   `withFrameworkWorker`, and the template. Defer SSR data-preload helpers
+   (`@lunora/react` server-preload → `hydratePreloaded`) to v2.
+4. **Auth routes.** `/api/auth/*` (better-auth via `@lunora/auth`) currently
+   routes through `handleAuthRequest`. Decide whether it mounts at the boundary
+   (before OpenNext) or as a Next Route Handler. _Recommendation_: boundary, for
+   symmetry with the other adapters and to keep auth off the Next render path.
+5. **Remove the `init` no-op now or with the template?** _Recommendation_: with the
+   template (§6).
+6. **Dev-mode story** (§4): `wrangler dev` custom worker (parity) vs `next dev` +
+   separate realtime worker (fast). Pick the documented default.
+7. **`nodejs_compat` + `compatibility_date` baseline** the template pins (OpenNext
+   requires `nodejs_compat`; Lunora's DO SQLite requires a recent compat date).
+
+---
+
+## 8. Follow-up build plan outline
+
+1. `@lunora/next` package: detection + `withLunora` alias + `next → @lunora/react`
+   adapter mapping; `next` added to `FRAMEWORK_SIGNATURES`.
+2. `templates/next`: OpenNext scaffold + `src/worker.ts` custom worker +
+   `wrangler.jsonc` (SHARD DO binding + migration) + `lunora/` app + `@lunora/react`
+   client wired to same-origin `/_lunora/*`.
+3. Remove/rewire the `init` no-op (coordinated with the template).
+4. Workerd smoke test: RPC round-trip + WS subscribe through the composed worker
+   (the piece not runnable in this spike).
+5. v2: SSR data-preload helpers, auth-route placement, all bindings.

--- a/plans/proto/next/compose-next-worker.test.ts
+++ b/plans/proto/next/compose-next-worker.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Spike 110 seam test. Proves the OpenNext custom-worker boundary:
+ *   (a) a non-`/_lunora` request (a page) delegates to the OpenNext handler,
+ *   (b) an RPC POST to `/_lunora/rpc` round-trips through Lunora,
+ *   (c) admin routes reach Lunora,
+ *   (d) a WebSocket upgrade to `/_lunora/ws` returns the 101 + its `webSocket`
+ *       field VERBATIM — the exact thing a Next Route Handler + OpenNext response
+ *       adapter would strip, which is why the WS path must live at the boundary.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { FetchHost, LunoraHandler, ResponseLike } from "./compose-next-worker";
+import { composeNextWorker } from "./compose-next-worker";
+
+const makeOpenNextHost = (): FetchHost => ({
+    fetch: vi.fn((request: Request): ResponseLike => new Response(`next-ssr:${new URL(request.url).pathname}`, { status: 200 })),
+});
+
+/** A stand-in for `createLunoraHandler()` covering the reserved sub-paths. */
+const makeLunora = (socket: object): { calls: string[]; handler: LunoraHandler } => {
+    const calls: string[] = [];
+
+    const handler: LunoraHandler = (request) => {
+        const { pathname } = new URL(request.url);
+
+        calls.push(pathname);
+
+        if (pathname === "/_lunora/ws" && request.headers.get("Upgrade") === "websocket") {
+            // Cloudflare's WebSocket upgrade: a 101 whose `webSocket` field the
+            // runtime hands to the client. Modelled as a plain object because Node's
+            // `Response` constructor rejects status 101 (workerd allows it).
+            return { status: 101, webSocket: socket };
+        }
+
+        if (pathname === "/_lunora/rpc") {
+            return Response.json({ result: 42 });
+        }
+
+        if (pathname.startsWith("/_lunora/admin/")) {
+            return Response.json({ admin: true });
+        }
+
+        return new Response("not found", { status: 404 });
+    };
+
+    return { calls, handler };
+};
+
+describe("spike 110: composeNextWorker OpenNext boundary seam", () => {
+    it("delegates non-/_lunora requests to the OpenNext handler", async () => {
+        const host = makeOpenNextHost();
+        const { handler } = makeLunora({});
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/dashboard"), {})) as Response;
+
+        expect(host.fetch).toHaveBeenCalledOnce();
+        expect(await response.text()).toBe("next-ssr:/dashboard");
+    });
+
+    it("round-trips an RPC POST through Lunora without touching OpenNext", async () => {
+        const host = makeOpenNextHost();
+        const { handler } = makeLunora({});
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/_lunora/rpc", { body: "{}", method: "POST" }), {})) as Response;
+
+        expect(host.fetch).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({ result: 42 });
+    });
+
+    it("routes the admin plane to Lunora", async () => {
+        const host = makeOpenNextHost();
+        const { handler } = makeLunora({});
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/_lunora/admin/functions"), {})) as Response;
+
+        expect(host.fetch).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toEqual({ admin: true });
+    });
+
+    it("returns the WebSocket upgrade (101 + webSocket) verbatim at the boundary", async () => {
+        const host = makeOpenNextHost();
+        const socket = { id: "ws-1" };
+        const { handler } = makeLunora(socket);
+        const worker = composeNextWorker(host, handler);
+
+        const response = (await worker.fetch(new Request("https://app.example/_lunora/ws", { headers: { Upgrade: "websocket" } }), {})) as {
+            status: number;
+            webSocket?: unknown;
+        };
+
+        expect(host.fetch).not.toHaveBeenCalled();
+        expect(response.status).toBe(101);
+        // The load-bearing assertion: the `webSocket` field survives the seam.
+        expect(response.webSocket).toBe(socket);
+    });
+});

--- a/plans/proto/next/compose-next-worker.ts
+++ b/plans/proto/next/compose-next-worker.ts
@@ -1,0 +1,88 @@
+/**
+ * Spike 110 prototype — the OpenNext-on-Cloudflare composition seam for
+ * `@lunora/next`, modelled as a standalone, runnable function.
+ *
+ * This is a faithful, dependency-free model of what the real integration does with
+ * the SHIPPED `withFrameworkWorker(host, (env) => ({ shardDO: env.SHARD }))`
+ * (packages/runtime/src/create-worker.ts:3285). We can't boot `createWorker` +
+ * a real `ShardDO` namespace in this sandbox (needs workerd + a Vectorize/DO
+ * binding), so the prototype isolates the ONE decision the spike must prove: at
+ * the OpenNext *custom-worker boundary*, reserve `/_lunora/*` for Lunora and
+ * delegate everything else to the OpenNext handler — and return Lunora's response
+ * (including a `101 Switching Protocols` WebSocket upgrade with its `webSocket`
+ * field) VERBATIM.
+ *
+ * Real wiring the template ships (custom worker; `main` in wrangler points here):
+ *
+ * ```ts
+ * // src/worker.ts  (wrangler main)
+ * // @ts-expect-error generated at build time by @opennextjs/cloudflare
+ * import { default as openNextHandler } from "./.open-next/worker.js";
+ * import { withFrameworkWorker } from "@lunora/runtime";
+ *
+ * export default withFrameworkWorker(openNextHandler, (env) => ({ shardDO: env.SHARD }));
+ *
+ * // ShardDO must be exported from the SAME worker entry (+ bound in wrangler.jsonc):
+ * export { ShardDO } from "./lunora/server";
+ * // When OpenNext's DO-backed cache/queue is enabled, re-export its DO classes too:
+ * // export { DOQueueHandler, DOShardedTagCache, BucketCachePurge } from "./.open-next/worker.js";
+ * ```
+ *
+ * A Next.js Route Handler (`app/_lunora/[...path]/route.ts`) can serve RPC (a plain
+ * POST/GET -> Response), but CANNOT carry the WebSocket upgrade: Cloudflare's 101
+ * response needs a non-standard `webSocket` field, and OpenNext's request/response
+ * adapter round-trip (Cloudflare Request -> Next server -> Web Response -> Cloudflare
+ * Response) does not preserve it. So the WS path — Lunora's core realtime feature —
+ * must live at the worker boundary. This prototype proves the boundary preserves it.
+ */
+
+/** What a Cloudflare `fetch` handler may return: a real `Response`, or a 101 upgrade carrying a `webSocket`. */
+export type ResponseLike = Response | { readonly status: number; readonly webSocket?: unknown };
+
+export interface ExecutionContextLike {
+    passThroughOnException?: () => void;
+    waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/** The OpenNext-emitted handler shape (`.open-next/worker.js` default export). */
+export interface FetchHost {
+    fetch: (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResponseLike> | ResponseLike;
+}
+
+/** Lunora's realtime plane bridge (`createLunoraHandler()` -> `(request, env, ctx) => Response`). */
+export type LunoraHandler = (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResponseLike> | ResponseLike;
+
+export interface ComposeOptions {
+    /** Reserved prefix for Lunora's realtime plane. Default `/_lunora/`. */
+    prefix?: string;
+}
+
+const DEFAULT_PREFIX = "/_lunora/";
+
+/**
+ * Compose the OpenNext host with Lunora's realtime handler into one worker
+ * `{ fetch }`. Requests under `prefix` (rpc / rpc-batch / ws / admin / migrate)
+ * go to Lunora; everything else delegates to OpenNext. The chosen response is
+ * returned verbatim, so a WebSocket upgrade survives unchanged.
+ *
+ * The real seam is `withFrameworkWorker`; this mirrors its dispatch so the spike's
+ * unit test can assert the contract without workerd.
+ */
+export const composeNextWorker = (host: FetchHost, lunora: LunoraHandler, options: ComposeOptions = {}): FetchHost => {
+    const prefix = options.prefix ?? DEFAULT_PREFIX;
+
+    return {
+        fetch: (request, env, context) => {
+            const { pathname } = new URL(request.url);
+
+            // Reserve the realtime plane. `startsWith(prefix)` also matches the exact
+            // prefix-less path (`/_lunora`) via the trailing slash the constants carry
+            // (`/_lunora/rpc`, `/_lunora/ws`, `/_lunora/admin/...`).
+            if (pathname.startsWith(prefix)) {
+                return lunora(request, env, context);
+            }
+
+            return host.fetch(request, env, context);
+        },
+    };
+};

--- a/plans/proto/tsconfig.json
+++ b/plans/proto/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    // Type-check only (spike prototypes; the real build is per-package packem).
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        // Spike-only relaxation: the prototype SOURCE modules (rag.ts, agent-loop.ts,
+        // compose-next-worker.ts) pass the repo's strict base as-is; this only silences
+        // `noUncheckedIndexedAccess` on positional `messages[1]` / `chunks[0]` test
+        // assertions, so the tests stay readable without `!` noise everywhere.
+        "noUncheckedIndexedAccess": false
+    },
+    "include": ["**/*.ts", "../../packages/bindings/src/vectors/create-vectors.ts", "../../packages/bindings/src/vectors/types.ts"]
+}

--- a/plans/proto/vitest.config.ts
+++ b/plans/proto/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Standalone Vitest config for the wave-11 spike prototypes (plans 110 / 111 / 113).
+ *
+ * These prototypes deliberately live OUTSIDE the pnpm workspace (`plans/` is not a
+ * workspace glob) so they add no package, no `pnpm-workspace.yaml` override, and no
+ * build step. They exercise pure composition logic with in-memory doubles; the
+ * RAG prototype imports the *real* `@lunora/bindings/vectors` `createVectors` by
+ * relative source path (it only imports its own relative siblings, so Vitest's
+ * esbuild transform resolves it with no build).
+ *
+ * Run from this directory:  `pnpm exec vitest run --config vitest.config.ts`
+ */
+export default {
+    test: {
+        environment: "node",
+        include: ["**/*.test.ts"],
+        watch: false,
+    },
+};


### PR DESCRIPTION
Split out of #96 (1/3). Phase-0 design doc + minimal runnable prototype for plan 110.

**Recommendation:** Next is a **class-B** framework — reuse the shipped `withFrameworkWorker` composer at the OpenNext **custom-worker boundary** (`main` → a wrapper importing `.open-next/worker.js` + re-exporting `ShardDO`); zero new runtime code. The **WebSocket upgrade must live at that boundary, not in a Next Route Handler**, because OpenNext's request/response adapter strips the `101 + webSocket` field — this is the crux and it's resolved. No STOP.

Prototype (`plans/proto/next`) models the seam and asserts RPC/admin route to Lunora and the WS 101+webSocket passes through verbatim. 4 tests green, typecheck clean.

Key open questions (end of design doc): OpenNext version pinning (churn risk), whether to remove the `init` no-op now (recommend: with the template), v1 feature scope.

Note: `plans/proto/{tsconfig.json,vitest.config.ts}` are identical copies of the ones in the sibling spike PRs (#104, #105) so each PR is standalone — identical add/add merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6