### PR TITLE
docs(ai): spike design + PoC for ctx.rag over ai.embed + vectors (plan 111)

### DIFF
--- a/plans/111-phase0-design.md
+++ b/plans/111-phase0-design.md
@@ -1,0 +1,257 @@
+# Plan 111 — Phase 0 design: first-class RAG helper (`ctx.ai.embed` + `ctx.vectors`)
+
+> **Spike outcome (TL;DR)**: The two primitives compose **cleanly** into an
+> index→retrieve helper with **no change** to `@lunora/ai` or
+> `@lunora/bindings/vectors` public surfaces — so **no STOP**. Recommended shape:
+> a `defineRag(config)` helper shipped as an **`@lunora/ai/rag` subpath** (a thin
+> library, _not_ a new binding or codegen-wired `ctx.rag`), callable as
+> `defineRag({...})(ctx).{index,retrieve}`. It respects the Vectorize `topK`
+> ceilings and the namespace/metadata constraints, and its `retrieve` return shape
+> is designed for the plan-113 agent memory step to consume directly.
+>
+> Prototype: `plans/proto/rag/rag.ts` (+ passing test over the **real**
+> `createVectors`). Ran green in-sandbox.
+
+---
+
+## 1. The two primitives, precisely (what the helper composes)
+
+### 1.1 Embedding — from `@lunora/ai`
+
+`ctx.ai` (`LunoraAi`, `packages/ai/src/types.ts:83-98`) exposes:
+
+```ts
+model: (model?: ModelInput) => LanguageModel;
+embeddingModel: (model?: EmbeddingModelInput) => EmbeddingModel; // string id → Workers AI; object → passthrough
+run: (model, inputs, options?) => Promise<unknown>;
+workersai: WorkersAiProviderLike;
+```
+
+**`ctx.ai` does NOT expose `embed` itself.** The actual embedding call is the AI
+SDK `embed`, **re-exported** from `@lunora/ai` (`packages/ai/src/index.ts:8`):
+
+```ts
+import { embed } from "@lunora/ai";
+const { embedding } = await embed({ model: ctx.ai.embeddingModel("@cf/baai/bge-base-en-v1.5"), value: text });
+// embedding: number[]
+```
+
+So the helper's embed seam is a **one-liner adapter**:
+
+```ts
+const embed = async (text: string): Promise<number[]> => (await aiEmbed({ model: ctx.ai.embeddingModel(cfg.embeddingModel), value: text })).embedding;
+```
+
+The embedding model is **provider-agnostic**: a string id resolves against Workers
+AI; an AI SDK `EmbeddingModel` (OpenAI, etc.) passes through (create-ai.ts:77-93).
+
+### 1.2 Vectorize — from `@lunora/bindings/vectors`
+
+`LunoraVectors` (`packages/bindings/src/vectors/types.ts:98-105`) — the helper only
+needs `upsertMany` (write) and `query` (read):
+
+```ts
+upsert     (indexName, { id, input, embed, metadata?, namespace? })      → VectorizeUpsertMutation
+upsertMany (indexName, ReadonlyArray<UpsertInput>)                       → VectorizeUpsertMutation   // ≤1000/batch
+query      (indexName, { input?, vector?, embed?, topK?, filter?,
+                         namespace?, returnMetadata?, returnValues? })   → VectorizeMatches
+```
+
+Crucially, `upsert`/`query` take the **`embed` function directly** on their input
+(`toVector` calls `input.embed(input.input)`, create-vectors.ts:25-33; `query`
+calls `input.embed(input.input)`, :107-111). The helper passes its §1.1 adapter
+straight into that slot — the two facades were **built to compose**.
+
+### 1.3 Constraints the helper MUST respect
+
+- **`topK` ceilings** (create-vectors.ts:37-96): `topK ∈ [1,100]`, lowered to
+  `[1,20]` when `returnValues: true` **or** `returnMetadata: "all"`. Violations
+  throw `RangeError` locally. Because the helper reads chunk text back from
+  metadata (§3.3), it queries with `returnMetadata: "all"` → **it must cap `topK`
+  at 20**.
+- **`upsertMany` batch ≤ 1000** and embedder fan-out is internally bounded to 8
+  (`UPSERT_EMBED_CONCURRENCY`, create-vectors.ts:67-81) — the helper must split
+  documents that chunk to >1000 pieces.
+- **Namespace = the tenant key.** Vectorize indexes are **account-global**
+  (`packages/bindings/src/vectors/context.ts:213-223`): a namespace-less upsert in
+  a multi-tenant/sharded app leaks vectors (ids/scores + metadata) cross-tenant.
+  The helper **must** thread `namespace` on **both** write and query. (The shipped
+  schema-driven sync hook emits a one-time dev warning on namespace-less sync; the
+  RAG helper should do the same or require an explicit `allowSharedNamespace`.)
+- **Metadata default `"indexed"`, not `"all"`** in the context bridge
+  (context.ts:99-104) so queries don't leak arbitrary stored fields — but the RAG
+  helper deliberately opts into `"all"` to retrieve chunk text (a documented
+  tradeoff; §3.3 discusses the DO-table alternative).
+
+---
+
+## 2. Placement recommendation: `@lunora/ai/rag` subpath, `defineRag`
+
+The plan lists three candidates. Assessment against the "scale invisibly" north
+star, the existing ctx-facade pattern, and the "keep it a thin composition"
+maintenance note:
+
+| Option                                           | Verdict                                                                                                                                                                                                                    |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **(a) new `@lunora/rag` package**                | Overweight. RAG adds **no** new binding, no runtime elasticity — it is pure glue over two facades. A package + release + `pnpm-workspace` override is disproportionate.                                                    |
+| **(c) `defineRag(...)` codegen-wired `ctx.rag`** | Premature. Wiring `ctx.rag` via codegen (like `defineSchema`/`defineFlags`) adds discovery + `_generated/*` surface for something that is a library call. Reserve as an _upgrade path_ if boilerplate proves painful (§6). |
+| **(b) `@lunora/ai/rag` subpath, `defineRag`** ✅ | **Recommended.** Lives next to `ctx.ai` (where embedding lives), ships in the package a RAG app already installs, adds no binding/codegen, stays a thin composition. `sideEffects:false` subpath keeps it tree-shakeable.  |
+
+**Why not a new `ctx.*` facade at all initially**: `ctx.ai` and `ctx.vectors` are
+_invisible_ bindings. RAG is a _pattern_ over them, not a new capability of the
+runtime. The north star favors not minting user-facing runtime surface unless it
+removes real complexity that a library cannot. `defineRag` removes the complexity
+(chunk→embed→upsert / embed→query→assemble) **as a library**, keeping the runtime
+surface unchanged. If real-world boilerplate (threading `ctx` + the embed adapter)
+proves annoying, graduate to `ctx.rag` in a follow-up — the API below is
+forward-compatible with that.
+
+---
+
+## 3. The API
+
+### 3.1 Declaration + binding
+
+```ts
+// lunora/rag.ts
+import { defineRag } from "@lunora/ai/rag";
+
+export const docs = defineRag({
+    index: "docs", // a ctx.vectors index binding key
+    embeddingModel: "@cf/baai/bge-base-en-v1.5", // declared ONCE → index + retrieve embed identically
+    chunkSize: 1000, // built-in fixed-window chunker (chars)
+    chunkOverlap: 200,
+    // chunk: (text) => string[]                     // optional override (token/sentence/semantic)
+    topK: 5, // default retrieval depth
+});
+```
+
+`defineRag(config)` returns a **per-request factory** `(ctx) => { index, retrieve }`.
+Binding `ctx` once reads well because both facades live on it:
+
+```ts
+// inside a mutation (write) or action/query (read):
+await docs(ctx).index({ id: doc._id, text: doc.body, metadata: { title: doc.title }, namespace: ctx.shardKey });
+const { context, chunks, sources } = await docs(ctx).retrieve(question, { topK: 5, namespace: ctx.shardKey });
+```
+
+In the real package, `ctx` supplies both `ctx.ai` and `ctx.vectors`; `defineRag`
+builds the §1.1 embed adapter internally. (The prototype's `RagCtx` passes the
+`embed` adapter explicitly to stay AI-SDK-free; the doc shows the real wiring.)
+
+### 3.2 Write side — `index({ id, text, metadata?, namespace? })`
+
+1. **Chunk** `text` via the built-in fixed-window splitter (default 1000 chars,
+   200 overlap) or the `chunk` override.
+2. **Embed + upsert** each chunk via `ctx.vectors.upsertMany(index, inputs)` — one
+   `embed` call per chunk (fan-out bounded to 8 internally).
+3. **Metadata schema linking chunk → source** (the helper owns these keys):
+    - vector `id` = `` `${sourceId}#${chunkIndex}` `` (deterministic).
+    - `metadata.__ragSource = sourceId`, `metadata.__ragChunk = chunkIndex`,
+      `metadata.__ragText = chunkText`, plus the caller's `metadata` spread in.
+    - `namespace` threaded through for tenant isolation.
+
+Returns `{ chunks: number }`.
+
+### 3.3 Read side — `retrieve(query, { topK?, filter?, namespace? })`
+
+1. **Embed** the query with the _same_ model (declared once → symmetric).
+2. **Query** `ctx.vectors.query(index, { input: query, embed, topK, filter,
+namespace, returnMetadata: "all" })` — capping `topK` at **20** (the ceiling
+   when full metadata is requested).
+3. **Assemble** the ranked result:
+
+```ts
+interface RetrieveResult {
+    chunks: { id; sourceId; chunkIndex; text; score; metadata? }[]; // best-first
+    context: string; // chunks joined under `[source:<id>#<n>]` headers — prompt-ready
+    sources: { id; metadata? }[]; // deduped, best-first
+}
+```
+
+The `context` string is drop-in for a prompt; `chunks` allow custom assembly;
+`sources` are deduped refs. **This shape is the plan-113 contract**: an agent's
+memory/retrieval step calls `docs(ctx).retrieve(userMsg)` and injects `.context`
+(and cites `.sources`).
+
+### 3.4 Storing chunk text — metadata vs DO table (design note)
+
+The prototype stores chunk text in vector metadata and reads it back with
+`returnMetadata: "all"` (topK ≤ 20, simple, self-contained). **For production the
+design recommends the alternative**: store chunk text in a Lunora **DO SQLite
+table** keyed by chunk id, query Vectorize with `returnMetadata: "none"` (topK ≤
+**100**), then hydrate text from the DB by id. Benefits: no Vectorize metadata-size
+pressure (~10 KiB/vector cap), higher `topK`, and it reuses the DO the app already
+has. This is an open question (§6.3) because it introduces a table the helper must
+own or the app must declare.
+
+---
+
+## 4. Prototype + test evidence
+
+`plans/proto/rag/rag.ts` implements `defineRag` exactly as §3. The test
+(`rag.test.ts`, **ran green**) drives it over the **real**
+`@lunora/bindings/vectors` `createVectors` (imported by source path) with:
+
+- an in-memory `VectorizeIndexLike` double (cosine similarity; honours `topK`,
+  `returnMetadata`, `namespace`), and
+- a deterministic token-bag embedder (similar text → similar vectors).
+
+Asserts: index→retrieve round-trips; chunk↔source metadata survives (id shape +
+user metadata preserved, internal keys stripped); ranking returns the right source;
+`context` + `sources` are well-formed; **namespace scopes retrieval** (tenant
+isolation); and the **real** `createVectors` throws when `topK: 50` is requested
+with `returnMetadata: "all"` (ceiling enforced live). What was mocked: the actual
+Workers AI embedder + a real Vectorize index (unreachable in-sandbox) — but the
+**composition logic and the real ceiling/validation code path run for real**.
+
+---
+
+## 5. STOP-condition assessment
+
+| STOP condition                                                                          | Triggered?                                                        | Notes                                                                                                                                                      |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Can't compose without changing `@lunora/ai` / `@lunora/bindings/vectors` public surface | **No**                                                            | `upsert`/`query` already accept an `embed` fn; `ctx.ai` already yields the model. Pure composition.                                                        |
+| Chunking/metadata opens a genuinely large product surface                               | **Partial → surfaced as open questions, not decided arbitrarily** | Chunking default is fixed-window + override hook; re-index/delete and text-storage location are real decisions (§6) — deliberately left to the maintainer. |
+
+No hard STOP. One **bounded gap** worth flagging (not a blocker): `LunoraVectors`
+has `deleteByIds` but no "delete by metadata filter" / "list ids by source", so
+**cleanly re-indexing a changed document** (deleting its old chunks) requires
+knowing the prior chunk ids. Deterministic ids + a stored chunk-count sidestep it
+(delete `${id}#0..n-1`), so it needs no surface change — but a future
+`vectors.deleteByFilter` would be cleaner (§6.4).
+
+---
+
+## 6. Open questions (maintainer decisions)
+
+1. **Placement — subpath vs `defineRag`-wired `ctx.rag`.** _Recommendation_:
+   `@lunora/ai/rag` subpath now (§2); graduate to codegen-wired `ctx.rag` only if
+   boilerplate warrants — the API is forward-compatible.
+2. **Default chunking strategy.** _Recommendation_: fixed-window chars (1000/200)
+   as the zero-config default + a `chunk` override; leave token-aware/semantic
+   chunkers to userland or a later `@lunora/ai/rag/chunkers` export.
+3. **Chunk-text storage: metadata vs DO table (§3.4).** _Recommendation_: DO table
+   for production (higher `topK`, no metadata bloat); who owns the table (helper
+   auto-declares vs app declares) is the sub-decision.
+4. **Re-index / delete-old-chunks (§5).** Deterministic-id delete now; consider a
+   `vectors.deleteByFilter` follow-up in `@lunora/bindings/vectors`.
+5. **Metadata schema ownership.** The helper owns `__ragSource/__ragChunk/__ragText`
+   — confirm the reserved-key convention (or a nested `__lunoraRag` object) so it
+   never collides with user metadata.
+6. **Tool integration for agents (ties to plan 113).** Should `retrieve` also be
+   exposable as an AI SDK `tool()` so an agent calls it as a function?
+   _Recommendation_: yes, ship a `docs(ctx).asTool()` in the 113 timeframe; the
+   `RetrieveResult` shape already fits.
+7. **Reranking scope.** Out of v1. Note as a future `retrieve({ rerank })` hook.
+8. **Embedding-model declaration site.** _Recommendation_: declared once on
+   `defineRag({ embeddingModel })` (as designed) so index + retrieve never drift;
+   allow a per-call override only for advanced cases.
+
+---
+
+## 7. Cross-plan note (for 113)
+
+Design `retrieve`'s return **for the agent consumer**: `{ context, chunks, sources }`
+lets an agent memory step inject `.context` and cite `.sources` with zero
+reshaping. Sequence **111 before any 113 build** (the plan's maintenance note).

--- a/plans/proto/rag/rag.test.ts
+++ b/plans/proto/rag/rag.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Spike 111 composition test. Drives `defineRag`'s index -> retrieve loop over the
+ * REAL `@lunora/bindings/vectors` `createVectors` (imported by source path) plus:
+ *   - an in-memory `VectorizeIndexLike` double (cosine similarity, honours topK,
+ *     returnMetadata, namespace) standing in for a Vectorize binding, and
+ *   - a deterministic token-bag `embed` (similar text -> similar vectors), standing
+ *     in for `ctx.ai.embeddingModel` + AI SDK `embed`.
+ *
+ * Asserts the chunk<->source metadata round-trips, retrieval ranks by similarity,
+ * the assembled context + source refs are well-formed, and the Vectorize topK
+ * ceiling (20 with returnMetadata:"all") is enforced by the real code.
+ */
+import { describe, expect, it } from "vitest";
+
+import createVectors from "../../../packages/bindings/src/vectors/create-vectors";
+import type {
+    VectorizeIndexLike,
+    VectorizeMatch,
+    VectorizeMatches,
+    VectorizeQueryOptions,
+    VectorizeVector,
+} from "../../../packages/bindings/src/vectors/types";
+import { defineRag } from "./rag";
+
+/** Deterministic 64-dim token-bag embedder: cosine similarity ~ token overlap. */
+const EMBED_DIMENSIONS = 64;
+
+const embedText = (text: string): ReadonlyArray<number> => {
+    const vector = Array.from({ length: EMBED_DIMENSIONS }, () => 0);
+
+    for (const token of text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter(Boolean)) {
+        let hash = 0;
+
+        for (let index = 0; index < token.length; index += 1) {
+            hash = (hash * 31 + token.charCodeAt(index)) >>> 0;
+        }
+
+        vector[hash % EMBED_DIMENSIONS] += 1;
+    }
+
+    return vector;
+};
+
+const dot = (a: ReadonlyArray<number>, b: ReadonlyArray<number>): number => a.reduce((sum, value, index) => sum + value * b[index], 0);
+const norm = (a: ReadonlyArray<number>): number => Math.sqrt(dot(a, a)) || 1;
+const cosine = (a: ReadonlyArray<number>, b: ReadonlyArray<number>): number => dot(a, b) / (norm(a) * norm(b));
+
+/** Minimal in-memory Vectorize index double. */
+const createMemoryIndex = (): VectorizeIndexLike => {
+    const store = new Map<string, VectorizeVector>();
+
+    const upsert = async (vectors: ReadonlyArray<VectorizeVector>): Promise<{ mutationId: string }> => {
+        for (const vector of vectors) {
+            store.set(vector.id, vector);
+        }
+
+        return { mutationId: `m${String(store.size)}` };
+    };
+
+    const query = async (vector: ReadonlyArray<number>, options?: VectorizeQueryOptions): Promise<VectorizeMatches> => {
+        const namespace = options?.namespace;
+        const topK = options?.topK ?? 5;
+
+        const scored: VectorizeMatch[] = [...store.values()]
+            .filter((candidate) => namespace === undefined || candidate.namespace === namespace)
+            .map((candidate) => ({
+                id: candidate.id,
+                metadata: options?.returnMetadata === "none" ? undefined : candidate.metadata,
+                namespace: candidate.namespace,
+                score: cosine(vector, candidate.values),
+                values: options?.returnValues ? candidate.values : undefined,
+            }))
+            .sort((a, b) => b.score - a.score)
+            .slice(0, topK);
+
+        return { count: scored.length, matches: scored };
+    };
+
+    return {
+        deleteByIds: async (ids) => {
+            for (const id of ids) {
+                store.delete(id);
+            }
+
+            return { count: ids.length, mutationId: "d" };
+        },
+        getByIds: async (ids) => ids.map((id) => store.get(id)).filter((value): value is VectorizeVector => value !== undefined),
+        insert: upsert,
+        query,
+        upsert,
+    };
+};
+
+describe("spike 111: defineRag index -> retrieve composition", () => {
+    const buildCtx = () => {
+        const vectors = createVectors({ indexes: { docs: createMemoryIndex() } });
+
+        return { embed: async (text: string) => embedText(text), vectors };
+    };
+
+    it("indexes a document, then retrieves ranked chunks with assembled context + source refs", async () => {
+        const rag = defineRag({ chunkOverlap: 5, chunkSize: 40, index: "docs" })(buildCtx());
+
+        const durable = await rag.index({
+            id: "doc-durable",
+            metadata: { title: "Durable Objects" },
+            namespace: "tenant-1",
+            text: "Durable Objects give Cloudflare Workers stateful single-threaded actors with persistent storage and websockets.",
+        });
+        await rag.index({
+            id: "doc-vectorize",
+            metadata: { title: "Vectorize" },
+            namespace: "tenant-1",
+            text: "Vectorize is an account global vector database for similarity search over embeddings.",
+        });
+
+        expect(durable.chunks).toBeGreaterThan(1);
+
+        const result = await rag.retrieve("stateful durable objects websockets storage", { namespace: "tenant-1", topK: 3 });
+
+        // Best match is a chunk from the durable-objects document (highest token overlap).
+        expect(result.chunks.length).toBeGreaterThan(0);
+        expect(result.chunks[0].sourceId).toBe("doc-durable");
+        // chunk <-> source metadata round-trips (id shape + user metadata preserved, internal keys stripped).
+        expect(result.chunks[0].id).toMatch(/^doc-durable#\d+$/);
+        expect(result.chunks[0].metadata).toEqual({ title: "Durable Objects" });
+        expect(result.chunks[0].text.length).toBeGreaterThan(0);
+        // assembled context carries each chunk's text under a source-attribution header,
+        // and collectively covers the query's key terms across the winning document's chunks.
+        expect(result.context).toMatch(/\[source:doc-durable#\d+\]/);
+        expect(result.context.toLowerCase()).toContain("durable");
+        expect(result.context.toLowerCase()).toContain("stateful");
+        // deduped source refs, best-first.
+        expect(result.sources[0]).toEqual({ id: "doc-durable", metadata: { title: "Durable Objects" } });
+    });
+
+    it("scopes retrieval by namespace (tenant isolation)", async () => {
+        const rag = defineRag({ chunkSize: 200, index: "docs" })(buildCtx());
+
+        await rag.index({ id: "a", namespace: "tenant-1", text: "alpha widgets and gadgets" });
+        await rag.index({ id: "b", namespace: "tenant-2", text: "alpha widgets and gadgets" });
+
+        const result = await rag.retrieve("alpha widgets", { namespace: "tenant-1", topK: 10 });
+
+        expect(result.chunks.every((chunk) => chunk.sourceId === "a")).toBe(true);
+    });
+
+    it("enforces the Vectorize topK ceiling (<=20 with full metadata) via the real createVectors", async () => {
+        // The helper caps its OWN default topK, but a config asking for >20 must still be
+        // rejected by the real binding. Bypass the helper cap by calling the facade directly
+        // with the exact args the helper would pass, to prove the ceiling is live.
+        const ctx = buildCtx();
+
+        await expect(ctx.vectors.query("docs", { embed: ctx.embed, input: "q", returnMetadata: "all", topK: 50 })).rejects.toThrow(
+            /topK must be an integer in \[1, 20\]/,
+        );
+    });
+});

--- a/plans/proto/rag/rag.ts
+++ b/plans/proto/rag/rag.ts
@@ -1,0 +1,236 @@
+/**
+ * Spike 111 prototype — `defineRag`: a thin RAG helper composing the two existing
+ * facades (`ctx.ai` embeddings + `ctx.vectors` Vectorize) into an index -> retrieve
+ * loop. No new binding, no reimplemented embedding or vector query.
+ *
+ * `defineRag(config)` returns a per-request factory `rag(ctx)` that binds the two
+ * facades the app already has. In a real Lunora function:
+ *
+ * ```ts
+ * // lunora/rag.ts
+ * export const docs = defineRag({ index: "docs", embeddingModel: "@cf/baai/bge-base-en-v1.5" });
+ *
+ * // inside a mutation/action:
+ * import { embed } from "@lunora/ai";
+ * const r = docs({
+ *   vectors: ctx.vectors,
+ *   embed: async (text) => (await embed({ model: ctx.ai.embeddingModel("@cf/baai/bge-base-en-v1.5"), value: text })).embedding,
+ * });
+ * await r.index({ id: doc._id, text: doc.body, metadata: { title: doc.title }, namespace: ctx.shardKey });
+ * const { context, chunks, sources } = await r.retrieve("how do durable objects work?", { topK: 5, namespace: ctx.shardKey });
+ * ```
+ *
+ * The `embed` adapter is the seam to `ctx.ai`: `ctx.ai` exposes `embeddingModel(id)`
+ * (a resolved AI SDK model) but not `embed` itself — that is the AI SDK `embed`
+ * re-exported from `@lunora/ai`. The helper wires this adapter straight into
+ * `ctx.vectors.{upsert,query}`'s `embed` slot, so `createVectors` calls it per chunk.
+ */
+import type { LunoraVectors } from "../../../packages/bindings/src/vectors/types";
+
+/** The two facades the RAG helper binds — both already live on a Lunora `ctx`. */
+export interface RagCtx {
+    /** `(text) => vector`, adapting `ctx.ai`: `embed({ model: ctx.ai.embeddingModel(id), value: text }).embedding`. */
+    embed: (text: string) => Promise<ReadonlyArray<number>>;
+    /** The `@lunora/bindings/vectors` facade (`ctx.vectors`). */
+    vectors: LunoraVectors;
+}
+
+export interface RagConfig {
+    /** Optional custom chunker; overrides the built-in fixed-window splitter. */
+    chunk?: (text: string) => ReadonlyArray<string>;
+    /** Overlap (chars) between adjacent chunks. Default 200. */
+    chunkOverlap?: number;
+    /** Target chunk size (chars). Default 1000. */
+    chunkSize?: number;
+    /** Workers AI (or any AI SDK) embedding-model id, declared once so index + retrieve embed identically. */
+    embeddingModel?: string;
+    /** The Vectorize index name (a `ctx.vectors` binding key). */
+    index: string;
+    /** Default retrieval `topK`. Default 5. Capped by Vectorize (<=20 with full metadata). */
+    topK?: number;
+}
+
+export interface IndexInput {
+    /** Source document id — chunk ids derive from it as `${id}#${chunkIndex}`. */
+    id: string;
+    /** Arbitrary source metadata copied onto every chunk vector (e.g. title, url). */
+    metadata?: Record<string, unknown>;
+    /** Tenant/shard key. REQUIRED for multi-tenant apps — Vectorize is account-global. */
+    namespace?: string;
+    /** The document body to chunk + embed + upsert. */
+    text: string;
+}
+
+export interface RetrieveOptions {
+    filter?: Record<string, unknown>;
+    namespace?: string;
+    topK?: number;
+}
+
+export interface RetrievedChunk {
+    chunkIndex: number;
+    id: string;
+    metadata?: Record<string, unknown>;
+    score: number;
+    sourceId: string;
+    text: string;
+}
+
+/** The retrieve return shape — designed so a plan-113 agent memory step consumes it directly. */
+export interface RetrieveResult {
+    /** Ranked chunks (best first). */
+    chunks: ReadonlyArray<RetrievedChunk>;
+    /** Ready-to-inject assembled prompt context (chunks joined with source separators). */
+    context: string;
+    /** Deduped source references, in first-seen (best) order. */
+    sources: ReadonlyArray<{ id: string; metadata?: Record<string, unknown> }>;
+}
+
+export interface Rag {
+    index: (input: IndexInput) => Promise<{ chunks: number }>;
+    retrieve: (query: string, options?: RetrieveOptions) => Promise<RetrieveResult>;
+}
+
+const DEFAULT_CHUNK_SIZE = 1000;
+const DEFAULT_CHUNK_OVERLAP = 200;
+const DEFAULT_TOP_K = 5;
+
+/**
+ * Vectorize lowers the `topK` ceiling to 20 when a query asks for full metadata
+ * (`returnMetadata: "all"`). This prototype stores the chunk text in metadata and
+ * reads it back with `returnMetadata: "all"`, so it must honour the 20 ceiling —
+ * `createVectors` enforces it and throws on a violation.
+ */
+const MAX_TOP_K_FULL_METADATA = 20;
+
+/** Metadata key under which each chunk's text is stored on its vector. */
+const TEXT_KEY = "__ragText";
+/** Metadata key under which the owning source id is stored. */
+const SOURCE_KEY = "__ragSource";
+/** Metadata key under which the chunk index is stored. */
+const CHUNK_INDEX_KEY = "__ragChunk";
+
+/**
+ * Built-in fixed-window chunker: split into `size`-char windows overlapping by
+ * `overlap`. Deliberately simple + deterministic (a spike default); the real
+ * helper takes a `chunk` override for token/sentence/semantic strategies.
+ */
+const fixedWindowChunks = (text: string, size: number, overlap: number): ReadonlyArray<string> => {
+    const trimmed = text.trim();
+
+    if (trimmed.length === 0) {
+        return [];
+    }
+
+    if (trimmed.length <= size) {
+        return [trimmed];
+    }
+
+    const step = Math.max(1, size - overlap);
+    const chunks: string[] = [];
+
+    for (let start = 0; start < trimmed.length; start += step) {
+        chunks.push(trimmed.slice(start, start + size));
+
+        if (start + size >= trimmed.length) {
+            break;
+        }
+    }
+
+    return chunks;
+};
+
+/**
+ * Assemble ranked chunks into one prompt-ready context string, delimited by a
+ * source header so the model (and a human reader) can attribute each passage.
+ */
+const assembleContext = (chunks: ReadonlyArray<RetrievedChunk>): string =>
+    chunks.map((chunk) => `[source:${chunk.sourceId}#${String(chunk.chunkIndex)}]\n${chunk.text}`).join("\n\n");
+
+/**
+ * Declare a RAG index. Returns a factory that binds a request's `ctx` facades and
+ * exposes `{ index, retrieve }`. Pure composition — no I/O until a method runs.
+ */
+export const defineRag = (config: RagConfig): ((ctx: RagCtx) => Rag) => {
+    if (typeof config.index !== "string" || config.index.length === 0) {
+        throw new TypeError("defineRag: `index` must be a non-empty Vectorize index name");
+    }
+
+    const chunkSize = config.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    const chunkOverlap = config.chunkOverlap ?? DEFAULT_CHUNK_OVERLAP;
+    const defaultTopK = config.topK ?? DEFAULT_TOP_K;
+    const splitter = config.chunk ?? ((text: string) => fixedWindowChunks(text, chunkSize, chunkOverlap));
+
+    return (ctx: RagCtx): Rag => {
+        const index = async (input: IndexInput): Promise<{ chunks: number }> => {
+            const pieces = splitter(input.text);
+
+            if (pieces.length === 0) {
+                return { chunks: 0 };
+            }
+
+            // Compose the two facades: each chunk becomes an `UpsertInput` whose
+            // `embed` is the ctx.ai adapter and whose metadata links chunk -> source
+            // and carries the chunk text (so retrieve can reconstruct context).
+            const inputs = pieces.map((piece, chunkIndex) => ({
+                embed: ctx.embed,
+                id: `${input.id}#${String(chunkIndex)}`,
+                input: piece,
+                metadata: {
+                    ...input.metadata,
+                    [CHUNK_INDEX_KEY]: chunkIndex,
+                    [SOURCE_KEY]: input.id,
+                    [TEXT_KEY]: piece,
+                },
+                namespace: input.namespace,
+            }));
+
+            await ctx.vectors.upsertMany(config.index, inputs);
+
+            return { chunks: pieces.length };
+        };
+
+        const retrieve = async (query: string, options?: RetrieveOptions): Promise<RetrieveResult> => {
+            const topK = Math.min(options?.topK ?? defaultTopK, MAX_TOP_K_FULL_METADATA);
+
+            // Read side: embed the query (same adapter -> same model) and run the
+            // Vectorize query, asking for full metadata so we get the chunk text back.
+            const result = await ctx.vectors.query(config.index, {
+                embed: ctx.embed,
+                filter: options?.filter,
+                input: query,
+                namespace: options?.namespace,
+                returnMetadata: "all",
+                topK,
+            });
+
+            const chunks: RetrievedChunk[] = result.matches.map((match) => {
+                const metadata = match.metadata ?? {};
+                const { [CHUNK_INDEX_KEY]: rawIndex, [SOURCE_KEY]: rawSource, [TEXT_KEY]: rawText, ...userMetadata } = metadata;
+
+                return {
+                    chunkIndex: typeof rawIndex === "number" ? rawIndex : Number(rawIndex ?? 0),
+                    id: match.id,
+                    metadata: userMetadata,
+                    score: match.score,
+                    sourceId: typeof rawSource === "string" ? rawSource : String(rawSource ?? match.id),
+                    text: typeof rawText === "string" ? rawText : "",
+                };
+            });
+
+            const sources: { id: string; metadata?: Record<string, unknown> }[] = [];
+            const seen = new Set<string>();
+
+            for (const chunk of chunks) {
+                if (!seen.has(chunk.sourceId)) {
+                    seen.add(chunk.sourceId);
+                    sources.push({ id: chunk.sourceId, metadata: chunk.metadata });
+                }
+            }
+
+            return { chunks, context: assembleContext(chunks), sources };
+        };
+
+        return { index, retrieve };
+    };
+};

--- a/plans/proto/tsconfig.json
+++ b/plans/proto/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    // Type-check only (spike prototypes; the real build is per-package packem).
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        // Spike-only relaxation: the prototype SOURCE modules (rag.ts, agent-loop.ts,
+        // compose-next-worker.ts) pass the repo's strict base as-is; this only silences
+        // `noUncheckedIndexedAccess` on positional `messages[1]` / `chunks[0]` test
+        // assertions, so the tests stay readable without `!` noise everywhere.
+        "noUncheckedIndexedAccess": false
+    },
+    "include": ["**/*.ts", "../../packages/bindings/src/vectors/create-vectors.ts", "../../packages/bindings/src/vectors/types.ts"]
+}

--- a/plans/proto/vitest.config.ts
+++ b/plans/proto/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Standalone Vitest config for the wave-11 spike prototypes (plans 110 / 111 / 113).
+ *
+ * These prototypes deliberately live OUTSIDE the pnpm workspace (`plans/` is not a
+ * workspace glob) so they add no package, no `pnpm-workspace.yaml` override, and no
+ * build step. They exercise pure composition logic with in-memory doubles; the
+ * RAG prototype imports the *real* `@lunora/bindings/vectors` `createVectors` by
+ * relative source path (it only imports its own relative siblings, so Vitest's
+ * esbuild transform resolves it with no build).
+ *
+ * Run from this directory:  `pnpm exec vitest run --config vitest.config.ts`
+ */
+export default {
+    test: {
+        environment: "node",
+        include: ["**/*.test.ts"],
+        watch: false,
+    },
+};


### PR DESCRIPTION
Split out of #96 (2/3). Phase-0 design doc + minimal runnable prototype for plan 111.

**Recommendation:** a thin `defineRag(config)(ctx)` helper shipped as a **`@lunora/ai/rag` subpath** (not a new package, not a codegen-wired `ctx.rag` — respects "scale invisibly"). The two facades compose with **no public-surface change**. Respects the Vectorize `topK` ceilings (≤20 with full metadata) and namespace tenant-isolation; the `retrieve` → `{ context, chunks, sources }` return shape is designed for the plan-113 agent memory step. No STOP.

Prototype (`plans/proto/rag`) runs index→retrieve over the **real** `createVectors` with passing tests (incl. the live topK-ceiling throw). 3 tests green, typecheck clean.

Key open questions (end of design doc): chunk-text storage (metadata vs a DO table), re-index/delete-old-chunks gap, default chunking.

Note: `plans/proto/{tsconfig.json,vitest.config.ts}` are identical copies of the ones in the sibling spike PRs so each PR is standalone — identical add/add merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6