### PR TITLE
docs(ai): spike design + PoC for defineAgent durable tool-loop (plan 113)

### DIFF
--- a/plans/113-phase0-design.md
+++ b/plans/113-phase0-design.md
@@ -1,0 +1,291 @@
+# Plan 113 — Phase 0 design: durable AI-agent primitive (`defineAgent`)
+
+> **Spike outcome (TL;DR)**: Every part of a durable tool-loop maps onto a **shipped**
+> Lunora primitive — durable steps (`ctx.runStep` → native `step.do`), DO SQLite
+> thread tables, the WS `type:"stream"` transport, and (plan 111) `rag.retrieve`.
+> Replay-safety for **completed** steps is guaranteed by native `step.do`
+> memoization; a **failed/retried** side-effecting tool still needs an idempotency
+> key, which the deterministic step name provides. **No STOP** — but the honest
+> recommendation is **document-first / opt-in add-on, not a core primitive**,
+> because this is a _user-facing_ surface in tension with the "scale invisibly"
+> north star. That tension is the **top open question** for the maintainer (§7.1).
+>
+> PoC: `plans/proto/agent/agent-loop.ts` (+ passing test asserting thread ordering
+> **and** resume-doesn't-re-run-a-completed-tool). Ran green in-sandbox.
+
+---
+
+## 1. Machinery map — each loop part → a shipped primitive
+
+| Agent-loop part                                  | Reused Lunora primitive                                           | Reference                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------ | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LLM turn** (call model, get text or tool-call) | a **named durable step**                                          | `ctx.runStep(defineStep("llm:turn:N", …))` → `deps.step.do("llm:turn:N", cb)` — `packages/workflow/src/run-step.ts:130`; `define-step.ts:40`                                                                                                                                                   |
+| **Tool call** (execute a tool)                   | a **named durable step** (name = idempotency key)                 | same `ctx.runStep`; step name `tool:<name>:<callId>`                                                                                                                                                                                                                                           |
+| **Message persist** (user/assistant/tool rows)   | **DO SQLite table write**, idempotent by deterministic message id | `defineSchema` tables + `ctx.db`; shipped idempotency machinery `packages/do/src/ctx-db-idempotency.ts`                                                                                                                                                                                        |
+| **Stream deltas to client**                      | WS **`type:"stream"`** transport                                  | authored as a `query(...).stream()` async generator — `packages/server/src/builder/types.ts:67` (`RegisteredStream`); dispatched by `packages/do/src/shard-do.ts:2261` `handleStream`; consumed client-side via `createStream`/`StreamIterable` — `packages/client/src/lunora-client.ts:18-19` |
+| **Memory / RAG step**                            | `defineRag(...)(ctx).retrieve` (plan 111)                         | returns `{ context, chunks, sources }` — designed for this consumer                                                                                                                                                                                                                            |
+| **Loop orchestration** (durable, replayable)     | Cloudflare Workflows via `@lunora/workflow`                       | `defineWorkflow` + `createWorkflowContext` — `packages/workflow/src/index.ts`                                                                                                                                                                                                                  |
+| **Fan-out / parallel tools + saga rollback**     | shipped `branch`/`MAX_BRANCHES` + step `rollback`                 | `fan-out.ts`; `run-step.ts:113-128` (rollback wiring)                                                                                                                                                                                                                                          |
+| **Duplicate-step-name guard**                    | shipped workflow lint                                             | keep agent step names unique + deterministic                                                                                                                                                                                                                                                   |
+
+**Nothing new is required at the runtime layer.** The agent loop is an
+_assembly_ of these. That fact is the crux of the build-vs-document decision (§7.1).
+
+---
+
+## 2. Replay-safety / idempotency argument (the correctness core)
+
+### 2.1 What native `step.do` guarantees
+
+`run-step.ts:130` runs each step as `deps.step.do(step.name, callback, …)` —
+Cloudflare Workflows' native durable step. Its contract: **a step that has already
+completed is memoized by name; on a resume/replay the recorded output is returned
+WITHOUT re-invoking the callback.** So if the workflow crashes after a tool step
+committed, the resumed run **does not re-run that tool** — a card is charged once.
+
+Each LLM turn and each tool call is a **uniquely + deterministically named** step:
+
+- `llm:turn:<n>` — `n` is the loop turn index (deterministic across replays).
+- `tool:<name>:<callId>` — `callId` is the **provider's stable tool-call id** from
+  the LLM response (deterministic — it is itself replayed from the memoized
+  `llm:turn` output).
+
+Determinism of the **loop control** matters: which steps run is derived from
+**persisted step outputs** (the memoized `llm:turn` decisions), never from fresh
+`Date.now()`/`Math.random()` at the top level. Non-determinism _inside_ a step body
+is fine — the body's output is memoized. (Lunora already flags top-level
+non-determinism via the `nondeterministic_query_mutation` advisor lint.)
+
+The shipped **duplicate-step-name lint** is the guard that keeps names unique; the
+agent's naming scheme (`llm:turn:<n>`, `tool:<name>:<callId>`) is compatible with
+it.
+
+### 2.2 The nuance the design must NOT hide — retry ≠ replay
+
+`step.do` memoizes on **success**. A step whose body **fails mid-execution** (after
+a side effect, before the step records completion) is **retried at-least-once** —
+and re-run. So:
+
+- **Replay of a COMPLETED step** → safe (memoized). ✅
+- **Retry of a FAILED, side-effecting step** → the tool body must be **internally
+  idempotent**. This is _not_ a Lunora gap — it is the same at-least-once reality
+  in Temporal/Convex/every durable-execution engine. The standard answer is an
+  **idempotency key**, and the agent already has a perfect one: **the deterministic
+  step name** (`tool:<name>:<callId>`). The design hands that key to the tool
+  (e.g. as `ctx.idempotencyKey`) so a payment/side-effecting tool dedupes.
+
+**Therefore the STOP condition "the durable-step machinery can't guarantee tool
+idempotency across replays without changes to `@lunora/workflow`" does NOT
+trigger**: across _replays_ it is guaranteed by memoization; across _retries_ it is
+handled by the idempotency-key convention with zero engine change. The follow-up's
+first task is to **document + surface the idempotency key**, and optionally add a
+tiny `defineTool({ idempotent: true })` helper — a convenience, not a correctness
+prerequisite. This is open question §7.2.
+
+### 2.3 PoC evidence
+
+`plans/proto/agent/agent-loop.ts` models the loop and a faithful
+`DurableStepJournal` (an exact in-memory model of `step.do` memoization — a step
+name with a recorded output returns it without re-invoking `cb`, persisted across a
+resume by reusing the journal instance). The test (`agent-loop.test.ts`, **ran
+green**) asserts:
+
+- **(a) thread ordering**: messages persist as `user → assistant(tool_call) → tool
+→ assistant(final)` with monotonic `seq`, correct `toolCall`/`toolCallId`
+  correlation, and the tool ran exactly once.
+- **(b) resume safety**: a simulated crash **after** the tool step commits (before
+  turn-1's LLM call) is followed by a resume with the **same** journal + message
+  store; the resumed run serves `llm:turn:0` and `tool:getWeather:call_1` from the
+  journal — the tool's side-effect counter stays **1**, each step body was invoked
+  **exactly once** across crash+resume (`["llm:turn:0","tool:getWeather:call_1","llm:turn:1"]`),
+  and the final thread has no duplicated messages (idempotent upsert by message id).
+
+What was mocked: the LLM + the tool + Cloudflare Workflows itself (unreachable
+in-sandbox). The memoization contract modelled is the _documented_ `step.do`
+behavior that `run-step.ts:130` delegates to, so the replay-safety argument holds
+for the real machinery.
+
+---
+
+## 3. The API + thread schema
+
+### 3.1 `defineAgent`
+
+```ts
+// lunora/agents.ts
+import { defineAgent } from "@lunora/agent"; // recommended home — §7.1
+import { tool } from "@lunora/ai";
+import { docs } from "./rag"; // plan 111
+
+export const support = defineAgent({
+    model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", // string id or AI SDK model
+    thread: "supportThreads", // thread table name (see §3.3)
+    tools: {
+        getWeather: tool({/* AI SDK tool: description, inputSchema, execute */}),
+    },
+    memory: docs, // optional: a defineRag index → auto retrieval step (§4)
+    maxSteps: 8, // cost/step cap
+    // idempotentTools: ["charge"],   // §7.2
+});
+```
+
+### 3.2 Runtime surface — how an app invokes it
+
+The loop needs `ctx.runStep`, which only exists inside a **workflow run**. So
+`defineAgent` **compiles to a generated `defineWorkflow`** whose handler runs the
+loop. The app invokes it like any workflow producer:
+
+```ts
+// inside an action/mutation:
+const run = await ctx.agents.support.run(threadId, { message: input }); // → creates a workflow instance
+// stream deltas to the client with a paired streaming query (§4):
+// useStream(api.agents.support.stream, { threadId })
+```
+
+_Recommendation_: `ctx.agents.<name>.run(threadId, input)` (mirrors
+`ctx.workflows`/`ctx.queues` producer style) over a bare action, so the durable
+workflow instance + status are first-class. The streamed response is a **separate**
+`query(...).stream()` the client subscribes to by `threadId` (§4).
+
+### 3.3 Thread + message schema (`defineSchema` tables in the DO)
+
+```ts
+export default defineSchema({
+    agentThreads: defineTable({
+        agent: v.string(),
+        title: v.optional(v.string()),
+        createdAt: v.number(),
+        status: v.union(v.literal("idle"), v.literal("running"), v.literal("error")),
+    }).index("by_agent", ["agent"]),
+
+    agentMessages: defineTable({
+        threadId: v.id("agentThreads"),
+        seq: v.number(), // monotonic per-thread ordering
+        role: v.union(v.literal("user"), v.literal("assistant"), v.literal("tool"), v.literal("system")),
+        content: v.string(),
+        toolCall: v.optional(v.object({ id: v.string(), name: v.string(), args: v.any() })), // assistant → tool intent
+        toolCallId: v.optional(v.string()), // tool row → correlates to toolCall.id
+        stepName: v.optional(v.string()), // the durable step that produced it (audit/idempotency)
+        createdAt: v.number(),
+    }).index("by_thread", ["threadId", "seq"]),
+});
+```
+
+Message writes are **idempotent by a deterministic id** (`stepName` or
+`${threadId}:${role}:${turn}`) so a replay re-persist does not duplicate — the PoC
+proves this, and the shipped `ctx-db-idempotency.ts` provides the mechanism.
+
+---
+
+## 4. Streaming + memory integration
+
+- **Streaming**: author the agent's live response as a `query(...).stream()` async
+  generator (`RegisteredStream`, builder/types.ts:67) that yields token/tool-event
+  deltas; the DO's `handleStream` (shard-do.ts:2261) delivers them as
+  `ServerChunkMessage` frames over the existing WS `type:"stream"` transport; the
+  client consumes via `createStream`/`StreamIterable`. **No new transport.** The
+  stream reads from the persisted thread + in-flight step outputs, so a reconnect
+  resumes from the durable state.
+- **Memory/RAG (plan 111)**: `memory: docs` inserts a retrieval step at turn start
+  — `docs(ctx).retrieve(userMessage)` — and injects `.context` into the model
+  prompt (and can be exposed as an AI SDK `tool()` so the agent _chooses_ to
+  retrieve; plan 111 §6.6). `retrieve`'s `{ context, chunks, sources }` shape was
+  designed for exactly this.
+
+---
+
+## 5. STOP-condition assessment
+
+| STOP condition                                                                                            | Triggered?                                                 | Notes                                                                                                                               |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Durable-step machinery can't guarantee tool idempotency across replays without `@lunora/workflow` changes | **No**                                                     | Completed-step memoization is native (§2.1); retry needs an idempotency key = the deterministic step name, no engine change (§2.2). |
+| Design surface balloons (streaming + HITL + memory + cost caps each open sub-designs)                     | **Expected for XL → surfaced as open questions**           | §7 scopes them; recommend a phased build, not an attempt here.                                                                      |
+| "Scale invisibly" argues against a bespoke user-facing primitive                                          | **This is the real tension → §7.1, the TOP open question** | Honest outcome may be "document the composition; ship at most an opt-in add-on."                                                    |
+
+No hard STOP. The spike's job is to make the build-vs-document call _decidable_ — §7.
+
+---
+
+## 6. HITL, cost caps, cancellation (noted, not designed)
+
+- **Human-in-the-loop**: Cloudflare Workflows' `waitForEvent` pauses the run until
+  an external event (approval) arrives — a natural fit for a `pause`/`resume`
+  tool. Design in the build phase.
+- **Cost/step caps**: `maxSteps` (turns) + a token/$ budget checked between turns;
+  exceed → terminate with a persisted `status:"error"`.
+- **Cancellation**: the streaming query's `AbortSignal` + a workflow terminate.
+
+---
+
+## 7. Open questions (maintainer decisions)
+
+### 7.1 (TOP) Build a bespoke `defineAgent` primitive, or document the composition? — the "scale invisibly" tension
+
+This is a **user-facing primitive**, unlike the invisible runtime elasticity the
+north star prizes. §1 shows the loop is a _thin assembly_ of shipped primitives.
+That pulls two ways:
+
+- **Against building** (north-star-aligned): the composition is genuinely thin; a
+  bespoke primitive **locks in opinions prematurely** (thread schema, tool
+  protocol, streaming shape, HITL semantics) that are still moving industry-wide;
+  and it adds core user-facing surface that a good **recipe/example + a tiny
+  helper** could cover without commitment.
+- **For building** (parity/marketing): the assembled agent primitive is Convex's
+  **most-marketed differentiator** (`@convex-dev/agent`). "Build an agent on my
+  backend" is the current top AI use case; a first-class `defineAgent` is a
+  headline capability, and leaving it as docs concedes the comparison.
+
+**Recommendation (for the maintainer to ratify, not a unilateral decision)**:
+**document-first, then ship a MINIMAL `defineAgent` as an OPT-IN add-on package
+`@lunora/agent`, not in core `@lunora/ai`.** Concretely, phased:
+
+1. **Now**: a documented "durable agent" recipe/example composing
+   `@lunora/workflow` + `@lunora/ai` + `defineRag` (plan 111), plus a tiny
+   `runAgentLoop(...)` helper in `@lunora/ai` (the PoC, hardened). Zero new
+   user-facing primitive → keeps core invisible.
+2. **After the recipe validates demand**: graduate to `@lunora/agent`'s
+   `defineAgent` (§3) as an **opt-in add-on** (like `@lunora/auth`/`@lunora/mail`),
+   so the _core_ stays invisible while power users get the assembled primitive.
+
+Rationale: the add-on boundary is exactly how Lunora keeps its core small while
+still shipping big capabilities — building `defineAgent` as an _opt-in package_
+resolves the tension rather than compromising the core. **But the placement and the
+build-vs-document sequencing are the maintainer's call — this design is the
+artifact for that decision.**
+
+### 7.2 Idempotency-key convention for side-effecting tools (§2.2)
+
+_Recommendation_: pass the deterministic step name to the tool as
+`ctx.idempotencyKey`; optionally a `defineTool({ idempotent })` marker. Document
+loudly — a tool that runs twice on a _retry_ (not a replay) is the correctness
+cliff. No `@lunora/workflow` change required.
+
+### 7.3 Home: `@lunora/ai` vs new `@lunora/agent`
+
+_Recommendation_: new **`@lunora/agent`** opt-in package (§7.1) — keeps the loop's
+opinions out of the lean `@lunora/ai`.
+
+### 7.4 Memory/RAG integration shape
+
+_Recommendation_: `memory: <defineRag>` auto-injects a retrieval step **and**
+exposes `retrieve` as a `tool()` the agent may call (plan 111 §6.6). Sequence 111
+first.
+
+### 7.5 HITL via `waitForEvent` (§6) — in v1 or deferred? _Recommendation_: deferred to v2.
+
+### 7.6 Streaming transport details — token deltas + tool-call events over one
+
+`type:"stream"` query, keyed by `threadId`; confirm the delta envelope schema.
+
+### 7.7 Cost/step caps + cancellation (§6) — the default `maxSteps` and budget policy.
+
+---
+
+## 8. Cross-plan sequencing
+
+- **Sequence 111 (RAG) before any 113 build** — the agent memory step consumes
+  `defineRag(...).retrieve` (plan maintenance note).
+- Reuse the shipped **fan-out/saga** (plans 075/076) + the **duplicate-step-name
+  lint**; keep agent step names unique + deterministic (§2.1).
+- If built, this is the flagship Convex-parity AI feature — this design doc is the
+  decision artifact for build-vs-document (§7.1).

--- a/plans/proto/agent/agent-loop.test.ts
+++ b/plans/proto/agent/agent-loop.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Spike 113 PoC test. Asserts the two properties the plan requires:
+ *   (a) the message thread is persisted in order (user -> assistant tool-call ->
+ *       tool result -> final assistant), and
+ *   (b) on a simulated mid-loop crash + resume, the already-completed tool step is
+ *       NOT re-executed (no double side effect) and completed LLM turns are not
+ *       re-called.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { AgentDeps, LlmTurn, ThreadMessage } from "./agent-loop";
+import { DurableStepJournal, MessageStore, runAgent } from "./agent-loop";
+
+/** Build a mock LLM that returns one tool call on turn 0, then a final answer on turn 1. */
+const makeLlm = (): { fn: AgentDeps["llm"]; turns: number } => {
+    const state = { turns: 0 };
+
+    const fn = (): LlmTurn => {
+        const current = state.turns;
+
+        state.turns += 1;
+
+        if (current === 0) {
+            return { args: { city: "SF" }, id: "call_1", kind: "tool_call", name: "getWeather", text: "let me check the weather" };
+        }
+
+        return { kind: "final", text: "It is 21C and sunny in SF." };
+    };
+
+    return {
+        fn,
+        get turns() {
+            return state.turns;
+        },
+    };
+};
+
+/** Deterministic clock so `createdAt` is stable across the crash + resume. */
+const makeClock = () => {
+    let tick = 0;
+
+    return () => {
+        tick += 1;
+
+        return `2026-07-03T00:00:${String(tick).padStart(2, "0")}Z`;
+    };
+};
+
+describe("spike 113: durable single-tool agent loop", () => {
+    it("persists the thread in order across LLM -> tool -> LLM", async () => {
+        const llm = makeLlm();
+        const toolCalls: unknown[] = [];
+
+        const messages = await runAgent({
+            journal: new DurableStepJournal(),
+            llm: llm.fn,
+            messages: new MessageStore(),
+            now: makeClock(),
+            threadId: "t1",
+            tool: {
+                handler: (args) => {
+                    toolCalls.push(args);
+
+                    return "21C sunny";
+                },
+                name: "getWeather",
+            },
+            userInput: "what's the weather in SF?",
+        });
+
+        expect(messages.map((message: ThreadMessage) => message.role)).toEqual(["user", "assistant", "tool", "assistant"]);
+        expect(messages.map((message) => message.seq)).toEqual([0, 1, 2, 3]);
+        expect(messages[1].toolCall).toEqual({ args: { city: "SF" }, id: "call_1", name: "getWeather" });
+        expect(messages[2].toolCallId).toBe("call_1");
+        expect(messages[3].content).toContain("sunny");
+        expect(toolCalls).toHaveLength(1);
+    });
+
+    it("does not re-run a completed tool step on resume after a mid-loop crash", async () => {
+        // Shared, DURABLE state that survives the crash (the DO's SQLite + the
+        // Workflows step journal in the real design).
+        const journal = new DurableStepJournal();
+        const messages = new MessageStore();
+        const clock = makeClock();
+
+        const sideEffects = { count: 0 };
+        const llm = makeLlm();
+
+        const tool = {
+            handler: (): string => {
+                sideEffects.count += 1; // e.g. "charge the card" — must happen exactly once
+
+                return "21C sunny";
+            },
+            name: "getWeather",
+        };
+
+        // First attempt: crash right after the tool step commits, before turn 1's LLM call.
+        let crashed = false;
+
+        await expect(
+            runAgent({
+                checkpoint: (label) => {
+                    if (label === "after-tool:call_1") {
+                        crashed = true;
+
+                        throw new Error("SIMULATED_CRASH");
+                    }
+                },
+                journal,
+                llm: llm.fn,
+                messages,
+                now: clock,
+                threadId: "t1",
+                tool,
+                userInput: "what's the weather in SF?",
+            }),
+        ).rejects.toThrow("SIMULATED_CRASH");
+
+        expect(crashed).toBe(true);
+        expect(sideEffects.count).toBe(1); // tool ran once pre-crash
+        expect(journal.has("tool:getWeather:call_1")).toBe(true); // recorded in the journal
+        expect(journal.has("llm:turn:1")).toBe(false); // never reached
+
+        // RESUME: same journal + same message store, no checkpoint crash this time.
+        const invokedBeforeResume = [...journal.invoked];
+        const finalMessages = await runAgent({
+            journal,
+            llm: llm.fn,
+            messages,
+            now: clock,
+            threadId: "t1",
+            tool,
+            userInput: "what's the weather in SF?",
+        });
+
+        // (b) The tool did NOT run again — memoized by its step name.
+        expect(sideEffects.count).toBe(1);
+        // Each step body was invoked EXACTLY ONCE across the crash + resume: the two
+        // completed steps (llm:turn:0, tool:getWeather:call_1) ran pre-crash and were
+        // served from the journal on resume; only the new step (llm:turn:1) ran on resume.
+        expect(invokedBeforeResume).toEqual(["llm:turn:0", "tool:getWeather:call_1"]);
+        expect(journal.invoked).toEqual(["llm:turn:0", "tool:getWeather:call_1", "llm:turn:1"]);
+
+        // (a) The resumed thread is complete + in order, with no duplicated messages.
+        expect(finalMessages.map((message) => message.role)).toEqual(["user", "assistant", "tool", "assistant"]);
+        expect(finalMessages.map((message) => message.id)).toEqual(["t1:user:0", "t1:assistant:0", "t1:tool:call_1", "t1:assistant:1"]);
+        expect(finalMessages[3].content).toContain("sunny");
+    });
+});

--- a/plans/proto/agent/agent-loop.ts
+++ b/plans/proto/agent/agent-loop.ts
@@ -1,0 +1,191 @@
+/**
+ * Spike 113 proof-of-concept — a durable, replay-safe single-tool agent loop.
+ *
+ * Models the machinery Lunora already ships, so the loop is a *composition*, not a
+ * new engine:
+ *   - LLM turn  -> a named durable step  (real: `ctx.runStep(defineStep("llm:turn-N", ...))`
+ *                  -> `step.do("llm:turn-N", cb)`; packages/workflow/src/run-step.ts:130)
+ *   - tool call -> a named durable step  (real: `ctx.runStep(defineStep("tool:<name>:<callId>", ...))`)
+ *   - message persist -> a DO SQLite write, idempotent by a deterministic message id
+ *                  (real: `ctx.db` + the shipped ctx-db idempotency machinery)
+ *
+ * The replay-safety guarantee comes entirely from the native step memoization that
+ * Cloudflare Workflows provides and `run-step.ts` delegates to: `step.do(name, cb)`
+ * returns the persisted output of an ALREADY-COMPLETED step WITHOUT re-invoking `cb`.
+ * `DurableStepJournal` below is a faithful in-memory model of exactly that contract,
+ * so the PoC can assert "a completed tool step does not re-run on resume" without
+ * booting Cloudflare Workflows.
+ *
+ * IMPORTANT nuance the design doc expands on: memoization makes a COMPLETED step
+ * replay-safe. A step that FAILS mid-body is retried at-least-once, so a
+ * side-effecting tool (charge a card) must still be internally idempotent — the
+ * deterministic step name doubles as the idempotency key handed to the tool.
+ */
+
+/** A completed step's recorded output (mirrors Cloudflare Workflows' step journal). */
+interface JournalEntry {
+    output: unknown;
+}
+
+/**
+ * Faithful model of Cloudflare Workflows' `step.do(name, cb)` memoization:
+ * a step name that already has a recorded output returns it WITHOUT calling `cb`.
+ * Persisted across a resume by reusing the same journal instance.
+ */
+export class DurableStepJournal {
+    private readonly entries = new Map<string, JournalEntry>();
+
+    /** Names whose `cb` was actually invoked this process (for test assertions). */
+    public readonly invoked: string[] = [];
+
+    public async do<T>(name: string, callback: () => Promise<T> | T): Promise<T> {
+        const existing = this.entries.get(name);
+
+        if (existing) {
+            // Completed on a prior attempt/replay: return cached output, DO NOT re-run.
+            return existing.output as T;
+        }
+
+        this.invoked.push(name);
+
+        const output = await callback();
+
+        this.entries.set(name, { output });
+
+        return output;
+    }
+
+    public has(name: string): boolean {
+        return this.entries.has(name);
+    }
+}
+
+export type Role = "assistant" | "tool" | "user";
+
+export interface ThreadMessage {
+    /** Deterministic id -> idempotent across replays. */
+    id: string;
+    /** ISO timestamp (produced inside a step in the real design so replays are stable). */
+    createdAt: string;
+    content: string;
+    role: Role;
+    /** Present on an assistant message that requested a tool. */
+    toolCall?: { args: unknown; id: string; name: string };
+    /** Present on a tool message (correlates to the assistant `toolCall.id`). */
+    toolCallId?: string;
+    /** Monotonic per-thread sequence, assigned at persist time. */
+    seq: number;
+}
+
+/**
+ * Idempotent, ordered message store — models a DO SQLite thread table. Upsert by
+ * `id` so a replay that re-persists the same message does not duplicate it, and a
+ * monotonic `seq` gives a stable thread ordering.
+ */
+export class MessageStore {
+    private readonly byId = new Map<string, ThreadMessage>();
+
+    private nextSeq = 0;
+
+    public upsert(message: Omit<ThreadMessage, "seq"> & { seq?: number }): ThreadMessage {
+        const existing = this.byId.get(message.id);
+
+        if (existing) {
+            return existing;
+        }
+
+        const stored: ThreadMessage = { ...message, seq: this.nextSeq };
+
+        this.nextSeq += 1;
+        this.byId.set(message.id, stored);
+
+        return stored;
+    }
+
+    public list(): ThreadMessage[] {
+        return [...this.byId.values()].sort((a, b) => a.seq - b.seq);
+    }
+}
+
+/** What the (mocked) LLM returns for a turn: either a tool call or a final answer. */
+export type LlmTurn = { kind: "final"; text: string } | { args: unknown; id: string; kind: "tool_call"; name: string; text: string };
+
+export interface AgentDeps {
+    /** The durable-step journal (native `step.do` model). Reuse across a resume. */
+    journal: DurableStepJournal;
+    /** Mock LLM: given the running history, return this turn's action. */
+    llm: (history: ReadonlyArray<ThreadMessage>) => Promise<LlmTurn> | LlmTurn;
+    /** The message thread store (idempotent, ordered). */
+    messages: MessageStore;
+    /** Deterministic clock — a step body owns real time in the real design; injected here for stable tests. */
+    now: () => string;
+    /** Max LLM turns before bailing (cost/step cap — an open question in the design). */
+    maxTurns?: number;
+    /** Single tool for the PoC. Its step name (`tool:<name>:<callId>`) is its idempotency key. */
+    tool: { handler: (args: unknown) => Promise<string> | string; name: string };
+    /** Test hook: simulate a mid-loop crash at a labelled checkpoint. */
+    checkpoint?: (label: string) => void;
+    threadId: string;
+    userInput: string;
+}
+
+/**
+ * Run the durable single-tool agent loop. Each LLM turn and the tool call are
+ * named durable steps; message writes are idempotent. Safe to re-invoke with the
+ * same `journal` + `messages` after a crash — completed steps are not re-run.
+ */
+export const runAgent = async (deps: AgentDeps): Promise<ThreadMessage[]> => {
+    const maxTurns = deps.maxTurns ?? 8;
+
+    // Persist the user message once (idempotent by deterministic id).
+    deps.messages.upsert({ content: deps.userInput, createdAt: deps.now(), id: `${deps.threadId}:user:0`, role: "user" });
+
+    for (let turn = 0; turn < maxTurns; turn += 1) {
+        const history = deps.messages.list();
+
+        // LLM turn as a durable step: memoized by name, so a resume returns the
+        // recorded decision instead of paying for the model again.
+        const decision = await deps.journal.do<LlmTurn>(`llm:turn:${String(turn)}`, () => deps.llm(history));
+
+        if (decision.kind === "final") {
+            deps.messages.upsert({
+                content: decision.text,
+                createdAt: deps.now(),
+                id: `${deps.threadId}:assistant:${String(turn)}`,
+                role: "assistant",
+            });
+
+            return deps.messages.list();
+        }
+
+        // Persist the assistant's tool-call intent (idempotent).
+        deps.messages.upsert({
+            content: decision.text,
+            createdAt: deps.now(),
+            id: `${deps.threadId}:assistant:${String(turn)}`,
+            role: "assistant",
+            toolCall: { args: decision.args, id: decision.id, name: decision.name },
+        });
+
+        // Tool call as a durable step. The step name IS the idempotency key: on a
+        // resume the completed tool returns its recorded result and NEVER re-runs
+        // (no double-charge). `decision.id` is the provider's stable tool-call id.
+        const stepName = `tool:${decision.name}:${decision.id}`;
+        const toolResult = await deps.journal.do<string>(stepName, () => deps.tool.handler(decision.args));
+
+        deps.messages.upsert({
+            content: toolResult,
+            createdAt: deps.now(),
+            id: `${deps.threadId}:tool:${decision.id}`,
+            role: "tool",
+            toolCallId: decision.id,
+        });
+
+        // Injected crash point (test-only): a failure AFTER the tool step committed
+        // but BEFORE the next LLM turn. On resume the loop replays from the top and
+        // the tool step is served from the journal.
+        deps.checkpoint?.(`after-tool:${decision.id}`);
+    }
+
+    return deps.messages.list();
+};

--- a/plans/proto/tsconfig.json
+++ b/plans/proto/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    // Type-check only (spike prototypes; the real build is per-package packem).
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        // Spike-only relaxation: the prototype SOURCE modules (rag.ts, agent-loop.ts,
+        // compose-next-worker.ts) pass the repo's strict base as-is; this only silences
+        // `noUncheckedIndexedAccess` on positional `messages[1]` / `chunks[0]` test
+        // assertions, so the tests stay readable without `!` noise everywhere.
+        "noUncheckedIndexedAccess": false
+    },
+    "include": ["**/*.ts", "../../packages/bindings/src/vectors/create-vectors.ts", "../../packages/bindings/src/vectors/types.ts"]
+}

--- a/plans/proto/vitest.config.ts
+++ b/plans/proto/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Standalone Vitest config for the wave-11 spike prototypes (plans 110 / 111 / 113).
+ *
+ * These prototypes deliberately live OUTSIDE the pnpm workspace (`plans/` is not a
+ * workspace glob) so they add no package, no `pnpm-workspace.yaml` override, and no
+ * build step. They exercise pure composition logic with in-memory doubles; the
+ * RAG prototype imports the *real* `@lunora/bindings/vectors` `createVectors` by
+ * relative source path (it only imports its own relative siblings, so Vitest's
+ * esbuild transform resolves it with no build).
+ *
+ * Run from this directory:  `pnpm exec vitest run --config vitest.config.ts`
+ */
+export default {
+    test: {
+        environment: "node",
+        include: ["**/*.test.ts"],
+        watch: false,
+    },
+};


### PR DESCRIPTION
Split out of #96 (3/3). Phase-0 design doc + minimal runnable prototype for plan 113.

**Recommendation:** the loop maps **entirely onto shipped primitives** (`ctx.runStep`/native `step.do`, DO SQLite thread tables, the WS `type:"stream"` transport, plan-111 `rag.retrieve`) — so the **top open question is build-vs-document** given the "scale invisibly" tension. Recommend **document-first, then an opt-in `@lunora/agent` add-on** (keep core invisible). Replay-safety: completed-step memoization is native; a retried side-effecting tool needs an idempotency key = the deterministic step name (no `@lunora/workflow` change) — so **no STOP**.

PoC (`plans/proto/agent`) asserts thread ordering **and** resume-doesn't-re-run-a-completed-tool. 2 tests green, typecheck clean.

Note: `plans/proto/{tsconfig.json,vitest.config.ts}` are identical copies of the ones in the sibling spike PRs so each PR is standalone — identical add/add merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN6S2xjVhSNFXbH1qxijD6