### PR TITLE
fix(nuxt): make the single-worker `nuxt build` actually work

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -66,6 +66,7 @@
     },
     "dependencies": {
         "@lunora/client": "1.0.0-alpha.19",
+        "@lunora/runtime": "1.0.0-alpha.20",
         "@nuxt/kit": "^4.4.8"
     },
     "devDependencies": {

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -25,9 +25,94 @@
  * ```
  */
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { addServerHandler, createResolver, defineNuxtModule, useLogger } from "@nuxt/kit";
+
+/** Matches a trailing `.js` extension so it can be swapped for `.ts` (module-scope: compiled once). */
+const JS_EXTENSION_SUFFIX = /\.js$/;
+
+/**
+ * Minimal structural shape of the rollup plugin this module contributes (a
+ * `name` + an object-form `resolveId` hook). Declared locally because `rollup`
+ * is not a direct dependency — it's the Nitro server bundler, resolved at the
+ * consumer's build time — and this object is a valid rollup plugin at runtime.
+ */
+interface TsSourceResolverPlugin {
+    name: string;
+    resolveId: {
+        handler: (source: string, importer: string | undefined) => string | undefined;
+        order: "pre";
+    };
+}
+
+/** Minimal shape of the `nitro:config` hook payload this module mutates (Nitro's `NitroConfig` isn't in the installed Nuxt Kit typed hook map). */
+interface NitroConfigLike {
+    rollupConfig?: { plugins?: unknown[] };
+}
+
+/**
+ * Expand a Nuxt `~`/`~~` tilde specifier to an absolute path. `~/` is the project
+ * srcDir, `~~/` the rootDir; a bare or already-absolute specifier is returned
+ * untouched. Used for the `#lunora/app` alias, which the Nitro server bundle
+ * consumes: Nitro re-resolves a tilde against its OWN srcDir (the `server/` dir),
+ * so `~/lunora/server` would wrongly land at `server/lunora/server` and abort the
+ * build. An absolute path resolves identically in the Nuxt and Nitro graphs.
+ */
+const resolveTildePath = (specifier: string, rootDirectory: string, sourceDirectory: string): string => {
+    if (specifier.startsWith("~~/")) {
+        return join(rootDirectory, specifier.slice(3));
+    }
+
+    if (specifier.startsWith("~/")) {
+        return join(sourceDirectory, specifier.slice(2));
+    }
+
+    return specifier;
+};
+
+/**
+ * Rollup plugin (injected into the Nitro server build) that rewrites codegen's
+ * NodeNext `.js`-extension imports to their real `.ts` source. `@lunora/codegen`
+ * deliberately emits `.js` specifiers (mandatory under NodeNext), and Vite/esbuild
+ * resolve those to the `.ts` files — but Nitro's server rollup does NOT, so the
+ * Lunora app entry chain (`lunora/server.ts` to `_generated/app.ts`) fails to
+ * bundle with "Cannot resolve ... and externals are not allowed". This resolves
+ * `#lunora/*` (mapped to `rootDir/lunora/*` by the project package.json
+ * `imports`) and relative `.js` imports to a sibling `.ts` when one exists — a
+ * strict no-op for every other `.js` (only rewrites when the `.ts` is present).
+ */
+const lunoraTsSourceResolver = (rootDirectory: string): TsSourceResolverPlugin => {
+    const lunoraDirectory = join(rootDirectory, "lunora");
+
+    return {
+        name: "lunora:nitro-ts-source-resolve",
+        resolveId: {
+            handler(source: string, importer: string | undefined): string | undefined {
+                if (!source.endsWith(".js")) {
+                    return undefined;
+                }
+
+                let absolute: string | undefined;
+
+                if (source.startsWith("#lunora/")) {
+                    absolute = join(lunoraDirectory, source.slice("#lunora/".length));
+                } else if (source.startsWith(".") && importer !== undefined) {
+                    absolute = resolve(dirname(importer), source);
+                }
+
+                if (absolute === undefined) {
+                    return undefined;
+                }
+
+                const tsSource = absolute.replace(JS_EXTENSION_SUFFIX, ".ts");
+
+                return existsSync(tsSource) ? tsSource : undefined;
+            },
+            order: "pre",
+        },
+    };
+};
 
 /** Options for the `@lunora/nuxt` module (configurable under the `lunora` key in `nuxt.config`). */
 interface ModuleOptions {
@@ -54,10 +139,25 @@ export default defineNuxtModule<ModuleOptions>({
         const resolver = createResolver(import.meta.url);
 
         // Alias the `#lunora/app` virtual (imported by the Nitro server route) to
-        // the project's Lunora app entry. Nuxt forwards `options.alias` into the
-        // Nitro server bundle, so the server route resolves it there too.
+        // the project's Lunora app entry, resolved to an ABSOLUTE path first (see
+        // resolveTildePath — a `~` tilde would be re-resolved against Nitro's own
+        // `server/` dir and break the server build). Nuxt forwards `options.alias`
+        // into the Nitro server bundle, so the server route resolves it there too.
         // eslint-disable-next-line no-param-reassign -- nuxt.options is the documented module-mutation surface
-        nuxt.options.alias["#lunora/app"] = options.appEntry;
+        nuxt.options.alias["#lunora/app"] = resolveTildePath(options.appEntry, nuxt.options.rootDir, nuxt.options.srcDir);
+
+        // Teach the Nitro server bundle to resolve codegen's `.js` imports to
+        // their `.ts` source (rollup, unlike Vite/esbuild, won't). Without this
+        // the aliased app entry chain (`lunora/server.ts` → `_generated/*`) fails
+        // to bundle. Injected via `nitro:config` so it rides on the server build.
+        // That hook + `NitroConfig` aren't in this @nuxt/kit version's typed maps,
+        // so cast the hook name + config to the minimal shape this touches.
+        (nuxt as unknown as { hook: (name: "nitro:config", callback: (config: NitroConfigLike) => void) => void }).hook("nitro:config", (nitroConfig) => {
+            const plugins = [...(nitroConfig.rollupConfig?.plugins ?? []), lunoraTsSourceResolver(nuxt.options.rootDir)];
+
+            // eslint-disable-next-line no-param-reassign -- the nitro:config hook exists to mutate the passed config
+            nitroConfig.rollupConfig = { ...nitroConfig.rollupConfig, plugins };
+        });
 
         // Mount Lunora realtime (RPC + WebSocket + admin) as a Nitro server route.
         // The handler reconstructs a Web Request, resolves the Cloudflare env/ctx

--- a/packages/nuxt/src/runtime/cloudflare.ts
+++ b/packages/nuxt/src/runtime/cloudflare.ts
@@ -18,7 +18,7 @@
  * so this seam stays pure (no Nitro types needed) and unit-testable with a plain
  * object — a real `H3Event` is still assignable here.
  */
-import type { ExecutionContextLike } from "../../../../shared/execution-context";
+import type { ExecutionContextLike } from "@lunora/runtime";
 
 /** The `{ env, context|ctx }` payload Nitro attaches for the Cloudflare runtime. */
 interface CloudflareEventBag {
@@ -68,4 +68,4 @@ const resolveCloudflare = (event: H3EventLike): ResolvedCloudflare => {
 export type { H3EventLike, ResolvedCloudflare };
 export { resolveCloudflare };
 
-export { type ExecutionContextLike } from "../../../../shared/execution-context";
+export { type ExecutionContextLike } from "@lunora/runtime";

--- a/packages/nuxt/src/runtime/handler.ts
+++ b/packages/nuxt/src/runtime/handler.ts
@@ -15,8 +15,8 @@
  * boot required. The thin H3 adapter that reads `env`/`ctx` off the event and
  * the raw `Request`/`Response` lives in the `[...].ts` route module.
  */
-import type { ExecutionContextLike } from "../../../../shared/execution-context";
-import { NOOP_EXECUTION_CONTEXT } from "../../../../shared/execution-context";
+import type { ExecutionContextLike } from "@lunora/runtime";
+import { NOOP_EXECUTION_CONTEXT } from "@lunora/runtime";
 
 /**
  * Structural view of the Lunora worker the route delegates to — just the
@@ -59,4 +59,4 @@ const delegateToLunora = async (
 export type { LunoraWorkerLike };
 export { delegateToLunora };
 
-export { NOOP_EXECUTION_CONTEXT } from "../../../../shared/execution-context";
+export { NOOP_EXECUTION_CONTEXT } from "@lunora/runtime";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2559,6 +2559,9 @@ importers:
       '@lunora/client':
         specifier: workspace:*
         version: link:../client
+      '@lunora/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@nuxt/kit':
         specifier: ^4.4.8
         version: 4.4.8(magicast@0.5.3)


### PR DESCRIPTION
The `@lunora/nuxt` single-worker composition never built (three layered bugs, all masked because the template smoke harness failed at install until it was repaired). Fixed so `nuxt build` produces a deployable `.output/server`:

1. `#lunora/app` was aliased to a `~/lunora/server` tilde. The alias is consumed by BOTH Nuxt (client) and the Nitro server bundle, and Nitro re-resolves `~` against its OWN srcDir (the `server/` dir) → `server/lunora/server` → "Cannot resolve … and externals are not allowed". Resolve the app entry to an ABSOLUTE path first (resolveTildePath), so it resolves identically in both.

2. After (1) the server bundle loaded `lunora/server.ts` but couldn't resolve its codegen `.js` imports (`_generated/app.js` → only `app.ts` exists). Vite/ esbuild rewrite `.js`→`.ts`; Nitro's rollup doesn't. Inject a small `.js`→`.ts` source resolver into the Nitro rollup config (via the `nitro:config` hook), scoped to imports that have a real `.ts` sibling — a no-op otherwise.

3. The Nitro runtime files (`runtime/handler.ts`, `runtime/cloudflare.ts`) imported `NOOP_EXECUTION_CONTEXT` / `ExecutionContextLike` from the repo's top-level `shared/` via a relative path. `shared/*` is only bundler-INLINED into rolled-up entries; the Nuxt runtime ships per-file, so the relative path escaped the published package ("Cannot resolve ../../../../shared/…"). Import these from `@lunora/runtime` (which re-exports them) instead, and add it as a dependency.

Verified end-to-end: a scaffolded Nuxt template now builds to a deployable `.output/server/index.mjs` with the pristine template config (no template changes needed — all three fixes live in the module). Existing @lunora/nuxt tests pass; typecheck + eslint clean.

<!--
Thank you for contributing to Lunora!

Please fill out the sections below so reviewers can land your change quickly.
Keep the title in conventional-commit form (e.g. `feat(cli): add migrate flag`).
-->

## Summary

<!--
Explain *why* this change is needed and *what* it does at a high level.
Link to the relevant package(s) (e.g. `@lunora/d1`, `@lunora/codegen`) so
reviewers know which Wave / area is touched.
-->

## Linked issues

<!--
- Closes #...
- Refs #...
-->

## Test plan

<!--
Bulleted checklist of what you ran locally and what reviewers should re-run:

- [ ] `pnpm lint:types` passes
- [ ] `pnpm lint:eslint` passes
- [ ] `pnpm test` passes (234+ tests)
- [ ] If schema changed: `pnpm --filter @lunora/cli run codegen` regenerated cleanly
- [ ] If Durable Object / D1 code changed: workerd-based Vitest pool tests still pass
- [ ] Manual smoke test in `apps/playground` (if user-facing)
-->

## Checklist

- [ ] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change
- [ ] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs)
- [ ] No `package.json` files in `packages/*` modified outside the touched package
- [ ] If a new package was added: `project.json` has `type:package` and a `category:*` tag
- [ ] If migration impact: noted upgrade steps in the PR description and changelog entry

## Notes for reviewers

<!--
Anything reviewers should look at first, follow-up work you deferred, screenshots
for UI changes, etc.
-->

## Contributor License Agreement

<!--
Required for external contributors. Keep the line below in your PR description
exactly as written — the CLA check (.github/workflows/cla.yml) looks for it.
Members of the @anolilab organization can omit it (the check is skipped).
-->

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.
