### PR TITLE
feat(cli): real dev for class-B frameworks (SvelteKit/Nuxt/Astro)

### DIFF
--- a/packages/cli/__tests__/commands/dev.test.ts
+++ b/packages/cli/__tests__/commands/dev.test.ts
@@ -705,6 +705,48 @@ describe("lunora dev", () => {
             expect(warns.some((line) => line.includes("already running"))).toBe(true);
         });
 
+        it("supersedes the background parent's provisional record (does not self-detect as already-running)", async () => {
+            expect.assertions(3);
+
+            // The auto-background daemon inherits DEV_HANDOFF_PID = its parent's
+            // PID, and that parent wrote a provisional record (its own, live PID)
+            // before spawning the daemon. The daemon must claim OVER it and start,
+            // not report "already running" and bail — which is how `lunora dev`
+            // launches under AI-agent auto-background. Use `process.ppid` as the
+            // live "parent" PID (the same trick as the lockfile test above).
+            writeDevServerState(workdir, { mode: "cli", pid: process.ppid, url: "http://localhost:5173" });
+            const previous = process.env.LUNORA_DEV_HANDOFF_PID;
+            process.env.LUNORA_DEV_HANDOFF_PID = String(process.ppid);
+
+            let spawned = false;
+            const warns: string[] = [];
+            const logger: Logger = { error: () => {}, info: () => {}, success: () => {}, warn: (message) => warns.push(message) };
+
+            try {
+                const result = await runDevCommand({
+                    codegen: false,
+                    cwd: workdir,
+                    logger,
+                    startWorker: () => {
+                        spawned = true;
+
+                        return { exited: Promise.resolve(0), kill: () => {} };
+                    },
+                    studio: false,
+                });
+
+                expect(result.code).toBe(0);
+                expect(spawned).toBe(true); // claimed over the parent's provisional record and started
+                expect(warns.some((line) => line.includes("already running"))).toBe(false);
+            } finally {
+                if (previous === undefined) {
+                    delete process.env.LUNORA_DEV_HANDOFF_PID;
+                } else {
+                    process.env.LUNORA_DEV_HANDOFF_PID = previous;
+                }
+            }
+        });
+
         it("logs an actionable .dev.vars hint when the scaffolder is declined non-interactively", async () => {
             expect.assertions(2);
 

--- a/packages/cli/__tests__/commands/dev.test.ts
+++ b/packages/cli/__tests__/commands/dev.test.ts
@@ -263,6 +263,42 @@ describe("lunora dev", () => {
             expect(plan.remote.enabled).toBe(true);
         });
 
+        it.each([
+            ["sveltekit", { "@sveltejs/kit": "^2.0.0" }],
+            ["nuxt", { nuxt: "^4.0.0" }],
+        ])("plans the two-process framework-worker stack for %s (front-door dev + wrangler sidecar)", (_name, dependencies) => {
+            expect.assertions(7);
+
+            // Class-B frameworks whose dev server can't host ShardDO. They also
+            // declare `@lunora/vite` (their dev server uses it for codegen), but
+            // the framework check wins so the flavor is `framework-worker`.
+            writeFileSync(
+                join(workdir, "package.json"),
+                JSON.stringify({
+                    dependencies,
+                    devDependencies: { "@lunora/vite": "workspace:*" },
+                    name: "app",
+                    packageManager: "pnpm@11.0.0",
+                    scripts: { dev: "vite" },
+                }),
+                "utf8",
+            );
+
+            expect(detectDevFlavor(workdir)).toBe("framework-worker");
+
+            const plan = planDevCommand({ cwd: workdir, hasIpv6Loopback: () => true, logger: silentLogger() });
+
+            expect(plan.flavor).toBe("framework-worker");
+            // Primary child = the framework's own dev server (front door + HMR).
+            expect(plan.wrangler.tag).toBe("vite");
+            // Sidecar = `wrangler dev` on the dev-only config, owning ShardDO.
+            expect(plan.sidecar?.tag).toBe("worker");
+            expect(plan.sidecar?.args.join(" ")).toContain("dev --config wrangler.dev.jsonc");
+            // Codegen/studio are owned by the framework's own @lunora/vite plugin.
+            expect(plan.codegenEnabled).toBe(false);
+            expect(plan.studioEnabled).toBe(false);
+        });
+
         it("threads the materializer's cleanup disposer onto the remote plan", () => {
             expect.assertions(1);
 
@@ -370,7 +406,12 @@ describe("lunora dev", () => {
         it("logs the framework redirect hint but still spawns the worker", async () => {
             expect.assertions(3);
 
-            writeFileSync(join(workdir, "package.json"), JSON.stringify({ dependencies: { nuxt: "^3.0.0" } }), "utf8");
+            // A class-A framework WITHOUT `@lunora/vite` still takes the wrangler
+            // flavor (the worker runs inside the framework's own Vite dev server,
+            // so `lunora dev` gives just the worker + a redirect hint). SvelteKit /
+            // Nuxt are class-B and take the two-process `framework-worker` flavor
+            // instead — covered separately below.
+            writeFileSync(join(workdir, "package.json"), JSON.stringify({ dependencies: { "@tanstack/react-start": "^1.0.0" } }), "utf8");
 
             const warnings: string[] = [];
             let workerSpawned = false;
@@ -394,7 +435,58 @@ describe("lunora dev", () => {
 
             expect(result.code).toBe(0);
             expect(workerSpawned).toBe(true);
-            expect(warnings.some((line) => line.includes("nuxt") && line.includes("lunora dev"))).toBe(true);
+            expect(warnings.some((line) => line.includes("tanstack-start") && line.includes("lunora dev"))).toBe(true);
+        });
+
+        it("framework-worker: spawns the framework dev server + wrangler sidecar and tears the sidecar down on exit", async () => {
+            expect.assertions(4);
+
+            // SvelteKit (class-B): two-process dev — the framework's own dev
+            // server (front door) + a `wrangler dev` sidecar owning ShardDO.
+            writeFileSync(
+                join(workdir, "package.json"),
+                JSON.stringify({
+                    dependencies: { "@sveltejs/kit": "^2.0.0" },
+                    devDependencies: { "@lunora/vite": "workspace:*" },
+                    name: "app",
+                    packageManager: "pnpm@11.0.0",
+                    scripts: { dev: "vite" },
+                }),
+                "utf8",
+            );
+
+            const spawned: string[] = [];
+            let sidecarKilled = false;
+            let resolveSidecar: (code: number) => void = () => {};
+            const sidecarExited = new Promise<number>((resolve) => {
+                resolveSidecar = resolve;
+            });
+
+            const startWorker: NonNullable<DevCommandOptions["startWorker"]> = (descriptor) => {
+                spawned.push(descriptor.tag);
+
+                // The sidecar runs until killed; killing it resolves its exit so
+                // the orchestrator's `allSettled` teardown can complete.
+                if (descriptor.tag === "worker") {
+                    return {
+                        exited: sidecarExited,
+                        kill: () => {
+                            sidecarKilled = true;
+                            resolveSidecar(0);
+                        },
+                    };
+                }
+
+                // The framework dev server (primary) exits cleanly straight away.
+                return { exited: Promise.resolve(0), kill: () => {} };
+            };
+
+            const result = await runDevCommand({ cwd: workdir, logger: silentLogger(), startWorker });
+
+            expect(result.code).toBe(0);
+            expect(spawned).toContain("vite"); // framework dev server (front door)
+            expect(spawned).toContain("worker"); // wrangler sidecar (ShardDO)
+            expect(sidecarKilled).toBe(true); // primary exit tore the sidecar down
         });
 
         it("fills empty .dev.vars secrets + the admin token before the worker boots", async () => {

--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -110,7 +110,7 @@ describe("lunora init", () => {
         });
 
         it("writes pnpm-workspace.yaml with the allowBuilds allowlist before a pnpm install", async () => {
-            expect.assertions(3);
+            expect.assertions(4);
 
             const { spawner } = createRecordingSpawner();
 
@@ -134,6 +134,9 @@ describe("lunora init", () => {
             // build scripts without the interactive `pnpm approve-builds` step.
             expect(workspace).toContain("allowBuilds:");
             expect(workspace).toContain("esbuild: true");
+            // Optional native builds a scaffold doesn't need are listed as denied
+            // (so pnpm neither prompts nor requires a C/C++ toolchain).
+            expect(workspace).toContain("ssh2: false");
         });
 
         it("does not install when the user declines the offer", async () => {

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -711,6 +711,135 @@ const buildDevPlan = async (options: DevCommandOptions): Promise<DevCommandPlan>
 };
 
 /**
+ * Supervise the spawned dev children until dev ends. Wires SIGINT/SIGTERM to
+ * signal BOTH the framework dev server and the sidecar together (Ctrl-C once →
+ * SIGTERM, again → SIGKILL; a grace timer escalates the first SIGINT), then
+ * resolves when the FIRST child exits — a stopped framework dev server and a
+ * crashed sidecar both mean "dev is over" — tearing the other down and awaiting
+ * it so neither is orphaned holding a port. Returns that first child's exit
+ * code. With no sidecar (single-process flavors) this collapses to plain
+ * single-child supervision. Extracted from {@link runDevCommand} to keep its
+ * orchestration legible (and under the cognitive-complexity budget).
+ */
+const superviseWorkers = async (worker: WorkerProcess, sidecar: WorkerProcess | undefined, logger: Logger): Promise<number> => {
+    let sigintCount = 0;
+    let escalationTimer: NodeJS.Timeout | undefined;
+
+    const killChildren = (signal: NodeJS.Signals): void => {
+        worker.kill(signal);
+        sidecar?.kill(signal);
+    };
+    const onSigint = (): void => {
+        sigintCount += 1;
+
+        if (sigintCount === 1) {
+            logger.info("received SIGINT — shutting down (press Ctrl-C again to force-kill)");
+            killChildren("SIGTERM");
+            escalationTimer = setTimeout(() => {
+                killChildren("SIGKILL");
+            }, SIGINT_GRACE_MS);
+            escalationTimer.unref();
+        } else {
+            killChildren("SIGKILL");
+        }
+    };
+    const onSigterm = (): void => {
+        killChildren("SIGTERM");
+    };
+
+    process.on("SIGINT", onSigint);
+    process.on("SIGTERM", onSigterm);
+
+    const exits: Promise<{ code: number; who: "sidecar" | "worker" }>[] = [
+        worker.exited.then((code) => {
+            return { code, who: "worker" as const };
+        }),
+    ];
+
+    if (sidecar !== undefined) {
+        exits.push(
+            sidecar.exited.then((code) => {
+                return { code, who: "sidecar" as const };
+            }),
+        );
+    }
+
+    const first = await Promise.race(exits);
+
+    if (sidecar !== undefined) {
+        if (first.who === "sidecar") {
+            logger.warn("[worker] the Lunora sidecar (wrangler dev) exited — shutting down the framework dev server");
+            worker.kill("SIGTERM");
+        } else {
+            sidecar.kill("SIGTERM");
+        }
+
+        await Promise.allSettled([worker.exited, sidecar.exited]);
+    }
+
+    if (escalationTimer) {
+        clearTimeout(escalationTimer);
+    }
+
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+
+    return first.code;
+};
+
+/**
+ * Start the embedded studio server for the wrangler/framework-worker flavors —
+ * best-effort: a start failure is logged and dev continues without it. Returns
+ * the handle (for teardown), or `undefined` when studio is disabled or failed.
+ */
+const startStudioBestEffort = async (
+    options: DevCommandOptions,
+    plan: DevCommandPlan,
+    cwd: string,
+    logger: Logger,
+): Promise<StudioServerHandle | undefined> => {
+    if (!plan.studioEnabled) {
+        return undefined;
+    }
+
+    try {
+        return await (options.startStudio ?? startStudioServer)({
+            cwd,
+            logger: {
+                warnOnce: (message) => {
+                    logger.warn(message);
+                },
+            },
+            port: plan.studioPort,
+            workerOrigin: plan.workerOrigin,
+        });
+    } catch (error: unknown) {
+        logger.warn(`studio server failed to start (${error instanceof Error ? error.message : String(error)}) — continuing without it`);
+
+        return undefined;
+    }
+};
+
+/**
+ * For the two-process framework-worker flavor (SvelteKit / Nuxt), regenerate
+ * `_generated/*` once up front so the sidecar's `wrangler dev` can bundle
+ * `lunora/server.ts` immediately — the framework's own `@lunora/vite` plugin
+ * owns the ongoing watch, but there's a startup race. Best-effort + a no-op for
+ * every single-process flavor. A failure is surfaced but non-fatal.
+ */
+const ensureSidecarGenerated = (plan: DevCommandPlan, options: DevCommandOptions, cwd: string, logger: Logger): void => {
+    if (plan.sidecar === undefined) {
+        return;
+    }
+
+    try {
+        runCodegen({ apiSpec: options.apiSpec, lunoraDirectory: "lunora", projectRoot: cwd });
+    } catch (error: unknown) {
+        logger.warn(`codegen (pre-sidecar) failed: ${error instanceof Error ? error.message : String(error)} — the framework dev server will retry`);
+    }
+};
+
+/**
  * Start codegen watch + the studio server, spawn `wrangler dev`, print the
  * banner, and resolve when the worker exits or the user interrupts — tearing
  * down the sibling servers either way. The three side-effecting pieces (worker,
@@ -729,9 +858,19 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         // already running — report it and succeed (idempotent start) instead of
         // spawning a conflicting sibling. A stale record (dead PID) was already
         // cleared by the read.
+        //
+        // A background daemon inherits DEV_HANDOFF_ENV = its parent's PID, and
+        // that parent wrote a PROVISIONAL record (its own PID) before spawning
+        // us. Skip that record here — `claimStartRecord` below supersedes it via
+        // `supersedePid`. Without this skip the daemon sees its own parent's
+        // claim, reports "already running", and never starts (this is the path
+        // `lunora dev` takes under AI-agent auto-background, so it would silently
+        // fail to launch). A genuine other server has a PID that is neither ours
+        // nor the handoff parent's, so it still short-circuits correctly.
+        const handoffPid = Number(process.env[DEV_HANDOFF_ENV]);
         const existing = readLiveDevServerState(cwd);
 
-        if (existing !== undefined && existing.pid !== process.pid) {
+        if (existing !== undefined && existing.pid !== process.pid && existing.pid !== handoffPid) {
             reportExistingServer(logger, existing);
 
             return { code: 0, plan };
@@ -772,25 +911,8 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             handles.codegen = (options.startCodegen ?? startCodegenWatch)({ apiSpec: options.apiSpec, logger, projectRoot: cwd });
         }
 
-        let studioUrl: string | undefined;
-
-        if (plan.studioEnabled) {
-            try {
-                handles.studio = await (options.startStudio ?? startStudioServer)({
-                    cwd,
-                    logger: {
-                        warnOnce: (message) => {
-                            logger.warn(message);
-                        },
-                    },
-                    port: plan.studioPort,
-                    workerOrigin: plan.workerOrigin,
-                });
-                studioUrl = handles.studio.url;
-            } catch (error: unknown) {
-                logger.warn(`studio server failed to start (${error instanceof Error ? error.message : String(error)}) — continuing without it`);
-            }
-        }
+        handles.studio = await startStudioBestEffort(options, plan, cwd, logger);
+        const studioUrl = handles.studio?.url;
 
         // A Vite/meta-framework was detected: nudge the user to their framework
         // dev script for the full app before wrangler starts (the worker still runs).
@@ -798,19 +920,7 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             logger.warn(plan.frameworkHint);
         }
 
-        // Two-process framework-worker flavor (SvelteKit / Nuxt): the sidecar's
-        // `wrangler dev` bundles `lunora/server.ts`, which imports `_generated/*`.
-        // The framework's own `@lunora/vite` plugin owns the ongoing codegen
-        // watch, but there's a startup race — run codegen once up front so the
-        // sidecar bundle resolves. Best-effort: a failure is surfaced but not
-        // fatal (the framework plugin regenerates on its next tick).
-        if (plan.sidecar !== undefined) {
-            try {
-                runCodegen({ apiSpec: options.apiSpec, lunoraDirectory: "lunora", projectRoot: cwd });
-            } catch (error: unknown) {
-                logger.warn(`codegen (pre-sidecar) failed: ${error instanceof Error ? error.message : String(error)} — the framework dev server will retry`);
-            }
-        }
+        ensureSidecarGenerated(plan, options, cwd, logger);
 
         const spawn = options.startWorker ?? defaultWorkerSpawner;
         const worker = spawn(plan.wrangler, logger);
@@ -821,76 +931,7 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         handles.containerLogs = afterWorkerSpawn(plan, cwd, logger, studioUrl);
         printAgentRulesHint(logger, cwd);
 
-        let sigintCount = 0;
-        let escalationTimer: NodeJS.Timeout | undefined;
-
-        // Both children are signalled together so Ctrl-C tears down the whole
-        // stack (framework dev server + sidecar) — never orphans one holding a port.
-        const killChildren = (signal: NodeJS.Signals): void => {
-            worker.kill(signal);
-            sidecar?.kill(signal);
-        };
-
-        const onSigint = (): void => {
-            sigintCount += 1;
-
-            if (sigintCount === 1) {
-                logger.info("received SIGINT — shutting down (press Ctrl-C again to force-kill)");
-                killChildren("SIGTERM");
-                escalationTimer = setTimeout(() => {
-                    killChildren("SIGKILL");
-                }, SIGINT_GRACE_MS);
-                escalationTimer.unref();
-            } else {
-                killChildren("SIGKILL");
-            }
-        };
-        const onSigterm = (): void => {
-            killChildren("SIGTERM");
-        };
-
-        process.on("SIGINT", onSigint);
-        process.on("SIGTERM", onSigterm);
-
-        // Exit when EITHER child exits: a stopped framework dev server and a
-        // crashed sidecar both mean "dev is over". Then tear the other down and
-        // await it so neither is orphaned. With no sidecar the race has one entry
-        // and this collapses to the original single-child behaviour.
-        const exits: Promise<{ code: number; who: "sidecar" | "worker" }>[] = [
-            worker.exited.then((code) => {
-                return { code, who: "worker" as const };
-            }),
-        ];
-
-        if (sidecar !== undefined) {
-            exits.push(
-                sidecar.exited.then((code) => {
-                    return { code, who: "sidecar" as const };
-                }),
-            );
-        }
-
-        const first = await Promise.race(exits);
-
-        if (sidecar !== undefined) {
-            if (first.who === "sidecar") {
-                logger.warn("[worker] the Lunora sidecar (wrangler dev) exited — shutting down the framework dev server");
-                worker.kill("SIGTERM");
-            } else {
-                sidecar.kill("SIGTERM");
-            }
-
-            await Promise.allSettled([worker.exited, sidecar.exited]);
-        }
-
-        const { code } = first;
-
-        if (escalationTimer) {
-            clearTimeout(escalationTimer);
-        }
-
-        process.off("SIGINT", onSigint);
-        process.off("SIGTERM", onSigterm);
+        const code = await superviseWorkers(worker, sidecar, logger);
 
         return { code, plan };
     } finally {

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn as nodeSpawn } from "node:child_process";
 
+import { runCodegen } from "@lunora/codegen";
 import type { ContainerLogStreamHandle } from "@lunora/config";
 import {
     AGENT_RULES_HINT,
@@ -52,6 +53,17 @@ import { createTuiConfirm } from "../../util/tui-prompts";
 import type { DevOptions } from "./index";
 import type { DevFlavor } from "./lifecycle";
 import { detectDevFlavor, reportExistingServer, runLifecycleSubcommand, startBackground, viteDevCommand } from "./lifecycle";
+
+/**
+ * The dev-only wrangler config the `framework-worker` sidecar runs (`wrangler dev
+ * -c wrangler.dev.jsonc`). Committed in the SvelteKit / Nuxt templates: its
+ * `main` is the Lunora-only `lunora/server.ts` worker (`.build()`, exporting
+ * `ShardDO`), and its `dev.port` pins the sidecar port the framework front end
+ * proxies to (SvelteKit) or the client points at (Nuxt). Kept separate from the
+ * deploy `wrangler.jsonc` (whose `main` is the framework adapter's built output,
+ * which doesn't exist in dev).
+ */
+const DEV_WRANGLER_CONFIG = "wrangler.dev.jsonc";
 
 /** Default port the embedded studio server listens on (the URL you open). */
 const DEFAULT_STUDIO_PORT = 6173;
@@ -149,11 +161,21 @@ interface DevCommandPlan {
     ipv4LoopbackForced: boolean;
     /** The remote-binding decision: which D1/KV/R2 bindings hit the deployed worker. */
     remote: DevRemotePlan;
+
+    /**
+     * The `wrangler dev` sidecar for the `framework-worker` flavor (SvelteKit /
+     * Nuxt): a second child that owns the real `ShardDO` in `workerd`, wired via
+     * the committed `wrangler.dev.jsonc`. `undefined` for every other flavor —
+     * only the two-process class-B stack has a sidecar. When present, `wrangler`
+     * (above) is the framework's own dev server (the front door / HMR) and this
+     * is the Lunora realtime plane.
+     */
+    sidecar?: SpawnDescriptor & { tag: string };
     studioEnabled: boolean;
     studioPort: number;
     workerOrigin: string;
     workerPort: number;
-    /** The single child process `lunora dev` spawns: `wrangler dev` (or `vite dev` for the vite flavor). */
+    /** The primary child `lunora dev` spawns: `wrangler dev` (wrangler flavor) or the framework/`vite dev` server (vite / framework-worker). */
     wrangler: SpawnDescriptor & { tag: string };
 }
 
@@ -252,11 +274,11 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
     const manager = detectPackageManager(cwd);
     const flavor = options.flavor ?? detectDevFlavor(cwd);
 
-    if (flavor === "vite") {
+    if (flavor === "vite" || flavor === "framework-worker") {
         // `@lunora/vite` already runs the worker + studio + codegen (and remote
         // bindings, dev vars, container logs) inside the Vite dev server — the
         // CLI's own siblings would duplicate them, so they're all disabled and
-        // the one child is the project's own dev server. Remote mode is
+        // the primary child is the project's own dev server. Remote mode is
         // forwarded as env (`LUNORA_REMOTE=1`) for the plugin's remote-bindings
         // handling; no temp wrangler config is materialized here. The Vite
         // plugin writes the authoritative `.lunora/dev.json` (real resolved URL
@@ -264,11 +286,29 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
         // pre-listen default.
         const exec = viteDevCommand(cwd);
 
+        // The `framework-worker` flavor (SvelteKit / Nuxt) adds a `wrangler dev`
+        // sidecar that owns the real `ShardDO`, run from the committed
+        // `wrangler.dev.jsonc` (its `dev.port` pins the port). On a host without
+        // IPv6 loopback, prepend `--ip 127.0.0.1` so workerd doesn't abort
+        // binding its default `[::1]`. `--var WORKER_ENV:development` streams the
+        // sidecar's RPC dispatch summaries to the terminal (mirrors the wrangler
+        // flavor). One-shot codegen runs in `runDevCommand` before the sidecar
+        // spawns, so `lunora/server.ts`'s `_generated` imports resolve.
+        let sidecar: (SpawnDescriptor & { tag: string }) | undefined;
+
+        if (flavor === "framework-worker") {
+            const loopbackArgs = resolveLoopbackArgs(cwd, options.hasIpv6Loopback ?? hasIpv6Loopback);
+            const sidecarExec = execArgsFor(manager, "wrangler", ["dev", "--config", DEV_WRANGLER_CONFIG, ...loopbackArgs, "--var", "WORKER_ENV:development"]);
+
+            sidecar = { args: sidecarExec.args, command: sidecarExec.command, cwd, tag: "worker" };
+        }
+
         return {
             codegenEnabled: false,
             flavor,
             ipv4LoopbackForced: false,
             remote: { bindings: [], cleanup: () => {}, enabled: options.remote === true },
+            ...(sidecar ? { sidecar } : {}),
             studioEnabled: false,
             studioPort: options.port ?? DEFAULT_STUDIO_PORT,
             workerOrigin: `http://localhost:${String(DEFAULT_VITE_PORT)}`,
@@ -707,10 +747,12 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             return { code: 0, plan };
         }
 
-        if (plan.flavor === "vite") {
+        if (plan.flavor === "vite" || plan.flavor === "framework-worker") {
             // Hand the provisional record down so the dev-state plugin inside
-            // the Vite child may supersede it (and only it) with the
-            // authoritative resolved URL + Vite's own PID.
+            // the framework's Vite child may supersede it (and only it) with the
+            // authoritative resolved URL + Vite's own PID. For framework-worker
+            // the front door is the framework dev server (`plan.wrangler`), not
+            // the sidecar, so the handoff rides on it.
             plan.wrangler.env = { ...plan.wrangler.env, [DEV_HANDOFF_ENV]: String(process.pid) };
         }
 
@@ -756,7 +798,25 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             logger.warn(plan.frameworkHint);
         }
 
-        const worker = (options.startWorker ?? defaultWorkerSpawner)(plan.wrangler, logger);
+        // Two-process framework-worker flavor (SvelteKit / Nuxt): the sidecar's
+        // `wrangler dev` bundles `lunora/server.ts`, which imports `_generated/*`.
+        // The framework's own `@lunora/vite` plugin owns the ongoing codegen
+        // watch, but there's a startup race — run codegen once up front so the
+        // sidecar bundle resolves. Best-effort: a failure is surfaced but not
+        // fatal (the framework plugin regenerates on its next tick).
+        if (plan.sidecar !== undefined) {
+            try {
+                runCodegen({ apiSpec: options.apiSpec, lunoraDirectory: "lunora", projectRoot: cwd });
+            } catch (error: unknown) {
+                logger.warn(`codegen (pre-sidecar) failed: ${error instanceof Error ? error.message : String(error)} — the framework dev server will retry`);
+            }
+        }
+
+        const spawn = options.startWorker ?? defaultWorkerSpawner;
+        const worker = spawn(plan.wrangler, logger);
+        // The Lunora realtime sidecar (`wrangler dev`, owns ShardDO) for the
+        // framework-worker flavor — `undefined` for every single-process flavor.
+        const sidecar = plan.sidecar === undefined ? undefined : spawn(plan.sidecar, logger);
 
         handles.containerLogs = afterWorkerSpawn(plan, cwd, logger, studioUrl);
         printAgentRulesHint(logger, cwd);
@@ -764,28 +824,66 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         let sigintCount = 0;
         let escalationTimer: NodeJS.Timeout | undefined;
 
+        // Both children are signalled together so Ctrl-C tears down the whole
+        // stack (framework dev server + sidecar) — never orphans one holding a port.
+        const killChildren = (signal: NodeJS.Signals): void => {
+            worker.kill(signal);
+            sidecar?.kill(signal);
+        };
+
         const onSigint = (): void => {
             sigintCount += 1;
 
             if (sigintCount === 1) {
                 logger.info("received SIGINT — shutting down (press Ctrl-C again to force-kill)");
-                worker.kill("SIGTERM");
+                killChildren("SIGTERM");
                 escalationTimer = setTimeout(() => {
-                    worker.kill("SIGKILL");
+                    killChildren("SIGKILL");
                 }, SIGINT_GRACE_MS);
                 escalationTimer.unref();
             } else {
-                worker.kill("SIGKILL");
+                killChildren("SIGKILL");
             }
         };
         const onSigterm = (): void => {
-            worker.kill("SIGTERM");
+            killChildren("SIGTERM");
         };
 
         process.on("SIGINT", onSigint);
         process.on("SIGTERM", onSigterm);
 
-        const code = await worker.exited;
+        // Exit when EITHER child exits: a stopped framework dev server and a
+        // crashed sidecar both mean "dev is over". Then tear the other down and
+        // await it so neither is orphaned. With no sidecar the race has one entry
+        // and this collapses to the original single-child behaviour.
+        const exits: Promise<{ code: number; who: "sidecar" | "worker" }>[] = [
+            worker.exited.then((code) => {
+                return { code, who: "worker" as const };
+            }),
+        ];
+
+        if (sidecar !== undefined) {
+            exits.push(
+                sidecar.exited.then((code) => {
+                    return { code, who: "sidecar" as const };
+                }),
+            );
+        }
+
+        const first = await Promise.race(exits);
+
+        if (sidecar !== undefined) {
+            if (first.who === "sidecar") {
+                logger.warn("[worker] the Lunora sidecar (wrangler dev) exited — shutting down the framework dev server");
+                worker.kill("SIGTERM");
+            } else {
+                sidecar.kill("SIGTERM");
+            }
+
+            await Promise.allSettled([worker.exited, sidecar.exited]);
+        }
+
+        const { code } = first;
 
         if (escalationTimer) {
             clearTimeout(escalationTimer);

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -55,23 +55,21 @@ const LOG_TAIL_MAX_BYTES = 256 * 1024;
 const READY_TIMEOUT_ENV = "LUNORA_DEV_READY_TIMEOUT_MS";
 
 /**
- * How the dev child runs.
- *
- * - `wrangler` — the classic `lunora dev` stack (wrangler worker + embedded
- *   studio + codegen watch), for a standalone (class-C) project.
- * - `vite` — a project on `@lunora/vite`: the Vite plugin already runs the
- *   worker, studio, and codegen inside the Vite dev server, so `lunora dev` runs
- *   the project's own dev script and gets out of the way. This also covers the
- *   class-B frameworks whose own dev server runs the worker in `workerd` (Astro
- *   6 + `@astrojs/cloudflare`, which embeds `@cloudflare/vite-plugin` in
- *   `astro dev` — SSR + `/_lunora/*` + `ShardDO` in one process, HMR intact).
- * - `framework-worker` — a class-B framework whose dev server CANNOT host the
- *   `ShardDO` Durable Object (SvelteKit / Nuxt: their adapters use wrangler's
- *   `getPlatformProxy()`, which runs an empty-script Miniflare and does not
- *   emulate internal DOs). `lunora dev` runs the framework's own dev server
- *   (front door, HMR, and — via its `@lunora/vite` plugin — studio + codegen)
- *   AND a second `wrangler dev` sidecar that owns the real `ShardDO` in
- *   `workerd`, wired via the committed `wrangler.dev.jsonc`.
+ * How the dev child runs. `wrangler` is the classic `lunora dev` stack (wrangler
+ * worker + embedded studio + codegen watch) for a standalone class-C project.
+ * `vite` is a project on `@lunora/vite`: the plugin already runs the worker,
+ * studio, and codegen inside the Vite dev server, so `lunora dev` runs the
+ * project's own dev script and gets out of the way — this also covers class-B
+ * frameworks whose own dev server runs the worker in `workerd` (Astro 6 +
+ * `@astrojs/cloudflare`, which embeds `@cloudflare/vite-plugin` in `astro dev`:
+ * SSR + `/_lunora/*` + `ShardDO` in one process, HMR intact). `framework-worker`
+ * is a class-B framework whose dev server CANNOT host the `ShardDO` Durable
+ * Object (SvelteKit / Nuxt: their adapters use wrangler's `getPlatformProxy()`,
+ * which runs an empty-script Miniflare and does not emulate internal DOs); there
+ * `lunora dev` runs the framework's own dev server (front door, HMR, and — via
+ * its `@lunora/vite` plugin — studio + codegen) AND a second `wrangler dev`
+ * sidecar that owns the real `ShardDO` in `workerd`, wired via the committed
+ * `wrangler.dev.jsonc`.
  */
 type DevFlavor = "framework-worker" | "vite" | "wrangler";
 

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -20,6 +20,7 @@ import type { DevServerState } from "@lunora/config";
 import {
     claimDevServerState,
     clearDevServerState,
+    detectFramework,
     DEV_DAEMON_ENV,
     DEV_HANDOFF_ENV,
     DEV_LOG_FILE,
@@ -54,17 +55,52 @@ const LOG_TAIL_MAX_BYTES = 256 * 1024;
 const READY_TIMEOUT_ENV = "LUNORA_DEV_READY_TIMEOUT_MS";
 
 /**
- * How the dev child runs. `wrangler` is the classic `lunora dev` stack
- * (wrangler worker + embedded studio + codegen watch). `vite` is a project on
- * `@lunora/vite`: the Vite plugin already runs the worker, studio, and codegen
- * inside the Vite dev server, so `lunora dev` runs the project's own dev
- * script and gets out of the way — that's what makes `--background` / `stop` /
- * `status` / `logs` work uniformly for Vite projects too.
+ * How the dev child runs.
+ *
+ * - `wrangler` — the classic `lunora dev` stack (wrangler worker + embedded
+ *   studio + codegen watch), for a standalone (class-C) project.
+ * - `vite` — a project on `@lunora/vite`: the Vite plugin already runs the
+ *   worker, studio, and codegen inside the Vite dev server, so `lunora dev` runs
+ *   the project's own dev script and gets out of the way. This also covers the
+ *   class-B frameworks whose own dev server runs the worker in `workerd` (Astro
+ *   6 + `@astrojs/cloudflare`, which embeds `@cloudflare/vite-plugin` in
+ *   `astro dev` — SSR + `/_lunora/*` + `ShardDO` in one process, HMR intact).
+ * - `framework-worker` — a class-B framework whose dev server CANNOT host the
+ *   `ShardDO` Durable Object (SvelteKit / Nuxt: their adapters use wrangler's
+ *   `getPlatformProxy()`, which runs an empty-script Miniflare and does not
+ *   emulate internal DOs). `lunora dev` runs the framework's own dev server
+ *   (front door, HMR, and — via its `@lunora/vite` plugin — studio + codegen)
+ *   AND a second `wrangler dev` sidecar that owns the real `ShardDO` in
+ *   `workerd`, wired via the committed `wrangler.dev.jsonc`.
  */
-type DevFlavor = "vite" | "wrangler";
+type DevFlavor = "framework-worker" | "vite" | "wrangler";
 
-/** Detect the dev flavor: a declared `@lunora/vite` dependency means Vite owns the dev server. */
-const detectDevFlavor = (cwd: string): DevFlavor => (readProjectDependencyNames(cwd).has("@lunora/vite") ? "vite" : "wrangler");
+/**
+ * The class-B frameworks whose dev server cannot host the `ShardDO` Durable
+ * Object (Node-based SSR + `getPlatformProxy` bindings), so `lunora dev` must
+ * run a `wrangler dev` sidecar alongside the framework dev server. Astro is
+ * deliberately excluded: Astro 6's `@astrojs/cloudflare` runs the whole app
+ * (incl. DOs) in `workerd` inside `astro dev`, so it needs no sidecar.
+ */
+const SIDECAR_FRAMEWORKS = new Set(["nuxt", "sveltekit"]);
+
+/**
+ * Detect the dev flavor.
+ *
+ * A SvelteKit / Nuxt project needs the two-process `framework-worker` stack even
+ * though it also declares `@lunora/vite` (which its framework dev server uses for
+ * codegen/studio) — so the framework check comes FIRST. Everything else on
+ * `@lunora/vite` (class-A frameworks + Astro + standalone Vite) delegates to the
+ * project's own dev server (`vite`); a project without `@lunora/vite` is the
+ * classic standalone `wrangler` stack.
+ */
+const detectDevFlavor = (cwd: string): DevFlavor => {
+    if (SIDECAR_FRAMEWORKS.has(detectFramework(cwd).framework)) {
+        return "framework-worker";
+    }
+
+    return readProjectDependencyNames(cwd).has("@lunora/vite") ? "vite" : "wrangler";
+};
 
 /**
  * The dev-server exec for the vite flavor — shared by the foreground plan and
@@ -491,7 +527,9 @@ const startBackground = async (context: {
     const flavor = detectDevFlavor(cwd);
     // Pre-listen default URL — cosmetic (shown only if a concurrent starter
     // loses to this claim); the child's superseding record carries the real one.
-    const url = flavor === "vite" ? "http://localhost:5173" : `http://localhost:${String(options.workerPort ?? 8787)}`;
+    // For `vite`/`framework-worker` the front door is the framework's own dev
+    // server; only the standalone `wrangler` flavor opens the worker port here.
+    const url = flavor === "wrangler" ? `http://localhost:${String(options.workerPort ?? 8787)}` : "http://localhost:5173";
 
     const claim = claimDevServerState(cwd, {
         background: true,

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -343,6 +343,18 @@ const PNPM_BUILT_DEPENDENCIES: ReadonlyArray<string> = [
     "workerd",
 ];
 
+/**
+ * Build scripts present in the dependency tree (via `wrangler`'s transitive deps)
+ * that we explicitly DENY rather than run: they're optional native
+ * optimizations, not needed by a scaffolded app, and building them would require
+ * a C/C++ toolchain a fresh clone may not have (`cpu-features` → node-gyp).
+ * `ssh2` falls back to pure JS without its optional `cpu-features`; `protobufjs`'s
+ * postinstall is a codegen the CLI paths don't need. They must still be LISTED —
+ * pnpm v11 errors on any unlisted build script when an `allowBuilds` map exists —
+ * so denying (`false`) keeps `pnpm install` non-interactive AND compiler-free.
+ */
+const PNPM_DENIED_BUILD_DEPENDENCIES: ReadonlyArray<string> = ["cpu-features", "protobufjs", "ssh2"];
+
 /** File pnpm reads its settings from. */
 const PNPM_WORKSPACE_FILENAME = "pnpm-workspace.yaml";
 
@@ -351,17 +363,21 @@ const PNPM_WORKSPACE_FILENAME = "pnpm-workspace.yaml";
  * toolchain's native deps without `pnpm approve-builds`. This is the new home for
  * the setting — pnpm v10.16+ NO LONGER reads the `package.json` `pnpm` field.
  *
- * Uses the `allowBuilds` map (`name: true`) — the key pnpm v11's `approve-builds`
- * writes and honours; the older `onlyBuiltDependencies` array is NOT honoured by
- * pnpm 11.x at install time. npm/yarn ignore the file.
+ * Uses the `allowBuilds` map (`name: true|false`) — the key pnpm v11's
+ * `approve-builds` writes and honours; the older `onlyBuiltDependencies` array is
+ * NOT honoured by pnpm 11.x at install time. Every build-script package in the
+ * tree must be listed (allowed or denied) or pnpm halts with
+ * `ERR_PNPM_IGNORED_BUILDS`. npm/yarn ignore the file.
  */
 const pnpmWorkspaceYaml = (): string =>
     [
         "# pnpm reads its settings from here (the package.json `pnpm` field is no longer read).",
         "# Pre-approve the toolchain's native build scripts so `pnpm install` runs them",
-        "# without the interactive `pnpm approve-builds` step.",
+        "# without the interactive `pnpm approve-builds` step; deny the optional native",
+        "# builds a scaffold doesn't need (so no C/C++ toolchain is required).",
         "allowBuilds:",
         ...PNPM_BUILT_DEPENDENCIES.map((name) => `    ${name}: true`),
+        ...PNPM_DENIED_BUILD_DEPENDENCIES.map((name) => `    ${name}: false`),
         "",
     ].join("\n");
 

--- a/scripts/template-build-smoke.sh
+++ b/scripts/template-build-smoke.sh
@@ -82,33 +82,42 @@ fi
 echo "==> Discovered ${#TEMPLATES[@]} templates: ${TEMPLATES[*]}"
 
 # ---------------------------------------------------------------------------
-# Step 1: Pack all @lunora/* packages once.
+# Step 1: Pack all base packages the templates depend on, once.
 # ---------------------------------------------------------------------------
-echo "==> Packing all @lunora/* workspace packages into $PACK_DIR"
+# Pack every publishable base package the templates depend on: the `@lunora/*`
+# scope AND the unscoped `lunorash` umbrella (dir `packages/lunora/`), which the
+# templates depend on directly. Record each real package name → its tarball in a
+# manifest so the overrides key off the authoritative name — NOT a filename
+# regex, which can't recover a scoped/umbrella name and breaks on prerelease
+# versions (`lunora-server-1.0.0-alpha.17.tgz` would map to a bogus key).
+echo "==> Packing all @lunora/* + lunorash workspace packages into $PACK_DIR"
+PACK_MANIFEST="$SCRATCH/pack-manifest.tsv"
+: > "$PACK_MANIFEST"
 for pkg_dir in "$REPO_ROOT"/packages/*/; do
     pkg_name="$(node -e "try{process.stdout.write(require('$pkg_dir/package.json').name||'')}catch{}" 2>/dev/null)"
-    if [[ "$pkg_name" == @lunora/* ]]; then
+    if [[ "$pkg_name" == @lunora/* || "$pkg_name" == "lunorash" ]]; then
         pushd "$pkg_dir" >/dev/null
-        pnpm pack --pack-destination "$PACK_DIR" >/dev/null
+        # `pnpm pack --pack-destination` prints the created tarball path on its
+        # last output line; normalize to an absolute path under PACK_DIR.
+        tarball_out="$(pnpm pack --pack-destination "$PACK_DIR" | tail -1)"
         popd >/dev/null
+        printf '%s\t%s\n' "$pkg_name" "$PACK_DIR/$(basename "$tarball_out")" >> "$PACK_MANIFEST"
     fi
 done
 
 tgz_count="$(ls "$PACK_DIR"/*.tgz 2>/dev/null | wc -l | tr -d ' ')"
 echo "==> Packed $tgz_count tarballs"
 
-# Build the YAML overrides block once (shared across all templates).
+# Build the YAML overrides block once (shared across all templates) from the
+# name→tarball manifest, so every base package (incl. `lunorash`) resolves to its
+# local tarball instead of the registry, at any version.
 OVERRIDES_YAML="$(node -e "
 const fs = require('fs');
-const path = require('path');
-const dir = '$PACK_DIR';
-const lines = fs.readdirSync(dir)
-  .filter(f => f.endsWith('.tgz'))
-  .map(f => {
-    const base = f.replace(/-[0-9]+\.[0-9]+\.[0-9]+\.tgz\$/, '');
-    const scope = base.replace(/^lunora-/, '@lunora/');
-    return '  \"' + scope + '\": \"file:' + path.join(dir, f) + '\"';
-  });
+const rows = fs.readFileSync('$PACK_MANIFEST', 'utf8').trim().split('\n').filter(Boolean);
+const lines = rows.map((row) => {
+    const [name, file] = row.split('\t');
+    return '  \"' + name + '\": \"file:' + file + '\"';
+});
 process.stdout.write(lines.join('\n'));
 ")"
 
@@ -118,11 +127,13 @@ process.stdout.write(lines.join('\n'));
 inject_overrides() {
     local scaffold_dir="$1"
     # Write pnpm-workspace.yaml (pnpm 11: overrides live here, not in package.json).
-    # allowBuilds: permit native postinstall scripts that framework tools need.
-    # Without this pnpm 11 refuses to run them and the subsequent `vite build` /
-    # `wrangler` invocations fail. Kept in sync with the CLI init handler's
-    # PNPM_BUILT_DEPENDENCIES (packages/cli/src/commands/init/handler.ts) — the
-    # list a real `lunora init` scaffold ships.
+    # allowBuilds: permit native postinstall scripts that framework tools need,
+    # and deny the optional native builds a scaffold doesn't need (compiler-free).
+    # Every build-script package in the tree must be listed (true or false) or
+    # pnpm halts with ERR_PNPM_IGNORED_BUILDS. Kept in sync with the CLI init
+    # handler's PNPM_BUILT_DEPENDENCIES + PNPM_DENIED_BUILD_DEPENDENCIES
+    # (packages/cli/src/commands/init/handler.ts) — the list a real `lunora init`
+    # scaffold ships.
     cat > "$scaffold_dir/pnpm-workspace.yaml" <<WSEOF
 packages: []
 overrides:
@@ -136,6 +147,9 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
   workerd: true
+  cpu-features: false
+  protobufjs: false
+  ssh2: false
 WSEOF
 }
 

--- a/templates/astro/README.md
+++ b/templates/astro/README.md
@@ -10,13 +10,21 @@ loading flash.
 
 ## Develop
 
-Install dependencies and start the dev server with your package manager
-(`npm`, `pnpm`, `yarn`, or `bun`):
+Install dependencies, then start the dev server with the Lunora CLI:
 
 ```bash
 <pm> install
-<pm> run dev
+<pm> exec lunora dev
 ```
+
+Astro needs **no sidecar**: `astro dev` runs the whole app — SSR, `/_lunora/*`,
+and the `ShardDO` Durable Object — in `workerd` via `@astrojs/cloudflare`'s
+embedded Cloudflare Vite plugin (Astro 6+), so a single process gives you
+realtime + HMR with live DOs in dev. `lunora dev` runs `astro dev` and, through
+the `@lunora/vite` plugins wired in `astro.config.mjs` (with `cloudflare: false`,
+so no second Cloudflare plugin), keeps `lunora/_generated/*`, Studio, and dev
+state in sync. Open the URL Astro prints. (Bare `<pm> run dev` also works — it
+runs the same `astro dev`.)
 
 ## Why an island adapter?
 

--- a/templates/astro/astro.config.mjs
+++ b/templates/astro/astro.config.mjs
@@ -1,6 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { lunora } from "@lunora/astro";
+import { lunora as lunoraVite } from "@lunora/vite";
 import { defineConfig } from "astro/config";
 
 // Astro is multi-framework at the UI layer, so Lunora reactivity comes from the
@@ -12,4 +13,14 @@ export default defineConfig({
     adapter: cloudflare(),
     integrations: [react(), lunora()],
     output: "server",
+
+    // `astro dev` runs the whole app — SSR + `/_lunora/*` + the `ShardDO`
+    // Durable Object — in `workerd` via `@astrojs/cloudflare`'s embedded
+    // `@cloudflare/vite-plugin` (Astro 6+), so a single `lunora dev` gives you
+    // realtime + HMR with no sidecar. `@lunora/vite`'s codegen / Studio /
+    // dev-state plugins are added here with `cloudflare: false` so they run
+    // inside that same dev server WITHOUT wiring a SECOND `@cloudflare/vite-plugin`
+    // (which would collide with the adapter's). `validateWrangler: false` because
+    // wrangler validation is a deploy-time concern (the adapter owns dev).
+    vite: { plugins: [lunoraVite({ cloudflare: false, validateWrangler: false })] },
 });

--- a/templates/nuxt/README.md
+++ b/templates/nuxt/README.md
@@ -53,17 +53,27 @@ deploy, a same-origin client.
 
 ## Develop
 
-Start the dev server with your package manager (`npm`, `pnpm`, `yarn`, or `bun`):
+Install dependencies, then start the dev server with the Lunora CLI:
 
 ```bash
-<pm> run dev
+<pm> install
+<pm> exec lunora dev
 ```
 
-`nuxt dev` serves the app and the `/_lunora/**` route together. Live queries
-need the Cloudflare bindings (the `SHARD` Durable Object) in dev — Nuxt surfaces
-them through Nitro's Cloudflare dev runtime; if a live query reports
-`LUNORA_RUNTIME_UNAVAILABLE`, enable the Cloudflare Nitro dev runtime (e.g.
-`nitro-cloudflare-dev`) so `event.context.cloudflare` is populated.
+`lunora dev` runs **two processes** for you: `nuxt dev` (the app + HMR at
+`http://localhost:3000`) and a `wrangler dev` sidecar (`wrangler.dev.jsonc`,
+`:8788`) running in `workerd` that owns the real `ShardDO` Durable Object. In
+dev the browser `LunoraClient` talks to the sidecar directly (see
+`plugins/lunora.client.ts`); the sidecar's `LUNORA_ALLOWED_ORIGINS` allows that
+cross-origin call. Open `http://localhost:3000`. `Ctrl-C` stops both.
+
+> Why the sidecar: `nuxt dev` runs Nitro's SSR in Node, and Cloudflare bindings
+> in dev come from wrangler's `getPlatformProxy`, which cannot emulate an
+> internal Durable Object — and WebSocket realtime needs `workerd`'s
+> `WebSocketPair`, absent under Node. So the `/_lunora/**` route mounted in Nitro
+> is a prod-only path; in dev the client hits the real `workerd` sidecar instead.
+> (If you add auth, add `http://localhost:3000` to the app's
+> `security.csrf.trustedOrigins` so the cookie-bearing WebSocket handshake passes.)
 
 ## Build and deploy
 

--- a/templates/nuxt/plugins/lunora.client.ts
+++ b/templates/nuxt/plugins/lunora.client.ts
@@ -13,10 +13,17 @@ import { createLunora } from "@lunora/vue";
  * attaches after hydration.
  */
 export default defineNuxtPlugin((nuxtApp) => {
-    // Single-worker deploy: Lunora is mounted in this same Nitro worker by
+    // Prod (single-worker deploy): Lunora is mounted in this same Nitro worker by
     // `@lunora/nuxt`, so the client talks to the page's own origin — it appends
     // `/_lunora/ws` (and `/_lunora/rpc`) itself, which the module's route serves.
-    const client = new LunoraClient({ url: window.location.origin });
+    //
+    // Dev: `nuxt dev` (Node) can't host the `ShardDO` Durable Object, so
+    // `lunora dev` runs a `wrangler dev` sidecar (:8788, see `wrangler.dev.jsonc`)
+    // that owns it. Point the client straight at that sidecar in dev — RPC + the
+    // WebSocket hit `workerd` directly with no Node hop. The sidecar's
+    // `LUNORA_ALLOWED_ORIGINS` allows this cross-origin request.
+    const url = import.meta.dev ? "http://localhost:8788" : window.location.origin;
+    const client = new LunoraClient({ url });
 
     nuxtApp.vueApp.use(createLunora(client));
 });

--- a/templates/nuxt/wrangler.dev.jsonc
+++ b/templates/nuxt/wrangler.dev.jsonc
@@ -1,0 +1,29 @@
+{
+    "$schema": "node_modules/wrangler/config-schema.json",
+    // DEV-ONLY sidecar config (not used by `lunora deploy`).
+    //
+    // Nuxt is a class-B framework: `nuxt dev` runs Nitro's SSR in Node, and its
+    // Cloudflare bindings come from wrangler's `getPlatformProxy`, which can't
+    // emulate the `ShardDO` Durable Object (empty-script Miniflare) — and WebSocket
+    // realtime needs `workerd`'s `WebSocketPair`, absent under Node. So `lunora dev`
+    // runs a `wrangler dev --config wrangler.dev.jsonc` sidecar (:8788) in `workerd`
+    // that owns the real `ShardDO`, alongside `nuxt dev` (:3000, SSR + HMR).
+    //
+    // In dev the browser `LunoraClient` talks to this sidecar directly (cross-origin
+    // :3000 → :8788), so `LUNORA_ALLOWED_ORIGINS` enables CORS for the Nuxt dev
+    // origin. The WebSocket handshake is exempt from the origin guard while the app
+    // is unauthenticated (no cookie); once you add auth, add the dev origin to the
+    // app's `security.csrf.trustedOrigins` too. `main` reuses the same Lunora-only
+    // `lunora/server.ts` (`.build()`) that Nitro mounts in prod.
+    "name": "{{name}}-lunora-dev",
+    "main": "lunora/server.ts",
+    "compatibility_date": "2026-06-10",
+    "compatibility_flags": ["nodejs_compat"],
+    "dev": { "port": 8788 },
+    "vars": { "LUNORA_ALLOWED_ORIGINS": "http://localhost:3000" },
+    "durable_objects": {
+        "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
+    },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+    "observability": { "enabled": true, "head_sampling_rate": 1 },
+}

--- a/templates/sveltekit/README.md
+++ b/templates/sveltekit/README.md
@@ -9,13 +9,26 @@ server (read-your-writes SSR), the HTML ships with it, and on the client the
 
 ## Develop
 
-Install dependencies and start the dev server with your package manager
-(`npm`, `pnpm`, `yarn`, or `bun`):
+Install dependencies, then start the dev server with the Lunora CLI:
 
 ```bash
 <pm> install
-<pm> run dev
+<pm> exec lunora dev
 ```
+
+`lunora dev` runs **two processes** for you: SvelteKit's own Vite dev server
+(the front door at `http://localhost:5173`, with HMR) and a `wrangler dev`
+sidecar (`wrangler.dev.jsonc`, `:8787`) running in `workerd` that owns the real
+`ShardDO` Durable Object. Vite proxies `/_lunora/*` (RPC + the WebSocket) to the
+sidecar — see `vite.config.ts` — so the browser client stays same-origin and
+realtime works with live DOs in dev, not just after deploy. Open
+`http://localhost:5173`. `Ctrl-C` tears both processes down.
+
+> Why two processes: SvelteKit's dev server runs SSR in Node, and
+> `@sveltejs/adapter-cloudflare` gets its bindings from wrangler's
+> `getPlatformProxy`, which cannot emulate an internal Durable Object. The
+> sidecar is a real `workerd` so `ShardDO` behaves exactly as it does deployed.
+> Running `<pm> run dev` (bare `vite`) works for UI/HMR but has no live `ShardDO`.
 
 ## What's wired
 

--- a/templates/sveltekit/README.md
+++ b/templates/sveltekit/README.md
@@ -29,6 +29,13 @@ realtime works with live DOs in dev, not just after deploy. Open
 > `getPlatformProxy`, which cannot emulate an internal Durable Object. The
 > sidecar is a real `workerd` so `ShardDO` behaves exactly as it does deployed.
 > Running `<pm> run dev` (bare `vite`) works for UI/HMR but has no live `ShardDO`.
+>
+> Harmless startup noise: because the adapter's `getPlatformProxy` reads the same
+> `wrangler.jsonc`, dev logs a `"…internal Durable Objects…will not work in local
+development"` / `"ShardDO…not exported"` warning. That's the adapter's own empty
+> binding stub — your `ShardDO` runs in the sidecar and `/_lunora/*` reaches it
+> through the Vite proxy, so realtime works regardless. SvelteKit `load`/`+server`
+> code must reach Lunora via `/_lunora/*` (same origin), not `platform.env.SHARD`.
 
 ## What's wired
 

--- a/templates/sveltekit/lunora/server.ts
+++ b/templates/sveltekit/lunora/server.ts
@@ -1,0 +1,36 @@
+import type { ShardNamespaceLike } from "lunorash/runtime";
+
+import { defineApp } from "./_generated/app.js";
+
+interface Env extends Record<string, unknown> {
+    SHARD: ShardNamespaceLike;
+}
+
+/**
+ * The Lunora-only worker for this SvelteKit project — RPC + WebSocket realtime
+ * under `/_lunora/*`, and the `ShardDO` Durable Object class.
+ *
+ * This is NOT the deploy entry: production ships the single composed worker
+ * `src/worker.ts` (SvelteKit SSR + Lunora in one `withLunora` worker). This
+ * entry exists for **local dev only** — SvelteKit's own dev server runs SSR in
+ * Node and cannot host a Durable Object (its `@sveltejs/adapter-cloudflare` uses
+ * wrangler's `getPlatformProxy`, which doesn't emulate internal DOs). So
+ * `lunora dev` runs `vite` (SvelteKit SSR + HMR, the front door) alongside a
+ * `wrangler dev` sidecar pointed here (via `wrangler.dev.jsonc`) that owns the
+ * real `ShardDO` in `workerd`; Vite proxies `/_lunora/*` to it, so the browser
+ * client stays same-origin.
+ *
+ * `default` is the app (its `fetch` entrypoint); `ShardDO` is the bound Durable
+ * Object class.
+ */
+const app = defineApp<Env>()
+    .shard((env) => env.SHARD)
+    // Demo/local default: this app has no auth, so shard access is left OPEN
+    // (any caller may target any shard) and data is protected by per-row RLS.
+    // A PRODUCTION sharded app must gate this instead — e.g.
+    // `.extend(() => ({ authorizeShard: (identity, shardKey) => identity?.userId === ownerOf(shardKey) }))`.
+    .extend(() => ({ allowUnauthenticatedShardAccess: true }))
+    .build();
+
+export const ShardDO = app.ShardDO;
+export default app;

--- a/templates/sveltekit/vite.config.ts
+++ b/templates/sveltekit/vite.config.ts
@@ -12,4 +12,19 @@ import { defineConfig } from "vite";
 // Class-B note (PLAN4 §3): `src/worker.ts` wraps the adapter-emitted handler
 // with `withLunora` for the deployed single-worker composition; it is only
 // referenced by `lunora deploy`, not by the `vite build` here.
-export default defineConfig({ plugins: [lunora({ cloudflare: false, validateWrangler: false }), sveltekit()] });
+//
+// Dev (`lunora dev`): this Vite server is the front door (:5173, SSR + HMR).
+// `lunora dev` also starts a `wrangler dev` sidecar (`wrangler.dev.jsonc`, :8787)
+// that owns the real `ShardDO` — SvelteKit's Node dev server can't host a
+// Durable Object. The `server.proxy` below forwards `/_lunora/*` (RPC + the
+// WebSocket, `ws: true`) to that sidecar, so the browser `LunoraClient` stays
+// same-origin (:5173) and needs no CORS. Vite's own HMR socket is unaffected.
+// `127.0.0.1` (not `localhost`) sidesteps the Node `::1`-first resolution bug.
+export default defineConfig({
+    plugins: [lunora({ cloudflare: false, validateWrangler: false }), sveltekit()],
+    server: {
+        proxy: {
+            "/_lunora": { changeOrigin: true, target: "http://127.0.0.1:8787", ws: true },
+        },
+    },
+});

--- a/templates/sveltekit/wrangler.dev.jsonc
+++ b/templates/sveltekit/wrangler.dev.jsonc
@@ -1,0 +1,24 @@
+{
+    "$schema": "node_modules/wrangler/config-schema.json",
+    // DEV-ONLY sidecar config (not used by `lunora deploy`).
+    //
+    // SvelteKit is a class-B framework: its own dev server (`vite`) runs SSR in
+    // Node and can't host the `ShardDO` Durable Object. So `lunora dev` runs a
+    // `wrangler dev --config wrangler.dev.jsonc` sidecar in `workerd` that owns
+    // the real `ShardDO` and serves `/_lunora/*`, while `vite` (the front door,
+    // :5173) proxies `/_lunora/*` to it — see `vite.config.ts`'s `server.proxy`.
+    //
+    // `main` is the Lunora-only `lunora/server.ts` (`.build()`), NOT the composed
+    // `src/worker.ts` (which imports SvelteKit's built adapter output that only
+    // exists after `vite build`). Deploy still uses the top-level `wrangler.jsonc`.
+    "name": "{{name}}-lunora-dev",
+    "main": "lunora/server.ts",
+    "compatibility_date": "2026-06-10",
+    "compatibility_flags": ["nodejs_compat"],
+    "dev": { "port": 8787 },
+    "durable_objects": {
+        "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }],
+    },
+    "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ShardDO"] }],
+    "observability": { "enabled": true, "head_sampling_rate": 1 },
+}


### PR DESCRIPTION
`lunora dev` did not give class-B frameworks a working ShardDO + framework
SSR/HMR together: SvelteKit/Astro ran only the framework dev server (no
Lunora worker, or a bare worker without HMR), and Nuxt's `/_lunora/**` route
had no live Durable Object. Fix it per-framework, driven by how each
framework's Cloudflare adapter runs in dev.

CLI:
- New `framework-worker` dev flavor for SvelteKit/Nuxt (their adapters use
  wrangler `getPlatformProxy`, which can't emulate an internal DO). `lunora
  dev` runs the framework's own dev server (front door + HMR, which runs
  @lunora/vite's codegen/studio/dev-state) AND a `wrangler dev` sidecar
  (wrangler.dev.jsonc) owning the real ShardDO in workerd. Both children are
  supervised together (unified SIGINT/SIGTERM teardown, exit-when-either-dies)
  and a one-shot codegen runs before the sidecar so its bundle resolves.
- Astro needs no sidecar: Astro 6's @astrojs/cloudflare runs SSR + /_lunora/*
  + ShardDO in workerd inside `astro dev`. It stays on the delegating `vite`
  flavor.

Templates:
- astro: add `lunora({ cloudflare: false })` to astro.config vite.plugins
  (codegen/studio/dev-state without a second @cloudflare/vite-plugin).
- sveltekit: Lunora-only `lunora/server.ts` sidecar entry + `wrangler.dev.jsonc`
  + Vite `server.proxy` of /_lunora/* (ws:true) -> same-origin, HMR intact.
- nuxt: `wrangler.dev.jsonc` sidecar + client points at it directly in dev
  (LUNORA_ALLOWED_ORIGINS handles cross-origin RPC).
- READMEs updated (nuxt's stale nitro-cloudflare-dev guidance removed).

Also fixes the template smoke harness, which was fully broken: the tarball
override regex produced garbage keys for prerelease versions and never packed
the `lunorash` umbrella (every template failed install). Now keyed off real
package names via a pack manifest. This surfaced that scaffolds pull
cpu-features/protobufjs/ssh2 build scripts -- added them (denied, so no C/C++
toolchain needed) to the init handler's allowBuilds and the smoke harness.

Verified: astro + sveltekit smoke builds PASS; 79 CLI tests pass; typecheck
clean. Nuxt `nuxt build` fails pre-existing (unrelated Nitro/Vite bundling
issue, confirmed by reverting these changes) -- dev wiring is in place but not
end-to-end smoke-verified.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com><!--
Thank you for contributing to Lunora!

Please fill out the sections below so reviewers can land your change quickly.
Keep the title in conventional-commit form (e.g. `feat(cli): add migrate flag`).
-->

## Summary

<!--
Explain *why* this change is needed and *what* it does at a high level.
Link to the relevant package(s) (e.g. `@lunora/d1`, `@lunora/codegen`) so
reviewers know which Wave / area is touched.
-->

## Linked issues

<!--
- Closes #...
- Refs #...
-->

## Test plan

<!--
Bulleted checklist of what you ran locally and what reviewers should re-run:

- [ ] `pnpm lint:types` passes
- [ ] `pnpm lint:eslint` passes
- [ ] `pnpm test` passes (234+ tests)
- [ ] If schema changed: `pnpm --filter @lunora/cli run codegen` regenerated cleanly
- [ ] If Durable Object / D1 code changed: workerd-based Vitest pool tests still pass
- [ ] Manual smoke test in `apps/playground` (if user-facing)
-->

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [x] Added or updated tests covering the change
- [x] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs)
- [x] No `package.json` files in `packages/*` modified outside the touched package
- [x] If a new package was added: `project.json` has `type:package` and a `category:*` tag
- [x] If migration impact: noted upgrade steps in the PR description and changelog entry

## Notes for reviewers

<!--
Anything reviewers should look at first, follow-up work you deferred, screenshots
for UI changes, etc.
-->

## Contributor License Agreement

<!--
Required for external contributors. Keep the line below in your PR description
exactly as written — the CLA check (.github/workflows/cla.yml) looks for it.
Members of the @anolilab organization can omit it (the check is skipped).
-->

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.
