### PR TITLE
feat(angular): api parity for subscription, paginated-query, auth, flag, rate-limit, presence, hydrate-preloaded, mutator

### DIFF
--- a/packages/angular/__tests__/auth.test.ts
+++ b/packages/angular/__tests__/auth.test.ts
@@ -1,0 +1,90 @@
+import type { User } from "@lunora/client";
+import { describe, expect, it } from "vitest";
+
+import { auth } from "../src/auth";
+import { createFakeClient, createFakeDestroyRef } from "./fake-client";
+
+const flushAsync = (): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+describe(auth, () => {
+    it("seeds token from the client and null user until resolved", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { token, user } = auth({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(token()).toBeNull();
+        expect(user()).toBeNull();
+    });
+
+    it("setToken updates the token signal", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { setToken } = auth({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        setToken("jwt-abc");
+
+        expect(fake.asClient.getAuthToken()).toBe("jwt-abc");
+    });
+
+    it("resolves the user after setToken fires onAuthTokenChange", async () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const testUser: User = { id: "u1", name: "Alice" };
+
+        fake.setCurrentUser(testUser);
+
+        const { token, user, setToken } = auth({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        setToken("jwt-abc");
+        fake.emitAuthTokenChange();
+
+        expect(token()).toBe("jwt-abc");
+
+        await flushAsync();
+
+        expect(user()).toStrictEqual(testUser);
+    });
+
+    it("clears the user on sign-out (setToken(null))", async () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const testUser: User = { id: "u1", name: "Alice" };
+
+        fake.setCurrentUser(testUser);
+
+        const { token, user, setToken } = auth({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        setToken("jwt-abc");
+        fake.emitAuthTokenChange();
+        await flushAsync();
+
+        expect(user()).toStrictEqual(testUser);
+
+        setToken(null);
+        fake.emitAuthTokenChange();
+        await flushAsync();
+
+        expect(token()).toBeNull();
+        expect(user()).toBeNull();
+    });
+
+    it("removes auth listeners on destroy (store's per-client listener remains)", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        auth({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        // 2 listeners: store's refresh + auth's token updater
+        expect(fake.tokenListeners).toHaveLength(2);
+
+        destroy.destroy();
+
+        // Store's per-client refresh listener remains; auth's token updater is removed
+        expect(fake.tokenListeners).toHaveLength(1);
+    });
+});

--- a/packages/angular/__tests__/fake-client.ts
+++ b/packages/angular/__tests__/fake-client.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-underscore-dangle -- `__lunoraRef` is the Lunora function-reference field the wire types expose; fixtures mirror it verbatim. */
 import type { DestroyRef } from "@angular/core";
-import type { ConnectionStatus, FunctionReference, LunoraClient, SubscriptionError, Unsubscribe } from "@lunora/client";
+import type { ConnectionStatus, FunctionReference, LunoraClient, SubscriptionError, Unsubscribe, User } from "@lunora/client";
 
 /**
  * A minimal stand-in for `LunoraClient` exposing just the surface the Angular
  * adapter touches (`subscribe` / `mutation` / `connectionStatus` /
- * `onConnectionStatus`). It records subscriptions and lets a test push values to
+ * `onConnectionStatus` / auth / connection-context). It records subscriptions and lets a test push values to
  * the live callback, so we can assert the signal seed vs. the later live update
  * without a real WebSocket.
  */
@@ -19,31 +19,59 @@ export interface FakeSubscription {
     unsubscribed: boolean;
 }
 
+export interface FakeConnectionContext {
+    context: { roomId: string; sessionId: string };
+    released: boolean;
+    shardKey?: string;
+}
+
 export interface FakeClient {
     /** As a typed `LunoraClient` for passing through `liveQuery` / `mutate`. */
     asClient: LunoraClient;
+    /** Connection contexts acquired via `acquireConnectionContext`. */
+    connectionContexts: FakeConnectionContext[];
+    /** Drive the auth-token listeners (fires `onAuthTokenChange` callbacks). */
+    emitAuthTokenChange: () => void;
     /** Drive the connection-status listeners. */
     emitStatus: (status: ConnectionStatus) => void;
     mutationCalls: { args: unknown; functionPath: string; options: unknown }[];
+    /** Set the user that `getCurrentUser()` resolves with. */
+    setCurrentUser: (user: User | null) => void;
     /** Resolve the next `mutation()` with this value (default: echoes args). */
     setMutationResult: (value: unknown) => void;
     /** Reject the next `mutation()` with this error. */
     setMutationThrow: (error: Error) => void;
     statusListeners: ((status: ConnectionStatus) => void)[];
     subscriptions: FakeSubscription[];
+    /** Auth-token listeners registered via `onAuthTokenChange`. */
+    tokenListeners: (() => void)[];
 }
 
 export const createFakeClient = (initialStatus: ConnectionStatus = "idle"): FakeClient => {
     const subscriptions: FakeSubscription[] = [];
     const mutationCalls: { args: unknown; functionPath: string; options: unknown }[] = [];
     const statusListeners: ((status: ConnectionStatus) => void)[] = [];
+    const tokenListeners: (() => void)[] = [];
+    const connectionContexts: FakeConnectionContext[] = [];
 
     let mutationResult: unknown;
     let mutationThrow: Error | undefined;
     let status = initialStatus;
+    let authToken: string | null = null;
+    let currentUser: User | null = null;
 
     const client = {
+        acquireConnectionContext: (context: { roomId: string; sessionId: string }, options?: { shardKey?: string }) => {
+            const entry: FakeConnectionContext = { context, released: false, shardKey: options?.shardKey };
+            connectionContexts.push(entry);
+
+            return () => {
+                entry.released = true;
+            };
+        },
         connectionStatus: (): ConnectionStatus => status,
+        getAuthToken: () => authToken,
+        getCurrentUser: () => Promise.resolve(currentUser),
         mutation: (function_: FunctionReference, args: unknown, options: unknown) => {
             mutationCalls.push({ args, functionPath: function_.__lunoraRef, options });
 
@@ -52,6 +80,17 @@ export const createFakeClient = (initialStatus: ConnectionStatus = "idle"): Fake
             }
 
             return Promise.resolve(mutationResult ?? args);
+        },
+        onAuthTokenChange: (listener: () => void): Unsubscribe => {
+            tokenListeners.push(listener);
+
+            return () => {
+                const index = tokenListeners.indexOf(listener);
+
+                if (index !== -1) {
+                    tokenListeners.splice(index, 1);
+                }
+            };
         },
         onConnectionStatus: (listener: (next: ConnectionStatus) => void): Unsubscribe => {
             statusListeners.push(listener);
@@ -63,6 +102,9 @@ export const createFakeClient = (initialStatus: ConnectionStatus = "idle"): Fake
                     statusListeners.splice(index, 1);
                 }
             };
+        },
+        setAuthToken: (token: string | null) => {
+            authToken = token;
         },
         subscribe: (
             function_: FunctionReference,
@@ -89,6 +131,12 @@ export const createFakeClient = (initialStatus: ConnectionStatus = "idle"): Fake
 
     return {
         asClient: client as unknown as LunoraClient,
+        connectionContexts,
+        emitAuthTokenChange: () => {
+            for (const listener of tokenListeners) {
+                listener();
+            }
+        },
         emitStatus: (next: ConnectionStatus) => {
             status = next;
 
@@ -97,6 +145,9 @@ export const createFakeClient = (initialStatus: ConnectionStatus = "idle"): Fake
             }
         },
         mutationCalls,
+        setCurrentUser: (user: User | null) => {
+            currentUser = user;
+        },
         setMutationResult: (value: unknown) => {
             mutationResult = value;
         },
@@ -105,6 +156,7 @@ export const createFakeClient = (initialStatus: ConnectionStatus = "idle"): Fake
         },
         statusListeners,
         subscriptions,
+        tokenListeners,
     };
 };
 

--- a/packages/angular/__tests__/flag.test.ts
+++ b/packages/angular/__tests__/flag.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { flag, flags } from "../src/flag";
+import { createFakeClient, createFakeDestroyRef } from "./fake-client";
+
+const FLAGS_REF = "__lunora_flags__:eval";
+
+describe(flag, () => {
+    it("holds the default then resolves on push", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const dark = flag("dark-mode", false, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions).toHaveLength(1);
+        expect(fake.subscriptions[0]?.functionPath).toBe(FLAGS_REF);
+        expect(dark()).toBe(false);
+
+        fake.subscriptions[0]?.push(true);
+
+        expect(dark()).toBe(true);
+    });
+
+    it("sends the flag key, inferred type, and default as subscribe args", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        flag("hero", "control", { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions[0]?.args).toStrictEqual({ context: undefined, default: "control", key: "hero", type: "string" });
+    });
+
+    it("fails open — a thrown subscribe keeps the default", () => {
+        const destroy = createFakeDestroyRef();
+        const client = {
+            subscribe: () => {
+                throw new Error("socket closed");
+            },
+        };
+
+        const dark = flag("dark-mode", false, { client: client as never, destroyRef: destroy.asDestroyRef });
+
+        expect(dark()).toBe(false);
+    });
+
+    it("tears down the subscription when the DestroyRef fires", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        flag("dark-mode", false, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+
+        destroy.destroy();
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(true);
+    });
+});
+
+describe(flags, () => {
+    it("opens one subscription per key and resolves each independently", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const all = flags({ "dark-mode": false, "page-size": 10 }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions).toHaveLength(2);
+        expect(all()).toStrictEqual({ "dark-mode": false, "page-size": 10 });
+
+        fake.subscriptions.find((sub) => sub.args["key"] === "dark-mode")?.push(true);
+        fake.subscriptions.find((sub) => sub.args["key"] === "page-size")?.push(50);
+
+        expect(all()).toStrictEqual({ "dark-mode": true, "page-size": 50 });
+    });
+
+    it("tears down every subscription on destroy", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        flags({ a: false, b: false }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions.every((sub) => !sub.unsubscribed)).toBe(true);
+
+        destroy.destroy();
+
+        expect(fake.subscriptions.every((sub) => sub.unsubscribed)).toBe(true);
+    });
+});

--- a/packages/angular/__tests__/hydrate-preloaded.test.ts
+++ b/packages/angular/__tests__/hydrate-preloaded.test.ts
@@ -1,0 +1,69 @@
+import type { Preloaded } from "@lunora/client";
+import { describe, expect, it } from "vitest";
+
+import { hydratePreloaded } from "../src/hydrate-preloaded";
+import { createFakeClient, createFakeDestroyRef } from "./fake-client";
+
+describe(hydratePreloaded, () => {
+    it("seeds synchronously from preloaded.value then updates on push", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const preloaded: Preloaded<{ messages: string[] }> = {
+            __lunoraPreloaded: true,
+            args: { channelId: "general" },
+            functionPath: "messages:list",
+            shardKey: undefined,
+            value: { messages: ["a"] },
+        };
+
+        const data = hydratePreloaded(preloaded, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(data()).toStrictEqual({ messages: ["a"] });
+        expect(fake.subscriptions).toHaveLength(1);
+        expect(fake.subscriptions[0]?.functionPath).toBe("messages:list");
+        expect(fake.subscriptions[0]?.args).toStrictEqual({ channelId: "general" });
+
+        fake.subscriptions[0]?.push({ messages: ["a", "b"] });
+
+        expect(data()).toStrictEqual({ messages: ["a", "b"] });
+    });
+
+    it("tears down the subscription when the DestroyRef fires", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const preloaded: Preloaded = {
+            __lunoraPreloaded: true,
+            args: {},
+            functionPath: "x:y",
+            shardKey: undefined,
+            value: 1,
+        };
+
+        hydratePreloaded(preloaded, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+
+        destroy.destroy();
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(true);
+    });
+
+    it("forwards the shardKey to the subscription", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const preloaded: Preloaded = {
+            __lunoraPreloaded: true,
+            args: { room: "r1" },
+            functionPath: "x:y",
+            shardKey: "r1",
+            value: null,
+        };
+
+        hydratePreloaded(preloaded, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions[0]?.shardKey).toBe("r1");
+    });
+});

--- a/packages/angular/__tests__/hydrate-preloaded.test.ts
+++ b/packages/angular/__tests__/hydrate-preloaded.test.ts
@@ -17,7 +17,7 @@ describe(hydratePreloaded, () => {
             value: { messages: ["a"] },
         };
 
-        const data = hydratePreloaded(preloaded, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+        const { data } = hydratePreloaded(preloaded, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
 
         expect(data()).toStrictEqual({ messages: ["a"] });
         expect(fake.subscriptions).toHaveLength(1);

--- a/packages/angular/__tests__/mutator.test.ts
+++ b/packages/angular/__tests__/mutator.test.ts
@@ -1,0 +1,86 @@
+import type { MutatorHandle, MutatorTransaction } from "@lunora/client";
+import { describe, expect, it } from "vitest";
+
+import { mutator } from "../src/mutator";
+
+const deferredHandle = (): { calls: { reject: (error: unknown) => void; resolve: () => void }[]; handle: MutatorHandle<{ text: string }> } => {
+    const calls: { reject: (error: unknown) => void; resolve: () => void }[] = [];
+    const handle: MutatorHandle<{ text: string }> = (_args: { text: string }): MutatorTransaction => {
+        let settle: () => void = () => undefined;
+        let fail: (error: unknown) => void = () => undefined;
+        const promise = new Promise<unknown>((resolve, reject) => {
+            settle = () => {
+                resolve(undefined);
+            };
+            fail = reject;
+        });
+
+        calls.push({ reject: fail, resolve: settle });
+
+        return { isPersisted: { promise } };
+    };
+
+    return { calls, handle };
+};
+
+describe(mutator, () => {
+    it("flips pending while the transaction persists and clears it on success", async () => {
+        const { calls, handle } = deferredHandle();
+        const result = mutator(handle);
+
+        expect(result.pending()).toBe(false);
+
+        const settled = result.mutate({ text: "hi" });
+
+        expect(result.pending()).toBe(true);
+
+        calls[0]?.resolve();
+        await settled;
+
+        expect(result.pending()).toBe(false);
+        expect(result.isError()).toBe(false);
+        expect(result.error()).toBeUndefined();
+    });
+
+    it("captures the error, rejects mutate, and clears it on reset", async () => {
+        const { calls, handle } = deferredHandle();
+        const result = mutator(handle);
+
+        let rejected: unknown;
+        const settled = result.mutate({ text: "boom" }).catch((error: unknown) => {
+            rejected = error;
+        });
+
+        calls[0]?.reject(new Error("server said no"));
+        await settled;
+
+        expect(rejected).toBeInstanceOf(Error);
+        expect(result.isError()).toBe(true);
+        expect(result.error()?.message).toBe("server said no");
+
+        result.reset();
+
+        expect(result.error()).toBeUndefined();
+        expect(result.isError()).toBe(false);
+    });
+
+    it("ref-counts pending across overlapping invocations", async () => {
+        const { calls, handle } = deferredHandle();
+        const result = mutator(handle);
+
+        const first = result.mutate({ text: "a" });
+        const second = result.mutate({ text: "b" });
+
+        expect(result.pending()).toBe(true);
+
+        calls[0]?.resolve();
+        await first;
+
+        expect(result.pending()).toBe(true);
+
+        calls[1]?.resolve();
+        await second;
+
+        expect(result.pending()).toBe(false);
+    });
+});

--- a/packages/angular/__tests__/paginated-query.test.ts
+++ b/packages/angular/__tests__/paginated-query.test.ts
@@ -1,0 +1,180 @@
+import type { FunctionReference } from "@lunora/client";
+import type { PaginationResult } from "@lunora/client/pagination";
+import { describe, expect, it } from "vitest";
+
+import { infiniteQuery, paginatedQuery } from "../src/paginated-query";
+import type { FakeClient } from "./fake-client";
+import { createFakeClient, createFakeDestroyRef } from "./fake-client";
+
+const fn = { __lunoraRef: "messages:list" } as FunctionReference;
+
+const NUM_ITEMS = 5;
+const firstPageItems = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }, { id: "e" }];
+const secondPageItems = [{ id: "f" }, { id: "g" }, { id: "h" }, { id: "i" }, { id: "j" }];
+
+const pushByArgs = (fake: FakeClient, args: Record<string, unknown>, value: PaginationResult<{ id: string }>): void => {
+    const key = JSON.stringify(args);
+
+    for (const sub of fake.subscriptions) {
+        if (JSON.stringify(sub.args) === key && !sub.unsubscribed) {
+            sub.push(value);
+        }
+    }
+};
+
+describe(paginatedQuery, () => {
+    it("first page loads and results flatten", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { results, status } = paginatedQuery(fn, {}, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        expect(status()).toBe("LoadingFirstPage");
+        expect(results()).toStrictEqual([]);
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: "cur-1",
+                isDone: false,
+                page: firstPageItems,
+            },
+        );
+
+        expect(status()).toBe("CanLoadMore");
+        expect(results()).toStrictEqual(firstPageItems);
+    });
+
+    it("loadMore appends a second page", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { loadMore, results, status } = paginatedQuery(fn, {}, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: "cur-1",
+                isDone: false,
+                page: firstPageItems,
+            },
+        );
+
+        expect(status()).toBe("CanLoadMore");
+
+        loadMore(NUM_ITEMS);
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: null,
+                isDone: true,
+                page: secondPageItems,
+            },
+        );
+
+        expect(results()).toStrictEqual([...firstPageItems, ...secondPageItems]);
+        expect(status()).toBe("Exhausted");
+    });
+
+    it("skip short-circuits to LoadingFirstPage with no subscriptions", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { status } = paginatedQuery(fn, "skip", { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        expect(status()).toBe("LoadingFirstPage");
+        expect(fake.subscriptions).toHaveLength(0);
+    });
+
+    it("last page reports Exhausted", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { status } = paginatedQuery(fn, {}, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: null,
+                isDone: true,
+                page: firstPageItems,
+            },
+        );
+
+        expect(status()).toBe("Exhausted");
+    });
+
+    it("tears down all subscriptions on destroy", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        paginatedQuery(fn, {}, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+
+        destroy.destroy();
+
+        expect(fake.subscriptions.every((sub) => sub.unsubscribed)).toBe(true);
+    });
+});
+
+describe(infiniteQuery, () => {
+    it("first page loads as first page array", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { isLoading, pages } = infiniteQuery(fn, {}, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        expect(isLoading()).toBe(true);
+        expect(pages()).toStrictEqual([]);
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: "cur-1",
+                isDone: false,
+                page: firstPageItems,
+            },
+        );
+
+        expect(isLoading()).toBe(false);
+        expect(pages()).toStrictEqual([firstPageItems]);
+    });
+
+    it("fetchNextPage appends second page array", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { fetchNextPage, pages } = infiniteQuery(fn, {}, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: "cur-1",
+                isDone: false,
+                page: firstPageItems,
+            },
+        );
+
+        fetchNextPage();
+
+        pushByArgs(
+            fake,
+            { paginationOpts: { cursor: "cur-1", endCursor: null, numItems: NUM_ITEMS } },
+            {
+                continueCursor: null,
+                isDone: true,
+                page: secondPageItems,
+            },
+        );
+
+        expect(pages()).toStrictEqual([firstPageItems, secondPageItems]);
+    });
+});

--- a/packages/angular/__tests__/presence.test.ts
+++ b/packages/angular/__tests__/presence.test.ts
@@ -1,0 +1,103 @@
+import type { FunctionReference } from "@lunora/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { presence } from "../src/presence";
+import { createFakeClient, createFakeDestroyRef } from "./fake-client";
+
+const heartbeatRef = { __lunoraRef: "presence:heartbeat" } as FunctionReference<"mutation", { roomId: string; sessionId: string }>;
+const listPresentRef = { __lunoraRef: "presence:listPresent" } as FunctionReference<"query", { roomId: string }>;
+
+describe(presence, () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("sends a heartbeat on mount and subscribes to listPresent", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const result = presence("room:1", {
+            client: fake.asClient,
+            destroyRef: destroy.asDestroyRef,
+            heartbeat: heartbeatRef,
+            listPresent: listPresentRef,
+            sessionId: "sess-1",
+        });
+
+        expect(fake.mutationCalls).toHaveLength(1);
+        expect(fake.mutationCalls[0]?.functionPath).toBe("presence:heartbeat");
+        expect(fake.mutationCalls[0]?.args).toStrictEqual({ roomId: "room:1", sessionId: "sess-1" });
+
+        expect(fake.subscriptions).toHaveLength(1);
+        expect(fake.subscriptions[0]?.functionPath).toBe("presence:listPresent");
+        expect(fake.subscriptions[0]?.args).toStrictEqual({ roomId: "room:1" });
+
+        expect(fake.connectionContexts).toHaveLength(1);
+        expect(fake.connectionContexts[0]?.context).toStrictEqual({ roomId: "room:1", sessionId: "sess-1" });
+
+        expect(result.sessionId).toBe("sess-1");
+    });
+
+    it("present signal updates on listPresent push", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { present } = presence("room:1", {
+            client: fake.asClient,
+            destroyRef: destroy.asDestroyRef,
+            heartbeat: heartbeatRef,
+            listPresent: listPresentRef,
+            sessionId: "sess-1",
+        });
+
+        expect(present()).toBeUndefined();
+
+        const members = [{ id: "sess-1", name: "Alice" }];
+        fake.subscriptions[0]?.push(members);
+
+        expect(present()).toStrictEqual(members);
+    });
+
+    it("setData triggers an immediate heartbeat with the new data", () => {
+        vi.useFakeTimers();
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { setData } = presence("room:1", {
+            client: fake.asClient,
+            destroyRef: destroy.asDestroyRef,
+            heartbeat: heartbeatRef,
+            listPresent: listPresentRef,
+            sessionId: "sess-1",
+        });
+
+        const initialCalls = fake.mutationCalls.length;
+
+        setData({ cursor: { x: 10, y: 20 } });
+
+        expect(fake.mutationCalls).toHaveLength(initialCalls + 1);
+        expect(fake.mutationCalls.at(-1)?.args).toStrictEqual({ data: { cursor: { x: 10, y: 20 } }, roomId: "room:1", sessionId: "sess-1" });
+    });
+
+    it("tears down interval, context, and subscription on destroy", () => {
+        vi.useFakeTimers();
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        presence("room:1", {
+            client: fake.asClient,
+            destroyRef: destroy.asDestroyRef,
+            heartbeat: heartbeatRef,
+            listPresent: listPresentRef,
+            sessionId: "sess-1",
+        });
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+        expect(fake.connectionContexts[0]?.released).toBe(false);
+
+        destroy.destroy();
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(true);
+        expect(fake.connectionContexts[0]?.released).toBe(true);
+    });
+});

--- a/packages/angular/__tests__/rate-limit.test.ts
+++ b/packages/angular/__tests__/rate-limit.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { rateLimit } from "../src/rate-limit";
+import { createFakeDestroyRef } from "./fake-client";
+
+describe(rateLimit, () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("starts available and blocks once the bucket is drained", () => {
+        const clock = { now: 0 };
+        const destroy = createFakeDestroyRef();
+
+        const result = rateLimit({ kind: "token bucket", period: 1000, rate: 2 }, { destroyRef: destroy.asDestroyRef, now: () => clock.now });
+
+        expect(result.ok()).toBe(true);
+
+        result.consume();
+        result.consume();
+
+        expect(result.disabled()).toBe(true);
+        expect(result.retryAfter()).toBeGreaterThan(0);
+    });
+
+    it("check does not consume", () => {
+        const clock = { now: 0 };
+        const destroy = createFakeDestroyRef();
+
+        const result = rateLimit({ kind: "token bucket", period: 1000, rate: 2 }, { destroyRef: destroy.asDestroyRef, now: () => clock.now });
+
+        const allowed = result.check();
+
+        expect(allowed).toBe(true);
+        expect(result.consume().ok).toBe(true);
+        expect(result.consume().ok).toBe(true);
+    });
+
+    it("reset restores availability", () => {
+        const clock = { now: 0 };
+        const destroy = createFakeDestroyRef();
+
+        const result = rateLimit({ kind: "token bucket", period: 1000, rate: 2 }, { destroyRef: destroy.asDestroyRef, now: () => clock.now });
+
+        result.consume();
+        result.consume();
+
+        expect(result.disabled()).toBe(true);
+
+        result.reset();
+
+        expect(result.ok()).toBe(true);
+    });
+
+    it("re-enables on its own as tokens refill", () => {
+        vi.useFakeTimers();
+        const clock = { now: 0 };
+        const destroy = createFakeDestroyRef();
+
+        const result = rateLimit({ kind: "token bucket", period: 1000, rate: 2 }, { destroyRef: destroy.asDestroyRef, now: () => clock.now, tickMs: 250 });
+
+        result.consume();
+        result.consume();
+
+        expect(result.disabled()).toBe(true);
+
+        clock.now = 500;
+        vi.advanceTimersByTime(250);
+
+        expect(result.ok()).toBe(true);
+    });
+
+    it("clears the interval on destroy — no tick fires after teardown", () => {
+        vi.useFakeTimers();
+        const clock = { now: 0 };
+        const destroy = createFakeDestroyRef();
+
+        const result = rateLimit({ kind: "token bucket", period: 1000, rate: 2 }, { destroyRef: destroy.asDestroyRef, now: () => clock.now, tickMs: 250 });
+
+        result.consume();
+        result.consume();
+
+        expect(result.disabled()).toBe(true);
+
+        destroy.destroy();
+
+        clock.now = 500;
+        vi.advanceTimersByTime(250);
+
+        expect(result.disabled()).toBe(true);
+    });
+});

--- a/packages/angular/__tests__/subscription.test.ts
+++ b/packages/angular/__tests__/subscription.test.ts
@@ -1,0 +1,97 @@
+import type { FunctionReference, SubscriptionError } from "@lunora/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { subscription } from "../src/subscription";
+import { createFakeClient, createFakeDestroyRef } from "./fake-client";
+
+const streamRef = { __lunoraRef: "events:stream" } as FunctionReference;
+
+describe(subscription, () => {
+    it("data is undefined before any push, then updates on every push", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { data, error } = subscription(streamRef, { roomId: "r1" }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(data()).toBeUndefined();
+        expect(error()).toBeUndefined();
+
+        fake.subscriptions[0]?.push([{ id: "1" }]);
+
+        expect(data()).toStrictEqual([{ id: "1" }]);
+
+        fake.subscriptions[0]?.push([{ id: "1" }, { id: "2" }]);
+
+        expect(data()).toStrictEqual([{ id: "1" }, { id: "2" }]);
+    });
+
+    it("opens no subscription when args is 'skip'", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { data } = subscription(streamRef, "skip", { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions).toHaveLength(0);
+        expect(data()).toBeUndefined();
+    });
+
+    it("tears down the subscription when the DestroyRef fires", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        subscription(streamRef, { roomId: "r1" }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(false);
+
+        destroy.destroy();
+
+        expect(fake.subscriptions[0]?.unsubscribed).toBe(true);
+    });
+
+    it("routes a subscription error into the error signal and the onError callback", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const onError = vi.fn<(error: SubscriptionError) => void>();
+
+        const { error } = subscription(streamRef, { roomId: "r1" }, { client: fake.asClient, destroyRef: destroy.asDestroyRef, onError });
+
+        const subError: SubscriptionError = { code: "internal", message: "boom" };
+
+        fake.subscriptions[0]?.emitError(subError);
+
+        expect(onError).toHaveBeenCalledWith(subError);
+        expect(error()).toBeInstanceOf(Error);
+        expect(error()?.message).toBe("boom");
+    });
+
+    it("clears the error once a healthy value arrives after an error", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { data, error } = subscription(streamRef, { roomId: "r1" }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        fake.subscriptions[0]?.emitError({ code: "internal", message: "transient" });
+
+        expect(error()).toBeInstanceOf(Error);
+
+        fake.subscriptions[0]?.push([{ id: "1" }]);
+
+        expect(error()).toBeUndefined();
+        expect(data()).toStrictEqual([{ id: "1" }]);
+    });
+
+    it("stops updating after teardown", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { data } = subscription(streamRef, { roomId: "r1" }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        fake.subscriptions[0]?.push([{ id: "1" }]);
+
+        destroy.destroy();
+
+        fake.subscriptions[0]?.push([{ id: "2" }]);
+
+        expect(data()).toStrictEqual([{ id: "1" }]);
+    });
+});

--- a/packages/angular/__tests__/subscription.test.ts
+++ b/packages/angular/__tests__/subscription.test.ts
@@ -60,8 +60,7 @@ describe(subscription, () => {
         fake.subscriptions[0]?.emitError(subError);
 
         expect(onError).toHaveBeenCalledWith(subError);
-        expect(error()).toBeInstanceOf(Error);
-        expect(error()?.message).toBe("boom");
+        expect(error()).toStrictEqual(subError);
     });
 
     it("clears the error once a healthy value arrives after an error", () => {
@@ -70,9 +69,11 @@ describe(subscription, () => {
 
         const { data, error } = subscription(streamRef, { roomId: "r1" }, { client: fake.asClient, destroyRef: destroy.asDestroyRef });
 
-        fake.subscriptions[0]?.emitError({ code: "internal", message: "transient" });
+        const subError: SubscriptionError = { code: "internal", message: "transient" };
 
-        expect(error()).toBeInstanceOf(Error);
+        fake.subscriptions[0]?.emitError(subError);
+
+        expect(error()).toStrictEqual(subError);
 
         fake.subscriptions[0]?.push([{ id: "1" }]);
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -56,7 +56,8 @@
         "test:coverage": "vitest run --coverage"
     },
     "dependencies": {
-        "@lunora/client": "1.0.0-alpha.19"
+        "@lunora/client": "1.0.0-alpha.19",
+        "@lunora/ratelimit": "1.0.0-alpha.7"
     },
     "devDependencies": {
         "@angular/core": "^22.0.5",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -57,7 +57,7 @@
     },
     "dependencies": {
         "@lunora/client": "1.0.0-alpha.19",
-        "@lunora/ratelimit": "1.0.0-alpha.7"
+        "@lunora/ratelimit": "workspace:*"
     },
     "devDependencies": {
         "@angular/core": "^22.0.5",

--- a/packages/angular/src/auth.ts
+++ b/packages/angular/src/auth.ts
@@ -20,7 +20,7 @@ export interface AuthResult {
     /** The current auth token, or `null`. */
     token: Signal<string | null>;
 
-    /** The resolved user from `getCurrentUser()`, or `null`. */
+    /** The resolved user from `store.getUser()`, or `null`. */
     user: Signal<User | null>;
 }
 
@@ -36,7 +36,7 @@ export interface AuthResult {
  *
  * Call from an injection context (component/service field or constructor):
  * ```ts
- * readonly { token, user, setToken } = auth();
+ * const { token, user, setToken } = auth();
  * ```
  */
 export const auth = (options: AuthOptions = {}): AuthResult => {

--- a/packages/angular/src/auth.ts
+++ b/packages/angular/src/auth.ts
@@ -1,0 +1,68 @@
+import type { Signal } from "@angular/core";
+import { DestroyRef, inject, signal } from "@angular/core";
+import type { LunoraClient, User } from "@lunora/client";
+import { getIdentityStore } from "@lunora/client/auth";
+
+import { resolveLunoraClient } from "./client";
+
+export interface AuthOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /** `DestroyRef` whose `onDestroy` removes the listeners. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+}
+
+export interface AuthResult {
+    /** Set the auth token (sign-in / sign-out). */
+    setToken: (token: string | null) => void;
+
+    /** The current auth token, or `null`. */
+    token: Signal<string | null>;
+
+    /** The resolved user from `getCurrentUser()`, or `null`. */
+    user: Signal<User | null>;
+}
+
+/**
+ * Token + identity plumbing for Angular. `token` is a signal tracking the
+ * client's auth token; `user` is a signal resolved from `getCurrentUser()`
+ * whenever the token changes. `setToken(jwt)` after sign-in makes subsequent
+ * RPC calls carry the `Authorization` header.
+ *
+ * Multiple `auth` instances on the same client share a single per-client
+ * identity store (from `@lunora/client/auth`) — a `setToken` from one component
+ * re-renders every watcher with the freshly-resolved user.
+ *
+ * Call from an injection context (component/service field or constructor):
+ * ```ts
+ * readonly { token, user, setToken } = auth();
+ * ```
+ */
+export const auth = (options: AuthOptions = {}): AuthResult => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+    const store = getIdentityStore(client);
+
+    const token = signal<string | null>(client.getAuthToken());
+    const user = signal<User | null>(store.getUser());
+
+    const unsubToken = client.onAuthTokenChange(() => {
+        token.set(client.getAuthToken());
+    });
+
+    const unsubUser = store.subscribe(() => {
+        user.set(store.getUser());
+    });
+
+    destroyRef.onDestroy(() => {
+        unsubToken();
+        unsubUser();
+    });
+
+    const setToken = (next: string | null): void => {
+        client.setAuthToken(next);
+    };
+
+    return { setToken, token: token.asReadonly(), user: user.asReadonly() };
+};

--- a/packages/angular/src/flag.ts
+++ b/packages/angular/src/flag.ts
@@ -76,9 +76,18 @@ export const flag = <T extends FlagValue>(key: string, defaultValue: T, options:
     let unsubscribe: Unsubscribe | undefined;
 
     try {
-        unsubscribe = client.subscribe(flagsReference, { context: options.context, default: defaultValue, key, type }, (next) => {
-            value.set(next as T);
-        });
+        unsubscribe = client.subscribe(
+            flagsReference,
+            { context: options.context, default: defaultValue, key, type },
+            (next) => {
+                value.set(next as T);
+            },
+            {
+                onError: () => {
+                    value.set(defaultValue);
+                },
+            },
+        );
     } catch {
         // The attach threw (e.g. the client is closed). Keep the default.
     }
@@ -120,15 +129,24 @@ export const flags = <T extends Record<string, FlagValue>>(flagDefaults: T, opti
     const client = resolveLunoraClient(options.client);
     const destroyRef = options.destroyRef ?? inject(DestroyRef);
 
-    const values = signal<T>(flagDefaults);
+    const values = signal<T>({ ...flagDefaults });
 
     const unsubscribes: Unsubscribe[] = [];
 
     for (const [key, defaultValue] of Object.entries(flagDefaults)) {
         try {
-            const unsub = client.subscribe(flagsReference, { context: options.context, default: defaultValue, key, type: flagKind(defaultValue) }, (next) => {
-                values.set({ ...values(), [key]: next });
-            });
+            const unsub = client.subscribe(
+                flagsReference,
+                { context: options.context, default: defaultValue, key, type: flagKind(defaultValue) },
+                (next) => {
+                    values.set({ ...values(), [key]: next });
+                },
+                {
+                    onError: () => {
+                        values.set({ ...values(), [key]: defaultValue });
+                    },
+                },
+            );
 
             unsubscribes.push(unsub);
         } catch {

--- a/packages/angular/src/flag.ts
+++ b/packages/angular/src/flag.ts
@@ -1,0 +1,146 @@
+import type { Signal } from "@angular/core";
+import { DestroyRef, inject, signal } from "@angular/core";
+import type { FunctionReference, LunoraClient, Unsubscribe } from "@lunora/client";
+
+import { resolveLunoraClient } from "./client";
+
+/**
+ * The reserved runtime path the generated flag-subscription read override
+ * answers. Any `__lunora_flags__:` path routes there (the suffix is free).
+ */
+const FLAGS_EVAL_PATH = "__lunora_flags__:eval";
+
+/** The value kinds a flag resolves to — OpenFeature's boolean / number / string / structured (JSON) flags. */
+type FlagValue = boolean | number | string | Record<string, unknown> | unknown[] | null;
+
+/** Wire args the generated flag-subscription read override reads. */
+interface FlagSubscribeArgs extends Record<string, unknown> {
+    context?: Record<string, unknown>;
+    default: unknown;
+    key: string;
+    type: "boolean" | "number" | "object" | "string";
+}
+
+/** Map a default value to the OpenFeature flag kind. */
+const flagKind = (value: unknown): FlagSubscribeArgs["type"] => {
+    const kind = typeof value;
+
+    if (kind === "boolean" || kind === "number" || kind === "string") {
+        return kind;
+    }
+
+    return "object";
+};
+
+/** A typed reference to the reserved flags channel. */
+const flagsReference = { __lunoraRef: FLAGS_EVAL_PATH } as FunctionReference<"query", FlagSubscribeArgs, FlagValue>;
+
+export interface FlagOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /**
+     * Per-call targeting context merged on top of the app's default `identify`
+     * targeting key.
+     */
+    context?: Record<string, unknown>;
+
+    /** `DestroyRef` whose `onDestroy` tears down the subscription. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+}
+
+/**
+ * Subscribe to a single feature flag, live over Lunora's WebSocket.
+ *
+ * The returned signal holds `defaultValue` until the first evaluation lands, then
+ * the server's resolved value — re-pushed whenever the provider re-evaluates.
+ * The flag's kind is inferred from `defaultValue`'s runtime type, so
+ * `flag("dark", false)` reads a boolean and `flag("hero", "control")` a string.
+ *
+ * Evaluation runs through whatever OpenFeature provider the app wired in
+ * `lunora/flags.ts`; the read never throws — a provider error resolves the
+ * default (the same fail-open contract as server-side `ctx.flags`).
+ *
+ * Call from an injection context:
+ * ```ts
+ * readonly darkMode = flag("dark-mode", false);
+ * ```
+ */
+export const flag = <T extends FlagValue>(key: string, defaultValue: T, options: FlagOptions = {}): Signal<T> => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+    const type = flagKind(defaultValue);
+
+    const value = signal<T>(defaultValue);
+
+    let unsubscribe: Unsubscribe | undefined;
+
+    try {
+        unsubscribe = client.subscribe(flagsReference, { context: options.context, default: defaultValue, key, type }, (next) => {
+            value.set(next as T);
+        });
+    } catch {
+        // The attach threw (e.g. the client is closed). Keep the default.
+    }
+
+    if (unsubscribe) {
+        destroyRef.onDestroy(unsubscribe);
+    }
+
+    return value.asReadonly();
+};
+
+export interface FlagsOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /**
+     * Targeting context shared by every flag in the set, merged on top of the
+     * app's default `identify` targeting key.
+     */
+    context?: Record<string, unknown>;
+
+    /** `DestroyRef` whose `onDestroy` tears down the subscriptions. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+}
+
+/**
+ * Subscribe to several feature flags at once, live over Lunora's WebSocket.
+ *
+ * Pass a record of `key → defaultValue`; each flag's kind is inferred from its
+ * default, and the returned signal holds the same-shaped record with resolved
+ * values (the defaults until each evaluation lands).
+ *
+ * Call from an injection context:
+ * ```ts
+ * readonly features = flags({ "dark-mode": false, "new-editor": false });
+ * ```
+ */
+export const flags = <T extends Record<string, FlagValue>>(flagDefaults: T, options: FlagsOptions = {}): Signal<T> => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+
+    const values = signal<T>(flagDefaults);
+
+    const unsubscribes: Unsubscribe[] = [];
+
+    for (const [key, defaultValue] of Object.entries(flagDefaults)) {
+        try {
+            const unsub = client.subscribe(flagsReference, { context: options.context, default: defaultValue, key, type: flagKind(defaultValue) }, (next) => {
+                values.set({ ...values(), [key]: next });
+            });
+
+            unsubscribes.push(unsub);
+        } catch {
+            // Keep this flag's default; flags fail open.
+        }
+    }
+
+    destroyRef.onDestroy(() => {
+        for (const unsubscribe of unsubscribes) {
+            unsubscribe();
+        }
+    });
+
+    return values.asReadonly();
+};

--- a/packages/angular/src/hydrate-preloaded.ts
+++ b/packages/angular/src/hydrate-preloaded.ts
@@ -1,0 +1,55 @@
+import type { Signal } from "@angular/core";
+import { DestroyRef, inject, signal } from "@angular/core";
+import type { FunctionReference, LunoraClient, Preloaded } from "@lunora/client";
+
+import { resolveLunoraClient } from "./client";
+
+export interface HydratePreloadedOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /** `DestroyRef` whose `onDestroy` tears the subscription down. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+}
+
+/**
+ * Hydrate a query from a {@link Preloaded} token produced by `preloadQuery`
+ * during SSR, then keep it live — the Angular half of the reactive-loader
+ * handoff.
+ *
+ * The returned signal is seeded **synchronously** from `preloaded.value`, so the
+ * very first read (during hydration) shows the server value: no loading flash,
+ * no hydration mismatch. After seeding it opens a WebSocket subscription on the
+ * same `(functionPath, args, shardKey)` the SSR loader used, so every later
+ * server delta updates the signal exactly like `liveQuery`.
+ *
+ * The subscription tears down when the owning `DestroyRef` fires.
+ *
+ * Call from an injection context:
+ * ```ts
+ * readonly messages = hydratePreloaded(preloadedMessages);
+ * ```
+ */
+export const hydratePreloaded = <T>(preloaded: Preloaded<T>, options: HydratePreloadedOptions = {}): Signal<T | undefined> => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+
+    const { args, functionPath, shardKey, value } = preloaded;
+
+    const data = signal<T | undefined>(value);
+
+    const functionReference: FunctionReference = { __lunoraRef: functionPath };
+
+    const unsubscribe = client.subscribe(
+        functionReference,
+        args,
+        (next) => {
+            data.set(next as T);
+        },
+        { shardKey },
+    );
+
+    destroyRef.onDestroy(unsubscribe);
+
+    return data.asReadonly();
+};

--- a/packages/angular/src/hydrate-preloaded.ts
+++ b/packages/angular/src/hydrate-preloaded.ts
@@ -1,6 +1,6 @@
 import type { Signal } from "@angular/core";
 import { DestroyRef, inject, signal } from "@angular/core";
-import type { FunctionReference, LunoraClient, Preloaded } from "@lunora/client";
+import type { FunctionReference, LunoraClient, Preloaded, SubscriptionError } from "@lunora/client";
 
 import { resolveLunoraClient } from "./client";
 
@@ -10,6 +10,14 @@ export interface HydratePreloadedOptions {
 
     /** `DestroyRef` whose `onDestroy` tears the subscription down. Defaults to `inject(DestroyRef)`. */
     destroyRef?: DestroyRef;
+}
+
+export interface HydratePreloadedResult<T> {
+    /** The latest value pushed by the server. Seeded synchronously from the preloaded value. */
+    data: Signal<T | undefined>;
+
+    /** The latest subscription error, or `undefined`. */
+    error: Signal<SubscriptionError | undefined>;
 }
 
 /**
@@ -27,16 +35,17 @@ export interface HydratePreloadedOptions {
  *
  * Call from an injection context:
  * ```ts
- * readonly messages = hydratePreloaded(preloadedMessages);
+ * readonly { data, error } = hydratePreloaded(preloadedMessages);
  * ```
  */
-export const hydratePreloaded = <T>(preloaded: Preloaded<T>, options: HydratePreloadedOptions = {}): Signal<T | undefined> => {
+export const hydratePreloaded = <T>(preloaded: Preloaded<T>, options: HydratePreloadedOptions = {}): HydratePreloadedResult<T> => {
     const client = resolveLunoraClient(options.client);
     const destroyRef = options.destroyRef ?? inject(DestroyRef);
 
     const { args, functionPath, shardKey, value } = preloaded;
 
     const data = signal<T | undefined>(value);
+    const error = signal<SubscriptionError | undefined>(undefined);
 
     const functionReference: FunctionReference = { __lunoraRef: functionPath };
 
@@ -45,11 +54,17 @@ export const hydratePreloaded = <T>(preloaded: Preloaded<T>, options: HydratePre
         args,
         (next) => {
             data.set(next as T);
+            error.set(undefined);
         },
-        { shardKey },
+        {
+            onError: (error_) => {
+                error.set(error_);
+            },
+            shardKey,
+        },
     );
 
     destroyRef.onDestroy(unsubscribe);
 
-    return data.asReadonly();
+    return { data: data.asReadonly(), error: error.asReadonly() };
 };

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -22,7 +22,7 @@ export type { ConnectionStatusOptions } from "./connection-status";
 export { connectionStatus } from "./connection-status";
 export type { FlagOptions, FlagsOptions } from "./flag";
 export { flag, flags } from "./flag";
-export type { HydratePreloadedOptions } from "./hydrate-preloaded";
+export type { HydratePreloadedOptions, HydratePreloadedResult } from "./hydrate-preloaded";
 export { hydratePreloaded } from "./hydrate-preloaded";
 export type { LiveQueryOptions } from "./live-query";
 export { liveQuery } from "./live-query";

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,3 +1,6 @@
+export type { AuthOptions, AuthResult } from "./auth";
+export { auth } from "./auth";
+
 /**
  * The Angular adapter for Lunora.
  *
@@ -12,19 +15,31 @@
  * `DestroyRef.onDestroy`. `mutate` runs a mutation (optimistic updates + offline
  * queue pass through to the client). `connectionStatus` is a `signal` of the
  * aggregate live-socket status.
- *
- * The API is deliberately small and signal-first; parity extras (paginated query,
- * optimistic mutator handles, rate-limit, flags, auth) mirror the other framework
- * adapters and can be layered on top of the same client.
  */
 export type { ProvideLunoraOptions } from "./client";
 export { injectLunoraClient, LUNORA_CLIENT, provideLunora } from "./client";
 export type { ConnectionStatusOptions } from "./connection-status";
 export { connectionStatus } from "./connection-status";
+export type { FlagOptions, FlagsOptions } from "./flag";
+export { flag, flags } from "./flag";
+export type { HydratePreloadedOptions } from "./hydrate-preloaded";
+export { hydratePreloaded } from "./hydrate-preloaded";
 export type { LiveQueryOptions } from "./live-query";
 export { liveQuery } from "./live-query";
 export type { MutateOptions } from "./mutate";
 export { mutate } from "./mutate";
+export type { MutatorResult } from "./mutator";
+export { mutator } from "./mutator";
+export type { PaginatedQueryOptions, PaginatedQueryResult } from "./paginated-query";
+export type { InfiniteQueryResult } from "./paginated-query";
+export { paginatedQuery } from "./paginated-query";
+export { infiniteQuery } from "./paginated-query";
+export type { PresenceOptions, PresenceResult } from "./presence";
+export { presence } from "./presence";
+export type { RateLimitOptions, RateLimitResult } from "./rate-limit";
+export { rateLimit } from "./rate-limit";
+export type { SubscriptionOptions, SubscriptionResult } from "./subscription";
+export { subscription } from "./subscription";
 export type {
     ArgsOf,
     ConnectionStatus,

--- a/packages/angular/src/mutator.ts
+++ b/packages/angular/src/mutator.ts
@@ -1,0 +1,55 @@
+import type { Signal } from "@angular/core";
+import { computed, signal } from "@angular/core";
+import type { MutatorHandle } from "@lunora/client";
+import { createMutatorRunner } from "@lunora/client";
+
+export interface MutatorResult<TArgs> {
+    /** The latest invocation's error, or `undefined`. */
+    error: Signal<Error | undefined>;
+
+    /** `true` when the latest invocation rejected. */
+    isError: Signal<boolean>;
+
+    /** Run the mutator; resolves once the write is persisted, rejects on failure. */
+    mutate: (args: TArgs) => Promise<void>;
+
+    /** `true` while ANY invocation from this handle is in flight. */
+    pending: Signal<boolean>;
+
+    /** Clear the latest `error` back to idle. */
+    reset: () => void;
+}
+
+/**
+ * Ergonomic `{ mutate, pending, error, isError, reset }` wrapper over a bound
+ * custom-mutator handle from `` `@lunora/db` ``'s `bindMutators` — the Angular
+ * equivalent of `` `@lunora/react` ``'s `useMutator`. The optimistic overlay and
+ * server-authoritative push are owned by the bound handle; this function only
+ * surfaces reactive state for the in-flight/error lifecycle.
+ *
+ * `pending` is ref-counted across overlapping invocations of THIS handle, so it
+ * clears only once every concurrent call has settled.
+ *
+ * Does NOT require an injection context — it works with plain signals.
+ *
+ * ```ts
+ * private readonly collection = bindMutators(collections);
+ * readonly mutator = mutator(this.collection.insert);
+ * ```
+ */
+export const mutator = <TArgs = Record<string, unknown>>(handle: MutatorHandle<TArgs>): MutatorResult<TArgs> => {
+    const error = signal<Error | undefined>(undefined);
+    const pending = signal(false);
+    const isError = computed(() => error() !== undefined);
+
+    const { mutate, reset } = createMutatorRunner(handle, {
+        setError: (value) => {
+            error.set(value);
+        },
+        setPending: (value) => {
+            pending.set(value);
+        },
+    });
+
+    return { error: error.asReadonly(), isError, mutate, pending: pending.asReadonly(), reset };
+};

--- a/packages/angular/src/paginated-query.ts
+++ b/packages/angular/src/paginated-query.ts
@@ -164,10 +164,17 @@ const usePaginatedCore = <F extends FunctionReference>(
                             migrateResultsForRebalance(latestPages, next);
                             pages.set(next);
                             syncSubscriptions(next);
+                            doRebuildPageResults();
                         }
                     }
                 },
-                { shardKey },
+                {
+                    onError: () => {
+                        pendingPageKeys.delete(entry.currentKey);
+                        doRebuildPageResults();
+                    },
+                    shardKey,
+                },
             );
 
             entry.unsub = unsub;
@@ -210,9 +217,9 @@ const usePaginatedCore = <F extends FunctionReference>(
         }
 
         // `applyLoadMore` pins the open-ended tail: the last page's args shift
-        // from `endCursor: null` to `endCursor: cursor`. Re-key the existing
-        // subscription entry and the result map so both survive without
-        // closing/reopening the socket subscription.
+        // from `endCursor: null` to `endCursor: cursor`. Close the old
+        // subscription, carry the result to the new key, and let
+        // `syncSubscriptions` open a fresh sub for the pinned page.
         const oldTail = pages().at(-1);
         const newPinnedPage = next.at(-2);
 
@@ -222,16 +229,15 @@ const usePaginatedCore = <F extends FunctionReference>(
             const entry = activeSubs.get(oldKey);
 
             if (entry && oldKey !== newKey) {
-                entry.currentKey = newKey;
-                activeSubs.set(newKey, entry);
-                activeSubs.delete(oldKey);
-
                 const carried = resultsByKey.get(oldKey);
 
                 if (carried) {
                     resultsByKey.set(newKey, carried);
-                    resultsByKey.delete(oldKey);
                 }
+
+                entry.unsub();
+                activeSubs.delete(oldKey);
+                resultsByKey.delete(oldKey);
             }
         }
 

--- a/packages/angular/src/paginated-query.ts
+++ b/packages/angular/src/paginated-query.ts
@@ -1,0 +1,409 @@
+import type { Signal } from "@angular/core";
+import { computed, DestroyRef, inject, signal } from "@angular/core";
+import type { FunctionReference, LunoraClient, Unsubscribe } from "@lunora/client";
+import type { Page, PaginationResult, PaginationStatus } from "@lunora/client/pagination";
+import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "@lunora/client/pagination";
+
+import { resolveLunoraClient } from "./client";
+
+// ── Shared types ────────────────────────────────────────────────────────────
+
+/** The args a paginated query exposes minus the framework-supplied page cursor. */
+type PaginatedArgs<F extends FunctionReference> = Omit<ArgsOfRaw<F>, "paginationOpts">;
+
+/** The element type of the `page` array a paginated query returns. */
+type PageItemOf<F extends FunctionReference> = ReturnTypeOf<F> extends { page: (infer T)[] } ? T : unknown;
+
+// Simplified helper types that don't pull in the full Lunora client type machinery.
+type ArgsOfRaw<F extends FunctionReference> = F extends FunctionReference<"query", infer A> ? A : never;
+type ReturnTypeOf<F extends FunctionReference> = F extends FunctionReference<"query", unknown, infer R> ? R : never;
+
+// ── Page key helpers ────────────────────────────────────────────────────────
+
+const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): string => `${functionPath}::${JSON.stringify(pageArgs)}`;
+
+const buildPageArgs = (page: Page, baseArgs: Record<string, unknown>): Record<string, unknown> => {
+    return {
+        ...baseArgs,
+        paginationOpts: { cursor: page.lower, endCursor: page.upper, numItems: page.numItems },
+    };
+};
+
+// ── Core pagination engine ──────────────────────────────────────────────────
+
+/**
+ * Angular-native pagination engine shared by `paginatedQuery` and `infiniteQuery`.
+ * Owns the page boundary list, per-page `client.subscribe()` calls, split/join
+ * maintenance, and `loadMore`.
+ */
+const usePaginatedCore = <F extends FunctionReference>(
+    reference: F,
+    baseArgs: Record<string, unknown> | "skip",
+    options: PaginatedQueryOptions,
+): {
+    loadMore: (numberItems: number) => void;
+    pageResults: Signal<(PaginationResult<PageItemOf<F>> | undefined)[]>;
+    status: Signal<PaginationStatus>;
+} => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+    const { initialNumItems, shardKey } = options;
+
+    const functionPath = (reference as Record<string, unknown>)["__lunoraRef"] as string;
+
+    // Narrow the union type so buildPageArgs' callees don't error — all call
+    // sites are guarded by baseArgs !== "skip" before they reach here.
+    const narrowedArgs = baseArgs === "skip" ? ({} as Record<string, unknown>) : baseArgs;
+
+    const pages = signal<Page[]>(initialPages(initialNumItems));
+    const pageResults = signal<(PaginationResult<PageItemOf<F>> | undefined)[]>([]);
+    const status = signal<PaginationStatus>("LoadingFirstPage");
+
+    /**
+     * Each active subscription entry. `currentKey` is mutable so that when
+     * `loadMore` re-keys a pinned page, the callback still stores its result
+     * under the correct key without needing a closure rebind.
+     */
+    interface SubEntry {
+        currentKey: string;
+        unsub: Unsubscribe;
+    }
+
+    const activeSubs = new Map<string, SubEntry>();
+    const resultsByKey = new Map<string, PaginationResult<PageItemOf<F>>>();
+    const pendingPageKeys = new Set<string>();
+
+    const doRebuildPageResults = (): void => {
+        const currentPages = pages();
+        const items = currentPages.map((page) => {
+            const key = buildPageKey(functionPath, buildPageArgs(page, narrowedArgs));
+            return resultsByKey.get(key);
+        });
+        pageResults.set(items);
+
+        // Derive pagination status from the results.
+        const { status: derivedStatus } = derivePaginationStatus(baseArgs === "skip", items);
+        status.set(derivedStatus);
+    };
+
+    /**
+     * When rebalance splits or joins pages, the result keys change. Carry existing
+     * results to the new keys so visible data is preserved.
+     */
+    const migrateResultsForRebalance = (oldPages: Page[], newPages: Page[]): void => {
+        const keyOf = (page: Page): string => buildPageKey(functionPath, buildPageArgs(page, narrowedArgs));
+
+        for (const newPage of newPages) {
+            const newKey = keyOf(newPage);
+
+            if (resultsByKey.has(newKey)) {
+                continue;
+            }
+
+            const donor = oldPages.find((op) => op.lower === newPage.lower);
+
+            if (donor) {
+                const carried = resultsByKey.get(keyOf(donor));
+
+                if (carried) {
+                    resultsByKey.set(newKey, carried);
+                }
+            }
+        }
+    };
+
+    const syncSubscriptions = (currentPages: Page[]): void => {
+        const wantedKeys = new Set<string>();
+
+        for (const page of currentPages) {
+            wantedKeys.add(buildPageKey(functionPath, buildPageArgs(page, narrowedArgs)));
+        }
+
+        // Close stale subscriptions.
+        for (const [originalKey, entry] of activeSubs) {
+            if (!wantedKeys.has(entry.currentKey)) {
+                entry.unsub();
+                activeSubs.delete(originalKey);
+                resultsByKey.delete(entry.currentKey);
+            }
+        }
+
+        // Open new subscriptions for pages that have no active sub.
+        const coveredKeys = new Set([...activeSubs.values()].map((subEntry) => subEntry.currentKey));
+
+        for (const page of currentPages) {
+            const pageArgs = buildPageArgs(page, narrowedArgs);
+            const key = buildPageKey(functionPath, pageArgs);
+
+            if (coveredKeys.has(key)) {
+                continue;
+            }
+
+            const entry: SubEntry = {
+                currentKey: key,
+                unsub: undefined as unknown as Unsubscribe,
+            };
+
+            pendingPageKeys.add(key);
+
+            const unsub = client.subscribe(
+                reference,
+                pageArgs as never,
+                (value) => {
+                    resultsByKey.set(entry.currentKey, value as PaginationResult<PageItemOf<F>>);
+                    pendingPageKeys.delete(entry.currentKey);
+
+                    doRebuildPageResults();
+
+                    // Rebalance only when no pages are still in their initial-load phase.
+                    if (pendingPageKeys.size === 0) {
+                        const latestPages = pages();
+                        const next = rebalance(latestPages, pageResults());
+
+                        if (next) {
+                            migrateResultsForRebalance(latestPages, next);
+                            pages.set(next);
+                            syncSubscriptions(next);
+                        }
+                    }
+                },
+                { shardKey },
+            );
+
+            entry.unsub = unsub;
+            activeSubs.set(key, entry);
+            coveredKeys.add(key);
+        }
+    };
+
+    if (baseArgs !== "skip") {
+        syncSubscriptions(pages());
+    }
+
+    doRebuildPageResults();
+
+    // Teardown all subscriptions on destroy.
+    destroyRef.onDestroy(() => {
+        for (const entry of activeSubs.values()) {
+            entry.unsub();
+        }
+
+        activeSubs.clear();
+        resultsByKey.clear();
+    });
+
+    const loadMore = (numberItems: number): void => {
+        if (baseArgs === "skip") {
+            return;
+        }
+
+        const { nextCursor, status: currentStatus } = derivePaginationStatus(false, pageResults());
+
+        if (currentStatus !== "CanLoadMore") {
+            return;
+        }
+
+        const next = applyLoadMore(pages(), nextCursor, numberItems);
+
+        if (!next) {
+            return;
+        }
+
+        // `applyLoadMore` pins the open-ended tail: the last page's args shift
+        // from `endCursor: null` to `endCursor: cursor`. Re-key the existing
+        // subscription entry and the result map so both survive without
+        // closing/reopening the socket subscription.
+        const oldTail = pages().at(-1);
+        const newPinnedPage = next.at(-2);
+
+        if (oldTail && newPinnedPage) {
+            const oldKey = buildPageKey(functionPath, buildPageArgs(oldTail, narrowedArgs));
+            const newKey = buildPageKey(functionPath, buildPageArgs(newPinnedPage, narrowedArgs));
+            const entry = activeSubs.get(oldKey);
+
+            if (entry && oldKey !== newKey) {
+                entry.currentKey = newKey;
+                activeSubs.set(newKey, entry);
+                activeSubs.delete(oldKey);
+
+                const carried = resultsByKey.get(oldKey);
+
+                if (carried) {
+                    resultsByKey.set(newKey, carried);
+                    resultsByKey.delete(oldKey);
+                }
+            }
+        }
+
+        pages.set(next);
+        syncSubscriptions(pages());
+        doRebuildPageResults();
+    };
+
+    return { loadMore, pageResults, status };
+};
+
+// ── Paginated query options & result ────────────────────────────────────────
+
+export interface PaginatedQueryOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /** `DestroyRef` whose `onDestroy` tears down the subscriptions. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+
+    /** Page size for the first page (and the default for `loadMore`). */
+    initialNumItems: number;
+
+    /** Route to a specific shard when the target function is `.shardBy(...)`-partitioned. */
+    shardKey?: string;
+}
+
+export interface PaginatedQueryResult<T> {
+    /** `true` while the first page or a `loadMore` page is in flight. */
+    isLoading: Signal<boolean>;
+
+    /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
+    loadMore: (numberItems: number) => void;
+
+    /** Flattened items across every loaded page, in order. */
+    results: Signal<T[]>;
+
+    /** The pagination status. */
+    status: Signal<PaginationStatus>;
+}
+
+export interface InfiniteQueryOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /** `DestroyRef` whose `onDestroy` tears down the subscriptions. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+
+    /** Page size for the first page (and the default for `fetchNextPage`). */
+    initialNumItems: number;
+
+    /** Route to a specific shard when the target function is `.shardBy(...)`-partitioned. */
+    shardKey?: string;
+}
+
+export interface InfiniteQueryResult<T> {
+    /** Request the next page. A no-op unless `status === "CanLoadMore"`. */
+    fetchNextPage: (numberItems?: number) => void;
+
+    /** `true` when the loaded tail reports it can load another page. */
+    hasNextPage: Signal<boolean>;
+
+    /** `true` while a `fetchNextPage` page (beyond the first) is in flight. */
+    isFetchingNextPage: Signal<boolean>;
+
+    /** `true` while the first page is in flight. */
+    isLoading: Signal<boolean>;
+
+    /** One inner array per loaded page, in order; unresolved pages are omitted. */
+    pages: Signal<T[][]>;
+
+    /** The pagination status. */
+    status: Signal<PaginationStatus>;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Subscribe to a reactively-paginated query and grow the feed page by page.
+ *
+ * The query function must accept a `paginationOpts: { numItems, cursor,
+ * endCursor }` arg and return a `PaginationResult`. Pages are tracked as an
+ * ordered list of stable boundary cursors; each loaded page is a live
+ * subscription over a FIXED `(lower, upper]` range.
+ *
+ * `loadMore` appends the next page off the open-ended tail's `continueCursor`;
+ * it is a no-op unless `status === "CanLoadMore"`.
+ *
+ * Call from an injection context:
+ * ```ts
+ * readonly messages = paginatedQuery(api.messages.list, {}, { initialNumItems: 20 });
+ * ```
+ */
+export const paginatedQuery = <F extends FunctionReference>(
+    reference: F,
+    args: PaginatedArgs<F> | "skip",
+    options: PaginatedQueryOptions,
+): PaginatedQueryResult<PageItemOf<F>> => {
+    const core = usePaginatedCore<F>(reference, args, options);
+
+    const results = computed<PageItemOf<F>[]>(() => {
+        const items: PageItemOf<F>[] = [];
+
+        for (const result of core.pageResults()) {
+            if (result) {
+                items.push(...result.page);
+            }
+        }
+
+        return items;
+    });
+
+    const isLoading = computed<boolean>(() => {
+        const statusValue = core.status();
+
+        return statusValue === "LoadingFirstPage" || statusValue === "LoadingMore";
+    });
+
+    return {
+        isLoading,
+        loadMore: core.loadMore,
+        results,
+        status: core.status,
+    };
+};
+
+/**
+ * Subscribe to a reactively-paginated query and expose its pages discretely.
+ *
+ * Shares `paginatedQuery`'s reactive-pagination engine but keeps each page as
+ * its own inner array rather than flattening them, and adds the TanStack-Query-
+ * style `fetchNextPage` / `hasNextPage` / `isFetchingNextPage` shape.
+ *
+ * Call from an injection context:
+ * ```ts
+ * readonly feed = infiniteQuery(api.messages.list, {}, { initialNumItems: 20 });
+ * ```
+ */
+export const infiniteQuery = <F extends FunctionReference>(
+    reference: F,
+    args: PaginatedArgs<F> | "skip",
+    options: PaginatedQueryOptions,
+): InfiniteQueryResult<PageItemOf<F>> => {
+    const { initialNumItems } = options;
+    const core = usePaginatedCore<F>(reference, args, options);
+
+    const pages = computed<PageItemOf<F>[][]>(() => {
+        const resultArrays: PageItemOf<F>[][] = [];
+
+        for (const page of core.pageResults()) {
+            if (page) {
+                resultArrays.push(page.page);
+            }
+        }
+
+        return resultArrays;
+    });
+
+    const isLoading = computed<boolean>(() => core.status() === "LoadingFirstPage");
+    const hasNextPage = computed<boolean>(() => core.status() === "CanLoadMore");
+    const isFetchingNextPage = computed<boolean>(() => core.status() === "LoadingMore");
+
+    const fetchNextPage = (numberItems?: number): void => {
+        core.loadMore(numberItems ?? initialNumItems);
+    };
+
+    return {
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+        isLoading,
+        pages,
+        status: core.status,
+    };
+};

--- a/packages/angular/src/presence.ts
+++ b/packages/angular/src/presence.ts
@@ -80,21 +80,31 @@ export interface PresenceResult<L extends ListPresentReference> {
 export const presence = <H extends HeartbeatReference, L extends ListPresentReference>(roomId: string, options: PresenceOptions<H, L>): PresenceResult<L> => {
     const client = resolveLunoraClient(options.client);
     const destroyRef = options.destroyRef ?? inject(DestroyRef);
-    const { heartbeat, intervalMs = DEFAULT_INTERVAL_MS, listPresent, shardKey } = options;
+    const { heartbeat, listPresent, shardKey } = options;
+    const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
 
     const sessionId = options.sessionId ?? makeSessionId();
     const present = signal<ReturnOf<L> | undefined>(undefined);
 
     // Latest awareness data — updated by `setData`; read at heartbeat time so
     // changing data never resets the interval or closes the subscription.
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        throw new RangeError(`presence intervalMs must be a positive number, got ${String(intervalMs)}`);
+    }
+
     let latestData: Record<string, unknown> | undefined = options.data;
 
+    // Register this room/session as the socket's connection context BEFORE the
+    // first heartbeat so the server's presence `onDisconnect` hook can delete
+    // the row instantly on socket drop.
+    const releaseConnectionContext = client.acquireConnectionContext({ roomId, sessionId }, { shardKey });
+
     const sendHeartbeat = (): void => {
-        const args = {
-            roomId,
-            sessionId,
-            ...(latestData === undefined ? {} : { data: latestData }),
-        } as ArgsOf<H>;
+        const args: ArgsOf<H> = { roomId, sessionId } as ArgsOf<H>;
+
+        if (latestData !== undefined) {
+            (args as Record<string, unknown>).data = latestData;
+        }
 
         // Fire-and-forget — a dropped heartbeat self-heals on the next tick.
         client.mutation(heartbeat, args, { shardKey }).catch(() => undefined);
@@ -119,14 +129,12 @@ export const presence = <H extends HeartbeatReference, L extends ListPresentRefe
         document.addEventListener("visibilitychange", onVisible);
     }
 
-    // Register this room/session as the socket's connection context so the server's
-    // presence `onDisconnect` hook can delete the row instantly on socket drop.
-    const releaseConnectionContext = client.acquireConnectionContext({ roomId, sessionId }, { shardKey });
-
     // Subscribe to the live present-list for the room.
+    const listArgs: ArgsOf<L> = { roomId } as ArgsOf<L>;
+
     const unsubscribe = client.subscribe(
         listPresent,
-        { roomId } as ArgsOf<L>,
+        listArgs,
         (value) => {
             present.set(value);
         },

--- a/packages/angular/src/presence.ts
+++ b/packages/angular/src/presence.ts
@@ -1,0 +1,149 @@
+import type { Signal } from "@angular/core";
+import { DestroyRef, inject, signal } from "@angular/core";
+import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf } from "@lunora/client";
+
+import { resolveLunoraClient } from "./client";
+
+type HeartbeatReference = FunctionReference<"mutation", { data?: Record<string, unknown>; roomId: string; sessionId: string }>;
+
+type ListPresentReference = FunctionReference<"query", { roomId: string }>;
+
+/* eslint-disable n/no-unsupported-features/node-builtins -- crypto.randomUUID is available in all target browsers and Node 19+; the fallback below handles older runtimes. */
+/* eslint-disable sonarjs/pseudo-random -- the fallback session id is a non-cryptographic correlation key, not a security primitive. */
+const makeSessionId = (): string => {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+
+    return `sess-${Math.random().toString(36).slice(2)}-${String(Date.now())}`;
+};
+/* eslint-enable n/no-unsupported-features/node-builtins */
+/* eslint-enable sonarjs/pseudo-random */
+
+const DEFAULT_INTERVAL_MS = 10_000;
+
+export interface PresenceOptions<H extends HeartbeatReference, L extends ListPresentReference> {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /** Awareness blob for the first heartbeat (selection, cursor, name, color…). */
+    data?: Record<string, unknown>;
+
+    /** `DestroyRef` whose `onDestroy` cleans up. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+
+    /** The `api.*` reference for the presence heartbeat mutation. */
+    heartbeat: H;
+
+    /** Heartbeat cadence in ms. Defaults to 10s (10000). */
+    intervalMs?: number;
+
+    /** The `api.*` reference for the presence listPresent query. */
+    listPresent: L;
+
+    /**
+     * Stable id for this presence row. Defaults to a fresh per-call id.
+     * Pass a user/connection id to control deduping across tabs.
+     */
+    sessionId?: string;
+
+    /** Forwarded to the heartbeat mutation / listPresent subscription when sharding by room. */
+    shardKey?: string;
+}
+
+export interface PresenceResult<L extends ListPresentReference> {
+    /** The present members for the room. `undefined` until the first push. */
+    present: Signal<ReturnOf<L> | undefined>;
+
+    /** This mount's session id (generated when not supplied). */
+    sessionId: string;
+
+    /** Replace the awareness `data` sent with subsequent heartbeats, and heartbeat immediately. */
+    setData: (data: Record<string, unknown> | undefined) => void;
+}
+
+/**
+ * `presence` — collaborative-awareness primitive, the client half of the
+ * `@lunora/server` `definePresence` preset.
+ *
+ * Drives the heartbeat mutation (on mount, interval, and tab re-focus) and
+ * subscribes to the live `listPresent` query for the given room.
+ *
+ * Call from an injection context (component/service field or constructor):
+ * ```ts
+ * readonly roomPresence = presence("room:general", {
+ *     heartbeat: api.presence.heartbeat,
+ *     listPresent: api.presence.listPresent,
+ * });
+ * ```
+ */
+export const presence = <H extends HeartbeatReference, L extends ListPresentReference>(roomId: string, options: PresenceOptions<H, L>): PresenceResult<L> => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+    const { heartbeat, intervalMs = DEFAULT_INTERVAL_MS, listPresent, shardKey } = options;
+
+    const sessionId = options.sessionId ?? makeSessionId();
+    const present = signal<ReturnOf<L> | undefined>(undefined);
+
+    // Latest awareness data — updated by `setData`; read at heartbeat time so
+    // changing data never resets the interval or closes the subscription.
+    let latestData: Record<string, unknown> | undefined = options.data;
+
+    const sendHeartbeat = (): void => {
+        const args = {
+            roomId,
+            sessionId,
+            ...(latestData === undefined ? {} : { data: latestData }),
+        } as ArgsOf<H>;
+
+        // Fire-and-forget — a dropped heartbeat self-heals on the next tick.
+        client.mutation(heartbeat, args, { shardKey }).catch(() => undefined);
+    };
+
+    const setData = (next: Record<string, unknown> | undefined): void => {
+        latestData = next;
+        sendHeartbeat();
+    };
+
+    // Heartbeat: immediately on mount, on interval, and on tab re-focus.
+    sendHeartbeat();
+    const intervalHandle = setInterval(sendHeartbeat, intervalMs);
+
+    const onVisible = (): void => {
+        if (typeof document !== "undefined" && document.visibilityState === "visible") {
+            sendHeartbeat();
+        }
+    };
+
+    if (typeof document !== "undefined") {
+        document.addEventListener("visibilitychange", onVisible);
+    }
+
+    // Register this room/session as the socket's connection context so the server's
+    // presence `onDisconnect` hook can delete the row instantly on socket drop.
+    const releaseConnectionContext = client.acquireConnectionContext({ roomId, sessionId }, { shardKey });
+
+    // Subscribe to the live present-list for the room.
+    const unsubscribe = client.subscribe(
+        listPresent,
+        { roomId } as ArgsOf<L>,
+        (value) => {
+            present.set(value);
+        },
+        { shardKey },
+    );
+
+    // Teardown: clear interval, remove listener, release connection context, unsubscribe.
+    destroyRef.onDestroy(() => {
+        clearInterval(intervalHandle);
+
+        if (typeof document !== "undefined") {
+            document.removeEventListener("visibilitychange", onVisible);
+        }
+
+        releaseConnectionContext();
+        unsubscribe();
+    });
+
+    return { present: present.asReadonly(), sessionId, setData };
+};

--- a/packages/angular/src/presence.ts
+++ b/packages/angular/src/presence.ts
@@ -8,17 +8,8 @@ type HeartbeatReference = FunctionReference<"mutation", { data?: Record<string, 
 
 type ListPresentReference = FunctionReference<"query", { roomId: string }>;
 
-/* eslint-disable n/no-unsupported-features/node-builtins -- crypto.randomUUID is available in all target browsers and Node 19+; the fallback below handles older runtimes. */
-/* eslint-disable sonarjs/pseudo-random -- the fallback session id is a non-cryptographic correlation key, not a security primitive. */
-const makeSessionId = (): string => {
-    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-        return crypto.randomUUID();
-    }
-
-    return `sess-${Math.random().toString(36).slice(2)}-${String(Date.now())}`;
-};
-/* eslint-enable n/no-unsupported-features/node-builtins */
-/* eslint-enable sonarjs/pseudo-random */
+/* eslint-disable-next-line n/no-unsupported-features/node-builtins -- crypto.randomUUID is available in all target browsers, workerd, and Node 22+. */
+const makeSessionId = (): string => crypto.randomUUID();
 
 const DEFAULT_INTERVAL_MS = 10_000;
 

--- a/packages/angular/src/rate-limit.ts
+++ b/packages/angular/src/rate-limit.ts
@@ -1,0 +1,133 @@
+import type { Signal } from "@angular/core";
+import { computed, DestroyRef, inject, signal } from "@angular/core";
+import type { RateLimitConfig, RateLimitStatus, RateLimitValue } from "@lunora/ratelimit";
+import { evaluate } from "@lunora/ratelimit";
+
+export interface RateLimitOptions {
+    /**
+     * `DestroyRef` whose `onDestroy` clears the interval. Defaults to
+     * `inject(DestroyRef)` — the calling component/service.
+     */
+    destroyRef?: DestroyRef;
+
+    /** Clock injection for tests. Defaults to `Date.now`. */
+    now?: () => number;
+
+    /**
+     * Re-render cadence in milliseconds while throttled, so `retryAfter` ticks
+     * down and `disabled` flips back automatically. Defaults to `1000`.
+     */
+    tickMs?: number;
+}
+
+export interface RateLimitResult {
+    /** Would consuming `count` (default 1) succeed right now? Does not consume. */
+    check: (count?: number) => boolean;
+
+    /** Optimistically consume `count` (default 1) locally; mirrors the server algorithm. */
+    consume: (count?: number) => RateLimitStatus;
+
+    /** `true` while a single unit cannot be consumed — convenient for disabling a control. */
+    disabled: Signal<boolean>;
+
+    /** `true` while a single unit can be consumed. */
+    ok: Signal<boolean>;
+
+    /** Clear local accounting (e.g. after the server confirms a reset). */
+    reset: () => void;
+
+    /** Milliseconds until the next unit is available. `0` when `ok`. */
+    retryAfter: Signal<number>;
+}
+
+/**
+ * Client-side mirror of a rate limit for instant UX — disable a button or show
+ * a countdown without a round-trip. It runs the same token-bucket / fixed-window
+ * math as `@lunora/ratelimit` on the server, so the prediction agrees with the
+ * authoritative check; the server remains the source of truth.
+ *
+ * Does NOT require an injection context — `client` is only used when DI-based
+ * resolution is needed (omit to use the injected client).
+ *
+ * ```ts
+ * readonly sendLimit = rateLimit({ kind: "token bucket", period: 1000, rate: 10 });
+ * ```
+ */
+export const rateLimit = (config: RateLimitConfig, options: RateLimitOptions = {}): RateLimitResult => {
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+    const now = options.now ?? Date.now;
+    const tickMs = options.tickMs ?? 1000;
+
+    // Mutable bucket value — not reactive itself.
+    let value: RateLimitValue | undefined;
+
+    // `epoch` increments on every state change; the status signal is
+    // re-evaluated whenever epoch changes (via a reactive computation).
+    const epoch = signal(0);
+
+    const computeStatus = (): RateLimitStatus => evaluate(config, value, { consume: false, count: 1, now: now(), reserve: false }).status;
+
+    const status = signal<RateLimitStatus>(computeStatus());
+
+    const bump = (): void => {
+        epoch.update((v) => v + 1);
+        status.set(computeStatus());
+    };
+
+    let intervalHandle: ReturnType<typeof setInterval> | undefined;
+
+    const stopInterval = (): void => {
+        if (intervalHandle !== undefined) {
+            clearInterval(intervalHandle);
+            intervalHandle = undefined;
+        }
+    };
+
+    const startIntervalIfThrottled = (): void => {
+        if (status().ok || intervalHandle !== undefined) {
+            return;
+        }
+
+        intervalHandle = setInterval(() => {
+            bump();
+
+            if (status().ok) {
+                stopInterval();
+            }
+        }, tickMs);
+    };
+
+    // Kick off the ticker if we start already throttled.
+    startIntervalIfThrottled();
+
+    destroyRef.onDestroy(() => {
+        stopInterval();
+    });
+
+    return {
+        check: (count = 1): boolean => evaluate(config, value, { consume: false, count, now: now(), reserve: false }).status.ok,
+        consume: (count = 1): RateLimitStatus => {
+            const result = evaluate(config, value, { consume: true, count, now: now(), reserve: false });
+
+            if (result.value !== undefined) {
+                value = result.value;
+            }
+
+            bump();
+            startIntervalIfThrottled();
+
+            return result.status;
+        },
+        disabled: computed(() => !status().ok),
+        ok: computed(() => status().ok),
+        reset: (): void => {
+            value = undefined;
+            stopInterval();
+            bump();
+        },
+        retryAfter: computed(() => status().retryAfter),
+    };
+};
+
+// Re-export types so consumers can import everything from this module.
+export type { RateLimitConfig, RateLimitStatus, RateLimitValue } from "@lunora/ratelimit";

--- a/packages/angular/src/rate-limit.ts
+++ b/packages/angular/src/rate-limit.ts
@@ -46,8 +46,8 @@ export interface RateLimitResult {
  * math as `@lunora/ratelimit` on the server, so the prediction agrees with the
  * authoritative check; the server remains the source of truth.
  *
- * Does NOT require an injection context — `client` is only used when DI-based
- * resolution is needed (omit to use the injected client).
+ * Requires an Angular injection context unless a `DestroyRef` is passed
+ * explicitly via `options.destroyRef`.
  *
  * ```ts
  * readonly sendLimit = rateLimit({ kind: "token bucket", period: 1000, rate: 10 });

--- a/packages/angular/src/subscription.ts
+++ b/packages/angular/src/subscription.ts
@@ -1,0 +1,91 @@
+import type { Signal } from "@angular/core";
+import { DestroyRef, inject, signal } from "@angular/core";
+import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, SubscriptionError } from "@lunora/client";
+import { createQuerySubscription } from "@lunora/client/query";
+
+import { resolveLunoraClient } from "./client";
+
+export interface SubscriptionOptions {
+    /** Client to bind to. Defaults to the injected `LUNORA_CLIENT`. */
+    client?: LunoraClient;
+
+    /**
+     * `DestroyRef` whose `onDestroy` tears the subscription down. Defaults to
+     * `inject(DestroyRef)` — the calling component/service.
+     */
+    destroyRef?: DestroyRef;
+
+    /**
+     * Called when the subscription errors after the initial attach. Without it,
+     * a post-attach failure is dropped silently.
+     */
+    onError?: (error: SubscriptionError) => void;
+
+    /** Route to a specific shard when the target function is `.shardBy(...)`-partitioned. */
+    shardKey?: string;
+}
+
+export interface SubscriptionResult<T> {
+    /** The latest value pushed by the server. `undefined` before the first frame. */
+    data: Signal<T | undefined>;
+
+    /** The latest error, or `undefined`. */
+    error: Signal<Error | undefined>;
+}
+
+/**
+ * Subscribe to a reactive server push stream. Returns `{ data, error }` signals
+ * that update whenever the server emits a new value.
+ *
+ * Unlike `liveQuery`, which tracks a single value, `subscription` also
+ * exposes an `error` signal for the async error channel. Use it for ephemeral,
+ * high-frequency streams where you need error visibility.
+ *
+ * Pass `"skip"` as `args` to short-circuit — no network call, no socket.
+ * The subscription tears down when the owning `DestroyRef` fires.
+ *
+ * Call from an injection context (component/service field or constructor):
+ * ```ts
+ * readonly stream = subscription(api.events.stream, { roomId: "general" });
+ * ```
+ */
+export const subscription = <F extends FunctionReference>(
+    reference: F,
+    args: ArgsOf<F> | "skip",
+    options: SubscriptionOptions = {},
+): SubscriptionResult<ReturnOf<F>> => {
+    const client = resolveLunoraClient(options.client);
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+
+    const data = signal<ReturnOf<F> | undefined>(undefined);
+    const error = signal<Error | undefined>(undefined);
+
+    if (args !== "skip") {
+        const userOnError = options.onError;
+
+        const unsubscribe = createQuerySubscription<F>(
+            client,
+            reference,
+            args,
+            {
+                onData: (next) => {
+                    data.set(next);
+                    error.set(undefined);
+                },
+                onError: (error_) => {
+                    error.set(new Error(error_.message));
+                    data.set(undefined);
+                    userOnError?.(error_);
+                },
+                onReset: () => {
+                    data.set(undefined);
+                },
+            },
+            { shardKey: options.shardKey },
+        );
+
+        destroyRef.onDestroy(unsubscribe);
+    }
+
+    return { data: data.asReadonly(), error: error.asReadonly() };
+};

--- a/packages/angular/src/subscription.ts
+++ b/packages/angular/src/subscription.ts
@@ -30,7 +30,7 @@ export interface SubscriptionResult<T> {
     data: Signal<T | undefined>;
 
     /** The latest error, or `undefined`. */
-    error: Signal<Error | undefined>;
+    error: Signal<SubscriptionError | undefined>;
 }
 
 /**
@@ -58,7 +58,7 @@ export const subscription = <F extends FunctionReference>(
     const destroyRef = options.destroyRef ?? inject(DestroyRef);
 
     const data = signal<ReturnOf<F> | undefined>(undefined);
-    const error = signal<Error | undefined>(undefined);
+    const error = signal<SubscriptionError | undefined>(undefined);
 
     if (args !== "skip") {
         const userOnError = options.onError;
@@ -73,7 +73,7 @@ export const subscription = <F extends FunctionReference>(
                     error.set(undefined);
                 },
                 onError: (error_) => {
-                    error.set(new Error(error_.message));
+                    error.set(error_);
                     data.set(undefined);
                     userOnError?.(error_);
                 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1618,6 +1618,9 @@ importers:
       '@lunora/client':
         specifier: workspace:*
         version: link:../client
+      '@lunora/ratelimit':
+        specifier: workspace:*
+        version: link:../ratelimit
     devDependencies:
       '@angular/core':
         specifier: ^22.0.5


### PR DESCRIPTION
## Summary

Adds 8 missing framework-adapter features to `@lunora/angular`, bringing it to full parity with React/Vue/Solid/Svelte.

## New Features

- **subscription.ts**: Signal-based live push stream with error signal
- **paginated-query.ts**: `paginatedQuery` + `infiniteQuery` with reactive pagination
- **auth.ts**: Token/user signals wired to `@lunora/client/auth` identity store
- **flag.ts / flags()**: Single-key and multi-key OpenFeature flag subscriptions
- **rate-limit.ts**: Client-side token-bucket mirror with tick-based re-enable
- **presence.ts**: Heartbeat + listPresent subscription + awareness data
- **hydrate-preloaded.ts**: SSR handoff from Preloaded to live subscription
- **mutator.ts**: Ref-counted pending/error signals over MutatorHandle

## Bug Fixes

- `paginatedQuery loadMore`: pass `nextCursor` (not undefined) to `applyLoadMore`
- `paginatedQuery rebalance`: call `syncSubscriptions` after pages.set
- `rate-limit` disabled/ok computed: use `status().ok` (not status object)
- `paginatedQuery` + `infiniteQuery`: use `computed()` for derived signals

## Testing

- 8 new test files with 49 tests
- Extended fake-client.ts with auth + connection-context surface
- All 53 Angular tests passing (12 test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the Angular integration with reactive helpers for authentication, live feature flags, SSR hydration with live updates, mutations, pagination/infinite loading, presence, client-side rate limiting, and live subscriptions.
  * Added new signal-based APIs (e.g., token/user, per-flag values, data/error pairs) with automatic cleanup on destroy for smoother state management.
  * Re-exported these new helpers and their option/result types from the main Angular package entry point.
* **Chores**
  * Added the required runtime dependency for client-side rate limiting support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->