### PR TITLE
feat(angular): export missing types for framework parity

### DIFF
--- a/packages/angular/src/flag.ts
+++ b/packages/angular/src/flag.ts
@@ -13,6 +13,9 @@ const FLAGS_EVAL_PATH = "__lunora_flags__:eval";
 /** The value kinds a flag resolves to — OpenFeature's boolean / number / string / structured (JSON) flags. */
 type FlagValue = boolean | number | string | Record<string, unknown> | unknown[] | null;
 
+/** Targeting context bag forwarded to the OpenFeature provider. */
+type FlagContext = Record<string, unknown>;
+
 /** Wire args the generated flag-subscription read override reads. */
 interface FlagSubscribeArgs extends Record<string, unknown> {
     context?: Record<string, unknown>;
@@ -43,7 +46,7 @@ export interface FlagOptions {
      * Per-call targeting context merged on top of the app's default `identify`
      * targeting key.
      */
-    context?: Record<string, unknown>;
+    context?: FlagContext;
 
     /** `DestroyRef` whose `onDestroy` tears down the subscription. Defaults to `inject(DestroyRef)`. */
     destroyRef?: DestroyRef;
@@ -107,7 +110,7 @@ export interface FlagsOptions {
      * Targeting context shared by every flag in the set, merged on top of the
      * app's default `identify` targeting key.
      */
-    context?: Record<string, unknown>;
+    context?: FlagContext;
 
     /** `DestroyRef` whose `onDestroy` tears down the subscriptions. Defaults to `inject(DestroyRef)`. */
     destroyRef?: DestroyRef;
@@ -162,3 +165,5 @@ export const flags = <T extends Record<string, FlagValue>>(flagDefaults: T, opti
 
     return values.asReadonly();
 };
+
+export type { FlagContext, FlagValue };

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -20,7 +20,7 @@ export type { ProvideLunoraOptions } from "./client";
 export { injectLunoraClient, LUNORA_CLIENT, provideLunora } from "./client";
 export type { ConnectionStatusOptions } from "./connection-status";
 export { connectionStatus } from "./connection-status";
-export type { FlagOptions, FlagsOptions } from "./flag";
+export type { FlagContext, FlagOptions, FlagsOptions, FlagValue } from "./flag";
 export { flag, flags } from "./flag";
 export type { HydratePreloadedOptions, HydratePreloadedResult } from "./hydrate-preloaded";
 export { hydratePreloaded } from "./hydrate-preloaded";
@@ -34,7 +34,7 @@ export type { PaginatedQueryOptions, PaginatedQueryResult } from "./paginated-qu
 export type { InfiniteQueryResult } from "./paginated-query";
 export { paginatedQuery } from "./paginated-query";
 export { infiniteQuery } from "./paginated-query";
-export type { PresenceOptions, PresenceResult } from "./presence";
+export type { HeartbeatReference, ListPresentReference, PresenceOptions, PresenceResult } from "./presence";
 export { presence } from "./presence";
 export type { RateLimitOptions, RateLimitResult } from "./rate-limit";
 export { rateLimit } from "./rate-limit";
@@ -47,6 +47,7 @@ export type {
     LunoraClient,
     LunoraClientOptions,
     MutationCallOptions,
+    Preloaded,
     ReturnOf,
     SubscriptionError,
     Unsubscribe,

--- a/packages/angular/src/presence.ts
+++ b/packages/angular/src/presence.ts
@@ -146,3 +146,5 @@ export const presence = <H extends HeartbeatReference, L extends ListPresentRefe
 
     return { present: present.asReadonly(), sessionId, setData };
 };
+
+export type { HeartbeatReference, ListPresentReference };


### PR DESCRIPTION
Exports types that the other four framework packages (React, Vue, Solid, Svelte) already expose but Angular was missing:

- **`Preloaded`** — re-exported from `@lunora/client`
- **`HeartbeatReference`** and **`ListPresentReference`** — exported from `presence.ts`
- **`FlagContext`** and **`FlagValue`** — exported from `flag.ts`

All 53 tests pass, lint:types and lint:eslint are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Angular package’s public type exports for flags and presence-related APIs.
  * Added a dedicated context type for flag options, making option typing more specific and easier to use.
  * Exposed additional client types for improved type access in consuming projects.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->