### PR TITLE
refactor(errors): migrate Object.assign(new Error()) patterns to LunoraError

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,13 +107,12 @@
                       pnpm run test:affected
                   fi
 
-            # INVARIANT: studio's `unit` vitest project must stay runtime-dist-free
-            # (node-env, DOM-free, at most TYPE-only imports of @lunora/* — types
-            # are erased at runtime). This step runs on every packages-affected PR
-            # without building studio's deps; a unit test that VALUE-imports an
-            # @lunora/* package would fail here whenever the affected build didn't
-            # include studio's dependency graph. If that need ever arises, move
-            # this step behind a studio-affected gate + a dep build instead.
+            # `derive-runtime-advisories.ts` value-imports `runAdvisor`/`RUNTIME_LINTS`
+            # from `@lunora/advisor`, so its dist must exist for the unit tests to
+            # resolve. Build it unconditionally (it's small) before running.
+            - "name": "Build @lunora/advisor for studio unit tests"
+              "run": |
+                  pnpm --filter "@lunora/advisor" run build
             - "name": "Run studio unit tests"
               "run": |
                   pnpm --filter "@lunora/studio" run test:unit

--- a/examples/auth-playground/lunora/_generated/functions.ts
+++ b/examples/auth-playground/lunora/_generated/functions.ts
@@ -4,6 +4,7 @@
 import * as lunora_documents_0 from "../documents.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "lunorash/values";
+import { LunoraError } from "lunorash/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 import type { Id } from "./dataModel.js";
 
@@ -74,11 +75,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -107,11 +104,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike } from "lunorash/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets } from "lunorash/server";
+import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -292,11 +292,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -324,11 +320,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -438,11 +430,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -478,18 +466,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -533,17 +517,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -584,7 +564,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -614,7 +594,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/examples/blog/lunora/_generated/functions.ts
+++ b/examples/blog/lunora/_generated/functions.ts
@@ -6,6 +6,7 @@ import * as lunora_drafts_1 from "../drafts.js";
 import * as lunora_posts_2 from "../posts.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "lunorash/values";
+import { LunoraError } from "lunorash/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 import type { Id } from "./dataModel.js";
 
@@ -118,11 +119,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -161,11 +158,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike, WriteHook } from "lunorash/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets } from "lunorash/server";
+import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 import type { SchemaLike as VectorSchemaLike, VectorizeIndexLike, VectorSearchLike } from "@lunora/bindings/vectors";
 import { createContextVectors, createVectors, createVectorSyncHook } from "@lunora/bindings/vectors";
@@ -665,11 +665,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -697,11 +693,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -819,11 +811,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -859,18 +847,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -914,17 +898,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -965,7 +945,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -995,7 +975,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/examples/offline-rejections/lunora/_generated/functions.ts
+++ b/examples/offline-rejections/lunora/_generated/functions.ts
@@ -4,6 +4,7 @@
 import * as lunora_messages_0 from "../messages.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "lunorash/values";
+import { LunoraError } from "lunorash/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 import type { Id } from "./dataModel.js";
 
@@ -68,11 +69,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -101,11 +98,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike } from "lunorash/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets } from "lunorash/server";
+import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -243,11 +243,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -275,11 +271,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -389,11 +381,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -429,18 +417,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -484,17 +468,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -535,7 +515,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -565,7 +545,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/examples/payment-demo/lunora/_generated/functions.ts
+++ b/examples/payment-demo/lunora/_generated/functions.ts
@@ -4,6 +4,7 @@
 import * as lunora_billing_0 from "../billing.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "lunorash/values";
+import { LunoraError } from "lunorash/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 
 /**
@@ -76,11 +77,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -113,11 +110,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/examples/payment-demo/lunora/_generated/shard.ts
+++ b/examples/payment-demo/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike } from "lunorash/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets } from "lunorash/server";
+import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 import type { LunoraDatabaseLike as LunoraPaymentDbLike, LunoraPayment, PaymentsFromContextOptions } from "@lunora/payment";
 import { paymentsFromContext } from "@lunora/payment";
@@ -671,11 +671,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -703,11 +699,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -817,11 +809,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -857,18 +845,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -912,17 +896,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -963,7 +943,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -993,7 +973,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/examples/realtime-cursors/lunora/_generated/functions.ts
+++ b/examples/realtime-cursors/lunora/_generated/functions.ts
@@ -4,6 +4,7 @@
 import * as lunora_cursors_0 from "../cursors.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "lunorash/values";
+import { LunoraError } from "lunorash/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 import type { Id } from "./dataModel.js";
 
@@ -84,11 +85,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -118,11 +115,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike } from "lunorash/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets } from "lunorash/server";
+import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -419,11 +419,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -451,11 +447,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -565,11 +557,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -605,18 +593,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -660,17 +644,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -711,7 +691,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -741,7 +721,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/examples/todo-app/lunora/_generated/functions.ts
+++ b/examples/todo-app/lunora/_generated/functions.ts
@@ -4,6 +4,7 @@
 import * as lunora_todos_0 from "../todos.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "lunorash/values";
+import { LunoraError } from "lunorash/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 import type { Id } from "./dataModel.js";
 
@@ -80,11 +81,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -115,11 +112,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike } from "lunorash/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, ShardDO as ShardDOBase } from "lunorash/do";
-import { asBucketStorage, createSecrets } from "lunorash/server";
+import { asBucketStorage, createSecrets, LunoraError } from "lunorash/server";
 import { bindOrm, bindTableFacade } from "lunorash/server";
 
 import schema from "../schema.js";
@@ -262,11 +262,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -294,11 +290,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -408,11 +400,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -448,18 +436,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -503,17 +487,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -554,7 +534,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -584,7 +564,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/packages/auth/src/turnstile-middleware.ts
+++ b/packages/auth/src/turnstile-middleware.ts
@@ -121,7 +121,9 @@ export const verifyTurnstileMiddleware =
         }
 
         if (!result.success || (options.validate !== undefined && !options.validate(result))) {
-            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile verification failed", { data: result.errorCodes.length > 0 ? { errorCodes: result.errorCodes } : undefined });
+            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile verification failed", {
+                data: result.errorCodes.length > 0 ? { errorCodes: result.errorCodes } : undefined,
+            });
         }
 
         return next();

--- a/packages/auth/src/turnstile-middleware.ts
+++ b/packages/auth/src/turnstile-middleware.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import type { Middleware } from "@lunora/server";
 
 import type { FetchLike, TurnstileVerifyResult } from "./turnstile";
@@ -120,7 +121,7 @@ export const verifyTurnstileMiddleware =
         }
 
         if (!result.success || (options.validate !== undefined && !options.validate(result))) {
-            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile verification failed", { data: result.errorCodes ? { errorCodes: result.errorCodes } : undefined });
+            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile verification failed", { data: result.errorCodes.length > 0 ? { errorCodes: result.errorCodes } : undefined });
         }
 
         return next();

--- a/packages/auth/src/turnstile-middleware.ts
+++ b/packages/auth/src/turnstile-middleware.ts
@@ -92,11 +92,7 @@ export const verifyTurnstileMiddleware =
         const token = options.token(ctx);
 
         if (token === undefined || token === "") {
-            throw Object.assign(new Error(options.message ?? "turnstile token missing"), {
-                code: "FORBIDDEN",
-                name: "LunoraError",
-                status: 403,
-            });
+            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile token missing");
         }
 
         let result;
@@ -120,21 +116,11 @@ export const verifyTurnstileMiddleware =
                 return next();
             }
 
-            throw Object.assign(new Error(options.message ?? "turnstile verification unavailable"), {
-                cause: error,
-                code: "FORBIDDEN",
-                name: "LunoraError",
-                status: 403,
-            });
+            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile verification unavailable", { cause: error });
         }
 
         if (!result.success || (options.validate !== undefined && !options.validate(result))) {
-            throw Object.assign(new Error(options.message ?? "turnstile verification failed"), {
-                code: "FORBIDDEN",
-                errorCodes: result.errorCodes,
-                name: "LunoraError",
-                status: 403,
-            });
+            throw new LunoraError("FORBIDDEN", options.message ?? "turnstile verification failed", { data: result.errorCodes ? { errorCodes: result.errorCodes } : undefined });
         }
 
         return next();

--- a/packages/auth/src/turnstile.ts
+++ b/packages/auth/src/turnstile.ts
@@ -9,6 +9,8 @@
  * @see https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
  */
 
+import { LunoraError } from "@lunora/errors";
+
 /** Cloudflare's public Turnstile `siteverify` endpoint. */
 const TURNSTILE_VERIFY_ENDPOINT = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
@@ -129,20 +131,11 @@ const verifyTurnstile = async ({
             method: "POST",
         });
     } catch (error) {
-        throw Object.assign(new Error("turnstile siteverify request failed"), {
-            cause: error,
-            code: "SERVICE_UNAVAILABLE",
-            name: "LunoraError",
-            status: 503,
-        });
+        throw new LunoraError("SERVICE_UNAVAILABLE", "turnstile siteverify request failed", { cause: error, status: 503 });
     }
 
     if (!response.ok) {
-        throw Object.assign(new Error(`turnstile siteverify returned ${String(response.status)}`), {
-            code: "SERVICE_UNAVAILABLE",
-            name: "LunoraError",
-            status: 503,
-        });
+        throw new LunoraError("SERVICE_UNAVAILABLE", `turnstile siteverify returned ${String(response.status)}`, { status: 503 });
     }
 
     const raw: RawSiteverifyResponse = await response.json();

--- a/packages/client/__tests__/errors.test.ts
+++ b/packages/client/__tests__/errors.test.ts
@@ -1,9 +1,10 @@
+import { LunoraError } from "@lunora/errors";
 import { describe, expect, it } from "vitest";
 
 import { CONFLICT_ERROR_CODE, getErrorCode, getRetryAfterMs, isConflictError, isForbiddenError, isRateLimitedError, isUnauthorizedError } from "../src/errors";
 
 /** Build an `Error` carrying the machine-readable `code` the client attaches when decoding the worker envelope. */
-const errorWithCode = (code: string): Error & { code: string } => Object.assign(new Error("boom"), { code });
+const errorWithCode = (code: string): LunoraError => new LunoraError(code, "boom");
 
 describe("isConflictError", () => {
     it("exposes CONFLICT_ERROR_CODE as the server's 409 code", () => {
@@ -15,7 +16,7 @@ describe("isConflictError", () => {
     it("a coded Error with code CONFLICT is a conflict", () => {
         expect.assertions(1);
 
-        const error = Object.assign(new Error("optimistic concurrency conflict"), { code: "CONFLICT" });
+        const error = new LunoraError("CONFLICT", "optimistic concurrency conflict");
 
         expect(isConflictError(error)).toBe(true);
     });
@@ -23,7 +24,7 @@ describe("isConflictError", () => {
     it("a coded Error with a different code is not a conflict", () => {
         expect.assertions(1);
 
-        const error = Object.assign(new Error("missing"), { code: "NOT_FOUND" });
+        const error = new LunoraError("NOT_FOUND", "missing");
 
         expect(isConflictError(error)).toBe(false);
     });
@@ -96,7 +97,7 @@ describe("getRetryAfterMs", () => {
 
         expect(getRetryAfterMs({ data: { retryAfterMs: 1500 } })).toBe(1500);
         // Works off a real reconstructed error too, not just a plain object.
-        expect(getRetryAfterMs(Object.assign(new Error("slow down"), { code: "TOO_MANY_REQUESTS", data: { retryAfterMs: 250 } }))).toBe(250);
+        expect(getRetryAfterMs(new LunoraError("TOO_MANY_REQUESTS", "slow down", { data: { retryAfterMs: 250 } }))).toBe(250);
     });
 
     it("returns undefined when absent or non-numeric", () => {

--- a/packages/client/__tests__/wire-codec.test.ts
+++ b/packages/client/__tests__/wire-codec.test.ts
@@ -1,6 +1,6 @@
+import { LunoraError } from "@lunora/errors";
 import { describe, expect, it } from "vitest";
 
-import { LunoraError } from "@lunora/errors";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 
 /** JSON round-trip of the encoded form, mirroring what the transport actually does. */

--- a/packages/client/__tests__/wire-codec.test.ts
+++ b/packages/client/__tests__/wire-codec.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { LunoraError } from "@lunora/errors";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 
 /** JSON round-trip of the encoded form, mirroring what the transport actually does. */
@@ -123,7 +124,7 @@ describe("wireCodec round-trips", () => {
 
         // A subclass whose ctor is not on the allow-list (e.g. a server LunoraError)
         // rebuilds as a generic Error with its `.name` and `.message` preserved.
-        const source = Object.assign(new Error("nope"), { name: "LunoraError" });
+        const source = new LunoraError("INTERNAL", "nope");
         const decoded = wire(source) as Error;
 
         expect(decoded).toBeInstanceOf(Error);

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -363,7 +363,7 @@ const buildStreamError = (message: ServerErrorMessage): Error => {
     const nestedMessage = typeof errorEnvelope?.message === "string" ? errorEnvelope.message : undefined;
     const messageText = (typeof message.message === "string" ? message.message : undefined) ?? nestedMessage ?? "stream error";
 
-    return Object.assign(new Error(messageText), code === undefined ? undefined : { code });
+    return code !== undefined ? new LunoraError(code, messageText) : new Error(messageText);
 };
 
 /**
@@ -2725,7 +2725,7 @@ class LunoraClient {
 
                 if (droppedStream) {
                     droppedStream.handle.fail(
-                        Object.assign(new Error("stream-start frame evicted while socket was unreachable"), { code: "STREAM_QUEUE_OVERFLOW" }),
+                        new LunoraError("STREAM_QUEUE_OVERFLOW", "stream-start frame evicted while socket was unreachable"),
                     );
                     this.streams.delete(droppedId as string);
                 }
@@ -2748,7 +2748,7 @@ class LunoraClient {
         // termination instead of an iterator that hangs forever after the
         // underlying socket goes away.
         for (const stream of this.streams.values()) {
-            stream.handle.fail(Object.assign(new Error("LunoraClient closed"), { code: "CLIENT_CLOSED" }));
+            stream.handle.fail(new LunoraError("CLIENT_CLOSED", "LunoraClient closed"));
         }
 
         this.streams.clear();

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -2724,9 +2724,7 @@ class LunoraClient {
                 const droppedStream = droppedId ? this.streams.get(droppedId) : undefined;
 
                 if (droppedStream) {
-                    droppedStream.handle.fail(
-                        new LunoraError("STREAM_QUEUE_OVERFLOW", "stream-start frame evicted while socket was unreachable"),
-                    );
+                    droppedStream.handle.fail(new LunoraError("STREAM_QUEUE_OVERFLOW", "stream-start frame evicted while socket was unreachable"));
                     this.streams.delete(droppedId as string);
                 }
             }

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -363,7 +363,7 @@ const buildStreamError = (message: ServerErrorMessage): Error => {
     const nestedMessage = typeof errorEnvelope?.message === "string" ? errorEnvelope.message : undefined;
     const messageText = (typeof message.message === "string" ? message.message : undefined) ?? nestedMessage ?? "stream error";
 
-    return code !== undefined ? new LunoraError(code, messageText) : new Error(messageText);
+    return code === undefined ? new Error(messageText) : new LunoraError(code, messageText);
 };
 
 /**

--- a/packages/client/src/stream.ts
+++ b/packages/client/src/stream.ts
@@ -12,6 +12,8 @@
  * are silent no-ops so a duplicate `complete` frame after a cancel doesn't
  * crash the page.
  */
+import { LunoraError } from "@lunora/errors";
+
 const DEFAULT_MAX_BUFFER = 1024;
 
 interface StreamHandle<T = unknown> {
@@ -127,9 +129,7 @@ const createStream = <T>(options: { maxBuffer?: number; onCancel: () => void }):
 
             if (buffer.length >= maxBuffer) {
                 handle.fail(
-                    Object.assign(new Error(`stream buffer overflow (max=${maxBuffer.toString()}); the consumer cannot keep up with the producer`), {
-                        code: "STREAM_BACKPRESSURE",
-                    }),
+                    new LunoraError("STREAM_BACKPRESSURE", `stream buffer overflow (max=${maxBuffer.toString()}); the consumer cannot keep up with the producer`),
                 );
 
                 return;

--- a/packages/client/src/stream.ts
+++ b/packages/client/src/stream.ts
@@ -129,7 +129,10 @@ const createStream = <T>(options: { maxBuffer?: number; onCancel: () => void }):
 
             if (buffer.length >= maxBuffer) {
                 handle.fail(
-                    new LunoraError("STREAM_BACKPRESSURE", `stream buffer overflow (max=${maxBuffer.toString()}); the consumer cannot keep up with the producer`),
+                    new LunoraError(
+                        "STREAM_BACKPRESSURE",
+                        `stream buffer overflow (max=${maxBuffer.toString()}); the consumer cannot keep up with the producer`,
+                    ),
                 );
 
                 return;

--- a/packages/cloudflare-access/LICENSE.md
+++ b/packages/cloudflare-access/LICENSE.md
@@ -110,14 +110,11 @@ specific language governing permissions and limitations under the License.
 <!-- TYPE_DEPENDENCIES -->
 
 # Licenses of bundled types
-
 The published @lunora/cloudflare-access artifact additionally contains code with the following licenses:
 FSL-1.1-Apache-2.0
 
 # Bundled types:
-
 ## @lunora/server
-
 License: FSL-1.1-Apache-2.0
 By: Daniel Bannert
 Repository: git+https://github.com/anolilab/lunora.git

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/functions.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/functions.ts
@@ -5,6 +5,7 @@ import * as lunora_messages_0 from "../messages.js";
 import * as lunora_migrations_1 from "../migrations.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "@lunora/values";
+import { LunoraError } from "@lunora/server";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 import type { Id } from "./dataModel.js";
 
@@ -81,11 +82,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return registered.handler(context, args);
@@ -115,11 +112,7 @@ const callRegistered = async <R>(context: CallerCtx, functionPath: string, args:
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/shard.ts
@@ -3,7 +3,7 @@
 
 import type { AdvisoryFinding, DatabaseWriterLike, DataMigrationLike, LogSink, MaskPoliciesResult, MigrationRunResult, RunShardApplyCdcArgs, RunShardMigrationArgs, RlsPoliciesResult, RunShardRankBeforeArgs, RunShardRankPageArgs, RunShardWriteArgs, RunShardWriteResult, SchedulerLike, SchemaLike, ShardDOState, ShardRankPageResult, SqlExec, StorageRulesResult, StudioFeaturesResult, SystemReaderStorageLike } from "@lunora/do";
 import { applyCdcChanges, createShardCtxDb, runDataMigration, runShardMigrations, serveRelationFanout, ShardDO as ShardDOBase } from "@lunora/do";
-import { asBucketStorage, createSecrets } from "@lunora/server";
+import { asBucketStorage, createSecrets, LunoraError } from "@lunora/server";
 import { bindOrm, bindTableFacade } from "@lunora/server";
 
 import schema from "../schema.js";
@@ -317,11 +317,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(`ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", `ctx.run*: composition depth limit (${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation`);
     }
 
     runDepth += 1;
@@ -349,11 +345,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `isSystemDispatch()`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(`function not registered: ${functionPath}`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", `function not registered: ${functionPath}`);
             }
 
             this.ensureMigrated();
@@ -471,11 +463,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(`data migration "${args.id}" is not registered`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -511,18 +499,14 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${args.table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${args.table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${args.table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -566,17 +550,13 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(`unknown table: ${table}`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
             }
 
             // `.global()` tables live in D1, not this DO's SQLite — the same
             // guard `runShardWrite` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(`table "${table}" is global; edit it through D1, not the shard`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", `table "${table}" is global; edit it through D1, not the shard`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -617,7 +597,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // `rankBefore` is optional on `DatabaseWriterLike` (the D1 twin omits it),
             // but the shard writer from `createShardCtxDb` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -647,7 +627,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // `args.directions` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/packages/codegen/src/discover-crons.ts
+++ b/packages/codegen/src/discover-crons.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { compileCronSchedule, CRON_SCHEDULE_KINDS, isValidCronExpression } from "@lunora/scheduler";
 import type { CallExpression, Identifier, ObjectLiteralExpression, Project, PropertyAccessExpression, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
@@ -345,11 +346,7 @@ const assertUniqueNames = (crons: ReadonlyArray<CronJobIR>): void => {
 
     for (const cron of crons) {
         if (seen.has(cron.name)) {
-            throw Object.assign(new Error(`Duplicate cron job name "${cron.name}": cron names must be unique across the project.`), {
-                code: "DUPLICATE_CRON_NAME",
-                name: "LunoraError",
-                status: 500,
-            });
+            throw new LunoraError("DUPLICATE_CRON_NAME", `Duplicate cron job name "${cron.name}": cron names must be unique across the project.`, { status: 500 });
         }
 
         seen.add(cron.name);

--- a/packages/codegen/src/discover-crons.ts
+++ b/packages/codegen/src/discover-crons.ts
@@ -346,7 +346,9 @@ const assertUniqueNames = (crons: ReadonlyArray<CronJobIR>): void => {
 
     for (const cron of crons) {
         if (seen.has(cron.name)) {
-            throw new LunoraError("DUPLICATE_CRON_NAME", `Duplicate cron job name "${cron.name}": cron names must be unique across the project.`, { status: 500 });
+            throw new LunoraError("DUPLICATE_CRON_NAME", `Duplicate cron job name "${cron.name}": cron names must be unique across the project.`, {
+                status: 500,
+            });
         }
 
         seen.add(cron.name);

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -772,11 +772,7 @@ const CALL_REGISTERED_HELPER = `const callRegistered = async <R>(context: Caller
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered) {
-        throw Object.assign(new Error(\`function not registered: \${functionPath}\`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", \`function not registered: \${functionPath}\`);
     }
 
     return (await registered.handler(context, args ?? {})) as R;
@@ -1530,7 +1526,7 @@ const emitFunctions = (
     const callerParameter = hasFunctions ? "context" : "_context";
     const callRegisteredHelper = hasFunctions ? `${CALL_REGISTERED_HELPER}\n\n` : "";
 
-    return `${GENERATED_HEADER}${importBlock}${compiledArgsImport}${shapeTypeImport}import type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
+    return `${GENERATED_HEADER}${importBlock}${compiledArgsImport}${shapeTypeImport}import { LunoraError } from "${base.server}";\nimport type { ActionCtx, MutationCtx, QueryCtx } from "./server.js";
 ${dataModelImport}
 /**
  * Single registered function, narrowed to the shape \`handleRpc\` needs.
@@ -1578,11 +1574,7 @@ export const dispatchLunoraFunction = async (functionPath: string, context: unkn
     const registered = LUNORA_FUNCTIONS[functionPath];
 
     if (!registered || registered.visibility === "internal") {
-        throw Object.assign(new Error(\`function not registered: \${functionPath}\`), {
-            name: "LunoraError",
-            code: "FUNCTION_NOT_FOUND",
-            status: 404,
-        });
+        throw new LunoraError("FUNCTION_NOT_FOUND", \`function not registered: \${functionPath}\`);
     }
 
     return registered.handler(context, args);
@@ -3117,8 +3109,8 @@ const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCT
         // read-registry builder + `composeShapeReadWhere` so `resolveShape` can
         // AND-merge a shape's predicate with the table's read base-where.
         hasShapes
-            ? `import { asBucketStorage, buildRlsReadRegistry, composeShapeReadWhere, createSecrets } from "${base.server}";`
-            : `import { asBucketStorage, createSecrets } from "${base.server}";`,
+            ? `import { asBucketStorage, buildRlsReadRegistry, composeShapeReadWhere, createSecrets, LunoraError } from "${base.server}";`
+            : `import { asBucketStorage, createSecrets, LunoraError } from "${base.server}";`,
     ];
 
     // The per-table facade binding lives in `@lunora/server` so codegen and the
@@ -3673,11 +3665,7 @@ const dispatchRun = async (expected: FunctionKind, functionPath: string, args: R
     }
 
     if (runDepth >= MAX_RUN_DEPTH) {
-        throw Object.assign(new Error(\`ctx.run*: composition depth limit (\${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation\`), {
-            name: "LunoraError",
-            code: "RUN_DEPTH_EXCEEDED",
-            status: 500,
-        });
+        throw new LunoraError("RUN_DEPTH_EXCEEDED", \`ctx.run*: composition depth limit (\${MAX_RUN_DEPTH}) exceeded — likely a cyclic runQuery/runMutation\`);
     }
 
     runDepth += 1;
@@ -3705,11 +3693,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             // \`isSystemDispatch()\`). A client RPC never carries that flag, so its
             // internals stay not-found and never leak across the external boundary.
             if (!registered || (registered.visibility === "internal" && !this.isSystemDispatch())) {
-                throw Object.assign(new Error(\`function not registered: \${functionPath}\`), {
-                    name: "LunoraError",
-                    code: "FUNCTION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("FUNCTION_NOT_FOUND", \`function not registered: \${functionPath}\`);
             }
 
             this.ensureMigrated();
@@ -3819,11 +3803,7 @@ ${flagsOverrides.evaluateOverride}${flagsOverrides.subscriptionOverride}${workfl
             const migration = LUNORA_MIGRATIONS[args.id];
 
             if (!migration) {
-                throw Object.assign(new Error(\`data migration "\${args.id}" is not registered\`), {
-                    name: "LunoraError",
-                    code: "MIGRATION_NOT_FOUND",
-                    status: 404,
-                });
+                throw new LunoraError("MIGRATION_NOT_FOUND", \`data migration "\${args.id}" is not registered\`, { status: 404 });
             }
 
             this.ensureMigrated();
@@ -3859,18 +3839,14 @@ ${flagsOverrides.evaluateOverride}${flagsOverrides.subscriptionOverride}${workfl
             const definition = (schema as unknown as SchemaLike).tables[args.table];
 
             if (!definition) {
-                throw Object.assign(new Error(\`unknown table: \${args.table}\`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", \`unknown table: \${args.table}\`, { status: 404 });
             }
 
             // \`.global()\` tables live in D1, not this DO's SQLite — editing them
             // here would corrupt nothing but would fail confusingly, so reject up
             // front with a clear code the studio can surface.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(\`table "\${args.table}" is global; edit it through D1, not the shard\`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", \`table "\${args.table}" is global; edit it through D1, not the shard\`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -3914,17 +3890,13 @@ ${flagsOverrides.evaluateOverride}${flagsOverrides.subscriptionOverride}${workfl
             const definition = (schema as unknown as SchemaLike).tables[table];
 
             if (!definition) {
-                throw Object.assign(new Error(\`unknown table: \${table}\`), { name: "LunoraError", code: "UNKNOWN_TABLE", status: 404 });
+                throw new LunoraError("UNKNOWN_TABLE", \`unknown table: \${table}\`, { status: 404 });
             }
 
             // \`.global()\` tables live in D1, not this DO's SQLite — the same
             // guard \`runShardWrite\` applies to single-row edits.
             if (definition.shardMode?.kind === "global") {
-                throw Object.assign(new Error(\`table "\${table}" is global; edit it through D1, not the shard\`), {
-                    name: "LunoraError",
-                    code: "GLOBAL_TABLE_NOT_EDITABLE",
-                    status: 400,
-                });
+                throw new LunoraError("GLOBAL_TABLE_NOT_EDITABLE", \`table "\${table}" is global; edit it through D1, not the shard\`, { status: 400 });
             }
 
             this.ensureMigrated();
@@ -3965,7 +3937,7 @@ ${flagsOverrides.evaluateOverride}${flagsOverrides.subscriptionOverride}${workfl
             // \`rankBefore\` is optional on \`DatabaseWriterLike\` (the D1 twin omits it),
             // but the shard writer from \`createShardCtxDb\` always defines it.
             if (!writer.rankBefore) {
-                throw Object.assign(new Error("rankBefore is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankBefore is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankBefore(args.table, args.index, {
@@ -3995,7 +3967,7 @@ ${flagsOverrides.evaluateOverride}${flagsOverrides.subscriptionOverride}${workfl
             // directions live in the schema's rankIndex, so the shard reads them itself;
             // \`args.directions\` is only the coordinator's comparator hint and isn't forwarded.
             if (!writer.rankPageRows) {
-                throw Object.assign(new Error("rankPage is unavailable on the shard writer"), { name: "LunoraError", code: "NOT_IMPLEMENTED", status: 500 });
+                throw new LunoraError("NOT_IMPLEMENTED", "rankPage is unavailable on the shard writer", { status: 500 });
             }
 
             return writer.rankPageRows(args.table, args.index, {

--- a/packages/d1/src/introspect.ts
+++ b/packages/d1/src/introspect.ts
@@ -18,6 +18,7 @@
  * shape (re-exposing `_id`, folding booleans); any other table is shown with its
  * real physical columns.
  */
+import { LunoraError } from "@lunora/errors";
 import type { SchemaLike } from "@lunora/do";
 
 import type { D1Exec } from "./d1-ctx-db";
@@ -180,7 +181,7 @@ const buildEqPredicate = (
 
     for (const filter of filters) {
         if (!displayColumns.includes(filter.column)) {
-            throw Object.assign(new Error(`unknown column: ${filter.column}`), { code: "UNKNOWN_COLUMN", name: "LunoraError", status: 404 });
+            throw new LunoraError("UNKNOWN_COLUMN", `unknown column: ${filter.column}`, { status: 404 });
         }
 
         const quoted = quoteIdentifier(physicalColumnName(schema, table, filter.column));
@@ -303,7 +304,7 @@ const readGlobalTablePage = async (exec: D1Exec, schema: SchemaLike, options: Re
     const tableNames = await listTableNames(exec);
 
     if (!tableNames.includes(table)) {
-        throw Object.assign(new Error(`unknown table: ${table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
     }
 
     const limit = clamp(Math.trunc(options.limit ?? DEFAULT_PAGE_SIZE), 1, MAX_PAGE_SIZE);
@@ -343,13 +344,13 @@ const facetGlobalColumn = async (exec: D1Exec, schema: SchemaLike, options: Face
     const tableNames = await listTableNames(exec);
 
     if (!tableNames.includes(table)) {
-        throw Object.assign(new Error(`unknown table: ${table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
     }
 
     const columns = await resolveColumns(exec, schema, table);
 
     if (!columns.includes(column)) {
-        throw Object.assign(new Error(`unknown column: ${column}`), { code: "UNKNOWN_COLUMN", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_COLUMN", `unknown column: ${column}`, { status: 404 });
     }
 
     const quoted = quoteIdentifier(table);

--- a/packages/d1/src/introspect.ts
+++ b/packages/d1/src/introspect.ts
@@ -18,8 +18,8 @@
  * shape (re-exposing `_id`, folding booleans); any other table is shown with its
  * real physical columns.
  */
-import { LunoraError } from "@lunora/errors";
 import type { SchemaLike } from "@lunora/do";
+import { LunoraError } from "@lunora/errors";
 
 import type { D1Exec } from "./d1-ctx-db";
 import { decodeGlobalRow, runD1GlobalTableMigrations } from "./d1-ctx-db";

--- a/packages/db/__tests__/define-collections.test.ts
+++ b/packages/db/__tests__/define-collections.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle -- `_id`/`_creationTime` are Lunora document fields the fixtures mirror */
 import type { OfflineExecutor } from "@tanstack/offline-transactions";
+import { LunoraError } from "@lunora/errors";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { defineCollections } from "../src";
@@ -230,7 +231,7 @@ describe(defineCollections, () => {
     it("reports a permanently-rejected write on onWriteRejected (fire-and-forget safe)", async () => {
         // The server rejects the write with a coded application error — a
         // permanent verdict the outbox surfaces as a NonRetriableError.
-        const coded = Object.assign(new Error("duplicate name"), { code: "CONFLICT" });
+        const coded = new LunoraError("CONFLICT", "duplicate name");
         const { client } = makeClient(async () => {
             throw coded;
         });

--- a/packages/db/__tests__/internals.test.ts
+++ b/packages/db/__tests__/internals.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle -- `_id` is the Lunora document-id field; test fixtures mirror it verbatim */
+import { LunoraError } from "@lunora/errors";
 import { NonRetriableError } from "@tanstack/offline-transactions";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -250,7 +251,7 @@ describe(runOutboxMutation, () => {
     });
 
     it("wraps a coded server rejection in NonRetriableError so the optimistic insert rolls back", async () => {
-        const rejected = Object.assign(new Error("duplicate name"), { code: "CONFLICT" });
+        const rejected = new LunoraError("CONFLICT", "duplicate name");
 
         await expect(runOutboxMutation(() => Promise.reject(rejected))).rejects.toBeInstanceOf(NonRetriableError);
     });

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -1334,9 +1334,7 @@ class MigrationShard extends ShardDO {
         const migration = MIGRATIONS[args.id];
 
         if (!migration) {
-            return Promise.reject(
-                new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 }),
-            );
+            return Promise.reject(new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 }));
         }
 
         const writer = createShardContextDatabase({

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AggregateIndexDefinitionLike } from "../src/aggregates";
@@ -1334,7 +1335,7 @@ class MigrationShard extends ShardDO {
 
         if (!migration) {
             return Promise.reject(
-                Object.assign(new Error(`data migration "${args.id}" is not registered`), { code: "MIGRATION_NOT_FOUND", name: "LunoraError", status: 404 }),
+                new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 }),
             );
         }
 

--- a/packages/do/__tests__/shard-do.stream.test.ts
+++ b/packages/do/__tests__/shard-do.stream.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { encodeWire } from "../../../shared/wire-codec";
@@ -298,7 +299,7 @@ describe("shardDO streaming queries", () => {
             // A full LunoraError shape (code + numeric status) is the developer-facing
             // error the redaction gate echoes; a code-only value would (correctly) be
             // redacted now, since a bare `.code` also rides Node errors like `ENOENT`.
-            throw Object.assign(new Error("kaboom"), { code: "FORBIDDEN", status: 403 });
+            throw new LunoraError("FORBIDDEN", "kaboom", { status: 403 });
         });
 
         const ws = createFakeWebSocket();

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -500,7 +500,11 @@ const assertBatchLimit = (count: number, limit: number | undefined, op: string):
     const cap = limit ?? DEFAULT_BATCH_LIMIT;
 
     if (count > cap) {
-        throw new LunoraError("BATCH_LIMIT_EXCEEDED", `${op}: batch of ${String(count)} exceeds the limit of ${String(cap)} (raise options.limit or chunk the call)`, { status: 400 });
+        throw new LunoraError(
+            "BATCH_LIMIT_EXCEEDED",
+            `${op}: batch of ${String(count)} exceeds the limit of ${String(cap)} (raise options.limit or chunk the call)`,
+            { status: 400 },
+        );
     }
 };
 

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -500,11 +500,7 @@ const assertBatchLimit = (count: number, limit: number | undefined, op: string):
     const cap = limit ?? DEFAULT_BATCH_LIMIT;
 
     if (count > cap) {
-        throw Object.assign(new Error(`${op}: batch of ${String(count)} exceeds the limit of ${String(cap)} (raise options.limit or chunk the call)`), {
-            code: "BATCH_LIMIT_EXCEEDED",
-            name: "LunoraError",
-            status: 400,
-        });
+        throw new LunoraError("BATCH_LIMIT_EXCEEDED", `${op}: batch of ${String(count)} exceeds the limit of ${String(cap)} (raise options.limit or chunk the call)`, { status: 400 });
     }
 };
 

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import type { AuditEntry } from "./audit-log";
 import type { SqlExec } from "./ctx-db";
@@ -993,7 +994,7 @@ const readTablePage = (sql: SqlExec, options: ReadTablePageOptions): TablePage =
     const { table } = options;
 
     if (isInternalTable(table) || !tableExists(sql, table)) {
-        throw Object.assign(new Error(`unknown table: ${table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
     }
 
     const limit = clamp(Math.trunc(options.limit ?? DEFAULT_PAGE_SIZE), 1, MAX_PAGE_SIZE);
@@ -1071,7 +1072,7 @@ const selectMatchingIds = (sql: SqlExec, options: SelectMatchingIdsOptions): { h
     const { table } = options;
 
     if (isInternalTable(table) || !tableExists(sql, table)) {
-        throw Object.assign(new Error(`unknown table: ${table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
     }
 
     const limit = clamp(Math.trunc(options.limit ?? MAX_PAGE_SIZE), 1, MAX_PAGE_SIZE);
@@ -1148,7 +1149,7 @@ const facetColumn = (sql: SqlExec, options: FacetColumnOptions): FacetColumnResu
     const { column, table } = options;
 
     if (isInternalTable(table) || !tableExists(sql, table)) {
-        throw Object.assign(new Error(`unknown table: ${table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_TABLE", `unknown table: ${table}`, { status: 404 });
     }
 
     const quoted = quoteIdentifier(table);
@@ -1158,7 +1159,7 @@ const facetColumn = (sql: SqlExec, options: FacetColumnOptions): FacetColumnResu
         .map((info) => info.name);
 
     if (!knownDisplayColumns(sql, quoted, physicalColumns).has(column)) {
-        throw Object.assign(new Error(`unknown column: ${column}`), { code: "UNKNOWN_COLUMN", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_COLUMN", `unknown column: ${column}`, { status: 404 });
     }
 
     const resolved = resolveColumnExpression(column, physicalColumns);
@@ -1166,7 +1167,7 @@ const facetColumn = (sql: SqlExec, options: FacetColumnOptions): FacetColumnResu
     if (resolved === undefined) {
         // Defensive: a known column always resolves; if it somehow doesn't, fail
         // closed rather than build SQL without a bound expression.
-        throw Object.assign(new Error(`unknown column: ${column}`), { code: "UNKNOWN_COLUMN", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_COLUMN", `unknown column: ${column}`, { status: 404 });
     }
 
     const limit = clamp(Math.trunc(options.limit ?? DEFAULT_FACET_LIMIT), 1, MAX_FACET_LIMIT);

--- a/packages/do/src/introspect.ts
+++ b/packages/do/src/introspect.ts
@@ -1,4 +1,5 @@
 import { LunoraError } from "@lunora/errors";
+
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import type { AuditEntry } from "./audit-log";
 import type { SqlExec } from "./ctx-db";

--- a/packages/do/src/pitr.ts
+++ b/packages/do/src/pitr.ts
@@ -1,3 +1,5 @@
+import { LunoraError } from "@lunora/errors";
+
 /**
  * Native Durable-Object point-in-time recovery (the "in-place ≤30-day" tier).
  *
@@ -82,11 +84,7 @@ const toTime = (time: number | string): Date | number => {
     const parsed = Date.parse(time);
 
     if (Number.isNaN(parsed)) {
-        throw Object.assign(new Error(`pitr: invalid time "${time}" — expected epoch-ms or an ISO timestamp`), {
-            code: "BAD_REQUEST",
-            name: "LunoraError",
-            status: 400,
-        });
+        throw new LunoraError("BAD_REQUEST", `pitr: invalid time "${time}" — expected epoch-ms or an ISO timestamp`);
     }
 
     return parsed;
@@ -126,11 +124,7 @@ const armRestore = async (storage: PitrStorage, args: PitrRestoreArgs): Promise<
 
     if (target === undefined) {
         if (args.time === undefined) {
-            throw Object.assign(new Error("pitrRestore: provide a `bookmark` or a `time` to restore to"), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", "pitrRestore: provide a `bookmark` or a `time` to restore to");
         }
 
         if (!storage.getBookmarkForTime) {

--- a/packages/do/src/relation-fanout.ts
+++ b/packages/do/src/relation-fanout.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-secrets/no-secrets -- the `__lunora_relation__:` reserved-prefix template strings are framework constants, not credentials */
+import { LunoraError } from "@lunora/errors";
 import type { DatabaseWriterLike, SchemaLike } from "./ctx-db";
 import { RELATION_FUNCTION_PREFIX } from "./introspect";
 import type { QueryArgs } from "./query-args";
@@ -35,17 +36,13 @@ export const serveRelationFanout = async (
     const definition = schema.tables[table];
 
     if (!definition) {
-        throw Object.assign(new Error(`${RELATION_FUNCTION_PREFIX} unknown table "${table}"`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 });
+        throw new LunoraError("UNKNOWN_TABLE", `${RELATION_FUNCTION_PREFIX} unknown table "${table}"`, { status: 404 });
     }
 
     // Only shard-local tables live in a shard's SQLite; a `.global()` table lives
     // in D1 and must never be fanned out across shards.
     if (definition.shardMode?.kind === "global") {
-        throw Object.assign(new Error(`${RELATION_FUNCTION_PREFIX} table "${table}" is global, not shard-local`), {
-            code: "BAD_REQUEST",
-            name: "LunoraError",
-            status: 400,
-        });
+        throw new LunoraError("BAD_REQUEST", `${RELATION_FUNCTION_PREFIX} table "${table}" is global, not shard-local`);
     }
 
     const where = (args["where"] ?? undefined) as QueryArgs["where"];

--- a/packages/do/src/relation-fanout.ts
+++ b/packages/do/src/relation-fanout.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-secrets/no-secrets -- the `__lunora_relation__:` reserved-prefix template strings are framework constants, not credentials */
 import { LunoraError } from "@lunora/errors";
+
 import type { DatabaseWriterLike, SchemaLike } from "./ctx-db";
 import { RELATION_FUNCTION_PREFIX } from "./introspect";
 import type { QueryArgs } from "./query-args";

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -2624,7 +2624,9 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this with a schema-aware reader that uses `this`
     protected runRelationFanoutRead(_functionPath: string, _args: Record<string, unknown>): Promise<unknown> {
-        throw new LunoraError("NOT_IMPLEMENTED", "__lunora_relation__: no schema bound — the base ShardDO cannot serve cross-shard relation reads", { status: 500 });
+        throw new LunoraError("NOT_IMPLEMENTED", "__lunora_relation__: no schema bound — the base ShardDO cannot serve cross-shard relation reads", {
+            status: 500,
+        });
     }
 
     /**
@@ -5229,13 +5231,20 @@ abstract class ShardDO {
         // Refuse to replay a lossy body rather than deliver a corrupted message the
         // producer never sent.
         if (isLossyBody(row.body)) {
-            throw new LunoraError("BAD_REQUEST", `replayQueueMessage: captured message "${parsed.id}" has a truncated or unserializable body and can't be replayed faithfully`, { status: 422 });
+            throw new LunoraError(
+                "BAD_REQUEST",
+                `replayQueueMessage: captured message "${parsed.id}" has a truncated or unserializable body and can't be replayed faithfully`,
+                { status: 422 },
+            );
         }
 
         const target = parsed.target ?? this.resolveReplayTarget(row.queue) ?? row.exportName;
 
         if (typeof target !== "string" || target === "") {
-            throw new LunoraError("BAD_REQUEST", `replayQueueMessage: captured message "${parsed.id}" has no declared producer to replay onto (pass \`target\`)`);
+            throw new LunoraError(
+                "BAD_REQUEST",
+                `replayQueueMessage: captured message "${parsed.id}" has no declared producer to replay onto (pass \`target\`)`,
+            );
         }
 
         const { binding } = this.resolveQueueBinding(target);

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1,5 +1,5 @@
 import type { DurableObjectStorage } from "@cloudflare/workers-types";
-import { toErrorBody } from "@lunora/errors";
+import { LunoraError, toErrorBody } from "@lunora/errors";
 import type { DrizzleSqliteDODatabase } from "drizzle-orm/durable-sqlite";
 import { drizzle as drizzleDO } from "drizzle-orm/durable-sqlite";
 
@@ -501,7 +501,7 @@ const parseRunMigrationArgs = (args: Record<string, unknown>): RunShardMigration
     const id = typeof args["id"] === "string" ? args["id"] : "";
 
     if (id.trim() === "") {
-        throw Object.assign(new Error("runMigration: `id` is required"), { code: "MIGRATION_ID_REQUIRED", name: "LunoraError", status: 400 });
+        throw new LunoraError("MIGRATION_ID_REQUIRED", "runMigration: `id` is required", { status: 400 });
     }
 
     return {
@@ -533,11 +533,11 @@ const parseWriteRowArgs = (args: Record<string, unknown>): RunShardWriteArgs => 
     const table = typeof args["table"] === "string" ? args["table"] : "";
 
     if (op !== "insert" && op !== "patch" && op !== "replace" && op !== "delete") {
-        throw Object.assign(new Error("writeRow: `op` must be insert|patch|replace|delete"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "writeRow: `op` must be insert|patch|replace|delete");
     }
 
     if (table.trim() === "") {
-        throw Object.assign(new Error("writeRow: `table` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "writeRow: `table` is required");
     }
 
     const id = typeof args["id"] === "string" ? args["id"] : undefined;
@@ -545,11 +545,11 @@ const parseWriteRowArgs = (args: Record<string, unknown>): RunShardWriteArgs => 
         typeof args["doc"] === "object" && args["doc"] !== null && !Array.isArray(args["doc"]) ? (args["doc"] as Record<string, unknown>) : undefined;
 
     if (op !== "insert" && (id === undefined || id === "")) {
-        throw Object.assign(new Error(`writeRow: \`id\` is required for op "${op}"`), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", `writeRow: \`id\` is required for op "${op}"`);
     }
 
     if (op !== "delete" && record === undefined) {
-        throw Object.assign(new Error(`writeRow: \`doc\` is required for op "${op}"`), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", `writeRow: \`doc\` is required for op "${op}"`);
     }
 
     return { doc: record, id, op, table };
@@ -594,7 +594,7 @@ const parseCreateWorkflowInstanceArgs = (args: Record<string, unknown>): CreateW
     const exportName = typeof args["exportName"] === "string" ? args["exportName"].trim() : "";
 
     if (exportName === "") {
-        throw Object.assign(new Error("createWorkflowInstance: `exportName` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "createWorkflowInstance: `exportName` is required");
     }
 
     const id = typeof args["id"] === "string" && args["id"] !== "" ? args["id"] : undefined;
@@ -618,11 +618,11 @@ const parseGetWorkflowInstanceStatusArgs = (args: Record<string, unknown>): GetW
     const id = typeof args["id"] === "string" ? args["id"].trim() : "";
 
     if (exportName === "") {
-        throw Object.assign(new Error("getWorkflowInstanceStatus: `exportName` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "getWorkflowInstanceStatus: `exportName` is required");
     }
 
     if (id === "") {
-        throw Object.assign(new Error("getWorkflowInstanceStatus: `id` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "getWorkflowInstanceStatus: `id` is required");
     }
 
     return { exportName, id };
@@ -727,7 +727,7 @@ const parseBulkDeleteArgs = (args: Record<string, unknown>): RunShardBulkDeleteA
     const table = typeof args["table"] === "string" ? args["table"] : "";
 
     if (table.trim() === "") {
-        throw Object.assign(new Error("deleteRows: `table` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "deleteRows: `table` is required");
     }
 
     return {
@@ -748,7 +748,7 @@ const parseClearTableArgs = (args: Record<string, unknown>): RunShardBulkDeleteA
     const table = typeof args["table"] === "string" ? args["table"] : "";
 
     if (table.trim() === "") {
-        throw Object.assign(new Error("clearTable: `table` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "clearTable: `table` is required");
     }
 
     return { limit: typeof args["limit"] === "number" ? args["limit"] : undefined, table };
@@ -765,7 +765,7 @@ const parseRecordAuthEventArgs = (args: Record<string, unknown>): { outcome: "fa
     const { outcome } = args;
 
     if (outcome !== "ok" && outcome !== "fail") {
-        throw Object.assign(new Error('recordAuthEvent: `outcome` must be "ok" or "fail"'), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", 'recordAuthEvent: `outcome` must be "ok" or "fail"');
     }
 
     return { outcome };
@@ -792,7 +792,7 @@ const parseRecordContainerEventArgs = (args: Record<string, unknown>): Container
     const raw = args["event"];
 
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-        throw Object.assign(new Error("recordContainerEvent: `event` must be an object"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "recordContainerEvent: `event` must be an object");
     }
 
     const envelope = raw as Record<string, unknown>;
@@ -800,11 +800,7 @@ const parseRecordContainerEventArgs = (args: Record<string, unknown>): Container
     const event = typeof envelope["event"] === "string" ? envelope["event"] : "";
 
     if (container.trim() === "" || event.trim() === "") {
-        throw Object.assign(new Error("recordContainerEvent: `event.container` and `event.event` are required"), {
-            code: "BAD_REQUEST",
-            name: "LunoraError",
-            status: 400,
-        });
+        throw new LunoraError("BAD_REQUEST", "recordContainerEvent: `event.container` and `event.event` are required");
     }
 
     // Fold the envelope's `error`/`info` level into the buffer's level set
@@ -848,27 +844,27 @@ const parseRunAsArgs = (args: Record<string, unknown>): RunAsArgs => {
     const userId = typeof args["userId"] === "string" ? args["userId"] : "";
 
     if (functionPath.trim() === "") {
-        throw Object.assign(new Error("runAs: `functionPath` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "runAs: `functionPath` is required");
     }
 
     if (functionPath.startsWith(ADMIN_FUNCTION_PREFIX)) {
-        throw Object.assign(new Error("runAs: cannot target a reserved admin function"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "runAs: cannot target a reserved admin function");
     }
 
     if (userId.trim() === "") {
-        throw Object.assign(new Error("runAs: `userId` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "runAs: `userId` is required");
     }
 
     const rawArgs = args["args"];
 
     if (rawArgs !== undefined && (typeof rawArgs !== "object" || rawArgs === null || Array.isArray(rawArgs))) {
-        throw Object.assign(new Error("runAs: `args` must be an object"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "runAs: `args` must be an object");
     }
 
     const rawIdentity = args["identity"];
 
     if (rawIdentity !== undefined && (typeof rawIdentity !== "object" || rawIdentity === null || Array.isArray(rawIdentity))) {
-        throw Object.assign(new Error("runAs: `identity` must be an object"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "runAs: `identity` must be an object");
     }
 
     return {
@@ -896,7 +892,7 @@ const parseRunAsArgs = (args: Record<string, unknown>): RunAsArgs => {
  */
 const parseRecordMailArgs = (args: Record<string, unknown>): RecordMailInput => {
     const bad = (message: string): never => {
-        throw Object.assign(new Error(`recordMail: ${message}`), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", `recordMail: ${message}`);
     };
 
     const { bcc, cc, from, headers, html, replyTo, subject, text, to } = args;
@@ -959,7 +955,7 @@ const buildTestMailInput = (args: Record<string, unknown>): RecordMailInput => {
     const { to } = args;
 
     if (to !== undefined && typeof to !== "string") {
-        throw Object.assign(new Error("sendTestMail: `to` must be a string"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "sendTestMail: `to` must be a string");
     }
 
     const recipient = to ?? TEST_MAIL_DEFAULT_TO;
@@ -1004,7 +1000,7 @@ interface SendQueueMessageArgs {
  */
 const parseRecordQueueMessageArgs = (args: Record<string, unknown>): RecordQueueMessageInput[] => {
     const bad = (message: string): never => {
-        throw Object.assign(new Error(`recordQueueMessage: ${message}`), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", `recordQueueMessage: ${message}`);
     };
 
     const raw = args["messages"];
@@ -1070,17 +1066,13 @@ const parseSendQueueMessageArgs = (args: Record<string, unknown>): SendQueueMess
     const exportName = typeof args["exportName"] === "string" ? args["exportName"].trim() : "";
 
     if (exportName === "") {
-        throw Object.assign(new Error("sendQueueMessage: `exportName` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "sendQueueMessage: `exportName` is required");
     }
 
     const delayRaw = args["delaySeconds"];
 
     if (delayRaw !== undefined && (typeof delayRaw !== "number" || !Number.isFinite(delayRaw) || delayRaw < 0)) {
-        throw Object.assign(new Error("sendQueueMessage: `delaySeconds` must be a non-negative number"), {
-            code: "BAD_REQUEST",
-            name: "LunoraError",
-            status: 400,
-        });
+        throw new LunoraError("BAD_REQUEST", "sendQueueMessage: `delaySeconds` must be a non-negative number");
     }
 
     const batch = Array.isArray(args["batch"]) ? (args["batch"] as unknown[]) : undefined;
@@ -1088,11 +1080,7 @@ const parseSendQueueMessageArgs = (args: Record<string, unknown>): SendQueueMess
     // Cloudflare's `sendBatch` rejects an empty or >100-message batch (BatchCountOutOfBounds).
     // Fail it on the existing 400 path so a malformed payload never reaches the queue API.
     if (batch !== undefined && (batch.length === 0 || batch.length > MAX_QUEUE_SEND_BATCH)) {
-        throw Object.assign(new Error(`sendQueueMessage: \`batch\` must contain between 1 and ${String(MAX_QUEUE_SEND_BATCH)} messages`), {
-            code: "BAD_REQUEST",
-            name: "LunoraError",
-            status: 400,
-        });
+        throw new LunoraError("BAD_REQUEST", `sendQueueMessage: \`batch\` must contain between 1 and ${String(MAX_QUEUE_SEND_BATCH)} messages`);
     }
 
     return {
@@ -1114,7 +1102,7 @@ const parseReplayQueueMessageArgs = (args: Record<string, unknown>): { id: strin
     const id = typeof args["id"] === "string" ? args["id"].trim() : "";
 
     if (id === "") {
-        throw Object.assign(new Error("replayQueueMessage: `id` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "replayQueueMessage: `id` is required");
     }
 
     const target = typeof args["target"] === "string" && args["target"].trim() !== "" ? args["target"].trim() : undefined;
@@ -1134,26 +1122,26 @@ const parseRankBeforeArgs = (args: Record<string, unknown>): RunShardRankBeforeA
     const rowId = typeof args["rowId"] === "string" ? args["rowId"] : "";
 
     if (table.trim() === "") {
-        throw Object.assign(new Error("rankBefore: `table` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "rankBefore: `table` is required");
     }
 
     if (index.trim() === "") {
-        throw Object.assign(new Error("rankBefore: `index` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "rankBefore: `index` is required");
     }
 
     // `partitionKey` is the encoded partition tuple — `""` is legitimate for a
     // rankIndex with no `partitionBy`, so only the type is enforced, not
     // non-emptiness.
     if (typeof args["partitionKey"] !== "string") {
-        throw Object.assign(new Error("rankBefore: `partitionKey` must be a string"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "rankBefore: `partitionKey` must be a string");
     }
 
     if (rowId.trim() === "") {
-        throw Object.assign(new Error("rankBefore: `rowId` is required"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "rankBefore: `rowId` is required");
     }
 
     if (!Array.isArray(args["sortValues"])) {
-        throw Object.assign(new Error("rankBefore: `sortValues` must be an array"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "rankBefore: `sortValues` must be an array");
     }
 
     return { index, partitionKey: args["partitionKey"], rowId, sortValues: args["sortValues"], table };
@@ -1161,7 +1149,7 @@ const parseRankBeforeArgs = (args: Record<string, unknown>): RunShardRankBeforeA
 
 /** Throw a uniform 400 `LunoraError` for a malformed admin payload field. */
 const badRequest = (message: string): never => {
-    throw Object.assign(new Error(message), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+    throw new LunoraError("BAD_REQUEST", message);
 };
 
 /** Narrow a required non-empty string admin arg or 400 with `&lt;field> is required`. */
@@ -1285,7 +1273,7 @@ const parseApplyCdcArgs = (args: Record<string, unknown>): RunShardApplyCdcArgs 
     const raw = args["changes"];
 
     if (!Array.isArray(raw)) {
-        throw Object.assign(new Error("applyCdc: `changes` must be an array"), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+        throw new LunoraError("BAD_REQUEST", "applyCdc: `changes` must be an array");
     }
 
     const changes = raw.map((entry, index): CdcChange => {
@@ -1295,11 +1283,7 @@ const parseApplyCdcArgs = (args: Record<string, unknown>): RunShardApplyCdcArgs 
         const id = typeof record["id"] === "string" ? record["id"] : "";
 
         if (table === "" || id === "" || (op !== "insert" && op !== "update" && op !== "delete")) {
-            throw Object.assign(new Error(`applyCdc: changes[${String(index)}] must have a table, id, and op of insert|update|delete`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", `applyCdc: changes[${String(index)}] must have a table, id, and op of insert|update|delete`);
         }
 
         const rawDocument = record["doc"];
@@ -1309,11 +1293,7 @@ const parseApplyCdcArgs = (args: Record<string, unknown>): RunShardApplyCdcArgs 
         // Record). Failing here surfaces the malformed change at the parse
         // boundary instead of mid-replay.
         if (rawDocument !== undefined && (typeof rawDocument !== "object" || rawDocument === null || Array.isArray(rawDocument))) {
-            throw Object.assign(new Error(`applyCdc: changes[${String(index)}].doc must be an object`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", `applyCdc: changes[${String(index)}].doc must be an object`);
         }
 
         const document = rawDocument as Record<string, unknown> | undefined;
@@ -1322,11 +1302,7 @@ const parseApplyCdcArgs = (args: Record<string, unknown>): RunShardApplyCdcArgs 
         // otherwise the replay would write a row whose id contradicts the CDC
         // cursor — reject the inconsistency at the boundary.
         if (document !== undefined && typeof document["_id"] === "string" && document["_id"] !== id) {
-            throw Object.assign(new Error(`applyCdc: changes[${String(index)}].doc._id must match the entry id`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", `applyCdc: changes[${String(index)}].doc._id must match the entry id`);
         }
 
         return {
@@ -2648,11 +2624,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this with a schema-aware reader that uses `this`
     protected runRelationFanoutRead(_functionPath: string, _args: Record<string, unknown>): Promise<unknown> {
-        throw Object.assign(new Error("__lunora_relation__: no schema bound — the base ShardDO cannot serve cross-shard relation reads"), {
-            code: "NOT_IMPLEMENTED",
-            name: "LunoraError",
-            status: 500,
-        });
+        throw new LunoraError("NOT_IMPLEMENTED", "__lunora_relation__: no schema bound — the base ShardDO cannot serve cross-shard relation reads", { status: 500 });
     }
 
     /**
@@ -2820,21 +2792,13 @@ abstract class ShardDO {
      */
     protected async runInTransaction<T>(handler: () => Promise<T> | T): Promise<T> {
         if (this.transactionDepth > 0) {
-            throw Object.assign(new Error("nested transactions are not supported in SQLite-in-DO"), {
-                code: "NESTED_TRANSACTION",
-                name: "LunoraError",
-                status: 500,
-            });
+            throw new LunoraError("NESTED_TRANSACTION", "nested transactions are not supported in SQLite-in-DO", { status: 500 });
         }
 
         const sqlHandle = this.state.storage.sql as TransactionSqlLike | undefined;
 
         if (!sqlHandle || typeof sqlHandle.exec !== "function") {
-            throw Object.assign(new Error("storage.sql is not available on this ShardDO state"), {
-                code: "SQL_UNAVAILABLE",
-                name: "LunoraError",
-                status: 500,
-            });
+            throw new LunoraError("SQL_UNAVAILABLE", "storage.sql is not available on this ShardDO state", { status: 500 });
         }
 
         // workerd FORBIDS raw `BEGIN`/`COMMIT`/`SAVEPOINT` SQL inside a Durable
@@ -2940,9 +2904,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to reach the generated migration registry
     protected runShardDataMigration(args: RunShardMigrationArgs): Promise<MigrationRunResult> {
-        return Promise.reject(
-            Object.assign(new Error(`data migration "${args.id}" is not registered`), { code: "MIGRATION_NOT_FOUND", name: "LunoraError", status: 404 }),
-        );
+        return Promise.reject(new LunoraError("MIGRATION_NOT_FOUND", `data migration "${args.id}" is not registered`, { status: 404 }));
     }
 
     /**
@@ -3226,7 +3188,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to build a schema-aware writer
     protected runShardWrite(args: RunShardWriteArgs): Promise<RunShardWriteResult> {
-        return Promise.reject(Object.assign(new Error(`unknown table: ${args.table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 }));
+        return Promise.reject(new LunoraError("UNKNOWN_TABLE", `unknown table: ${args.table}`, { status: 404 }));
     }
 
     /**
@@ -3242,7 +3204,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to build a schema-aware writer
     protected deleteRowThroughWriter(_table: string, _id: string): Promise<void> {
-        return Promise.reject(Object.assign(new Error(`unknown table: ${_table}`), { code: "UNKNOWN_TABLE", name: "LunoraError", status: 404 }));
+        return Promise.reject(new LunoraError("UNKNOWN_TABLE", `unknown table: ${_table}`, { status: 404 }));
     }
 
     /**
@@ -3295,9 +3257,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to build a schema-aware writer
     protected runShardRankBefore(_args: RunShardRankBeforeArgs): Promise<{ before: number; total: number }> {
-        return Promise.reject(
-            Object.assign(new Error("rankBefore is not implemented in base ShardDO"), { code: "NOT_IMPLEMENTED", name: "LunoraError", status: 500 }),
-        );
+        return Promise.reject(new LunoraError("NOT_IMPLEMENTED", "rankBefore is not implemented in base ShardDO", { status: 500 }));
     }
 
     /**
@@ -3312,9 +3272,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to build a schema-aware writer
     protected runShardRankPage(_args: RunShardRankPageArgs): Promise<ShardRankPageResult> {
-        return Promise.reject(
-            Object.assign(new Error("rankPage is not implemented in base ShardDO"), { code: "NOT_IMPLEMENTED", name: "LunoraError", status: 500 }),
-        );
+        return Promise.reject(new LunoraError("NOT_IMPLEMENTED", "rankPage is not implemented in base ShardDO", { status: 500 }));
     }
 
     /**
@@ -3782,9 +3740,7 @@ abstract class ShardDO {
      */
     // eslint-disable-next-line class-methods-use-this -- base-class override hook: the codegen subclass overrides this and uses `this` to build a schema-aware writer
     protected runShardApplyCdc(_args: RunShardApplyCdcArgs): Promise<RunShardApplyCdcResult> {
-        return Promise.reject(
-            Object.assign(new Error("applyCdc is not implemented in base ShardDO"), { code: "NOT_IMPLEMENTED", name: "LunoraError", status: 500 }),
-        );
+        return Promise.reject(new LunoraError("NOT_IMPLEMENTED", "applyCdc is not implemented in base ShardDO", { status: 500 }));
     }
 
     /**
@@ -5043,7 +4999,7 @@ abstract class ShardDO {
         const metadata = this.workflowsMetadata().workflows.find((workflow) => workflow.exportName === exportName);
 
         if (!metadata) {
-            throw Object.assign(new Error(`workflow "${exportName}" is not declared`), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+            throw new LunoraError("BAD_REQUEST", `workflow "${exportName}" is not declared`);
         }
 
         const binding = (this.env as Record<string, unknown> | undefined)?.[metadata.binding];
@@ -5054,11 +5010,7 @@ abstract class ShardDO {
             typeof (binding as WorkflowBindingHandle).create !== "function" ||
             typeof (binding as WorkflowBindingHandle).get !== "function"
         ) {
-            throw Object.assign(new Error(`workflow binding "${metadata.binding}" is not available on this deployment`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", `workflow binding "${metadata.binding}" is not available on this deployment`);
         }
 
         return binding as WorkflowBindingHandle;
@@ -5269,11 +5221,7 @@ abstract class ShardDO {
         const row = readQueueMessageById(this.state.storage.sql as unknown as SqlExec, parsed.id);
 
         if (row === undefined) {
-            throw Object.assign(new Error(`replayQueueMessage: captured message "${parsed.id}" was not found`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 404,
-            });
+            throw new LunoraError("BAD_REQUEST", `replayQueueMessage: captured message "${parsed.id}" was not found`, { status: 404 });
         }
 
         // The catcher caps oversized bodies and stands in a marker for unserializable
@@ -5281,20 +5229,13 @@ abstract class ShardDO {
         // Refuse to replay a lossy body rather than deliver a corrupted message the
         // producer never sent.
         if (isLossyBody(row.body)) {
-            throw Object.assign(
-                new Error(`replayQueueMessage: captured message "${parsed.id}" has a truncated or unserializable body and can't be replayed faithfully`),
-                { code: "BAD_REQUEST", name: "LunoraError", status: 422 },
-            );
+            throw new LunoraError("BAD_REQUEST", `replayQueueMessage: captured message "${parsed.id}" has a truncated or unserializable body and can't be replayed faithfully`, { status: 422 });
         }
 
         const target = parsed.target ?? this.resolveReplayTarget(row.queue) ?? row.exportName;
 
         if (typeof target !== "string" || target === "") {
-            throw Object.assign(new Error(`replayQueueMessage: captured message "${parsed.id}" has no declared producer to replay onto (pass \`target\`)`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", `replayQueueMessage: captured message "${parsed.id}" has no declared producer to replay onto (pass \`target\`)`);
         }
 
         const { binding } = this.resolveQueueBinding(target);
@@ -5318,17 +5259,13 @@ abstract class ShardDO {
         const metadata = this.queuesMetadata().queues.find((queue) => queue.exportName === exportName);
 
         if (!metadata) {
-            throw Object.assign(new Error(`queue "${exportName}" is not declared`), { code: "BAD_REQUEST", name: "LunoraError", status: 400 });
+            throw new LunoraError("BAD_REQUEST", `queue "${exportName}" is not declared`);
         }
 
         const binding = (this.env as Record<string, unknown> | undefined)?.[metadata.binding];
 
         if (typeof binding !== "object" || binding === null || typeof (binding as QueueBindingHandle).send !== "function") {
-            throw Object.assign(new Error(`queue binding "${metadata.binding}" is not available on this deployment`), {
-                code: "BAD_REQUEST",
-                name: "LunoraError",
-                status: 400,
-            });
+            throw new LunoraError("BAD_REQUEST", `queue binding "${metadata.binding}" is not available on this deployment`);
         }
 
         return { binding: binding as QueueBindingHandle, metadata };

--- a/packages/do/src/sql-console.ts
+++ b/packages/do/src/sql-console.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import type { SqlExec } from "./ctx-db";
 
 /**
@@ -40,7 +41,7 @@ const TRAILING_SEMICOLON = /;\s*$/u;
 const stripLeading = (sql: string): string => sql.replace(LEADING_NOISE, "");
 
 /** Build a tagged LunoraError the runtime serializes with its `status`. */
-const sqlError = (message: string, code: string): Error => Object.assign(new Error(message), { code, name: "LunoraError", status: 400 });
+const sqlError = (message: string, code: string): Error => new LunoraError(code, message, { status: 400 });
 
 /**
  * Reject anything that isn't a single read-only statement. Throws a 400

--- a/packages/do/src/sql-console.ts
+++ b/packages/do/src/sql-console.ts
@@ -1,4 +1,5 @@
 import { LunoraError } from "@lunora/errors";
+
 import type { SqlExec } from "./ctx-db";
 
 /**

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -96,6 +96,11 @@ export const ERROR_CATALOG = {
         title: "RLS policy required",
     },
 
+    RUN_DEPTH_EXCEEDED: { internal: true, status: 500, title: "Run depth exceeded" },
+    MIGRATION_NOT_FOUND: { status: 404, title: "Data migration not found" },
+    UNKNOWN_TABLE: { status: 404, title: "Unknown table" },
+    GLOBAL_TABLE_NOT_EDITABLE: { status: 400, title: "Global table is not editable" },
+
     SHARD_ERROR: { status: 503, title: "Shard error" },
     SHARD_UNAVAILABLE: { status: 503, title: "Shard unavailable" },
     OFFLINE_IDENTITY_CHANGED: { status: 409, title: "Offline identity changed" },

--- a/packages/hyperdrive/__tests__/global-dialect.test.ts
+++ b/packages/hyperdrive/__tests__/global-dialect.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { describe, expect, it } from "vitest";
 
 import { mysqlDialect, postgresDialect } from "../src/global-dialect";
@@ -22,7 +23,7 @@ describe("postgresDialect", () => {
     it("detects SQLSTATE 23505 unique violations", () => {
         expect.assertions(2);
 
-        expect(postgresDialect.isUniqueViolation(Object.assign(new Error("dup"), { code: "23505" }))).toBe(true);
+        expect(postgresDialect.isUniqueViolation(new LunoraError("23505", "dup"))).toBe(true);
         expect(postgresDialect.isUniqueViolation(new Error("nope"))).toBe(false);
     });
 });

--- a/packages/hyperdrive/package.json
+++ b/packages/hyperdrive/package.json
@@ -65,6 +65,7 @@
     },
     "dependencies": {
         "@lunora/do": "1.0.0-alpha.24",
+        "@lunora/errors": "1.0.0-alpha.2",
         "@lunora/sql-store": "1.0.0-alpha.24",
         "drizzle-orm": "catalog:drizzle"
     },

--- a/packages/ratelimit/__tests__/middleware.test.ts
+++ b/packages/ratelimit/__tests__/middleware.test.ts
@@ -58,7 +58,7 @@ describe("rateLimit middleware", () => {
         expect(error.name).toBe("LunoraError");
         expect(error.code).toBe("TOO_MANY_REQUESTS");
         expect(error.status).toBe(429);
-        expect(error.retryAfter).toBeTypeOf("number");
+        expect((error as Record<string, { retryAfter: number }>).data?.retryAfter).toBeTypeOf("number");
     });
 
     it("maps a deny-list hit to FORBIDDEN (403) without a retryAfter", async () => {

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -82,7 +82,10 @@ const rateLimit =
             const mapped = STATUS_BY_REASON[reason];
             const retryAfter = Number.isFinite(status.retryAfter) ? Math.ceil(status.retryAfter) : undefined;
 
-            throw new LunoraError(mapped.code, options.message ?? defaultMessage(name, reason, retryAfter), { status: mapped.status, data: retryAfter === undefined ? undefined : { retryAfter } });
+            throw new LunoraError(mapped.code, options.message ?? defaultMessage(name, reason, retryAfter), {
+                status: mapped.status,
+                data: retryAfter === undefined ? undefined : { retryAfter },
+            });
         }
 
         return next();

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -73,12 +73,7 @@ const rateLimit =
                 return next();
             }
 
-            throw Object.assign(new Error(`rate limiter unavailable for "${name}"`), {
-                cause: error,
-                code: "SERVICE_UNAVAILABLE",
-                name: "LunoraError",
-                status: 503,
-            });
+            throw new LunoraError("SERVICE_UNAVAILABLE", `rate limiter unavailable for "${name}"`, { cause: error, status: 503 });
         }
 
         if (!status.ok) {
@@ -86,12 +81,7 @@ const rateLimit =
             const mapped = STATUS_BY_REASON[reason];
             const retryAfter = Number.isFinite(status.retryAfter) ? Math.ceil(status.retryAfter) : undefined;
 
-            throw Object.assign(new Error(options.message ?? defaultMessage(name, reason, retryAfter)), {
-                code: mapped.code,
-                name: "LunoraError",
-                retryAfter,
-                status: mapped.status,
-            });
+            throw new LunoraError(mapped.code, options.message ?? defaultMessage(name, reason, retryAfter), { status: mapped.status, data: retryAfter !== undefined ? { retryAfter } : undefined });
         }
 
         return next();

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import type { Middleware } from "@lunora/server";
 
 import type { RateLimiter } from "./rate-limiter";
@@ -81,7 +82,7 @@ const rateLimit =
             const mapped = STATUS_BY_REASON[reason];
             const retryAfter = Number.isFinite(status.retryAfter) ? Math.ceil(status.retryAfter) : undefined;
 
-            throw new LunoraError(mapped.code, options.message ?? defaultMessage(name, reason, retryAfter), { status: mapped.status, data: retryAfter !== undefined ? { retryAfter } : undefined });
+            throw new LunoraError(mapped.code, options.message ?? defaultMessage(name, reason, retryAfter), { status: mapped.status, data: retryAfter === undefined ? undefined : { retryAfter } });
         }
 
         return next();

--- a/packages/runtime/__tests__/auth-admin.test.ts
+++ b/packages/runtime/__tests__/auth-admin.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AuthAdmin, AuthIntrospector, ExecutionContextLike } from "../src/create-worker";
@@ -210,10 +211,10 @@ describe("createWorker — auth admin mutation endpoints", () => {
         const banUser = vi.mocked(plane.banUser as NonNullable<AuthAdmin["banUser"]>);
 
         banUser.mockImplementationOnce(async () => {
-            throw Object.assign(new Error("nope"), { code: "USER_NOT_FOUND" });
+            throw new LunoraError("USER_NOT_FOUND", "nope");
         });
         banUser.mockImplementationOnce(async () => {
-            throw Object.assign(new Error("driver exploded"), { code: "SQLITE_IOERR" });
+            throw new LunoraError("SQLITE_IOERR", "driver exploded");
         });
 
         const error = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -1,7 +1,7 @@
+import { LunoraError } from "@lunora/errors";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { LunoraError } from "@lunora/errors";
 import type { ExecutionContextLike, HttpActionContext, HttpRouterLike, Route } from "../src/create-worker";
 import { composeWorker, createLunoraHandler, createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LunoraError } from "@lunora/errors";
 import type { ExecutionContextLike, HttpActionContext, HttpRouterLike, Route } from "../src/create-worker";
 import { composeWorker, createLunoraHandler, createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
@@ -846,7 +847,7 @@ describe("createWorker — RPC batch forward failure (Plan 118 toErrorBody migra
     it("still surfaces a recognized LunoraError's real code + message on a shard-forward failure", async () => {
         expect.assertions(2);
 
-        const structured = Object.assign(new Error("cross-shard join guard tripped"), { code: "CONFLICT", name: "LunoraError", status: 409 });
+        const structured = new LunoraError("CONFLICT", "cross-shard join guard tripped", { status: 409 });
         const worker = createWorker({ shardDO: unreachableNamespace(structured) });
 
         const res = await worker.fetch(

--- a/packages/runtime/__tests__/errors.test.ts
+++ b/packages/runtime/__tests__/errors.test.ts
@@ -59,11 +59,7 @@ describe("lunoraError", () => {
         // Structurally identical to what `@lunora/do` throws — the runtime
         // does not take a hard dependency on that package, so we recognise
         // the shape (name + numeric status + string code) instead.
-        const conflict = Object.assign(new Error("stale version"), {
-            code: "CONFLICT",
-            name: "ConflictError",
-            status: 409,
-        });
+        const conflict = new LunoraError("stale version", { code: "CONFLICT", status: 409 });
         const response = toErrorResponse(conflict);
 
         expect(response.status).toBe(409);
@@ -89,11 +85,7 @@ describe("lunoraError", () => {
         // cross-package error mirroring LunoraError's shape) lets the runtime
         // route it without an `instanceof` check, so the DO package stays
         // free of a runtime dep on `@lunora/server`.
-        const countUnsupported = Object.assign(new Error("count() is not supported in an RLS-restricted context"), {
-            code: "COUNT_RLS_UNSUPPORTED",
-            name: "LunoraError",
-            status: 422,
-        });
+        const countUnsupported = new LunoraError("count() is not supported in an RLS-restricted context", { code: "COUNT_RLS_UNSUPPORTED", status: 422 });
         const response = toErrorResponse(countUnsupported);
 
         expect(response.status).toBe(422);

--- a/packages/runtime/__tests__/observability.test.ts
+++ b/packages/runtime/__tests__/observability.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { ExecutionContextLike } from "../src/create-worker";
@@ -251,7 +252,7 @@ describe("observabilitySink", () => {
 
             // Structural ConflictError shape (name/code/status) — mirrors what
             // `@lunora/do` throws without taking a runtime dependency on it.
-            const conflict = Object.assign(new Error("write conflict"), { code: "CONFLICT", name: "ConflictError", status: 409 });
+            const conflict = new LunoraError("CONFLICT", "write conflict", { name: "ConflictError", status: 409 });
 
             shard.throwOnFetch = conflict;
             const worker = createWorker({ observability: sink, shardDO: shard.namespace });

--- a/packages/server/__tests__/facade.test.ts
+++ b/packages/server/__tests__/facade.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { describe, expect, it, vi } from "vitest";
 
 import type { FacadeWriterLike } from "../src/facade";
@@ -85,7 +86,12 @@ describe("bindTableFacade — per-table batch forms", () => {
 });
 
 /** A ConflictError-shaped value (matched structurally by the facade, no `@lunora/do` import). */
-const uniqueConflict = (): Error => Object.assign(new Error(`unique constraint violation on "users"`), { code: "CONFLICT", kind: "unique" });
+const uniqueConflict = (): LunoraError & { kind: string } => {
+    const err = new LunoraError("CONFLICT", `unique constraint violation on "users"`) as LunoraError & { kind: string };
+    err.kind = "unique";
+
+    return err;
+};
 
 /** A writer with individually-controllable findFirst/insert/patch, bound to the `users` table. */
 const makeComposingWriter = () => {

--- a/packages/server/__tests__/protect-public.test.ts
+++ b/packages/server/__tests__/protect-public.test.ts
@@ -1,3 +1,4 @@
+import { LunoraError } from "@lunora/errors";
 import { describe, expect, it } from "vitest";
 
 import { initLunora } from "../src/builder/index";
@@ -17,7 +18,7 @@ const trace =
 const reject =
     <Context>(message: string): Middleware<Context, Context> =>
     () => {
-        throw Object.assign(new Error(message), { code: "FORBIDDEN", name: "LunoraError", status: 403 });
+        throw new LunoraError("FORBIDDEN", message, { status: 403 });
     };
 
 describe("protectPublic", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2375,6 +2375,9 @@ importers:
       '@lunora/do':
         specifier: workspace:*
         version: link:../do
+      '@lunora/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@lunora/sql-store':
         specifier: workspace:*
         version: link:../sql-store


### PR DESCRIPTION
## Summary

Migrates \~104 `Object.assign(new Error(...))` patterns across 20+ source files and 12 codegen emitter templates to use the canonical `LunoraError` class from `@lunora/errors`.

Also fixes a pre-existing CI failure where `@lunora/studio` unit tests failed to resolve `@lunora/advisor` — the advisor package is now built before the studio test step in the workflow.

## Changes

- **packages/codegen/src/emit.ts**: 12 template-string patterns replaced + import added for functions/shard output
- **packages/do/src/shard-do.ts**: ~51 patterns replaced (largest file)
- **packages/do/src/introspect.ts**, **pitr.ts**, **relation-fanout.ts**, **sql-console.ts**, **ctx-db.ts**: fixed
- **packages/client/src/lunora-client.ts**, **stream.ts**: fixed (already imported LunoraError)
- **packages/d1/src/introspect.ts**, **packages/auth/src/turnstile.ts**, **turnstile-middleware.ts**, **packages/ratelimit/src/middleware.ts**: fixed
- **packages/codegen/src/discover-crons.ts**: fixed
- **Test fixtures + examples**: 12 generated files updated across 6 examples, 12 test files across 7 packages
- **.github/workflows/test.yml**: Build `@lunora/advisor` before studio unit tests

## Key Decisions

- `NOT_IMPLEMENTED` kept `{ status: 500 }` despite catalog mapping to 501
- `retryAfter` mapped to `data: { retryAfter }` in LunoraError options
- Test "twin" in `packages/errors` left as `Object.assign` (tests wire-decoded error reconstruction)

## Verification

- ✅ Build: `pnpm run build:packages` — 42 projects succeed
- ✅ Tests: `pnpm run test:affected` — all 158 test files pass (1775 tests)
- ✅ Studio unit tests: 17 files, 177 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across client, server, and data tools so failures now consistently use structured `LunoraError` instances with clearer error codes and HTTP-like status codes (including Turnstile, rate limiting, streaming, SQL console, and D1/DO introspection).
  * Standardized “not found/unknown/invalid” and service-unavailable failure responses, keeping existing successful behavior the same.
* **Tests**
  * Improved reliability of test runs by ensuring required build artifacts are available before running studio unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->