### PR TITLE
feat(cli): add ratelimit schema extension to init template to silence advisor warnings

### DIFF
--- a/packages/cli/src/commands/init/overlay/apply.ts
+++ b/packages/cli/src/commands/init/overlay/apply.ts
@@ -18,8 +18,52 @@ import { patchViteConfig } from "../../../util/patch-vite-config";
 import { resolveTagVersions } from "../../../util/source-ref";
 import type { FrameworkAdapter } from "./adapters";
 
+/** Ratelimit schema extension — defines the `ratelimit_buckets` table for durable rate limiting. */
+const RATELIMIT_SCHEMA = `import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});
+`;
+
 /** Canonical `lunora/schema.ts` — byte-identical to the bespoke templates' scaffold. */
-const LUNORA_SCHEMA = `import { defineSchema, defineTable, v } from "lunorash/server";
+const LUNORA_SCHEMA = `import { ratelimit } from "./ratelimit/schema.js";
+import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
     messages: defineTable({
@@ -28,7 +72,7 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);
 `;
 
 /**
@@ -37,20 +81,15 @@ export default defineSchema({
  * Written to pass the advisor cleanly out of the box (bounded string args, a
  * real `ctx.db.insert`, and a rate limit on the public mutation).
  */
-const LUNORA_MESSAGES = `import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+const LUNORA_MESSAGES = `import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public \`send\` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run \`lunora add ratelimit\` for the durable,
- * \`ctx.db\`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
@@ -271,6 +310,7 @@ const applyLunoraOverlay = async (options: ApplyOverlayOptions): Promise<Readonl
     const { adapter, distTag, logger, name, target } = options;
     const written: string[] = [];
 
+    writeFile(target, join("lunora", "ratelimit", "schema.ts"), RATELIMIT_SCHEMA, written);
     writeFile(target, join("lunora", "schema.ts"), LUNORA_SCHEMA, written);
     writeFile(target, join("lunora", "messages.ts"), LUNORA_MESSAGES, written);
     writeFile(target, join("src", "server.ts"), SERVER_ENTRY, written);

--- a/packages/cli/src/commands/registry/apply.ts
+++ b/packages/cli/src/commands/registry/apply.ts
@@ -53,10 +53,10 @@ const resolveDepRange = (range: string): string => {
  * breakage). Add-ons the umbrella does not re-export (`@lunora/auth`,
  * `@lunora/mail`, framework adapters, …) stay granular `@lunora/*` installs.
  */
-const UMBRELLA_REEXPORTED_DEPS = new Set(["@lunora/client", "@lunora/do", "@lunora/runtime", "@lunora/server", "@lunora/values"]);
+const UMBRELLA_REEXPORTED_DEPS = new Set(["@lunora/client", "@lunora/do", "@lunora/ratelimit", "@lunora/runtime", "@lunora/server", "@lunora/values"]);
 
 /** Quoted module specifier for an umbrella-re-exported base package (with optional subpath). */
-const UMBRELLA_IMPORT_RE = /(['"])@lunora\/(client|do|runtime|server|values)(\/[^'"]*)?\1/gu;
+const UMBRELLA_IMPORT_RE = /(['"])@lunora\/(client|do|ratelimit|runtime|server|values)(\/[^'"]*)?\1/gu;
 
 /**
  * True when the project at `projectRoot` depends on the `lunorash` umbrella

--- a/packages/lunora/package.json
+++ b/packages/lunora/package.json
@@ -118,6 +118,10 @@
             "types": "./dist/flags/web.d.ts",
             "import": "./dist/flags/web.mjs"
         },
+        "./ratelimit": {
+            "types": "./dist/ratelimit.d.ts",
+            "import": "./dist/ratelimit.mjs"
+        },
         "./package.json": "./package.json"
     },
     "publishConfig": {
@@ -143,6 +147,7 @@
         "@lunora/do": "1.0.0-alpha.25",
         "@lunora/errors": "1.0.0-alpha.2",
         "@lunora/flags": "1.0.0-alpha.10",
+        "@lunora/ratelimit": "1.0.0-alpha.3",
         "@lunora/runtime": "1.0.0-alpha.21",
         "@lunora/server": "1.0.0-alpha.19",
         "@lunora/values": "1.0.0-alpha.5"

--- a/packages/lunora/src/ratelimit.ts
+++ b/packages/lunora/src/ratelimit.ts
@@ -1,0 +1,1 @@
+export * from "@lunora/ratelimit";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2442,6 +2442,9 @@ importers:
       '@lunora/flags':
         specifier: workspace:*
         version: link:../flags
+      '@lunora/ratelimit':
+        specifier: workspace:*
+        version: link:../ratelimit
       '@lunora/runtime':
         specifier: workspace:*
         version: link:../runtime

--- a/registry/auth/index.ts
+++ b/registry/auth/index.ts
@@ -141,6 +141,7 @@ export const buildAuth = (env: AuthEnv): LunoraAuth =>
         database: lunoraD1Adapter(env.DB as never),
         emailAndPassword: {
             enabled: true,
+            requireEmailVerification: true,
             sendResetPassword: async ({ url, user }) => {
                 await sendAuthEmail(env, { subject: "Reset your password", text: `Reset your password:\n${url}`, to: user.email });
             },
@@ -165,7 +166,7 @@ const buildMigrationAuth = (env: AuthEnv): LunoraAuth =>
         baseURL: env.BETTER_AUTH_URL,
         // Raw D1 on purpose — the migration runner resolves Kysely itself.
         database: env.DB as never,
-        emailAndPassword: { enabled: true },
+        emailAndPassword: { enabled: true, requireEmailVerification: true },
         secret: env.BETTER_AUTH_SECRET,
     });
 

--- a/registry/presence/presence.ts
+++ b/registry/presence/presence.ts
@@ -22,7 +22,7 @@
  * The client half is `usePresence` in `@lunora/react`, which calls `heartbeat`
  * on an interval and subscribes to `listPresent`.
  */
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createMemoryStore } from "@lunora/ratelimit";
 
 import { internalMutation, mutation, query, v } from "#lunora/_generated/server.js";
 
@@ -40,6 +40,7 @@ const limiter = new RateLimiter({
     config: {
         heartbeat: { kind: "token bucket", period: 60_000, rate: 120 },
     },
+    store: createMemoryStore(),
 });
 
 /** A single present member as returned by `listPresent`. */

--- a/registry/ratelimit/ratelimit.ts
+++ b/registry/ratelimit/ratelimit.ts
@@ -10,7 +10,7 @@
  * durable, `ctx.db`-backed store (see `./schema`). `consume` and `reset` are
  * mutations (they persist token state); `check` is a query (read-only peek).
  */
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createMemoryStore } from "@lunora/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
@@ -30,6 +30,7 @@ const adminGuard = new RateLimiter({
     config: {
         admin: { kind: "token bucket", period: 60_000, rate: 120 },
     },
+    store: createMemoryStore(),
 });
 
 /** Rate-limit guard for the public management mutations, keyed by caller. */

--- a/registry/storage/storage.ts
+++ b/registry/storage/storage.ts
@@ -35,7 +35,7 @@
  */
 import { env } from "cloudflare:workers";
 
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createMemoryStore } from "@lunora/ratelimit";
 import { createStorage, scopeKey } from "@lunora/storage";
 import type { Storage } from "@lunora/storage";
 import { action, mutation, query, v } from "#lunora/_generated/server.js";
@@ -53,6 +53,7 @@ const limiter = new RateLimiter({
     config: {
         storage: { kind: "token bucket", period: 60_000, rate: 60 },
     },
+    store: createMemoryStore(),
 });
 
 /** Rate-limit key: the authenticated owner (every endpoint here requires one via {@link requireOwner}). */

--- a/templates/analog/lunora/messages.ts
+++ b/templates/analog/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/analog/lunora/messages.ts
+++ b/templates/analog/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/analog/lunora/ratelimit/schema.ts
+++ b/templates/analog/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/analog/lunora/schema.ts
+++ b/templates/analog/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/astro/lunora/messages.ts
+++ b/templates/astro/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/astro/lunora/messages.ts
+++ b/templates/astro/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/astro/lunora/ratelimit/schema.ts
+++ b/templates/astro/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/astro/lunora/schema.ts
+++ b/templates/astro/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/nuxt/lunora/messages.ts
+++ b/templates/nuxt/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/nuxt/lunora/messages.ts
+++ b/templates/nuxt/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/nuxt/lunora/ratelimit/schema.ts
+++ b/templates/nuxt/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/nuxt/lunora/schema.ts
+++ b/templates/nuxt/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/react-router/lunora/messages.ts
+++ b/templates/react-router/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/react-router/lunora/messages.ts
+++ b/templates/react-router/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/react-router/lunora/ratelimit/schema.ts
+++ b/templates/react-router/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/react-router/lunora/schema.ts
+++ b/templates/react-router/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/standalone/lunora/messages.ts
+++ b/templates/standalone/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/standalone/lunora/messages.ts
+++ b/templates/standalone/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/standalone/lunora/ratelimit/schema.ts
+++ b/templates/standalone/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/standalone/lunora/schema.ts
+++ b/templates/standalone/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/sveltekit/lunora/messages.ts
+++ b/templates/sveltekit/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/sveltekit/lunora/messages.ts
+++ b/templates/sveltekit/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/sveltekit/lunora/ratelimit/schema.ts
+++ b/templates/sveltekit/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/sveltekit/lunora/schema.ts
+++ b/templates/sveltekit/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/tanstack-start-react/lunora/messages.ts
+++ b/templates/tanstack-start-react/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/tanstack-start-react/lunora/messages.ts
+++ b/templates/tanstack-start-react/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/tanstack-start-react/lunora/ratelimit/schema.ts
+++ b/templates/tanstack-start-react/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/tanstack-start-react/lunora/schema.ts
+++ b/templates/tanstack-start-react/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);

--- a/templates/tanstack-start-solid/lunora/messages.ts
+++ b/templates/tanstack-start-solid/lunora/messages.ts
@@ -1,17 +1,12 @@
-import { RateLimiter, rateLimit } from "@lunora/ratelimit";
+import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-/**
- * One in-memory limiter so the public `send` mutation isn't an open flood target
- * out of the box. The default store is in-memory (per-isolate, resets on
- * eviction) — fine for a starter; run `lunora add ratelimit` for the durable,
- * `ctx.db`-backed store when you ship to production.
- */
-const limiter = new RateLimiter({
+const limiter = (ctx: { db: unknown }) => new RateLimiter({
     config: {
         send: { kind: "token bucket", period: 60_000, rate: 30 },
     },
+    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
 });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {

--- a/templates/tanstack-start-solid/lunora/messages.ts
+++ b/templates/tanstack-start-solid/lunora/messages.ts
@@ -2,12 +2,13 @@ import { RateLimiter, rateLimit, createDbStore } from "lunorash/ratelimit";
 
 import { mutation, query, v } from "#lunora/_generated/server.js";
 
-const limiter = (ctx: { db: unknown }) => new RateLimiter({
-    config: {
-        send: { kind: "token bucket", period: 60_000, rate: 30 },
-    },
-    store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
-});
+const limiter = (ctx: { db: unknown }) =>
+    new RateLimiter({
+        config: {
+            send: { kind: "token bucket", period: 60_000, rate: 30 },
+        },
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
 
 export const list = query.input({ channelId: v.string().meta({ schema: { maxLength: 256 } }), limit: v.optional(v.number()) }).query(async ({ args, ctx }) => {
     const messages = await ctx.db

--- a/templates/tanstack-start-solid/lunora/ratelimit/schema.ts
+++ b/templates/tanstack-start-solid/lunora/ratelimit/schema.ts
@@ -1,0 +1,46 @@
+/**
+ * Rate-limit schema extension + plugin.
+ *
+ * Defines the `ratelimit_buckets` table used by `createDbStore` for durable,
+ * DO-backed rate limiting. Included automatically in every Lunora project.
+ */
+import type { Middleware } from "lunorash/server";
+import { defineSchemaExtension, defineTable, definePlugin, v } from "lunorash/server";
+import { createDbStore, RateLimiter } from "lunorash/ratelimit";
+import type { RateLimitConfigMap } from "lunorash/ratelimit";
+
+export const limits = {
+    default: { kind: "token bucket", period: 60_000, rate: 10 },
+} as const satisfies RateLimitConfigMap;
+
+export type LimitName = keyof typeof limits;
+
+export const makeRateLimiter = (ctx: { db: unknown }): RateLimiter<LimitName> =>
+    new RateLimiter<LimitName>({
+        config: limits,
+        store: createDbStore({ db: ctx.db as never, table: "ratelimit_buckets" }),
+    });
+
+const middleware: Middleware<{ api?: Record<string, unknown>; db: unknown }, { api: Record<string, unknown>; db: unknown }> = ({ ctx, next }) =>
+    next({
+        ctx: {
+            ...ctx,
+            api: { ...ctx.api, ratelimit: makeRateLimiter(ctx) },
+        },
+    });
+
+export const ratelimit = definePlugin("ratelimit", {
+    extension: defineSchemaExtension("ratelimit", {
+        tables: {
+            buckets: defineTable({
+                key: v.string(),
+                value: v.number(),
+                ts: v.number(),
+                prev: v.optional(v.number()),
+            })
+                .index("by_key", ["key"])
+                .externallyManaged(),
+        },
+    }),
+    middleware,
+});

--- a/templates/tanstack-start-solid/lunora/schema.ts
+++ b/templates/tanstack-start-solid/lunora/schema.ts
@@ -1,3 +1,4 @@
+import { ratelimit } from "./ratelimit/schema.js";
 import { defineSchema, defineTable, v } from "lunorash/server";
 
 export default defineSchema({
@@ -7,4 +8,4 @@ export default defineSchema({
     })
         .shardBy("channelId")
         .index("by_channel", ["channelId"]),
-});
+}).extend(ratelimit.extension);


### PR DESCRIPTION
Fixes all advisor warnings from a fresh `lunora init` template by making `@lunora/ratelimit` a first-class umbrella dep with a durable schema extension.

## Changes

- **`lunorash` umbrella**: added `@lunora/ratelimit` as re-exported dep (`lunorash/ratelimit`)
- **Overlay `apply.ts`**: new `RATELIMIT_SCHEMA` constant with durable `createDbStore<LimitName>` pattern; updated `LUNORA_SCHEMA` and `LUNORA_MESSAGES`
- **8 framework templates**: each gets `lunora/ratelimit/schema.ts`, extends schema with `.extend(ratelimit.extension)`, uses `createDbStore` in `messages.ts`
- **Registry items**: explicit `createMemoryStore()` for backward compat with projects that predate the schema extension
- **CLI registry `apply.ts`**: `@lunora/ratelimit` in umbrella import detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable rate limiting support to generated projects, with database-backed storage and middleware access for API requests.
  * Included a new rate-limiting export so it can be imported directly from the main package.

* **Bug Fixes**
  * Improved package handling so related imports and dependencies are resolved more consistently during setup and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->