### PR TITLE
feat: OTLP telemetry transport for workers and containers

### DIFF
--- a/apps/docs/src/content/docs/concepts/observability.mdx
+++ b/apps/docs/src/content/docs/concepts/observability.mdx
@@ -1,0 +1,182 @@
+---
+title: Observability
+description: Ship Lunora's RPC and log telemetry to any OTLP collector — the otlpSink worker option, the zero-config container exporter, and the one wire contract they share.
+---
+
+Every Lunora function call produces two kinds of telemetry: an **RPC event** (one
+per query/mutation/action — path, duration, ok/error, shard, fan-out) and **log
+events** (the lines your handlers emit). A _sink_ receives them. Locally, the
+Studio groups error events into an **Issues** view with no setup. To watch a
+deployed app you point a sink at an [OpenTelemetry](https://opentelemetry.io/)
+collector — your own, a vendor's, or the Lunora cloud — and the worker **and** any
+container ship the same telemetry over one protocol.
+
+## Sinks
+
+A sink is passed to `createWorker` as the `observability` option. Lunora ships
+several; combine them with `combineSinks`.
+
+| Sink                         | Ships to                                         |
+| ---------------------------- | ------------------------------------------------ |
+| `consoleSink()`              | `console` (local dev)                            |
+| `otlpSink({ endpoint })`     | any OTLP-over-HTTP collector                     |
+| `webhookSink({ url })`       | an arbitrary HTTP endpoint (your own JSON shape) |
+| `sentrySink({ dsn })`        | Sentry                                           |
+| `analyticsEngineSink({ … })` | a Cloudflare Analytics Engine dataset            |
+
+```ts
+import { analyticsEngineSink, combineSinks, otlpSink } from "@lunora/runtime";
+
+export default createWorker({
+    // …schema, functions…
+    observability: combineSinks(
+        otlpSink({ endpoint: env.LUNORA_OTLP_ENDPOINT, token: env.LUNORA_OTLP_TOKEN }),
+        analyticsEngineSink({ dataset: env.ANALYTICS }),
+    ),
+});
+```
+
+Every sink accepts `onlyErrors: true` to drop successful RPC events and export
+only failures (log events always pass through).
+
+### `otlpSink`
+
+```ts
+otlpSink({
+    endpoint: env.LUNORA_OTLP_ENDPOINT, // required — the collector base URL
+    token: env.LUNORA_OTLP_TOKEN, // optional — sent as `Authorization: Bearer <token>`
+    headers: { "x-lunora-deployment": env.LUNORA_DEPLOYMENT_ID }, // optional correlation headers
+    serviceName: "my-app", // optional — the `service.name` resource attribute (default `"lunora"`)
+    onlyErrors: false, // optional — export only error spans
+});
+```
+
+Read `endpoint`/`token` from the environment so the platform can inject them at
+deploy time with no code change. Each event is one fire-and-forget POST; on a
+Worker it is registered with `waitUntil` so it outlives the response.
+
+## Container telemetry
+
+Code running **inside** a [container](/docs/packages/container) can't use a worker
+sink — it is a separate process. `@lunora/container/otel` gives it a zero-config exporter that
+speaks the exact same wire contract, so container spans and worker spans land in
+the same collector side by side.
+
+```ts
+import { createContainerTelemetry } from "@lunora/container/otel";
+
+// Reads LUNORA_OTLP_ENDPOINT / LUNORA_OTLP_TOKEN from the container env.
+const telemetry = createContainerTelemetry();
+
+// Time a unit of work — records an ok span, or an error span if it throws.
+const result = await telemetry.trace("transcode", () => transcode(job), { jobId: job.id });
+
+telemetry.emitLog({ level: "info", message: "done", attributes: { jobId: job.id } });
+
+// Before the process exits, flush any in-flight sends.
+await telemetry.flush();
+```
+
+With no endpoint resolvable the exporter is a **silent no-op** (`telemetry.enabled
+=== false`) — `trace` still runs your work, it just records nothing. The same code
+runs unchanged locally and in the cloud.
+
+Thread the endpoint/token into the container the same way any other config
+reaches it — declare them on `defineContainer`:
+
+```ts
+defineContainer({
+    name: "transcoder",
+    // …
+    env: { LUNORA_OTLP_ENDPOINT: env.LUNORA_OTLP_ENDPOINT },
+    secrets: ["LUNORA_OTLP_TOKEN"],
+    // The collector host must be reachable from the container egress allow-list.
+    allowedHosts: ["collector.example.com"],
+});
+```
+
+## The wire contract
+
+Both the worker `otlpSink` and the container exporter conform to one contract, so
+any OTLP-compatible collector — and the Lunora cloud ingest — accepts either
+without special-casing.
+
+**Transport.** [OTLP over HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp)
+with **JSON** encoding (not protobuf). Two endpoints, derived from the configured
+base `endpoint` (trailing slashes are tolerated):
+
+| Signal | Request                     |
+| ------ | --------------------------- |
+| Spans  | `POST {endpoint}/v1/traces` |
+| Logs   | `POST {endpoint}/v1/logs`   |
+
+**Headers.**
+
+| Header                             | Value                                                     |
+| ---------------------------------- | --------------------------------------------------------- |
+| `content-type`                     | `application/json`                                        |
+| `authorization`                    | `Bearer <token>` — when a `token` is configured           |
+| `x-lunora-deployment` (convention) | the deployment id, for the ingest to attribute the sender |
+| `x-lunora-org` (convention)        | the organization id                                       |
+
+The `x-lunora-*` headers are a convention the cloud ingest reads to route
+telemetry; pass them through the `headers` option. A collector that ignores them
+still accepts the payload.
+
+**Encoding.** Bodies are standard OTLP `ExportTraceServiceRequest` /
+`ExportLogsServiceRequest` JSON. Per the OTLP/JSON spec:
+
+- `traceId` is 16 random bytes as **32 lowercase hex** chars; `spanId` is 8 bytes
+  as **16 hex** chars (the documented exception to proto3 JSON's base64 `bytes`).
+- `timeUnixNano` fields are the **nanoseconds since the epoch as a decimal
+  string** (Lunora works in millis, so this is the millisecond value followed by
+  six zeros — exact).
+- `resource` carries a `service.name` attribute; the instrumentation `scope.name`
+  is `@lunora/runtime` (worker) or `@lunora/container` (container).
+- Attribute values follow the OTLP `AnyValue` union — strings as `stringValue`,
+  booleans as `boolValue`, integers as `intValue` (a decimal string), floats as
+  `doubleValue`.
+
+**Span shape.** One span per RPC event (worker) or per `trace`/`emitSpan`
+(container):
+
+| Field               | Worker (`otlpSink`)                        | Container      |
+| ------------------- | ------------------------------------------ | -------------- |
+| `kind`              | `2` (SERVER)                               | `1` (INTERNAL) |
+| `startTimeUnixNano` | end − `durationMs`                         | your `startMs` |
+| `status.code`       | `1` ok / `2` error (with `status.message`) | same           |
+
+Worker spans carry these attributes:
+
+| Attribute              | When         | Value                                   |
+| ---------------------- | ------------ | --------------------------------------- |
+| `lunora.function_path` | always       | the function path, e.g. `messages:list` |
+| `lunora.ok`            | always       | boolean                                 |
+| `lunora.shard_key`     | if sharded   | the shard key                           |
+| `error.type`           | on error     | the Lunora error `code`                 |
+| `lunora.error_status`  | on error     | the HTTP/RPC status (int)               |
+| `lunora.fanout.table`  | on a fan-out | the table fanned across                 |
+| `lunora.fanout.shards` | on a fan-out | shard count (int)                       |
+| `lunora.fanout.failed` | on a fan-out | failed-shard count (int)                |
+
+Container spans carry whatever `attributes` you pass, plus `error.type` when the
+work throws.
+
+**Log record shape.** `body.stringValue` is the message; `severityText` is the
+upper-cased level; `severityNumber` maps as:
+
+| Level          | `severityNumber` |
+| -------------- | ---------------- |
+| `debug`        | 5                |
+| `info` / `log` | 9                |
+| `warn`         | 13               |
+| `error`        | 17               |
+
+Worker log records also carry `lunora.function_path`, and `lunora.shard_key` /
+`lunora.user_id` when known.
+
+## Privacy
+
+Spans carry `error.type` and error messages, and log records carry the rendered
+message — either can include user-supplied input. Point `endpoint` only at a
+collector you trust, and use `onlyErrors` to narrow what leaves the deployment.

--- a/apps/docs/src/content/docs/concepts/observability.mdx
+++ b/apps/docs/src/content/docs/concepts/observability.mdx
@@ -81,6 +81,10 @@ With no endpoint resolvable the exporter is a **silent no-op** (`telemetry.enabl
 === false`) — `trace` still runs your work, it just records nothing. The same code
 runs unchanged locally and in the cloud.
 
+Each POST is bounded by `timeoutMs` (default 10s), so a hung collector aborts
+instead of pinning a send in flight and stalling `flush()`; failures are handed to
+the optional `onError` callback and never break the container.
+
 Thread the endpoint/token into the container the same way any other config
 reaches it — declare them on `defineContainer`:
 

--- a/apps/docs/src/content/docs/meta.json
+++ b/apps/docs/src/content/docs/meta.json
@@ -57,6 +57,7 @@
         "concepts/best-practices",
         "---Operations---",
         "deployment",
+        "concepts/observability",
         "architecture",
         "limits",
         "---Reference---",

--- a/packages/container/__tests__/otel.test.ts
+++ b/packages/container/__tests__/otel.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { OtelFetchLike } from "../src/otel";
+import { createContainerTelemetry } from "../src/otel";
+
+/** One OTLP `AnyValue`, as decoded from a POSTed body. */
+interface OtlpValue {
+    boolValue?: boolean;
+    doubleValue?: number;
+    intValue?: string;
+    stringValue?: string;
+}
+
+/** One OTLP `KeyValue` attribute. */
+interface OtlpKeyValue {
+    key: string;
+    value: OtlpValue;
+}
+
+/** A decoded OTLP span. */
+interface ParsedSpan {
+    attributes: OtlpKeyValue[];
+    endTimeUnixNano: string;
+    kind: number;
+    name: string;
+    spanId: string;
+    startTimeUnixNano: string;
+    status: { code: number; message?: string };
+    traceId: string;
+}
+
+/** A decoded OTLP log record. */
+interface ParsedLogRecord {
+    attributes: OtlpKeyValue[];
+    body: { stringValue: string };
+    severityNumber: number;
+    severityText: string;
+    timeUnixNano: string;
+}
+
+const TRACE_ID_HEX = /^[0-9a-f]{32}$/;
+const SPAN_ID_HEX = /^[0-9a-f]{16}$/;
+const UNIX_NANO = /^\d+000000$/;
+
+/** A fetch stub recording every request; resolves `{ ok, status }`. */
+const stubFetch = (
+    init: { ok?: boolean; status?: number } = {},
+): { calls: { body: string; headers: Record<string, string>; url: string }[]; fetch: OtelFetchLike } => {
+    const calls: { body: string; headers: Record<string, string>; url: string }[] = [];
+
+    const fetch: OtelFetchLike = async (url, requestInit) => {
+        calls.push({ body: requestInit.body, headers: requestInit.headers, url });
+
+        return { ok: init.ok ?? true, status: init.status ?? 200 };
+    };
+
+    return { calls, fetch };
+};
+
+/** Find an attribute value by key. */
+const attrValue = (attributes: OtlpKeyValue[], key: string): OtlpValue | undefined => attributes.find((attribute) => attribute.key === key)?.value;
+
+/** Decode a POSTed OTLP trace-export body into its single span. */
+const spanFrom = (body: string): { resourceAttributes: OtlpKeyValue[]; scopeName: string; span: ParsedSpan } => {
+    const parsed = JSON.parse(body) as {
+        resourceSpans: { resource: { attributes: OtlpKeyValue[] }; scopeSpans: { scope: { name: string }; spans: ParsedSpan[] }[] }[];
+    };
+    const resourceSpan = parsed.resourceSpans[0]!;
+    const scopeSpan = resourceSpan.scopeSpans[0]!;
+
+    return { resourceAttributes: resourceSpan.resource.attributes, scopeName: scopeSpan.scope.name, span: scopeSpan.spans[0]! };
+};
+
+/** Decode a POSTed OTLP log-export body into its single record. */
+const logFrom = (body: string): { record: ParsedLogRecord; resourceAttributes: OtlpKeyValue[]; scopeName: string } => {
+    const parsed = JSON.parse(body) as {
+        resourceLogs: { resource: { attributes: OtlpKeyValue[] }; scopeLogs: { logRecords: ParsedLogRecord[]; scope: { name: string } }[] }[];
+    };
+    const resourceLog = parsed.resourceLogs[0]!;
+    const scopeLog = resourceLog.scopeLogs[0]!;
+
+    return { record: scopeLog.logRecords[0]!, resourceAttributes: resourceLog.resource.attributes, scopeName: scopeLog.scope.name };
+};
+
+describe(createContainerTelemetry, () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("is disabled and no-ops when no endpoint resolves", async () => {
+        expect.assertions(3);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ fetch });
+
+        expect(telemetry.enabled).toBe(false);
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        telemetry.emitLog({ message: "hi" });
+        await telemetry.flush();
+
+        expect(calls).toHaveLength(0);
+        // `trace` still runs its work even when disabled.
+        await expect(telemetry.trace("op", async () => 42)).resolves.toBe(42);
+    });
+
+    it("resolves the endpoint from LUNORA_OTLP_ENDPOINT", async () => {
+        expect.assertions(2);
+
+        vi.stubEnv("LUNORA_OTLP_ENDPOINT", "https://collect.example.com");
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ fetch });
+
+        expect(telemetry.enabled).toBe(true);
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        expect(calls[0]!.url).toBe("https://collect.example.com/v1/traces");
+    });
+
+    it("posts a well-formed span for a successful operation", async () => {
+        expect.assertions(9);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ attributes: { jobId: "j1" }, endMs: 10, name: "transcode", startMs: 5 });
+        await telemetry.flush();
+
+        expect(calls[0]!.url).toBe("https://collect.example.com/v1/traces");
+
+        const { resourceAttributes, scopeName, span } = spanFrom(calls[0]!.body);
+
+        expect(span.name).toBe("transcode");
+        // SPAN_KIND_INTERNAL / STATUS_CODE_OK.
+        expect(span.kind).toBe(1);
+        expect(span.status.code).toBe(1);
+        expect(span.traceId).toMatch(TRACE_ID_HEX);
+        expect(span.spanId).toMatch(SPAN_ID_HEX);
+        expect(attrValue(span.attributes, "jobId")?.stringValue).toBe("j1");
+        expect(attrValue(resourceAttributes, "service.name")?.stringValue).toBe("lunora-container");
+        expect(scopeName).toBe("@lunora/container");
+    });
+
+    it("marks an errored span with status ERROR, message, and error.type", async () => {
+        expect.assertions(4);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ endMs: 10, error: { message: "boom", type: "RangeError" }, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        // STATUS_CODE_ERROR.
+        expect(span.status.code).toBe(2);
+        expect(span.status.message).toBe("boom");
+        expect(attrValue(span.attributes, "error.type")?.stringValue).toBe("RangeError");
+        expect(span.name).toBe("op");
+    });
+
+    it("encodes start/end as nanosecond strings with exact ms→ns precision", async () => {
+        expect.assertions(3);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ endMs: 1005, name: "op", startMs: 1000 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(span.startTimeUnixNano).toMatch(UNIX_NANO);
+        expect(span.endTimeUnixNano).toMatch(UNIX_NANO);
+        expect(BigInt(span.endTimeUnixNano) - BigInt(span.startTimeUnixNano)).toBe(BigInt(5 * 1_000_000));
+    });
+
+    it("encodes attribute value kinds by JS type", async () => {
+        expect.assertions(4);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ attributes: { count: 3, ok: true, ratio: 1.5, tag: "x" }, endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(attrValue(span.attributes, "count")?.intValue).toBe("3");
+        expect(attrValue(span.attributes, "ratio")?.doubleValue).toBe(1.5);
+        expect(attrValue(span.attributes, "ok")?.boolValue).toBe(true);
+        expect(attrValue(span.attributes, "tag")?.stringValue).toBe("x");
+    });
+
+    it("posts a well-formed log record with mapped severity", async () => {
+        expect.assertions(6);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitLog({ attributes: { jobId: "j1" }, level: "warn", message: "slow", ts: 1700 });
+        await telemetry.flush();
+
+        expect(calls[0]!.url).toBe("https://collect.example.com/v1/logs");
+
+        const { record, scopeName } = logFrom(calls[0]!.body);
+
+        expect(record.body.stringValue).toBe("slow");
+        expect(record.severityNumber).toBe(13);
+        expect(record.severityText).toBe("WARN");
+        expect(attrValue(record.attributes, "jobId")?.stringValue).toBe("j1");
+        expect(scopeName).toBe("@lunora/container");
+    });
+
+    it("maps each log level to its OTLP severity number and defaults to info", async () => {
+        expect.assertions(1);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitLog({ level: "debug", message: "d" });
+        telemetry.emitLog({ level: "error", message: "e" });
+        telemetry.emitLog({ level: "info", message: "i" });
+        telemetry.emitLog({ message: "default" });
+        telemetry.emitLog({ level: "warn", message: "w" });
+        await telemetry.flush();
+
+        expect(calls.map((call) => logFrom(call.body).record.severityNumber)).toStrictEqual([5, 17, 9, 9, 13]);
+    });
+
+    it("tolerates a trailing slash on the endpoint", async () => {
+        expect.assertions(2);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com///", fetch });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        telemetry.emitLog({ message: "hi" });
+        await telemetry.flush();
+
+        expect(calls[0]!.url).toBe("https://collect.example.com/v1/traces");
+        expect(calls[1]!.url).toBe("https://collect.example.com/v1/logs");
+    });
+
+    it("sends a bearer token and merges headers case-insensitively", async () => {
+        expect.assertions(3);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({
+            endpoint: "https://collect.example.com",
+            fetch,
+            headers: { "Content-Type": "application/json; charset=utf-8", "x-lunora-deployment": "dep-1" },
+            token: "svc-token",
+        });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        expect(calls[0]!.headers.authorization).toBe("Bearer svc-token");
+        expect(calls[0]!.headers["x-lunora-deployment"]).toBe("dep-1");
+        // A cased `Content-Type` override replaces the default rather than duplicating it.
+        expect(calls[0]!.headers["content-type"]).toBe("application/json; charset=utf-8");
+    });
+
+    it("honors a custom serviceName on spans and logs", async () => {
+        expect.assertions(2);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch, serviceName: "transcoder" });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        telemetry.emitLog({ message: "hi" });
+        await telemetry.flush();
+
+        expect(attrValue(spanFrom(calls[0]!.body).resourceAttributes, "service.name")?.stringValue).toBe("transcoder");
+        expect(attrValue(logFrom(calls[1]!.body).resourceAttributes, "service.name")?.stringValue).toBe("transcoder");
+    });
+
+    it("times a successful trace() and returns its value", async () => {
+        expect.assertions(4);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        const result = await telemetry.trace("op", async () => 42, { k: "v" });
+
+        await telemetry.flush();
+
+        expect(result).toBe(42);
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(span.name).toBe("op");
+        expect(span.status.code).toBe(1);
+        expect(attrValue(span.attributes, "k")?.stringValue).toBe("v");
+    });
+
+    it("records an errored span and rethrows when trace()'s work throws", async () => {
+        expect.assertions(4);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        await expect(
+            telemetry.trace("op", async () => {
+                throw new TypeError("boom");
+            }),
+        ).rejects.toThrow("boom");
+
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(span.status.code).toBe(2);
+        expect(span.status.message).toBe("boom");
+        expect(attrValue(span.attributes, "error.type")?.stringValue).toBe("TypeError");
+    });
+
+    it("reports a rejected send to onError without throwing", async () => {
+        expect.assertions(2);
+
+        const onError = vi.fn<(error: unknown) => void>();
+        const failing: OtelFetchLike = async () => {
+            throw new Error("network down");
+        };
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch: failing, onError });
+
+        expect(() => {
+            telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        }).not.toThrow();
+
+        await telemetry.flush();
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it("reports a missing fetch to onError without throwing", async () => {
+        expect.assertions(2);
+
+        vi.stubGlobal("fetch", undefined);
+        const onError = vi.fn<(error: unknown) => void>();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", onError });
+
+        expect(() => {
+            telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        }).not.toThrow();
+        expect(onError).toHaveBeenCalledWith(expect.any(TypeError));
+    });
+});

--- a/packages/container/__tests__/otel.test.ts
+++ b/packages/container/__tests__/otel.test.ts
@@ -350,4 +350,103 @@ describe(createContainerTelemetry, () => {
         }).not.toThrow();
         expect(onError).toHaveBeenCalledWith(expect.any(TypeError));
     });
+
+    it("cancels the response body so the socket can be released", async () => {
+        expect.assertions(2);
+
+        const cancel = vi.fn<() => Promise<void>>().mockResolvedValue();
+        const fetch: OtelFetchLike = async () => {
+            return { body: { cancel }, ok: true, status: 200 };
+        };
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        telemetry.emitLog({ message: "hi" });
+        await telemetry.flush();
+
+        expect(cancel).toHaveBeenCalledTimes(2);
+        // A response without a body (e.g. 204) must not throw.
+        expect(cancel).toHaveBeenCalledWith();
+    });
+
+    it("passes an abort signal on every POST", async () => {
+        expect.assertions(1);
+
+        let signal: AbortSignal | undefined;
+        const fetch: OtelFetchLike = async (_url, init) => {
+            signal = init.signal;
+
+            return { ok: true, status: 200 };
+        };
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        expect(signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("aborts a hung POST after timeoutMs so flush can complete", async () => {
+        expect.assertions(3);
+
+        const onError = vi.fn<(error: unknown) => void>();
+        let signal: AbortSignal | undefined;
+        // Only settles when its abort signal fires — without the timeout, flush would hang forever.
+        const hanging: OtelFetchLike = (_url, init) => {
+            signal = init.signal;
+
+            return new Promise((_resolve, reject) => {
+                init.signal?.addEventListener("abort", () => {
+                    reject(new Error("aborted"));
+                });
+            });
+        };
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch: hanging, onError, timeoutMs: 5 });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        expect(onError).toHaveBeenCalledTimes(1);
+        // The bound came from the per-request timeout, not a manual abort.
+        expect(signal?.aborted).toBe(true);
+        expect((signal?.reason as Error).name).toBe("TimeoutError");
+    });
+
+    it("reports a non-2xx collector response to onError and still releases the socket", async () => {
+        expect.assertions(2);
+
+        const onError = vi.fn<(error: unknown) => void>();
+        const cancel = vi.fn<() => Promise<void>>().mockResolvedValue();
+        // A rejected export (bad token / wrong path / 5xx) resolves, but not ok.
+        const rejecting: OtelFetchLike = async () => {
+            return { body: { cancel }, ok: false, status: 401 };
+        };
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch: rejecting, onError });
+
+        telemetry.emitSpan({ endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        // The socket is released for keep-alive reuse even on a rejected export.
+        expect(cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("encodes non-finite and unsafe-integer attributes as valid OTLP", async () => {
+        expect.assertions(3);
+
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch });
+
+        telemetry.emitSpan({ attributes: { big: 1e21, count: 3, ratio: Number.NaN }, endMs: 10, name: "op", startMs: 0 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        // NaN has no valid AnyValue → falls back to a string, not JSON `null`.
+        expect(attrValue(span.attributes, "ratio")).toStrictEqual({ stringValue: "NaN" });
+        // A value beyond 2^53 can't be a proto3 int64 decimal string → doubleValue.
+        expect(attrValue(span.attributes, "big")).toStrictEqual({ doubleValue: 1e21 });
+        // A safe integer stays an `intValue` decimal string.
+        expect(attrValue(span.attributes, "count")).toStrictEqual({ intValue: "3" });
+    });
 });

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -46,6 +46,10 @@
             "types": "./dist/bridge.d.ts",
             "import": "./dist/bridge.mjs"
         },
+        "./otel": {
+            "types": "./dist/otel.d.ts",
+            "import": "./dist/otel.mjs"
+        },
         "./package.json": "./package.json"
     },
     "publishConfig": {

--- a/packages/container/src/otel.ts
+++ b/packages/container/src/otel.ts
@@ -1,0 +1,362 @@
+/**
+ * `@lunora/container/otel` — a zero-config OTLP exporter for container code.
+ *
+ * The in-container process (any JS runtime — Node, Bun, Deno) uses this to ship
+ * its own spans and logs to the same OTLP collector the Worker's `otlpSink`
+ * targets, so container and Worker telemetry land side by side. It reads the
+ * collector endpoint + bearer the platform injects as container env
+ * (`LUNORA_OTLP_ENDPOINT` / `LUNORA_OTLP_TOKEN`); with no endpoint configured it
+ * degrades to a silent no-op, so a container never fails for want of telemetry.
+ *
+ * Pure `fetch` over OTLP-over-HTTP (JSON) — no `@opentelemetry/*` dependency and
+ * no Cloudflare imports — so it runs in any container and is unit-testable with
+ * an injected `fetch`. Each span/log is one fire-and-forget POST; `flush()`
+ * awaits in-flight sends before the process exits. Reaching the collector still
+ * requires the container's egress allow-list to include its host (declare it on
+ * `defineContainer({ allowedHosts })` or via `handle.egress.allow(host)`).
+ */
+
+/** An attribute value carried on a span or log. */
+type ContainerAttributeValue = boolean | number | string;
+
+/**
+ * A `fetch` implementation — defaults to the runtime global. Only the promise's
+ * settlement matters to the exporter; the response body is never read.
+ */
+type OtelFetchLike = (input: string, init: { body: string; headers: Record<string, string>; method: string }) => Promise<{ ok: boolean; status: number }>;
+
+/** A single span the container process asks the exporter to record. */
+interface ContainerSpanInput {
+    /** Attributes attached to the span (rendered under the OTLP `attributes` list). */
+    attributes?: Record<string, ContainerAttributeValue>;
+    /** Wall-clock millis when the operation ended. */
+    endMs: number;
+    /** When set, the span is marked errored with this message (and optional `error.type`). */
+    error?: { message: string; type?: string };
+    /** Span name — the operation being timed, e.g. `"transcode"`. */
+    name: string;
+    /** Wall-clock millis when the operation started. */
+    startMs: number;
+}
+
+/** A single log line the container process asks the exporter to record. */
+interface ContainerLogInput {
+    /** Attributes attached to the log record. */
+    attributes?: Record<string, ContainerAttributeValue>;
+    /** Severity — defaults to `"info"`. */
+    level?: "debug" | "error" | "info" | "warn";
+    /** The log message body. */
+    message: string;
+    /** Wall-clock millis the line was emitted; defaults to now. */
+    ts?: number;
+}
+
+/** Options for {@link createContainerTelemetry}. */
+interface ContainerTelemetryOptions {
+    /** Base OTLP collector endpoint; defaults to the `LUNORA_OTLP_ENDPOINT` env var. */
+    endpoint?: string;
+    /** Injectable `fetch` (tests / non-global runtimes). Defaults to `globalThis.fetch`. */
+    fetch?: OtelFetchLike;
+    /** Extra headers merged onto every POST — e.g. deployment/org correlation. `content-type` is set by default. */
+    headers?: Record<string, string>;
+    /** Called with any send failure so the caller can surface it; the export itself always swallows. */
+    onError?: (error: unknown) => void;
+    /** `service.name` resource attribute; defaults to the `LUNORA_SERVICE_NAME` env var then `"lunora-container"`. */
+    serviceName?: string;
+    /** Bearer token sent as an `Authorization: Bearer` header; defaults to the `LUNORA_OTLP_TOKEN` env var. */
+    token?: string;
+}
+
+/** The exporter handle {@link createContainerTelemetry} returns. */
+interface ContainerTelemetry {
+    /** Record one log line (no-op when disabled). */
+    emitLog: (log: ContainerLogInput) => void;
+    /** Record one span (no-op when disabled). */
+    emitSpan: (span: ContainerSpanInput) => void;
+    /** True when an endpoint resolved and exports are actually sent. */
+    readonly enabled: boolean;
+    /** Await all in-flight sends — call before the process exits. */
+    flush: () => Promise<void>;
+    /** Time `run()`, recording a span named `name` (ok, or errored if it throws). Always runs `run()`, even when disabled. */
+    trace: <T>(name: string, run: () => Promise<T>, attributes?: Record<string, ContainerAttributeValue>) => Promise<T>;
+}
+
+/** OTLP log severity numbers keyed by {@link ContainerLogInput.level}. */
+const SEVERITY: Record<NonNullable<ContainerLogInput["level"]>, number> = {
+    debug: 5, // DEBUG
+    error: 17, // ERROR
+    info: 9, // INFO
+    warn: 13, // WARN
+};
+
+/** One OTLP `AnyValue` — the JSON encoding of a typed attribute value. */
+type OtlpValue = { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string };
+
+/** One OTLP `KeyValue` attribute. */
+interface OtlpAttribute {
+    key: string;
+    value: OtlpValue;
+}
+
+/**
+ * Read an environment variable, tolerating runtimes without a `process` global
+ * (e.g. Deno without node-compat) so the caller's explicit options still work.
+ */
+const readEnv = (name: string): string | undefined => {
+    if (typeof process === "undefined") {
+        return undefined;
+    }
+
+    return process.env[name];
+};
+
+/** Resolve the `fetch` to use: the injected one, else the runtime global, else undefined. */
+const resolveFetch = (injected: OtelFetchLike | undefined): OtelFetchLike | undefined => {
+    if (injected !== undefined) {
+        return injected;
+    }
+
+    if (typeof globalThis.fetch === "function") {
+        return globalThis.fetch;
+    }
+
+    return undefined;
+};
+
+/**
+ * Encode ms as an OTLP `*UnixNano` string. proto3 JSON represents uint64 as a
+ * decimal string, and ms→ns is ×10^6, so the six trailing zeros are exact.
+ */
+const unixNano = (ms: number): string => `${String(Math.round(ms))}000000`;
+
+/**
+ * A random lowercase hex id of `bytes` length. OTLP/JSON encodes `trace_id`/
+ * `span_id` as hex strings (the one documented exception to proto3 JSON's
+ * base64 `bytes` encoding). Uses the Web Crypto global (present in Node ≥19,
+ * Bun, Deno) — no Node built-in import.
+ */
+const randomHex = (bytes: number): string => {
+    const buffer = new Uint8Array(bytes);
+
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the WebCrypto `crypto` global is stable in Node ≥19, Bun, Deno, and workerd; engines guarantee Node ≥22.15
+    crypto.getRandomValues(buffer);
+
+    let hex = "";
+
+    for (const byte of buffer) {
+        hex += byte.toString(16).padStart(2, "0");
+    }
+
+    return hex;
+};
+
+/** Encode one attribute, picking the OTLP value kind from the JS type. */
+const encodeAttribute = (key: string, value: ContainerAttributeValue): OtlpAttribute => {
+    if (typeof value === "boolean") {
+        return { key, value: { boolValue: value } };
+    }
+
+    if (typeof value === "number") {
+        // int64s are decimal strings in proto3 JSON; non-integers use doubleValue.
+        return Number.isInteger(value) ? { key, value: { intValue: String(value) } } : { key, value: { doubleValue: value } };
+    }
+
+    return { key, value: { stringValue: value } };
+};
+
+/** Encode an attribute bag into the OTLP `KeyValue` list. */
+const encodeAttributes = (attributes: Record<string, ContainerAttributeValue> | undefined): OtlpAttribute[] => {
+    if (attributes === undefined) {
+        return [];
+    }
+
+    return Object.entries(attributes).map(([key, value]) => encodeAttribute(key, value));
+};
+
+/** Build the OTLP trace-export body for one container span. */
+const traceBody = (span: ContainerSpanInput, serviceName: string): unknown => {
+    const attributes = encodeAttributes(span.attributes);
+
+    if (span.error?.type !== undefined) {
+        attributes.push({ key: "error.type", value: { stringValue: span.error.type } });
+    }
+
+    const otlpSpan = {
+        attributes,
+        endTimeUnixNano: unixNano(span.endMs),
+        // SPAN_KIND_INTERNAL — the container's own work, not a server/client edge.
+        kind: 1,
+        name: span.name,
+        spanId: randomHex(8),
+        startTimeUnixNano: unixNano(span.startMs),
+        // STATUS_CODE_OK (1) / STATUS_CODE_ERROR (2).
+        status: span.error === undefined ? { code: 1 } : { code: 2, message: span.error.message },
+        traceId: randomHex(16),
+    };
+
+    return {
+        resourceSpans: [
+            {
+                resource: { attributes: [{ key: "service.name", value: { stringValue: serviceName } }] },
+                scopeSpans: [{ scope: { name: "@lunora/container" }, spans: [otlpSpan] }],
+            },
+        ],
+    };
+};
+
+/** Build the OTLP log-export body for one container log line. */
+const logBody = (log: ContainerLogInput, serviceName: string, nowMs: number): unknown => {
+    const level = log.level ?? "info";
+
+    const record = {
+        attributes: encodeAttributes(log.attributes),
+        body: { stringValue: log.message },
+        severityNumber: SEVERITY[level],
+        severityText: level.toUpperCase(),
+        timeUnixNano: unixNano(log.ts ?? nowMs),
+    };
+
+    return {
+        resourceLogs: [
+            {
+                resource: { attributes: [{ key: "service.name", value: { stringValue: serviceName } }] },
+                scopeLogs: [{ logRecords: [record], scope: { name: "@lunora/container" } }],
+            },
+        ],
+    };
+};
+
+/**
+ * Case-insensitively build the POST headers: a default `content-type`, the
+ * caller's `overrides` (deduped by lowercased name so a `Content-Type` override
+ * replaces rather than duplicates the default), and a bearer `authorization`
+ * from `token` (which wins over any caller-supplied authorization).
+ */
+const buildHeaders = (overrides: Record<string, string> | undefined, token: string | undefined): Record<string, string> => {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    const seen = new Map<string, string>([["content-type", "content-type"]]);
+
+    for (const [name, value] of Object.entries(overrides ?? {})) {
+        const lower = name.toLowerCase();
+        const existing = seen.get(lower);
+
+        if (existing === undefined) {
+            seen.set(lower, name);
+            headers[name] = value;
+        } else {
+            headers[existing] = value;
+        }
+    }
+
+    if (token !== undefined && token.length > 0) {
+        headers[seen.get("authorization") ?? "authorization"] = `Bearer ${token}`;
+    }
+
+    return headers;
+};
+
+/**
+ * Create a zero-config OTLP exporter for the container process.
+ *
+ * ```ts
+ * const telemetry = createContainerTelemetry(); // reads LUNORA_OTLP_ENDPOINT / _TOKEN
+ * await telemetry.trace("transcode", () => transcode(job), { jobId: job.id });
+ * telemetry.emitLog({ level: "info", message: "done", attributes: { jobId: job.id } });
+ * await telemetry.flush(); // before the process exits
+ * ```
+ *
+ * With no endpoint resolvable the returned exporter is disabled (`enabled ===
+ * false`): `emitSpan`/`emitLog` no-op and `trace` still runs its work but records
+ * nothing — so the same code runs unchanged locally and in the cloud.
+ * @param options Exporter options; every field falls back to a `LUNORA_*` env var.
+ */
+const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): ContainerTelemetry => {
+    const endpoint = options.endpoint ?? readEnv("LUNORA_OTLP_ENDPOINT");
+    const enabled = endpoint !== undefined && endpoint.length > 0;
+    const token = options.token ?? readEnv("LUNORA_OTLP_TOKEN");
+    const serviceName = options.serviceName ?? readEnv("LUNORA_SERVICE_NAME") ?? "lunora-container";
+    const fetchImpl = resolveFetch(options.fetch);
+    const headers = buildHeaders(options.headers, token);
+
+    // Strip trailing slashes without a regex (ReDoS-linter friendly).
+    let base = endpoint ?? "";
+
+    while (base.endsWith("/")) {
+        base = base.slice(0, -1);
+    }
+
+    const tracesUrl = `${base}/v1/traces`;
+    const logsUrl = `${base}/v1/logs`;
+    const inflight = new Set<Promise<void>>();
+
+    const send = (url: string, body: unknown): void => {
+        if (!enabled) {
+            return;
+        }
+
+        const post = fetchImpl;
+
+        if (post === undefined) {
+            options.onError?.(new TypeError("createContainerTelemetry: no `fetch` available — pass `fetch` in options for this runtime."));
+
+            return;
+        }
+
+        // `dispatch` catches its own errors (including a synchronous `fetch` throw on
+        // e.g. an invalid URL), so the tracked chain never rejects and telemetry never
+        // breaks the container.
+        const dispatch = async (): Promise<void> => {
+            try {
+                await post(url, { body: JSON.stringify(body), headers, method: "POST" });
+            } catch (error) {
+                options.onError?.(error);
+            }
+        };
+
+        // Remove from the in-flight set once settled to bound memory over a long run.
+        const settled: Promise<void> = dispatch().finally(() => {
+            inflight.delete(settled);
+        });
+
+        inflight.add(settled);
+    };
+
+    const emitSpan = (span: ContainerSpanInput): void => {
+        send(tracesUrl, traceBody(span, serviceName));
+    };
+
+    const emitLog = (log: ContainerLogInput): void => {
+        send(logsUrl, logBody(log, serviceName, Date.now()));
+    };
+
+    const trace = async <T>(name: string, run: () => Promise<T>, attributes?: Record<string, ContainerAttributeValue>): Promise<T> => {
+        const startMs = Date.now();
+
+        try {
+            const result = await run();
+
+            emitSpan({ attributes, endMs: Date.now(), name, startMs });
+
+            return result;
+        } catch (error) {
+            emitSpan({
+                attributes,
+                endMs: Date.now(),
+                error: { message: error instanceof Error ? error.message : String(error), type: error instanceof Error ? error.name : undefined },
+                name,
+                startMs,
+            });
+
+            throw error;
+        }
+    };
+
+    const flush = async (): Promise<void> => {
+        await Promise.allSettled(inflight);
+    };
+
+    return { emitLog, emitSpan, enabled, flush, trace };
+};
+
+export type { ContainerAttributeValue, ContainerLogInput, ContainerSpanInput, ContainerTelemetry, ContainerTelemetryOptions, OtelFetchLike };
+export { createContainerTelemetry };

--- a/packages/container/src/otel.ts
+++ b/packages/container/src/otel.ts
@@ -10,20 +10,41 @@
  *
  * Pure `fetch` over OTLP-over-HTTP (JSON) — no `@opentelemetry/*` dependency and
  * no Cloudflare imports — so it runs in any container and is unit-testable with
- * an injected `fetch`. Each span/log is one fire-and-forget POST; `flush()`
- * awaits in-flight sends before the process exits. Reaching the collector still
- * requires the container's egress allow-list to include its host (declare it on
- * `defineContainer({ allowedHosts })` or via `handle.egress.allow(host)`).
+ * an injected `fetch`. Each span/log is one fire-and-forget POST, bounded by a
+ * per-request timeout (`timeoutMs`) so a hung collector can never pin a send in
+ * flight; `flush()` awaits the in-flight sends before the process exits.
+ * Reaching the collector still requires the container's egress allow-list to
+ * include its host (declare it on `defineContainer({ allowedHosts })` or via
+ * `handle.egress.allow(host)`).
+ *
+ * The OTLP/JSON wire encoding is shared with the worker `otlpSink` via
+ * `shared/otlp.ts` — one contract, bundler-inlined into both packages.
  */
+import {
+    encodeAttribute,
+    encodeAttributes,
+    mergeHeaders,
+    OTLP_SEVERITY,
+    otlpRandomHex,
+    otlpUnixNano,
+    wrapResourceLogs,
+    wrapResourceSpans,
+} from "../../../shared/otlp";
 
 /** An attribute value carried on a span or log. */
 type ContainerAttributeValue = boolean | number | string;
 
 /**
- * A `fetch` implementation — defaults to the runtime global. Only the promise's
- * settlement matters to the exporter; the response body is never read.
+ * A `fetch` implementation — defaults to the runtime global. The exporter passes
+ * an abort `signal` (for the per-request timeout) and, once the promise settles,
+ * cancels the response `body` so Node/undici can release the socket for
+ * keep-alive reuse instead of leaving it occupied by an unread stream. It reads
+ * `ok`/`status` to detect a rejected export and nothing else from the response.
  */
-type OtelFetchLike = (input: string, init: { body: string; headers: Record<string, string>; method: string }) => Promise<{ ok: boolean; status: number }>;
+type OtelFetchLike = (
+    input: string,
+    init: { body: string; headers: Record<string, string>; method: string; signal?: AbortSignal },
+) => Promise<{ body?: { cancel: () => Promise<void> } | null; ok: boolean; status: number }>;
 
 /** A single span the container process asks the exporter to record. */
 interface ContainerSpanInput {
@@ -63,9 +84,14 @@ interface ContainerTelemetryOptions {
     onError?: (error: unknown) => void;
     /** `service.name` resource attribute; defaults to the `LUNORA_SERVICE_NAME` env var then `"lunora-container"`. */
     serviceName?: string;
+    /** Per-POST timeout in ms; a collector that never responds aborts after this so a stuck send can't stall `flush()`. Defaults to {@link DEFAULT_TIMEOUT_MS} (10s). */
+    timeoutMs?: number;
     /** Bearer token sent as an `Authorization: Bearer` header; defaults to the `LUNORA_OTLP_TOKEN` env var. */
     token?: string;
 }
+
+/** Default {@link ContainerTelemetryOptions.timeoutMs} — the OTLP-exporter-conventional 10s. */
+const DEFAULT_TIMEOUT_MS = 10_000;
 
 /** The exporter handle {@link createContainerTelemetry} returns. */
 interface ContainerTelemetry {
@@ -79,23 +105,6 @@ interface ContainerTelemetry {
     flush: () => Promise<void>;
     /** Time `run()`, recording a span named `name` (ok, or errored if it throws). Always runs `run()`, even when disabled. */
     trace: <T>(name: string, run: () => Promise<T>, attributes?: Record<string, ContainerAttributeValue>) => Promise<T>;
-}
-
-/** OTLP log severity numbers keyed by {@link ContainerLogInput.level}. */
-const SEVERITY: Record<NonNullable<ContainerLogInput["level"]>, number> = {
-    debug: 5, // DEBUG
-    error: 17, // ERROR
-    info: 9, // INFO
-    warn: 13, // WARN
-};
-
-/** One OTLP `AnyValue` — the JSON encoding of a typed attribute value. */
-type OtlpValue = { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string };
-
-/** One OTLP `KeyValue` attribute. */
-interface OtlpAttribute {
-    key: string;
-    value: OtlpValue;
 }
 
 /**
@@ -123,85 +132,28 @@ const resolveFetch = (injected: OtelFetchLike | undefined): OtelFetchLike | unde
     return undefined;
 };
 
-/**
- * Encode ms as an OTLP `*UnixNano` string. proto3 JSON represents uint64 as a
- * decimal string, and ms→ns is ×10^6, so the six trailing zeros are exact.
- */
-const unixNano = (ms: number): string => `${String(Math.round(ms))}000000`;
-
-/**
- * A random lowercase hex id of `bytes` length. OTLP/JSON encodes `trace_id`/
- * `span_id` as hex strings (the one documented exception to proto3 JSON's
- * base64 `bytes` encoding). Uses the Web Crypto global (present in Node ≥19,
- * Bun, Deno) — no Node built-in import.
- */
-const randomHex = (bytes: number): string => {
-    const buffer = new Uint8Array(bytes);
-
-    // eslint-disable-next-line n/no-unsupported-features/node-builtins -- the WebCrypto `crypto` global is stable in Node ≥19, Bun, Deno, and workerd; engines guarantee Node ≥22.15
-    crypto.getRandomValues(buffer);
-
-    let hex = "";
-
-    for (const byte of buffer) {
-        hex += byte.toString(16).padStart(2, "0");
-    }
-
-    return hex;
-};
-
-/** Encode one attribute, picking the OTLP value kind from the JS type. */
-const encodeAttribute = (key: string, value: ContainerAttributeValue): OtlpAttribute => {
-    if (typeof value === "boolean") {
-        return { key, value: { boolValue: value } };
-    }
-
-    if (typeof value === "number") {
-        // int64s are decimal strings in proto3 JSON; non-integers use doubleValue.
-        return Number.isInteger(value) ? { key, value: { intValue: String(value) } } : { key, value: { doubleValue: value } };
-    }
-
-    return { key, value: { stringValue: value } };
-};
-
-/** Encode an attribute bag into the OTLP `KeyValue` list. */
-const encodeAttributes = (attributes: Record<string, ContainerAttributeValue> | undefined): OtlpAttribute[] => {
-    if (attributes === undefined) {
-        return [];
-    }
-
-    return Object.entries(attributes).map(([key, value]) => encodeAttribute(key, value));
-};
-
 /** Build the OTLP trace-export body for one container span. */
 const traceBody = (span: ContainerSpanInput, serviceName: string): unknown => {
     const attributes = encodeAttributes(span.attributes);
 
     if (span.error?.type !== undefined) {
-        attributes.push({ key: "error.type", value: { stringValue: span.error.type } });
+        attributes.push(encodeAttribute("error.type", span.error.type));
     }
 
     const otlpSpan = {
         attributes,
-        endTimeUnixNano: unixNano(span.endMs),
+        endTimeUnixNano: otlpUnixNano(span.endMs),
         // SPAN_KIND_INTERNAL — the container's own work, not a server/client edge.
         kind: 1,
         name: span.name,
-        spanId: randomHex(8),
-        startTimeUnixNano: unixNano(span.startMs),
+        spanId: otlpRandomHex(8),
+        startTimeUnixNano: otlpUnixNano(span.startMs),
         // STATUS_CODE_OK (1) / STATUS_CODE_ERROR (2).
         status: span.error === undefined ? { code: 1 } : { code: 2, message: span.error.message },
-        traceId: randomHex(16),
+        traceId: otlpRandomHex(16),
     };
 
-    return {
-        resourceSpans: [
-            {
-                resource: { attributes: [{ key: "service.name", value: { stringValue: serviceName } }] },
-                scopeSpans: [{ scope: { name: "@lunora/container" }, spans: [otlpSpan] }],
-            },
-        ],
-    };
+    return wrapResourceSpans(otlpSpan, "@lunora/container", serviceName);
 };
 
 /** Build the OTLP log-export body for one container log line. */
@@ -211,48 +163,12 @@ const logBody = (log: ContainerLogInput, serviceName: string, nowMs: number): un
     const record = {
         attributes: encodeAttributes(log.attributes),
         body: { stringValue: log.message },
-        severityNumber: SEVERITY[level],
+        severityNumber: OTLP_SEVERITY[level],
         severityText: level.toUpperCase(),
-        timeUnixNano: unixNano(log.ts ?? nowMs),
+        timeUnixNano: otlpUnixNano(log.ts ?? nowMs),
     };
 
-    return {
-        resourceLogs: [
-            {
-                resource: { attributes: [{ key: "service.name", value: { stringValue: serviceName } }] },
-                scopeLogs: [{ logRecords: [record], scope: { name: "@lunora/container" } }],
-            },
-        ],
-    };
-};
-
-/**
- * Case-insensitively build the POST headers: a default `content-type`, the
- * caller's `overrides` (deduped by lowercased name so a `Content-Type` override
- * replaces rather than duplicates the default), and a bearer `authorization`
- * from `token` (which wins over any caller-supplied authorization).
- */
-const buildHeaders = (overrides: Record<string, string> | undefined, token: string | undefined): Record<string, string> => {
-    const headers: Record<string, string> = { "content-type": "application/json" };
-    const seen = new Map<string, string>([["content-type", "content-type"]]);
-
-    for (const [name, value] of Object.entries(overrides ?? {})) {
-        const lower = name.toLowerCase();
-        const existing = seen.get(lower);
-
-        if (existing === undefined) {
-            seen.set(lower, name);
-            headers[name] = value;
-        } else {
-            headers[existing] = value;
-        }
-    }
-
-    if (token !== undefined && token.length > 0) {
-        headers[seen.get("authorization") ?? "authorization"] = `Bearer ${token}`;
-    }
-
-    return headers;
+    return wrapResourceLogs(record, "@lunora/container", serviceName);
 };
 
 /**
@@ -275,8 +191,9 @@ const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): Cont
     const enabled = endpoint !== undefined && endpoint.length > 0;
     const token = options.token ?? readEnv("LUNORA_OTLP_TOKEN");
     const serviceName = options.serviceName ?? readEnv("LUNORA_SERVICE_NAME") ?? "lunora-container";
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const fetchImpl = resolveFetch(options.fetch);
-    const headers = buildHeaders(options.headers, token);
+    const headers = mergeHeaders({ "content-type": "application/json" }, options.headers, token);
 
     // Strip trailing slashes without a regex (ReDoS-linter friendly).
     let base = endpoint ?? "";
@@ -289,14 +206,10 @@ const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): Cont
     const logsUrl = `${base}/v1/logs`;
     const inflight = new Set<Promise<void>>();
 
+    // Only reached from `emitSpan`/`emitLog`, which already gate on `enabled`, so
+    // the disabled path never builds a body or touches `fetch`.
     const send = (url: string, body: unknown): void => {
-        if (!enabled) {
-            return;
-        }
-
-        const post = fetchImpl;
-
-        if (post === undefined) {
+        if (fetchImpl === undefined) {
             options.onError?.(new TypeError("createContainerTelemetry: no `fetch` available — pass `fetch` in options for this runtime."));
 
             return;
@@ -307,7 +220,28 @@ const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): Cont
         // breaks the container.
         const dispatch = async (): Promise<void> => {
             try {
-                await post(url, { body: JSON.stringify(body), headers, method: "POST" });
+                // `AbortSignal.timeout` bounds the POST: a hung collector aborts
+                // after `timeoutMs` instead of pinning this send in `inflight` and
+                // stalling `flush()`. Its internal timer is unref'd, so it never
+                // keeps the container process alive on its own.
+                const response = await fetchImpl(url, { body: JSON.stringify(body), headers, method: "POST", signal: AbortSignal.timeout(timeoutMs) });
+
+                // A non-2xx collector response (bad token, wrong base path, payload
+                // too large, 5xx) is a real send failure the caller must be able to
+                // see — `onError` is the container's only telemetry feedback channel.
+                if (!response.ok) {
+                    options.onError?.(new Error(`createContainerTelemetry: OTLP export to ${url} failed with status ${String(response.status)}.`));
+                }
+
+                // Cancel the response body so Node/undici can return the socket to
+                // the keep-alive pool rather than leaving it occupied by an unread
+                // stream over a long-lived container run. A rejecting `cancel()` is
+                // not a send failure, so it is swallowed here rather than reported.
+                try {
+                    await response.body?.cancel();
+                } catch {
+                    // Best-effort socket release; ignore.
+                }
             } catch (error) {
                 options.onError?.(error);
             }
@@ -322,10 +256,18 @@ const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): Cont
     };
 
     const emitSpan = (span: ContainerSpanInput): void => {
+        if (!enabled) {
+            return;
+        }
+
         send(tracesUrl, traceBody(span, serviceName));
     };
 
     const emitLog = (log: ContainerLogInput): void => {
+        if (!enabled) {
+            return;
+        }
+
         send(logsUrl, logBody(log, serviceName, Date.now()));
     };
 

--- a/packages/container/tsconfig.json
+++ b/packages/container/tsconfig.json
@@ -1,10 +1,13 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["@cloudflare/workers-types", "node"]
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): `lint:types`
+        // is `tsc --noEmit` and the real build is packem (driven by package.json
+        // exports), so neither is load-bearing here. A set `rootDir` would raise
+        // TS6059 for the inlined `../../../shared/otlp` import (a file outside this
+        // package, bundled in at build time). See shared/otlp.ts.
     },
     "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/runtime/__tests__/observability-sinks.test.ts
+++ b/packages/runtime/__tests__/observability-sinks.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { LogEvent, ObservabilityEvent } from "../src/observability";
+import type { LogEvent, LogLevel, ObservabilityEvent } from "../src/observability";
 import type { AnalyticsEngineDataPointLike } from "../src/observability-sinks";
-import { analyticsEngineSink, combineSinks, consoleSink, sentrySink, webhookSink } from "../src/observability-sinks";
+import { analyticsEngineSink, combineSinks, consoleSink, otlpSink, sentrySink, webhookSink } from "../src/observability-sinks";
 
 const okEvent: ObservabilityEvent = { durationMs: 5, functionPath: "messages:list", ok: true, shardKey: "channel-1" };
 const errorEvent: ObservabilityEvent = {
@@ -11,6 +11,72 @@ const errorEvent: ObservabilityEvent = {
     functionPath: "messages:send",
     ok: false,
     shardKey: "channel-1",
+};
+
+/** A 16-byte trace id, hex-encoded per the OTLP/JSON `trace_id` exception. */
+const TRACE_ID_HEX = /^[0-9a-f]{32}$/;
+/** An 8-byte span id, hex-encoded per the OTLP/JSON `span_id` exception. */
+const SPAN_ID_HEX = /^[0-9a-f]{16}$/;
+/** A `*UnixNano` value derived from whole milliseconds — the six trailing zeros are exact. */
+const UNIX_NANO = /^\d+000000$/;
+
+/** One OTLP `AnyValue`, as it appears in the JSON wire form. */
+interface OtlpValue {
+    boolValue?: boolean;
+    doubleValue?: number;
+    intValue?: string;
+    stringValue?: string;
+}
+
+/** One OTLP `KeyValue` attribute. */
+interface OtlpKeyValue {
+    key: string;
+    value: OtlpValue;
+}
+
+/** The subset of an OTLP span the tests assert on. */
+interface ParsedSpan {
+    attributes: OtlpKeyValue[];
+    endTimeUnixNano: string;
+    kind: number;
+    name: string;
+    spanId: string;
+    startTimeUnixNano: string;
+    status: { code: number; message?: string };
+    traceId: string;
+}
+
+/** The subset of an OTLP log record the tests assert on. */
+interface ParsedLogRecord {
+    attributes: OtlpKeyValue[];
+    body: OtlpValue;
+    severityNumber: number;
+    severityText: string;
+    timeUnixNano: string;
+}
+
+/** Look up an attribute's value by key. */
+const attrValue = (attributes: OtlpKeyValue[], key: string): OtlpValue | undefined => attributes.find((entry) => entry.key === key)?.value;
+
+/** Decode a POSTed OTLP trace-export body down to its single span + resource attributes. */
+const spanFrom = (init: RequestInit): { resourceAttributes: OtlpKeyValue[]; scopeName: string; span: ParsedSpan } => {
+    const parsed = JSON.parse(init.body as string) as {
+        resourceSpans: { resource: { attributes: OtlpKeyValue[] }; scopeSpans: { scope: { name: string }; spans: ParsedSpan[] }[] }[];
+    };
+    const resourceSpan = parsed.resourceSpans[0]!;
+    const scopeSpan = resourceSpan.scopeSpans[0]!;
+
+    return { resourceAttributes: resourceSpan.resource.attributes, scopeName: scopeSpan.scope.name, span: scopeSpan.spans[0]! };
+};
+
+/** Decode a POSTed OTLP log-export body down to its single log record + resource attributes. */
+const logFrom = (init: RequestInit): { record: ParsedLogRecord; resourceAttributes: OtlpKeyValue[] } => {
+    const parsed = JSON.parse(init.body as string) as {
+        resourceLogs: { resource: { attributes: OtlpKeyValue[] }; scopeLogs: { logRecords: ParsedLogRecord[]; scope: { name: string } }[] }[];
+    };
+    const resourceLog = parsed.resourceLogs[0]!;
+
+    return { record: resourceLog.scopeLogs[0]!.logRecords[0]!, resourceAttributes: resourceLog.resource.attributes };
 };
 
 describe("observability-sinks", () => {
@@ -452,6 +518,314 @@ describe("observability-sinks", () => {
                     },
                 },
             });
+
+            expect(() => {
+                sink.onRpc!(okEvent);
+            }).not.toThrow();
+        });
+    });
+
+    describe("otlpSink", () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+            vi.unstubAllGlobals();
+        });
+
+        it("posts a well-formed OTLP span to the traces endpoint for an ok rpc event", () => {
+            expect.assertions(9);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onRpc!(okEvent);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+
+            expect(url).toBe("https://collector.example/v1/traces");
+            expect(init.method).toBe("POST");
+
+            const { resourceAttributes, span } = spanFrom(init);
+
+            expect(attrValue(resourceAttributes, "service.name")).toStrictEqual({ stringValue: "lunora" });
+            expect(span.name).toBe("messages:list");
+            // SPAN_KIND_SERVER — a dispatched RPC is server-side handling.
+            expect(span.kind).toBe(2);
+            // STATUS_CODE_OK, with no status message.
+            expect(span.status).toStrictEqual({ code: 1 });
+            expect(span.traceId).toMatch(TRACE_ID_HEX);
+            expect(span.spanId).toMatch(SPAN_ID_HEX);
+        });
+
+        it("encodes error status, error.type, and the status message for a failed event", () => {
+            expect.assertions(4);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onRpc!(errorEvent);
+
+            const { span } = spanFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
+
+            // STATUS_CODE_ERROR carries the human-readable message.
+            expect(span.status).toStrictEqual({ code: 2, message: "boom: user@example.com" });
+            expect(attrValue(span.attributes, "error.type")).toStrictEqual({ stringValue: "CONFLICT" });
+            expect(attrValue(span.attributes, "lunora.error_status")).toStrictEqual({ intValue: "409" });
+            expect(attrValue(span.attributes, "lunora.ok")).toStrictEqual({ boolValue: false });
+        });
+
+        it("derives span start and end from durationMs at nanosecond precision", () => {
+            expect.assertions(3);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onRpc!(okEvent);
+
+            const { span } = spanFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
+
+            expect(span.startTimeUnixNano).toMatch(UNIX_NANO);
+            expect(span.endTimeUnixNano).toMatch(UNIX_NANO);
+            // end - start must equal durationMs (5ms) in nanos, exactly — BigInt
+            // avoids the double-rounding a ~1.7e18 nanosecond value would suffer.
+            expect(BigInt(span.endTimeUnixNano) - BigInt(span.startTimeUnixNano)).toBe(BigInt(5 * 1_000_000));
+        });
+
+        it("records fan-out cardinality and the aggregated table as attributes", () => {
+            expect.assertions(4);
+
+            const fanOutEvent: ObservabilityEvent = {
+                durationMs: 12,
+                fanOut: { failed: 1, shards: 4, table: "messages" },
+                functionPath: "messages:countAll",
+                ok: true,
+            };
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onRpc!(fanOutEvent);
+
+            const { span } = spanFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
+
+            expect(attrValue(span.attributes, "lunora.fanout.table")).toStrictEqual({ stringValue: "messages" });
+            expect(attrValue(span.attributes, "lunora.fanout.shards")).toStrictEqual({ intValue: "4" });
+            expect(attrValue(span.attributes, "lunora.fanout.failed")).toStrictEqual({ intValue: "1" });
+            // A fan-out has no single shard key.
+            expect(attrValue(span.attributes, "lunora.shard_key")).toBeUndefined();
+        });
+
+        it("posts a well-formed OTLP log record to the logs endpoint", () => {
+            expect.assertions(6);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onLog!({ args: ["hi"], functionPath: "messages:list", level: "info", message: "hello", shardKey: "channel-1", ts: 1700, userId: "user-1" });
+
+            const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+
+            expect(url).toBe("https://collector.example/v1/logs");
+
+            const { record } = logFrom(init);
+
+            expect(record.body).toStrictEqual({ stringValue: "hello" });
+            expect(record.severityNumber).toBe(9);
+            expect(record.severityText).toBe("INFO");
+            // ts (1700ms) → nanos with six trailing zeros.
+            expect(record.timeUnixNano).toBe("1700000000");
+            expect(attrValue(record.attributes, "lunora.user_id")).toStrictEqual({ stringValue: "user-1" });
+        });
+
+        it("maps each log level to its OTLP severity number", () => {
+            expect.assertions(1);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+            const levels: LogLevel[] = ["debug", "error", "info", "log", "warn"];
+
+            for (const level of levels) {
+                sink.onLog!({ args: [], functionPath: "a:b", level, message: "m", ts: 1 });
+            }
+
+            const numbers = fetchMock.mock.calls.map((call) => logFrom(call[1] as RequestInit).record.severityNumber);
+
+            // debug=DEBUG(5), error=ERROR(17), info=INFO(9), log→INFO(9), warn=WARN(13).
+            expect(numbers).toStrictEqual([5, 17, 9, 9, 13]);
+        });
+
+        it("tolerates a trailing slash on the endpoint", () => {
+            expect.assertions(1);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example///" });
+
+            sink.onRpc!(okEvent);
+
+            const [url] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+
+            expect(url).toBe("https://collector.example/v1/traces");
+        });
+
+        it("skips ok rpc spans when onlyErrors is set but still exports logs", () => {
+            expect.assertions(3);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example", onlyErrors: true });
+
+            sink.onRpc!(okEvent);
+
+            expect(fetchMock).not.toHaveBeenCalled();
+
+            sink.onRpc!(errorEvent);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            // onlyErrors scopes the RPC span stream, not developer log lines.
+            sink.onLog!({ args: [], functionPath: "a:b", level: "info", message: "m", ts: 1 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it("merges auth and correlation headers onto a default content-type", () => {
+            expect.assertions(1);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({
+                endpoint: "https://collector.example",
+                headers: { authorization: "Bearer tok", "x-lunora-deployment": "dep_1", "x-lunora-org": "org_1" },
+            });
+
+            sink.onRpc!(okEvent);
+
+            const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+
+            expect(init.headers).toStrictEqual({
+                authorization: "Bearer tok",
+                "content-type": "application/json",
+                "x-lunora-deployment": "dep_1",
+                "x-lunora-org": "org_1",
+            });
+        });
+
+        it("adds a Bearer token that overrides any authorization in headers", () => {
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({
+                endpoint: "https://collector.example",
+                headers: { Authorization: "Bearer stale" },
+                token: "svc-token",
+            });
+
+            sink.onRpc!(okEvent);
+
+            const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const sentHeaders = init.headers as Record<string, string>;
+            const authKeys = Object.keys(sentHeaders).filter((key) => key.toLowerCase() === "authorization");
+
+            // The token wins over the stale header, without introducing a second key.
+            expect(sentHeaders[authKeys[0]!]).toBe("Bearer svc-token");
+            expect(authKeys).toHaveLength(1);
+        });
+
+        it("lets a differently-cased content-type override the default without duplicating it", () => {
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example", headers: { "Content-Type": "application/x-protobuf" } });
+
+            sink.onRpc!(okEvent);
+
+            const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+            const sentHeaders = init.headers as Record<string, string>;
+
+            expect(sentHeaders["content-type"]).toBe("application/x-protobuf");
+            expect(Object.keys(sentHeaders).filter((key) => key.toLowerCase() === "content-type")).toHaveLength(1);
+        });
+
+        it("sets a custom service.name resource attribute on spans and logs", () => {
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example", serviceName: "checkout-api" });
+
+            sink.onRpc!(okEvent);
+            sink.onLog!({ args: [], functionPath: "a:b", level: "info", message: "m", ts: 1 });
+
+            const { resourceAttributes: spanResource } = spanFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
+            const { resourceAttributes: logResource } = logFrom((fetchMock.mock.calls[1] as unknown as [string, RequestInit])[1]);
+
+            expect(attrValue(spanResource, "service.name")).toStrictEqual({ stringValue: "checkout-api" });
+            expect(attrValue(logResource, "service.name")).toStrictEqual({ stringValue: "checkout-api" });
+        });
+
+        it("registers the send with ctx.waitUntil when a request context is provided", () => {
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const waitUntil = vi.fn<(promise: Promise<unknown>) => void>();
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onRpc!(okEvent, { waitUntil });
+
+            expect(waitUntil).toHaveBeenCalledTimes(1);
+            expect(waitUntil).toHaveBeenCalledWith(expect.any(Promise));
+        });
+
+        it("swallows a rejected fetch", async () => {
+            expect.assertions(1);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => {
+                throw new Error("collector down");
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            expect(() => {
+                sink.onRpc!(okEvent);
+            }).not.toThrow();
+
+            // Let the rejected promise settle without an unhandled rejection.
+            await Promise.resolve();
+        });
+
+        it("swallows a synchronous fetch throw", () => {
+            expect.assertions(1);
+
+            const fetchMock = vi.fn<typeof fetch>(() => {
+                throw new Error("invalid url");
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "not-a-url" });
 
             expect(() => {
                 sink.onRpc!(okEvent);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -76,10 +76,11 @@ export type {
     AnalyticsEngineDataPointLike,
     AnalyticsEngineDatasetLike,
     AnalyticsEngineSinkOptions,
+    OtlpSinkOptions,
     SentrySinkOptions,
     WebhookSinkOptions,
 } from "./observability-sinks";
-export { analyticsEngineSink, combineSinks, consoleSink, sentrySink, webhookSink } from "./observability-sinks";
+export { analyticsEngineSink, combineSinks, consoleSink, otlpSink, sentrySink, webhookSink } from "./observability-sinks";
 export type {
     ExportFanOutRequest,
     ExportFanOutResult,

--- a/packages/runtime/src/observability-sinks.ts
+++ b/packages/runtime/src/observability-sinks.ts
@@ -18,7 +18,8 @@
  * third party. Scrub or redact before enabling it against an external service
  * if that is a concern.
  */
-import type { LogEvent, LogLevel, ObservabilityEvent, ObservabilitySink, ObservabilitySinkContext } from "./observability";
+import { encodeAttribute, mergeHeaders, OTLP_SEVERITY, otlpRandomHex, otlpUnixNano, wrapResourceLogs, wrapResourceSpans } from "../../../shared/otlp";
+import type { LogEvent, ObservabilityEvent, ObservabilitySink, ObservabilitySinkContext } from "./observability";
 
 /** Shared shape for sinks that can be limited to error events only. */
 interface OnlyErrorsOption {
@@ -29,128 +30,25 @@ interface OnlyErrorsOption {
 /** Returns true when the event should be skipped under an `onlyErrors` filter. */
 const shouldSkip = (event: ObservabilityEvent, onlyErrors: boolean | undefined): boolean => onlyErrors === true && event.ok;
 
-/**
- * Case-insensitively merge `overrides` onto `defaults`, with `overrides`
- * winning. HTTP header names are case-insensitive, so a naive object spread of
- * `{ "content-type": ..., ...overrides }` would keep BOTH `content-type` and a
- * user-supplied `Content-Type` as distinct object keys; the `fetch`/`Headers`
- * constructor then *combines* them ("application/json, text/plain") instead of
- * letting the caller override. Normalising the key first guarantees a single,
- * caller-controlled value per header.
- */
-const mergeHeaders = (defaults: Record<string, string>, overrides: Record<string, string> | undefined): Record<string, string> => {
-    if (!overrides) {
-        return { ...defaults };
-    }
-
-    const merged: Record<string, string> = {};
-    const seen = new Map<string, string>();
-
-    for (const [name, value] of Object.entries(defaults)) {
-        const lower = name.toLowerCase();
-
-        seen.set(lower, name);
-        merged[name] = value;
-    }
-
-    for (const [name, value] of Object.entries(overrides)) {
-        const lower = name.toLowerCase();
-        const existing = seen.get(lower);
-
-        if (existing === undefined) {
-            seen.set(lower, name);
-            merged[name] = value;
-        } else {
-            // Replace the existing key's value in place so the override wins
-            // without introducing a second, differently-cased duplicate.
-            merged[existing] = value;
-        }
-    }
-
-    return merged;
-};
-
-/**
- * OTLP log severity numbers (`SeverityNumber` in the spec) keyed by Lunora
- * {@link LogLevel}. `log` has no distinct OTLP level, so it maps to INFO like a
- * plain `console.log`.
- */
-const OTLP_SEVERITY: Record<LogLevel, number> = {
-    debug: 5, // DEBUG
-    error: 17, // ERROR
-    info: 9, // INFO
-    log: 9, // INFO
-    warn: 13, // WARN
-};
-
-/** One OTLP `AnyValue` — the JSON encoding of a typed attribute value. */
-type OtlpAnyValue = { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string };
-
-/** One OTLP `KeyValue` attribute. */
-interface OtlpAttribute {
-    key: string;
-    value: OtlpAnyValue;
-}
-
-const stringAttribute = (key: string, value: string): OtlpAttribute => {
-    return { key, value: { stringValue: value } };
-};
-
-const boolAttribute = (key: string, value: boolean): OtlpAttribute => {
-    return { key, value: { boolValue: value } };
-};
-
-/** OTLP int64 values are decimal strings in proto3 JSON. */
-const intAttribute = (key: string, value: number): OtlpAttribute => {
-    return { key, value: { intValue: String(Math.trunc(value)) } };
-};
-
-/**
- * Encode wall-clock milliseconds as an OTLP `*UnixNano` string. proto3 JSON
- * represents uint64 as a decimal string, and ms→ns is ×10^6, so the six
- * trailing zeros are exact — no `BigInt`, no float rounding.
- */
-const otlpUnixNano = (ms: number): string => `${String(Math.round(ms))}000000`;
-
-/**
- * A random 16-char-per-8-byte lowercase hex id. OTLP/JSON is explicit that
- * `trace_id`/`span_id` are hex strings (the one documented exception to proto3
- * JSON's base64 `bytes` encoding), so this is the correct on-wire form. Uses
- * the Web Crypto global (present in workerd and Node ≥18) — no Node built-in.
- */
-const otlpRandomHex = (bytes: number): string => {
-    const buffer = new Uint8Array(bytes);
-
-    crypto.getRandomValues(buffer);
-
-    let hex = "";
-
-    for (const byte of buffer) {
-        hex += byte.toString(16).padStart(2, "0");
-    }
-
-    return hex;
-};
-
 /** Build the OTLP trace-export body for one RPC dispatch event. */
 const otlpTraceBody = (event: ObservabilityEvent, serviceName: string, endMs: number): unknown => {
-    const attributes: OtlpAttribute[] = [stringAttribute("lunora.function_path", event.functionPath), boolAttribute("lunora.ok", event.ok)];
+    const attributes = [encodeAttribute("lunora.function_path", event.functionPath), encodeAttribute("lunora.ok", event.ok)];
 
     if (event.shardKey !== undefined) {
-        attributes.push(stringAttribute("lunora.shard_key", event.shardKey));
+        attributes.push(encodeAttribute("lunora.shard_key", event.shardKey));
     }
 
     if (event.error) {
         // `error.type` is the OTel semantic-convention key; keep the numeric
         // HTTP-ish status under the lunora namespace.
-        attributes.push(stringAttribute("error.type", event.error.code), intAttribute("lunora.error_status", event.error.status));
+        attributes.push(encodeAttribute("error.type", event.error.code), encodeAttribute("lunora.error_status", event.error.status));
     }
 
     if (event.fanOut) {
         attributes.push(
-            stringAttribute("lunora.fanout.table", event.fanOut.table),
-            intAttribute("lunora.fanout.shards", event.fanOut.shards),
-            intAttribute("lunora.fanout.failed", event.fanOut.failed),
+            encodeAttribute("lunora.fanout.table", event.fanOut.table),
+            encodeAttribute("lunora.fanout.shards", event.fanOut.shards),
+            encodeAttribute("lunora.fanout.failed", event.fanOut.failed),
         );
     }
 
@@ -167,26 +65,19 @@ const otlpTraceBody = (event: ObservabilityEvent, serviceName: string, endMs: nu
         traceId: otlpRandomHex(16),
     };
 
-    return {
-        resourceSpans: [
-            {
-                resource: { attributes: [stringAttribute("service.name", serviceName)] },
-                scopeSpans: [{ scope: { name: "@lunora/runtime" }, spans: [span] }],
-            },
-        ],
-    };
+    return wrapResourceSpans(span, "@lunora/runtime", serviceName);
 };
 
 /** Build the OTLP log-export body for one application log line. */
 const otlpLogBody = (event: LogEvent, serviceName: string): unknown => {
-    const attributes: OtlpAttribute[] = [stringAttribute("lunora.function_path", event.functionPath)];
+    const attributes = [encodeAttribute("lunora.function_path", event.functionPath)];
 
     if (event.shardKey !== undefined) {
-        attributes.push(stringAttribute("lunora.shard_key", event.shardKey));
+        attributes.push(encodeAttribute("lunora.shard_key", event.shardKey));
     }
 
     if (event.userId !== undefined) {
-        attributes.push(stringAttribute("lunora.user_id", event.userId));
+        attributes.push(encodeAttribute("lunora.user_id", event.userId));
     }
 
     const logRecord = {
@@ -197,14 +88,7 @@ const otlpLogBody = (event: LogEvent, serviceName: string): unknown => {
         timeUnixNano: otlpUnixNano(event.ts),
     };
 
-    return {
-        resourceLogs: [
-            {
-                resource: { attributes: [stringAttribute("service.name", serviceName)] },
-                scopeLogs: [{ logRecords: [logRecord], scope: { name: "@lunora/runtime" } }],
-            },
-        ],
-    };
+    return wrapResourceLogs(logRecord, "@lunora/runtime", serviceName);
 };
 
 /** POST an OTLP payload fire-and-forget, keeping it alive past the response when a request context is present. */
@@ -538,13 +422,9 @@ export const otlpSink = (options: OtlpSinkOptions): ObservabilitySink => {
 
     const tracesUrl = `${base}/v1/traces`;
     const logsUrl = `${base}/v1/logs`;
-    let mergedHeaders = mergeHeaders({ "content-type": "application/json" }, headers);
-
-    // Apply the `token` convenience last so it wins over any authorization in
-    // `headers`, matching the container exporter's precedence.
-    if (token !== undefined && token.length > 0) {
-        mergedHeaders = mergeHeaders(mergedHeaders, { authorization: `Bearer ${token}` });
-    }
+    // `token` is applied last (inside `mergeHeaders`) so it wins over any
+    // authorization in `headers`, matching the container exporter's precedence.
+    const mergedHeaders = mergeHeaders({ "content-type": "application/json" }, headers, token);
 
     return {
         onLog: (event, context) => {

--- a/packages/runtime/src/observability-sinks.ts
+++ b/packages/runtime/src/observability-sinks.ts
@@ -18,7 +18,7 @@
  * third party. Scrub or redact before enabling it against an external service
  * if that is a concern.
  */
-import type { LogEvent, ObservabilityEvent, ObservabilitySink, ObservabilitySinkContext } from "./observability";
+import type { LogEvent, LogLevel, ObservabilityEvent, ObservabilitySink, ObservabilitySinkContext } from "./observability";
 
 /** Shared shape for sinks that can be limited to error events only. */
 interface OnlyErrorsOption {
@@ -68,6 +68,160 @@ const mergeHeaders = (defaults: Record<string, string>, overrides: Record<string
     }
 
     return merged;
+};
+
+/**
+ * OTLP log severity numbers (`SeverityNumber` in the spec) keyed by Lunora
+ * {@link LogLevel}. `log` has no distinct OTLP level, so it maps to INFO like a
+ * plain `console.log`.
+ */
+const OTLP_SEVERITY: Record<LogLevel, number> = {
+    debug: 5, // DEBUG
+    error: 17, // ERROR
+    info: 9, // INFO
+    log: 9, // INFO
+    warn: 13, // WARN
+};
+
+/** One OTLP `AnyValue` — the JSON encoding of a typed attribute value. */
+type OtlpAnyValue = { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string };
+
+/** One OTLP `KeyValue` attribute. */
+interface OtlpAttribute {
+    key: string;
+    value: OtlpAnyValue;
+}
+
+const stringAttribute = (key: string, value: string): OtlpAttribute => {
+    return { key, value: { stringValue: value } };
+};
+
+const boolAttribute = (key: string, value: boolean): OtlpAttribute => {
+    return { key, value: { boolValue: value } };
+};
+
+/** OTLP int64 values are decimal strings in proto3 JSON. */
+const intAttribute = (key: string, value: number): OtlpAttribute => {
+    return { key, value: { intValue: String(Math.trunc(value)) } };
+};
+
+/**
+ * Encode wall-clock milliseconds as an OTLP `*UnixNano` string. proto3 JSON
+ * represents uint64 as a decimal string, and ms→ns is ×10^6, so the six
+ * trailing zeros are exact — no `BigInt`, no float rounding.
+ */
+const otlpUnixNano = (ms: number): string => `${String(Math.round(ms))}000000`;
+
+/**
+ * A random 16-char-per-8-byte lowercase hex id. OTLP/JSON is explicit that
+ * `trace_id`/`span_id` are hex strings (the one documented exception to proto3
+ * JSON's base64 `bytes` encoding), so this is the correct on-wire form. Uses
+ * the Web Crypto global (present in workerd and Node ≥18) — no Node built-in.
+ */
+const otlpRandomHex = (bytes: number): string => {
+    const buffer = new Uint8Array(bytes);
+
+    crypto.getRandomValues(buffer);
+
+    let hex = "";
+
+    for (const byte of buffer) {
+        hex += byte.toString(16).padStart(2, "0");
+    }
+
+    return hex;
+};
+
+/** Build the OTLP trace-export body for one RPC dispatch event. */
+const otlpTraceBody = (event: ObservabilityEvent, serviceName: string, endMs: number): unknown => {
+    const attributes: OtlpAttribute[] = [stringAttribute("lunora.function_path", event.functionPath), boolAttribute("lunora.ok", event.ok)];
+
+    if (event.shardKey !== undefined) {
+        attributes.push(stringAttribute("lunora.shard_key", event.shardKey));
+    }
+
+    if (event.error) {
+        // `error.type` is the OTel semantic-convention key; keep the numeric
+        // HTTP-ish status under the lunora namespace.
+        attributes.push(stringAttribute("error.type", event.error.code), intAttribute("lunora.error_status", event.error.status));
+    }
+
+    if (event.fanOut) {
+        attributes.push(
+            stringAttribute("lunora.fanout.table", event.fanOut.table),
+            intAttribute("lunora.fanout.shards", event.fanOut.shards),
+            intAttribute("lunora.fanout.failed", event.fanOut.failed),
+        );
+    }
+
+    const span = {
+        attributes,
+        endTimeUnixNano: otlpUnixNano(endMs),
+        // SPAN_KIND_SERVER — a dispatched RPC is server-side request handling.
+        kind: 2,
+        name: event.functionPath,
+        spanId: otlpRandomHex(8),
+        startTimeUnixNano: otlpUnixNano(endMs - event.durationMs),
+        // STATUS_CODE_OK (1) / STATUS_CODE_ERROR (2).
+        status: event.ok ? { code: 1 } : { code: 2, message: event.error?.message ?? "" },
+        traceId: otlpRandomHex(16),
+    };
+
+    return {
+        resourceSpans: [
+            {
+                resource: { attributes: [stringAttribute("service.name", serviceName)] },
+                scopeSpans: [{ scope: { name: "@lunora/runtime" }, spans: [span] }],
+            },
+        ],
+    };
+};
+
+/** Build the OTLP log-export body for one application log line. */
+const otlpLogBody = (event: LogEvent, serviceName: string): unknown => {
+    const attributes: OtlpAttribute[] = [stringAttribute("lunora.function_path", event.functionPath)];
+
+    if (event.shardKey !== undefined) {
+        attributes.push(stringAttribute("lunora.shard_key", event.shardKey));
+    }
+
+    if (event.userId !== undefined) {
+        attributes.push(stringAttribute("lunora.user_id", event.userId));
+    }
+
+    const logRecord = {
+        attributes,
+        body: { stringValue: event.message },
+        severityNumber: OTLP_SEVERITY[event.level],
+        severityText: event.level.toUpperCase(),
+        timeUnixNano: otlpUnixNano(event.ts),
+    };
+
+    return {
+        resourceLogs: [
+            {
+                resource: { attributes: [stringAttribute("service.name", serviceName)] },
+                scopeLogs: [{ logRecords: [logRecord], scope: { name: "@lunora/runtime" } }],
+            },
+        ],
+    };
+};
+
+/** POST an OTLP payload fire-and-forget, keeping it alive past the response when a request context is present. */
+const otlpPost = (url: string, body: unknown, headers: Record<string, string>, context?: ObservabilitySinkContext): void => {
+    try {
+        // `.catch` swallows any rejection so a failed export can never reject
+        // into the dispatch path.
+        const sent = fetch(url, { body: JSON.stringify(body), headers, method: "POST" }).catch(() => {
+            // Network error / non-OK response — intentionally ignored.
+        });
+
+        if (context?.waitUntil) {
+            context.waitUntil(sent);
+        }
+    } catch {
+        // `fetch` throwing synchronously (e.g. an invalid URL) must not break dispatch.
+    }
 };
 
 /**
@@ -309,6 +463,101 @@ export const analyticsEngineSink = (options: AnalyticsEngineSinkOptions): Observ
             } catch {
                 // A missing or throwing dataset binding must not break dispatch.
             }
+        },
+    };
+};
+
+/** Options for {@link otlpSink}. */
+export interface OtlpSinkOptions extends OnlyErrorsOption {
+    /**
+     * The OTLP-over-HTTP collector base endpoint (e.g.
+     * `https://collector.example.com`). Following the OTel base-endpoint
+     * convention, the sink POSTs spans to `${endpoint}/v1/traces` and log
+     * records to `${endpoint}/v1/logs`; a trailing slash is tolerated.
+     */
+    endpoint: string;
+
+    /**
+     * Extra headers merged onto every OTLP POST — typically an `Authorization`
+     * bearer plus the `x-lunora-deployment` / `x-lunora-org` correlation headers
+     * the platform injects at deploy. `Content-Type: application/json` is set by
+     * default and may be overridden here.
+     */
+    headers?: Record<string, string>;
+
+    /**
+     * Value of the `service.name` resource attribute on every exported span and
+     * log — the logical service the telemetry belongs to. Defaults to `lunora`.
+     */
+    serviceName?: string;
+
+    /**
+     * Convenience bearer token: when set, an `Authorization: Bearer` header
+     * carrying it is added to every POST (overriding any authorization in
+     * `headers`). Mirrors the container exporter so the platform can inject the
+     * same `LUNORA_OTLP_TOKEN` into both. Leave unset for an unauthenticated collector.
+     */
+    token?: string;
+}
+
+/**
+ * A fire-and-forget sink that exports telemetry over OTLP-over-HTTP (JSON).
+ *
+ * This is the single, standard wire contract both the worker and (via the
+ * container exporter helper) container processes use, so telemetry from either
+ * side lands in the same collector. Each RPC dispatch becomes one OTLP **span**
+ * (`${endpoint}/v1/traces`) named after its `functionPath`, with start/end
+ * derived from `durationMs` and status OK/ERROR; each `ctx.log.*` line becomes
+ * one OTLP **log record** (`${endpoint}/v1/logs`). Trace/span ids are random
+ * per span — real trace correlation (worker→container `traceparent`) is a later
+ * phase.
+ *
+ * Like {@link webhookSink}, each export is its own `fetch`, registered with the
+ * request's `context.waitUntil` when present so it survives isolate teardown,
+ * and every rejection is swallowed so a flaky collector never surfaces to the
+ * caller.
+ *
+ * Privacy: spans carry `error.type`/`error.message` and logs carry the rendered
+ * `message`, which may include user input. Point `endpoint` only at a collector
+ * you trust, and gate PII upstream if that is a concern.
+ * @param options Sink options: `endpoint` is the collector base URL, `headers`
+ * are merged onto every POST (auth + correlation), `serviceName` sets the
+ * resource `service.name`, and `onlyErrors` exports error spans only.
+ */
+export const otlpSink = (options: OtlpSinkOptions): ObservabilitySink => {
+    const { endpoint, headers, onlyErrors, token } = options;
+    const serviceName = options.serviceName ?? "lunora";
+
+    // Strip trailing slashes without a regex — a `/\/+$/`-style pattern trips
+    // the ReDoS linter, and this runs once per sink construction anyway.
+    let base = endpoint;
+
+    while (base.endsWith("/")) {
+        base = base.slice(0, -1);
+    }
+
+    const tracesUrl = `${base}/v1/traces`;
+    const logsUrl = `${base}/v1/logs`;
+    let mergedHeaders = mergeHeaders({ "content-type": "application/json" }, headers);
+
+    // Apply the `token` convenience last so it wins over any authorization in
+    // `headers`, matching the container exporter's precedence.
+    if (token !== undefined && token.length > 0) {
+        mergedHeaders = mergeHeaders(mergedHeaders, { authorization: `Bearer ${token}` });
+    }
+
+    return {
+        onLog: (event, context) => {
+            // Application log lines are exported whole; `onlyErrors` scopes the
+            // RPC span stream, not the developer's `ctx.log` output.
+            otlpPost(logsUrl, otlpLogBody(event, serviceName), mergedHeaders, context);
+        },
+        onRpc: (event, context) => {
+            if (shouldSkip(event, onlyErrors)) {
+                return;
+            }
+
+            otlpPost(tracesUrl, otlpTraceBody(event, serviceName, Date.now()), mergedHeaders, context);
         },
     };
 };

--- a/shared/otlp.ts
+++ b/shared/otlp.ts
@@ -1,0 +1,173 @@
+/**
+ * Shared OTLP-over-HTTP/JSON wire primitives, bundler-inlined (like
+ * {@link file://./batch-wire.ts}) so the worker sink (`@lunora/runtime`) and the
+ * container exporter (`@lunora/container`) build their OTLP bodies from ONE
+ * encoder instead of two drifting mirrors. The two consumers sit on opposite
+ * tiers (leaf server runtime vs. zero-Cloudflare container helper) and must not
+ * gain a runtime dependency edge on each other, so this lives in `shared/` and is
+ * inlined into each `dist` rather than published as a package.
+ *
+ * These are the pure, dependency-free pieces of the OTLP/JSON contract both sides
+ * share: the `AnyValue`/`KeyValue` encoding, `SeverityNumber` map, the
+ * decimal-string `*UnixNano` and hex `trace_id`/`span_id` encoders, the
+ * case-insensitive header merge, and the `resourceSpans`/`resourceLogs`
+ * envelopes. Each package keeps only its own transport and event→OTLP mapping.
+ *
+ * Keep this genuinely zero-dependency (only built-ins) so inlining stays sound.
+ */
+
+/** OTLP `SeverityNumber` levels Lunora emits (the worker adds `log`; the container never uses it). */
+type OtlpLevel = "debug" | "error" | "info" | "log" | "warn";
+
+/**
+ * OTLP log severity numbers (`SeverityNumber` in the spec) keyed by level. `log`
+ * has no distinct OTLP level, so it maps to INFO like a plain `console.log`.
+ */
+const OTLP_SEVERITY: Record<OtlpLevel, number> = {
+    debug: 5, // DEBUG
+    error: 17, // ERROR
+    info: 9, // INFO
+    log: 9, // INFO
+    warn: 13, // WARN
+};
+
+/** One OTLP `AnyValue` — the JSON encoding of a typed attribute value. */
+type OtlpAnyValue = { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string };
+
+/** One OTLP `KeyValue` attribute. */
+interface OtlpAttribute {
+    key: string;
+    value: OtlpAnyValue;
+}
+
+/** A JS attribute value the encoder maps onto an OTLP `AnyValue`. */
+type OtlpAttributeValue = boolean | number | string;
+
+/**
+ * Encode wall-clock milliseconds as an OTLP `*UnixNano` string. proto3 JSON
+ * represents uint64 as a decimal string, and ms→ns is ×10^6, so the six trailing
+ * zeros are exact — no `BigInt`, no float rounding.
+ */
+const otlpUnixNano = (ms: number): string => `${String(Math.round(ms))}000000`;
+
+/**
+ * A random lowercase-hex id of `bytes` length. OTLP/JSON is explicit that
+ * `trace_id`/`span_id` are hex strings (the one documented exception to proto3
+ * JSON's base64 `bytes` encoding), so this is the correct on-wire form. Uses the
+ * Web Crypto global (present in workerd, Node ≥ 19, Bun, Deno) — no Node built-in
+ * import; the engines field guarantees Node ≥ 22.15, so it is always present.
+ */
+const otlpRandomHex = (bytes: number): string => {
+    const buffer = new Uint8Array(bytes);
+
+    crypto.getRandomValues(buffer);
+
+    let hex = "";
+
+    for (const byte of buffer) {
+        hex += byte.toString(16).padStart(2, "0");
+    }
+
+    return hex;
+};
+
+/** Encode one attribute, choosing the OTLP value kind from the JS type. */
+const encodeAttribute = (key: string, value: OtlpAttributeValue): OtlpAttribute => {
+    if (typeof value === "boolean") {
+        return { key, value: { boolValue: value } };
+    }
+
+    if (typeof value === "number") {
+        // Non-finite (NaN/±Infinity) has no valid `AnyValue` encoding — `JSON.stringify`
+        // would emit `null`, which a strict collector rejects — so fall back to a
+        // string. Safe integers use `intValue` (a decimal string, per proto3 JSON);
+        // everything else uses `doubleValue`, which also keeps values beyond 2^53 out
+        // of the int64 decimal path (where `String(1e21)` would yield "1e+21").
+        if (!Number.isFinite(value)) {
+            return { key, value: { stringValue: String(value) } };
+        }
+
+        return Number.isSafeInteger(value) ? { key, value: { intValue: String(value) } } : { key, value: { doubleValue: value } };
+    }
+
+    return { key, value: { stringValue: value } };
+};
+
+/** Encode an attribute bag into the OTLP `KeyValue` list. */
+const encodeAttributes = (attributes: Record<string, OtlpAttributeValue> | undefined): OtlpAttribute[] => {
+    if (attributes === undefined) {
+        return [];
+    }
+
+    return Object.entries(attributes).map(([key, value]) => encodeAttribute(key, value));
+};
+
+/**
+ * Case-insensitively merge headers: `defaults` first, then `overrides` (which
+ * win). HTTP header names are case-insensitive, so a naive spread of
+ * `{ "content-type": ..., ...overrides }` would keep BOTH `content-type` and a
+ * caller's `Content-Type` as distinct keys and `fetch`/`Headers` would then
+ * *combine* them ("application/json, text/plain") rather than let the caller
+ * override; normalising the key first guarantees one caller-controlled value per
+ * header. A non-empty `token` is applied last as `authorization: Bearer <token>`
+ * so it wins over any caller-supplied authorization.
+ */
+const mergeHeaders = (defaults: Record<string, string>, overrides: Record<string, string> | undefined, token?: string): Record<string, string> => {
+    const merged: Record<string, string> = {};
+    const seen = new Map<string, string>();
+
+    const put = (name: string, value: string): void => {
+        const lower = name.toLowerCase();
+        const existing = seen.get(lower);
+
+        if (existing === undefined) {
+            seen.set(lower, name);
+            merged[name] = value;
+        } else {
+            // Replace the existing key's value in place so the override wins
+            // without introducing a second, differently-cased duplicate.
+            merged[existing] = value;
+        }
+    };
+
+    for (const [name, value] of Object.entries(defaults)) {
+        put(name, value);
+    }
+
+    for (const [name, value] of Object.entries(overrides ?? {})) {
+        put(name, value);
+    }
+
+    if (token !== undefined && token.length > 0) {
+        put("authorization", `Bearer ${token}`);
+    }
+
+    return merged;
+};
+
+/** Wrap one encoded OTLP span in the `ExportTraceServiceRequest` envelope. */
+const wrapResourceSpans = (span: unknown, scopeName: string, serviceName: string): unknown => {
+    return {
+        resourceSpans: [
+            {
+                resource: { attributes: [encodeAttribute("service.name", serviceName)] },
+                scopeSpans: [{ scope: { name: scopeName }, spans: [span] }],
+            },
+        ],
+    };
+};
+
+/** Wrap one encoded OTLP log record in the `ExportLogsServiceRequest` envelope. */
+const wrapResourceLogs = (logRecord: unknown, scopeName: string, serviceName: string): unknown => {
+    return {
+        resourceLogs: [
+            {
+                resource: { attributes: [encodeAttribute("service.name", serviceName)] },
+                scopeLogs: [{ logRecords: [logRecord], scope: { name: scopeName } }],
+            },
+        ],
+    };
+};
+
+export type { OtlpAnyValue, OtlpAttribute, OtlpAttributeValue, OtlpLevel };
+export { encodeAttribute, encodeAttributes, mergeHeaders, OTLP_SEVERITY, otlpRandomHex, otlpUnixNano, wrapResourceLogs, wrapResourceSpans };


### PR DESCRIPTION
## Phase 2 — OTLP transport + wire contract (OSS)

Second phase of the [observability plan](https://github.com/superloglabs/superlog) (superlog → Lunora). Phase 1 shipped in #138. This phase gives worker **and** container telemetry a single, standard egress protocol — **OTLP-over-HTTP/JSON** — so any OpenTelemetry collector (or, later, the Lunora cloud ingest) accepts both without special-casing.

### What's here

- **`@lunora/runtime` — `otlpSink({ endpoint, token, headers, serviceName })`** beside the existing sinks (`consoleSink`/`webhookSink`/`sentrySink`/`analyticsEngineSink`). Maps each RPC `ObservabilityEvent` → an OTLP **span** (`POST {endpoint}/v1/traces`) and each `LogEvent` → an OTLP **log record** (`POST {endpoint}/v1/logs`), fire-and-forget via `context.waitUntil`. `token` is a bearer-auth convenience applied **last** so it wins over any `authorization` in `headers`. `endpoint`/`token` are meant to be read from env so the platform can inject them at deploy with no app-code change. Honors `onlyErrors`.
- **`@lunora/container/otel` — `createContainerTelemetry(...)`**: a zero-dependency, zero-config OTLP exporter for code running **inside** a container (a separate process, can't use a worker sink). Speaks the exact same wire contract, so container spans land next to worker spans in one collector. Reads `LUNORA_OTLP_ENDPOINT`/`LUNORA_OTLP_TOKEN`/`LUNORA_SERVICE_NAME` from the container env; **silent no-op** (`enabled === false`) when no endpoint resolves. Injectable `fetch` for testing. Exposes `trace()` / `emitSpan()` / `emitLog()` / `flush()`.
- **Docs** — new `concepts/observability` page: the sink table, `combineSinks`, the `otlpSink` options, the container exporter, and **the single wire contract** both paths share (transport, endpoints, headers, encoding rules, span/attribute/log-record shapes + severity mapping) plus a privacy note.

### Wire contract (summary)

OTLP-over-HTTP with **JSON** encoding. `traceId`/`spanId` as lowercase hex (the documented OTLP/JSON exception), `timeUnixNano` as decimal-string nanos, attributes as the `AnyValue` union. Worker spans are `kind: 2` (SERVER) with `lunora.*` attributes; container spans are `kind: 1` (INTERNAL). Log `severityNumber` maps debug→5, info/log→9, warn→13, error→17. Full tables in the docs page.

### Verification

- `@lunora/runtime` — **499 passed** (incl. new `otlpSink` well-formed-OTLP tests for ok/error/fan-out + token precedence).
- `@lunora/container` — **127 passed** (incl. 15 new `otel.ts` tests: disabled no-op, env resolution, ns precision, attribute kinds, severity mapping, header/token merge, `trace()` ok/error, error surfacing).
- All changed files clean under eslint / tsc / prettier (and re-verified by the pre-commit hook).

### Notes

- Pure OSS, no cloud dependency — targets `alpha`.
- Privacy: OTLP spans carry `error.type`/error messages and logs carry the rendered message (may contain user input); point `endpoint` only at a trusted collector, and use `onlyErrors` to narrow egress. Documented on the concept page.
- Next: **Phase 3** (cloud ingest `POST /v1/telemetry` + `TelemetryStore` adapter + hosted Issues/Incidents) stacks on the cloud branch (#85), not on `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sRFb1136YE8KDmDbFMYmm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OTLP-over-HTTP export support for worker telemetry (RPC operations and application logs), including configurable endpoint, authentication, headers, optional service naming, and `onlyErrors` filtering.
  * Added container-side OTLP telemetry via a new public `@lunora/container/otel` entry point with `createContainerTelemetry`, including `flush` for in-flight exports.

* **Documentation**
  * Added a new observability concepts page to the docs, detailing sink configuration, delivery behavior, OTLP JSON “wire contract,” and privacy considerations.

* **Chores**
  * Updated container TypeScript configuration to avoid build/type issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->