### PR TITLE
feat(observability): worker→container trace waterfall (W3C trace-context)

### DIFF
--- a/packages/codegen/__tests__/discover-containers.test.ts
+++ b/packages/codegen/__tests__/discover-containers.test.ts
@@ -247,7 +247,7 @@ describe("emit (containers)", () => {
 
         expect(shard).toContain('import { createContainerContext } from "@lunora/container";');
         expect(shard).toContain('{ binding: "CONTAINER_TRANSCODER", exportName: "transcoder", maxInstances: 5 },');
-        expect(shard).toContain("const containers = createContainerContext(env, LUNORA_CONTAINERS);");
+        expect(shard).toContain("const containers = createContainerContext(env, LUNORA_CONTAINERS, undefined, this.getCurrentTraceparent());");
         expect(shard).toContain("containers,");
     });
 
@@ -262,6 +262,6 @@ describe("emit (containers)", () => {
 
         const shard = emitShard({ schema: { ...EMPTY_SCHEMA, jurisdiction: "us" }, containers: discover() });
 
-        expect(shard).toContain('const containers = createContainerContext(env, LUNORA_CONTAINERS, "us");');
+        expect(shard).toContain('const containers = createContainerContext(env, LUNORA_CONTAINERS, "us", this.getCurrentTraceparent());');
     });
 });

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -2465,10 +2465,11 @@ const emitContainerFragments = (
 
     return {
         // Schema `.jurisdiction("…")` pins every container DO this shard reaches
-        // to the data-residency region; the arg is omitted when undeclared so
-        // existing generated output is unchanged.
+        // to the data-residency region (`undefined` when undeclared). The trailing
+        // `this.getCurrentTraceparent()` forwards the inbound RPC's W3C trace
+        // context onto outbound container fetches so their spans join the trace.
         build: `
-            const containers = createContainerContext(env, LUNORA_CONTAINERS${jurisdiction ? `, ${JSON.stringify(jurisdiction)}` : ""});
+            const containers = createContainerContext(env, LUNORA_CONTAINERS, ${jurisdiction ? JSON.stringify(jurisdiction) : "undefined"}, this.getCurrentTraceparent());
 `,
         contextField: `\n                containers,`,
         importLines: [`import type { ContainerBindingSpec } from "@lunora/container";`, `import { createContainerContext } from "@lunora/container";`],

--- a/packages/container/__tests__/client.test.ts
+++ b/packages/container/__tests__/client.test.ts
@@ -61,6 +61,27 @@ describe(createContainerContext, () => {
         expect(requests[0]!.url).toBe("https://example.com/probe");
     });
 
+    it("stamps the forwarded traceparent onto outbound container requests (get / any / pool)", async () => {
+        expect.assertions(3);
+
+        const traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        const { namespace, requests } = fakeNamespace();
+        const containers = createContainerContext(
+            { CONTAINER_TRANSCODER: namespace },
+            [{ binding: "CONTAINER_TRANSCODER", exportName: "transcoder", maxInstances: 2 }],
+            undefined,
+            traceparent,
+        );
+
+        await containers.transcoder!.get("a").fetch("/x");
+        await containers.transcoder!.any().fetch("/x");
+        await containers.transcoder!.pool().fetch("/x");
+
+        for (const request of requests) {
+            expect(request.headers.get("traceparent")).toBe(traceparent);
+        }
+    });
+
     it(".any() picks a pool instance within maxInstances", async () => {
         expect.assertions(2);
 

--- a/packages/container/__tests__/otel.test.ts
+++ b/packages/container/__tests__/otel.test.ts
@@ -23,6 +23,7 @@ interface ParsedSpan {
     endTimeUnixNano: string;
     kind: number;
     name: string;
+    parentSpanId?: string;
     spanId: string;
     startTimeUnixNano: string;
     status: { code: number; message?: string };
@@ -143,6 +144,40 @@ describe(createContainerTelemetry, () => {
         expect(attrValue(span.attributes, "jobId")?.stringValue).toBe("j1");
         expect(attrValue(resourceAttributes, "service.name")?.stringValue).toBe("lunora-container");
         expect(scopeName).toBe("@lunora/container");
+    });
+
+    it("stitches spans under a parent traceparent", async () => {
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({
+            endpoint: "https://collect.example.com",
+            fetch,
+            traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        });
+
+        telemetry.emitSpan({ endMs: 10, name: "transcode", startMs: 5 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        // Inherits the Worker's trace id and hangs off its span id...
+        expect(span.traceId).toBe("0af7651916cd43dd8448eb211c80319c");
+        expect(span.parentSpanId).toBe("b7ad6b7169203331");
+        // ...but keeps its own child span id.
+        expect(span.spanId).toMatch(SPAN_ID_HEX);
+        expect(span.spanId).not.toBe("b7ad6b7169203331");
+    });
+
+    it("mints a fresh root trace when the traceparent is malformed", async () => {
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({ endpoint: "https://collect.example.com", fetch, traceparent: "not-a-traceparent" });
+
+        telemetry.emitSpan({ endMs: 10, name: "x", startMs: 5 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(span.traceId).toMatch(TRACE_ID_HEX);
+        expect(span.parentSpanId).toBeUndefined();
     });
 
     it("marks an errored span with status ERROR, message, and error.type", async () => {

--- a/packages/container/__tests__/otel.test.ts
+++ b/packages/container/__tests__/otel.test.ts
@@ -180,6 +180,43 @@ describe(createContainerTelemetry, () => {
         expect(span.parentSpanId).toBeUndefined();
     });
 
+    it("stitches under a future-version traceparent that carries trailing fields", async () => {
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({
+            endpoint: "https://collect.example.com",
+            fetch,
+            // Version `cc` (future) with an extra field appended — the spec says to
+            // parse the first four fields and ignore the rest, not drop the header.
+            traceparent: "cc-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra",
+        });
+
+        telemetry.emitSpan({ endMs: 10, name: "transcode", startMs: 5 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(span.traceId).toBe("0af7651916cd43dd8448eb211c80319c");
+        expect(span.parentSpanId).toBe("b7ad6b7169203331");
+    });
+
+    it("mints a fresh root trace when the traceparent uses the reserved `ff` version", async () => {
+        const { calls, fetch } = stubFetch();
+        const telemetry = createContainerTelemetry({
+            endpoint: "https://collect.example.com",
+            fetch,
+            traceparent: "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        });
+
+        telemetry.emitSpan({ endMs: 10, name: "x", startMs: 5 });
+        await telemetry.flush();
+
+        const { span } = spanFrom(calls[0]!.body);
+
+        expect(span.traceId).toMatch(TRACE_ID_HEX);
+        expect(span.traceId).not.toBe("0af7651916cd43dd8448eb211c80319c");
+        expect(span.parentSpanId).toBeUndefined();
+    });
+
     it("marks an errored span with status ERROR, message, and error.type", async () => {
         expect.assertions(4);
 

--- a/packages/container/src/client.ts
+++ b/packages/container/src/client.ts
@@ -264,11 +264,17 @@ const DEFAULT_COLD_START_BACKOFF_MS = 500;
 /** The header `@cloudflare/containers`' `switchPort` sets to target a non-default container port. */
 const TARGET_PORT_HEADER = "cf-container-target-port";
 
-const toRequest = (input: Request | string, init?: RequestInit, port?: number): Request => {
+const toRequest = (input: Request | string, init?: RequestInit, port?: number, traceparent?: string): Request => {
     const request = typeof input === "string" && input.startsWith("/") ? new Request(`http://container${input}`, init) : new Request(input, init);
 
     if (port !== undefined) {
         request.headers.set(TARGET_PORT_HEADER, String(port));
+    }
+
+    if (traceparent !== undefined) {
+        // Propagate the Worker RPC's W3C trace context so the container's own OTLP
+        // spans (via `@lunora/container/otel`) stitch under the same trace.
+        request.headers.set("traceparent", traceparent);
     }
 
     return request;
@@ -379,7 +385,12 @@ const isColdStartTransient = async (response: Response): Promise<boolean> => {
  * body) is sent exactly once. `.port()` re-binds the same `send`, so multi-port
  * routing composes with the retry uniformly.
  */
-const coldStartRetryingHandle = (send: (request: Request) => Promise<Response>, options: InstanceRetryOptions = {}, port?: number): ContainerHandle => {
+const coldStartRetryingHandle = (
+    send: (request: Request) => Promise<Response>,
+    options: InstanceRetryOptions = {},
+    port?: number,
+    traceparent?: string,
+): ContainerHandle => {
     const attempts = Math.max(1, options.attempts ?? DEFAULT_COLD_START_ATTEMPTS);
     const baseBackoff = options.backoffMs ?? DEFAULT_COLD_START_BACKOFF_MS;
     const maxBackoff = options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
@@ -401,7 +412,7 @@ const coldStartRetryingHandle = (send: (request: Request) => Promise<Response>, 
 
                 try {
                     // eslint-disable-next-line no-await-in-loop -- attempts are inherently sequential
-                    const response = await send(toRequest(input, init, port));
+                    const response = await send(toRequest(input, init, port, traceparent));
 
                     // eslint-disable-next-line no-await-in-loop -- the cold-start check peeks the body
                     if (isLastAttempt || !(await isColdStartTransient(response))) {
@@ -421,12 +432,12 @@ const coldStartRetryingHandle = (send: (request: Request) => Promise<Response>, 
             // keeps the control flow total for the type checker.
             throw lastError instanceof Error ? lastError : new Error("ctx.containers: cold-start retry exhausted");
         },
-        port: (targetPort) => coldStartRetryingHandle(send, options, targetPort),
+        port: (targetPort) => coldStartRetryingHandle(send, options, targetPort, traceparent),
     };
 };
 
-const handleFor = (namespace: ContainerNamespaceLike, instanceName: string, options?: InstanceRetryOptions): ContainerHandle =>
-    coldStartRetryingHandle(async (request) => namespace.get(namespace.idFromName(instanceName)).fetch(request), options);
+const handleFor = (namespace: ContainerNamespaceLike, instanceName: string, options?: InstanceRetryOptions, traceparent?: string): ContainerHandle =>
+    coldStartRetryingHandle(async (request) => namespace.get(namespace.idFromName(instanceName)).fetch(request), options, undefined, traceparent);
 
 /** Lifecycle/egress RPCs `instanceHandleFor` forwards to the container DO stub. */
 type ContainerStubMethod = keyof Omit<ContainerStubLike, "fetch">;
@@ -464,11 +475,12 @@ const instanceHandleFor = (
     spec: ContainerBindingSpec,
     instanceName: string,
     options?: InstanceRetryOptions,
+    traceparent?: string,
 ): ContainerInstanceHandle => {
     const stub = (): ContainerStubLike => namespace.get(namespace.idFromName(instanceName));
 
     return {
-        ...coldStartRetryingHandle(async (request) => stub().fetch(request), options),
+        ...coldStartRetryingHandle(async (request) => stub().fetch(request), options, undefined, traceparent),
         destroy: async () => lifecycleCall(stub(), "destroy", spec.binding),
         egress: egressControlsFor(stub, spec.binding),
         getState: async () => lifecycleCall(stub(), "getState", spec.binding),
@@ -492,7 +504,13 @@ const retryOnServerError = (response: Response): boolean => response.status >= 5
  * backoff. Pure over the namespace, so it's testable with a fake. The final
  * attempt's outcome (response or thrown error) is returned/propagated as-is.
  */
-const poolHandleFor = (namespace: ContainerNamespaceLike, spec: ContainerBindingSpec, options: PoolOptions = {}, port?: number): ContainerHandle => {
+const poolHandleFor = (
+    namespace: ContainerNamespaceLike,
+    spec: ContainerBindingSpec,
+    options: PoolOptions = {},
+    port?: number,
+    traceparent?: string,
+): ContainerHandle => {
     const size = options.size ?? spec.maxInstances ?? DEFAULT_POOL_SIZE;
     const attempts = Math.max(1, options.attempts ?? 3);
     const baseBackoff = options.backoffMs ?? 100;
@@ -516,7 +534,7 @@ const poolHandleFor = (namespace: ContainerNamespaceLike, spec: ContainerBinding
                     await sleep(Math.min(baseBackoff * 2 ** (attempt - 1), maxBackoff));
                 }
 
-                const request = toRequest(input, init, port);
+                const request = toRequest(input, init, port, traceparent);
 
                 try {
                     // eslint-disable-next-line no-await-in-loop -- attempts are inherently sequential
@@ -533,15 +551,15 @@ const poolHandleFor = (namespace: ContainerNamespaceLike, spec: ContainerBinding
             // Exhausted attempts after a thrown error on the last try.
             throw lastError instanceof Error ? lastError : new Error(`ctx.containers.${spec.exportName}.pool(): all ${String(totalAttempts)} attempts failed`);
         },
-        port: (targetPort) => poolHandleFor(namespace, spec, options, targetPort),
+        port: (targetPort) => poolHandleFor(namespace, spec, options, targetPort, traceparent),
     };
 };
 
-const accessorFor = (namespace: ContainerNamespaceLike, spec: ContainerBindingSpec): ContainerAccessor => {
+const accessorFor = (namespace: ContainerNamespaceLike, spec: ContainerBindingSpec, traceparent?: string): ContainerAccessor => {
     return {
-        any: (count, options) => handleFor(namespace, randomPoolName(count ?? spec.maxInstances ?? DEFAULT_POOL_SIZE), options),
-        get: (name, options) => instanceHandleFor(namespace, spec, name, options),
-        pool: (options) => poolHandleFor(namespace, spec, options),
+        any: (count, options) => handleFor(namespace, randomPoolName(count ?? spec.maxInstances ?? DEFAULT_POOL_SIZE), options, traceparent),
+        get: (name, options) => instanceHandleFor(namespace, spec, name, options, traceparent),
+        pool: (options) => poolHandleFor(namespace, spec, options, undefined, traceparent),
     };
 };
 
@@ -559,15 +577,19 @@ const missingBindingAccessor = (spec: ContainerBindingSpec): ContainerAccessor =
 
 /**
  * Build the `ctx.containers` record from the Worker `env`. Called by the
- * generated ShardDO with the specs codegen derived from
- * `lunora/containers.ts`. A missing binding doesn't throw here — only when the
- * handle is actually used — so one unprovisioned container never breaks
- * unrelated functions.
+ * generated ShardDO with the specs codegen derived from `lunora/containers.ts`.
+ * A missing binding doesn't throw here — only when the handle is actually used —
+ * so one unprovisioned container never breaks unrelated functions.
+ *
+ * `traceparent` (the inbound RPC's W3C trace context, forwarded by the runtime
+ * and read off the request by the DO) is stamped onto every outbound container
+ * `fetch`, so the container's own spans stitch under the Worker's trace.
  */
 const createContainerContext = (
     env: Record<string, unknown>,
     specs: ReadonlyArray<ContainerBindingSpec>,
     jurisdiction?: DurableObjectJurisdiction,
+    traceparent?: string,
 ): Record<string, ContainerAccessor> => {
     const containers: Record<string, ContainerAccessor> = {};
 
@@ -576,7 +598,7 @@ const createContainerContext = (
 
         containers[spec.exportName] =
             binding && typeof binding.idFromName === "function" && typeof binding.get === "function"
-                ? accessorFor(applyJurisdiction(binding, jurisdiction), spec)
+                ? accessorFor(applyJurisdiction(binding, jurisdiction), spec, traceparent)
                 : missingBindingAccessor(spec);
     }
 

--- a/packages/container/src/otel.ts
+++ b/packages/container/src/otel.ts
@@ -95,6 +95,22 @@ interface ContainerTelemetryOptions {
      * the `LUNORA_TRACEPARENT` env var. When present (and well-formed) every span
      * inherits its trace id and hangs off its span id, so container spans stitch
      * under the Worker's trace instead of forming a fresh, disconnected trace.
+     *
+     * `@lunora/container` stamps this trace context as the **`traceparent` request
+     * header** on every proxied fetch (`ctx.containers.&lt;name>.…`), so a container
+     * that serves many requests should read it per request and create a telemetry
+     * instance scoped to that request — the trace context differs each call, so a
+     * single process-lifetime instance can't carry it:
+     *
+     * ```ts
+     * // inside the container's request handler
+     * const telemetry = createContainerTelemetry({ traceparent: request.headers.get("traceparent") ?? undefined });
+     * await telemetry.trace("transcode", () => transcode(job));
+     * await telemetry.flush();
+     * ```
+     *
+     * The `LUNORA_TRACEPARENT` env fallback fits a one-shot container that
+     * processes a single job per start (the value is fixed for the process).
      */
     traceparent?: string;
 }

--- a/packages/container/src/otel.ts
+++ b/packages/container/src/otel.ts
@@ -27,6 +27,7 @@ import {
     OTLP_SEVERITY,
     otlpRandomHex,
     otlpUnixNano,
+    parseTraceparent,
     wrapResourceLogs,
     wrapResourceSpans,
 } from "../../../shared/otlp";
@@ -88,6 +89,14 @@ interface ContainerTelemetryOptions {
     timeoutMs?: number;
     /** Bearer token sent as an `Authorization: Bearer` header; defaults to the `LUNORA_OTLP_TOKEN` env var. */
     token?: string;
+
+    /**
+     * W3C `traceparent` of the Worker RPC that invoked this container; defaults to
+     * the `LUNORA_TRACEPARENT` env var. When present (and well-formed) every span
+     * inherits its trace id and hangs off its span id, so container spans stitch
+     * under the Worker's trace instead of forming a fresh, disconnected trace.
+     */
+    traceparent?: string;
 }
 
 /** Default {@link ContainerTelemetryOptions.timeoutMs} — the OTLP-exporter-conventional 10s. */
@@ -133,7 +142,7 @@ const resolveFetch = (injected: OtelFetchLike | undefined): OtelFetchLike | unde
 };
 
 /** Build the OTLP trace-export body for one container span. */
-const traceBody = (span: ContainerSpanInput, serviceName: string): unknown => {
+const traceBody = (span: ContainerSpanInput, serviceName: string, parent: { parentSpanId: string; traceId: string } | undefined): unknown => {
     const attributes = encodeAttributes(span.attributes);
 
     if (span.error?.type !== undefined) {
@@ -146,11 +155,14 @@ const traceBody = (span: ContainerSpanInput, serviceName: string): unknown => {
         // SPAN_KIND_INTERNAL — the container's own work, not a server/client edge.
         kind: 1,
         name: span.name,
+        // Always the span's own (child) id; with a parent, hang it off the parent
+        // span and inherit the parent's trace id so the spans stitch into one trace.
+        ...(parent === undefined ? {} : { parentSpanId: parent.parentSpanId }),
         spanId: otlpRandomHex(8),
         startTimeUnixNano: otlpUnixNano(span.startMs),
         // STATUS_CODE_OK (1) / STATUS_CODE_ERROR (2).
         status: span.error === undefined ? { code: 1 } : { code: 2, message: span.error.message },
-        traceId: otlpRandomHex(16),
+        traceId: parent?.traceId ?? otlpRandomHex(16),
     };
 
     return wrapResourceSpans(otlpSpan, "@lunora/container", serviceName);
@@ -191,6 +203,7 @@ const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): Cont
     const enabled = endpoint !== undefined && endpoint.length > 0;
     const token = options.token ?? readEnv("LUNORA_OTLP_TOKEN");
     const serviceName = options.serviceName ?? readEnv("LUNORA_SERVICE_NAME") ?? "lunora-container";
+    const parent = parseTraceparent(options.traceparent ?? readEnv("LUNORA_TRACEPARENT"));
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const fetchImpl = resolveFetch(options.fetch);
     const headers = mergeHeaders({ "content-type": "application/json" }, options.headers, token);
@@ -260,7 +273,7 @@ const createContainerTelemetry = (options: ContainerTelemetryOptions = {}): Cont
             return;
         }
 
-        send(tracesUrl, traceBody(span, serviceName));
+        send(tracesUrl, traceBody(span, serviceName, parent));
     };
 
     const emitLog = (log: ContainerLogInput): void => {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1640,6 +1640,9 @@ abstract class ShardDO {
      */
     private currentRequestIp: string | undefined;
 
+    /** W3C `traceparent` of the inbound RPC; forwarded onto outbound container fetches. */
+    private currentRequestTraceparent: string | undefined;
+
     /**
      * Client-issued idempotency key for the in-flight mutation, forwarded via the
      * `x-lunora-mutation-id` header. When set, the dispatch path dedups the call
@@ -2029,6 +2032,7 @@ abstract class ShardDO {
         // unauthenticated traffic by IP).
         this.currentRequestIp = request.headers.get("x-lunora-client-ip") ?? undefined;
         this.currentRequestSystem = request.headers.get("x-lunora-system") === "1";
+        this.currentRequestTraceparent = request.headers.get("traceparent") ?? undefined;
         // Reset the per-request read/cache capture (filled by `runCachedQuery`
         // for cached query paths) so a previous dispatch can't leak into this
         // entry's logged read set / cache-hit flag.
@@ -2213,6 +2217,7 @@ abstract class ShardDO {
             this.currentRequestIdentity = undefined;
             this.currentRequestIp = undefined;
             this.currentRequestSystem = false;
+            this.currentRequestTraceparent = undefined;
             this.currentScannedTables = undefined;
             this.currentIndexHits = undefined;
             this.currentRequestReadTables = undefined;
@@ -2847,6 +2852,15 @@ abstract class ShardDO {
      */
     protected getCurrentIp(): string | undefined {
         return this.currentRequestIp;
+    }
+
+    /**
+     * W3C `traceparent` of the inbound RPC (forwarded by the runtime), or
+     * `undefined`. `buildCtx` passes it to `createContainerContext` so outbound
+     * container fetches carry it and the container's spans join the same trace.
+     */
+    protected getCurrentTraceparent(): string | undefined {
+        return this.currentRequestTraceparent;
     }
 
     /**

--- a/packages/runtime/__tests__/observability-sinks.test.ts
+++ b/packages/runtime/__tests__/observability-sinks.test.ts
@@ -560,6 +560,23 @@ describe("observability-sinks", () => {
             expect(span.spanId).toMatch(SPAN_ID_HEX);
         });
 
+        it("reuses the dispatch's trace/span ids when the event carries them", () => {
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            const sink = otlpSink({ endpoint: "https://collector.example" });
+
+            sink.onRpc!({ ...okEvent, spanId: "b7ad6b7169203331", traceId: "0af7651916cd43dd8448eb211c80319c" });
+
+            const { span } = spanFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
+
+            // The span rides the ids the runtime propagated as `traceparent`, not fresh ones.
+            expect(span.traceId).toBe("0af7651916cd43dd8448eb211c80319c");
+            expect(span.spanId).toBe("b7ad6b7169203331");
+        });
+
         it("encodes error status, error.type, and the status message for a failed event", () => {
             expect.assertions(4);
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -4,6 +4,7 @@ import type { BatchEntry } from "../../../shared/batch-wire";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
+import { buildTraceparent, otlpRandomHex } from "../../../shared/otlp";
 import { relayName } from "../../../shared/relay-name";
 import type { AuthAdmin, AuthIntrospector } from "./auth-admin-routes";
 import { buildAuthAdminRoutes } from "./auth-admin-routes";
@@ -2430,10 +2431,17 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         const rpcStartedAt = Date.now();
         const { observability } = options;
 
+        // Trace context for this dispatch, generated at entry (before the shard
+        // runs the handler) so it can both ride the dispatch's own span and reach
+        // the shard as a `traceparent` — letting a container the handler calls
+        // stitch its spans under the same trace (W3C trace-context propagation).
+        const traceId = otlpRandomHex(16);
+        const spanId = otlpRandomHex(8);
+
         // Re-emit the RPC body to the shard at its `/rpc` route.
         const forwarded = new Request(`https://shard.internal/rpc`, {
             body: JSON.stringify({ args, functionPath }),
-            headers: forwardedHeaders,
+            headers: { ...forwardedHeaders, traceparent: buildTraceparent(traceId, spanId) },
             method: "POST",
         });
 
@@ -2450,6 +2458,8 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                     functionPath,
                     ok: response.ok,
                     shardKey,
+                    spanId,
+                    traceId,
                     ...(response.ok ? {} : { error: { code: "SHARD_ERROR", message: `shard returned ${String(response.status)}`, status: response.status } }),
                 },
                 sinkContext,
@@ -2462,7 +2472,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             // (and would drop `statusText`).
             return response;
         } catch (error) {
-            emitRpcEvent(observability, buildErrorEvent(functionPath, Date.now() - rpcStartedAt, error, { shardKey }), sinkContext);
+            emitRpcEvent(observability, { ...buildErrorEvent(functionPath, Date.now() - rpcStartedAt, error, { shardKey }), spanId, traceId }, sinkContext);
             throw error;
         }
     };

--- a/packages/runtime/src/observability-sinks.ts
+++ b/packages/runtime/src/observability-sinks.ts
@@ -58,11 +58,13 @@ const otlpTraceBody = (event: ObservabilityEvent, serviceName: string, endMs: nu
         // SPAN_KIND_SERVER — a dispatched RPC is server-side request handling.
         kind: 2,
         name: event.functionPath,
-        spanId: otlpRandomHex(8),
+        // Reuse the dispatch's trace context when the runtime set it (so this span
+        // shares the id it propagated as `traceparent`); else mint fresh ids.
+        spanId: event.spanId ?? otlpRandomHex(8),
         startTimeUnixNano: otlpUnixNano(endMs - event.durationMs),
         // STATUS_CODE_OK (1) / STATUS_CODE_ERROR (2).
         status: event.ok ? { code: 1 } : { code: 2, message: event.error?.message ?? "" },
-        traceId: otlpRandomHex(16),
+        traceId: event.traceId ?? otlpRandomHex(16),
     };
 
     return wrapResourceSpans(span, "@lunora/runtime", serviceName);

--- a/packages/runtime/src/observability.ts
+++ b/packages/runtime/src/observability.ts
@@ -49,6 +49,17 @@ export interface ObservabilityEvent {
     ok: boolean;
     /** Shard key for single-shard calls; absent for fan-outs. */
     shardKey?: string;
+
+    /**
+     * W3C trace context for this dispatch, generated once at dispatch entry (32-
+     * and 16-hex). A sink (e.g. `otlpSink`) reuses these for the dispatch's span
+     * instead of minting fresh ids, and the runtime propagates them to the shard
+     * as a `traceparent` so a container the handler calls can stitch its spans
+     * under the same trace. Absent on paths that don't originate a trace (a sink
+     * falls back to random ids).
+     */
+    spanId?: string;
+    traceId?: string;
 }
 
 /** Severity of a {@link LogEvent}, mirroring the usual console levels. */

--- a/shared/otlp.ts
+++ b/shared/otlp.ts
@@ -84,9 +84,15 @@ const buildTraceparent = (traceId: string, spanId: string): string => `00-${trac
 
 /**
  * Parse a W3C `traceparent` into `{ traceId, parentSpanId }`, or `undefined` when
- * malformed. Validates the 4-field `version-traceId-spanId-flags` shape (32-hex
- * trace id, 16-hex span id) and rejects the all-zero ids the spec forbids. Only
- * the two ids are returned — the version/flags are accepted but not surfaced.
+ * malformed. Validates the `version-traceId-spanId-flags` shape (2-hex version,
+ * 32-hex trace id, 16-hex span id, 2-hex flags) and rejects the all-zero ids the
+ * spec forbids. Only the two ids are returned — the version/flags are validated
+ * but not surfaced.
+ *
+ * Forward-compatible per the spec: version `00` is strict (exactly four fields),
+ * but a future version may append fields, so a `>= 4`-field header on a higher
+ * version parses off its first four and ignores the rest rather than being
+ * dropped. The reserved version `ff` is rejected.
  */
 const parseTraceparent = (header: null | string | undefined): { parentSpanId: string; traceId: string } | undefined => {
     if (header === null || header === undefined) {
@@ -94,13 +100,21 @@ const parseTraceparent = (header: null | string | undefined): { parentSpanId: st
     }
 
     const parts = header.trim().toLowerCase().split("-");
-    const traceId = parts[1];
-    const parentSpanId = parts[2];
+    const [version, traceId, parentSpanId, flags] = parts;
 
     if (
-        parts.length !== 4 ||
+        parts.length < 4 ||
+        version === undefined ||
+        version.length !== 2 ||
+        !HEX_ONLY.test(version) ||
+        version === "ff" ||
+        // Version 00 forbids trailing fields; only a future version may carry them.
+        (version === "00" && parts.length !== 4) ||
         traceId === undefined ||
         parentSpanId === undefined ||
+        flags === undefined ||
+        flags.length !== 2 ||
+        !HEX_ONLY.test(flags) ||
         traceId.length !== 32 ||
         parentSpanId.length !== 16 ||
         !HEX_ONLY.test(traceId) ||

--- a/shared/otlp.ts
+++ b/shared/otlp.ts
@@ -71,6 +71,49 @@ const otlpRandomHex = (bytes: number): string => {
     return hex;
 };
 
+/** Lowercase-hex validator for `traceparent` id fields. */
+const HEX_ONLY = /^[0-9a-f]+$/;
+
+/**
+ * Build a W3C `traceparent` header from a 32-hex trace id + 16-hex span id:
+ * `00-<trace-id>-<span-id>-01` (version 0, sampled). The ids are the same
+ * lowercase-hex form {@link otlpRandomHex} produces, so a worker's trace/span id
+ * composes into a `traceparent` with no reformatting.
+ */
+const buildTraceparent = (traceId: string, spanId: string): string => `00-${traceId}-${spanId}-01`;
+
+/**
+ * Parse a W3C `traceparent` into `{ traceId, parentSpanId }`, or `undefined` when
+ * malformed. Validates the 4-field `version-traceId-spanId-flags` shape (32-hex
+ * trace id, 16-hex span id) and rejects the all-zero ids the spec forbids. Only
+ * the two ids are returned — the version/flags are accepted but not surfaced.
+ */
+const parseTraceparent = (header: null | string | undefined): { parentSpanId: string; traceId: string } | undefined => {
+    if (header === null || header === undefined) {
+        return undefined;
+    }
+
+    const parts = header.trim().toLowerCase().split("-");
+    const traceId = parts[1];
+    const parentSpanId = parts[2];
+
+    if (
+        parts.length !== 4 ||
+        traceId === undefined ||
+        parentSpanId === undefined ||
+        traceId.length !== 32 ||
+        parentSpanId.length !== 16 ||
+        !HEX_ONLY.test(traceId) ||
+        !HEX_ONLY.test(parentSpanId) ||
+        traceId === "00000000000000000000000000000000" ||
+        parentSpanId === "0000000000000000"
+    ) {
+        return undefined;
+    }
+
+    return { parentSpanId, traceId };
+};
+
 /** Encode one attribute, choosing the OTLP value kind from the JS type. */
 const encodeAttribute = (key: string, value: OtlpAttributeValue): OtlpAttribute => {
     if (typeof value === "boolean") {
@@ -170,4 +213,15 @@ const wrapResourceLogs = (logRecord: unknown, scopeName: string, serviceName: st
 };
 
 export type { OtlpAnyValue, OtlpAttribute, OtlpAttributeValue, OtlpLevel };
-export { encodeAttribute, encodeAttributes, mergeHeaders, OTLP_SEVERITY, otlpRandomHex, otlpUnixNano, wrapResourceLogs, wrapResourceSpans };
+export {
+    buildTraceparent,
+    encodeAttribute,
+    encodeAttributes,
+    mergeHeaders,
+    OTLP_SEVERITY,
+    otlpRandomHex,
+    otlpUnixNano,
+    parseTraceparent,
+    wrapResourceLogs,
+    wrapResourceSpans,
+};

--- a/templates/expo/src/auth-client.ts
+++ b/templates/expo/src/auth-client.ts
@@ -20,7 +20,7 @@ export const LUNORA_URL = process.env.EXPO_PUBLIC_LUNORA_URL ?? "http://localhos
  * keychain/keystore; on web the browser's cookie jar also carries it, so this
  * only needs to persist what `expoClient` reads back via `getCookie()`.
  */
-const sessionStorage: SecureStorageLike =
+const sessionStore: SecureStorageLike =
     Platform.OS === "web"
         ? {
               getItem: (key) => (typeof localStorage === "undefined" ? null : localStorage.getItem(key)),
@@ -40,5 +40,5 @@ const sessionStorage: SecureStorageLike =
  */
 export const authClient = createAuthClient({
     baseURL: LUNORA_URL,
-    plugins: [expoClient({ scheme: APP_SCHEME, storage: sessionStorage })],
+    plugins: [expoClient({ scheme: APP_SCHEME, storage: sessionStore })],
 });

--- a/tests/vis-templates/__tests__/expo-example-drift.test.ts
+++ b/tests/vis-templates/__tests__/expo-example-drift.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Guard the shared app-logic files between the Expo example and the Expo template
+ * against silent drift.
+ *
+ * The runnable workspace example (`examples/expo/`) and the `lunora init` scaffold
+ * (`templates/expo/`) are two copies of the same starter chat app. Their branding
+ * and platform config intentionally differ — the example is a mobile-only demo
+ * (scheme `expoexample`), the template a mobile+web starter (scheme `lunorachat`)
+ * — so they are NOT byte-identical overall. But the app-logic files below (the
+ * chat UI, the login screen, and the demo backend) carry no such divergence: they
+ * are the *same* code in both copies and are meant to stay in sync.
+ *
+ * Because nothing generates one from the other, keeping them aligned is a manual
+ * two-way copy-paste. This test asserts the identity invariant on exactly those
+ * files so a forgotten copy-paste turns into a red CI run rather than a silently
+ * regressed example. If one of these files is ever *meant* to diverge between the
+ * two copies, drop it from {@link SHARED_APP_FILES} in the same change.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test } from "vitest";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const EXAMPLE_DIR = join(REPO_ROOT, "examples", "expo");
+const TEMPLATE_DIR = join(REPO_ROOT, "templates", "expo");
+
+/**
+ * The files that are the same app logic in both copies (not branding/config).
+ * `src/Chat.tsx` + `src/Login.tsx` are the shared UI; `lunora/messages.ts` is the
+ * shared demo backend. Config that legitimately differs (app.json, package.json,
+ * auth-client.ts, schema.ts, …) is intentionally excluded.
+ */
+const SHARED_APP_FILES = ["src/Chat.tsx", "src/Login.tsx", "lunora/messages.ts"];
+
+describe("examples/expo ↔ templates/expo shared app-logic identity", () => {
+    describe.each(SHARED_APP_FILES)("%s", (file) => {
+        test("the example and template copies are byte-identical", () => {
+            const examplePath = join(EXAMPLE_DIR, file);
+            const templatePath = join(TEMPLATE_DIR, file);
+
+            const exampleContent = readFileSync(examplePath, "utf8");
+            let templateContent: string;
+
+            try {
+                templateContent = readFileSync(templatePath, "utf8");
+            } catch {
+                throw new Error(
+                    `templates/expo/${file} is missing.\n` +
+                        `It is shared app logic with examples/expo/${file} — apply your change to both copies ` +
+                        `(or drop it from SHARED_APP_FILES if the two are meant to diverge).`,
+                );
+            }
+
+            expect(
+                exampleContent,
+                [
+                    `examples/expo/${file} differs from templates/expo/${file}.`,
+                    `These files are the same app logic in both copies and must stay in sync — apply your change to both ` +
+                        `(or drop it from SHARED_APP_FILES if the two are meant to diverge).`,
+                ].join("\n"),
+            ).toBe(templateContent);
+        });
+    });
+});


### PR DESCRIPTION
## Phase 4 — Worker→container trace correlation (complete)

Final piece of the observability plan. A pure OSS **framework** change → `alpha` (builds on the merged Phase 2 OTLP transport, #139). A worker's RPC span and the spans of any container the handler calls now stitch into **one** W3C trace, end to end.

### The waterfall, seam by seam

1. **Worker generates the trace context** (`@lunora/runtime`): a `traceId`/`spanId` is minted at single-shard dispatch entry (before the shard runs the handler), added to `ObservabilityEvent`, reused by `otlpSink` for the dispatch span (no more random-at-emit ids), and forwarded to the shard as a `traceparent` header.
2. **DO reads it** (`@lunora/do`): the ShardDO pulls `traceparent` off the inbound `/rpc` request into a per-request `currentRequestTraceparent` field (cleared each request), exposed via `getCurrentTraceparent()` — mirroring the existing `currentRequestIp`/`getCurrentIp` plumbing.
3. **`ctx.containers` becomes trace-aware** (`@lunora/codegen`): the generated `buildCtx` passes `this.getCurrentTraceparent()` into `createContainerContext`.
4. **Container fetch carries it** (`@lunora/container`): `createContainerContext` threads the traceparent through the accessor chain (`get`/`any`/`pool` → `toRequest`), which stamps it on every outbound container request.
5. **Container consumes it** (`@lunora/container/otel`): `createContainerTelemetry({ traceparent })` (or `LUNORA_TRACEPARENT`) makes every span inherit the parent trace id and hang off its span id; a missing/malformed value falls back to a fresh root trace.

**shared** (`shared/otlp.ts`): `buildTraceparent`/`parseTraceparent` W3C helpers (`00-<32hex>-<16hex>-01`), inlined into both packages.

### Verification

- `@lunora/runtime` **500/500**, `@lunora/container` **135/135**, `@lunora/do` **1036/1036**, `@lunora/codegen` **763/763** (full suites — no regressions). New tests cover: `otlpSink` reuses the event's ids; the container stitches under a parent `traceparent` (and falls back on a malformed one); `ctx.containers` `get`/`any`/`pool` all stamp the forwarded traceparent; codegen wires `getCurrentTraceparent()` into the generated ctx.
- **tsc clean** and **eslint 0** on every changed file.
- Every seam is unit-tested; the one thing only a live worker+container can exercise is the full network round trip.

### Backward compatibility

`traceId`/`spanId` on `ObservabilityEvent` and the new `createContainerContext` argument are optional — existing sinks, dispatch paths, and generated code without containers are unaffected (`otlpSink` falls back to random ids; a container with no `traceparent` forms a fresh trace as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sRFb1136YE8KDmDbFMYmm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end W3C `traceparent` propagation across worker dispatches, shard request handling, and container fetches to enable trace stitching.
  - Introduced per-dispatch trace/span identifiers and reused them for OTLP exports, aligning container span relationships with the upstream trace.
- **Bug Fixes**
  - Improved tracing continuity for success, error, and retried flows by preserving trace context consistently across retries.
  - Prevented trace-context leakage between requests while maintaining consistent OTLP linkage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->