### PR TITLE
fix(replica): add publishing metadata and coverage

### DIFF
--- a/packages/replica/package.json
+++ b/packages/replica/package.json
@@ -2,7 +2,29 @@
     "name": "@lunora/replica",
     "version": "1.0.0-alpha.1",
     "description": "Local-first replica runtime + local SQLite mirror for Lunora",
+    "keywords": [
+        "cloudflare",
+        "durable-objects",
+        "event-sourcing",
+        "local-first",
+        "lunora",
+        "replica",
+        "sqlite",
+        "sync",
+        "workers"
+    ],
+    "homepage": "https://lunora.sh",
+    "bugs": "https://github.com/anolilab/lunora/issues",
     "license": "FSL-1.1-Apache-2.0",
+    "author": {
+        "name": "Daniel Bannert",
+        "email": "d.bannert@anolilab.de"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/anolilab/lunora.git",
+        "directory": "packages/replica"
+    },
     "files": [
         "dist",
         "README.md",
@@ -47,13 +69,15 @@
         "lint:prettier": "prettier --check . --ignore-path ../../.prettierignore",
         "lint:prettier:fix": "prettier --write . --ignore-path ../../.prettierignore",
         "lint:types": "tsc --noEmit",
-        "test": "vitest run"
+        "test": "vitest run",
+        "test:coverage": "vitest run --coverage"
     },
     "devDependencies": {
         "@lunora/server": "1.0.0-alpha.24",
         "@types/node": "catalog:types",
         "@types/react": "catalog:frontend",
         "@visulima/packem": "catalog:build",
+        "@vitest/coverage-v8": "catalog:test",
         "esbuild": "catalog:build",
         "react": "catalog:frontend",
         "typescript": "catalog:tsc",
@@ -84,6 +108,6 @@
         }
     },
     "engines": {
-        "node": "^22.15.0 || >=24.10.0"
+        "node": "^22.15.0 || >=24.11.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3066,6 +3066,9 @@ importers:
       '@visulima/packem':
         specifier: catalog:build
         version: 2.0.0-alpha.93(3d14972a43cfad196c20f1651b85c453)
+      '@vitest/coverage-v8':
+        specifier: catalog:test
+        version: 4.1.10(vitest@4.1.10)
       esbuild:
         specifier: catalog:build
         version: 0.28.1


### PR DESCRIPTION
## What

`@lunora/replica` shipped to `alpha` as `1.0.0-alpha.1` missing its publishing metadata and a couple of consistency items surfaced by a full `package.json` audit across all 46 published packages.

## Changes to `packages/replica/package.json`

- **Add `repository`** (`git+https://github.com/anolilab/lunora.git`, `directory: packages/replica`) — the missing GitHub link, so npm's "Repository" points at the source.
- **Add `bugs`, `homepage`, `author`, `keywords`** — matching the `@lunora/errors` template and field ordering.
- **Fix `engines.node`** `^22.15.0 || >=24.10.0` → `^22.15.0 || >=24.11.0` (the repo standard).
- **Add `test:coverage` script + `@vitest/coverage-v8` devDep** — replica was the only published package (1 of 46) missing both.

## Audit notes (ruled out, not defects)

- The exact `@lunora/server` peer-pin is the monorepo norm (same pattern as `@lunora/seed` / `@lunora/cloudflare-access`).
- `@lunora/dispatch` intentionally has no `.releaserc.json` (internal, not published).
- No CommonJS anywhere in the manifests; all packages are ESM-only and pass `publint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package keywords and updated publishing metadata.
  * Added a test coverage command for development workflows.
  * Updated the supported Node.js version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->