### PR TITLE
docs(plans): Wave 14 — competitive-parity plans (164–177)

### DIFF
--- a/apps/cloud/ROADMAP.md
+++ b/apps/cloud/ROADMAP.md
@@ -77,6 +77,9 @@ Lunora Cloud ships in **two phases**, and the roadmap reflects the transition:
   framework's deterministic error-fingerprinting) with alerting.
 - **Billing for the control plane.** Transparent, usage-honest pricing for the
   managed console — separate from your own Cloudflare bill.
+- **Preview environments / database branching.** Per-PR ephemeral backends and
+  branchable state, so review deploys don't touch production — parity with
+  Supabase branching / Convex preview deployments.
 - **A human on support.** Real support channels and response expectations for
   paying teams.
 
@@ -91,6 +94,9 @@ Lunora Cloud ships in **two phases**, and the roadmap reflects the transition:
   BYO (or fully self-hosted) without a rewrite — the no-lock-in promise, enforced
   as a shipped, tested path.
 - **Templates & marketplace.** One-click starters and shareable app templates.
+- **Managed warehouse connectors.** Turn-key Snowflake / BigQuery / Airbyte /
+  Fivetran pipes on top of the framework's change-data export tap (plan 170) —
+  the framework ships the tap, Cloud ships the managed connectors.
 
 ---
 

--- a/plans/164-non-ts-client-sdk.md
+++ b/plans/164-non-ts-client-sdk.md
@@ -1,0 +1,63 @@
+# Plan 164 — Non-TypeScript client SDK
+
+- **Category**: feat (competitive parity — gap #3 in `plans/README.md` Wave 14)
+- **Priority**: P2
+- **Effort**: L · **Risk**: MED
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: prove the Lunora wire protocol is not TypeScript-bound by shipping a
+  minimal client SDK in one non-TS language (Swift **or** Python), breaking the
+  single biggest capability ceiling vs Convex (which ships Swift/Kotlin/Python/Rust).
+
+## Context (verified)
+
+The entire client surface is TypeScript: `@lunora/client`
+(`packages/client/src/lunora-client.ts`, `subscription.ts`, `http-stream.ts`)
+and `@lunora/react-native` are TS. There is **no** Swift/Kotlin/Python/Dart/Go/Rust
+client. This blocks native mobile (Swift/Kotlin), Python data/ML consumers, and
+non-TS backends from talking to a Lunora deployment.
+
+The wire protocol already exists and is exercised end-to-end; it is simply not
+documented as a language-independent contract. Reference implementation and
+framing anchors:
+
+- Worker endpoints / RPC + WS handshake: `packages/runtime/src/create-worker.ts`.
+- Live-subscription frames: `packages/client/src/subscription.ts`.
+- Arg/wire encoding (bigint/Date/Map/Set/bytes): `shared/wire-key.ts`
+  (`stableWireKey` / `encodeWire`).
+- HTTP-SSE streaming framing: `packages/client/src/http-stream.ts`.
+
+## Phase 0 — Formalize the wire protocol (prerequisite)
+
+- [ ] Extract a **language-independent protocol spec** (docs) from the TS client:
+      connect/auth handshake, query/mutation request+response envelopes, the
+      subscribe/poke/shape frames, `encodeWire` value grammar, error-body shape,
+      and the ephemeral-WS-token flow (plan 095).
+- [ ] Add a protocol-conformance fixture set (golden request/response frames)
+      the TS client is tested against, so any SDK can target the same fixtures.
+
+## Phase 1 — Minimal SDK (pick one language)
+
+Decision: **Swift** (unlock native iOS) or **Python** (unlock data/ML/backends).
+
+- [ ] Connect + auth (accept an async token provider, mirror `WsTokenProvider`).
+- [ ] `query` and `mutation` round-trips over the documented envelopes.
+- [ ] One live `subscribe` consuming the poke/shape frames.
+- [ ] `encodeWire` value codec for the language.
+- [ ] Run against the Phase-0 conformance fixtures + a real workerd deployment.
+
+## Phase 2 — Parity follow-ups (separate, demand-gated)
+
+- [ ] Optimistic updates / offline queue (only if the target platform needs it).
+- [ ] Codegen: emit typed bindings for the language from `schema.ts`.
+
+## Exit criteria
+
+- [ ] Protocol spec + conformance fixtures published; TS client tested against them.
+- [ ] One non-TS SDK does query/mutation/subscribe against a live deployment.
+- [ ] Docs page + example app for the new SDK.
+
+## Non-goals
+
+- Full optimistic/offline parity with `@lunora/client` in v1.
+- More than one language in this plan — prove the model once, then templatize.

--- a/plans/165-push-notifications.md
+++ b/plans/165-push-notifications.md
@@ -1,0 +1,74 @@
+# Plan 165 — `@lunora/push` (push notifications)
+
+- **Category**: feat (competitive parity — gap #7 in `plans/README.md` Wave 14)
+- **Priority**: P2
+- **Effort**: M · **Risk**: MED
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: ship a first-class notification package (`ctx.notify` / `ctx.push`) —
+  Web Push + FCM first — closing a table-stakes consumer/mobile gap vs Firebase
+  Cloud Messaging, by **wrapping `@visulima/notification`** rather than building
+  a push engine from scratch.
+
+> **Reuse (visulima) — reframes this plan.** `@visulima/notification` already
+> ships the engine: channels for **Push (FCM, Expo, Web Push, APNs)**, SMS, Chat
+> (Slack/Discord/Teams/Telegram), In-app inbox, generic Webhook, and Email (via
+> `@visulima/email`, already used by `@lunora/mail`). Crucially, **"nearly every
+> provider is `fetch` + Web Crypto only and runs on Cloudflare Workers"** — Web
+> Push + FCM are edge-safe. It brings routing (failover/broadcast), middleware
+> (retry, rate-limit, circuit-breaker), queues, and preferences/opt-outs. So this
+> plan becomes a **thin `ctx.notify` adapter + subscription storage + Studio
+> surface**, not a from-scratch build — effort drops L → M, and scope expands from
+> push-only to multi-channel for near-free. It also delivers the **outbound-webhook
+> sliver** that plan 132 tracks, and the **in-app inbox** that was a non-goal.
+
+## Context (verified)
+
+Grep for `web-?push|fcm|apns|push.?notification|VAPID` over `packages/*/src`
+returns **zero** hits. Lunora has no notification story at all. Firebase FCM (+
+web push) is a default expectation for consumer and mobile apps.
+
+Fits the existing binding-facade pattern (`@lunora/bindings` → `ctx.*`) and reuses
+Cloudflare primitives: a DO/D1 for subscription storage, `@lunora/scheduler` for
+scheduled sends, `@lunora/queue` for fan-out, `@lunora/studio` for a surface.
+
+## Phase 0 — Edge-safety spike
+
+- [ ] Confirm `@visulima/notification`'s Web Push + FCM providers run under
+      `workerd` (`fetch` + Web Crypto). **Caveat (like SAML):** APNs uses Node's
+      `http2` and the BullMQ/pg-boss/SQS queue adapters are Node-only — scope APNs
+      + heavy queueing out of the edge path or route them via `@lunora/queue`.
+
+## Phase 1 — Web Push + FCM via `ctx.notify`
+
+- [ ] New package `packages/notify` (`@lunora/notify`, alias `ctx.push`), ESM-only.
+- [ ] Wire `@visulima/notification` (Web Push + FCM channels); VAPID/FCM config via
+      `@lunora/config` + `.dev.vars` grammar.
+- [ ] Device/subscription storage (endpoint + keys) in a DO or D1 table.
+- [ ] Typed `ctx.notify.send(...)` / `ctx.push.broadcast(...)`; client helper to
+      register a service-worker push subscription.
+
+## Phase 2 — Additional channels (near-free from the engine)
+
+- [ ] Expose the engine's Chat / In-app inbox / Webhook channels through
+      `ctx.notify`; SMS + APNs behind the edge-safety scoping from Phase 0.
+
+## Phase 3 — Surface & safety
+
+- [ ] Studio page: registered devices, last-send status, delivery errors, inbox.
+- [ ] Advisor lints (send-outside-action, missing VAPID/FCM config).
+- [ ] Queue-backed fan-out via `@lunora/queue`; reuse the engine's retry/backoff +
+      circuit-breaker middleware.
+
+## Exit criteria
+
+- [ ] Web Push + FCM send/receive works end-to-end (workerd + a browser) via the
+      `@visulima/notification` engine.
+- [ ] Subscription lifecycle (register, expire, prune) handled and tested.
+- [ ] APNs/SMS either edge-verified or explicitly scoped to a Node/queue path.
+- [ ] Docs + example.
+
+## Non-goals
+
+- Rebuilding a notification engine — adapt `@visulima/notification`, don't rebuild.
+- Rich campaign/marketing tooling in v1 (keep `ctx.notify` a primitive).

--- a/plans/166-enterprise-auth-saml-scim.md
+++ b/plans/166-enterprise-auth-saml-scim.md
@@ -1,0 +1,100 @@
+# Plan 166 — Enterprise auth: SAML SSO + SCIM
+
+- **Category**: feat (competitive parity — gap #11 in `plans/README.md` Wave 14)
+- **Priority**: P2
+- **Effort**: M–L · **Risk**: MED (LOW for the OIDC-SSO + SCIM-Users half;
+  MED–HIGH for SAML-on-workerd — see Phase 0)
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: make enterprise SSO and SCIM directory provisioning first-class in
+  `@lunora/auth`, closing the enterprise-auth gap vs Supabase / Firebase Identity
+  Platform / WorkOS-style offerings.
+
+> **Risk correction (Fable 5 deep-analysis, 2026-07-21).** The original "LOW —
+> mostly wiring" rating only holds for the **OIDC-based SSO + SCIM-Users** path.
+> **SAML on Cloudflare Workers is the risk**: better-auth's SAML support pulls in
+> `samlify` → `xml-crypto` / `node-rsa` (pure-JS RSA) / `@xmldom/xmldom`, and
+> upstream better-auth#10343 (open, 2026-07-09) states SAML ACS "is a poor fit
+> for Worker CPU budgets and Node-only dependencies," with a pluggable remote
+> executor proposed in unmerged PR #10347. Treat SAML-on-workerd as unproven
+> until the Phase-0 spike says otherwise.
+
+## Context (verified — code + upstream)
+
+`@lunora/auth` is a thin pass-through to `betterAuth(resolveAuthOptions(options))`
+(`create-auth.ts`); `options.plugins` forwards verbatim, `plugins.ts` /
+`plugins-client.ts` are one-line-per-plugin curated re-exports (`oidcProvider`
+already exported), `schema.ts` auto-derives D1 tables from any plugin via
+`getAuthTables`, `migrate.ts` uses better-auth's own diffing, and `handler.ts`
+prefix-routes `/api/auth/*` method-agnostically — so adding a plugin is genuinely
+low wiring on the D1/OIDC side. Grep for `saml|scim|sso` over `packages/auth/src`
+returns **zero** hits today.
+
+The plugins exist and are first-party MIT, version-locked to the repo's pinned
+`better-auth ^1.6.23`:
+
+- **`@better-auth/sso` v1.6.23** — OIDC + OAuth2 + SAML 2.0, SP metadata + ACS,
+  SP/IdP-initiated, `provisionUser` + `organizationProvisioning` hooks. SAML path
+  depends on `samlify` (the workerd risk above); OIDC path is edge-safe.
+- **`@better-auth/scim` v1.6.23** — SCIM 2.0 **server**, **Users only** (no
+  `/Groups`), zod-only (edge-safe); `active:false` deactivation requires the
+  `admin` plugin, org scoping requires the `organization` plugin.
+
+One code caveat: `lunoraAuthAdapter` (`adapter.ts`) is single-table CRUD and does
+**not** handle better-auth's relational `join` reads — must be validated against
+the sso/scim endpoints.
+
+## Phase 0 — De-risk SAML-on-workerd (blocking spike)
+
+The plugin-availability question is answered (above). What's left is the real
+unknown:
+
+- [x] Confirm plugins + licensing + edge-safety of the non-SAML path.
+      _Done 2026-07-21 (Fable 5): `@better-auth/sso` + `@better-auth/scim`, MIT,
+      v1.6.23; OIDC/SCIM edge-safe, SAML is the risk._
+- [ ] **Workerd SAML spike (blocking).** Import `@better-auth/sso`, run a SAML ACS
+      verify under `wrangler dev` with `nodejs_compat` (signed + encrypted
+      assertion), measure CPU ms (`node-rsa` is pure-JS RSA). GO/NO-GO on
+      SAML-on-workerd.
+- [ ] Track better-auth#10343 / PR #10347 (pluggable remote SAML executor) as the
+      sanctioned edge path; decide the fallback (OIDC façade in front of the IdP)
+      if it stays unmerged.
+- [ ] Adapter compat: run sso/scim endpoints against `lunoraAuthAdapter`'s no-join
+      CRUD; confirm `authTables` auto-picks up `ssoProvider` / `scimProvider`.
+- [ ] Confirm the generated worker dispatch passes PUT/PATCH/DELETE through
+      `handleAuthRequest` (SCIM requires them).
+
+## Phase 1a — OIDC-based enterprise SSO + SCIM Users (LOW, do first)
+
+- [ ] Add `@better-auth/sso` + `@better-auth/scim` to `catalog:auth` (lockstep with
+      `better-auth ^1.6.23`); export `ssoClient` in `plugins-client.ts`.
+- [ ] Wire `sso` (OIDC/OAuth2 mode) + `scim` into the curated plugin surface;
+      D1 tables auto-surface via `authTables`.
+- [ ] Map SSO identity → `ctx.auth` used by RLS; SCIM create/replace/patch/delete
+      + `active:false` deactivation (with the `admin` plugin) → identity lifecycle.
+
+## Phase 1b — SAML (gated on the Phase-0 GO)
+
+- [ ] Only if the workerd spike is GREEN (or via the remote-executor path): enable
+      the SAML mode, SP metadata + ACS through `handler.ts`, assertion → `ctx.auth`.
+
+## Phase 2 — SCIM Groups → roles (rescoped)
+
+- [ ] `@better-auth/scim` is **Users-only** — Group sync is custom work. Either
+      build `/Groups` → org membership/role mapping on top (requires the
+      `organization` plugin) or **defer**; document the admin+organization
+      prerequisites.
+
+## Exit criteria
+
+- [ ] OIDC-SSO login + SCIM Users provisioning work end-to-end against a real IdP
+      (Okta/Entra test tenant).
+- [ ] SAML either works on workerd (spike GREEN) or is explicitly deferred with the
+      remote-executor path documented — not silently half-wired.
+- [ ] Docs + example; tests over the identity map and SCIM lifecycle.
+
+## Non-goals
+
+- Building SAML/SCIM from scratch — adapt better-auth, don't rebuild.
+- Custom IdP admin UI (config via `.dev.vars` / dashboard is sufficient v1).
+- Blocking the whole plan on SAML — ship the OIDC + SCIM-Users value first.

--- a/plans/167-public-rest-graphql-surface.md
+++ b/plans/167-public-rest-graphql-surface.md
@@ -1,0 +1,50 @@
+# Plan 167 — Opt-in public REST / GraphQL surface
+
+- **Category**: feat (competitive parity — gap #9 in `plans/README.md` Wave 14)
+- **Priority**: P3
+- **Effort**: L · **Risk**: MED
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: expose an **opt-in** HTTP REST (and optionally GraphQL) surface over
+  declared procedures so non-TS clients, webhooks-in, and no-code tools
+  (Zapier/n8n) can call a Lunora deployment — closing the interop gap vs
+  Supabase's PostgREST + GraphQL, without displacing typed RPC as the primary
+  contract.
+
+## Context (verified)
+
+An OpenAPI/OpenRPC **spec** is already generated
+(`packages/cli/src/util/api-spec.ts`, wired into codegen/prepare/deploy/verify),
+but there is no runtime REST CRUD surface — clients must speak the typed RPC.
+That blocks any consumer that can't import the TS client.
+
+Design constraint: everything must route **through procedures** so RLS/auth
+(`ctx.auth`) and validators are enforced — no direct table CRUD that bypasses them.
+
+## Phase 1 — REST over procedures (opt-in)
+
+- [ ] Per-procedure opt-in (`.expose({ rest: true })` or schema annotation) so the
+      surface is deliberate, never automatic.
+- [ ] Runtime router mapping exposed procedures → REST endpoints
+      (`packages/runtime/src/*-admin-routes.ts` pattern), enforcing auth + RLS +
+      validators.
+- [ ] Make the existing OpenAPI spec (`api-spec.ts`) describe exactly the exposed
+      REST surface (single source of truth).
+- [ ] Rate-limit hookup (`@lunora/ratelimit`) on the public surface.
+
+## Phase 2 — GraphQL (optional, demand-gated)
+
+- [ ] Generate a GraphQL schema from exposed procedures + the data model; resolvers
+      delegate to the same procedure path. Only if there's demand.
+
+## Exit criteria
+
+- [ ] An exposed procedure is callable over REST with auth + RLS enforced.
+- [ ] The published OpenAPI matches the live REST surface (contract test).
+- [ ] Non-exposed procedures are unreachable over REST (default-closed).
+- [ ] Docs: "public API surface" guide + security guidance.
+
+## Non-goals
+
+- REST/GraphQL becoming the primary contract — typed RPC stays primary.
+- Auto-CRUD directly on tables (would bypass RLS) — always via procedures.

--- a/plans/168-cross-shard-transactions-spike.md
+++ b/plans/168-cross-shard-transactions-spike.md
@@ -1,0 +1,50 @@
+# Plan 168 — Cross-shard transaction story (design spike)
+
+- **Category**: architecture (competitive parity — gap #5 in `plans/README.md` Wave 14)
+- **Priority**: P2
+- **Effort**: XL · **Risk**: HIGH
+- **Status**: TODO (spike first — no implementation until direction is ratified)
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: decide Lunora's cross-shard write-consistency story. Either (a) offer
+  a bounded cross-shard transaction/saga primitive, or (b) make the boundary a
+  documented, lint-enforced non-goal. Convex offers global serializable
+  transactions; once a Lunora app calls `.shardBy()`, cross-shard writes are not
+  atomic — a real limitation for multi-entity invariants.
+
+## Context (verified)
+
+Storage is per-DO SQLite with OCC (`packages/do/src/shard-do.ts`). Cross-shard
+**reads/relations** already exist (`packages/runtime/src/cross-shard-relations.ts`,
+`query-coordinator.ts`, plus cross-shard rank/rankPage per prior work), but there
+is no atomic cross-shard **write**. This is arguably a deliberate boundary — the
+spike must decide, not assume.
+
+## Phase 0 — Design spike (the only deliverable until ratified)
+
+Produce a design doc (`plans/168-phase0-design.md`) covering:
+
+- [ ] Enumerate the invariants users actually hit that need cross-shard atomicity
+      (money transfer between tenants, unique-across-shards, etc.) — is the demand real?
+- [ ] Option A — **saga / compensation** over DOs (reuse the workflow fan-out
+      compensation machinery, plan 076): eventual, not ACID, but composable.
+- [ ] Option B — **2PC/coordinator transaction** across DOs: stronger, higher
+      latency + failure complexity on the DO model.
+- [ ] Option C — **documented boundary + advisor lint**: no primitive; a static
+      lint flags a mutation writing across shard boundaries, and docs state the
+      guarantee. Cheapest, most honest if demand is thin.
+- [ ] Recommendation + guarantee wording, latency/complexity cost, and a STOP/GO.
+
+## Phase 1+ — Implement the chosen option
+
+Only after Phase 0 is ratified. Scope defined by the chosen option.
+
+## Exit criteria (spike)
+
+- [ ] `plans/168-phase0-design.md` filed with a clear recommendation + go/no-go.
+- [ ] If NON-GOAL: the advisor lint + docs boundary lands (the Wave 14 NON-GOAL routing).
+- [ ] If BUILD: a follow-up implementation plan is filed with phased steps.
+
+## Non-goals
+
+- Writing any transaction code before the spike concludes.
+- Weakening single-DO OCC guarantees (those stay as-is).

--- a/plans/169-collab-crdt.md
+++ b/plans/169-collab-crdt.md
@@ -1,0 +1,49 @@
+# Plan 169 — `@lunora/collab` (CRDT / collaborative editing)
+
+- **Category**: feat (competitive parity — gap #8 in `plans/README.md` Wave 14; Wave 5 PartyKit gap)
+- **Priority**: P3
+- **Effort**: XL · **Risk**: MED
+- **Status**: TODO (demand-gated — file, don't build until a design partner needs it)
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: offer CRDT-based collaborative editing (rich-text, canvas) via a
+  prospective `@lunora/collab` package — Yjs document persistence + awareness over
+  `ShardDO` storage and the `whisper` channel — closing the gap vs Liveblocks /
+  PartyKit (`y-partyserver`).
+
+## Context (verified)
+
+Recorded as the outstanding PartyKit gap in `plans/README.md` Wave 5: "Reuse,
+don't rebuild — `y-partyserver` is ISC and solves Yjs document persistence +
+awareness, which map onto `ShardDO` storage + the `whisper` channel." No plan was
+filed until now; no `@lunora/collab` package exists.
+
+Anchors: `packages/do/src/shard-do.ts` (SQLite storage), `subscription-delivery.ts`,
+the `whisper` ephemeral channel, and `usePresence` (awareness maps onto presence).
+
+## Phase 1 — Yjs persistence
+
+- [ ] New package `packages/collab` (`@lunora/collab`), ESM-only.
+- [ ] Adapt `y-partyserver` (ISC) to persist a Yjs doc in `ShardDO` SQLite storage
+      (one doc per shard/room), with snapshot + update-log compaction.
+
+## Phase 2 — Awareness
+
+- [ ] Route Yjs awareness (cursors/selections) over the `whisper` channel, reusing
+      the `usePresence` ephemeral-broadcast path.
+
+## Phase 3 — Client binding
+
+- [ ] `useYDoc` / provider for React (then other adapters) that connects a Yjs doc
+      to a Lunora room over the existing WS transport.
+- [ ] Example: collaborative rich-text (Tiptap/ProseMirror) or a shared canvas.
+
+## Exit criteria
+
+- [ ] Two clients edit the same Yjs doc with convergence + live awareness.
+- [ ] Doc survives DO hibernation/restart (persistence verified on workerd).
+- [ ] Docs + example.
+
+## Non-goals
+
+- Building a CRDT from scratch — reuse Yjs / `y-partyserver`.
+- Starting before a concrete design partner / product goal exists (parked by design).

--- a/plans/170-cdc-export-tap.md
+++ b/plans/170-cdc-export-tap.md
@@ -1,0 +1,54 @@
+# Plan 170 — Continuous change-data export tap (warehouse-out)
+
+- **Category**: feat (competitive parity — gap #10 in `plans/README.md` Wave 14)
+- **Priority**: P3
+- **Effort**: L · **Risk**: MED
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: add a **continuous** change-stream export tap (op-log → external sink)
+  so Lunora data can flow to warehouses (Snowflake/BigQuery) and ETL tools
+  (Airbyte/Fivetran) — the export-out counterpart to the existing CDC-in path,
+  closing the streaming-export gap vs Convex/Supabase/Firebase.
+
+## Context (verified — scope is narrower than it looks)
+
+Two halves already exist:
+
+- **Snapshot export + backup**: `packages/runtime/src/export-stream.ts`
+  (`streamExportRows`, NDJSON) powers the admin export endpoint and the scheduled
+  R2 backup. This is a point-in-time dump, **not** a continuous stream.
+- **CDC-in**: `packages/runtime/src/connector-cdc.ts` / `connector-format.ts` /
+  `import-stream.ts` bring external changes *into* DO shapes (plan 136).
+
+The genuine gap is the **outbound continuous tap**: a subscription to the shard
+op-log that emits change events (insert/update/delete, ordered per shard) to an
+external sink — not a re-run of the snapshot exporter.
+
+## Phase 1 — Change tap (framework)
+
+- [ ] Expose an ordered per-shard change feed off the op-log
+      (`packages/do/src/subscription-delivery.ts` / `shard-do.ts`) as an internal tap.
+- [ ] Sink abstraction: `defineExportSink` with at-least-once delivery, a durable
+      per-shard cursor (mirror the `__lunora_source_cursor` watermark from CDC-in),
+      and retry/backoff.
+- [ ] Built-in sinks: webhook (POST NDJSON) and R2; wired via
+      `data-movement-admin-routes.ts`.
+
+## Phase 2 — Warehouse connectors (mostly CLOUD)
+
+- [ ] Managed Snowflake/BigQuery/Airbyte/Fivetran connectors — tracked in
+      `apps/cloud/ROADMAP.md` (the framework ships the tap; Cloud ships the
+      managed pipes).
+
+## Exit criteria
+
+- [ ] A row change in a shard produces an ordered change event at a sink,
+      at-least-once, with a resumable cursor (verified on workerd).
+- [ ] Backpressure / retry on sink failure does not stall the shard.
+- [ ] Docs: "streaming export" guide; advisor lint if a sink is misconfigured.
+
+## Non-goals
+
+- Reimplementing the snapshot exporter (already shipped) — this is the streaming path.
+- Hosting managed warehouse connectors (that's Lunora Cloud).
+- Exactly-once delivery in v1 (at-least-once + idempotent cursor is the target).

--- a/plans/171-non-goals-docs-page.md
+++ b/plans/171-non-goals-docs-page.md
@@ -1,0 +1,50 @@
+# Plan 171 — "Design boundaries / non-goals" docs page
+
+- **Category**: docs (competitive parity — Wave 14 in `plans/README.md`)
+- **Priority**: P2
+- **Effort**: S · **Risk**: LOW
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: publish a single, linkable docs page that states Lunora's deliberate
+  design boundaries, so the gaps a competitor comparison surfaces read as
+  **intentional choices**, not missing features. The cheapest trust win from the
+  Wave 14 competitive pass — boundaries stated plainly beat boundaries discovered
+  by a frustrated user.
+
+## Context
+
+The Wave 14 routing rule assigns several competitive gaps to a **NON-GOAL**
+bucket (documented boundary, not built). Plans 167 and 168 both reference this
+page but nothing owns it. Related existing pages:
+`apps/docs/src/content/docs/architecture.mdx`,
+`apps/docs/src/content/docs/versioning.mdx`,
+`apps/docs/src/content/docs/production-checklist.mdx`.
+
+## Deliverables
+
+- [ ] `apps/docs/src/content/docs/non-goals.mdx` (or `design-boundaries.mdx`),
+      wired into the docs nav (`meta.json` / the tag-derived sidebar).
+- [ ] State each boundary with the *reason* and the *escape hatch*:
+  - **No arbitrary external SQL / ad-hoc cross-dataset joins.** Data is per-DO
+    SQLite reached via typed RPC by design; `@lunora/hyperdrive` covers BYO
+    external Postgres/MySQL (action-only, non-reactive) when you need raw SQL.
+  - **RPC-first, not REST-first.** The typed RPC surface is the primary contract;
+    the opt-in generated REST/GraphQL surface (plan 167) is an interop layer, not
+    the main API.
+  - **Cross-shard writes are eventual** unless/until the plan 168 primitive lands;
+    single-DO writes are OCC-serializable. State the exact guarantee.
+  - Any additional boundaries confirmed by the Wave 14 deep pass (e.g. no
+    warehouse hosting in the framework — that's Lunora Cloud).
+- [ ] Cross-link the page from `versioning.mdx` and the root `README.md`.
+
+## Exit criteria
+
+- [ ] Page published and reachable in the site nav.
+- [ ] Each NON-GOAL-bucketed Wave 14 gap has a plain-language entry with reason +
+      escape hatch.
+- [ ] Plans 167 and 168 link to it instead of describing the boundary inline.
+
+## Non-goals
+
+- Apologizing for the boundaries — state them as deliberate trade-offs, with the
+  workaround, and move on.

--- a/plans/172-geospatial.md
+++ b/plans/172-geospatial.md
@@ -1,0 +1,47 @@
+# Plan 172 — Geospatial indexing & queries
+
+- **Category**: feat (competitive parity — Wave 14 deep-pass, in `plans/README.md`)
+- **Priority**: P2
+- **Effort**: L · **Risk**: MED
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: add first-class geospatial storage + queries (`near` / within-radius /
+  bounding-box) to Lunora — the only wholly-missing data-layer capability that
+  Convex, Supabase, and Firebase all answer.
+
+## Context (verified)
+
+Grep for `geo|geospatial|geohash|haversine|withinRadius|boundingBox|latLng|s2`
+over `packages/*/src` and package docs returns **zero** hits. `packages/server/src/schema.ts`
+has `index` / `searchIndex` / `softDelete` / relations — no geo counterpart.
+Competitors: Convex (official geospatial component — point index, nearest /
+within-radius / rectangle), Supabase (full PostGIS), Firebase (documented
+geohash/GeoFire pattern). "Things near me" is a top-tier app query all three serve.
+
+The existing index machinery is the seam: a geohash-prefix range query slots into
+`ShardDO` SQLite exactly like `.searchIndex()` does.
+
+## Phase 1 — Type + index
+
+- [ ] `v.geoPoint()` validator in `@lunora/values` (lat/lng, validated ranges).
+- [ ] `.geoIndex(name, { field })` on the `TableBuilder`
+      (`packages/server/src/schema.ts`), mirroring the `.searchIndex()` shape;
+      store a geohash column alongside the row.
+
+## Phase 2 — Query
+
+- [ ] `withGeoIndex(name, q => q.near(point, radius))` (and `.within(bbox)`) on the
+      table reader, resolved as a geohash-prefix range scan in `ShardDO` +
+      Haversine refine/sort on candidates.
+- [ ] Codegen + typed inference for the geo query surface.
+
+## Exit criteria
+
+- [ ] Insert points, query `near`/`within` with correct ordering, verified on workerd.
+- [ ] Advisor lint: `geoIndex` declared but unused / query without a geo index.
+- [ ] Docs + example (a "places near me" query).
+
+## Non-goals
+
+- Full PostGIS geometry (polygons, projections) — points + radius/bbox is the target.
+- Cross-shard geo ranking in v1 (single-shard first; revisit with the coordinator).

--- a/plans/173-client-upload-sdk.md
+++ b/plans/173-client-upload-sdk.md
@@ -1,0 +1,59 @@
+# Plan 173 — Client-side upload SDK (progress / pause-resume / resumable)
+
+- **Category**: feat (competitive parity — Wave 14 deep-pass, in `plans/README.md`)
+- **Priority**: P2
+- **Effort**: S–M · **Risk**: LOW
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: give end-user browsers a real upload story — progress, pause/resume,
+  large-file resumable uploads — matching Firebase `uploadBytesResumable`,
+  Supabase TUS, and Convex's upload flow, by **adopting `@visulima/storage-client`**
+  rather than hand-rolling the client. The **server primitives already exist**;
+  only the client DX layer is missing.
+
+> **Reuse (visulima) — nearly the whole plan.** `@visulima/storage-client` already
+> ships browser-safe hooks for exactly this: `useUpload()`, `useMultipartUpload()`,
+> `useTusUpload()`, `useChunkedRestUpload()`, `useBatchUpload()` — with real-time
+> progress, pause/resume (TUS), and first-class React/Vue/Solid/Svelte support
+> (`UploadControl`, `UploadError`). On the server, **`@visulima/storage`** abstracts
+> **Cloudflare R2** (S3-compatible) with a **`@visulima/storage/handler/http/cloudflare`
+> edge adapter**, presigned URLs, multipart, and TUS/REST handlers. So this plan is
+> mostly **integration + an RLS-gated presign procedure**, not a build — effort M →
+> S–M. Caveat: the hooks require **TanStack Query**; wrap the framework-agnostic
+> core (`UploadControl`) if that clashes with `@lunora/react`'s own `useQuery`.
+
+## Context (verified)
+
+Server side is covered: `packages/storage/src/signed-url.ts` exports
+`createMultipartUpload` + `buildPresignedUrl` over R2 native multipart. The only
+client upload today is the **admin-gated Studio path**
+(`packages/client/src/lunora-client.ts:2321` `uploadStorageObject`, hits the
+admin-gated `storageUpload` fn with an `adminToken`). There is **no** end-user
+`useUpload` hook in any framework adapter (zero `storage|upload` hits in
+`packages/react/src`), and no progress/pause/resume in `packages/client/src`.
+
+## Phase 1 — RLS-gated presign + client wiring
+
+- [ ] A non-admin client upload flow: an RLS-gated user procedure issues presigned
+      multipart (or TUS) URLs — reuse `@lunora/storage` `createMultipartUpload` /
+      `buildPresignedUrl` (optionally the `@visulima/storage` cloudflare handler).
+- [ ] Wire `@visulima/storage-client` against that endpoint; verify progress,
+      pause/resume, cancel, per-part retry against a live R2 bucket.
+
+## Phase 2 — Framework hooks
+
+- [ ] Re-export / thin-wrap the `@visulima/storage-client` `useUpload()` family
+      through `@lunora/react` (then Vue/Solid/Svelte), reconciling the TanStack
+      Query dependency with `@lunora/react`'s own query layer.
+- [ ] Example: a drag-drop uploader with a progress bar over a large file.
+
+## Exit criteria
+
+- [ ] A large file uploads with a live progress bar, survives a pause/resume, and
+      resumes after a dropped connection — RLS enforced (not admin-gated).
+- [ ] Docs + example; tests over the presign + resume integration.
+
+## Non-goals
+
+- A new storage backend — this rides the existing R2 multipart + presigned server API.
+- Rebuilding the client uploader — adopt `@visulima/storage-client`, don't hand-roll.

--- a/plans/174-auth-audit-trail.md
+++ b/plans/174-auth-audit-trail.md
@@ -1,0 +1,45 @@
+# Plan 174 — Auth / security event audit trail
+
+- **Category**: feat (competitive parity — Wave 14 deep-pass, in `plans/README.md`)
+- **Priority**: P2
+- **Effort**: M · **Risk**: LOW
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: record authentication & security events (sign-in, sign-up, token
+  refresh, password change, MFA enable/disable, SSO link) to a durable, queryable
+  audit trail — the compliance/forensics surface Supabase
+  (`auth.audit_log_entries`), Firebase, and Convex (paid) all offer.
+
+## Context (verified)
+
+An audit log already exists but is scoped to **admin state-changing operations**:
+`packages/do/src/audit-log.ts` records `writeRow` / `runMigration` / `importShard`
+/ `applyCdc` with ~1000-row retention. Grep `-i audit packages/auth/src` yields
+only doc-comment mentions — **no auth-event recording anywhere**. better-auth
+exposes lifecycle hooks that can feed the same reserved-audit-table pattern.
+
+## Phase 1 — Record auth events
+
+- [ ] Hook better-auth lifecycle events (`packages/auth/src/create-auth.ts` /
+      `handler.ts` / `session.ts`) → append to a durable auth-audit store,
+      reusing the `do/audit-log.ts` reserved-table pattern (configurable retention,
+      not capped at 1000 for compliance use).
+- [ ] Capture actor, event type, IP/UA, timestamp, outcome; **redact secrets with
+      `@visulima/redact`** (already a `@lunora/do` dependency) and optionally scan
+      payloads with `@visulima/secret-scanner`.
+
+## Phase 2 — Query & surface
+
+- [ ] Read API (RLS/admin-gated) + a Studio "Security / audit" page.
+- [ ] Optional export tap hook (pairs with plan 170) for SIEM forwarding.
+
+## Exit criteria
+
+- [ ] Sign-in / password-change / MFA-toggle events are recorded and queryable.
+- [ ] Retention is configurable; PII/secret redaction verified by tests.
+- [ ] Docs + example.
+
+## Non-goals
+
+- A full SIEM — this is a recorded, queryable trail; forwarding is a hook, not a product.
+- Duplicating the admin-op audit log — extend the pattern to auth events.

--- a/plans/175-schema-ttl-auto-expiry.md
+++ b/plans/175-schema-ttl-auto-expiry.md
@@ -1,0 +1,41 @@
+# Plan 175 — Schema-level TTL / document auto-expiry
+
+- **Category**: feat (competitive parity — Wave 14 deep-pass, in `plans/README.md`)
+- **Priority**: P3
+- **Effort**: S–M · **Risk**: LOW
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: a declarative `.ttl(field)` table option that auto-deletes expired
+  rows — the ephemeral-data chore (sessions, OTPs, short-lived tokens, transient
+  events) that Firestore (native TTL) and Supabase (pg_cron pattern) handle.
+  Convex notably lacks it, so this is a cheap differentiator.
+
+## Context (verified)
+
+No `ttl|expire|expireAfter|autoDelete` in `packages/server/src/schema.ts` — the
+`TableBuilder` has `index` / `searchIndex` / `softDelete` / relations, no expiry.
+Only presence-heartbeat TTL (`packages/server/src/presence.ts:210`) and
+observability retention exist. The sweep infrastructure is already present: the DO
+alarm / trigger machinery in `packages/do/src/triggers.ts`.
+
+## Phase 1
+
+- [ ] `.ttl(field, { after? })` on the `TableBuilder`
+      (`packages/server/src/schema.ts`) — `field` holds an expiry timestamp (or
+      `after` derives it from a base column).
+- [ ] A DO alarm-driven sweep (`packages/do/src/triggers.ts`) that deletes expired
+      rows in batches; honor `softDelete` if the table declares it.
+- [ ] Codegen wiring so the sweep is scheduled per table that declares a TTL.
+
+## Exit criteria
+
+- [ ] Rows past their TTL are deleted (or soft-deleted) within a bounded window,
+      verified on workerd with the alarm advanced.
+- [ ] Sweep is batched and doesn't stall the shard; advisor lint for a TTL field
+      that isn't a timestamp.
+- [ ] Docs + example (expiring sessions/OTPs).
+
+## Non-goals
+
+- Per-row arbitrary schedules (that's `@lunora/scheduler`) — this is coarse,
+  cheap, table-level expiry.

--- a/plans/176-auth-email-hardening.md
+++ b/plans/176-auth-email-hardening.md
@@ -1,0 +1,53 @@
+# Plan 176 — Auth email hardening (disposable / free-email gating + verification)
+
+- **Category**: feat (security/DX — Wave 14 visulima reuse, in `plans/README.md`)
+- **Priority**: P3
+- **Effort**: S · **Risk**: LOW
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: let apps reject throwaway/disposable signups and reason about
+  free-vs-business email at registration, by reusing the visulima email packages
+  in `@lunora/auth`. A cheap trust/anti-abuse win enabled by reuse, not a from-
+  scratch build.
+
+## Context
+
+`@lunora/auth` (better-auth) already does email verification via the
+`emailAndPassword` flow; what it lacks is **domain-based gating** at signup. The
+visulima catalog covers this directly and edge-safely:
+
+- **`@visulima/disposable-email-domains`** — blocklist of temporary/throwaway
+  domains (pure data → edge-safe).
+- **`@visulima/free-email-domains`** — list of free consumer providers (pure data
+  → edge-safe); useful to flag/branch B2B signups.
+- **`@visulima/email-verifier`** — syntax + domain + MX validation. **Caveat: MX
+  verification needs DNS**, which on workerd means DNS-over-HTTPS or scoping the
+  MX step out of the edge path; the domain-list checks are pure-data and always safe.
+
+## Phase 1 — Domain gating at signup
+
+- [ ] Add a signup middleware/hook in `@lunora/auth` (`middleware.ts` /
+      `create-auth.ts`) that consults `@visulima/disposable-email-domains` and
+      rejects disposable addresses with a coded error (`@lunora/errors`).
+- [ ] Config knobs: `blockDisposable`, `flagFreeEmail`, custom allow/deny lists;
+      expose a resolved `emailClass` (`disposable | free | business`) on the signup
+      context for app policy.
+
+## Phase 2 — Optional deeper verification
+
+- [ ] Opt-in `@visulima/email-verifier` syntax + MX validation, with the DNS caveat
+      documented; wire it behind a flag so the default path stays pure-data/edge-safe.
+- [ ] Advisor lint: signup mutation without disposable gating (pairs with the
+      existing `user-creating-mutation-without-captcha` lint).
+
+## Exit criteria
+
+- [ ] A disposable-domain signup is rejected with a clear error; a business email
+      passes; behavior is config-gated and defaults sensibly.
+- [ ] The default path is edge-safe (no DNS); MX verify is opt-in + documented.
+- [ ] Docs + tests.
+
+## Non-goals
+
+- Maintaining the domain lists ourselves — track `@visulima/*` upstream.
+- Full email deliverability scoring — this is signup-time gating, not a mail product.

--- a/plans/177-health-check-endpoint.md
+++ b/plans/177-health-check-endpoint.md
@@ -1,0 +1,46 @@
+# Plan 177 — Health-check endpoint
+
+- **Category**: feat (DX/ops — Wave 14 visulima reuse, in `plans/README.md`)
+- **Priority**: P3
+- **Effort**: S · **Risk**: LOW
+- **Status**: TODO
+- **Baseline**: `70331e9b` (2026-07-21)
+- **Goal**: ship a first-class health/readiness endpoint for a deployed Lunora
+  worker — reporting binding/subsystem health and basic metrics — by reusing
+  **`@visulima/health-check`**. A production-readiness win that feeds the
+  existing production-checklist.
+
+## Context
+
+Lunora has observability groundwork (traces/metrics in Studio) but no standard
+**health/readiness probe** an uptime monitor, load balancer, or Cloudflare Health
+Check can hit. `@visulima/health-check` provides service checks + metrics and is
+`fetch`-based (edge-safe). It slots into the existing admin-route pattern
+(`packages/runtime/src/*-admin-routes.ts`).
+
+## Phase 1
+
+- [ ] A `GET /_lunora/health` (and `/health/ready`) route via the admin-route
+      pattern, backed by `@visulima/health-check`.
+- [ ] Register checks for the deployment's critical bindings/subsystems: DO
+      reachability, D1, R2, and any configured externals (Hyperdrive, queues).
+- [ ] Liveness (process up) vs readiness (dependencies healthy) split; return
+      standard status + JSON body; keep it unauthenticated-safe (no secrets leaked)
+      or admin-gated per config.
+
+## Phase 2 — Surface & docs
+
+- [ ] Studio "Health" indicator; wire the endpoint into the production-checklist
+      docs and the deploy verify step.
+
+## Exit criteria
+
+- [ ] `/_lunora/health` returns green when bindings resolve and red/`503` when a
+      critical dependency is down, verified on workerd.
+- [ ] No secret/PII leakage in the health body; auth posture is configurable.
+- [ ] Docs + example (wiring a Cloudflare Health Check / uptime monitor).
+
+## Non-goals
+
+- A full metrics/APM product — this is a probe, not a dashboard (that's the
+  observability work + Lunora Cloud).

--- a/plans/README.md
+++ b/plans/README.md
@@ -888,6 +888,146 @@ commit on `alpha`, stripped of the stray local `chore(release)` version-bump sta
   revised (per-asset-decimals) approach now in the plan.
 - **146** needs a small ESLint cleanup on its source (non-null assertions, JSDoc, complexity).
 
+## Wave 14 — competitive parity (baseline `70331e9b`, 2026-07-21)
+
+User-requested gap pass over the whole repo vs **Convex, Supabase, Firebase**
+(and the wider field: InstantDB, Zero, Triplit, ElectricSQL, PowerSync,
+Liveblocks, PartyKit, Wasp). Builds on the two prior competitive passes (Wave 5 =
+PartyKit, Wave 6 = workflais). Findings were grounded against `packages/*/src`,
+so **verified non-gaps are excluded**: full-text search (`.searchIndex()` /
+`withSearchIndex()`), vector/RAG (`@lunora/ai/rag`), cron (`@lunora/scheduler`),
+storage (`@lunora/storage`), offline/local-first (`@lunora/replica`,
+`@lunora/db`), presence (`whisper` + `usePresence`), flags (`@lunora/flags`),
+workflows + fan-out (`@lunora/workflow`). Full analysis: `.tmp/competitive-gap-analysis.md`
+(gitignored, not committed). All plans **TODO — none executed yet.**
+
+**Routing rule.** Every gap lands in exactly one bucket: **FRAMEWORK** (a plan
+below), **CLOUD** (owned by `apps/cloud/ROADMAP.md` — managed hosting, hosted
+dashboard, retained observability, preview envs, backups/PITR, managed
+multi-region, templates/marketplace, warehouse connectors — *not* re-planned
+here), or **NON-GOAL** (a documented design boundary: no arbitrary external SQL /
+ad-hoc cross-dataset joins; RPC-first not REST-first; cross-shard writes eventual
+unless plan 168 lands). Publishing the NON-GOALs as a docs page is the cheapest
+trust win — boundaries read as deliberate, not missing.
+
+### Plans (FRAMEWORK-bucketed gaps)
+
+| Plan | Title                                                                       | Category     | Pkg          | Pri | Effort | Risk | Status |
+| ---- | --------------------------------------------------------------------------- | ------------ | ------------ | --- | ------ | ---- | ------ |
+| 164  | Non-TypeScript client SDK (Swift *or* Python) — prove the wire protocol isn't TS-bound; biggest ceiling vs Convex | feat         | client (new) | P2  | L      | MED  | TODO   |
+| 165  | `@lunora/push` — Web Push (VAPID) → FCM/APNs; grep-confirmed zero push code today | feat         | push (new)   | P2  | L      | MED  | TODO   |
+| 166  | Enterprise auth: SSO + SCIM — `@better-auth/sso` + `@better-auth/scim` (MIT); OIDC/SCIM-Users LOW, SAML-on-workerd is the risk | feat         | auth         | P2  | M–L    | MED  | TODO   |
+| 167  | Opt-in public REST/GraphQL surface — extend the existing OpenAPI/OpenRPC spec (`cli/api-spec.ts`) for non-TS/interop, RLS-enforced | feat         | runtime/cli  | P3  | L      | MED  | TODO   |
+| 168  | Cross-shard transaction story — **design spike first** (saga vs 2PC vs documented boundary+lint); no code until ratified | architecture | do/runtime   | P2  | XL     | HIGH | TODO   |
+| 169  | `@lunora/collab` (CRDT) — Yjs persistence + awareness over `ShardDO` + `whisper`; reuse `y-partyserver` (ISC); demand-gated | feat         | collab (new) | P3  | XL     | MED  | TODO   |
+| 170  | Continuous CDC export tap (op-log → external sink) — the streaming counterpart to CDC-in; snapshot export/backup already exist | feat         | runtime/do   | P3  | L      | MED  | TODO   |
+| 171  | "Design boundaries / non-goals" docs page — state the NON-GOAL bucket plainly (no arbitrary SQL, RPC-not-REST-first, cross-shard eventual); cheapest trust win | docs         | docs         | P2  | S      | LOW  | TODO   |
+
+### Considered / newly surfaced (Fable 5 deep pass, 2026-07-21)
+
+**The three follow-up gaps — verified:**
+
+- **A/B testing / experimentation** — *real but narrow.* `@lunora/flags` already
+  serves variants + provider-side percentage rollouts; only the experiment layer
+  is missing (log `details.variant` exposures → `@lunora/bindings/analytics` + a
+  Studio results view). Only Firebase (of the three) has it. **M · P3 · FRAMEWORK**
+  (thin flags extension; a heavy stats engine stays NON-GOAL/CLOUD).
+- **Product analytics** — *partial.* Ingestion exists (`@lunora/bindings/analytics`
+  typed `track`/`writeDataPoint` + SQL-API + Studio panel), but Analytics Engine is
+  sampled with ~3-month retention — the wrong substrate for canonical product
+  analytics (no taxonomy/sessions/funnels/retention). Only Firebase ships a
+  first-party product. **P3 · CLOUD** primarily (retained, unsampled = hosted);
+  optional small FRAMEWORK event-helper slice. Near-term answer: document a
+  PostHog integration.
+- **Server-side DB triggers / webhooks** — *NOT a gap (core); small (packaging).*
+  Triggers already ship: `defineTable().triggers()` — before/after × insert/update/
+  delete, typed `previous` row, `before*` aborts the write, `TriggerCtx = {db,
+  scheduler}` (`server/src/schema.ts`, `types.ts:1104`) — stronger than Convex's
+  helper. Plan 133 is unrelated (CDC-*in*). The only open sliver is **packaged
+  outbound HTTP webhooks**, already spiked as **plan 132** (Standard-Webhooks over
+  `TriggerCtx.scheduler` + SchedulerDO retry/dead-letter, zero core changes).
+  **S–M · P2 · FRAMEWORK** = execute plan 132.
+
+**Additional gaps found by the deep gap-hunt (all repo-verified):**
+
+| Plan | Gap | Competitors with it | Lunora today | Sev | Bucket |
+| --- | --- | --- | --- | --- | --- |
+| [172](172-geospatial.md) | **Geospatial indexing / queries** (`near`, within-radius) | Convex (geo component), Supabase (PostGIS), Firebase (geohash) | none — zero geo code in `packages/server/src` | **HIGH** | FRAMEWORK |
+| [173](173-client-upload-sdk.md) | **Client-side upload SDK** (progress, pause/resume, resumable) | Firebase, Supabase (TUS), Convex | server R2 multipart + presigned exist; only admin-gated client upload, no `useUpload` | MED | FRAMEWORK |
+| [174](174-auth-audit-trail.md) | **Auth/security audit trail** | Supabase (`auth.audit_log_entries`), Firebase, Convex (paid) | admin-state audit log exists (`do/audit-log.ts`) but no auth-event recording | MED | FRAMEWORK |
+| [175](175-schema-ttl-auto-expiry.md) | **Schema-level TTL / auto-expiry** | Firebase (Firestore TTL), Supabase (pg_cron) — Convex also lacks | no `.ttl()`; only presence-heartbeat TTL. DO alarm infra (`do/triggers.ts`) already exists | LOW–MED | FRAMEWORK |
+| — | **Client integrity / attestation** (App Check) | Firebase only | none; Turnstile/WAF already front every Worker | LOW | CLOUD / NON-GOAL → plan 171 |
+
+**Verified non-gaps** confirmed by the deep pass (Lunora already ships — do not
+re-file): passkeys / anonymous / magic-link / email-OTP / phone / 2FA / SIWE /
+OIDC-provider / captcha / impersonation / orgs-RBAC (`auth/plugins.ts`);
+data-residency (DO jurisdiction pinning); aggregation (`count`/`aggregate`/
+`groupBy` + cross-shard rank); custom HTTP endpoints (`httpAction`/`httpRouter`);
+soft-delete + cascade/restrict/set-null + unique indexes + typed enums; Studio SQL
+editor; snapshot export/import + **backups with PITR restore** + CSV transfer
+(CLI); online batched migrations; paginated/infinite live queries; flag targeting +
+percentage rollouts; server-side R2 multipart uploads.
+
+### Competitor facts (verified July 2026 — closes `.tmp` §5)
+
+- **Convex SDKs**: TS/React/React-Native, Python, Rust, Swift, Kotlin — **no Go**;
+  streaming export via **Fivetran (Pro)**. Confirms plan 164 (Lunora is TS-only).
+- **Supabase**: branching GA (2.0 drops the Git requirement, paid/hourly); read
+  replicas (≤2, paid, geo-routed GETs); PostgREST + pg_graphql first-party (with a
+  2026 breaking change — `public` no longer auto-exposed). Confirms plans 167/012-branching.
+- **Firebase**: FCM still the only supported push path (legacy APIs shut down
+  2024-07); **Analytics (GA4) + A/B (Remote Config experiments) both still
+  first-party**. Confirms plan 165 + gap α.
+
+### Reuse — `@visulima/*` packages (2026-07-21)
+
+The visulima ecosystem (same author; `fetch` + Web-Crypto-first, Cloudflare-aware)
+already covers several of these gaps — **reuse over rebuild**:
+
+| Plan / need | Reuse | What it saves | Edge-safe? |
+| --- | --- | --- | --- |
+| **165** push | **`@visulima/notification`** | whole multi-channel engine (Web Push, FCM, Expo, APNs, SMS, chat, in-app inbox, webhook) + routing / retry / circuit-breaker | Web Push + FCM ✅; **APNs needs Node http2**, queue adapters Node-only |
+| **173** upload | **`@visulima/storage-client`** (+ `@visulima/storage` cloudflare handler) | `useUpload`/multipart/TUS hooks w/ progress + pause/resume; R2 + presigned server | ✅ (hooks want TanStack Query) |
+| **174** audit | **`@visulima/redact`** (already in `do`) + **`@visulima/secret-scanner`** | PII/secret redaction + leak scan | ✅ |
+| **167** REST | **`@visulima/pagination`**; `@visulima/jsdoc-open-api` (weak — Lunora derives the spec from codegen, not JSDoc) | pagination helpers; OpenAPI gen | build-time |
+
+New opportunities the catalog surfaces (not previously listed):
+
+- **`@visulima/email-verifier`** + **`disposable-email-domains`** + **`free-email-domains`**
+  → `@lunora/auth`: block throwaway signups / validate email (domain lists are
+  pure-data / edge-safe; MX verify needs DNS). → **[plan 176](176-auth-email-hardening.md)**.
+- **`@visulima/health-check`** → production-readiness health/metrics endpoint
+  (feeds the production-checklist). → **[plan 177](177-health-check-endpoint.md)**.
+- **`@visulima/content-safety`** → optional moderation for user-generated content
+  (multi-language filtering) — a `ctx` helper or small package. *(not yet a plan)*
+- **`@visulima/bytes`** → `encodeWire` Uint8Array handling (plan 164 SDK / storage).
+- Wider reuse of ones already in the tree: **`@visulima/error`/`ono`/`source-map`**
+  (`@lunora/errors`, vite-overlay), **`humanizer`** (Studio formatting),
+  **`inspector`** (Studio debug), **`iso-locale`** (time/locale).
+
+**No visulima reuse** for: 172 geospatial, 175 TTL, 168 cross-shard txn, 169 CRDT
+(that's `y-partyserver`). **`@visulima/workflow`** exists but `@lunora/workflow` is
+deliberately on Cloudflare Workflows — different substrate, not a reuse.
+
+### Notes
+
+- **166 is LOW-risk only for the OIDC-SSO + SCIM-Users half** (Fable 5 verified:
+  `@better-auth/sso` + `@better-auth/scim`, first-party MIT, edge-safe on that
+  path). **SAML is the risk** — `samlify` → `xml-crypto`/`node-rsa` are Node-only,
+  and upstream better-auth#10343 flags SAML ACS as a poor fit for Worker CPU
+  budgets (pluggable remote executor proposed, PR #10347 unmerged). Plan 166 is
+  re-split into Phase 1a (SSO+SCIM, do first) and Phase 1b (SAML, gated on a
+  workerd spike); risk raised LOW → MED.
+- **168 is decision-first** — the spike (`plans/168-phase0-design.md`, to be
+  filed) must decide whether cross-shard atomicity is a real need or a
+  documented boundary. Do not write transaction code before it concludes.
+- **169 and 170 are demand-gated** — file, don't build until a design partner
+  needs collab / warehouse export. 170 is scoped narrowly: the snapshot NDJSON
+  exporter (`runtime/export-stream.ts`) and R2 backup already ship; only the
+  continuous change tap is missing.
+- **164 has a prerequisite** — formalize the wire protocol as a
+  language-independent spec + conformance fixtures before writing the SDK.
+
 ## Notes for executors (carried from prior waves)
 
 - `dist/` is gitignored and built on demand. Build deps first:


### PR DESCRIPTION
## Summary

Turns the competitive gap analysis (Lunora vs **Convex / Supabase / Firebase**, plus the wider field) into a prioritized, routed backlog. Adds **plans 164–177** under a new **Wave 14** section in `plans/README.md`, and routes the CLOUD-owned gaps to `apps/cloud/ROADMAP.md`.

Docs-only change — no runtime code. 16 files, +927 lines.

## Plans added

**Core competitive gaps**
- **164** non-TS client SDK · **165** notifications (wraps `@visulima/notification`) · **166** enterprise SSO + SCIM · **167** public REST/GraphQL surface · **168** cross-shard txn (design spike) · **169** `@lunora/collab` CRDT · **170** CDC export tap · **171** non-goals docs page

**Newly surfaced (Fable 5 deep pass)**
- **172** geospatial · **173** client upload SDK (adopts `@visulima/storage-client`) · **174** auth audit trail · **175** schema TTL · **176** auth email hardening · **177** health-check endpoint

## How the plans were validated

- A **Fable 5 deep pass** verified competitor facts and corrected the picture where it mattered:
  - **166 risk LOW → MED** — `@better-auth/sso`/`scim` are edge-safe, but SAML pulls in Node-only `samlify`/`node-rsa` (upstream better-auth#10343 flags it as a poor fit for Worker CPU budgets); plan split into 1a (OIDC+SCIM) / 1b (SAML, gated on a workerd spike).
  - **Server-side triggers are NOT a gap** — `defineTable().triggers()` already ships; only outbound-webhook packaging (existing plan 132) remains.
  - **Backups + PITR restore already ship** (CLI) — only the *managed* layer is a CLOUD gap.
- A **`@visulima/*` reuse map** — `@visulima/notification` (165), `@visulima/storage-client` (173), `@visulima/redact`/`secret-scanner` (174), and the email-hardening/health-check packages (176/177) — with Cloudflare-Workers edge-safety caveats called out.
- Every gap was grep-verified against `packages/*/src` before filing (verified non-gaps like full-text search, aggregation, and triggers are explicitly excluded).

## Not in scope

- CLOUD-owned gaps (managed hosting, hosted dashboard, preview envs, warehouse connectors) live in `apps/cloud/ROADMAP.md`, not re-planned here.
- `@visulima/content-safety` left as a Wave 14 note, not a plan (no committed direction yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap with new plans for preview environments and database branching, enabling per-PR ephemeral backends with parity to common preview deployment workflows.
  * Added new roadmap items for managed warehouse connectors, including Snowflake and BigQuery, with turn-key pipeline options powered by connector integrations such as Airbyte and Fivetran.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->