### PR TITLE
feat(agent,runtime): gzip OTLP posts + auto-wire agent generations + eslint fixes

### DIFF
--- a/packages/agent/__tests__/telemetry/otlp.test.ts
+++ b/packages/agent/__tests__/telemetry/otlp.test.ts
@@ -49,11 +49,16 @@ const attribute = (span: ReturnType<typeof spanOf>, key: string): unknown => {
     return Object.values(found.value)[0];
 };
 
-afterEach(() => {
-    vi.unstubAllGlobals();
-});
+// A fixed 32-hex trace id used to assert span grouping. Not a credential — the
+// `no-secrets` heuristic just sees a high-entropy hex run.
+// eslint-disable-next-line no-secrets/no-secrets -- fake test trace id, not a real secret
+const FIXED_TRACE_ID = "0123456789abcdef0123456789abcdef";
 
 describe(otlpTelemetry, () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
     it("emits a language-model span with model + token attributes and returns the result", async () => {
         const calls = captureFetch();
         const telemetry = otlpTelemetry({ endpoint: "https://collector.test/", token: "ingest-key" });
@@ -85,7 +90,7 @@ describe(otlpTelemetry, () => {
 
     it("groups every span under a shared traceId when one is given", async () => {
         const calls = captureFetch();
-        const telemetry = otlpTelemetry({ endpoint: "https://collector.test", traceId: "0123456789abcdef0123456789abcdef" });
+        const telemetry = otlpTelemetry({ endpoint: "https://collector.test", traceId: FIXED_TRACE_ID });
 
         await telemetry.executeLanguageModelCall?.(evt({ execute: () => Promise.resolve({}), modelId: "m" }));
         await telemetry.executeTool?.(evt({ execute: () => Promise.resolve("ok"), toolCall: { toolName: "lookup" }, toolCallId: "tc-1" }));
@@ -94,7 +99,7 @@ describe(otlpTelemetry, () => {
             (post) => (post.body.resourceSpans[0] as { scopeSpans: { spans: { traceId: string }[] }[] }).scopeSpans[0]?.spans[0]?.traceId,
         );
 
-        expect(traceIds).toStrictEqual(["0123456789abcdef0123456789abcdef", "0123456789abcdef0123456789abcdef"]);
+        expect(traceIds).toStrictEqual([FIXED_TRACE_ID, FIXED_TRACE_ID]);
     });
 
     it("does not record the prompt unless recordInputs is set", async () => {

--- a/packages/agent/src/telemetry/otlp.ts
+++ b/packages/agent/src/telemetry/otlp.ts
@@ -5,6 +5,23 @@ import { encodeAttribute, mergeHeaders, otlpRandomHex, otlpUnixNano, wrapResourc
 import type { CommonOptions } from "./common";
 import { contentText, readField, summarizeUsage, toolInputOf, toolNameOf } from "./common";
 
+/** Push one attribute, skipping nullish values and JSON-stringifying non-primitives. */
+const pushAttribute = (attributes: OtlpAttribute[], key: string, value: unknown): void => {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+        attributes.push(encodeAttribute(key, value satisfies OtlpAttributeValue));
+
+        return;
+    }
+
+    // Objects/arrays (a recorded prompt, tool input) — serialize so the
+    // collector stores a queryable string rather than dropping the attribute.
+    attributes.push(encodeAttribute(key, JSON.stringify(value)));
+};
+
 /**
  * Options for {@link otlpTelemetry}.
  * @experimental
@@ -49,27 +66,10 @@ export interface OtlpTelemetryOptions extends CommonOptions {
     waitUntil?: (promise: Promise<unknown>) => void;
 }
 
-/** Push one attribute, skipping nullish values and JSON-stringifying non-primitives. */
-const pushAttribute = (attributes: OtlpAttribute[], key: string, value: unknown): void => {
-    if (value === undefined || value === null) {
-        return;
-    }
-
-    if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
-        attributes.push(encodeAttribute(key, value satisfies OtlpAttributeValue));
-
-        return;
-    }
-
-    // Objects/arrays (a recorded prompt, tool input) — serialize so the
-    // collector stores a queryable string rather than dropping the attribute.
-    attributes.push(encodeAttribute(key, JSON.stringify(value)));
-};
-
 /**
  * An OTLP-over-HTTP telemetry integration for `@lunora/agent`.
  *
- * The OTLP counterpart to {@link sentryTelemetry} / {@link braintrustTelemetry}:
+ * The OTLP counterpart to the `sentryTelemetry` / `braintrustTelemetry` bridges:
  * it wraps each language-model call and tool execution in an OTLP **span**
  * (`gen_ai.*` semantic-convention attributes — model, provider, token usage,
  * tool name) and ships it to a collector, so agent generations land in the same
@@ -87,13 +87,13 @@ const pushAttribute = (attributes: OtlpAttribute[], key: string, value: unknown)
  * Each export is fire-and-forget (registered with `waitUntil` when supplied);
  * every rejection is swallowed so a flaky collector never surfaces to the run.
  *
- * Two deliberate differences from the SDK-backed integrations (`sentryTelemetry`
- * / `braintrustTelemetry`), which delegate to a host tracer:
- * - **No `onError`.** A failed call already emits a span with `status.code === 2`,
- *   so the failure is on the trace; there is no host client to also notify.
- * - **Flat, not nested.** Every span gets `traceId` (shared when `traceId` is set)
- *   but no `parentSpanId`, so model-call and tool spans are siblings under the run
- *   rather than a tree — OTLP has no ambient span context to parent to here.
+ * Two deliberate differences from the SDK-backed bridges, which delegate to a
+ * host tracer. First, no `onError`: a failed call already emits a span with
+ * `status.code === 2`, so the failure is on the trace and there is no host client
+ * to also notify. Second, flat not nested: every span gets `traceId` (shared when
+ * `traceId` is set) but no `parentSpanId`, so model-call and tool spans are
+ * siblings under the run rather than a tree — OTLP has no ambient span context to
+ * parent to here.
  * @param options `endpoint` (+ optional `token`/`headers`/`serviceName`),
  * `traceId` to group a run's spans, `waitUntil`, and the `recordInputs`/
  * `recordOutputs` privacy flags.
@@ -182,14 +182,18 @@ export const otlpTelemetry = (options: OtlpTelemetryOptions): Telemetry => {
                 emitSpan(typeof modelId === "string" ? `chat ${modelId}` : "language_model_call", startTs, ok, message, attributes);
             };
 
-            promise.then(
-                (result) => {
-                    emit(true, undefined, result);
-                },
-                (error: unknown) => {
+            // Detached observer: emit the span once the call settles, without
+            // awaiting or returning it into the caller's chain. The `.catch` keeps
+            // it from floating; the caller's own `promise` still rejects for them.
+            const observe = async (): Promise<void> => {
+                try {
+                    emit(true, undefined, await promise);
+                } catch (error) {
                     emit(false, error instanceof Error ? error.message : String(error), undefined);
-                },
-            );
+                }
+            };
+
+            observe().catch(() => undefined);
 
             return promise;
         },
@@ -213,14 +217,17 @@ export const otlpTelemetry = (options: OtlpTelemetryOptions): Telemetry => {
                 emitSpan(typeof toolName === "string" ? `execute_tool ${toolName}` : "execute_tool", startTs, ok, message, attributes);
             };
 
-            promise.then(
-                () => {
+            // Detached observer — see `executeLanguageModelCall`.
+            const observe = async (): Promise<void> => {
+                try {
+                    await promise;
                     emit(true, undefined);
-                },
-                (error: unknown) => {
+                } catch (error) {
                     emit(false, error instanceof Error ? error.message : String(error));
-                },
-            );
+                }
+            };
+
+            observe().catch(() => undefined);
 
             return promise;
         },

--- a/packages/agent/src/telemetry/otlp.ts
+++ b/packages/agent/src/telemetry/otlp.ts
@@ -23,6 +23,33 @@ const pushAttribute = (attributes: OtlpAttribute[], key: string, value: unknown)
 };
 
 /**
+ * Run `onSettle` once when `promise` settles — `(true, undefined, result)` on
+ * success, `(false, message, undefined)` on rejection — as a **detached** observer
+ * (not awaited/returned into the caller's chain). Only the `await` is guarded, so
+ * a throw from `onSettle` on the success path can't be mis-caught and recorded as a
+ * failure (the earlier `try { emit(true, await p) } catch { emit(false) }` did that);
+ * the trailing `.catch` keeps the detached chain from floating. The caller's own
+ * `promise` is returned untouched, so it still rejects for them.
+ */
+const observeSettled = (promise: PromiseLike<unknown>, onSettle: (ok: boolean, message: string | undefined, result: unknown) => void): void => {
+    const run = async (): Promise<void> => {
+        let result: unknown;
+
+        try {
+            result = await promise;
+        } catch (error) {
+            onSettle(false, error instanceof Error ? error.message : String(error), undefined);
+
+            return;
+        }
+
+        onSettle(true, undefined, result);
+    };
+
+    run().catch(() => undefined);
+};
+
+/**
  * Options for {@link otlpTelemetry}.
  * @experimental
  */
@@ -182,18 +209,7 @@ export const otlpTelemetry = (options: OtlpTelemetryOptions): Telemetry => {
                 emitSpan(typeof modelId === "string" ? `chat ${modelId}` : "language_model_call", startTs, ok, message, attributes);
             };
 
-            // Detached observer: emit the span once the call settles, without
-            // awaiting or returning it into the caller's chain. The `.catch` keeps
-            // it from floating; the caller's own `promise` still rejects for them.
-            const observe = async (): Promise<void> => {
-                try {
-                    emit(true, undefined, await promise);
-                } catch (error) {
-                    emit(false, error instanceof Error ? error.message : String(error), undefined);
-                }
-            };
-
-            observe().catch(() => undefined);
+            observeSettled(promise, emit);
 
             return promise;
         },
@@ -217,17 +233,7 @@ export const otlpTelemetry = (options: OtlpTelemetryOptions): Telemetry => {
                 emitSpan(typeof toolName === "string" ? `execute_tool ${toolName}` : "execute_tool", startTs, ok, message, attributes);
             };
 
-            // Detached observer — see `executeLanguageModelCall`.
-            const observe = async (): Promise<void> => {
-                try {
-                    await promise;
-                    emit(true, undefined);
-                } catch (error) {
-                    emit(false, error instanceof Error ? error.message : String(error));
-                }
-            };
-
-            observe().catch(() => undefined);
+            observeSettled(promise, emit);
 
             return promise;
         },

--- a/packages/agent/src/workflow.ts
+++ b/packages/agent/src/workflow.ts
@@ -6,7 +6,43 @@ import { createAgentGenerate, createCompact, createEpisodeExtract, createGraphEx
 import { agentDefaultName } from "./naming";
 import { DEFAULT_AGENT_FUNCTION_PATHS } from "./paths";
 import resolveAgentRun from "./resolve-run";
+import { otlpTelemetry } from "./telemetry/otlp";
 import type { AgentDefinition, AgentFunctionPaths, AgentRunInput, AgentRunResult } from "./types";
+
+/**
+ * On the Lunora platform the deploy path injects `LUNORA_OTLP_ENDPOINT` /
+ * `LUNORA_OTLP_TOKEN` into every tenant. When they're present, auto-append an
+ * `otlpTelemetry` integration so a deployed agent's model turns and tool calls
+ * emit `gen_ai.*` generation spans to the cloud with **no app wiring** — the same
+ * way `otlpSink` auto-ships RPC telemetry.
+ *
+ * Privacy-safe: `otlpTelemetry` records only structural metadata (model, token
+ * counts) unless the app opts into `recordInputs`/`recordOutputs`. Byte-identical
+ * no-op when no endpoint is set (local / self-hosted) or when the app explicitly
+ * set `telemetry.isEnabled: false`.
+ */
+const withAutoOtlpTelemetry = (agent: AgentDefinition, env: Record<string, unknown>): AgentDefinition => {
+    const endpoint = env.LUNORA_OTLP_ENDPOINT;
+
+    if (typeof endpoint !== "string" || endpoint === "" || agent.telemetry?.isEnabled === false) {
+        return agent;
+    }
+
+    const token = typeof env.LUNORA_OTLP_TOKEN === "string" ? env.LUNORA_OTLP_TOKEN : undefined;
+
+    // `integrations` may be a single `Telemetry` or an array — normalize before appending.
+    const existing = agent.telemetry?.integrations;
+    const existingList = existing === undefined ? [] : Array.isArray(existing) ? existing : [existing];
+
+    return {
+        ...agent,
+        telemetry: {
+            ...agent.telemetry,
+            integrations: [...existingList, otlpTelemetry({ endpoint, token })],
+            isEnabled: true,
+        },
+    };
+};
 
 /**
  * Compile a `defineAgent` definition into the workflow the generated
@@ -34,9 +70,13 @@ const compileAgentWorkflow = (
     options?: { paths?: AgentFunctionPaths },
 ): WorkflowDefinition<AgentRunInput, AgentRunResult> =>
     defineWorkflow<AgentRunInput, AgentRunResult>({
-        handler: async (context) =>
-            runAgentLoop({
-                agent,
+        handler: async (context) => {
+            // On the platform, auto-append OTLP generation telemetry from the
+            // injected endpoint; local/self-hosted agents are unaffected.
+            const runtimeAgent = withAutoOtlpTelemetry(agent, context.env as Record<string, unknown>);
+
+            return runAgentLoop({
+                agent: runtimeAgent,
                 // Automatic history compaction. Dormant unless the agent declares
                 // a `compaction` config; the loop gates on it, so any other agent
                 // takes the byte-identical no-compaction path.
@@ -52,7 +92,7 @@ const compileAgentWorkflow = (
                 // `kind: "episodic"` memory source AND the run carries an owner —
                 // the loop gates on both, so any other agent is byte-identical.
                 extractEpisode: createEpisodeExtract(),
-                generate: createAgentGenerate(agent, context.env),
+                generate: createAgentGenerate(runtimeAgent, context.env),
                 instanceId: context.event.instanceId,
                 params: context.params,
                 paths: options?.paths ?? DEFAULT_AGENT_FUNCTION_PATHS,
@@ -69,8 +109,9 @@ const compileAgentWorkflow = (
                 // live token sink is threaded onto the run (a follow-up wires
                 // `onTokenDelta` to the stream transport). With no sink the loop
                 // takes the byte-identical non-streaming `generate` path.
-                streamGenerate: createStreamGenerate(agent, context.env),
-            }),
+                streamGenerate: createStreamGenerate(runtimeAgent, context.env),
+            });
+        },
         name: agent.name ?? agentDefaultName(exportName),
     });
 

--- a/packages/agent/src/workflow.ts
+++ b/packages/agent/src/workflow.ts
@@ -30,9 +30,9 @@ const withAutoOtlpTelemetry = (agent: AgentDefinition, env: Record<string, unkno
 
     const token = typeof env.LUNORA_OTLP_TOKEN === "string" ? env.LUNORA_OTLP_TOKEN : undefined;
 
-    // `integrations` may be a single `Telemetry` or an array — normalize before appending.
-    const existing = agent.telemetry?.integrations;
-    const existingList = existing === undefined ? [] : Array.isArray(existing) ? existing : [existing];
+    // `integrations` may be a single `Telemetry`, an array, or absent — normalize
+    // to an array (`[x].flat()` keeps a single value and unwraps an array).
+    const existingList = [agent.telemetry?.integrations].flat().filter((integration) => integration !== undefined);
 
     return {
         ...agent,
@@ -73,7 +73,7 @@ const compileAgentWorkflow = (
         handler: async (context) => {
             // On the platform, auto-append OTLP generation telemetry from the
             // injected endpoint; local/self-hosted agents are unaffected.
-            const runtimeAgent = withAutoOtlpTelemetry(agent, context.env as Record<string, unknown>);
+            const runtimeAgent = withAutoOtlpTelemetry(agent, context.env);
 
             return runAgentLoop({
                 agent: runtimeAgent,

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -176,6 +176,7 @@ const resolveEmbeddingModel = (input: RagConfig["embeddingModel"], ai: RagContex
  * needs no `env.AI` binding (bind any context carrying just `vectors`).
  * @experimental
  */
+
 /**
  * Structural slice of `ctx.trace` (see the server `LunoraTracer`) — enough to
  * wrap one embed. Declared here rather than imported so `@lunora/ai/rag` takes
@@ -251,7 +252,8 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
         const embedText = async (text: string): Promise<ReadonlyArray<number>> => {
             // Resolve once and bind to a local `const`, so the nested `run` closure
             // sees a non-nullable model without a cast.
-            const resolvedModel = (model ??= resolveEmbeddingModel(config.embeddingModel, context.ai));
+            model ??= resolveEmbeddingModel(config.embeddingModel, context.ai);
+            const resolvedModel = model;
 
             const run = async (): Promise<ReadonlyArray<number>> => {
                 const { embedding } = await aiEmbed({ model: resolvedModel, value: text });

--- a/packages/ai/src/rag/types.ts
+++ b/packages/ai/src/rag/types.ts
@@ -115,7 +115,7 @@ export interface RagContext {
 
     /**
      * Optional `ctx.trace` span factory — an `ActionCtx`'s `ctx.trace` satisfies
-     * it structurally. When present, {@link defineRag} wraps each embedding-model
+     * it structurally. When present, `defineRag` wraps each embedding-model
      * call in a `generation` span (`gen_ai.operation.name: "embeddings"` +
      * `gen_ai.request.model`), so the embed shows up on the trace waterfall like
      * any other instrumented sub-operation. `unknown` on purpose — the same

--- a/packages/runtime/src/observability-sinks.ts
+++ b/packages/runtime/src/observability-sinks.ts
@@ -243,13 +243,33 @@ const otlpLogBody = (event: LogEvent, serviceName: string): unknown => {
     return wrapResourceLogs(logRecord, "@lunora/runtime", serviceName);
 };
 
-/** POST an OTLP payload fire-and-forget, keeping it alive past the response when a request context is present. */
+/** Above this serialized size, an OTLP body is gzipped; tiny single-span posts skip it (the CPU isn't worth the few saved bytes). */
+const OTLP_GZIP_THRESHOLD = 1024;
+
+/** gzip a UTF-8 string to an `ArrayBuffer` (a `BodyInit`) via the platform `CompressionStream` (no dependency). */
+const gzipEncode = async (text: string): Promise<ArrayBuffer> => {
+    const stream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"));
+
+    return new Response(stream).arrayBuffer();
+};
+
+/**
+ * POST an OTLP payload fire-and-forget, keeping it alive past the response when a
+ * request context is present. Bodies past {@link OTLP_GZIP_THRESHOLD} are gzipped
+ * (`Content-Encoding: gzip`) — standard OTLP/HTTP, which every collector (and the
+ * Lunora cloud ingest) decodes.
+ */
 const otlpPost = (url: string, body: unknown, headers: Record<string, string>, context?: ObservabilitySinkContext): void => {
     try {
+        const json = JSON.stringify(body);
         // `.catch` swallows any rejection so a failed export can never reject
         // into the dispatch path.
-        const sent = fetch(url, { body: JSON.stringify(body), headers, method: "POST" }).catch(() => {
-            // Network error / non-OK response — intentionally ignored.
+        const sent = (
+            json.length < OTLP_GZIP_THRESHOLD
+                ? fetch(url, { body: json, headers, method: "POST" })
+                : gzipEncode(json).then((gz) => fetch(url, { body: gz, headers: { ...headers, "content-encoding": "gzip" }, method: "POST" }))
+        ).catch(() => {
+            // Network error / non-OK response / gzip failure — intentionally ignored.
         });
 
         if (context?.waitUntil) {

--- a/packages/runtime/src/observability-sinks.ts
+++ b/packages/runtime/src/observability-sinks.ts
@@ -246,7 +246,7 @@ const otlpLogBody = (event: LogEvent, serviceName: string): unknown => {
 /** Above this serialized size, an OTLP body is gzipped; tiny single-span posts skip it (the CPU isn't worth the few saved bytes). */
 const OTLP_GZIP_THRESHOLD = 1024;
 
-/** gzip a UTF-8 string to an `ArrayBuffer` (a `BodyInit`) via the platform `CompressionStream` (no dependency). */
+/** Gzip a UTF-8 string to an `ArrayBuffer` (a `BodyInit`) via the platform `CompressionStream` (no dependency). */
 const gzipEncode = async (text: string): Promise<ArrayBuffer> => {
     const stream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"));
 


### PR DESCRIPTION
Follow-up to the merged #160 (OTLP generation spans), completing items 8, 9, and the eslint pass from the "do 1 to 10" gap-closure:

- **gzip OTLP posts (item 9)** — `otlpSink` gzips bodies past 1 KB (`Content-Encoding: gzip`, via `CompressionStream`); tiny single-span posts stay plain.
- **Auto-wire agent generations (item 8)** — the compiled agent workflow auto-appends `otlpTelemetry` when `LUNORA_OTLP_ENDPOINT` is injected (the platform), so a deployed agent emits `gen_ai.*` spans with no app wiring. No-op locally / when telemetry is explicitly disabled; privacy-safe (structural metadata only).
- **eslint fixes** — #160 merged with eslint findings that only the alpha TS-6 pin surfaces (the detached observer's `promise/always-return`, exports-last, jsdoc nits, a nested ternary, a chained assignment). Fixed here; no behavior change.

## Test plan
`@lunora/agent` + `@lunora/runtime` tsc clean, agent telemetry suite green, `@lunora/ai`/`@lunora/runtime` unchanged behavior. eslint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OTLP generation telemetry is now automatically enabled when an endpoint is configured, while respecting explicit telemetry settings.
  * Large telemetry payloads are compressed to improve transmission efficiency.

* **Bug Fixes**
  * Improved telemetry reporting for successful and failed model or tool operations.
  * Prevented background telemetry processing from causing unhandled errors.

* **Documentation**
  * Clarified telemetry integration and RAG context documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->