### PR TITLE
feat(cloud): archive read-back, error→trace links, gen-redaction, capability test

### DIFF
--- a/apps/cloud/__tests__/archive-read.test.ts
+++ b/apps/cloud/__tests__/archive-read.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { archiveRowToObservation } from "../src/telemetry/archive-read";
+import { createCloudflareTelemetryStore, spanArchiveRecord } from "../src/telemetry/store";
+
+describe(archiveRowToObservation, () => {
+    it("round-trips a span through the archive record shape", () => {
+        const observation = {
+            durationMs: 100,
+            endedAt: 1100,
+            kind: "worker" as const,
+            level: "info" as const,
+            name: "messages:send",
+            spanId: "s1",
+            startedAt: 1000,
+            traceId: "t1",
+        };
+        const row = spanArchiveRecord(observation, "org_1");
+
+        expect(archiveRowToObservation(row)).toMatchObject(observation);
+    });
+
+    it("coerces numeric strings (Iceberg types) and drops absent generation fields", () => {
+        const mapped = archiveRowToObservation({
+            durationMs: "50",
+            endedAt: "1050",
+            kind: "generation",
+            level: "info",
+            model: "@cf/meta/llama",
+            name: "chat",
+            promptTokens: "12",
+            spanId: "s2",
+            startedAt: "1000",
+            traceId: "t2",
+        });
+
+        expect(mapped).toMatchObject({ durationMs: 50, kind: "generation", model: "@cf/meta/llama", promptTokens: 12 });
+        expect("completionTokens" in mapped).toBe(false);
+    });
+});
+
+describe("TelemetryStore.readArchivedTrace", () => {
+    it("no-ops to [] without R2-SQL config", async () => {
+        await expect(createCloudflareTelemetryStore({}).readArchivedTrace({ organizationId: "org_1", traceId: "t1" })).resolves.toStrictEqual([]);
+    });
+});

--- a/apps/cloud/__tests__/capability.test.ts
+++ b/apps/cloud/__tests__/capability.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { isDeployCapable } from "../src/deploy/capability";
+
+describe(isDeployCapable, () => {
+    it("treats a key with no capability as deploy-capable (the historical default)", () => {
+        expect(isDeployCapable({})).toBe(true);
+    });
+
+    it("allows an explicit deploy key", () => {
+        expect(isDeployCapable({ capability: "deploy" })).toBe(true);
+    });
+
+    it("rejects an ingest key from deploy/admin — the injected telemetry token can't ship code", () => {
+        expect(isDeployCapable({ capability: "ingest" })).toBe(false);
+    });
+});

--- a/apps/cloud/__tests__/redact.test.ts
+++ b/apps/cloud/__tests__/redact.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isSensitiveKey, REDACTED, redactRecord } from "../src/telemetry/redact";
+import { isSensitiveKey, REDACTED, redactRecord, redactText } from "../src/telemetry/redact";
 
 describe(isSensitiveKey, () => {
     it("flags credential-ish keys, case-insensitively", () => {
@@ -58,5 +58,20 @@ describe(redactRecord, () => {
 
     it("passes undefined through", () => {
         expect(redactRecord(undefined)).toBeUndefined();
+    });
+});
+
+describe(redactText, () => {
+    it("scrubs secret-shaped substrings from free text", () => {
+        expect(redactText("call with Authorization: Bearer sk_live_abcdefgh12345678")).toContain("Bearer [redacted]");
+        expect(redactText("here is my key sk-ABCDEFGHIJKLMNOP1234")).toContain(REDACTED);
+        expect(redactText("token=supersecretvalue123 in the log")).toBe(`token=${REDACTED} in the log`);
+    });
+
+    it("leaves ordinary prose untouched and passes undefined through", () => {
+        const prose = "The user asked about the weather in Berlin.";
+
+        expect(redactText(prose)).toBe(prose);
+        expect(redactText(undefined)).toBeUndefined();
     });
 });

--- a/apps/cloud/lunora/_generated/api.ts
+++ b/apps/cloud/lunora/_generated/api.ts
@@ -79,7 +79,7 @@ export interface ApiTypes {
         revoke: FunctionReference<"mutation", { id: Id<"invitations">; organizationId: Id<"organizations"> }, void>;
     };
     issues: {
-        list: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"issues">; count: number; culprit: string; firstSeen: number; hash: string; lastSeen: number; organizationId: Id<"organizations">; sampleMessage: string; status: "open" | "resolved"; title: string }[]>;
+        list: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"issues">; count: number; culprit: string; firstSeen: number; hash: string; lastSeen: number; organizationId: Id<"organizations">; sampleMessage: string; sampleTraceId?: string; status: "open" | "resolved"; title: string }[]>;
         setStatus: FunctionReference<"mutation", { id: Id<"issues">; organizationId: Id<"organizations">; status: unknown }, Id<"issues">>;
     };
     logs: {

--- a/apps/cloud/lunora/_generated/dataModel.ts
+++ b/apps/cloud/lunora/_generated/dataModel.ts
@@ -283,6 +283,7 @@ export interface Doc_issues {
     lastSeen: number;
     organizationId: Id<"organizations">;
     sampleMessage: string;
+    sampleTraceId?: string;
     status: "open" | "resolved";
     title: string;
     updatedAt: number;
@@ -824,6 +825,7 @@ export interface Insert_issues {
     lastSeen: number;
     organizationId: Id<"organizations">;
     sampleMessage: string;
+    sampleTraceId?: string;
     status: "open" | "resolved";
     title: string;
     updatedAt: number;

--- a/apps/cloud/lunora/_generated/drizzle.global.ts
+++ b/apps/cloud/lunora/_generated/drizzle.global.ts
@@ -295,6 +295,7 @@ export const issues = sqliteTable("issues", {
     lastSeen: real("lastSeen").notNull(),
     organizationId: text("organizationId").references(() => organizations._id).notNull(),
     sampleMessage: text("sampleMessage").notNull(),
+    sampleTraceId: text("sampleTraceId"),
     status: text("status", { mode: "json" }).$type<"open" | "resolved">().notNull(),
     title: text("title").notNull(),
     updatedAt: real("updatedAt").notNull(),

--- a/apps/cloud/lunora/_generated/functions.ts
+++ b/apps/cloud/lunora/_generated/functions.ts
@@ -870,7 +870,7 @@ export interface Caller {
         revoke: (args: { id: Id<"invitations">; organizationId: Id<"organizations"> }) => Promise<void>;
     };
     issues: {
-        list: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"issues">; count: number; culprit: string; firstSeen: number; hash: string; lastSeen: number; organizationId: Id<"organizations">; sampleMessage: string; status: "open" | "resolved"; title: string }[]>;
+        list: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"issues">; count: number; culprit: string; firstSeen: number; hash: string; lastSeen: number; organizationId: Id<"organizations">; sampleMessage: string; sampleTraceId?: string; status: "open" | "resolved"; title: string }[]>;
         setStatus: (args: { id: Id<"issues">; organizationId: Id<"organizations">; status: unknown }) => Promise<Id<"issues">>;
     };
     logs: {

--- a/apps/cloud/lunora/_generated/shard.ts
+++ b/apps/cloud/lunora/_generated/shard.ts
@@ -1633,6 +1633,11 @@ const LUNORA_TABLE_COLUMNS: Record<string, Array<{ isStorage?: boolean; name: st
             "type": "string"
         },
         {
+            "name": "sampleTraceId",
+            "optional": true,
+            "type": "string"
+        },
+        {
             "name": "status",
             "optional": false,
             "type": "union"
@@ -2911,12 +2916,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:deploy-keys:134:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:deploy-keys:138:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in verify (deploy-keys:134) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in verify (deploy-keys:138) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2924,19 +2929,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "verify",
             "file": "deploy-keys",
             "kind": "mutation",
-            "line": 134
+            "line": 138
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:deploy-keys:200:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:deploy-keys:207:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in recordIngestKey (deploy-keys:200) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in recordIngestKey (deploy-keys:207) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2944,7 +2949,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
             "kind": "mutation",
-            "line": 200
+            "line": 207
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -3291,12 +3296,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:issues:44:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:issues:45:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in setStatus (issues:44) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in setStatus (issues:45) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -3304,7 +3309,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "setStatus",
             "file": "issues",
             "kind": "mutation",
-            "line": 44
+            "line": 45
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -3571,12 +3576,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:telemetry:256:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:telemetry:274:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in ingest (telemetry:256) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in ingest (telemetry:274) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -3584,19 +3589,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "ingest",
             "file": "telemetry",
             "kind": "mutation",
-            "line": 256
+            "line": 274
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:telemetry:352:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:telemetry:370:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in pruneObservations (telemetry:352) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in pruneObservations (telemetry:370) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -3604,7 +3609,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "pruneObservations",
             "file": "telemetry",
             "kind": "mutation",
-            "line": 352
+            "line": 370
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -5012,14 +5017,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `ingestKeyCipher` (deploy-keys:160) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `ingestKeyCipher` (deploy-keys:172) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "ingestKeyCipher",
             "file": "deploy-keys",
-            "line": 160
+            "line": 172
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5031,14 +5036,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `recordIngestKey` (deploy-keys:179) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `recordIngestKey` (deploy-keys:188) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
-            "line": 179
+            "line": 188
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5050,14 +5055,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `encryptedSecret` of public procedure `recordIngestKey` (deploy-keys:179) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `encryptedSecret` of public procedure `recordIngestKey` (deploy-keys:188) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "encryptedSecret",
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
-            "line": 179
+            "line": 188
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5069,14 +5074,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `hashedKey` of public procedure `recordIngestKey` (deploy-keys:179) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `hashedKey` of public procedure `recordIngestKey` (deploy-keys:188) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "hashedKey",
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
-            "line": 179
+            "line": 188
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5886,14 +5891,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `ingest` (telemetry:227) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `ingest` (telemetry:245) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "ingest",
             "file": "telemetry",
-            "line": 227
+            "line": 245
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",

--- a/apps/cloud/lunora/_generated/shard.ts
+++ b/apps/cloud/lunora/_generated/shard.ts
@@ -2876,12 +2876,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:deploy-keys:78:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:deploy-keys:79:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in issue (deploy-keys:78) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in issue (deploy-keys:79) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2889,19 +2889,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "issue",
             "file": "deploy-keys",
             "kind": "mutation",
-            "line": 78
+            "line": 79
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:deploy-keys:96:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:deploy-keys:97:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in revoke (deploy-keys:96) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in revoke (deploy-keys:97) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2909,19 +2909,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "revoke",
             "file": "deploy-keys",
             "kind": "mutation",
-            "line": 96
+            "line": 97
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:deploy-keys:138:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:deploy-keys:140:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in verify (deploy-keys:138) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in verify (deploy-keys:140) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2929,19 +2929,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "verify",
             "file": "deploy-keys",
             "kind": "mutation",
-            "line": 138
+            "line": 140
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:deploy-keys:207:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:deploy-keys:209:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in recordIngestKey (deploy-keys:207) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in recordIngestKey (deploy-keys:209) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2949,7 +2949,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
             "kind": "mutation",
-            "line": 207
+            "line": 209
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -4979,14 +4979,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `name` of public procedure `issue` (deploy-keys:54) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `name` of public procedure `issue` (deploy-keys:55) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "name",
             "exportName": "issue",
             "file": "deploy-keys",
-            "line": 54
+            "line": 55
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -4998,14 +4998,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `key` of public procedure `verify` (deploy-keys:112) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `key` of public procedure `verify` (deploy-keys:113) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "key",
             "exportName": "verify",
             "file": "deploy-keys",
-            "line": 112
+            "line": 113
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5017,14 +5017,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `ingestKeyCipher` (deploy-keys:172) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `ingestKeyCipher` (deploy-keys:174) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "ingestKeyCipher",
             "file": "deploy-keys",
-            "line": 172
+            "line": 174
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5036,14 +5036,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `recordIngestKey` (deploy-keys:188) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `recordIngestKey` (deploy-keys:190) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
-            "line": 188
+            "line": 190
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5055,14 +5055,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `encryptedSecret` of public procedure `recordIngestKey` (deploy-keys:188) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `encryptedSecret` of public procedure `recordIngestKey` (deploy-keys:190) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "encryptedSecret",
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
-            "line": 188
+            "line": 190
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -5074,14 +5074,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `hashedKey` of public procedure `recordIngestKey` (deploy-keys:188) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `hashedKey` of public procedure `recordIngestKey` (deploy-keys:190) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "hashedKey",
             "exportName": "recordIngestKey",
             "file": "deploy-keys",
-            "line": 188
+            "line": 190
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",

--- a/apps/cloud/lunora/authz.ts
+++ b/apps/cloud/lunora/authz.ts
@@ -1,5 +1,6 @@
 import { LunoraError } from "@lunora/server";
 
+import { isDeployCapable } from "../src/deploy/capability";
 import { hashDeployKey } from "../src/deploy/keys";
 import type { Id, TableName } from "./_generated/dataModel.js";
 import type { QueryCtx as QueryContext } from "./_generated/server.js";
@@ -97,7 +98,7 @@ export const authorizeDeployKey = async (
     const row = await resolveKeyRow(context, organizationId, key);
 
     // An ingest key is telemetry-only — it must never authorize a deploy/admin write.
-    if (row.capability === "ingest") {
+    if (!isDeployCapable(row)) {
         throw new LunoraError("FORBIDDEN", "this is a telemetry ingest key, not a deploy key");
     }
 

--- a/apps/cloud/lunora/deploy-keys.ts
+++ b/apps/cloud/lunora/deploy-keys.ts
@@ -1,3 +1,4 @@
+import { isDeployCapable } from "../src/deploy/capability";
 import { formatDeployKey, hashDeployKey, parseDeployKey, randomSecret } from "../src/deploy/keys";
 import type { Id } from "./_generated/dataModel.js";
 import { mutation, query, v } from "./_generated/server.js";
@@ -130,8 +131,9 @@ export const verify = mutation.input({ key: v.string() }).mutation(
         // Reject a telemetry `ingest` key here too — this is the guard the deploy
         // route actually runs (`verifyKey`), so without it a scoped ingest token
         // would still be able to deploy. `authorizeDeployKey` blocks it on the
-        // per-mutation paths; this blocks it at the deploy entrypoint.
-        if (!row || row.revokedAt !== undefined || row.capability === "ingest") {
+        // per-mutation paths; this blocks it at the deploy entrypoint (same
+        // predicate, so they can't disagree).
+        if (!row || row.revokedAt !== undefined || !isDeployCapable(row)) {
             return null;
         }
 

--- a/apps/cloud/lunora/issues.ts
+++ b/apps/cloud/lunora/issues.ts
@@ -22,6 +22,7 @@ interface IssueRow {
     lastSeen: number;
     organizationId: Id<"organizations">;
     sampleMessage: string;
+    sampleTraceId?: string;
     status: "open" | "resolved";
     title: string;
 }

--- a/apps/cloud/lunora/schema.ts
+++ b/apps/cloud/lunora/schema.ts
@@ -449,6 +449,8 @@ export default defineSchema({
         organizationId: v.id("organizations"),
         // A representative raw message for the group (last seen).
         sampleMessage: v.string(),
+        // A sample trace id (the latest error span's), to jump to the trace.
+        sampleTraceId: v.optional(v.string()),
         status: v.union(v.literal("open"), v.literal("resolved")),
         title: v.string(),
         updatedAt: v.number(),

--- a/apps/cloud/lunora/telemetry.ts
+++ b/apps/cloud/lunora/telemetry.ts
@@ -63,6 +63,8 @@ const telemetryEvent = v.object({
     instance: v.optional(v.string()),
     kind: v.union(v.literal("error"), v.literal("container")),
     message: v.string(),
+    // The error span's trace id — carried onto the Issue as a sample link.
+    traceId: v.optional(v.string()),
     // Event time in epoch ms (decoded from the span's end time).
     ts: v.number(),
 });
@@ -102,6 +104,8 @@ interface EventGroup {
     kind: "container" | "error";
     lastTs: number;
     sampleMessage: string;
+    /** A sample trace id (the latest event's), so the Issue links to a trace. */
+    sampleTraceId?: string;
     title: string;
 }
 
@@ -114,7 +118,16 @@ const detectIncidentKind = (message: string): "crash_loop" | "error_spike" | "oo
 
 /** Fold a batch of events into one pre-aggregated group per fingerprint hash. */
 const groupEvents = (
-    events: { code?: string; container?: string; functionPath: string; instance?: string; kind: "container" | "error"; message: string; ts: number }[],
+    events: {
+        code?: string;
+        container?: string;
+        functionPath: string;
+        instance?: string;
+        kind: "container" | "error";
+        message: string;
+        traceId?: string;
+        ts: number;
+    }[],
 ): Map<string, EventGroup> => {
     const groups = new Map<string, EventGroup>();
 
@@ -126,6 +139,7 @@ const groupEvents = (
             group.count += 1;
             group.lastTs = Math.max(group.lastTs, event.ts);
             group.sampleMessage = event.message;
+            group.sampleTraceId = event.traceId ?? group.sampleTraceId;
         } else {
             groups.set(fingerprint.hash, {
                 container: event.container,
@@ -136,6 +150,7 @@ const groupEvents = (
                 kind: event.kind,
                 lastTs: event.ts,
                 sampleMessage: event.message,
+                sampleTraceId: event.traceId,
                 title: fingerprint.title,
             });
         }
@@ -161,6 +176,8 @@ const upsertIssue = async (
             count: before + group.count,
             lastSeen: Math.max(existing.lastSeen, group.lastTs),
             sampleMessage: group.sampleMessage,
+            // Only refresh the sample trace when this batch carried one.
+            ...(group.sampleTraceId ? { sampleTraceId: group.sampleTraceId } : {}),
             updatedAt: now,
         });
     } else {
@@ -174,6 +191,7 @@ const upsertIssue = async (
             lastSeen: group.lastTs,
             organizationId,
             sampleMessage: group.sampleMessage,
+            sampleTraceId: group.sampleTraceId,
             status: "open",
             title: group.title,
             updatedAt: now,

--- a/apps/cloud/src/client/CrossTabLink.tsx
+++ b/apps/cloud/src/client/CrossTabLink.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement, ReactNode } from "react";
+
+interface CrossTabLinkProps {
+    children: ReactNode;
+    /** Deep-link to another tab, carrying an optional trace id for it to focus. */
+    onOpenTab: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
+    /** The tab to open. */
+    target: "logs" | "traces";
+    /** The trace to focus in the target tab (omit to just switch tabs). */
+    traceId?: string;
+    /** `inline` sits within a text line (e.g. a log line); `standalone` stands on its own. */
+    variant?: "inline" | "standalone";
+}
+
+/**
+ * The shared cross-tab deep-link button — Issue → trace, trace → logs, log line →
+ * trace. One element and one style, so the three call sites can't drift apart (the
+ * finding that motivated this: near-duplicate `.trace-link`/`.log-trace-link` markup
+ * + CSS). The dashboard's `onOpenTab` bumps the focus seq and remounts the target.
+ */
+export const CrossTabLink = ({ children, onOpenTab, target, traceId, variant = "standalone" }: CrossTabLinkProps): ReactElement => (
+    <button
+        className={variant === "inline" ? "cross-tab-link cross-tab-link-inline" : "cross-tab-link"}
+        onClick={() => onOpenTab(target, { traceId })}
+        type="button"
+    >
+        {children}
+    </button>
+);

--- a/apps/cloud/src/client/IssuesSection.tsx
+++ b/apps/cloud/src/client/IssuesSection.tsx
@@ -6,6 +6,7 @@ import { AsyncList } from "./AsyncList";
 import type { OrgId } from "./types";
 
 interface IssuesSectionProps {
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
     organizationId: OrgId;
 }
 
@@ -14,7 +15,7 @@ interface IssuesSectionProps {
  * deployments (the hosted counterpart of the local Studio's Issues). Read-only
  * and members-only; gated behind the `logStreams` plan entitlement.
  */
-export const IssuesSection = ({ organizationId }: IssuesSectionProps): ReactElement => {
+export const IssuesSection = ({ onOpenTab, organizationId }: IssuesSectionProps): ReactElement => {
     const entitlements = useQuery(api.billing.entitlements, { organizationId });
     const gated = entitlements ? !entitlements.features.includes("logStreams") : false;
     const issues = useQuery(api.issues.list, gated ? "skip" : { organizationId });
@@ -42,6 +43,7 @@ export const IssuesSection = ({ organizationId }: IssuesSectionProps): ReactElem
                                 <th>Culprit</th>
                                 <th>Events</th>
                                 <th>Status</th>
+                                <th>Trace</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -54,6 +56,15 @@ export const IssuesSection = ({ organizationId }: IssuesSectionProps): ReactElem
                                         <span className="badge">{issue.count}</span>
                                     </td>
                                     <td>{issue.status}</td>
+                                    <td>
+                                        {issue.sampleTraceId && onOpenTab ? (
+                                            <button className="trace-link" onClick={() => onOpenTab("traces", { traceId: issue.sampleTraceId })} type="button">
+                                                View trace
+                                            </button>
+                                        ) : (
+                                            <span className="muted">—</span>
+                                        )}
+                                    </td>
                                 </tr>
                             ))}
                         </tbody>

--- a/apps/cloud/src/client/IssuesSection.tsx
+++ b/apps/cloud/src/client/IssuesSection.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
 import { AsyncList } from "./AsyncList";
+import { CrossTabLink } from "./CrossTabLink";
 import type { OrgId } from "./types";
 
 interface IssuesSectionProps {
@@ -58,9 +59,9 @@ export const IssuesSection = ({ onOpenTab, organizationId }: IssuesSectionProps)
                                     <td>{issue.status}</td>
                                     <td>
                                         {issue.sampleTraceId && onOpenTab ? (
-                                            <button className="trace-link" onClick={() => onOpenTab("traces", { traceId: issue.sampleTraceId })} type="button">
+                                            <CrossTabLink onOpenTab={onOpenTab} target="traces" traceId={issue.sampleTraceId}>
                                                 View trace
-                                            </button>
+                                            </CrossTabLink>
                                         ) : (
                                             <span className="muted">—</span>
                                         )}

--- a/apps/cloud/src/client/LogsSection.tsx
+++ b/apps/cloud/src/client/LogsSection.tsx
@@ -1,11 +1,15 @@
 import { useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
 import type { OrgId, ProjectId } from "./types";
 
 interface LogsSectionProps {
+    /** Deep-link in: prefilter the log lines to this trace (from a trace's "View logs"). */
+    focusTraceId?: string;
+    /** Deep-link out: jump to a line's trace waterfall. */
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
     organizationId: OrgId;
 }
 
@@ -29,13 +33,21 @@ const renderFields = (fields: Record<string, unknown>): string =>
  * both push to the server-side `logs.list`. The query is live, so the view tails
  * on its own — no polling.
  */
-export const LogsSection = ({ organizationId }: LogsSectionProps): ReactElement => {
+export const LogsSection = ({ focusTraceId, onOpenTab, organizationId }: LogsSectionProps): ReactElement => {
     const projects = useQuery(api.projects.listByOrg, { organizationId });
     const [projectId, setProjectId] = useState<ProjectId | "">("");
     const deployments = useQuery(api.deployments.listByProject, projectId ? { organizationId, projectId } : "skip");
     const [scriptName, setScriptName] = useState("");
     const [levels, setLevels] = useState<Set<LogLevel>>(new Set());
     const [search, setSearch] = useState("");
+    const [traceFilter, setTraceFilter] = useState<string | undefined>(focusTraceId);
+
+    // Deep-link in: adopt an incoming trace filter (from a trace's "View logs").
+    useEffect(() => {
+        if (focusTraceId) {
+            setTraceFilter(focusTraceId);
+        }
+    }, [focusTraceId]);
 
     const logs = useQuery(
         api.logs.list,
@@ -45,6 +57,7 @@ export const LogsSection = ({ organizationId }: LogsSectionProps): ReactElement 
                   organizationId,
                   scriptName,
                   search: search.trim() === "" ? undefined : search.trim(),
+                  traceId: traceFilter,
               }
             : "skip",
     );
@@ -109,6 +122,14 @@ export const LogsSection = ({ organizationId }: LogsSectionProps): ReactElement 
 
             {scriptName ? (
                 <section className="card">
+                    {traceFilter ? (
+                        <div className="log-trace-filter">
+                            Filtering by trace <code>{traceFilter.slice(0, 12)}</code>
+                            <button className="trace-link" onClick={() => setTraceFilter(undefined)} type="button">
+                                clear
+                            </button>
+                        </div>
+                    ) : null}
                     <div className="log-toolbar">
                         <input
                             aria-label="Search logs"
@@ -140,7 +161,15 @@ export const LogsSection = ({ organizationId }: LogsSectionProps): ReactElement 
                                 <span className={`log-badge log-badge-${entry.level}`}>{entry.level}</span>{" "}
                                 {entry.functionPath ? <span className="log-fn">{entry.functionPath}</span> : null} {entry.message}
                                 {entry.fields ? <span className="log-fields"> {renderFields(entry.fields)}</span> : null}
-                                {entry.traceId ? <span className="log-trace"> trace={entry.traceId.slice(0, 8)}</span> : null}
+                                {entry.traceId ? (
+                                    onOpenTab ? (
+                                        <button className="log-trace-link" onClick={() => onOpenTab("traces", { traceId: entry.traceId })} type="button">
+                                            trace={entry.traceId.slice(0, 8)}
+                                        </button>
+                                    ) : (
+                                        <span className="log-trace"> trace={entry.traceId.slice(0, 8)}</span>
+                                    )
+                                ) : null}
                                 {"\n"}
                             </span>
                         ))}

--- a/apps/cloud/src/client/LogsSection.tsx
+++ b/apps/cloud/src/client/LogsSection.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
+import { CrossTabLink } from "./CrossTabLink";
 import type { OrgId, ProjectId } from "./types";
 
 interface LogsSectionProps {
@@ -40,14 +41,11 @@ export const LogsSection = ({ focusTraceId, onOpenTab, organizationId }: LogsSec
     const [scriptName, setScriptName] = useState("");
     const [levels, setLevels] = useState<Set<LogLevel>>(new Set());
     const [search, setSearch] = useState("");
+    // Deep-link in: adopt an incoming trace filter (from a trace's "View logs")
+    // as a one-shot state seed. The dashboard remounts the section on each
+    // deep-link (via a `key`), so `focusTraceId` is consumed here rather than
+    // synced in a `useEffect` that would re-apply a stale filter on re-render.
     const [traceFilter, setTraceFilter] = useState<string | undefined>(focusTraceId);
-
-    // Deep-link in: adopt an incoming trace filter (from a trace's "View logs").
-    useEffect(() => {
-        if (focusTraceId) {
-            setTraceFilter(focusTraceId);
-        }
-    }, [focusTraceId]);
 
     const logs = useQuery(
         api.logs.list,
@@ -125,7 +123,7 @@ export const LogsSection = ({ focusTraceId, onOpenTab, organizationId }: LogsSec
                     {traceFilter ? (
                         <div className="log-trace-filter">
                             Filtering by trace <code>{traceFilter.slice(0, 12)}</code>
-                            <button className="trace-link" onClick={() => setTraceFilter(undefined)} type="button">
+                            <button className="cross-tab-link" onClick={() => setTraceFilter(undefined)} type="button">
                                 clear
                             </button>
                         </div>
@@ -163,9 +161,9 @@ export const LogsSection = ({ focusTraceId, onOpenTab, organizationId }: LogsSec
                                 {entry.fields ? <span className="log-fields"> {renderFields(entry.fields)}</span> : null}
                                 {entry.traceId ? (
                                     onOpenTab ? (
-                                        <button className="log-trace-link" onClick={() => onOpenTab("traces", { traceId: entry.traceId })} type="button">
+                                        <CrossTabLink onOpenTab={onOpenTab} target="traces" traceId={entry.traceId} variant="inline">
                                             trace={entry.traceId.slice(0, 8)}
-                                        </button>
+                                        </CrossTabLink>
                                     ) : (
                                         <span className="log-trace"> trace={entry.traceId.slice(0, 8)}</span>
                                     )

--- a/apps/cloud/src/client/OrganizationDashboard.tsx
+++ b/apps/cloud/src/client/OrganizationDashboard.tsx
@@ -136,11 +136,18 @@ const OrgBanners = ({ org }: { org: OrgFlags }): ReactElement | null => {
 export const OrganizationDashboard = ({ onBack, organizationId }: OrganizationDashboardProps): ReactElement => {
     const organizations = useQuery(api.organizations.list, {});
     const [tab, setTab] = useState<Tab>("projects");
-    // Cross-tab deep-link: a section calls `onOpenTab` to jump to Traces/Logs
-    // focused on a trace (an Issue → its trace, a trace → its logs).
-    const [focusTraceId, setFocusTraceId] = useState<string>();
+    // Cross-tab deep-link. `seq` bumps on EVERY navigation so the target section
+    // remounts each time (via its `key`) — a one-shot: it consumes `traceId` in
+    // its state initializer, never a `useEffect` sync. A manual tab click bumps
+    // `seq` with no `traceId`, so a stale trace can't re-open, and deep-linking the
+    // SAME trace twice still re-focuses (the seq — hence the key — changed).
+    const [focus, setFocus] = useState<{ seq: number; traceId?: string }>({ seq: 0 });
+    const navigate = (target: Tab): void => {
+        setFocus((previous) => ({ seq: previous.seq + 1 }));
+        setTab(target);
+    };
     const onOpenTab = (target: "logs" | "traces", context?: { traceId?: string }): void => {
-        setFocusTraceId(context?.traceId);
+        setFocus((previous) => ({ seq: previous.seq + 1, traceId: context?.traceId }));
         setTab(target);
     };
     const palette = useCommandPalette();
@@ -155,6 +162,7 @@ export const OrganizationDashboard = ({ onBack, organizationId }: OrganizationDa
                     id: `tab:${entry.id}`,
                     label: entry.label,
                     run: () => {
+                        setFocus((previous) => ({ seq: previous.seq + 1 }));
                         setTab(entry.id);
                     },
                 };
@@ -180,20 +188,18 @@ export const OrganizationDashboard = ({ onBack, organizationId }: OrganizationDa
 
             <nav className="tabs">
                 {TABS.map((entry) => (
-                    <button
-                        className={entry.id === tab ? "tab active" : "tab"}
-                        key={entry.id}
-                        onClick={() => {
-                            setTab(entry.id);
-                        }}
-                        type="button"
-                    >
+                    <button className={entry.id === tab ? "tab active" : "tab"} key={entry.id} onClick={() => navigate(entry.id)} type="button">
                         {entry.label}
                     </button>
                 ))}
             </nav>
 
-            <ActiveSection focusTraceId={tab === "logs" || tab === "traces" ? focusTraceId : undefined} onOpenTab={onOpenTab} organizationId={organizationId} />
+            <ActiveSection
+                focusTraceId={tab === "logs" || tab === "traces" ? focus.traceId : undefined}
+                key={`${tab}:${String(focus.seq)}`}
+                onOpenTab={onOpenTab}
+                organizationId={organizationId}
+            />
         </div>
     );
 };

--- a/apps/cloud/src/client/OrganizationDashboard.tsx
+++ b/apps/cloud/src/client/OrganizationDashboard.tsx
@@ -47,6 +47,17 @@ type Tab =
     | "uptime"
     | "usage";
 
+/**
+ * Props every section receives. Beyond `organizationId`, sections may use
+ * `openTab` to deep-link to another tab (e.g. an Issue → its trace), and
+ * `focusTraceId` — the trace/trace-filter the target tab should open on.
+ */
+export interface SectionProps {
+    focusTraceId?: string;
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
+    organizationId: OrgId;
+}
+
 const TABS: { id: Tab; label: string }[] = [
     { id: "projects", label: "Projects" },
     { id: "members", label: "Members" },
@@ -67,7 +78,7 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 /** Tab → live section. Every section mounts against the same `organizationId`. */
-const SECTIONS: Record<Tab, (props: { organizationId: OrgId }) => ReactElement> = {
+const SECTIONS: Record<Tab, (props: SectionProps) => ReactElement> = {
     activity: ActivitySection,
     alerts: AlertsSection,
     billing: BillingSection,
@@ -125,6 +136,13 @@ const OrgBanners = ({ org }: { org: OrgFlags }): ReactElement | null => {
 export const OrganizationDashboard = ({ onBack, organizationId }: OrganizationDashboardProps): ReactElement => {
     const organizations = useQuery(api.organizations.list, {});
     const [tab, setTab] = useState<Tab>("projects");
+    // Cross-tab deep-link: a section calls `onOpenTab` to jump to Traces/Logs
+    // focused on a trace (an Issue → its trace, a trace → its logs).
+    const [focusTraceId, setFocusTraceId] = useState<string>();
+    const onOpenTab = (target: "logs" | "traces", context?: { traceId?: string }): void => {
+        setFocusTraceId(context?.traceId);
+        setTab(target);
+    };
     const palette = useCommandPalette();
 
     const org = organizations?.find((candidate) => candidate._id === organizationId);
@@ -175,7 +193,7 @@ export const OrganizationDashboard = ({ onBack, organizationId }: OrganizationDa
                 ))}
             </nav>
 
-            <ActiveSection organizationId={organizationId} />
+            <ActiveSection focusTraceId={tab === "logs" || tab === "traces" ? focusTraceId : undefined} onOpenTab={onOpenTab} organizationId={organizationId} />
         </div>
     );
 };

--- a/apps/cloud/src/client/TracesSection.tsx
+++ b/apps/cloud/src/client/TracesSection.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { buildTraceTree } from "../telemetry/trace-tree";
 import { api } from "../../lunora/_generated/api.js";
+import { CrossTabLink } from "./CrossTabLink";
 import type { DeploymentId, OrgId, ProjectId } from "./types";
 
 interface TracesSectionProps {
@@ -32,18 +33,14 @@ export const TracesSection = ({ focusTraceId, onOpenTab, organizationId }: Trace
     const [projectId, setProjectId] = useState<ProjectId | "">("");
     const deployments = useQuery(api.deployments.listByProject, projectId ? { organizationId, projectId } : "skip");
     const [deploymentId, setDeploymentId] = useState<DeploymentId | "">("");
-    const [traceId, setTraceId] = useState("");
+    // Deep-link in: open the focused trace's waterfall directly (`traces.get`
+    // needs only org + traceId, so no project/deployment pick is required). This
+    // is a one-shot state seed — the dashboard remounts the section on each
+    // deep-link (via a `key`), so `focusTraceId` is consumed here, not synced in
+    // a `useEffect` that would re-fire a stale trace on unrelated re-renders.
+    const [traceId, setTraceId] = useState(focusTraceId ?? "");
     const [errorOnly, setErrorOnly] = useState(false);
     const [selectedSpanId, setSelectedSpanId] = useState("");
-
-    // Deep-link in: open the focused trace's waterfall directly (`traces.get`
-    // needs only org + traceId, so no project/deployment pick is required).
-    useEffect(() => {
-        if (focusTraceId) {
-            setTraceId(focusTraceId);
-            setSelectedSpanId("");
-        }
-    }, [focusTraceId]);
 
     const traces = useQuery(api.traces.list, deploymentId ? { deploymentId, errorOnly, organizationId } : "skip");
     const spans = useQuery(api.traces.get, traceId ? { organizationId, traceId } : "skip");
@@ -177,9 +174,9 @@ export const TracesSection = ({ focusTraceId, onOpenTab, organizationId }: Trace
                         </div>
                         <div className="trace-detail-actions">
                             {onOpenTab ? (
-                                <button className="trace-link" onClick={() => onOpenTab("logs", { traceId })} type="button">
+                                <CrossTabLink onOpenTab={onOpenTab} target="logs" traceId={traceId}>
                                     View logs
-                                </button>
+                                </CrossTabLink>
                             ) : null}
                             <button className="trace-close" onClick={() => setTraceId("")} type="button">
                                 Close

--- a/apps/cloud/src/client/TracesSection.tsx
+++ b/apps/cloud/src/client/TracesSection.tsx
@@ -1,12 +1,16 @@
 import { useQuery } from "@lunora/react";
 import type { ReactElement } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { buildTraceTree } from "../telemetry/trace-tree";
 import { api } from "../../lunora/_generated/api.js";
 import type { DeploymentId, OrgId, ProjectId } from "./types";
 
 interface TracesSectionProps {
+    /** Deep-link: when set (e.g. from an Issue or a log line), open this trace's waterfall. */
+    focusTraceId?: string;
+    /** Deep-link out to another tab (e.g. this trace's logs). */
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
     organizationId: OrgId;
 }
 
@@ -23,7 +27,7 @@ const formatMs = (ms: number): string => (ms < 1000 ? `${String(Math.round(ms))}
  * indented by its depth under `parentSpanId` — a true span waterfall, not a
  * log-gap timeline. Both queries are live.
  */
-export const TracesSection = ({ organizationId }: TracesSectionProps): ReactElement => {
+export const TracesSection = ({ focusTraceId, onOpenTab, organizationId }: TracesSectionProps): ReactElement => {
     const projects = useQuery(api.projects.listByOrg, { organizationId });
     const [projectId, setProjectId] = useState<ProjectId | "">("");
     const deployments = useQuery(api.deployments.listByProject, projectId ? { organizationId, projectId } : "skip");
@@ -31,6 +35,15 @@ export const TracesSection = ({ organizationId }: TracesSectionProps): ReactElem
     const [traceId, setTraceId] = useState("");
     const [errorOnly, setErrorOnly] = useState(false);
     const [selectedSpanId, setSelectedSpanId] = useState("");
+
+    // Deep-link in: open the focused trace's waterfall directly (`traces.get`
+    // needs only org + traceId, so no project/deployment pick is required).
+    useEffect(() => {
+        if (focusTraceId) {
+            setTraceId(focusTraceId);
+            setSelectedSpanId("");
+        }
+    }, [focusTraceId]);
 
     const traces = useQuery(api.traces.list, deploymentId ? { deploymentId, errorOnly, organizationId } : "skip");
     const spans = useQuery(api.traces.get, traceId ? { organizationId, traceId } : "skip");
@@ -162,9 +175,16 @@ export const TracesSection = ({ organizationId }: TracesSectionProps): ReactElem
                                 </span>
                             ) : null}
                         </div>
-                        <button className="trace-close" onClick={() => setTraceId("")} type="button">
-                            Close
-                        </button>
+                        <div className="trace-detail-actions">
+                            {onOpenTab ? (
+                                <button className="trace-link" onClick={() => onOpenTab("logs", { traceId })} type="button">
+                                    View logs
+                                </button>
+                            ) : null}
+                            <button className="trace-close" onClick={() => setTraceId("")} type="button">
+                                Close
+                            </button>
+                        </div>
                     </header>
 
                     {spans === undefined ? <p className="muted">Loading…</p> : null}

--- a/apps/cloud/src/client/styles.css
+++ b/apps/cloud/src/client/styles.css
@@ -852,6 +852,42 @@ button.link.danger {
     word-break: break-word;
 }
 
+/* Cross-tab deep-link buttons (Issue → trace, trace → logs, log → trace). */
+.trace-link,
+.log-trace-link {
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--primary);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.trace-link:hover,
+.log-trace-link:hover {
+    border-color: var(--primary);
+}
+
+.log-trace-link {
+    margin-left: 6px;
+    font-family: inherit;
+}
+
+.trace-detail-actions {
+    display: inline-flex;
+    gap: 8px;
+}
+
+.log-trace-filter {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    color: var(--muted);
+    font-size: 13px;
+}
+
 /* Trace-list filter row (errors-only, …). */
 .trace-filter {
     display: inline-flex;

--- a/apps/cloud/src/client/styles.css
+++ b/apps/cloud/src/client/styles.css
@@ -852,9 +852,8 @@ button.link.danger {
     word-break: break-word;
 }
 
-/* Cross-tab deep-link buttons (Issue → trace, trace → logs, log → trace). */
-.trace-link,
-.log-trace-link {
+/* Shared cross-tab deep-link button (Issue → trace, trace → logs, log → trace). */
+.cross-tab-link {
     padding: 2px 8px;
     border: 1px solid var(--border);
     border-radius: 4px;
@@ -864,12 +863,12 @@ button.link.danger {
     cursor: pointer;
 }
 
-.trace-link:hover,
-.log-trace-link:hover {
+.cross-tab-link:hover {
     border-color: var(--primary);
 }
 
-.log-trace-link {
+/* Inline variant — sits within a log line, so it inherits the mono line font. */
+.cross-tab-link-inline {
     margin-left: 6px;
     font-family: inherit;
 }

--- a/apps/cloud/src/deploy/capability.ts
+++ b/apps/cloud/src/deploy/capability.ts
@@ -1,0 +1,13 @@
+/**
+ * The scoped-key capability check, as one pure predicate.
+ *
+ * An `ingest`-capability deploy key is telemetry-only: it authorizes the OTLP
+ * ingest paths (via `authorizeTelemetryKey`) but must be rejected by every
+ * deploy/admin path — so the ingest token the platform injects into every tenant
+ * can never be used to ship code. Both the deploy entrypoint (`deploy_keys.verify`)
+ * and the per-mutation gate (`authorizeDeployKey`) call this, so the two can never
+ * disagree on what "may deploy" means.
+ */
+
+/** True when a key may authorize a deploy/admin action (i.e. it is NOT an ingest-only key). */
+export const isDeployCapable = (row: { capability?: "deploy" | "ingest" }): boolean => row.capability !== "ingest";

--- a/apps/cloud/src/telemetry/archive-read.ts
+++ b/apps/cloud/src/telemetry/archive-read.ts
@@ -1,0 +1,62 @@
+/**
+ * Read-back of tiered spans from the columnar archive (R2 SQL over the Iceberg
+ * table `archiveSpans` writes). This is the read half of the tiering that lets the
+ * Traces view reach past D1's hot window. The **query + row mapping** live here as
+ * pure, tested functions; the live query itself is gated on the R2-SQL config
+ * (`R2_SQL_TOKEN` + the catalog), so it no-ops to `[]` until a cell provisions
+ * them — the same posture as the raw-event archive.
+ */
+import type { SpanObservation } from "./otlp";
+
+/** Default Iceberg table the span archive Pipeline lands in; override via env. */
+export const DEFAULT_SPAN_ARCHIVE_TABLE = "default.telemetry_spans";
+
+/** Coerce an archive cell to a finite number (Iceberg may hand back a number or a numeric string). */
+const asNumber = (value: unknown): number | undefined => {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    return undefined;
+};
+
+/** Coerce an archive cell to a non-empty string. */
+const asString = (value: unknown): string | undefined => (typeof value === "string" && value !== "" ? value : undefined);
+
+/**
+ * Map one archived row (the flat record `spanArchiveRecord` wrote) back to a
+ * {@link SpanObservation}. Tolerant: a missing/mistyped column is dropped rather
+ * than thrown on, and required fields fall back so a partial row still places on
+ * the waterfall.
+ */
+export const archiveRowToObservation = (row: Record<string, unknown>): SpanObservation => {
+    const startedAt = asNumber(row.startedAt) ?? 0;
+    const endedAt = asNumber(row.endedAt) ?? startedAt;
+    const kind = row.kind === "container" || row.kind === "generation" ? row.kind : "worker";
+
+    return {
+        ...(asNumber(row.completionTokens) === undefined ? {} : { completionTokens: asNumber(row.completionTokens) }),
+        durationMs: asNumber(row.durationMs) ?? Math.max(endedAt - startedAt, 0),
+        endedAt,
+        ...(asString(row.functionPath) === undefined ? {} : { functionPath: asString(row.functionPath) }),
+        ...(asString(row.input) === undefined ? {} : { input: asString(row.input) }),
+        kind,
+        level: row.level === "error" ? "error" : "info",
+        ...(asString(row.model) === undefined ? {} : { model: asString(row.model) }),
+        name: asString(row.name) ?? "span",
+        ...(asString(row.output) === undefined ? {} : { output: asString(row.output) }),
+        ...(asString(row.parentSpanId) === undefined ? {} : { parentSpanId: asString(row.parentSpanId) }),
+        ...(asNumber(row.promptTokens) === undefined ? {} : { promptTokens: asNumber(row.promptTokens) }),
+        ...(asString(row.serviceName) === undefined ? {} : { serviceName: asString(row.serviceName) }),
+        spanId: asString(row.spanId) ?? "",
+        startedAt,
+        ...(asString(row.statusMessage) === undefined ? {} : { statusMessage: asString(row.statusMessage) }),
+        traceId: asString(row.traceId) ?? "",
+    };
+};

--- a/apps/cloud/src/telemetry/archive-read.ts
+++ b/apps/cloud/src/telemetry/archive-read.ts
@@ -29,34 +29,48 @@ const asNumber = (value: unknown): number | undefined => {
 /** Coerce an archive cell to a non-empty string. */
 const asString = (value: unknown): string | undefined => (typeof value === "string" && value !== "" ? value : undefined);
 
+/** Drop keys whose value is `undefined` so optional fields are omitted, not set to `undefined` (exactOptionalPropertyTypes). */
+const compact = <T extends Record<string, unknown>>(record: T): T => {
+    const out: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(record)) {
+        if (value !== undefined) {
+            out[key] = value;
+        }
+    }
+
+    return out as T;
+};
+
 /**
  * Map one archived row (the flat record `spanArchiveRecord` wrote) back to a
  * {@link SpanObservation}. Tolerant: a missing/mistyped column is dropped rather
  * than thrown on, and required fields fall back so a partial row still places on
- * the waterfall.
+ * the waterfall. Each cell is coerced exactly once, then {@link compact} strips
+ * the optional fields that came back `undefined`.
  */
 export const archiveRowToObservation = (row: Record<string, unknown>): SpanObservation => {
     const startedAt = asNumber(row.startedAt) ?? 0;
     const endedAt = asNumber(row.endedAt) ?? startedAt;
     const kind = row.kind === "container" || row.kind === "generation" ? row.kind : "worker";
 
-    return {
-        ...(asNumber(row.completionTokens) === undefined ? {} : { completionTokens: asNumber(row.completionTokens) }),
+    return compact({
+        completionTokens: asNumber(row.completionTokens),
         durationMs: asNumber(row.durationMs) ?? Math.max(endedAt - startedAt, 0),
         endedAt,
-        ...(asString(row.functionPath) === undefined ? {} : { functionPath: asString(row.functionPath) }),
-        ...(asString(row.input) === undefined ? {} : { input: asString(row.input) }),
+        functionPath: asString(row.functionPath),
+        input: asString(row.input),
         kind,
         level: row.level === "error" ? "error" : "info",
-        ...(asString(row.model) === undefined ? {} : { model: asString(row.model) }),
+        model: asString(row.model),
         name: asString(row.name) ?? "span",
-        ...(asString(row.output) === undefined ? {} : { output: asString(row.output) }),
-        ...(asString(row.parentSpanId) === undefined ? {} : { parentSpanId: asString(row.parentSpanId) }),
-        ...(asNumber(row.promptTokens) === undefined ? {} : { promptTokens: asNumber(row.promptTokens) }),
-        ...(asString(row.serviceName) === undefined ? {} : { serviceName: asString(row.serviceName) }),
+        output: asString(row.output),
+        parentSpanId: asString(row.parentSpanId),
+        promptTokens: asNumber(row.promptTokens),
+        serviceName: asString(row.serviceName),
         spanId: asString(row.spanId) ?? "",
         startedAt,
-        ...(asString(row.statusMessage) === undefined ? {} : { statusMessage: asString(row.statusMessage) }),
+        statusMessage: asString(row.statusMessage),
         traceId: asString(row.traceId) ?? "",
-    };
+    }) as SpanObservation;
 };

--- a/apps/cloud/src/telemetry/otlp.ts
+++ b/apps/cloud/src/telemetry/otlp.ts
@@ -12,7 +12,7 @@
  * `error.type`, and container spans (scope `@lunora/container`) identify the
  * container via the `service.name` resource attribute.
  */
-import { redactRecord } from "./redact";
+import { redactRecord, redactText } from "./redact";
 
 /** OTLP `AnyValue` — only the variants Lunora emits are read. */
 interface OtlpAnyValue {
@@ -61,6 +61,8 @@ export interface TelemetryEvent {
     instance?: string;
     kind: "container" | "error";
     message: string;
+    /** The error span's trace, so the Issue can link to a sample trace. */
+    traceId?: string;
     ts: number;
 }
 
@@ -180,6 +182,8 @@ export const decodeTelemetryEvents = (payload: OtlpTracePayload): TelemetryEvent
                 const code = attributeString(span.attributes, "error.type");
                 const ts = epochMsFromNano(span.endTimeUnixNano);
 
+                const traceId = span.traceId === undefined || span.traceId === "" ? undefined : span.traceId;
+
                 if (isContainer) {
                     const container = serviceName ?? "container";
 
@@ -190,6 +194,7 @@ export const decodeTelemetryEvents = (payload: OtlpTracePayload): TelemetryEvent
                         instance: attributeString(span.attributes, "lunora.instance"),
                         kind: "container",
                         message,
+                        ...(traceId === undefined ? {} : { traceId }),
                         ts,
                     });
                 } else {
@@ -198,6 +203,7 @@ export const decodeTelemetryEvents = (payload: OtlpTracePayload): TelemetryEvent
                         functionPath: attributeString(span.attributes, "lunora.function_path") ?? span.name ?? "unknown",
                         kind: "error",
                         message,
+                        ...(traceId === undefined ? {} : { traceId }),
                         ts,
                     });
                 }
@@ -411,8 +417,8 @@ export const decodeObservations = (payload: OtlpTracePayload): SpanObservation[]
                     observation.model = model;
                     observation.promptTokens = attributeNumber(span.attributes, "gen_ai.usage.input_tokens");
                     observation.completionTokens = attributeNumber(span.attributes, "gen_ai.usage.output_tokens");
-                    observation.input = truncateText(attributeString(span.attributes, "gen_ai.prompt"));
-                    observation.output = truncateText(attributeString(span.attributes, "gen_ai.completion"));
+                    observation.input = truncateText(redactText(attributeString(span.attributes, "gen_ai.prompt")));
+                    observation.output = truncateText(redactText(attributeString(span.attributes, "gen_ai.completion")));
                 }
 
                 observations.push(observation);

--- a/apps/cloud/src/telemetry/redact.ts
+++ b/apps/cloud/src/telemetry/redact.ts
@@ -32,11 +32,11 @@ export const isSensitiveKey = (key: string): boolean => SENSITIVE_KEY.test(key);
 // nested quantifiers, so no ReDoS. Case-insensitive.
 const SECRET_IN_TEXT = new RegExp(
     [
-        String.raw`(bearer\s+)[\w.~+/=-]{8,}`, // Authorization: Bearer <token>
+        String.raw`(?<bearer>bearer\s+)[\w.~+/=-]{8,}`, // Authorization: Bearer <token>
         String.raw`\bsk-[a-z\d]{16,}\b`, // OpenAI-style api keys
         String.raw`\beyJ[\w-]{10,}\.[\w-]{10,}\.[\w-]{6,}`, // JWTs
         String.raw`\bAKIA[a-z\d]{16}\b`, // AWS access key ids
-        String.raw`((?:password|passwd|secret|token|api[_-]?key)\s*[=:]\s*)\S+`, // key=value / key: value
+        String.raw`(?<kv>(?:password|passwd|secret|token|api[_-]?key)\s*[=:]\s*)\S+`, // key=value / key: value
     ].join("|"),
     "gi",
 );
@@ -53,9 +53,15 @@ export const redactText = (text: string | undefined): string | undefined => {
         return undefined;
     }
 
-    // The regex has two prefix-capturing alternatives — `(bearer )` and
-    // `(key=)` — so use whichever one matched (the rest capture nothing).
-    return text.replaceAll(SECRET_IN_TEXT, (_match, bearerPrefix?: string, keyPrefix?: string) => `${bearerPrefix ?? keyPrefix ?? ""}${REDACTED}`);
+    // The regex has two prefix-capturing alternatives — a named `bearer ` and a
+    // named `key=` group — so keep whichever one matched (the other alternatives
+    // capture nothing) and drop only the secret that follows. Named groups arrive
+    // as the final `groups` argument, robust to alternatives being reordered.
+    return text.replaceAll(SECRET_IN_TEXT, (...arguments_: unknown[]) => {
+        const groups = arguments_.at(-1) as { bearer?: string; kv?: string } | undefined;
+
+        return `${groups?.bearer ?? groups?.kv ?? ""}${REDACTED}`;
+    });
 };
 
 /**

--- a/apps/cloud/src/telemetry/redact.ts
+++ b/apps/cloud/src/telemetry/redact.ts
@@ -22,8 +22,7 @@ export const REDACTED = "[redacted]";
 // are caught, where a bounded `\btoken\b` silently leaked them. `key` stays scoped
 // to credential-ish prefixes so an innocuous `shard_key` / `idempotency_key` is not
 // redacted.
-const SENSITIVE_KEY =
-    /authorization|password|passwd|secret|credential|(?:api|access|private|secret|client|encryption)[-_]?key|token|\bcookie\b|set-cookie|session/i;
+const SENSITIVE_KEY = /authorization|password|passwd|secret|credential|(?:api|access|private|client|encryption)[_-]?key|token|\bcookie\b|set-cookie|session/i;
 
 /** True when a field/attribute key names something secret and its value should be scrubbed. */
 export const isSensitiveKey = (key: string): boolean => SENSITIVE_KEY.test(key);
@@ -33,11 +32,11 @@ export const isSensitiveKey = (key: string): boolean => SENSITIVE_KEY.test(key);
 // nested quantifiers, so no ReDoS. Case-insensitive.
 const SECRET_IN_TEXT = new RegExp(
     [
-        "(bearer\\s+)[A-Za-z0-9._~+/-]{8,}={0,2}", // Authorization: Bearer <token>
-        "\\bsk-[A-Za-z0-9]{16,}\\b", // OpenAI-style api keys
-        "\\beyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{6,}", // JWTs
-        "\\bAKIA[0-9A-Z]{16}\\b", // AWS access key ids
-        "((?:password|passwd|secret|token|api[_-]?key)\\s*[=:]\\s*)\\S+", // key=value / key: value
+        String.raw`(bearer\s+)[\w.~+/=-]{8,}`, // Authorization: Bearer <token>
+        String.raw`\bsk-[a-z\d]{16,}\b`, // OpenAI-style api keys
+        String.raw`\beyJ[\w-]{10,}\.[\w-]{10,}\.[\w-]{6,}`, // JWTs
+        String.raw`\bAKIA[a-z\d]{16}\b`, // AWS access key ids
+        String.raw`((?:password|passwd|secret|token|api[_-]?key)\s*[=:]\s*)\S+`, // key=value / key: value
     ].join("|"),
     "gi",
 );
@@ -56,7 +55,7 @@ export const redactText = (text: string | undefined): string | undefined => {
 
     // The regex has two prefix-capturing alternatives — `(bearer )` and
     // `(key=)` — so use whichever one matched (the rest capture nothing).
-    return text.replace(SECRET_IN_TEXT, (_match, bearerPrefix?: string, keyPrefix?: string) => `${bearerPrefix ?? keyPrefix ?? ""}${REDACTED}`);
+    return text.replaceAll(SECRET_IN_TEXT, (_match, bearerPrefix?: string, keyPrefix?: string) => `${bearerPrefix ?? keyPrefix ?? ""}${REDACTED}`);
 };
 
 /**

--- a/apps/cloud/src/telemetry/redact.ts
+++ b/apps/cloud/src/telemetry/redact.ts
@@ -28,6 +28,37 @@ const SENSITIVE_KEY =
 /** True when a field/attribute key names something secret and its value should be scrubbed. */
 export const isSensitiveKey = (key: string): boolean => SENSITIVE_KEY.test(key);
 
+// Secret-shaped SUBSTRINGS in free text (a recorded prompt/completion), where
+// there is no key to match on. Each alternative is independently bounded — no
+// nested quantifiers, so no ReDoS. Case-insensitive.
+const SECRET_IN_TEXT = new RegExp(
+    [
+        "(bearer\\s+)[A-Za-z0-9._~+/-]{8,}={0,2}", // Authorization: Bearer <token>
+        "\\bsk-[A-Za-z0-9]{16,}\\b", // OpenAI-style api keys
+        "\\beyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{6,}", // JWTs
+        "\\bAKIA[0-9A-Z]{16}\\b", // AWS access key ids
+        "((?:password|passwd|secret|token|api[_-]?key)\\s*[=:]\\s*)\\S+", // key=value / key: value
+    ].join("|"),
+    "gi",
+);
+
+/**
+ * Scrub secret-shaped substrings from free text (a recorded generation
+ * prompt/completion), where {@link redactRecord}'s key-based match can't reach.
+ * Replaces bearer tokens, api keys, JWTs, and `secret=…` pairs with a placeholder;
+ * a `bearer `/`key=` prefix is preserved so the line still reads. `undefined`
+ * passes through.
+ */
+export const redactText = (text: string | undefined): string | undefined => {
+    if (text === undefined) {
+        return undefined;
+    }
+
+    // The regex has two prefix-capturing alternatives — `(bearer )` and
+    // `(key=)` — so use whichever one matched (the rest capture nothing).
+    return text.replace(SECRET_IN_TEXT, (_match, bearerPrefix?: string, keyPrefix?: string) => `${bearerPrefix ?? keyPrefix ?? ""}${REDACTED}`);
+};
+
 /**
  * Return a copy of `record` with every sensitive-keyed value replaced by
  * {@link REDACTED}. Returns the original reference untouched when nothing

--- a/apps/cloud/src/telemetry/store.ts
+++ b/apps/cloud/src/telemetry/store.ts
@@ -16,7 +16,7 @@ import type { AnalyticsEngineDatasetLike } from "@lunora/bindings/analytics";
 import { createAnalytics } from "@lunora/bindings/analytics";
 import type { PipelineBindingLike } from "@lunora/bindings/pipelines";
 import { createPipelines } from "@lunora/bindings/pipelines";
-import { createR2Sql, raw, sql } from "@lunora/bindings/r2sql";
+import { createR2Sql, raw, sql, tableRef } from "@lunora/bindings/r2sql";
 
 import { archiveRowToObservation, DEFAULT_SPAN_ARCHIVE_TABLE } from "./archive-read";
 import type { MetricPoint, SpanObservation, TelemetryEvent } from "./otlp";
@@ -118,8 +118,11 @@ export const createCloudflareTelemetryStore = (env: TelemetryStoreEnv): Telemetr
 
             try {
                 const client = createR2Sql({ accountId: env.CLOUDFLARE_ACCOUNT_ID, apiToken: env.R2_SQL_TOKEN, bucket: env.TELEMETRY_BUCKET_NAME });
-                // The table name is trusted config → `raw`; values are bound via `sql`.
-                const table = env.TELEMETRY_SPAN_TABLE ?? DEFAULT_SPAN_ARCHIVE_TABLE;
+                // The table name is trusted config, but `tableRef` still validates it
+                // (a `namespace.table` shape) before `raw` splices it verbatim — so a
+                // fat-fingered env var throws here (caught below → D1-only fallback)
+                // rather than forming odd SQL. Values stay bound via the escaping `sql` tag.
+                const table = tableRef(env.TELEMETRY_SPAN_TABLE ?? DEFAULT_SPAN_ARCHIVE_TABLE);
                 const result = await client.query(
                     sql`SELECT * FROM ${raw(table)} WHERE recordType = ${"span"} AND organizationId = ${organizationId} AND traceId = ${traceId} ORDER BY startedAt`,
                 );

--- a/apps/cloud/src/telemetry/store.ts
+++ b/apps/cloud/src/telemetry/store.ts
@@ -16,7 +16,9 @@ import type { AnalyticsEngineDatasetLike } from "@lunora/bindings/analytics";
 import { createAnalytics } from "@lunora/bindings/analytics";
 import type { PipelineBindingLike } from "@lunora/bindings/pipelines";
 import { createPipelines } from "@lunora/bindings/pipelines";
+import { createR2Sql, raw, sql } from "@lunora/bindings/r2sql";
 
+import { archiveRowToObservation, DEFAULT_SPAN_ARCHIVE_TABLE } from "./archive-read";
 import type { MetricPoint, SpanObservation, TelemetryEvent } from "./otlp";
 
 /** Per-ingest counts, recorded as one metric point for dashboards/alerts. */
@@ -40,6 +42,14 @@ export interface TelemetryStore {
      * and carries its `organizationId` so the archive is one queryable table.
      */
     archiveSpans: (observations: ReadonlyArray<SpanObservation>, organizationId: string) => Promise<void>;
+    /**
+     * Read one trace's spans back from the columnar archive (R2 SQL over Iceberg),
+     * for traces older than D1's hot window. Returns `[]` when R2 SQL isn't
+     * configured (no `R2_SQL_TOKEN`/bucket) or on any query failure — a best-effort
+     * fallback, never a hard error. Requires the archive Pipeline to have landed
+     * spans (🌐 per-cell provisioning).
+     */
+    readArchivedTrace: (input: { organizationId: string; traceId: string }) => Promise<SpanObservation[]>;
     /** Record one ingest's issue/incident counts as an AE data point. */
     recordCounts: (counts: TelemetryCounts) => void;
     /** Write each `ctx.metrics.*` measurement to AE (`/v1/metrics`). No-op without the binding. */
@@ -53,10 +63,18 @@ export const spanArchiveRecord = (observation: SpanObservation, organizationId: 
     recordType: "span",
 });
 
-/** The telemetry bindings the store reads off the worker env (all optional). */
+/** The telemetry bindings + config the store reads off the worker env (all optional). */
 export interface TelemetryStoreEnv {
+    /** Account id for the R2-SQL read-back endpoint. */
+    CLOUDFLARE_ACCOUNT_ID?: string;
+    /** Bearer token for R2 SQL (read the span archive). Absent → read-back no-ops. */
+    R2_SQL_TOKEN?: string;
     TELEMETRY?: AnalyticsEngineDatasetLike;
+    /** R2 bucket name backing the span archive's Iceberg table. */
+    TELEMETRY_BUCKET_NAME?: string;
     TELEMETRY_PIPELINE?: PipelineBindingLike;
+    /** Iceberg table the span archive lands in (`namespace.table`); defaults to `default.telemetry_spans`. */
+    TELEMETRY_SPAN_TABLE?: string;
 }
 
 /**
@@ -92,6 +110,25 @@ export const createCloudflareTelemetryStore = (env: TelemetryStoreEnv): Telemetr
                 doubles: [counts.issues, counts.incidents],
                 indexes: [counts.organizationId],
             });
+        },
+        readArchivedTrace: async ({ organizationId, traceId }) => {
+            if (!env.R2_SQL_TOKEN || !env.CLOUDFLARE_ACCOUNT_ID || !env.TELEMETRY_BUCKET_NAME) {
+                return [];
+            }
+
+            try {
+                const client = createR2Sql({ accountId: env.CLOUDFLARE_ACCOUNT_ID, apiToken: env.R2_SQL_TOKEN, bucket: env.TELEMETRY_BUCKET_NAME });
+                // The table name is trusted config → `raw`; values are bound via `sql`.
+                const table = env.TELEMETRY_SPAN_TABLE ?? DEFAULT_SPAN_ARCHIVE_TABLE;
+                const result = await client.query(
+                    sql`SELECT * FROM ${raw(table)} WHERE recordType = ${"span"} AND organizationId = ${organizationId} AND traceId = ${traceId} ORDER BY startedAt`,
+                );
+
+                return (result.rows ?? []).map((row) => archiveRowToObservation(row));
+            } catch {
+                // R2 SQL unreachable / table absent — degrade to the D1-only view.
+                return [];
+            }
         },
         recordMetrics: (points, organizationId) => {
             if (!env.TELEMETRY || points.length === 0) {

--- a/packages/bindings/src/r2sql/index.ts
+++ b/packages/bindings/src/r2sql/index.ts
@@ -19,7 +19,7 @@ export type { OrderTerm } from "./order";
 export { asc, desc, renderOrderTerm } from "./order";
 export type { Condition, Queryable, QueryExecutor } from "./query";
 export { default as SetOperation } from "./set-operation";
-export { isSql, joinSql, lit, raw, Sql, sql, toText } from "./sql";
+export { ident, isSql, joinSql, lit, raw, Sql, sql, tableRef, toText } from "./sql";
 export type { R2SqlColumn, R2SqlConfig, R2SqlExplainOptions, R2SqlResult } from "./types";
 export type { OverSpec } from "./window";
 export { fn, WindowFunction } from "./window";


### PR DESCRIPTION
Follow-up to the merged #161 (full OTel integration), completing items 1, 2, 6, 4 from the "do 1 to 10" gap-closure:

- **R2-SQL span read-back (item 1)** — `TelemetryStore.readArchivedTrace` reads a trace's spans from the columnar archive (Iceberg) via R2 SQL, with a pure, tested row→observation mapper — the read symmetric to `archiveSpans`. Gated on `R2_SQL_TOKEN` (no-op `[]` until a cell provisions it).
- **Error → trace linking (item 2)** — error spans carry `traceId` into the Issue (`issues.sampleTraceId`); the dashboard gained cross-tab deep-links (Issue → trace, trace → logs, log → trace), keyboard-safe.
- **Generation-text redaction (item 6)** — `redactText` scrubs secret-shaped substrings from a recorded prompt/completion.
- **Auth-fix coverage (item 4)** — the scoped-key decision extracted to a pure, unit-tested `isDeployCapable` shared by the deploy entrypoint + the per-mutation gate.

Not included (🌐): the read-back's UI wiring + `R2_SQL_TOKEN` provisioning, a metrics dashboard (AE, SQL-only), a live E2E run; eslint needs the Phase-0 rebase (which also clears a pre-existing cloud lint backlog).

## Test plan
325 cloud tests pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)