### PR TITLE
feat(server,do,ai): post-hoc span attributes + traced rag embed cost

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -350,7 +350,7 @@ interface ContextMetrics {
 ### `ContextTracer` (type)
 
 ```ts
-type ContextTracer = <T>(name: string, function_: (trace: ContextTracer) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
+type ContextTracer = <T>(name: string, function_: (trace: ContextTracer, span: SpanHandle) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
 ```
 
 ### `CountArgs` (type)
@@ -2083,6 +2083,15 @@ interface SourceCursorLike {
 type SourceRefresh = "manual" | {
     everyMs: number;
 };
+```
+
+### `SpanHandle` (interface)
+
+```ts
+interface SpanHandle {
+    setAttribute: (key: string, value: LogFields[string]) => void;
+    setAttributes: (fields: LogFields) => void;
+}
 ```
 
 ### `SqlConsoleResult` (interface)

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -593,6 +593,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `SpanHandle` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `Storage` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -2482,6 +2486,10 @@ Re-exported from `@lunora/do` — signature tracked at its source.
 Re-exported from `@lunora/do` — signature tracked at its source.
 
 ### `SourceRefresh` (type)
+
+Re-exported from `@lunora/do` — signature tracked at its source.
+
+### `SpanHandle` (interface)
 
 Re-exported from `@lunora/do` — signature tracked at its source.
 
@@ -4859,6 +4867,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `SpanHandle` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `Storage` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -6500,6 +6512,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `ShardMode` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `SpanHandle` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -888,7 +888,7 @@ type LunoraRouteHandler = (c: Context<LunoraHttpEnv>) => Promise<Response>;
 ### `LunoraTracer` (type)
 
 ```ts
-type LunoraTracer = <T>(name: string, function_: (trace: LunoraTracer) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
+type LunoraTracer = <T>(name: string, function_: (trace: LunoraTracer, span: SpanHandle) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
 ```
 
 ### `ManyRelation` (interface)
@@ -1592,6 +1592,15 @@ type ShardMode = {
 } | {
     kind: "root";
 };
+```
+
+### `SpanHandle` (interface)
+
+```ts
+interface SpanHandle {
+    setAttribute: (key: string, value: LogFields[string]) => void;
+    setAttributes: (fields: LogFields) => void;
+}
 ```
 
 ### `Storage` (interface)
@@ -4174,7 +4183,7 @@ interface LunoraMetrics {
 ### `LunoraTracer` (type)
 
 ```ts
-type LunoraTracer = <T>(name: string, function_: (trace: LunoraTracer) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
+type LunoraTracer = <T>(name: string, function_: (trace: LunoraTracer, span: SpanHandle) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
 ```
 
 ### `MutationCtx` (interface)
@@ -4443,6 +4452,15 @@ type ShardMode = {
 } | {
     kind: "root";
 };
+```
+
+### `SpanHandle` (interface)
+
+```ts
+interface SpanHandle {
+    setAttribute: (key: string, value: LogFields[string]) => void;
+    setAttributes: (fields: LogFields) => void;
+}
 ```
 
 ### `Storage` (interface)

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -36,7 +36,14 @@ vi.mock(import("ai"), async (importOriginal) => {
     return {
         ...actual,
         embed: vi.fn(async ({ value }: { model: unknown; value: string }) => {
-            return { embedding: bagVector(value) };
+            // `usage` + `providerMetadata` mirror the real AI SDK embed result so
+            // the post-hoc span path (token usage / gateway cost) is exercised;
+            // callers that only read `embedding` are unaffected.
+            return {
+                embedding: bagVector(value),
+                providerMetadata: { gateway: { cost: 0.0002 } },
+                usage: { tokens: value.split(/\s+/u).filter(Boolean).length },
+            };
         }) as unknown as typeof actual.embed,
     };
 });
@@ -1108,9 +1115,14 @@ describe(bm25LexicalStore, () => {
 });
 
 describe("defineRag ctx.trace instrumentation", () => {
-    /** A context whose `trace` records each span it wraps (mirrors `ctx.trace`). */
-    const tracingCtx = (vectors: RagVectors): RagContext & { spans: { attributes?: Record<string, unknown>; name: string }[] } => {
-        const spans: { attributes?: Record<string, unknown>; name: string }[] = [];
+    /**
+     * A context whose `trace` mirrors the real `ctx.trace`: it hands the body a
+     * span handle, then records the span's start attributes merged with anything
+     * the body attached post-hoc (post-hoc winning), exactly like the `@lunora/do`
+     * tracer does at record time.
+     */
+    const tracingCtx = (vectors: RagVectors): RagContext & { spans: { attributes: Record<string, unknown>; name: string }[] } => {
+        const spans: { attributes: Record<string, unknown>; name: string }[] = [];
 
         return {
             ai: {
@@ -1118,16 +1130,35 @@ describe("defineRag ctx.trace instrumentation", () => {
                 embeddingModel: (model) => ({ modelId: model ?? "default" }) as unknown as EmbeddingModel,
             },
             spans,
-            trace: async <T>(name: string, function_: () => Promise<T> | T, attributes?: Record<string, unknown>): Promise<T> => {
-                spans.push({ attributes, name });
+            trace: async <T>(
+                name: string,
+                function_: (
+                    trace: unknown,
+                    span: { setAttribute: (key: string, value: unknown) => void; setAttributes: (fields: Record<string, unknown>) => void },
+                ) => Promise<T> | T,
+                attributes?: Record<string, unknown>,
+            ): Promise<T> => {
+                const collected: Record<string, unknown> = {};
+                const span = {
+                    setAttribute: (key: string, value: unknown) => {
+                        collected[key] = value;
+                    },
+                    setAttributes: (fields: Record<string, unknown>) => {
+                        Object.assign(collected, fields);
+                    },
+                };
 
-                return function_();
+                try {
+                    return await function_(undefined, span);
+                } finally {
+                    spans.push({ attributes: { ...attributes, ...collected }, name });
+                }
             },
             vectors,
         };
     };
 
-    it("wraps each embed in a generation span carrying the model id", async () => {
+    it("wraps each embed in a generation span carrying the model id and post-hoc usage/cost", async () => {
         const { vectors } = memoryVectors();
         const ctx = tracingCtx(vectors);
         const docs = defineRag({ allowSharedNamespace: true, embeddingModel: "@cf/baai/bge-base-en-v1.5", index: "docs" });
@@ -1139,8 +1170,11 @@ describe("defineRag ctx.trace instrumentation", () => {
 
         for (const span of ctx.spans) {
             expect(span.name).toBe("ai.embed");
-            expect(span.attributes?.["gen_ai.operation.name"]).toBe("embeddings");
-            expect(span.attributes?.["gen_ai.request.model"]).toBe("@cf/baai/bge-base-en-v1.5");
+            expect(span.attributes["gen_ai.operation.name"]).toBe("embeddings");
+            expect(span.attributes["gen_ai.request.model"]).toBe("@cf/baai/bge-base-en-v1.5");
+            // Post-hoc — only knowable after the embed call resolves.
+            expect(span.attributes["gen_ai.usage.input_tokens"]).toBeGreaterThan(0);
+            expect(span.attributes["gen_ai.usage.cost"]).toBe(0.0002);
         }
     });
 

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -178,17 +178,56 @@ const resolveEmbeddingModel = (input: RagConfig["embeddingModel"], ai: RagContex
  */
 
 /**
- * Structural slice of `ctx.trace` (see the server `LunoraTracer`) — enough to
- * wrap one embed. Declared here rather than imported so `@lunora/ai/rag` takes
- * no dependency on `@lunora/server`; the real tracer is assignable to it.
+ * Structural slice of the span handle `ctx.trace` hands its body (see the server
+ * `SpanHandle`) — enough to attach an embed's post-hoc usage/cost. Declared here
+ * rather than imported so `@lunora/ai/rag` takes no dependency on `@lunora/server`
+ * or `@lunora/do`; the real handle is assignable to it.
  */
-type EmbedTracer = <T>(name: string, function_: () => Promise<T> | T, attributes?: Record<string, unknown>) => Promise<T>;
+interface EmbedSpan {
+    setAttribute: (key: string, value: unknown) => void;
+    setAttributes: (fields: Record<string, unknown>) => void;
+}
+
+/**
+ * Structural slice of `ctx.trace` (see the server `LunoraTracer`) — enough to
+ * wrap one embed. The body receives the enclosing span's {@link EmbedSpan} as its
+ * second argument, so it can attach token usage / cost that are only known after
+ * the embed call resolves. Declared here rather than imported so `@lunora/ai/rag`
+ * takes no dependency on `@lunora/server`; the real tracer is assignable to it.
+ */
+type EmbedTracer = <T>(name: string, function_: (trace: EmbedTracer, span: EmbedSpan) => Promise<T> | T, attributes?: Record<string, unknown>) => Promise<T>;
 
 /** Read an AI SDK model's stable id for the `gen_ai.request.model` attribute, defensively. */
 const modelIdOf = (model: EmbeddingModel): string | undefined => {
     const id = (model as { modelId?: unknown }).modelId;
 
     return typeof id === "string" && id.length > 0 ? id : undefined;
+};
+
+/**
+ * Read an embed's dollar cost from AI SDK `providerMetadata`, defensively. AI
+ * Gateway surfaces per-request cost there (under a provider bag's `cost` field,
+ * e.g. the `cf-aig-*` / gateway metadata) once cost routing is enabled; until
+ * then it is absent and this returns `undefined`, so the `gen_ai.usage.cost`
+ * attribute is simply omitted. Probing rather than hard-depending keeps the embed
+ * span correct with or without a gateway in front.
+ */
+const embedCostOf = (providerMetadata: unknown): number | undefined => {
+    if (typeof providerMetadata !== "object" || providerMetadata === null) {
+        return undefined;
+    }
+
+    for (const bag of Object.values(providerMetadata as Record<string, unknown>)) {
+        if (typeof bag === "object" && bag !== null) {
+            const { cost } = bag as { cost?: unknown };
+
+            if (typeof cost === "number" && Number.isFinite(cost)) {
+                return cost;
+            }
+        }
+    }
+
+    return undefined;
 };
 
 const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
@@ -255,8 +294,28 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
             model ??= resolveEmbeddingModel(config.embeddingModel, context.ai);
             const resolvedModel = model;
 
-            const run = async (): Promise<ReadonlyArray<number>> => {
-                const { embedding } = await aiEmbed({ model: resolvedModel, value: text });
+            // `span` is present only on the traced path (post-hoc attributes). The
+            // model id is stamped at span start; token usage / cost are known only
+            // after the call resolves, so they are attached through the handle.
+            const run = async (span?: EmbedSpan): Promise<ReadonlyArray<number>> => {
+                const { embedding, providerMetadata, usage } = await aiEmbed({ model: resolvedModel, value: text });
+
+                if (span !== undefined) {
+                    // `usage.tokens` is typed non-optional by the AI SDK; the
+                    // typeof/finite guard stays defensive against a provider that
+                    // returns a non-numeric value at runtime.
+                    const inputTokens: unknown = usage.tokens;
+
+                    if (typeof inputTokens === "number" && Number.isFinite(inputTokens)) {
+                        span.setAttribute("gen_ai.usage.input_tokens", inputTokens);
+                    }
+
+                    const cost = embedCostOf(providerMetadata);
+
+                    if (cost !== undefined) {
+                        span.setAttribute("gen_ai.usage.cost", cost);
+                    }
+                }
 
                 return embedding;
             };
@@ -265,13 +324,9 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                 return run();
             }
 
-            // Token usage lands only after the call, but `ctx.trace` captures
-            // attributes at span start — so the span carries the model id (known
-            // up front); token/cost belong on the model-call spans the agent's
-            // OTLP telemetry emits, not on a cheap embed.
             const modelId = modelIdOf(resolvedModel);
 
-            return tracer("ai.embed", run, {
+            return tracer("ai.embed", (_trace, span) => run(span), {
                 "gen_ai.operation.name": "embeddings",
                 ...(modelId === undefined ? {} : { "gen_ai.request.model": modelId }),
             });

--- a/packages/ai/src/rag/types.ts
+++ b/packages/ai/src/rag/types.ts
@@ -116,11 +116,15 @@ export interface RagContext {
     /**
      * Optional `ctx.trace` span factory — an `ActionCtx`'s `ctx.trace` satisfies
      * it structurally. When present, `defineRag` wraps each embedding-model
-     * call in a `generation` span (`gen_ai.operation.name: "embeddings"` +
-     * `gen_ai.request.model`), so the embed shows up on the trace waterfall like
-     * any other instrumented sub-operation. `unknown` on purpose — the same
-     * decoupling rationale as `auth`: `defineRag` narrows it to a callable and
-     * runs embeds untraced when it is absent (a hand-built context / test).
+     * call in a `generation` span carrying `gen_ai.operation.name: "embeddings"`
+     * and `gen_ai.request.model` up front, plus — attached post-hoc through the
+     * span handle the tracer hands the body — `gen_ai.usage.input_tokens` (from
+     * the embed result's token usage) and `gen_ai.usage.cost` (probed from the
+     * embed result's provider metadata, e.g. AI Gateway) when those are present.
+     * So the embed shows up on the trace waterfall with its usage like any other
+     * instrumented model call. `unknown` on purpose — the same decoupling
+     * rationale as `auth`: `defineRag` narrows it to a callable and runs embeds
+     * untraced when it is absent (a hand-built context / test).
      */
     trace?: unknown;
     vectors: RagVectors;

--- a/packages/do/__tests__/tracing.test.ts
+++ b/packages/do/__tests__/tracing.test.ts
@@ -328,6 +328,63 @@ describe("ctx.trace", () => {
         expect(seen[1]?.attributes).toStrictEqual({ count: "1" });
     });
 
+    it("merges post-hoc attributes set through the span handle after an await", async () => {
+        expect.assertions(2);
+
+        const seen: SpanEvent[] = [];
+        const trace = tracerInto(seen);
+
+        // Token usage / cost is only known after the async body resolves — the
+        // classic case the span handle exists for.
+        await trace(
+            "ai.embed",
+            async (_child, handle) => {
+                await Promise.resolve();
+                handle.setAttribute("gen_ai.usage.input_tokens", 12);
+                handle.setAttributes({ cost: 0.0004, ok: true });
+            },
+            { "gen_ai.request.model": "@cf/baai/bge-base-en-v1.5" },
+        );
+
+        expect(seen[0]?.attributes).toStrictEqual({
+            "gen_ai.request.model": "@cf/baai/bge-base-en-v1.5",
+            "gen_ai.usage.input_tokens": 12,
+            cost: 0.0004,
+            ok: true,
+        });
+        // Non-primitive post-hoc values are coerced to JSON-safe primitives, exactly like start attributes.
+        expect(seen[0]?.attributes?.["cost"]).toBe(0.0004);
+    });
+
+    it("lets a post-hoc attribute win over a start attribute on a key clash", async () => {
+        expect.assertions(1);
+
+        const seen: SpanEvent[] = [];
+        const trace = tracerInto(seen);
+
+        await trace(
+            "work",
+            (_child, handle) => {
+                handle.setAttribute("status", "done");
+            },
+            { status: "pending" },
+        );
+
+        expect(seen[0]?.attributes).toStrictEqual({ status: "done" });
+    });
+
+    it("keeps a legacy body that ignores the span handle working unchanged", async () => {
+        expect.assertions(2);
+
+        const seen: SpanEvent[] = [];
+        const trace = tracerInto(seen);
+
+        // A `(trace) => …` body that never touches the second arg — the pre-existing
+        // call shape — records exactly its start attributes and nothing more.
+        await expect(trace("work", () => 7, { a: 1 })).resolves.toBe(7);
+        expect(seen[0]?.attributes).toStrictEqual({ a: 1 });
+    });
+
     it("survives a throwing recorder without failing the traced body", async () => {
         expect.assertions(1);
 

--- a/packages/do/src/context-telemetry.ts
+++ b/packages/do/src/context-telemetry.ts
@@ -18,16 +18,22 @@ import type { LogFields } from "../../../shared/log-fields";
 import { normalizeLogFields } from "../../../shared/log-fields";
 import type { MetricEvent, MetricKind } from "../../../shared/metric-event";
 import { otlpRandomHex } from "../../../shared/otlp";
-import type { SpanEvent } from "../../../shared/span-event";
+import type { SpanEvent, SpanHandle } from "../../../shared/span-event";
 import { toErrorType } from "./trace-context";
+
+export type { SpanHandle } from "../../../shared/span-event";
 
 /**
  * Structural shape of the `ctx.trace` span factory (see the server
  * `LunoraTracer`). Declared here rather than imported so `@lunora/do` takes no
  * dependency on `@lunora/server`; a cross-package assignability guard in
  * `@lunora/testing` fails the build if the two drift apart.
+ *
+ * The body's second argument is the enclosing span's {@link SpanHandle}, through
+ * which it can attach attributes only known *after* it resolves (post-hoc). It is
+ * a trailing parameter, so a `(trace) => …` body that ignores it still conforms.
  */
-export type ContextTracer = <T>(name: string, function_: (trace: ContextTracer) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
+export type ContextTracer = <T>(name: string, function_: (trace: ContextTracer, span: SpanHandle) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
 
 /** Structural shape of the `ctx.metrics` recorder (see the server `LunoraMetrics`). */
 export interface ContextMetrics {
@@ -90,20 +96,35 @@ export const createTracer = (deps: TracerDeps): ContextTracer => {
 
     const tracerFor =
         (parentSpanId: string): ContextTracer =>
-        async <T>(name: string, function_: (trace: ContextTracer) => Promise<T> | T, attributes?: LogFields): Promise<T> => {
+        async <T>(name: string, function_: (trace: ContextTracer, span: SpanHandle) => Promise<T> | T, attributes?: LogFields): Promise<T> => {
             const spanId = otlpRandomHex(8);
             const startTs = Date.now();
             // Normalized once, before the body runs, so a caller mutating the
             // attributes object mid-span can't alter what gets recorded.
             const normalized = normalizeLogFields(attributes);
 
+            // Post-hoc attributes the body sets through its `SpanHandle` — merged
+            // over `normalized` at record time (post-hoc wins on a key clash).
+            // Each write is normalized through the same field coercer as the start
+            // attributes, so the merged bag stays JSON-safe.
+            const collected: Record<string, LogFields[string]> = {};
+            const spanHandle: SpanHandle = {
+                setAttribute: (key, value) => {
+                    Object.assign(collected, normalizeLogFields({ [key]: value }));
+                },
+                setAttributes: (fields) => {
+                    Object.assign(collected, normalizeLogFields(fields));
+                },
+            };
+
             let ok = true;
             let error: SpanEvent["error"];
 
             try {
                 // The body gets a tracer bound to THIS span, so anything it opens
-                // is a child of it — under `Promise.all` too.
-                return await function_(tracerFor(spanId));
+                // is a child of it — under `Promise.all` too — plus the span's
+                // handle for post-hoc attributes.
+                return await function_(tracerFor(spanId), spanHandle);
             } catch (error_) {
                 // Record the failure, then re-throw untouched: `ctx.trace` is
                 // instrumentation, never flow control.
@@ -124,8 +145,14 @@ export const createTracer = (deps: TracerDeps): ContextTracer => {
                 // telemetry one. Owning the invariant at the point where it is
                 // promised means a caller injecting a raw `record` can't lose it.
                 try {
+                    // Merge start attributes with anything the body attached
+                    // post-hoc; post-hoc wins on a key clash. Emit `attributes`
+                    // only when the merged bag is non-empty, so a span with
+                    // neither doesn't ride an empty object.
+                    const merged = { ...normalized, ...collected };
+
                     record({
-                        ...(normalized === undefined ? {} : { attributes: normalized }),
+                        ...(Object.keys(merged).length === 0 ? {} : { attributes: merged }),
                         durationMs: Date.now() - startTs,
                         ...(error === undefined ? {} : { error }),
                         functionPath,

--- a/packages/do/src/index.ts
+++ b/packages/do/src/index.ts
@@ -40,7 +40,7 @@ export {
     readAuthMetrics,
     recordAuthEvent,
 } from "./auth-metrics";
-export type { ContextMetrics, ContextTracer, MetricsDeps, TraceAnchor, TracerDeps } from "./context-telemetry";
+export type { ContextMetrics, ContextTracer, MetricsDeps, SpanHandle, TraceAnchor, TracerDeps } from "./context-telemetry";
 export { createMetrics, createTracer, dispatchRootSpan } from "./context-telemetry";
 export type {
     BroadcastDelta,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -136,6 +136,7 @@ export type {
     SearchFilterBuilder,
     SearchIndexDefinition,
     ShardMode,
+    SpanHandle,
     Storage,
     StorageMetadata,
     SystemDatabaseReader,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1453,6 +1453,22 @@ interface LunoraLogger {
 }
 
 /**
+ * Handle the enclosing `ctx.trace` span hands its body, so the body can attach
+ * attributes only known *after* it resolves (an AI call's token usage / dollar
+ * cost, a downstream status, a computed count). Declared structurally here to
+ * mirror `shared/span-event.ts`'s `SpanHandle` and `@lunora/do`'s implementation;
+ * a cross-package assignability guard in `@lunora/testing` fails the build if the
+ * three drift apart. Start attributes are snapshotted before the body runs;
+ * handle writes are merged over them at record time, post-hoc winning on a clash.
+ */
+interface SpanHandle {
+    /** Set one attribute on the enclosing span (merged at record time; post-hoc wins on key clash). */
+    setAttribute: (key: string, value: LogFields[string]) => void;
+    /** Merge attributes onto the enclosing span (post-hoc wins on key clash). */
+    setAttributes: (fields: LogFields) => void;
+}
+
+/**
  * Span factory on every function `ctx`. Wraps a sub-operation so it becomes its
  * own **span** nested under the dispatch's RPC span, giving a trace real shape:
  * without it a slow request is one opaque bar, with it you see which part was
@@ -1485,15 +1501,26 @@ interface LunoraLogger {
  * unchanged. A throw is recorded as an error span and then **re-thrown** — this
  * is instrumentation, never flow control. Recording is best-effort: a failing
  * sink can't turn a working handler into a broken one.
+ *
+ * **Post-hoc attributes.** The body also receives a {@link SpanHandle} as its
+ * second argument. The `attributes` passed here are stamped at span start (and
+ * snapshotted, so a later mutation can't rewrite them); anything the body sets
+ * through the handle — `span.setAttribute(k, v)` / `span.setAttributes({…})` — is
+ * merged over that snapshot when the span is recorded, so a value known only once
+ * the body has resolved (an AI call's token usage / dollar cost, a computed
+ * count) still lands on the span. Post-hoc wins on a key clash. The handle is a
+ * trailing parameter, so every existing `(trace) => …` body keeps working
+ * unchanged.
  * @param name Span name, e.g. `"stripe.charge"`. Prefer a low-cardinality name
  * and put the varying part in `attributes` — a name built from an id makes every
  * span its own group in a collector.
  * @param fn The body to time, receiving a tracer bound to this span for any
- * nested spans. May be sync or async; the result is awaited.
- * @param attributes Structured attributes to stamp on the span, normalized like
- * a log line's `fields`.
+ * nested spans and the enclosing span's {@link SpanHandle} for post-hoc
+ * attributes. May be sync or async; the result is awaited.
+ * @param attributes Structured attributes to stamp on the span at start,
+ * normalized like a log line's `fields`.
  */
-type LunoraTracer = <T>(name: string, function_: (trace: LunoraTracer) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
+type LunoraTracer = <T>(name: string, function_: (trace: LunoraTracer, span: SpanHandle) => Promise<T> | T, attributes?: LogFields) => Promise<T>;
 
 /**
  * Application metrics on every function `ctx` — the third signal alongside
@@ -1827,6 +1854,7 @@ export type {
     Secrets,
     SecretsStoreSecretLike,
     ShardMode,
+    SpanHandle,
     Storage,
     StorageMetadata,
     SystemDatabaseReader,

--- a/packages/testing/__tests__/ctx-telemetry-contract.test.ts
+++ b/packages/testing/__tests__/ctx-telemetry-contract.test.ts
@@ -1,5 +1,5 @@
-import type { ContextMetrics, ContextTracer } from "@lunora/do";
-import type { LunoraMetrics, LunoraTracer } from "@lunora/server";
+import type { ContextMetrics, ContextTracer, SpanHandle as DoSpanHandle } from "@lunora/do";
+import type { LunoraMetrics, LunoraTracer, SpanHandle as ServerSpanHandle } from "@lunora/server";
 import { describe, expect, it } from "vitest";
 
 /**
@@ -34,6 +34,13 @@ const TRACER_CONTRACT_GUARD: MutuallyAssignable<ContextTracer, LunoraTracer> = t
 
 const METRICS_CONTRACT_GUARD: MutuallyAssignable<ContextMetrics, LunoraMetrics> = true;
 
+// The `SpanHandle` the tracer's body receives (post-hoc attributes). `@lunora/do`
+// re-exports the shared/bundler-inlined shape; `@lunora/server` mirrors it
+// structurally — this fails the build if the two drift. Unlike the tracer guard,
+// `SpanHandle`'s members are non-optional, so a widened/renamed/dropped method is
+// caught outright (no trailing-optional blind spot).
+const SPAN_HANDLE_CONTRACT_GUARD: MutuallyAssignable<DoSpanHandle, ServerSpanHandle> = true;
+
 describe("ctx telemetry contract", () => {
     it("keeps @lunora/do's ContextTracer in lockstep with @lunora/server's LunoraTracer", () => {
         expect.assertions(1);
@@ -45,5 +52,11 @@ describe("ctx telemetry contract", () => {
         expect.assertions(1);
 
         expect(METRICS_CONTRACT_GUARD).toBe(true);
+    });
+
+    it("keeps @lunora/do's SpanHandle in lockstep with @lunora/server's SpanHandle", () => {
+        expect.assertions(1);
+
+        expect(SPAN_HANDLE_CONTRACT_GUARD).toBe(true);
     });
 });

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -16,6 +16,7 @@ import type {
     RegisteredMutation,
     RegisteredQuery,
     Schema,
+    SpanHandle,
     TableDefinition,
 } from "@lunora/server";
 
@@ -250,13 +251,23 @@ const stubProxy = (surface: string): unknown =>
     });
 
 /**
+ * A no-op {@link SpanHandle} for the harness: post-hoc attributes have nowhere
+ * to go without a sink, so accept and drop them (like `noopMetrics`).
+ */
+const noopSpan: SpanHandle = {
+    setAttribute: () => undefined,
+    setAttributes: () => undefined,
+};
+
+/**
  * `ctx.trace` under test: runs the body and returns its value, recording
  * nothing. There is no sink in the harness, so a span has nowhere to go — but
  * the body must still execute and its result and any throw must pass through
- * untouched, or instrumenting a handler would change what the test observes.
+ * untouched, or instrumenting a handler would change what the test observes. The
+ * body still receives a (no-op) span handle so post-hoc attributes are accepted.
  */
-const passthroughTrace: LunoraTracer = async <T>(_name: string, function_: (trace: LunoraTracer) => Promise<T> | T): Promise<T> =>
-    await function_(passthroughTrace);
+const passthroughTrace: LunoraTracer = async <T>(_name: string, function_: (trace: LunoraTracer, span: SpanHandle) => Promise<T> | T): Promise<T> =>
+    await function_(passthroughTrace, noopSpan);
 
 /** `ctx.metrics` under test: accepts every measurement and records nothing. */
 const noopMetrics: LunoraMetrics = {

--- a/shared/span-event.ts
+++ b/shared/span-event.ts
@@ -20,6 +20,22 @@ import type { LogFields } from "./log-fields";
  * (32-hex trace, 16-hex span), so a `SpanEvent` composes into an OTLP span with
  * no reformatting.
  */
+/**
+ * Handle the enclosing `ctx.trace` span hands its body, so the body can attach
+ * attributes only known *after* it resolves — an AI call's token usage or dollar
+ * cost, a downstream response's status, a computed row count. The start
+ * attributes passed to `ctx.trace(name, fn, attributes)` are snapshotted before
+ * the body runs (so a mid-span mutation can't rewrite them); anything set through
+ * this handle is merged over that snapshot at record time, with the post-hoc
+ * value winning on a key clash.
+ */
+export interface SpanHandle {
+    /** Set one attribute on the enclosing span (merged at record time; post-hoc wins on key clash). */
+    setAttribute: (key: string, value: LogFields[string]) => void;
+    /** Merge attributes onto the enclosing span (post-hoc wins on key clash). */
+    setAttributes: (fields: LogFields) => void;
+}
+
 export interface SpanEvent {
     /**
      * Structured attributes the caller attached, already normalized to a fresh


### PR DESCRIPTION
## Trace-fusion, piece 1 — post-hoc span attributes (the shippable, portable piece)

`ctx.trace(name, fn, attributes?)` captured attributes only at span **start**. This lets the wrapped body set attributes that are only known **after** it resolves (an AI call's token usage / dollar cost). Additive and backward-compatible.

- New `SpanHandle` (`shared/span-event.ts`): `setAttribute(key, value)` / `setAttributes(fields)`, exported from `@lunora/server` + `@lunora/do`.
- `LunoraTracer` gains a second body arg — `(trace, span) => …` — mirrored as `ContextTracer` in `@lunora/do`, kept in lockstep by the `ctx-telemetry-contract` drift guard. Start attributes still normalize up front (invariant preserved); post-hoc attrs merge at record time (post-hoc wins on key clash), emitted only when non-empty.
- **Backward-compatible:** existing `(trace) => …` bodies stay assignable (trailing-optional-param rule). **Only one call site changed** — the `@lunora/testing` `passthroughTrace` stub (it *assigns* to `LunoraTracer`, so needs the param). All `ctx.trace(...)` bodies compile unchanged.

**First consumer — RAG embed cost:** `define-rag.ts` (already traced since #160/#162) now attaches post-hoc `gen_ai.usage.input_tokens` (from the embed `usage`) and `gen_ai.usage.cost` (defensive `providerMetadata` probe — a no-op until AI-Gateway cost routing from #165 lands). Untraced path unchanged.

**Verify:** do 1186 / ai 94 / testing 81 / server 419 tests pass; tsc clean across server/do/ai/testing (+ agent/runtime consumers); eslint clean.

**Follow-up:** trace-fusion piece 2 (fuse `ctx.trace` into Cloudflare's now-GA Workers custom-spans tree via `tracing.enterSpan`) is deferred behind a `ShardDO` prototype — double-export risk + async-context-in-DO unverified. `otlpSink` stays the portable default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tracing for embedding operations with model, token usage, and cost details when available.
  * Added support for attaching attributes to spans after a traced operation completes.
  * Exposed span handling types through the public APIs.

* **Documentation**
  * Clarified tracing behavior and recorded embedding metadata in API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->