### PR TITLE
feat(agent,ai,testing): llm session id + eval score telemetry

### DIFF
--- a/api-snapshots/testing.api.md
+++ b/api-snapshots/testing.api.md
@@ -70,6 +70,20 @@ interface EvalResult {
 }
 ```
 
+### `EvaluationAttributeValue` (type)
+
+```ts
+type EvaluationAttributeValue = number | string;
+```
+
+### `EvaluationSpanHandle` (interface)
+
+```ts
+interface EvaluationSpanHandle {
+    setAttributes: (fields: Record<string, EvaluationAttributeValue>) => void;
+}
+```
+
 ### `FakeScheduledJob` (interface)
 
 ```ts
@@ -141,6 +155,17 @@ interface LunoraTestOptions {
     fetch?: typeof globalThis.fetch;
     functions?: FunctionRegistry;
     now?: number;
+}
+```
+
+### `RecordEvaluationInput` (interface)
+
+```ts
+interface RecordEvaluationInput {
+    label?: string;
+    name: string;
+    score: number;
+    span?: EvaluationSpanHandle;
 }
 ```
 
@@ -260,6 +285,12 @@ const containsScorer: (needle: string, options?: {
 const evaluate: (cases: ReadonlyArray<EvalCase>, produce: (input: string) => Promise<string> | string, scorers: ReadonlyArray<Scorer>) => Promise<EvalResult>;
 ```
 
+### `evaluationAttributes` (const)
+
+```ts
+const evaluationAttributes: (input: Pick<RecordEvaluationInput, "label" | "name" | "score">) => Record<string, EvaluationAttributeValue>;
+```
+
 ### `exactMatchScorer` (const)
 
 ```ts
@@ -300,6 +331,12 @@ const llmScorer: (options: {
 
 ```ts
 const lunoraTest: (schema: TestSchema, options?: LunoraTestOptions) => TestHarness;
+```
+
+### `recordEvaluation` (const)
+
+```ts
+const recordEvaluation: (input: RecordEvaluationInput) => Record<string, EvaluationAttributeValue>;
 ```
 
 ### `regexScorer` (const)

--- a/packages/agent/__tests__/telemetry/otlp.test.ts
+++ b/packages/agent/__tests__/telemetry/otlp.test.ts
@@ -88,6 +88,24 @@ describe(otlpTelemetry, () => {
         expect(attribute(span, "gen_ai.usage.output_tokens")).toBe("3");
     });
 
+    it("tags the generation span with gen_ai.conversation.id when a conversation id is set", async () => {
+        const calls = captureFetch();
+
+        await otlpTelemetry({ conversationId: "thread-42", endpoint: "https://collector.test" }).executeLanguageModelCall?.(
+            evt({ execute: () => Promise.resolve({}), modelId: "m" }),
+        );
+
+        expect(attribute(spanOf(calls[0] as CapturedPost), "gen_ai.conversation.id")).toBe("thread-42");
+    });
+
+    it("omits gen_ai.conversation.id when no conversation id is set", async () => {
+        const calls = captureFetch();
+
+        await otlpTelemetry({ endpoint: "https://collector.test" }).executeLanguageModelCall?.(evt({ execute: () => Promise.resolve({}), modelId: "m" }));
+
+        expect(attribute(spanOf(calls[0] as CapturedPost), "gen_ai.conversation.id")).toBeUndefined();
+    });
+
     it("groups every span under a shared traceId when one is given", async () => {
         const calls = captureFetch();
         const telemetry = otlpTelemetry({ endpoint: "https://collector.test", traceId: FIXED_TRACE_ID });

--- a/packages/agent/src/telemetry/otlp.ts
+++ b/packages/agent/src/telemetry/otlp.ts
@@ -55,6 +55,16 @@ const observeSettled = (promise: PromiseLike<unknown>, onSettle: (ok: boolean, m
  */
 export interface OtlpTelemetryOptions extends CommonOptions {
     /**
+     * Conversation / session id to tag each generation span with, emitted as the
+     * `gen_ai.conversation.id` semantic-convention attribute so a multi-turn
+     * conversation's model turns group in the trace store. On a deployed agent the
+     * platform wiring passes the run's `threadKey` here automatically (one thread =
+     * one conversation). Omitted → the attribute is absent (backward-compatible),
+     * and each turn's span is ungrouped.
+     */
+    conversationId?: string;
+
+    /**
      * The OTLP-over-HTTP collector base endpoint (e.g. the Lunora Cloud's `/v1`
      * base). Spans are POSTed to `${endpoint}/v1/traces`; a trailing slash is
      * tolerated. On the platform this is the injected `LUNORA_OTLP_ENDPOINT`.
@@ -127,7 +137,7 @@ export interface OtlpTelemetryOptions extends CommonOptions {
  * @experimental
  */
 export const otlpTelemetry = (options: OtlpTelemetryOptions): Telemetry => {
-    const { endpoint, headers, recordInputs = false, recordOutputs = false, token, traceId: fixedTraceId, waitUntil } = options;
+    const { conversationId, endpoint, headers, recordInputs = false, recordOutputs = false, token, traceId: fixedTraceId, waitUntil } = options;
     const serviceName = options.serviceName ?? "lunora";
 
     // Strip trailing slashes without a regex (ReDoS-linter-safe; runs once).
@@ -189,6 +199,9 @@ export const otlpTelemetry = (options: OtlpTelemetryOptions): Telemetry => {
                 pushAttribute(attributes, "gen_ai.operation.name", "chat");
                 pushAttribute(attributes, "gen_ai.request.model", modelId);
                 pushAttribute(attributes, "gen_ai.system", readField(options_, "provider"));
+                // Session/thread grouping — absent unless a conversation id was set,
+                // so a run with no session id emits exactly as before.
+                pushAttribute(attributes, "gen_ai.conversation.id", conversationId);
 
                 const usage = summarizeUsage(readField(result, "usage"));
 

--- a/packages/agent/src/workflow.ts
+++ b/packages/agent/src/workflow.ts
@@ -21,7 +21,7 @@ import type { AgentDefinition, AgentFunctionPaths, AgentRunInput, AgentRunResult
  * no-op when no endpoint is set (local / self-hosted) or when the app explicitly
  * set `telemetry.isEnabled: false`.
  */
-const withAutoOtlpTelemetry = (agent: AgentDefinition, env: Record<string, unknown>): AgentDefinition => {
+const withAutoOtlpTelemetry = (agent: AgentDefinition, env: Record<string, unknown>, conversationId?: string): AgentDefinition => {
     const endpoint = env.LUNORA_OTLP_ENDPOINT;
 
     if (typeof endpoint !== "string" || endpoint === "" || agent.telemetry?.isEnabled === false) {
@@ -38,7 +38,10 @@ const withAutoOtlpTelemetry = (agent: AgentDefinition, env: Record<string, unkno
         ...agent,
         telemetry: {
             ...agent.telemetry,
-            integrations: [...existingList, otlpTelemetry({ endpoint, token })],
+            // Tag every generation span with the run's thread as its conversation
+            // id (one thread = one multi-turn conversation), so the cloud groups a
+            // deployed agent's turns with no app wiring. Absent → ungrouped, as before.
+            integrations: [...existingList, otlpTelemetry({ conversationId, endpoint, token })],
             isEnabled: true,
         },
     };
@@ -72,8 +75,10 @@ const compileAgentWorkflow = (
     defineWorkflow<AgentRunInput, AgentRunResult>({
         handler: async (context) => {
             // On the platform, auto-append OTLP generation telemetry from the
-            // injected endpoint; local/self-hosted agents are unaffected.
-            const runtimeAgent = withAutoOtlpTelemetry(agent, context.env);
+            // injected endpoint; local/self-hosted agents are unaffected. The run's
+            // `threadKey` rides along as the conversation/session id so multi-turn
+            // spans group in the cloud.
+            const runtimeAgent = withAutoOtlpTelemetry(agent, context.env, context.params.threadKey);
 
             return runAgentLoop({
                 agent: runtimeAgent,

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -1187,4 +1187,32 @@ describe("defineRag ctx.trace instrumentation", () => {
         await expect(docs(ctx).index({ id: "doc-1", text: "hello world" })).resolves.toBeDefined();
         expect(store.size).toBeGreaterThan(0);
     });
+
+    it("emits gen_ai.conversation.id on the embed span when the context carries one", async () => {
+        const { vectors } = memoryVectors();
+        const ctx = { ...tracingCtx(vectors), conversationId: "thread-42" };
+        const docs = defineRag({ allowSharedNamespace: true, embeddingModel: "@cf/baai/bge-base-en-v1.5", index: "docs" });
+
+        await docs(ctx).index({ id: "doc-1", text: "hello world" });
+
+        expect(ctx.spans.length).toBeGreaterThan(0);
+
+        for (const span of ctx.spans) {
+            expect(span.attributes["gen_ai.conversation.id"]).toBe("thread-42");
+        }
+    });
+
+    it("omits gen_ai.conversation.id when no conversation id is set", async () => {
+        const { vectors } = memoryVectors();
+        const ctx = tracingCtx(vectors);
+        const docs = defineRag({ allowSharedNamespace: true, embeddingModel: "@cf/baai/bge-base-en-v1.5", index: "docs" });
+
+        await docs(ctx).index({ id: "doc-1", text: "hello world" });
+
+        expect(ctx.spans.length).toBeGreaterThan(0);
+
+        for (const span of ctx.spans) {
+            expect(span.attributes).not.toHaveProperty("gen_ai.conversation.id");
+        }
+    });
 });

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -325,10 +325,13 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
             }
 
             const modelId = modelIdOf(resolvedModel);
+            const conversationId = typeof context.conversationId === "string" && context.conversationId.length > 0 ? context.conversationId : undefined;
 
             return tracer("ai.embed", (_trace, span) => run(span), {
                 "gen_ai.operation.name": "embeddings",
                 ...(modelId === undefined ? {} : { "gen_ai.request.model": modelId }),
+                // Session/thread grouping — absent unless a conversation id was set.
+                ...(conversationId === undefined ? {} : { "gen_ai.conversation.id": conversationId }),
             });
         };
 

--- a/packages/ai/src/rag/types.ts
+++ b/packages/ai/src/rag/types.ts
@@ -114,6 +114,15 @@ export interface RagContext {
     auth?: unknown;
 
     /**
+     * Optional conversation / session id. When set (and `trace` is present), each
+     * embedding-model span additionally carries `gen_ai.conversation.id`, so a
+     * RAG embed done inside a multi-turn conversation groups with that
+     * conversation's other generation spans in the trace store. Omitted → the
+     * attribute is absent (backward-compatible).
+     */
+    conversationId?: string;
+
+    /**
      * Optional `ctx.trace` span factory — an `ActionCtx`'s `ctx.trace` satisfies
      * it structurally. When present, `defineRag` wraps each embedding-model
      * call in a `generation` span carrying `gen_ai.operation.name: "embeddings"`

--- a/packages/testing/__tests__/evaluation-telemetry.test.ts
+++ b/packages/testing/__tests__/evaluation-telemetry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { evaluationAttributes, recordEvaluation } from "../src/evaluation-telemetry";
+
+describe("recordEvaluation", () => {
+    it("produces gen_ai.evaluation.<name>.score for the verdict", () => {
+        expect.assertions(1);
+
+        expect(recordEvaluation({ name: "exact-match", score: 1 })).toStrictEqual({ "gen_ai.evaluation.exact-match.score": 1 });
+    });
+
+    it("adds a gen_ai.evaluation.<name>.label when a label is given", () => {
+        expect.assertions(1);
+
+        expect(recordEvaluation({ label: "pass", name: "keyword-coverage", score: 0.8 })).toStrictEqual({
+            "gen_ai.evaluation.keyword-coverage.label": "pass",
+            "gen_ai.evaluation.keyword-coverage.score": 0.8,
+        });
+    });
+
+    it("sanitizes a scorer name carrying a colon into a well-formed key", () => {
+        expect.assertions(1);
+
+        expect(evaluationAttributes({ name: "contains:shipped", score: 1 })).toStrictEqual({ "gen_ai.evaluation.contains_shipped.score": 1 });
+    });
+
+    it("attaches the attributes to a span handle when one is passed", () => {
+        expect.assertions(2);
+
+        const setAttributes = vi.fn<(fields: Record<string, number | string>) => void>();
+        const attributes = recordEvaluation({ name: "llm-judge", score: 0.5, span: { setAttributes } });
+
+        expect(setAttributes).toHaveBeenCalledWith({ "gen_ai.evaluation.llm-judge.score": 0.5 });
+        // Also returned, so a span-less caller can ship it as a standalone event/metric.
+        expect(attributes).toStrictEqual({ "gen_ai.evaluation.llm-judge.score": 0.5 });
+    });
+
+    it("rejects an empty name and a non-finite score", () => {
+        expect.assertions(2);
+
+        expect(() => recordEvaluation({ name: "", score: 1 })).toThrow("non-empty `name`");
+        expect(() => recordEvaluation({ name: "x", score: Number.NaN })).toThrow("finite number");
+    });
+});

--- a/packages/testing/src/evaluation-telemetry.ts
+++ b/packages/testing/src/evaluation-telemetry.ts
@@ -1,0 +1,113 @@
+/**
+ * Bridge an eval score onto telemetry — the emission half of the testing
+ * toolkit's `evaluate` scorers. A scorer produces a `[0, 1]` score (see
+ * {@link file://./scorer.ts}); `recordEvaluation` turns one such verdict into the
+ * `gen_ai.evaluation.*` OpenTelemetry semantic-convention attributes so a score
+ * can ride the same trace as the generation it grades.
+ *
+ * Two shapes, both additive and privacy-safe — only the scorer name, a number,
+ * and an optional short label leave, never the graded prompt or completion:
+ *
+ * Attach to a generation span by passing the post-hoc `SpanHandle` a
+ * `ctx.trace(name, (trace, span) =&gt; …)` body receives as `span`, and the score
+ * lands on that generation's span. Or omit `span` and use the returned attribute
+ * bag as a standalone eval event/metric payload — e.g. `recordEvaluation({ label:
+ * "pass", name: "exact-match", score: 1 })` returns
+ * `{ "gen_ai.evaluation.exact-match.score": 1, "gen_ai.evaluation.exact-match.label": "pass" }`.
+ */
+import { LunoraError } from "@lunora/errors";
+
+/** The primitive an eval attaches to a span: a numeric score or a string label. */
+type EvaluationAttributeValue = number | string;
+
+/**
+ * Structural slice of the post-hoc span handle `ctx.trace` hands its body (see the
+ * server `SpanHandle`) — enough to attach an eval's attributes. Declared here
+ * rather than imported so `@lunora/testing` takes no dependency on `@lunora/server`
+ * or `@lunora/do`; the real handle is assignable to it.
+ */
+interface EvaluationSpanHandle {
+    setAttributes: (fields: Record<string, EvaluationAttributeValue>) => void;
+}
+
+/** One eval verdict to emit. */
+interface RecordEvaluationInput {
+    /**
+     * Optional categorical label (e.g. `"pass"` / `"fail"` / a rubric bucket),
+     * emitted as the `.label` attribute. Omitted → no label attribute.
+     */
+    label?: string;
+
+    /**
+     * The scorer/evaluation name — becomes the key's name segment. Any character
+     * outside `[A-Za-z0-9._-]` is replaced with `_` so a scorer name carrying a
+     * colon (e.g. `"contains:shipped"`) still yields a well-formed attribute key.
+     */
+    name: string;
+
+    /** The numeric score (typically `[0, 1]`), emitted as the `.score` attribute. */
+    score: number;
+
+    /**
+     * Optional generation span to attach the attributes to — the post-hoc
+     * `SpanHandle` a `ctx.trace` body receives. Omitted → nothing is attached and
+     * the caller uses the returned bag for a standalone event/metric.
+     */
+    span?: EvaluationSpanHandle;
+}
+
+/** Characters allowed unescaped in an evaluation-name key segment. */
+const SAFE_NAME_CHAR = /[\w.-]/u;
+
+/** Replace every character outside the OTEL-safe set with `_`. */
+const sanitizeName = (name: string): string => {
+    let out = "";
+
+    for (const char of name) {
+        out += SAFE_NAME_CHAR.test(char) ? char : "_";
+    }
+
+    return out;
+};
+
+/**
+ * Build the `gen_ai.evaluation.NAME.*` attribute bag for one eval verdict — the
+ * `.score` (number) always, the `.label` (string) when a label is given. Exported
+ * so a caller can emit the score as a standalone event/metric without a span.
+ */
+const evaluationAttributes = (input: Pick<RecordEvaluationInput, "label" | "name" | "score">): Record<string, EvaluationAttributeValue> => {
+    if (typeof input.name !== "string" || input.name.length === 0) {
+        throw new LunoraError("BAD_REQUEST", "@lunora/testing: recordEvaluation requires a non-empty `name`");
+    }
+
+    if (typeof input.score !== "number" || !Number.isFinite(input.score)) {
+        throw new LunoraError("BAD_REQUEST", "@lunora/testing: recordEvaluation `score` must be a finite number");
+    }
+
+    const key = sanitizeName(input.name);
+    const attributes: Record<string, EvaluationAttributeValue> = { [`gen_ai.evaluation.${key}.score`]: input.score };
+
+    if (input.label !== undefined) {
+        attributes[`gen_ai.evaluation.${key}.label`] = input.label;
+    }
+
+    return attributes;
+};
+
+/**
+ * Emit one eval verdict as `gen_ai.evaluation.NAME.*` attributes. Attaches them to
+ * `input.span` when supplied (the post-hoc generation-span handle), and always
+ * returns the attribute bag so a span-less caller can ship it as an eval
+ * event/metric. Privacy-safe: only the name, score, and optional label are
+ * emitted — never the graded prompt or output.
+ */
+const recordEvaluation = (input: RecordEvaluationInput): Record<string, EvaluationAttributeValue> => {
+    const attributes = evaluationAttributes(input);
+
+    input.span?.setAttributes(attributes);
+
+    return attributes;
+};
+
+export type { EvaluationAttributeValue, EvaluationSpanHandle, RecordEvaluationInput };
+export { evaluationAttributes, recordEvaluation };

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,7 @@
 export type { AgentHarness, AgentHarnessOptions, AgentRunOverrides, HarnessDispatch, HarnessMessage, HarnessThread } from "./agent-harness";
 export { agentHarness, finalTurn, toolCallTurn } from "./agent-harness";
+export type { EvaluationAttributeValue, EvaluationSpanHandle, RecordEvaluationInput } from "./evaluation-telemetry";
+export { evaluationAttributes, recordEvaluation } from "./evaluation-telemetry";
 export type {
     FakeScheduledJob,
     FakeSchedulerControls,


### PR DESCRIPTION
## Tier 1 — LLM sessions + evals (framework emit side)

- **Sessions/threads**: generation spans now carry `gen_ai.conversation.id` — auto-threaded from an agent run's `threadKey` (`@lunora/agent`) and settable on RAG embeds via `RagContext.conversationId`. Absent unless set (backward-compatible).
- **Evals**: new `recordEvaluation({ name, score, label?, span? })` + `evaluationAttributes(...)` in `@lunora/testing` — emits `gen_ai.evaluation.<name>.score` (+ optional `.label`), attachable to a generation span via the #170 `SpanHandle` or returned for standalone use. Privacy-safe (name/score/label only).

Additive; the cloud side (`feat/cloud-sessions-evals`) decodes these exact attribute names.

**Verify:** agent 285 / ai 109 / testing 86 tests pass; tsc clean; touched files eslint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation and session identifiers to AI generation and embedding telemetry.
  * Added evaluation telemetry utilities for recording scores and optional labels on generation spans.
  * Exported evaluation telemetry tools through the testing package.
* **Bug Fixes**
  * Preserved existing telemetry output when no conversation identifier is provided.
  * Added validation for missing evaluation names and invalid scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->