### PR TITLE
feat(do,runtime): opt-in cloudflare custom-spans trace bridge

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -2370,6 +2370,7 @@ interface TablesColumnsResult {
 
 ```ts
 interface TelemetrySink {
+    fuseCloudflareTraces?: boolean;
     onLog?: (event: LogEventInput, context?: LogSinkContext) => void;
     onMetric?: (event: MetricEvent, context?: LogSinkContext) => void;
     onSpan?: (event: SpanEvent, context?: LogSinkContext) => void;
@@ -2391,7 +2392,9 @@ interface TraceAnchor {
 interface TracerDeps {
     anchor: TraceAnchor;
     functionPath: string;
+    fuseCloudflareSpans?: boolean;
     record: (span: SpanEvent) => void;
+    resolveCloudflareTracing?: CloudflareTracingResolver;
     shardKey: string | undefined;
     userId: () => string | undefined;
 }

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -1288,6 +1288,7 @@ interface ObservabilityEvent {
 
 ```ts
 interface ObservabilitySink {
+    fuseCloudflareTraces?: boolean;
     onLog?: (event: LogEvent, context?: ObservabilitySinkContext) => void;
     onMetric?: (event: MetricEvent, context?: ObservabilitySinkContext) => void;
     onRpc?: (event: ObservabilityEvent, context?: ObservabilitySinkContext) => void;

--- a/packages/do/__tests__/context-telemetry-cf-bridge.test.ts
+++ b/packages/do/__tests__/context-telemetry-cf-bridge.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CloudflareSpanLike, CloudflareTracingLike, SpanHandle, TracerDeps } from "../src/context-telemetry";
+import { createTracer } from "../src/context-telemetry";
+
+/**
+ * Unit coverage for the opt-in Cloudflare custom-spans bridge in
+ * {@link createTracer}. The bridge is deliberately injectable
+ * (`fuseCloudflareSpans` + `resolveCloudflareTracing`) so it can be exercised in
+ * plain Node with a fake/undefined `tracing` — no `cloudflare:workers`, no DO.
+ */
+
+/** A fake CF custom span that records every `setAttribute` write. */
+const makeFakeSpan = (isTraced = true): CloudflareSpanLike & { readonly writes: [string, unknown][] } => {
+    const writes: [string, unknown][] = [];
+
+    return {
+        isTraced,
+        setAttribute: (key, value) => {
+            writes.push([key, value]);
+        },
+        writes,
+    };
+};
+
+/** A fake `tracing` namespace whose `enterSpan` runs the callback with `span`. */
+const makeFakeTracing = (span: CloudflareSpanLike): CloudflareTracingLike & { readonly names: string[] } => {
+    const names: string[] = [];
+
+    return {
+        enterSpan: (name, callback) => {
+            names.push(name);
+
+            return callback(span);
+        },
+        names,
+    };
+};
+
+/** Build a tracer over a captured `record`, with bridge deps merged in. */
+const setup = (overrides: Partial<TracerDeps> = {}) => {
+    const recorded: Parameters<TracerDeps["record"]>[0][] = [];
+
+    const trace = createTracer({
+        anchor: { rootSpanId: "root0000root0000", traceId: "trace00000000000000000000000000" },
+        functionPath: "messages:list",
+        record: (span) => {
+            recorded.push(span);
+        },
+        shardKey: "room-1",
+        userId: () => "user-42",
+        ...overrides,
+    });
+
+    return { recorded, trace };
+};
+
+describe("createTracer cloudflare custom-spans bridge", () => {
+    it("no-ops (default off): never resolves tracing, records unchanged", async () => {
+        expect.assertions(4);
+
+        const resolveCloudflareTracing = vi.fn<() => Promise<CloudflareTracingLike>>(async () => makeFakeTracing(makeFakeSpan()));
+        const { recorded, trace } = setup({ resolveCloudflareTracing });
+
+        const result = await trace("stripe.charge", () => "ok");
+
+        expect(result).toBe("ok");
+        expect(resolveCloudflareTracing).not.toHaveBeenCalled();
+        expect(recorded).toHaveLength(1);
+        expect(recorded[0]).toMatchObject({ functionPath: "messages:list", name: "stripe.charge", ok: true });
+    });
+
+    it("no-ops when the flag is on but tracing resolves to undefined", async () => {
+        expect.assertions(3);
+
+        const resolveCloudflareTracing = vi.fn<() => Promise<undefined>>(async () => undefined);
+        const { recorded, trace } = setup({ fuseCloudflareSpans: true, resolveCloudflareTracing });
+
+        const result = await trace("span", () => 7);
+
+        expect(result).toBe(7);
+        expect(resolveCloudflareTracing).toHaveBeenCalledTimes(1);
+        expect(recorded).toHaveLength(1);
+    });
+
+    it("no-ops when the resolved tracing lacks a callable enterSpan", async () => {
+        expect.assertions(2);
+
+        // Probe must reject a partial `tracing` without throwing.
+        const resolveCloudflareTracing = async () => ({ enterSpan: undefined }) as unknown as CloudflareTracingLike;
+        const { recorded, trace } = setup({ fuseCloudflareSpans: true, resolveCloudflareTracing });
+
+        const result = await trace("span", () => "still-runs");
+
+        expect(result).toBe("still-runs");
+        expect(recorded).toHaveLength(1);
+    });
+
+    it("wraps the body in enterSpan and mirrors key attributes onto the CF span", async () => {
+        expect.assertions(6);
+
+        const span = makeFakeSpan();
+        const tracing = makeFakeTracing(span);
+        const { trace } = setup({
+            fuseCloudflareSpans: true,
+            resolveCloudflareTracing: async () => tracing,
+        });
+
+        const result = await trace("stripe.charge", () => "done", { attempt: 2, mode: "live", nested: { skip: true } });
+
+        expect(result).toBe("done");
+        expect(tracing.names).toStrictEqual(["stripe.charge"]);
+
+        const writes = new Map(span.writes);
+
+        expect(writes.get("lunora.function_path")).toBe("messages:list");
+        expect(writes.get("lunora.ok")).toBe(true);
+        // User attributes are copied under `lunora.attr.*`, already coerced to
+        // JSON primitives by `normalizeLogFields` (a nested object arrives as its
+        // JSON string, not the object).
+        expect(writes.get("lunora.attr.attempt")).toBe(2);
+        expect(writes.get("lunora.attr.nested")).toBe(String.raw`{"skip":true}`);
+    });
+
+    it("skips setAttribute work when the CF span is not traced, but still records", async () => {
+        expect.assertions(3);
+
+        const span = makeFakeSpan(false);
+        const { recorded, trace } = setup({
+            fuseCloudflareSpans: true,
+            resolveCloudflareTracing: async () => makeFakeTracing(span),
+        });
+
+        await trace("span", () => undefined);
+
+        expect(span.isTraced).toBe(false);
+        expect(span.writes).toHaveLength(0);
+        expect(recorded).toHaveLength(1);
+    });
+
+    it("mirrors error attributes and re-throws, with the CF span still entered", async () => {
+        expect.assertions(5);
+
+        const span = makeFakeSpan();
+        const tracing = makeFakeTracing(span);
+        const { recorded, trace } = setup({
+            fuseCloudflareSpans: true,
+            resolveCloudflareTracing: async () => tracing,
+        });
+
+        const boom = new Error("kaboom");
+
+        await expect(
+            trace("span", () => {
+                throw boom;
+            }),
+        ).rejects.toBe(boom);
+
+        expect(tracing.names).toStrictEqual(["span"]);
+        expect(recorded[0]).toMatchObject({ error: { message: "kaboom" }, ok: false });
+
+        const writes = new Map(span.writes);
+
+        expect(writes.get("lunora.ok")).toBe(false);
+        expect(writes.get("lunora.error.message")).toBe("kaboom");
+    });
+
+    it("records an IDENTICAL SpanEvent (bar the per-call id/timestamps) with the bridge on", async () => {
+        expect.assertions(1);
+
+        const body = (_trace: unknown, span: SpanHandle) => {
+            span.setAttribute("posthoc", "yes");
+
+            return "v";
+        };
+
+        // Strip the fields that are intrinsically per-call (random id, wall clock)
+        // so the comparison isolates whether the bridge altered span CONTENT.
+        const stable = (span: Record<string, unknown>) => {
+            const { durationMs, spanId, startTs, ...rest } = span;
+
+            return rest;
+        };
+
+        const off = setup();
+
+        await off.trace("span", body, { start: 1 });
+
+        const on = setup({
+            fuseCloudflareSpans: true,
+            resolveCloudflareTracing: async () => makeFakeTracing(makeFakeSpan()),
+        });
+
+        await on.trace("span", body, { start: 1 });
+
+        expect(stable(on.recorded[0] as unknown as Record<string, unknown>)).toStrictEqual(stable(off.recorded[0] as unknown as Record<string, unknown>));
+    });
+
+    it("swallows a setAttribute throw without failing the handler or losing the record", async () => {
+        expect.assertions(2);
+
+        const explodingSpan: CloudflareSpanLike = {
+            isTraced: true,
+            setAttribute: () => {
+                throw new Error("attribute sink down");
+            },
+        };
+        const { recorded, trace } = setup({
+            fuseCloudflareSpans: true,
+            resolveCloudflareTracing: async () => makeFakeTracing(explodingSpan),
+        });
+
+        const result = await trace("span", () => "safe");
+
+        expect(result).toBe("safe");
+        expect(recorded).toHaveLength(1);
+    });
+});

--- a/packages/do/src/context-telemetry.ts
+++ b/packages/do/src/context-telemetry.ts
@@ -48,16 +48,77 @@ export interface TraceAnchor {
     traceId: string;
 }
 
+/**
+ * Minimal structural shape of one **Cloudflare custom span** — the object CF's
+ * `tracing.enterSpan(name, (span) => …)` callback receives (GA 2026-06-16). Only
+ * the surface the bridge touches is declared, so `@lunora/do` needs no runtime
+ * dependency on `cloudflare:workers`; the real platform span is structurally
+ * assignable.
+ */
+export interface CloudflareSpanLike {
+    /**
+     * Whether this span is actually being recorded by the runtime's sampler.
+     * `false` off the traced path (unsampled) — the bridge skips its
+     * `setAttribute` work in that case rather than building attribute strings for
+     * a span nobody will read.
+     */
+    readonly isTraced: boolean;
+    /** Attach one primitive attribute to the CF span. */
+    setAttribute: (key: string, value: boolean | number | string | undefined) => void;
+}
+
+/**
+ * Minimal structural shape of the `tracing` namespace exported by
+ * `cloudflare:workers`. `enterSpan` opens a custom span that auto-nests under the
+ * runtime's ambient span and ends when `callback` settles.
+ */
+export interface CloudflareTracingLike {
+    enterSpan: <T>(name: string, callback: (span: CloudflareSpanLike) => T) => T;
+}
+
+/**
+ * Resolves CF's `tracing` namespace, or `undefined` when it is unavailable —
+ * off-Cloudflare, on a compat date predating custom spans, or when
+ * `tracing.enterSpan` is not a function. **Injected, never imported here**, so the
+ * tracer stays pure and unit-testable without `cloudflare:workers`; the shard
+ * supplies the real resolver, tests a fake or `undefined`.
+ */
+export type CloudflareTracingResolver = () => CloudflareTracingLike | Promise<CloudflareTracingLike | undefined> | undefined;
+
 /** What {@link createTracer} needs from the shard to build a span. */
 export interface TracerDeps {
     /** The trace this ctx's spans belong to. */
     anchor: TraceAnchor;
+
     /** Function path the spans are attributed to. */
     functionPath: string;
+
+    /**
+     * **Opt-in, EXPERIMENTAL, default off.** When `true` *and*
+     * {@link TracerDeps.resolveCloudflareTracing} yields a working
+     * `tracing.enterSpan`, each `ctx.trace` span is ALSO emitted as a Cloudflare
+     * **custom span**, so it nests inside CF's native binding/fetch/handler trace
+     * tree on the hosted path. This only ADDS a CF-side span — the recorded
+     * {@link SpanEvent} (our `SpanBuffer`/`otlpSink`) is untouched and remains the
+     * source of truth plus the local studio waterfall. See {@link createTracer}
+     * for the double-export and Durable-Object async-context caveats.
+     */
+    fuseCloudflareSpans?: boolean;
+
     /** Hand a finished span to the buffer + sink. */
     record: (span: SpanEvent) => void;
+
+    /**
+     * Injected resolver for CF's `tracing` namespace (see
+     * {@link CloudflareTracingResolver}). Only consulted when
+     * {@link TracerDeps.fuseCloudflareSpans} is `true`, so the default path never
+     * calls it.
+     */
+    resolveCloudflareTracing?: CloudflareTracingResolver;
+
     /** Shard key for single-shard calls; absent for the unnamed root DO. */
     shardKey: string | undefined;
+
     /** Read lazily — the acting user is resolved per span, not per ctx. */
     userId: () => string | undefined;
 }
@@ -68,6 +129,59 @@ export interface MetricsDeps {
     record: (event: MetricEvent) => void;
     shardKey: string | undefined;
 }
+
+/**
+ * Mirror a finished span's name-independent key attributes onto its Cloudflare
+ * custom span, best-effort. Pure and side-effect-only, so the wrapping in
+ * {@link createTracer} stays readable and this is directly unit-testable with a
+ * fake span.
+ *
+ * Gated on `span.isTraced`: an untraced span discards attributes, so building the
+ * strings would be waste. User attributes are already coerced to JSON primitives
+ * by `normalizeLogFields` (a nested value arrives as its JSON string), so every
+ * one is copyable; the `typeof` guard is a defensive net against a non-primitive
+ * ever reaching CF's `setAttribute`, which takes `string | number | boolean |
+ * undefined`.
+ */
+export const applyCloudflareSpanAttributes = (
+    span: CloudflareSpanLike,
+    meta: {
+        attributes: Record<string, LogFields[string]>;
+        durationMs: number;
+        error: SpanEvent["error"];
+        functionPath: string;
+        ok: boolean;
+        shardKey: string | undefined;
+        userId: string | undefined;
+    },
+): void => {
+    if (!span.isTraced) {
+        return;
+    }
+
+    span.setAttribute("lunora.function_path", meta.functionPath);
+    span.setAttribute("lunora.ok", meta.ok);
+    span.setAttribute("lunora.duration_ms", meta.durationMs);
+
+    if (meta.shardKey !== undefined) {
+        span.setAttribute("lunora.shard_key", meta.shardKey);
+    }
+
+    if (meta.userId !== undefined) {
+        span.setAttribute("lunora.user_id", meta.userId);
+    }
+
+    if (meta.error !== undefined) {
+        span.setAttribute("lunora.error.type", meta.error.type);
+        span.setAttribute("lunora.error.message", meta.error.message);
+    }
+
+    for (const [key, value] of Object.entries(meta.attributes)) {
+        if (typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+            span.setAttribute(`lunora.attr.${key}`, value);
+        }
+    }
+};
 
 /**
  * Build the `ctx.trace` span factory for one dispatched function.
@@ -90,9 +204,33 @@ export interface MetricsDeps {
  * cleared in the dispatch `finally`, and a subscription re-run builds its ctx
  * during* the writing mutation's flush — so reading that shared field at span
  * time would file the re-run's spans under the mutation's trace.
+ *
+ * **Cloudflare custom-spans bridge (opt-in, EXPERIMENTAL).** When
+ * `deps.fuseCloudflareSpans` is `true` and `deps.resolveCloudflareTracing` yields
+ * a working `tracing.enterSpan` (`cloudflare:workers`, GA 2026-06-16), each span
+ * body runs inside a CF custom span so our span nests under CF's native
+ * binding/fetch/handler trace tree on the hosted path, and the finished span's
+ * key attributes are mirrored onto it (gated on `span.isTraced`). Two deliberate
+ * boundaries hold.
+ *
+ * **No double-export by default, and never a replacement.** The bridge only ADDS a
+ * CF-side span; the recorded {@link SpanEvent} handed to `record` (our
+ * `SpanBuffer`/`otlpSink`) is byte-for-byte the same as without the bridge and
+ * stays the source of truth. It is off unless explicitly enabled precisely
+ * because, once on, a deployment that ALSO ships our `otlpSink` to a collector
+ * AND lets CF export its trace tree emits the same logical span down two
+ * pipelines — an intentional, documented trade the operator opts into, not a
+ * default.
+ *
+ * **DO async-context caveat.** `tracing.enterSpan`'s parent-linking inside Durable
+ * Objects is unverified upstream, so this is capability-probed: an
+ * absent/undefined `tracing`, a missing `enterSpan`, or an off-CF/unsampled run
+ * all resolve to `undefined` and the bridge is a total no-op — exact prior
+ * behavior. If CF's ambient-span linkage misbehaves in a DO, the worst case is a
+ * mis-parented CF span; our own recorded waterfall is unaffected.
  */
 export const createTracer = (deps: TracerDeps): ContextTracer => {
-    const { anchor, functionPath, record, shardKey, userId } = deps;
+    const { anchor, fuseCloudflareSpans, functionPath, record, resolveCloudflareTracing, shardKey, userId } = deps;
 
     const tracerFor =
         (parentSpanId: string): ContextTracer =>
@@ -117,58 +255,101 @@ export const createTracer = (deps: TracerDeps): ContextTracer => {
                 },
             };
 
-            let ok = true;
-            let error: SpanEvent["error"];
+            // The recorded span (our `SpanBuffer`/`otlpSink`) is produced here
+            // IDENTICALLY whether or not the CF bridge is active. An optional
+            // `cfSpan` only receives a MIRROR of the finished span's attributes —
+            // it never alters, gates, or replaces what we record.
+            const runRecorded = async (cfSpan?: CloudflareSpanLike): Promise<T> => {
+                let ok = true;
+                let error: SpanEvent["error"];
 
-            try {
-                // The body gets a tracer bound to THIS span, so anything it opens
-                // is a child of it — under `Promise.all` too — plus the span's
-                // handle for post-hoc attributes.
-                return await function_(tracerFor(spanId), spanHandle);
-            } catch (error_) {
-                // Record the failure, then re-throw untouched: `ctx.trace` is
-                // instrumentation, never flow control.
-                ok = false;
-                error = {
-                    message: error_ instanceof Error ? error_.message : String(error_),
-                    // Prefer a LunoraError's stable `code` over the class name so
-                    // spans group by the same taxonomy the RPC spans use.
-                    type: toErrorType(error_),
-                };
-
-                throw error_;
-            } finally {
-                // Guarded here, not only in the injected `record`: the span is
-                // recorded *after* the body already settled, so a telemetry
-                // failure escaping would turn a succeeded operation into a failed
-                // request — and worse, replace the body's own error with a
-                // telemetry one. Owning the invariant at the point where it is
-                // promised means a caller injecting a raw `record` can't lose it.
                 try {
+                    // The body gets a tracer bound to THIS span, so anything it
+                    // opens is a child of it — under `Promise.all` too — plus the
+                    // span's handle for post-hoc attributes.
+                    return await function_(tracerFor(spanId), spanHandle);
+                } catch (error_) {
+                    // Record the failure, then re-throw untouched: `ctx.trace` is
+                    // instrumentation, never flow control.
+                    ok = false;
+                    error = {
+                        message: error_ instanceof Error ? error_.message : String(error_),
+                        // Prefer a LunoraError's stable `code` over the class name
+                        // so spans group by the same taxonomy the RPC spans use.
+                        type: toErrorType(error_),
+                    };
+
+                    throw error_;
+                } finally {
+                    const durationMs = Date.now() - startTs;
+                    const resolvedUserId = userId();
                     // Merge start attributes with anything the body attached
                     // post-hoc; post-hoc wins on a key clash. Emit `attributes`
                     // only when the merged bag is non-empty, so a span with
                     // neither doesn't ride an empty object.
                     const merged = { ...normalized, ...collected };
 
-                    record({
-                        ...(Object.keys(merged).length === 0 ? {} : { attributes: merged }),
-                        durationMs: Date.now() - startTs,
-                        ...(error === undefined ? {} : { error }),
-                        functionPath,
-                        name,
-                        ok,
-                        parentSpanId,
-                        shardKey,
-                        spanId,
-                        startTs,
-                        traceId: anchor.traceId,
-                        userId: userId(),
-                    });
-                } catch {
-                    // Best-effort — never let span capture fail the handler.
+                    // Guarded here, not only in the injected `record`: the span is
+                    // recorded *after* the body already settled, so a telemetry
+                    // failure escaping would turn a succeeded operation into a
+                    // failed request — and worse, replace the body's own error
+                    // with a telemetry one. Owning the invariant at the point
+                    // where it is promised means a caller injecting a raw `record`
+                    // can't lose it.
+                    try {
+                        record({
+                            ...(Object.keys(merged).length === 0 ? {} : { attributes: merged }),
+                            durationMs,
+                            ...(error === undefined ? {} : { error }),
+                            functionPath,
+                            name,
+                            ok,
+                            parentSpanId,
+                            shardKey,
+                            spanId,
+                            startTs,
+                            traceId: anchor.traceId,
+                            userId: resolvedUserId,
+                        });
+                    } catch {
+                        // Best-effort — never let span capture fail the handler.
+                    }
+
+                    // Mirror onto the CF custom span, in its OWN guard so a
+                    // `setAttribute` throw can neither skip our recording above nor
+                    // escape into the handler.
+                    if (cfSpan !== undefined) {
+                        try {
+                            applyCloudflareSpanAttributes(cfSpan, {
+                                attributes: merged,
+                                durationMs,
+                                error,
+                                functionPath,
+                                ok,
+                                shardKey,
+                                userId: resolvedUserId,
+                            });
+                        } catch {
+                            // Best-effort — the CF mirror is additive telemetry.
+                        }
+                    }
+                }
+            };
+
+            // Default path: no bridge, exact prior behavior. Only when opted in
+            // AND CF's `tracing.enterSpan` resolves do we open a custom span and
+            // run the recorded body inside it, so our span nests under CF's native
+            // trace tree. The probe returns `undefined` off-CF / on older compat /
+            // unsampled, in which case this is a safe no-op.
+            if (fuseCloudflareSpans === true && resolveCloudflareTracing !== undefined) {
+                const cfTracing = await resolveCloudflareTracing();
+
+                if (cfTracing !== undefined && typeof cfTracing.enterSpan === "function") {
+                    return await cfTracing.enterSpan(name, (span) => runRecorded(span));
                 }
             }
+
+            return await runRecorded();
         };
 
     return tracerFor(anchor.rootSpanId);

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -20,7 +20,7 @@ import { appendAuditEntry, ensureAuditTable, readAuditLog } from "./audit-log";
 import type { AuthMetrics } from "./auth-metrics";
 import { readAuthMetrics, recordAuthEvent } from "./auth-metrics";
 import { buildBatchEntryRequest } from "./batch";
-import type { ContextMetrics, ContextTracer, TraceAnchor } from "./context-telemetry";
+import type { CloudflareTracingLike, ContextMetrics, ContextTracer, TraceAnchor } from "./context-telemetry";
 import { createMetrics, createTracer, dispatchRootSpan } from "./context-telemetry";
 import type { CdcChange, SqlExec } from "./ctx-db";
 import {
@@ -186,10 +186,65 @@ const REQUIRE_EPHEMERAL_ENV_VALUES = new Set(["1", "enabled", "on", "true", "yes
  * `@lunora/runtime`'s `ObservabilitySink` without taking a dependency on it.
  */
 interface TelemetrySink {
+    /**
+     * **Opt-in, EXPERIMENTAL, default off.** When `true`, each `ctx.trace` span is
+     * ALSO emitted as a Cloudflare **custom span** (`tracing.enterSpan` from
+     * `cloudflare:workers`, GA 2026-06-16) so it nests inside CF's native trace
+     * tree on the hosted path — capability-probed, and a safe no-op off-CF / on an
+     * older compat date / when unsampled. This only ADDS a CF-side span; the
+     * `onSpan` event below (our `SpanBuffer`/`otlpSink`) is unchanged and stays the
+     * source of truth. Mirror of `@lunora/runtime`'s `ObservabilitySink`
+     * `fuseCloudflareTraces`; see {@link createTracer} for the double-export caveat.
+     */
+    fuseCloudflareTraces?: boolean;
     onLog?: (event: LogEventInput, context?: LogSinkContext) => void;
     onMetric?: (event: MetricEvent, context?: LogSinkContext) => void;
     onSpan?: (event: SpanEvent, context?: LogSinkContext) => void;
 }
+
+/**
+ * Memoized resolution of CF's `tracing` namespace, or `undefined` when custom
+ * spans are unavailable. Backs the opt-in `makeTracer` Cloudflare custom-spans
+ * bridge (see {@link createTracer}).
+ *
+ * Deliberately a guarded DYNAMIC import, not a top-level
+ * `import { tracing } from "cloudflare:workers"`. A static named import of
+ * `tracing` would be a module link-time dependency — on a compat date predating
+ * custom spans the binding may not exist, and `@lunora/do` is also imported in
+ * plain Node (the `@lunora/testing` harness), where `cloudflare:workers` cannot
+ * resolve at all. The dynamic import runs ONLY when the bridge is enabled
+ * (default off), and its `catch` turns any absence into a safe `undefined`.
+ * `enterSpan` is additionally feature-probed (`typeof … === "function"`) so an
+ * older runtime exposing a partial `tracing` still no-ops rather than throwing.
+ *
+ * Resolved at most once per isolate and cached (including the "unavailable"
+ * verdict), so the import cost is paid a single time.
+ */
+let cloudflareTracingResolved = false;
+
+let cloudflareTracing: CloudflareTracingLike | undefined;
+
+const resolveCloudflareTracing = async (): Promise<CloudflareTracingLike | undefined> => {
+    if (!cloudflareTracingResolved) {
+        cloudflareTracingResolved = true;
+
+        try {
+            const cloudflareModule = (await import("cloudflare:workers")) as { tracing?: unknown };
+            const candidate = cloudflareModule.tracing;
+
+            cloudflareTracing =
+                candidate !== null && typeof candidate === "object" && typeof (candidate as CloudflareTracingLike).enterSpan === "function"
+                    ? (candidate as CloudflareTracingLike)
+                    : undefined;
+        } catch {
+            // Off-Cloudflare (e.g. the Node test harness) or a runtime without the
+            // module — custom spans simply aren't available. A safe no-op.
+            cloudflareTracing = undefined;
+        }
+    }
+
+    return cloudflareTracing;
+};
 
 /**
  * Structural shape of the `ctx.log` logger the DO builds (see the server
@@ -4731,14 +4786,19 @@ abstract class ShardDO {
      * `anchor` is the trace this ctx's spans belong to; omit it for a ctx with no
      * owning dispatch (an alarm, a subscription re-run) to mint a fresh anchor, so
      * `ctx.trace` still yields a coherent self-contained trace there.
+     *
+     * The Cloudflare custom-spans bridge is threaded here but stays off unless the
+     * resolved sink sets `fuseCloudflareTraces` (see {@link resolveCloudflareTracing}).
      */
     protected makeTracer(functionPath: string, sink?: TelemetrySink, anchor?: TraceAnchor): ContextTracer {
         return createTracer({
             anchor: anchor ?? resolveTraceAnchor(undefined),
+            fuseCloudflareSpans: sink?.fuseCloudflareTraces === true,
             functionPath,
             record: (span) => {
                 this.recordSpan(span, sink);
             },
+            resolveCloudflareTracing,
             shardKey: this.state.id?.name,
             userId: () => this.getCurrentUserId(),
         });

--- a/packages/runtime/src/observability.ts
+++ b/packages/runtime/src/observability.ts
@@ -87,6 +87,29 @@ export type ObservabilitySinkContext = LogSinkContext;
  * events it cares about; the runtime no-ops the others.
  */
 export interface ObservabilitySink {
+    /**
+     * **Opt-in, EXPERIMENTAL, default `false`.** When `true`, each `ctx.trace`
+     * span the Durable Object records is ALSO emitted as a Cloudflare **custom
+     * span** (`tracing.enterSpan` from `cloudflare:workers`, GA 2026-06-16) so it
+     * nests inside CF's native binding/fetch/handler trace tree on the hosted
+     * path — a deeper waterfall in Cloudflare's own trace viewer.
+     *
+     * Capability-probed: a safe no-op off-Cloudflare, on a compat date predating
+     * custom spans, or when the trace is unsampled. This ONLY ADDS a CF-side span;
+     * it never replaces {@link ObservabilitySink.onSpan}, which stays the source
+     * of truth and drives the local studio waterfall.
+     *
+     * **Double-export caveat.** Leave this off unless you understand the trade:
+     * with it on, a deployment that also ships `onSpan` to a collector via
+     * `otlpSink` AND lets Cloudflare export its trace tree will emit the same
+     * logical span down two pipelines. Enable it only when you want the CF-native
+     * nesting and have accounted for that overlap.
+     *
+     * Pass this on the SAME sink object you give both `createWorker` and
+     * `createShardDO` — the DO reads the flag when building `ctx.trace`.
+     */
+    fuseCloudflareTraces?: boolean;
+
     /** Invoked once per `ctx.log.*` call from a function handler. */
     onLog?: (event: LogEvent, context?: ObservabilitySinkContext) => void;
 


### PR DESCRIPTION
## Tier 0 — trace-fusion piece 2 (experimental, default-off)

Opt-in bridge nesting `ctx.trace` spans into Cloudflare's GA custom-spans tree (`tracing.enterSpan` from `cloudflare:workers`).

- Enabled only via `observability.fuseCloudflareTraces: true` (default `false`) **and** a capability probe (guarded dynamic `import("cloudflare:workers")`, memoized) — so `@lunora/do` stays Node-importable and it no-ops off-CF / on older compat.
- **Purely additive**: the recorded `SpanEvent` (SpanBuffer + `otlpSink`) is byte-identical whether the bridge runs or not (asserted by test) — `otlpSink` is never replaced, avoiding double-export unless an operator deliberately opts into both.
- The DO async-context parent-linking behavior is **unverified upstream** and documented as experimental; worst case is a mis-parented CF span, our own waterfall unaffected.

**Verify:** do 1208 / runtime 71 tests pass; tsc + eslint clean; drift guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)