### PR TITLE
feat(cloud): periodic alert sweep + slack/pagerduty channels

### DIFF
--- a/apps/cloud/GAPS.md
+++ b/apps/cloud/GAPS.md
@@ -425,25 +425,41 @@ Shipped in this pass (own implementations):
 Backlog (ranked; all our-own-code):
 
 1. **Alerting pillar** — rules (error-rate/latency/health on deployments),
-   incidents, notification destinations (email/webhook). A whole product
-   pillar; design against the platformUsage + tenantLogs streams.
-2. **Deployment health charts on the project page** — request volume / error
-   rate per deployment (needs status-code capture in the dispatcher metering
-   first: add `outcome` blob to the AE data point).
-3. **Log viewer upgrade** — severity chips, filter bar, virtualized list,
-   log↔deployment correlation links.
-4. **Design-system pass** — dark-first token palette, severity color ramp,
-   consistent empty states with actionable copy (Maple's DESIGN.md rigor is
-   the bar, not the source).
-5. **Onboarding checklist** — first-run "create project → issue key → first
-   deploy → see it live" checklist on the dashboard, replacing bare empty
-   tabs.
-6. **Time-range picker** — shared presets (1h/24h/7d/30d) across usage/logs
-   once the data streams carry enough resolution.
-7. **Deploy-key roll UX** — one-click roll (issue+revoke atomically) in the
-   keys tab.
-8. **MCP surface** — expose the control plane to agents (list projects,
-   deployments, logs, trigger rollback) via `@lunora/mcp`; strong
-   differentiator and cheap given the framework ships an MCP package.
-9. **Integrations hub** — OAuth connect cards (GitHub App install, Creem
-   portal) instead of bare settings fields.
+   incidents, notification destinations. A whole product pillar; design against
+   the platformUsage + tenantLogs streams.
+    - _Shipped:_ count-crossing rules (issue/incident/uptime) + metric-window
+      rules (`error_rate`/`latency_p95`/`llm_cost`, edge-triggered). Metric rules
+      evaluate both inline on telemetry ingest (fast feedback) **and** on a
+      periodic every-minute sweep (`src/telemetry/sweep.ts`) over a shared
+      `alertRuleState` latch, so a window that goes quiet (error rate falling to 0
+      with no fresh spans) still fires/clears rather than latching forever.
+      Delivery channels: `email`, `webhook`, `slack` (incoming-webhook JSON), and
+      `pagerduty` (Events API v2) — the webhook-family channels reuse the
+      `isSafeWebhookUrl` SSRF guard.
+
+#### Infra-level alerts: lean on Cloudflare Notifications + Health Checks
+
+The rules above are **app-semantic** — they watch the telemetry a tenant's code
+emits (error fingerprints, span metrics, LLM spend, synthetic uptime). For
+**infra-level** signals — Worker script errors/exceptions, CPU-time limit
+overruns, sustained 5xx, origin/health-check failures — don't rebuild what the
+platform already delivers: configure **Cloudflare Notifications** (Workers alerts
+on error rate / CPU / invocation-limit, and **Health Checks** on a deployment's
+URL) with email / PagerDuty / webhook destinations at the account level. The two
+layers compose: Cloudflare Notifications + Health Checks cover the infrastructure
+floor (is the Worker up, is it erroring at the edge), while these app-semantic
+rules run on top (is _this function_ over its error/latency/cost budget). This
+also gives an independent out-of-band path — an alert about the platform doesn't
+depend on the platform's own telemetry pipeline being healthy. 2. **Deployment health charts on the project page** — request volume / error
+rate per deployment (needs status-code capture in the dispatcher metering
+first: add `outcome` blob to the AE data point). 3. **Log viewer upgrade** — severity chips, filter bar, virtualized list,
+log↔deployment correlation links. 4. **Design-system pass** — dark-first token palette, severity color ramp,
+consistent empty states with actionable copy (Maple's DESIGN.md rigor is
+the bar, not the source). 5. **Onboarding checklist** — first-run "create project → issue key → first
+deploy → see it live" checklist on the dashboard, replacing bare empty
+tabs. 6. **Time-range picker** — shared presets (1h/24h/7d/30d) across usage/logs
+once the data streams carry enough resolution. 7. **Deploy-key roll UX** — one-click roll (issue+revoke atomically) in the
+keys tab. 8. **MCP surface** — expose the control plane to agents (list projects,
+deployments, logs, trigger rollback) via `@lunora/mcp`; strong
+differentiator and cheap given the framework ships an MCP package. 9. **Integrations hub** — OAuth connect cards (GitHub App install, Creem
+portal) instead of bare settings fields.

--- a/apps/cloud/__tests__/alert-sweep.test.ts
+++ b/apps/cloud/__tests__/alert-sweep.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ControlPlaneDb } from "../src/deploy/sweeps";
+import type { MetricObservation } from "../src/telemetry/alerts";
+import { runAlertSweep } from "../src/telemetry/sweep";
+
+/** A fake ControlPlaneDb answering findMany per-table, mirroring uptime.test.ts. */
+const fakeDb = (pages: Record<string, unknown[]>, spies: Partial<ControlPlaneDb> = {}): ControlPlaneDb => ({
+    findMany: (table) => Promise.resolve({ page: pages[table] ?? [] }),
+    insert: () => Promise.resolve("row_id"),
+    patch: () => Promise.resolve(undefined),
+    ...spies,
+});
+
+const now = 10 * 60_000; // 10 minutes in
+
+/** N observations, `errors` of which are error-level, in the current 5-min window. */
+const window = (total: number, errors: number): MetricObservation[] =>
+    Array.from({ length: total }, (_, index) => ({
+        durationMs: 10,
+        kind: "worker" as const,
+        level: index < errors ? ("error" as const) : ("info" as const),
+        startedAt: now - 60_000,
+    }));
+
+/** One enabled `error_rate > 50` rule over a 5-minute window, delivered by webhook. */
+const errorRateRule = {
+    _id: "rule1",
+    channel: "webhook",
+    comparator: "gt",
+    destination: "https://hook.example",
+    enabled: true,
+    name: "High error rate",
+    organizationId: "org1",
+    target: "error_rate",
+    threshold: 50,
+    windowMinutes: 5,
+};
+
+describe(runAlertSweep, () => {
+    it("re-fires a quiet error_rate window that the ingest path missed (no latch yet)", async () => {
+        const insert = vi.fn((table: string) => Promise.resolve(`${table}_id`));
+        const database = fakeDb(
+            {
+                alertRuleState: [], // never latched → wasFiring is false
+                alertRules: [errorRateRule],
+                observations: window(2, 2), // 100% error in the current window
+            },
+            { insert },
+        );
+
+        const result = await runAlertSweep(database, { now });
+
+        expect(result.evaluatedOrgs).toBe(1);
+        expect(result.deliveries).toHaveLength(1);
+        expect(result.deliveries[0]?.subject).toContain("Error rate above threshold");
+        // Fires an alert row AND latches the rule so it won't re-fire next tick.
+        expect(insert).toHaveBeenCalledWith("alerts", expect.objectContaining({ ruleId: "rule1", status: "firing", target: "error_rate" }));
+        expect(insert).toHaveBeenCalledWith("alertRuleState", expect.objectContaining({ firing: true, ruleId: "rule1" }));
+    });
+
+    it("clears a firing rule when its window falls back under threshold — no alert, latch reset", async () => {
+        const insert = vi.fn((table: string) => Promise.resolve(`${table}_id`));
+        const patch = vi.fn(() => Promise.resolve(undefined));
+        const database = fakeDb(
+            {
+                alertRuleState: [{ _id: "state1", firing: true, ruleId: "rule1" }],
+                alertRules: [errorRateRule],
+                observations: window(4, 0), // recovered: 0% error
+            },
+            { insert, patch },
+        );
+
+        const result = await runAlertSweep(database, { now });
+
+        expect(result.cleared).toBe(1);
+        expect(result.deliveries).toStrictEqual([]);
+        // Latch reset via patch on the existing state row; no alert row written.
+        expect(patch).toHaveBeenCalledWith("state1", expect.objectContaining({ firing: false }), "alertRuleState");
+        expect(insert).not.toHaveBeenCalledWith("alerts", expect.anything());
+    });
+
+    it("does not re-fire while the rule stays firing (latched, still breaching)", async () => {
+        const insert = vi.fn((table: string) => Promise.resolve(`${table}_id`));
+        const patch = vi.fn(() => Promise.resolve(undefined));
+        const database = fakeDb(
+            {
+                alertRuleState: [{ _id: "state1", firing: true, ruleId: "rule1" }],
+                alertRules: [errorRateRule],
+                observations: window(2, 2), // still 100% error
+            },
+            { insert, patch },
+        );
+
+        const result = await runAlertSweep(database, { now });
+
+        expect(result.deliveries).toStrictEqual([]);
+        expect(result.cleared).toBe(0);
+        expect(insert).not.toHaveBeenCalled();
+        expect(patch).not.toHaveBeenCalled(); // no state change → no write
+    });
+
+    it("ignores disabled rules and non-metric targets (never scans observations)", async () => {
+        const findMany = vi.fn((table: string) =>
+            Promise.resolve({
+                page:
+                    table === "alertRules"
+                        ? [
+                              { ...errorRateRule, enabled: false },
+                              { ...errorRateRule, _id: "u", target: "uptime" },
+                          ]
+                        : [],
+            }),
+        );
+        const database = fakeDb({}, { findMany });
+
+        const result = await runAlertSweep(database, { now });
+
+        expect(result.evaluatedOrgs).toBe(0);
+        expect(result.deliveries).toStrictEqual([]);
+        // No metric rule ⇒ never reads observations or state.
+        expect(findMany).not.toHaveBeenCalledWith("observations", expect.anything());
+        expect(findMany).not.toHaveBeenCalledWith("alertRuleState", expect.anything());
+    });
+});

--- a/apps/cloud/__tests__/alerts-metrics.test.ts
+++ b/apps/cloud/__tests__/alerts-metrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { FiringRule, MetricObservation, MetricRule } from "../src/telemetry/alerts";
+import type { FiringRule, MetricObservation, MetricRule, MetricRulePorts } from "../src/telemetry/alerts";
 import {
     compareMetric,
     computeErrorRate,
@@ -8,11 +8,16 @@ import {
     computeLlmCost,
     computeMetric,
     deviatesByPercent,
+    evaluateMetricLevel,
     evaluateMetricRule,
     fireCrossedRules,
     fireMetricRules,
+    PAGERDUTY_EVENTS_URL,
     percentile,
     rateOfChangePercent,
+    renderPagerDutyPayload,
+    renderSlackPayload,
+    webhookRequestFor,
 } from "../src/telemetry/alerts";
 
 /** Build a metric observation with sensible defaults; override what a case needs. */
@@ -155,17 +160,59 @@ describe(evaluateMetricRule, () => {
     });
 });
 
-/** Collect the rows a firing loop inserts; return incrementing string ids. */
-const capturingInsert = (): { insert: (row: Record<string, unknown>) => Promise<string>; rows: Record<string, unknown>[] } => {
+describe(evaluateMetricLevel, () => {
+    const rule = { comparator: "gt" as const, target: "error_rate" as const, threshold: 50 };
+
+    it("fires when the window breaches and the rule was not already firing", () => {
+        expect(evaluateMetricLevel(rule, mixed(2, 2), false)).toStrictEqual({ action: "fire", currentValue: 100, firing: true });
+    });
+
+    it("does not re-fire while the window stays breached (already firing)", () => {
+        expect(evaluateMetricLevel(rule, mixed(2, 2), true)).toStrictEqual({ action: "none", currentValue: 100, firing: true });
+    });
+
+    it("clears when the window falls back under threshold and the rule was firing", () => {
+        expect(evaluateMetricLevel(rule, mixed(4, 0), true)).toStrictEqual({ action: "clear", currentValue: 0, firing: false });
+    });
+
+    it("stays quiet when under threshold and not firing", () => {
+        expect(evaluateMetricLevel(rule, mixed(4, 0), false)).toStrictEqual({ action: "none", currentValue: 0, firing: false });
+    });
+});
+
+/**
+ * A metric firing-loop store: an `alerts` sink + an in-memory `alertRuleState`
+ * latch, exposing the injected {@link MetricRulePorts} plus the captured rows and
+ * final state for assertions.
+ */
+const metricStore = (
+    initial: Record<string, boolean> = {},
+): {
+    ports: MetricRulePorts<string>;
+    rows: Record<string, unknown>[];
+    state: Map<string, boolean>;
+    writes: { firing: boolean; ruleId: string; value: number }[];
+} => {
     const rows: Record<string, unknown>[] = [];
+    const state = new Map(Object.entries(initial));
+    const writes: { firing: boolean; ruleId: string; value: number }[] = [];
 
     return {
-        insert: async (row) => {
-            rows.push(row);
+        ports: {
+            insertAlert: async (row) => {
+                rows.push(row);
 
-            return `alert_${String(rows.length)}`;
+                return `alert_${String(rows.length)}`;
+            },
+            wasFiring: (ruleId) => state.get(ruleId) ?? false,
+            writeState: async (ruleId, firing, value) => {
+                state.set(ruleId, firing);
+                writes.push({ firing, ruleId, value });
+            },
         },
         rows,
+        state,
+        writes,
     };
 };
 
@@ -182,31 +229,59 @@ describe(fireMetricRules, () => {
         windowMinutes: 5,
     };
 
-    it("fires a metric rule when the current window breaches and the prior did not", async () => {
-        // Current window (last 5 min): 2 errors of 2 = 100%. Prior window: 1 of 4 = 25%.
-        const observations: MetricObservation[] = [
-            ...mixed(2, 2, now - 60_000), // inside current window
-            ...mixed(4, 1, now - 7 * 60_000), // inside prior window
-        ];
-        const { insert, rows } = capturingInsert();
+    it("fires a metric rule when the current window breaches and the rule was not firing", async () => {
+        const observations: MetricObservation[] = mixed(2, 2, now - 60_000); // 100% in the current window
+        const store = metricStore();
 
-        const deliveries = await fireMetricRules([rule], observations, "org_1", insert, now);
+        const outcome = await fireMetricRules([rule], observations, "org_1", store.ports, now);
 
-        expect(deliveries).toHaveLength(1);
-        expect(deliveries[0]?.channel).toBe("email");
-        expect(deliveries[0]?.subject).toContain("Error rate above threshold");
-        expect(deliveries[0]?.body).toContain("100% over the last 5 min");
-        expect(rows[0]).toMatchObject({ hash: "error_rate:*", organizationId: "org_1", ruleId: "rule_1", status: "firing", target: "error_rate" });
+        expect(outcome.fired).toBe(1);
+        expect(outcome.deliveries).toHaveLength(1);
+        expect(outcome.deliveries[0]?.channel).toBe("email");
+        expect(outcome.deliveries[0]?.subject).toContain("Error rate above threshold");
+        expect(outcome.deliveries[0]?.body).toContain("100% over the last 5 min");
+        expect(store.rows[0]).toMatchObject({ hash: "error_rate:*", organizationId: "org_1", ruleId: "rule_1", status: "firing", target: "error_rate" });
+        // The latch was persisted so the next pass won't re-fire.
+        expect(store.state.get("rule_1")).toBe(true);
     });
 
-    it("does not fire when the prior window was already breaching", async () => {
+    it("fires even when the prior window was ALSO breaching — the edge-trigger miss the sweep catches", async () => {
+        // Both windows at 100%: the old window-over-window edge trigger would suppress
+        // this, but level-triggered against a not-firing latch it correctly fires.
         const observations: MetricObservation[] = [...mixed(2, 2, now - 60_000), ...mixed(2, 2, now - 7 * 60_000)];
-        const { insert, rows } = capturingInsert();
+        const store = metricStore();
 
-        const deliveries = await fireMetricRules([rule], observations, "org_1", insert, now);
+        const outcome = await fireMetricRules([rule], observations, "org_1", store.ports, now);
 
-        expect(deliveries).toHaveLength(0);
-        expect(rows).toHaveLength(0);
+        expect(outcome.fired).toBe(1);
+        expect(store.state.get("rule_1")).toBe(true);
+    });
+
+    it("does not re-fire while the rule stays firing", async () => {
+        const observations: MetricObservation[] = mixed(2, 2, now - 60_000);
+        const store = metricStore({ rule_1: true });
+
+        const outcome = await fireMetricRules([rule], observations, "org_1", store.ports, now);
+
+        expect(outcome.fired).toBe(0);
+        expect(outcome.cleared).toBe(0);
+        expect(outcome.deliveries).toHaveLength(0);
+        expect(store.rows).toHaveLength(0);
+    });
+
+    it("clears a firing rule when its window falls back under threshold — no alert, latch reset", async () => {
+        // Quiet current window (only info spans): 0% error, back under the threshold.
+        const observations: MetricObservation[] = mixed(3, 0, now - 60_000);
+        const store = metricStore({ rule_1: true });
+
+        const outcome = await fireMetricRules([rule], observations, "org_1", store.ports, now);
+
+        expect(outcome.cleared).toBe(1);
+        expect(outcome.fired).toBe(0);
+        expect(outcome.deliveries).toHaveLength(0);
+        expect(store.rows).toHaveLength(0); // clearing never writes an alert row
+        expect(store.state.get("rule_1")).toBe(false);
+        expect(store.writes).toStrictEqual([{ firing: false, ruleId: "rule_1", value: 0 }]);
     });
 
     it("honors a functionPath scope", async () => {
@@ -217,13 +292,66 @@ describe(fireMetricRules, () => {
             // The scoped path: only info spans → not breaching.
             observation({ functionPath: "messages:send", level: "info", startedAt: now - 60_000 }),
         ];
-        const { insert } = capturingInsert();
+        const store = metricStore();
 
-        const deliveries = await fireMetricRules([scoped], observations, "org_1", insert, now);
+        const outcome = await fireMetricRules([scoped], observations, "org_1", store.ports, now);
 
-        expect(deliveries).toHaveLength(0);
+        expect(outcome.deliveries).toHaveLength(0);
+        expect(outcome.fired).toBe(0);
     });
 });
+
+describe("channel payloads", () => {
+    const alert = {
+        body: "Error rate is 100% over the last 5 min.",
+        destination: "https://hooks.slack.com/services/T/B/x",
+        subject: "[Lunora] High error rate",
+    };
+
+    it("renders a Slack incoming-webhook message", () => {
+        expect(renderSlackPayload(alert)).toStrictEqual({ text: "*[Lunora] High error rate*\nError rate is 100% over the last 5 min." });
+    });
+
+    it("renders a PagerDuty Events API v2 trigger with the destination as the routing key", () => {
+        expect(renderPagerDutyPayload({ ...alert, destination: "routing-key-123" })).toStrictEqual({
+            dedup_key: "[Lunora] High error rate",
+            event_action: "trigger",
+            payload: { severity: "error", source: "lunora-cloud", summary: "[Lunora] High error rate — Error rate is 100% over the last 5 min." },
+            routing_key: "routing-key-123",
+        });
+    });
+
+    it("routes each webhook-family channel to the right URL + body", () => {
+        const slack = webhookRequestFor({ ...alert, channel: "slack" });
+
+        expect(slack.url).toBe("https://hooks.slack.com/services/T/B/x");
+        expect(JSON.parse(slack.body)).toMatchObject({ text: expect.stringContaining("High error rate") });
+
+        const pd = webhookRequestFor({ ...alert, channel: "pagerduty", destination: "routing-key-123" });
+
+        expect(pd.url).toBe(PAGERDUTY_EVENTS_URL);
+        expect(JSON.parse(pd.body)).toMatchObject({ event_action: "trigger", routing_key: "routing-key-123" });
+
+        const plain = webhookRequestFor({ ...alert, channel: "webhook", destination: "https://hooks.example.com/x" });
+
+        expect(plain.url).toBe("https://hooks.example.com/x");
+        expect(JSON.parse(plain.body)).toStrictEqual({ body: alert.body, subject: alert.subject });
+    });
+});
+
+/** Collect the rows the count-crossing firing loop inserts; return incrementing string ids. */
+const capturingInsert = (): { insert: (row: Record<string, unknown>) => Promise<string>; rows: Record<string, unknown>[] } => {
+    const rows: Record<string, unknown>[] = [];
+
+    return {
+        insert: async (row) => {
+            rows.push(row);
+
+            return `alert_${String(rows.length)}`;
+        },
+        rows,
+    };
+};
 
 describe(fireCrossedRules, () => {
     it("still fires an existing count-crossing rule exactly once on the crossing ingest", async () => {

--- a/apps/cloud/lunora/_generated/api.ts
+++ b/apps/cloud/lunora/_generated/api.ts
@@ -8,11 +8,11 @@ import type { Id } from "./dataModel.js";
 
 export interface ApiTypes {
     alerts: {
-        createRule: FunctionReference<"mutation", { channel: "email" | "webhook"; comparator?: "gt" | "lt"; destination: string; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "issue" | "incident" | "uptime" | "error_rate" | "latency_p95" | "llm_cost"; threshold: number; windowMinutes?: number }, Id<"alertRules">>;
+        createRule: FunctionReference<"mutation", { channel: "email" | "webhook" | "slack" | "pagerduty"; comparator?: "gt" | "lt"; destination: string; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "issue" | "incident" | "uptime" | "error_rate" | "latency_p95" | "llm_cost"; threshold: number; windowMinutes?: number }, Id<"alertRules">>;
         deleteRule: FunctionReference<"mutation", { id: Id<"alertRules">; organizationId: Id<"organizations"> }, Id<"alertRules">>;
-        list: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"alerts">; channel: "email" | "webhook"; createdAt: number; deliveredAt?: number; destination: string; status: "delivered" | "failed" | "firing"; subject: string; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime" }[]>;
+        list: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"alerts">; channel: "email" | "pagerduty" | "slack" | "webhook"; createdAt: number; deliveredAt?: number; destination: string; status: "delivered" | "failed" | "firing"; subject: string; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime" }[]>;
         markDelivered: FunctionReference<"mutation", { deployKey: string; ids: Array<Id<"alerts">>; organizationId: Id<"organizations"> }, { delivered: number; }>;
-        rules: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"alertRules">; channel: "email" | "webhook"; comparator?: "gt" | "lt"; createdAt: number; destination: string; enabled: boolean; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime"; threshold: number; windowMinutes?: number }[]>;
+        rules: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"alertRules">; channel: "email" | "pagerduty" | "slack" | "webhook"; comparator?: "gt" | "lt"; createdAt: number; destination: string; enabled: boolean; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime"; threshold: number; windowMinutes?: number }[]>;
         setRuleEnabled: FunctionReference<"mutation", { enabled: boolean; id: Id<"alertRules">; organizationId: Id<"organizations"> }, Id<"alertRules">>;
     };
     audit_log: {
@@ -128,7 +128,7 @@ export interface ApiTypes {
         list: FunctionReference<"query", { limit?: number; organizationId: Id<"organizations"> }, { completionTokens: number; errorCount: number; firstSeen: number; lastSeen: number; models: string[]; promptTokens: number; sessionId: string; totalTokens: number; turnCount: number }[]>;
     };
     telemetry: {
-        ingest: FunctionReference<"mutation", { deployKey: string; deploymentId?: Id<"deployments">; events: Array<unknown>; observations?: Array<unknown>; organizationId: Id<"organizations"> }, { alerts: { body: string; channel: "email" | "webhook"; destination: string; id: Id<"alerts">; subject: string; }[]; incidents: number; issues: number; }>;
+        ingest: FunctionReference<"mutation", { deployKey: string; deploymentId?: Id<"deployments">; events: Array<unknown>; observations?: Array<unknown>; organizationId: Id<"organizations"> }, { alerts: { body: string; channel: "email" | "pagerduty" | "slack" | "webhook"; destination: string; id: Id<"alerts">; subject: string; }[]; incidents: number; issues: number; }>;
     };
     traces: {
         get: FunctionReference<"query", { organizationId: Id<"organizations">; traceId: string }, { attributes?: Record<string, string>; completionTokens?: number; durationMs: number; endedAt: number; evaluations?: { label?: string; name: string; score: number; }[]; functionPath?: string; input?: string; kind?: "container" | "generation" | "worker"; level: "info" | "error"; model?: string; name: string; output?: string; parentSpanId?: string; promptTokens?: number; sessionId?: string; spanId: string; startedAt: number; statusMessage?: string; traceId: string }[]>;

--- a/apps/cloud/lunora/_generated/dataModel.ts
+++ b/apps/cloud/lunora/_generated/dataModel.ts
@@ -33,7 +33,7 @@ export type {
     WhereOperators,
 } from "@lunora/server/data-model";
 
-export type TableName = "cells" | "organizations" | "members" | "projects" | "deployments" | "deployKeys" | "overageDebits" | "tenantLogs" | "observations" | "githubInstallations" | "builds" | "buildLogs" | "domains" | "auditLog" | "invitations" | "platformUsage" | "issues" | "incidents" | "alertRules" | "alerts" | "uptimeChecks" | "uptimeState" | "secrets" | "dashboards" | "customers" | "events" | "paymentSessions" | "subscriptions" | "usageEvents";
+export type TableName = "cells" | "organizations" | "members" | "projects" | "deployments" | "deployKeys" | "overageDebits" | "tenantLogs" | "observations" | "githubInstallations" | "builds" | "buildLogs" | "domains" | "auditLog" | "invitations" | "platformUsage" | "issues" | "incidents" | "alertRules" | "alertRuleState" | "alerts" | "uptimeChecks" | "uptimeState" | "secrets" | "dashboards" | "customers" | "events" | "paymentSessions" | "subscriptions" | "usageEvents";
 
 export type Id<TName extends string> = string & { readonly __table: TName };
 
@@ -315,7 +315,7 @@ export interface Doc_incidents {
 export interface Doc_alertRules {
     _id: Id<"alertRules">;
     _creationTime: number;
-    channel: "email" | "webhook";
+    channel: "email" | "webhook" | "slack" | "pagerduty";
     comparator?: "gt" | "lt";
     createdAt: number;
     destination: string;
@@ -329,11 +329,23 @@ export interface Doc_alertRules {
     windowMinutes?: number;
 }
 
+export interface Doc_alertRuleState {
+    _id: Id<"alertRuleState">;
+    _creationTime: number;
+    createdAt: number;
+    firing: boolean;
+    lastEvaluatedAt: number;
+    lastValue: number;
+    organizationId: Id<"organizations">;
+    ruleId: Id<"alertRules">;
+    updatedAt: number;
+}
+
 export interface Doc_alerts {
     _id: Id<"alerts">;
     _creationTime: number;
     body: string;
-    channel: "email" | "webhook";
+    channel: "email" | "webhook" | "slack" | "pagerduty";
     createdAt: number;
     deliveredAt?: number;
     destination: string;
@@ -475,6 +487,7 @@ export interface DataModel {
     issues: Doc_issues;
     incidents: Doc_incidents;
     alertRules: Doc_alertRules;
+    alertRuleState: Doc_alertRuleState;
     alerts: Doc_alerts;
     uptimeChecks: Doc_uptimeChecks;
     uptimeState: Doc_uptimeState;
@@ -513,6 +526,7 @@ export interface IndexNamesByTable {
     issues: "by_org_culprit" | "by_org_hash" | "by_org";
     incidents: "by_org_hash" | "by_org";
     alertRules: "by_org";
+    alertRuleState: "by_org" | "by_rule";
     alerts: "by_status" | "by_org";
     uptimeChecks: "by_org_deployment" | "by_org";
     uptimeState: "by_org" | "by_deployment";
@@ -548,6 +562,7 @@ export interface SearchIndexNamesByTable {
     issues: never;
     incidents: never;
     alertRules: never;
+    alertRuleState: never;
     alerts: never;
     uptimeChecks: never;
     uptimeState: never;
@@ -583,6 +598,7 @@ export interface RankIndexNamesByTable {
     issues: never;
     incidents: never;
     alertRules: never;
+    alertRuleState: never;
     alerts: never;
     uptimeChecks: never;
     uptimeState: never;
@@ -878,7 +894,7 @@ export interface Insert_incidents {
 export interface Insert_alertRules {
     _id?: Id<"alertRules">;
     _creationTime?: number;
-    channel: "email" | "webhook";
+    channel: "email" | "webhook" | "slack" | "pagerduty";
     comparator?: "gt" | "lt";
     createdAt: number;
     destination: string;
@@ -892,11 +908,23 @@ export interface Insert_alertRules {
     windowMinutes?: number;
 }
 
+export interface Insert_alertRuleState {
+    _id?: Id<"alertRuleState">;
+    _creationTime?: number;
+    createdAt: number;
+    firing: boolean;
+    lastEvaluatedAt: number;
+    lastValue: number;
+    organizationId: Id<"organizations">;
+    ruleId: Id<"alertRules">;
+    updatedAt: number;
+}
+
 export interface Insert_alerts {
     _id?: Id<"alerts">;
     _creationTime?: number;
     body: string;
-    channel: "email" | "webhook";
+    channel: "email" | "webhook" | "slack" | "pagerduty";
     createdAt: number;
     deliveredAt?: number;
     destination: string;
@@ -1039,6 +1067,7 @@ export interface InsertModel {
     issues: Insert_issues;
     incidents: Insert_incidents;
     alertRules: Insert_alertRules;
+    alertRuleState: Insert_alertRuleState;
     alerts: Insert_alerts;
     uptimeChecks: Insert_uptimeChecks;
     uptimeState: Insert_uptimeState;
@@ -1089,6 +1118,7 @@ export interface Relations {
     issues: {};
     incidents: {};
     alertRules: {};
+    alertRuleState: {};
     alerts: {};
     uptimeChecks: {};
     uptimeState: {};

--- a/apps/cloud/lunora/_generated/drizzle.global.ts
+++ b/apps/cloud/lunora/_generated/drizzle.global.ts
@@ -335,7 +335,7 @@ export const incidents = sqliteTable("incidents", {
 export const alertRules = sqliteTable("alertRules", {
     _id: text("_id").primaryKey(),
     _creationTime: integer("_creationTime").notNull(),
-    channel: text("channel", { mode: "json" }).$type<"email" | "webhook">().notNull(),
+    channel: text("channel", { mode: "json" }).$type<"email" | "webhook" | "slack" | "pagerduty">().notNull(),
     comparator: text("comparator", { mode: "json" }).$type<"gt" | "lt">(),
     createdAt: real("createdAt").notNull(),
     destination: text("destination").notNull(),
@@ -351,11 +351,26 @@ export const alertRules = sqliteTable("alertRules", {
     by_org: index("by_org").on(t.organizationId),
 }));
 
+export const alertRuleState = sqliteTable("alertRuleState", {
+    _id: text("_id").primaryKey(),
+    _creationTime: integer("_creationTime").notNull(),
+    createdAt: real("createdAt").notNull(),
+    firing: integer("firing", { mode: "boolean" }).notNull(),
+    lastEvaluatedAt: real("lastEvaluatedAt").notNull(),
+    lastValue: real("lastValue").notNull(),
+    organizationId: text("organizationId").references(() => organizations._id).notNull(),
+    ruleId: text("ruleId").references(() => alertRules._id).notNull(),
+    updatedAt: real("updatedAt").notNull(),
+}, (t) => ({
+    by_org: index("by_org").on(t.organizationId),
+    by_rule: uniqueIndex("by_rule").on(t.ruleId),
+}));
+
 export const alerts = sqliteTable("alerts", {
     _id: text("_id").primaryKey(),
     _creationTime: integer("_creationTime").notNull(),
     body: text("body").notNull(),
-    channel: text("channel", { mode: "json" }).$type<"email" | "webhook">().notNull(),
+    channel: text("channel", { mode: "json" }).$type<"email" | "webhook" | "slack" | "pagerduty">().notNull(),
     createdAt: real("createdAt").notNull(),
     deliveredAt: real("deliveredAt"),
     destination: text("destination").notNull(),

--- a/apps/cloud/lunora/_generated/functions.ts
+++ b/apps/cloud/lunora/_generated/functions.ts
@@ -867,11 +867,11 @@ export type CallerCtx = ActionCtx | MutationCtx | QueryCtx;
  */
 export interface Caller {
     alerts: {
-        createRule: (args: { channel: "email" | "webhook"; comparator?: "gt" | "lt"; destination: string; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "issue" | "incident" | "uptime" | "error_rate" | "latency_p95" | "llm_cost"; threshold: number; windowMinutes?: number }) => Promise<Id<"alertRules">>;
+        createRule: (args: { channel: "email" | "webhook" | "slack" | "pagerduty"; comparator?: "gt" | "lt"; destination: string; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "issue" | "incident" | "uptime" | "error_rate" | "latency_p95" | "llm_cost"; threshold: number; windowMinutes?: number }) => Promise<Id<"alertRules">>;
         deleteRule: (args: { id: Id<"alertRules">; organizationId: Id<"organizations"> }) => Promise<Id<"alertRules">>;
-        list: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"alerts">; channel: "email" | "webhook"; createdAt: number; deliveredAt?: number; destination: string; status: "delivered" | "failed" | "firing"; subject: string; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime" }[]>;
+        list: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"alerts">; channel: "email" | "pagerduty" | "slack" | "webhook"; createdAt: number; deliveredAt?: number; destination: string; status: "delivered" | "failed" | "firing"; subject: string; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime" }[]>;
         markDelivered: (args: { deployKey: string; ids: Array<Id<"alerts">>; organizationId: Id<"organizations"> }) => Promise<{ delivered: number; }>;
-        rules: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"alertRules">; channel: "email" | "webhook"; comparator?: "gt" | "lt"; createdAt: number; destination: string; enabled: boolean; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime"; threshold: number; windowMinutes?: number }[]>;
+        rules: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"alertRules">; channel: "email" | "pagerduty" | "slack" | "webhook"; comparator?: "gt" | "lt"; createdAt: number; destination: string; enabled: boolean; functionPath?: string; name: string; organizationId: Id<"organizations">; target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime"; threshold: number; windowMinutes?: number }[]>;
         setRuleEnabled: (args: { enabled: boolean; id: Id<"alertRules">; organizationId: Id<"organizations"> }) => Promise<Id<"alertRules">>;
     };
     audit_log: {
@@ -1003,7 +1003,7 @@ export interface Caller {
         list: (args: { limit?: number; organizationId: Id<"organizations"> }) => Promise<{ completionTokens: number; errorCount: number; firstSeen: number; lastSeen: number; models: string[]; promptTokens: number; sessionId: string; totalTokens: number; turnCount: number }[]>;
     };
     telemetry: {
-        ingest: (args: { deployKey: string; deploymentId?: Id<"deployments">; events: Array<unknown>; observations?: Array<unknown>; organizationId: Id<"organizations"> }) => Promise<{ alerts: { body: string; channel: "email" | "webhook"; destination: string; id: Id<"alerts">; subject: string; }[]; incidents: number; issues: number; }>;
+        ingest: (args: { deployKey: string; deploymentId?: Id<"deployments">; events: Array<unknown>; observations?: Array<unknown>; organizationId: Id<"organizations"> }) => Promise<{ alerts: { body: string; channel: "email" | "pagerduty" | "slack" | "webhook"; destination: string; id: Id<"alerts">; subject: string; }[]; incidents: number; issues: number; }>;
         orgForDeployKey: (args: { deployKey: string }) => Promise<{ organizationId: Id<"organizations">; } | null>;
         pruneObservations: (args?: {}) => Promise<{ pruned: number; }>;
     };

--- a/apps/cloud/lunora/_generated/openapi.json
+++ b/apps/cloud/lunora/_generated/openapi.json
@@ -84,6 +84,14 @@
                           {
                             "const": "webhook",
                             "type": "string"
+                          },
+                          {
+                            "const": "slack",
+                            "type": "string"
+                          },
+                          {
+                            "const": "pagerduty",
+                            "type": "string"
                           }
                         ]
                       },

--- a/apps/cloud/lunora/_generated/openapi.ts
+++ b/apps/cloud/lunora/_generated/openapi.ts
@@ -87,6 +87,14 @@ export const openApiSpec: Record<string, unknown> = {
                                                     {
                                                         "const": "webhook",
                                                         "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "slack",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "pagerduty",
+                                                        "type": "string"
                                                     }
                                                 ]
                                             },

--- a/apps/cloud/lunora/_generated/shard.ts
+++ b/apps/cloud/lunora/_generated/shard.ts
@@ -85,6 +85,10 @@ const LUNORA_TABLE_REFS: Record<string, Record<string, string>> = {
     "alertRules": {
         "organizationId": "organizations"
     },
+    "alertRuleState": {
+        "organizationId": "organizations",
+        "ruleId": "alertRules"
+    },
     "alerts": {
         "organizationId": "organizations",
         "ruleId": "alertRules"
@@ -427,6 +431,23 @@ const LUNORA_TABLE_INDEXES: Record<string, Array<{ fields: string[]; name: strin
             ],
             "name": "by_org",
             "type": "index"
+        }
+    ],
+    "alertRuleState": [
+        {
+            "fields": [
+                "organizationId"
+            ],
+            "name": "by_org",
+            "type": "index"
+        },
+        {
+            "fields": [
+                "ruleId"
+            ],
+            "name": "by_rule",
+            "type": "index",
+            "unique": true
         }
     ],
     "alerts": [
@@ -1853,6 +1874,56 @@ const LUNORA_TABLE_COLUMNS: Record<string, Array<{ isStorage?: boolean; name: st
             "type": "number"
         }
     ],
+    "alertRuleState": [
+        {
+            "name": "_id",
+            "optional": false,
+            "pk": true,
+            "type": "id"
+        },
+        {
+            "name": "_creationTime",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "createdAt",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "firing",
+            "optional": false,
+            "type": "boolean"
+        },
+        {
+            "name": "lastEvaluatedAt",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "lastValue",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "organizationId",
+            "optional": false,
+            "type": "id",
+            "ref": "organizations"
+        },
+        {
+            "name": "ruleId",
+            "optional": false,
+            "type": "id",
+            "ref": "alertRules"
+        },
+        {
+            "name": "updatedAt",
+            "optional": false,
+            "type": "number"
+        }
+    ],
     "alerts": [
         {
             "name": "_id",
@@ -2731,12 +2802,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Table has no insert path"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:alerts:103:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:alerts:110:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in createRule (alerts:103) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in createRule (alerts:110) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2744,19 +2815,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "createRule",
             "file": "alerts",
             "kind": "mutation",
-            "line": 103
+            "line": 110
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:alerts:129:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:alerts:136:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in setRuleEnabled (alerts:129) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in setRuleEnabled (alerts:136) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2764,19 +2835,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "setRuleEnabled",
             "file": "alerts",
             "kind": "mutation",
-            "line": 129
+            "line": 136
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:alerts:164:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:alerts:171:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in markDelivered (alerts:164) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in markDelivered (alerts:171) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -2784,7 +2855,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "markDelivered",
             "file": "alerts",
             "kind": "mutation",
-            "line": 164
+            "line": 171
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -3711,12 +3782,12 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:telemetry:295:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:telemetry:303:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in ingest (telemetry:295) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in ingest (telemetry:303) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -3724,19 +3795,19 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "ingest",
             "file": "telemetry",
             "kind": "mutation",
-            "line": 295
+            "line": 303
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
-        "cacheKey": "nondeterministic_query_mutation:telemetry:427:Date.now",
+        "cacheKey": "nondeterministic_query_mutation:telemetry:461:Date.now",
         "categories": [
             "SCHEMA"
         ],
         "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in pruneObservations (telemetry:427) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "detail": "`Date.now(…)` in pruneObservations (telemetry:461) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
         "facing": "EXTERNAL",
         "level": "WARN",
         "metadata": {
@@ -3744,7 +3815,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "pruneObservations",
             "file": "telemetry",
             "kind": "mutation",
-            "line": 427
+            "line": 461
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -4943,14 +5014,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `markDelivered` (alerts:159) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `markDelivered` (alerts:166) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "markDelivered",
             "file": "alerts",
-            "line": 159
+            "line": 166
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -6216,14 +6287,14 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "SECURITY"
         ],
         "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
-        "detail": "Arg `deployKey` of public procedure `ingest` (telemetry:266) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "detail": "Arg `deployKey` of public procedure `ingest` (telemetry:273) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
         "facing": "EXTERNAL",
         "level": "INFO",
         "metadata": {
             "argument": "deployKey",
             "exportName": "ingest",
             "file": "telemetry",
-            "line": 266
+            "line": 273
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -6911,6 +6982,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             facade["issues"] = bindTableFacade(db, "issues");
             facade["incidents"] = bindTableFacade(db, "incidents");
             facade["alertRules"] = bindTableFacade(db, "alertRules");
+            facade["alertRuleState"] = bindTableFacade(db, "alertRuleState");
             facade["alerts"] = bindTableFacade(db, "alerts");
             facade["uptimeChecks"] = bindTableFacade(db, "uptimeChecks");
             facade["uptimeState"] = bindTableFacade(db, "uptimeState");

--- a/apps/cloud/lunora/alerts.ts
+++ b/apps/cloud/lunora/alerts.ts
@@ -22,7 +22,7 @@ const METRIC_TARGETS = new Set<RuleTarget>(["error_rate", "latency_p95", "llm_co
 
 interface AlertRuleRow {
     _id: Id<"alertRules">;
-    channel: "email" | "webhook";
+    channel: "email" | "pagerduty" | "slack" | "webhook";
     comparator?: "gt" | "lt";
     createdAt: number;
     destination: string;
@@ -37,7 +37,7 @@ interface AlertRuleRow {
 
 interface AlertRow {
     _id: Id<"alerts">;
-    channel: "email" | "webhook";
+    channel: "email" | "pagerduty" | "slack" | "webhook";
     createdAt: number;
     deliveredAt?: number;
     destination: string;
@@ -60,7 +60,7 @@ export const rules = query
 /** Create an alert rule (owners/admins). New rules start enabled. */
 export const createRule = mutation
     .input({
-        channel: v.union(v.literal("email"), v.literal("webhook")),
+        channel: v.union(v.literal("email"), v.literal("webhook"), v.literal("slack"), v.literal("pagerduty")),
         // Metric targets only: how the window value is compared to `threshold`. Default `gt`.
         comparator: v.optional(v.union(v.literal("gt"), v.literal("lt"))),
         destination: v.string(),
@@ -95,9 +95,16 @@ export const createRule = mutation
             throw new LunoraError("BAD_REQUEST", "windowMinutes must be at least 1 for a metric rule");
         }
 
-        // SSRF guard: the edge `fetch`es a webhook destination when the alert fires.
-        if (args.channel === "webhook" && !isSafeWebhookUrl(args.destination)) {
-            throw new LunoraError("BAD_REQUEST", "webhook destination must be an https:// URL to a public host");
+        // SSRF guard: the edge `fetch`es a `webhook`/`slack` destination when the
+        // alert fires, so both must be an https URL to a public host. `pagerduty`'s
+        // destination is an integration (routing) key posted to PagerDuty's own
+        // fixed endpoint — it just has to be non-empty.
+        if ((args.channel === "webhook" || args.channel === "slack") && !isSafeWebhookUrl(args.destination)) {
+            throw new LunoraError("BAD_REQUEST", `${args.channel} destination must be an https:// URL to a public host`);
+        }
+
+        if (args.channel === "pagerduty" && args.destination.trim() === "") {
+            throw new LunoraError("BAD_REQUEST", "pagerduty destination must be an integration (routing) key");
         }
 
         const now = Date.now();

--- a/apps/cloud/lunora/crons.ts
+++ b/apps/cloud/lunora/crons.ts
@@ -49,7 +49,10 @@ crons.interval("purge deleted organizations", { hours: 6 }, internal.organizatio
 crons.interval("prune uptime checks", { hours: 6 }, internal.uptime.prune, {});
 
 // Every-minute heartbeat that emits the `*/1 * * * *` trigger the edge cron
-// fan-out (and the uptime sweep) ride on (§2.4) — the job itself is a no-op; see lunora/fanout.ts.
+// fan-out, the uptime sweep, AND the metric-alert sweep (src/telemetry/sweep.ts —
+// re-evaluates error_rate/latency_p95/llm_cost rules so quiet windows still
+// fire/clear) all ride on (§2.4) — the job itself is a no-op; see lunora/fanout.ts.
+// Folding these onto this one trigger keeps us within Cloudflare's 3-trigger cap.
 crons.interval("tenant cron fan-out tick", { minutes: 1 }, internal.fanout.tick, {});
 
 export default crons;

--- a/apps/cloud/lunora/schema.ts
+++ b/apps/cloud/lunora/schema.ts
@@ -528,7 +528,9 @@ export default defineSchema({
     // Configured from the dashboard; evaluated (pure) inside the telemetry ingest
     // (metric rules) / uptime sweep (uptime).
     alertRules: defineTable({
-        channel: v.union(v.literal("email"), v.literal("webhook")),
+        // Delivery channel. `email` via the mailer; `webhook`/`slack`/`pagerduty`
+        // are typed JSON POSTs (Slack incoming-webhook JSON, PagerDuty Events v2).
+        channel: v.union(v.literal("email"), v.literal("webhook"), v.literal("slack"), v.literal("pagerduty")),
         // How the metric value is compared to `threshold` (metric targets only).
         // Absent ⇒ `gt`; irrelevant for count-crossing targets.
         comparator: v.optional(v.union(v.literal("gt"), v.literal("lt"))),
@@ -565,6 +567,31 @@ export default defineSchema({
         .global()
         .index("by_org", ["organizationId"]),
 
+    // Per-rule firing state for METRIC-window rules (error_rate/latency_p95/llm_cost)
+    // — the level-triggered latch behind the alert sweep (src/telemetry/sweep.ts),
+    // analogous to `uptimeState` for uptime. A metric rule's window value rises and
+    // falls, so — unlike a monotone count crossing — it needs remembered state to
+    // fire once on a breach and re-arm on recovery. Both the ingest path and the
+    // periodic sweep read/advance this latch, so a sustained breach alerts once and
+    // a window that goes quiet still clears (and can fire again later). One row per
+    // rule; count-crossing/uptime rules don't use it.
+    alertRuleState: defineTable({
+        createdAt: v.number(),
+        // `true` while the rule's window is over threshold (already alerted).
+        firing: v.boolean(),
+        // When the sweep/ingest last evaluated this rule (freshness/debugging).
+        lastEvaluatedAt: v.number(),
+        // The window metric value at the last evaluation (audit/debugging).
+        lastValue: v.number(),
+        organizationId: v.id("organizations"),
+        ruleId: v.id("alertRules"),
+        updatedAt: v.number(),
+    })
+        .global()
+        // One state row per rule; the ingest/sweep upsert through this index.
+        .index("by_rule", ["ruleId"], { unique: true })
+        .index("by_org", ["organizationId"]),
+
     // Fired alerts — the audit trail + delivery state for each rule trip. The
     // ingest inserts a `firing` row (with the notification denormalized so the
     // edge needs no re-read); the edge delivers it (email/webhook) and stamps it
@@ -572,7 +599,7 @@ export default defineSchema({
     alerts: defineTable({
         // Rendered notification content, denormalized at fire time.
         body: v.string(),
-        channel: v.union(v.literal("email"), v.literal("webhook")),
+        channel: v.union(v.literal("email"), v.literal("webhook"), v.literal("slack"), v.literal("pagerduty")),
         createdAt: v.number(),
         deliveredAt: v.optional(v.number()),
         destination: v.string(),

--- a/apps/cloud/lunora/telemetry.ts
+++ b/apps/cloud/lunora/telemetry.ts
@@ -1,7 +1,7 @@
 import { fingerprintError } from "@lunora/fingerprint";
 import { LunoraError } from "@lunora/server";
 
-import type { AlertDelivery as AlertDeliveryBase, FiringRule, MetricObservation, MetricRule, MetricTarget } from "../src/telemetry/alerts";
+import type { AlertChannel, AlertDelivery as AlertDeliveryBase, FiringRule, MetricObservation, MetricRule, MetricTarget } from "../src/telemetry/alerts";
 import { fireCrossedRules, fireMetricRules } from "../src/telemetry/alerts";
 import type { Id } from "./_generated/dataModel.js";
 import type { MutationCtx as MutationContext } from "./_generated/server.js";
@@ -87,7 +87,7 @@ interface IncidentRow {
 
 interface AlertRuleRow {
     _id: Id<"alertRules">;
-    channel: "email" | "webhook";
+    channel: AlertChannel;
     comparator?: "gt" | "lt";
     destination: string;
     enabled: boolean;
@@ -96,6 +96,13 @@ interface AlertRuleRow {
     target: "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cost" | "uptime";
     threshold: number;
     windowMinutes?: number;
+}
+
+/** A metric rule's persisted firing latch (alertRuleState), read + advanced by the ingest. */
+interface AlertRuleStateRow {
+    _id: Id<"alertRuleState">;
+    firing: boolean;
+    ruleId: Id<"alertRules">;
 }
 
 /** Count-crossing rule targets the ingest evaluates via `fireCrossedRules`. */
@@ -276,9 +283,10 @@ export const ingest = mutation
             ctx: context,
             args,
         }): Promise<{
-            // Inlined (not `AlertDelivery[]`) so codegen serializes the return type
+            // Inlined (not `AlertDelivery[]`, and the channel union spelled out not
+            // via the `AlertChannel` alias) so codegen serializes the return type
             // without an unresolved type reference — see `members.ts`.
-            alerts: { body: string; channel: "email" | "webhook"; destination: string; id: Id<"alerts">; subject: string }[];
+            alerts: { body: string; channel: "email" | "pagerduty" | "slack" | "webhook"; destination: string; id: Id<"alerts">; subject: string }[];
             incidents: number;
             issues: number;
         }> => {
@@ -390,13 +398,12 @@ export const ingest = mutation
                 });
             }
 
-            // Metric-window rules — evaluated once over the org's recent
-            // observations (this batch's spans are already persisted above), only
-            // when such a rule exists so the common no-metric-rules path pays
-            // nothing. Edge-triggered inside `fireMetricRules`, so a sustained
-            // breach alerts once, not every ingest. FOLLOW-UP: windows with no
-            // fresh ingest (e.g. error_rate falling to 0) aren't re-evaluated
-            // here — a periodic sweep (like the uptime sweep) would close that.
+            // Metric-window rules — evaluated over the org's recent observations
+            // (this batch's spans are already persisted above), only when such a
+            // rule exists so the common no-metric-rules path pays nothing. This is
+            // the fast-feedback path; the level-triggered latch in `alertRuleState`
+            // (shared with the periodic sweep in `src/telemetry/sweep.ts`) makes a
+            // sustained breach alert once and lets a quiet window still clear + re-arm.
             if (metricRules.length > 0) {
                 const { page: observationPage } = await context.db.observations.findMany({
                     limit: METRIC_SCAN_LIMIT,
@@ -404,9 +411,36 @@ export const ingest = mutation
                     where: { organizationId: args.organizationId },
                 });
                 const windowObservations = observationPage as unknown as MetricObservationRow[];
-                const metricFired = await fireMetricRules(metricRules, windowObservations, args.organizationId, insertAlert, now);
+                const { page: statePage } = await context.db.alertRuleState.findMany({ where: { organizationId: args.organizationId } });
+                const stateByRule = new Map((statePage as unknown as AlertRuleStateRow[]).map((row) => [row.ruleId as string, row]));
 
-                firedAlerts.push(...metricFired);
+                const outcome = await fireMetricRules(
+                    metricRules,
+                    windowObservations,
+                    args.organizationId,
+                    {
+                        insertAlert,
+                        wasFiring: (ruleId) => stateByRule.get(ruleId)?.firing ?? false,
+                        writeState: async (ruleId, firing, value) => {
+                            const existing = stateByRule.get(ruleId);
+
+                            await (existing
+                                ? context.db.patch(existing._id, { firing, lastEvaluatedAt: now, lastValue: value, updatedAt: now })
+                                : context.db.insert("alertRuleState", {
+                                      createdAt: now,
+                                      firing,
+                                      lastEvaluatedAt: now,
+                                      lastValue: value,
+                                      organizationId: args.organizationId,
+                                      ruleId: ruleId as Id<"alertRules">,
+                                      updatedAt: now,
+                                  }));
+                        },
+                    },
+                    now,
+                );
+
+                firedAlerts.push(...outcome.deliveries);
             }
 
             return { alerts: firedAlerts, incidents, issues };

--- a/apps/cloud/src/client/AlertsSection.tsx
+++ b/apps/cloud/src/client/AlertsSection.tsx
@@ -16,6 +16,17 @@ type RuleTarget = "error_rate" | "incident" | "issue" | "latency_p95" | "llm_cos
 /** Metric-window targets, which take a rolling window (+ comparator + optional scope). */
 const METRIC_TARGETS = new Set<RuleTarget>(["error_rate", "latency_p95", "llm_cost"]);
 
+/** Delivery channels — `email` via the mailer, the rest typed webhook POSTs. */
+type Channel = "email" | "pagerduty" | "slack" | "webhook";
+
+/** Placeholder hint for a channel's destination field. */
+const DESTINATION_HINT: Record<Channel, string> = {
+    email: "alerts@example.com",
+    pagerduty: "PagerDuty integration (routing) key",
+    slack: "https://hooks.slack.com/services/…",
+    webhook: "https://hooks.example.com/…",
+};
+
 /** Human labels for each target in the create form. */
 const TARGET_LABELS: Record<RuleTarget, string> = {
     error_rate: "Error rate (%)",
@@ -29,8 +40,9 @@ const TARGET_LABELS: Record<RuleTarget, string> = {
 /**
  * Cloud Observability "Alerts" — the watches-while-you-sleep tier. Owners/admins
  * configure rules (fire when an issue/incident's event count crosses a
- * threshold, deliver over email or webhook); the telemetry ingest evaluates them
- * and the edge delivers. This section manages rules and lists recent fired
+ * threshold, deliver over email, webhook, Slack, or PagerDuty); the telemetry
+ * ingest + periodic sweep evaluate them and the edge delivers. This section
+ * manages rules and lists recent fired
  * alerts. Gated behind the `logStreams` plan entitlement.
  */
 export const AlertsSection = ({ organizationId }: AlertsSectionProps): ReactElement => {
@@ -48,7 +60,7 @@ export const AlertsSection = ({ organizationId }: AlertsSectionProps): ReactElem
     const [comparator, setComparator] = useState<"gt" | "lt">("gt");
     const [windowMinutes, setWindowMinutes] = useState("15");
     const [functionPath, setFunctionPath] = useState("");
-    const [channel, setChannel] = useState<"email" | "webhook">("email");
+    const [channel, setChannel] = useState<Channel>("email");
     const [destination, setDestination] = useState("");
     const [error, setError] = useState<string | null>(null);
 
@@ -206,19 +218,21 @@ export const AlertsSection = ({ organizationId }: AlertsSectionProps): ReactElem
                     <select
                         aria-label="Channel"
                         onChange={(event) => {
-                            setChannel(event.target.value as "email" | "webhook");
+                            setChannel(event.target.value as Channel);
                         }}
                         value={channel}
                     >
                         <option value="email">Email</option>
                         <option value="webhook">Webhook</option>
+                        <option value="slack">Slack</option>
+                        <option value="pagerduty">PagerDuty</option>
                     </select>
                     <input
                         aria-label="Destination"
                         onChange={(event) => {
                             setDestination(event.target.value);
                         }}
-                        placeholder={channel === "email" ? "alerts@example.com" : "https://hooks.example.com/…"}
+                        placeholder={DESTINATION_HINT[channel]}
                         required
                         value={destination}
                     />

--- a/apps/cloud/src/deploy/sweeps.ts
+++ b/apps/cloud/src/deploy/sweeps.ts
@@ -13,7 +13,13 @@ import type { TeardownPorts } from "./teardown";
 
 /** The minimal control-plane store surface the sweeps use (structurally the D1 ctx-db). */
 export interface ControlPlaneDb {
-    findMany: (table: string, args?: { where?: Record<string, unknown> }) => Promise<{ page: unknown[] }>;
+    findMany: (
+        table: string,
+        // `limit`/`orderBy` are pass-throughs the underlying ctx-db already honors
+        // (the alert sweep bounds its recent-observation read with them); the
+        // teardown/usage sweeps pass only `where`.
+        args?: { limit?: number; orderBy?: Record<string, "asc" | "desc">[]; where?: Record<string, unknown> },
+    ) => Promise<{ page: unknown[] }>;
     insert: (table: string, document: Record<string, unknown>) => Promise<unknown>;
     patch: (id: string, patch: Record<string, unknown>, table?: string) => Promise<unknown>;
 }

--- a/apps/cloud/src/mail/notify.ts
+++ b/apps/cloud/src/mail/notify.ts
@@ -1,6 +1,7 @@
 import { createMailerFromEnv } from "@lunora/mail";
 
-import { isSafeWebhookUrl } from "../telemetry/alerts";
+import type { AlertChannel } from "../telemetry/alerts";
+import { isSafeWebhookUrl, webhookRequestFor } from "../telemetry/alerts";
 
 /**
  * Transactional email for the control plane (CLOUD-PLAN.md §3). Built on
@@ -35,45 +36,50 @@ export const sendInvitationEmail = async (env: Record<string, unknown>, invitati
 export interface AlertNotification {
     /** Rendered notification body. */
     body: string;
-    channel: "email" | "webhook";
-    /** Email address (`email`) or URL to POST (`webhook`). */
+    channel: AlertChannel;
+    /** Email address (`email`), webhook/Slack URL, or PagerDuty routing key. */
     destination: string;
     /** Notification subject / summary line. */
     subject: string;
 }
 
 /**
- * Deliver a fired Observability alert over its channel. A webhook is a JSON POST
- * of `{ subject, body }`; email goes through the same env-driven mailer as
- * invitations. Runs at the Worker edge (the telemetry ingest handler); throws on
- * transport failure so the caller can mark the alert failed (best-effort — a
+ * Deliver a fired Observability alert over its channel. `email` goes through the
+ * same env-driven mailer as invitations; every other channel is a typed JSON
+ * POST whose URL + body come from {@link webhookRequestFor} (`webhook` → plain
+ * `{ subject, body }`, `slack` → incoming-webhook message, `pagerduty` → Events
+ * API v2 event to the fixed PagerDuty endpoint). Runs at the Worker edge; throws
+ * on transport failure so the caller can mark the alert failed (best-effort — a
  * failed send never blocks ingest).
  */
 export const deliverAlert = async (env: Record<string, unknown>, alert: AlertNotification): Promise<void> => {
-    if (alert.channel === "webhook") {
-        // Defense in depth against SSRF: never fetch an unsafe destination, even if
-        // one slipped past `createRule` (e.g. a rule created before this guard).
-        if (!isSafeWebhookUrl(alert.destination)) {
-            throw new Error("unsafe webhook destination");
-        }
-
-        const response = await fetch(alert.destination, {
-            body: JSON.stringify({ body: alert.body, subject: alert.subject }),
-            headers: { "content-type": "application/json" },
-            method: "POST",
-            // `isSafeWebhookUrl` only vets the original URL, so a vetted public host that
-            // 3xx-redirects to an internal address (e.g. the metadata IP) would still be
-            // an SSRF sink if we followed it. `redirect: "manual"` surfaces the redirect
-            // here instead of the runtime chasing the `Location` header.
-            redirect: "manual",
-        });
-
-        if (response.status >= 300 && response.status < 400) {
-            throw new Error("unsafe webhook redirect");
-        }
+    if (alert.channel === "email") {
+        await createMailerFromEnv(env).send({ subject: alert.subject, text: alert.body, to: alert.destination });
 
         return;
     }
 
-    await createMailerFromEnv(env).send({ subject: alert.subject, text: alert.body, to: alert.destination });
+    const request = webhookRequestFor(alert);
+
+    // Defense in depth against SSRF: never fetch an unsafe destination, even if
+    // one slipped past `createRule` (e.g. a rule created before this guard). The
+    // fixed PagerDuty endpoint clears the same guard, so every channel goes through it.
+    if (!isSafeWebhookUrl(request.url)) {
+        throw new Error("unsafe webhook destination");
+    }
+
+    const response = await fetch(request.url, {
+        body: request.body,
+        headers: { "content-type": "application/json" },
+        method: "POST",
+        // `isSafeWebhookUrl` only vets the original URL, so a vetted public host that
+        // 3xx-redirects to an internal address (e.g. the metadata IP) would still be
+        // an SSRF sink if we followed it. `redirect: "manual"` surfaces the redirect
+        // here instead of the runtime chasing the `Location` header.
+        redirect: "manual",
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+        throw new Error("unsafe webhook redirect");
+    }
 };

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -26,6 +26,8 @@ import { runUsageRollback } from "./metering/rollback";
 import type { CronTarget } from "./fanout/cron";
 import { fanOutCron } from "./fanout/cron";
 import { deliverAlert } from "./mail/notify";
+import type { AlertDelivery } from "./telemetry/alerts";
+import { runAlertSweep } from "./telemetry/sweep";
 import { runUptimeSweep } from "./uptime/sweep";
 import type { QueueMessage, TenantQueueGroup } from "./fanout/queue";
 import { fanOutQueue, groupByTenant } from "./fanout/queue";
@@ -300,6 +302,35 @@ const sweepUsageRollback = async (env: Env): Promise<void> => {
 };
 
 /**
+ * Deliver fired alerts (uptime or metric sweep) over each one's channel and stamp
+ * its row with the true outcome — a thrown `deliverAlert` (transport failure /
+ * SSRF re-rejection) marks the row `failed`. `deliveredAt` is stamped only on
+ * success (an undelivered alert has no delivery time), unlike the deploy-key
+ * `markDelivered` path which only ever records `delivered`; a sweep runs in a
+ * trusted system context, so it patches directly.
+ */
+const deliverFiredAlerts = async (env: Env, database: ControlPlaneDb, deliveries: readonly AlertDelivery[], now: number): Promise<void> => {
+    if (deliveries.length === 0) {
+        return;
+    }
+
+    const environmentRecord = env as unknown as Record<string, unknown>;
+
+    await Promise.all(
+        deliveries.map(async (delivery) => {
+            const delivered = await deliverAlert(environmentRecord, delivery).then(
+                () => true,
+                () => false,
+            );
+
+            await database
+                .patch(delivery.id, { ...(delivered ? { deliveredAt: now } : {}), status: delivered ? "delivered" : "failed", updatedAt: now }, "alerts")
+                .catch(() => undefined);
+        }),
+    );
+};
+
+/**
  * Synthetic uptime sweep (§ Observability): probe each live deployment's URL from
  * outside, record the result, and deliver any uptime alerts a probe fired. The
  * pure `runUptimeSweep` does the probe→record→fire; the edge supplies the real
@@ -314,29 +345,26 @@ const sweepUptime = async (env: Env): Promise<void> => {
     const now = Date.now();
     const { deliveries } = await runUptimeSweep(database, { fetch: globalThis.fetch, now });
 
-    if (deliveries.length === 0) {
+    await deliverFiredAlerts(env, database, deliveries, now);
+};
+
+/**
+ * Metric-alert sweep (§ Observability): re-evaluate every enabled metric-window
+ * rule over its window and fire/clear as its latch crosses, catching quiet
+ * windows the ingest-time path never re-examines (e.g. an error rate that fell to
+ * 0 with no new spans). The pure `runAlertSweep` does the evaluate→fire/clear over
+ * the shared `alertRuleState` latch; the edge supplies the real D1 and delivers.
+ */
+const sweepAlerts = async (env: Env): Promise<void> => {
+    if (!env.DB) {
         return;
     }
 
-    const environmentRecord = env as unknown as Record<string, unknown>;
+    const database = controlPlaneDb(env.DB as D1DatabaseLike);
+    const now = Date.now();
+    const { deliveries } = await runAlertSweep(database, { now });
 
-    // Deliver each fired alert and stamp its row with the true outcome — a thrown
-    // `deliverAlert` (transport failure / SSRF re-rejection) marks the row `failed`.
-    // `deliveredAt` is stamped only on success (an undelivered alert has no delivery
-    // time), unlike the deploy-key `markDelivered` path which only ever records
-    // `delivered`; the sweep runs in a trusted system context, so it patches directly.
-    await Promise.all(
-        deliveries.map(async (delivery) => {
-            const delivered = await deliverAlert(environmentRecord, delivery).then(
-                () => true,
-                () => false,
-            );
-
-            await database
-                .patch(delivery.id, { ...(delivered ? { deliveredAt: now } : {}), status: delivered ? "delivered" : "failed", updatedAt: now }, "alerts")
-                .catch(() => undefined);
-        }),
-    );
+    await deliverFiredAlerts(env, database, deliveries, now);
 };
 
 /** Script id → per-deployment admin token, for the queue fan-out. */
@@ -573,6 +601,11 @@ export default {
         // minute and page on threshold-crossing outages (§ Observability).
         if (controller.cron === EVERY_MINUTE) {
             await sweepUptime(env);
+            // Metric-window rules (error_rate/latency_p95/llm_cost): re-evaluate on
+            // the same tick so quiet windows the ingest never re-examines still
+            // fire/clear. Rides the existing every-minute trigger — no new cron
+            // expression, so we stay within Cloudflare's 3-trigger cap.
+            await sweepAlerts(env);
         }
     },
 };

--- a/apps/cloud/src/telemetry/alerts.ts
+++ b/apps/cloud/src/telemetry/alerts.ts
@@ -27,6 +27,15 @@ export type AlertTarget = CountTarget | MetricTarget;
 /** How a metric value is compared to the rule threshold. Absent on a rule ⇒ `gt`. */
 export type Comparator = "gt" | "lt";
 
+/**
+ * Where a fired alert is delivered. `email` goes through the mailer; the other
+ * three are typed webhook POSTs (see {@link webhookRequestFor}): `webhook` posts
+ * a plain `{ subject, body }`, `slack` an incoming-webhook message, `pagerduty` a
+ * PagerDuty Events API v2 event. App-semantic rules use these; infra-level alerts
+ * (Worker errors, health) are better served by Cloudflare Notifications (GAPS.md).
+ */
+export type AlertChannel = "email" | "pagerduty" | "slack" | "webhook";
+
 /** The source (issue/incident/uptime) a rule is evaluated against, for rendering. */
 export interface AlertSource {
     count: number;
@@ -73,7 +82,7 @@ export const renderAlert = (rule: { name: string; target: CountTarget }, source:
  */
 export interface AlertDelivery<TId extends string = string> {
     body: string;
-    channel: "email" | "webhook";
+    channel: AlertChannel;
     destination: string;
     id: TId;
     subject: string;
@@ -81,7 +90,7 @@ export interface AlertDelivery<TId extends string = string> {
 
 /** An enabled count-crossing rule the firing loop evaluates. `ruleId` is the alertRules row id (any string id form). */
 export interface FiringRule {
-    channel: "email" | "webhook";
+    channel: AlertChannel;
     destination: string;
     name: string;
     ruleId: string;
@@ -279,7 +288,7 @@ export const deviatesByPercent = (current: number, prior: number, thresholdPerce
 
 /** An enabled metric-window rule the metric firing loop evaluates. */
 export interface MetricRule {
-    channel: "email" | "webhook";
+    channel: AlertChannel;
     comparator: Comparator;
     destination: string;
     /** Optional scope: evaluate only observations from this function path. */
@@ -373,34 +382,101 @@ const windowsFor = (
 };
 
 /**
- * Fire every enabled metric rule whose window value edge-crosses its threshold,
- * over the org's recent `observations`. Mirrors {@link fireCrossedRules} — same
- * `alerts` row shape + injected `insertAlert` — so the metric path can't drift
- * from the count path. The alert `hash` groups a rule's alerts by target +
- * scope (mirroring the issue/incident hash), so the recent-alerts list dedupes
- * cleanly. `insertAlert` uses the same structural row the count path writes.
+ * Level-triggered transition for a metric rule, evaluated against its current
+ * window plus the rule's PERSISTED firing state (`wasFiring`) rather than only
+ * the prior window. This is what lets a periodic sweep re-fire a breach that a
+ * quiet window kept the ingest path from seeing, and clear a firing rule once its
+ * window falls back under the threshold — a true state machine, not a one-shot
+ * edge on window-over-window:
+ *  • `fire`  — the window breaches and the rule was not already firing.
+ *  • `clear` — the window no longer breaches and the rule was firing.
+ *  • `none`  — no state change (still breaching, or still clear).
+ * `firing` is the rule's state AFTER this evaluation, for the caller to persist.
+ */
+export interface MetricLevelEvaluation {
+    action: "clear" | "fire" | "none";
+    currentValue: number;
+    firing: boolean;
+}
+
+/** Decide a metric rule's level-triggered transition from its current window + prior firing state. */
+export const evaluateMetricLevel = (
+    rule: Pick<MetricRule, "comparator" | "target" | "threshold">,
+    currentWindow: readonly MetricObservation[],
+    wasFiring: boolean,
+): MetricLevelEvaluation => {
+    const currentValue = computeMetric(rule.target, currentWindow);
+    const breaching = compareMetric(currentValue, rule.comparator, rule.threshold);
+    const action = breaching && !wasFiring ? "fire" : !breaching && wasFiring ? "clear" : "none";
+
+    return { action, currentValue, firing: breaching };
+};
+
+/**
+ * Ports the metric firing loop reads + writes through, injected so the two
+ * callers can share one loop over different stores: the ingest path (typed
+ * `ctx.db`, branded `Id<"alerts">`) and the periodic sweep (structural
+ * control-plane store, string ids). `wasFiring` returns a rule's persisted
+ * firing state (false when never evaluated); `writeState` persists the new
+ * state + last value after a transition; `insertAlert` writes the `alerts` row.
+ */
+export interface MetricRulePorts<TId extends string> {
+    insertAlert: (row: Record<string, unknown>) => Promise<TId>;
+    wasFiring: (ruleId: string) => boolean;
+    writeState: (ruleId: string, firing: boolean, value: number) => Promise<void>;
+}
+
+/** The outcome of one metric-firing pass: deliveries to send + how many rules fired/cleared. */
+export interface MetricRuleOutcome<TId extends string> {
+    cleared: number;
+    deliveries: AlertDelivery<TId>[];
+    fired: number;
+}
+
+/**
+ * Evaluate every enabled metric rule over the org's recent `observations` as a
+ * level-triggered state machine (see {@link evaluateMetricLevel}), fire on a
+ * fresh breach and clear on a recovery, persisting each transition through
+ * `ports`. Shared verbatim by the ingest path (fast feedback on new spans) and
+ * the periodic sweep (re-evaluates quiet windows the ingest never sees), so the
+ * two can't drift. Mirrors {@link fireCrossedRules}'s `alerts` row shape; the
+ * alert `hash` groups a rule's alerts by target + scope (like the issue/incident
+ * hash) so the recent-alerts list dedupes cleanly.
  */
 export const fireMetricRules = async <TId extends string>(
     rules: readonly MetricRule[],
     observations: readonly MetricObservation[],
     organizationId: string,
-    insertAlert: (row: Record<string, unknown>) => Promise<TId>,
+    ports: MetricRulePorts<TId>,
     now: number,
-): Promise<AlertDelivery<TId>[]> => {
+): Promise<MetricRuleOutcome<TId>> => {
     const deliveries: AlertDelivery<TId>[] = [];
+    let fired = 0;
+    let cleared = 0;
 
     for (const rule of rules) {
         const { current, prior } = windowsFor(rule, observations, now);
-        const evaluation = evaluateMetricRule(rule, current, prior);
+        const evaluation = evaluateMetricLevel(rule, current, ports.wasFiring(rule.ruleId));
 
-        if (!evaluation.fired) {
+        if (evaluation.action === "none") {
             continue;
         }
 
-        const rendered = renderMetricAlert(rule, evaluation);
+        // eslint-disable-next-line no-await-in-loop -- one write per transitioning rule; small, serialized
+        await ports.writeState(rule.ruleId, evaluation.firing, evaluation.currentValue);
+
+        if (evaluation.action === "clear") {
+            cleared += 1;
+
+            continue;
+        }
+
+        // The prior-window value is still used for the "vs the prior window" narrative,
+        // even though the fire/clear decision is level-triggered against persisted state.
+        const rendered = renderMetricAlert(rule, { currentValue: evaluation.currentValue, priorValue: computeMetric(rule.target, prior) });
         const hash = `${rule.target}:${rule.functionPath ?? "*"}`;
         // eslint-disable-next-line no-await-in-loop -- one insert per fired rule; small, serialized
-        const id = await insertAlert({
+        const id = await ports.insertAlert({
             body: rendered.body,
             channel: rule.channel,
             createdAt: now,
@@ -415,9 +491,10 @@ export const fireMetricRules = async <TId extends string>(
         });
 
         deliveries.push({ body: rendered.body, channel: rule.channel, destination: rule.destination, id, subject: rendered.subject });
+        fired += 1;
     }
 
-    return deliveries;
+    return { cleared, deliveries, fired };
 };
 
 /** An IPv4 octet's digit shape (numeric range is checked separately). */
@@ -490,4 +567,67 @@ export const isSafeWebhookUrl = (destination: string): boolean => {
     }
 
     return !isPrivateIpv4(host);
+};
+
+// ── Delivery-channel payloads (webhook / slack / pagerduty) ──────────────────
+//
+// `email` is delivered through the mailer; the other three channels are typed
+// JSON POSTs. Each renders a channel-appropriate body from the shared
+// `{ subject, body, destination }` shape so the edge (`src/mail/notify.ts`) can
+// deliver any channel uniformly, and the shapes stay unit-testable here.
+
+/** The single, fixed PagerDuty Events API v2 ingestion endpoint — the routing key selects the service. */
+export const PAGERDUTY_EVENTS_URL = "https://events.pagerduty.com/v2/enqueue";
+
+/** The subset of a fired alert the channel renderers read. */
+export interface ChannelAlert {
+    body: string;
+    channel: AlertChannel;
+    destination: string;
+    subject: string;
+}
+
+/** Slack incoming-webhook message — subject as a bold heading, body beneath. */
+export const renderSlackPayload = (alert: Pick<ChannelAlert, "body" | "subject">): { text: string } => ({
+    text: `*${alert.subject}*\n${alert.body}`,
+});
+
+/**
+ * PagerDuty Events API v2 `trigger` event. The rule's `destination` is the
+ * integration (routing) key, posted to the fixed {@link PAGERDUTY_EVENTS_URL};
+ * `dedup_key` groups an alert's re-fires into one incident on PagerDuty's side.
+ */
+export const renderPagerDutyPayload = (
+    alert: Pick<ChannelAlert, "body" | "destination" | "subject">,
+): {
+    dedup_key: string;
+    event_action: "trigger";
+    payload: { severity: "error"; source: string; summary: string };
+    routing_key: string;
+} => ({
+    dedup_key: alert.subject,
+    event_action: "trigger",
+    payload: { severity: "error", source: "lunora-cloud", summary: `${alert.subject} — ${alert.body}` },
+    routing_key: alert.destination,
+});
+
+/**
+ * The concrete webhook request (URL + JSON body) for a webhook-family channel.
+ * `slack`/`webhook` POST to the user's `destination` (so it must clear
+ * {@link isSafeWebhookUrl} — an SSRF gate); `pagerduty` POSTs the Events v2
+ * payload to the fixed, trusted PagerDuty endpoint (which itself clears the same
+ * guard, so callers can gate every channel through one check). Not for `email`.
+ */
+export const webhookRequestFor = (alert: ChannelAlert): { body: string; url: string } => {
+    switch (alert.channel) {
+        case "pagerduty": {
+            return { body: JSON.stringify(renderPagerDutyPayload(alert)), url: PAGERDUTY_EVENTS_URL };
+        }
+        case "slack": {
+            return { body: JSON.stringify(renderSlackPayload(alert)), url: alert.destination };
+        }
+        default: {
+            return { body: JSON.stringify({ body: alert.body, subject: alert.subject }), url: alert.destination };
+        }
+    }
 };

--- a/apps/cloud/src/telemetry/sweep.ts
+++ b/apps/cloud/src/telemetry/sweep.ts
@@ -1,0 +1,156 @@
+/**
+ * The periodic metric-alert sweep (§ Observability). Runs from the control
+ * plane's every-minute `scheduled()` tick alongside the uptime sweep: re-evaluate
+ * every enabled metric-window rule (`error_rate` / `latency_p95` / `llm_cost`)
+ * over its rolling window and fire/clear as its firing state crosses.
+ *
+ * Metric rules also evaluate inline on telemetry ingest (fast feedback), but a
+ * window that goes quiet — the error rate falling to 0 because no new spans
+ * arrive — is never re-examined by ingest, so a firing rule would never clear and
+ * a breach that developed without a fresh ingest would never fire. This sweep
+ * closes that gap: it drives the SAME level-triggered `fireMetricRules` the ingest
+ * uses, over the SAME `alertRuleState` latch, so the two paths can't drift and a
+ * breach alerts exactly once regardless of which path first sees it.
+ *
+ * Expressed as a pure function over the injected {@link ControlPlaneDb} ports,
+ * like `runUptimeSweep`, so the evaluate→fire/clear logic is testable against a
+ * fake store. The edge (`src/server.ts`) supplies the real D1 and delivers the
+ * returned alerts.
+ */
+import type { ControlPlaneDb } from "../deploy/sweeps";
+import type { AlertChannel, AlertDelivery, MetricObservation, MetricRule, MetricTarget } from "./alerts";
+import { fireMetricRules } from "./alerts";
+
+/** An `alertRules` row as the control-plane store returns it. */
+interface AlertRuleRow {
+    _id: string;
+    channel: AlertChannel;
+    comparator?: "gt" | "lt";
+    destination: string;
+    enabled: boolean;
+    functionPath?: string;
+    name: string;
+    organizationId: string;
+    target: string;
+    threshold: number;
+    windowMinutes?: number;
+}
+
+/** A span observation row scanned for a rule's window. */
+interface ObservationRow extends MetricObservation {
+    organizationId: string;
+}
+
+/** A metric rule's persisted firing latch (`alertRuleState`). */
+interface AlertRuleStateRow {
+    _id: string;
+    firing: boolean;
+    ruleId: string;
+}
+
+export interface AlertSweepResult {
+    /** Rules whose window fell back under threshold this sweep (latch cleared). */
+    cleared: number;
+    /** Alerts fired this sweep, for the edge to deliver + mark delivered. */
+    deliveries: AlertDelivery[];
+    /** Orgs whose recent observations were scanned (had ≥1 enabled metric rule). */
+    evaluatedOrgs: number;
+}
+
+/** Options for {@link runAlertSweep}. */
+export interface AlertSweepOptions {
+    now: number;
+    /** Max recent observations scanned per org (bounds the D1 read). */
+    scanLimit?: number;
+}
+
+/** The metric-window rule targets this sweep evaluates. */
+const METRIC_TARGETS = new Set<MetricTarget>(["error_rate", "latency_p95", "llm_cost"]);
+
+/** Recent spans scanned per org when slicing metric windows (bounds the read). */
+const DEFAULT_SCAN_LIMIT = 2000;
+
+/** Map an `alertRules` row to the shared {@link MetricRule} the firing loop reads. */
+const toMetricRule = (row: AlertRuleRow): MetricRule => ({
+    channel: row.channel,
+    comparator: row.comparator ?? "gt",
+    destination: row.destination,
+    functionPath: row.functionPath,
+    name: row.name,
+    ruleId: row._id,
+    target: row.target as MetricTarget,
+    threshold: row.threshold,
+    windowMinutes: row.windowMinutes ?? 60,
+});
+
+/**
+ * Re-evaluate every enabled metric rule over its window and fire/clear as its
+ * latch crosses. Reads all rules once, groups the metric ones by org, and — only
+ * for orgs that actually have such a rule — scans that org's recent observations
+ * and drives {@link fireMetricRules} against the persisted `alertRuleState`.
+ * Returns the fired alerts for the edge to deliver.
+ */
+export const runAlertSweep = async (database: ControlPlaneDb, options: AlertSweepOptions): Promise<AlertSweepResult> => {
+    const scanLimit = options.scanLimit ?? DEFAULT_SCAN_LIMIT;
+
+    const { page: rulePage } = await database.findMany("alertRules", {});
+    const rulesByOrg = new Map<string, MetricRule[]>();
+
+    for (const row of rulePage as AlertRuleRow[]) {
+        if (row.enabled && METRIC_TARGETS.has(row.target as MetricTarget)) {
+            const list = rulesByOrg.get(row.organizationId) ?? [];
+
+            list.push(toMetricRule(row));
+            rulesByOrg.set(row.organizationId, list);
+        }
+    }
+
+    if (rulesByOrg.size === 0) {
+        return { cleared: 0, deliveries: [], evaluatedOrgs: 0 };
+    }
+
+    // Prior firing latches, read once and keyed by ruleId (across all orgs — the
+    // table is small, one row per metric rule).
+    const { page: statePage } = await database.findMany("alertRuleState", {});
+    const stateByRule = new Map((statePage as AlertRuleStateRow[]).map((row) => [row.ruleId, row]));
+
+    const deliveries: AlertDelivery[] = [];
+    let cleared = 0;
+
+    for (const [organizationId, rules] of rulesByOrg) {
+        // The org's recent spans, newest-first and bounded — the windows are sliced
+        // from these in `fireMetricRules`.
+        // eslint-disable-next-line no-await-in-loop -- one bounded read per org with a metric rule; serialized like the uptime sweep
+        const { page: observationPage } = await database.findMany("observations", {
+            limit: scanLimit,
+            orderBy: [{ startedAt: "desc" }],
+            where: { organizationId },
+        });
+        const observations = observationPage as ObservationRow[];
+
+        // eslint-disable-next-line no-await-in-loop -- serialized D1 writes, one org at a time
+        const outcome = await fireMetricRules<string>(
+            rules,
+            observations,
+            organizationId,
+            {
+                insertAlert: (row) => database.insert("alerts", row) as Promise<string>,
+                wasFiring: (ruleId) => stateByRule.get(ruleId)?.firing ?? false,
+                writeState: async (ruleId, firing, value) => {
+                    const existing = stateByRule.get(ruleId);
+                    const patch = { firing, lastEvaluatedAt: options.now, lastValue: value, updatedAt: options.now };
+
+                    await (existing
+                        ? database.patch(existing._id, patch, "alertRuleState")
+                        : database.insert("alertRuleState", { createdAt: options.now, organizationId, ruleId, ...patch }));
+                },
+            },
+            options.now,
+        );
+
+        deliveries.push(...outcome.deliveries);
+        cleared += outcome.cleared;
+    }
+
+    return { cleared, deliveries, evaluatedOrgs: rulesByOrg.size };
+};


### PR DESCRIPTION
## Tier 0/1 — alerting follow-ups

- **Periodic metric-rule sweep**: metric rules (error-rate/latency-p95/llm-cost) can rise *and* fall, so a quiet window (error rate dropping to 0 with no new spans) never re-fired under ingest-only eval. Added a level-triggered latch table `alertRuleState` (mirrors `uptimeState`); ingest and the new sweep both drive one shared `fireMetricRules` over it — fire once on breach, clear on recovery. Sweep runs on the existing `*/1` uptime tick (no new cron; stays under the 3-trigger cap).
- **Channels**: `slack` (incoming-webhook JSON) + `pagerduty` (Events API v2), both SSRF-gated via `isSafeWebhookUrl`. GAPS.md notes leaning on Cloudflare Notifications/Health-Checks for infra alerts.

**Verify:** 384 cloud tests pass; tsc clean; codegen regenerated.

> **Cloud merge order:** merge **first**; rebase the other two cloud PRs + re-run `apps/cloud` codegen after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)