### PR TITLE
feat(cloud): user-defined custom dashboards

### DIFF
--- a/apps/cloud/__tests__/dashboards.test.ts
+++ b/apps/cloud/__tests__/dashboards.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import type { DashboardPanel, MetricSeriesLike } from "../src/telemetry/dashboards";
+import {
+    addPanel,
+    createPanel,
+    isMetricPanel,
+    movePanel,
+    normalizePanelConfig,
+    PANEL_KIND_LABELS,
+    removePanel,
+    statValue,
+    validatePanel,
+    validatePanels,
+} from "../src/telemetry/dashboards";
+
+const panel = (id: string, overrides: Partial<DashboardPanel> = {}): DashboardPanel => ({
+    config: { metricName: "requests" },
+    id,
+    kind: "metric",
+    title: id,
+    ...overrides,
+});
+
+describe("panel reducers", () => {
+    it("appends a panel immutably", () => {
+        const before: DashboardPanel[] = [panel("a")];
+        const after = addPanel(before, panel("b"));
+
+        expect(after.map((p) => p.id)).toStrictEqual(["a", "b"]);
+        expect(before).toHaveLength(1);
+    });
+
+    it("removes a panel by id, and is a no-op for an unknown id", () => {
+        const panels = [panel("a"), panel("b"), panel("c")];
+
+        expect(removePanel(panels, "b").map((p) => p.id)).toStrictEqual(["a", "c"]);
+        expect(removePanel(panels, "zzz").map((p) => p.id)).toStrictEqual(["a", "b", "c"]);
+    });
+
+    it("moves a panel up and down by swapping with its neighbor", () => {
+        const panels = [panel("a"), panel("b"), panel("c")];
+
+        expect(movePanel(panels, "b", "up").map((p) => p.id)).toStrictEqual(["b", "a", "c"]);
+        expect(movePanel(panels, "b", "down").map((p) => p.id)).toStrictEqual(["a", "c", "b"]);
+    });
+
+    it("clamps a move at the ends and no-ops an unknown id", () => {
+        const panels = [panel("a"), panel("b")];
+
+        expect(movePanel(panels, "a", "up").map((p) => p.id)).toStrictEqual(["a", "b"]);
+        expect(movePanel(panels, "b", "down").map((p) => p.id)).toStrictEqual(["a", "b"]);
+        expect(movePanel(panels, "zzz", "up").map((p) => p.id)).toStrictEqual(["a", "b"]);
+    });
+
+    it("does not mutate the input array when moving", () => {
+        const panels = [panel("a"), panel("b")];
+
+        movePanel(panels, "a", "down");
+        expect(panels.map((p) => p.id)).toStrictEqual(["a", "b"]);
+    });
+});
+
+describe(normalizePanelConfig, () => {
+    it("keeps only the metric name for a metric panel", () => {
+        expect(normalizePanelConfig("metric", { filter: "x", metricName: "requests", stat: "count" })).toStrictEqual({ metricName: "requests" });
+        expect(normalizePanelConfig("metric", { metricName: "" })).toStrictEqual({});
+    });
+
+    it("always defines a stat aggregation for a stat panel", () => {
+        expect(normalizePanelConfig("stat", { metricName: "requests" })).toStrictEqual({ metricName: "requests", stat: "last" });
+        expect(normalizePanelConfig("stat", { metricName: "requests", stat: "count" })).toStrictEqual({ metricName: "requests", stat: "count" });
+    });
+
+    it("keeps only a trimmed non-empty filter for a shortcut panel", () => {
+        expect(normalizePanelConfig("traces", { filter: "  status:error  ", metricName: "requests" })).toStrictEqual({ filter: "status:error" });
+        expect(normalizePanelConfig("logs", { filter: "   " })).toStrictEqual({});
+    });
+});
+
+describe(createPanel, () => {
+    it("normalizes config to the kind and falls back to the kind label when the title is blank", () => {
+        const built = createPanel({ config: { filter: "drop", metricName: "requests" }, id: "p1", kind: "stat", title: "  " });
+
+        expect(built).toStrictEqual({ config: { metricName: "requests", stat: "last" }, id: "p1", kind: "stat", title: PANEL_KIND_LABELS.stat });
+    });
+
+    it("trims a provided title", () => {
+        expect(createPanel({ config: {}, id: "p2", kind: "logs", title: "  Errors " }).title).toBe("Errors");
+    });
+});
+
+describe(validatePanel, () => {
+    it("requires a metric name for metric and stat panels", () => {
+        expect(validatePanel(panel("a", { config: {} }))).toMatch(/needs a metric name/);
+        expect(validatePanel(panel("a", { config: { metricName: "requests" } }))).toBeNull();
+        expect(validatePanel(panel("a", { config: {}, kind: "stat" }))).toMatch(/needs a metric name/);
+    });
+
+    it("accepts shortcut panels with or without a filter", () => {
+        expect(validatePanel(panel("a", { config: {}, kind: "traces" }))).toBeNull();
+        expect(validatePanel(panel("a", { config: { filter: "x" }, kind: "logs" }))).toBeNull();
+    });
+
+    it("validatePanels returns the first offending panel's error", () => {
+        expect(validatePanels([panel("ok"), panel("bad", { config: {} })])).toMatch(/needs a metric name/);
+        expect(validatePanels([panel("ok"), panel("also-ok", { config: {}, kind: "traces" })])).toBeNull();
+    });
+});
+
+describe(isMetricPanel, () => {
+    it("is true only for metric and stat kinds", () => {
+        expect(isMetricPanel("metric")).toBe(true);
+        expect(isMetricPanel("stat")).toBe(true);
+        expect(isMetricPanel("traces")).toBe(false);
+        expect(isMetricPanel("logs")).toBe(false);
+    });
+});
+
+describe(statValue, () => {
+    const series: MetricSeriesLike[] = [{ firstValue: 10, lastValue: 42, name: "requests", points: [1, 2, 3] }];
+
+    it("reduces the named series per aggregation", () => {
+        expect(statValue(series, panel("a", { config: { metricName: "requests", stat: "last" } }))).toBe(42);
+        expect(statValue(series, panel("a", { config: { metricName: "requests", stat: "first" } }))).toBe(10);
+        expect(statValue(series, panel("a", { config: { metricName: "requests", stat: "count" } }))).toBe(3);
+    });
+
+    it("defaults to the last value when no aggregation is set", () => {
+        expect(statValue(series, panel("a", { config: { metricName: "requests" } }))).toBe(42);
+    });
+
+    it("is undefined when the panel has no metric name or the series is absent", () => {
+        expect(statValue(series, panel("a", { config: {} }))).toBeUndefined();
+        expect(statValue(series, panel("a", { config: { metricName: "missing" } }))).toBeUndefined();
+    });
+});

--- a/apps/cloud/lunora/_generated/api.ts
+++ b/apps/cloud/lunora/_generated/api.ts
@@ -35,6 +35,13 @@ export interface ApiTypes {
         list: FunctionReference<"query", {}, { _id: Id<"cells">; cloudflareAccountId: string; createdAt: number; dispatchNamespacePrefix: string; jurisdiction?: string; name: string; status: "active" | "draining" | "suspended" }[]>;
         register: FunctionReference<"mutation", { cloudflareAccountId: string; dispatchNamespacePrefix: string; jurisdiction?: string; name: string }, Id<"cells">>;
     };
+    dashboards: {
+        create: FunctionReference<"mutation", { name: string; organizationId: Id<"organizations">; panels?: Array<unknown> }, Id<"dashboards">>;
+        get: FunctionReference<"query", { id: Id<"dashboards">; organizationId: Id<"organizations"> }, null | { _id: Id<"dashboards">; createdAt: number; name: string; panels: { config: { filter?: string; metricName?: string; stat?: "count" | "first" | "last"; }; id: string; kind: "logs" | "metric" | "stat" | "traces"; title: string }[]; updatedAt: number }>;
+        list: FunctionReference<"query", { organizationId: Id<"organizations"> }, { _id: Id<"dashboards">; createdAt: number; name: string; panels: { config: { filter?: string; metricName?: string; stat?: "count" | "first" | "last"; }; id: string; kind: "logs" | "metric" | "stat" | "traces"; title: string }[]; updatedAt: number }[]>;
+        remove: FunctionReference<"mutation", { id: Id<"dashboards">; organizationId: Id<"organizations"> }, Id<"dashboards">>;
+        update: FunctionReference<"mutation", { id: Id<"dashboards">; name?: string; organizationId: Id<"organizations">; panels?: Array<unknown> }, Id<"dashboards">>;
+    };
     deploy_keys: {
         ingestKeyCipher: FunctionReference<"query", { deployKey: string; organizationId: Id<"organizations"> }, null | { ciphertext: string; iv: string }>;
         issue: FunctionReference<"mutation", { capability?: "deploy" | "ingest"; name: string; organizationId: Id<"organizations">; projectId?: Id<"projects">; type: "production" | "dev" | "preview" }, { id: Id<"deployKeys">; key: string; }>;

--- a/apps/cloud/lunora/_generated/dataModel.ts
+++ b/apps/cloud/lunora/_generated/dataModel.ts
@@ -33,7 +33,7 @@ export type {
     WhereOperators,
 } from "@lunora/server/data-model";
 
-export type TableName = "cells" | "organizations" | "members" | "projects" | "deployments" | "deployKeys" | "overageDebits" | "tenantLogs" | "observations" | "githubInstallations" | "builds" | "buildLogs" | "domains" | "auditLog" | "invitations" | "platformUsage" | "issues" | "incidents" | "alertRules" | "alerts" | "uptimeChecks" | "uptimeState" | "secrets" | "customers" | "events" | "paymentSessions" | "subscriptions" | "usageEvents";
+export type TableName = "cells" | "organizations" | "members" | "projects" | "deployments" | "deployKeys" | "overageDebits" | "tenantLogs" | "observations" | "githubInstallations" | "builds" | "buildLogs" | "domains" | "auditLog" | "invitations" | "platformUsage" | "issues" | "incidents" | "alertRules" | "alerts" | "uptimeChecks" | "uptimeState" | "secrets" | "dashboards" | "customers" | "events" | "paymentSessions" | "subscriptions" | "usageEvents";
 
 export type Id<TName extends string> = string & { readonly __table: TName };
 
@@ -381,6 +381,16 @@ export interface Doc_secrets {
     updatedAt: number;
 }
 
+export interface Doc_dashboards {
+    _id: Id<"dashboards">;
+    _creationTime: number;
+    createdAt: number;
+    name: string;
+    organizationId: Id<"organizations">;
+    panels: Array<{ config: { filter: string | undefined; metricName: string | undefined; stat: "last" | "first" | "count" | undefined }; id: string; kind: "metric" | "stat" | "traces" | "logs"; title: string }>;
+    updatedAt: number;
+}
+
 export interface Doc_customers {
     _id: Id<"customers">;
     _creationTime: number;
@@ -467,6 +477,7 @@ export interface DataModel {
     uptimeChecks: Doc_uptimeChecks;
     uptimeState: Doc_uptimeState;
     secrets: Doc_secrets;
+    dashboards: Doc_dashboards;
     customers: Doc_customers;
     events: Doc_events;
     paymentSessions: Doc_paymentSessions;
@@ -504,6 +515,7 @@ export interface IndexNamesByTable {
     uptimeChecks: "by_org_deployment" | "by_org";
     uptimeState: "by_org" | "by_deployment";
     secrets: "by_project_env_name" | "by_project";
+    dashboards: "by_org";
     customers: "by_reference" | "by_provider_customer";
     events: "by_provider_event";
     paymentSessions: "by_reference" | "by_provider_session";
@@ -538,6 +550,7 @@ export interface SearchIndexNamesByTable {
     uptimeChecks: never;
     uptimeState: never;
     secrets: never;
+    dashboards: never;
     customers: never;
     events: never;
     paymentSessions: never;
@@ -572,6 +585,7 @@ export interface RankIndexNamesByTable {
     uptimeChecks: never;
     uptimeState: never;
     secrets: never;
+    dashboards: never;
     customers: never;
     events: never;
     paymentSessions: never;
@@ -928,6 +942,16 @@ export interface Insert_secrets {
     updatedAt: number;
 }
 
+export interface Insert_dashboards {
+    _id?: Id<"dashboards">;
+    _creationTime?: number;
+    createdAt: number;
+    name: string;
+    organizationId: Id<"organizations">;
+    panels: Array<{ config: { filter: string | undefined; metricName: string | undefined; stat: "last" | "first" | "count" | undefined }; id: string; kind: "metric" | "stat" | "traces" | "logs"; title: string }>;
+    updatedAt: number;
+}
+
 export interface Insert_customers {
     _id?: Id<"customers">;
     _creationTime?: number;
@@ -1015,6 +1039,7 @@ export interface InsertModel {
     uptimeChecks: Insert_uptimeChecks;
     uptimeState: Insert_uptimeState;
     secrets: Insert_secrets;
+    dashboards: Insert_dashboards;
     customers: Insert_customers;
     events: Insert_events;
     paymentSessions: Insert_paymentSessions;
@@ -1064,6 +1089,7 @@ export interface Relations {
     uptimeChecks: {};
     uptimeState: {};
     secrets: {};
+    dashboards: {};
     customers: {};
     events: {};
     paymentSessions: {};

--- a/apps/cloud/lunora/_generated/drizzle.global.ts
+++ b/apps/cloud/lunora/_generated/drizzle.global.ts
@@ -414,6 +414,18 @@ export const secrets = sqliteTable("secrets", {
     by_project: index("by_project").on(t.projectId),
 }));
 
+export const dashboards = sqliteTable("dashboards", {
+    _id: text("_id").primaryKey(),
+    _creationTime: integer("_creationTime").notNull(),
+    createdAt: real("createdAt").notNull(),
+    name: text("name").notNull(),
+    organizationId: text("organizationId").references(() => organizations._id).notNull(),
+    panels: text("panels", { mode: "json" }).$type<Array<{ config: { filter: string | undefined; metricName: string | undefined; stat: "last" | "first" | "count" | undefined }; id: string; kind: "metric" | "stat" | "traces" | "logs"; title: string }>>().notNull(),
+    updatedAt: real("updatedAt").notNull(),
+}, (t) => ({
+    by_org: index("by_org").on(t.organizationId),
+}));
+
 export const customers = sqliteTable("customers", {
     _id: text("_id").primaryKey(),
     _creationTime: integer("_creationTime").notNull(),

--- a/apps/cloud/lunora/_generated/functions.ts
+++ b/apps/cloud/lunora/_generated/functions.ts
@@ -6,24 +6,25 @@ import * as lunora_audit_log_1 from "../audit-log.js";
 import * as lunora_billing_2 from "../billing.js";
 import * as lunora_builds_3 from "../builds.js";
 import * as lunora_cells_4 from "../cells.js";
-import * as lunora_deploy_keys_5 from "../deploy-keys.js";
-import * as lunora_deployments_6 from "../deployments.js";
-import * as lunora_domains_7 from "../domains.js";
-import * as lunora_fanout_8 from "../fanout.js";
-import * as lunora_github_installations_9 from "../github-installations.js";
-import * as lunora_incidents_10 from "../incidents.js";
-import * as lunora_invitations_11 from "../invitations.js";
-import * as lunora_issues_12 from "../issues.js";
-import * as lunora_logs_13 from "../logs.js";
-import * as lunora_members_14 from "../members.js";
-import * as lunora_metrics_15 from "../metrics.js";
-import * as lunora_organizations_16 from "../organizations.js";
-import * as lunora_projects_17 from "../projects.js";
-import * as lunora_secrets_18 from "../secrets.js";
-import * as lunora_telemetry_19 from "../telemetry.js";
-import * as lunora_traces_20 from "../traces.js";
-import * as lunora_uptime_21 from "../uptime.js";
-import * as lunora_usage_22 from "../usage.js";
+import * as lunora_dashboards_5 from "../dashboards.js";
+import * as lunora_deploy_keys_6 from "../deploy-keys.js";
+import * as lunora_deployments_7 from "../deployments.js";
+import * as lunora_domains_8 from "../domains.js";
+import * as lunora_fanout_9 from "../fanout.js";
+import * as lunora_github_installations_10 from "../github-installations.js";
+import * as lunora_incidents_11 from "../incidents.js";
+import * as lunora_invitations_12 from "../invitations.js";
+import * as lunora_issues_13 from "../issues.js";
+import * as lunora_logs_14 from "../logs.js";
+import * as lunora_members_15 from "../members.js";
+import * as lunora_metrics_16 from "../metrics.js";
+import * as lunora_organizations_17 from "../organizations.js";
+import * as lunora_projects_18 from "../projects.js";
+import * as lunora_secrets_19 from "../secrets.js";
+import * as lunora_telemetry_20 from "../telemetry.js";
+import * as lunora_traces_21 from "../traces.js";
+import * as lunora_uptime_22 from "../uptime.js";
+import * as lunora_usage_23 from "../usage.js";
 
 import { DEFER_VALIDATION as DEFER, installCompiledValidatorMap } from "@lunora/values";
 import { LunoraError } from "@lunora/server";
@@ -78,86 +79,91 @@ export const LUNORA_FUNCTIONS: Record<string, RegisteredLunoraFunction> = {
     "builds:recordPush": lunora_builds_3.recordPush as unknown as RegisteredLunoraFunction,
     "cells:list": lunora_cells_4.list as unknown as RegisteredLunoraFunction,
     "cells:register": lunora_cells_4.register as unknown as RegisteredLunoraFunction,
-    "deploy_keys:ingestKeyCipher": lunora_deploy_keys_5.ingestKeyCipher as unknown as RegisteredLunoraFunction,
-    "deploy_keys:issue": lunora_deploy_keys_5.issue as unknown as RegisteredLunoraFunction,
-    "deploy_keys:list": lunora_deploy_keys_5.list as unknown as RegisteredLunoraFunction,
-    "deploy_keys:recordIngestKey": lunora_deploy_keys_5.recordIngestKey as unknown as RegisteredLunoraFunction,
-    "deploy_keys:revoke": lunora_deploy_keys_5.revoke as unknown as RegisteredLunoraFunction,
-    "deploy_keys:verify": lunora_deploy_keys_5.verify as unknown as RegisteredLunoraFunction,
-    "deployments:activate": lunora_deployments_6.activate as unknown as RegisteredLunoraFunction,
-    "deployments:adminTarget": lunora_deployments_6.adminTarget as unknown as RegisteredLunoraFunction,
-    "deployments:cleanupExpiredPreviews": lunora_deployments_6.cleanupExpiredPreviews as unknown as RegisteredLunoraFunction,
-    "deployments:create": lunora_deployments_6.create as unknown as RegisteredLunoraFunction,
-    "deployments:listByProject": lunora_deployments_6.listByProject as unknown as RegisteredLunoraFunction,
-    "deployments:planForScript": lunora_deployments_6.planForScript as unknown as RegisteredLunoraFunction,
-    "deployments:pruneSuperseded": lunora_deployments_6.pruneSuperseded as unknown as RegisteredLunoraFunction,
-    "deployments:rollback": lunora_deployments_6.rollback as unknown as RegisteredLunoraFunction,
-    "deployments:routeForAlias": lunora_deployments_6.routeForAlias as unknown as RegisteredLunoraFunction,
-    "deployments:updateStatus": lunora_deployments_6.updateStatus as unknown as RegisteredLunoraFunction,
-    "domains:add": lunora_domains_7.add as unknown as RegisteredLunoraFunction,
-    "domains:get": lunora_domains_7.get as unknown as RegisteredLunoraFunction,
-    "domains:list": lunora_domains_7.list as unknown as RegisteredLunoraFunction,
-    "domains:markVerified": lunora_domains_7.markVerified as unknown as RegisteredLunoraFunction,
-    "domains:remove": lunora_domains_7.remove as unknown as RegisteredLunoraFunction,
-    "domains:routeForHostname": lunora_domains_7.routeForHostname as unknown as RegisteredLunoraFunction,
-    "fanout:tick": lunora_fanout_8.tick as unknown as RegisteredLunoraFunction,
-    "github_installations:claim": lunora_github_installations_9.claim as unknown as RegisteredLunoraFunction,
-    "github_installations:list": lunora_github_installations_9.list as unknown as RegisteredLunoraFunction,
-    "github_installations:record": lunora_github_installations_9.record as unknown as RegisteredLunoraFunction,
-    "github_installations:remove": lunora_github_installations_9.remove as unknown as RegisteredLunoraFunction,
-    "incidents:investigate": lunora_incidents_10.investigate as unknown as RegisteredLunoraFunction,
-    "incidents:list": lunora_incidents_10.list as unknown as RegisteredLunoraFunction,
-    "incidents:setStatus": lunora_incidents_10.setStatus as unknown as RegisteredLunoraFunction,
-    "incidents:triage": lunora_incidents_10.triage as unknown as RegisteredLunoraFunction,
-    "invitations:accept": lunora_invitations_11.accept as unknown as RegisteredLunoraFunction,
-    "invitations:invite": lunora_invitations_11.invite as unknown as RegisteredLunoraFunction,
-    "invitations:list": lunora_invitations_11.list as unknown as RegisteredLunoraFunction,
-    "invitations:revoke": lunora_invitations_11.revoke as unknown as RegisteredLunoraFunction,
-    "issues:list": lunora_issues_12.list as unknown as RegisteredLunoraFunction,
-    "issues:setStatus": lunora_issues_12.setStatus as unknown as RegisteredLunoraFunction,
-    "logs:ingest": lunora_logs_13.ingest as unknown as RegisteredLunoraFunction,
-    "logs:ingestInternal": lunora_logs_13.ingestInternal as unknown as RegisteredLunoraFunction,
-    "logs:list": lunora_logs_13.list as unknown as RegisteredLunoraFunction,
-    "logs:orgForScript": lunora_logs_13.orgForScript as unknown as RegisteredLunoraFunction,
-    "logs:prune": lunora_logs_13.prune as unknown as RegisteredLunoraFunction,
-    "members:add": lunora_members_14.add as unknown as RegisteredLunoraFunction,
-    "members:list": lunora_members_14.list as unknown as RegisteredLunoraFunction,
-    "members:remove": lunora_members_14.remove as unknown as RegisteredLunoraFunction,
-    "members:setRole": lunora_members_14.setRole as unknown as RegisteredLunoraFunction,
-    "metrics:list": lunora_metrics_15.list as unknown as RegisteredLunoraFunction,
-    "organizations:cancelDeletion": lunora_organizations_16.cancelDeletion as unknown as RegisteredLunoraFunction,
-    "organizations:create": lunora_organizations_16.create as unknown as RegisteredLunoraFunction,
-    "organizations:getBySlug": lunora_organizations_16.getBySlug as unknown as RegisteredLunoraFunction,
-    "organizations:linkCreditsAccount": lunora_organizations_16.linkCreditsAccount as unknown as RegisteredLunoraFunction,
-    "organizations:list": lunora_organizations_16.list as unknown as RegisteredLunoraFunction,
-    "organizations:purgeDeleted": lunora_organizations_16.purgeDeleted as unknown as RegisteredLunoraFunction,
-    "organizations:rename": lunora_organizations_16.rename as unknown as RegisteredLunoraFunction,
-    "organizations:requestDeletion": lunora_organizations_16.requestDeletion as unknown as RegisteredLunoraFunction,
-    "projects:byGithubRepo": lunora_projects_17.byGithubRepo as unknown as RegisteredLunoraFunction,
-    "projects:create": lunora_projects_17.create as unknown as RegisteredLunoraFunction,
-    "projects:listByOrg": lunora_projects_17.listByOrg as unknown as RegisteredLunoraFunction,
-    "projects:rename": lunora_projects_17.rename as unknown as RegisteredLunoraFunction,
-    "secrets:list": lunora_secrets_18.list as unknown as RegisteredLunoraFunction,
-    "secrets:listEncrypted": lunora_secrets_18.listEncrypted as unknown as RegisteredLunoraFunction,
-    "secrets:remove": lunora_secrets_18.remove as unknown as RegisteredLunoraFunction,
-    "secrets:store": lunora_secrets_18.store as unknown as RegisteredLunoraFunction,
-    "telemetry:ingest": lunora_telemetry_19.ingest as unknown as RegisteredLunoraFunction,
-    "telemetry:orgForDeployKey": lunora_telemetry_19.orgForDeployKey as unknown as RegisteredLunoraFunction,
-    "telemetry:pruneObservations": lunora_telemetry_19.pruneObservations as unknown as RegisteredLunoraFunction,
-    "traces:get": lunora_traces_20.get as unknown as RegisteredLunoraFunction,
-    "traces:getArchived": lunora_traces_20.getArchived as unknown as RegisteredLunoraFunction,
-    "traces:list": lunora_traces_20.list as unknown as RegisteredLunoraFunction,
-    "uptime:prune": lunora_uptime_21.prune as unknown as RegisteredLunoraFunction,
-    "uptime:recent": lunora_uptime_21.recent as unknown as RegisteredLunoraFunction,
-    "uptime:summary": lunora_uptime_21.summary as unknown as RegisteredLunoraFunction,
-    "usage:enforceSpendCaps": lunora_usage_22.enforceSpendCaps as unknown as RegisteredLunoraFunction,
-    "usage:ingest": lunora_usage_22.ingest as unknown as RegisteredLunoraFunction,
-    "usage:overageWatermark": lunora_usage_22.overageWatermark as unknown as RegisteredLunoraFunction,
-    "usage:record": lunora_usage_22.record as unknown as RegisteredLunoraFunction,
-    "usage:recordOverageDebit": lunora_usage_22.recordOverageDebit as unknown as RegisteredLunoraFunction,
-    "usage:rollup": lunora_usage_22.rollup as unknown as RegisteredLunoraFunction,
-    "usage:series": lunora_usage_22.series as unknown as RegisteredLunoraFunction,
-    "usage:summary": lunora_usage_22.summary as unknown as RegisteredLunoraFunction,
+    "dashboards:create": lunora_dashboards_5.create as unknown as RegisteredLunoraFunction,
+    "dashboards:get": lunora_dashboards_5.get as unknown as RegisteredLunoraFunction,
+    "dashboards:list": lunora_dashboards_5.list as unknown as RegisteredLunoraFunction,
+    "dashboards:remove": lunora_dashboards_5.remove as unknown as RegisteredLunoraFunction,
+    "dashboards:update": lunora_dashboards_5.update as unknown as RegisteredLunoraFunction,
+    "deploy_keys:ingestKeyCipher": lunora_deploy_keys_6.ingestKeyCipher as unknown as RegisteredLunoraFunction,
+    "deploy_keys:issue": lunora_deploy_keys_6.issue as unknown as RegisteredLunoraFunction,
+    "deploy_keys:list": lunora_deploy_keys_6.list as unknown as RegisteredLunoraFunction,
+    "deploy_keys:recordIngestKey": lunora_deploy_keys_6.recordIngestKey as unknown as RegisteredLunoraFunction,
+    "deploy_keys:revoke": lunora_deploy_keys_6.revoke as unknown as RegisteredLunoraFunction,
+    "deploy_keys:verify": lunora_deploy_keys_6.verify as unknown as RegisteredLunoraFunction,
+    "deployments:activate": lunora_deployments_7.activate as unknown as RegisteredLunoraFunction,
+    "deployments:adminTarget": lunora_deployments_7.adminTarget as unknown as RegisteredLunoraFunction,
+    "deployments:cleanupExpiredPreviews": lunora_deployments_7.cleanupExpiredPreviews as unknown as RegisteredLunoraFunction,
+    "deployments:create": lunora_deployments_7.create as unknown as RegisteredLunoraFunction,
+    "deployments:listByProject": lunora_deployments_7.listByProject as unknown as RegisteredLunoraFunction,
+    "deployments:planForScript": lunora_deployments_7.planForScript as unknown as RegisteredLunoraFunction,
+    "deployments:pruneSuperseded": lunora_deployments_7.pruneSuperseded as unknown as RegisteredLunoraFunction,
+    "deployments:rollback": lunora_deployments_7.rollback as unknown as RegisteredLunoraFunction,
+    "deployments:routeForAlias": lunora_deployments_7.routeForAlias as unknown as RegisteredLunoraFunction,
+    "deployments:updateStatus": lunora_deployments_7.updateStatus as unknown as RegisteredLunoraFunction,
+    "domains:add": lunora_domains_8.add as unknown as RegisteredLunoraFunction,
+    "domains:get": lunora_domains_8.get as unknown as RegisteredLunoraFunction,
+    "domains:list": lunora_domains_8.list as unknown as RegisteredLunoraFunction,
+    "domains:markVerified": lunora_domains_8.markVerified as unknown as RegisteredLunoraFunction,
+    "domains:remove": lunora_domains_8.remove as unknown as RegisteredLunoraFunction,
+    "domains:routeForHostname": lunora_domains_8.routeForHostname as unknown as RegisteredLunoraFunction,
+    "fanout:tick": lunora_fanout_9.tick as unknown as RegisteredLunoraFunction,
+    "github_installations:claim": lunora_github_installations_10.claim as unknown as RegisteredLunoraFunction,
+    "github_installations:list": lunora_github_installations_10.list as unknown as RegisteredLunoraFunction,
+    "github_installations:record": lunora_github_installations_10.record as unknown as RegisteredLunoraFunction,
+    "github_installations:remove": lunora_github_installations_10.remove as unknown as RegisteredLunoraFunction,
+    "incidents:investigate": lunora_incidents_11.investigate as unknown as RegisteredLunoraFunction,
+    "incidents:list": lunora_incidents_11.list as unknown as RegisteredLunoraFunction,
+    "incidents:setStatus": lunora_incidents_11.setStatus as unknown as RegisteredLunoraFunction,
+    "incidents:triage": lunora_incidents_11.triage as unknown as RegisteredLunoraFunction,
+    "invitations:accept": lunora_invitations_12.accept as unknown as RegisteredLunoraFunction,
+    "invitations:invite": lunora_invitations_12.invite as unknown as RegisteredLunoraFunction,
+    "invitations:list": lunora_invitations_12.list as unknown as RegisteredLunoraFunction,
+    "invitations:revoke": lunora_invitations_12.revoke as unknown as RegisteredLunoraFunction,
+    "issues:list": lunora_issues_13.list as unknown as RegisteredLunoraFunction,
+    "issues:setStatus": lunora_issues_13.setStatus as unknown as RegisteredLunoraFunction,
+    "logs:ingest": lunora_logs_14.ingest as unknown as RegisteredLunoraFunction,
+    "logs:ingestInternal": lunora_logs_14.ingestInternal as unknown as RegisteredLunoraFunction,
+    "logs:list": lunora_logs_14.list as unknown as RegisteredLunoraFunction,
+    "logs:orgForScript": lunora_logs_14.orgForScript as unknown as RegisteredLunoraFunction,
+    "logs:prune": lunora_logs_14.prune as unknown as RegisteredLunoraFunction,
+    "members:add": lunora_members_15.add as unknown as RegisteredLunoraFunction,
+    "members:list": lunora_members_15.list as unknown as RegisteredLunoraFunction,
+    "members:remove": lunora_members_15.remove as unknown as RegisteredLunoraFunction,
+    "members:setRole": lunora_members_15.setRole as unknown as RegisteredLunoraFunction,
+    "metrics:list": lunora_metrics_16.list as unknown as RegisteredLunoraFunction,
+    "organizations:cancelDeletion": lunora_organizations_17.cancelDeletion as unknown as RegisteredLunoraFunction,
+    "organizations:create": lunora_organizations_17.create as unknown as RegisteredLunoraFunction,
+    "organizations:getBySlug": lunora_organizations_17.getBySlug as unknown as RegisteredLunoraFunction,
+    "organizations:linkCreditsAccount": lunora_organizations_17.linkCreditsAccount as unknown as RegisteredLunoraFunction,
+    "organizations:list": lunora_organizations_17.list as unknown as RegisteredLunoraFunction,
+    "organizations:purgeDeleted": lunora_organizations_17.purgeDeleted as unknown as RegisteredLunoraFunction,
+    "organizations:rename": lunora_organizations_17.rename as unknown as RegisteredLunoraFunction,
+    "organizations:requestDeletion": lunora_organizations_17.requestDeletion as unknown as RegisteredLunoraFunction,
+    "projects:byGithubRepo": lunora_projects_18.byGithubRepo as unknown as RegisteredLunoraFunction,
+    "projects:create": lunora_projects_18.create as unknown as RegisteredLunoraFunction,
+    "projects:listByOrg": lunora_projects_18.listByOrg as unknown as RegisteredLunoraFunction,
+    "projects:rename": lunora_projects_18.rename as unknown as RegisteredLunoraFunction,
+    "secrets:list": lunora_secrets_19.list as unknown as RegisteredLunoraFunction,
+    "secrets:listEncrypted": lunora_secrets_19.listEncrypted as unknown as RegisteredLunoraFunction,
+    "secrets:remove": lunora_secrets_19.remove as unknown as RegisteredLunoraFunction,
+    "secrets:store": lunora_secrets_19.store as unknown as RegisteredLunoraFunction,
+    "telemetry:ingest": lunora_telemetry_20.ingest as unknown as RegisteredLunoraFunction,
+    "telemetry:orgForDeployKey": lunora_telemetry_20.orgForDeployKey as unknown as RegisteredLunoraFunction,
+    "telemetry:pruneObservations": lunora_telemetry_20.pruneObservations as unknown as RegisteredLunoraFunction,
+    "traces:get": lunora_traces_21.get as unknown as RegisteredLunoraFunction,
+    "traces:getArchived": lunora_traces_21.getArchived as unknown as RegisteredLunoraFunction,
+    "traces:list": lunora_traces_21.list as unknown as RegisteredLunoraFunction,
+    "uptime:prune": lunora_uptime_22.prune as unknown as RegisteredLunoraFunction,
+    "uptime:recent": lunora_uptime_22.recent as unknown as RegisteredLunoraFunction,
+    "uptime:summary": lunora_uptime_22.summary as unknown as RegisteredLunoraFunction,
+    "usage:enforceSpendCaps": lunora_usage_23.enforceSpendCaps as unknown as RegisteredLunoraFunction,
+    "usage:ingest": lunora_usage_23.ingest as unknown as RegisteredLunoraFunction,
+    "usage:overageWatermark": lunora_usage_23.overageWatermark as unknown as RegisteredLunoraFunction,
+    "usage:record": lunora_usage_23.record as unknown as RegisteredLunoraFunction,
+    "usage:recordOverageDebit": lunora_usage_23.recordOverageDebit as unknown as RegisteredLunoraFunction,
+    "usage:rollup": lunora_usage_23.rollup as unknown as RegisteredLunoraFunction,
+    "usage:series": lunora_usage_23.series as unknown as RegisteredLunoraFunction,
+    "usage:summary": lunora_usage_23.summary as unknown as RegisteredLunoraFunction,
 };
 
 /**
@@ -316,18 +322,35 @@ __has1 = true;
 if (typeof source["name"] !== "string") return DEFER;
 return { "cloudflareAccountId": source["cloudflareAccountId"], "dispatchNamespacePrefix": source["dispatchNamespacePrefix"], ...(__has1 ? { "jurisdiction": __val1 } : {}), "name": source["name"] };
 });
-installCompiledValidatorMap(lunora_deploy_keys_5.ingestKeyCipher.args, (source) => {
+installCompiledValidatorMap(lunora_dashboards_5.get.args, (source) => {
+if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
+if (typeof source["id"] !== "string") return DEFER;
+if (typeof source["organizationId"] !== "string") return DEFER;
+return { "id": source["id"], "organizationId": source["organizationId"] };
+});
+installCompiledValidatorMap(lunora_dashboards_5.list.args, (source) => {
+if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
+if (typeof source["organizationId"] !== "string") return DEFER;
+return { "organizationId": source["organizationId"] };
+});
+installCompiledValidatorMap(lunora_dashboards_5.remove.args, (source) => {
+if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
+if (typeof source["id"] !== "string") return DEFER;
+if (typeof source["organizationId"] !== "string") return DEFER;
+return { "id": source["id"], "organizationId": source["organizationId"] };
+});
+installCompiledValidatorMap(lunora_deploy_keys_6.ingestKeyCipher.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["deployKey"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "deployKey": source["deployKey"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_deploy_keys_5.list.args, (source) => {
+installCompiledValidatorMap(lunora_deploy_keys_6.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_deploy_keys_5.recordIngestKey.args, (source) => {
+installCompiledValidatorMap(lunora_deploy_keys_6.recordIngestKey.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["deployKey"] !== "string") return DEFER;
 if (typeof source["encryptedSecret"] !== "object" || source["encryptedSecret"] === null || Array.isArray(source["encryptedSecret"])) return DEFER;
@@ -338,18 +361,18 @@ if (typeof source["hashedKey"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "deployKey": source["deployKey"], "encryptedSecret": __obj1, "hashedKey": source["hashedKey"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_deploy_keys_5.revoke.args, (source) => {
+installCompiledValidatorMap(lunora_deploy_keys_6.revoke.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_deploy_keys_5.verify.args, (source) => {
+installCompiledValidatorMap(lunora_deploy_keys_6.verify.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["key"] !== "string") return DEFER;
 return { "key": source["key"] };
 });
-installCompiledValidatorMap(lunora_deployments_6.activate.args, (source) => {
+installCompiledValidatorMap(lunora_deployments_7.activate.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -361,24 +384,24 @@ __has1 = true;
 if (typeof source["id"] !== "string") return DEFER;
 return { ...(__has1 ? { "deployKey": __val1 } : {}), "id": source["id"] };
 });
-installCompiledValidatorMap(lunora_deployments_6.adminTarget.args, (source) => {
+installCompiledValidatorMap(lunora_deployments_7.adminTarget.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["deploymentId"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "deploymentId": source["deploymentId"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_deployments_6.listByProject.args, (source) => {
+installCompiledValidatorMap(lunora_deployments_7.listByProject.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["projectId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"], "projectId": source["projectId"] };
 });
-installCompiledValidatorMap(lunora_deployments_6.planForScript.args, (source) => {
+installCompiledValidatorMap(lunora_deployments_7.planForScript.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["scriptName"] !== "string") return DEFER;
 return { "scriptName": source["scriptName"] };
 });
-installCompiledValidatorMap(lunora_deployments_6.rollback.args, (source) => {
+installCompiledValidatorMap(lunora_deployments_7.rollback.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -391,12 +414,12 @@ if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { ...(__has1 ? { "deployKey": __val1 } : {}), "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_deployments_6.routeForAlias.args, (source) => {
+installCompiledValidatorMap(lunora_deployments_7.routeForAlias.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["alias"] !== "string") return DEFER;
 return { "alias": source["alias"] };
 });
-installCompiledValidatorMap(lunora_domains_7.add.args, (source) => {
+installCompiledValidatorMap(lunora_domains_8.add.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["hostname"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
@@ -417,19 +440,19 @@ __has2 = true;
 }
 return { "hostname": source["hostname"], "organizationId": source["organizationId"], "projectId": source["projectId"], ...(__has1 ? { "redirectStatusCode": __val1 } : {}), ...(__has2 ? { "redirectTo": __val2 } : {}) };
 });
-installCompiledValidatorMap(lunora_domains_7.get.args, (source) => {
+installCompiledValidatorMap(lunora_domains_8.get.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_domains_7.list.args, (source) => {
+installCompiledValidatorMap(lunora_domains_8.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["projectId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"], "projectId": source["projectId"] };
 });
-installCompiledValidatorMap(lunora_domains_7.markVerified.args, (source) => {
+installCompiledValidatorMap(lunora_domains_8.markVerified.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -443,106 +466,106 @@ if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["verified"] !== "boolean") return DEFER;
 return { ...(__has1 ? { "customHostnameId": __val1 } : {}), "id": source["id"], "organizationId": source["organizationId"], "verified": source["verified"] };
 });
-installCompiledValidatorMap(lunora_domains_7.remove.args, (source) => {
+installCompiledValidatorMap(lunora_domains_8.remove.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_domains_7.routeForHostname.args, (source) => {
+installCompiledValidatorMap(lunora_domains_8.routeForHostname.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["hostname"] !== "string") return DEFER;
 return { "hostname": source["hostname"] };
 });
-installCompiledValidatorMap(lunora_github_installations_9.claim.args, (source) => {
+installCompiledValidatorMap(lunora_github_installations_10.claim.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["installationId"] !== "number" || !Number.isFinite(source["installationId"])) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "installationId": source["installationId"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_github_installations_9.list.args, (source) => {
+installCompiledValidatorMap(lunora_github_installations_10.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_github_installations_9.record.args, (source) => {
+installCompiledValidatorMap(lunora_github_installations_10.record.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["accountLogin"] !== "string") return DEFER;
 if (typeof source["installationId"] !== "number" || !Number.isFinite(source["installationId"])) return DEFER;
 return { "accountLogin": source["accountLogin"], "installationId": source["installationId"] };
 });
-installCompiledValidatorMap(lunora_github_installations_9.remove.args, (source) => {
+installCompiledValidatorMap(lunora_github_installations_10.remove.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["installationId"] !== "number" || !Number.isFinite(source["installationId"])) return DEFER;
 return { "installationId": source["installationId"] };
 });
-installCompiledValidatorMap(lunora_incidents_10.investigate.args, (source) => {
+installCompiledValidatorMap(lunora_incidents_11.investigate.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_incidents_10.list.args, (source) => {
+installCompiledValidatorMap(lunora_incidents_11.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_incidents_10.triage.args, (source) => {
+installCompiledValidatorMap(lunora_incidents_11.triage.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_invitations_11.accept.args, (source) => {
+installCompiledValidatorMap(lunora_invitations_12.accept.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["token"] !== "string") return DEFER;
 return { "token": source["token"] };
 });
-installCompiledValidatorMap(lunora_invitations_11.invite.args, (source) => {
+installCompiledValidatorMap(lunora_invitations_12.invite.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["email"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "email": source["email"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_invitations_11.list.args, (source) => {
+installCompiledValidatorMap(lunora_invitations_12.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_invitations_11.revoke.args, (source) => {
+installCompiledValidatorMap(lunora_invitations_12.revoke.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_issues_12.list.args, (source) => {
+installCompiledValidatorMap(lunora_issues_13.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_logs_13.orgForScript.args, (source) => {
+installCompiledValidatorMap(lunora_logs_14.orgForScript.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["scriptName"] !== "string") return DEFER;
 return { "scriptName": source["scriptName"] };
 });
-installCompiledValidatorMap(lunora_members_14.add.args, (source) => {
+installCompiledValidatorMap(lunora_members_15.add.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["userId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"], "userId": source["userId"] };
 });
-installCompiledValidatorMap(lunora_members_14.list.args, (source) => {
+installCompiledValidatorMap(lunora_members_15.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_members_14.remove.args, (source) => {
+installCompiledValidatorMap(lunora_members_15.remove.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_metrics_15.list.args, (source) => {
+installCompiledValidatorMap(lunora_metrics_16.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -561,39 +584,39 @@ __has2 = true;
 }
 return { ...(__has1 ? { "from": __val1 } : {}), "organizationId": source["organizationId"], ...(__has2 ? { "to": __val2 } : {}) };
 });
-installCompiledValidatorMap(lunora_organizations_16.cancelDeletion.args, (source) => {
+installCompiledValidatorMap(lunora_organizations_17.cancelDeletion.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_organizations_16.getBySlug.args, (source) => {
+installCompiledValidatorMap(lunora_organizations_17.getBySlug.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["slug"] !== "string") return DEFER;
 return { "slug": source["slug"] };
 });
-installCompiledValidatorMap(lunora_organizations_16.linkCreditsAccount.args, (source) => {
+installCompiledValidatorMap(lunora_organizations_17.linkCreditsAccount.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["creditsAccountId"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "creditsAccountId": source["creditsAccountId"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_organizations_16.rename.args, (source) => {
+installCompiledValidatorMap(lunora_organizations_17.rename.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["name"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "name": source["name"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_organizations_16.requestDeletion.args, (source) => {
+installCompiledValidatorMap(lunora_organizations_17.requestDeletion.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_projects_17.byGithubRepo.args, (source) => {
+installCompiledValidatorMap(lunora_projects_18.byGithubRepo.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["repository"] !== "string") return DEFER;
 return { "repository": source["repository"] };
 });
-installCompiledValidatorMap(lunora_projects_17.create.args, (source) => {
+installCompiledValidatorMap(lunora_projects_18.create.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -614,48 +637,48 @@ if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["slug"] !== "string") return DEFER;
 return { ...(__has1 ? { "framework": __val1 } : {}), ...(__has2 ? { "githubRepo": __val2 } : {}), "name": source["name"], "organizationId": source["organizationId"], "slug": source["slug"] };
 });
-installCompiledValidatorMap(lunora_projects_17.listByOrg.args, (source) => {
+installCompiledValidatorMap(lunora_projects_18.listByOrg.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_projects_17.rename.args, (source) => {
+installCompiledValidatorMap(lunora_projects_18.rename.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["name"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "name": source["name"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_secrets_18.list.args, (source) => {
+installCompiledValidatorMap(lunora_secrets_19.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["projectId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"], "projectId": source["projectId"] };
 });
-installCompiledValidatorMap(lunora_secrets_18.remove.args, (source) => {
+installCompiledValidatorMap(lunora_secrets_19.remove.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["id"] !== "string") return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "id": source["id"], "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_telemetry_19.orgForDeployKey.args, (source) => {
+installCompiledValidatorMap(lunora_telemetry_20.orgForDeployKey.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["deployKey"] !== "string") return DEFER;
 return { "deployKey": source["deployKey"] };
 });
-installCompiledValidatorMap(lunora_traces_20.get.args, (source) => {
+installCompiledValidatorMap(lunora_traces_21.get.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["traceId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"], "traceId": source["traceId"] };
 });
-installCompiledValidatorMap(lunora_traces_20.getArchived.args, (source) => {
+installCompiledValidatorMap(lunora_traces_21.getArchived.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["traceId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"], "traceId": source["traceId"] };
 });
-installCompiledValidatorMap(lunora_traces_20.list.args, (source) => {
+installCompiledValidatorMap(lunora_traces_21.list.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -709,7 +732,7 @@ __has7 = true;
 }
 return { ...(__has1 ? { "deploymentId": __val1 } : {}), ...(__has2 ? { "errorOnly": __val2 } : {}), ...(__has3 ? { "from": __val3 } : {}), ...(__has4 ? { "functionPath": __val4 } : {}), ...(__has5 ? { "limit": __val5 } : {}), ...(__has6 ? { "minDurationMs": __val6 } : {}), "organizationId": source["organizationId"], ...(__has7 ? { "to": __val7 } : {}) };
 });
-installCompiledValidatorMap(lunora_uptime_21.recent.args, (source) => {
+installCompiledValidatorMap(lunora_uptime_22.recent.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["deploymentId"] !== "string") return DEFER;
 let __has1 = false;
@@ -722,12 +745,12 @@ __has1 = true;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "deploymentId": source["deploymentId"], ...(__has1 ? { "limit": __val1 } : {}), "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_uptime_21.summary.args, (source) => {
+installCompiledValidatorMap(lunora_uptime_22.summary.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 return { "organizationId": source["organizationId"] };
 });
-installCompiledValidatorMap(lunora_usage_22.ingest.args, (source) => {
+installCompiledValidatorMap(lunora_usage_23.ingest.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["deployKey"] !== "string") return DEFER;
 let __has1 = false;
@@ -742,13 +765,13 @@ if (typeof source["periodStart"] !== "number" || !Number.isFinite(source["period
 if (typeof source["quantity"] !== "number" || !Number.isFinite(source["quantity"])) return DEFER;
 return { "deployKey": source["deployKey"], ...(__has1 ? { "deploymentId": __val1 } : {}), "organizationId": source["organizationId"], "periodStart": source["periodStart"], "quantity": source["quantity"] };
 });
-installCompiledValidatorMap(lunora_usage_22.overageWatermark.args, (source) => {
+installCompiledValidatorMap(lunora_usage_23.overageWatermark.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["periodStart"] !== "number" || !Number.isFinite(source["periodStart"])) return DEFER;
 return { "organizationId": source["organizationId"], "periodStart": source["periodStart"] };
 });
-installCompiledValidatorMap(lunora_usage_22.record.args, (source) => {
+installCompiledValidatorMap(lunora_usage_23.record.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 let __has1 = false;
 let __val1;
@@ -762,20 +785,20 @@ if (typeof source["periodStart"] !== "number" || !Number.isFinite(source["period
 if (typeof source["quantity"] !== "number" || !Number.isFinite(source["quantity"])) return DEFER;
 return { ...(__has1 ? { "deploymentId": __val1 } : {}), "organizationId": source["organizationId"], "periodStart": source["periodStart"], "quantity": source["quantity"] };
 });
-installCompiledValidatorMap(lunora_usage_22.recordOverageDebit.args, (source) => {
+installCompiledValidatorMap(lunora_usage_23.recordOverageDebit.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["debitedCredits"] !== "number" || !Number.isFinite(source["debitedCredits"])) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["periodStart"] !== "number" || !Number.isFinite(source["periodStart"])) return DEFER;
 return { "debitedCredits": source["debitedCredits"], "organizationId": source["organizationId"], "periodStart": source["periodStart"] };
 });
-installCompiledValidatorMap(lunora_usage_22.series.args, (source) => {
+installCompiledValidatorMap(lunora_usage_23.series.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["periodStart"] !== "number" || !Number.isFinite(source["periodStart"])) return DEFER;
 return { "organizationId": source["organizationId"], "periodStart": source["periodStart"] };
 });
-installCompiledValidatorMap(lunora_usage_22.summary.args, (source) => {
+installCompiledValidatorMap(lunora_usage_23.summary.args, (source) => {
 if (typeof source !== "object" || source === null || Array.isArray(source)) return DEFER;
 if (typeof source["organizationId"] !== "string") return DEFER;
 if (typeof source["periodStart"] !== "number" || !Number.isFinite(source["periodStart"])) return DEFER;
@@ -855,6 +878,13 @@ export interface Caller {
     cells: {
         list: (args?: {}) => Promise<{ _id: Id<"cells">; cloudflareAccountId: string; createdAt: number; dispatchNamespacePrefix: string; jurisdiction?: string; name: string; status: "active" | "draining" | "suspended" }[]>;
         register: (args: { cloudflareAccountId: string; dispatchNamespacePrefix: string; jurisdiction?: string; name: string }) => Promise<Id<"cells">>;
+    };
+    dashboards: {
+        create: (args: { name: string; organizationId: Id<"organizations">; panels?: Array<unknown> }) => Promise<Id<"dashboards">>;
+        get: (args: { id: Id<"dashboards">; organizationId: Id<"organizations"> }) => Promise<null | { _id: Id<"dashboards">; createdAt: number; name: string; panels: { config: { filter?: string; metricName?: string; stat?: "count" | "first" | "last"; }; id: string; kind: "logs" | "metric" | "stat" | "traces"; title: string }[]; updatedAt: number }>;
+        list: (args: { organizationId: Id<"organizations"> }) => Promise<{ _id: Id<"dashboards">; createdAt: number; name: string; panels: { config: { filter?: string; metricName?: string; stat?: "count" | "first" | "last"; }; id: string; kind: "logs" | "metric" | "stat" | "traces"; title: string }[]; updatedAt: number }[]>;
+        remove: (args: { id: Id<"dashboards">; organizationId: Id<"organizations"> }) => Promise<Id<"dashboards">>;
+        update: (args: { id: Id<"dashboards">; name?: string; organizationId: Id<"organizations">; panels?: Array<unknown> }) => Promise<Id<"dashboards">>;
     };
     deploy_keys: {
         ingestKeyCipher: (args: { deployKey: string; organizationId: Id<"organizations"> }) => Promise<null | { ciphertext: string; iv: string }>;
@@ -1019,6 +1049,13 @@ export const createCaller = (context: CallerCtx): Caller => ({
     cells: {
         list: (args) => callRegistered(context, "cells:list", args),
         register: (args) => callRegistered(context, "cells:register", args),
+    },
+    dashboards: {
+        create: (args) => callRegistered(context, "dashboards:create", args),
+        get: (args) => callRegistered(context, "dashboards:get", args),
+        list: (args) => callRegistered(context, "dashboards:list", args),
+        remove: (args) => callRegistered(context, "dashboards:remove", args),
+        update: (args) => callRegistered(context, "dashboards:update", args),
     },
     deploy_keys: {
         ingestKeyCipher: (args) => callRegistered(context, "deploy_keys:ingestKeyCipher", args),

--- a/apps/cloud/lunora/_generated/openapi.json
+++ b/apps/cloud/lunora/_generated/openapi.json
@@ -1366,6 +1366,359 @@
         "x-lunora-function-kind": "mutation"
       }
     },
+    "/_lunora/rpc#dashboards:create": {
+      "post": {
+        "description": "Invoke the `mutation` `dashboards:create` over the Lunora RPC envelope (POST /_lunora/rpc).",
+        "operationId": "dashboards:create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "organizationId": {
+                        "description": "Id<\"organizations\">",
+                        "type": "string",
+                        "x-lunora-table": "organizations"
+                      },
+                      "panels": {
+                        "items": {},
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "organizationId"
+                    ],
+                    "type": "object"
+                  },
+                  "functionPath": {
+                    "const": "dashboards:create",
+                    "type": "string"
+                  },
+                  "shardKey": {
+                    "description": "Optional shard key; omitted routes to the default shard.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "functionPath"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                }
+              }
+            },
+            "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+          },
+          "default": {
+            "$ref": "#/components/responses/LunoraError"
+          }
+        },
+        "summary": "mutation: dashboards:create",
+        "tags": [
+          "dashboards"
+        ],
+        "x-lunora-function-kind": "mutation"
+      }
+    },
+    "/_lunora/rpc#dashboards:get": {
+      "post": {
+        "description": "Invoke the `query` `dashboards:get` over the Lunora RPC envelope (POST /_lunora/rpc).",
+        "operationId": "dashboards:get",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "description": "Id<\"dashboards\">",
+                        "type": "string",
+                        "x-lunora-table": "dashboards"
+                      },
+                      "organizationId": {
+                        "description": "Id<\"organizations\">",
+                        "type": "string",
+                        "x-lunora-table": "organizations"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "organizationId"
+                    ],
+                    "type": "object"
+                  },
+                  "functionPath": {
+                    "const": "dashboards:get",
+                    "type": "string"
+                  },
+                  "shardKey": {
+                    "description": "Optional shard key; omitted routes to the default shard.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "functionPath"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                }
+              }
+            },
+            "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+          },
+          "default": {
+            "$ref": "#/components/responses/LunoraError"
+          }
+        },
+        "summary": "query: dashboards:get",
+        "tags": [
+          "dashboards"
+        ],
+        "x-lunora-function-kind": "query"
+      }
+    },
+    "/_lunora/rpc#dashboards:list": {
+      "post": {
+        "description": "Invoke the `query` `dashboards:list` over the Lunora RPC envelope (POST /_lunora/rpc).",
+        "operationId": "dashboards:list",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "organizationId": {
+                        "description": "Id<\"organizations\">",
+                        "type": "string",
+                        "x-lunora-table": "organizations"
+                      }
+                    },
+                    "required": [
+                      "organizationId"
+                    ],
+                    "type": "object"
+                  },
+                  "functionPath": {
+                    "const": "dashboards:list",
+                    "type": "string"
+                  },
+                  "shardKey": {
+                    "description": "Optional shard key; omitted routes to the default shard.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "functionPath"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                }
+              }
+            },
+            "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+          },
+          "default": {
+            "$ref": "#/components/responses/LunoraError"
+          }
+        },
+        "summary": "query: dashboards:list",
+        "tags": [
+          "dashboards"
+        ],
+        "x-lunora-function-kind": "query"
+      }
+    },
+    "/_lunora/rpc#dashboards:remove": {
+      "post": {
+        "description": "Invoke the `mutation` `dashboards:remove` over the Lunora RPC envelope (POST /_lunora/rpc).",
+        "operationId": "dashboards:remove",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "description": "Id<\"dashboards\">",
+                        "type": "string",
+                        "x-lunora-table": "dashboards"
+                      },
+                      "organizationId": {
+                        "description": "Id<\"organizations\">",
+                        "type": "string",
+                        "x-lunora-table": "organizations"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "organizationId"
+                    ],
+                    "type": "object"
+                  },
+                  "functionPath": {
+                    "const": "dashboards:remove",
+                    "type": "string"
+                  },
+                  "shardKey": {
+                    "description": "Optional shard key; omitted routes to the default shard.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "functionPath"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                }
+              }
+            },
+            "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+          },
+          "default": {
+            "$ref": "#/components/responses/LunoraError"
+          }
+        },
+        "summary": "mutation: dashboards:remove",
+        "tags": [
+          "dashboards"
+        ],
+        "x-lunora-function-kind": "mutation"
+      }
+    },
+    "/_lunora/rpc#dashboards:update": {
+      "post": {
+        "description": "Invoke the `mutation` `dashboards:update` over the Lunora RPC envelope (POST /_lunora/rpc).",
+        "operationId": "dashboards:update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "args": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "id": {
+                        "description": "Id<\"dashboards\">",
+                        "type": "string",
+                        "x-lunora-table": "dashboards"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "organizationId": {
+                        "description": "Id<\"organizations\">",
+                        "type": "string",
+                        "x-lunora-table": "organizations"
+                      },
+                      "panels": {
+                        "items": {},
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "organizationId"
+                    ],
+                    "type": "object"
+                  },
+                  "functionPath": {
+                    "const": "dashboards:update",
+                    "type": "string"
+                  },
+                  "shardKey": {
+                    "description": "Optional shard key; omitted routes to the default shard.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "functionPath"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                }
+              }
+            },
+            "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+          },
+          "default": {
+            "$ref": "#/components/responses/LunoraError"
+          }
+        },
+        "summary": "mutation: dashboards:update",
+        "tags": [
+          "dashboards"
+        ],
+        "x-lunora-function-kind": "mutation"
+      }
+    },
     "/_lunora/rpc#deploy_keys:ingestKeyCipher": {
       "post": {
         "description": "Invoke the `query` `deploy_keys:ingestKeyCipher` over the Lunora RPC envelope (POST /_lunora/rpc).",
@@ -6035,6 +6388,10 @@
     {
       "description": "Operations declared in `lunora/cells`.",
       "name": "cells"
+    },
+    {
+      "description": "Operations declared in `lunora/dashboards`.",
+      "name": "dashboards"
     },
     {
       "description": "Operations declared in `lunora/deploy_keys`.",

--- a/apps/cloud/lunora/_generated/openapi.ts
+++ b/apps/cloud/lunora/_generated/openapi.ts
@@ -1369,6 +1369,359 @@ export const openApiSpec: Record<string, unknown> = {
                 "x-lunora-function-kind": "mutation"
             }
         },
+        "/_lunora/rpc#dashboards:create": {
+            "post": {
+                "description": "Invoke the `mutation` `dashboards:create` over the Lunora RPC envelope (POST /_lunora/rpc).",
+                "operationId": "dashboards:create",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "args": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "organizationId": {
+                                                "description": "Id<\"organizations\">",
+                                                "type": "string",
+                                                "x-lunora-table": "organizations"
+                                            },
+                                            "panels": {
+                                                "items": {},
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "organizationId"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "functionPath": {
+                                        "const": "dashboards:create",
+                                        "type": "string"
+                                    },
+                                    "shardKey": {
+                                        "description": "Optional shard key; omitted routes to the default shard.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "functionPath"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                                }
+                            }
+                        },
+                        "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/LunoraError"
+                    }
+                },
+                "summary": "mutation: dashboards:create",
+                "tags": [
+                    "dashboards"
+                ],
+                "x-lunora-function-kind": "mutation"
+            }
+        },
+        "/_lunora/rpc#dashboards:get": {
+            "post": {
+                "description": "Invoke the `query` `dashboards:get` over the Lunora RPC envelope (POST /_lunora/rpc).",
+                "operationId": "dashboards:get",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "args": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "id": {
+                                                "description": "Id<\"dashboards\">",
+                                                "type": "string",
+                                                "x-lunora-table": "dashboards"
+                                            },
+                                            "organizationId": {
+                                                "description": "Id<\"organizations\">",
+                                                "type": "string",
+                                                "x-lunora-table": "organizations"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "organizationId"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "functionPath": {
+                                        "const": "dashboards:get",
+                                        "type": "string"
+                                    },
+                                    "shardKey": {
+                                        "description": "Optional shard key; omitted routes to the default shard.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "functionPath"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                                }
+                            }
+                        },
+                        "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/LunoraError"
+                    }
+                },
+                "summary": "query: dashboards:get",
+                "tags": [
+                    "dashboards"
+                ],
+                "x-lunora-function-kind": "query"
+            }
+        },
+        "/_lunora/rpc#dashboards:list": {
+            "post": {
+                "description": "Invoke the `query` `dashboards:list` over the Lunora RPC envelope (POST /_lunora/rpc).",
+                "operationId": "dashboards:list",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "args": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "organizationId": {
+                                                "description": "Id<\"organizations\">",
+                                                "type": "string",
+                                                "x-lunora-table": "organizations"
+                                            }
+                                        },
+                                        "required": [
+                                            "organizationId"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "functionPath": {
+                                        "const": "dashboards:list",
+                                        "type": "string"
+                                    },
+                                    "shardKey": {
+                                        "description": "Optional shard key; omitted routes to the default shard.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "functionPath"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                                }
+                            }
+                        },
+                        "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/LunoraError"
+                    }
+                },
+                "summary": "query: dashboards:list",
+                "tags": [
+                    "dashboards"
+                ],
+                "x-lunora-function-kind": "query"
+            }
+        },
+        "/_lunora/rpc#dashboards:remove": {
+            "post": {
+                "description": "Invoke the `mutation` `dashboards:remove` over the Lunora RPC envelope (POST /_lunora/rpc).",
+                "operationId": "dashboards:remove",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "args": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "id": {
+                                                "description": "Id<\"dashboards\">",
+                                                "type": "string",
+                                                "x-lunora-table": "dashboards"
+                                            },
+                                            "organizationId": {
+                                                "description": "Id<\"organizations\">",
+                                                "type": "string",
+                                                "x-lunora-table": "organizations"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "organizationId"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "functionPath": {
+                                        "const": "dashboards:remove",
+                                        "type": "string"
+                                    },
+                                    "shardKey": {
+                                        "description": "Optional shard key; omitted routes to the default shard.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "functionPath"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                                }
+                            }
+                        },
+                        "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/LunoraError"
+                    }
+                },
+                "summary": "mutation: dashboards:remove",
+                "tags": [
+                    "dashboards"
+                ],
+                "x-lunora-function-kind": "mutation"
+            }
+        },
+        "/_lunora/rpc#dashboards:update": {
+            "post": {
+                "description": "Invoke the `mutation` `dashboards:update` over the Lunora RPC envelope (POST /_lunora/rpc).",
+                "operationId": "dashboards:update",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "args": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "id": {
+                                                "description": "Id<\"dashboards\">",
+                                                "type": "string",
+                                                "x-lunora-table": "dashboards"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "organizationId": {
+                                                "description": "Id<\"organizations\">",
+                                                "type": "string",
+                                                "x-lunora-table": "organizations"
+                                            },
+                                            "panels": {
+                                                "items": {},
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "organizationId"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "functionPath": {
+                                        "const": "dashboards:update",
+                                        "type": "string"
+                                    },
+                                    "shardKey": {
+                                        "description": "Optional shard key; omitted routes to the default shard.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "functionPath"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "description": "RPC result. The shape is TS-inferred from the function's return type; best-effort — any JSON."
+                                }
+                            }
+                        },
+                        "description": "Successful RPC result (TypeScript-inferred return shape, documented best-effort)."
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/LunoraError"
+                    }
+                },
+                "summary": "mutation: dashboards:update",
+                "tags": [
+                    "dashboards"
+                ],
+                "x-lunora-function-kind": "mutation"
+            }
+        },
         "/_lunora/rpc#deploy_keys:ingestKeyCipher": {
             "post": {
                 "description": "Invoke the `query` `deploy_keys:ingestKeyCipher` over the Lunora RPC envelope (POST /_lunora/rpc).",
@@ -6038,6 +6391,10 @@ export const openApiSpec: Record<string, unknown> = {
         {
             "description": "Operations declared in `lunora/cells`.",
             "name": "cells"
+        },
+        {
+            "description": "Operations declared in `lunora/dashboards`.",
+            "name": "dashboards"
         },
         {
             "description": "Operations declared in `lunora/deploy_keys`.",

--- a/apps/cloud/lunora/_generated/shard.ts
+++ b/apps/cloud/lunora/_generated/shard.ts
@@ -100,6 +100,9 @@ const LUNORA_TABLE_REFS: Record<string, Record<string, string>> = {
     "secrets": {
         "organizationId": "organizations",
         "projectId": "projects"
+    },
+    "dashboards": {
+        "organizationId": "organizations"
     }
 };
 
@@ -483,6 +486,15 @@ const LUNORA_TABLE_INDEXES: Record<string, Array<{ fields: string[]; name: strin
                 "projectId"
             ],
             "name": "by_project",
+            "type": "index"
+        }
+    ],
+    "dashboards": [
+        {
+            "fields": [
+                "organizationId"
+            ],
+            "name": "by_org",
             "type": "index"
         }
     ],
@@ -2053,6 +2065,45 @@ const LUNORA_TABLE_COLUMNS: Record<string, Array<{ isStorage?: boolean; name: st
             "type": "number"
         }
     ],
+    "dashboards": [
+        {
+            "name": "_id",
+            "optional": false,
+            "pk": true,
+            "type": "id"
+        },
+        {
+            "name": "_creationTime",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "createdAt",
+            "optional": false,
+            "type": "number"
+        },
+        {
+            "name": "name",
+            "optional": false,
+            "type": "string"
+        },
+        {
+            "name": "organizationId",
+            "optional": false,
+            "type": "id",
+            "ref": "organizations"
+        },
+        {
+            "name": "panels",
+            "optional": false,
+            "type": "array"
+        },
+        {
+            "name": "updatedAt",
+            "optional": false,
+            "type": "number"
+        }
+    ],
     "customers": [
         {
             "name": "_id",
@@ -2896,6 +2947,46 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "file": "cells",
             "kind": "mutation",
             "line": 52
+        },
+        "name": "nondeterministic_query_mutation",
+        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "title": "Non-deterministic call in query/mutation handler"
+    },
+    {
+        "cacheKey": "nondeterministic_query_mutation:dashboards:144:Date.now",
+        "categories": [
+            "SCHEMA"
+        ],
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
+        "detail": "`Date.now(…)` in create (dashboards:144) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "callee": "Date.now",
+            "exportName": "create",
+            "file": "dashboards",
+            "kind": "mutation",
+            "line": 144
+        },
+        "name": "nondeterministic_query_mutation",
+        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "title": "Non-deterministic call in query/mutation handler"
+    },
+    {
+        "cacheKey": "nondeterministic_query_mutation:dashboards:172:Date.now",
+        "categories": [
+            "SCHEMA"
+        ],
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
+        "detail": "`Date.now(…)` in update (dashboards:172) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "callee": "Date.now",
+            "exportName": "update",
+            "file": "dashboards",
+            "kind": "mutation",
+            "line": 172
         },
         "name": "nondeterministic_query_mutation",
         "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
@@ -3946,6 +4037,63 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "file": "cells",
             "kind": "mutation",
             "sensitive": true
+        },
+        "name": "public_mutation_without_ratelimit",
+        "remediation": "Attach a rate limit: `.use(rateLimit(limiter, \"<bucket>\"))` from `@lunora/ratelimit`, or wrap the recommended public-procedure guards with `.use(protectPublic({ rateLimit, captcha }))` from `@lunora/server`. Genuinely-open writes can be acknowledged by adding a permissive limiter.",
+        "title": "Public write without a rate limit"
+    },
+    {
+        "cacheKey": "public_mutation_without_ratelimit:dashboards:create",
+        "categories": [
+            "SECURITY"
+        ],
+        "description": "A public `mutation`/`action` has no `rateLimit` middleware. Publicly-callable writes are flood and brute-force targets — an attacker can exhaust writes, mail quota, or credits, or guess credentials on auth-shaped endpoints.",
+        "detail": "Public mutation `create` (dashboards) has no rate limit. Add `.use(rateLimit(...))` or `.use(protectPublic({ rateLimit }))`.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "create",
+            "file": "dashboards",
+            "kind": "mutation",
+            "sensitive": false
+        },
+        "name": "public_mutation_without_ratelimit",
+        "remediation": "Attach a rate limit: `.use(rateLimit(limiter, \"<bucket>\"))` from `@lunora/ratelimit`, or wrap the recommended public-procedure guards with `.use(protectPublic({ rateLimit, captcha }))` from `@lunora/server`. Genuinely-open writes can be acknowledged by adding a permissive limiter.",
+        "title": "Public write without a rate limit"
+    },
+    {
+        "cacheKey": "public_mutation_without_ratelimit:dashboards:update",
+        "categories": [
+            "SECURITY"
+        ],
+        "description": "A public `mutation`/`action` has no `rateLimit` middleware. Publicly-callable writes are flood and brute-force targets — an attacker can exhaust writes, mail quota, or credits, or guess credentials on auth-shaped endpoints.",
+        "detail": "Public mutation `update` (dashboards) has no rate limit. Add `.use(rateLimit(...))` or `.use(protectPublic({ rateLimit }))`.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "update",
+            "file": "dashboards",
+            "kind": "mutation",
+            "sensitive": false
+        },
+        "name": "public_mutation_without_ratelimit",
+        "remediation": "Attach a rate limit: `.use(rateLimit(limiter, \"<bucket>\"))` from `@lunora/ratelimit`, or wrap the recommended public-procedure guards with `.use(protectPublic({ rateLimit, captcha }))` from `@lunora/server`. Genuinely-open writes can be acknowledged by adding a permissive limiter.",
+        "title": "Public write without a rate limit"
+    },
+    {
+        "cacheKey": "public_mutation_without_ratelimit:dashboards:remove",
+        "categories": [
+            "SECURITY"
+        ],
+        "description": "A public `mutation`/`action` has no `rateLimit` middleware. Publicly-callable writes are flood and brute-force targets — an attacker can exhaust writes, mail quota, or credits, or guess credentials on auth-shaped endpoints.",
+        "detail": "Public mutation `remove` (dashboards) has no rate limit. Add `.use(rateLimit(...))` or `.use(protectPublic({ rateLimit }))`.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "remove",
+            "file": "dashboards",
+            "kind": "mutation",
+            "sensitive": false
         },
         "name": "public_mutation_without_ratelimit",
         "remediation": "Attach a rate limit: `.use(rateLimit(limiter, \"<bucket>\"))` from `@lunora/ratelimit`, or wrap the recommended public-procedure guards with `.use(protectPublic({ rateLimit, captcha }))` from `@lunora/server`. Genuinely-open writes can be acknowledged by adding a permissive limiter.",
@@ -5070,6 +5218,44 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "exportName": "register",
             "file": "cells",
             "line": 40
+        },
+        "name": "unbounded_string_arg",
+        "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
+        "title": "Public string argument has no length bound"
+    },
+    {
+        "cacheKey": "unbounded_string_arg:dashboards:create:name",
+        "categories": [
+            "SECURITY"
+        ],
+        "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
+        "detail": "Arg `name` of public procedure `create` (dashboards:134) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "facing": "EXTERNAL",
+        "level": "INFO",
+        "metadata": {
+            "argument": "name",
+            "exportName": "create",
+            "file": "dashboards",
+            "line": 134
+        },
+        "name": "unbounded_string_arg",
+        "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
+        "title": "Public string argument has no length bound"
+    },
+    {
+        "cacheKey": "unbounded_string_arg:dashboards:update:name",
+        "categories": [
+            "SECURITY"
+        ],
+        "description": "A public `v.string()` argument has no maximum-length bound. An unbounded string lets a client submit arbitrarily large input — abusing storage and CPU on every request that processes it.",
+        "detail": "Arg `name` of public procedure `update` (dashboards:161) is an unbounded `v.string()`. Add a max-length bound to cap payload size.",
+        "facing": "EXTERNAL",
+        "level": "INFO",
+        "metadata": {
+            "argument": "name",
+            "exportName": "update",
+            "file": "dashboards",
+            "line": 161
         },
         "name": "unbounded_string_arg",
         "remediation": "Add a max-length bound via `.check(...)` / `.meta({ maxLength })` on the string validator (e.g. cap a name at 256, a body at a few KB). Size the cap to the field's real-world maximum.",
@@ -6692,6 +6878,7 @@ export const createShardDO = (config: ShardDOConfig = {}): new (state: ShardDOSt
             facade["uptimeChecks"] = bindTableFacade(db, "uptimeChecks");
             facade["uptimeState"] = bindTableFacade(db, "uptimeState");
             facade["secrets"] = bindTableFacade(db, "secrets");
+            facade["dashboards"] = bindTableFacade(db, "dashboards");
             facade["customers"] = bindTableFacade(db, "customers");
             facade["events"] = bindTableFacade(db, "events");
             facade["paymentSessions"] = bindTableFacade(db, "paymentSessions");

--- a/apps/cloud/lunora/dashboards.ts
+++ b/apps/cloud/lunora/dashboards.ts
@@ -1,0 +1,199 @@
+import { LunoraError } from "@lunora/server";
+
+import type { DashboardPanel } from "../src/telemetry/dashboards";
+import { validatePanels } from "../src/telemetry/dashboards";
+import type { Id } from "./_generated/dataModel.js";
+import { mutation, query, v } from "./_generated/server.js";
+import { assertMember, assertRowInOrg } from "./authz";
+
+/**
+ * User-defined custom dashboards (Tier 2 observability) — Grafana-style saved
+ * boards over the org's telemetry. A dashboard holds an ordered list of panels;
+ * each panel is a saved query over data the console already serves (a metric
+ * trend, a single stat, or a saved Traces/Logs filter shortcut). No new backend:
+ * the panels render from `metrics.list` and the Traces/Logs deep-links.
+ *
+ * Org-scoped like every sibling: reads are members-only; writes (create/update/
+ * remove) are owners/admins (the same gate `lunora/alerts.ts` uses). Panel
+ * shaping (add/remove/reorder + validation) is the pure `src/telemetry/dashboards`
+ * model — the client mutates panels with those reducers and sends the whole array
+ * back, which this file re-validates before persisting.
+ */
+
+/** A panel as the dashboard wire view carries it — mirrors {@link DashboardPanel} locally so codegen inlines it. */
+interface DashboardPanelView {
+    config: {
+        filter?: string;
+        metricName?: string;
+        stat?: "count" | "first" | "last";
+    };
+    id: string;
+    kind: "logs" | "metric" | "stat" | "traces";
+    title: string;
+}
+
+/** One dashboard as the client consumes it (identity + ordered panels + timestamps). */
+interface DashboardView {
+    _id: Id<"dashboards">;
+    createdAt: number;
+    name: string;
+    panels: DashboardPanelView[];
+    updatedAt: number;
+}
+
+/** The panel-config validator — only the keys a panel's kind uses are ever set. */
+const panelConfig = v.object({
+    filter: v.optional(v.string()),
+    metricName: v.optional(v.string()),
+    stat: v.optional(v.union(v.literal("last"), v.literal("first"), v.literal("count"))),
+});
+
+/** The panel validator shared by `create`/`update` inputs. */
+const panel = v.object({
+    config: panelConfig,
+    id: v.string(),
+    kind: v.union(v.literal("metric"), v.literal("stat"), v.literal("traces"), v.literal("logs")),
+    title: v.string(),
+});
+
+/** Project a stored dashboard row onto the wire view. */
+const toView = (row: DashboardRow): DashboardView => ({
+    _id: row._id,
+    createdAt: row.createdAt,
+    name: row.name,
+    panels: row.panels.map((current) => ({
+        config: {
+            ...(current.config.filter === undefined ? {} : { filter: current.config.filter }),
+            ...(current.config.metricName === undefined ? {} : { metricName: current.config.metricName }),
+            ...(current.config.stat === undefined ? {} : { stat: current.config.stat }),
+        },
+        id: current.id,
+        kind: current.kind,
+        title: current.title,
+    })),
+    updatedAt: row.updatedAt,
+});
+
+/** The stored dashboard row shape (the columns `findMany`/`get` return). */
+interface DashboardRow {
+    _id: Id<"dashboards">;
+    createdAt: number;
+    name: string;
+    organizationId: Id<"organizations">;
+    panels: DashboardPanel[];
+    updatedAt: number;
+}
+
+/** Reject a blank dashboard name up front (shared by create/update). */
+const requireName = (name: string): string => {
+    const trimmed = name.trim();
+
+    if (trimmed === "") {
+        throw new LunoraError("BAD_REQUEST", "dashboard name is required");
+    }
+
+    return trimmed;
+};
+
+/** Re-validate panels on the server (the client validates too) before persisting. */
+const requireValidPanels = (panels: readonly DashboardPanel[]): void => {
+    const error = validatePanels(panels);
+
+    if (error !== null) {
+        throw new LunoraError("BAD_REQUEST", error);
+    }
+};
+
+/** An org's dashboards, most-recent first (any member). */
+export const list = query
+    .input({ organizationId: v.id("organizations") })
+    .query(async ({ ctx: context, args: { organizationId } }): Promise<DashboardView[]> => {
+        await assertMember(context, organizationId);
+
+        const { page } = await context.db.dashboards.findMany({ where: { organizationId } });
+
+        return (page as unknown as DashboardRow[]).toSorted((a, b) => b.createdAt - a.createdAt).map(toView);
+    });
+
+/** One dashboard by id, org-checked (any member). `null` when it isn't in the org. */
+export const get = query
+    .input({ id: v.id("dashboards"), organizationId: v.id("organizations") })
+    .query(async ({ ctx: context, args: { id, organizationId } }): Promise<DashboardView | null> => {
+        await assertMember(context, organizationId);
+
+        const row = (await context.db.get(id)) as DashboardRow | null;
+
+        if (row === null || row.organizationId !== organizationId) {
+            return null;
+        }
+
+        return toView(row);
+    });
+
+/** Create a named dashboard (owners/admins). Starts with the given panels (usually none). */
+export const create = mutation
+    .input({ name: v.string(), organizationId: v.id("organizations"), panels: v.optional(v.array(panel)) })
+    .mutation(async ({ ctx: context, args }): Promise<Id<"dashboards">> => {
+        await assertMember(context, args.organizationId, ["owner", "admin"]);
+
+        const name = requireName(args.name);
+        const panels = (args.panels ?? []) as DashboardPanel[];
+
+        requireValidPanels(panels);
+
+        const now = Date.now();
+
+        return context.db.insert("dashboards", {
+            createdAt: now,
+            name,
+            organizationId: args.organizationId,
+            panels,
+            updatedAt: now,
+        });
+    });
+
+/**
+ * Update a dashboard (owners/admins). `name` renames it; `panels` replaces the
+ * whole ordered list — the client computes add/remove/reorder with the pure
+ * reducers and sends the result, which is re-validated here. Both are optional so
+ * a rename and a panel edit are independent calls.
+ */
+export const update = mutation
+    .input({
+        id: v.id("dashboards"),
+        name: v.optional(v.string()),
+        organizationId: v.id("organizations"),
+        panels: v.optional(v.array(panel)),
+    })
+    .mutation(async ({ ctx: context, args }): Promise<Id<"dashboards">> => {
+        await assertMember(context, args.organizationId, ["owner", "admin"]);
+        await assertRowInOrg(context, args.id, args.organizationId, "dashboard");
+
+        const patch: { name?: string; panels?: DashboardPanel[]; updatedAt: number } = { updatedAt: Date.now() };
+
+        if (args.name !== undefined) {
+            patch.name = requireName(args.name);
+        }
+
+        if (args.panels !== undefined) {
+            const panels = args.panels as DashboardPanel[];
+
+            requireValidPanels(panels);
+            patch.panels = panels;
+        }
+
+        await context.db.patch(args.id, patch);
+
+        return args.id;
+    });
+
+/** Delete a dashboard (owners/admins), org-checked. */
+export const remove = mutation
+    .input({ id: v.id("dashboards"), organizationId: v.id("organizations") })
+    .mutation(async ({ ctx: context, args: { id, organizationId } }): Promise<Id<"dashboards">> => {
+        await assertMember(context, organizationId, ["owner", "admin"]);
+        await assertRowInOrg(context, id, organizationId, "dashboard");
+        await context.db.delete(id);
+
+        return id;
+    });

--- a/apps/cloud/lunora/schema.ts
+++ b/apps/cloud/lunora/schema.ts
@@ -644,6 +644,36 @@ export default defineSchema({
         .index("by_project", ["projectId"])
         .index("by_project_env_name", ["projectId", "environment", "name"], { unique: true }),
 
+    // User-defined custom dashboards (Tier 2 observability). A named, per-org
+    // collection of saved panels — each panel a saved query over telemetry the
+    // console already serves (a metric trend, a single-stat number, or a saved
+    // Traces/Logs filter shortcut). Grafana-style boards composed from the
+    // existing read paths; no new telemetry backend. Panels are stored inline as
+    // a JSON array (low cardinality, always read whole with the board).
+    dashboards: defineTable({
+        createdAt: v.number(),
+        name: v.string(),
+        organizationId: v.id("organizations"),
+        // Ordered panels. `kind` selects the widget; `config` carries only the
+        // keys that kind uses (`metricName` for metric/stat, `stat` for a stat's
+        // aggregation, `filter` for a traces/logs deep-link shortcut).
+        panels: v.array(
+            v.object({
+                config: v.object({
+                    filter: v.optional(v.string()),
+                    metricName: v.optional(v.string()),
+                    stat: v.optional(v.union(v.literal("last"), v.literal("first"), v.literal("count"))),
+                }),
+                id: v.string(),
+                kind: v.union(v.literal("metric"), v.literal("stat"), v.literal("traces"), v.literal("logs")),
+                title: v.string(),
+            }),
+        ),
+        updatedAt: v.number(),
+    })
+        .global()
+        .index("by_org", ["organizationId"]),
+
     // ── @lunora/payment tables (§4 billing) ───────────────────────────────────
     // Declared inline (codegen parses this file's AST and can't resolve a cross-
     // package `...paymentTables` spread). `@lunora/payment`'s exported

--- a/apps/cloud/src/client/AddPanelForm.tsx
+++ b/apps/cloud/src/client/AddPanelForm.tsx
@@ -1,0 +1,131 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+
+import type { DashboardPanel, PanelKind, StatAggregation } from "../telemetry/dashboards";
+import { createPanel, isMetricPanel, PANEL_KIND_LABELS, PANEL_KINDS, STAT_AGGREGATION_LABELS, STAT_AGGREGATIONS } from "../telemetry/dashboards";
+
+interface AddPanelFormProps {
+    /** Metric names to offer as suggestions for metric/stat panels. */
+    metricNames: readonly string[];
+    /** Append the built panel to the board. */
+    onAdd: (panel: DashboardPanel) => void;
+}
+
+/**
+ * The add-panel form for a dashboard. Picks a kind and its kind-specific config
+ * (a metric name for metric/stat, an aggregation for stat, a saved filter for the
+ * Traces/Logs shortcuts), then builds a validated panel with the pure model. The
+ * panel id is minted in the submit handler (an event handler — the sanctioned
+ * place for impurity), never in render.
+ */
+export const AddPanelForm = ({ metricNames, onAdd }: AddPanelFormProps): ReactElement => {
+    const [title, setTitle] = useState("");
+    const [kind, setKind] = useState<PanelKind>("metric");
+    const [metricName, setMetricName] = useState("");
+    const [stat, setStat] = useState<StatAggregation>("last");
+    const [filter, setFilter] = useState("");
+    const [error, setError] = useState<null | string>(null);
+
+    const usesMetric = isMetricPanel(kind);
+
+    return (
+        <form
+            className="inline-form"
+            onSubmit={(event) => {
+                event.preventDefault();
+                setError(null);
+
+                if (usesMetric && metricName.trim() === "") {
+                    setError("Pick a metric for this panel.");
+
+                    return;
+                }
+
+                onAdd(
+                    createPanel({
+                        config: { filter, metricName, stat },
+                        id: crypto.randomUUID(),
+                        kind,
+                        title,
+                    }),
+                );
+                setTitle("");
+                setMetricName("");
+                setFilter("");
+            }}
+        >
+            <input
+                aria-label="Panel title"
+                onChange={(event) => {
+                    setTitle(event.target.value);
+                }}
+                placeholder="Panel title"
+                value={title}
+            />
+            <select
+                aria-label="Panel kind"
+                onChange={(event) => {
+                    setKind(event.target.value as PanelKind);
+                }}
+                value={kind}
+            >
+                {PANEL_KINDS.map((value) => (
+                    <option key={value} value={value}>
+                        {PANEL_KIND_LABELS[value]}
+                    </option>
+                ))}
+            </select>
+            {usesMetric ? (
+                <>
+                    <input
+                        aria-label="Metric name"
+                        list="dashboard-metric-names"
+                        onChange={(event) => {
+                            setMetricName(event.target.value);
+                        }}
+                        placeholder="metric name"
+                        value={metricName}
+                    />
+                    <datalist id="dashboard-metric-names">
+                        {metricNames.map((name) => (
+                            <option key={name} value={name} />
+                        ))}
+                    </datalist>
+                </>
+            ) : null}
+            {kind === "stat" ? (
+                <select
+                    aria-label="Stat aggregation"
+                    onChange={(event) => {
+                        setStat(event.target.value as StatAggregation);
+                    }}
+                    value={stat}
+                >
+                    {STAT_AGGREGATIONS.map((value) => (
+                        <option key={value} value={value}>
+                            {STAT_AGGREGATION_LABELS[value]}
+                        </option>
+                    ))}
+                </select>
+            ) : null}
+            {usesMetric ? null : (
+                <input
+                    aria-label="Saved filter"
+                    onChange={(event) => {
+                        setFilter(event.target.value);
+                    }}
+                    placeholder="saved filter (optional)"
+                    value={filter}
+                />
+            )}
+            <button className="primary" type="submit">
+                Add panel
+            </button>
+            {error ? (
+                <p className="error" role="alert">
+                    {error}
+                </p>
+            ) : null}
+        </form>
+    );
+};

--- a/apps/cloud/src/client/DashboardBoard.tsx
+++ b/apps/cloud/src/client/DashboardBoard.tsx
@@ -1,0 +1,106 @@
+import type { ReactElement } from "react";
+
+import type { DashboardPanel } from "../telemetry/dashboards";
+import { movePanel, PANEL_KIND_LABELS, removePanel } from "../telemetry/dashboards";
+import { AddPanelForm } from "./AddPanelForm";
+import { PanelWidget } from "./DashboardPanel";
+import type { MetricSeries } from "./use-metrics-series";
+
+interface DashboardBoardProps {
+    metricNames: readonly string[];
+    name: string;
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
+    onRemoveDashboard: () => void;
+    /** Persist a new ordered panel list (the reducers compute it; the parent mutates). */
+    onUpdatePanels: (panels: DashboardPanel[]) => void;
+    panels: readonly DashboardPanel[];
+}
+
+/** One panel tile — its widget body plus the reorder/remove chrome. */
+const PanelCard = ({
+    isFirst,
+    isLast,
+    onMove,
+    onOpenTab,
+    onRemove,
+    panel,
+    series,
+}: {
+    isFirst: boolean;
+    isLast: boolean;
+    onMove: (direction: "down" | "up") => void;
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
+    onRemove: () => void;
+    panel: DashboardPanel;
+    series: MetricSeries[] | undefined;
+}): ReactElement => (
+    <div className="card dash-panel">
+        <div className="dash-panel-head">
+            <div className="dash-panel-id">
+                <span className="row-title">{panel.title}</span>
+                <span className="metric-kind">{PANEL_KIND_LABELS[panel.kind]}</span>
+            </div>
+            <div className="dash-panel-controls">
+                <button aria-label="Move panel up" className="link" disabled={isFirst} onClick={() => onMove("up")} type="button">
+                    ↑
+                </button>
+                <button aria-label="Move panel down" className="link" disabled={isLast} onClick={() => onMove("down")} type="button">
+                    ↓
+                </button>
+                <button aria-label="Remove panel" className="link danger" onClick={onRemove} type="button">
+                    ✕
+                </button>
+            </div>
+        </div>
+        <PanelWidget onOpenTab={onOpenTab} panel={panel} series={series} />
+    </div>
+);
+
+/**
+ * The selected dashboard's board: a grid of panel widgets plus the add-panel
+ * form. Add/remove/reorder are pure reducers over the panel list; each produces a
+ * new array the parent persists via `dashboards.update`. `series` is fetched once
+ * by the parent and shared across every metric/stat panel.
+ */
+export const DashboardBoard = ({
+    metricNames,
+    name,
+    onOpenTab,
+    onRemoveDashboard,
+    onUpdatePanels,
+    panels,
+    series,
+}: { series: MetricSeries[] | undefined } & DashboardBoardProps): ReactElement => (
+    <div className="stack">
+        <section className="card">
+            <div className="metrics-head">
+                <h3>{name}</h3>
+                <button className="link danger" onClick={onRemoveDashboard} type="button">
+                    Delete dashboard
+                </button>
+            </div>
+            <AddPanelForm metricNames={metricNames} onAdd={(panel) => onUpdatePanels([...panels, panel])} />
+        </section>
+
+        {panels.length === 0 ? (
+            <section className="card">
+                <p className="muted">No panels yet — add a metric trend, a single stat, or a Traces/Logs shortcut above.</p>
+            </section>
+        ) : (
+            <div className="dash-grid">
+                {panels.map((panel, index) => (
+                    <PanelCard
+                        isFirst={index === 0}
+                        isLast={index === panels.length - 1}
+                        key={panel.id}
+                        onMove={(direction) => onUpdatePanels(movePanel(panels, panel.id, direction))}
+                        onOpenTab={onOpenTab}
+                        onRemove={() => onUpdatePanels(removePanel(panels, panel.id))}
+                        panel={panel}
+                        series={series}
+                    />
+                ))}
+            </div>
+        )}
+    </div>
+);

--- a/apps/cloud/src/client/DashboardPanel.tsx
+++ b/apps/cloud/src/client/DashboardPanel.tsx
@@ -1,0 +1,91 @@
+import type { ReactElement } from "react";
+
+import type { DashboardPanel } from "../telemetry/dashboards";
+import { statValue } from "../telemetry/dashboards";
+import { formatValue } from "./metric-format";
+import { Sparkline, TrendBadge } from "./MetricSparkline";
+import type { MetricSeries } from "./use-metrics-series";
+
+/**
+ * The custom-dashboard panel widgets. Each renders one saved panel from data the
+ * console already serves: `metric`/`stat` panels off the shared metric series,
+ * and `traces`/`logs` panels as a deep-link shortcut into that tab. The board
+ * owns the panel chrome (title, move/remove); this file owns the widget bodies.
+ */
+
+interface PanelBodyProps {
+    onOpenTab?: (tab: "logs" | "traces", context?: { traceId?: string }) => void;
+    panel: DashboardPanel;
+    /** `undefined` while the metric read is loading; `[]` once resolved-empty. */
+    series: MetricSeries[] | undefined;
+}
+
+/** A metric-trend widget — the named series' last value, trend badge, and sparkline. */
+const MetricPanelBody = ({ panel, series }: { panel: DashboardPanel; series: MetricSeries[] | undefined }): ReactElement => {
+    if (series === undefined) {
+        return <p className="muted">Loading…</p>;
+    }
+
+    const match = series.find((candidate) => candidate.name === panel.config.metricName);
+
+    if (match === undefined) {
+        return <p className="muted">No data for {panel.config.metricName ?? "this metric"} in this window.</p>;
+    }
+
+    return (
+        <div className="dash-metric">
+            <div className="metric-tile-value">
+                <span className="metric-last">{formatValue(match.lastValue)}</span>
+                <TrendBadge trend={match.trend} />
+            </div>
+            <Sparkline points={match.points} />
+        </div>
+    );
+};
+
+/** A single-stat widget — one big number reduced from the named series. */
+const StatPanelBody = ({ panel, series }: { panel: DashboardPanel; series: MetricSeries[] | undefined }): ReactElement => {
+    if (series === undefined) {
+        return <p className="muted">Loading…</p>;
+    }
+
+    const value = statValue(series, panel);
+
+    if (value === undefined) {
+        return <p className="muted">No data for {panel.config.metricName ?? "this metric"} in this window.</p>;
+    }
+
+    return (
+        <div className="dash-stat">
+            <span className="dash-stat-value">{formatValue(value)}</span>
+            <span className="muted">{panel.config.metricName}</span>
+        </div>
+    );
+};
+
+/** A Traces/Logs shortcut widget — its saved filter + a button that deep-links the tab. */
+const ShortcutPanelBody = ({ onOpenTab, panel }: PanelBodyProps): ReactElement => {
+    const tab = panel.kind === "logs" ? "logs" : "traces";
+
+    return (
+        <div className="dash-shortcut">
+            <p className="muted">{panel.config.filter ? <code>{panel.config.filter}</code> : `Open the ${tab} tab.`}</p>
+            <button className="link" disabled={onOpenTab === undefined} onClick={() => onOpenTab?.(tab)} type="button">
+                Open {tab} →
+            </button>
+        </div>
+    );
+};
+
+/** Render a panel's body for its kind. */
+export const PanelWidget = ({ onOpenTab, panel, series }: PanelBodyProps): ReactElement => {
+    if (panel.kind === "metric") {
+        return <MetricPanelBody panel={panel} series={series} />;
+    }
+
+    if (panel.kind === "stat") {
+        return <StatPanelBody panel={panel} series={series} />;
+    }
+
+    return <ShortcutPanelBody onOpenTab={onOpenTab} panel={panel} series={series} />;
+};

--- a/apps/cloud/src/client/DashboardsSection.tsx
+++ b/apps/cloud/src/client/DashboardsSection.tsx
@@ -1,0 +1,141 @@
+import { useMutation, useQuery } from "@lunora/react";
+import type { ReactElement } from "react";
+import { useState } from "react";
+
+import type { DashboardPanel } from "../telemetry/dashboards";
+import { api } from "../../lunora/_generated/api.js";
+import { DashboardBoard } from "./DashboardBoard";
+import type { SectionProps } from "./OrganizationDashboard";
+import { TimeRangePicker, useTimeRange } from "./TimeRangeProvider";
+import { useMetricsSeries } from "./use-metrics-series";
+
+/**
+ * Dashboards tab (Tier 2 observability) — user-defined, Grafana-style boards over
+ * the org's telemetry. A dashboard is a named list of panels; each panel is a
+ * saved query over data the console already serves (`metrics.list`, or a saved
+ * Traces/Logs deep-link). Owners/admins create boards and edit panels; the metric
+ * series backing every metric/stat panel is fetched once here and shared down.
+ *
+ * The selected board is *derived* (the clicked id, falling back to the first),
+ * never synced through an effect — a deleted board just falls back, and creating
+ * one selects it from the mutation's resolve (an event handler). Panel edits are
+ * pure reducers (`DashboardBoard`) whose result is persisted via `update`.
+ */
+export const DashboardsSection = ({ onOpenTab, organizationId }: SectionProps): ReactElement => {
+    const dashboards = useQuery(api.dashboards.list, { organizationId });
+    const { from, to } = useTimeRange();
+    const { series } = useMetricsSeries(organizationId, from, to);
+
+    const create = useMutation(api.dashboards.create);
+    const update = useMutation(api.dashboards.update);
+    const remove = useMutation(api.dashboards.remove);
+
+    const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+    const [name, setName] = useState("");
+    const [error, setError] = useState<null | string>(null);
+
+    const metricNames = series === undefined ? [] : series.map((metric) => metric.name);
+    const selected = dashboards?.find((board) => board._id === selectedId) ?? dashboards?.[0];
+
+    const persistPanels = (id: string, panels: DashboardPanel[]): void => {
+        setError(null);
+        void update.mutate({ id: id as never, organizationId, panels }).catch((caught: unknown) => {
+            setError(caught instanceof Error ? caught.message : "could not save panels");
+        });
+    };
+
+    return (
+        <div className="stack">
+            <section className="card">
+                <div className="metrics-head">
+                    <h3>Dashboards</h3>
+                    <TimeRangePicker />
+                </div>
+                <p className="muted">
+                    Saved boards over your telemetry. Compose panels from the metrics the console already collects — a trend sparkline, a single stat, or a
+                    saved Traces/Logs shortcut. Panel windows follow the shared time range above.
+                </p>
+                <form
+                    className="inline-form"
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        setError(null);
+
+                        void create
+                            .mutate({ name, organizationId })
+                            .then((id) => {
+                                setSelectedId(id as unknown as string);
+                                setName("");
+                            })
+                            .catch((caught: unknown) => {
+                                setError(caught instanceof Error ? caught.message : "could not create dashboard");
+                            });
+                    }}
+                >
+                    <input
+                        aria-label="Dashboard name"
+                        onChange={(event) => {
+                            setName(event.target.value);
+                        }}
+                        placeholder="New dashboard name"
+                        required
+                        value={name}
+                    />
+                    <button className="primary" type="submit">
+                        Create dashboard
+                    </button>
+                    {error ? (
+                        <p className="error" role="alert">
+                            {error}
+                        </p>
+                    ) : null}
+                </form>
+            </section>
+
+            {dashboards === undefined ? <p className="muted">Loading…</p> : null}
+
+            {dashboards !== undefined && dashboards.length === 0 ? (
+                <section className="card">
+                    <p className="muted">No dashboards yet — create one above, then add panels to it.</p>
+                </section>
+            ) : null}
+
+            {dashboards !== undefined && dashboards.length > 0 ? (
+                <div className="dash-layout">
+                    <nav aria-label="Dashboards" className="dash-list">
+                        {dashboards.map((board) => (
+                            <button
+                                className={board._id === selected?._id ? "dash-list-item active" : "dash-list-item"}
+                                key={board._id}
+                                onClick={() => setSelectedId(board._id)}
+                                type="button"
+                            >
+                                <span className="row-title">{board.name}</span>
+                                <span className="muted">
+                                    {board.panels.length} panel{board.panels.length === 1 ? "" : "s"}
+                                </span>
+                            </button>
+                        ))}
+                    </nav>
+
+                    {selected ? (
+                        <DashboardBoard
+                            metricNames={metricNames}
+                            name={selected.name}
+                            onOpenTab={onOpenTab}
+                            onRemoveDashboard={() => {
+                                setError(null);
+                                void remove.mutate({ id: selected._id, organizationId }).catch((caught: unknown) => {
+                                    setError(caught instanceof Error ? caught.message : "could not delete dashboard");
+                                });
+                            }}
+                            onUpdatePanels={(panels) => persistPanels(selected._id, panels)}
+                            panels={selected.panels}
+                            series={series}
+                        />
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+};

--- a/apps/cloud/src/client/MetricSparkline.tsx
+++ b/apps/cloud/src/client/MetricSparkline.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from "react";
+
+import { formatValue } from "./metric-format";
+
+/**
+ * The metric-trend rendering shared by the Metrics tab and the custom-dashboard
+ * metric panels: an inline-SVG sparkline over a series' bucketed points, and a
+ * direction/delta trend badge. Extracted so a dashboard `metric` panel renders a
+ * series exactly as the Metrics tab does (no divergent copy).
+ */
+
+/** One point on a metric's trend line — an epoch-ms bucket start + its value. */
+export interface SparklinePoint {
+    t: number;
+    value: number;
+}
+
+/**
+ * A minimal inline-SVG sparkline over a metric's bucketed trend points. Points
+ * are spaced evenly on x (by index) and scaled to the series' own min→max on y,
+ * so a flat series still renders a centered line rather than dividing by zero.
+ */
+export const Sparkline = ({ points }: { points: readonly SparklinePoint[] }): ReactElement => {
+    if (points.length === 0) {
+        return <div className="metric-spark metric-spark-empty" />;
+    }
+
+    const values = points.map((point) => point.value);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const span = max - min || 1;
+    const step = points.length > 1 ? 100 / (points.length - 1) : 0;
+
+    // y is inverted (SVG origin top-left): the max value sits at y=2, min at y=28.
+    const coords = points.map((point, index) => `${(index * step).toFixed(2)},${(28 - ((point.value - min) / span) * 26).toFixed(2)}`).join(" ");
+
+    return (
+        <svg className="metric-spark" preserveAspectRatio="none" role="img" viewBox="0 0 100 30">
+            {points.length === 1 ? (
+                <circle cx="50" cy="15" r="1.5" />
+            ) : (
+                <polyline fill="none" points={coords} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+            )}
+        </svg>
+    );
+};
+
+/** Direction arrow + delta for a series' net movement over the window. */
+export const TrendBadge = ({ trend }: { trend: number }): ReactElement => {
+    const direction = trend > 0 ? "up" : trend < 0 ? "down" : "flat";
+    const arrow = trend > 0 ? "▲" : trend < 0 ? "▼" : "→";
+
+    return (
+        <span className={`metric-trend metric-trend-${direction}`}>
+            {arrow} {formatValue(Math.abs(trend))}
+        </span>
+    );
+};

--- a/apps/cloud/src/client/MetricsSection.tsx
+++ b/apps/cloud/src/client/MetricsSection.tsx
@@ -3,6 +3,8 @@ import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
+import { formatValue } from "./metric-format";
+import { Sparkline, TrendBadge } from "./MetricSparkline";
 import { TimeRangePicker, useTimeRange } from "./TimeRangeProvider";
 import type { OrgId } from "./types";
 
@@ -20,63 +22,6 @@ interface MetricSeries {
     points: { t: number; value: number }[];
     trend: number;
 }
-
-/** Compact number format for the headline last-value (`1.2k`, `3.4M`). */
-const formatValue = (value: number): string => {
-    const abs = Math.abs(value);
-
-    if (abs >= 1_000_000) {
-        return `${(value / 1_000_000).toFixed(1)}M`;
-    }
-
-    if (abs >= 1000) {
-        return `${(value / 1000).toFixed(1)}k`;
-    }
-
-    return Number.isInteger(value) ? String(value) : value.toFixed(2);
-};
-
-/**
- * A minimal inline-SVG sparkline over a metric's bucketed trend points. Points
- * are spaced evenly on x (by index) and scaled to the series' own min→max on y,
- * so a flat series still renders a centered line rather than dividing by zero.
- */
-const Sparkline = ({ points }: { points: { t: number; value: number }[] }): ReactElement => {
-    if (points.length === 0) {
-        return <div className="metric-spark metric-spark-empty" />;
-    }
-
-    const values = points.map((point) => point.value);
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    const span = max - min || 1;
-    const step = points.length > 1 ? 100 / (points.length - 1) : 0;
-
-    // y is inverted (SVG origin top-left): the max value sits at y=2, min at y=28.
-    const coords = points.map((point, index) => `${(index * step).toFixed(2)},${(28 - ((point.value - min) / span) * 26).toFixed(2)}`).join(" ");
-
-    return (
-        <svg className="metric-spark" preserveAspectRatio="none" role="img" viewBox="0 0 100 30">
-            {points.length === 1 ? (
-                <circle cx="50" cy="15" r="1.5" />
-            ) : (
-                <polyline fill="none" points={coords} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-            )}
-        </svg>
-    );
-};
-
-/** Direction arrow + delta for a series' net movement over the window. */
-const TrendBadge = ({ trend }: { trend: number }): ReactElement => {
-    const direction = trend > 0 ? "up" : trend < 0 ? "down" : "flat";
-    const arrow = trend > 0 ? "▲" : trend < 0 ? "▼" : "→";
-
-    return (
-        <span className={`metric-trend metric-trend-${direction}`}>
-            {arrow} {formatValue(Math.abs(trend))}
-        </span>
-    );
-};
 
 /**
  * Metrics tab (GAPS.md ring 3) — per-metric trend sparklines over the tenant

--- a/apps/cloud/src/client/OrganizationDashboard.tsx
+++ b/apps/cloud/src/client/OrganizationDashboard.tsx
@@ -8,6 +8,7 @@ import { AlertsSection } from "./AlertsSection";
 import { BillingSection } from "./BillingSection";
 import { BuildsSection } from "./BuildsSection";
 import { CommandPalette } from "./CommandPalette";
+import { DashboardsSection } from "./DashboardsSection";
 import { DeployKeysSection } from "./DeployKeysSection";
 import { DomainsSection } from "./DomainsSection";
 import { IncidentsSection } from "./IncidentsSection";
@@ -36,6 +37,7 @@ type Tab =
     | "alerts"
     | "billing"
     | "builds"
+    | "dashboards"
     | "domains"
     | "incidents"
     | "invitations"
@@ -71,6 +73,7 @@ const TABS: { id: Tab; label: string }[] = [
     { id: "logs", label: "Logs" },
     { id: "traces", label: "Traces" },
     { id: "metrics", label: "Metrics" },
+    { id: "dashboards", label: "Dashboards" },
     { id: "issues", label: "Issues" },
     { id: "incidents", label: "Incidents" },
     { id: "uptime", label: "Uptime" },
@@ -87,6 +90,7 @@ const SECTIONS: Record<Tab, (props: SectionProps) => ReactElement> = {
     alerts: AlertsSection,
     billing: BillingSection,
     builds: BuildsSection,
+    dashboards: DashboardsSection,
     domains: DomainsSection,
     incidents: IncidentsSection,
     invitations: InvitationsSection,

--- a/apps/cloud/src/client/metric-format.ts
+++ b/apps/cloud/src/client/metric-format.ts
@@ -1,0 +1,20 @@
+/**
+ * Compact number formatting shared by the Metrics tab and the custom-dashboard
+ * metric/stat panels — the headline last-value display (`1.2k`, `3.4M`). Pure, so
+ * it unit-tests under the node vitest env and both renderers format identically.
+ */
+
+/** Compact number format for a headline value (`1.2k`, `3.4M`, `42`, `3.14`). */
+export const formatValue = (value: number): string => {
+    const abs = Math.abs(value);
+
+    if (abs >= 1_000_000) {
+        return `${(value / 1_000_000).toFixed(1)}M`;
+    }
+
+    if (abs >= 1000) {
+        return `${(value / 1000).toFixed(1)}k`;
+    }
+
+    return Number.isInteger(value) ? String(value) : value.toFixed(2);
+};

--- a/apps/cloud/src/client/styles.css
+++ b/apps/cloud/src/client/styles.css
@@ -1020,6 +1020,99 @@ button.link.danger {
     border-bottom: 1px dashed var(--border);
 }
 
+/* --- Custom dashboards ------------------------------------------------------ */
+.dash-layout {
+    display: grid;
+    grid-template-columns: minmax(160px, 220px) 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+@media (max-width: 720px) {
+    .dash-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.dash-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.dash-list-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface-2);
+    text-align: left;
+    cursor: pointer;
+}
+
+.dash-list-item.active {
+    border-color: var(--primary);
+}
+
+.dash-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 12px;
+}
+
+.dash-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.dash-panel-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.dash-panel-id {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.dash-panel-controls {
+    display: inline-flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.dash-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.dash-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.dash-stat-value {
+    font-size: 28px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.dash-shortcut {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-start;
+}
+
 .trace-archive-badge {
     margin-left: 8px;
     background: var(--surface-2);

--- a/apps/cloud/src/client/use-metrics-series.ts
+++ b/apps/cloud/src/client/use-metrics-series.ts
@@ -1,0 +1,63 @@
+import { useLunora } from "@lunora/react";
+import { useEffect, useState } from "react";
+
+import { api } from "../../lunora/_generated/api.js";
+import type { OrgId } from "./types";
+
+/**
+ * Load the org's metric series for a `[from, to]` window — the data both the
+ * Metrics tab and the custom-dashboard metric/stat panels render. `metrics.list`
+ * is an action (the AE read is a `fetch`, not reactive), so this polls it when
+ * the org or window changes, writing state only in the async callbacks (the
+ * sanctioned effect pattern) with an out-of-order guard. Kept as a hook so the
+ * Dashboards board fetches once and shares the result across every metric panel.
+ */
+
+/** One metric series as `metrics.list` returns it. */
+export interface MetricSeries {
+    firstValue: number;
+    functionPath?: string;
+    kind: string;
+    lastValue: number;
+    name: string;
+    points: { t: number; value: number }[];
+    trend: number;
+}
+
+/** The series over the window (`undefined` while loading) plus any read error. */
+export interface MetricsSeriesState {
+    error: string | undefined;
+    series: MetricSeries[] | undefined;
+}
+
+/** Poll `metrics.list` for one org over a window; re-fetches when org/from/to change. */
+export const useMetricsSeries = (organizationId: OrgId, from: number, to: number): MetricsSeriesState => {
+    const client = useLunora();
+    const [series, setSeries] = useState<MetricSeries[] | undefined>(undefined);
+    const [error, setError] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        client
+            .action(api.metrics.list, { from, organizationId, to })
+            .then((result) => {
+                if (!cancelled) {
+                    setSeries(result);
+                    setError(undefined);
+                }
+            })
+            .catch((caught: unknown) => {
+                if (!cancelled) {
+                    setError(caught instanceof Error ? caught.message : "failed to load metrics");
+                    setSeries([]);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [client, from, to, organizationId]);
+
+    return { error, series };
+};

--- a/apps/cloud/src/telemetry/dashboards.ts
+++ b/apps/cloud/src/telemetry/dashboards.ts
@@ -1,0 +1,194 @@
+/**
+ * Pure model for **user-defined custom dashboards** (Tier 2 observability). A
+ * dashboard is a named, per-org list of panels; each panel is a saved query over
+ * telemetry the console already serves — a metric trend sparkline, a single-stat
+ * number, or a saved Traces/Logs filter shortcut. No new backend: `metric`/`stat`
+ * panels read `metrics.list`, the shortcut panels deep-link the Traces/Logs tabs.
+ *
+ * This module is the shared, side-effect-free core: the panel types, the CRUD
+ * reducers the client mutates panels with (add/remove/reorder are pure array
+ * transforms), the per-kind config normalizer, validation, and the stat
+ * aggregation. Both `lunora/dashboards.ts` (server validation + wire view) and
+ * `DashboardsSection` (the editor) import it, so the shaping is unit-tested once
+ * and can't drift between the two.
+ */
+
+/** Panel widget kinds. `metric`/`stat` render metric data; `traces`/`logs` are saved-filter shortcuts. */
+export type PanelKind = "logs" | "metric" | "stat" | "traces";
+
+/** How a `stat` panel reduces its metric series to one number. */
+export type StatAggregation = "count" | "first" | "last";
+
+/** Panel configuration — only the keys the panel's kind uses are set. */
+export interface PanelConfig {
+    /** `traces`/`logs`: the saved free-text filter the shortcut deep-links with. */
+    filter?: string;
+    /** `metric`/`stat`: which `ctx.metrics.*` series the panel renders. */
+    metricName?: string;
+    /** `stat`: which value of the series to show (defaults to `last`). */
+    stat?: StatAggregation;
+}
+
+/** One saved panel on a dashboard. */
+export interface DashboardPanel {
+    config: PanelConfig;
+    id: string;
+    kind: PanelKind;
+    title: string;
+}
+
+/** The panel kinds, in the order the editor offers them. */
+export const PANEL_KINDS: readonly PanelKind[] = ["metric", "stat", "traces", "logs"];
+
+/** Human labels for each panel kind (editor dropdown + widget headers). */
+export const PANEL_KIND_LABELS: Record<PanelKind, string> = {
+    logs: "Logs shortcut",
+    metric: "Metric trend",
+    stat: "Single stat",
+    traces: "Traces shortcut",
+};
+
+/** The stat aggregations, in the order the editor offers them. */
+export const STAT_AGGREGATIONS: readonly StatAggregation[] = ["last", "first", "count"];
+
+/** Human labels for each stat aggregation. */
+export const STAT_AGGREGATION_LABELS: Record<StatAggregation, string> = {
+    count: "Data points",
+    first: "First value",
+    last: "Latest value",
+};
+
+/** `true` for the two kinds that render a metric series (`metric`, `stat`). */
+export const isMetricPanel = (kind: PanelKind): boolean => kind === "metric" || kind === "stat";
+
+/**
+ * Reduce a raw config to only the keys the kind uses, so a config never carries
+ * a stale `metricName` after switching to a shortcut (or a stray `filter` on a
+ * metric panel). A `stat` panel always keeps a defined aggregation (`last`).
+ */
+export const normalizePanelConfig = (kind: PanelKind, raw: PanelConfig): PanelConfig => {
+    if (kind === "metric") {
+        return raw.metricName === undefined || raw.metricName === "" ? {} : { metricName: raw.metricName };
+    }
+
+    if (kind === "stat") {
+        return {
+            stat: raw.stat ?? "last",
+            ...(raw.metricName === undefined || raw.metricName === "" ? {} : { metricName: raw.metricName }),
+        };
+    }
+
+    // traces / logs shortcut: only the saved filter, and only when non-empty.
+    return raw.filter === undefined || raw.filter.trim() === "" ? {} : { filter: raw.filter.trim() };
+};
+
+/**
+ * Build a panel from editor input. `id` is passed in (the caller mints it in an
+ * event handler, keeping this pure and testable); the title falls back to the
+ * kind label when blank, and the config is normalized to the kind.
+ */
+export const createPanel = (input: { config: PanelConfig; id: string; kind: PanelKind; title: string }): DashboardPanel => {
+    const title = input.title.trim();
+
+    return {
+        config: normalizePanelConfig(input.kind, input.config),
+        id: input.id,
+        kind: input.kind,
+        title: title === "" ? PANEL_KIND_LABELS[input.kind] : title,
+    };
+};
+
+/** Append a panel to a board (immutably). */
+export const addPanel = (panels: readonly DashboardPanel[], panel: DashboardPanel): DashboardPanel[] => [...panels, panel];
+
+/** Remove the panel with `id` from a board (immutably); a no-op when absent. */
+export const removePanel = (panels: readonly DashboardPanel[], id: string): DashboardPanel[] => panels.filter((panel) => panel.id !== id);
+
+/**
+ * Move a panel one slot toward the front (`up`) or back (`down`) by swapping it
+ * with its neighbor. Clamped at the ends (moving the first panel up, or the last
+ * down, returns an unchanged copy) and a no-op for an unknown id.
+ */
+export const movePanel = (panels: readonly DashboardPanel[], id: string, direction: "down" | "up"): DashboardPanel[] => {
+    const index = panels.findIndex((panel) => panel.id === id);
+
+    if (index === -1) {
+        return [...panels];
+    }
+
+    const target = direction === "up" ? index - 1 : index + 1;
+
+    if (target < 0 || target >= panels.length) {
+        return [...panels];
+    }
+
+    const next = [...panels];
+
+    [next[index], next[target]] = [next[target], next[index]];
+
+    return next;
+};
+
+/**
+ * Validate a single panel, returning a human error string or `null` when valid.
+ * Metric and stat panels require a metric name; shortcut panels are always valid
+ * (an empty filter simply deep-links the tab with no pre-set filter).
+ */
+export const validatePanel = (panel: DashboardPanel): null | string => {
+    if (isMetricPanel(panel.kind) && (panel.config.metricName === undefined || panel.config.metricName === "")) {
+        return `${PANEL_KIND_LABELS[panel.kind]} panel "${panel.title}" needs a metric name`;
+    }
+
+    return null;
+};
+
+/** Validate every panel on a board; returns the first error, or `null` when all are valid. */
+export const validatePanels = (panels: readonly DashboardPanel[]): null | string => {
+    for (const panel of panels) {
+        const error = validatePanel(panel);
+
+        if (error !== null) {
+            return error;
+        }
+    }
+
+    return null;
+};
+
+/** Minimal shape of a metric series a stat panel reduces (decoupled from `metrics-read`). */
+export interface MetricSeriesLike {
+    firstValue: number;
+    lastValue: number;
+    name: string;
+    points: readonly unknown[];
+}
+
+/**
+ * Reduce the metric series a `stat` panel points at to its single number, per the
+ * panel's aggregation (`last`/`first`/`count`). Returns `undefined` when the
+ * panel has no metric name or the named series isn't in the window (so the widget
+ * can render a "no data" state rather than a misleading zero).
+ */
+export const statValue = (series: readonly MetricSeriesLike[], panel: DashboardPanel): number | undefined => {
+    if (panel.config.metricName === undefined || panel.config.metricName === "") {
+        return undefined;
+    }
+
+    const match = series.find((candidate) => candidate.name === panel.config.metricName);
+
+    if (match === undefined) {
+        return undefined;
+    }
+
+    switch (panel.config.stat ?? "last") {
+        case "count": {
+            return match.points.length;
+        }
+        case "first": {
+            return match.firstValue;
+        }
+        default: {
+            return match.lastValue;
+        }
+    }
+};


### PR DESCRIPTION
## Tier 2 — custom dashboards

A **Dashboards** tab of user-defined, Grafana-style boards over existing telemetry (no new backend):
- `dashboards` `.global()` table (per-org: name + ordered inline panels); org-scoped `list`/`get`/`create`/`update`/`remove` with the sibling authz + `assertRowInOrg` IDOR guard.
- Panel kinds: `metric` (sparkline/trend), `stat` (single number), `traces`/`logs` saved-filter deep-links. Pure add/remove/reorder reducers (tested). `MetricSparkline` extracted from `MetricsSection` for reuse.
- React-Doctor-clean (pure render, no setState-in-effect, all components <300 lines).

**Verify:** 388 cloud tests pass (17 new); tsc clean; codegen regenerated.

> **Cloud merge order:** merge **last**; rebase + re-codegen (shared `OrganizationDashboard` tab + `MetricsSection` extraction + `schema.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)