### PR TITLE
test(vite): satisfy prefer-expect-assertions on studio-plugin test

### DIFF
--- a/packages/vite/__tests__/studio-plugin.test.ts
+++ b/packages/vite/__tests__/studio-plugin.test.ts
@@ -174,6 +174,11 @@ describe("studioPlugin", () => {
     });
 
     it("serves studio assets with revalidation headers and honours a matching ETag", () => {
+        // At least one assertion always runs (the 200/501 check below), so this is
+        // safe on both the built and unbuilt-studio paths — and it satisfies
+        // `vitest/prefer-expect-assertions` (which wants it as the first expression).
+        expect.hasAssertions();
+
         const middleware = installMiddleware("localhost");
         const next = vi.fn<() => void>();
         const { response } = makeResponse();


### PR DESCRIPTION
Follow-up to #172: restore `expect.hasAssertions()` as the first expression of the studio-plugin ETag test (the unconditional `expect([200,501])` guarantees ≥1 assertion, so it's safe on the unbuilt-studio path). Clears a `vitest/prefer-expect-assertions` warning that fails `Lint (eslint)` (--max-warnings=0) on any PR making @lunora/vite affected — currently blocking #173/#174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)