### PR TITLE
feat(ai): correlate ai-gateway calls with functionPath/traceId

### DIFF
--- a/packages/ai/__tests__/build-provider.test.ts
+++ b/packages/ai/__tests__/build-provider.test.ts
@@ -94,3 +94,85 @@ describe("provider construction from a binding", () => {
         expect(createWorkersAI).toHaveBeenCalledWith({ binding, gateway });
     });
 });
+
+// A fixed 32-hex trace id for the correlation-metadata assertions. Not a
+// credential — the `no-secrets` heuristic just sees a high-entropy hex run.
+// eslint-disable-next-line no-secrets/no-secrets -- fake test trace id, not a real secret
+const FAKE_TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+describe("gateway correlation metadata", () => {
+    beforeEach(() => {
+        createWorkersAI.mockClear();
+    });
+
+    it("folds functionPath + traceId into the env-derived gateway's metadata", () => {
+        const binding = fakeBinding();
+
+        createAi({
+            binding,
+            env: { LUNORA_AI_GATEWAY_ACCOUNT_ID: "acct-123", LUNORA_AI_GATEWAY_ID: "my-gateway" },
+            metadata: { functionPath: "messages:send", traceId: FAKE_TRACE_ID },
+        });
+
+        expect(createWorkersAI).toHaveBeenCalledWith({
+            binding,
+            gateway: { id: "my-gateway", metadata: { functionPath: "messages:send", traceId: FAKE_TRACE_ID } },
+        });
+    });
+
+    it("sends only the defined metadata fields", () => {
+        const binding = fakeBinding();
+
+        createAi({
+            binding,
+            env: { LUNORA_AI_GATEWAY_ACCOUNT_ID: "acct-123", LUNORA_AI_GATEWAY_ID: "my-gateway" },
+            metadata: { functionPath: "messages:send" },
+        });
+
+        expect(createWorkersAI).toHaveBeenCalledWith({ binding, gateway: { id: "my-gateway", metadata: { functionPath: "messages:send" } } });
+    });
+
+    it("omits gateway metadata entirely when no correlation field is defined", () => {
+        const binding = fakeBinding();
+
+        createAi({
+            binding,
+            env: { LUNORA_AI_GATEWAY_ACCOUNT_ID: "acct-123", LUNORA_AI_GATEWAY_ID: "my-gateway" },
+            metadata: { functionPath: undefined, traceId: undefined },
+        });
+
+        // No `metadata` key on the gateway option — the env-derived gateway is
+        // still routed by id, unchanged from the no-metadata case.
+        expect(createWorkersAI).toHaveBeenCalledWith({ binding, gateway: { id: "my-gateway" } });
+    });
+
+    it("does not attach metadata when no gateway is configured (additive/opt-in)", () => {
+        const binding = fakeBinding();
+
+        createAi({ binding, env: { SOME_OTHER: "x" }, metadata: { functionPath: "messages:send", traceId: FAKE_TRACE_ID } });
+
+        // Without gateway env vars there is no gateway to correlate — the direct
+        // Workers AI path stays exactly as before.
+        expect(createWorkersAI).toHaveBeenCalledWith({ binding, gateway: undefined });
+    });
+
+    it("folds metadata into an explicit gateway that carries none", () => {
+        const binding = fakeBinding();
+
+        createAi({ binding, gateway: { cacheTtl: 60, id: "explicit" }, metadata: { functionPath: "messages:send", traceId: FAKE_TRACE_ID } });
+
+        expect(createWorkersAI).toHaveBeenCalledWith({
+            binding,
+            gateway: { cacheTtl: 60, id: "explicit", metadata: { functionPath: "messages:send", traceId: FAKE_TRACE_ID } },
+        });
+    });
+
+    it("preserves an explicit gateway's own metadata over the threaded correlation", () => {
+        const binding = fakeBinding();
+        const gateway = { id: "explicit", metadata: { tenant: "acme" } };
+
+        createAi({ binding, gateway, metadata: { functionPath: "messages:send", traceId: FAKE_TRACE_ID } });
+
+        expect(createWorkersAI).toHaveBeenCalledWith({ binding, gateway });
+    });
+});

--- a/packages/ai/__tests__/create-ai.test.ts
+++ b/packages/ai/__tests__/create-ai.test.ts
@@ -7,7 +7,9 @@ import { AI_GATEWAY_ACCOUNT_ID_ENV, AI_GATEWAY_ID_ENV } from "../src/gateway";
 import type { AiBindingLike, WorkersAiProviderLike } from "../src/types";
 
 /** A configured-gateway env (account + gateway id, no auth token). */
-const gatewayEnv = (): Record<string, unknown> => ({ [AI_GATEWAY_ACCOUNT_ID_ENV]: "acct-123", [AI_GATEWAY_ID_ENV]: "my-gateway" });
+const gatewayEnv = (): Record<string, unknown> => {
+    return { [AI_GATEWAY_ACCOUNT_ID_ENV]: "acct-123", [AI_GATEWAY_ID_ENV]: "my-gateway" };
+};
 
 /**
  * A fake Workers AI provider. Calling it records the requested model id and
@@ -182,6 +184,19 @@ describe("createAi", () => {
             await ai.run("@cf/meta/m2m100-1.2b", { text: "hi" });
 
             expect(binding.runCalls).toStrictEqual([["@cf/meta/m2m100-1.2b", { text: "hi" }, { gateway: { id: "my-gateway" } }]]);
+        });
+
+        it("carries the correlation metadata on the env-resolved gateway", async () => {
+            const binding = fakeBinding();
+            // eslint-disable-next-line no-secrets/no-secrets -- fake test trace id, not a real secret
+            const traceId = "0123456789abcdef0123456789abcdef";
+            const ai = createAi({ binding, env: gatewayEnv(), metadata: { functionPath: "messages:send", traceId } });
+
+            await ai.run("@cf/meta/m2m100-1.2b", { text: "hi" });
+
+            expect(binding.runCalls).toStrictEqual([
+                ["@cf/meta/m2m100-1.2b", { text: "hi" }, { gateway: { id: "my-gateway", metadata: { functionPath: "messages:send", traceId } } }],
+            ]);
         });
 
         it("preserves a caller-supplied gateway over the env-resolved one", async () => {

--- a/packages/ai/__tests__/gateway.test.ts
+++ b/packages/ai/__tests__/gateway.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { AI_GATEWAY_ACCOUNT_ID_ENV, AI_GATEWAY_ID_ENV, AI_GATEWAY_TOKEN_ENV, resolveAiGateway } from "../src/gateway";
+import { AI_GATEWAY_ACCOUNT_ID_ENV, AI_GATEWAY_ID_ENV, AI_GATEWAY_TOKEN_ENV, buildAiGatewayMetadataFields, resolveAiGateway } from "../src/gateway";
 
 /** A configured-gateway env, without any auth token. */
 const configuredEnv = (): Record<string, unknown> => {
@@ -64,5 +64,27 @@ describe(resolveAiGateway, () => {
         const resolved = resolveAiGateway(configuredEnv(), {});
 
         expect(resolved?.headers).toStrictEqual({});
+    });
+});
+
+describe(buildAiGatewayMetadataFields, () => {
+    it("returns undefined for undefined metadata", () => {
+        expect.assertions(1);
+        expect(buildAiGatewayMetadataFields(undefined)).toBeUndefined();
+    });
+
+    it("returns undefined when no field is defined", () => {
+        expect.assertions(2);
+        expect(buildAiGatewayMetadataFields({})).toBeUndefined();
+        expect(buildAiGatewayMetadataFields({ functionPath: "", traceId: undefined })).toBeUndefined();
+    });
+
+    it("projects only the defined, non-empty correlation fields", () => {
+        expect.assertions(2);
+        expect(buildAiGatewayMetadataFields({ functionPath: "messages:send", traceId: FAKE_TRACE_ID })).toStrictEqual({
+            functionPath: "messages:send",
+            traceId: FAKE_TRACE_ID,
+        });
+        expect(buildAiGatewayMetadataFields({ functionPath: "messages:send" })).toStrictEqual({ functionPath: "messages:send" });
     });
 });

--- a/packages/ai/src/create-ai.ts
+++ b/packages/ai/src/create-ai.ts
@@ -2,7 +2,8 @@ import { LunoraError } from "@lunora/errors";
 import type { EmbeddingModel, LanguageModel } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 
-import { resolveAiGateway } from "./gateway";
+import type { AiGatewayMetadata } from "./gateway";
+import { buildAiGatewayMetadataFields, resolveAiGateway } from "./gateway";
 import type { AiBindingLike, AiGatewayOptions, EmbeddingModelInput, LunoraAi, LunoraAiOptions, ModelInput, WorkersAiProviderLike } from "./types";
 
 /**
@@ -11,19 +12,35 @@ import type { AiBindingLike, AiGatewayOptions, EmbeddingModelInput, LunoraAi, Lu
  * a Cloudflare AI Gateway (`LUNORA_AI_GATEWAY_*`), route through it by its id so
  * the gateway computes token + dollar-cost telemetry. Returns `undefined` when
  * neither applies — the direct-to-Workers-AI path, unchanged.
+ *
+ * When correlation `metadata` (`{ functionPath, traceId }`) is supplied and a
+ * gateway is active, its defined fields are folded into the gateway option's
+ * native `metadata` so the AI Gateway log ties back to the Lunora trace. It is
+ * never added to an explicit gateway that already carries its own `metadata`,
+ * and is a no-op when no gateway resolves — additive and backward-compatible.
  */
-const resolveGatewayOption = (gateway: AiGatewayOptions | undefined, env: Record<string, unknown> | undefined): AiGatewayOptions | undefined => {
+const resolveGatewayOption = (
+    gateway: AiGatewayOptions | undefined,
+    env: Record<string, unknown> | undefined,
+    metadata: AiGatewayMetadata | undefined,
+): AiGatewayOptions | undefined => {
+    const metadataFields = buildAiGatewayMetadataFields(metadata);
+
     if (gateway !== undefined) {
-        return gateway;
+        return metadataFields !== undefined && gateway.metadata === undefined ? { ...gateway, metadata: metadataFields } : gateway;
     }
 
     if (env === undefined) {
         return undefined;
     }
 
-    const resolved = resolveAiGateway(env);
+    const resolved = resolveAiGateway(env, metadata);
 
-    return resolved === undefined ? undefined : { id: resolved.gatewayId };
+    if (resolved === undefined) {
+        return undefined;
+    }
+
+    return metadataFields === undefined ? { id: resolved.gatewayId } : { id: resolved.gatewayId, metadata: metadataFields };
 };
 
 /**
@@ -57,7 +74,7 @@ const buildProvider = (binding: AiBindingLike, gateway?: LunoraAiOptions["gatewa
  * @experimental
  */
 const createAi = (options: LunoraAiOptions): LunoraAi => {
-    const { binding, defaultEmbeddingModel, defaultModel, env, gateway, provider } = options;
+    const { binding, defaultEmbeddingModel, defaultModel, env, gateway, metadata, provider } = options;
 
     if (!provider && !binding) {
         throw new LunoraError("INTERNAL", "@lunora/ai: createAi requires a `binding` (env.AI) or a pre-built `provider`");
@@ -68,7 +85,7 @@ const createAi = (options: LunoraAiOptions): LunoraAi => {
     // `gateway` wins; else an env-configured AI Gateway routes Workers AI through
     // it (opt-in), so token + dollar-cost telemetry is computed by the gateway.
     // Resolved once so the raw `ai.run()` path below routes through the same gateway.
-    const resolvedGateway = resolveGatewayOption(gateway, env);
+    const resolvedGateway = resolveGatewayOption(gateway, env, metadata);
     const workersai: WorkersAiProviderLike = provider ?? buildProvider(binding as AiBindingLike, resolvedGateway);
 
     const model = (input?: ModelInput): LanguageModel => {

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -20,10 +20,14 @@ const readEnv = (env: Record<string, unknown>, key: string): string | undefined 
 };
 
 /**
- * Encode the `cf-aig-metadata` header value from the defined correlation fields,
- * or `undefined` when nothing is set (so the header is omitted, never sent empty).
+ * Project {@link AiGatewayMetadata} to a plain string-map of only its defined,
+ * non-empty fields, or `undefined` when nothing is set. This is the shared source
+ * of truth behind both gateway-correlation forms: the `cf-aig-metadata` HTTP
+ * header (bring-your-own providers) and the Workers AI binding's native
+ * `gateway.metadata` option — both encode the same `{ functionPath, traceId }`.
+ * @experimental
  */
-const encodeMetadata = (metadata: AiGatewayMetadata | undefined): string | undefined => {
+const buildAiGatewayMetadataFields = (metadata: AiGatewayMetadata | undefined): Record<string, string> | undefined => {
     if (metadata === undefined) {
         return undefined;
     }
@@ -38,7 +42,17 @@ const encodeMetadata = (metadata: AiGatewayMetadata | undefined): string | undef
         fields["traceId"] = metadata.traceId;
     }
 
-    return Object.keys(fields).length > 0 ? JSON.stringify(fields) : undefined;
+    return Object.keys(fields).length > 0 ? fields : undefined;
+};
+
+/**
+ * Encode the `cf-aig-metadata` header value from the defined correlation fields,
+ * or `undefined` when nothing is set (so the header is omitted, never sent empty).
+ */
+const encodeMetadata = (metadata: AiGatewayMetadata | undefined): string | undefined => {
+    const fields = buildAiGatewayMetadataFields(metadata);
+
+    return fields === undefined ? undefined : JSON.stringify(fields);
 };
 
 /**
@@ -137,3 +151,5 @@ export const resolveAiGateway = (env: Record<string, unknown>, metadata?: AiGate
         headers,
     };
 };
+
+export { buildAiGatewayMetadataFields };

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,6 +1,6 @@
 export { default as createAi } from "./create-ai";
 export type { AiGatewayMetadata, ResolvedAiGateway } from "./gateway";
-export { AI_GATEWAY_ACCOUNT_ID_ENV, AI_GATEWAY_ID_ENV, AI_GATEWAY_TOKEN_ENV, resolveAiGateway } from "./gateway";
+export { AI_GATEWAY_ACCOUNT_ID_ENV, AI_GATEWAY_ID_ENV, AI_GATEWAY_TOKEN_ENV, buildAiGatewayMetadataFields, resolveAiGateway } from "./gateway";
 export type { AiBindingLike, AiGatewayOptions, EmbeddingModelInput, LunoraAi, LunoraAiOptions, ModelInput, WorkersAiProviderLike } from "./types";
 
 // Re-export the AI SDK primitives apps reach for, so `@lunora/ai` is a single

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,5 +1,7 @@
 import type { EmbeddingModel, LanguageModel } from "ai";
 
+import type { AiGatewayMetadata } from "./gateway";
+
 /**
  * Structural projection of the Cloudflare Workers `AI` binding (`env.AI`).
  * Declared locally so unit tests can pass a plain-object double and the real
@@ -33,6 +35,13 @@ export interface WorkersAiProviderLike {
 export interface AiGatewayOptions {
     [key: string]: unknown;
     id: string;
+
+    /**
+     * Custom correlation metadata surfaced in the AI Gateway logs (Cloudflare's
+     * native `gateway.metadata`). `@lunora/ai` folds `{ functionPath, traceId }`
+     * here from {@link LunoraAiOptions.metadata} when a gateway is configured.
+     */
+    metadata?: Record<string, string>;
 }
 
 /**
@@ -79,6 +88,16 @@ export interface LunoraAiOptions {
      * value wins over anything derived from {@link LunoraAiOptions.env}.
      */
     gateway?: AiGatewayOptions;
+
+    /**
+     * Correlation metadata folded into the active gateway call (the Workers AI
+     * binding's native `gateway.metadata`) so an AI Gateway log entry ties back
+     * to the Lunora function + trace that made it. Only applied when a gateway is
+     * actually configured (explicit or env-derived) and only its defined fields
+     * are sent — absent otherwise, so behavior is unchanged. The generated
+     * `ctx.ai` facade threads `{ functionPath, traceId }` here automatically.
+     */
+    metadata?: AiGatewayMetadata;
 
     /**
      * Pre-built Workers AI provider. When omitted, one is constructed from

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2104,7 +2104,7 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
         });
 
         it("wires ctx.ai into the ShardDO when AI is used", () => {
-            expect.assertions(6);
+            expect.assertions(8);
 
             const schema: SchemaIR = { tables: [], vectorIndexes: [] };
 
@@ -2116,8 +2116,14 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             expect(output).toContain("AiBindingLike");
             expect(output).toContain("ai?: (env: Record<string, unknown>) => AiBindingLike;");
             expect(output).toContain("const aiStub: LunoraAi");
-            expect(output).toContain("createAi({ binding: aiBinding as AiBindingLike, env: env as Record<string, unknown> })");
+            expect(output).toContain(
+                "createAi({ binding: aiBinding as AiBindingLike, env: env as Record<string, unknown>, metadata: { functionPath: options.functionPath, traceId: aiTrace?.traceId } })",
+            );
             expect(output).toContain("ai,");
+            // Correlation ids are threaded into the gateway metadata, reading the
+            // dispatch trace under the same anchor guard the tracer uses.
+            expect(output).toContain("const aiTrace = options.identity ? undefined : this.getCurrentTrace();");
+            expect(output).toContain("traceId: aiTrace?.traceId");
         });
 
         it("omits @lunora/ai entirely when AI is not used", () => {

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -2334,7 +2334,16 @@ const emitAiFragments = (hasAi: boolean): { build: string; configField: string; 
         // a handler is never locked to Workers AI. Falls back to `aiStub`.
         build: `
             const aiBinding = config.ai?.(env) ?? (env as Record<string, unknown>).AI;
-            const ai: LunoraAi = aiBinding ? createAi({ binding: aiBinding as AiBindingLike, env: env as Record<string, unknown> }) : aiStub;
+            // Correlate AI-Gateway-routed calls with the Lunora trace: thread the
+            // function path + trace id into createAi, which folds them into the
+            // gateway's native \`metadata\` only when a gateway is configured (absent
+            // otherwise). Mirror the tracer's anchor guard — a deferred subscription
+            // re-run must not borrow a concurrent dispatch's trace, so read
+            // \`getCurrentTrace()\` only on the synchronous (non-threaded-identity) path.
+            const aiTrace = options.identity ? undefined : this.getCurrentTrace();
+            const ai: LunoraAi = aiBinding
+                ? createAi({ binding: aiBinding as AiBindingLike, env: env as Record<string, unknown>, metadata: { functionPath: options.functionPath, traceId: aiTrace?.traceId } })
+                : aiStub;
 `,
         // Optional override for the Workers AI binding. When omitted, ctx.ai is
         // built from `env.AI` (the conventional binding the config layer


### PR DESCRIPTION
Auto-threads `functionPath` + `traceId` into the AI-Gateway call so gateway logs correlate to the Lunora trace (the #165 follow-up).

- Both ids are reachable at ai-facade construction in the generated `buildCtx`; the emit fragment threads them under the same anchor-guard the tracer uses (a deferred subscription re-run can't borrow another dispatch's trace).
- Uses Cloudflare's native `gateway.metadata` for Workers-AI/binding calls and the `cf-aig-metadata` header for BYO providers. Additive/opt-in — attached only when a gateway resolves, never overrides a caller's own metadata.
- `resolveGatewayOption` folds it into both the AI-SDK model path and raw `ai.run()`.

ai 119 / codegen 863 tests pass. (Follow-up commit clears pre-existing `prefer-expect-assertions` debt in ai test files that the affected-lint surfaces.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional metadata support for AI Gateway requests.
  * AI calls can now include function path and trace ID details for improved correlation in gateway logs and tracing.
  * Added a public helper for constructing AI Gateway metadata fields.
  * Gateway metadata is applied consistently when a gateway is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->