### PR TITLE
fix(codegen): sort schema snapshot keys by code unit, not locale

### DIFF
--- a/packages/cli/__tests__/commands/init-smoke.test.ts
+++ b/packages/cli/__tests__/commands/init-smoke.test.ts
@@ -48,7 +48,19 @@ describe("lunora init smoke", () => {
         rmSync(workdir, { force: true, recursive: true });
     });
 
-    describe("lunora init → codegen → wrangler validator (Phase 5 smoke)", () => {
+    /*
+     * Each case scaffolds a whole project, parses its schema + function modules
+     * through `runCodegen` (a real TypeScript parse), and runs the wrangler
+     * validator. That is far more work than a unit test, and it lands against the
+     * shared 10s local budget (`tools/get-vitest-config.ts`; CI gets 30s). On an
+     * unloaded machine the heaviest case takes ~6.4s of that 10s — thin enough
+     * that running anything else concurrently tips it over, which surfaced as
+     * intermittent "Test timed out in 10000ms" locally while CI stayed green.
+     *
+     * Scoped to this suite rather than raising the global default, so genuinely
+     * hung unit tests elsewhere still fail fast.
+     */
+    describe("lunora init → codegen → wrangler validator (Phase 5 smoke)", { timeout: 60_000 }, () => {
         it("vite template produces a project that codegen + wrangler validator accept", async () => {
             expect.assertions(9);
 

--- a/packages/codegen/__tests__/schema-drift.test.ts
+++ b/packages/codegen/__tests__/schema-drift.test.ts
@@ -52,6 +52,26 @@ describe("schema-drift", () => {
             expect(snapshot.migrationIds).toStrictEqual(["m1", "m2"]);
         });
 
+        it("orders tables and migration ids by code unit, not locale collation", () => {
+            expect.assertions(2);
+
+            /*
+             * `.lunora-schema.json` is committed, so its byte order must not depend
+             * on the machine that generated it. `localeCompare` resolves against the
+             * runtime's default locale and ICU version — under ICU collation "a"
+             * sorts BEFORE "B", while by code unit "B" (0x42) sorts before "a"
+             * (0x61). These fixtures are chosen so the two orderings disagree: a
+             * regression to a locale-aware comparator flips both assertions.
+             */
+            const snapshot = buildSchemaSnapshot(
+                schema([table("apples", { x: stringField }), table("Berries", { x: stringField }), table("_hidden", { x: stringField })]),
+                ["b_two", "A_one"],
+            );
+
+            expect(Object.keys(snapshot.tables)).toStrictEqual(["Berries", "_hidden", "apples"]);
+            expect(snapshot.migrationIds).toStrictEqual(["A_one", "b_two"]);
+        });
+
         it("encodes shard mode as a stable string", () => {
             expect.assertions(3);
 

--- a/packages/codegen/src/schema-drift.ts
+++ b/packages/codegen/src/schema-drift.ts
@@ -161,11 +161,25 @@ const tableSnapshotOf = (table: TableIR): TableSnapshot => {
     return { fields, indexes, relations, shardMode: encodeShardMode(table.shardMode) };
 };
 
-/** Return a new object with its keys sorted, so JSON serialization is deterministic. */
+/**
+ * Return a new object with its keys sorted, so JSON serialization is deterministic.
+ *
+ * Sorted by UTF-16 code unit, NOT `localeCompare`. `localeCompare` resolves
+ * against the runtime's default locale and ICU version, so it is not stable
+ * across machines — which defeats the entire purpose here: `.lunora-schema.json`
+ * is a COMMITTED file, so a locale-sensitive ordering means two developers (or a
+ * developer and CI, or one machine before and after a Node upgrade) can
+ * regenerate the same schema and produce different bytes, showing up as a
+ * spurious diff and a false drift signal.
+ */
 const sortKeys = <T>(record: Record<string, T>): Record<string, T> => {
     const sorted: Record<string, T> = {};
+    const keys = Object.keys(record);
 
-    for (const key of Object.keys(record).toSorted((a, b) => a.localeCompare(b))) {
+    // eslint-disable-next-line sonarjs/no-alphabetical-sort -- code-unit order is required for cross-machine byte stability; a localeCompare comparator is the bug, not the fix
+    keys.sort();
+
+    for (const key of keys) {
         sorted[key] = record[key] as T;
     }
 
@@ -175,7 +189,12 @@ const sortKeys = <T>(record: Record<string, T>): Record<string, T> => {
 /**
  * Build a {@link SchemaSnapshot} from a parsed {@link SchemaIR} and the set of
  * declared migration ids. Tables and migration ids are sorted so the emitted
- * JSON is byte-stable across runs (no spurious diffs / churn).
+ * JSON is byte-stable across runs AND across machines (no spurious diffs /
+ * churn) — see {@link sortKeys} for why that ordering must not be locale-aware.
+ *
+ * Field / index / relation keys are deliberately NOT sorted: they are emitted in
+ * declaration order from the schema source, which is already deterministic for a
+ * given source file and keeps the snapshot readable next to the schema it mirrors.
  */
 const buildSchemaSnapshot = (schema: SchemaIR, migrationIds: ReadonlyArray<string>): SchemaSnapshot => {
     const tables: Record<string, TableSnapshot> = {};
@@ -184,9 +203,12 @@ const buildSchemaSnapshot = (schema: SchemaIR, migrationIds: ReadonlyArray<strin
         tables[table.name] = tableSnapshotOf(table);
     }
 
+    // eslint-disable-next-line sonarjs/no-alphabetical-sort, unicorn/no-array-sort -- see `sortKeys`: code-unit order, not locale collation; the spread already copies
+    const sortedMigrationIds = [...migrationIds].sort();
+
     return {
         jurisdiction: schema.jurisdiction,
-        migrationIds: [...migrationIds].toSorted((a, b) => a.localeCompare(b)),
+        migrationIds: sortedMigrationIds,
         tables: sortKeys(tables),
         version: SCHEMA_SNAPSHOT_VERSION,
     };


### PR DESCRIPTION
The two follow-ups flagged during the benchmark/perf audit in #185, which were out of scope there. Independent of that PR — this branches off `alpha` directly.

## 1. `codegen` — schema snapshot ordering was locale-dependent

`packages/codegen/src/schema-drift.ts` sorted table names and migration ids with `localeCompare`. That resolves against the runtime's default locale and ICU version, so it is not stable across machines — which defeats the entire point, since `.lunora-schema.json` is a **committed** file and the sort exists specifically to make it byte-stable.

The failure mode: two developers, or a developer and CI, or one machine either side of a Node upgrade, regenerate the same schema and get different bytes. That reads as a spurious diff and a false drift signal.

Now sorted by UTF-16 code unit, which is locale-independent. Same bug class as the two instances fixed in `@lunora/replica` in #185 — this was the third, in a different package.

**No committed snapshot changes.** I checked all 9 in-repo `.lunora-schema.json` files object-by-object (191 objects) and no key ordering differs between the two comparators: every table and migration name is lowercase ASCII, where ICU collation and code-unit order agree. So no fixture regeneration, and the diff is confined to source plus a test.

The new test uses fixtures where the two orderings genuinely disagree (`Berries` / `_hidden` / `apples`, and `A_one` / `b_two`), so a regression to a locale-aware comparator flips it. Without that, a test using ordinary lowercase names would pass under either comparator and guard nothing.

Field / index / relation keys are left in declaration order — they were never locale-sorted, and that is now documented rather than left ambiguous.

## 2. `cli` — the init smoke suite runs against too tight a timeout

Each case scaffolds a whole project, parses its schema and function modules through `runCodegen` (a real TypeScript parse), and runs the wrangler validator. That is far more work than a unit test, and it lands against the shared 10s local budget (`tools/get-vitest-config.ts`; CI gets 30s).

On an unloaded machine the heaviest case takes ~6.4s of that 10s — thin enough that running anything else concurrently tips it over. It failed exactly that way twice during the #185 audit and passed on re-run, while CI stayed green. Each occurrence costs a full re-run to diagnose.

Scoped to this suite via `describe(name, { timeout }, fn)` rather than raising the global default, so genuinely hung unit tests elsewhere still fail fast.

Worth noting for anyone who saw my earlier description of this: the suite is **offline** — it scaffolds via `--from` against the local templates root, not giget. The cost is CPU, not network.

## Verification

`codegen` 864 tests, `cli` 684 tests, types clean, zero eslint errors. Affected run green across 6 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Schema snapshots are now generated consistently across different locales and environments.
  - Migration ordering and snapshot key ordering are deterministic, producing stable output for comparisons and reviews.
  - Existing declaration order for fields, indexes, and relations is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->