### PR TITLE
fix(do): propagate the inbound sampled bit instead of hardcoding it

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -2414,6 +2414,7 @@ interface TelemetrySink {
 ```ts
 interface TraceAnchor {
     rootSpanId: string;
+    sampled?: boolean;
     traceId: string;
 }
 ```

--- a/packages/do/__tests__/trace-context.test.ts
+++ b/packages/do/__tests__/trace-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTraceAnchor } from "../src/trace-context";
+
+/**
+ * The dispatch's trace anchor.
+ *
+ * `resolveTraceAnchor` decides two things a whole dispatch's telemetry hangs
+ * off: which trace its spans belong to, and whether that trace is sampled. Both
+ * have to come from the inbound `traceparent` when there is one — a shard that
+ * mints its own ids strands its spans in a trace the collector has no root for,
+ * and a shard that re-decides sampling produces a trace kept in the middle and
+ * dropped at both ends.
+ */
+
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+const PARENT_SPAN_ID = "b7ad6b7169203331";
+
+describe("resolveTraceAnchor", () => {
+    it("adopts the inbound trace and parent span so shard spans join the caller's trace", () => {
+        expect.assertions(2);
+
+        const anchor = resolveTraceAnchor(`00-${TRACE_ID}-${PARENT_SPAN_ID}-01`);
+
+        expect(anchor.traceId).toBe(TRACE_ID);
+        expect(anchor.rootSpanId).toBe(PARENT_SPAN_ID);
+    });
+
+    it("inherits an inbound sampled-out verdict instead of re-deciding it", () => {
+        expect.assertions(2);
+
+        // The `00` flags octet is an upstream that already sampled this trace out.
+        expect(resolveTraceAnchor(`00-${TRACE_ID}-${PARENT_SPAN_ID}-00`).sampled).toBe(false);
+        expect(resolveTraceAnchor(`00-${TRACE_ID}-${PARENT_SPAN_ID}-01`).sampled).toBe(true);
+    });
+
+    it("mints a sampled, self-contained trace when there is no inbound context", () => {
+        expect.assertions(4);
+
+        // A subscription re-run or a server-initiated call: no caller to inherit
+        // from, so the shard IS the root and there is no verdict to honour.
+        const anchor = resolveTraceAnchor(undefined);
+
+        expect(anchor.sampled).toBe(true);
+        expect(anchor.traceId).toHaveLength(32);
+        expect(anchor.rootSpanId).toHaveLength(16);
+        expect(anchor.traceId).not.toBe(resolveTraceAnchor(undefined).traceId);
+    });
+
+    it("falls back to a fresh trace when the inbound header is malformed", () => {
+        expect.assertions(2);
+
+        // A truncated trace id is not a trace we can join. Adopting it anyway
+        // would emit spans under an id no other service will ever report.
+        const anchor = resolveTraceAnchor("00-deadbeef-b7ad6b7169203331-01");
+
+        expect(anchor.traceId).not.toBe("deadbeef");
+        expect(anchor.traceId).toHaveLength(32);
+    });
+});

--- a/packages/do/__tests__/traced-fetch.test.ts
+++ b/packages/do/__tests__/traced-fetch.test.ts
@@ -16,9 +16,9 @@ import { createTracedFetch } from "../src/context-telemetry";
 
 const anchor = { rootSpanId: "b7ad6b7169203331", traceId: "0af7651916cd43dd8448eb211c80319c" };
 
-const makeDeps = (spans: SpanEvent[], propagate?: ((url: URL) => boolean) | boolean) => {
+const makeDeps = (spans: SpanEvent[], propagate?: ((url: URL) => boolean) | boolean, anchorOverride?: typeof anchor & { sampled?: boolean }) => {
     return {
-        anchor,
+        anchor: anchorOverride ?? anchor,
         functionPath: "orders:checkout",
         ...(propagate === undefined ? {} : { propagate }),
         record: (span: SpanEvent) => {
@@ -47,6 +47,33 @@ describe("createTracedFetch", () => {
         // callee parented to a span that was never exported.
         expect(sent?.parentSpanId).toBe(spans[0]?.spanId);
         expect(spans[0]?.traceId).toBe(anchor.traceId);
+    });
+
+    it("propagates the anchor's sampled verdict rather than always claiming sampled", async () => {
+        expect.assertions(2);
+
+        const spans: SpanEvent[] = [];
+        const seen: (null | string)[] = [];
+        const base = vi.fn<(request: Request) => Promise<Response>>(async (request) => {
+            seen.push(request.headers.get("traceparent"));
+
+            return new Response("ok");
+        });
+
+        // An upstream that sampled this trace OUT. Telling the callee otherwise
+        // makes it record spans for a trace nobody kept.
+        const unsampled = createTracedFetch(makeDeps(spans, undefined, { ...anchor, sampled: false }), base as never);
+
+        await unsampled("https://api.stripe.com/v1/charges");
+
+        expect(parseTraceparent(seen[0])?.sampled).toBe(false);
+
+        // No inbound verdict to honour — the shard is the trace root, so it samples.
+        const sampled = createTracedFetch(makeDeps(spans, undefined, { ...anchor, sampled: true }), base as never);
+
+        await sampled("https://api.stripe.com/v1/charges");
+
+        expect(parseTraceparent(seen[1])?.sampled).toBe(true);
     });
 
     it("records a CLIENT span with a low-cardinality name", async () => {

--- a/packages/do/src/context-telemetry.ts
+++ b/packages/do/src/context-telemetry.ts
@@ -129,6 +129,14 @@ export interface ContextMetrics {
 /** The trace a ctx's spans hang off: the shared id, and the span they parent to. */
 export interface TraceAnchor {
     rootSpanId: string;
+
+    /**
+     * The W3C `sampled` verdict for this trace, inherited from the inbound
+     * `traceparent` when there was one. Carried on the anchor rather than
+     * re-derived per outbound call so every `ctx.fetch` of one dispatch
+     * propagates the same answer.
+     */
+    sampled?: boolean;
     traceId: string;
 }
 
@@ -590,7 +598,10 @@ export const createTracedFetch = (deps: TracedFetchDeps, base: ContextFetch): Co
             // Set, not appended: a caller that already put a `traceparent` on the
             // request meant it, but our span is the immediate parent of whatever
             // the callee records, so ours is the correct one to send.
-            request.headers.set("traceparent", buildTraceparent(anchor.traceId, spanId, true));
+            // `anchor.sampled` — NOT a hardcoded `true`. Telling the callee a trace
+            // is sampled when it was sampled out upstream makes it record spans
+            // for a trace nobody kept, and the collector holds an orphan.
+            request.headers.set("traceparent", buildTraceparent(anchor.traceId, spanId, anchor.sampled ?? true));
         }
 
         // No separate `ok` flag: it is exactly `error === undefined` on every path

--- a/packages/do/src/trace-context.ts
+++ b/packages/do/src/trace-context.ts
@@ -18,10 +18,19 @@ import { otlpRandomHex, parseTraceparent } from "../../../shared/otlp";
  * dispatch with no inbound context — a subscription re-run, a server-initiated
  * call — still produces a coherent, self-contained local trace.
  */
-export const resolveTraceAnchor = (traceparent: string | undefined): { rootSpanId: string; traceId: string } => {
+export const resolveTraceAnchor = (traceparent: string | undefined): { rootSpanId: string; sampled: boolean; traceId: string } => {
     const inbound = parseTraceparent(traceparent);
 
-    return { rootSpanId: inbound?.parentSpanId ?? otlpRandomHex(8), traceId: inbound?.traceId ?? otlpRandomHex(16) };
+    return {
+        rootSpanId: inbound?.parentSpanId ?? otlpRandomHex(8),
+        // Honour the upstream verdict. An unsampled inbound trace stays unsampled
+        // through the shard and out to whatever the handler calls, which is the
+        // whole point of the bit — deciding again downstream produces a trace the
+        // collector holds only the middle of. Absent a `traceparent` there is no
+        // verdict to honour and the shard is the trace root, so it samples.
+        sampled: inbound?.sampled ?? true,
+        traceId: inbound?.traceId ?? otlpRandomHex(16),
+    };
 };
 
 /**


### PR DESCRIPTION
## What

`createTracedFetch` set the sampled flag on every outbound `traceparent` to a
literal `true`:

```ts
request.headers.set("traceparent", buildTraceparent(anchor.traceId, spanId, true));
```

`parseTraceparent` already reads the inbound bit, but `resolveTraceAnchor`
discarded it — so a trace an upstream had sampled **out** was announced to every
callee as sampled **in**.

## Why it matters

The callee records and exports spans for a trace nobody kept. The collector gets
a fragment with no root and no siblings, and the sampling decision the upstream
made is silently not the decision the system applied — the exact failure the
flag exists to prevent.

The runtime's own propagation (`otel-trace.ts:197`) already threaded
`trace.sampled` correctly. Only the shard path diverged, so worker-originated
and shard-originated hops of the same trace disagreed.

## The fix

The verdict rides on the `TraceAnchor`, resolved once per dispatch, so every
`ctx.fetch` of one dispatch propagates one consistent answer rather than each
deriving its own.

A dispatch with **no** inbound `traceparent` — a subscription re-run, a
server-initiated call — still samples: it is the trace root, so there is no
upstream verdict to inherit.

## Tests

- `traced-fetch.test.ts` — both directions through `ctx.fetch`
- `trace-context.test.ts` (new) — the anchor inheriting, defaulting, and
  rejecting a malformed inbound header

Both halves are mutation-verified: restoring the hardcoded `true`, or making the
anchor ignore the inbound verdict, each fail a test. `@lunora/do` 1245 passing,
`@lunora/runtime` 741 passing.

## Scope

Deliberately one fix. This was extracted by content from
`feat/platform-abstraction-layer` (#190); everything else OTel-related on that
branch either already exists on `alpha` (resource detection, tail-sampler
reporting, fail-closed redaction, the `createOtelTracer` bridge as
`@lunora/server/otel`) or is structural divergence with no behavioural benefit.
This was the only genuine bug that `alpha` still carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved distributed tracing to preserve the inbound trace’s sampling decision across outbound requests.
  - Prevented downstream spans from being recorded when the originating trace was not sampled.
  - Reduced orphaned telemetry data and improved trace consistency across connected services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->