### PR TITLE
fix(adapters): retire optimistic agent-chat rows under a windowed limit (Wave 15: 188)

### DIFF
--- a/api-snapshots/client.api.md
+++ b/api-snapshots/client.api.md
@@ -911,6 +911,16 @@ interface OptimisticLocalStore {
 }
 ```
 
+### `OptimisticMessage` (interface)
+
+```ts
+interface OptimisticMessage {
+    content: string;
+    id: number;
+    maxDurableSeqAtSend: number;
+}
+```
+
 ### `OptimisticUpdate` (type)
 
 ```ts
@@ -1026,6 +1036,22 @@ interface QueuedMutation<T = unknown> {
     readonly reject: (error: unknown) => void;
     readonly resolve: (value: T) => void;
     readonly shardKey?: string;
+}
+```
+
+### `RETIRE_AFTER_DURABLE_SEQ_ADVANCE` (const)
+
+```ts
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+```
+
+### `ReconcileDurableMessage` (interface)
+
+```ts
+interface ReconcileDurableMessage {
+    content: string;
+    role: "assistant" | "system" | "tool" | "user";
+    seq: number;
 }
 ```
 
@@ -1587,6 +1613,14 @@ const isUnauthorizedError: (error: unknown) => error is Error & {
 };
 ```
 
+### `maxSeq` (const)
+
+```ts
+const maxSeq: (messages: ReadonlyArray<{
+    seq: number;
+}>) => number;
+```
+
 ### `preloadQuery` (const)
 
 ```ts
@@ -1605,6 +1639,12 @@ const preloadedQueryResult: <T>(preloaded: Preloaded<T>) => T;
 
 ```ts
 const queryCacheKey: (functionPath: string, argsKey: string, shardKey?: string) => string;
+```
+
+### `reconcileOptimistic` (const)
+
+```ts
+const reconcileOptimistic: (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<ReconcileDurableMessage>) => OptimisticMessage[];
 ```
 
 ### `sendToSw` (const)

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -1307,6 +1307,10 @@ Re-exported from `@lunora/client` — signature tracked at its source.
 
 Re-exported from `@lunora/client` — signature tracked at its source.
 
+### `OptimisticMessage` (interface)
+
+Re-exported from `@lunora/client` — signature tracked at its source.
+
 ### `OptimisticUpdate` (type)
 
 Re-exported from `@lunora/client` — signature tracked at its source.
@@ -1360,6 +1364,14 @@ Re-exported from `@lunora/client` — signature tracked at its source.
 Re-exported from `@lunora/client` — signature tracked at its source.
 
 ### `QueuedMutation` (interface)
+
+Re-exported from `@lunora/client` — signature tracked at its source.
+
+### `RETIRE_AFTER_DURABLE_SEQ_ADVANCE` (const)
+
+Re-exported from `@lunora/client` — signature tracked at its source.
+
+### `ReconcileDurableMessage` (interface)
 
 Re-exported from `@lunora/client` — signature tracked at its source.
 
@@ -1611,6 +1623,10 @@ Re-exported from `@lunora/client` — signature tracked at its source.
 
 Re-exported from `@lunora/client` — signature tracked at its source.
 
+### `maxSeq` (const)
+
+Re-exported from `@lunora/client` — signature tracked at its source.
+
 ### `preloadQuery` (const)
 
 Re-exported from `@lunora/client` — signature tracked at its source.
@@ -1620,6 +1636,10 @@ Re-exported from `@lunora/client` — signature tracked at its source.
 Re-exported from `@lunora/client` — signature tracked at its source.
 
 ### `queryCacheKey` (const)
+
+Re-exported from `@lunora/client` — signature tracked at its source.
+
+### `reconcileOptimistic` (const)
 
 Re-exported from `@lunora/client` — signature tracked at its source.
 

--- a/packages/angular/__tests__/agent-chat.test.ts
+++ b/packages/angular/__tests__/agent-chat.test.ts
@@ -207,8 +207,10 @@ describe(agentChat, () => {
 
         // The turn lands (user seq 50 + assistant seq 51) and the window slides to
         // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
-        // USER-row count is unchanged (still 25), so the positional reconcile can
-        // never see the acknowledging row — only the seq-advance fallback retires it.
+        // USER-row count is unchanged (still 25), so a positional/count reconcile
+        // could never see the acknowledging row — the seq-based content match
+        // (user "new turn" at seq 50 > the send-time max of 49) retires it instead,
+        // window-independent because it matches on the monotonic seq, not a count.
         const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
 
         fake.push(MESSAGES_REF, { key: "t1", limit: 50 }, slidWindow);

--- a/packages/angular/__tests__/agent-chat.test.ts
+++ b/packages/angular/__tests__/agent-chat.test.ts
@@ -174,6 +174,55 @@ describe(agentChat, () => {
         destroy.destroy();
     });
 
+    it("retires the optimistic row under a saturated windowed limit, where the durable user-row count stays flat", async () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const chat: AgentChatResult = agentChat({
+            api: buildApi(),
+            client: fake.asClient,
+            destroyRef: destroy.asDestroyRef,
+            limit: 50,
+            send: makeRef(SEND_REF) as FunctionReference<"mutation">,
+            threadKey: "t1",
+        });
+
+        // A bounded window (limit 50) saturated by 25 completed turns — a user row
+        // and an assistant row each, seqs 0..49, so 25 durable user rows.
+        const seededWindow: Record<string, unknown>[] = [];
+
+        for (let turn = 0; turn < 25; turn += 1) {
+            seededWindow.push(
+                { content: `q-${String(turn)}`, role: "user", seq: turn * 2 },
+                { content: `a-${String(turn)}`, role: "assistant", seq: turn * 2 + 1 },
+            );
+        }
+
+        fake.push(MESSAGES_REF, { key: "t1", limit: 50 }, seededWindow);
+
+        // Send a new turn — its optimistic row renders atop the saturated window.
+        await chat.send("new turn");
+
+        expect(chat.messages().at(-1)).toStrictEqual({ content: "new turn", optimistic: true, role: "user", seq: 50 });
+
+        // The turn lands (user seq 50 + assistant seq 51) and the window slides to
+        // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
+        // USER-row count is unchanged (still 25), so the positional reconcile can
+        // never see the acknowledging row — only the seq-advance fallback retires it.
+        const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
+
+        fake.push(MESSAGES_REF, { key: "t1", limit: 50 }, slidWindow);
+
+        const reconciled = chat.messages();
+
+        // No ghost: "new turn" appears exactly once, as the durable row, never
+        // flagged optimistic — and the merged list is just the 50-row window.
+        expect(reconciled.filter((message) => message.content === "new turn")).toStrictEqual([{ content: "new turn", role: "user", seq: 50 }]);
+        expect(reconciled).toHaveLength(50);
+
+        destroy.destroy();
+    });
+
     it("routes approve / reject / cancel with the in-flight instanceId", async () => {
         const fake = createFakeClient();
         const destroy = createFakeDestroyRef();

--- a/packages/angular/src/agent-chat.ts
+++ b/packages/angular/src/agent-chat.ts
@@ -1,6 +1,7 @@
 import type { Signal } from "@angular/core";
 import { computed, DestroyRef, inject, signal } from "@angular/core";
-import type { FunctionReference, LunoraClient } from "@lunora/client";
+import type { FunctionReference, LunoraClient, OptimisticMessage } from "@lunora/client";
+import { maxSeq, reconcileOptimistic } from "@lunora/client";
 
 import type { AgentChatMessage, AgentLiveEvent, AgentThreadRecord, AgentThreadStatus, AgentTokenDelta } from "./agent";
 import { resolveLunoraClient } from "./client";
@@ -114,98 +115,12 @@ interface AgentChatResult {
     streamingText: Signal<string>;
 }
 
-/** A local optimistic user turn awaiting server acknowledgement. */
-interface OptimisticMessage {
-    content: string;
-
-    /**
-     * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position (clamped to the
-     * current count) can retire it, so a durable row that predates the send (e.g.
-     * an identical earlier prompt already acknowledged) can never satisfy it.
-     */
-    durableUserCountAtSend: number;
-    id: number;
-
-    /**
-     * The highest durable `seq` present when this row was sent — the age baseline
-     * for the windowed fallback. Once the durable history advances at least
-     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
-     * a bounded `limit` evicted its acknowledging turn before the positional scan
-     * could match it; without this a saturated window would ghost the row forever.
-     */
-    maxDurableSeqAtSend: number;
-}
-
 /**
  * A placeholder stream reference so the stream primitive is called unconditionally
  * even when the caller supplies no token stream. Paired with `"skip"` args, it
  * never opens a stream.
  */
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
-
-/**
- * Retire a pending optimistic row once the durable history's highest `seq` has
- * advanced at least this far past the value present when the row was sent, even
- * though positional matching never claimed it. Under a bounded `limit` a new turn
- * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
- * the positional scan never fires — the optimistic row would otherwise ghost for
- * the rest of the session. `seq` is globally monotonic, so it still climbs when the
- * count does not; one acknowledged turn persists at least a user row and an
- * assistant row, so a `>= 2` advance means the window has moved on by a full turn
- * and the pending row should be retired (a late drop, never a permanent duplicate).
- * This is the client-only mitigation; the robust fix is a server-echoed correlation
- * id (see plan 188).
- */
-const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
-
-/**
- * Drop the optimistic user turns the durable history has now caught up on. A
- * pending row is retired when a durable `user` row at or after the count present
- * when it was sent (clamped to the current count, so a slid or shrunk window still
- * scans a valid range) carries the same content — one-to-one consumption, lowest
- * eligible index first, keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row. It is also retired when the durable
- * history's highest `seq` has advanced at least
- * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
- * fallback for when a bounded `limit` evicted the acknowledging row before the
- * positional scan could see it (the user-row count stayed flat).
- *
- * Pure: it reads only the two arrays plus values captured on each pending row at
- * send time — no clock, no state mutation — so it is safe to run in render.
- */
-const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
-    const durableUserRows = durable.filter((message) => message.role === "user");
-
-    let maxDurableSeq = -1;
-
-    for (const message of durable) {
-        if (message.seq > maxDurableSeq) {
-            maxDurableSeq = message.seq;
-        }
-    }
-
-    const consumed = new Set<number>();
-
-    return optimistic.filter((pending) => {
-        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
-            const row = durableUserRows[index];
-
-            if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
-                consumed.add(index);
-
-                return false;
-            }
-        }
-
-        // Windowed fallback: the acknowledging row was evicted by the bounded
-        // `limit` (user-row count stayed flat), so the positional scan above can't
-        // see it. `seq` still advances even when the count does not, so keep the
-        // pending row only while the durable history has moved on by less than a
-        // full turn; once it has caught up, retire rather than ghost.
-        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
-    });
-};
 
 /**
  * A first-class agent chat surface: live durable history + in-flight token
@@ -268,13 +183,7 @@ const agentChat = (options: AgentChatOptions): AgentChatResult => {
         // Base synthetic seqs above the highest real durable seq (not just
         // `rows.length`, which can under-count when durable rows have gaps) so an
         // optimistic row's placeholder seq never collides with a real one.
-        let maxDurableSeq = -1;
-
-        for (const message of rows) {
-            if (message.seq > maxDurableSeq) {
-                maxDurableSeq = message.seq;
-            }
-        }
+        const maxDurableSeq = maxSeq(rows);
 
         return [
             ...rows,
@@ -310,19 +219,13 @@ const agentChat = (options: AgentChatOptions): AgentChatResult => {
 
         nextId += 1;
 
+        // Capture the reconcile baseline: the highest durable `seq` present now, so
+        // only a matching user row that lands AFTER this send retires the row.
+        const maxDurableSeqAtSend = maxSeq(durable());
+
         // Prune already-acknowledged optimistic rows as we add the new one, so the
         // list stays bounded without a history-dependent effect.
-        const durableUserCountAtSend = durable().filter((message) => message.role === "user").length;
-
-        let maxDurableSeqAtSend = -1;
-
-        for (const message of durable()) {
-            if (message.seq > maxDurableSeqAtSend) {
-                maxDurableSeqAtSend = message.seq;
-            }
-        }
-
-        optimistic.set([...reconcileOptimistic(optimistic(), durable()), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }]);
+        optimistic.set([...reconcileOptimistic(optimistic(), durable()), { content: input, id, maxDurableSeqAtSend }]);
 
         try {
             await client.mutation(sendReference, { input, threadKey, ...sendArgs, ...arguments_ });

--- a/packages/angular/src/agent-chat.ts
+++ b/packages/angular/src/agent-chat.ts
@@ -120,12 +120,21 @@ interface OptimisticMessage {
 
     /**
      * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position can retire it,
-     * so a durable row that predates the send (e.g. an identical earlier prompt
-     * already acknowledged) can never satisfy it.
+     * baseline. Only a durable user row at or after this position (clamped to the
+     * current count) can retire it, so a durable row that predates the send (e.g.
+     * an identical earlier prompt already acknowledged) can never satisfy it.
      */
     durableUserCountAtSend: number;
     id: number;
+
+    /**
+     * The highest durable `seq` present when this row was sent — the age baseline
+     * for the windowed fallback. Once the durable history advances at least
+     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
+     * a bounded `limit` evicted its acknowledging turn before the positional scan
+     * could match it; without this a saturated window would ghost the row forever.
+     */
+    maxDurableSeqAtSend: number;
 }
 
 /**
@@ -136,20 +145,50 @@ interface OptimisticMessage {
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 
 /**
- * Drop the optimistic user turns the durable history has now caught up on: a
- * pending row is only retired by a durable `user` row at or after the count of
- * durable user rows present when it was sent (`durableUserCountAtSend`) — so a
- * durable row that predates the send (e.g. an identical earlier prompt already
- * acknowledged) can never satisfy it. One-to-one consumption (lowest eligible
- * index first) still keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row.
+ * Retire a pending optimistic row once the durable history's highest `seq` has
+ * advanced at least this far past the value present when the row was sent, even
+ * though positional matching never claimed it. Under a bounded `limit` a new turn
+ * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
+ * the positional scan never fires — the optimistic row would otherwise ghost for
+ * the rest of the session. `seq` is globally monotonic, so it still climbs when the
+ * count does not; one acknowledged turn persists at least a user row and an
+ * assistant row, so a `>= 2` advance means the window has moved on by a full turn
+ * and the pending row should be retired (a late drop, never a permanent duplicate).
+ * This is the client-only mitigation; the robust fix is a server-echoed correlation
+ * id (see plan 188).
+ */
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+
+/**
+ * Drop the optimistic user turns the durable history has now caught up on. A
+ * pending row is retired when a durable `user` row at or after the count present
+ * when it was sent (clamped to the current count, so a slid or shrunk window still
+ * scans a valid range) carries the same content — one-to-one consumption, lowest
+ * eligible index first, keeps repeated identical prompts sent back-to-back from
+ * collapsing onto a single durable row. It is also retired when the durable
+ * history's highest `seq` has advanced at least
+ * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
+ * fallback for when a bounded `limit` evicted the acknowledging row before the
+ * positional scan could see it (the user-row count stayed flat).
+ *
+ * Pure: it reads only the two arrays plus values captured on each pending row at
+ * send time — no clock, no state mutation — so it is safe to run in render.
  */
 const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
     const durableUserRows = durable.filter((message) => message.role === "user");
+
+    let maxDurableSeq = -1;
+
+    for (const message of durable) {
+        if (message.seq > maxDurableSeq) {
+            maxDurableSeq = message.seq;
+        }
+    }
+
     const consumed = new Set<number>();
 
     return optimistic.filter((pending) => {
-        for (let index = pending.durableUserCountAtSend; index < durableUserRows.length; index += 1) {
+        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
             const row = durableUserRows[index];
 
             if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
@@ -159,7 +198,12 @@ const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durab
             }
         }
 
-        return true;
+        // Windowed fallback: the acknowledging row was evicted by the bounded
+        // `limit` (user-row count stayed flat), so the positional scan above can't
+        // see it. `seq` still advances even when the count does not, so keep the
+        // pending row only while the durable history has moved on by less than a
+        // full turn; once it has caught up, retire rather than ghost.
+        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
     });
 };
 
@@ -270,7 +314,15 @@ const agentChat = (options: AgentChatOptions): AgentChatResult => {
         // list stays bounded without a history-dependent effect.
         const durableUserCountAtSend = durable().filter((message) => message.role === "user").length;
 
-        optimistic.set([...reconcileOptimistic(optimistic(), durable()), { content: input, durableUserCountAtSend, id }]);
+        let maxDurableSeqAtSend = -1;
+
+        for (const message of durable()) {
+            if (message.seq > maxDurableSeqAtSend) {
+                maxDurableSeqAtSend = message.seq;
+            }
+        }
+
+        optimistic.set([...reconcileOptimistic(optimistic(), durable()), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }]);
 
         try {
             await client.mutation(sendReference, { input, threadKey, ...sendArgs, ...arguments_ });

--- a/packages/client/__tests__/agent-chat-reconcile.test.ts
+++ b/packages/client/__tests__/agent-chat-reconcile.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import type { OptimisticMessage, ReconcileDurableMessage } from "../src/agent-chat-reconcile";
+import { maxSeq, reconcileOptimistic, RETIRE_AFTER_DURABLE_SEQ_ADVANCE } from "../src/agent-chat-reconcile";
+
+/** A durable user row. */
+const user = (content: string, seq: number): ReconcileDurableMessage => {
+    return { content, role: "user", seq };
+};
+
+/** A durable assistant row. */
+const assistant = (content: string, seq: number): ReconcileDurableMessage => {
+    return { content, role: "assistant", seq };
+};
+
+/** A pending optimistic user turn captured at `maxDurableSeqAtSend`. */
+const pending = (id: number, content: string, maxDurableSeqAtSend: number): OptimisticMessage => {
+    return { content, id, maxDurableSeqAtSend };
+};
+
+interface ReconcileCase {
+    /** The durable history the reconcile runs against. */
+    durable: ReconcileDurableMessage[];
+    name: string;
+    /** The pending optimistic rows going in. */
+    optimistic: OptimisticMessage[];
+    /** The `id`s expected to SURVIVE (still pending) after the reconcile. */
+    survivingIds: number[];
+}
+
+const cases: ReconcileCase[] = [
+    {
+        // A normal turn persists a user row (and an assistant row) at a seq above
+        // the send-time max — the primary content match retires the pending row.
+        durable: [user("hi", 5), assistant("hello", 6)],
+        name: "normal turn retires",
+        optimistic: [pending(0, "hi", 4)],
+        survivingIds: [],
+    },
+    {
+        // P1: an ERRORED turn persists ONLY the user row (+1), never an assistant
+        // row, and the window is saturated so older rows slid out. The user row
+        // still lands at a seq strictly above the send-time max (11 > 10), so the
+        // seq-based primary match retires it even though the window advanced by only
+        // 1 (< RETIRE_AFTER_DURABLE_SEQ_ADVANCE) — the exact permanent-ghost this fix
+        // targets for errored turns.
+        durable: [user("q-8", 8), assistant("a-8", 9), assistant("a-9", 10), user("boom", 11)],
+        name: "errored/single-row (+1) turn retires under a saturated window",
+        optimistic: [pending(0, "boom", 10)],
+        survivingIds: [],
+    },
+    {
+        // The durable history advanced by exactly 1 (an unrelated assistant row from
+        // a still-generating turn), and NO matching-content user row landed above the
+        // send-time max. A genuinely-pending row must NOT be retired: 1 <
+        // RETIRE_AFTER_DURABLE_SEQ_ADVANCE, and there is nothing for the primary match
+        // to consume.
+        durable: [user("earlier", 9), assistant("thinking", 10)],
+        name: "seq-advance-of-1 does not prematurely retire a genuinely-pending row",
+        optimistic: [pending(0, "still pending", 9)],
+        survivingIds: [0],
+    },
+    {
+        // Two identical prompts sent back-to-back (both captured before either
+        // persisted, so both share maxDurableSeqAtSend = 4). Only ONE durable "hi"
+        // has landed so far (seq 5): the first pending row consumes it one-to-one and
+        // retires; the second must NOT collapse onto the same row — it stays pending
+        // until its OWN durable row arrives.
+        durable: [user("hi", 5)],
+        name: "repeated identical prompts do not collapse when only one durable row landed",
+        optimistic: [pending(0, "hi", 4), pending(1, "hi", 4)],
+        survivingIds: [1],
+    },
+    {
+        // Same two identical prompts, now BOTH durable rows have landed (seq 5 and
+        // seq 7). Each pending row consumes a distinct durable row, so both retire.
+        durable: [user("hi", 5), assistant("a", 6), user("hi", 7)],
+        name: "repeated identical prompts both retire once both durable rows land",
+        optimistic: [pending(0, "hi", 4), pending(1, "hi", 4)],
+        survivingIds: [],
+    },
+    {
+        // A durable "hi" already existed BEFORE the send (seq 3, below the send-time
+        // max of 5) and no new "hi" has landed since. It must NOT retire the pending
+        // row via the primary match (3 is not strictly greater than 5), and the
+        // window has not advanced a full turn (5 - 5 = 0), so it stays pending.
+        durable: [user("hi", 3), assistant("a", 4), assistant("b", 5)],
+        name: "a durable row that predates the send never satisfies the pending row",
+        optimistic: [pending(0, "hi", 5)],
+        survivingIds: [0],
+    },
+    {
+        // Pathological "identical content already present at send" case: the pending
+        // "hi" had a same-content durable row at send time (seq 3), and its OWN
+        // acknowledging row was evicted by the bounded window before reconcile saw
+        // it — no strictly-greater "hi" is visible. The window has advanced a full
+        // turn (7 - 5 = 2 >= RETIRE_AFTER_DURABLE_SEQ_ADVANCE), so the secondary
+        // fallback retires it rather than ghosting forever.
+        durable: [user("hi", 3), assistant("a", 6), assistant("b", 7)],
+        name: "windowed fallback retires when the acknowledging row was evicted",
+        optimistic: [pending(0, "hi", 5)],
+        survivingIds: [],
+    },
+    {
+        // Empty durable history: nothing to reconcile against, the pending row stays.
+        durable: [],
+        name: "an unacknowledged row survives against empty durable history",
+        optimistic: [pending(0, "hello", -1)],
+        survivingIds: [0],
+    },
+];
+
+describe("reconcileOptimistic", () => {
+    it.each(cases)("$name", ({ durable, optimistic, survivingIds }) => {
+        expect.hasAssertions();
+
+        const survivors = reconcileOptimistic(optimistic, durable);
+
+        expect(survivors.map((row) => row.id)).toStrictEqual(survivingIds);
+    });
+
+    it("is pure — it does not mutate its inputs", () => {
+        expect.assertions(2);
+
+        const optimistic = [pending(0, "hi", 4)];
+        const durable = [user("hi", 5)];
+
+        reconcileOptimistic(optimistic, durable);
+
+        expect(optimistic).toStrictEqual([pending(0, "hi", 4)]);
+        expect(durable).toStrictEqual([user("hi", 5)]);
+    });
+});
+
+describe("maxSeq", () => {
+    it("returns -1 for an empty list so synthetic seqs start at 0", () => {
+        expect.assertions(1);
+
+        expect(maxSeq([])).toBe(-1);
+    });
+
+    it("returns the highest seq even when rows are out of order or have gaps", () => {
+        expect.assertions(1);
+
+        expect(maxSeq([{ seq: 2 }, { seq: 9 }, { seq: 5 }])).toBe(9);
+    });
+});
+
+describe("the RETIRE_AFTER_DURABLE_SEQ_ADVANCE threshold", () => {
+    it("is the documented full-turn fallback threshold", () => {
+        expect.assertions(1);
+
+        expect(RETIRE_AFTER_DURABLE_SEQ_ADVANCE).toBe(2);
+    });
+});

--- a/packages/client/src/agent-chat-reconcile.ts
+++ b/packages/client/src/agent-chat-reconcile.ts
@@ -1,0 +1,127 @@
+/**
+ * Optimistic-reconcile logic shared by every `@lunora/*` framework adapter's
+ * agent-chat surface (`@lunora/react` `useAgentChat`, plus the `@lunora/vue`,
+ * `@lunora/solid`, `@lunora/svelte`, and `@lunora/angular` counterparts). The
+ * adapters keep only their framework-specific state plumbing
+ * (`useState` / `.value` / `.set()` / a store) and delegate the pure merge decision
+ * here, so the heuristic lives — and is tested — in exactly one place.
+ */
+
+/**
+ * The durable-message shape the reconcile reads: a structural subset of each
+ * adapter's `AgentChatMessage` (itself a client-safe mirror of `@lunora/agent`'s
+ * `AgentMessageRow`). Only `content`, `role`, and the globally-monotonic `seq` are
+ * consulted; adapters pass their fuller row type, which is assignable to this.
+ */
+interface ReconcileDurableMessage {
+    content: string;
+    role: "assistant" | "system" | "tool" | "user";
+    seq: number;
+}
+
+/**
+ * A local optimistic user turn awaiting server acknowledgement. `id` is a
+ * client-generated handle the adapter uses to roll the row back on a failed send;
+ * the reconcile itself reads only `content` and `maxDurableSeqAtSend`.
+ */
+interface OptimisticMessage {
+    content: string;
+    id: number;
+
+    /**
+     * The highest durable `seq` present when this row was sent. The reconcile
+     * retires the row when a durable `user` row with matching `content` lands at a
+     * STRICTLY GREATER `seq` (i.e. after the send) — window-independent because
+     * `seq` is globally monotonic, not a positional count. Also the age baseline for
+     * the {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} fallback.
+     */
+    maxDurableSeqAtSend: number;
+}
+
+/**
+ * The highest `seq` across `messages`, or `-1` when empty. Used both to capture an
+ * optimistic row's `maxDurableSeqAtSend` at send time and to base the synthetic
+ * seqs of rendered optimistic rows above the highest real durable seq (not just
+ * `messages.length`, which under-counts when durable rows have gaps), so a
+ * placeholder seq never collides with a real one.
+ */
+const maxSeq = (messages: ReadonlyArray<{ seq: number }>): number => {
+    let max = -1;
+
+    for (const message of messages) {
+        if (message.seq > max) {
+            max = message.seq;
+        }
+    }
+
+    return max;
+};
+
+/**
+ * Secondary, windowed fallback: retire a pending optimistic row once the durable
+ * history's highest `seq` has advanced at least this far past the value seen at
+ * send, even though no matching-content user row is currently visible to claim it.
+ * This covers the pathological "identical content already present at send time"
+ * case, where no user row with a STRICTLY GREATER `seq` than the send-time max will
+ * ever appear for the primary content match to consume (e.g. the acknowledging row
+ * was evicted by a bounded `limit` before reconcile could see it). `seq` is globally
+ * monotonic, so it keeps climbing even when the visible user-row COUNT does not.
+ *
+ * The `2` is a heuristic threshold, NOT an invariant about turn shape. It is
+ * tempting to read it as "one turn == a user row and an assistant row (+2)", but
+ * `@lunora/agent`'s tool-loop turns can persist MANY rows, and an ERRORED turn
+ * persists only the user row (+1). Those non-(+2) turns are retired by the PRIMARY
+ * seq-based content match below (which sees the user row land at a greater `seq`),
+ * never by this count-based fallback. The fully robust fix is a server-echoed
+ * correlation id on each persisted user row (deferred — see plan 188).
+ *
+ * KNOWN LIMITATION (inherent to a client-only heuristic): on an ownerless /
+ * `instanceId`-less thread a FOREIGN writer that advances `seq` by >= 2 between this
+ * row's send and its own acknowledgement can trip this fallback and retire the row a
+ * beat early. The correlation id closes that gap; until then it is the accepted
+ * residual edge.
+ */
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+
+/**
+ * Drop the optimistic user turns the durable history has now caught up on. Pure —
+ * it reads only the two arrays plus values captured on each pending row at send
+ * time (no clock, no state mutation), so it is safe to run in render.
+ *
+ * The primary retire condition: a durable `user` row with the same `content` exists
+ * whose `seq` is STRICTLY GREATER than the row's `maxDurableSeqAtSend` — i.e. a user
+ * row that landed AFTER the send. This is window-independent (it matches on monotonic
+ * `seq`, not a positional count), so it retires the normal turn AND an errored
+ * single-row (+1) turn even under a saturated, sliding `limit`. Each durable row is
+ * consumed at most once (the `consumed` set), so repeated identical prompts sent
+ * back-to-back each wait for their OWN durable row instead of collapsing onto one.
+ *
+ * Failing that, the {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} windowed fallback fires
+ * (see its doc) for the "identical content already present" pathological case.
+ */
+const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<ReconcileDurableMessage>): OptimisticMessage[] => {
+    const durableUserRows = durable.filter((message) => message.role === "user");
+    const maxDurableSeq = maxSeq(durable);
+    const consumed = new Set<number>();
+
+    return optimistic.filter((pending) => {
+        // Primary: a matching-content user row that landed AFTER this send (its
+        // `seq` strictly greater than the send-time max), claimed one-to-one so
+        // repeated identical prompts don't collapse onto a single durable row.
+        for (const [index, row] of durableUserRows.entries()) {
+            if (!consumed.has(index) && row.seq > pending.maxDurableSeqAtSend && row.content === pending.content) {
+                consumed.add(index);
+
+                return false;
+            }
+        }
+
+        // Secondary fallback: no strictly-greater matching row is visible (evicted
+        // by a bounded `limit`, or identical content was already present at send).
+        // Keep the row only while the window has moved on by less than a full turn.
+        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
+    });
+};
+
+export type { OptimisticMessage, ReconcileDurableMessage };
+export { maxSeq, reconcileOptimistic, RETIRE_AFTER_DURABLE_SEQ_ADVANCE };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,5 @@
+export type { OptimisticMessage, ReconcileDurableMessage } from "./agent-chat-reconcile";
+export { maxSeq, reconcileOptimistic, RETIRE_AFTER_DURABLE_SEQ_ADVANCE } from "./agent-chat-reconcile";
 export type { AsyncStorageLike, AsyncStoragePersistenceOptions } from "./async-storage-persistence";
 export { createAsyncStoragePersistence } from "./async-storage-persistence";
 export { default as createInMemoryBookmarkStorage } from "./bookmark";

--- a/packages/react/__tests__/use-agent-chat.test.tsx
+++ b/packages/react/__tests__/use-agent-chat.test.tsx
@@ -277,6 +277,66 @@ describe("useAgentChat", () => {
         ]);
     });
 
+    it("retires the optimistic row under a saturated windowed limit, where the durable user-row count stays flat", async () => {
+        expect.hasAssertions();
+
+        const { client, emit } = buildClient();
+        let latest: UseAgentChatResult | undefined;
+
+        // A bounded window (limit 50) saturated by 25 completed turns — a user row
+        // and an assistant row each, seqs 0..49, so 25 durable user rows.
+        const seededWindow: Record<string, unknown>[] = [];
+
+        for (let turn = 0; turn < 25; turn += 1) {
+            seededWindow.push(
+                { content: `q-${String(turn)}`, role: "user", seq: turn * 2 },
+                { content: `a-${String(turn)}`, role: "assistant", seq: turn * 2 + 1 },
+            );
+        }
+
+        render(
+            <LunoraProvider client={client}>
+                <Harness
+                    // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop -- test harness callback; a stable ref adds no value in a one-shot render.
+                    onReady={(result) => {
+                        latest = result;
+                    }}
+                    options={buildOptions({ limit: 50 })}
+                />
+            </LunoraProvider>,
+        );
+
+        await act(async () => {
+            emit(MESSAGES_REF, seededWindow);
+        });
+
+        // Send a new turn — its optimistic row renders atop the saturated window.
+        await act(async () => {
+            await latest?.send("new turn");
+        });
+
+        const withOptimistic = JSON.parse(screen.getByTestId("messages").textContent ?? "[]") as Record<string, unknown>[];
+
+        expect(withOptimistic.at(-1)).toStrictEqual({ content: "new turn", optimistic: true, role: "user", seq: 50 });
+
+        // The turn lands (user seq 50 + assistant seq 51) and the window slides to
+        // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
+        // USER-row count is unchanged (still 25), so the positional reconcile can
+        // never see the acknowledging row — only the seq-advance fallback retires it.
+        const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
+
+        await act(async () => {
+            emit(MESSAGES_REF, slidWindow);
+        });
+
+        const reconciled = JSON.parse(screen.getByTestId("messages").textContent ?? "[]") as Record<string, unknown>[];
+
+        // No ghost: "new turn" appears exactly once, as the durable row, never
+        // flagged optimistic — and the merged list is just the 50-row window.
+        expect(reconciled.filter((message) => message.content === "new turn")).toStrictEqual([{ content: "new turn", role: "user", seq: 50 }]);
+        expect(reconciled).toHaveLength(50);
+    });
+
     it("rolls the optimistic user turn back when the send mutation fails", async () => {
         expect.hasAssertions();
 

--- a/packages/react/__tests__/use-agent-chat.test.tsx
+++ b/packages/react/__tests__/use-agent-chat.test.tsx
@@ -321,8 +321,10 @@ describe("useAgentChat", () => {
 
         // The turn lands (user seq 50 + assistant seq 51) and the window slides to
         // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
-        // USER-row count is unchanged (still 25), so the positional reconcile can
-        // never see the acknowledging row — only the seq-advance fallback retires it.
+        // USER-row count is unchanged (still 25), so a positional/count reconcile
+        // could never see the acknowledging row — the seq-based content match
+        // (user "new turn" at seq 50 > the send-time max of 49) retires it instead,
+        // window-independent because it matches on the monotonic seq, not a count.
         const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
 
         await act(async () => {

--- a/packages/react/src/use-agent-chat.ts
+++ b/packages/react/src/use-agent-chat.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import type { FunctionReference } from "@lunora/client";
+import type { FunctionReference, OptimisticMessage } from "@lunora/client";
+import { maxSeq, reconcileOptimistic } from "@lunora/client";
 import { useRef, useState } from "react";
 
 import type { AgentThreadRecord, AgentThreadStatus } from "./use-agent";
@@ -160,29 +161,6 @@ interface UseAgentChatResult {
     streamingText: string;
 }
 
-/** A local optimistic user turn awaiting server acknowledgement. */
-interface OptimisticMessage {
-    content: string;
-
-    /**
-     * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position (clamped to the
-     * current count) can retire it, so a durable row that predates the send (e.g.
-     * an identical earlier prompt already acknowledged) can never satisfy it.
-     */
-    durableUserCountAtSend: number;
-    id: number;
-
-    /**
-     * The highest durable `seq` present when this row was sent — the age baseline
-     * for the windowed fallback. Once the durable history advances at least
-     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
-     * a bounded `limit` evicted its acknowledging turn before the positional scan
-     * could match it; without this a saturated window would ghost the row forever.
-     */
-    maxDurableSeqAtSend: number;
-}
-
 /**
  * A placeholder mutation reference so `useMutation` is called unconditionally
  * (Rules of Hooks) even when the caller supplies no `cancel` mutation. Never
@@ -200,69 +178,6 @@ const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 
 /** Stable empty history so the un-loaded subscription doesn't churn the merged list identity. */
 const EMPTY_MESSAGES: ReadonlyArray<Record<string, unknown>> = [];
-
-/**
- * Retire a pending optimistic row once the durable history's highest `seq` has
- * advanced at least this far past the value present when the row was sent, even
- * though positional matching never claimed it. Under a bounded `limit` a new turn
- * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
- * the positional scan never fires — the optimistic row would otherwise ghost for
- * the rest of the session. `seq` is globally monotonic, so it still climbs when the
- * count does not; one acknowledged turn persists at least a user row and an
- * assistant row, so a `>= 2` advance means the window has moved on by a full turn
- * and the pending row should be retired (a late drop, never a permanent duplicate).
- * This is the client-only mitigation; the robust fix is a server-echoed correlation
- * id (see plan 188).
- */
-const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
-
-/**
- * Drop the optimistic user turns the durable history has now caught up on. A
- * pending row is retired when a durable `user` row at or after the count present
- * when it was sent (clamped to the current count, so a slid or shrunk window still
- * scans a valid range) carries the same content — one-to-one consumption, lowest
- * eligible index first, keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row. It is also retired when the durable
- * history's highest `seq` has advanced at least
- * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
- * fallback for when a bounded `limit` evicted the acknowledging row before the
- * positional scan could see it (the user-row count stayed flat).
- *
- * Pure: it reads only the two arrays plus values captured on each pending row at
- * send time — no clock, no state mutation — so it is safe to run in render.
- */
-const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
-    const durableUserRows = durable.filter((message) => message.role === "user");
-
-    let maxDurableSeq = -1;
-
-    for (const message of durable) {
-        if (message.seq > maxDurableSeq) {
-            maxDurableSeq = message.seq;
-        }
-    }
-
-    const consumed = new Set<number>();
-
-    return optimistic.filter((pending) => {
-        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
-            const row = durableUserRows[index];
-
-            if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
-                consumed.add(index);
-
-                return false;
-            }
-        }
-
-        // Windowed fallback: the acknowledging row was evicted by the bounded
-        // `limit` (user-row count stayed flat), so the positional scan above can't
-        // see it. `seq` still advances even when the count does not, so keep the
-        // pending row only while the durable history has moved on by less than a
-        // full turn; once it has caught up, retire rather than ghost.
-        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
-    });
-};
 
 /**
  * A first-class agent chat surface: live durable history + in-flight token
@@ -316,13 +231,7 @@ const useAgentChat = (options: UseAgentChatOptions): UseAgentChatResult => {
     // Base synthetic seqs above the highest real durable seq (not just
     // `durable.length`, which can under-count when durable rows have gaps) so an
     // optimistic row's placeholder seq never collides with a real one.
-    let maxDurableSeq = -1;
-
-    for (const message of durable) {
-        if (message.seq > maxDurableSeq) {
-            maxDurableSeq = message.seq;
-        }
-    }
+    const maxDurableSeq = maxSeq(durable);
     const messages: ReadonlyArray<AgentChatMessage> =
         visibleOptimistic.length === 0
             ? durable
@@ -360,19 +269,13 @@ const useAgentChat = (options: UseAgentChatOptions): UseAgentChatResult => {
 
         nextIdRef.current += 1;
 
+        // Capture the reconcile baseline: the highest durable `seq` present now, so
+        // only a matching user row that lands AFTER this send retires the row.
+        const maxDurableSeqAtSend = maxSeq(durable);
+
         // Prune already-acknowledged optimistic rows as we add the new one, so the
         // list stays bounded without a messages-dependent effect.
-        const durableUserCountAtSend = durable.filter((message) => message.role === "user").length;
-
-        let maxDurableSeqAtSend = -1;
-
-        for (const message of durable) {
-            if (message.seq > maxDurableSeqAtSend) {
-                maxDurableSeqAtSend = message.seq;
-            }
-        }
-
-        setOptimistic((previous) => [...reconcileOptimistic(previous, durable), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }]);
+        setOptimistic((previous) => [...reconcileOptimistic(previous, durable), { content: input, id, maxDurableSeqAtSend }]);
 
         try {
             await sendMutate({ input, threadKey, ...sendArgs, ...args });

--- a/packages/react/src/use-agent-chat.ts
+++ b/packages/react/src/use-agent-chat.ts
@@ -166,12 +166,21 @@ interface OptimisticMessage {
 
     /**
      * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position can retire it,
-     * so a durable row that predates the send (e.g. an identical earlier prompt
-     * already acknowledged) can never satisfy it.
+     * baseline. Only a durable user row at or after this position (clamped to the
+     * current count) can retire it, so a durable row that predates the send (e.g.
+     * an identical earlier prompt already acknowledged) can never satisfy it.
      */
     durableUserCountAtSend: number;
     id: number;
+
+    /**
+     * The highest durable `seq` present when this row was sent — the age baseline
+     * for the windowed fallback. Once the durable history advances at least
+     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
+     * a bounded `limit` evicted its acknowledging turn before the positional scan
+     * could match it; without this a saturated window would ghost the row forever.
+     */
+    maxDurableSeqAtSend: number;
 }
 
 /**
@@ -193,20 +202,50 @@ const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 const EMPTY_MESSAGES: ReadonlyArray<Record<string, unknown>> = [];
 
 /**
- * Drop the optimistic user turns the durable history has now caught up on: a
- * pending row is only retired by a durable `user` row at or after the count of
- * durable user rows present when it was sent (`durableUserCountAtSend`) — so a
- * durable row that predates the send (e.g. an identical earlier prompt already
- * acknowledged) can never satisfy it. One-to-one consumption (lowest eligible
- * index first) still keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row.
+ * Retire a pending optimistic row once the durable history's highest `seq` has
+ * advanced at least this far past the value present when the row was sent, even
+ * though positional matching never claimed it. Under a bounded `limit` a new turn
+ * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
+ * the positional scan never fires — the optimistic row would otherwise ghost for
+ * the rest of the session. `seq` is globally monotonic, so it still climbs when the
+ * count does not; one acknowledged turn persists at least a user row and an
+ * assistant row, so a `>= 2` advance means the window has moved on by a full turn
+ * and the pending row should be retired (a late drop, never a permanent duplicate).
+ * This is the client-only mitigation; the robust fix is a server-echoed correlation
+ * id (see plan 188).
+ */
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+
+/**
+ * Drop the optimistic user turns the durable history has now caught up on. A
+ * pending row is retired when a durable `user` row at or after the count present
+ * when it was sent (clamped to the current count, so a slid or shrunk window still
+ * scans a valid range) carries the same content — one-to-one consumption, lowest
+ * eligible index first, keeps repeated identical prompts sent back-to-back from
+ * collapsing onto a single durable row. It is also retired when the durable
+ * history's highest `seq` has advanced at least
+ * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
+ * fallback for when a bounded `limit` evicted the acknowledging row before the
+ * positional scan could see it (the user-row count stayed flat).
+ *
+ * Pure: it reads only the two arrays plus values captured on each pending row at
+ * send time — no clock, no state mutation — so it is safe to run in render.
  */
 const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
     const durableUserRows = durable.filter((message) => message.role === "user");
+
+    let maxDurableSeq = -1;
+
+    for (const message of durable) {
+        if (message.seq > maxDurableSeq) {
+            maxDurableSeq = message.seq;
+        }
+    }
+
     const consumed = new Set<number>();
 
     return optimistic.filter((pending) => {
-        for (let index = pending.durableUserCountAtSend; index < durableUserRows.length; index += 1) {
+        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
             const row = durableUserRows[index];
 
             if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
@@ -216,7 +255,12 @@ const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durab
             }
         }
 
-        return true;
+        // Windowed fallback: the acknowledging row was evicted by the bounded
+        // `limit` (user-row count stayed flat), so the positional scan above can't
+        // see it. `seq` still advances even when the count does not, so keep the
+        // pending row only while the durable history has moved on by less than a
+        // full turn; once it has caught up, retire rather than ghost.
+        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
     });
 };
 
@@ -320,7 +364,15 @@ const useAgentChat = (options: UseAgentChatOptions): UseAgentChatResult => {
         // list stays bounded without a messages-dependent effect.
         const durableUserCountAtSend = durable.filter((message) => message.role === "user").length;
 
-        setOptimistic((previous) => [...reconcileOptimistic(previous, durable), { content: input, durableUserCountAtSend, id }]);
+        let maxDurableSeqAtSend = -1;
+
+        for (const message of durable) {
+            if (message.seq > maxDurableSeqAtSend) {
+                maxDurableSeqAtSend = message.seq;
+            }
+        }
+
+        setOptimistic((previous) => [...reconcileOptimistic(previous, durable), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }]);
 
         try {
             await sendMutate({ input, threadKey, ...sendArgs, ...args });

--- a/packages/solid/__tests__/create-agent-chat.test.tsx
+++ b/packages/solid/__tests__/create-agent-chat.test.tsx
@@ -212,8 +212,10 @@ describe(createAgentChat, () => {
 
         // The turn lands (user seq 50 + assistant seq 51) and the window slides to
         // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
-        // USER-row count is unchanged (still 25), so the positional reconcile can
-        // never see the acknowledging row — only the seq-advance fallback retires it.
+        // USER-row count is unchanged (still 25), so a positional/count reconcile
+        // could never see the acknowledging row — the seq-based content match
+        // (user "new turn" at seq 50 > the send-time max of 49) retires it instead,
+        // window-independent because it matches on the monotonic seq, not a count.
         const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
 
         pushTo(fake.subscriptions, MESSAGES_REF, slidWindow);

--- a/packages/solid/__tests__/create-agent-chat.test.tsx
+++ b/packages/solid/__tests__/create-agent-chat.test.tsx
@@ -179,6 +179,53 @@ describe(createAgentChat, () => {
         ]);
     });
 
+    it("retires the optimistic row under a saturated windowed limit, where the durable user-row count stays flat", async () => {
+        const fake = createFakeClient();
+        let latest: CreateAgentChatResult | undefined;
+
+        // A bounded window (limit 50) saturated by 25 completed turns — a user row
+        // and an assistant row each, seqs 0..49, so 25 durable user rows.
+        const seededWindow: Record<string, unknown>[] = [];
+
+        for (let turn = 0; turn < 25; turn += 1) {
+            seededWindow.push(
+                { content: `q-${String(turn)}`, role: "user", seq: turn * 2 },
+                { content: `a-${String(turn)}`, role: "assistant", seq: turn * 2 + 1 },
+            );
+        }
+
+        render(
+            () => {
+                latest = createAgentChat({ api: buildApi(), limit: 50, send: makeRef(SEND_REF) as FunctionReference<"mutation">, threadKey: "t1" });
+
+                return <pre>{JSON.stringify(latest.messages())}</pre>;
+            },
+            { wrapper: (props) => <LunoraProvider client={fake.asClient}>{props.children}</LunoraProvider> },
+        );
+
+        pushTo(fake.subscriptions, MESSAGES_REF, seededWindow);
+
+        // Send a new turn — its optimistic row renders atop the saturated window.
+        await latest?.send("new turn");
+
+        expect(latest?.messages().at(-1)).toStrictEqual({ content: "new turn", optimistic: true, role: "user", seq: 50 });
+
+        // The turn lands (user seq 50 + assistant seq 51) and the window slides to
+        // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
+        // USER-row count is unchanged (still 25), so the positional reconcile can
+        // never see the acknowledging row — only the seq-advance fallback retires it.
+        const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
+
+        pushTo(fake.subscriptions, MESSAGES_REF, slidWindow);
+
+        const reconciled = latest?.messages() ?? [];
+
+        // No ghost: "new turn" appears exactly once, as the durable row, never
+        // flagged optimistic — and the merged list is just the 50-row window.
+        expect(reconciled.filter((message) => message.content === "new turn")).toStrictEqual([{ content: "new turn", role: "user", seq: 50 }]);
+        expect(reconciled).toHaveLength(50);
+    });
+
     it("routes approve / reject / cancel with the in-flight instanceId", async () => {
         const fake = createFakeClient();
         let latest: CreateAgentChatResult | undefined;

--- a/packages/solid/src/create-agent-chat.ts
+++ b/packages/solid/src/create-agent-chat.ts
@@ -1,4 +1,5 @@
-import type { FunctionReference } from "@lunora/client";
+import type { FunctionReference, OptimisticMessage } from "@lunora/client";
+import { maxSeq, reconcileOptimistic } from "@lunora/client";
 import type { Accessor } from "solid-js";
 import { createMemo, createSignal } from "solid-js";
 
@@ -162,98 +163,12 @@ interface CreateAgentChatResult {
     streamingText: Accessor<string>;
 }
 
-/** A local optimistic user turn awaiting server acknowledgement. */
-interface OptimisticMessage {
-    content: string;
-
-    /**
-     * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position (clamped to the
-     * current count) can retire it, so a durable row that predates the send (e.g.
-     * an identical earlier prompt already acknowledged) can never satisfy it.
-     */
-    durableUserCountAtSend: number;
-    id: number;
-
-    /**
-     * The highest durable `seq` present when this row was sent — the age baseline
-     * for the windowed fallback. Once the durable history advances at least
-     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
-     * a bounded `limit` evicted its acknowledging turn before the positional scan
-     * could match it; without this a saturated window would ghost the row forever.
-     */
-    maxDurableSeqAtSend: number;
-}
-
 /**
  * A placeholder stream reference so `createStream` is called unconditionally even
  * when the caller supplies no token stream. Paired with `"skip"` args, it never
  * opens a stream.
  */
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
-
-/**
- * Retire a pending optimistic row once the durable history's highest `seq` has
- * advanced at least this far past the value present when the row was sent, even
- * though positional matching never claimed it. Under a bounded `limit` a new turn
- * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
- * the positional scan never fires — the optimistic row would otherwise ghost for
- * the rest of the session. `seq` is globally monotonic, so it still climbs when the
- * count does not; one acknowledged turn persists at least a user row and an
- * assistant row, so a `>= 2` advance means the window has moved on by a full turn
- * and the pending row should be retired (a late drop, never a permanent duplicate).
- * This is the client-only mitigation; the robust fix is a server-echoed correlation
- * id (see plan 188).
- */
-const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
-
-/**
- * Drop the optimistic user turns the durable history has now caught up on. A
- * pending row is retired when a durable `user` row at or after the count present
- * when it was sent (clamped to the current count, so a slid or shrunk window still
- * scans a valid range) carries the same content — one-to-one consumption, lowest
- * eligible index first, keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row. It is also retired when the durable
- * history's highest `seq` has advanced at least
- * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
- * fallback for when a bounded `limit` evicted the acknowledging row before the
- * positional scan could see it (the user-row count stayed flat).
- *
- * Pure: it reads only the two arrays plus values captured on each pending row at
- * send time — no clock, no state mutation — so it is safe to run in render.
- */
-const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
-    const durableUserRows = durable.filter((message) => message.role === "user");
-
-    let maxDurableSeq = -1;
-
-    for (const message of durable) {
-        if (message.seq > maxDurableSeq) {
-            maxDurableSeq = message.seq;
-        }
-    }
-
-    const consumed = new Set<number>();
-
-    return optimistic.filter((pending) => {
-        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
-            const row = durableUserRows[index];
-
-            if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
-                consumed.add(index);
-
-                return false;
-            }
-        }
-
-        // Windowed fallback: the acknowledging row was evicted by the bounded
-        // `limit` (user-row count stayed flat), so the positional scan above can't
-        // see it. `seq` still advances even when the count does not, so keep the
-        // pending row only while the durable history has moved on by less than a
-        // full turn; once it has caught up, retire rather than ghost.
-        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
-    });
-};
 
 /**
  * A first-class agent chat surface: live durable history + in-flight token
@@ -323,13 +238,7 @@ const createAgentChat = (options: CreateAgentChatOptions): CreateAgentChatResult
         // Base synthetic seqs above the highest real durable seq (not just
         // `rows.length`, which can under-count when durable rows have gaps) so an
         // optimistic row's placeholder seq never collides with a real one.
-        let maxDurableSeq = -1;
-
-        for (const message of rows) {
-            if (message.seq > maxDurableSeq) {
-                maxDurableSeq = message.seq;
-            }
-        }
+        const maxDurableSeq = maxSeq(rows);
 
         return [
             ...rows,
@@ -366,19 +275,13 @@ const createAgentChat = (options: CreateAgentChatOptions): CreateAgentChatResult
 
         nextId += 1;
 
+        // Capture the reconcile baseline: the highest durable `seq` present now, so
+        // only a matching user row that lands AFTER this send retires the row.
+        const maxDurableSeqAtSend = maxSeq(durable());
+
         // Prune already-acknowledged optimistic rows as we add the new one, so the
         // list stays bounded without a history-dependent effect.
-        const durableUserCountAtSend = durable().filter((message) => message.role === "user").length;
-
-        let maxDurableSeqAtSend = -1;
-
-        for (const message of durable()) {
-            if (message.seq > maxDurableSeqAtSend) {
-                maxDurableSeqAtSend = message.seq;
-            }
-        }
-
-        setOptimistic((previous) => [...reconcileOptimistic(previous, durable()), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }]);
+        setOptimistic((previous) => [...reconcileOptimistic(previous, durable()), { content: input, id, maxDurableSeqAtSend }]);
 
         try {
             await sendMutation.mutate({ input, threadKey: resolveMaybe(threadKey), ...sendArgs, ...arguments_ });

--- a/packages/solid/src/create-agent-chat.ts
+++ b/packages/solid/src/create-agent-chat.ts
@@ -168,12 +168,21 @@ interface OptimisticMessage {
 
     /**
      * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position can retire it,
-     * so a durable row that predates the send (e.g. an identical earlier prompt
-     * already acknowledged) can never satisfy it.
+     * baseline. Only a durable user row at or after this position (clamped to the
+     * current count) can retire it, so a durable row that predates the send (e.g.
+     * an identical earlier prompt already acknowledged) can never satisfy it.
      */
     durableUserCountAtSend: number;
     id: number;
+
+    /**
+     * The highest durable `seq` present when this row was sent — the age baseline
+     * for the windowed fallback. Once the durable history advances at least
+     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
+     * a bounded `limit` evicted its acknowledging turn before the positional scan
+     * could match it; without this a saturated window would ghost the row forever.
+     */
+    maxDurableSeqAtSend: number;
 }
 
 /**
@@ -184,20 +193,50 @@ interface OptimisticMessage {
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 
 /**
- * Drop the optimistic user turns the durable history has now caught up on: a
- * pending row is only retired by a durable `user` row at or after the count of
- * durable user rows present when it was sent (`durableUserCountAtSend`) — so a
- * durable row that predates the send (e.g. an identical earlier prompt already
- * acknowledged) can never satisfy it. One-to-one consumption (lowest eligible
- * index first) still keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row.
+ * Retire a pending optimistic row once the durable history's highest `seq` has
+ * advanced at least this far past the value present when the row was sent, even
+ * though positional matching never claimed it. Under a bounded `limit` a new turn
+ * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
+ * the positional scan never fires — the optimistic row would otherwise ghost for
+ * the rest of the session. `seq` is globally monotonic, so it still climbs when the
+ * count does not; one acknowledged turn persists at least a user row and an
+ * assistant row, so a `>= 2` advance means the window has moved on by a full turn
+ * and the pending row should be retired (a late drop, never a permanent duplicate).
+ * This is the client-only mitigation; the robust fix is a server-echoed correlation
+ * id (see plan 188).
+ */
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+
+/**
+ * Drop the optimistic user turns the durable history has now caught up on. A
+ * pending row is retired when a durable `user` row at or after the count present
+ * when it was sent (clamped to the current count, so a slid or shrunk window still
+ * scans a valid range) carries the same content — one-to-one consumption, lowest
+ * eligible index first, keeps repeated identical prompts sent back-to-back from
+ * collapsing onto a single durable row. It is also retired when the durable
+ * history's highest `seq` has advanced at least
+ * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
+ * fallback for when a bounded `limit` evicted the acknowledging row before the
+ * positional scan could see it (the user-row count stayed flat).
+ *
+ * Pure: it reads only the two arrays plus values captured on each pending row at
+ * send time — no clock, no state mutation — so it is safe to run in render.
  */
 const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
     const durableUserRows = durable.filter((message) => message.role === "user");
+
+    let maxDurableSeq = -1;
+
+    for (const message of durable) {
+        if (message.seq > maxDurableSeq) {
+            maxDurableSeq = message.seq;
+        }
+    }
+
     const consumed = new Set<number>();
 
     return optimistic.filter((pending) => {
-        for (let index = pending.durableUserCountAtSend; index < durableUserRows.length; index += 1) {
+        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
             const row = durableUserRows[index];
 
             if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
@@ -207,7 +246,12 @@ const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durab
             }
         }
 
-        return true;
+        // Windowed fallback: the acknowledging row was evicted by the bounded
+        // `limit` (user-row count stayed flat), so the positional scan above can't
+        // see it. `seq` still advances even when the count does not, so keep the
+        // pending row only while the durable history has moved on by less than a
+        // full turn; once it has caught up, retire rather than ghost.
+        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
     });
 };
 
@@ -326,7 +370,15 @@ const createAgentChat = (options: CreateAgentChatOptions): CreateAgentChatResult
         // list stays bounded without a history-dependent effect.
         const durableUserCountAtSend = durable().filter((message) => message.role === "user").length;
 
-        setOptimistic((previous) => [...reconcileOptimistic(previous, durable()), { content: input, durableUserCountAtSend, id }]);
+        let maxDurableSeqAtSend = -1;
+
+        for (const message of durable()) {
+            if (message.seq > maxDurableSeqAtSend) {
+                maxDurableSeqAtSend = message.seq;
+            }
+        }
+
+        setOptimistic((previous) => [...reconcileOptimistic(previous, durable()), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }]);
 
         try {
             await sendMutation.mutate({ input, threadKey: resolveMaybe(threadKey), ...sendArgs, ...arguments_ });

--- a/packages/svelte/__tests__/agent-chat.test.ts
+++ b/packages/svelte/__tests__/agent-chat.test.ts
@@ -140,6 +140,46 @@ describe(agentChat, () => {
         handle.teardown();
     });
 
+    it("retires the optimistic row under a saturated windowed limit, where the durable user-row count stays flat", async () => {
+        const fake = createFakeClient();
+        const handle = agentChat(fake.client, { api: buildApi(), limit: 50, send: makeRef(SEND_REF) as FunctionReference<"mutation">, threadKey: "t1" });
+
+        // A bounded window (limit 50) saturated by 25 completed turns — a user row
+        // and an assistant row each, seqs 0..49, so 25 durable user rows.
+        const seededWindow: Record<string, unknown>[] = [];
+
+        for (let turn = 0; turn < 25; turn += 1) {
+            seededWindow.push(
+                { content: `q-${String(turn)}`, role: "user", seq: turn * 2 },
+                { content: `a-${String(turn)}`, role: "assistant", seq: turn * 2 + 1 },
+            );
+        }
+
+        fake.push(MESSAGES_REF, seededWindow);
+
+        // Send a new turn — its optimistic row renders atop the saturated window.
+        await handle.send("new turn");
+
+        expect(get(handle.messages).at(-1)).toStrictEqual({ content: "new turn", optimistic: true, role: "user", seq: 50 });
+
+        // The turn lands (user seq 50 + assistant seq 51) and the window slides to
+        // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
+        // USER-row count is unchanged (still 25), so the positional reconcile can
+        // never see the acknowledging row — only the seq-advance fallback retires it.
+        const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
+
+        fake.push(MESSAGES_REF, slidWindow);
+
+        const reconciled = get(handle.messages);
+
+        // No ghost: "new turn" appears exactly once, as the durable row, never
+        // flagged optimistic — and the merged list is just the 50-row window.
+        expect(reconciled.filter((message) => message.content === "new turn")).toStrictEqual([{ content: "new turn", role: "user", seq: 50 }]);
+        expect(reconciled).toHaveLength(50);
+
+        handle.teardown();
+    });
+
     it("routes approve / reject / cancel with the in-flight instanceId", async () => {
         const fake = createFakeClient();
         const handle = agentChat(fake.client, {

--- a/packages/svelte/__tests__/agent-chat.test.ts
+++ b/packages/svelte/__tests__/agent-chat.test.ts
@@ -164,8 +164,10 @@ describe(agentChat, () => {
 
         // The turn lands (user seq 50 + assistant seq 51) and the window slides to
         // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
-        // USER-row count is unchanged (still 25), so the positional reconcile can
-        // never see the acknowledging row — only the seq-advance fallback retires it.
+        // USER-row count is unchanged (still 25), so a positional/count reconcile
+        // could never see the acknowledging row — the seq-based content match
+        // (user "new turn" at seq 50 > the send-time max of 49) retires it instead,
+        // window-independent because it matches on the monotonic seq, not a count.
         const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
 
         fake.push(MESSAGES_REF, slidWindow);

--- a/packages/svelte/src/agent-chat.ts
+++ b/packages/svelte/src/agent-chat.ts
@@ -178,12 +178,21 @@ interface OptimisticMessage {
 
     /**
      * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position can retire it,
-     * so a durable row that predates the send (e.g. an identical earlier prompt
-     * already acknowledged) can never satisfy it.
+     * baseline. Only a durable user row at or after this position (clamped to the
+     * current count) can retire it, so a durable row that predates the send (e.g.
+     * an identical earlier prompt already acknowledged) can never satisfy it.
      */
     durableUserCountAtSend: number;
     id: number;
+
+    /**
+     * The highest durable `seq` present when this row was sent — the age baseline
+     * for the windowed fallback. Once the durable history advances at least
+     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
+     * a bounded `limit` evicted its acknowledging turn before the positional scan
+     * could match it; without this a saturated window would ghost the row forever.
+     */
+    maxDurableSeqAtSend: number;
 }
 
 /**
@@ -194,20 +203,50 @@ interface OptimisticMessage {
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 
 /**
- * Drop the optimistic user turns the durable history has now caught up on: a
- * pending row is only retired by a durable `user` row at or after the count of
- * durable user rows present when it was sent (`durableUserCountAtSend`) — so a
- * durable row that predates the send (e.g. an identical earlier prompt already
- * acknowledged) can never satisfy it. One-to-one consumption (lowest eligible
- * index first) still keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row.
+ * Retire a pending optimistic row once the durable history's highest `seq` has
+ * advanced at least this far past the value present when the row was sent, even
+ * though positional matching never claimed it. Under a bounded `limit` a new turn
+ * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
+ * the positional scan never fires — the optimistic row would otherwise ghost for
+ * the rest of the session. `seq` is globally monotonic, so it still climbs when the
+ * count does not; one acknowledged turn persists at least a user row and an
+ * assistant row, so a `>= 2` advance means the window has moved on by a full turn
+ * and the pending row should be retired (a late drop, never a permanent duplicate).
+ * This is the client-only mitigation; the robust fix is a server-echoed correlation
+ * id (see plan 188).
+ */
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+
+/**
+ * Drop the optimistic user turns the durable history has now caught up on. A
+ * pending row is retired when a durable `user` row at or after the count present
+ * when it was sent (clamped to the current count, so a slid or shrunk window still
+ * scans a valid range) carries the same content — one-to-one consumption, lowest
+ * eligible index first, keeps repeated identical prompts sent back-to-back from
+ * collapsing onto a single durable row. It is also retired when the durable
+ * history's highest `seq` has advanced at least
+ * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
+ * fallback for when a bounded `limit` evicted the acknowledging row before the
+ * positional scan could see it (the user-row count stayed flat).
+ *
+ * Pure: it reads only the two arrays plus values captured on each pending row at
+ * send time — no clock, no state mutation — so it is safe to run in render.
  */
 const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
     const durableUserRows = durable.filter((message) => message.role === "user");
+
+    let maxDurableSeq = -1;
+
+    for (const message of durable) {
+        if (message.seq > maxDurableSeq) {
+            maxDurableSeq = message.seq;
+        }
+    }
+
     const consumed = new Set<number>();
 
     return optimistic.filter((pending) => {
-        for (let index = pending.durableUserCountAtSend; index < durableUserRows.length; index += 1) {
+        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
             const row = durableUserRows[index];
 
             if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
@@ -217,7 +256,12 @@ const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durab
             }
         }
 
-        return true;
+        // Windowed fallback: the acknowledging row was evicted by the bounded
+        // `limit` (user-row count stayed flat), so the positional scan above can't
+        // see it. `seq` still advances even when the count does not, so keep the
+        // pending row only while the durable history has moved on by less than a
+        // full turn; once it has caught up, retire rather than ghost.
+        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
     });
 };
 
@@ -327,7 +371,15 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
         // list stays bounded, then reflect it immediately.
         const durableUserCountAtSend = durable.filter((message) => message.role === "user").length;
 
-        optimistic = [...reconcileOptimistic(optimistic, durable), { content: input, durableUserCountAtSend, id }];
+        let maxDurableSeqAtSend = -1;
+
+        for (const message of durable) {
+            if (message.seq > maxDurableSeqAtSend) {
+                maxDurableSeqAtSend = message.seq;
+            }
+        }
+
+        optimistic = [...reconcileOptimistic(optimistic, durable), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }];
         recompute();
 
         try {

--- a/packages/svelte/src/agent-chat.ts
+++ b/packages/svelte/src/agent-chat.ts
@@ -1,4 +1,5 @@
-import type { FunctionReference, LunoraClient } from "@lunora/client";
+import type { FunctionReference, LunoraClient, OptimisticMessage } from "@lunora/client";
+import { maxSeq, reconcileOptimistic } from "@lunora/client";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
@@ -172,98 +173,12 @@ interface AgentChatHandle {
     teardown: () => void;
 }
 
-/** A local optimistic user turn awaiting server acknowledgement. */
-interface OptimisticMessage {
-    content: string;
-
-    /**
-     * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position (clamped to the
-     * current count) can retire it, so a durable row that predates the send (e.g.
-     * an identical earlier prompt already acknowledged) can never satisfy it.
-     */
-    durableUserCountAtSend: number;
-    id: number;
-
-    /**
-     * The highest durable `seq` present when this row was sent — the age baseline
-     * for the windowed fallback. Once the durable history advances at least
-     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
-     * a bounded `limit` evicted its acknowledging turn before the positional scan
-     * could match it; without this a saturated window would ghost the row forever.
-     */
-    maxDurableSeqAtSend: number;
-}
-
 /**
  * A placeholder stream reference so {@link stream} is opened unconditionally even
  * when the caller supplies no token stream. Paired with `"skip"` args, it never
  * opens a stream.
  */
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
-
-/**
- * Retire a pending optimistic row once the durable history's highest `seq` has
- * advanced at least this far past the value present when the row was sent, even
- * though positional matching never claimed it. Under a bounded `limit` a new turn
- * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
- * the positional scan never fires — the optimistic row would otherwise ghost for
- * the rest of the session. `seq` is globally monotonic, so it still climbs when the
- * count does not; one acknowledged turn persists at least a user row and an
- * assistant row, so a `>= 2` advance means the window has moved on by a full turn
- * and the pending row should be retired (a late drop, never a permanent duplicate).
- * This is the client-only mitigation; the robust fix is a server-echoed correlation
- * id (see plan 188).
- */
-const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
-
-/**
- * Drop the optimistic user turns the durable history has now caught up on. A
- * pending row is retired when a durable `user` row at or after the count present
- * when it was sent (clamped to the current count, so a slid or shrunk window still
- * scans a valid range) carries the same content — one-to-one consumption, lowest
- * eligible index first, keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row. It is also retired when the durable
- * history's highest `seq` has advanced at least
- * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
- * fallback for when a bounded `limit` evicted the acknowledging row before the
- * positional scan could see it (the user-row count stayed flat).
- *
- * Pure: it reads only the two arrays plus values captured on each pending row at
- * send time — no clock, no state mutation — so it is safe to run in render.
- */
-const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
-    const durableUserRows = durable.filter((message) => message.role === "user");
-
-    let maxDurableSeq = -1;
-
-    for (const message of durable) {
-        if (message.seq > maxDurableSeq) {
-            maxDurableSeq = message.seq;
-        }
-    }
-
-    const consumed = new Set<number>();
-
-    return optimistic.filter((pending) => {
-        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
-            const row = durableUserRows[index];
-
-            if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
-                consumed.add(index);
-
-                return false;
-            }
-        }
-
-        // Windowed fallback: the acknowledging row was evicted by the bounded
-        // `limit` (user-row count stayed flat), so the positional scan above can't
-        // see it. `seq` still advances even when the count does not, so keep the
-        // pending row only while the durable history has moved on by less than a
-        // full turn; once it has caught up, retire rather than ghost.
-        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
-    });
-};
 
 const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions): AgentChatHandle => {
     const { api, cancel: cancelReference, limit, send: sendReference, sendArgs, stream: streamReference, threadKey } = options;
@@ -301,13 +216,7 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
         // Base synthetic seqs above the highest real durable seq (not just
         // `durable.length`, which can under-count when durable rows have gaps) so
         // an optimistic row's placeholder seq never collides with a real one.
-        let maxDurableSeq = -1;
-
-        for (const message of durable) {
-            if (message.seq > maxDurableSeq) {
-                maxDurableSeq = message.seq;
-            }
-        }
+        const maxDurableSeq = maxSeq(durable);
 
         messagesStore.set([
             ...durable,
@@ -367,19 +276,13 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
 
         nextId += 1;
 
+        // Capture the reconcile baseline: the highest durable `seq` present now, so
+        // only a matching user row that lands AFTER this send retires the row.
+        const maxDurableSeqAtSend = maxSeq(durable);
+
         // Prune already-acknowledged optimistic rows as we add the new one, so the
         // list stays bounded, then reflect it immediately.
-        const durableUserCountAtSend = durable.filter((message) => message.role === "user").length;
-
-        let maxDurableSeqAtSend = -1;
-
-        for (const message of durable) {
-            if (message.seq > maxDurableSeqAtSend) {
-                maxDurableSeqAtSend = message.seq;
-            }
-        }
-
-        optimistic = [...reconcileOptimistic(optimistic, durable), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }];
+        optimistic = [...reconcileOptimistic(optimistic, durable), { content: input, id, maxDurableSeqAtSend }];
         recompute();
 
         try {

--- a/packages/vue/__tests__/use-agent-chat.test.ts
+++ b/packages/vue/__tests__/use-agent-chat.test.ts
@@ -174,6 +174,53 @@ describe(useAgentChat, () => {
         scope.stop();
     });
 
+    it("retires the optimistic row under a saturated windowed limit, where the durable user-row count stays flat", async () => {
+        expect.hasAssertions();
+
+        const fake = createFakeClient();
+        const scope = effectScope();
+        const chat = scope.run(() =>
+            fake.provide((): UseAgentChatResult =>
+                useAgentChat({ api: buildApi(), limit: 50, send: makeRef(SEND_REF) as FunctionReference<"mutation">, threadKey: "t1" }),
+            ),
+        )!;
+
+        // A bounded window (limit 50) saturated by 25 completed turns — a user row
+        // and an assistant row each, seqs 0..49, so 25 durable user rows.
+        const seededWindow: Record<string, unknown>[] = [];
+
+        for (let turn = 0; turn < 25; turn += 1) {
+            seededWindow.push(
+                { content: `q-${String(turn)}`, role: "user", seq: turn * 2 },
+                { content: `a-${String(turn)}`, role: "assistant", seq: turn * 2 + 1 },
+            );
+        }
+
+        fake.push(MESSAGES_REF, { key: "t1", limit: 50 }, seededWindow);
+
+        // Send a new turn — its optimistic row renders atop the saturated window.
+        await chat.send("new turn");
+
+        expect(chat.messages.value.at(-1)).toStrictEqual({ content: "new turn", optimistic: true, role: "user", seq: 50 });
+
+        // The turn lands (user seq 50 + assistant seq 51) and the window slides to
+        // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
+        // USER-row count is unchanged (still 25), so the positional reconcile can
+        // never see the acknowledging row — only the seq-advance fallback retires it.
+        const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
+
+        fake.push(MESSAGES_REF, { key: "t1", limit: 50 }, slidWindow);
+
+        const reconciled = chat.messages.value;
+
+        // No ghost: "new turn" appears exactly once, as the durable row, never
+        // flagged optimistic — and the merged list is just the 50-row window.
+        expect(reconciled.filter((message) => message.content === "new turn")).toStrictEqual([{ content: "new turn", role: "user", seq: 50 }]);
+        expect(reconciled).toHaveLength(50);
+
+        scope.stop();
+    });
+
     it("routes approve / reject / cancel with the in-flight instanceId", async () => {
         expect.hasAssertions();
 

--- a/packages/vue/__tests__/use-agent-chat.test.ts
+++ b/packages/vue/__tests__/use-agent-chat.test.ts
@@ -205,8 +205,10 @@ describe(useAgentChat, () => {
 
         // The turn lands (user seq 50 + assistant seq 51) and the window slides to
         // keep its last 50 rows, evicting the oldest turn (seqs 0, 1). The durable
-        // USER-row count is unchanged (still 25), so the positional reconcile can
-        // never see the acknowledging row — only the seq-advance fallback retires it.
+        // USER-row count is unchanged (still 25), so a positional/count reconcile
+        // could never see the acknowledging row — the seq-based content match
+        // (user "new turn" at seq 50 > the send-time max of 49) retires it instead,
+        // window-independent because it matches on the monotonic seq, not a count.
         const slidWindow = [...seededWindow.slice(2), { content: "new turn", role: "user", seq: 50 }, { content: "answer", role: "assistant", seq: 51 }];
 
         fake.push(MESSAGES_REF, { key: "t1", limit: 50 }, slidWindow);

--- a/packages/vue/src/use-agent-chat.ts
+++ b/packages/vue/src/use-agent-chat.ts
@@ -168,12 +168,21 @@ interface OptimisticMessage {
 
     /**
      * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position can retire it,
-     * so a durable row that predates the send (e.g. an identical earlier prompt
-     * already acknowledged) can never satisfy it.
+     * baseline. Only a durable user row at or after this position (clamped to the
+     * current count) can retire it, so a durable row that predates the send (e.g.
+     * an identical earlier prompt already acknowledged) can never satisfy it.
      */
     durableUserCountAtSend: number;
     id: number;
+
+    /**
+     * The highest durable `seq` present when this row was sent — the age baseline
+     * for the windowed fallback. Once the durable history advances at least
+     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
+     * a bounded `limit` evicted its acknowledging turn before the positional scan
+     * could match it; without this a saturated window would ghost the row forever.
+     */
+    maxDurableSeqAtSend: number;
 }
 
 /**
@@ -184,20 +193,50 @@ interface OptimisticMessage {
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
 
 /**
- * Drop the optimistic user turns the durable history has now caught up on: a
- * pending row is only retired by a durable `user` row at or after the count of
- * durable user rows present when it was sent (`durableUserCountAtSend`) — so a
- * durable row that predates the send (e.g. an identical earlier prompt already
- * acknowledged) can never satisfy it. One-to-one consumption (lowest eligible
- * index first) still keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row.
+ * Retire a pending optimistic row once the durable history's highest `seq` has
+ * advanced at least this far past the value present when the row was sent, even
+ * though positional matching never claimed it. Under a bounded `limit` a new turn
+ * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
+ * the positional scan never fires — the optimistic row would otherwise ghost for
+ * the rest of the session. `seq` is globally monotonic, so it still climbs when the
+ * count does not; one acknowledged turn persists at least a user row and an
+ * assistant row, so a `>= 2` advance means the window has moved on by a full turn
+ * and the pending row should be retired (a late drop, never a permanent duplicate).
+ * This is the client-only mitigation; the robust fix is a server-echoed correlation
+ * id (see plan 188).
+ */
+const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
+
+/**
+ * Drop the optimistic user turns the durable history has now caught up on. A
+ * pending row is retired when a durable `user` row at or after the count present
+ * when it was sent (clamped to the current count, so a slid or shrunk window still
+ * scans a valid range) carries the same content — one-to-one consumption, lowest
+ * eligible index first, keeps repeated identical prompts sent back-to-back from
+ * collapsing onto a single durable row. It is also retired when the durable
+ * history's highest `seq` has advanced at least
+ * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
+ * fallback for when a bounded `limit` evicted the acknowledging row before the
+ * positional scan could see it (the user-row count stayed flat).
+ *
+ * Pure: it reads only the two arrays plus values captured on each pending row at
+ * send time — no clock, no state mutation — so it is safe to run in render.
  */
 const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
     const durableUserRows = durable.filter((message) => message.role === "user");
+
+    let maxDurableSeq = -1;
+
+    for (const message of durable) {
+        if (message.seq > maxDurableSeq) {
+            maxDurableSeq = message.seq;
+        }
+    }
+
     const consumed = new Set<number>();
 
     return optimistic.filter((pending) => {
-        for (let index = pending.durableUserCountAtSend; index < durableUserRows.length; index += 1) {
+        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
             const row = durableUserRows[index];
 
             if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
@@ -207,7 +246,12 @@ const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durab
             }
         }
 
-        return true;
+        // Windowed fallback: the acknowledging row was evicted by the bounded
+        // `limit` (user-row count stayed flat), so the positional scan above can't
+        // see it. `seq` still advances even when the count does not, so keep the
+        // pending row only while the durable history has moved on by less than a
+        // full turn; once it has caught up, retire rather than ghost.
+        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
     });
 };
 
@@ -326,7 +370,15 @@ const useAgentChat = (options: UseAgentChatOptions): UseAgentChatResult => {
         // list stays bounded without a history-dependent watcher.
         const durableUserCountAtSend = durable.value.filter((message) => message.role === "user").length;
 
-        optimistic.value = [...reconcileOptimistic(optimistic.value, durable.value), { content: input, durableUserCountAtSend, id }];
+        let maxDurableSeqAtSend = -1;
+
+        for (const message of durable.value) {
+            if (message.seq > maxDurableSeqAtSend) {
+                maxDurableSeqAtSend = message.seq;
+            }
+        }
+
+        optimistic.value = [...reconcileOptimistic(optimistic.value, durable.value), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }];
 
         try {
             await sendMutation.mutate({ input, threadKey: toValue(threadKey), ...sendArgs, ...arguments_ });

--- a/packages/vue/src/use-agent-chat.ts
+++ b/packages/vue/src/use-agent-chat.ts
@@ -1,4 +1,5 @@
-import type { FunctionReference } from "@lunora/client";
+import type { FunctionReference, OptimisticMessage } from "@lunora/client";
+import { maxSeq, reconcileOptimistic } from "@lunora/client";
 import type { ComputedRef, MaybeRefOrGetter } from "vue";
 import { computed, ref, toValue } from "vue";
 
@@ -162,98 +163,12 @@ interface UseAgentChatResult {
     streamingText: ComputedRef<string>;
 }
 
-/** A local optimistic user turn awaiting server acknowledgement. */
-interface OptimisticMessage {
-    content: string;
-
-    /**
-     * Count of durable `user` rows present when this row was sent — the reconcile
-     * baseline. Only a durable user row at or after this position (clamped to the
-     * current count) can retire it, so a durable row that predates the send (e.g.
-     * an identical earlier prompt already acknowledged) can never satisfy it.
-     */
-    durableUserCountAtSend: number;
-    id: number;
-
-    /**
-     * The highest durable `seq` present when this row was sent — the age baseline
-     * for the windowed fallback. Once the durable history advances at least
-     * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past it the row is retired even when
-     * a bounded `limit` evicted its acknowledging turn before the positional scan
-     * could match it; without this a saturated window would ghost the row forever.
-     */
-    maxDurableSeqAtSend: number;
-}
-
 /**
  * A placeholder stream reference so `useStream` is called unconditionally even
  * when the caller supplies no token stream. Paired with `"skip"` args, it never
  * opens a stream.
  */
 const NO_STREAM_REF: AgentTokenStreamReference = { __lunoraRef: "" };
-
-/**
- * Retire a pending optimistic row once the durable history's highest `seq` has
- * advanced at least this far past the value present when the row was sent, even
- * though positional matching never claimed it. Under a bounded `limit` a new turn
- * evicts an older row as it lands, so the durable user-row COUNT can stay flat and
- * the positional scan never fires — the optimistic row would otherwise ghost for
- * the rest of the session. `seq` is globally monotonic, so it still climbs when the
- * count does not; one acknowledged turn persists at least a user row and an
- * assistant row, so a `>= 2` advance means the window has moved on by a full turn
- * and the pending row should be retired (a late drop, never a permanent duplicate).
- * This is the client-only mitigation; the robust fix is a server-echoed correlation
- * id (see plan 188).
- */
-const RETIRE_AFTER_DURABLE_SEQ_ADVANCE = 2;
-
-/**
- * Drop the optimistic user turns the durable history has now caught up on. A
- * pending row is retired when a durable `user` row at or after the count present
- * when it was sent (clamped to the current count, so a slid or shrunk window still
- * scans a valid range) carries the same content — one-to-one consumption, lowest
- * eligible index first, keeps repeated identical prompts sent back-to-back from
- * collapsing onto a single durable row. It is also retired when the durable
- * history's highest `seq` has advanced at least
- * {@link RETIRE_AFTER_DURABLE_SEQ_ADVANCE} past the value seen at send: the windowed
- * fallback for when a bounded `limit` evicted the acknowledging row before the
- * positional scan could see it (the user-row count stayed flat).
- *
- * Pure: it reads only the two arrays plus values captured on each pending row at
- * send time — no clock, no state mutation — so it is safe to run in render.
- */
-const reconcileOptimistic = (optimistic: ReadonlyArray<OptimisticMessage>, durable: ReadonlyArray<AgentChatMessage>): OptimisticMessage[] => {
-    const durableUserRows = durable.filter((message) => message.role === "user");
-
-    let maxDurableSeq = -1;
-
-    for (const message of durable) {
-        if (message.seq > maxDurableSeq) {
-            maxDurableSeq = message.seq;
-        }
-    }
-
-    const consumed = new Set<number>();
-
-    return optimistic.filter((pending) => {
-        for (let index = Math.min(pending.durableUserCountAtSend, durableUserRows.length); index < durableUserRows.length; index += 1) {
-            const row = durableUserRows[index];
-
-            if (row !== undefined && !consumed.has(index) && row.content === pending.content) {
-                consumed.add(index);
-
-                return false;
-            }
-        }
-
-        // Windowed fallback: the acknowledging row was evicted by the bounded
-        // `limit` (user-row count stayed flat), so the positional scan above can't
-        // see it. `seq` still advances even when the count does not, so keep the
-        // pending row only while the durable history has moved on by less than a
-        // full turn; once it has caught up, retire rather than ghost.
-        return maxDurableSeq - pending.maxDurableSeqAtSend < RETIRE_AFTER_DURABLE_SEQ_ADVANCE;
-    });
-};
 
 /**
  * A first-class agent chat surface: live durable history + in-flight token
@@ -323,13 +238,7 @@ const useAgentChat = (options: UseAgentChatOptions): UseAgentChatResult => {
         // Base synthetic seqs above the highest real durable seq (not just
         // `rows.length`, which can under-count when durable rows have gaps) so an
         // optimistic row's placeholder seq never collides with a real one.
-        let maxDurableSeq = -1;
-
-        for (const message of rows) {
-            if (message.seq > maxDurableSeq) {
-                maxDurableSeq = message.seq;
-            }
-        }
+        const maxDurableSeq = maxSeq(rows);
 
         return [
             ...rows,
@@ -366,19 +275,13 @@ const useAgentChat = (options: UseAgentChatOptions): UseAgentChatResult => {
 
         nextId += 1;
 
+        // Capture the reconcile baseline: the highest durable `seq` present now, so
+        // only a matching user row that lands AFTER this send retires the row.
+        const maxDurableSeqAtSend = maxSeq(durable.value);
+
         // Prune already-acknowledged optimistic rows as we add the new one, so the
         // list stays bounded without a history-dependent watcher.
-        const durableUserCountAtSend = durable.value.filter((message) => message.role === "user").length;
-
-        let maxDurableSeqAtSend = -1;
-
-        for (const message of durable.value) {
-            if (message.seq > maxDurableSeqAtSend) {
-                maxDurableSeqAtSend = message.seq;
-            }
-        }
-
-        optimistic.value = [...reconcileOptimistic(optimistic.value, durable.value), { content: input, durableUserCountAtSend, id, maxDurableSeqAtSend }];
+        optimistic.value = [...reconcileOptimistic(optimistic.value, durable.value), { content: input, id, maxDurableSeqAtSend }];
 
         try {
             await sendMutation.mutate({ input, threadKey: toValue(threadKey), ...sendArgs, ...arguments_ });


### PR DESCRIPTION
## Wave 15 — agent-chat optimistic ghost under a windowed `limit` (plan 188, CLI-01)

`useAgentChat` (and its four sibling-adapter twins) reconciled optimistic user messages against durable history by a **positional count** (`durableUserCountAtSend`), but the durable subscription is a bounded window (`agentMessages({ key, limit })`). With `limit` set and the window saturated, a new turn evicts an older row as it lands, so the user-row count stays flat, the reconcile loop never runs, and the optimistic row is **never retired** — the user sees their message rendered twice, permanently, for the session.

### Fix (Option B — client-only, no server change)
Retire on the globally-**monotonic** durable `seq` advancing `>= 2` past a baseline captured at send (`maxDurableSeqAtSend`) — seq keeps climbing as the window slides, where count does not. Kept pure in render (no setState-in-effect / impure render — React Doctor rule). Mirrored byte-identically across all five adapters.

A server-echoed correlation id is the fully-robust fix (noted as deferred — it would expand scope to `@lunora/agent` + codegen); this client-only mitigation degrades the worst case to a late drop, never a permanent ghost.

### Verification
One saturated-window test per adapter (seed 50 durable rows, `limit: 50`, send, slide the window, assert the optimistic row retires) + the existing repeated-identical-prompt echo behavior preserved. react 140 / solid 81 / svelte 87 / vue 91 / angular 89 tests; all five `tsc` clean.

Generated by the `/improve` advisor workflow (isolated-worktree Opus executor → tech-lead review). Plan text on `improve/alpha-audit` under `plans/188-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved optimistic chat-message reconciliation across Angular, React, Solid, Svelte, and Vue integrations.
  - Pending messages now clear more reliably as durable chat history updates, including when messages are added or reordered.
  - Standardized reconciliation behavior across supported framework adapters.
- **Developer Experience**
  - Added shared chat reconciliation utilities to the client package for consistent adapter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->