### PR TITLE
feat(observability)!: sampling coherence, health, log-archive, DO telemetry + OTLP (Wave 15: 179,180,181,186,190)

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -1992,7 +1992,7 @@ abstract class ShardDO {
     protected makeMetrics(functionPath: string, sink?: TelemetrySink): ContextMetrics;
     protected recordMetric(event: MetricEvent, sink?: TelemetrySink): void;
     protected handleWebSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void>;
-    protected recordSpan(span: SpanEvent, sink?: TelemetrySink): void;
+    protected recordSpan(span: SpanEvent, sink?: TelemetrySink, sampledSnapshot?: boolean): void;
     protected isIdentityIndependent(functionPath: string): boolean;
     protected readShapeCdcPage(sql: SqlExec, sinceSeq: number, tables: ReadonlySet<string>): {
         changes: CdcChange[];
@@ -2400,6 +2400,7 @@ interface TelemetrySink {
     flush?: (context?: LogSinkContext) => void;
     fuseCloudflareTraces?: boolean;
     instrumentDatabase?: DatabaseInstrumentation;
+    metricHistory?: boolean | MetricHistoryOptions;
     onLog?: (event: LogEventInput, context?: LogSinkContext) => void;
     onMetric?: (event: MetricEvent, context?: LogSinkContext) => void;
     onSpan?: (event: SpanEvent, context?: LogSinkContext) => void;

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -1312,6 +1312,10 @@ interface ObservabilitySink {
     flush?: (context?: ObservabilitySinkContext) => void;
     fuseCloudflareTraces?: boolean;
     instrumentDatabase?: "off" | "spans" | "summary";
+    metricHistory?: boolean | {
+        maxSeries?: number;
+        retentionBuckets?: number;
+    };
     onLog?: (event: LogEvent, context?: ObservabilitySinkContext) => void;
     onMetric?: (event: MetricEvent, context?: ObservabilitySinkContext) => void;
     onRpc?: (event: ObservabilityEvent, context?: ObservabilitySinkContext) => void;
@@ -1371,6 +1375,7 @@ type PipelineLogColumnMap = Partial<Record<PipelineLogField, string>>;
 
 ```ts
 interface PipelineLogCursor {
+    seen?: string[];
     ts: number;
 }
 ```
@@ -2320,7 +2325,7 @@ const emitLogEvent: (sink: ObservabilitySink | undefined, event: LogEvent, conte
 ### `emitRpcEvent` (const)
 
 ```ts
-const emitRpcEvent: (sink: ObservabilitySink | undefined, event: ObservabilityEvent, context?: ObservabilitySinkContext, sampling?: TraceSamplingConfig) => void;
+const emitRpcEvent: (sink: ObservabilitySink | undefined, event: ObservabilityEvent, context?: ObservabilitySinkContext, sampling?: TraceSamplingConfig, decision?: TraceSamplingDecision) => void;
 ```
 
 ### `enforceOrigin` (const)

--- a/apps/docs/src/content/docs/concepts/observability.mdx
+++ b/apps/docs/src/content/docs/concepts/observability.mdx
@@ -528,6 +528,18 @@ That keeps the sink model identical to logs and spans, at the cost of one export
 per call — so in a hot loop, sum locally and record once at the end rather than
 calling per iteration.
 
+:::caution[Durable per-minute history is opt-in]
+The Durable Object can also keep a **per-minute rollup** of every measurement in a
+reserved per-shard SQLite table, so the Studio can chart a 24h local trend without
+an external collector. It is **off by default** because it is not free: with it on,
+each `ctx.metrics.*` call becomes a **durable SQLite write** on the request path —
+a billed, rate-limited storage op that competes with your app's own data for the
+shard's write budget. Turn it on with `metricHistory: true` on the sink you pass to
+`createShardDO` (or an object — `{ maxSeries, retentionBuckets }` — to tune the
+caps). The live, cross-instance path is `onMetric` → your collector, and is
+unaffected either way.
+:::
+
 Metrics have no local buffer and no Studio panel: their value is in the aggregate
 over time, which an in-memory ring on a hibernating instance can't represent.
 `consoleSink` prints them in dev; for anything real, point `otlpSink` at a

--- a/apps/docs/src/content/docs/production-checklist.mdx
+++ b/apps/docs/src/content/docs/production-checklist.mdx
@@ -152,12 +152,14 @@ Checklist:
       `/_lunora/health` (open in dashboard: Traffic → Health Checks) so a
       critical-binding outage pages you. Use `/_lunora/health/ready` for a load
       balancer's origin health / readiness pool.
-- [ ] Decide the **auth posture**. The default is `"public"`: unauthenticated
-      and message-redacted (only a check name and `up`/`down` survive — no
-      per-check detail reaches an anonymous caller). Set it to `"admin"` to
-      bearer-gate the endpoint (via `LUNORA_ADMIN_TOKEN`) and include the
-      runtime-authored per-check `message`s to aid an operator — but a monitor
-      polling it must then send the token.
+- [ ] Decide the **auth posture**. The default is `"public"`: unauthenticated,
+      message-redacted, and **name-redacted** — each check surfaces only its
+      probe _kind_ (`d1`, `r2`, `queue`, …, with a `#2` suffix if a kind
+      repeats) plus `up`/`down`, so the operator's real binding keys never reach
+      an anonymous caller. Set it to `"admin"` to bearer-gate the endpoint (via
+      `LUNORA_ADMIN_TOKEN`) and include the runtime-authored per-check
+      `message`s **and** the full `kind:key` binding names to aid an operator —
+      but a monitor polling it must then send the token.
 - [ ] Set `cacheTtlMs` if an orchestrator polls every few seconds, so repeated
       probes don't re-hit the bindings on every request — the last computed
       report is reused within the window.

--- a/apps/docs/src/content/docs/production-checklist.mdx
+++ b/apps/docs/src/content/docs/production-checklist.mdx
@@ -160,9 +160,10 @@ Checklist:
       `LUNORA_ADMIN_TOKEN`) and include the runtime-authored per-check
       `message`s **and** the full `kind:key` binding names to aid an operator —
       but a monitor polling it must then send the token.
-- [ ] Set `cacheTtlMs` if an orchestrator polls every few seconds, so repeated
-      probes don't re-hit the bindings on every request — the last computed
-      report is reused within the window.
+- [ ] Tune `cacheTtlMs` if needed. The last computed report is reused within the
+      window so repeated probes (or an unauthenticated flood) don't re-hit the
+      bindings on every request. It defaults to `5000` ms in the `"public"`
+      posture and `0` (no cache) in `"admin"`; set `0` to always run live.
 - [ ] The Studio's **Deployment health** page (under Observability) reads these
       same endpoints live — a quick operator view of liveness, readiness, and
       per-binding status.

--- a/packages/ai/__tests__/gateway.test.ts
+++ b/packages/ai/__tests__/gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { AI_GATEWAY_ACCOUNT_ID_ENV, AI_GATEWAY_ID_ENV, AI_GATEWAY_TOKEN_ENV, buildAiGatewayMetadataFields, resolveAiGateway } from "../src/gateway";
 
@@ -64,6 +64,34 @@ describe(resolveAiGateway, () => {
         const resolved = resolveAiGateway(configuredEnv(), {});
 
         expect(resolved?.headers).toStrictEqual({});
+    });
+
+    it("warns once when a token is set on the Workers AI binding path (which can't carry it)", () => {
+        expect.assertions(4);
+
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        try {
+            const env = { ...configuredEnv(), [AI_GATEWAY_TOKEN_ENV]: "gw-secret" };
+
+            // The Workers AI binding's native `gateway` option has no authorization
+            // field, so a configured token would be silently dropped on this path —
+            // resolveAiGateway warns instead so it isn't diagnosed at inference time.
+            const resolved = resolveAiGateway(env, undefined, "workers-ai-binding");
+
+            // The token still appears in `headers` (that is what the BYO-provider
+            // path sends); only the binding path can't use it.
+            expect(resolved?.headers).toStrictEqual({ "cf-aig-authorization": "Bearer gw-secret" });
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(String(warn.mock.calls[0]?.[0])).toContain(AI_GATEWAY_TOKEN_ENV);
+
+            // One-shot per isolate: a second binding-path resolution stays quiet so a
+            // hot dispatch path doesn't flood the log.
+            resolveAiGateway(env, undefined, "workers-ai-binding");
+            expect(warn).toHaveBeenCalledTimes(1);
+        } finally {
+            warn.mockRestore();
+        }
     });
 });
 

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -515,6 +515,48 @@ describe(defineRag, () => {
             expect(result.sources[0]?.weight).toBe(0.4);
         });
 
+        it("keeps the score finite when importance is 0 (guards the rescale divide)", async () => {
+            expect.assertions(3);
+
+            // When `__ragImportance` is an INDEXED field, the vector query returns
+            // it even under `returnMetadata: "indexed"`, so `parseMatches` sees
+            // importance 0 and `chunk.score` is `cosine * 0 = 0`. The hydrate rescale
+            // then computed `chunk.score / chunk.importance` = `0 / 0` = NaN,
+            // corrupting the ENTIRE retrieval ordering (not just this chunk). 0 is a
+            // validated, accepted importance — the guard must keep the score finite.
+            const { store, vectors } = memoryVectors();
+            // Surface the indexed importance on the query leg (a real backend that
+            // indexes `__ragImportance` does exactly this).
+            const baseQuery = vectors.query;
+            const patched: RagVectors = {
+                ...vectors,
+                query: async (index, input) => {
+                    const result = await baseQuery(index, input);
+
+                    return {
+                        ...result,
+                        matches: result.matches.map((match) => ({
+                            ...match,
+                            metadata: { ...(match.metadata ?? {}), __ragImportance: store.get(match.id)?.metadata?.["__ragImportance"] },
+                        })),
+                    };
+                },
+            };
+
+            const { store: textStore } = memoryTextStore();
+            const ctx = fakeCtx(patched);
+            const docs = defineRag({ allowSharedNamespace: true, index: "docs", textStore });
+            const rag = docs(ctx);
+
+            await rag.index({ id: "doc-1", importance: 0, text: "rain storm cloud" });
+
+            const result = await rag.retrieve("rain storm cloud");
+
+            expect(result.chunks[0]?.importance).toBe(0);
+            expect(Number.isFinite(result.chunks[0]?.score)).toBe(true);
+            expect(result.chunks[0]?.score).toBe(0);
+        });
+
         it("propagates removals into the text store", async () => {
             const { vectors } = memoryVectors();
             const { removed, store: textStore } = memoryTextStore();

--- a/packages/ai/src/create-ai.ts
+++ b/packages/ai/src/create-ai.ts
@@ -34,7 +34,12 @@ const resolveGatewayOption = (
         return undefined;
     }
 
-    const resolved = resolveAiGateway(env, metadata);
+    // `"workers-ai-binding"`: this env-derived option feeds the Workers AI binding
+    // (`createWorkersAI({ binding, gateway })` / `ai.run`), whose native `gateway`
+    // option has no authorization field — so `resolved.headers` (incl. any
+    // `cf-aig-authorization`) is discarded here, and `resolveAiGateway` warns once
+    // when an auth token was configured. See `AI_GATEWAY_TOKEN_ENV`.
+    const resolved = resolveAiGateway(env, metadata, "workers-ai-binding");
 
     if (resolved === undefined) {
         return undefined;

--- a/packages/ai/src/gateway.ts
+++ b/packages/ai/src/gateway.ts
@@ -20,6 +20,25 @@ const readEnv = (env: Record<string, unknown>, key: string): string | undefined 
 };
 
 /**
+ * Which surface resolved the gateway. The two paths handle the auth token
+ * differently: a bring-your-own AI SDK provider sends it as the
+ * `cf-aig-authorization` header (`ResolvedAiGateway.headers`), but the Workers AI
+ * **binding** routes through the gateway using the account's own credentials and
+ * its native `gateway` option (Cloudflare `GatewayOptions`) has **no** field to
+ * carry an authorization token — so a token set for the binding path cannot be
+ * delivered and is warned about instead of silently dropped.
+ * @experimental
+ */
+export type AiGatewayConsumer = "byo-provider" | "workers-ai-binding";
+
+/**
+ * One-shot guard: the Workers-AI-binding auth-token warning fires at most once
+ * per isolate, so a hot dispatch path routing every call through the gateway
+ * doesn't flood the log with the same line.
+ */
+let warnedWorkersAiBindingToken = false;
+
+/**
  * Project {@link AiGatewayMetadata} to a plain string-map of only its defined,
  * non-empty fields, or `undefined` when nothing is set. This is the shared source
  * of truth behind both gateway-correlation forms: the `cf-aig-metadata` HTTP
@@ -109,7 +128,21 @@ export const AI_GATEWAY_ACCOUNT_ID_ENV = "LUNORA_AI_GATEWAY_ACCOUNT_ID";
 /** Env var naming the AI Gateway id (the gateway's slug). */
 export const AI_GATEWAY_ID_ENV = "LUNORA_AI_GATEWAY_ID";
 
-/** Env var carrying the gateway's authentication token (only for authenticated gateways). */
+/**
+ * Env var carrying the gateway's authentication token (only for authenticated
+ * gateways).
+ *
+ * **Workers AI binding limitation.** This token is delivered only on the
+ * bring-your-own AI SDK provider path, as the `cf-aig-authorization` header (see
+ * {@link ResolvedAiGateway.headers}). The Workers AI **binding** (`ctx.ai` over
+ * `env.AI`) routes through the gateway with the account's own credentials and its
+ * native `gateway` option (Cloudflare's `GatewayOptions`: `id` / `cacheKey` /
+ * `metadata` / …) has no authorization field — so an *authenticated* gateway that
+ * requires a token cannot be reached on the binding path. Set this only for a BYO
+ * provider; for Workers AI, leave the gateway unauthenticated (or front it with a
+ * BYO provider). {@link resolveAiGateway} warns once per isolate if the token is
+ * set on the binding path.
+ */
 export const AI_GATEWAY_TOKEN_ENV = "LUNORA_AI_GATEWAY_TOKEN";
 
 /**
@@ -121,9 +154,20 @@ export const AI_GATEWAY_TOKEN_ENV = "LUNORA_AI_GATEWAY_TOKEN";
  *
  * Pass optional {@link AiGatewayMetadata} to fold a `cf-aig-metadata` correlation
  * header into `headers` — only its defined fields are sent.
+ *
+ * `consumer` names the surface resolving the gateway (default `"byo-provider"`).
+ * When it is `"workers-ai-binding"` and an {@link AI_GATEWAY_TOKEN_ENV} token is
+ * configured, this warns once per isolate: the binding path cannot carry the
+ * token (see {@link AI_GATEWAY_TOKEN_ENV}), so it would otherwise be dropped with
+ * no diagnostic and every `ctx.ai.model(...)` call would fail against an
+ * authenticated gateway while the token var reads as "configured".
  * @experimental
  */
-export const resolveAiGateway = (env: Record<string, unknown>, metadata?: AiGatewayMetadata): ResolvedAiGateway | undefined => {
+export const resolveAiGateway = (
+    env: Record<string, unknown>,
+    metadata?: AiGatewayMetadata,
+    consumer: AiGatewayConsumer = "byo-provider",
+): ResolvedAiGateway | undefined => {
     const accountId = readEnv(env, AI_GATEWAY_ACCOUNT_ID_ENV);
     const gatewayId = readEnv(env, AI_GATEWAY_ID_ENV);
 
@@ -136,6 +180,14 @@ export const resolveAiGateway = (env: Record<string, unknown>, metadata?: AiGate
 
     if (token !== undefined) {
         headers["cf-aig-authorization"] = `Bearer ${token}`;
+
+        if (consumer === "workers-ai-binding" && !warnedWorkersAiBindingToken) {
+            warnedWorkersAiBindingToken = true;
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[lunora:ai] ${AI_GATEWAY_TOKEN_ENV} is set, but the Workers AI binding cannot send a gateway auth token — Cloudflare's native gateway option has no authorization field. The token is ignored on this path; use a bring-your-own AI SDK provider (which sends cf-aig-authorization), or make the AI Gateway unauthenticated for Workers AI.`,
+            );
+        }
     }
 
     const metadataHeader = encodeMetadata(metadata);

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -654,11 +654,16 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                 const rawImportance = fullMetadata?.[IMPORTANCE_KEY];
                 const importance = typeof rawImportance === "number" && rawImportance >= 0 && rawImportance <= 1 ? rawImportance : chunk.importance;
 
-                // `chunk.score` was computed against `chunk.importance` (always
-                // 1 here — text-store `query()` never sees `__ragImportance`);
-                // rescale it to the recovered importance so weighting actually
-                // takes effect.
-                const score = (chunk.score / chunk.importance) * importance;
+                // `chunk.score` was computed as `match.score * chunk.importance`
+                // (usually 1 in text-store mode — `query()` returns only indexed
+                // metadata, so `__ragImportance` is absent — but 0 is a valid,
+                // validated importance and IS returned when it was indexed).
+                // Rescale to the recovered importance so weighting takes effect.
+                // Guard the divide: `chunk.importance === 0` makes `chunk.score`
+                // 0 too, so `0 / 0` would yield `NaN` and corrupt the whole
+                // retrieval ordering, not just this chunk — treat it as base 0.
+                const base = chunk.importance === 0 ? 0 : chunk.score / chunk.importance;
+                const score = base * importance;
 
                 return [{ ...chunk, importance, metadata: userMetadataOf(fullMetadata) ?? chunk.metadata, score, text }];
             });

--- a/packages/cli/src/commands/logs/durable.ts
+++ b/packages/cli/src/commands/logs/durable.ts
@@ -13,7 +13,7 @@
  * operator has wired the Pipeline → R2 Data Catalog table (see the docs).
  */
 import { createR2Sql } from "@lunora/bindings/r2sql";
-import type { PipelineLogQuery, PipelineLogRow } from "@lunora/runtime";
+import type { PipelineLogCursor, PipelineLogQuery, PipelineLogRow } from "@lunora/runtime";
 import { createPipelineLogReader } from "@lunora/runtime";
 
 import type { Logger } from "../../util/logger";
@@ -32,7 +32,7 @@ interface DurableLogsEnvironment {
 }
 
 interface DurableLogsCommandOptions {
-    /** Resume after a previous page: the `ts` from the prior page's `nextCursor`. */
+    /** Resume after a previous page: the opaque `--cursor` token the prior page printed (a bare epoch-millis `ts` is also accepted). */
     cursor?: string;
     /** Inject env (tests); defaults to `process.env`. */
     environment?: DurableLogsEnvironment;
@@ -94,6 +94,48 @@ const parseTimestamp = (value: string | undefined, flag: string): number | undef
     }
 
     return parsed;
+};
+
+/** Serialize a keyset cursor to a compact, opaque `--cursor` token (base64url JSON) that round-trips its `seen` boundary hashes. */
+const encodeCursor = (cursor: PipelineLogCursor): string => Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+/**
+ * Parse a `--cursor` value back to a {@link PipelineLogCursor}. Accepts the opaque
+ * base64url token minted by {@link encodeCursor} (which carries the `seen` boundary
+ * hashes, so resuming pages neither drops nor duplicates rows) and, for
+ * convenience, a bare epoch-millis integer (a `ts`-only cursor — still lossless via
+ * the reader's inclusive resume, but without `seen` it may re-emit boundary ties).
+ */
+const parseCursor = (raw: string): PipelineLogCursor => {
+    const trimmed = raw.trim();
+
+    // Back-compat / hand-typed convenience: a bare epoch-millis is a `ts`-only cursor.
+    if (EPOCH_MILLIS_RE.test(trimmed)) {
+        return { ts: Number(trimmed) };
+    }
+
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(Buffer.from(trimmed, "base64url").toString("utf8"));
+    } catch {
+        throw new TypeError(`logs: invalid --cursor "${raw}" — expected the token printed by the previous page (or a bare epoch-millis ts)`);
+    }
+
+    if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        typeof (parsed as { ts?: unknown }).ts !== "number" ||
+        !Number.isFinite((parsed as { ts: number }).ts)
+    ) {
+        throw new TypeError(`logs: invalid --cursor "${raw}" — expected the token printed by the previous page (or a bare epoch-millis ts)`);
+    }
+
+    const { ts } = parsed as { ts: number };
+    const seenRaw = (parsed as { seen?: unknown }).seen;
+    const seen = Array.isArray(seenRaw) ? seenRaw.filter((entry): entry is string => typeof entry === "string") : undefined;
+
+    return seen !== undefined && seen.length > 0 ? { seen, ts } : { ts };
 };
 
 /** Validate a severity against the known level set, throwing an actionable error otherwise. */
@@ -164,13 +206,7 @@ const buildQuery = (options: DurableLogsCommandOptions): PipelineLogQuery => {
     }
 
     if (options.cursor !== undefined) {
-        const cursorTs = Number(options.cursor);
-
-        if (!Number.isFinite(cursorTs)) {
-            throw new TypeError(`logs: invalid --cursor "${options.cursor}" — expected the epoch-millis ts from a prior page's nextCursor`);
-        }
-
-        query.cursor = { ts: cursorTs };
+        query.cursor = parseCursor(options.cursor);
     }
 
     return query;
@@ -248,7 +284,7 @@ const runDurableLogsCommand = async (options: DurableLogsCommandOptions): Promis
     if (page.rows.length === 0) {
         options.logger.info("logs --durable: no matching log records");
     } else if (page.nextCursor !== undefined) {
-        options.logger.info(`logs --durable: more rows available — pass --cursor ${String(page.nextCursor.ts)} for the next page`);
+        options.logger.info(`logs --durable: more rows available — pass --cursor ${encodeCursor(page.nextCursor)} for the next page`);
     }
 
     return { code: 0, rows: page.rows };

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -39,7 +39,12 @@ const logsCommand: Command = {
         { description: "durable: shard-key filter", name: "shard-key", type: String },
         { description: "durable: user-id filter", name: "user-id", type: String },
         { description: "durable: max rows (clamped to 1–10000; default 500)", name: "limit", type: String },
-        { description: "durable: resume after a prior page — the ts from its nextCursor", name: "cursor", type: String },
+        {
+            description:
+                "durable: resume after a prior page — the opaque cursor token printed by the previous page (bare epoch-millis also accepted for back-compat)",
+            name: "cursor",
+            type: String,
+        },
         { description: "durable: emit one JSON object per line instead of a table", name: "ndjson", type: Boolean },
     ],
 };

--- a/packages/do/__tests__/context-telemetry-cf-bridge.test.ts
+++ b/packages/do/__tests__/context-telemetry-cf-bridge.test.ts
@@ -162,7 +162,7 @@ describe("createTracer cloudflare custom-spans bridge", () => {
         const writes = new Map(span.writes);
 
         expect(writes.get("lunora.ok")).toBe(false);
-        expect(writes.get("lunora.error.message")).toBe("kaboom");
+        expect(writes.get("error.message")).toBe("kaboom");
     });
 
     it("records an IDENTICAL SpanEvent (bar the per-call id/timestamps) with the bridge on", async () => {

--- a/packages/do/__tests__/shard-do.sampling.test.ts
+++ b/packages/do/__tests__/shard-do.sampling.test.ts
@@ -228,4 +228,152 @@ describe("shardDO trace sampling", () => {
             database.close();
         }
     });
+
+    it("flushes a sampled-out trace's held error span even after the ring evicted it (eviction race closed)", async () => {
+        expect.assertions(1);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new SamplingShard(makeState(database), {});
+
+            let markRecorded!: () => void;
+            const slowRecorded = new Promise<void>((resolve) => {
+                markRecorded = resolve;
+            });
+            let releaseSlow!: () => void;
+            const slowGate = new Promise<void>((resolve) => {
+                releaseSlow = resolve;
+            });
+
+            shard.plan = async (trace, functionPath) => {
+                if (functionPath === "slow:out") {
+                    // Sampled out + errors: the span is held on the per-trace entry.
+                    await trace("slow-error", () => {
+                        throw new Error("boom");
+                    }).catch(() => undefined);
+                    markRecorded();
+                    // Park so this dispatch's `finally` (which flushes the held error
+                    // span) runs AFTER the flood below has evicted it from the ring.
+                    await slowGate;
+
+                    return;
+                }
+
+                // Flood a DIFFERENT (sampled-in) trace with more spans than the span
+                // ring can hold, so the slow trace's held error span is evicted FROM
+                // THE RING while its dispatch is parked. The held spans now live on the
+                // per-trace entry, not the ring, so the flush must still find it — the
+                // ring-copy implementation would silently drop it here.
+                for (let index = 0; index < 550; index += 1) {
+                    // eslint-disable-next-line no-await-in-loop -- ordering is the point: fill the ring sequentially so the oldest (slow-error) is evicted.
+                    await trace(`filler-${index.toString()}`, () => undefined);
+                }
+            };
+
+            const slow = shard.fetch(request("slow:out", { keepErrors: true, sampled: false, traceId: TRACE_ID }));
+
+            await slowRecorded;
+
+            // Sampled-in flood on its own trace: streams live AND fills the ring past
+            // capacity, evicting the slow trace's held error span from the ring.
+            await shard.fetch(request("flood:in", { sampled: true, traceId: TRACE_ID_B }));
+
+            releaseSlow();
+            await slow;
+
+            expect(shard.exportedSpans.filter((span) => span.traceId === TRACE_ID).map((span) => span.name)).toContain("slow-error");
+        } finally {
+            database.close();
+        }
+    });
+
+    it("does not export a span that ends after its sampled-out dispatch tore down (late-span verdict snapshot)", async () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new SamplingShard(makeState(database), {});
+
+            let markStarted!: () => void;
+            const started = new Promise<void>((resolve) => {
+                markStarted = resolve;
+            });
+            let releaseLate!: () => void;
+            const lateGate = new Promise<void>((resolve) => {
+                releaseLate = resolve;
+            });
+            let latePromise!: Promise<void>;
+
+            shard.plan = async (trace) => {
+                // Detached: the body parks on the gate, so the dispatch returns — and
+                // its `finally` deletes the traceSampling entry — while the span is
+                // still open. This is the streaming-AI-SDK / detached-hook shape.
+                latePromise = trace("late", async () => {
+                    markStarted();
+                    await lateGate;
+                });
+                await started;
+            };
+
+            await shard.fetch(request("a:b", { keepErrors: true, sampled: false }));
+
+            // Dispatch settled, entry gone; the span has not recorded yet.
+            expect(shard.exportedSpans).toHaveLength(0);
+
+            releaseLate();
+            await latePromise;
+
+            // The late span records now, with NO live traceSampling entry. The verdict
+            // snapshotted when it opened (sampled out) is honoured — it is dropped, not
+            // exported. Before the fix a missing entry fell through to an unconditional
+            // export, leaking an orphan child of a sampled-out trace.
+            expect(shard.exportedSpans).toHaveLength(0);
+        } finally {
+            database.close();
+        }
+    });
+
+    it("still exports a span that ends after a sampled-in dispatch tore down", async () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new SamplingShard(makeState(database), {});
+
+            let markStarted!: () => void;
+            const started = new Promise<void>((resolve) => {
+                markStarted = resolve;
+            });
+            let releaseLate!: () => void;
+            const lateGate = new Promise<void>((resolve) => {
+                releaseLate = resolve;
+            });
+            let latePromise!: Promise<void>;
+
+            shard.plan = async (trace) => {
+                latePromise = trace("late", async () => {
+                    markStarted();
+                    await lateGate;
+                });
+                await started;
+            };
+
+            await shard.fetch(request("a:b", { sampled: true }));
+
+            // Parked span hasn't recorded yet.
+            expect(shard.exportedSpans).toHaveLength(0);
+
+            releaseLate();
+            await latePromise;
+
+            // No live entry now, but the open-time snapshot (sampled in) keeps it — a
+            // kept trace's late span still exports.
+            expect(shard.exportedSpans.map((span) => span.name)).toContain("late");
+        } finally {
+            database.close();
+        }
+    });
 });

--- a/packages/do/__tests__/tracing.test.ts
+++ b/packages/do/__tests__/tracing.test.ts
@@ -37,7 +37,9 @@ class TracingShard extends ShardDO {
     }
 
     public metricRecorder(functionPath: string): ReturnType<TracingShard["makeMetrics"]> {
-        return this.makeMetrics(functionPath);
+        // Durable metric history is opt-in (default off); enable it so the
+        // getMetricHistory admin-RPC test still exercises the persistence path.
+        return this.makeMetrics(functionPath, { metricHistory: true });
     }
 
     public tracer(functionPath: string): ReturnType<TracingShard["makeTracer"]> {

--- a/packages/do/src/context-telemetry.ts
+++ b/packages/do/src/context-telemetry.ts
@@ -17,7 +17,7 @@
 import type { LogFields } from "../../../shared/log-fields";
 import { normalizeLogFields } from "../../../shared/log-fields";
 import type { MetricEvent, MetricKind } from "../../../shared/metric-event";
-import { buildTraceparent, otlpRandomHex } from "../../../shared/otlp";
+import { buildTraceparent, LUNORA_ATTR, otlpRandomHex } from "../../../shared/otlp";
 import type { SpanEvent, SpanEventPoint, SpanHandle, SpanLink, SpanOptions } from "../../../shared/span-event";
 import { toErrorType } from "./trace-context";
 
@@ -254,21 +254,24 @@ export const applyCloudflareSpanAttributes = (
         return;
     }
 
-    span.setAttribute("lunora.function_path", meta.functionPath);
-    span.setAttribute("lunora.ok", meta.ok);
-    span.setAttribute("lunora.duration_ms", meta.durationMs);
+    span.setAttribute(LUNORA_ATTR.functionPath, meta.functionPath);
+    span.setAttribute(LUNORA_ATTR.ok, meta.ok);
+    span.setAttribute(LUNORA_ATTR.durationMs, meta.durationMs);
 
     if (meta.shardKey !== undefined) {
-        span.setAttribute("lunora.shard_key", meta.shardKey);
+        span.setAttribute(LUNORA_ATTR.shardKey, meta.shardKey);
     }
 
     if (meta.userId !== undefined) {
-        span.setAttribute("lunora.user_id", meta.userId);
+        span.setAttribute(LUNORA_ATTR.userId, meta.userId);
     }
 
     if (meta.error !== undefined) {
-        span.setAttribute("lunora.error.type", meta.error.type);
-        span.setAttribute("lunora.error.message", meta.error.message);
+        // Wire change: these were `lunora.error.type` / `lunora.error.message`;
+        // they now converge on the OTel-standard `error.type` / `error.message`
+        // so a collector query matches the worker exporter's span too.
+        span.setAttribute(LUNORA_ATTR.errorType, meta.error.type);
+        span.setAttribute(LUNORA_ATTR.errorMessage, meta.error.message);
     }
 
     for (const [key, value] of Object.entries(meta.attributes)) {

--- a/packages/do/src/database-telemetry.ts
+++ b/packages/do/src/database-telemetry.ts
@@ -299,16 +299,15 @@ const instrumentDatabase = <T extends object>(database: T, deps: DatabaseTelemet
 /** A zero'd tally for one dispatch. */
 const createDatabaseTally = (): DatabaseTally => {
     return { calls: 0, durationMs: 0, errors: 0, perOperation: {}, spansEmitted: 0, spansTruncated: false };
-
-    /**
-     * Render the running tally as span attributes.
-     *
-     * Called ONCE per dispatch, from the shard's root-span recorder — not per query.
-     * Building this object on every call was pure waste on a hot path. It is a handful of keys, so the per-call cost is a small object
-     * assignment — the property that makes `"summary"` mode scale to any call count.
-     */
 };
 
+/**
+ * Render the running tally as span attributes.
+ *
+ * Called ONCE per dispatch, from the shard's root-span recorder — not per query.
+ * Building this object on every call was pure waste on a hot path. It is a handful of keys, so the per-call cost is a small object
+ * assignment — the property that makes `"summary"` mode scale to any call count.
+ */
 const formatTally = (tally: DatabaseTally): LogFields => {
     const fields: LogFields = {
         "db.calls": tally.calls,

--- a/packages/do/src/metric-history.ts
+++ b/packages/do/src/metric-history.ts
@@ -171,6 +171,18 @@ const knownBucketsFor = (sql: SqlExec): Set<string> => {
 };
 
 /**
+ * Tunable caps for {@link recordMetricHistory}, threaded from the sink's
+ * `metricHistory` option. Each falls back to its module-constant default, so an
+ * omitted field keeps the historical behaviour.
+ */
+interface MetricHistoryOptions {
+    /** Distinct series tracked before a brand-new one is dropped (default {@link METRIC_HISTORY_MAX_SERIES}). */
+    maxSeries?: number;
+    /** Minute-buckets kept per series before older rows are trimmed (default {@link METRIC_HISTORY_BUCKET_RETENTION}). */
+    retentionBuckets?: number;
+}
+
+/**
  * Fold one measurement into its `(series, minute)` bucket. Runs per
  * `ctx.metrics.*` call (unlike `function-metrics.ts`, which runs once per
  * dispatch), so it's tuned for the in-minute repeat: a bucket this instance has
@@ -184,19 +196,11 @@ const knownBucketsFor = (sql: SqlExec): Set<string> => {
  * `exemplarTraceId` (the recording dispatch's trace, when it had one) is stored on
  * the bucket so the studio can link a chart point back to a trace. Latest wins:
  * a later sample carrying a trace replaces an earlier bucket's exemplar.
+ *
+ * `options` tunes the distinct-series cap and retention window from the sink's
+ * `metricHistory` flag (see {@link MetricHistoryOptions}); each defaults to its
+ * module constant.
  */
-/**
- * Tunable caps for {@link recordMetricHistory}, threaded from the sink's
- * `metricHistory` option. Each falls back to its module-constant default, so an
- * omitted field keeps the historical behaviour.
- */
-interface MetricHistoryOptions {
-    /** Distinct series tracked before a brand-new one is dropped (default {@link METRIC_HISTORY_MAX_SERIES}). */
-    maxSeries?: number;
-    /** Minute-buckets kept per series before older rows are trimmed (default {@link METRIC_HISTORY_BUCKET_RETENTION}). */
-    retentionBuckets?: number;
-}
-
 const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?: string, options: MetricHistoryOptions = {}): void => {
     const maxSeries = options.maxSeries ?? METRIC_HISTORY_MAX_SERIES;
     const retentionBuckets = options.retentionBuckets ?? METRIC_HISTORY_BUCKET_RETENTION;

--- a/packages/do/src/metric-history.ts
+++ b/packages/do/src/metric-history.ts
@@ -185,7 +185,22 @@ const knownBucketsFor = (sql: SqlExec): Set<string> => {
  * the bucket so the studio can link a chart point back to a trace. Latest wins:
  * a later sample carrying a trace replaces an earlier bucket's exemplar.
  */
-const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?: string): void => {
+/**
+ * Tunable caps for {@link recordMetricHistory}, threaded from the sink's
+ * `metricHistory` option. Each falls back to its module-constant default, so an
+ * omitted field keeps the historical behaviour.
+ */
+interface MetricHistoryOptions {
+    /** Distinct series tracked before a brand-new one is dropped (default {@link METRIC_HISTORY_MAX_SERIES}). */
+    maxSeries?: number;
+    /** Minute-buckets kept per series before older rows are trimmed (default {@link METRIC_HISTORY_BUCKET_RETENTION}). */
+    retentionBuckets?: number;
+}
+
+const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?: string, options: MetricHistoryOptions = {}): void => {
+    const maxSeries = options.maxSeries ?? METRIC_HISTORY_MAX_SERIES;
+    const retentionBuckets = options.retentionBuckets ?? METRIC_HISTORY_BUCKET_RETENTION;
+
     ensureMetricHistoryTable(sql);
 
     const key = metricSeriesKey(event);
@@ -216,7 +231,7 @@ const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?:
         if (!seriesTracked) {
             const seriesCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(DISTINCT series_key) AS n FROM "${METRIC_HISTORY_TABLE}"`).one();
 
-            if (seriesCountRow.n >= METRIC_HISTORY_MAX_SERIES) {
+            if (seriesCountRow.n >= maxSeries) {
                 return;
             }
         }
@@ -266,7 +281,7 @@ const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?:
                 SELECT MAX(bucket_ms) - ? FROM "${METRIC_HISTORY_TABLE}" WHERE series_key = ?
                )`,
             key,
-            METRIC_HISTORY_BUCKET_RETENTION * METRIC_HISTORY_BUCKET_MS,
+            retentionBuckets * METRIC_HISTORY_BUCKET_MS,
             key,
         );
     }
@@ -369,4 +384,4 @@ const readMetricHistory = (sql: SqlExec, options: { sinceMs?: number } = {}): Me
 };
 
 export { readMetricHistory, recordMetricHistory };
-export type { MetricHistoryPoint, MetricHistoryResult, MetricHistorySeries };
+export type { MetricHistoryOptions, MetricHistoryPoint, MetricHistoryResult, MetricHistorySeries };

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -106,6 +106,7 @@ import { LogBuffer } from "./log-buffer";
 import type { RecordMailInput } from "./mail-catcher";
 import { clearCapturedMail, MAIL_TABLE, readCapturedMail, recordCapturedMail } from "./mail-catcher";
 import { MetricBuffer } from "./metric-buffer";
+import type { MetricHistoryOptions } from "./metric-history";
 import { readMetricHistory, recordMetricHistory } from "./metric-history";
 import { armRestore, readBookmark } from "./pitr";
 import type { QueryStatEntry } from "./query-metrics";
@@ -231,7 +232,7 @@ interface TelemetrySink {
      * `true` uses the built-in defaults. Mirror of `@lunora/runtime`'s
      * `ObservabilitySink`.
      */
-    metricHistory?: boolean | { maxSeries?: number; retentionBuckets?: number };
+    metricHistory?: boolean | MetricHistoryOptions;
     onLog?: (event: LogEventInput, context?: LogSinkContext) => void;
     onMetric?: (event: MetricEvent, context?: LogSinkContext) => void;
     onSpan?: (event: SpanEvent, context?: LogSinkContext) => void;
@@ -4917,13 +4918,10 @@ abstract class ShardDO {
             // that recorded the metric (matching recordFunctionMetric et al., which
             // all write through the raw handle for the same reason).
             const rawSql = this.state.storage.sql as unknown as SqlExec;
-            const historyOptions =
-                typeof metricHistory === "object"
-                    ? {
-                          ...(metricHistory.maxSeries === undefined ? {} : { maxSeries: metricHistory.maxSeries }),
-                          ...(metricHistory.retentionBuckets === undefined ? {} : { retentionBuckets: metricHistory.retentionBuckets }),
-                      }
-                    : {};
+            // Pass the tune object straight through: `recordMetricHistory` already
+            // coalesces every field with `?? DEFAULT`, so stripping `undefined`
+            // keys here bought nothing. `true` (no tuning) becomes `{}`.
+            const historyOptions: MetricHistoryOptions = typeof metricHistory === "object" ? metricHistory : {};
 
             bestEffort(() => {
                 recordMetricHistory(rawSql, stamped, exemplarTraceId, historyOptions);

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -221,6 +221,17 @@ interface TelemetrySink {
      * emits nothing extra. Mirror of `@lunora/runtime`'s `ObservabilitySink`.
      */
     instrumentDatabase?: DatabaseInstrumentation;
+
+    /**
+     * **Opt-in, default off.** Durable per-minute `ctx.metrics.*` rollups written to
+     * the reserved per-shard SQLite table (the Studio's local trend chart). Off by
+     * default because every measurement then costs a durable SQLite write on the
+     * request path — the live cross-instance path is `onMetric`, this is only the
+     * local convenience. An object tunes the caps (`maxSeries` / `retentionBuckets`);
+     * `true` uses the built-in defaults. Mirror of `@lunora/runtime`'s
+     * `ObservabilitySink`.
+     */
+    metricHistory?: boolean | { maxSeries?: number; retentionBuckets?: number };
     onLog?: (event: LogEventInput, context?: LogSinkContext) => void;
     onMetric?: (event: MetricEvent, context?: LogSinkContext) => void;
     onSpan?: (event: SpanEvent, context?: LogSinkContext) => void;
@@ -4870,16 +4881,33 @@ abstract class ShardDO {
             this.metricSeries.push(stamped);
         });
 
-        // Durable per-minute rollups. Use the RAW storage handle, NOT `this.sql`:
-        // the getter instruments statements into the Query Insights leaderboard
-        // during a dispatch, and these housekeeping writes would be misattributed
-        // to the user function that recorded the metric (matching recordFunctionMetric
-        // et al., which all write through the raw handle for the same reason).
-        const rawSql = this.state.storage.sql as unknown as SqlExec;
+        // Durable per-minute rollups — OPT-IN (default off). Every measurement
+        // otherwise pays a billed, rate-limited SQLite write on the request path,
+        // competing with app data for the shard's write budget; the payoff is only
+        // the Studio's 24h local trend chart. The live cross-instance path is
+        // `sink.onMetric` below. Gated BEFORE touching `rawSql` so a disabled sink
+        // allocates nothing and runs no SQL.
+        const metricHistory = sink?.metricHistory;
 
-        bestEffort(() => {
-            recordMetricHistory(rawSql, stamped, exemplarTraceId);
-        });
+        if (metricHistory !== undefined && metricHistory !== false) {
+            // Use the RAW storage handle, NOT `this.sql`: the getter instruments
+            // statements into the Query Insights leaderboard during a dispatch, and
+            // these housekeeping writes would be misattributed to the user function
+            // that recorded the metric (matching recordFunctionMetric et al., which
+            // all write through the raw handle for the same reason).
+            const rawSql = this.state.storage.sql as unknown as SqlExec;
+            const historyOptions =
+                typeof metricHistory === "object"
+                    ? {
+                          ...(metricHistory.maxSeries === undefined ? {} : { maxSeries: metricHistory.maxSeries }),
+                          ...(metricHistory.retentionBuckets === undefined ? {} : { retentionBuckets: metricHistory.retentionBuckets }),
+                      }
+                    : {};
+
+            bestEffort(() => {
+                recordMetricHistory(rawSql, stamped, exemplarTraceId, historyOptions);
+            });
+        }
 
         // Optional export sink (the durable, cross-instance path).
         if (sink?.onMetric) {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1323,6 +1323,16 @@ const dispatchSpanKey = (anchor: TraceAnchor): string => `${anchor.traceId}:${an
 const MAX_TRACKED_DISPATCH_SPANS = 256;
 
 /**
+ * Bound on the per-trace held-span array a sampled-out dispatch accumulates for
+ * the tail-bias flush (see {@link ShardDO.recordSpan}). Matches the span ring's
+ * capacity — a trace holding more spans than the whole ring could retain is
+ * already pathological, and the array is dropped wholesale when the dispatch
+ * `finally` deletes the `traceSampling` entry, so this is a backstop against a
+ * runaway single trace, not a working set.
+ */
+const MAX_HELD_SPANS_PER_TRACE = 500;
+
+/**
  * `event.name` of the per-dispatch wide event. Namespaced so it never collides
  * with an application's own `ctx.log.event(...)` names, and stable because
  * dashboards and alerts will filter on it.
@@ -1966,12 +1976,17 @@ abstract class ShardDO {
      * before — when false, `ctx.trace` INTERNAL spans are held out of the live export
      * and re-decided in the dispatch `finally` as a tail bias), `keepErrors` (the
      * runtime's `x-lunora-sample-errors` / `alwaysSampleErrors` toggle — a sampled-out
-     * trace that errored is still exported whole unless off), and `sink` (captured
+     * trace that errored is still exported whole unless off), `sink` (captured
      * when a sampled-out span is first held, so the `finally` can flush the trace's
-     * held spans). Registered at dispatch entry by the dispatch's own `traceId`, read
-     * by `span.traceId`, and deleted in the `finally`.
+     * held spans), and `held` (the sampled-out spans themselves, buffered ON THIS
+     * ENTRY rather than read back from the shared span ring — the ring is bounded and
+     * a concurrent trace could evict this trace's error spans before the flush, which
+     * would silently defeat `alwaysSampleErrors`; bounded by
+     * {@link MAX_HELD_SPANS_PER_TRACE}). Registered at dispatch entry by the
+     * dispatch's own `traceId`, read by `span.traceId`, and deleted in the `finally`
+     * (which drops `held` with it, so no spans leak past the dispatch).
      */
-    private traceSampling = new Map<string, { keepErrors: boolean; sampled: boolean; sink?: TelemetrySink }>();
+    private traceSampling = new Map<string, { held?: SpanEvent[]; keepErrors: boolean; sampled: boolean; sink?: TelemetrySink }>();
 
     /**
      * The per-dispatch **wide event** — everything a handler attached through
@@ -4665,12 +4680,18 @@ abstract class ShardDO {
      * resolved sink sets `fuseCloudflareTraces` (see {@link resolveCloudflareTracing}).
      */
     protected makeTracer(functionPath: string, sink?: TelemetrySink, anchor?: TraceAnchor): ContextTracer {
+        // Resolve the anchor once so its `sampled` verdict is snapshotted for every
+        // span this tracer records — carried to `recordSpan` rather than re-looked-up
+        // from `traceSampling` at span-close time, so a span that ends AFTER the
+        // dispatch tore its entry down still honours the trace's sampling decision.
+        const resolvedAnchor = anchor ?? resolveTraceAnchor(undefined);
+
         return createTracer({
-            anchor: anchor ?? resolveTraceAnchor(undefined),
+            anchor: resolvedAnchor,
             fuseCloudflareSpans: sink?.fuseCloudflareTraces === true,
             functionPath,
             record: (span) => {
-                this.recordSpan(span, sink);
+                this.recordSpan(span, sink, resolvedAnchor.sampled);
             },
             resolveCloudflareTracing,
             shardKey: this.state.id?.name,
@@ -4718,7 +4739,7 @@ abstract class ShardDO {
             functionPath,
             mode,
             record: (recorded) => {
-                this.recordSpan(recorded, sink);
+                this.recordSpan(recorded, sink, anchor.sampled);
             },
             shardKey: this.state.id?.name,
             // Parked on the dispatch entry rather than written through `ctx.span`:
@@ -4756,7 +4777,7 @@ abstract class ShardDO {
                 functionPath,
                 ...(typeof sink.traceFetch === "object" && sink.traceFetch.propagate !== undefined ? { propagate: sink.traceFetch.propagate } : {}),
                 record: (span) => {
-                    this.recordSpan(span, sink);
+                    this.recordSpan(span, sink, anchor.sampled);
                 },
                 shardKey: this.state.id?.name,
                 userId: () => this.getCurrentUserId(),
@@ -5446,7 +5467,7 @@ abstract class ShardDO {
      * trace (a subscription re-run mints its own anchor), stream immediately.
      */
     // eslint-disable-next-line @typescript-eslint/member-ordering -- kept in the span-recording cluster (next to recordDispatchRootSpan) for cohesion rather than hoisted above every private member
-    protected recordSpan(span: SpanEvent, sink?: TelemetrySink): void {
+    protected recordSpan(span: SpanEvent, sink?: TelemetrySink, sampledSnapshot?: boolean): void {
         try {
             this.spans.push(span);
         } catch {
@@ -5457,15 +5478,49 @@ abstract class ShardDO {
             return;
         }
 
-        // Look the verdict up by the SPAN's own `traceId` (not the shared
+        // Look the live verdict up by the SPAN's own `traceId` (not the shared
         // `currentRequestTrace`, which a sibling dispatch may have overwritten by now).
         const sampling = this.traceSampling.get(span.traceId);
 
-        if (sampling && !sampling.sampled) {
-            // Sampled out: hold this span back and remember the sink so the
-            // `finally` can flush the trace's held spans if it turns out to error.
-            sampling.sink = sink;
+        if (sampling !== undefined) {
+            if (!sampling.sampled) {
+                // Sampled out, dispatch still in flight: hold this span back and
+                // remember the sink so the `finally` can flush the trace's held
+                // spans if it turns out to error. Held ON THIS PER-TRACE ENTRY —
+                // NOT re-read from the shared span ring at flush time, where a
+                // concurrent trace could have evicted these error spans first.
+                sampling.sink = sink;
 
+                // The synthetic dispatch root never goes to `onSpan`, so it is not
+                // held either — flushSampledOutTrace only ever emits `ctx.trace` spans.
+                if (span.dispatch !== true) {
+                    const held = sampling.held ?? (sampling.held = []);
+
+                    held.push(span);
+
+                    if (held.length > MAX_HELD_SPANS_PER_TRACE) {
+                        held.shift();
+                    }
+                }
+
+                return;
+            }
+
+            this.emitSpan(span, sink);
+
+            return;
+        }
+
+        // No LIVE `traceSampling` entry. Either a span from a self-anchored trace
+        // (an alarm or subscription re-run mints its own anchor and never registers
+        // one — those must export) or a LATE span whose dispatch already tore its
+        // entry down in the `finally` (a streaming AI-SDK span, a detached hook).
+        // Decide from the verdict snapshotted onto the span when it OPENED (the
+        // `createTracedFetch`/`anchor.sampled` pattern) rather than the deleted
+        // entry: a sampled-OUT late span is dropped (previously it fell through and
+        // exported unconditionally, leaking an orphan child of a sampled-out trace),
+        // a sampled-in one still exports.
+        if (sampledSnapshot === false) {
             return;
         }
 
@@ -5497,8 +5552,11 @@ abstract class ShardDO {
      * streamed live, so this returns early for it; a sampled-out trace exports its
      * held `ctx.trace` spans only when `alwaysSampleErrors` is set AND the trace
      * errored (the dispatch threw, or a held span settled `ok: false`) — the tail
-     * bias — and otherwise drops them. Held spans are read back from the local ring
-     * (excluding the synthetic dispatch root, which never goes to `onSpan`).
+     * bias — and otherwise drops them. Held spans are drained from the per-trace
+     * `held` array `recordSpan` accumulated (the synthetic dispatch root is never
+     * held, since it never goes to `onSpan`) — NOT re-read from the shared span
+     * ring, whose bound a concurrent trace could have used to evict these very
+     * error spans before this flush ran.
      */
     private flushSampledOutTrace(trace: { traceId: string }, dispatchFailed: boolean): void {
         // Read THIS trace's own verdict + held sink (keyed by traceId), so an
@@ -5509,13 +5567,14 @@ abstract class ShardDO {
             return;
         }
 
-        const { sink } = sampling;
+        const { held, sink } = sampling;
 
-        if (!sink?.onSpan) {
+        // Allocation-free short-circuit for the common sampled-out dispatch: no
+        // sink, or nothing was held (a handler that never touched `ctx.trace`).
+        if (!sink?.onSpan || held === undefined || held.length === 0) {
             return;
         }
 
-        const held = this.spans.entries().filter((span) => span.traceId === trace.traceId && span.dispatch !== true);
         const traceHasError = dispatchFailed || held.some((span) => !span.ok);
 
         if (!traceHasError) {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -11,7 +11,7 @@ import { jsonResponse } from "../../../shared/json-response";
 import type { LogSinkContext } from "../../../shared/log-event";
 import type { LogFields } from "../../../shared/log-fields";
 import type { MetricEvent } from "../../../shared/metric-event";
-import { parseTraceparent } from "../../../shared/otlp";
+import { LUNORA_ATTR, parseTraceparent } from "../../../shared/otlp";
 import type { SpanEvent, SpanHandle } from "../../../shared/span-event";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import { verifyWsAdminToken } from "../../../shared/ws-admin-token";
@@ -5438,9 +5438,9 @@ abstract class ShardDO {
                     // The always-present skeleton, under OTel-ish names so the
                     // record is useful even from a handler that attached nothing
                     // but a couple of business fields.
-                    "lunora.duration_ms": durationMs,
-                    "lunora.function_path": functionPath,
-                    "lunora.ok": failure === undefined,
+                    [LUNORA_ATTR.durationMs]: durationMs,
+                    [LUNORA_ATTR.functionPath]: functionPath,
+                    [LUNORA_ATTR.ok]: failure === undefined,
                 },
                 wide.sink,
                 WIDE_EVENT_NAME,

--- a/packages/runtime/__tests__/health.test.ts
+++ b/packages/runtime/__tests__/health.test.ts
@@ -66,6 +66,24 @@ const downD1 = (): unknown => {
 
 const get = (path: string): Request => new Request(`https://app.example${path}`, { method: "GET" });
 
+/** A probe that counts how many times it ran, proving whether the live probes re-ran between requests. `kind: "both"` (default) so it runs on both endpoints. */
+const makeCountingProbe = (): { probe: HealthProbe; runs: () => number } => {
+    let runs = 0;
+
+    return {
+        probe: {
+            check: () => {
+                runs += 1;
+
+                return { healthy: true };
+            },
+            critical: false,
+            name: "counter",
+        },
+        runs: () => runs,
+    };
+};
+
 describe("createWorker — health / readiness endpoints", () => {
     it("returns 200 + healthy when the DO is reachable and D1 resolves", async () => {
         expect.assertions(4);
@@ -192,24 +210,6 @@ describe("createWorker — health / readiness endpoints", () => {
     it("caches the public report across requests within the TTL, and re-runs when disabled", async () => {
         expect.assertions(2);
 
-        // A counting probe proves whether the live probes re-ran between requests.
-        const makeCountingProbe = (): { probe: HealthProbe; runs: () => number } => {
-            let runs = 0;
-
-            return {
-                probe: {
-                    check: () => {
-                        runs += 1;
-
-                        return { healthy: true };
-                    },
-                    critical: false,
-                    name: "counter",
-                },
-                runs: () => runs,
-            };
-        };
-
         const cached = makeCountingProbe();
         const cachedWorker = createWorker({ health: { cacheTtlMs: 60_000, probes: [cached.probe] }, shardDO: reachableNamespace });
 
@@ -261,5 +261,87 @@ describe("createWorker — health / readiness endpoints", () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it("does not cache the readiness gate by default while the aggregate probe caches (public)", async () => {
+        expect.assertions(2);
+
+        // No `cacheTtlMs` → the aggregate probe defaults to a 5s public cache…
+        const aggregate = makeCountingProbe();
+        const aggregateWorker = createWorker({ health: { probes: [aggregate.probe] }, shardDO: reachableNamespace });
+
+        await aggregateWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+        await aggregateWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+
+        expect(aggregate.runs()).toBe(1);
+
+        // …but the readiness gate must NOT inherit that default cache: a k8s / LB
+        // readiness poll must re-run the probes on every call so it sees a
+        // dependency go down immediately, not up to 5s later.
+        const readiness = makeCountingProbe();
+        const readinessWorker = createWorker({ health: { probes: [readiness.probe] }, shardDO: reachableNamespace });
+
+        await readinessWorker.fetch(get("/_lunora/health/ready"), {}, fakeContext);
+        await readinessWorker.fetch(get("/_lunora/health/ready"), {}, fakeContext);
+
+        expect(readiness.runs()).toBe(2);
+    });
+
+    it("caches the readiness gate when the operator sets cacheTtlMs explicitly", async () => {
+        expect.assertions(1);
+
+        let runs = 0;
+        const probe: HealthProbe = {
+            check: () => {
+                runs += 1;
+
+                return { healthy: true };
+            },
+            critical: false,
+            name: "counter",
+        };
+        const worker = createWorker({ health: { cacheTtlMs: 60_000, probes: [probe] }, shardDO: reachableNamespace });
+
+        await worker.fetch(get("/_lunora/health/ready"), {}, fakeContext);
+        await worker.fetch(get("/_lunora/health/ready"), {}, fakeContext);
+
+        // An explicit TTL overrides the readiness default and re-enables caching.
+        expect(runs).toBe(1);
+    });
+
+    it("redacts a colon-less custom probe name in the public posture but keeps it under admin", async () => {
+        expect.assertions(3);
+
+        const customProbe: HealthProbe = {
+            check: () => {
+                return { healthy: true };
+            },
+            critical: false,
+            // An operator-supplied name with no `kind:` prefix — must not reach an
+            // unauthenticated caller verbatim.
+            name: "acme-prod-billing",
+        };
+
+        const publicWorker = createWorker({ health: { probes: [customProbe] }, shardDO: reachableNamespace });
+        const publicResponse = await publicWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+        const publicRaw = await publicResponse.text();
+
+        expect(publicRaw).not.toContain("acme-prod-billing");
+
+        const publicBody: HealthBody = JSON.parse(publicRaw);
+
+        // Redacted to the generic `probe` label instead of leaking the raw name.
+        expect(publicBody.checks.some((check) => check.name === "probe")).toBe(true);
+
+        const adminWorker = createWorker({ adminToken: "tok", health: { auth: "admin", probes: [customProbe] }, shardDO: reachableNamespace });
+        const adminResponse = await adminWorker.fetch(
+            new Request("https://app.example/_lunora/health", { headers: { authorization: "Bearer tok" }, method: "GET" }),
+            {},
+            fakeContext,
+        );
+        const adminRaw = await adminResponse.text();
+
+        // Admin posture keeps the full operator-supplied name.
+        expect(adminRaw).toContain("acme-prod-billing");
     });
 });

--- a/packages/runtime/__tests__/health.test.ts
+++ b/packages/runtime/__tests__/health.test.ts
@@ -79,7 +79,8 @@ describe("createWorker — health / readiness endpoints", () => {
 
         expect(body.status).toBe("healthy");
         expect(body.checks.find((c) => c.name === "durable-object")?.status).toBe("up");
-        expect(body.checks.find((c) => c.name === "d1:DB")?.status).toBe("up");
+        // Public posture: the D1 check surfaces as its redacted kind `d1`, never the `DB` binding key.
+        expect(body.checks.find((c) => c.name === "d1")?.status).toBe("up");
     });
 
     it("returns 503 + unhealthy when a critical dependency (D1) is down", async () => {
@@ -93,7 +94,7 @@ describe("createWorker — health / readiness endpoints", () => {
         const body: HealthBody = JSON.parse(await response.text());
 
         expect(body.status).toBe("unhealthy");
-        expect(body.checks.find((c) => c.name === "d1:DB")?.status).toBe("down");
+        expect(body.checks.find((c) => c.name === "d1")?.status).toBe("down");
     });
 
     it("returns 503 when the Durable Object is unreachable", async () => {
@@ -160,8 +161,31 @@ describe("createWorker — health / readiness endpoints", () => {
 
         const body: HealthBody = JSON.parse(await response.text());
 
-        expect(body.checks.map((check) => check.name)).toEqual(expect.arrayContaining(["r2:BUCKET", "queue:QUEUE", "hyperdrive:HYPERDRIVE"]));
+        // Public posture: presence checks surface as their redacted kinds, never the binding keys.
+        expect(body.checks.map((check) => check.name)).toEqual(expect.arrayContaining(["r2", "queue", "hyperdrive"]));
         // Hyperdrive connection string must never appear in the body.
         expect(JSON.stringify(body)).not.toContain("postgres://redacted");
+    });
+
+    it("redacts the configured binding key from the public body but keeps it under admin", async () => {
+        expect.assertions(2);
+
+        // Public posture: a D1 binding named `SECRET_DB` must surface only as `d1`.
+        const publicWorker = createWorker({ shardDO: reachableNamespace });
+        const publicResponse = await publicWorker.fetch(get("/_lunora/health"), { SECRET_DB: healthyD1() }, fakeContext);
+        const publicRaw = await publicResponse.text();
+
+        expect(publicRaw).not.toContain("SECRET_DB");
+
+        // Admin posture: the full `d1:SECRET_DB` name is retained for the operator.
+        const adminWorker = createWorker({ adminToken: "tok", health: { auth: "admin" }, shardDO: reachableNamespace });
+        const adminResponse = await adminWorker.fetch(
+            new Request("https://app.example/_lunora/health", { headers: { authorization: "Bearer tok" }, method: "GET" }),
+            { SECRET_DB: healthyD1() },
+            fakeContext,
+        );
+        const adminRaw = await adminResponse.text();
+
+        expect(adminRaw).toContain("d1:SECRET_DB");
     });
 });

--- a/packages/runtime/__tests__/health.test.ts
+++ b/packages/runtime/__tests__/health.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { ExecutionContextLike } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
-import type { HealthBody } from "../src/health-routes";
+import type { HealthBody, HealthProbe } from "../src/health-routes";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
 
 const fakeContext: ExecutionContextLike = {
@@ -187,5 +187,79 @@ describe("createWorker — health / readiness endpoints", () => {
         const adminRaw = await adminResponse.text();
 
         expect(adminRaw).toContain("d1:SECRET_DB");
+    });
+
+    it("caches the public report across requests within the TTL, and re-runs when disabled", async () => {
+        expect.assertions(2);
+
+        // A counting probe proves whether the live probes re-ran between requests.
+        const makeCountingProbe = (): { probe: HealthProbe; runs: () => number } => {
+            let runs = 0;
+
+            return {
+                probe: {
+                    check: () => {
+                        runs += 1;
+
+                        return { healthy: true };
+                    },
+                    critical: false,
+                    name: "counter",
+                },
+                runs: () => runs,
+            };
+        };
+
+        const cached = makeCountingProbe();
+        const cachedWorker = createWorker({ health: { cacheTtlMs: 60_000, probes: [cached.probe] }, shardDO: reachableNamespace });
+
+        await cachedWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+        await cachedWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+
+        expect(cached.runs()).toBe(1);
+
+        const uncached = makeCountingProbe();
+        const uncachedWorker = createWorker({ health: { cacheTtlMs: 0, probes: [uncached.probe] }, shardDO: reachableNamespace });
+
+        await uncachedWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+        await uncachedWorker.fetch(get("/_lunora/health"), {}, fakeContext);
+
+        expect(uncached.runs()).toBe(2);
+    });
+
+    it("re-runs the probes once the cache TTL has expired", async () => {
+        expect.assertions(3);
+
+        vi.useFakeTimers();
+
+        try {
+            let runs = 0;
+            const probe: HealthProbe = {
+                check: () => {
+                    runs += 1;
+
+                    return { healthy: true };
+                },
+                critical: false,
+                name: "counter",
+            };
+            const worker = createWorker({ health: { cacheTtlMs: 1000, probes: [probe] }, shardDO: reachableNamespace });
+
+            await worker.fetch(get("/_lunora/health"), {}, fakeContext);
+
+            expect(runs).toBe(1);
+
+            await worker.fetch(get("/_lunora/health"), {}, fakeContext);
+
+            expect(runs).toBe(1);
+
+            vi.advanceTimersByTime(1001);
+
+            await worker.fetch(get("/_lunora/health"), {}, fakeContext);
+
+            expect(runs).toBe(2);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/packages/runtime/__tests__/observability-sinks.test.ts
+++ b/packages/runtime/__tests__/observability-sinks.test.ts
@@ -1326,7 +1326,12 @@ describe("observability-sinks", () => {
             const sink = otlpSink({ detectResources: true, endpoint: "https://collector.example" });
 
             const contextFor = (): ObservabilitySinkContext => {
-                return { resourceAttributes: () => ({ "host.name": "worker-1" }), waitUntil: () => undefined };
+                return {
+                    resourceAttributes: () => {
+                        return { "host.name": "worker-1" };
+                    },
+                    waitUntil: () => undefined,
+                };
             };
 
             sink.onRpc!(okEvent, contextFor());

--- a/packages/runtime/__tests__/observability-sinks.test.ts
+++ b/packages/runtime/__tests__/observability-sinks.test.ts
@@ -2,7 +2,7 @@ import { gunzipSync } from "node:zlib";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { LogEvent, LogLevel, MetricEvent, ObservabilityEvent, SpanEvent } from "../src/observability";
+import type { LogEvent, LogLevel, MetricEvent, ObservabilityEvent, ObservabilitySinkContext, SpanEvent } from "../src/observability";
 import type { AnalyticsEngineDataPointLike } from "../src/observability-sinks";
 import { analyticsEngineSink, combineSinks, consoleSink, otlpSink, pipelineLogSink, sentrySink, webhookSink } from "../src/observability-sinks";
 import { createResourceAttributeResolver } from "../src/resource-detect";
@@ -1310,6 +1310,42 @@ describe("observability-sinks", () => {
             const { resourceAttributes } = spanFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
 
             expect(attrValue(resourceAttributes, "cloud.region")).toStrictEqual({ stringValue: "overridden-region" });
+        });
+
+        it("collapses byte-identical resource bags from different requests into one export call", async () => {
+            expect.assertions(2);
+
+            const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+            vi.stubGlobal("fetch", fetchMock);
+
+            // Batched (default) with detection on: `resourceAttributesFor` memoizes
+            // its merged bag per request context, so two requests in one flush window
+            // produce two DISTINCT object instances with identical content. Keyed by
+            // object identity that was two envelopes / two `fetch` calls; keyed by a
+            // stable serialization it is one call carrying both spans.
+            const sink = otlpSink({ detectResources: true, endpoint: "https://collector.example" });
+
+            const contextFor = (): ObservabilitySinkContext => {
+                return { resourceAttributes: () => ({ "host.name": "worker-1" }), waitUntil: () => undefined };
+            };
+
+            sink.onRpc!(okEvent, contextFor());
+            sink.onRpc!({ ...okEvent, functionPath: "messages:send" }, contextFor());
+
+            const pending: Promise<unknown>[] = [];
+
+            sink.flush!({
+                waitUntil: (promise) => {
+                    pending.push(promise);
+                },
+            });
+            await Promise.all(pending);
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            const spans = await spansFrom((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]);
+
+            expect(spans).toHaveLength(2);
         });
 
         it("registers the send with ctx.waitUntil when a request context is provided", () => {

--- a/packages/runtime/__tests__/otlp-export.test.ts
+++ b/packages/runtime/__tests__/otlp-export.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OTLP_GZIP_THRESHOLD, otlpSend } from "../src/otlp-export";
+
+/** Pull the request headers off a recorded `fetch` call. */
+const headersOf = (init: RequestInit): Record<string, string> => (init.headers ?? {}) as Record<string, string>;
+
+describe("otlpSend gzip threshold", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("gzips a body that clears the threshold in UTF-8 bytes even when its UTF-16 length does not", async () => {
+        expect.assertions(4);
+
+        // "€" is ONE UTF-16 code unit but THREE UTF-8 bytes — the multibyte case
+        // common in `error.message`. This body sits UNDER the threshold by `.length`
+        // (the old heuristic) but well OVER it by byte length (the fix).
+        const message = "€".repeat(OTLP_GZIP_THRESHOLD - 200);
+        const body = { message };
+        const json = JSON.stringify(body);
+
+        // Precondition: the old `json.length` check would have SKIPPED gzip…
+        expect(json.length).toBeLessThan(OTLP_GZIP_THRESHOLD);
+        // …while the actual byte length clearly warrants it.
+        expect(new TextEncoder().encode(json).byteLength).toBeGreaterThanOrEqual(OTLP_GZIP_THRESHOLD);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+        vi.stubGlobal("fetch", fetchMock);
+
+        await otlpSend("https://collector.example/v1/logs", body, { "content-type": "application/json" });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(headersOf((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1])["content-encoding"]).toBe("gzip");
+    });
+
+    it("does not gzip a small ASCII body", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => new Response("ok"));
+        vi.stubGlobal("fetch", fetchMock);
+
+        await otlpSend("https://collector.example/v1/logs", { message: "hi" }, { "content-type": "application/json" });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(headersOf((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1])["content-encoding"]).toBeUndefined();
+    });
+});

--- a/packages/runtime/__tests__/pipeline-log-reader.test.ts
+++ b/packages/runtime/__tests__/pipeline-log-reader.test.ts
@@ -1,7 +1,7 @@
 import { createR2Sql } from "@lunora/bindings/r2sql";
 import { describe, expect, it } from "vitest";
 
-import type { PipelineLogQuery, PipelineLogReaderOptions } from "../src/pipeline-log-reader";
+import type { PipelineLogQuery, PipelineLogReaderOptions, PipelineLogRow } from "../src/pipeline-log-reader";
 import { createPipelineLogReader } from "../src/pipeline-log-reader";
 
 /** Captures the SQL text the reader sends and returns caller-supplied rows. */
@@ -45,6 +45,61 @@ const rowAt = (ts: number): Record<string, unknown> => {
         ts,
         userId: null,
     };
+};
+
+/**
+ * A stored record with a distinct `message` — so its identity hash is unique even
+ * when many rows share one `ts` (the dedup relies on distinguishable rows).
+ */
+const rowMsg = (ts: number, message: string): Record<string, unknown> => {
+    return { fields: null, functionPath: "messages:list", level: "info", message, shardKey: null, spanId: null, traceId: null, ts, userId: null };
+};
+
+/**
+ * A reader over a `fetch` double that actually HONORS the query — it parses the
+ * inclusive keyset bound and the row limit out of the statement and returns the
+ * matching prefix of a fixed, `ts DESC` dataset. This models a real engine closely
+ * enough to page it to exhaustion (the simple echo `makeReader` ignores the
+ * predicate, so it cannot round-trip pagination).
+ */
+const makePagingReader = (dataset: Record<string, unknown>[]): ReturnType<typeof createPipelineLogReader> => {
+    const fetch: typeof globalThis.fetch = async (_url, init) => {
+        const body = (init?.body as string | undefined) ?? "{}";
+        const statement = (JSON.parse(body) as { query: string }).query;
+
+        const limitMatch = /LIMIT (\d+)/.exec(statement);
+        const limit = limitMatch ? Number(limitMatch[1]) : dataset.length;
+
+        const boundMatch = /ts <= (\d+)/.exec(statement);
+        const bounded = boundMatch ? dataset.filter((row) => Number(row.ts) <= Number(boundMatch[1])) : dataset;
+
+        return Response.json({ result: { rows: bounded.slice(0, limit) }, success: true }, { status: 200 });
+    };
+
+    const client = createR2Sql({ accountId: "acc", apiToken: "tok", bucket: "bkt", fetch });
+
+    return createPipelineLogReader(client, { table: "logs" });
+};
+
+/** Page a reader to exhaustion, concatenating every page's rows. Throws rather than hang if pagination never terminates. */
+const drain = async (reader: ReturnType<typeof createPipelineLogReader>, query: PipelineLogQuery): Promise<PipelineLogRow[]> => {
+    const collected: PipelineLogRow[] = [];
+    let cursor: PipelineLogQuery["cursor"];
+
+    for (let guard = 0; guard < 1000; guard += 1) {
+        // eslint-disable-next-line no-await-in-loop -- paging is inherently sequential: each request needs the prior page's cursor
+        const page = await reader.query({ ...query, cursor });
+
+        collected.push(...page.rows);
+
+        if (page.nextCursor === undefined) {
+            return collected;
+        }
+
+        cursor = page.nextCursor;
+    }
+
+    throw new Error("drain: pagination did not terminate");
 };
 
 describe("createPipelineLogReader", () => {
@@ -150,10 +205,11 @@ describe("createPipelineLogReader", () => {
         expect(capture.statement).toContain("LIMIT 2");
     });
 
-    it("returns a keyset cursor from the (limit + 1)th overflow row", async () => {
-        expect.assertions(4);
+    it("mints the keyset cursor from the last RETURNED row (not the overflow row) and records its boundary hash", async () => {
+        expect.assertions(5);
 
-        // Three rows for a limit of two → one overflow row supplies the cursor.
+        // Three rows for a limit of two → the third is the overflow that only
+        // proves a next page exists; the cursor rides the last returned row (ts 200).
         const { reader } = makeReader([rowAt(300), rowAt(200), rowAt(100)]);
 
         const page = await reader.query({ limit: 2 });
@@ -161,8 +217,11 @@ describe("createPipelineLogReader", () => {
         expect(page.rows).toHaveLength(2);
         expect(page.rows[0]?.ts).toBe(300);
         expect(page.rows[1]?.ts).toBe(200);
-        // Cursor is the overflow row's ts (rows[limit]).
-        expect(page.nextCursor?.ts).toBe(100);
+        // Cursor ts is the last returned row (200), so the inclusive resume re-reads
+        // that millisecond and cannot skip a tied row the overflow-cursor would drop.
+        expect(page.nextCursor?.ts).toBe(200);
+        // The boundary row (ts 200) is carried by hash so the next page drops it.
+        expect(page.nextCursor?.seen).toHaveLength(1);
     });
 
     it("omits the cursor when the result does not overflow the page", async () => {
@@ -176,14 +235,16 @@ describe("createPipelineLogReader", () => {
         expect(page.nextCursor).toBeUndefined();
     });
 
-    it("resumes strictly past a supplied cursor ts", async () => {
-        expect.assertions(1);
+    it("resumes inclusively (<=) at a supplied cursor ts so tied rows are not skipped", async () => {
+        expect.assertions(2);
 
         const { capture, reader } = makeReader([]);
 
-        await reader.query({ cursor: { ts: 100 } });
+        await reader.query({ cursor: { seen: ["abc"], ts: 100 } });
 
-        expect(capture.statement).toContain("ts < 100");
+        expect(capture.statement).toContain("ts <= 100");
+        // The old exclusive `< 100` predicate is exactly the row-loss bug this fixes.
+        expect(capture.statement).not.toContain("ts < 100");
     });
 
     it("remaps every clause to the operator's columns via columnMap", async () => {
@@ -252,5 +313,63 @@ describe("createPipelineLogReader", () => {
         await reader.query(query);
 
         expect(capture.statement).toContain("WHERE ts >= 1 AND ts <= 9 AND functionPath LIKE 'm:%' AND shardKey = 's'");
+    });
+
+    it("pages a duplicate-ts dataset to exhaustion losslessly — the union of all pages equals the full result, no gaps, no dupes", async () => {
+        expect.assertions(4);
+
+        // 25 rows, ts DESC, with ties (ts 400 ×10, 300 ×6, 200 ×5) engineered so the
+        // limit-10 page boundaries land *inside* a tie — exactly where the old
+        // exclusive `< cursor.ts` cursor dropped every co-millisecond row.
+        const dataset: Record<string, unknown>[] = [];
+        let id = 0;
+        const push = (ts: number, count: number): void => {
+            for (let index = 0; index < count; index += 1) {
+                dataset.push(rowMsg(ts, `m${String(id)}`));
+                id += 1;
+            }
+        };
+
+        push(500, 1);
+        push(490, 1);
+        push(480, 1);
+        push(470, 1);
+        push(400, 10);
+        push(300, 6);
+        push(200, 5);
+
+        const reader = makePagingReader(dataset);
+
+        // The full unpaged result: one query large enough to return everything.
+        const full = await reader.query({ limit: 100 });
+        const paged = await drain(reader, { limit: 10 });
+
+        const fullKeys = full.rows.map((row) => `${String(row.ts)}:${row.message}`);
+        const pagedKeys = paged.map((row) => `${String(row.ts)}:${row.message}`);
+
+        // Every row exactly once, in the same order, with nothing lost or repeated.
+        expect(full.rows).toHaveLength(25);
+        expect(paged).toHaveLength(25);
+        expect(new Set(pagedKeys).size).toBe(25);
+        expect(pagedKeys).toStrictEqual(fullKeys);
+    });
+
+    it("terminates and returns every row exactly once when a whole page shares one ts (degenerate tie)", async () => {
+        expect.assertions(2);
+
+        // 15 rows all at ts 100 with a limit of 10: the boundary can never advance by
+        // `ts` alone, so the reader must grow its fetch window and dedup by hash to
+        // finish. Distinct messages keep the 15 rows individually identifiable.
+        const dataset: Record<string, unknown>[] = [];
+        for (let index = 0; index < 15; index += 1) {
+            dataset.push(rowMsg(100, `d${String(index)}`));
+        }
+
+        const reader = makePagingReader(dataset);
+
+        const collected = await drain(reader, { limit: 10 });
+
+        expect(collected).toHaveLength(15);
+        expect(new Set(collected.map((row) => row.message)).size).toBe(15);
     });
 });

--- a/packages/runtime/__tests__/sampling.test.ts
+++ b/packages/runtime/__tests__/sampling.test.ts
@@ -143,20 +143,13 @@ describe("sampling verdict coherence — the propagated bit and the export gate 
     // Replay the dispatch call site exactly: settle the verdict once via
     // `beginDispatchTrace`, then gate the SERVER-span export on that same settled
     // verdict (`trace.sampled`, NOT `decision.isTraced`).
-    const exportsServerSpan = (
-        trace: { sampled: boolean; traceId: string },
-        decision: { keepErrors: boolean },
-        ok: boolean,
-    ): boolean => {
+    const exportsServerSpan = (trace: { sampled: boolean; traceId: string }, decision: { keepErrors: boolean }, ok: boolean): boolean => {
         const seen: ObservabilityEvent[] = [];
 
-        emitRpcEvent(
-            sinkInto(seen),
-            { durationMs: 5, functionPath: "a:b", ok, traceId: trace.traceId },
-            undefined,
-            undefined,
-            { isTraced: trace.sampled, keepErrors: decision.keepErrors },
-        );
+        emitRpcEvent(sinkInto(seen), { durationMs: 5, functionPath: "a:b", ok, traceId: trace.traceId }, undefined, undefined, {
+            isTraced: trace.sampled,
+            keepErrors: decision.keepErrors,
+        });
 
         return seen.length === 1;
     };

--- a/packages/runtime/__tests__/sampling.test.ts
+++ b/packages/runtime/__tests__/sampling.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { isTraceHeadSampled, resolveTraceSampling, shouldExportTrace, traceIdToUnitInterval } from "../../../shared/sampling";
 import type { ObservabilityEvent, ObservabilitySink } from "../src/observability";
 import { emitRpcEvent } from "../src/observability";
+import { beginDispatchTrace } from "../src/otel-trace";
 
 // A trace id whose first 8 hex chars are `19999999` → ~0.1 on the unit interval,
 // so it is kept at headRate 0.2 and dropped at 0.05. The suffix is padding to a
@@ -131,5 +132,89 @@ describe("emitRpcEvent — trace sampling of the SERVER span", () => {
         emitRpcEvent(sinkInto(seen), rpcEvent({ ok: true, traceId: undefined }), undefined, { headRate: 0 });
 
         expect(seen).toHaveLength(1);
+    });
+});
+
+describe("sampling verdict coherence — the propagated bit and the export gate agree", () => {
+    const sinkInto = (seen: ObservabilityEvent[]): ObservabilitySink => {
+        return { onRpc: (event) => seen.push(event) };
+    };
+
+    // Replay the dispatch call site exactly: settle the verdict once via
+    // `beginDispatchTrace`, then gate the SERVER-span export on that same settled
+    // verdict (`trace.sampled`, NOT `decision.isTraced`).
+    const exportsServerSpan = (
+        trace: { sampled: boolean; traceId: string },
+        decision: { keepErrors: boolean },
+        ok: boolean,
+    ): boolean => {
+        const seen: ObservabilityEvent[] = [];
+
+        emitRpcEvent(
+            sinkInto(seen),
+            { durationMs: 5, functionPath: "a:b", ok, traceId: trace.traceId },
+            undefined,
+            undefined,
+            { isTraced: trace.sampled, keepErrors: decision.keepErrors },
+        );
+
+        return seen.length === 1;
+    };
+
+    it("untrusted path: the exported SERVER span matches the propagated sampled bit for every request", () => {
+        expect.assertions(3);
+
+        // No `traceparent` → untrusted, so `beginDispatchTrace` keys the head
+        // decision on the freshly-minted span id. headRate 0.5 gives a mix.
+        const mismatches: number[] = [];
+        let kept = 0;
+        let dropped = 0;
+
+        for (let index = 0; index < 200; index += 1) {
+            const { decision, trace } = beginDispatchTrace(new Request("https://worker.internal/rpc", { method: "POST" }), {
+                sampling: { headRate: 0.5 },
+            });
+
+            // (a) the bit we would propagate in the outbound `traceparent`.
+            const propagated = trace.sampled;
+            // (b) whether the export gate keeps this dispatch's SERVER span (no error).
+            const exported = exportsServerSpan(trace, decision, true);
+
+            if (propagated !== exported) {
+                mismatches.push(index);
+            }
+
+            if (propagated) {
+                kept += 1;
+            } else {
+                dropped += 1;
+            }
+        }
+
+        // Every request agrees, and the batch actually exercised both outcomes
+        // (otherwise a trivially-constant gate would pass this vacuously).
+        expect(mismatches).toStrictEqual([]);
+        expect(kept).toBeGreaterThan(0);
+        expect(dropped).toBeGreaterThan(0);
+    });
+
+    it("trusted sampled-out upstream (flags 00): the SERVER span stays out, even at headRate 1", () => {
+        expect.assertions(3);
+
+        // A well-formed inbound trace sampled OUT by a trusted upstream.
+        const request = new Request("https://worker.internal/rpc", {
+            headers: { traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00" },
+            method: "POST",
+        });
+
+        const { decision, trace } = beginDispatchTrace(request, { sampling: { headRate: 1 }, trustInbound: true });
+
+        // The trace is kept or dropped whole: a trusted `00` propagates as unsampled
+        // regardless of our own head rate.
+        expect(trace.sampled).toBe(false);
+        // Non-error dispatch → the SERVER span is held back, no orphan on the collector.
+        expect(exportsServerSpan(trace, decision, true)).toBe(false);
+        // But an errored dispatch is still force-kept by the tail bias (alwaysSampleErrors default).
+        expect(exportsServerSpan(trace, decision, false)).toBe(true);
     });
 });

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -504,7 +504,7 @@ interface HealthOptions {
      * includes the (runtime-authored) messages.
      */
     auth?: "admin" | "public";
-    /** Cache the computed report for this many ms so a frequent poller does not re-run every probe. Defaults to `0`. */
+    /** Cache the computed report for this many ms so a frequent poller (or an unauthenticated flood) does not re-run every probe. Defaults to `5000` for the public posture and `0` (no cache) for the bearer-gated admin posture. */
     cacheTtlMs?: number;
     /** Skip the auto-registered D1 / R2 / queue / Hyperdrive binding probes (keep only the DO probe + `probes`). Defaults to `false`. */
     disableBindingProbes?: boolean;

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -3293,6 +3293,11 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                 },
                 sinkContext,
                 sampling,
+                // The verdict `beginDispatchTrace` already settled — `trace.sampled`
+                // is the propagated bit (honoring a trusted upstream's sampled-out
+                // `00`), NOT `decision.isTraced`, so the export gate can never
+                // disagree with the `traceparent` we forwarded.
+                { isTraced: trace.sampled, keepErrors: decision.keepErrors },
             );
 
             // The DO's `x-d1-bookmark` header (which lets the client pin reads
@@ -3311,6 +3316,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                 },
                 sinkContext,
                 sampling,
+                { isTraced: trace.sampled, keepErrors: decision.keepErrors },
             );
             throw error;
         }

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -2810,7 +2810,11 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         const namespace = (shardDO as ShardNamespaceLike | undefined) ?? (env as { SHARD?: ShardNamespaceLike } | undefined)?.SHARD;
 
         if (namespace !== undefined) {
-            probes.push(durableObjectProbe("durable-object", namespace, defaultShard));
+            // `durable-object:default` follows the same `kind:key` shape as the
+            // binding probes (`d1:…`, `r2:…`) so the public posture reduces it to
+            // the safe kind `durable-object` via the shared colon rule — the `key`
+            // is the fixed literal `default`, never the operator's `defaultShard`.
+            probes.push(durableObjectProbe("durable-object:default", namespace, defaultShard));
         }
 
         if (options.health?.disableBindingProbes !== true) {
@@ -3292,7 +3296,10 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                     ...(response.ok ? {} : { error: { code: "SHARD_ERROR", message: `shard returned ${String(response.status)}`, status: response.status } }),
                 },
                 sinkContext,
-                sampling,
+                // No `sampling` fallback: `emitRpcEvent` ignores it whenever a
+                // settled `decision` is passed, so passing it here would only
+                // mislead a reader into thinking both are live.
+                undefined,
                 // The verdict `beginDispatchTrace` already settled — `trace.sampled`
                 // is the propagated bit (honoring a trusted upstream's sampled-out
                 // `00`), NOT `decision.isTraced`, so the export gate can never
@@ -3315,7 +3322,9 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
                     ...buildErrorEvent(functionPath, Date.now() - rpcStartedAt, error, { shardKey }),
                 },
                 sinkContext,
-                sampling,
+                // See the success path above: `sampling` is dead once a settled
+                // `decision` is passed, so it is omitted here too.
+                undefined,
                 { isTraced: trace.sampled, keepErrors: decision.keepErrors },
             );
             throw error;

--- a/packages/runtime/src/health-routes.ts
+++ b/packages/runtime/src/health-routes.ts
@@ -17,9 +17,12 @@
  * Security posture (plan 177 exit criteria): the body leaks NO secrets or PII. A
  * probe returns only a boolean and a message string the runtime controls — never
  * an env value, connection string, or binding name from user config. In the
- * default `"public"` posture the per-check `message` is omitted entirely; in the
- * `"admin"` posture the endpoint is bearer-gated AND the (still runtime-authored)
- * messages are included to aid an operator.
+ * default `"public"` posture the per-check `message` is omitted entirely AND the
+ * check `name` is reduced to its probe kind (`d1`, `r2`, …) so the operator's
+ * real binding keys never reach an unauthenticated caller (see `buildBody`); in
+ * the `"admin"` posture the endpoint is bearer-gated AND the (still
+ * runtime-authored) messages plus the full `kind:key` names are included to aid
+ * an operator.
  */
 import { LunoraError } from "./errors";
 import { methodGuard } from "./method-guard";
@@ -65,6 +68,7 @@ interface HealthCheckReport {
     critical: boolean;
     /** Present only in the `admin` posture. */
     message?: string;
+    /** The redacted probe kind (`d1`, `r2`, `d1#2`, …) in the `public` posture; the full `kind:key` name in `admin`. */
     name: string;
     status: "down" | "up";
 }
@@ -192,11 +196,16 @@ const buildRegistry = (probes: ReadonlyArray<HealthProbe>): { criticalNames: Set
 
 /**
  * Assemble the sanitised response body from a registry report. In the `public`
- * posture the per-check `message` is dropped (only name + up/down survive), so
- * no runtime-authored detail — however benign — reaches an unauthenticated
- * caller. The overall `status` is `unhealthy` when any CRITICAL check is down
- * (drives the `503`), `degraded` when only non-critical checks are down, else
- * `healthy`.
+ * posture two things are redacted: the per-check `message` is dropped (only name
+ * + up/down survive), and the check `name` is reduced to its probe KIND — the
+ * name prefix up to the first `:` (`d1`, `r2`, `queue`, …) with a `#n`
+ * disambiguator when a kind repeats. This keeps the operator's real binding keys
+ * (`d1:BILLING_LEGACY`, `queue:PII_EXPORT`) out of an unauthenticated response,
+ * where they would otherwise leak internal systems / environments / tenant
+ * structure. The `admin` posture keeps the full `kind:key` names (Studio and
+ * operators depend on their readability). The overall `status` is `unhealthy`
+ * when any CRITICAL check is down (drives the `503`), `degraded` when only
+ * non-critical checks are down, else `healthy`.
  */
 const buildBody = (
     report: Record<string, { health: { healthy: boolean; message?: string } }>,
@@ -208,6 +217,10 @@ const buildBody = (
     const checks: HealthCheckReport[] = [];
     let anyCriticalDown = false;
     let anyDown = false;
+    // Public-posture disambiguation: how many times each redacted kind has been
+    // seen so far, so a second `d1` binding surfaces as `d1#2` rather than
+    // colliding. Keyed by kind; unused in the admin posture.
+    const kindCounts = new Map<string, number>();
 
     for (const [name, entry] of Object.entries(report)) {
         const critical = criticalNames.has(name);
@@ -221,10 +234,20 @@ const buildBody = (
             }
         }
 
+        let reportedName = name;
+
+        if (posture !== "admin") {
+            const kind = name.includes(":") ? name.slice(0, name.indexOf(":")) : name;
+            const seen = (kindCounts.get(kind) ?? 0) + 1;
+
+            kindCounts.set(kind, seen);
+            reportedName = seen === 1 ? kind : `${kind}#${String(seen)}`;
+        }
+
         checks.push({
             critical,
             ...(posture === "admin" && entry.health.message !== undefined ? { message: entry.health.message } : {}),
-            name,
+            name: reportedName,
             status: up ? "up" : "down",
         });
     }

--- a/packages/runtime/src/health-routes.ts
+++ b/packages/runtime/src/health-routes.ts
@@ -212,6 +212,38 @@ const buildRegistry = (probes: ReadonlyArray<HealthProbe>): { criticalNames: Set
  * when any CRITICAL check is down (drives the `503`), `degraded` when only
  * non-critical checks are down, else `healthy`.
  */
+
+/**
+ * Public-posture name redaction: reduce a check name to its probe KIND — the part
+ * before the first `:`. Auto-detected probes are `kind:key`, so this yields `d1`,
+ * `r2`, … A custom probe name lacking a `:` (e.g. an operator-supplied
+ * `acme-prod-billing`) has no safe kind prefix, so it collapses to a generic
+ * `probe` label rather than leaking the raw name to an unauthenticated caller.
+ * `kindCounts` is read and mutated so a repeated kind surfaces disambiguated
+ * (`d1#2`) instead of colliding.
+ */
+const redactCheckName = (name: string, kindCounts: Map<string, number>): string => {
+    const kind = name.includes(":") ? name.slice(0, name.indexOf(":")) : "probe";
+    const seen = (kindCounts.get(kind) ?? 0) + 1;
+
+    kindCounts.set(kind, seen);
+
+    return seen === 1 ? kind : `${kind}#${String(seen)}`;
+};
+
+/** Roll the per-check up/down tally into the body's overall status: any critical down → `unhealthy` (drives the 503), any non-critical down → `degraded`, else `healthy`. */
+const overallStatus = (anyCriticalDown: boolean, anyDown: boolean): HealthBody["status"] => {
+    if (anyCriticalDown) {
+        return "unhealthy";
+    }
+
+    if (anyDown) {
+        return "degraded";
+    }
+
+    return "healthy";
+};
+
 const buildBody = (
     report: Record<string, { health: { healthy: boolean; message?: string } }>,
     criticalNames: Set<string>,
@@ -231,23 +263,11 @@ const buildBody = (
         const critical = criticalNames.has(name);
         const up = entry.health.healthy;
 
-        if (!up) {
-            anyDown = true;
+        anyDown = anyDown || !up;
+        anyCriticalDown = anyCriticalDown || (!up && critical);
 
-            if (critical) {
-                anyCriticalDown = true;
-            }
-        }
-
-        let reportedName = name;
-
-        if (posture !== "admin") {
-            const kind = name.includes(":") ? name.slice(0, name.indexOf(":")) : name;
-            const seen = (kindCounts.get(kind) ?? 0) + 1;
-
-            kindCounts.set(kind, seen);
-            reportedName = seen === 1 ? kind : `${kind}#${String(seen)}`;
-        }
+        // Admin keeps the full `kind:key` name; the public posture redacts it.
+        const reportedName = posture === "admin" ? name : redactCheckName(name, kindCounts);
 
         checks.push({
             critical,
@@ -260,17 +280,9 @@ const buildBody = (
     // Stable ordering so a contract/snapshot never flakes on registry iteration order.
     checks.sort((a, b) => a.name.localeCompare(b.name));
 
-    let status: HealthBody["status"] = "healthy";
-
-    if (anyCriticalDown) {
-        status = "unhealthy";
-    } else if (anyDown) {
-        status = "degraded";
-    }
-
     return {
         anyCriticalDown,
-        body: { appName, appVersion, checks, status, timestamp: new Date().toISOString() },
+        body: { appName, appVersion, checks, status: overallStatus(anyCriticalDown, anyDown), timestamp: new Date().toISOString() },
     };
 };
 
@@ -281,13 +293,28 @@ const buildHealthRoutes = (deps: HealthRouteDeps): Record<string, (request: Requ
     // Cache the computed report so a frequent poller (and, more importantly, an
     // unauthenticated flood) does not re-run the live probes — a real Durable
     // Object subrequest plus one `SELECT 1` per detected D1 binding — on every
-    // request. The default is `5000` ms for the unauthenticated `public` posture
-    // (the amplification vector) and `0` (no cache) for the bearer-gated `admin`
-    // posture, where the operator wants a fresh read and cannot be flooded. Keyed
-    // by probe kind because the aggregate and readiness endpoints, though served
-    // under the same posture, produce different bodies. This closure is built
-    // once per worker, so the cache persists across requests in the isolate.
-    const effectiveCacheTtlMs = cacheTtlMs ?? (auth === "public" ? 5000 : 0);
+    // request. Keyed by probe kind because the aggregate and readiness endpoints,
+    // though served under the same posture, produce different bodies. This closure
+    // is built once per worker, so the cache persists across requests in the isolate.
+    //
+    // The DEFAULT TTL differs by probe kind. The aggregate probe defaults to
+    // `5000` ms in the unauthenticated `public` posture (the amplification vector)
+    // and `0` in the bearer-gated `admin` posture. The readiness gate defaults to
+    // `0` (uncached) in BOTH postures: a load-balancer / k8s readiness poll must
+    // observe a dependency going down on the very next poll, not up to 5s later.
+    // An operator can still opt the readiness gate into caching by setting
+    // `cacheTtlMs` explicitly, which overrides the default for both endpoints.
+    const cacheTtlFor = (probeKind: "aggregate" | "readiness"): number => {
+        if (cacheTtlMs !== undefined) {
+            return cacheTtlMs;
+        }
+
+        if (probeKind === "readiness") {
+            return 0;
+        }
+
+        return auth === "public" ? 5000 : 0;
+    };
     const cache: Partial<Record<"aggregate" | "readiness", { body: HealthBody; down: boolean; expiresAt: number }>> = {};
 
     const gate = (request: Request): void => {
@@ -304,6 +331,8 @@ const buildHealthRoutes = (deps: HealthRouteDeps): Record<string, (request: Requ
         }
 
         gate(request);
+
+        const effectiveCacheTtlMs = cacheTtlFor(probeKind);
 
         if (effectiveCacheTtlMs > 0) {
             const hit = cache[probeKind];

--- a/packages/runtime/src/health-routes.ts
+++ b/packages/runtime/src/health-routes.ts
@@ -93,7 +93,12 @@ interface HealthRouteDeps {
 
     /**
      * Cache the last computed report for this many ms so an orchestrator polling
-     * every few seconds does not hammer the bindings. Defaults to `0` (no cache).
+     * every few seconds does not hammer the bindings (each uncached request runs
+     * a real Durable Object subrequest plus one `SELECT 1` per detected D1
+     * binding, which an unauthenticated flood would otherwise amplify). Cached
+     * independently for the aggregate and readiness probes, since their bodies
+     * differ. When omitted it defaults to `5000` in the `public` posture and `0`
+     * (no cache) in the bearer-gated `admin` posture.
      */
     cacheTtlMs?: number;
     /** Admin-bearer predicate, consulted only when `auth === "admin"`. */
@@ -271,10 +276,19 @@ const buildBody = (
 
 /** Build the health + readiness route map merged into the worker's internal route table. */
 const buildHealthRoutes = (deps: HealthRouteDeps): Record<string, (request: Request, env: unknown) => Promise<Response>> => {
-    // `cacheTtlMs` is accepted for API/back-compat but is currently a no-op: a
-    // fresh registry is built per request, so there is no cross-request cache to
-    // TTL. (It never cached across requests under the old dependency either.)
-    const { appName = "lunora", appVersion = "0.0.0", auth = "public", isAdmin, resolveProbes } = deps;
+    const { appName = "lunora", appVersion = "0.0.0", auth = "public", cacheTtlMs, isAdmin, resolveProbes } = deps;
+
+    // Cache the computed report so a frequent poller (and, more importantly, an
+    // unauthenticated flood) does not re-run the live probes — a real Durable
+    // Object subrequest plus one `SELECT 1` per detected D1 binding — on every
+    // request. The default is `5000` ms for the unauthenticated `public` posture
+    // (the amplification vector) and `0` (no cache) for the bearer-gated `admin`
+    // posture, where the operator wants a fresh read and cannot be flooded. Keyed
+    // by probe kind because the aggregate and readiness endpoints, though served
+    // under the same posture, produce different bodies. This closure is built
+    // once per worker, so the cache persists across requests in the isolate.
+    const effectiveCacheTtlMs = cacheTtlMs ?? (auth === "public" ? 5000 : 0);
+    const cache: Partial<Record<"aggregate" | "readiness", { body: HealthBody; down: boolean; expiresAt: number }>> = {};
 
     const gate = (request: Request): void => {
         if (auth === "admin" && !isAdmin(request)) {
@@ -291,6 +305,14 @@ const buildHealthRoutes = (deps: HealthRouteDeps): Record<string, (request: Requ
 
         gate(request);
 
+        if (effectiveCacheTtlMs > 0) {
+            const hit = cache[probeKind];
+
+            if (hit !== undefined && Date.now() < hit.expiresAt) {
+                return Response.json(hit.body, { headers: { "cache-control": "no-store" }, status: hit.down ? 503 : 200 });
+            }
+        }
+
         const { criticalNames, registry } = buildRegistry(resolveProbes(env));
         const { healthy, report } = await registry.getReport(probeKind === "readiness" ? "readiness" : undefined);
         const { anyCriticalDown, body } = buildBody(report, criticalNames, auth, appName, appVersion);
@@ -299,6 +321,10 @@ const buildHealthRoutes = (deps: HealthRouteDeps): Record<string, (request: Requ
         // the readiness gate is `503` whenever any readiness check is unhealthy
         // (a load balancer should stop routing on any readiness failure).
         const down = probeKind === "readiness" ? !healthy : anyCriticalDown;
+
+        if (effectiveCacheTtlMs > 0) {
+            cache[probeKind] = { body, down, expiresAt: Date.now() + effectiveCacheTtlMs };
+        }
 
         return Response.json(body, { headers: { "cache-control": "no-store" }, status: down ? 503 : 200 });
     };

--- a/packages/runtime/src/observability-sinks.ts
+++ b/packages/runtime/src/observability-sinks.ts
@@ -27,6 +27,7 @@ import type { OtlpResourceAttributes } from "../../../shared/otlp";
 import { mergeHeaders, wrapResourceLogs, wrapResourceMetrics, wrapResourceSpans } from "../../../shared/otlp";
 import { createSignalBatcher } from "../../../shared/otlp-batch";
 import { mergeResourceAttributes } from "../../../shared/otlp-resource";
+import { stableStringify } from "../../../shared/stable-key";
 import type { LogEvent, MetricEvent, ObservabilityEvent, ObservabilitySink, ObservabilitySinkContext, SpanEvent } from "./observability";
 import { otlpLogBody, otlpMetricBody, otlpPost, otlpSend, otlpSpanBody, otlpTraceBody } from "./otlp-export";
 
@@ -947,7 +948,13 @@ export const otlpSink = (options: OtlpSinkOptions): ObservabilitySink => {
      */
     const exportBatch = async (signals: BufferedSignal[]): Promise<void> => {
         const kept = applyTailSampler(signals, tailSampler, reportTailSamplerFailure);
-        const groups = new Map<OtlpResourceAttributes, { logs: unknown[]; metrics: unknown[]; spans: unknown[] }>();
+        // Key on a STABLE serialization of the resource bag, not object identity.
+        // `resourceAttributesFor` memoizes per request, so two requests in one
+        // flush window with byte-identical resource bags previously produced two
+        // distinct map keys → two envelopes → two `fetch` calls, the exact
+        // subrequest multiplication the batcher exists to prevent. The map value
+        // keeps one representative resource object for the envelope wrapper.
+        const groups = new Map<string, { logs: unknown[]; metrics: unknown[]; resource: OtlpResourceAttributes; spans: unknown[] }>();
 
         for (const signal of kept) {
             const encoded = encodeSignal(signal, postProcessor);
@@ -956,11 +963,12 @@ export const otlpSink = (options: OtlpSinkOptions): ObservabilitySink => {
                 continue;
             }
 
-            let group = groups.get(signal.resource);
+            const key = stableStringify(signal.resource);
+            let group = groups.get(key);
 
             if (group === undefined) {
-                group = { logs: [], metrics: [], spans: [] };
-                groups.set(signal.resource, group);
+                group = { logs: [], metrics: [], resource: signal.resource, spans: [] };
+                groups.set(key, group);
             }
 
             group[encoded.bucket].push(encoded.encoded);
@@ -968,7 +976,9 @@ export const otlpSink = (options: OtlpSinkOptions): ObservabilitySink => {
 
         const sends: Promise<void>[] = [];
 
-        for (const [resource, group] of groups) {
+        for (const [, group] of groups) {
+            const { resource } = group;
+
             if (group.spans.length > 0) {
                 sends.push(otlpSend(tracesUrl, wrapResourceSpans(group.spans, "@lunora/runtime", serviceName, resource), mergedHeaders));
             }

--- a/packages/runtime/src/observability.ts
+++ b/packages/runtime/src/observability.ts
@@ -199,6 +199,10 @@ export interface ObservabilitySink {
      * Pass this on the SAME sink object you give `createShardDO` — the DO reads it
      * when recording a measurement.
      */
+    // keep in sync with MetricHistoryOptions (`@lunora/do`'s `metric-history.ts`).
+    // Inlined rather than imported so this public runtime type stays free of a
+    // (type) dependency on `@lunora/do`'s internal module — the object is the same
+    // `{ maxSeries?, retentionBuckets? }` the DO consumes.
     metricHistory?: boolean | { maxSeries?: number; retentionBuckets?: number };
 
     /** Invoked once per `ctx.log.*` call from a function handler. */

--- a/packages/runtime/src/observability.ts
+++ b/packages/runtime/src/observability.ts
@@ -15,7 +15,7 @@
 /* eslint-disable no-secrets/no-secrets -- the entropy heuristic flags a CamelCase sink-context type name quoted in a doc comment below, not a credential */
 import type { ContextLogLevel, LogEvent, LogSinkContext } from "../../../shared/log-event";
 import type { MetricEvent } from "../../../shared/metric-event";
-import type { TraceSamplingConfig } from "../../../shared/sampling";
+import type { TraceSamplingConfig, TraceSamplingDecision } from "../../../shared/sampling";
 import { resolveTraceSampling, shouldExportTrace } from "../../../shared/sampling";
 import type { SpanEvent } from "../../../shared/span-event";
 
@@ -219,23 +219,39 @@ export interface ObservabilitySink {
  * sink-originating throw bubble up past this point. `context.waitUntil`, when
  * supplied, lets a network sink keep its send alive past the response.
  *
- * `sampling` applies the trace-sampling verdict to this dispatch's SERVER span:
- * the event is dropped unless the trace was head-sampled or (with errors
- * force-kept) this dispatch errored — the tail bias. A dispatch with no
- * `traceId` (a fan-out aggregation, which mints none) is always kept, and an
- * absent `sampling` keeps everything, so both are backward-compatible.
+ * The verdict applied to this dispatch's SERVER span comes from `decision` when
+ * the caller settled one — pass the dispatch's already-settled decision so the
+ * export gate can never disagree with the propagated `traceparent` (a trace kept
+ * or dropped as a whole, per PR #191). Its `isTraced` must carry the propagated
+ * sampled bit (`trace.sampled`), not the raw head verdict, so a trusted upstream
+ * that sampled the trace out keeps its SERVER span out here too. The event is
+ * dropped unless the trace was sampled or (with errors force-kept) this dispatch
+ * errored — the tail bias.
+ *
+ * `sampling` is the legacy fallback for callers with no settled decision: it
+ * re-derives the verdict from `event.traceId`. A dispatch with no `traceId` (a
+ * fan-out aggregation, which mints none) is always kept, and both an absent
+ * `decision` and an absent `sampling` keep everything, so all are
+ * backward-compatible.
  */
 export const emitRpcEvent = (
     sink: ObservabilitySink | undefined,
     event: ObservabilityEvent,
     context?: ObservabilitySinkContext,
     sampling?: TraceSamplingConfig,
+    decision?: TraceSamplingDecision,
 ): void => {
     if (!sink?.onRpc) {
         return;
     }
 
-    if (sampling !== undefined && event.traceId !== undefined && !shouldExportTrace(resolveTraceSampling(sampling, event.traceId), !event.ok)) {
+    if (decision !== undefined) {
+        // Settled-verdict path: honor the decision the dispatch already made
+        // (including a trusted upstream's sampled-out `00`), never re-derive it.
+        if (!shouldExportTrace(decision, !event.ok)) {
+            return;
+        }
+    } else if (sampling !== undefined && event.traceId !== undefined && !shouldExportTrace(resolveTraceSampling(sampling, event.traceId), !event.ok)) {
         return;
     }
 

--- a/packages/runtime/src/observability.ts
+++ b/packages/runtime/src/observability.ts
@@ -180,6 +180,27 @@ export interface ObservabilitySink {
      */
     instrumentDatabase?: "off" | "spans" | "summary";
 
+    /**
+     * **Opt-in, default `false`.** Durable per-minute rollups of every
+     * `ctx.metrics.*` measurement, kept in a reserved per-shard SQLite table so the
+     * Studio can chart a 24h local trend without an external collector.
+     *
+     * Off by default because it is **not free**: each `ctx.metrics.count/gauge/record`
+     * becomes a durable SQLite write (a billed, rate-limited storage op that competes
+     * with your app's own data for the shard's write budget), on the request path. The
+     * live cross-instance path is `onMetric` → your collector; this is only the local
+     * trend convenience, so enable it deliberately.
+     *
+     * `true` uses the built-in caps (≈24h retention, 1000 distinct series). Pass an
+     * object to tune them: `maxSeries` bounds the distinct series tracked (a
+     * high-cardinality attribute otherwise mints a series per value), `retentionBuckets`
+     * the minute-buckets kept per series before older ones are trimmed.
+     *
+     * Pass this on the SAME sink object you give `createShardDO` — the DO reads it
+     * when recording a measurement.
+     */
+    metricHistory?: boolean | { maxSeries?: number; retentionBuckets?: number };
+
     /** Invoked once per `ctx.log.*` call from a function handler. */
     onLog?: (event: LogEvent, context?: ObservabilitySinkContext) => void;
 

--- a/packages/runtime/src/otlp-export.ts
+++ b/packages/runtime/src/otlp-export.ts
@@ -320,8 +320,13 @@ const gzipEncode = async (text: string): Promise<ArrayBuffer> => {
 const otlpSend = async (url: string, body: unknown, headers: Record<string, string>, keepAlive?: KeepAlive): Promise<void> => {
     try {
         const json = JSON.stringify(body);
+        // Measure the UTF-8 byte length, not `json.length` (UTF-16 code units):
+        // non-ASCII text (common in `error.message`) can exceed the threshold in
+        // bytes while its code-unit count stays under, so a byte-length check is
+        // what actually decides whether the wire body is worth gzipping.
+        const byteLength = new TextEncoder().encode(json).byteLength;
         const sent = (
-            json.length < OTLP_GZIP_THRESHOLD
+            byteLength < OTLP_GZIP_THRESHOLD
                 ? fetch(url, { body: json, headers, method: "POST" })
                 : gzipEncode(json).then((gz) => fetch(url, { body: gz, headers: { ...headers, "content-encoding": "gzip" }, method: "POST" }))
         ).then(

--- a/packages/runtime/src/otlp-export.ts
+++ b/packages/runtime/src/otlp-export.ts
@@ -16,13 +16,13 @@
  */
 import { coerceFieldValue } from "../../../shared/log-fields";
 import type { OtlpAttribute } from "../../../shared/otlp";
-import { encodeAttribute, encodeAttributes, OTLP_SEVERITY, OTLP_SPAN_KIND, otlpRandomHex, otlpUnixNano } from "../../../shared/otlp";
+import { encodeAttribute, encodeAttributes, LUNORA_ATTR, OTLP_SEVERITY, OTLP_SPAN_KIND, otlpRandomHex, otlpUnixNano } from "../../../shared/otlp";
 import type { KeepAlive } from "../../../shared/otlp-batch";
 import type { LogEvent, MetricEvent, ObservabilityEvent, ObservabilitySinkContext, SpanEvent } from "./observability";
 
 /** Build the OTLP trace-export body for one RPC dispatch event. */
 const otlpTraceBody = (event: ObservabilityEvent, endMs: number): unknown => {
-    const attributes = [encodeAttribute("lunora.function_path", event.functionPath), encodeAttribute("lunora.ok", event.ok)];
+    const attributes = [encodeAttribute(LUNORA_ATTR.functionPath, event.functionPath), encodeAttribute(LUNORA_ATTR.ok, event.ok)];
 
     // HTTP server semantic conventions: the RPC endpoint is an HTTP handler from
     // the collector's point of view, so expose method/route/status even though
@@ -55,7 +55,7 @@ const otlpTraceBody = (event: ObservabilityEvent, endMs: number): unknown => {
     }
 
     if (event.shardKey !== undefined) {
-        attributes.push(encodeAttribute("lunora.shard_key", event.shardKey));
+        attributes.push(encodeAttribute(LUNORA_ATTR.shardKey, event.shardKey));
     }
 
     // HTTP response status code is present on every RPC span. Successful
@@ -66,7 +66,7 @@ const otlpTraceBody = (event: ObservabilityEvent, endMs: number): unknown => {
     if (event.error) {
         // `error.type` is the OTel semantic-convention key; keep the numeric
         // HTTP-ish status under the lunora namespace.
-        attributes.push(encodeAttribute("error.type", event.error.code), encodeAttribute("lunora.error_status", event.error.status));
+        attributes.push(encodeAttribute(LUNORA_ATTR.errorType, event.error.code), encodeAttribute("lunora.error_status", event.error.status));
     }
 
     if (event.fanOut) {
@@ -129,19 +129,19 @@ const encodeSignalAttributes = (
     reserved: { errorType?: string; functionPath: string; shardKey?: string; userId?: string },
     caller: Record<string, unknown> | undefined,
 ): OtlpAttribute[] => {
-    const byKey = new Map<string, OtlpAttribute>([["lunora.function_path", encodeAttribute("lunora.function_path", reserved.functionPath)]]);
+    const byKey = new Map<string, OtlpAttribute>([[LUNORA_ATTR.functionPath, encodeAttribute(LUNORA_ATTR.functionPath, reserved.functionPath)]]);
 
     if (reserved.shardKey !== undefined) {
-        byKey.set("lunora.shard_key", encodeAttribute("lunora.shard_key", reserved.shardKey));
+        byKey.set(LUNORA_ATTR.shardKey, encodeAttribute(LUNORA_ATTR.shardKey, reserved.shardKey));
     }
 
     if (reserved.userId !== undefined) {
-        byKey.set("lunora.user_id", encodeAttribute("lunora.user_id", reserved.userId));
+        byKey.set(LUNORA_ATTR.userId, encodeAttribute(LUNORA_ATTR.userId, reserved.userId));
     }
 
     if (reserved.errorType !== undefined) {
         // `error.type` is the OTel semantic-convention key.
-        byKey.set("error.type", encodeAttribute("error.type", reserved.errorType));
+        byKey.set(LUNORA_ATTR.errorType, encodeAttribute(LUNORA_ATTR.errorType, reserved.errorType));
     }
 
     // Caller values arrive pre-normalized to JSON-safe primitives;

--- a/packages/runtime/src/otlp-export.ts
+++ b/packages/runtime/src/otlp-export.ts
@@ -324,7 +324,7 @@ const otlpSend = async (url: string, body: unknown, headers: Record<string, stri
         // non-ASCII text (common in `error.message`) can exceed the threshold in
         // bytes while its code-unit count stays under, so a byte-length check is
         // what actually decides whether the wire body is worth gzipping.
-        const byteLength = new TextEncoder().encode(json).byteLength;
+        const { byteLength } = new TextEncoder().encode(json);
         const sent = (
             byteLength < OTLP_GZIP_THRESHOLD
                 ? fetch(url, { body: json, headers, method: "POST" })

--- a/packages/runtime/src/pipeline-log-reader.ts
+++ b/packages/runtime/src/pipeline-log-reader.ts
@@ -23,11 +23,16 @@
  *
  * **Pagination.** Keyset on `ts DESC`, not `OFFSET` — R2 SQL scans Iceberg data
  * files and a large `OFFSET` re-scans every skipped row, whereas a `ts`-bounded
- * `WHERE` prunes whole files. We fetch one more row than asked: the extra
- * "overflow" row, when present, both signals there is a next page and supplies
- * its cursor `ts`. The next page then asks for rows strictly older than it.
+ * `WHERE` prunes whole files. `ts` is **not unique**, so the keyset is lossless
+ * only if resume is *inclusive*: the cursor `ts` is the last returned row's `ts`,
+ * the next page fetches every row at-or-older-than it, and the
+ * {@link PipelineLogCursor} `seen` hashes drop exactly the boundary rows already
+ * emitted — no row on a tied millisecond is skipped (the old exclusive
+ * strictly-older cursor silently dropped them) or duplicated. We still over-fetch
+ * by one to detect a next page; a page dominated by a single `ts` grows that
+ * window (bounded) so pagination still advances.
  */
-import type { R2SqlClient } from "@lunora/bindings/r2sql";
+import type { R2SqlClient, SelectBuilder } from "@lunora/bindings/r2sql";
 import { desc, raw, sql } from "@lunora/bindings/r2sql";
 
 import type { ContextLogLevel } from "../../../shared/log-event";
@@ -110,6 +115,107 @@ const decodeFields = (value: StoredCell): unknown => {
 };
 
 /**
+ * A stable ~62-bit identity hash of a decoded row, rendered as two base-36 parts.
+ *
+ * The sink shape carries no guaranteed-unique column (`traceId`/`spanId` are
+ * optional and often absent), so keyset pagination over the non-unique `ts`
+ * cannot dedup boundary ties by id. Instead we hash the row's whole rendered
+ * identity — `ts` plus every canonical field — and carry those hashes on the
+ * cursor. Two rows that are byte-for-byte identical within one millisecond hash
+ * the same and are treated as interchangeable duplicates (acceptable: they are
+ * indistinguishable to a consumer anyway). The combined ~62-bit width makes an
+ * accidental collision between genuinely different rows on the same `ts`
+ * negligible.
+ */
+const hashRow = (row: PipelineLogRow): string => {
+    // A JSON tuple so no field delimiter can be forged by a value that happens to
+    // contain the separator (an absent optional serialises as `null`); `fields` is
+    // included so structured payloads distinguish otherwise-identical lines.
+    const identity = JSON.stringify([row.ts, row.level, row.functionPath, row.message, row.traceId, row.spanId, row.shardKey, row.userId, row.fields]);
+
+    // Two independent polynomial rolling hashes over large primes, combined into
+    // one token. Pure modular arithmetic (no bit ops): each accumulator stays well
+    // under 2^53 so every step is exact in a JS double. The two moduli together
+    // give ~62 bits of identity — ample for de-duping rows within a single `ts`.
+    let h1 = 0;
+    let h2 = 0;
+
+    for (const character of identity) {
+        const code = character.codePointAt(0) ?? 0;
+
+        h1 = (h1 * 31 + code) % 2_147_483_647;
+        h2 = (h2 * 131 + code) % 4_294_967_291;
+    }
+
+    return `${h1.toString(36)}.${h2.toString(36)}`;
+};
+
+/**
+ * Apply every value filter and the inclusive keyset bound to a prepared builder.
+ * Extracted so the paginated query stays readable; each value flows through the
+ * `sql` tag (escaped), column names come from operator config via `raw`.
+ */
+const applyLogFilters = (
+    builder: SelectBuilder<StoredRow>,
+    query: PipelineLogQuery,
+    columns: Record<PipelineLogField, string>,
+    cursorTs: number | undefined,
+): void => {
+    if (query.sinceTs !== undefined) {
+        builder.where(sql`${raw(columns.ts)} >= ${query.sinceTs}`);
+    }
+
+    if (query.untilTs !== undefined) {
+        builder.where(sql`${raw(columns.ts)} <= ${query.untilTs}`);
+    }
+
+    if (query.level !== undefined) {
+        // Exact severity wins over `minLevel` (documented on the type): a caller
+        // asking for one level should not also get everything above it.
+        builder.where(sql`${raw(columns.level)} = ${query.level}`);
+    } else if (query.minLevel !== undefined) {
+        // Expand the floor to the explicit set at/above it in the severity ramp; an
+        // `IN (...)` over a small closed set is clearer to the engine (and reader)
+        // than a comparison over a non-numeric column.
+        const floorIndex = LOG_LEVEL_ORDER.indexOf(query.minLevel);
+        const allowed = floorIndex === -1 ? [...LOG_LEVEL_ORDER] : LOG_LEVEL_ORDER.slice(floorIndex);
+
+        builder.where(sql`${raw(columns.level)} IN ${allowed}`);
+    }
+
+    if (query.functionPath !== undefined) {
+        builder.where(sql`${raw(columns.functionPath)} = ${query.functionPath}`);
+    }
+
+    if (query.functionPathPrefix !== undefined) {
+        // `LIKE 'prefix%'`: the trailing `%` sits inside the escaped literal so it
+        // stays the wildcard, while the prefix itself is quote-escaped and cannot
+        // break out. (A `%`/`_` within the prefix acts as a wildcard — documented.)
+        builder.where(sql`${raw(columns.functionPath)} LIKE ${`${query.functionPathPrefix}%`}`);
+    }
+
+    if (query.traceId !== undefined) {
+        builder.where(sql`${raw(columns.traceId)} = ${query.traceId}`);
+    }
+
+    if (query.shardKey !== undefined) {
+        builder.where(sql`${raw(columns.shardKey)} = ${query.shardKey}`);
+    }
+
+    if (query.userId !== undefined) {
+        builder.where(sql`${raw(columns.userId)} = ${query.userId}`);
+    }
+
+    if (cursorTs !== undefined) {
+        // Keyset resume is inclusive (`<=`, not `<`): the boundary `ts` is the last
+        // row we returned, and other rows sharing that millisecond may still be
+        // unreturned. The caller's `seen` set drops the ones we already emitted, so
+        // no row is skipped or duplicated.
+        builder.where(sql`${raw(columns.ts)} <= ${cursorTs}`);
+    }
+};
+
+/**
  * The canonical field names of one persisted log record — the keys
  * `pipelineLogSink` writes. Used as the {@link PipelineLogColumnMap} keys and the
  * {@link PipelineLogRow} shape, so the reader stays decoupled from whatever
@@ -126,15 +232,31 @@ export type PipelineLogField = keyof typeof DEFAULT_COLUMNS;
  */
 export type PipelineLogColumnMap = Partial<Record<PipelineLogField, string>>;
 
-/** An opaque keyset cursor: the `ts` of the row after the last one returned. */
+/**
+ * An opaque keyset cursor. `ts` is the epoch-millis of the **last returned** row
+ * (not an un-returned overflow row), so the next page resumes *inclusively* at
+ * that boundary and never skips a row that shares that millisecond. Because `ts`
+ * is not unique, `seen` carries the identity hashes of the already-returned rows
+ * sitting exactly on that boundary `ts`, so the next page can drop them without
+ * re-emitting them. Both fields are JSON-serialisable; consumers pass the whole
+ * object back unchanged.
+ */
 export interface PipelineLogCursor {
-    /** Epoch-millis boundary; the next page is every row strictly older than this. */
+    /**
+     * Identity hashes (see the internal `hashRow`) of the rows already returned
+     * that share the boundary `ts`. The next page fetches every row at-or-older-than
+     * the boundary and filters out any whose hash is in this set, so boundary rows
+     * are neither dropped nor duplicated. Only ever holds rows at the single
+     * boundary `ts`; omitted (or empty) when the boundary carries no already-returned ties.
+     */
+    seen?: string[];
+    /** Epoch-millis boundary; the next page is every row at or older than this. */
     ts: number;
 }
 
 /** Filters for one {@link PipelineLogReader} query. Every value is inlined safely (`lit`/`sql`). */
 export interface PipelineLogQuery {
-    /** Continue after a previous page (keyset on `ts DESC`). Combined with the other filters. */
+    /** Continue after a previous page (inclusive keyset on `ts DESC`, dedup'd by {@link PipelineLogCursor} `seen`). Combined with the other filters. */
     cursor?: PipelineLogCursor;
     /** Match only this exact function path's records. Prefer `functionPathPrefix` for a namespace sweep. */
     functionPath?: string;
@@ -246,139 +368,169 @@ export const createPipelineLogReader = (client: R2SqlClient, options: PipelineLo
     // via a crafted table/namespace either.
     const tableReference = options.namespace === undefined ? options.table : `${options.namespace}.${options.table}`;
 
+    // Decode one raw storage row into the canonical, physical-name-agnostic shape.
+    const decodeRow = (row: StoredRow): PipelineLogRow => {
+        const out: PipelineLogRow = {
+            functionPath: renderCell(row[columns.functionPath]),
+            // The stored `level` is one of the canonical severities; the reader
+            // trusts the writer's contract here rather than re-validating.
+            level: renderCell(row[columns.level]) as ContextLogLevel,
+            message: renderCell(row[columns.message]),
+            ts: toTs(row[columns.ts]),
+        };
+
+        // Optional columns: attach only when the engine returned a value, so a
+        // `PipelineLogRow` mirrors the sparse record the sink wrote.
+        const fields = row[columns.fields];
+
+        if (fields !== undefined && fields !== null) {
+            out.fields = decodeFields(fields);
+        }
+
+        const shardKey = row[columns.shardKey];
+
+        if (shardKey !== undefined && shardKey !== null) {
+            out.shardKey = renderCell(shardKey);
+        }
+
+        const userId = row[columns.userId];
+
+        if (userId !== undefined && userId !== null) {
+            out.userId = renderCell(userId);
+        }
+
+        const traceId = row[columns.traceId];
+
+        if (traceId !== undefined && traceId !== null) {
+            out.traceId = renderCell(traceId);
+        }
+
+        const spanId = row[columns.spanId];
+
+        if (spanId !== undefined && spanId !== null) {
+            out.spanId = renderCell(spanId);
+        }
+
+        return out;
+    };
+
+    // Build + run one read of `fetchLimit` rows with every filter + the inclusive
+    // cursor bound. A fresh builder each call so a grown re-fetch does not
+    // accumulate WHERE clauses.
+    const fetchRows = async (query: PipelineLogQuery, cursorTs: number | undefined, fetchLimit: number): Promise<StoredRow[]> => {
+        const builder = client
+            .from<StoredRow>(tableReference)
+            // Project only the mapped columns (never `SELECT *`) so the read is
+            // stable against unrelated columns in the Iceberg table.
+            .select(
+                raw(columns.functionPath),
+                raw(columns.level),
+                raw(columns.message),
+                raw(columns.ts),
+                raw(columns.fields),
+                raw(columns.shardKey),
+                raw(columns.userId),
+                raw(columns.traceId),
+                raw(columns.spanId),
+            );
+
+        applyLogFilters(builder, query, columns, cursorTs);
+
+        builder.orderBy(desc(raw(columns.ts))).limit(fetchLimit);
+
+        const { rows } = await builder.run();
+
+        return rows;
+    };
+
+    // One grow-attempt: fetch `fetchLimit` rows, decode them, and drop any boundary
+    // row already returned on a prior page (its hash is in `seen`). `truncated`
+    // means the store filled the whole window, so more matching rows may remain
+    // unseen — the caller cannot yet conclude "no next page".
+    const readAttempt = async (
+        query: PipelineLogQuery,
+        cursorTs: number | undefined,
+        seen: Set<string> | undefined,
+        fetchLimit: number,
+    ): Promise<{ decoded: PipelineLogRow[]; truncated: boolean }> => {
+        const rows = await fetchRows(query, cursorTs, fetchLimit);
+        const decoded: PipelineLogRow[] = [];
+
+        for (const row of rows) {
+            const decodedRow = decodeRow(row);
+            const alreadyReturned = seen !== undefined && cursorTs !== undefined && decodedRow.ts === cursorTs && seen.has(hashRow(decodedRow));
+
+            if (!alreadyReturned) {
+                decoded.push(decodedRow);
+            }
+        }
+
+        return { decoded, truncated: rows.length >= fetchLimit };
+    };
+
     return {
         query: async (query: PipelineLogQuery = {}): Promise<PipelineLogPage> => {
             const limit = clampLimit(query.limit);
-            // Over-fetch by one so the presence of an extra row both flags a next
-            // page and carries its cursor `ts`. Never exceed the engine ceiling
-            // (at limit === 10000 the +1 would trip `assertLimit`), which caps
-            // pagination at the last full page — an accepted edge.
-            const fetchLimit = Math.min(limit + 1, MAX_LIMIT);
+            const { cursor } = query;
+            const cursorTs = cursor?.ts;
+            // Boundary rows already returned on prior page(s) sharing `cursorTs` —
+            // dropped from this page so an inclusive resume never re-emits them.
+            const seen = cursor?.seen !== undefined && cursor.seen.length > 0 ? new Set(cursor.seen) : undefined;
 
-            const builder = client
-                .from<StoredRow>(tableReference)
-                // Project only the mapped columns (never `SELECT *`) so the read
-                // is stable against unrelated columns in the Iceberg table.
-                .select(
-                    raw(columns.functionPath),
-                    raw(columns.level),
-                    raw(columns.message),
-                    raw(columns.ts),
-                    raw(columns.fields),
-                    raw(columns.shardKey),
-                    raw(columns.userId),
-                    raw(columns.traceId),
-                    raw(columns.spanId),
-                );
+            // Fetch one more than asked: an extra surviving row both flags a next
+            // page and lets us skip minting a cursor at a true end-of-stream. The
+            // base over-fetch may need to grow (below) when boundary de-duplication
+            // consumes the extra budget on a page dominated by one `ts`.
+            const baseFetchLimit = Math.min(limit + 1, MAX_LIMIT);
 
-            if (query.sinceTs !== undefined) {
-                builder.where(sql`${raw(columns.ts)} >= ${query.sinceTs}`);
-            }
+            // Grow the fetch window when boundary de-duplication leaves us unable to
+            // tell whether a next page exists. Doubling, hard-capped so a page made
+            // entirely of one `ts` cannot loop forever (the engine `LIMIT` ceiling
+            // caps it regardless). Rare — only bites a page dominated by a single ms.
+            const maxAttempts = 3;
+            let decoded: PipelineLogRow[] = [];
+            let truncated = false;
 
-            if (query.untilTs !== undefined) {
-                builder.where(sql`${raw(columns.ts)} <= ${query.untilTs}`);
-            }
+            for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+                const fetchLimit = Math.min(baseFetchLimit * 2 ** attempt, MAX_LIMIT);
 
-            if (query.level !== undefined) {
-                // Exact severity wins over `minLevel` (documented on the type): a
-                // caller asking for one level should not also get everything above it.
-                builder.where(sql`${raw(columns.level)} = ${query.level}`);
-            } else if (query.minLevel !== undefined) {
-                // Expand the floor to the explicit set at/above it in the severity
-                // ramp; an `IN (...)` over a small closed set is clearer to the
-                // engine (and to a reader) than a comparison over a non-numeric column.
-                const floorIndex = LOG_LEVEL_ORDER.indexOf(query.minLevel);
-                const allowed = floorIndex === -1 ? [...LOG_LEVEL_ORDER] : LOG_LEVEL_ORDER.slice(floorIndex);
+                // eslint-disable-next-line no-await-in-loop -- each grow depends on the prior fetch's result; sequential by nature
+                const attemptResult = await readAttempt(query, cursorTs, seen, fetchLimit);
 
-                builder.where(sql`${raw(columns.level)} IN ${allowed}`);
-            }
+                decoded = attemptResult.decoded;
+                truncated = attemptResult.truncated;
 
-            if (query.functionPath !== undefined) {
-                builder.where(sql`${raw(columns.functionPath)} = ${query.functionPath}`);
-            }
-
-            if (query.functionPathPrefix !== undefined) {
-                // `LIKE 'prefix%'`: the trailing `%` sits inside the escaped
-                // literal so it stays the wildcard, while the prefix itself is
-                // quote-escaped and cannot break out. (A `%`/`_` within the prefix
-                // acts as a wildcard — documented on the option.)
-                builder.where(sql`${raw(columns.functionPath)} LIKE ${`${query.functionPathPrefix}%`}`);
-            }
-
-            if (query.traceId !== undefined) {
-                builder.where(sql`${raw(columns.traceId)} = ${query.traceId}`);
-            }
-
-            if (query.shardKey !== undefined) {
-                builder.where(sql`${raw(columns.shardKey)} = ${query.shardKey}`);
-            }
-
-            if (query.userId !== undefined) {
-                builder.where(sql`${raw(columns.userId)} = ${query.userId}`);
-            }
-
-            if (query.cursor !== undefined) {
-                // Keyset: strictly older than the cursor `ts` (the overflow row's
-                // `ts` from the previous page) so we resume just past it.
-                builder.where(sql`${raw(columns.ts)} < ${query.cursor.ts}`);
-            }
-
-            builder.orderBy(desc(raw(columns.ts))).limit(fetchLimit);
-
-            const { rows } = await builder.run();
-
-            // The (limit + 1)th row, when present, is the overflow: it proves a
-            // next page exists and its `ts` becomes that page's cursor.
-            const hasMore = rows.length > limit;
-            const pageRows = hasMore ? rows.slice(0, limit) : rows;
-            const overflow = hasMore ? rows[limit] : undefined;
-
-            const decoded: PipelineLogRow[] = pageRows.map((row) => {
-                const out: PipelineLogRow = {
-                    functionPath: renderCell(row[columns.functionPath]),
-                    // The stored `level` is one of the canonical severities; the
-                    // reader trusts the writer's contract here rather than re-validating.
-                    level: renderCell(row[columns.level]) as ContextLogLevel,
-                    message: renderCell(row[columns.message]),
-                    ts: toTs(row[columns.ts]),
-                };
-
-                // Optional columns: attach only when the engine returned a value,
-                // so a `PipelineLogRow` mirrors the sparse record the sink wrote.
-                const fields = row[columns.fields];
-
-                if (fields !== undefined && fields !== null) {
-                    out.fields = decodeFields(fields);
+                // A confirmed overflow row, or a store that returned everything it
+                // has, both settle the "is there more?" question — stop growing.
+                if (decoded.length > limit || !truncated || fetchLimit >= MAX_LIMIT) {
+                    break;
                 }
+            }
 
-                const shardKey = row[columns.shardKey];
+            const hasOverflow = decoded.length > limit;
+            const pageRows = hasOverflow ? decoded.slice(0, limit) : decoded;
 
-                if (shardKey !== undefined && shardKey !== null) {
-                    out.shardKey = renderCell(shardKey);
-                }
+            // Emit a next cursor when either a real overflow row proved more remains,
+            // or we bailed out of the grow loop still `truncated` on a non-empty page
+            // (the deferred-fix degenerate case: more than one page of a single
+            // identical `ts`). The non-empty guard keeps that fallback from looping
+            // on a page that de-duplicated down to nothing.
+            const lastRow = pageRows.at(-1);
 
-                const userId = row[columns.userId];
+            if (lastRow === undefined || !(hasOverflow || truncated)) {
+                return { rows: pageRows };
+            }
 
-                if (userId !== undefined && userId !== null) {
-                    out.userId = renderCell(userId);
-                }
+            // Cursor `ts` is the **last returned** row's `ts`. `seen` carries every
+            // returned row on that boundary `ts`, accumulated across consecutive
+            // pages that share it (a tie spanning multiple pages) so none is
+            // re-emitted; it resets whenever the boundary advances to an older `ts`.
+            const boundaryTs = lastRow.ts;
+            const boundaryHashes = pageRows.filter((row) => row.ts === boundaryTs).map((row) => hashRow(row));
+            const carried = cursorTs === boundaryTs && cursor?.seen !== undefined ? cursor.seen : [];
+            const nextSeen = [...carried, ...boundaryHashes];
 
-                const traceId = row[columns.traceId];
-
-                if (traceId !== undefined && traceId !== null) {
-                    out.traceId = renderCell(traceId);
-                }
-
-                const spanId = row[columns.spanId];
-
-                if (spanId !== undefined && spanId !== null) {
-                    out.spanId = renderCell(spanId);
-                }
-
-                return out;
-            });
-
-            return overflow === undefined ? { rows: decoded } : { nextCursor: { ts: toTs(overflow[columns.ts]) }, rows: decoded };
+            return { nextCursor: nextSeen.length > 0 ? { seen: nextSeen, ts: boundaryTs } : { ts: boundaryTs }, rows: pageRows };
         },
     };
 };

--- a/packages/server/src/otel.ts
+++ b/packages/server/src/otel.ts
@@ -148,6 +148,19 @@ const flattenAttributes = (attributes: Attributes | undefined): Record<string, u
  *
  * A span that is never ended therefore never records. That matches OTel's own
  * contract (an unended span is not exported) and beats guessing an end time.
+ *
+ * **Late end and sampling.** A bridged span may `end()` AFTER its dispatch has
+ * settled — a streaming AI-SDK call, a detached handler. When it does, it records
+ * through the normal `ctx.trace` → `recordSpan` path, which now snapshots the
+ * trace's sampling verdict when the span opens and honours it at close (see
+ * `@lunora/do`'s `recordSpan`): a late child of a sampled-OUT trace is no longer
+ * exported unconditionally. The complementary lifetime bound — settling an
+ * ABANDONED span (one whose `end()` is never called) so its suspended `ctx.trace`
+ * body cannot pin this closure in a long-lived isolate — is deferred: the clean
+ * route is a dispatch-teardown hook, and the `LunoraTraceContext` surface this
+ * bridge is handed exposes none, while a timer is the very mechanism the DO
+ * profile avoids. The correctness half (no orphan export) is done; the retention
+ * half awaits a teardown hook on the ctx.
  */
 class BridgeSpan implements Span {
     private ended = false;

--- a/shared/otlp.ts
+++ b/shared/otlp.ts
@@ -271,7 +271,15 @@ const OTLP_SPAN_KIND: Record<OtlpSpanKind, number> = {
  * Every emit path MUST reference these constants; a literal `"lunora.…"`
  * attribute string in an emitter is a drift bug.
  */
-const LUNORA_ATTR = Object.freeze({
+const LUNORA_ATTR: Readonly<{
+    durationMs: "lunora.duration_ms";
+    errorMessage: "error.message";
+    errorType: "error.type";
+    functionPath: "lunora.function_path";
+    ok: "lunora.ok";
+    shardKey: "lunora.shard_key";
+    userId: "lunora.user_id";
+}> = Object.freeze({
     durationMs: "lunora.duration_ms",
     errorMessage: "error.message",
     errorType: "error.type",

--- a/shared/otlp.ts
+++ b/shared/otlp.ts
@@ -255,6 +255,33 @@ const OTLP_SPAN_KIND: Record<OtlpSpanKind, number> = {
 };
 
 /**
+ * Reserved Lunora attribute keys, defined once so the DO (`@lunora/do`) and
+ * worker (`@lunora/runtime`) exporters cannot drift apart — a collector query on
+ * one of these keys must match EVERY source that emits it. Before this record,
+ * the two exporters re-typed the same keys as string literals and had already
+ * diverged (`lunora.error.type` on one side, `error.type` on the other).
+ *
+ * The dispatch dimensions with no OTel equivalent — `functionPath`, `ok`,
+ * `shardKey`, `userId`, `durationMs` — stay under the `lunora.*` namespace. The
+ * error pair converges on OTel semantic-convention keys instead: `error.type`
+ * (stable) and `error.message` — both are span-*level* attributes, so the
+ * `exception.*` keys stay reserved for the exception span-*event* the runtime
+ * emits separately.
+ *
+ * Every emit path MUST reference these constants; a literal `"lunora.…"`
+ * attribute string in an emitter is a drift bug.
+ */
+const LUNORA_ATTR = Object.freeze({
+    durationMs: "lunora.duration_ms",
+    errorMessage: "error.message",
+    errorType: "error.type",
+    functionPath: "lunora.function_path",
+    ok: "lunora.ok",
+    shardKey: "lunora.shard_key",
+    userId: "lunora.user_id",
+} as const);
+
+/**
  * Build the OTLP `Resource.attributes` list for a signal envelope. `service.name`
  * is the default and `extra` is merged over it, so a caller-supplied
  * `service.name` in `extra` wins. Kept as a separate helper so `wrapResource*`
@@ -324,6 +351,7 @@ const wrapResourceMetrics = (
 export type { OtlpAnyValue, OtlpAttribute, OtlpAttributeValue, OtlpLevel, OtlpResourceAttributes, OtlpSpanKind };
 export {
     buildTraceparent,
+    LUNORA_ATTR,
     OTLP_SPAN_KIND,
     encodeAttribute,
     encodeAttributes,


### PR DESCRIPTION
## Wave 15 — observability, sampling & OTLP correctness (plans 179, 180, 181, 186, 190)

Five reviewed plans in the telemetry/runtime/DO surface, merged into one branch (all touch `create-worker.ts` / `shard-do.ts` / `observability.ts` — conflicts resolved and the combined suite re-run).

- **179 (OBS-01)** — settle the trace-sampling verdict once: the RPC-event export gate now consumes the dispatch's already-settled verdict instead of re-deriving it, so the propagated `traceparent` and the exported SERVER span can never disagree (re-fixes the orphan-span class from #191). +agreement tests.
- **180 (OBS-02/03)** — `/_lunora/health` hardening: the public posture no longer echoes operator binding **names** (recon leak vs the module's own invariant), and `cacheTtlMs` is now real (was a documented no-op that left the unauthenticated endpoint running live DO/D1 probes per request).
- **181 (OBS-04)** — lossless durable log-archive pagination: the keyset cursor dropped ≥1 record at every page boundary. Now inclusive `ts <=` resume + last-returned-row cursor + `seen`-hash dedup + degenerate-page grow. Completeness test proves union-of-pages == full result.
- **186 (OBS-07/08/09)** — DO telemetry hot path: `metricHistory` is now an opt-out (default off — it was an unconditional durable SQLite write per `ctx.metrics.*`); sampled-out held spans live on the per-trace entry (no whole-ring copy per dispatch; eviction race closed); a span ending after its sampled-out dispatch tore down no longer exports unconditionally (verdict snapshot).
- **190 (OBS-10/11/12, HLTH-03)** — OTLP export: reserved attribute keys converged across DO + worker via `LUNORA_ATTR` (**wire-format change** — see `fix(otlp)!`); gzip decided by byte length (not UTF-16 units); resource grouping keyed on a stable serialization (kills duplicate export subrequests); RAG importance-rescale divide-by-zero guarded; AI-gateway token warn+document fallback.
- **+ isolatedDeclarations fix**: `LUNORA_ATTR` got an explicit `Readonly<{…}>` annotation so the packem DTS build (`--isolatedDeclarations`, CI's `dist:check`) passes — this gate is stricter than `tsc --noEmit` and was missed on the individual branch.

### Verification (on the merged branch)
Full 48-package `build:packages` succeeds; `tsc` clean for runtime/do/server/ai/cli; tests: **runtime 751, do 1248, server 445, ai 121, cli 689**.

> **Merge-order note:** contains changes to `create-worker.ts` (also touched by the x402 PR) and `shard-do.ts` (also touched by the geospatial PR) — land this PR first, then rebase those.

Generated by the `/improve` advisor workflow (audit → isolated-worktree Opus executors → tech-lead review). Plan text + review notes on `improve/alpha-audit` under `plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
