### PR TITLE
fix(cli): keep triggers.crons intact when deploy skips codegen

### DIFF
--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -554,6 +554,32 @@ export default crons;
             expect(parsed.triggers?.crons).toEqual([]);
         });
 
+        it("preserves committed triggers.crons on the --prebuilt (skipCodegen) path", async () => {
+            expect.assertions(2);
+
+            // --prebuilt skips codegen, so no cron schedules are discovered. The
+            // committed triggers.crons must be left untouched — clearing it would
+            // silently stop every production cron. Remove the lunora/ schema so
+            // codegen would fail if it ran, proving the path really is skipped.
+            writeFileSync(
+                join(workdir, "wrangler.jsonc"),
+                VALID_WRANGLER.replace('"d1_databases"', '"triggers": { "crons": ["*/5 * * * *"] },\n    "d1_databases"'),
+                "utf8",
+            );
+            rmSync(join(workdir, "lunora"), { force: true, recursive: true });
+
+            const { spawner } = createRecordingSpawner();
+            const { logger } = silentLogger();
+
+            const result = await runDeployCommand({ cwd: workdir, secretLister: noRemoteSecrets, logger, skipCodegen: true, spawner });
+
+            expect(result.code).toBe(0);
+
+            const parsed = parseJsonc(readFileSync(join(workdir, "wrangler.jsonc"), "utf8")) as { triggers?: { crons?: string[] } };
+
+            expect(parsed.triggers?.crons).toEqual(["*/5 * * * *"]);
+        });
+
         it("does not run migrations when --migrate is not set", async () => {
             expect.assertions(2);
 

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -338,7 +338,7 @@ const buildContainerImages = async (cwd: string, options: DeployCommandOptions):
  * best-effort: a failure here must not abort the deploy, since the validator
  * still reports any genuinely missing requirement.
  */
-const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> = []): Promise<void> => {
+const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> | undefined): Promise<void> => {
     try {
         const inferred = await inferLunoraBindings({ projectRoot: cwd });
         const reconciled = reconcileWranglerBindings(cwd, inferred);
@@ -370,16 +370,23 @@ const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: Read
         logger.warn(`compatibility date sync skipped: ${message}`);
     }
 
-    try {
-        const reconciled = reconcileWranglerCrons(cwd, cronTriggers);
+    // `undefined` means codegen was skipped (e.g. `--prebuilt`): we have no
+    // evidence of the project's crons, so leave the committed `triggers.crons`
+    // untouched. A defined array (including `[]`) means codegen ran and
+    // reconciling — clearing a genuinely-removed last cron — is intended.
+    // Mirrors the `if (codegen !== undefined)` guard on the schema-drift gate.
+    if (cronTriggers !== undefined) {
+        try {
+            const reconciled = reconcileWranglerCrons(cwd, cronTriggers);
 
-        if (reconciled.changed) {
-            logger.success(`synced ${String(cronTriggers.length)} cron trigger(s) → ${reconciled.wranglerPath ?? "wrangler.jsonc"}`);
+            if (reconciled.changed) {
+                logger.success(`synced ${String(cronTriggers.length)} cron trigger(s) → ${reconciled.wranglerPath ?? "wrangler.jsonc"}`);
+            }
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+
+            logger.warn(`cron trigger sync skipped: ${message}`);
         }
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-
-        logger.warn(`cron trigger sync skipped: ${message}`);
     }
 };
 
@@ -972,7 +979,7 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
         reblessSchemaBaseline = gate.rebless;
     }
 
-    await provisionBindings(cwd, options.logger, codegen?.cronTriggers ?? []);
+    await provisionBindings(cwd, options.logger, codegen?.cronTriggers);
 
     const migratePreflightError = validateMigrateDeployPreflight(options);
 

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -332,6 +332,34 @@ const buildContainerImages = async (cwd: string, options: DeployCommandOptions):
 };
 
 /**
+ * Reconcile the committed `triggers.crons` with the schedules codegen discovered.
+ *
+ * `undefined` means codegen was skipped (e.g. `--prebuilt`): we have no evidence
+ * of the project's crons, so leave the committed `triggers.crons` untouched —
+ * clearing it would silently stop every production cron. A defined array
+ * (including `[]`) means codegen ran and reconciling — clearing a
+ * genuinely-removed last cron — is intended. Mirrors the
+ * `if (codegen !== undefined)` guard on the schema-drift gate.
+ */
+const syncCronTriggers = (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> | undefined): void => {
+    if (cronTriggers === undefined) {
+        return;
+    }
+
+    try {
+        const reconciled = reconcileWranglerCrons(cwd, cronTriggers);
+
+        if (reconciled.changed) {
+            logger.success(`synced ${String(cronTriggers.length)} cron trigger(s) → ${reconciled.wranglerPath ?? "wrangler.jsonc"}`);
+        }
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        logger.warn(`cron trigger sync skipped: ${message}`);
+    }
+};
+
+/**
  * Auto-provision the bindings the project's code implies before validating, so
  * a first deploy doesn't fail on a SESSION/SCHEDULER/DB binding the user never
  * had to hand-write. Idempotent — a no-op once the config is in sync — and
@@ -370,24 +398,7 @@ const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: Read
         logger.warn(`compatibility date sync skipped: ${message}`);
     }
 
-    // `undefined` means codegen was skipped (e.g. `--prebuilt`): we have no
-    // evidence of the project's crons, so leave the committed `triggers.crons`
-    // untouched. A defined array (including `[]`) means codegen ran and
-    // reconciling — clearing a genuinely-removed last cron — is intended.
-    // Mirrors the `if (codegen !== undefined)` guard on the schema-drift gate.
-    if (cronTriggers !== undefined) {
-        try {
-            const reconciled = reconcileWranglerCrons(cwd, cronTriggers);
-
-            if (reconciled.changed) {
-                logger.success(`synced ${String(cronTriggers.length)} cron trigger(s) → ${reconciled.wranglerPath ?? "wrangler.jsonc"}`);
-            }
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : String(error);
-
-            logger.warn(`cron trigger sync skipped: ${message}`);
-        }
-    }
+    syncCronTriggers(cwd, logger, cronTriggers);
 };
 
 /**


### PR DESCRIPTION
`lunora deploy --prebuilt` silently deletes every declared cron trigger from the committed `wrangler.jsonc` and deploys a worker with no scheduled triggers.

## The bug

`--prebuilt` skips codegen, so no cron schedules are discovered and `codegen` is `undefined`. But `packages/cli/src/commands/deploy/handler.ts` still coerced that into an empty array before handing it to the reconciler:

```ts
await provisionBindings(cwd, options.logger, codegen?.cronTriggers ?? []);
```

`provisionBindings` cannot distinguish "codegen ran and found zero crons" from "codegen never ran", so it treats the empty array as authoritative, calls `reconcileWranglerCrons(cwd, [])`, and structurally rewrites `wrangler.jsonc` — dropping `triggers.crons` entirely. Production crons stop, and nothing in the deploy output says so.

## The fix

Make the parameter genuinely optional and skip reconciliation when there is no evidence to reconcile against:

```ts
const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> | undefined)
...
if (cronTriggers !== undefined) { /* reconcile */ }
...
await provisionBindings(cwd, options.logger, codegen?.cronTriggers);
```

`undefined` means codegen was skipped → leave the committed `triggers.crons` untouched. A **defined** array — including `[]` — still reconciles, so the legitimate clear-on-empty behaviour for discovery-backed callers is preserved. This mirrors the existing `if (codegen !== undefined)` guard on the schema-drift gate.

## Scope

Only the `deploy` command changes. `packages/cli/src/commands/prepare/handler.ts` has its own copy of `provisionBindings` and always runs codegen, so it always passes a defined `codegen.cronTriggers` — untouched and unaffected. It is the sole other call site.

## Tests

New case asserting the committed `triggers.crons` survives the `skipCodegen` path. It deletes the `lunora/` directory first, so codegen would fail if it ever ran — proving the path really is skipped rather than quietly succeeding.

The pre-existing `clears a stale triggers.crons array when the project declares no crons` case still passes, confirming the clear-on-empty path is intact.

```
Tests  33 passed (33)
tsc --noEmit  clean
```

## Provenance

The fix was written on `advisor/178-deploy-prebuilt-cron-wipe`, which had drifted 146 commits behind. This branch is that single commit cherry-picked onto current alpha, so the diff is exactly the fix. I verified the surrounding handler code was unchanged on alpha before replaying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployments using prebuilt assets no longer unintentionally modify or clear existing cron trigger configuration.
  * Cron triggers are reconciled only when deployment code generation runs.
  * When code generation is skipped, the committed cron settings (for example in `wrangler.jsonc`) are preserved rather than being recalculated or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->