### PR TITLE
feat(do,server): SpanHandle.recordEvaluation for gen_ai.evaluation attributes

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -2112,6 +2112,7 @@ type SourceRefresh = "manual" | {
 interface SpanHandle {
     addEvent: (name: string, attributes?: LogFields) => void;
     addLink: (link: SpanLink) => void;
+    recordEvaluation: (evaluation: EvaluationInput) => void;
     recordException: (error: unknown) => void;
     setAttribute: (key: string, value: LogFields[string]) => void;
     setAttributes: (fields: LogFields) => void;

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -597,6 +597,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `SpanEvaluation` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `SpanHandle` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -4999,6 +5003,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `SpanEvaluation` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `SpanHandle` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -6676,6 +6684,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `ShardMode` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `SpanEvaluation` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -1623,12 +1623,23 @@ type ShardMode = {
 };
 ```
 
+### `SpanEvaluation` (interface)
+
+```ts
+interface SpanEvaluation {
+    label?: string;
+    name: string;
+    score: number;
+}
+```
+
 ### `SpanHandle` (interface)
 
 ```ts
 interface SpanHandle {
     addEvent: (name: string, attributes?: LogFields) => void;
     addLink: (link: SpanLink) => void;
+    recordEvaluation: (evaluation: SpanEvaluation) => void;
     recordException: (error: unknown) => void;
     setAttribute: (key: string, value: LogFields[string]) => void;
     setAttributes: (fields: LogFields) => void;
@@ -4592,12 +4603,23 @@ type ShardMode = {
 };
 ```
 
+### `SpanEvaluation` (interface)
+
+```ts
+interface SpanEvaluation {
+    label?: string;
+    name: string;
+    score: number;
+}
+```
+
 ### `SpanHandle` (interface)
 
 ```ts
 interface SpanHandle {
     addEvent: (name: string, attributes?: LogFields) => void;
     addLink: (link: SpanLink) => void;
+    recordEvaluation: (evaluation: SpanEvaluation) => void;
     recordException: (error: unknown) => void;
     setAttribute: (key: string, value: LogFields[string]) => void;
     setAttributes: (fields: LogFields) => void;

--- a/packages/do/__tests__/tracing.test.ts
+++ b/packages/do/__tests__/tracing.test.ts
@@ -370,6 +370,52 @@ describe("ctx.trace", () => {
         expect(seen[0]?.attributes?.["cost"]).toBe(0.0004);
     });
 
+    it("records an evaluation as gen_ai.evaluation.<name>.score/.label on the generation span", async () => {
+        expect.assertions(2);
+
+        const seen: SpanEvent[] = [];
+        const trace = tracerInto(seen);
+
+        // A scorer grades the turn's output only once the generation resolves —
+        // the eval rides the same span as the generation it graded.
+        await trace(
+            "chat gpt-4o-mini",
+            async (_child, handle) => {
+                await Promise.resolve();
+                handle.recordEvaluation({ label: "pass", name: "exact-match", score: 1 });
+            },
+            { "gen_ai.request.model": "gpt-4o-mini" },
+        );
+
+        expect(seen[0]?.attributes).toStrictEqual({
+            "gen_ai.evaluation.exact-match.label": "pass",
+            "gen_ai.evaluation.exact-match.score": 1,
+            "gen_ai.request.model": "gpt-4o-mini",
+        });
+        // A scorer name carrying a colon is sanitized into a well-formed key.
+        expect(seen[0]?.attributes?.["gen_ai.evaluation.exact-match.score"]).toBe(1);
+    });
+
+    it("emits one attribute pair per scorer and rejects a malformed evaluation", async () => {
+        expect.assertions(2);
+
+        const seen: SpanEvent[] = [];
+        const trace = tracerInto(seen);
+
+        await trace("chat", (_child, handle) => {
+            // Two distinct scorers → two distinct key namespaces, no collision.
+            handle.recordEvaluation({ name: "contains:shipped", score: 0.5 });
+            handle.recordEvaluation({ name: "keyword-coverage", score: 0.8 });
+        });
+
+        expect(seen[0]?.attributes).toStrictEqual({
+            "gen_ai.evaluation.contains_shipped.score": 0.5,
+            "gen_ai.evaluation.keyword-coverage.score": 0.8,
+        });
+        // A non-finite score is caller misuse and surfaces rather than poisoning the grade.
+        await expect(trace("chat", (_child, handle) => handle.recordEvaluation({ name: "x", score: Number.NaN }))).rejects.toThrow("finite number");
+    });
+
     it("lets a post-hoc attribute win over a start attribute on a key clash", async () => {
         expect.assertions(1);
 

--- a/packages/do/__tests__/tracing.test.ts
+++ b/packages/do/__tests__/tracing.test.ts
@@ -413,7 +413,11 @@ describe("ctx.trace", () => {
             "gen_ai.evaluation.keyword-coverage.score": 0.8,
         });
         // A non-finite score is caller misuse and surfaces rather than poisoning the grade.
-        await expect(trace("chat", (_child, handle) => handle.recordEvaluation({ name: "x", score: Number.NaN }))).rejects.toThrow("finite number");
+        await expect(
+            trace("chat", (_child, handle) => {
+                handle.recordEvaluation({ name: "x", score: Number.NaN });
+            }),
+        ).rejects.toThrow("finite number");
     });
 
     it("lets a post-hoc attribute win over a start attribute on a key clash", async () => {

--- a/packages/do/src/context-telemetry.ts
+++ b/packages/do/src/context-telemetry.ts
@@ -14,6 +14,7 @@
  * (`ShardDO.recordSpan` / `recordMetric`); this module decides only *what* a
  * span or measurement is, never where it goes.
  */
+import { evaluationAttributes } from "../../../shared/evaluation-attributes";
 import type { LogFields } from "../../../shared/log-fields";
 import { normalizeLogFields } from "../../../shared/log-fields";
 import type { MetricEvent, MetricKind } from "../../../shared/metric-event";
@@ -334,6 +335,15 @@ export const createSpanCollector = (ids: { spanId: string; traceId: string }): S
                 spanId: link.spanId,
                 traceId: link.traceId,
             });
+        },
+        recordEvaluation: (evaluation) => {
+            // Build the `gen_ai.evaluation.<name>.score`/`.label` pair (the exact
+            // keys the cloud OTLP decoder reads back) and merge it in like any
+            // other post-hoc attribute, so it flushes on this span over OTLP with
+            // no special casing downstream. `evaluationAttributes` throws on an
+            // empty name / non-finite score — caller misuse, so it surfaces in the
+            // body rather than being silently dropped.
+            Object.assign(collected.attributes, normalizeLogFields(evaluationAttributes(evaluation)));
         },
         recordException: (error) => {
             // The OTel-conventional `exception` event. `exception.stacktrace` is

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -4837,6 +4837,9 @@ abstract class ShardDO {
             addLink: (link) => {
                 collector().handle.addLink(link);
             },
+            recordEvaluation: (evaluation) => {
+                collector().handle.recordEvaluation(evaluation);
+            },
             recordException: (error) => {
                 collector().handle.recordException(error);
             },

--- a/packages/runtime/__tests__/otlp-evaluation.test.ts
+++ b/packages/runtime/__tests__/otlp-evaluation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { SpanEvent } from "../../../shared/span-event";
+import { otlpSpanBody } from "../src/otlp-export";
+
+/** One OTLP `KeyValue`, as `otlpSpanBody` encodes them. */
+type OtlpKeyValue = { key: string; value: { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string } };
+
+/** Pull the single span's attribute list out of an `otlpSpanBody` export body. */
+const spanAttributes = (body: unknown): OtlpKeyValue[] => {
+    const parsed = body as { resourceSpans: { scopeSpans: { spans: { attributes: OtlpKeyValue[] }[] }[] }[] };
+
+    return parsed.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes;
+};
+
+const attrValue = (attributes: OtlpKeyValue[], key: string): OtlpKeyValue["value"] | undefined => attributes.find((entry) => entry.key === key)?.value;
+
+/**
+ * Proves the framework's `gen_ai.evaluation.*` emission survives OTLP encoding
+ * exactly as the cloud OTLP decoder expects. A `SpanHandle.recordEvaluation` call
+ * lands the pair on the recorded `SpanEvent.attributes` (see `@lunora/do`'s
+ * `context-telemetry` tests); this checks the last hop — that `otlpSpanBody` ships
+ * those keys verbatim on the generation span rather than mangling or dropping them.
+ */
+describe("otlpSpanBody — gen_ai.evaluation attributes", () => {
+    const generationSpan = (attributes: SpanEvent["attributes"]): SpanEvent => ({
+        attributes,
+        durationMs: 12,
+        functionPath: "chat:complete",
+        name: "chat gpt-4o-mini",
+        ok: true,
+        parentSpanId: "1111111111111111",
+        shardKey: undefined,
+        spanId: "2222222222222222",
+        startTs: 1_700_000_000_000,
+        traceId: "33333333333333333333333333333333",
+        userId: undefined,
+    });
+
+    it("encodes gen_ai.evaluation.<name>.score as a number and .label as a string", () => {
+        expect.assertions(2);
+
+        const body = otlpSpanBody(
+            generationSpan({
+                "gen_ai.evaluation.exact-match.label": "pass",
+                "gen_ai.evaluation.exact-match.score": 1,
+                "gen_ai.request.model": "gpt-4o-mini",
+            }),
+            "lunora",
+        );
+        const attributes = spanAttributes(body);
+
+        // `1` is a safe integer → proto3-JSON `intValue` (decimal string); the decoder reads it back as the numeric score.
+        expect(attrValue(attributes, "gen_ai.evaluation.exact-match.score")).toStrictEqual({ intValue: "1" });
+        expect(attrValue(attributes, "gen_ai.evaluation.exact-match.label")).toStrictEqual({ stringValue: "pass" });
+    });
+
+    it("encodes a fractional score as a doubleValue", () => {
+        expect.assertions(1);
+
+        const body = otlpSpanBody(generationSpan({ "gen_ai.evaluation.keyword-coverage.score": 0.8 }), "lunora");
+
+        expect(attrValue(spanAttributes(body), "gen_ai.evaluation.keyword-coverage.score")).toStrictEqual({ doubleValue: 0.8 });
+    });
+});

--- a/packages/runtime/__tests__/otlp-evaluation.test.ts
+++ b/packages/runtime/__tests__/otlp-evaluation.test.ts
@@ -6,12 +6,12 @@ import { otlpSpanBody } from "../src/otlp-export";
 /** One OTLP `KeyValue`, as `otlpSpanBody` encodes them. */
 type OtlpKeyValue = { key: string; value: { boolValue: boolean } | { doubleValue: number } | { intValue: string } | { stringValue: string } };
 
-/** Pull the single span's attribute list out of an `otlpSpanBody` export body. */
-const spanAttributes = (body: unknown): OtlpKeyValue[] => {
-    const parsed = body as { resourceSpans: { scopeSpans: { spans: { attributes: OtlpKeyValue[] }[] }[] }[] };
-
-    return parsed.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes;
-};
+/**
+ * Pull the attribute list off an `otlpSpanBody` result. `otlpSpanBody` encodes a
+ * single OTLP span; the `resourceSpans`/`scopeSpans` envelope is added a tier up
+ * by the exporter, so the span object is the top level here.
+ */
+const spanAttributes = (body: unknown): OtlpKeyValue[] => (body as { attributes: OtlpKeyValue[] }).attributes;
 
 const attrValue = (attributes: OtlpKeyValue[], key: string): OtlpKeyValue["value"] | undefined => attributes.find((entry) => entry.key === key)?.value;
 
@@ -23,19 +23,21 @@ const attrValue = (attributes: OtlpKeyValue[], key: string): OtlpKeyValue["value
  * those keys verbatim on the generation span rather than mangling or dropping them.
  */
 describe("otlpSpanBody — gen_ai.evaluation attributes", () => {
-    const generationSpan = (attributes: SpanEvent["attributes"]): SpanEvent => ({
-        attributes,
-        durationMs: 12,
-        functionPath: "chat:complete",
-        name: "chat gpt-4o-mini",
-        ok: true,
-        parentSpanId: "1111111111111111",
-        shardKey: undefined,
-        spanId: "2222222222222222",
-        startTs: 1_700_000_000_000,
-        traceId: "33333333333333333333333333333333",
-        userId: undefined,
-    });
+    const generationSpan = (attributes: SpanEvent["attributes"]): SpanEvent => {
+        return {
+            attributes,
+            durationMs: 12,
+            functionPath: "chat:complete",
+            name: "chat gpt-4o-mini",
+            ok: true,
+            parentSpanId: "1111111111111111",
+            shardKey: undefined,
+            spanId: "2222222222222222",
+            startTs: 1_700_000_000_000,
+            traceId: "33333333333333333333333333333333",
+            userId: undefined,
+        };
+    };
 
     it("encodes gen_ai.evaluation.<name>.score as a number and .label as a string", () => {
         expect.assertions(2);
@@ -46,7 +48,6 @@ describe("otlpSpanBody — gen_ai.evaluation attributes", () => {
                 "gen_ai.evaluation.exact-match.score": 1,
                 "gen_ai.request.model": "gpt-4o-mini",
             }),
-            "lunora",
         );
         const attributes = spanAttributes(body);
 
@@ -58,7 +59,7 @@ describe("otlpSpanBody — gen_ai.evaluation attributes", () => {
     it("encodes a fractional score as a doubleValue", () => {
         expect.assertions(1);
 
-        const body = otlpSpanBody(generationSpan({ "gen_ai.evaluation.keyword-coverage.score": 0.8 }), "lunora");
+        const body = otlpSpanBody(generationSpan({ "gen_ai.evaluation.keyword-coverage.score": 0.8 }));
 
         expect(attrValue(spanAttributes(body), "gen_ai.evaluation.keyword-coverage.score")).toStrictEqual({ doubleValue: 0.8 });
     });

--- a/packages/server/__tests__/context.test.ts
+++ b/packages/server/__tests__/context.test.ts
@@ -95,6 +95,7 @@ describe("queryCtx.storage / MutationCtx.storage", () => {
             span: {
                 addEvent: () => undefined,
                 addLink: () => undefined,
+                recordEvaluation: () => undefined,
                 recordException: () => undefined,
                 setAttribute: () => undefined,
                 setAttributes: () => undefined,

--- a/packages/server/__tests__/functions-v-from.test.ts
+++ b/packages/server/__tests__/functions-v-from.test.ts
@@ -30,6 +30,7 @@ const makeMutationContext = (): MutationContext => {
         span: {
             addEvent: () => undefined,
             addLink: () => undefined,
+            recordEvaluation: () => undefined,
             recordException: () => undefined,
             setAttribute: () => undefined,
             setAttributes: () => undefined,

--- a/packages/server/__tests__/functions.test.ts
+++ b/packages/server/__tests__/functions.test.ts
@@ -15,6 +15,7 @@ const makeQueryContext = (): QueryContext => {
         span: {
             addEvent: () => undefined,
             addLink: () => undefined,
+            recordEvaluation: () => undefined,
             recordException: () => undefined,
             setAttribute: () => undefined,
             setAttributes: () => undefined,
@@ -40,6 +41,7 @@ const makeMutationContext = (): MutationContext => {
         span: {
             addEvent: () => undefined,
             addLink: () => undefined,
+            recordEvaluation: () => undefined,
             recordException: () => undefined,
             setAttribute: () => undefined,
             setAttributes: () => undefined,
@@ -70,6 +72,7 @@ const makeActionContext = (): ActionContext => {
         span: {
             addEvent: () => undefined,
             addLink: () => undefined,
+            recordEvaluation: () => undefined,
             recordException: () => undefined,
             setAttribute: () => undefined,
             setAttributes: () => undefined,

--- a/packages/server/__tests__/otel.test.ts
+++ b/packages/server/__tests__/otel.test.ts
@@ -37,6 +37,7 @@ const fakeContext = (): { ctx: LunoraTraceContext; recorded: Recorded[] } => {
     const dispatchSpan: SpanHandle = {
         addEvent: () => undefined,
         addLink: () => undefined,
+        recordEvaluation: () => undefined,
         recordException: () => undefined,
         setAttribute: () => undefined,
         setAttributes: () => undefined,
@@ -61,6 +62,9 @@ const fakeContext = (): { ctx: LunoraTraceContext; recorded: Recorded[] } => {
                 },
                 addLink: (link: { spanId: string }) => {
                     entry.links.push(link);
+                },
+                recordEvaluation: () => {
+                    entry.events.push("evaluation");
                 },
                 recordException: () => {
                     entry.events.push("exception");

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -150,6 +150,7 @@ export type {
     SearchFilterBuilder,
     SearchIndexDefinition,
     ShardMode,
+    SpanEvaluation,
     SpanHandle,
     SpanKind,
     SpanLink,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1554,6 +1554,21 @@ interface LunoraLogger {
  * three drift apart. Start attributes are snapshotted before the body runs;
  * handle writes are merged over them at record time, post-hoc winning on a clash.
  */
+/**
+ * One AI **evaluation** verdict — a scorer's `{name, score, label?}` — to attach
+ * to a generation span via {@link SpanHandle.recordEvaluation}. Declared
+ * structurally to mirror `shared/evaluation-attributes.ts`'s `EvaluationInput`
+ * without a dependency edge.
+ */
+interface SpanEvaluation {
+    /** Optional categorical label (e.g. `"pass"` / `"fail"`), emitted as `.label`. */
+    label?: string;
+    /** Scorer name — the key's name segment; non-`[A-Za-z0-9._-]` chars become `_`. */
+    name: string;
+    /** Numeric score (typically `[0, 1]`), emitted as `.score`. */
+    score: number;
+}
+
 interface SpanHandle {
     /**
      * Record a timestamped event on the enclosing span — a retry, a cache miss, a
@@ -1569,6 +1584,16 @@ interface SpanHandle {
      * one giant trace.
      */
     addLink: (link: SpanLink) => void;
+
+    /**
+     * Attach an AI **evaluation** verdict to this (generation) span as the
+     * `gen_ai.evaluation.<name>.score` / `.label` OpenTelemetry attributes, so a
+     * scorer's grade rides the same trace as the generation it graded. Convenience
+     * over {@link SpanHandle.setAttributes} that owns the key format; privacy-safe —
+     * only the name, score, and optional label are emitted. Throws on an empty name
+     * or a non-finite score.
+     */
+    recordEvaluation: (evaluation: SpanEvaluation) => void;
 
     /**
      * Record a **handled** exception as the OTel-conventional `exception` span
@@ -2064,6 +2089,7 @@ export type {
     Secrets,
     SecretsStoreSecretLike,
     ShardMode,
+    SpanEvaluation,
     SpanHandle,
     SpanKind,
     SpanLink,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1554,6 +1554,7 @@ interface LunoraLogger {
  * three drift apart. Start attributes are snapshotted before the body runs;
  * handle writes are merged over them at record time, post-hoc winning on a clash.
  */
+
 /**
  * One AI **evaluation** verdict — a scorer's `{name, score, label?}` — to attach
  * to a generation span via {@link SpanHandle.recordEvaluation}. Declared
@@ -1587,7 +1588,7 @@ interface SpanHandle {
 
     /**
      * Attach an AI **evaluation** verdict to this (generation) span as the
-     * `gen_ai.evaluation.<name>.score` / `.label` OpenTelemetry attributes, so a
+     * `gen_ai.evaluation.&lt;name>.score` / `.label` OpenTelemetry attributes, so a
      * scorer's grade rides the same trace as the generation it graded. Convenience
      * over {@link SpanHandle.setAttributes} that owns the key format; privacy-safe —
      * only the name, score, and optional label are emitted. Throws on an empty name

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -302,6 +302,7 @@ const HARNESS_SPAN_CONTEXT = { spanId: "0000000000000001", traceId: "00000000000
 const noopSpan: SpanHandle = {
     addEvent: () => undefined,
     addLink: () => undefined,
+    recordEvaluation: () => undefined,
     recordException: () => undefined,
     setAttribute: () => undefined,
     setAttributes: () => undefined,

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -21,6 +21,7 @@ import type {
     TableDefinition,
 } from "@lunora/server";
 
+import { evaluationAttributes } from "./evaluation-telemetry";
 import { createFakeScheduler } from "./fake-scheduler";
 import { createSqlExec } from "./node-sqlite";
 
@@ -331,6 +332,14 @@ const createRecordingSpan = (): { handle: SpanHandle; recorded: RecordedWideEven
         },
         addLink: (link) => {
             recorded.links.push({ spanId: link.spanId, traceId: link.traceId });
+        },
+        recordEvaluation: (evaluation) => {
+            // Merged into the recorded attributes exactly as production does, so a
+            // test asserting on `gen_ai.evaluation.<name>.score` sees the same keys
+            // the collector would. Reuses this package's own `evaluationAttributes`
+            // rather than the bundler-inlined `shared/` copy — same contract, no
+            // extra import path for the harness to carry.
+            Object.assign(recorded.attributes, evaluationAttributes(evaluation));
         },
         recordException: (error) => {
             // Mirrors the production recorder's attribute set, `exception.stacktrace`

--- a/shared/evaluation-attributes.ts
+++ b/shared/evaluation-attributes.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared, bundler-inlined builder for the OpenTelemetry `gen_ai.evaluation.*`
+ * attributes an AI **evaluation** verdict (a scorer's `{name, score, label?}`)
+ * contributes to a **generation span**.
+ *
+ * This is the emit-time counterpart of the cloud OTLP decoder, which reads
+ * `gen_ai.evaluation.<name>.score` (number) and optional
+ * `gen_ai.evaluation.<name>.label` (string) attribute pairs back off a generation
+ * span (`EVALUATION_PREFIX = "gen_ai.evaluation."`). The framework emits exactly
+ * that pair here so a score rides the same trace as the generation it grades.
+ *
+ * It lives in `shared/` because more than one layer needs the identical wire
+ * format with no runtime dependency edge between them: `@lunora/do` builds it into
+ * a live `ctx.trace` span's post-hoc attributes (`SpanHandle.recordEvaluation`),
+ * and `@lunora/server` mirrors the handle shape structurally. `@lunora/testing`
+ * ships a parallel test-time helper (`recordEvaluation` / `evaluationAttributes`)
+ * that targets the same `gen_ai.evaluation.*` contract for span-less eval
+ * events/metrics. Keep this file genuinely zero-dependency so inlining stays sound.
+ */
+
+/** The primitive an eval contributes to a span: a numeric score or a string label. */
+export type EvaluationAttributeValue = number | string;
+
+/** One eval verdict to turn into `gen_ai.evaluation.*` attributes. */
+export interface EvaluationInput {
+    /**
+     * Optional categorical label (e.g. `"pass"` / `"fail"` / a rubric bucket),
+     * emitted as the `.label` attribute. Omitted → no label attribute.
+     */
+    label?: string;
+
+    /**
+     * The scorer/evaluation name — becomes the key's name segment. Any character
+     * outside `[A-Za-z0-9._-]` is replaced with `_` so a scorer name carrying a
+     * colon (e.g. `"contains:shipped"`) still yields a well-formed attribute key.
+     */
+    name: string;
+
+    /** The numeric score (typically `[0, 1]`), emitted as the `.score` attribute. */
+    score: number;
+}
+
+/** Characters allowed unescaped in an evaluation-name key segment. */
+const SAFE_NAME_CHAR = /[\w.-]/u;
+
+/**
+ * Replace every character outside the OTEL-safe set with `_`, so a scorer name
+ * carrying a colon/space still yields a well-formed attribute key segment.
+ */
+export const sanitizeEvaluationName = (name: string): string => {
+    let out = "";
+
+    for (const char of name) {
+        out += SAFE_NAME_CHAR.test(char) ? char : "_";
+    }
+
+    return out;
+};
+
+/**
+ * Build the `gen_ai.evaluation.<name>.*` attribute bag for one eval verdict — the
+ * `.score` (number) always, the `.label` (string) when a label is given. Throws on
+ * caller misuse (empty name / non-finite score), since an ill-formed key or a
+ * `NaN`/`Infinity` score has no meaningful OTLP encoding and would poison the
+ * grade downstream.
+ */
+export const evaluationAttributes = (input: EvaluationInput): Record<string, EvaluationAttributeValue> => {
+    if (typeof input.name !== "string" || input.name.length === 0) {
+        throw new Error("recordEvaluation requires a non-empty `name`");
+    }
+
+    if (typeof input.score !== "number" || !Number.isFinite(input.score)) {
+        throw new Error("recordEvaluation `score` must be a finite number");
+    }
+
+    const key = sanitizeEvaluationName(input.name);
+    const attributes: Record<string, EvaluationAttributeValue> = { [`gen_ai.evaluation.${key}.score`]: input.score };
+
+    if (input.label !== undefined) {
+        attributes[`gen_ai.evaluation.${key}.label`] = input.label;
+    }
+
+    return attributes;
+};

--- a/shared/span-event.ts
+++ b/shared/span-event.ts
@@ -107,7 +107,6 @@ export interface SpanHandle {
      */
     recordException: (error: unknown) => void;
 
-
     /** Set one attribute on the enclosing span (merged at record time; post-hoc wins on key clash). */
     setAttribute: (key: string, value: LogFields[string]) => void;
     /** Merge attributes onto the enclosing span (post-hoc wins on key clash). */

--- a/shared/span-event.ts
+++ b/shared/span-event.ts
@@ -9,6 +9,7 @@
  * cross-package `onSpan` call structurally guaranteed rather than coincidentally
  * compatible. Keep genuinely zero-dependency so inlining stays sound.
  */
+import type { EvaluationInput } from "./evaluation-attributes";
 import type { LogFields } from "./log-fields";
 import type { OtlpSpanKind } from "./otlp";
 
@@ -85,6 +86,17 @@ export interface SpanHandle {
     addLink: (link: SpanLink) => void;
 
     /**
+     * Attach an AI **evaluation** verdict to this (generation) span as the
+     * `gen_ai.evaluation.<name>.score` / `.label` OpenTelemetry attributes, so a
+     * scorer's grade rides the same trace as the generation it graded and the
+     * collector reads it straight off the span. Convenience over
+     * {@link SpanHandle.setAttributes} that owns the key format; privacy-safe —
+     * only the name, score, and optional label are emitted, never the graded
+     * prompt or completion. Throws on an empty name or a non-finite score.
+     */
+    recordEvaluation: (evaluation: EvaluationInput) => void;
+
+    /**
      * Record a caught exception as the OTel-conventional `exception` span event
      * (`exception.type` / `exception.message` / `exception.stacktrace`).
      *
@@ -94,6 +106,7 @@ export interface SpanHandle {
      * the span body is recorded automatically and *does* set the error status.
      */
     recordException: (error: unknown) => void;
+
 
     /** Set one attribute on the enclosing span (merged at record time; post-hoc wins on key clash). */
     setAttribute: (key: string, value: LogFields[string]) => void;


### PR DESCRIPTION
Closes the last missing piece of the AI evaluation-telemetry feature: nothing in **production** code could emit `gen_ai.evaluation.*` attributes onto a generation span.

## The gap

The feature exists in three parts. Two were already merged:

| Part | Where | Status before this PR |
|---|---|---|
| Cloud decoder — reads `gen_ai.evaluation.*` off generation spans | `apps/cloud/src/telemetry/otlp.ts` (`EVALUATION_PREFIX`) | merged |
| Test-time emitter | `packages/testing/src/evaluation-telemetry.ts` | merged (alpha) |
| **Production span emitter** | `@lunora/do` + `@lunora/server` | **missing** |

Grepping alpha for `recordEvaluation` and `gen_ai.evaluation` returns hits only under `packages/testing`. So the cloud console has a decoder parsing eval attributes off real generation spans, but the only thing that ever produced them was the test harness — a scorer's grade from a real run never reached the trace.

## What this adds

`SpanHandle.recordEvaluation({ name, score, label? })` → emits `gen_ai.evaluation.<name>.score` (number) and, when given, `gen_ai.evaluation.<name>.label` (string).

- `shared/evaluation-attributes.ts` — bundler-inlined key builder, zero-dependency per the `shared/` convention. Sanitizes the name to `[A-Za-z0-9._-]` so a scorer called `contains:shipped` still yields a well-formed attribute key. Throws on an empty name or non-finite score rather than poisoning the grade downstream.
- `@lunora/do` — wired into `createSpanCollector`, so it merges in like any other post-hoc attribute and flushes over OTLP with no special casing.
- `@lunora/server` — declares `SpanEvaluation` structurally rather than importing the shared type, because `packages/server` pins `rootDir: "."` and cannot reference out-of-package files.

Privacy-safe by construction: only the name, score, and optional label are emitted — never the graded prompt or completion.

## Available on both span surfaces

Because alpha had already refactored the handle into the shared `createSpanCollector`, `recordEvaluation` lands on **both** `ctx.trace` spans and the per-dispatch wide event (`ctx.span`). The original draft only reached `ctx.trace`.

## Tests

- `@lunora/do` — the pair lands on the recorded span; non-finite score rejects.
- `@lunora/runtime` — survives OTLP encoding verbatim: an integer score encodes as `intValue: "1"`, a fractional one as `doubleValue: 0.8`, and the label as `stringValue`. This is the hop the cloud decoder depends on.
- `@lunora/testing` — the recording double records the same keys production does, so harness assertions can't pass against a narrower shape than what ships.

```
do 1253 · server 451 · testing 115 · runtime 759   all passing
tsc --noEmit  61 projects clean
eslint        clean
api:check     matches all 39 snapshots
```

## Provenance

Written against `alpha.100` and rebased ~150 commits onto current alpha. Three conflicts were genuine, not textual:

1. `SpanHandle` grew `addEvent` / `addLink` / `recordException` upstream — all kept, `recordEvaluation` inserted in alphabetical position.
2. The inline `spanHandle` literal in `context-telemetry.ts` became the `createSpanCollector` factory — the method was ported into the factory rather than either side taken verbatim.
3. `otlpSpanBody` changed to one argument returning the bare span (the `resourceSpans` envelope moved a tier up), so the runtime test was retargeted.

Split into two commits: the original work, then the adaptation, so the rebase decisions are reviewable on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recording AI evaluation results on generation/dispatch span telemetry.
  * Evaluation metric name, numeric score, and optional label are captured as standardized `gen_ai.evaluation.*` attributes.
  * Exposed a new `SpanEvaluation` type for integration use.
  * Updated the testing harness so evaluation attributes are recorded and can be asserted after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->