### PR TITLE
docs: state the client mutation-ordering boundary

### DIFF
--- a/apps/docs/src/content/docs/concepts/offline-first.mdx
+++ b/apps/docs/src/content/docs/concepts/offline-first.mdx
@@ -247,6 +247,40 @@ you writing sync glue:
    the cached reads and the queued writes rather than replaying them under the
    new identity.
 
+## Write ordering
+
+Lunora does not funnel `client.mutation` calls through a single ordered queue.
+Writes are concurrent, and the optimistic model above reconciles them by **commit
+cursor** rather than by a strict per-client sequence number — which buys the same
+gapless, no-double-count rebasing without making every write wait for the one
+before it.
+
+Three of the four ways to issue a write are ordered anyway:
+
+| How you write                                    | Ordered? | Why                                                                                                                                                              |
+| ------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `await mutation(A)`, then `await mutation(B)`    | Yes      | B isn't sent until A resolves.                                                                                                                                   |
+| Queued offline, replayed on reconnect            | Yes      | The outbox is FIFO and the flush sends its chunks sequentially, preserving submission order across the whole replay.                                             |
+| [`@lunora/db`](/docs/packages/db) mutators       | Yes      | Each write carries a monotonic `mutationId`; the DO applies it only when it equals `watermark + 1`, halts the batch on a gap, and the client resends from there. |
+| `mutation(A); mutation(B);` — online, un-awaited | **No**   | Two independent requests. The DO applies them in _arrival_ order, which can differ from call order.                                                              |
+
+Only the last row is unordered, and it only bites when those two writes are
+**causally dependent** — B assumes A has already committed. If that's your case,
+take whichever of these fits:
+
+- **Await the first.** `await mutation(A)` before issuing B. The simplest answer,
+  and the right one when B genuinely can't start until A lands.
+- **Make it one mutation.** Move both effects into a single server-side handler.
+  They then commit in one serialized transaction, which is strictly stronger than
+  ordering two calls: it's atomic, so a failure rolls back both instead of leaving
+  A applied and B rejected.
+- **Use [`@lunora/db`](/docs/packages/db) mutators.** The collection layer's outbox
+  is strictly ordered already, so a chain of fire-and-forget writes applies in call
+  order without you awaiting anything.
+
+An opt-in `{ ordered: true }` mode for plain mutations is deliberately not shipped
+— see [Design boundaries](/docs/non-goals#also-deliberately-absent).
+
 ## Surfacing rejected writes
 
 A queued write that the server ultimately rejects (a coded conflict, a validation

--- a/apps/docs/src/content/docs/non-goals.mdx
+++ b/apps/docs/src/content/docs/non-goals.mdx
@@ -144,13 +144,23 @@ requirement to unlock the framework.
 
 ## Also deliberately absent
 
-A few smaller boundaries, covered in depth on
+A few smaller boundaries, most of them covered in depth on
 [Architecture → Non-goals](/docs/architecture#non-goals):
 
 - **No external message broker** (MQTT / Pub/Sub / Redis) — real-time fan-out is
   entirely DO-based hibernatable WebSockets, so a delta never leaves the process.
 - **No OCC-retry loop on mutations** — serialized writes make a retry pointless; a
   `ConflictError` is a deterministic self-conflict, not a race.
+- **No serialized client mutation queue.** Plain `client.mutation` calls are
+  concurrent and may commit out of call order; optimistic state reconciles by
+  commit cursor instead of a per-client sequence number. Serializing a
+  general-purpose write API would cost head-of-line blocking (one slow write
+  stalls every write behind it), cap a client at one outstanding write per shard,
+  and force chain-failure semantics — a rejected A has to halt and roll back
+  everything queued behind it. Causally dependent writes have three cheaper
+  answers: await the first, combine both into one mutation, or use
+  [`@lunora/db`](/docs/packages/db) mutators, whose outbox is strictly ordered.
+  See [Write ordering](/docs/concepts/offline-first#write-ordering).
 - **No runtime enforcement of query/mutation determinism yet** — it's an advisor
   lint today, not a hard runtime guard.
 


### PR DESCRIPTION
Closes #75.

#75 recorded a deliberate divergence from Linear's sync engine: plain `client.mutation` calls stay **concurrent**, and optimistic overlays reconcile via a per-write **CDC commit cursor** rather than a serialized `clientSeq` watermark. The issue's own recommendation was *don't build `{ ordered: true }` — close the narrow gap with guidance instead.* The first half held (no `ordered` option exists anywhere in `@lunora/client` or the API snapshots); the guidance was never written.

Nothing in the docs said that un-awaited concurrent mutations can commit out of call order, or what to do about it. `non-goals.mdx` didn't cover the boundary either — its "Serialized mutations" link points at `architecture.mdx#serialized-mutations-no-occ-retry-loop`, which is DO-side serialization inside `blockConcurrencyWhile`, a different mechanism. Anyone who followed it looking for this answer landed on the wrong page.

## Changes

**`concepts/offline-first.mdx`** — new "Write ordering" section between the reconciliation model and rejected writes. Tabulates which of the four write paths are ordered:

| Path | Ordered? |
| --- | --- |
| `await mutation(A)` then `await mutation(B)` | yes — B isn't sent until A resolves |
| Queued offline, replayed on reconnect | yes — FIFO outbox, chunks flushed sequentially |
| `@lunora/db` mutators | yes — `mutationId == watermark + 1`, halt on gap, resend from there |
| `mutation(A); mutation(B);` online, un-awaited | **no** — arrival order, not call order |

…then the three answers for a causal chain: await the first, combine into one mutation (atomic, so strictly stronger than ordering two calls), or use `@lunora/db` mutators.

**`non-goals.mdx`** — a "No serialized client mutation queue" bullet carrying the cost side of the argument from #75's analysis comment: head-of-line blocking, one outstanding write per shard, and chain rollback when the head is rejected.

## Verification

Each ordering claim was checked against the implementation rather than the issue text:

- FIFO flush — `packages/client/src/lunora-client.ts`, the chunked replay loop preserving submission order (`no-await-in-loop` is annotated for exactly this reason).
- Watermark contract — `packages/do/src/ctx-db-client-watermark.ts` documents the `<= watermark` / `== watermark + 1` / `> watermark + 1` dispatch rule verbatim.
- No `ordered` option — absent from `packages/client/src` and from every `api-snapshots/*.api.md`.

`lint:doc-imports` and `prettier --check` pass. Docs-only; no package source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how client mutations are ordered and reconciled.
  * Documented which write patterns preserve ordering and which may commit out of order.
  * Added guidance for safely handling causally dependent writes.
  * Explicitly noted that the client does not use a serialized mutation queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->