### PR TITLE
fix(advisor): stop three setup lints firing where they can't be actioned

### DIFF
--- a/api-snapshots/advisor.api.md
+++ b/api-snapshots/advisor.api.md
@@ -482,6 +482,7 @@ interface AdvisorProcedureProtection {
     exportName: string;
     fanOut: boolean;
     file: string;
+    hasEmailArg?: boolean;
     kind: "action" | "mutation" | "query";
     unboundedAiGeneration: boolean;
     usesCaptcha: boolean;

--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -1087,6 +1087,7 @@ interface WranglerConfig {
     pipelines?: ReadonlyArray<{
         binding?: string;
         pipeline?: string;
+        stream?: string;
     } | null | undefined>;
     placement?: {
         mode?: string;

--- a/packages/advisor/__tests__/security-lints.test.ts
+++ b/packages/advisor/__tests__/security-lints.test.ts
@@ -131,6 +131,27 @@ describe("signup_mutation_without_disposable_gating", () => {
         expect(signupMutationWithoutDisposableGating.run({ procedureProtections: procedures, schema: schema() })).toHaveLength(0);
     });
 
+    it("ignores a user-table write that declares no email argument", () => {
+        expect.assertions(1);
+
+        // A B2B membership write (`members.add(userId, role)`) matches the
+        // user-table pattern but has no address to gate, so the lint is
+        // unactionable and must stay quiet.
+        const procedures = [procedure({ hasEmailArg: false, writesUserTable: true })];
+
+        expect(signupMutationWithoutDisposableGating.run({ procedureProtections: procedures, schema: schema() })).toHaveLength(0);
+    });
+
+    it("still flags when the feeder reports no email evidence at all", () => {
+        expect.assertions(1);
+
+        // `hasEmailArg` absent (an older feeder) must not clear the finding —
+        // the lint is fail-closed on unknown.
+        const procedures = [procedure({ hasEmailArg: undefined, writesUserTable: true })];
+
+        expect(signupMutationWithoutDisposableGating.run({ procedureProtections: procedures, schema: schema() })).toHaveLength(1);
+    });
+
     it("ignores a procedure that writes no user table, and internal procedures", () => {
         expect.assertions(2);
 

--- a/packages/advisor/src/lints/static/signup-mutation-without-disposable-gating.ts
+++ b/packages/advisor/src/lints/static/signup-mutation-without-disposable-gating.ts
@@ -15,6 +15,13 @@ import { isPublicWrite } from "../helpers";
  * lint (a CAPTCHA stops bots; the email gate stops throwaway domains — both are
  * worth having).
  *
+ * A procedure that declares **no email-shaped argument** is skipped: the gate
+ * needs a selector onto an address, so there is nothing to action. Without that
+ * check the lint fired on B2B membership writes — `members.add(userId, role)`,
+ * `organizations.create(name, slug)` — whose only tie to the user table is the
+ * word "member", and told the developer to write `email: (ctx) => ctx.args.email`
+ * for an argument that does not exist.
+ *
  * Runs only when the codegen feeder supplies protection evidence
  * (`context.procedureProtections`); a runtime caller with no evidence flags
  * nothing.
@@ -37,6 +44,16 @@ const signupMutationWithoutDisposableGating: Lint = {
 
         for (const procedure of context.procedureProtections) {
             if (!isPublicWrite(procedure) || !procedure.writesUserTable || procedure.usesEmailGate) {
+                continue;
+            }
+
+            // `emailGateMiddleware` gates an address selected off the args, so a
+            // procedure that declares none cannot action this lint — a B2B
+            // `members.add(userId, role)` or `organizations.create(name, slug)`
+            // writes a membership row with no email anywhere in sight. Only an
+            // explicit `false` skips: an older feeder leaves the field undefined,
+            // and this lint stays fail-closed on unknown.
+            if (procedure.hasEmailArg === false) {
                 continue;
             }
 

--- a/packages/advisor/src/procedure-protections.ts
+++ b/packages/advisor/src/procedure-protections.ts
@@ -16,6 +16,17 @@ export interface AdvisorProcedureProtection {
     fanOut: boolean;
     /** Source file relative to the lunora dir, no extension. */
     file: string;
+
+    /**
+     * `true` when the procedure declares an email-shaped argument. Read by the
+     * `signup_mutation_without_disposable_gating` lint: `emailGateMiddleware`
+     * gates an address selected off the args, so a procedure that never receives
+     * one cannot action the lint no matter what table it writes.
+     *
+     * Optional so a feeder predating this field (or a runtime caller) is treated
+     * as "unknown" rather than silently clearing every finding.
+     */
+    hasEmailArg?: boolean;
     /** Registration kind — `query` is read-only; `mutation`/`action` are write-shaped. */
     kind: "action" | "mutation" | "query";
     /** `true` when the handler runs an AI generation (`generateText`/`streamText`/`generateObject`/`streamObject`) with no `maxOutputTokens` bound. Read by the `ai_unbounded_generation_public` lint (paired with public visibility). */

--- a/packages/codegen/__tests__/discover-procedure-middleware.test.ts
+++ b/packages/codegen/__tests__/discover-procedure-middleware.test.ts
@@ -50,6 +50,60 @@ const NO_EMAIL_ARG_MEMBER_ADD = `${PREAMBLE}
         });
 `;
 
+/** Shorthand `{ email }` — the property is a ShorthandPropertyAssignment, not an assignment. */
+const SHORTHAND_EMAIL_SIGNUP = `${PREAMBLE}
+    declare const email: unknown;
+
+    export const signUp = c.mutation
+        .input({ email })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
+/** \`.input(sharedSchema)\` — the arg list is a reference, so its keys are unreadable. */
+const OPAQUE_INPUT_SIGNUP = `${PREAMBLE}
+    declare const sharedSchema: Record<string, unknown>;
+
+    export const signUp = c.mutation
+        .input(sharedSchema)
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
+/** A spread inside the input literal — the remaining keys are unenumerable. */
+const SPREAD_INPUT_SIGNUP = `${PREAMBLE}
+    declare const shared: Record<string, unknown>;
+
+    export const signUp = c.mutation
+        .input({ ...shared, name: v.string() })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
+/** Names that merely start with "email" but hold a flag/id, not an address. */
+const EMAIL_LOOKALIKE_ARGS = `${PREAMBLE}
+    export const update = c.mutation
+        .input({ emailOptIn: v.string(), emailTemplateId: v.string(), emailVerified: v.string() })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
+/** A bare-factory registration whose \`args\` declares an email. */
+const FACTORY_EMAIL_SIGNUP = `
+    import { mutation } from "@lunora/server";
+
+    export const signUp = mutation({
+        args: { email: 1 },
+        handler: async (ctx) => {
+            await ctx.db.insert("users", {});
+        },
+    });
+`;
+
 /** A bare-factory mutation that writes the user table — public, no protections. */
 const BARE_SIGNUP = `
     import { mutation } from "@lunora/server";
@@ -220,6 +274,62 @@ describe("discoverProcedureMiddleware", () => {
         const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
 
         expect(found[0]).toMatchObject({ exportName: "signUp", hasEmailArg: true, writesUserTable: true });
+    });
+
+    it("flags a shorthand `{ email }` input argument", () => {
+        expect.assertions(1);
+
+        // A ShorthandPropertyAssignment, not a PropertyAssignment — reading only
+        // the latter would report "no email" and silently clear the signup lint.
+        writeFileSync(join(workdir, "lunora", "signup.ts"), SHORTHAND_EMAIL_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]).toMatchObject({ exportName: "signUp", hasEmailArg: true });
+    });
+
+    it("flags an email argument declared on a bare-factory `args`", () => {
+        expect.assertions(1);
+
+        writeFileSync(join(workdir, "lunora", "signup.ts"), FACTORY_EMAIL_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]).toMatchObject({ exportName: "signUp", hasEmailArg: true });
+    });
+
+    it("leaves the email verdict unknown for a non-literal `.input(schema)`", () => {
+        expect.assertions(1);
+
+        // Unreadable keys must stay unknown: reporting `false` would clear the
+        // signup lint on a registration that may well expose an email.
+        writeFileSync(join(workdir, "lunora", "signup.ts"), OPAQUE_INPUT_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]?.hasEmailArg).toBeUndefined();
+    });
+
+    it("leaves the email verdict unknown when the input literal carries a spread", () => {
+        expect.assertions(1);
+
+        writeFileSync(join(workdir, "lunora", "signup.ts"), SPREAD_INPUT_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]?.hasEmailArg).toBeUndefined();
+    });
+
+    it("does not treat `emailVerified` / `emailOptIn` / `emailTemplateId` as an address", () => {
+        expect.assertions(1);
+
+        // These hold a flag or an id — there is no address for the gate to select,
+        // so matching them would resurrect the false positive on the other side.
+        writeFileSync(join(workdir, "lunora", "update.ts"), EMAIL_LOOKALIKE_ARGS, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]).toMatchObject({ exportName: "update", hasEmailArg: false });
     });
 
     it("reports no email argument for a membership write that never receives one", () => {

--- a/packages/codegen/__tests__/discover-procedure-middleware.test.ts
+++ b/packages/codegen/__tests__/discover-procedure-middleware.test.ts
@@ -20,13 +20,34 @@ const PREAMBLE = `
     declare const protectPublic: (options: { rateLimit?: unknown; captcha?: unknown }) => (options: { ctx: unknown }) => unknown;
     declare const mutation: <R>(config: { args: Record<string, unknown>; handler: (ctx: unknown) => R }) => { kind: "mutation" };
 
+    declare const v: { id: (table: string) => unknown; string: () => unknown };
+
     interface MutationBuilder<Args> {
         readonly __lunoraProcedure: "mutation";
         use: <C>(middleware: (options: { ctx: unknown }) => C) => MutationBuilder<Args>;
+        input: <A>(args: A) => MutationBuilder<A>;
         mutation: <R>(handler: (options: { args: Args; ctx: { db: { insert: (table: string, value: unknown) => Promise<void> }; mail: { send: (m: unknown) => Promise<void> } } }) => R) => { kind: "mutation" };
     }
 
     declare const c: { mutation: MutationBuilder<Record<never, never>> };
+`;
+
+/** A builder-form user-table write whose input carries an email — the gate is actionable. */
+const EMAIL_ARG_SIGNUP = `${PREAMBLE}
+    export const signUp = c.mutation
+        .input({ email: v.string() })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("users", {});
+        });
+`;
+
+/** The B2B shape: a membership write whose input has no email anywhere. */
+const NO_EMAIL_ARG_MEMBER_ADD = `${PREAMBLE}
+    export const add = c.mutation
+        .input({ organizationId: v.id("organizations"), userId: v.string() })
+        .mutation(async ({ ctx }) => {
+            await ctx.db.insert("members", {});
+        });
 `;
 
 /** A bare-factory mutation that writes the user table — public, no protections. */
@@ -189,6 +210,29 @@ describe("discoverProcedureMiddleware", () => {
             visibility: "public",
             writesUserTable: true,
         });
+    });
+
+    it("flags an email-shaped input argument", () => {
+        expect.assertions(1);
+
+        writeFileSync(join(workdir, "lunora", "signup.ts"), EMAIL_ARG_SIGNUP, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]).toMatchObject({ exportName: "signUp", hasEmailArg: true, writesUserTable: true });
+    });
+
+    it("reports no email argument for a membership write that never receives one", () => {
+        expect.assertions(1);
+
+        // The B2B false positive `signup_mutation_without_disposable_gating` used
+        // to hit: "members" matches the user-table pattern, but there is no
+        // address for `emailGateMiddleware` to select.
+        writeFileSync(join(workdir, "lunora", "members.ts"), NO_EMAIL_ARG_MEMBER_ADD, "utf8");
+
+        const found = discoverProcedureMiddleware(project, join(workdir, "lunora"));
+
+        expect(found[0]).toMatchObject({ exportName: "add", hasEmailArg: false, writesUserTable: true });
     });
 
     it("records a scheduler fan-out from a public mutation", () => {

--- a/packages/codegen/src/discover-argument-validators.ts
+++ b/packages/codegen/src/discover-argument-validators.ts
@@ -1,8 +1,9 @@
-import type { CallExpression, Node as TsNode, ObjectLiteralExpression, Project, SourceFile, VariableDeclaration } from "ts-morph";
+import type { ObjectLiteralExpression, Project, SourceFile, VariableDeclaration } from "ts-morph";
 import { Node } from "ts-morph";
 
 import { classifyProcedureCall, listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { ArgumentValidatorIR } from "./ir";
+import { procedureArgumentObjects } from "./procedure-argument-objects";
 
 /** A constraint fragment that bounds a string's length — its presence means the arg is *not* unbounded. */
 const BOUND_RE = /\.check\(|\.meta\(|length|max/iu;
@@ -16,51 +17,6 @@ const isAnyValidator = (text: string): boolean => ANY_VALIDATOR_RE.test(text);
 
 /** True for a `v.string()` validator (possibly `v.optional(v.string())`) with no length/max bound. */
 const isUnboundedString = (text: string): boolean => STRING_VALIDATOR_RE.test(text) && !BOUND_RE.test(text);
-
-/** The `args:` object literal of a bare-factory `query({ args, handler })` call, when present. */
-const argsObjectOfFactory = (call: CallExpression): ObjectLiteralExpression | undefined => {
-    const first = call.getArguments()[0];
-
-    if (!first || !Node.isObjectLiteralExpression(first)) {
-        return undefined;
-    }
-
-    const argsProperty = first.getProperty("args");
-
-    if (!argsProperty || !Node.isPropertyAssignment(argsProperty)) {
-        return undefined;
-    }
-
-    const initializer = argsProperty.getInitializer();
-
-    return initializer && Node.isObjectLiteralExpression(initializer) ? initializer : undefined;
-};
-
-/** Every `.input({...})` object literal walked leftward out of a builder chain. */
-const inputObjectsInChain = (receiver: TsNode): ObjectLiteralExpression[] => {
-    const objects: ObjectLiteralExpression[] = [];
-    let node: TsNode = receiver;
-
-    while (Node.isCallExpression(node)) {
-        const chainCallee = node.getExpression();
-
-        if (!Node.isPropertyAccessExpression(chainCallee)) {
-            break;
-        }
-
-        if (chainCallee.getName() === "input") {
-            const argument = node.getArguments()[0];
-
-            if (argument && Node.isObjectLiteralExpression(argument)) {
-                objects.push(argument);
-            }
-        }
-
-        node = chainCallee.getExpression();
-    }
-
-    return objects;
-};
 
 /** Classify every arg property across the given object literals into any-typed and unbounded-string buckets. */
 const classifyArgs = (objects: ReadonlyArray<ObjectLiteralExpression>): { anyArgs: string[]; unboundedStringArgs: string[] } => {
@@ -109,9 +65,7 @@ const argumentValidatorIrFromDeclaration = (declaration: VariableDeclaration, re
         return undefined;
     }
 
-    const objects = classified.receiver
-        ? inputObjectsInChain(classified.receiver)
-        : [argsObjectOfFactory(initializer)].filter((object): object is ObjectLiteralExpression => object !== undefined);
+    const { objects } = procedureArgumentObjects(initializer, classified.receiver);
 
     const { anyArgs, unboundedStringArgs } = classifyArgs(objects);
 

--- a/packages/codegen/src/discover-procedure-middleware.ts
+++ b/packages/codegen/src/discover-procedure-middleware.ts
@@ -1,8 +1,9 @@
-import type { CallExpression, Node as TsNode, ObjectLiteralExpression, Project, SourceFile, VariableDeclaration } from "ts-morph";
+import type { CallExpression, Node as TsNode, Project, SourceFile, VariableDeclaration } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
 import { classifyProcedureCall, listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { ProcedureMiddlewareIR } from "./ir";
+import { argumentNames, procedureArgumentObjects } from "./procedure-argument-objects";
 
 /**
  * Middleware factory names mapped to the protection flag they set. Matched by the
@@ -24,49 +25,41 @@ const MIDDLEWARE_FLAGS: Record<string, "usesCaptcha" | "usesEmailGate" | "usesMa
 const USER_TABLE_RE = /account|credential|member|passkey|session|user/iu;
 
 /**
- * Argument names that carry an email address. Matched against the keys of the
- * builder's `.input({...})` literals so `signup_mutation_without_disposable_gating`
- * only fires where there is actually an address to gate — `emailGateMiddleware`
- * needs a selector onto one, so a procedure that never receives an email cannot
- * action that lint.
+ * True for an argument name that carries an email **address**.
+ *
+ * Separators are folded away and the name is matched on its terminal word, so
+ * `email`, `e_mail`, `userEmail`, `billing_contact_email` and `emailAddress` all
+ * count, while `emailVerified`, `emailOptIn` and `emailTemplateId` — which hold a
+ * flag or an id, not an address `emailGateMiddleware` could select — do not.
+ * Folding first (rather than one regex) keeps snake_case, kebab-case and
+ * camelCase on the same path without a nested quantifier.
  */
-const EMAIL_ARG_RE = /^(?:.*_)?e-?mail(?:_?address)?$|email/iu;
+const isEmailArgumentName = (name: string): boolean => {
+    const folded = name.replaceAll(/[^a-z0-9]/giu, "").toLowerCase();
 
-/** Every `.input({...})` object literal walked leftward out of a builder chain. */
-const inputObjectsInChain = (receiver: TsNode): ObjectLiteralExpression[] => {
-    const objects: ObjectLiteralExpression[] = [];
-    let node: TsNode = receiver;
-
-    while (Node.isCallExpression(node)) {
-        const chainCallee = node.getExpression();
-
-        if (!Node.isPropertyAccessExpression(chainCallee)) {
-            break;
-        }
-
-        if (chainCallee.getName() === "input") {
-            const argument = node.getArguments()[0];
-
-            if (argument && Node.isObjectLiteralExpression(argument)) {
-                objects.push(argument);
-            }
-        }
-
-        node = chainCallee.getExpression();
-    }
-
-    return objects;
+    return folded.endsWith("email") || folded.endsWith("emailaddress");
 };
 
-/** True when any `.input({...})` in the chain declares an email-shaped argument. */
-const declaresEmailArgument = (receiver: TsNode | undefined): boolean => {
-    if (!receiver) {
-        return false;
+/**
+ * Whether the procedure declares an email-shaped argument, or `undefined` when
+ * its argument list can't be read statically (`.input(sharedSchema)`, a spread,
+ * or a factory whose `args` comes from a variable).
+ *
+ * Tri-state on purpose. This feeds `signup_mutation_without_disposable_gating`,
+ * which skips a procedure known to take no email — so collapsing "unreadable"
+ * into `false` would silently clear the lint on a registration that may well
+ * expose one. Unknown stays unknown and the lint keeps firing.
+ */
+const declaresEmailArgument = (call: CallExpression, receiver: TsNode | undefined): boolean | undefined => {
+    const { objects, opaque } = procedureArgumentObjects(call, receiver);
+
+    // A definite hit wins over opacity: finding the argument is enough, whatever
+    // else the declaration hides.
+    if (argumentNames(objects).some((name) => isEmailArgumentName(name))) {
+        return true;
     }
 
-    return inputObjectsInChain(receiver).some((object) =>
-        object.getProperties().some((property) => Node.isPropertyAssignment(property) && EMAIL_ARG_RE.test(property.getName())),
-    );
+    return opaque ? undefined : false;
 };
 
 /** The set of protections a builder chain carries. */
@@ -379,7 +372,7 @@ const middlewareIrFromDeclaration = (declaration: VariableDeclaration, relativeP
         exportName: declaration.getName(),
         fanOut,
         file: relativePath,
-        hasEmailArg: declaresEmailArgument(classified.receiver),
+        hasEmailArg: declaresEmailArgument(initializer, classified.receiver),
         kind: classified.kind,
         unboundedAiGeneration,
         usesCaptcha: protections.usesCaptcha,

--- a/packages/codegen/src/discover-procedure-middleware.ts
+++ b/packages/codegen/src/discover-procedure-middleware.ts
@@ -1,4 +1,4 @@
-import type { CallExpression, Node as TsNode, Project, SourceFile, VariableDeclaration } from "ts-morph";
+import type { CallExpression, Node as TsNode, ObjectLiteralExpression, Project, SourceFile, VariableDeclaration } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
 import { classifyProcedureCall, listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
@@ -22,6 +22,52 @@ const MIDDLEWARE_FLAGS: Record<string, "usesCaptcha" | "usesEmailGate" | "usesMa
 
 /** Tables whose insert marks a procedure as user/session-creating (captcha-expected). */
 const USER_TABLE_RE = /account|credential|member|passkey|session|user/iu;
+
+/**
+ * Argument names that carry an email address. Matched against the keys of the
+ * builder's `.input({...})` literals so `signup_mutation_without_disposable_gating`
+ * only fires where there is actually an address to gate — `emailGateMiddleware`
+ * needs a selector onto one, so a procedure that never receives an email cannot
+ * action that lint.
+ */
+const EMAIL_ARG_RE = /^(?:.*_)?e-?mail(?:_?address)?$|email/iu;
+
+/** Every `.input({...})` object literal walked leftward out of a builder chain. */
+const inputObjectsInChain = (receiver: TsNode): ObjectLiteralExpression[] => {
+    const objects: ObjectLiteralExpression[] = [];
+    let node: TsNode = receiver;
+
+    while (Node.isCallExpression(node)) {
+        const chainCallee = node.getExpression();
+
+        if (!Node.isPropertyAccessExpression(chainCallee)) {
+            break;
+        }
+
+        if (chainCallee.getName() === "input") {
+            const argument = node.getArguments()[0];
+
+            if (argument && Node.isObjectLiteralExpression(argument)) {
+                objects.push(argument);
+            }
+        }
+
+        node = chainCallee.getExpression();
+    }
+
+    return objects;
+};
+
+/** True when any `.input({...})` in the chain declares an email-shaped argument. */
+const declaresEmailArgument = (receiver: TsNode | undefined): boolean => {
+    if (!receiver) {
+        return false;
+    }
+
+    return inputObjectsInChain(receiver).some((object) =>
+        object.getProperties().some((property) => Node.isPropertyAssignment(property) && EMAIL_ARG_RE.test(property.getName())),
+    );
+};
 
 /** The set of protections a builder chain carries. */
 interface Protections {
@@ -333,6 +379,7 @@ const middlewareIrFromDeclaration = (declaration: VariableDeclaration, relativeP
         exportName: declaration.getName(),
         fanOut,
         file: relativePath,
+        hasEmailArg: declaresEmailArgument(classified.receiver),
         kind: classified.kind,
         unboundedAiGeneration,
         usesCaptcha: protections.usesCaptcha,

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -1020,8 +1020,18 @@ export interface ProcedureMiddlewareIR {
     fanOut: boolean;
     /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
     file: string;
-    /** `true` when the procedure declares an email-shaped argument (`email`, `emailAddress`, `userEmail`, …). Feeds `signup_mutation_without_disposable_gating`, which can only be actioned when there is an address to gate. */
-    hasEmailArg: boolean;
+
+    /**
+     * `true` when the procedure declares an email-shaped argument (`email`,
+     * `emailAddress`, `userEmail`, …), `false` when it provably declares none,
+     * and **absent** when the argument list can't be read statically (a
+     * `.input(sharedSchema)`, a spread, or a factory whose `args` comes from a
+     * variable). Feeds `signup_mutation_without_disposable_gating`, which can
+     * only be actioned when there is an address to gate — so "unreadable" must
+     * stay distinguishable from "none", or the lint would clear itself on a
+     * registration that may well expose one.
+     */
+    hasEmailArg?: boolean;
     /** Registration kind — only `mutation`/`action` are write-shaped; `query` is read-only. */
     kind: "action" | "mutation" | "query";
     /** `true` when the handler runs an AI generation (`generateText`/`streamText`/`generateObject`/`streamObject`) with no `maxOutputTokens` bound in its config literal. Feeds the `ai_unbounded_generation_public` lint. */

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -1020,6 +1020,8 @@ export interface ProcedureMiddlewareIR {
     fanOut: boolean;
     /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
     file: string;
+    /** `true` when the procedure declares an email-shaped argument (`email`, `emailAddress`, `userEmail`, …). Feeds `signup_mutation_without_disposable_gating`, which can only be actioned when there is an address to gate. */
+    hasEmailArg: boolean;
     /** Registration kind — only `mutation`/`action` are write-shaped; `query` is read-only. */
     kind: "action" | "mutation" | "query";
     /** `true` when the handler runs an AI generation (`generateText`/`streamText`/`generateObject`/`streamObject`) with no `maxOutputTokens` bound in its config literal. Feeds the `ai_unbounded_generation_public` lint. */

--- a/packages/codegen/src/procedure-argument-objects.ts
+++ b/packages/codegen/src/procedure-argument-objects.ts
@@ -1,0 +1,109 @@
+import type { CallExpression, Node as TsNode, ObjectLiteralExpression } from "ts-morph";
+import { Node } from "ts-morph";
+
+/**
+ * The argument declarations of one procedure, as read off its registration.
+ *
+ * Both registration forms are covered: the builder chain's `.input({...})` steps
+ * and a bare factory's `args:` property. `opaque` records that some declaration
+ * could not be read statically — a `.input(schema)` naming a shared validator, an
+ * `args` initialised from a variable, or a `{ ...spread }` inside the literal.
+ * Callers that gate a security lint on "this procedure has no such argument" must
+ * treat `opaque` as unknown rather than as absence.
+ */
+interface ProcedureArgumentObjects {
+    /** Every statically-readable object literal declaring args. */
+    objects: ObjectLiteralExpression[];
+    /** `true` when at least one declaration could not be read (non-literal, or spread-bearing). */
+    opaque: boolean;
+}
+
+/** True for an object literal carrying a `...spread` — its keys are not fully enumerable. */
+const hasSpread = (object: ObjectLiteralExpression): boolean => object.getProperties().some((property) => Node.isSpreadAssignment(property));
+
+/**
+ * The `args:` object literal of a bare-factory `query({ args, handler })` call.
+ * Returns `opaque` when the call carries an `args` property that isn't a literal
+ * (so its keys are unknown), and a plain empty result when it declares none.
+ */
+const argumentsOfFactory = (call: CallExpression): ProcedureArgumentObjects => {
+    const first = call.getArguments()[0];
+
+    if (!first || !Node.isObjectLiteralExpression(first)) {
+        return { objects: [], opaque: true };
+    }
+
+    const argumentsProperty = first.getProperty("args");
+
+    if (!argumentsProperty) {
+        return { objects: [], opaque: false };
+    }
+
+    if (!Node.isPropertyAssignment(argumentsProperty)) {
+        return { objects: [], opaque: true };
+    }
+
+    const initializer = argumentsProperty.getInitializer();
+
+    if (!initializer || !Node.isObjectLiteralExpression(initializer)) {
+        return { objects: [], opaque: true };
+    }
+
+    return { objects: [initializer], opaque: hasSpread(initializer) };
+};
+
+/**
+ * Every `.input({...})` object literal walked leftward out of a builder chain.
+ * A `.input(x)` whose argument is not an object literal marks the result opaque.
+ */
+const argumentsInChain = (receiver: TsNode): ProcedureArgumentObjects => {
+    const objects: ObjectLiteralExpression[] = [];
+    let opaque = false;
+    let node: TsNode = receiver;
+
+    while (Node.isCallExpression(node)) {
+        const chainCallee = node.getExpression();
+
+        if (!Node.isPropertyAccessExpression(chainCallee)) {
+            break;
+        }
+
+        if (chainCallee.getName() === "input") {
+            const argument = node.getArguments()[0];
+
+            if (argument && Node.isObjectLiteralExpression(argument)) {
+                objects.push(argument);
+                opaque ||= hasSpread(argument);
+            } else {
+                opaque = true;
+            }
+        }
+
+        node = chainCallee.getExpression();
+    }
+
+    return { objects, opaque };
+};
+
+/**
+ * Read a procedure's argument declarations from whichever registration form it
+ * uses: the builder chain when `receiver` is present, else the bare factory call.
+ */
+const procedureArgumentObjects = (call: CallExpression, receiver: TsNode | undefined): ProcedureArgumentObjects =>
+    receiver ? argumentsInChain(receiver) : argumentsOfFactory(call);
+
+/**
+ * The declared argument names across `objects`. Covers both `email: v.string()`
+ * (a property assignment) and the `{ email }` shorthand — missing the latter is
+ * how a "does this procedure take an X?" check silently answers no.
+ */
+const argumentNames = (objects: ReadonlyArray<ObjectLiteralExpression>): string[] =>
+    objects.flatMap((object) =>
+        object
+            .getProperties()
+            .filter((property) => Node.isPropertyAssignment(property) || Node.isShorthandPropertyAssignment(property))
+            .map((property) => (property as { getName: () => string }).getName()),
+    );
+
+export type { ProcedureArgumentObjects };
+export { argumentNames, procedureArgumentObjects };

--- a/packages/config/__tests__/reconcile-bindings.test.ts
+++ b/packages/config/__tests__/reconcile-bindings.test.ts
@@ -260,6 +260,32 @@ describe("reconcileWranglerBindings", () => {
         expect(readConfig().durable_objects.bindings.map((binding: { name: string }) => binding.name)).toEqual(["SHARD"]);
     });
 
+    it("suppresses the payment reminder once any provider's secret pair is set in .dev.vars", () => {
+        expect.assertions(2);
+
+        // Creem, not Stripe — the reminder must clear for every supported adapter,
+        // not just the two it used to name.
+        const devVars = ["CREEM_API_KEY=set", "CREEM_WEBHOOK_SECRET=set", ""].join("\n");
+
+        writeFileSync(join(root, ".dev.vars"), devVars);
+
+        const result = reconcileWranglerBindings(root, baseInferred({ usesPayment: true }));
+
+        expect(result.warnings.join(" ")).not.toMatch(/@lunora\/payment is used/u);
+        expect(result.changed).toBe(false);
+    });
+
+    it("still reminds when .dev.vars declares a provider key with an empty value", () => {
+        expect.assertions(1);
+
+        // A scaffolded-but-unfilled pair is not configured.
+        writeFileSync(join(root, ".dev.vars"), "CREEM_API_KEY=\nCREEM_WEBHOOK_SECRET=\n");
+
+        const result = reconcileWranglerBindings(root, baseInferred({ usesPayment: true }));
+
+        expect(result.warnings.join(" ")).toMatch(/@lunora\/payment is used/u);
+    });
+
     it("reminds to add a recipient [vars] entry when @lunora/x402/charge is used, without writing a binding", () => {
         expect.assertions(2);
 

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -953,6 +953,17 @@ describe("wrangler-validator", () => {
             expect(missingBinding.errors.join(" ")).toContain('must have a non-empty "binding"');
         });
 
+        it("accepts `stream`, wrangler's rename of the deprecated `pipeline` field, without warning", () => {
+            expect.assertions(2);
+
+            // wrangler deprecation-warns on `pipeline`, so a correctly-wired binding
+            // now spells it `stream`; that must not trip the missing-hint warning.
+            const stream = validateWranglerConfig(validBase({ pipelines: [{ binding: "PIPE", stream: "events" }] }));
+
+            expect(stream.valid).toBe(true);
+            expect(stream.warnings.join(" ")).not.toMatch(/wrangler pipelines create/u);
+        });
+
         it("accepts a well-formed analytics_engine_datasets binding; warns on a missing dataset; errors on a missing binding", () => {
             expect.assertions(3);
 

--- a/packages/config/src/reconcile-bindings.ts
+++ b/packages/config/src/reconcile-bindings.ts
@@ -14,10 +14,12 @@
  * exported — are returned as warnings rather than written, since a binding
  * referencing an unexported class would make `wrangler deploy` fail.
  */
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { containerBuildTag } from "@lunora/container";
 
+import { DEV_VARS_FILE, parseDevVariableEntries } from "./dev-variables-format";
 import type { DurableObjectSpec, InferredAgent, InferredBindings, InferredContainer, InferredQueue, InferredWorkflow } from "./infer-bindings";
 import { applyModify } from "./jsonc-edit";
 import { findWranglerFile, readWranglerJsonc } from "./wrangler-path";
@@ -87,7 +89,7 @@ interface WranglerShape {
     name?: string;
     observability?: { enabled?: boolean; head_sampling_rate?: number; logs?: { enabled?: boolean; head_sampling_rate?: number } };
     // Hint-only: the `pipeline` name is a remote resource Lunora can't mint — warned, never written.
-    pipelines?: ReadonlyArray<{ binding?: string; pipeline?: string }>;
+    pipelines?: ReadonlyArray<{ binding?: string; pipeline?: string; stream?: string }>;
     // Cloudflare Queues — producers + consumers, both reconciled from `lunora/queues.ts`.
     queues?: QueuesShape;
     r2_buckets?: ReadonlyArray<{ binding?: string }>;
@@ -256,7 +258,46 @@ const unexportedDeclarationWarnings = (
  *
  * Storage is silent once any `r2_buckets` binding exists (lunora can't pick the bucket name, but if one is already declared there's nothing to add). Auth is silent once sessions have a store — a `DB` D1 binding (the default, D1-backed) or an exported `SessionDO` (DO-backed); only a project with neither has nowhere to put sessions, so only that case warns. Scheduler keys on the `SchedulerDO` export, the safe binding signal. Payment has no binding at all — state rides the app's existing `ShardDO` via `ctx.db`; its only need is the provider secret pair, which lives in `.dev.vars` (not `wrangler.jsonc`), so the reminder fires whenever payment is used and nothing here can confirm it away.
  */
-const collectWarnings = (inferred: InferredBindings, parsed?: WranglerShape): string[] => {
+
+/**
+ * Every `@lunora/payment` provider adapter and the `.dev.vars` secret pair that
+ * configures it. Mirrors the `@lunora/payment` entry in
+ * `package-secrets-registry.ts` and the adapters under
+ * `packages/payment/src/providers/` — a provider is "configured" when **both**
+ * of its keys carry a non-empty value.
+ */
+const PAYMENT_PROVIDER_SECRETS: ReadonlyArray<{ keys: readonly [string, string]; label: string }> = [
+    { keys: ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"], label: "Stripe" },
+    { keys: ["POLAR_ACCESS_TOKEN", "POLAR_WEBHOOK_SECRET"], label: "Polar" },
+    { keys: ["CREEM_API_KEY", "CREEM_WEBHOOK_SECRET"], label: "Creem" },
+    { keys: ["AUTUMN_SECRET_KEY", "AUTUMN_WEBHOOK_SECRET"], label: "Autumn" },
+    { keys: ["DODO_PAYMENTS_API_KEY", "DODO_PAYMENTS_WEBHOOK_KEY"], label: "Dodo Payments" },
+];
+
+/** Render the provider list for the reminder, e.g. `STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET (Stripe) or …`. */
+const describePaymentProviders = (): string => PAYMENT_PROVIDER_SECRETS.map(({ keys, label }) => `${keys[0]} + ${keys[1]} (${label})`).join(" or ");
+
+/**
+ * True when `.dev.vars` already carries a complete secret pair for any supported
+ * payment provider — the reminder is then noise, so it is suppressed. A missing
+ * or unreadable `.dev.vars` counts as unconfigured (warn), which is the safe
+ * direction for a setup hint.
+ */
+const hasConfiguredPaymentProvider = (projectRoot: string): boolean => {
+    let content: string;
+
+    try {
+        content = readFileSync(join(projectRoot, DEV_VARS_FILE), "utf8");
+    } catch {
+        return false;
+    }
+
+    const values = new Map(parseDevVariableEntries(content).map((entry) => [entry.key, entry.value]));
+
+    return PAYMENT_PROVIDER_SECRETS.some(({ keys }) => keys.every((key) => (values.get(key) ?? "") !== ""));
+};
+
+const collectWarnings = (inferred: InferredBindings, projectRoot: string, parsed?: WranglerShape): string[] => {
     const exported = new Set(inferred.durableObjects.map((object) => object.className));
     const warnings: string[] = [];
 
@@ -294,14 +335,13 @@ const collectWarnings = (inferred: InferredBindings, parsed?: WranglerShape): st
         warnings.push("containers are declared but observability is explicitly disabled in wrangler.jsonc — container logs will not be captured.");
     }
 
-    if (inferred.usesPayment) {
+    if (inferred.usesPayment && !hasConfiguredPaymentProvider(projectRoot)) {
         // Payment state rides the app's existing ShardDO via ctx.db, so there is
         // no wrangler binding to provision — only the provider secrets, which
         // live in .dev.vars (not wrangler.jsonc) and the scaffolder can't
-        // fabricate. We always remind, since wrangler.jsonc can't confirm them.
-        warnings.push(
-            "@lunora/payment is used; set the provider secrets in .dev.vars — STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET (Stripe) or POLAR_ACCESS_TOKEN + POLAR_WEBHOOK_SECRET (Polar).",
-        );
+        // fabricate. Unlike the binding hints there is nothing in wrangler.jsonc
+        // to confirm against, so this reads .dev.vars directly.
+        warnings.push(`@lunora/payment is used; set one provider's secret pair in .dev.vars — ${describePaymentProviders()}.`);
     }
 
     warnings.push(...collectX402Warnings(inferred), ...collectHintBindingWarnings(inferred, parsed));
@@ -655,17 +695,24 @@ const reconcileWranglerBindings = (projectRoot: string, inferred: InferredBindin
 
     if (!wranglerPath) {
         // No config to inspect — emit the raw capability hints unfiltered.
-        return { added: [], changed: false, exportGaps, reason: "wrangler.jsonc not found", warnings: collectWarnings(inferred) };
+        return { added: [], changed: false, exportGaps, reason: "wrangler.jsonc not found", warnings: collectWarnings(inferred, projectRoot) };
     }
 
     const { parsed, text: original } = readWranglerJsonc<WranglerShape>(wranglerPath);
 
     if (parsed === undefined) {
-        return { added: [], changed: false, exportGaps, reason: `failed to parse ${wranglerPath} as JSONC`, warnings: collectWarnings(inferred), wranglerPath };
+        return {
+            added: [],
+            changed: false,
+            exportGaps,
+            reason: `failed to parse ${wranglerPath} as JSONC`,
+            warnings: collectWarnings(inferred, projectRoot),
+            wranglerPath,
+        };
     }
 
     // Hints are filtered against the existing config so a wired-up project is quiet.
-    const warnings = collectWarnings(inferred, parsed);
+    const warnings = collectWarnings(inferred, projectRoot, parsed);
 
     // Only exported container classes are provisionable — wrangler rejects a
     // class_name the worker doesn't export. Their DO bindings + migration

--- a/packages/config/src/wrangler-validator.ts
+++ b/packages/config/src/wrangler-validator.ts
@@ -134,7 +134,7 @@ interface WranglerConfig {
     // Pipelines (R2-backed streaming ingestion). The `pipeline` name is a remote
     // resource (`wrangler pipelines create`) Lunora can't mint — warn, don't
     // fail. See `validatePipelineBindings`.
-    pipelines?: ReadonlyArray<{ binding?: string; pipeline?: string } | null | undefined>;
+    pipelines?: ReadonlyArray<{ binding?: string; pipeline?: string; stream?: string } | null | undefined>;
     // Smart Placement (`{ mode: "smart" }` — the only documented mode). See
     // `validatePlacement`.
     placement?: { mode?: string };
@@ -555,11 +555,14 @@ const HINT_BINDING_RULES = [
         key: "hyperdrive",
     },
     {
-        arrayMessage: "pipelines must be an array of { binding, pipeline } entries",
+        arrayMessage: "pipelines must be an array of { binding, stream } entries",
         bindingMessage: (label: string) => `${label} must have a non-empty "binding" naming the Pipelines binding`,
-        hintField: "pipeline",
+        // wrangler renamed `pipeline` → `stream` and now deprecation-warns on the
+        // old spelling; accept both so neither wrangler nor this validator is the
+        // one complaining about a correctly-wired binding.
+        hintField: ["stream", "pipeline"],
         hintMessage: (label: string, binding: string) =>
-            `${label} ("${binding}") has no "pipeline" — run \`wrangler pipelines create <name>\` and set the pipeline name, or the binding can't resolve`,
+            `${label} ("${binding}") has no "stream" — run \`wrangler pipelines create <name>\` and set the stream name, or the binding can't resolve`,
         key: "pipelines",
     },
     {
@@ -573,7 +576,8 @@ const HINT_BINDING_RULES = [
 ] as const satisfies ReadonlyArray<{
     arrayMessage: string;
     bindingMessage: (label: string) => string;
-    hintField: string;
+    /** Field carrying the un-mintable remote id, or every accepted spelling of it. */
+    hintField: ReadonlyArray<string> | string;
     hintMessage: (label: string, binding: string) => string;
     key: keyof WranglerConfig;
 }>;
@@ -605,7 +609,13 @@ const validateHintBinding = (wrangler: WranglerConfig, rule: (typeof HINT_BINDIN
             continue;
         }
 
-        if (!isNonEmptyString(entry[rule.hintField])) {
+        // `hintField` may name several accepted spellings — a field wrangler has
+        // renamed still satisfies the rule under its old name (see `pipelines`).
+        // Narrowed with `typeof`, not `Array.isArray`: the latter widens a
+        // `ReadonlyArray<string> | string` union to `any[]`.
+        const hintFields = typeof rule.hintField === "string" ? [rule.hintField] : rule.hintField;
+
+        if (!hintFields.some((field) => isNonEmptyString(entry[field]))) {
             warnings.push(rule.hintMessage(label, entry.binding));
         }
     }


### PR DESCRIPTION
Found while dogfooding the advisors against a real control-plane app. Three diagnostics fired on correctly-wired code, so the only way to clear them was to make the app wrong.

## 1. `signup_mutation_without_disposable_gating` demanded a gate on procedures with no email

The lint keyed on `writesUserTable` alone and never checked that the procedure actually receives an address. `emailGateMiddleware` gates an email selected off the args, so on a B2B membership write there is nothing to select:

```ts
members.add({ organizationId, userId, role })   // no email
organizations.create({ name, slug, plan })      // no email
```

Both match the user-table pattern only through the word `member` in `USER_TABLE_RE`, and the remediation told the developer to write `email: (ctx) => ctx.args.email` for an argument that does not exist.

The codegen feeder now reports `hasEmailArg` by scanning the builder chain's `.input({...})` keys, and the lint skips a procedure that explicitly has none.

**Fail-closed preserved.** The field is optional and only an explicit `false` clears a finding, so a feeder predating it (or a runtime caller) leaves the lint firing rather than silently passing every account-creating write. A real signup mutation that takes an email and skips the gate is still flagged — covered by the retained test.

## 2. The `@lunora/payment` reminder named the wrong providers, unconditionally

It fired on every dev-server start whenever `@lunora/payment` was imported, and listed only Stripe and Polar — though the package ships five adapters (`providers/{stripe,polar,creem,autumn,dodopayments}.ts`, all present in `package-secrets-registry.ts`). A Creem-based app was repeatedly told to configure a provider it does not use.

It now reads `.dev.vars` and stays quiet once any supported provider's secret pair carries a value. A scaffolded-but-empty pair still counts as unconfigured, so the hint keeps working for its actual purpose.

## 3. The pipelines binding could not be spelled correctly

wrangler renamed `pipelines[].pipeline` to `stream` and now deprecation-warns on the old name, while `validateWranglerConfig` still required `pipeline`. Whichever you wrote, something warned:

| spelling | wrangler | lunora |
|---|---|---|
| `pipeline` | deprecation warning | ok |
| `stream` | ok | "has no pipeline" |

Hint rules may now list several accepted spellings; `pipelines` accepts `stream` (current) or `pipeline` (deprecated).

## Public API

Two additive optional fields — `AdvisorProcedureProtection.hasEmailArg` and the wrangler `pipelines[].stream` shape. Snapshots updated via `pnpm run api:update`; the diff is the two added lines.

## Verification

- `@lunora/config` 471, `@lunora/codegen` 912, `@lunora/advisor` 384 — all passing, 6 new tests covering both halves of each change (including the fail-closed-on-unknown path).
- `lint:types` clean on all three; `api:check` clean; prettier clean.
- eslint: config and codegen clean; advisor unchanged at its pre-existing 17.

Split out of the cloud control-plane branch — this PR is framework-only and touches no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced signup security warnings for procedures that do not accept email addresses, while retaining checks when email-based gating is relevant.
  - Improved payment configuration warnings by recognizing valid provider credentials in `.dev.vars`.
  - Fixed Wrangler pipeline validation to support both `pipeline` and `stream` configuration formats.

- **Improvements**
  - Automatically detects email-shaped procedure inputs to improve security guidance accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->