### PR TITLE
feat: REST DX — response caching, list-args convention, database introspection

### DIFF
--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -249,6 +249,7 @@ interface FunctionIR {
     args: Record<string, ValidatorIR>;
     exportName: string;
     expose?: {
+        cache?: ExposeCacheIR;
         rest?: boolean;
     };
     filePath: string;

--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -66,6 +66,9 @@ interface AddOptionalColumnEdit {
 
 ```ts
 interface AddTableEdit {
+    readonly global?: {
+        readonly backend?: GlobalBackend;
+    };
     readonly kind: "addTable";
     readonly table: string;
 }

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -73,6 +73,14 @@ Re-exported from `@lunora/scheduler` — signature tracked at its source.
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
 
+### `DEFAULT_LIMIT` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DEFAULT_MAX_LIMIT` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DailySchedule` (interface)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
@@ -94,6 +102,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `DefineIdentityOptions` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DefineListArgsConfig` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -282,6 +294,30 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `LifecycleHandler` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListArgsSpec` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListArgsValidators` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListArgsValue` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListFilterOperators` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListOrderByEntry` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListWhere` (type)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -542,6 +578,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `RelationDefinition` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `RestCacheConfig` (type)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -889,6 +929,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `clampLimit` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `composePluginMiddleware` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -922,6 +966,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `defineIdentity` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `defineListArgs` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -4201,6 +4249,10 @@ Re-exported from `@lunora/runtime` — signature tracked at its source.
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.
 
+### `applyRestCache` (const)
+
+Re-exported from `@lunora/runtime` — signature tracked at its source.
+
 ### `argsFromQuery` (const)
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.
@@ -4341,6 +4393,10 @@ Re-exported from `@lunora/runtime` — signature tracked at its source.
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.
 
+### `requestCarriesCredentials` (const)
+
+Re-exported from `@lunora/runtime` — signature tracked at its source.
+
 ### `resolveLogArchiveFromEnv` (const)
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.
@@ -4354,6 +4410,10 @@ Re-exported from `@lunora/runtime` — signature tracked at its source.
 Re-exported from `@lunora/runtime` — signature tracked at its source.
 
 ### `resolveShard` (const)
+
+Re-exported from `@lunora/runtime` — signature tracked at its source.
+
+### `restCacheHeaders` (const)
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.
 
@@ -4467,6 +4527,14 @@ Re-exported from `@lunora/scheduler` — signature tracked at its source.
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
 
+### `DEFAULT_LIMIT` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DEFAULT_MAX_LIMIT` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `DailySchedule` (interface)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
@@ -4488,6 +4556,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `DefineIdentityOptions` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `DefineListArgsConfig` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -4676,6 +4748,30 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `LifecycleHandler` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListArgsSpec` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListArgsValidators` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListArgsValue` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListFilterOperators` (type)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListOrderByEntry` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `ListWhere` (type)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -4936,6 +5032,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `RelationDefinition` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `RestCacheConfig` (type)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -5283,6 +5383,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `clampLimit` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `composePluginMiddleware` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5316,6 +5420,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `defineIdentity` (const)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `defineListArgs` (const)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
@@ -6636,6 +6744,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `RelationDefinition` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `RestCacheConfig` (type)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -718,9 +718,7 @@ interface FunctionDescriptor {
 ```ts
 interface FunctionRegistryEntry {
     args?: unknown;
-    expose?: {
-        readonly rest?: boolean;
-    };
+    expose?: RestExposure;
     kind: "action" | "mutation" | "query" | "stream";
     visibility?: "internal" | "public";
     x402?: {
@@ -2162,6 +2160,12 @@ const analyticsEngineSink: (options: AnalyticsEngineSinkOptions) => Observabilit
 const applyJurisdiction: (namespace: ShardNamespaceLike, jurisdiction?: DurableObjectJurisdiction) => ShardNamespaceLike;
 ```
 
+### `applyRestCache` (const)
+
+```ts
+const applyRestCache: (response: Response, policy: RestCachePolicy | undefined, request: Request) => Response;
+```
+
 ### `argsFromQuery` (const)
 
 ```ts
@@ -2402,6 +2406,12 @@ const r2Sink: (config: {
 const readShardKey: (url: URL, request: Request) => string | undefined;
 ```
 
+### `requestCarriesCredentials` (const)
+
+```ts
+const requestCarriesCredentials: (request: Request, policy: RestCachePolicy) => boolean;
+```
+
 ### `resolveLogArchiveFromEnv` (const)
 
 ```ts
@@ -2424,6 +2434,12 @@ const resolveSecurity: (security: SecurityOptions | undefined, env?: Record<stri
 
 ```ts
 const resolveShard: (namespace: ShardNamespaceLike, shardKey: string) => ResolvedShard;
+```
+
+### `restCacheHeaders` (const)
+
+```ts
+const restCacheHeaders: (policy: RestCachePolicy, request: Request, status: number) => Record<string, string> | undefined;
 ```
 
 ### `restSurfaceFromRegistry` (const)

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -158,6 +158,18 @@ Re-exported from `@lunora/scheduler` — signature tracked at its source.
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
 
+### `DEFAULT_LIMIT` (const)
+
+```ts
+const DEFAULT_LIMIT = 25;
+```
+
+### `DEFAULT_MAX_LIMIT` (const)
+
+```ts
+const DEFAULT_MAX_LIMIT = 100;
+```
+
 ### `DailySchedule` (interface)
 
 Re-exported from `@lunora/scheduler` — signature tracked at its source.
@@ -253,6 +265,19 @@ interface DefineIdentityOptions {
 }
 ```
 
+### `DefineListArgsConfig` (interface)
+
+```ts
+interface DefineListArgsConfig<F extends Record<string, Validator>, O extends string> {
+    readonly defaultLimit?: number;
+    readonly filter: F;
+    readonly maxLimit?: number;
+    readonly maxInValues?: number;
+    readonly maxOrderBy?: number;
+    readonly orderBy: ReadonlyArray<O>;
+}
+```
+
 ### `DefinePluginOptions` (interface)
 
 ```ts
@@ -332,6 +357,7 @@ type EnvShape = Record<string, Validator>;
 
 ```ts
 interface ExposeConfig {
+    readonly cache?: RestCacheConfig;
     readonly rest?: boolean;
 }
 ```
@@ -800,6 +826,60 @@ type LifecycleEventKind = "connect" | "disconnect";
 
 ```ts
 type LifecycleHandler = (context: MutationCtx, event: LifecycleEvent) => Promise<void> | void;
+```
+
+### `ListArgsSpec` (interface)
+
+```ts
+interface ListArgsSpec<F extends Record<string, Validator>, O extends string> {
+    readonly args: ListArgsValidators<F, O>;
+    readonly toQueryArgs: <TDocument>(args: ListArgsValue<F, O>) => QueryArgs$2<TDocument>;
+}
+```
+
+### `ListArgsValidators` (interface)
+
+```ts
+interface ListArgsValidators<F extends Record<string, Validator>, O extends string> {
+    cursor: ColumnValidator<null | number | string | undefined, null | number | string | undefined>;
+    limit: ColumnValidator<number | undefined, number | undefined>;
+    orderBy: ColumnValidator<ListOrderByEntry<O>[] | undefined, ListOrderByEntry<O>[] | undefined>;
+    where: ColumnValidator<ListWhere<F> | undefined, ListWhere<F> | undefined>;
+}
+```
+
+### `ListArgsValue` (interface)
+
+```ts
+interface ListArgsValue<F extends Record<string, Validator>, O extends string> {
+    cursor?: null | number | string;
+    limit?: number;
+    orderBy?: ListOrderByEntry<O>[];
+    where?: ListWhere<F>;
+}
+```
+
+### `ListFilterOperators` (type)
+
+```ts
+type ListFilterOperators<T> = WhereOperators<T>;
+```
+
+### `ListOrderByEntry` (interface)
+
+```ts
+interface ListOrderByEntry<O extends string> {
+    direction?: "asc" | "desc";
+    field: O;
+}
+```
+
+### `ListWhere` (type)
+
+```ts
+type ListWhere<F extends Record<string, Validator>> = {
+    [K in keyof F]?: Infer<F[K]> | ListFilterOperators<Infer<F[K]>>;
+};
 ```
 
 ### `LogFields` (type)
@@ -1473,6 +1553,12 @@ interface RelationDefinition {
     references: string;
     table: string;
 }
+```
+
+### `RestCacheConfig` (type)
+
+```ts
+type RestCacheConfig = RestCachePolicy;
 ```
 
 ### `RlsOptions` (interface)
@@ -2382,6 +2468,12 @@ const bindTableFacade: (writer: FacadeWriterLike, tableName: string) => FacadeEn
 const buildRlsReadRegistry: (functions: Iterable<unknown>) => RlsReadRegistry;
 ```
 
+### `clampLimit` (const)
+
+```ts
+const clampLimit: (limit: number | undefined, fallback: number, maxLimit: number) => number;
+```
+
 ### `composePluginMiddleware` (const)
 
 ```ts
@@ -2436,6 +2528,12 @@ const defineIdentity: <A extends ValidatorMap>(claims: InferValidatorMap<A> exte
 } ? A : never, options?: DefineIdentityOptions) => IdentityContract<InferValidatorMap<A> & {
     userId: string;
 }>;
+```
+
+### `defineListArgs` (const)
+
+```ts
+const defineListArgs: <F extends Record<string, Validator>, O extends string>(config: DefineListArgsConfig<F, O>) => ListArgsSpec<F, O>;
 ```
 
 ### `defineMigration` (const)
@@ -4141,6 +4239,7 @@ type DurableObjectJurisdiction = "eu" | "fedramp" | "us";
 
 ```ts
 interface ExposeConfig {
+    readonly cache?: RestCacheConfig;
     readonly rest?: boolean;
 }
 ```
@@ -4506,6 +4605,12 @@ interface RelationDefinition {
     references: string;
     table: string;
 }
+```
+
+### `RestCacheConfig` (type)
+
+```ts
+type RestCacheConfig = RestCachePolicy;
 ```
 
 ### `ScheduledFunctionDoc` (interface)

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -268,7 +268,7 @@ interface DefineIdentityOptions {
 ### `DefineListArgsConfig` (interface)
 
 ```ts
-interface DefineListArgsConfig<F extends Record<string, Validator>, O extends string> {
+interface DefineListArgsConfig<F, O extends string> {
     readonly defaultLimit?: number;
     readonly filter: F;
     readonly maxInValues?: number;
@@ -831,16 +831,16 @@ type LifecycleHandler = (context: MutationCtx, event: LifecycleEvent) => Promise
 ### `ListArgsSpec` (interface)
 
 ```ts
-interface ListArgsSpec<F extends Record<string, Validator>, O extends string> {
+interface ListArgsSpec<TDocument, F, O extends string> {
     readonly args: ListArgsValidators<F, O>;
-    readonly toQueryArgs: <TDocument>(args: ListArgsValue<F, O>) => QueryArgs$2<TDocument>;
+    readonly toQueryArgs: (args: ListArgsValue<F, O>) => QueryArgs$2<TDocument>;
 }
 ```
 
 ### `ListArgsValidators` (interface)
 
 ```ts
-interface ListArgsValidators<F extends Record<string, Validator>, O extends string> {
+interface ListArgsValidators<F, O extends string> {
     cursor: ColumnValidator<null | number | string | undefined, null | number | string | undefined>;
     limit: ColumnValidator<number | undefined, number | undefined>;
     orderBy: ColumnValidator<ListOrderByEntry<O>[] | undefined, ListOrderByEntry<O>[] | undefined>;
@@ -851,7 +851,7 @@ interface ListArgsValidators<F extends Record<string, Validator>, O extends stri
 ### `ListArgsValue` (interface)
 
 ```ts
-interface ListArgsValue<F extends Record<string, Validator>, O extends string> {
+interface ListArgsValue<F, O extends string> {
     cursor?: null | number | string;
     limit?: number;
     orderBy?: ListOrderByEntry<O>[];
@@ -877,8 +877,8 @@ interface ListOrderByEntry<O extends string> {
 ### `ListWhere` (type)
 
 ```ts
-type ListWhere<F extends Record<string, Validator>> = {
-    [K in keyof F]?: Infer<F[K]> | ListFilterOperators<Infer<F[K]>>;
+type ListWhere<F> = {
+    [K in keyof F]?: Infer<NonNullable<F[K]>> | ListFilterOperators<Infer<NonNullable<F[K]>>>;
 };
 ```
 
@@ -2533,7 +2533,7 @@ const defineIdentity: <A extends ValidatorMap>(claims: InferValidatorMap<A> exte
 ### `defineListArgs` (const)
 
 ```ts
-const defineListArgs: <F extends Record<string, Validator>, O extends string>(config: DefineListArgsConfig<F, O>) => ListArgsSpec<F, O>;
+const defineListArgs: <TDocument>() => <F extends ListFilterShape<TDocument>, O extends keyof TDocument & string>(config: DefineListArgsConfig<F, O>) => ListArgsSpec<TDocument, F, O>;
 ```
 
 ### `defineMigration` (const)

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -271,8 +271,8 @@ interface DefineIdentityOptions {
 interface DefineListArgsConfig<F extends Record<string, Validator>, O extends string> {
     readonly defaultLimit?: number;
     readonly filter: F;
-    readonly maxLimit?: number;
     readonly maxInValues?: number;
+    readonly maxLimit?: number;
     readonly maxOrderBy?: number;
     readonly orderBy: ReadonlyArray<O>;
 }

--- a/packages/cli/__tests__/introspect-merge.test.ts
+++ b/packages/cli/__tests__/introspect-merge.test.ts
@@ -1,0 +1,164 @@
+import type { SchemaTable } from "@lunora/config";
+import { parseSchema } from "@lunora/config";
+import { describe, expect, it } from "vitest";
+
+import { innerValidator, mergeIntoSchema, planMerge } from "../src/commands/introspect/merge";
+import type { IntrospectedDatabase } from "../src/commands/introspect/model";
+
+/** A schema the developer has already edited: `title` was tightened, a comment added. */
+const EXISTING = `import { defineSchema, defineTable, v } from "@lunora/server";
+
+export default defineSchema({
+    posts: defineTable({
+        // Tightened by hand after the first introspect run.
+        title: v.string(),
+    })
+        .global({ backend: "hyperdrive" })
+        .index("by_title", ["title"]),
+});
+`;
+
+/** Narrow `parseSchema` for fixtures — a fixture that doesn't parse is a broken test, not a case to handle. */
+const tablesOf = (source: string): SchemaTable[] => {
+    const parsed = parseSchema(source);
+
+    if (!parsed.ok) {
+        throw new Error(`fixture did not parse: ${parsed.reason}`);
+    }
+
+    return [...parsed.tables];
+};
+
+const database: IntrospectedDatabase = {
+    dialect: "postgres",
+    tables: [
+        {
+            columns: [
+                { arrayDepth: 0, dataType: "text", name: "title", nullable: false },
+                { arrayDepth: 0, dataType: "text", name: "subtitle", nullable: true },
+            ],
+            indexes: [
+                { columns: ["title"], name: "by_title", unique: false },
+                { columns: ["subtitle"], name: "by_subtitle", unique: false },
+            ],
+            name: "posts",
+            primaryKey: [],
+        },
+        {
+            columns: [{ arrayDepth: 0, dataType: "text", name: "email", nullable: false }],
+            indexes: [],
+            name: "authors",
+            primaryKey: [],
+        },
+    ],
+};
+
+describe("mergeIntoSchema", () => {
+    it("adds a newly-discovered table without touching the developer's edits", () => {
+        expect.assertions(3);
+
+        const result = mergeIntoSchema(EXISTING, database, "postgres");
+
+        expect(result.text).toContain("authors: defineTable(");
+        // The hand-written comment and the tightened validator both survive.
+        expect(result.text).toContain("// Tightened by hand after the first introspect run.");
+        expect(result.text).toContain("title: v.string(),");
+    });
+
+    it("marks a merged-in table .global() on the hyperdrive backend", () => {
+        expect.assertions(1);
+
+        const parsed = parseSchema(mergeIntoSchema(EXISTING, database, "postgres").text ?? "");
+
+        expect(parsed).toMatchObject({ tables: expect.arrayContaining([expect.objectContaining({ global: true, name: "authors" })]) });
+    });
+
+    it("adds a new column to an existing table and a new index, skipping the ones already there", () => {
+        expect.assertions(3);
+
+        const text = mergeIntoSchema(EXISTING, database, "postgres").text ?? "";
+
+        expect(text).toContain("subtitle:");
+        expect(text).toContain('.index("by_subtitle", ["subtitle"])');
+        // `by_title` was already declared — not duplicated.
+        expect(text.match(/by_title/gu)).toHaveLength(1);
+    });
+
+    it("reports nothing to do when the schema already matches", () => {
+        expect.assertions(2);
+
+        const merged = mergeIntoSchema(EXISTING, { dialect: "postgres", tables: [database.tables[0] as never] }, "postgres");
+        const second = mergeIntoSchema(merged.text ?? EXISTING, { dialect: "postgres", tables: [database.tables[0] as never] }, "postgres");
+
+        expect(second.applied).toBe(0);
+        expect(second.text).toBeUndefined();
+    });
+
+    it("leaves a column the source database dropped alone, because removing it would drop rows", () => {
+        expect.assertions(1);
+
+        const shrunk: IntrospectedDatabase = {
+            dialect: "postgres",
+            tables: [{ columns: [], indexes: [], name: "posts", primaryKey: [] }],
+        };
+
+        expect(mergeIntoSchema(EXISTING, shrunk, "postgres").text).toBeUndefined();
+    });
+
+    it("refuses to touch a schema it cannot parse rather than guessing", () => {
+        expect.assertions(2);
+
+        const result = mergeIntoSchema("export const nope = 1;", database, "postgres");
+
+        expect(result.text).toBeUndefined();
+        expect(result.warnings[0]).toContain("could not be parsed");
+    });
+});
+
+describe("planMerge", () => {
+    it("adds a required column as optional and says why", () => {
+        expect.assertions(2);
+
+        const plan = planMerge(database, tablesOf(EXISTING), "postgres");
+
+        // A NOT NULL column added to a table that already exists still lands
+        // optional, because tightening it needs a backfill.
+        const required: IntrospectedDatabase = {
+            dialect: "postgres",
+            tables: [
+                {
+                    columns: [{ arrayDepth: 0, dataType: "text", name: "slug", nullable: false }],
+                    indexes: [],
+                    name: "posts",
+                    primaryKey: [],
+                },
+            ],
+        };
+        const withRequired = planMerge(required, tablesOf(EXISTING), "postgres");
+
+        expect(plan.edits.length).toBeGreaterThan(0);
+        expect(withRequired.warnings.some((warning) => warning.includes("backfill migration"))).toBe(true);
+    });
+
+    it("skips names the schema editor's identifier rule would reject, and says so", () => {
+        expect.assertions(2);
+
+        const hostile: IntrospectedDatabase = {
+            dialect: "postgres",
+            tables: [{ columns: [{ arrayDepth: 0, dataType: "text", name: "a", nullable: false }], indexes: [], name: "order-items", primaryKey: [] }],
+        };
+        const plan = planMerge(hostile, [], "postgres");
+
+        expect(plan.edits).toEqual([]);
+        expect(plan.warnings[0]).toContain("bare identifier");
+    });
+});
+
+describe("innerValidator", () => {
+    it("unwraps v.optional so applyAdditiveEdit does not double it", () => {
+        expect.assertions(2);
+
+        expect(innerValidator("v.optional(v.string())")).toBe("v.string()");
+        expect(innerValidator("v.string()")).toBe("v.string()");
+    });
+});

--- a/packages/cli/__tests__/introspect.test.ts
+++ b/packages/cli/__tests__/introspect.test.ts
@@ -148,7 +148,9 @@ describe("emitIntrospection — procedure modules", () => {
 
         const posts = emitIntrospection(database, emitOptions).files.find((file) => file.path === "posts.ts");
 
-        expect(posts?.contents).toContain("defineListArgs({");
+        // Curried on the table's Doc, so a stale column in the scaffold is a
+        // compile error rather than a filter that silently never matches.
+        expect(posts?.contents).toContain('defineListArgs<Doc<"posts">>()({');
         expect(posts?.contents).toContain("export const list = c.query");
         expect(posts?.contents).toContain("export const get = c.query");
     });
@@ -219,14 +221,41 @@ describe("emitIntrospection — hostile catalog identifiers", () => {
         }
     });
 
+    it("escapes characters that stay dangerous once the emitted file travels", () => {
+        expect.assertions(3);
+
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [
+                    {
+                        columns: [{ arrayDepth: 0, dataType: "text", name: "a", nullable: false }],
+                        indexes: [],
+                        // `</script>` would close a host script block if the generated
+                        // file is ever inlined into HTML; U+2028 is a line terminator.
+                        name: "x</script>y\u2028z",
+                        primaryKey: [],
+                    },
+                ],
+            },
+            emitOptions,
+        );
+        const schema = result.files.find((file) => file.path === "schema.ts")?.contents ?? "";
+
+        expect(schema).not.toContain("</script>");
+        expect(schema).toContain(String.raw`\u003C`);
+        expect(schema).toContain(String.raw`\u2028`);
+    });
+
     it("escapes the payload rather than emitting it raw", () => {
         expect.assertions(2);
 
         const schema = emitIntrospection(hostile, emitOptions).files.find((file) => file.path === "schema.ts");
         const contents = schema?.contents ?? "";
 
-        // Every occurrence of the injected quote is backslash-escaped.
-        expect(contents).toContain(String.raw`evil\"); process.exit(1); //`);
+        // The injected quote is backslash-escaped, and the `//` that would have
+        // started a comment is now \u002F-escaped too.
+        expect(contents).toContain(String.raw`evil\"); process.exit(1); \u002F\u002F`);
         expect(contents).toContain(String.raw`v.id("other\"")`);
     });
 

--- a/packages/cli/__tests__/introspect.test.ts
+++ b/packages/cli/__tests__/introspect.test.ts
@@ -1,3 +1,4 @@
+import { DiagnosticCategory, Project } from "ts-morph";
 import { describe, expect, it, vi } from "vitest";
 
 import { dialectFromUrl } from "../src/commands/introspect/connect";
@@ -152,7 +153,7 @@ describe("emitIntrospection — procedure modules", () => {
         expect(posts?.contents).toContain("export const get = c.query");
     });
 
-    it("publishes only index-backed columns as filterable, so the scaffold can't hand out a table scan", () => {
+    it("publishes only index-backed columns as filterable", () => {
         expect.assertions(2);
 
         const users = emitIntrospection(database, emitOptions).files.find((file) => file.path === "users.ts");
@@ -168,7 +169,7 @@ describe("emitIntrospection — procedure modules", () => {
 
         const posts = emitIntrospection(database, emitOptions).files.find((file) => file.path === "posts.ts");
         // Only the guidance comment may mention `.expose` — no emitted code calls it.
-        const code = (posts?.contents ?? "").split("\n").filter((line) => !line.trimStart().startsWith("*") && !line.trimStart().startsWith("/*"));
+        const code = (posts?.contents ?? "").split("\n").filter((line) => !["*", "/*", "//"].some((marker) => line.trimStart().startsWith(marker)));
 
         expect(code.some((line) => line.includes(".expose("))).toBe(false);
         expect(posts?.contents).toContain("Add `.expose({ rest: true })`");
@@ -177,9 +178,159 @@ describe("emitIntrospection — procedure modules", () => {
     it("omits procedure modules entirely when procedures are disabled", () => {
         expect.assertions(1);
 
-        const {files} = emitIntrospection(database, { ...emitOptions, procedures: false });
+        const { files } = emitIntrospection(database, { ...emitOptions, procedures: false });
 
         expect(files.map((file) => file.path)).toEqual(["schema.ts"]);
+    });
+});
+
+describe("emitIntrospection — hostile catalog identifiers", () => {
+    /** A database whose names contain every character that could break out of generated source. */
+    const hostile: IntrospectedDatabase = {
+        dialect: "postgres",
+        tables: [
+            {
+                columns: [
+                    { arrayDepth: 0, dataType: "text", name: 'evil"); process.exit(1); //', nullable: false },
+                    { arrayDepth: 0, dataType: "int4", name: "ref", nullable: false, references: { column: "id", table: 'other"' } },
+                ],
+                indexes: [{ columns: ['evil"); process.exit(1); //'], name: 'idx"', unique: false }],
+                name: 'tbl"',
+                primaryKey: ['evil"); process.exit(1); //'],
+            },
+            { columns: [{ arrayDepth: 0, dataType: "text", name: "a", nullable: false }], indexes: [], name: 'other"', primaryKey: [] },
+        ],
+    };
+
+    it("emits syntactically valid TypeScript even when every identifier is hostile", () => {
+        // schema.ts plus one procedure module per table.
+        expect.assertions(3);
+
+        // Substring assertions can't tell `\"` from `"`, so parse instead: the only
+        // property that actually matters is that no name can break out of the
+        // literal it lands in, and a syntax-error count of zero proves exactly that.
+        for (const file of emitIntrospection(hostile, emitOptions).files) {
+            const project = new Project({ useInMemoryFileSystem: true });
+            const source = project.createSourceFile(file.path, file.contents);
+
+            expect(
+                source.getPreEmitDiagnostics().filter((d) => d.getCategory() === DiagnosticCategory.Error && d.getCode() >= 1000 && d.getCode() < 2000),
+            ).toEqual([]);
+        }
+    });
+
+    it("escapes the payload rather than emitting it raw", () => {
+        expect.assertions(2);
+
+        const schema = emitIntrospection(hostile, emitOptions).files.find((file) => file.path === "schema.ts");
+        const contents = schema?.contents ?? "";
+
+        // Every occurrence of the injected quote is backslash-escaped.
+        expect(contents).toContain(String.raw`evil\"); process.exit(1); //`);
+        expect(contents).toContain(String.raw`v.id("other\"")`);
+    });
+
+    it("never writes outside the output directory, whatever the table is called", () => {
+        expect.assertions(2);
+
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [
+                    { columns: [{ arrayDepth: 0, dataType: "text", name: "a", nullable: false }], indexes: [], name: "../../../etc/passwd", primaryKey: [] },
+                ],
+            },
+            emitOptions,
+        );
+
+        expect(result.files.every((file) => !file.path.includes("/") && !file.path.includes(".."))).toBe(true);
+        expect(result.warnings.some((warning) => warning.includes("isn't usable as a filename"))).toBe(true);
+    });
+
+    it("reports a filename collision instead of silently overwriting one table with another", () => {
+        expect.assertions(1);
+
+        const columns = [{ arrayDepth: 0, dataType: "text", name: "a", nullable: false }];
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [
+                    { columns, indexes: [], name: "a.b", primaryKey: [] },
+                    { columns, indexes: [], name: "a+b", primaryKey: [] },
+                ],
+            },
+            emitOptions,
+        );
+
+        expect(result.warnings.some((warning) => warning.includes("collides with table"))).toBe(true);
+    });
+
+    it("uses bracket access for a table name that isn't a bare identifier", () => {
+        expect.assertions(2);
+
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [{ columns: [{ arrayDepth: 0, dataType: "text", name: "a", nullable: false }], indexes: [], name: "order-items", primaryKey: [] }],
+            },
+            emitOptions,
+        );
+        const procedures = result.files.find((file) => file.path !== "schema.ts")?.contents ?? "";
+
+        // `ctx.db."order-items"` would be a syntax error.
+        expect(procedures).toContain('ctx.db["order-items"]');
+        expect(procedures).not.toContain('ctx.db."order-items"');
+    });
+});
+
+describe("emitIntrospection — dialect handling", () => {
+    it("maps filter validators with the real dialect, not a hardcoded Postgres", () => {
+        expect.assertions(2);
+
+        const mysql: IntrospectedDatabase = {
+            dialect: "mysql",
+            tables: [
+                {
+                    columns: [{ arrayDepth: 0, dataType: "datetime", name: "created_at", nullable: false }],
+                    indexes: [{ columns: ["created_at"], name: "by_created", unique: false }],
+                    name: "events",
+                    primaryKey: [],
+                },
+            ],
+        };
+
+        const procedures = emitIntrospection(mysql, emitOptions).files.find((file) => file.path === "events.ts")?.contents ?? "";
+
+        // `datetime` is MySQL-only; under the old hardcoded Postgres map it silently became `v.any()`.
+        expect(procedures).toContain("created_at: v.timestamp(),");
+        expect(procedures).not.toContain("created_at: v.any(),");
+    });
+});
+
+describe("emitIntrospection — dangling foreign keys", () => {
+    it("demotes an FK whose target is not in the emitted schema, so the output still compiles", () => {
+        expect.assertions(3);
+
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [
+                    {
+                        columns: [{ arrayDepth: 0, dataType: "int4", name: "author_id", nullable: false, references: { column: "id", table: "users" } }],
+                        indexes: [],
+                        name: "posts",
+                        primaryKey: [],
+                    },
+                ],
+            },
+            emitOptions,
+        );
+        const schema = result.files.find((file) => file.path === "schema.ts")?.contents ?? "";
+
+        // `users` was filtered out by --tables, so `v.id("users")` would not resolve.
+        expect(schema).not.toContain('v.id("users")');
+        expect(schema).toContain("author_id: v.number(),");
+        expect(result.warnings.some((warning) => warning.includes("isn't in the generated schema"))).toBe(true);
     });
 });
 

--- a/packages/cli/__tests__/introspect.test.ts
+++ b/packages/cli/__tests__/introspect.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dialectFromUrl } from "../src/commands/introspect/connect";
+import { emitIntrospection, identifierFor, indexedColumns } from "../src/commands/introspect/emit";
+import type { IntrospectedDatabase, IntrospectedTable } from "../src/commands/introspect/model";
+import { validatorForColumn } from "../src/commands/introspect/model";
+import type { SqlExecutor } from "../src/commands/introspect/read-database";
+import { readDatabase, resolveType } from "../src/commands/introspect/read-database";
+
+const emitOptions = { procedures: true, serverImport: "@lunora/server" };
+
+const usersTable: IntrospectedTable = {
+    columns: [
+        { arrayDepth: 0, dataType: "int4", name: "id", nullable: false },
+        { arrayDepth: 0, dataType: "text", name: "email", nullable: false },
+        { arrayDepth: 0, dataType: "text", name: "display_name", nullable: true },
+        { arrayDepth: 0, dataType: "timestamptz", name: "created_at", nullable: false },
+    ],
+    indexes: [{ columns: ["email"], name: "users_email_key", unique: true }],
+    name: "users",
+    primaryKey: ["id"],
+};
+
+const postsTable: IntrospectedTable = {
+    columns: [
+        { arrayDepth: 0, dataType: "int4", name: "id", nullable: false },
+        { arrayDepth: 0, dataType: "int4", name: "author_id", nullable: false, references: { column: "id", table: "users" } },
+        { arrayDepth: 1, dataType: "text", name: "tags", nullable: true },
+        { arrayDepth: 0, dataType: "geometry", name: "location", nullable: true },
+    ],
+    indexes: [],
+    name: "posts",
+    primaryKey: ["id"],
+};
+
+const database: IntrospectedDatabase = { dialect: "postgres", tables: [postsTable, usersTable] };
+
+describe("validatorForColumn", () => {
+    it("maps common Postgres types onto v.* validators", () => {
+        expect.assertions(4);
+
+        expect(validatorForColumn({ arrayDepth: 0, dataType: "text", name: "a", nullable: false }, "postgres").expression).toBe("v.string()");
+        expect(validatorForColumn({ arrayDepth: 0, dataType: "int8", name: "a", nullable: false }, "postgres").expression).toBe("v.bigint()");
+        expect(validatorForColumn({ arrayDepth: 0, dataType: "timestamptz", name: "a", nullable: false }, "postgres").expression).toBe("v.timestamp()");
+        expect(validatorForColumn({ arrayDepth: 0, dataType: "jsonb", name: "a", nullable: false }, "postgres").expression).toBe("v.any()");
+    });
+
+    it("wraps a nullable column in v.optional and an array column in v.array", () => {
+        expect.assertions(2);
+
+        expect(validatorForColumn({ arrayDepth: 0, dataType: "text", name: "a", nullable: true }, "postgres").expression).toBe("v.optional(v.string())");
+        expect(validatorForColumn({ arrayDepth: 1, dataType: "text", name: "a", nullable: true }, "postgres").expression).toBe(
+            "v.optional(v.array(v.string()))",
+        );
+    });
+
+    it("expresses a foreign key as a branded v.id of the target table", () => {
+        expect.assertions(1);
+
+        const column = { arrayDepth: 0, dataType: "int4", name: "author_id", nullable: false, references: { column: "id", table: "users" } };
+
+        expect(validatorForColumn(column, "postgres").expression).toBe('v.id("users")');
+    });
+
+    it("falls back to v.any() and reports the type as unknown rather than guessing", () => {
+        expect.assertions(2);
+
+        const result = validatorForColumn({ arrayDepth: 0, dataType: "geometry", name: "a", nullable: false }, "postgres");
+
+        expect(result.expression).toBe("v.any()");
+        expect(result.known).toBe(false);
+    });
+});
+
+describe("emitIntrospection — schema module", () => {
+    it("emits a defineSchema module with every table marked .global on the hyperdrive backend", () => {
+        expect.assertions(4);
+
+        const schema = emitIntrospection(database, emitOptions).files.find((file) => file.path === "schema.ts");
+
+        expect(schema?.contents).toContain('import { defineSchema, defineTable, v } from "@lunora/server";');
+        expect(schema?.contents).toContain("users: defineTable({");
+        // The rows live in the external database, so sharding into a DO is wrong.
+        expect(schema?.contents).toContain('.global({ backend: "hyperdrive" })');
+        expect(schema?.contents).toContain("email: v.string(),");
+    });
+
+    it("carries the source primary key over as a unique index, since Lunora mints its own _id", () => {
+        expect.assertions(1);
+
+        const schema = emitIntrospection(database, emitOptions).files.find((file) => file.path === "schema.ts");
+
+        expect(schema?.contents).toContain('.index("by_id", ["id"], { unique: true })');
+    });
+
+    it("carries secondary indexes over with their uniqueness", () => {
+        expect.assertions(1);
+
+        const schema = emitIntrospection(database, emitOptions).files.find((file) => file.path === "schema.ts");
+
+        expect(schema?.contents).toContain('.index("users_email_key", ["email"], { unique: true })');
+    });
+
+    it("annotates an unmapped column with a TODO and reports it as a warning", () => {
+        expect.assertions(2);
+
+        const result = emitIntrospection(database, emitOptions);
+        const schema = result.files.find((file) => file.path === "schema.ts");
+
+        expect(schema?.contents).toContain("// TODO: `geometry` has no direct validator");
+        expect(result.warnings.some((warning) => warning.includes("geometry"))).toBe(true);
+    });
+
+    it("skips a column that collides with a Lunora system field and says so", () => {
+        expect.assertions(2);
+
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [{ columns: [{ arrayDepth: 0, dataType: "text", name: "_id", nullable: false }], indexes: [], name: "t", primaryKey: [] }],
+            },
+            emitOptions,
+        );
+
+        expect(result.files[0]?.contents).not.toContain("_id: v.string()");
+        expect(result.warnings.some((warning) => warning.includes("system column"))).toBe(true);
+    });
+
+    it("quotes a column name that isn't a bare JS identifier", () => {
+        expect.assertions(1);
+
+        const result = emitIntrospection(
+            {
+                dialect: "postgres",
+                tables: [{ columns: [{ arrayDepth: 0, dataType: "text", name: "user-id", nullable: false }], indexes: [], name: "t", primaryKey: [] }],
+            },
+            emitOptions,
+        );
+
+        expect(result.files[0]?.contents).toContain('"user-id": v.string(),');
+    });
+});
+
+describe("emitIntrospection — procedure modules", () => {
+    it("emits a list/get module per table, built on defineListArgs", () => {
+        expect.assertions(3);
+
+        const posts = emitIntrospection(database, emitOptions).files.find((file) => file.path === "posts.ts");
+
+        expect(posts?.contents).toContain("defineListArgs({");
+        expect(posts?.contents).toContain("export const list = c.query");
+        expect(posts?.contents).toContain("export const get = c.query");
+    });
+
+    it("publishes only index-backed columns as filterable, so the scaffold can't hand out a table scan", () => {
+        expect.assertions(2);
+
+        const users = emitIntrospection(database, emitOptions).files.find((file) => file.path === "users.ts");
+
+        // `id` (primary key) and `email` (indexed) are filterable...
+        expect(users?.contents).toContain("email: v.string(),");
+        // ...`display_name` has no index, so it is not published as a filter.
+        expect(users?.contents).not.toContain("display_name:");
+    });
+
+    it("leaves the procedures RPC-only — publishing over REST stays an explicit decision", () => {
+        expect.assertions(2);
+
+        const posts = emitIntrospection(database, emitOptions).files.find((file) => file.path === "posts.ts");
+        // Only the guidance comment may mention `.expose` — no emitted code calls it.
+        const code = (posts?.contents ?? "").split("\n").filter((line) => !line.trimStart().startsWith("*") && !line.trimStart().startsWith("/*"));
+
+        expect(code.some((line) => line.includes(".expose("))).toBe(false);
+        expect(posts?.contents).toContain("Add `.expose({ rest: true })`");
+    });
+
+    it("omits procedure modules entirely when procedures are disabled", () => {
+        expect.assertions(1);
+
+        const {files} = emitIntrospection(database, { ...emitOptions, procedures: false });
+
+        expect(files.map((file) => file.path)).toEqual(["schema.ts"]);
+    });
+});
+
+describe("identifierFor", () => {
+    it("camelCases a snake_case table name into a usable const name", () => {
+        expect.assertions(3);
+
+        expect(identifierFor("order_items")).toBe("orderItems");
+        expect(identifierFor("users")).toBe("users");
+        expect(identifierFor("2fa_tokens")).toBe("faTokens");
+    });
+});
+
+describe("indexedColumns", () => {
+    it("includes primary-key, indexed, and foreign-key columns", () => {
+        expect.assertions(2);
+
+        expect(indexedColumns(usersTable).toSorted((a, b) => a.localeCompare(b))).toEqual(["email", "id"]);
+        expect(indexedColumns(postsTable).toSorted((a, b) => a.localeCompare(b))).toEqual(["author_id", "id"]);
+    });
+});
+
+describe("resolveType", () => {
+    it("unwraps a Postgres array into its element type plus a depth", () => {
+        expect.assertions(1);
+
+        expect(resolveType({ data_type: "ARRAY", udt_name: "_text" }, "postgres")).toEqual({ arrayDepth: 1, dataType: "text" });
+    });
+
+    it("prefers the specific udt_name spelling over the generic data_type", () => {
+        expect.assertions(1);
+
+        expect(resolveType({ data_type: "integer", udt_name: "int4" }, "postgres")).toEqual({ arrayDepth: 0, dataType: "int4" });
+    });
+
+    it("uses data_type directly for MySQL, which has no array types", () => {
+        expect.assertions(1);
+
+        expect(resolveType({ DATA_TYPE: "VARCHAR" }, "mysql")).toEqual({ arrayDepth: 0, dataType: "varchar" });
+    });
+});
+
+describe("readDatabase", () => {
+    /** Fake executor that answers each of the four introspection queries by matching on a distinctive fragment. */
+    const executor: SqlExecutor = vi.fn<SqlExecutor>(async (sql: string) => {
+        if (sql.includes("information_schema.columns")) {
+            return [
+                { column_name: "id", data_type: "integer", is_nullable: "NO", table_name: "users", udt_name: "int4" },
+                { column_name: "email", data_type: "text", is_nullable: "NO", table_name: "users", udt_name: "text" },
+                { column_name: "author_id", data_type: "integer", is_nullable: "NO", table_name: "posts", udt_name: "int4" },
+            ];
+        }
+
+        if (sql.includes("PRIMARY KEY")) {
+            return [{ column_name: "id", table_name: "users" }];
+        }
+
+        if (sql.includes("FOREIGN KEY")) {
+            return [{ column_name: "author_id", foreign_column: "id", foreign_table: "users", table_name: "posts" }];
+        }
+
+        return [
+            { column_name: "email", index_name: "users_email_key", is_unique: "true", table_name: "users" },
+            { column_name: "a", index_name: "posts_ab", is_unique: "false", table_name: "posts" },
+            { column_name: "b", index_name: "posts_ab", is_unique: "false", table_name: "posts" },
+        ];
+    });
+
+    it("folds the four queries into one dialect-neutral model, sorted by table name", async () => {
+        expect.assertions(4);
+
+        const result = await readDatabase(executor, "postgres", "public");
+
+        expect(result.tables.map((table) => table.name)).toEqual(["posts", "users"]);
+        expect(result.tables.find((table) => table.name === "users")?.primaryKey).toEqual(["id"]);
+        expect(result.tables.find((table) => table.name === "posts")?.columns[0]?.references).toEqual({ column: "id", table: "users" });
+        // A composite index keeps its column order.
+        expect(result.tables.find((table) => table.name === "posts")?.indexes).toEqual([{ columns: ["a", "b"], name: "posts_ab", unique: false }]);
+    });
+
+    it("never issues a write — every query is a read against information_schema/pg_catalog", async () => {
+        expect.assertions(1);
+
+        const seen: string[] = [];
+
+        await readDatabase(
+            async (sql) => {
+                seen.push(sql);
+
+                return [];
+            },
+            "postgres",
+            "public",
+        );
+
+        expect(seen.every((sql) => /^\s*SELECT/i.test(sql))).toBe(true);
+    });
+});
+
+describe("dialectFromUrl", () => {
+    it("infers the dialect from the connection-string scheme", () => {
+        expect.assertions(4);
+
+        expect(dialectFromUrl("postgres://localhost/shop")).toBe("postgres");
+        expect(dialectFromUrl("postgresql://localhost/shop")).toBe("postgres");
+        expect(dialectFromUrl("mysql://localhost/shop")).toBe("mysql");
+        expect(dialectFromUrl("mariadb://localhost/shop")).toBe("mysql");
+    });
+
+    it("rejects an unrecognised scheme with an actionable message", () => {
+        expect.assertions(1);
+
+        expect(() => dialectFromUrl("mongodb://localhost/shop")).toThrow(/Unrecognised database URL scheme/);
+    });
+});

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -66,6 +66,8 @@ lunora import <file> [--table <name>] [--batch-size n]
 lunora backup <create|list|restore|pitr> [--dir <d>] [--at <iso>]
 lunora seed [--table <t>] [--count n]   # deterministic fake data from schema.ts
             [--seed n] [--dry-run] [--reset]
+lunora introspect [--url <u>] [--tables <t1,t2>]  # scaffold schema.ts from an
+                  [--schema <s>] [--no-procedures] # existing Postgres/MySQL DB
 ```
 
 ### `lunora init`
@@ -463,6 +465,43 @@ Targeting a non-local worker needs `--prod` plus an explicit `--url`, and prompt
 unless you pass `--yes`; prefer `LUNORA_ADMIN_TOKEN` over `--token`, which is
 visible to other local processes through the process table. See
 [@lunora/seed](/docs/packages/seed) for using the same generator inside tests.
+
+### `lunora introspect`
+
+Reads an existing Postgres or MySQL database and scaffolds `lunora/schema.ts`
+from it, plus a `list`/`get` procedure module per table. Use it when you're
+adopting Lunora on top of a database that already exists, instead of
+transcribing the schema by hand.
+
+```bash
+lunora introspect --url postgres://localhost/shop  # every base table
+lunora introspect --tables users,orders            # just these (reads $DATABASE_URL)
+lunora introspect --dry-run                        # print, write nothing
+lunora introspect --no-procedures --force          # schema only, overwrite
+```
+
+The command is **read-only against the source database** — it queries
+`information_schema` (and `pg_index` on Postgres) and never writes. It also
+refuses to overwrite an existing file unless you pass `--force`.
+
+What it emits is a **starting point you own**, not a build artifact: review it
+before shipping. Specifically:
+
+- Every table is `.global({ backend: "hyperdrive" })`, because the rows live in
+  the external database. Point the `HYPERDRIVE` binding at it — see
+  [@lunora/hyperdrive](/docs/packages/hyperdrive).
+- Lunora mints its own `_id`, so the source primary key is carried over as a
+  unique index rather than replacing it.
+- Foreign keys become `v.id("<target>")`; a type with no direct validator becomes
+  `v.any()` with a `TODO` beside it, and is reported as a warning.
+- The emitted procedures are **RPC-only**. Publishing one over REST stays an
+  explicit `.expose({ rest: true })` decision you make after adding whatever auth
+  or RLS the table needs — `introspect` cannot know who may read your data.
+- `list` is built on [`defineListArgs`](/docs/packages/server#list-endpoints), so
+  only index-backed columns are filterable and paging is keyset-based.
+
+The driver is loaded on demand and is not a CLI dependency: install `pg` or
+`mysql2` in your project first.
 
 ### `lunora registry`
 

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -498,7 +498,9 @@ before shipping. Specifically:
   explicit `.expose({ rest: true })` decision you make after adding whatever auth
   or RLS the table needs — `introspect` cannot know who may read your data.
 - `list` is built on [`defineListArgs`](/docs/packages/server#list-endpoints), so
-  only index-backed columns are filterable and paging is keyset-based.
+  only index-backed columns are filterable and paging is keyset-based. That bounds
+  which columns a caller can reach, not the cost of every operator over them —
+  review the generated `filter` list before exposing the procedure.
 
 The driver is loaded on demand and is not a CLI dependency: install `pg` or
 `mysql2` in your project first.

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -481,8 +481,18 @@ lunora introspect --no-procedures --force          # schema only, overwrite
 ```
 
 The command is **read-only against the source database** — it queries
-`information_schema` (and `pg_index` on Postgres) and never writes. It also
-refuses to overwrite an existing file unless you pass `--force`.
+`information_schema` (and `pg_index` on Postgres) and never writes.
+
+**Re-runs merge, they don't clobber.** The first run writes a whole
+`lunora/schema.ts`; after that the file is yours, and a second run folds only
+what's new — tables, columns, indexes — into it as additive edits, preserving
+your formatting, comments, and any validator you tightened. That goes through the
+same ts-morph editor the Studio schema editor uses, so two of its rules apply: a
+column added to a table that already exists lands `v.optional(...)` (a required
+one needs a backfill migration), and names that aren't bare identifiers are
+reported and skipped. Nothing is ever removed — a column dropped upstream stays,
+because deleting it would drop rows. Pass `--force` to overwrite instead of merge,
+and `--dry-run` to see the plan first.
 
 What it emits is a **starting point you own**, not a build artifact: review it
 before shipping. Specifically:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,6 +104,18 @@
         "typescript": "catalog:tsc",
         "vitest": "catalog:test"
     },
+    "peerDependencies": {
+        "mysql2": "*",
+        "pg": "*"
+    },
+    "peerDependenciesMeta": {
+        "mysql2": {
+            "optional": true
+        },
+        "pg": {
+            "optional": true
+        }
+    },
     "engines": {
         "node": "^22.15.0 || >=24.11.0"
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import { importCommand } from "./commands/import";
 import { infoCommand } from "./commands/info";
 import { initCommand } from "./commands/init";
 import { insightsCommand } from "./commands/insights";
+import { introspectCommand } from "./commands/introspect";
 import { linkCommand } from "./commands/link";
 import { logsCommand } from "./commands/logs";
 import { mcpCommand } from "./commands/mcp";
@@ -151,6 +152,7 @@ const CLI_COMMANDS = [
     exportCommand,
     importCommand,
     seedCommand,
+    introspectCommand,
     backupCommand,
     verifyCommand,
     infoCommand,

--- a/packages/cli/src/commands/introspect/connect.ts
+++ b/packages/cli/src/commands/introspect/connect.ts
@@ -56,7 +56,15 @@ const loadDriver = (specifier: string, install: string, cwd: string): Record<str
         const projectRequire = createRequire(join(cwd, "noop.cjs"));
 
         return projectRequire(specifier) as Record<string, unknown>;
-    } catch {
+    } catch (error: unknown) {
+        // Only a genuine resolution failure means "not installed". A driver that IS
+        // present but throws while initialising (native binding mismatch, a broken
+        // transitive dep) must surface its own error — telling someone to install a
+        // package they already have sends them down the wrong path entirely.
+        if ((error as { code?: string } | undefined)?.code !== "MODULE_NOT_FOUND") {
+            throw error;
+        }
+
         throw new LunoraError(
             "INTERNAL",
             `\`lunora introspect\` needs the \`${install}\` driver to read this database, and it isn't installed.\n\nInstall it in your project:\n\n    pnpm add -D ${install}`,
@@ -125,7 +133,9 @@ const connect = async (url: string, dialect: SqlDialect, schemaOverride?: string
     }
 
     return {
-        close: async () => { await connection.end(); },
+        close: async () => {
+            await connection.end();
+        },
         execute: async (sql, parameters) => {
             const [rows] = await connection.execute(sql, [...parameters]);
 

--- a/packages/cli/src/commands/introspect/connect.ts
+++ b/packages/cli/src/commands/introspect/connect.ts
@@ -1,0 +1,139 @@
+/**
+ * Driver loading for `lunora introspect`.
+ *
+ * `pg` and `mysql2` are NOT dependencies of the CLI — they're heavy, and the vast
+ * majority of Lunora projects never introspect anything. They're loaded on demand
+ * and a missing one produces an install instruction rather than a stack trace.
+ * This mirrors how `@lunora/hyperdrive` treats the same two drivers (optional
+ * peer dependencies).
+ */
+import { createRequire } from "node:module";
+
+import { LunoraError } from "@lunora/errors";
+import { join } from "@visulima/path";
+
+import type { SqlDialect } from "./model";
+import type { SqlExecutor } from "./read-database";
+
+/** An open read-only connection to the source database. */
+interface Connection {
+    readonly close: () => Promise<void>;
+    readonly execute: SqlExecutor;
+    /** Postgres schema name, or MySQL database name — whichever scopes `information_schema`. */
+    readonly schema: string;
+}
+
+/** Minimal structural view of `pg`'s `Client`, so the CLI needs no `@types/pg`. */
+interface PgClientLike {
+    connect: () => Promise<void>;
+    end: () => Promise<void>;
+    query: (sql: string, values: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+}
+
+/** Minimal structural view of a `mysql2/promise` connection. */
+interface MysqlConnectionLike {
+    end: () => Promise<void>;
+    execute: (sql: string, values: unknown[]) => Promise<[unknown, unknown]>;
+}
+
+/** Leading slash of a URL pathname, stripped to recover the bare database name. */
+const LEADING_SLASH = /^\//;
+
+/**
+ * Load an optional driver by name, resolved from the USER'S project rather than
+ * the CLI's own `node_modules` — `pg` / `mysql2` are things they install, and the
+ * CLI is frequently run through a global binary that could never see them.
+ *
+ * `createRequire` rather than `import(specifier)`: a dynamic import with a
+ * variable specifier can't be statically analyzed, so the bundler rejects it at
+ * build time. This is the same escape hatch `@lunora/config` and `@lunora/codegen`
+ * use to reach into a host project at runtime. A missing driver becomes an
+ * install instruction instead of a module-resolution stack trace.
+ */
+const loadDriver = (specifier: string, install: string, cwd: string): Record<string, unknown> => {
+    try {
+        // `noop.cjs` is never read — it only anchors resolution at the project root.
+        const projectRequire = createRequire(join(cwd, "noop.cjs"));
+
+        return projectRequire(specifier) as Record<string, unknown>;
+    } catch {
+        throw new LunoraError(
+            "INTERNAL",
+            `\`lunora introspect\` needs the \`${install}\` driver to read this database, and it isn't installed.\n\nInstall it in your project:\n\n    pnpm add -D ${install}`,
+        );
+    }
+};
+
+/** Infer the dialect from a connection-string scheme. */
+const dialectFromUrl = (url: string): SqlDialect => {
+    const scheme = url.slice(0, Math.max(0, url.indexOf(":"))).toLowerCase();
+
+    if (scheme === "postgres" || scheme === "postgresql") {
+        return "postgres";
+    }
+
+    if (scheme === "mysql" || scheme === "mariadb") {
+        return "mysql";
+    }
+
+    throw new LunoraError(
+        "INTERNAL",
+        `Unrecognised database URL scheme \`${scheme}\`. Expected a \`postgres://\`, \`postgresql://\`, \`mysql://\`, or \`mariadb://\` connection string.`,
+    );
+};
+
+/** The database name embedded in a connection string's path, if any. */
+const databaseFromUrl = (url: string): string | undefined => {
+    try {
+        const path = new URL(url).pathname.replace(LEADING_SLASH, "");
+
+        return path === "" ? undefined : decodeURIComponent(path);
+    } catch {
+        return undefined;
+    }
+};
+
+/** Open a read-only connection using whichever driver the dialect needs. */
+const connect = async (url: string, dialect: SqlDialect, schemaOverride?: string, cwd: string = process.cwd()): Promise<Connection> => {
+    if (dialect === "postgres") {
+        const driver = loadDriver("pg", "pg", cwd);
+        const ClientConstructor = driver.Client as new (config: { connectionString: string }) => PgClientLike;
+        const client = new ClientConstructor({ connectionString: url });
+
+        await client.connect();
+
+        return {
+            close: async () => {
+                await client.end();
+            },
+            execute: async (sql, parameters) => {
+                const result = await client.query(sql, [...parameters]);
+
+                return result.rows;
+            },
+            schema: schemaOverride ?? "public",
+        };
+    }
+
+    const driver = loadDriver("mysql2/promise", "mysql2", cwd);
+    const createConnection = driver.createConnection as (config: string) => Promise<MysqlConnectionLike>;
+    const connection = await createConnection(url);
+    const database = schemaOverride ?? databaseFromUrl(url);
+
+    if (database === undefined) {
+        throw new LunoraError("INTERNAL", "A MySQL connection string must name a database (`mysql://host/<database>`), or pass `--schema`.");
+    }
+
+    return {
+        close: async () => { await connection.end(); },
+        execute: async (sql, parameters) => {
+            const [rows] = await connection.execute(sql, [...parameters]);
+
+            return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+        },
+        schema: database,
+    };
+};
+
+export type { Connection };
+export { connect, databaseFromUrl, dialectFromUrl, loadDriver };

--- a/packages/cli/src/commands/introspect/connect.ts
+++ b/packages/cli/src/commands/introspect/connect.ts
@@ -51,25 +51,24 @@ const LEADING_SLASH = /^\//;
  * install instruction instead of a module-resolution stack trace.
  */
 const loadDriver = (specifier: string, install: string, cwd: string): Record<string, unknown> => {
+    // `noop.cjs` is never read — it only anchors resolution at the project root.
+    const projectRequire = createRequire(join(cwd, "noop.cjs"));
+
     try {
-        // `noop.cjs` is never read — it only anchors resolution at the project root.
-        const projectRequire = createRequire(join(cwd, "noop.cjs"));
-
-        return projectRequire(specifier) as Record<string, unknown>;
-    } catch (error: unknown) {
-        // Only a genuine resolution failure means "not installed". A driver that IS
-        // present but throws while initialising (native binding mismatch, a broken
-        // transitive dep) must surface its own error — telling someone to install a
-        // package they already have sends them down the wrong path entirely.
-        if ((error as { code?: string } | undefined)?.code !== "MODULE_NOT_FOUND") {
-            throw error;
-        }
-
+        projectRequire.resolve(specifier);
+    } catch {
         throw new LunoraError(
             "INTERNAL",
             `\`lunora introspect\` needs the \`${install}\` driver to read this database, and it isn't installed.\n\nInstall it in your project:\n\n    pnpm add -D ${install}`,
         );
     }
+
+    // Resolution and loading are separated deliberately. Checking the thrown error's
+    // `code` would conflate them: a driver that IS installed but whose own nested
+    // dependency is missing also throws `MODULE_NOT_FOUND`, and telling someone to
+    // install a package they already have sends them down entirely the wrong path.
+    // Anything the load itself throws propagates untouched.
+    return projectRequire(specifier) as Record<string, unknown>;
 };
 
 /** Infer the dialect from a connection-string scheme. */

--- a/packages/cli/src/commands/introspect/emit.ts
+++ b/packages/cli/src/commands/introspect/emit.ts
@@ -11,8 +11,9 @@
  *
  * Two rules shape the emitted procedures, both inherited from `defineListArgs`:
  * only columns an index can serve are published as filterable, and only indexed
- * columns (plus `_creationTime`) are sortable. That keeps the scaffold from
- * handing out a full-table scan on day one.
+ * columns (plus `_creationTime`) are sortable. That bounds which columns a caller
+ * can reach — though not the cost of every operator over them, since `contains`
+ * and the negative operators are non-sargable whatever the column.
  */
 import type { IntrospectedColumn, IntrospectedDatabase, IntrospectedTable, SqlDialect } from "./model";
 import { RESERVED_COLUMNS, validatorForColumn } from "./model";
@@ -46,8 +47,52 @@ const SEPARATOR_RUN = /[^\dA-Z]+(.)?/gi;
 /** A leading digit run, which can't start a JS identifier. */
 const LEADING_DIGITS = /^\d+/;
 
+/**
+ * Characters that may appear in an emitted filename; everything else — including
+ * `.`, so no `..` segment can survive — is folded to `_`.
+ */
+const PATH_UNSAFE = /[^\w-]/g;
+
+/**
+ * Emit `value` as a TypeScript string literal.
+ *
+ * EVERY identifier read out of the source database must go through this. Table,
+ * column, and index names are attacker-adjacent input — they're legal to quote in
+ * both Postgres and MySQL, so they can contain `"`, `\`, or a newline — and the
+ * output of this emitter is TypeScript the developer subsequently runs. Splicing
+ * a raw name into a quoted literal is a code-injection hole, not a cosmetic bug.
+ * `JSON.stringify` escapes quotes, backslashes, and control characters, and its
+ * output is a valid TS string literal.
+ */
+const literal = (value: string): string => JSON.stringify(value);
+
 /** Quote an object key when it isn't a bare JS identifier, so a `user-id` column still emits valid source. */
-const key = (name: string): string => (IDENTIFIER.test(name) ? name : JSON.stringify(name));
+const key = (name: string): string => (IDENTIFIER.test(name) ? name : literal(name));
+
+/**
+ * Emit a property access for `name`: `.orders` for a bare identifier, but
+ * `["order-items"]` otherwise. Dot notation with a quoted key is a syntax error,
+ * so this cannot just reuse {@link key}.
+ */
+const member = (name: string): string => (IDENTIFIER.test(name) ? `.${name}` : `[${literal(name)}]`);
+
+/**
+ * Neutralize a value interpolated into an emitted block comment. A name
+ * containing a comment terminator would otherwise close the comment early and let
+ * the rest of the name land in code position.
+ */
+const comment = (text: string): string => text.replaceAll("*/", String.raw`*\/`);
+
+/**
+ * Fold a table name into a safe single filename segment. A name is free to
+ * contain `/` or `..`, which would otherwise escape the output directory once
+ * joined — introspection must never write outside `lunora/`.
+ */
+const fileSegment = (name: string): string => {
+    const safe = name.replaceAll(PATH_UNSAFE, "_");
+
+    return safe === "" ? "table" : safe;
+};
 
 /** Derive a valid TS export/const name from a table name (`order_items` → `orderItems`). */
 const identifierFor = (name: string): string => {
@@ -84,8 +129,30 @@ const indexedColumns = (table: IntrospectedTable): string[] => {
     return [...names].filter((name) => !RESERVED_COLUMNS.has(name));
 };
 
+/**
+ * Resolve a column against the set of tables actually being emitted. A foreign
+ * key can point somewhere that isn't in the output — `--tables` selected a
+ * subset, or the FK crosses into another schema — and `v.id("absent")` would not
+ * resolve, so the whole generated schema would fail to type-check. Demote such a
+ * column to its plain scalar type instead and report it: a schema that compiles
+ * with one weaker column beats one that doesn't compile at all.
+ */
+const resolveReference = (column: IntrospectedColumn, present: ReadonlySet<string>, table: string, warnings: string[]): IntrospectedColumn => {
+    if (column.references === undefined || present.has(column.references.table)) {
+        return column;
+    }
+
+    warnings.push(
+        `${table}.${column.name}: references \`${column.references.table}\`, which isn't in the generated schema — emitted as a plain column instead of \`v.id(...)\`.`,
+    );
+
+    // Rebuilt field-by-field rather than rest-destructured: `references` is the
+    // one property being dropped, and naming it explicitly keeps that visible.
+    return { arrayDepth: column.arrayDepth, dataType: column.dataType, name: column.name, nullable: column.nullable };
+};
+
 /** Emit the `defineTable({...})` body plus its chained `.global()` / `.index()` calls for one table. */
-const tableSource = (table: IntrospectedTable, dialect: SqlDialect, warnings: string[]): string => {
+const tableSource = (table: IntrospectedTable, dialect: SqlDialect, present: ReadonlySet<string>, warnings: string[]): string => {
     const lines: string[] = [];
 
     for (const column of table.columns) {
@@ -97,11 +164,15 @@ const tableSource = (table: IntrospectedTable, dialect: SqlDialect, warnings: st
             continue;
         }
 
-        const { expression, known } = validatorForColumn(column, dialect);
+        const resolved = resolveReference(column, present, table.name, warnings);
+        const { expression, known } = validatorForColumn(resolved, dialect);
 
-        if (!known && column.references === undefined) {
+        if (!known && resolved.references === undefined) {
             warnings.push(`${table.name}.${column.name}: no mapping for SQL type \`${column.dataType}\` — emitted as \`v.any()\`.`);
-            lines.push(`        // TODO: \`${column.dataType}\` has no direct validator; narrow this.`);
+            // A line comment, so only a newline could break out — and `dataType`
+            // comes from a single `information_schema` type column, which can't
+            // contain one. Still routed through `comment` for uniformity.
+            lines.push(`        // TODO: \`${comment(column.dataType)}\` has no direct validator; narrow this.`);
         }
 
         lines.push(`        ${key(column.name)}: ${expression},`);
@@ -116,9 +187,9 @@ const tableSource = (table: IntrospectedTable, dialect: SqlDialect, warnings: st
     if (table.primaryKey.length > 0 && table.primaryKey.every((column) => !RESERVED_COLUMNS.has(column))) {
         // Lunora mints its own `_id`; the source primary key becomes a unique index
         // so the original identity is still enforced and still indexed.
-        const columns = table.primaryKey.map((column) => `"${column}"`).join(", ");
+        const columns = table.primaryKey.map((column) => literal(column)).join(", ");
 
-        chain.push(`        .index("by_${table.primaryKey.join("_")}", [${columns}], { unique: true })`);
+        chain.push(`        .index(${literal(`by_${table.primaryKey.join("_")}`)}, [${columns}], { unique: true })`);
     }
 
     for (const index of table.indexes) {
@@ -128,10 +199,10 @@ const tableSource = (table: IntrospectedTable, dialect: SqlDialect, warnings: st
             continue;
         }
 
-        const rendered = columns.map((column) => `"${column}"`).join(", ");
+        const rendered = columns.map((column) => literal(column)).join(", ");
         const options = index.unique ? ", { unique: true }" : "";
 
-        chain.push(`        .index(${JSON.stringify(index.name)}, [${rendered}]${options})`);
+        chain.push(`        .index(${literal(index.name)}, [${rendered}]${options})`);
     }
 
     return `    ${key(table.name)}: defineTable({\n${lines.join("\n")}\n    })\n${chain.join("\n")},`;
@@ -139,7 +210,8 @@ const tableSource = (table: IntrospectedTable, dialect: SqlDialect, warnings: st
 
 /** Emit the whole `schema.ts` module. */
 const schemaSource = (database: IntrospectedDatabase, options: EmitOptions, warnings: string[]): string => {
-    const tables = database.tables.map((table) => tableSource(table, database.dialect, warnings)).join("\n");
+    const present = new Set(database.tables.map((table) => table.name));
+    const tables = database.tables.map((table) => tableSource(table, database.dialect, present, warnings)).join("\n");
 
     return `/**
  * Generated by \`lunora introspect\` from an existing ${database.dialect === "postgres" ? "Postgres" : "MySQL"} database.
@@ -167,7 +239,13 @@ ${tables}
  * is a decision the developer makes per endpoint, after they've added whatever
  * auth or RLS the table needs.
  */
-const procedureSource = (table: IntrospectedTable, options: EmitOptions): string => {
+const procedureSource = (
+    table: IntrospectedTable,
+    dialect: SqlDialect,
+    options: EmitOptions,
+    present: ReadonlySet<string> = new Set([table.name]),
+    warnings: string[] = [],
+): string => {
     const name = identifierFor(table.name);
     const filterable = indexedColumns(table);
     const columns = new Map(usableColumns(table).map((column) => [column.name, column]));
@@ -182,17 +260,23 @@ const procedureSource = (table: IntrospectedTable, options: EmitOptions): string
 
             // Filters are always matched against a concrete value, so drop the
             // `v.optional(...)` wrapper the column carries for nullability.
-            const { expression } = validatorForColumn({ ...definition, nullable: false }, "postgres");
+            const resolved = resolveReference({ ...definition, nullable: false }, present, table.name, []);
+            const { expression, known } = validatorForColumn(resolved, dialect);
+
+            if (!known && resolved.references === undefined) {
+                warnings.push(`${table.name}.${column}: filter falls back to \`v.any()\` (no mapping for SQL type \`${definition.dataType}\`).`);
+            }
 
             return `        ${key(column)}: ${expression},`;
         })
         .filter((line) => line !== undefined);
 
-    const sortable = ['"_creationTime"', ...filterable.map((column) => `"${column}"`)].join(", ");
+    const sortable = [literal("_creationTime"), ...filterable.map((column) => literal(column))].join(", ");
+    const accessor = `ctx.db${member(table.name)}`;
 
     return `/**
- * Generated by \`lunora introspect\` for the \`${table.name}\` table — a starting
- * point you own and edit.
+ * Generated by \`lunora introspect\` for the \`${comment(table.name)}\` table — a
+ * starting point you own and edit.
  *
  * Both procedures are RPC-only. Add \`.expose({ rest: true })\` once you've decided
  * this data should be public, and gate them with your auth/RLS middleware first —
@@ -204,25 +288,33 @@ import { c } from "./_generated/server";
 
 const ${name}List = defineListArgs({
     // Only index-backed columns are published as filterable, so a caller cannot
-    // force a full-table scan through the argument surface.
+    // reach a column you did not choose to expose. Note that \`contains\` and the
+    // negative operators still scan — narrow this list, and review it, before
+    // adding \`.expose({ rest: true })\`.
     filter: {
 ${filters.join("\n")}
     },
     orderBy: [${sortable}],
 });
 
-export const list = c.query.input(${name}List.args).query(({ args, ctx }) => ctx.db.${key(table.name)}.findMany(${name}List.toQueryArgs(args)));
+export const list = c.query.input(${name}List.args).query(({ args, ctx }) => ${accessor}.findMany(${name}List.toQueryArgs(args)));
 
-export const get = c.query.input({ id: v.id("${table.name}") }).query(({ args, ctx }) => ctx.db.${key(table.name)}.get(args.id));
+export const get = c.query.input({ id: v.id(${literal(table.name)}) }).query(({ args, ctx }) => ${accessor}.get(args.id));
 `;
 };
 
 /** Emit every file for an introspected database. */
 const emitIntrospection = (database: IntrospectedDatabase, options: EmitOptions): EmitResult => {
     const warnings: string[] = [];
+    const present = new Set(database.tables.map((table) => table.name));
     const files: EmittedFile[] = [{ contents: schemaSource(database, options, warnings), path: "schema.ts" }];
 
     if (options.procedures) {
+        // Pre-seeded with the schema module's own name: a table literally called
+        // `schema` would otherwise mint a second `schema.ts`, and `--force` would
+        // overwrite the generated schema with a procedure module.
+        const claimed = new Map<string, string>([["schema", "the generated schema module"]]);
+
         for (const table of database.tables) {
             if (usableColumns(table).length === 0) {
                 warnings.push(`${table.name}: no usable columns — procedure module skipped.`);
@@ -230,7 +322,25 @@ const emitIntrospection = (database: IntrospectedDatabase, options: EmitOptions)
                 continue;
             }
 
-            files.push({ contents: procedureSource(table, options), path: `${table.name}.ts` });
+            const segment = fileSegment(table.name);
+
+            if (segment !== table.name) {
+                warnings.push(`${table.name}: written as \`${segment}.ts\` — the table name isn't usable as a filename.`);
+            }
+
+            // Two source names can fold onto one filename (`a-b` and `a.b` both
+            // become `a_b`). Silently overwriting the first would lose a table, so
+            // skip and say which pair collided.
+            const previous = claimed.get(segment);
+
+            if (previous !== undefined) {
+                warnings.push(`${table.name}: procedure module skipped — its filename \`${segment}.ts\` collides with table \`${previous}\`.`);
+
+                continue;
+            }
+
+            claimed.set(segment, table.name);
+            files.push({ contents: procedureSource(table, database.dialect, options, present, warnings), path: `${segment}.ts` });
         }
     }
 

--- a/packages/cli/src/commands/introspect/emit.ts
+++ b/packages/cli/src/commands/introspect/emit.ts
@@ -1,0 +1,241 @@
+/**
+ * Turn an {@link IntrospectedDatabase} into authored TypeScript: a `defineSchema`
+ * module and, optionally, a list/get procedure module per table.
+ *
+ * What this deliberately is NOT: a runtime gateway that serves an existing
+ * database over HTTP. Lunora enforces auth and row-level security inside
+ * procedures, so a table auto-published as CRUD would be a hole straight past
+ * both. What `introspect` produces instead is a one-time scaffold the developer
+ * owns from that moment on — the schema declaration they'd otherwise transcribe
+ * by hand, plus procedures narrow enough to be safe to start from.
+ *
+ * Two rules shape the emitted procedures, both inherited from `defineListArgs`:
+ * only columns an index can serve are published as filterable, and only indexed
+ * columns (plus `_creationTime`) are sortable. That keeps the scaffold from
+ * handing out a full-table scan on day one.
+ */
+import type { IntrospectedColumn, IntrospectedDatabase, IntrospectedTable, SqlDialect } from "./model";
+import { RESERVED_COLUMNS, validatorForColumn } from "./model";
+
+/** A file the command is about to write. */
+interface EmittedFile {
+    readonly contents: string;
+    /** Path relative to the project's `lunora/` directory. */
+    readonly path: string;
+}
+
+/** Everything the emitter produces, including what it had to leave behind. */
+interface EmitResult {
+    readonly files: ReadonlyArray<EmittedFile>;
+    /** Human-readable notes (skipped columns, unmapped types) for the command to print. */
+    readonly warnings: ReadonlyArray<string>;
+}
+
+interface EmitOptions {
+    /** Emit `list`/`get` procedure modules alongside the schema. */
+    readonly procedures: boolean;
+    /** Import specifier for the server surface — `lunorash/server` or `@lunora/server`. */
+    readonly serverImport: string;
+}
+
+const IDENTIFIER = /^[A-Z_$][\w$]*$/i;
+
+/** Separator runs in a SQL identifier, consumed while camelCasing (`order_items` → `orderItems`). */
+const SEPARATOR_RUN = /[^\dA-Z]+(.)?/gi;
+
+/** A leading digit run, which can't start a JS identifier. */
+const LEADING_DIGITS = /^\d+/;
+
+/** Quote an object key when it isn't a bare JS identifier, so a `user-id` column still emits valid source. */
+const key = (name: string): string => (IDENTIFIER.test(name) ? name : JSON.stringify(name));
+
+/** Derive a valid TS export/const name from a table name (`order_items` → `orderItems`). */
+const identifierFor = (name: string): string => {
+    const camel = name.replaceAll(SEPARATOR_RUN, (_, next: string | undefined) => next?.toUpperCase() ?? "");
+    const safe = camel.replace(LEADING_DIGITS, "");
+
+    return safe === "" ? "table" : `${safe.charAt(0).toLowerCase()}${safe.slice(1)}`;
+};
+
+/** Columns Lunora can carry over, i.e. everything that doesn't collide with a system field. */
+const usableColumns = (table: IntrospectedTable): IntrospectedColumn[] => table.columns.filter((column) => !RESERVED_COLUMNS.has(column.name));
+
+/**
+ * Columns that an index (or a foreign key) can serve, so they're safe to publish
+ * as filterable. A composite index contributes all of its columns — the planner
+ * can use a prefix, and a filter on a non-prefix column still narrows against the
+ * index rather than scanning blind.
+ */
+const indexedColumns = (table: IntrospectedTable): string[] => {
+    const names = new Set<string>(table.primaryKey);
+
+    for (const index of table.indexes) {
+        for (const column of index.columns) {
+            names.add(column);
+        }
+    }
+
+    for (const column of table.columns) {
+        if (column.references !== undefined) {
+            names.add(column.name);
+        }
+    }
+
+    return [...names].filter((name) => !RESERVED_COLUMNS.has(name));
+};
+
+/** Emit the `defineTable({...})` body plus its chained `.global()` / `.index()` calls for one table. */
+const tableSource = (table: IntrospectedTable, dialect: SqlDialect, warnings: string[]): string => {
+    const lines: string[] = [];
+
+    for (const column of table.columns) {
+        if (RESERVED_COLUMNS.has(column.name)) {
+            warnings.push(
+                `${table.name}.${column.name}: skipped — \`${column.name}\` is a Lunora system column. Rename it in the source database or map it by hand.`,
+            );
+
+            continue;
+        }
+
+        const { expression, known } = validatorForColumn(column, dialect);
+
+        if (!known && column.references === undefined) {
+            warnings.push(`${table.name}.${column.name}: no mapping for SQL type \`${column.dataType}\` — emitted as \`v.any()\`.`);
+            lines.push(`        // TODO: \`${column.dataType}\` has no direct validator; narrow this.`);
+        }
+
+        lines.push(`        ${key(column.name)}: ${expression},`);
+    }
+
+    const chain: string[] = [
+        // The rows live in the external database, so the table is `.global()` on the
+        // hyperdrive backend rather than sharded into a Durable Object.
+        `        .global({ backend: "hyperdrive" })`,
+    ];
+
+    if (table.primaryKey.length > 0 && table.primaryKey.every((column) => !RESERVED_COLUMNS.has(column))) {
+        // Lunora mints its own `_id`; the source primary key becomes a unique index
+        // so the original identity is still enforced and still indexed.
+        const columns = table.primaryKey.map((column) => `"${column}"`).join(", ");
+
+        chain.push(`        .index("by_${table.primaryKey.join("_")}", [${columns}], { unique: true })`);
+    }
+
+    for (const index of table.indexes) {
+        const columns = index.columns.filter((column) => !RESERVED_COLUMNS.has(column));
+
+        if (columns.length === 0) {
+            continue;
+        }
+
+        const rendered = columns.map((column) => `"${column}"`).join(", ");
+        const options = index.unique ? ", { unique: true }" : "";
+
+        chain.push(`        .index(${JSON.stringify(index.name)}, [${rendered}]${options})`);
+    }
+
+    return `    ${key(table.name)}: defineTable({\n${lines.join("\n")}\n    })\n${chain.join("\n")},`;
+};
+
+/** Emit the whole `schema.ts` module. */
+const schemaSource = (database: IntrospectedDatabase, options: EmitOptions, warnings: string[]): string => {
+    const tables = database.tables.map((table) => tableSource(table, database.dialect, warnings)).join("\n");
+
+    return `/**
+ * Generated by \`lunora introspect\` from an existing ${database.dialect === "postgres" ? "Postgres" : "MySQL"} database.
+ *
+ * This file is a STARTING POINT, not a build artifact — it is written once and is
+ * yours to edit. Review it before shipping: column types are mapped
+ * conservatively, and every table is \`.global({ backend: "hyperdrive" })\` because
+ * its rows live in the external database. Re-running \`lunora introspect\` will not
+ * overwrite it unless you pass \`--force\`.
+ */
+import { defineSchema, defineTable, v } from "${options.serverImport}";
+
+export default defineSchema({
+${tables}
+});
+`;
+};
+
+/**
+ * Emit a `list` + `get` procedure module for one table. `list` is built on
+ * `defineListArgs`, so it inherits keyset paging, the clamped limit, and the
+ * enumerate-don't-open filter rule.
+ *
+ * Neither procedure is `.expose({ rest: true })`, and that is the point: publishing
+ * is a decision the developer makes per endpoint, after they've added whatever
+ * auth or RLS the table needs.
+ */
+const procedureSource = (table: IntrospectedTable, options: EmitOptions): string => {
+    const name = identifierFor(table.name);
+    const filterable = indexedColumns(table);
+    const columns = new Map(usableColumns(table).map((column) => [column.name, column]));
+
+    const filters = filterable
+        .map((column) => {
+            const definition = columns.get(column);
+
+            if (definition === undefined) {
+                return undefined;
+            }
+
+            // Filters are always matched against a concrete value, so drop the
+            // `v.optional(...)` wrapper the column carries for nullability.
+            const { expression } = validatorForColumn({ ...definition, nullable: false }, "postgres");
+
+            return `        ${key(column)}: ${expression},`;
+        })
+        .filter((line) => line !== undefined);
+
+    const sortable = ['"_creationTime"', ...filterable.map((column) => `"${column}"`)].join(", ");
+
+    return `/**
+ * Generated by \`lunora introspect\` for the \`${table.name}\` table — a starting
+ * point you own and edit.
+ *
+ * Both procedures are RPC-only. Add \`.expose({ rest: true })\` once you've decided
+ * this data should be public, and gate them with your auth/RLS middleware first —
+ * \`introspect\` cannot know who is allowed to read this table.
+ */
+import { defineListArgs, v } from "${options.serverImport}";
+
+import { c } from "./_generated/server";
+
+const ${name}List = defineListArgs({
+    // Only index-backed columns are published as filterable, so a caller cannot
+    // force a full-table scan through the argument surface.
+    filter: {
+${filters.join("\n")}
+    },
+    orderBy: [${sortable}],
+});
+
+export const list = c.query.input(${name}List.args).query(({ args, ctx }) => ctx.db.${key(table.name)}.findMany(${name}List.toQueryArgs(args)));
+
+export const get = c.query.input({ id: v.id("${table.name}") }).query(({ args, ctx }) => ctx.db.${key(table.name)}.get(args.id));
+`;
+};
+
+/** Emit every file for an introspected database. */
+const emitIntrospection = (database: IntrospectedDatabase, options: EmitOptions): EmitResult => {
+    const warnings: string[] = [];
+    const files: EmittedFile[] = [{ contents: schemaSource(database, options, warnings), path: "schema.ts" }];
+
+    if (options.procedures) {
+        for (const table of database.tables) {
+            if (usableColumns(table).length === 0) {
+                warnings.push(`${table.name}: no usable columns — procedure module skipped.`);
+
+                continue;
+            }
+
+            files.push({ contents: procedureSource(table, options), path: `${table.name}.ts` });
+        }
+    }
+
+    return { files, warnings };
+};
+
+export type { EmitOptions, EmitResult, EmittedFile };
+export { emitIntrospection, identifierFor, indexedColumns, procedureSource, schemaSource };

--- a/packages/cli/src/commands/introspect/emit.ts
+++ b/packages/cli/src/commands/introspect/emit.ts
@@ -54,6 +54,23 @@ const LEADING_DIGITS = /^\d+/;
 const PATH_UNSAFE = /[^\w-]/g;
 
 /**
+ * Characters `JSON.stringify` leaves raw that are still unsafe once the emitted
+ * source travels: `&lt;` / `>` / `/` can close a host `&lt;/script>` if the file is
+ * ever inlined into HTML (a code viewer, a docs page), and U+2028 / U+2029 are
+ * line terminators that older tooling treats as breaking the literal. Their
+ * escaped forms denote the identical string, so this costs nothing.
+ */
+const LITERAL_UNSAFE = /[\u003C\u003E\u002F\u2028\u2029]/g;
+
+const LITERAL_UNSAFE_ESCAPES: Readonly<Record<string, string>> = {
+    "\u002F": String.raw`\u002F`,
+    "\u2028": String.raw`\u2028`,
+    "\u2029": String.raw`\u2029`,
+    "\u003C": String.raw`\u003C`,
+    "\u003E": String.raw`\u003E`,
+};
+
+/**
  * Emit `value` as a TypeScript string literal.
  *
  * EVERY identifier read out of the source database must go through this. Table,
@@ -61,10 +78,12 @@ const PATH_UNSAFE = /[^\w-]/g;
  * both Postgres and MySQL, so they can contain `"`, `\`, or a newline — and the
  * output of this emitter is TypeScript the developer subsequently runs. Splicing
  * a raw name into a quoted literal is a code-injection hole, not a cosmetic bug.
- * `JSON.stringify` escapes quotes, backslashes, and control characters, and its
- * output is a valid TS string literal.
+ *
+ * `JSON.stringify` handles quotes, backslashes, and control characters;
+ * {@link LITERAL_UNSAFE} covers the rest, so the result is safe both as TypeScript
+ * and in any downstream context the generated file gets embedded in.
  */
-const literal = (value: string): string => JSON.stringify(value);
+const literal = (value: string): string => JSON.stringify(value).replaceAll(LITERAL_UNSAFE, (character) => LITERAL_UNSAFE_ESCAPES[character] ?? character);
 
 /** Quote an object key when it isn't a bare JS identifier, so a `user-id` column still emits valid source. */
 const key = (name: string): string => (IDENTIFIER.test(name) ? name : literal(name));
@@ -284,9 +303,10 @@ const procedureSource = (
  */
 import { defineListArgs, v } from "${options.serverImport}";
 
+import type { Doc } from "./_generated/dataModel";
 import { c } from "./_generated/server";
 
-const ${name}List = defineListArgs({
+const ${name}List = defineListArgs<Doc<${literal(table.name)}>>()({
     // Only index-backed columns are published as filterable, so a caller cannot
     // reach a column you did not choose to expose. Note that \`contains\` and the
     // negative operators still scan — narrow this list, and review it, before

--- a/packages/cli/src/commands/introspect/handler.ts
+++ b/packages/cli/src/commands/introspect/handler.ts
@@ -11,12 +11,15 @@ import { connect, dialectFromUrl } from "./connect";
 import type { EmittedFile } from "./emit";
 import { emitIntrospection } from "./emit";
 import type { IntrospectOptions } from "./index";
+import type { SqlDialect } from "./model";
 import { readDatabase } from "./read-database";
 
 interface IntrospectCommandOptions {
     /** Inject an already-open connection (tests). When set, `url` is not read. */
     connection?: Connection;
     cwd?: string;
+    /** Dialect to pair with an injected `connection`. Ignored when connecting from `url`, where the scheme decides. */
+    dialect?: SqlDialect;
     /** Write nothing; print what would be written. */
     dryRun?: boolean;
     /** Overwrite files that already exist. */
@@ -92,7 +95,10 @@ const runIntrospectCommand = async (options: IntrospectCommandOptions): Promise<
         return { code: 1, written: [] };
     }
 
-    const dialect = options.connection === undefined ? dialectFromUrl(options.url as string) : "postgres";
+    // With an injected connection there is no URL scheme to read the dialect from,
+    // so it has to be stated. `readDatabase` branches on it, and defaulting silently
+    // to Postgres would make the MySQL path unreachable through this seam.
+    const dialect = options.connection === undefined ? dialectFromUrl(options.url as string) : (options.dialect ?? "postgres");
     // Drivers resolve from the project, not the CLI install, so `cwd` matters.
     const connection = options.connection ?? (await connect(options.url as string, dialect, options.schema, cwd));
 
@@ -108,6 +114,14 @@ const runIntrospectCommand = async (options: IntrospectCommandOptions): Promise<
 
     const selected =
         options.tables === undefined || options.tables.length === 0 ? database.tables : database.tables.filter((table) => options.tables?.includes(table.name));
+
+    // A typo in `--tables` would otherwise vanish silently, and the run would look
+    // like it succeeded while quietly skipping the table the user actually wanted.
+    for (const requested of options.tables ?? []) {
+        if (!database.tables.some((table) => table.name === requested)) {
+            options.logger.warn(`--tables: no table named "${requested}" exists in this schema — skipped.`);
+        }
+    }
 
     if (selected.length === 0) {
         options.logger.error("no tables found to introspect — check --schema and --tables.");

--- a/packages/cli/src/commands/introspect/handler.ts
+++ b/packages/cli/src/commands/introspect/handler.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+
+import { join } from "@visulima/path";
+
+import type { CommandHandler } from "../../util/command";
+import { defineHandler } from "../../util/command";
+import type { Logger } from "../../util/logger";
+import type { Connection } from "./connect";
+import { connect, dialectFromUrl } from "./connect";
+import type { EmittedFile } from "./emit";
+import { emitIntrospection } from "./emit";
+import type { IntrospectOptions } from "./index";
+import { readDatabase } from "./read-database";
+
+interface IntrospectCommandOptions {
+    /** Inject an already-open connection (tests). When set, `url` is not read. */
+    connection?: Connection;
+    cwd?: string;
+    /** Write nothing; print what would be written. */
+    dryRun?: boolean;
+    /** Overwrite files that already exist. */
+    force?: boolean;
+    logger: Logger;
+    /** Emit `list`/`get` procedure modules alongside the schema. Defaults to `true`. */
+    procedures?: boolean;
+    /** Postgres schema (default `public`) or MySQL database name. */
+    schema?: string;
+    /** Only introspect these tables. */
+    tables?: ReadonlyArray<string>;
+    url?: string;
+}
+
+interface IntrospectCommandResult {
+    code: number;
+    /** Paths (relative to `lunora/`) actually written. */
+    written: string[];
+}
+
+/**
+ * Resolve which server package the emitted imports should point at. A project
+ * depending on the `lunorash` umbrella gets `lunorash/server`; everything else
+ * gets `@lunora/server`. Mirrors the rule codegen uses for `_generated/*`.
+ */
+const resolveServerImport = (cwd: string): string => {
+    try {
+        const manifest = JSON.parse(readFileSync(join(cwd, "package.json"), "utf8")) as {
+            dependencies?: Record<string, string>;
+            devDependencies?: Record<string, string>;
+        };
+
+        return manifest.dependencies?.lunorash === undefined && manifest.devDependencies?.lunorash === undefined ? "@lunora/server" : "lunorash/server";
+    } catch {
+        return "@lunora/server";
+    }
+};
+
+/** Write one emitted file, honoring `--force` and `--dry-run`. Returns `true` when it was written. */
+const writeEmittedFile = async (file: EmittedFile, directory: string, options: IntrospectCommandOptions): Promise<boolean> => {
+    const target = join(directory, file.path);
+
+    if (existsSync(target) && options.force !== true) {
+        options.logger.warn(`skipped lunora/${file.path} — it already exists (pass --force to overwrite)`);
+
+        return false;
+    }
+
+    if (options.dryRun === true) {
+        options.logger.info(`would write lunora/${file.path} (${String(file.contents.split("\n").length)} lines)`);
+
+        return false;
+    }
+
+    await mkdir(directory, { recursive: true });
+    await writeFile(target, file.contents, "utf8");
+    options.logger.info(`wrote lunora/${file.path}`);
+
+    return true;
+};
+
+/**
+ * Read an existing database and scaffold `lunora/schema.ts` (plus per-table
+ * procedure modules) from it. Read-only against the source database; never
+ * overwrites an existing file without `--force`.
+ */
+const runIntrospectCommand = async (options: IntrospectCommandOptions): Promise<IntrospectCommandResult> => {
+    const cwd = options.cwd ?? process.cwd();
+
+    if (options.connection === undefined && (options.url === undefined || options.url === "")) {
+        options.logger.error("`lunora introspect` needs a database URL: pass --url, or set DATABASE_URL.");
+
+        return { code: 1, written: [] };
+    }
+
+    const dialect = options.connection === undefined ? dialectFromUrl(options.url as string) : "postgres";
+    // Drivers resolve from the project, not the CLI install, so `cwd` matters.
+    const connection = options.connection ?? (await connect(options.url as string, dialect, options.schema, cwd));
+
+    let database;
+
+    try {
+        database = await readDatabase(connection.execute, dialect, connection.schema);
+    } finally {
+        if (options.connection === undefined) {
+            await connection.close();
+        }
+    }
+
+    const selected =
+        options.tables === undefined || options.tables.length === 0 ? database.tables : database.tables.filter((table) => options.tables?.includes(table.name));
+
+    if (selected.length === 0) {
+        options.logger.error("no tables found to introspect — check --schema and --tables.");
+
+        return { code: 1, written: [] };
+    }
+
+    const { files, warnings } = emitIntrospection(
+        { ...database, tables: selected },
+        { procedures: options.procedures !== false, serverImport: resolveServerImport(cwd) },
+    );
+
+    const directory = join(cwd, "lunora");
+    const written: string[] = [];
+
+    for (const file of files) {
+        // Sequential on purpose: the log lines are the command's progress output
+        // and interleaving them would make the report unreadable.
+        // eslint-disable-next-line no-await-in-loop -- ordered console output
+        if (await writeEmittedFile(file, directory, options)) {
+            written.push(file.path);
+        }
+    }
+
+    for (const warning of warnings) {
+        options.logger.warn(warning);
+    }
+
+    options.logger.info(`introspected ${String(selected.length)} table(s) from ${dialect}. Review the generated files before running \`lunora dev\`.`);
+
+    return { code: 0, written };
+};
+
+/** `lunora introspect` handler (lazy-loaded via the command's `loader`). */
+const execute: CommandHandler<IntrospectOptions> = defineHandler<IntrospectOptions>(async ({ cwd, logger, options }) => {
+    const result = await runIntrospectCommand({
+        cwd,
+        dryRun: options.dryRun === true,
+        force: options.force === true,
+        logger,
+        procedures: options.procedures !== false,
+        schema: options.schema,
+        tables: options.tables === undefined ? undefined : options.tables.split(",").map((name) => name.trim()),
+        url: options.url ?? process.env.DATABASE_URL,
+    });
+
+    return { code: result.code };
+});
+
+export { execute, resolveServerImport, runIntrospectCommand };
+export type { IntrospectCommandOptions, IntrospectCommandResult };

--- a/packages/cli/src/commands/introspect/handler.ts
+++ b/packages/cli/src/commands/introspect/handler.ts
@@ -11,7 +11,8 @@ import { connect, dialectFromUrl } from "./connect";
 import type { EmittedFile } from "./emit";
 import { emitIntrospection } from "./emit";
 import type { IntrospectOptions } from "./index";
-import type { SqlDialect } from "./model";
+import { mergeIntoSchema } from "./merge";
+import type { IntrospectedDatabase, SqlDialect } from "./model";
 import { readDatabase } from "./read-database";
 
 interface IntrospectCommandOptions {
@@ -82,6 +83,61 @@ const writeEmittedFile = async (file: EmittedFile, directory: string, options: I
 };
 
 /**
+ * Narrow the introspected tables to what `--tables` asked for, reporting any name
+ * that matched nothing — a typo would otherwise vanish silently and the run would
+ * look successful while skipping the table the user actually wanted.
+ */
+const selectTables = (database: IntrospectedDatabase, options: IntrospectCommandOptions): IntrospectedDatabase["tables"] => {
+    const requested = options.tables;
+
+    if (requested === undefined || requested.length === 0) {
+        return database.tables;
+    }
+
+    for (const name of requested) {
+        if (!database.tables.some((table) => table.name === name)) {
+            options.logger.warn(`--tables: no table named "${name}" exists in this schema — skipped.`);
+        }
+    }
+
+    return database.tables.filter((table) => requested.includes(table.name));
+};
+
+/**
+ * Fold an introspected database into a `schema.ts` that already exists, rather
+ * than overwriting it. Returns `true` when the file was rewritten.
+ */
+const mergeExistingSchema = async (
+    schemaPath: string,
+    database: IntrospectedDatabase,
+    dialect: SqlDialect,
+    options: IntrospectCommandOptions,
+): Promise<boolean> => {
+    const merged = mergeIntoSchema(readFileSync(schemaPath, "utf8"), database, dialect);
+
+    for (const warning of merged.warnings) {
+        options.logger.warn(warning);
+    }
+
+    if (merged.text === undefined) {
+        options.logger.info("lunora/schema.ts is already up to date with the database.");
+
+        return false;
+    }
+
+    if (options.dryRun === true) {
+        options.logger.info(`would merge ${String(merged.applied)} addition(s) into lunora/schema.ts`);
+
+        return false;
+    }
+
+    await writeFile(schemaPath, merged.text, "utf8");
+    options.logger.info(`merged ${String(merged.applied)} addition(s) into lunora/schema.ts`);
+
+    return true;
+};
+
+/**
  * Read an existing database and scaffold `lunora/schema.ts` (plus per-table
  * procedure modules) from it. Read-only against the source database; never
  * overwrites an existing file without `--force`.
@@ -112,16 +168,7 @@ const runIntrospectCommand = async (options: IntrospectCommandOptions): Promise<
         }
     }
 
-    const selected =
-        options.tables === undefined || options.tables.length === 0 ? database.tables : database.tables.filter((table) => options.tables?.includes(table.name));
-
-    // A typo in `--tables` would otherwise vanish silently, and the run would look
-    // like it succeeded while quietly skipping the table the user actually wanted.
-    for (const requested of options.tables ?? []) {
-        if (!database.tables.some((table) => table.name === requested)) {
-            options.logger.warn(`--tables: no table named "${requested}" exists in this schema — skipped.`);
-        }
-    }
+    const selected = selectTables(database, options);
 
     if (selected.length === 0) {
         options.logger.error("no tables found to introspect — check --schema and --tables.");
@@ -136,8 +183,20 @@ const runIntrospectCommand = async (options: IntrospectCommandOptions): Promise<
 
     const directory = join(cwd, "lunora");
     const written: string[] = [];
+    const schemaPath = join(directory, "schema.ts");
 
-    for (const file of files) {
+    // A schema already on disk is the developer's file, not ours. Rather than
+    // refusing (or clobbering under --force), fold newly-discovered tables,
+    // columns, and indexes into it as additive edits, preserving their formatting
+    // and everything they've changed since the first run.
+    const merging = existsSync(schemaPath) && options.force !== true;
+    const remaining = merging ? files.filter((file) => file.path !== "schema.ts") : files;
+
+    if (merging && (await mergeExistingSchema(schemaPath, { ...database, tables: selected }, dialect, options))) {
+        written.push("schema.ts");
+    }
+
+    for (const file of remaining) {
         // Sequential on purpose: the log lines are the command's progress output
         // and interleaving them would make the report unreadable.
         // eslint-disable-next-line no-await-in-loop -- ordered console output

--- a/packages/cli/src/commands/introspect/index.ts
+++ b/packages/cli/src/commands/introspect/index.ts
@@ -1,0 +1,36 @@
+import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
+
+const introspectCommand: Command = {
+    description: "Scaffold lunora/schema.ts (and list/get procedures) from an existing Postgres or MySQL database",
+    examples: [
+        ["lunora introspect --url postgres://localhost/shop", "Scaffold a schema + procedures from every table"],
+        ["lunora introspect --tables users,orders", "Introspect only these tables (DATABASE_URL is read by default)"],
+        ["lunora introspect --dry-run", "Print what would be written without touching the filesystem"],
+        ["lunora introspect --no-procedures --force", "Regenerate just the schema, overwriting the existing file"],
+    ],
+    group: "Data",
+    loader: () =>
+        import("./handler").then((m) => {
+            return { default: m.execute as CommandExecute<Toolbox> };
+        }),
+    name: "introspect",
+    options: [
+        { description: "Database connection string (default: $DATABASE_URL)", name: "url", type: String },
+        { description: "Postgres schema (default `public`) or MySQL database name", name: "schema", type: String },
+        { description: "Comma-separated table allow-list (default: every base table)", name: "tables", type: String },
+        { description: "Also emit list/get procedure modules per table (default true; --no-procedures to skip)", name: "procedures", type: Boolean },
+        { description: "Overwrite files that already exist", name: "force", type: Boolean },
+        { description: "Print what would be written without writing it", name: "dry-run", type: Boolean },
+    ],
+};
+
+export { introspectCommand };
+
+export type IntrospectOptions = CreateOptions<{
+    "dry-run": boolean | undefined;
+    force: boolean | undefined;
+    procedures: boolean | undefined;
+    schema: string | undefined;
+    tables: string | undefined;
+    url: string | undefined;
+}>;

--- a/packages/cli/src/commands/introspect/merge.ts
+++ b/packages/cli/src/commands/introspect/merge.ts
@@ -1,0 +1,179 @@
+/**
+ * Merge an introspected database into an EXISTING `lunora/schema.ts`.
+ *
+ * The first run writes a whole schema module; every run after that lands on a
+ * file the developer has since edited — renamed a column, tightened a validator,
+ * added a relation. Clobbering it (or refusing without `--force`) makes
+ * re-introspection useless exactly when it becomes useful: after the source
+ * database gains a table.
+ *
+ * So a re-run plans additive edits instead and applies them through
+ * `@lunora/config`'s `applyAdditiveEdit` — the same formatting-preserving,
+ * ts-morph-backed path the visual schema editor uses. Two of its rules are
+ * inherited deliberately rather than worked around. First, new columns land
+ * `v.optional(...)`: a required column added to a table that already exists needs
+ * a backfill, so the editor refuses to write one, and tightening it afterwards is
+ * the developer's call. Second, names must be bare identifiers — an `order-items`
+ * table is legal in Postgres and legal in the first-run emitter (which quotes it),
+ * but the editor's allow-list rejects it, so such tables are reported and skipped
+ * rather than half-applied.
+ *
+ * Nothing here is destructive: a column dropped from the source database is left
+ * alone in the schema, because deleting it would drop live rows.
+ */
+import type { SchemaEdit, SchemaTable } from "@lunora/config";
+import { applyAdditiveEdit, parseSchema } from "@lunora/config";
+
+import type { IntrospectedDatabase, IntrospectedTable, SqlDialect } from "./model";
+import { RESERVED_COLUMNS, validatorForColumn } from "./model";
+
+/** Same rule `@lunora/config`'s editor enforces; checked here so we can report a useful reason. */
+const IDENTIFIER = /^[A-Z_$][\w$]*$/i;
+
+interface MergePlan {
+    readonly edits: ReadonlyArray<SchemaEdit>;
+    readonly warnings: ReadonlyArray<string>;
+}
+
+interface MergeResult {
+    /** Number of edits successfully applied. */
+    readonly applied: number;
+    /** `undefined` when nothing changed. */
+    readonly text?: string;
+    readonly warnings: ReadonlyArray<string>;
+}
+
+/** Strip the `v.optional(...)` wrapper — `applyAdditiveEdit` re-adds it, and would otherwise double it. */
+const innerValidator = (expression: string): string =>
+    expression.startsWith("v.optional(") && expression.endsWith(")") ? expression.slice("v.optional(".length, -1) : expression;
+
+/** Shared inputs for {@link planColumns}, kept in one object so the signature stays readable. */
+interface ColumnPlanContext {
+    readonly dialect: SqlDialect;
+    /** Table names that will exist in the merged schema — used to demote dangling foreign keys. */
+    readonly present: ReadonlySet<string>;
+    readonly warnings: string[];
+}
+
+/** Additive column edits for one table: everything the source has that the schema doesn't. */
+const planColumns = (table: IntrospectedTable, current: SchemaTable | undefined, context: ColumnPlanContext): SchemaEdit[] => {
+    const edits: SchemaEdit[] = [];
+    const existingColumns = new Set(current?.columns.map((column) => column.name));
+
+    for (const column of table.columns) {
+        if (RESERVED_COLUMNS.has(column.name) || existingColumns.has(column.name)) {
+            continue;
+        }
+
+        if (!IDENTIFIER.test(column.name)) {
+            context.warnings.push(`${table.name}.${column.name}: skipped — column names must be bare identifiers to merge.`);
+
+            continue;
+        }
+
+        // An FK whose target isn't in the merged schema would emit an unresolvable
+        // `v.id(...)`, so demote it exactly as the first-run emitter does.
+        const dangling = column.references !== undefined && !context.present.has(column.references.table);
+        const { expression } = validatorForColumn(dangling ? { ...column, references: undefined } : column, context.dialect);
+
+        edits.push({ column: column.name, kind: "addOptionalColumn", table: table.name, validator: innerValidator(expression) });
+
+        if (!column.nullable && current !== undefined) {
+            context.warnings.push(
+                `${table.name}.${column.name}: added as \`v.optional(...)\` — a required column on an existing table needs a backfill migration.`,
+            );
+        }
+    }
+
+    return edits;
+};
+
+/** Additive index edits for one table: every source index the schema doesn't already declare. */
+const planIndexes = (table: IntrospectedTable, current: SchemaTable | undefined, warnings: string[]): SchemaEdit[] => {
+    const edits: SchemaEdit[] = [];
+    const existingIndexes = new Set(current?.indexes.map((index) => index.name));
+
+    for (const index of table.indexes) {
+        const columns = index.columns.filter((column) => !RESERVED_COLUMNS.has(column));
+
+        if (existingIndexes.has(index.name) || columns.length === 0) {
+            continue;
+        }
+
+        if (!IDENTIFIER.test(index.name) || !columns.every((column) => IDENTIFIER.test(column))) {
+            warnings.push(`${table.name}: index \`${index.name}\` skipped — index and column names must be bare identifiers to merge.`);
+
+            continue;
+        }
+
+        edits.push({ fields: columns, kind: "addIndex", name: index.name, table: table.name, ...(index.unique ? { unique: true } : {}) });
+    }
+
+    return edits;
+};
+
+/**
+ * Plan the additive edits that bring `existing` up to date with `database`.
+ * Pure — nothing is applied and no file is read here, so the planner is testable
+ * on its own.
+ */
+const planMerge = (database: IntrospectedDatabase, existing: ReadonlyArray<SchemaTable>, dialect: SqlDialect): MergePlan => {
+    const edits: SchemaEdit[] = [];
+    const warnings: string[] = [];
+    const byName = new Map(existing.map((table) => [table.name, table]));
+    const present = new Set([...byName.keys(), ...database.tables.map((table) => table.name)]);
+
+    for (const table of database.tables) {
+        if (!IDENTIFIER.test(table.name)) {
+            warnings.push(`${table.name}: skipped — merging into an existing schema needs a table name that is a bare identifier.`);
+
+            continue;
+        }
+
+        const current = byName.get(table.name);
+
+        if (current === undefined) {
+            // The rows live in the source database, so a newly-discovered table is
+            // `.global()` on the hyperdrive backend, matching the first-run emitter.
+            edits.push({ global: { backend: "hyperdrive" }, kind: "addTable", table: table.name });
+        }
+
+        edits.push(...planColumns(table, current, { dialect, present, warnings }), ...planIndexes(table, current, warnings));
+    }
+
+    return { edits, warnings };
+};
+
+/**
+ * Apply {@link planMerge}'s edits to a schema source string, in order. A single
+ * edit that fails is reported and skipped rather than aborting the run — the
+ * remaining tables are still worth landing.
+ */
+const mergeIntoSchema = (source: string, database: IntrospectedDatabase, dialect: SqlDialect): MergeResult => {
+    const parsed = parseSchema(source);
+
+    if (!parsed.ok) {
+        return { applied: 0, warnings: [`lunora/schema.ts could not be parsed (${parsed.reason}) — leave it alone and merge by hand, or pass --force.`] };
+    }
+
+    const plan = planMerge(database, parsed.tables, dialect);
+    const warnings = [...plan.warnings];
+    let text = source;
+    let applied = 0;
+
+    for (const edit of plan.edits) {
+        const result = applyAdditiveEdit(text, edit);
+
+        if (result.ok) {
+            text = result.text;
+            applied += 1;
+        } else {
+            warnings.push(`${edit.table}: skipped one edit (${result.reason}).`);
+        }
+    }
+
+    return { applied, warnings, ...(applied === 0 ? {} : { text }) };
+};
+
+export type { MergePlan, MergeResult };
+export { innerValidator, mergeIntoSchema, planMerge };

--- a/packages/cli/src/commands/introspect/model.ts
+++ b/packages/cli/src/commands/introspect/model.ts
@@ -160,7 +160,10 @@ const validatorForColumn = (column: IntrospectedColumn, dialect: SqlDialect): { 
     const mapped = table[column.dataType];
     // An FK is expressed as a branded id so the relationship survives into the
     // generated types; the underlying column stays a string/number in the database.
-    const base = column.references === undefined ? mapped : `v.id("${column.references.table}")`;
+    // The target name is a catalog identifier, so it is emitted as a JSON-escaped
+    // literal — a name containing `"` or `\` would otherwise break out of the
+    // string and inject code into the schema the developer later runs.
+    const base = column.references === undefined ? mapped : `v.id(${JSON.stringify(column.references.table)})`;
 
     let expression = base ?? "v.any()";
 

--- a/packages/cli/src/commands/introspect/model.ts
+++ b/packages/cli/src/commands/introspect/model.ts
@@ -1,0 +1,179 @@
+/**
+ * The dialect-neutral model `lunora introspect` builds from an existing
+ * Postgres/MySQL database, plus the mapping from a native SQL type onto a `v.*`
+ * validator.
+ *
+ * This is deliberately a SCAFFOLD model, not a runtime binding. `lunora
+ * introspect` reads someone else's database once and writes TypeScript the
+ * developer then owns and edits — so every mapping here errs toward "widest thing
+ * that round-trips" (an unrecognised type becomes `v.any()` with a TODO) rather
+ * than failing the run. Getting a schema file the developer can immediately
+ * `lunora dev` against matters more than being exhaustive on exotic types.
+ */
+
+/** The SQL engines introspection can read. Matches `@lunora/sql-store`'s dialect names. */
+type SqlDialect = "mysql" | "postgres";
+
+/** One column of an introspected table. `dataType` is the raw, lower-cased native type name. */
+interface IntrospectedColumn {
+    /** Nesting depth for array types (Postgres `text[]` → 1). `0` for a scalar. */
+    readonly arrayDepth: number;
+    readonly dataType: string;
+    readonly name: string;
+    readonly nullable: boolean;
+    /** Target of this column's foreign key, when it has one. */
+    readonly references?: { readonly column: string; readonly table: string };
+}
+
+/** A secondary index carried over as a `.index(...)` declaration. */
+interface IntrospectedIndex {
+    readonly columns: ReadonlyArray<string>;
+    readonly name: string;
+    readonly unique: boolean;
+}
+
+interface IntrospectedTable {
+    readonly columns: ReadonlyArray<IntrospectedColumn>;
+    readonly indexes: ReadonlyArray<IntrospectedIndex>;
+    readonly name: string;
+    readonly primaryKey: ReadonlyArray<string>;
+}
+
+interface IntrospectedDatabase {
+    readonly dialect: SqlDialect;
+    readonly tables: ReadonlyArray<IntrospectedTable>;
+}
+
+/**
+ * Column names Lunora owns on every row. A source column colliding with one of
+ * these can't be carried over verbatim — the emitter drops it and reports it, so
+ * the developer decides on a rename rather than getting a schema that silently
+ * shadows a system field.
+ */
+const RESERVED_COLUMNS = new Set(["_creationTime", "_id"]);
+
+/** Postgres native types → `v.*` factory call, keyed by the lower-cased `udt_name`/`data_type`. */
+const POSTGRES_TYPES: Record<string, string> = {
+    bigint: "v.bigint()",
+    bigserial: "v.bigint()",
+    bit: "v.string()",
+    bool: "v.boolean()",
+    boolean: "v.boolean()",
+    box: "v.string()",
+    bpchar: "v.string()",
+    bytea: "v.bytes()",
+    char: "v.string()",
+    character: "v.string()",
+    "character varying": "v.string()",
+    cidr: "v.string()",
+    circle: "v.string()",
+    citext: "v.string()",
+    date: "v.date()",
+    "double precision": "v.number()",
+    float4: "v.number()",
+    float8: "v.number()",
+    inet: "v.string()",
+    int: "v.number()",
+    int2: "v.number()",
+    int4: "v.number()",
+    int8: "v.bigint()",
+    integer: "v.number()",
+    interval: "v.string()",
+    json: "v.any()",
+    jsonb: "v.any()",
+    line: "v.string()",
+    lseg: "v.string()",
+    macaddr: "v.string()",
+    money: "v.number()",
+    name: "v.string()",
+    numeric: "v.number()",
+    path: "v.string()",
+    point: "v.string()",
+    polygon: "v.string()",
+    real: "v.number()",
+    serial: "v.number()",
+    smallint: "v.number()",
+    smallserial: "v.number()",
+    text: "v.string()",
+    time: "v.string()",
+    "time with time zone": "v.string()",
+    "time without time zone": "v.string()",
+    timestamp: "v.timestamp()",
+    "timestamp with time zone": "v.timestamp()",
+    "timestamp without time zone": "v.timestamp()",
+    timestamptz: "v.timestamp()",
+    tsquery: "v.string()",
+    tsvector: "v.string()",
+    uuid: "v.string()",
+    varbit: "v.string()",
+    varchar: "v.string()",
+    xml: "v.string()",
+};
+
+/** MySQL native types → `v.*` factory call, keyed by the lower-cased `DATA_TYPE`. */
+const MYSQL_TYPES: Record<string, string> = {
+    bigint: "v.bigint()",
+    binary: "v.bytes()",
+    bit: "v.number()",
+    blob: "v.bytes()",
+    char: "v.string()",
+    date: "v.date()",
+    datetime: "v.timestamp()",
+    decimal: "v.number()",
+    double: "v.number()",
+    enum: "v.string()",
+    float: "v.number()",
+    int: "v.number()",
+    integer: "v.number()",
+    json: "v.any()",
+    longblob: "v.bytes()",
+    longtext: "v.string()",
+    mediumblob: "v.bytes()",
+    mediumint: "v.number()",
+    mediumtext: "v.string()",
+    numeric: "v.number()",
+    set: "v.string()",
+    smallint: "v.number()",
+    text: "v.string()",
+    time: "v.string()",
+    timestamp: "v.timestamp()",
+    tinyblob: "v.bytes()",
+    tinyint: "v.number()",
+    tinytext: "v.string()",
+    varbinary: "v.bytes()",
+    varchar: "v.string()",
+    year: "v.number()",
+};
+
+/**
+ * Map one column onto the `v.*` expression that represents it, including array
+ * nesting and nullability. A foreign key becomes `v.id("&lt;target table>")` so the
+ * generated schema states the relationship in Lunora's own vocabulary instead of
+ * leaving a bare string.
+ *
+ * Returns the expression plus `known: false` when the native type had no mapping
+ * — the caller turns that into a `TODO` comment beside the column rather than
+ * guessing silently.
+ */
+const validatorForColumn = (column: IntrospectedColumn, dialect: SqlDialect): { expression: string; known: boolean } => {
+    const table = dialect === "postgres" ? POSTGRES_TYPES : MYSQL_TYPES;
+    const mapped = table[column.dataType];
+    // An FK is expressed as a branded id so the relationship survives into the
+    // generated types; the underlying column stays a string/number in the database.
+    const base = column.references === undefined ? mapped : `v.id("${column.references.table}")`;
+
+    let expression = base ?? "v.any()";
+
+    for (let depth = 0; depth < column.arrayDepth; depth += 1) {
+        expression = `v.array(${expression})`;
+    }
+
+    if (column.nullable) {
+        expression = `v.optional(${expression})`;
+    }
+
+    return { expression, known: base !== undefined };
+};
+
+export type { IntrospectedColumn, IntrospectedDatabase, IntrospectedIndex, IntrospectedTable, SqlDialect };
+export { MYSQL_TYPES, POSTGRES_TYPES, RESERVED_COLUMNS, validatorForColumn };

--- a/packages/cli/src/commands/introspect/read-database.ts
+++ b/packages/cli/src/commands/introspect/read-database.ts
@@ -156,7 +156,9 @@ const assembleIndexes = (rows: ReadonlyArray<Record<string, unknown>>, dialect: 
         }
     }
 
-    return [...byName.entries()].map(([name, index]) => {return { columns: index.columns, name, unique: index.unique }});
+    return [...byName.entries()].map(([name, index]) => {
+        return { columns: index.columns, name, unique: index.unique };
+    });
 };
 
 /**

--- a/packages/cli/src/commands/introspect/read-database.ts
+++ b/packages/cli/src/commands/introspect/read-database.ts
@@ -1,0 +1,216 @@
+/**
+ * Read an existing Postgres/MySQL database's shape out of `information_schema`
+ * (plus `pg_index` on Postgres, which is the only place index columns are
+ * reliably available in order).
+ *
+ * Query execution sits behind {@link SqlExecutor} so the assembly logic — which
+ * is where the fiddly part actually lives — is testable without a live database.
+ * Everything here is read-only: introspection never writes to the source.
+ */
+import type { IntrospectedColumn, IntrospectedDatabase, IntrospectedIndex, IntrospectedTable, SqlDialect } from "./model";
+
+/** Runs one parameterized query and returns its rows. Placeholders are dialect-native (`$1` / `?`). */
+type SqlExecutor = (sql: string, parameters: ReadonlyArray<unknown>) => Promise<ReadonlyArray<Record<string, unknown>>>;
+
+/**
+ * Read a column off a driver row, tolerating the case differences between
+ * drivers (`pg` lower-cases, `mysql2` preserves the `information_schema`
+ * spelling). Scalars are coerced to their string form; anything structural (a
+ * driver returning a Buffer or a row object) reads as `""` rather than
+ * `"[object Object]"`, so a surprising driver shape degrades to "absent".
+ */
+const field = (row: Record<string, unknown>, name: string): string => {
+    const value = row[name] ?? row[name.toLowerCase()] ?? row[name.toUpperCase()];
+
+    if (typeof value === "string") {
+        return value;
+    }
+
+    if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
+        return String(value);
+    }
+
+    return "";
+};
+
+const POSTGRES_COLUMNS = `
+    SELECT c.table_name, c.column_name, c.is_nullable, c.data_type, c.udt_name
+    FROM information_schema.columns c
+    JOIN information_schema.tables t
+      ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+    WHERE c.table_schema = $1 AND t.table_type = 'BASE TABLE'
+    ORDER BY c.table_name, c.ordinal_position`;
+
+const POSTGRES_PRIMARY_KEYS = `
+    SELECT tc.table_name, kcu.column_name
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+    WHERE tc.table_schema = $1 AND tc.constraint_type = 'PRIMARY KEY'
+    ORDER BY tc.table_name, kcu.ordinal_position`;
+
+const POSTGRES_FOREIGN_KEYS = `
+    SELECT tc.table_name, kcu.column_name, ccu.table_name AS foreign_table, ccu.column_name AS foreign_column
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+    WHERE tc.table_schema = $1 AND tc.constraint_type = 'FOREIGN KEY'`;
+
+// `pg_index.indkey` is an ordered attribute-number vector; unnesting it WITH
+// ORDINALITY is the only way to recover multi-column index order faithfully.
+const POSTGRES_INDEXES = `
+    SELECT t.relname AS table_name, i.relname AS index_name, ix.indisunique AS is_unique, a.attname AS column_name
+    FROM pg_class t
+    JOIN pg_index ix ON t.oid = ix.indrelid
+    JOIN pg_class i ON i.oid = ix.indexrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    CROSS JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+    WHERE n.nspname = $1 AND t.relkind = 'r' AND NOT ix.indisprimary
+    ORDER BY t.relname, i.relname, k.ord`;
+
+// eslint-disable-next-line no-secrets/no-secrets -- `information_schema.*` table names, not a credential
+const MYSQL_COLUMNS = `
+    SELECT c.TABLE_NAME, c.COLUMN_NAME, c.IS_NULLABLE, c.DATA_TYPE
+    FROM information_schema.COLUMNS c
+    JOIN information_schema.TABLES t
+      ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME
+    WHERE c.TABLE_SCHEMA = ? AND t.TABLE_TYPE = 'BASE TABLE'
+    ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION`;
+
+// eslint-disable-next-line no-secrets/no-secrets -- `information_schema.*` table names, not a credential
+const MYSQL_PRIMARY_KEYS = `
+    SELECT TABLE_NAME, COLUMN_NAME
+    FROM information_schema.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = ? AND CONSTRAINT_NAME = 'PRIMARY'
+    ORDER BY TABLE_NAME, ORDINAL_POSITION`;
+
+// eslint-disable-next-line no-secrets/no-secrets -- `information_schema.*` table names, not a credential
+const MYSQL_FOREIGN_KEYS = `
+    SELECT TABLE_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME AS foreign_table, REFERENCED_COLUMN_NAME AS foreign_column
+    FROM information_schema.KEY_COLUMN_USAGE
+    WHERE TABLE_SCHEMA = ? AND REFERENCED_TABLE_NAME IS NOT NULL`;
+
+const MYSQL_INDEXES = `
+    SELECT TABLE_NAME, INDEX_NAME AS index_name, NON_UNIQUE, COLUMN_NAME
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = ? AND INDEX_NAME <> 'PRIMARY'
+    ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX`;
+
+/** Group rows by their table name, preserving row order within each group. */
+const groupByTable = (rows: ReadonlyArray<Record<string, unknown>>): Map<string, Record<string, unknown>[]> => {
+    const grouped = new Map<string, Record<string, unknown>[]>();
+
+    for (const row of rows) {
+        const table = field(row, "table_name");
+        const bucket = grouped.get(table);
+
+        if (bucket === undefined) {
+            grouped.set(table, [row]);
+        } else {
+            bucket.push(row);
+        }
+    }
+
+    return grouped;
+};
+
+/**
+ * Resolve a column's native type name and array depth. Postgres reports an array
+ * as `data_type = 'ARRAY'` with the element type hidden in `udt_name` behind a
+ * leading underscore (`_text`); MySQL has no array types.
+ */
+const resolveType = (row: Record<string, unknown>, dialect: SqlDialect): { arrayDepth: number; dataType: string } => {
+    const dataType = field(row, "data_type").toLowerCase();
+
+    if (dialect !== "postgres") {
+        return { arrayDepth: 0, dataType };
+    }
+
+    const udt = field(row, "udt_name").toLowerCase();
+
+    if (dataType === "array" && udt.startsWith("_")) {
+        return { arrayDepth: 1, dataType: udt.slice(1) };
+    }
+
+    // `udt_name` is the more specific spelling (`int4` vs `integer`) and is what
+    // the type table is keyed on first, so prefer it when it maps.
+    return { arrayDepth: 0, dataType: udt === "" ? dataType : udt };
+};
+
+/** Assemble the index list for one table from its (already table-scoped) rows. */
+const assembleIndexes = (rows: ReadonlyArray<Record<string, unknown>>, dialect: SqlDialect): IntrospectedIndex[] => {
+    const byName = new Map<string, { columns: string[]; unique: boolean }>();
+
+    for (const row of rows) {
+        const name = field(row, "index_name");
+        const unique = dialect === "postgres" ? field(row, "is_unique") === "true" : field(row, "NON_UNIQUE") === "0";
+        const existing = byName.get(name);
+
+        if (existing === undefined) {
+            byName.set(name, { columns: [field(row, "column_name")], unique });
+        } else {
+            existing.columns.push(field(row, "column_name"));
+        }
+    }
+
+    return [...byName.entries()].map(([name, index]) => {return { columns: index.columns, name, unique: index.unique }});
+};
+
+/**
+ * Run the four introspection queries and fold them into the dialect-neutral
+ * model. `schema` is the Postgres schema name (usually `public`) or the MySQL
+ * database name.
+ */
+const readDatabase = async (execute: SqlExecutor, dialect: SqlDialect, schema: string): Promise<IntrospectedDatabase> => {
+    const postgres = dialect === "postgres";
+    const [columnRows, primaryKeyRows, foreignKeyRows, indexRows] = await Promise.all([
+        execute(postgres ? POSTGRES_COLUMNS : MYSQL_COLUMNS, [schema]),
+        execute(postgres ? POSTGRES_PRIMARY_KEYS : MYSQL_PRIMARY_KEYS, [schema]),
+        execute(postgres ? POSTGRES_FOREIGN_KEYS : MYSQL_FOREIGN_KEYS, [schema]),
+        execute(postgres ? POSTGRES_INDEXES : MYSQL_INDEXES, [schema]),
+    ]);
+
+    const primaryKeys = groupByTable(primaryKeyRows);
+    const foreignKeys = groupByTable(foreignKeyRows);
+    const indexes = groupByTable(indexRows);
+
+    const tables: IntrospectedTable[] = [];
+
+    for (const [name, rows] of groupByTable(columnRows)) {
+        const references = new Map(
+            (foreignKeys.get(name) ?? []).map((row) => [
+                field(row, "column_name"),
+                { column: field(row, "foreign_column"), table: field(row, "foreign_table") },
+            ]),
+        );
+
+        const columns: IntrospectedColumn[] = rows.map((row) => {
+            const columnName = field(row, "column_name");
+            const reference = references.get(columnName);
+
+            return {
+                ...resolveType(row, dialect),
+                name: columnName,
+                nullable: field(row, "is_nullable").toUpperCase() === "YES",
+                ...(reference === undefined ? {} : { references: reference }),
+            };
+        });
+
+        tables.push({
+            columns,
+            indexes: assembleIndexes(indexes.get(name) ?? [], dialect),
+            name,
+            primaryKey: (primaryKeys.get(name) ?? []).map((row) => field(row, "column_name")),
+        });
+    }
+
+    tables.sort((a, b) => a.name.localeCompare(b.name));
+
+    return { dialect, tables };
+};
+
+export type { SqlExecutor };
+export { assembleIndexes, groupByTable, readDatabase, resolveType };

--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -343,7 +343,7 @@ describe("discoverFunctions", () => {
 
     interface QueryBuilder<Args> {
         readonly __lunoraProcedure: "query";
-        expose: (config: { rest?: boolean }) => QueryBuilder<Args>;
+        expose: (config: { cache?: { maxAge: number; scope: "private" | "public"; staleWhileRevalidate?: number; tag?: string; vary?: string }; rest?: boolean }) => QueryBuilder<Args>;
         input: <X extends Record<string, unknown>>(validators: X) => QueryBuilder<Args & X>;
         use: <C>(middleware: (options: { ctx: unknown }) => C) => QueryBuilder<Args>;
         query: <R>(handler: (options: { args: Args; ctx: unknown }) => R) => { args: Args; handler: (ctx: unknown, args: Args) => R; kind: "query" };
@@ -351,7 +351,7 @@ describe("discoverFunctions", () => {
 
     interface MutationBuilder<Args> {
         readonly __lunoraProcedure: "mutation";
-        expose: (config: { rest?: boolean }) => MutationBuilder<Args>;
+        expose: (config: { cache?: { maxAge: number; scope: "private" | "public"; staleWhileRevalidate?: number; tag?: string; vary?: string }; rest?: boolean }) => MutationBuilder<Args>;
         input: <X extends Record<string, unknown>>(validators: X) => MutationBuilder<Args & X>;
         mutation: <R>(handler: (options: { args: Args; ctx: unknown }) => R) => { args: Args; handler: (ctx: unknown, args: Args) => R; kind: "mutation" };
     }
@@ -449,6 +449,42 @@ describe("discoverFunctions", () => {
             // A procedure without `.expose()` stays RPC-only (default-closed).
             expect(byName.get("secret")?.expose).toBeUndefined();
             expect(byName.get("list")?.args.channelId).toEqual({ kind: "id", tableName: "channels" });
+        });
+
+        it("reads the `cache` block of `.expose(...)`, recording only statically-readable literals", () => {
+            expect.assertions(4);
+
+            writeFunction(
+                "messages.ts",
+                `${BUILDER_PREAMBLE}
+            declare const computedMaxAge: number;
+
+            export const list = c.query
+                .expose({ rest: true, cache: { scope: "public", maxAge: 60, staleWhileRevalidate: 120, tag: "messages" } })
+                .query(() => null);
+
+            export const feed = c.query
+                .expose({ rest: true, cache: { scope: "private", maxAge: computedMaxAge } })
+                .query(() => null);
+
+            export const plain = c.query
+                .expose({ rest: true })
+                .query(() => null);
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+            const byName = new Map(discoverFunctions(project, workdir).map((f) => [f.exportName, f]));
+
+            expect(byName.get("list")?.expose).toEqual({
+                cache: { maxAge: 60, scope: "public", staleWhileRevalidate: 120, tag: "messages" },
+                rest: true,
+            });
+            // A computed `maxAge` can't be read statically — it is omitted rather
+            // than guessed, so the emitted spec under-documents instead of lying.
+            expect(byName.get("feed")?.expose?.cache).toEqual({ scope: "private" });
+            expect(byName.get("plain")?.expose).toEqual({ rest: true });
+            expect(byName.get("plain")?.expose?.cache).toBeUndefined();
         });
 
         it("falls back to the import name when the builder brand can't resolve (uninstalled deps)", () => {

--- a/packages/codegen/__tests__/openapi.test.ts
+++ b/packages/codegen/__tests__/openapi.test.ts
@@ -282,4 +282,46 @@ describe("emitOpenApi — opt-in public REST surface (plan 167)", () => {
 
         expect(restPaths).toEqual([]);
     });
+
+    it("documents the cache headers a `.expose({ cache })` endpoint answers with", () => {
+        expect.assertions(4);
+
+        const document = buildOpenApiDocument({
+            functions: [
+                makeFunction({
+                    expose: { cache: { maxAge: 60, scope: "public", staleWhileRevalidate: 120, tag: "messages" }, rest: true },
+                    exportName: "list",
+                }),
+            ],
+            httpRoutes: [],
+        });
+
+        const { paths } = document as {
+            paths: Record<
+                string,
+                Record<string, { responses: Record<string, { headers?: Record<string, { description: string; schema: { example?: string } }> }> }>
+            >;
+        };
+        const headers = paths["/_lunora/rest/messages/list"]?.get?.responses["200"]?.headers;
+
+        expect(headers?.["Cache-Control"]?.schema.example).toBe("public, max-age=60, stale-while-revalidate=120");
+        expect(headers?.["Cache-Tag"]?.schema.example).toBe("messages");
+        expect(headers?.Vary).toBeDefined();
+        // A caller reading the spec must learn about the credentialed downgrade,
+        // otherwise `public` reads as an unconditional promise.
+        expect(headers?.["Cache-Control"]?.description).toContain("always answered `private`");
+    });
+
+    it("omits the cache headers block entirely for an endpoint that declares no cache", () => {
+        expect.assertions(1);
+
+        const document = buildOpenApiDocument({
+            functions: [makeFunction({ expose: { rest: true }, exportName: "list" })],
+            httpRoutes: [],
+        });
+
+        const { paths } = document as { paths: Record<string, Record<string, { responses: Record<string, { headers?: unknown }> }>> };
+
+        expect(paths["/_lunora/rest/messages/list"]?.get?.responses["200"]?.headers).toBeUndefined();
+    });
 });

--- a/packages/codegen/__tests__/openapi.test.ts
+++ b/packages/codegen/__tests__/openapi.test.ts
@@ -312,6 +312,41 @@ describe("emitOpenApi — opt-in public REST surface (plan 167)", () => {
         expect(headers?.["Cache-Control"]?.description).toContain("always answered `private`");
     });
 
+    it("omits cache headers on a mutation, which the runtime never caches", () => {
+        expect.assertions(1);
+
+        const document = buildOpenApiDocument({
+            functions: [
+                makeFunction({
+                    expose: { cache: { maxAge: 60, scope: "public" }, rest: true },
+                    exportName: "send",
+                    kind: "mutation",
+                }),
+            ],
+            httpRoutes: [],
+        });
+
+        const { paths } = document as { paths: Record<string, Record<string, { responses: Record<string, { headers?: unknown }> }>> };
+
+        // A mutation is POST-only, and `rest-cache` refuses to cache a non-GET —
+        // documenting a Cache-Control here would make the spec contradict the runtime.
+        expect(paths["/_lunora/rest/messages/send"]?.post?.responses["200"]?.headers).toBeUndefined();
+    });
+
+    it("omits cache headers when the declaration used values discovery could not read", () => {
+        expect.assertions(1);
+
+        const document = buildOpenApiDocument({
+            // `scope` read, `maxAge` computed — an emitted example would be invented.
+            functions: [makeFunction({ expose: { cache: { scope: "public" }, rest: true }, exportName: "list" })],
+            httpRoutes: [],
+        });
+
+        const { paths } = document as { paths: Record<string, Record<string, { responses: Record<string, { headers?: unknown }> }>> };
+
+        expect(paths["/_lunora/rest/messages/list"]?.get?.responses["200"]?.headers).toBeUndefined();
+    });
+
     it("omits the cache headers block entirely for an endpoint that declares no cache", () => {
         expect.assertions(1);
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -255,13 +255,17 @@ const cacheFromExposeLiteral = (literal: ObjectLiteralExpression): ExposeCacheIR
     const tag = stringProperty(initializer, "tag");
     const vary = stringProperty(initializer, "vary");
 
-    return {
+    const read: ExposeCacheIR = {
         ...(maxAge === undefined ? {} : { maxAge }),
         ...(scope === "private" || scope === "public" ? { scope } : {}),
         ...(staleWhileRevalidate === undefined ? {} : { staleWhileRevalidate }),
         ...(tag === undefined ? {} : { tag }),
         ...(vary === undefined ? {} : { vary }),
     };
+
+    // Nothing readable (every field computed) is reported as absent rather than as
+    // an empty object, so a consumer can't mistake "unreadable" for "declared".
+    return Object.keys(read).length === 0 ? undefined : read;
 };
 
 /**

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -6,6 +6,7 @@ import type {
     CallExpression,
     FunctionExpression,
     Identifier,
+    ObjectLiteralExpression,
     Project,
     SourceFile,
     Symbol as TsSymbol,
@@ -14,7 +15,7 @@ import type {
 } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
-import type { FunctionIR, ValidatorIR } from "./ir";
+import type { ExposeCacheIR, FunctionIR, ValidatorIR } from "./ir";
 import { isServerSurfaceModule } from "./module-specifiers";
 import { parseObjectShape } from "./parse-validator";
 import sanitizeNamespace from "./paths";
@@ -81,7 +82,7 @@ const LIFECYCLE_FACTORIES: Record<string, "connect" | "disconnect"> = {
 interface DiscoveredFunction {
     args: Record<string, ValidatorIR>;
     /** Set when the builder chain includes `.expose({ rest: true })` (plan 167). */
-    expose?: { rest?: boolean };
+    expose?: { cache?: ExposeCacheIR; rest?: boolean };
     kind: string;
     lifecycle?: "connect" | "disconnect";
     returnType: string;
@@ -202,14 +203,97 @@ const resolveBuilderRootKind = (receiver: Node, followedLocal = false): "interna
     return INTERNAL_FACTORIES[rootName] ? "internal" : undefined;
 };
 
+/** Read a property off an object literal as a string literal, or `undefined` when absent / not statically readable. */
+const stringProperty = (literal: ObjectLiteralExpression, name: string): string | undefined => {
+    const property = literal.getProperty(name);
+
+    if (property === undefined || !Node.isPropertyAssignment(property)) {
+        return undefined;
+    }
+
+    const initializer = property.getInitializer();
+
+    return initializer !== undefined && Node.isStringLiteral(initializer) ? initializer.getLiteralValue() : undefined;
+};
+
+/** Read a property off an object literal as a numeric literal, or `undefined` when absent / not statically readable. */
+const numberProperty = (literal: ObjectLiteralExpression, name: string): number | undefined => {
+    const property = literal.getProperty(name);
+
+    if (property === undefined || !Node.isPropertyAssignment(property)) {
+        return undefined;
+    }
+
+    const initializer = property.getInitializer();
+
+    return initializer !== undefined && Node.isNumericLiteral(initializer) ? initializer.getLiteralValue() : undefined;
+};
+
+/**
+ * Read the `cache: { … }` sub-object of an `.expose(...)` argument into
+ * {@link ExposeCacheIR}. Only literal fields are recorded — a computed `maxAge`
+ * is simply omitted, so the emitted spec under-documents rather than states
+ * something the runtime won't do. Returns `undefined` when there is no readable
+ * `cache` object at all.
+ */
+const cacheFromExposeLiteral = (literal: ObjectLiteralExpression): ExposeCacheIR | undefined => {
+    const property = literal.getProperty("cache");
+
+    if (property === undefined || !Node.isPropertyAssignment(property)) {
+        return undefined;
+    }
+
+    const initializer = property.getInitializer();
+
+    if (initializer === undefined || !Node.isObjectLiteralExpression(initializer)) {
+        return undefined;
+    }
+
+    const scope = stringProperty(initializer, "scope");
+    const maxAge = numberProperty(initializer, "maxAge");
+    const staleWhileRevalidate = numberProperty(initializer, "staleWhileRevalidate");
+    const tag = stringProperty(initializer, "tag");
+    const vary = stringProperty(initializer, "vary");
+
+    return {
+        ...(maxAge === undefined ? {} : { maxAge }),
+        ...(scope === "private" || scope === "public" ? { scope } : {}),
+        ...(staleWhileRevalidate === undefined ? {} : { staleWhileRevalidate }),
+        ...(tag === undefined ? {} : { tag }),
+        ...(vary === undefined ? {} : { vary }),
+    };
+};
+
+/**
+ * Read the argument of a located `.expose(...)` call into the IR tag. An
+ * unreadable argument (not an object literal, or a computed `rest`) yields `{}` —
+ * "exposed, details unknown" — which is the safe default: the function is still
+ * treated as tagged, just without a `rest === true` that would publish it.
+ */
+const exposeFromArgument = (argument: Node | undefined): { cache?: ExposeCacheIR; rest?: boolean } => {
+    if (argument === undefined || !Node.isObjectLiteralExpression(argument)) {
+        return {};
+    }
+
+    const cache = cacheFromExposeLiteral(argument);
+    const restProperty = argument.getProperty("rest");
+
+    if (restProperty !== undefined && Node.isPropertyAssignment(restProperty)) {
+        return { ...(cache === undefined ? {} : { cache }), rest: restProperty.getInitializer()?.getText() === "true" };
+    }
+
+    return cache === undefined ? {} : { cache };
+};
+
 /**
  * Walk a builder-terminal chain (`c.input(...).expose({ rest: true }).query(...)`)
- * leftward looking for a `.expose({ ... })` modifier, and read its `rest` flag
- * from the object-literal argument. Returns `{ rest }` when found, else
- * `undefined` (RPC-only — the default). Mirrors {@link resolveBuilderRootKind}'s
- * chain descent so it works under degraded types (no `@lunora/server` install).
+ * leftward looking for a `.expose({ ... })` modifier, and read its `rest` flag and
+ * optional `cache` block from the object-literal argument. Returns the tag when
+ * found, else `undefined` (RPC-only — the default). Mirrors
+ * {@link resolveBuilderRootKind}'s chain descent so it works under degraded types
+ * (no `@lunora/server` install).
  */
-const exposeFromBuilderChain = (receiver: Node): { rest?: boolean } | undefined => {
+const exposeFromBuilderChain = (receiver: Node): { cache?: ExposeCacheIR; rest?: boolean } | undefined => {
     let current: Node = receiver;
 
     while (Node.isCallExpression(current)) {
@@ -220,22 +304,7 @@ const exposeFromBuilderChain = (receiver: Node): { rest?: boolean } | undefined 
         }
 
         if (inner.getName() === "expose") {
-            const argument = current.getArguments()[0];
-
-            if (argument !== undefined && Node.isObjectLiteralExpression(argument)) {
-                const restProperty = argument.getProperty("rest");
-
-                if (restProperty !== undefined && Node.isPropertyAssignment(restProperty)) {
-                    const initializer = restProperty.getInitializer();
-                    const rest = initializer?.getText() === "true";
-
-                    return { rest };
-                }
-            }
-
-            // `.expose(...)` present but its arg isn't a readable `{ rest: … }`
-            // literal — treat as exposed-unknown (`rest` absent), a safe default.
-            return {};
+            return exposeFromArgument(current.getArguments()[0]);
         }
 
         current = inner.getExpression();

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -254,6 +254,19 @@ export interface SchemaIR {
     vectorIndexes: ReadonlyArray<VectorIndexIR>;
 }
 
+/**
+ * Statically-read mirror of `@lunora/server`'s `RestCacheConfig`. Every field is
+ * optional because discovery only records literals it could actually read off the
+ * `.expose({ cache: … })` object.
+ */
+export interface ExposeCacheIR {
+    maxAge?: number;
+    scope?: "private" | "public";
+    staleWhileRevalidate?: number;
+    tag?: string;
+    vary?: string;
+}
+
 export interface FunctionIR {
     args: Record<string, ValidatorIR>;
     exportName: string;
@@ -264,8 +277,13 @@ export interface FunctionIR {
      * OpenAPI emitter describes it as a real `/_lunora/rest/&lt;namespace>/&lt;fn>` path
      * (the single source of truth the runtime router also derives from). Absent →
      * RPC-only (the default; not on the REST surface).
+     *
+     * `cache` mirrors the `RestCacheConfig` the runtime turns into response
+     * headers, so the emitted spec can document the `Cache-Control` a caller will
+     * actually observe. Only statically-readable literal fields are carried; a
+     * computed value is simply absent (the spec under-documents rather than lies).
      */
-    expose?: { rest?: boolean };
+    expose?: { cache?: ExposeCacheIR; rest?: boolean };
     /** Path relative to `&lt;projectRoot>/lunora/` without extension, e.g. "messages". */
     filePath: string;
     kind: "action" | "mutation" | "query" | "stream";

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -3,7 +3,7 @@ import type { JsonSchema } from "@lunora/values";
 import type { RestFunctionKind } from "../../../shared/rest-surface";
 import { restMethodForKind, restPathForFunction } from "../../../shared/rest-surface";
 import { GENERATED_HEADER } from "./emit";
-import type { FunctionIR, HttpRouteIR, ValidatorIR } from "./ir";
+import type { ExposeCacheIR, FunctionIR, HttpRouteIR, ValidatorIR } from "./ir";
 import sanitizeNamespace from "./paths";
 import { argsObjectSchema, LUNORA_ERROR_CODES, objectSchema, validatorIrToJsonSchema } from "./schema-ir";
 
@@ -171,6 +171,54 @@ const rpcOperation = (definition: FunctionIR): { operation: Record<string, unkno
 };
 
 /**
+ * Describe the cache headers a `.expose({ cache })` endpoint answers with, as an
+ * OpenAPI `headers` block for the 200 response. Returns `{}` when the endpoint
+ * declares no caching, so it spreads away to nothing.
+ *
+ * The documented `Cache-Control` states the DECLARED scope but spells out the
+ * runtime's downgrade rule, because a caller reading the spec needs to know that
+ * a credentialed request is answered `private` regardless (see
+ * `@lunora/runtime`'s `rest-cache`).
+ */
+const cacheResponseHeaders = (cache: ExposeCacheIR | undefined): { headers?: Record<string, unknown> } => {
+    if (cache === undefined) {
+        return {};
+    }
+
+    const directives = [cache.scope ?? "private", `max-age=${String(cache.maxAge ?? 0)}`];
+
+    if (cache.staleWhileRevalidate !== undefined) {
+        directives.push(`stale-while-revalidate=${String(cache.staleWhileRevalidate)}`);
+    }
+
+    const headers: Record<string, unknown> = {
+        "Cache-Control": {
+            description:
+                cache.scope === "public"
+                    ? "Caching policy. `public` applies only to an uncredentialed request — a request carrying `Authorization` or `Cookie` is always answered `private`."
+                    : "Caching policy. Restricted to the caller's own cache; never stored by a shared/edge cache.",
+            schema: { example: directives.join(", "), type: "string" },
+        },
+    };
+
+    if (cache.tag !== undefined) {
+        headers["Cache-Tag"] = {
+            description: "Purge tag for `ctx.cache.purge({ tags: [...] })`.",
+            schema: { example: cache.tag, type: "string" },
+        };
+    }
+
+    if (cache.scope === "public" || cache.vary !== undefined) {
+        headers.Vary = {
+            description: "Request headers this response varies by.",
+            schema: { type: "string" },
+        };
+    }
+
+    return { headers };
+};
+
+/**
  * Build the OpenAPI operation for one `.expose({ rest: true })` procedure (plan
  * 167). Unlike the synthetic RPC operations, these are REAL REST endpoints on
  * `/_lunora/rest/&lt;namespace>/&lt;fn>` — the exact path + method the runtime router
@@ -204,6 +252,7 @@ const restOperation = (definition: FunctionIR): { method: "get" | "post"; operat
                     },
                 },
                 description: "Successful result (TypeScript-inferred return shape, documented best-effort).",
+                ...cacheResponseHeaders(definition.expose?.cache),
             },
             default: { $ref: ERROR_COMPONENT_REF },
         },

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -1,7 +1,7 @@
 import type { JsonSchema } from "@lunora/values";
 
-import type { RestFunctionKind } from "../../../shared/rest-surface";
-import { restMethodForKind, restPathForFunction } from "../../../shared/rest-surface";
+import type { RestCachePolicy, RestFunctionKind } from "../../../shared/rest-surface";
+import { cacheControlValue, cacheVaryValue, restMethodForKind, restPathForFunction } from "../../../shared/rest-surface";
 import { GENERATED_HEADER } from "./emit";
 import type { ExposeCacheIR, FunctionIR, HttpRouteIR, ValidatorIR } from "./ir";
 import sanitizeNamespace from "./paths";
@@ -180,38 +180,50 @@ const rpcOperation = (definition: FunctionIR): { operation: Record<string, unkno
  * a credentialed request is answered `private` regardless (see
  * `@lunora/runtime`'s `rest-cache`).
  */
-const cacheResponseHeaders = (cache: ExposeCacheIR | undefined): { headers?: Record<string, unknown> } => {
-    if (cache === undefined) {
+const cacheResponseHeaders = (cache: ExposeCacheIR | undefined, method: "get" | "post"): { headers?: Record<string, unknown> } => {
+    // Three reasons to document nothing, all of them "the runtime won't do this":
+    // caching isn't declared; the operation isn't a GET (a mutation/action is
+    // POST-only and `rest-cache` refuses to cache it); or the declaration used
+    // computed values discovery couldn't read, so any example emitted here would
+    // be invented. The spec under-documenting beats the spec contradicting the
+    // runtime — that fidelity is the whole point of deriving it from the source.
+    if (cache === undefined || method !== "get" || cache.scope === undefined || cache.maxAge === undefined) {
         return {};
     }
 
-    const directives = [cache.scope ?? "private", `max-age=${String(cache.maxAge ?? 0)}`];
-
-    if (cache.staleWhileRevalidate !== undefined) {
-        directives.push(`stale-while-revalidate=${String(cache.staleWhileRevalidate)}`);
-    }
+    // Same two functions the runtime uses to WRITE these headers, so the example
+    // and the served value cannot disagree — including on clamping.
+    const policy: RestCachePolicy = {
+        maxAge: cache.maxAge,
+        scope: cache.scope,
+        ...(cache.staleWhileRevalidate === undefined ? {} : { staleWhileRevalidate: cache.staleWhileRevalidate }),
+        ...(cache.tag === undefined ? {} : { tag: cache.tag }),
+        ...(cache.vary === undefined ? {} : { vary: cache.vary }),
+    };
 
     const headers: Record<string, unknown> = {
         "Cache-Control": {
             description:
-                cache.scope === "public"
+                policy.scope === "public"
                     ? "Caching policy. `public` applies only to an uncredentialed request — a request carrying `Authorization` or `Cookie` is always answered `private`."
                     : "Caching policy. Restricted to the caller's own cache; never stored by a shared/edge cache.",
-            schema: { example: directives.join(", "), type: "string" },
+            schema: { example: cacheControlValue(policy, policy.scope), type: "string" },
         },
     };
 
-    if (cache.tag !== undefined) {
+    if (policy.tag !== undefined) {
         headers["Cache-Tag"] = {
             description: "Purge tag for `ctx.cache.purge({ tags: [...] })`.",
-            schema: { example: cache.tag, type: "string" },
+            schema: { example: policy.tag, type: "string" },
         };
     }
 
-    if (cache.scope === "public" || cache.vary !== undefined) {
+    const vary = cacheVaryValue(policy);
+
+    if (vary !== undefined) {
         headers.Vary = {
-            description: "Request headers this response varies by.",
-            schema: { type: "string" },
+            description: "Request headers this response varies by. The endpoint's own negotiated headers are merged in at runtime.",
+            schema: { example: vary, type: "string" },
         };
     }
 
@@ -252,7 +264,7 @@ const restOperation = (definition: FunctionIR): { method: "get" | "post"; operat
                     },
                 },
                 description: "Successful result (TypeScript-inferred return shape, documented best-effort).",
-                ...cacheResponseHeaders(definition.expose?.cache),
+                ...cacheResponseHeaders(definition.expose?.cache, isQuery ? "get" : "post"),
             },
             default: { $ref: ERROR_COMPONENT_REF },
         },

--- a/packages/config/__tests__/schema-edit/mutate.test.ts
+++ b/packages/config/__tests__/schema-edit/mutate.test.ts
@@ -96,6 +96,28 @@ describe("applyAdditiveEdit", () => {
         expect(reasonOf(applyAdditiveEdit(SCHEMA, { column: "x", kind: "addOptionalColumn", table: "ghost", validator: "v.string()" }))).toBe("unknown-table");
     });
 
+    it("marks a new table .global() with the requested backend", () => {
+        expect.assertions(2);
+
+        const text = textOf(applyAdditiveEdit(SCHEMA, { global: { backend: "hyperdrive" }, kind: "addTable", table: "invoices" }));
+
+        expect(text).toContain('.global({ backend: "hyperdrive" })');
+        // And the parser reads it back — `.global({ … })` used to look non-global.
+        expect(parseSchema(text)).toMatchObject({ tables: expect.arrayContaining([expect.objectContaining({ global: true, name: "invoices" })]) });
+    });
+
+    it("emits a bare .global() when no backend is named", () => {
+        expect.assertions(1);
+
+        expect(textOf(applyAdditiveEdit(SCHEMA, { global: {}, kind: "addTable", table: "invoices" }))).toContain(".global()");
+    });
+
+    it("refuses a backend outside the allow-list", () => {
+        expect.assertions(1);
+
+        expect(reasonOf(applyAdditiveEdit(SCHEMA, { global: { backend: "sqlite" as never }, kind: "addTable", table: "invoices" }))).toBe("invalid-identifier");
+    });
+
     it("rejects a validator that is not a v.* expression (code injection)", () => {
         expect.assertions(3);
 

--- a/packages/config/src/schema-edit/mutate.ts
+++ b/packages/config/src/schema-edit/mutate.ts
@@ -184,8 +184,17 @@ const isAllowedValidatorText = (validator: unknown): boolean => {
     return initializer !== undefined && isValidatorExpression(initializer);
 };
 
+/** Storage backends `.global()` accepts. A closed union, so it is never free text. */
+type GlobalBackend = "d1" | "hyperdrive";
+
 /** Add a new table to `defineSchema({ ... })`. */
 interface AddTableEdit {
+    /**
+     * Mark the table `.global()`. Pass `{}` for the D1 default, or a backend for
+     * an external store — `lunora introspect` uses `{ backend: "hyperdrive" }`
+     * because the rows live in the database it read.
+     */
+    readonly global?: { readonly backend?: GlobalBackend };
     readonly kind: "addTable";
     readonly table: string;
 }
@@ -234,6 +243,9 @@ type SchemaEdit = AdditiveEdit | DestructiveEdit;
 
 const ADDITIVE_KINDS = new Set<SchemaEdit["kind"]>(["addIndex", "addOptionalColumn", "addTable"]);
 
+/** Accepted `.global({ backend })` values, enforced server-side like {@link VALIDATOR_METHODS}. */
+const GLOBAL_BACKENDS = new Set<GlobalBackend>(["d1", "hyperdrive"]);
+
 /**
  * Classify an edit request. Additive edits ({@link AdditiveEdit}) apply
  * directly; everything else changes stored data and is destructive.
@@ -265,6 +277,10 @@ const isIdentifier = (value: unknown): value is string => typeof value === "stri
  */
 const validateAdditiveEdit = (edit: AdditiveEdit): ApplyFailureReason | undefined => {
     if (!isIdentifier(edit.table)) {
+        return "invalid-identifier";
+    }
+
+    if (edit.kind === "addTable" && edit.global?.backend !== undefined && !GLOBAL_BACKENDS.has(edit.global.backend)) {
         return "invalid-identifier";
     }
 
@@ -359,13 +375,19 @@ const applyAddTable = (tablesObject: ObjectLiteralExpression, edit: AddTableEdit
         return "duplicate-table";
     }
 
+    // `backend` is a closed union validated upstream, so this interpolation cannot
+    // carry arbitrary text.
+    const backend = edit.global?.backend;
+    const backendArgument = backend === undefined ? "" : `{ backend: ${JSON.stringify(backend)} }`;
+    const globalCall = edit.global === undefined ? "" : `.global(${backendArgument})`;
+
     tablesObject.addPropertyAssignment({
         initializer: `defineTable({
         // Add your column validators here.
         // Example:
         // text: v.string(),
         // createdAt: v.number(),
-    })`,
+    })${globalCall}`,
         name: edit.table,
     });
 
@@ -489,5 +511,15 @@ const applyAdditiveEdit = (source: string, edit: SchemaEdit): ApplyEditResult =>
     return { ok: true, text: sourceFile.getFullText() };
 };
 
-export type { AddIndexEdit, AdditiveEdit, AddOptionalColumnEdit, AddTableEdit, ApplyEditResult, ApplyFailureReason, DestructiveEdit, SchemaEdit };
+export type {
+    AddIndexEdit,
+    AdditiveEdit,
+    AddOptionalColumnEdit,
+    AddTableEdit,
+    ApplyEditResult,
+    ApplyFailureReason,
+    DestructiveEdit,
+    GlobalBackend,
+    SchemaEdit,
+};
 export { applyAdditiveEdit, classifyEdit };

--- a/packages/config/src/schema-edit/parse.ts
+++ b/packages/config/src/schema-edit/parse.ts
@@ -51,7 +51,9 @@ type ParseSchemaResult =
 
 const OPTIONAL_VALIDATOR_PATTERN = /^v\s*\.\s*optional\s*\(/u;
 const SHARD_BY_PATTERN = /\.shardBy\(\s*["']([^"']+)["']\s*\)/u;
-const GLOBAL_PATTERN = /\.global\(\s*\)/u;
+// Matches both `.global()` and `.global({ backend: "hyperdrive" })` — the latter
+// is what `lunora introspect` emits for a table whose rows live in an external database.
+const GLOBAL_PATTERN = /\.global\(\s*(?:\{[^{}]*\}\s*)?\)/u;
 const QUOTE_PATTERN = /["']/gu;
 
 /**

--- a/packages/runtime/__tests__/rest-cache.test.ts
+++ b/packages/runtime/__tests__/rest-cache.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import type { RestCacheConfigLike } from "../src/rest-cache";
+import { applyRestCache, mergeVary, requestCarriesCredentials, restCacheHeaders } from "../src/rest-cache";
+
+const publicCache: RestCacheConfigLike = { maxAge: 60, scope: "public" };
+const get = (init?: RequestInit): Request => new Request("https://app.example/_lunora/rest/messages/list", init);
+
+describe("restCacheHeaders", () => {
+    it("emits a shared-cacheable policy for an anonymous request under scope:public", () => {
+        expect.assertions(2);
+
+        const headers = restCacheHeaders(publicCache, get(), 200);
+
+        expect(headers?.["cache-control"]).toBe("public, max-age=60");
+        // The anonymous variant must be fenced off from credentialed callers, or a
+        // shared cache could hand it to a signed-in user in place of their own data.
+        expect(headers?.vary).toBe("authorization, cookie");
+    });
+
+    it("downgrades scope:public to private when the request carries an Authorization header", () => {
+        expect.assertions(1);
+
+        const headers = restCacheHeaders(publicCache, get({ headers: { authorization: "Bearer t" } }), 200); // secret-scanner:allow -- fake test fixture, not a real credential
+
+        expect(headers?.["cache-control"]).toBe("private, max-age=60");
+    });
+
+    it("downgrades scope:public to private when the request carries a Cookie", () => {
+        expect.assertions(1);
+
+        const headers = restCacheHeaders(publicCache, get({ headers: { cookie: "session=abc" } }), 200);
+
+        expect(headers?.["cache-control"]).toBe("private, max-age=60");
+    });
+
+    it("includes stale-while-revalidate and a purge tag when declared", () => {
+        expect.assertions(2);
+
+        const headers = restCacheHeaders({ maxAge: 30, scope: "private", staleWhileRevalidate: 120, tag: "messages" }, get(), 200);
+
+        expect(headers?.["cache-control"]).toBe("private, max-age=30, stale-while-revalidate=120");
+        expect(headers?.["cache-tag"]).toBe("messages");
+    });
+
+    it("merges an author-declared Vary with the credential names, case-insensitively and without duplicates", () => {
+        expect.assertions(1);
+
+        const headers = restCacheHeaders({ ...publicCache, vary: "Accept-Language, AUTHORIZATION" }, get(), 200);
+
+        expect(headers?.vary).toBe("accept-language, authorization, cookie");
+    });
+
+    it("omits Vary entirely for a private endpoint that declares none", () => {
+        expect.assertions(1);
+
+        const headers = restCacheHeaders({ maxAge: 60, scope: "private" }, get(), 200);
+
+        expect(headers?.vary).toBeUndefined();
+    });
+
+    it("refuses to cache a non-GET exchange", () => {
+        expect.assertions(1);
+
+        expect(restCacheHeaders(publicCache, get({ method: "POST" }), 200)).toBeUndefined();
+    });
+
+    it("refuses to cache a non-2xx response, so an error is never stored as the resource", () => {
+        expect.assertions(3);
+
+        expect(restCacheHeaders(publicCache, get(), 403)).toBeUndefined();
+        expect(restCacheHeaders(publicCache, get(), 404)).toBeUndefined();
+        expect(restCacheHeaders(publicCache, get(), 500)).toBeUndefined();
+    });
+
+    it("clamps a negative or non-finite maxAge to 0 rather than emitting a broken directive", () => {
+        expect.assertions(2);
+
+        expect(restCacheHeaders({ maxAge: -5, scope: "private" }, get(), 200)?.["cache-control"]).toBe("private, max-age=0");
+        expect(restCacheHeaders({ maxAge: Number.NaN, scope: "private" }, get(), 200)?.["cache-control"]).toBe("private, max-age=0");
+    });
+});
+
+describe("requestCarriesCredentials", () => {
+    it("is false only when neither Authorization nor Cookie is present", () => {
+        expect.assertions(3);
+
+        expect(requestCarriesCredentials(get())).toBe(false);
+        expect(requestCarriesCredentials(get({ headers: { authorization: "Bearer t" } }))).toBe(true); // secret-scanner:allow -- fake test fixture, not a real credential
+        expect(requestCarriesCredentials(get({ headers: { cookie: "a=b" } }))).toBe(true);
+    });
+});
+
+describe("mergeVary", () => {
+    it("returns undefined when every source is empty", () => {
+        expect.assertions(1);
+
+        expect(mergeVary(undefined, "", "  ,  ")).toBeUndefined();
+    });
+});
+
+describe("applyRestCache", () => {
+    it("returns the original response untouched when no cache is declared", async () => {
+        expect.assertions(2);
+
+        const original = Response.json({ ok: true });
+        const result = applyRestCache(original, undefined, get());
+
+        expect(result).toBe(original);
+        await expect(result.json()).resolves.toEqual({ ok: true });
+    });
+
+    it("rebuilds the response with cache headers while preserving status and body", async () => {
+        expect.assertions(3);
+
+        const result = applyRestCache(Response.json({ items: [1, 2] }, { status: 200 }), publicCache, get());
+
+        expect(result.status).toBe(200);
+        expect(result.headers.get("cache-control")).toBe("public, max-age=60");
+        await expect(result.json()).resolves.toEqual({ items: [1, 2] });
+    });
+
+    it("leaves an error response uncached", () => {
+        expect.assertions(1);
+
+        const result = applyRestCache(Response.json({ error: "nope" }, { status: 403 }), publicCache, get());
+
+        expect(result.headers.get("cache-control")).toBeNull();
+    });
+});

--- a/packages/runtime/__tests__/rest-cache.test.ts
+++ b/packages/runtime/__tests__/rest-cache.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import type { RestCacheConfigLike } from "../src/rest-cache";
-import { applyRestCache, mergeVary, requestCarriesCredentials, restCacheHeaders } from "../src/rest-cache";
+import type { RestCachePolicy } from "../../../shared/rest-surface";
+import { applyRestCache, requestCarriesCredentials, restCacheHeaders } from "../src/rest-cache";
 
-const publicCache: RestCacheConfigLike = { maxAge: 60, scope: "public" };
+const publicCache: RestCachePolicy = { maxAge: 60, scope: "public" };
 const get = (init?: RequestInit): Request => new Request("https://app.example/_lunora/rest/messages/list", init);
 
 describe("restCacheHeaders", () => {
@@ -15,7 +15,8 @@ describe("restCacheHeaders", () => {
         expect(headers?.["cache-control"]).toBe("public, max-age=60");
         // The anonymous variant must be fenced off from credentialed callers, or a
         // shared cache could hand it to a signed-in user in place of their own data.
-        expect(headers?.vary).toBe("authorization, cookie");
+        // Shard/bookmark headers ride along because they change the body too.
+        expect(headers?.vary).toBe("authorization, cf-access-jwt-assertion, cookie, x-d1-bookmark, x-lunora-shard-key");
     });
 
     it("downgrades scope:public to private when the request carries an Authorization header", () => {
@@ -48,15 +49,35 @@ describe("restCacheHeaders", () => {
 
         const headers = restCacheHeaders({ ...publicCache, vary: "Accept-Language, AUTHORIZATION" }, get(), 200);
 
-        expect(headers?.vary).toBe("accept-language, authorization, cookie");
+        expect(headers?.vary).toBe("accept-language, authorization, cf-access-jwt-assertion, cookie, x-d1-bookmark, x-lunora-shard-key");
     });
 
-    it("omits Vary entirely for a private endpoint that declares none", () => {
+    it("still varies a private endpoint on the data-selecting headers", () => {
         expect.assertions(1);
 
-        const headers = restCacheHeaders({ maxAge: 60, scope: "private" }, get(), 200);
+        // `x-lunora-shard-key` picks WHICH rows come back; without it in Vary one
+        // URL maps to many bodies even in a per-caller cache.
+        expect(restCacheHeaders({ maxAge: 60, scope: "private" }, get(), 200)?.vary).toBe("x-d1-bookmark, x-lunora-shard-key");
+    });
 
-        expect(headers?.vary).toBeUndefined();
+    it("downgrades for a Cloudflare Access service token, which sends a header and no cookie", () => {
+        expect.assertions(1);
+
+        // `@lunora/cloudflare-access` reads `cf-access-jwt-assertion` BEFORE its
+        // cookie, so a machine client is identified by the header alone.
+        const headers = restCacheHeaders(publicCache, get({ headers: { "cf-access-jwt-assertion": "jwt" } }), 200);
+
+        expect(headers?.["cache-control"]).toBe("private, max-age=60");
+    });
+
+    it("downgrades on an app-declared credential header", () => {
+        expect.assertions(2);
+
+        const policy: RestCachePolicy = { ...publicCache, credentialHeaders: ["X-Api-Key"] };
+
+        expect(restCacheHeaders(policy, get({ headers: { "x-api-key": "k" } }), 200)?.["cache-control"]).toBe("private, max-age=60");
+        // ...and it joins Vary, so an intermediary keys on it too.
+        expect(restCacheHeaders(policy, get(), 200)?.vary).toContain("x-api-key");
     });
 
     it("refuses to cache a non-GET exchange", () => {
@@ -82,20 +103,13 @@ describe("restCacheHeaders", () => {
 });
 
 describe("requestCarriesCredentials", () => {
-    it("is false only when neither Authorization nor Cookie is present", () => {
-        expect.assertions(3);
+    it("is false only when no identity-bearing header is present", () => {
+        expect.assertions(4);
 
-        expect(requestCarriesCredentials(get())).toBe(false);
-        expect(requestCarriesCredentials(get({ headers: { authorization: "Bearer t" } }))).toBe(true); // secret-scanner:allow -- fake test fixture, not a real credential
-        expect(requestCarriesCredentials(get({ headers: { cookie: "a=b" } }))).toBe(true);
-    });
-});
-
-describe("mergeVary", () => {
-    it("returns undefined when every source is empty", () => {
-        expect.assertions(1);
-
-        expect(mergeVary(undefined, "", "  ,  ")).toBeUndefined();
+        expect(requestCarriesCredentials(get(), publicCache)).toBe(false);
+        expect(requestCarriesCredentials(get({ headers: { authorization: "Bearer t" } }), publicCache)).toBe(true); // secret-scanner:allow -- fake test fixture, not a real credential
+        expect(requestCarriesCredentials(get({ headers: { cookie: "a=b" } }), publicCache)).toBe(true);
+        expect(requestCarriesCredentials(get({ headers: { "cf-access-jwt-assertion": "jwt" } }), publicCache)).toBe(true);
     });
 });
 
@@ -118,6 +132,20 @@ describe("applyRestCache", () => {
         expect(result.status).toBe(200);
         expect(result.headers.get("cache-control")).toBe("public, max-age=60");
         await expect(result.json()).resolves.toEqual({ items: [1, 2] });
+    });
+
+    it("merges an existing Vary from the procedure response instead of replacing it", () => {
+        expect.assertions(3);
+
+        // A procedure that negotiated on `Accept-Language` must keep that Vary, or a
+        // shared cache could hand one language's body to a caller expecting another.
+        const original = Response.json({ ok: true }, { headers: { vary: "Accept-Language" } });
+        const result = applyRestCache(original, publicCache, get());
+        const vary = result.headers.get("vary") ?? "";
+
+        expect(vary).toContain("accept-language");
+        expect(vary).toContain("authorization");
+        expect(vary).toContain("cookie");
     });
 
     it("leaves an error response uncached", () => {

--- a/packages/runtime/__tests__/rest-surface.test.ts
+++ b/packages/runtime/__tests__/rest-surface.test.ts
@@ -236,7 +236,20 @@ describe("createWorker — opt-in public REST surface", () => {
 
             expect(response.headers.get("cache-control")).toBe("public, max-age=60");
             expect(response.headers.get("cache-tag")).toBe("messages");
-            expect(response.headers.get("vary")).toBe("authorization, cookie");
+            expect(response.headers.get("vary")).toBe("authorization, cf-access-jwt-assertion, cookie, x-d1-bookmark, x-lunora-shard-key");
+        });
+
+        it("varies on the shard-key header, which selects which rows the caller sees", async () => {
+            expect.assertions(1);
+
+            const { namespace } = echoShard();
+            const worker = createWorker({ functions: cachingFunctions, shardDO: namespace });
+
+            const response = await worker.fetch(new Request("https://app.example/_lunora/rest/messages/list"), {}, fakeContext);
+
+            // The query-string form is already in the URL; the header form is not,
+            // so without this one URL would map to every shard's body.
+            expect(response.headers.get("vary")).toContain("x-lunora-shard-key");
         });
 
         it("downgrades to private once the caller presents credentials, so a per-user body never reaches a shared cache", async () => {

--- a/packages/runtime/__tests__/rest-surface.test.ts
+++ b/packages/runtime/__tests__/rest-surface.test.ts
@@ -216,4 +216,99 @@ describe("createWorker — opt-in public REST surface", () => {
         expect(kept).toHaveLength(1);
         await expect(kept[0]).resolves.toBe("sent");
     });
+
+    describe("declared response caching (.expose({ cache }))", () => {
+        // `list` is cacheable and public; `send` declares a cache that must never
+        // apply, because a mutation is POST-only.
+        const cachingFunctions: WorkerOptions["functions"] = {
+            "messages:list": { expose: { cache: { maxAge: 60, scope: "public", tag: "messages" }, rest: true }, kind: "query" },
+            "messages:plain": { expose: { rest: true }, kind: "query" },
+            "messages:send": { expose: { cache: { maxAge: 60, scope: "public" }, rest: true }, kind: "mutation" },
+        };
+
+        it("answers an anonymous GET with the declared shared-cache policy", async () => {
+            expect.assertions(3);
+
+            const { namespace } = echoShard();
+            const worker = createWorker({ functions: cachingFunctions, shardDO: namespace });
+
+            const response = await worker.fetch(new Request("https://app.example/_lunora/rest/messages/list"), {}, fakeContext);
+
+            expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+            expect(response.headers.get("cache-tag")).toBe("messages");
+            expect(response.headers.get("vary")).toBe("authorization, cookie");
+        });
+
+        it("downgrades to private once the caller presents credentials, so a per-user body never reaches a shared cache", async () => {
+            expect.assertions(1);
+
+            const { namespace } = echoShard();
+            const worker = createWorker({ functions: cachingFunctions, shardDO: namespace });
+
+            const response = await worker.fetch(
+                new Request("https://app.example/_lunora/rest/messages/list", { headers: { authorization: "Bearer user-token" } }), // secret-scanner:allow -- fake test fixture, not a real credential
+                {},
+                fakeContext,
+            );
+
+            expect(response.headers.get("cache-control")).toBe("private, max-age=60");
+        });
+
+        it("never caches a POST exchange, even when the procedure declares a cache", async () => {
+            expect.assertions(2);
+
+            const { namespace } = echoShard();
+            const worker = createWorker({ functions: cachingFunctions, shardDO: namespace });
+
+            const mutation = await worker.fetch(
+                new Request("https://app.example/_lunora/rest/messages/send", {
+                    body: JSON.stringify({ text: "hi" }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+                {},
+                fakeContext,
+            );
+
+            expect(mutation.headers.get("cache-control")).toBeNull();
+
+            // Same procedure reached as a POST-bodied query — still not cacheable.
+            const query = await worker.fetch(
+                new Request("https://app.example/_lunora/rest/messages/list", {
+                    body: JSON.stringify({}),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+                {},
+                fakeContext,
+            );
+
+            expect(query.headers.get("cache-control")).toBeNull();
+        });
+
+        it("leaves an endpoint that declares no cache completely untouched", async () => {
+            expect.assertions(2);
+
+            const { namespace } = echoShard();
+            const worker = createWorker({ functions: cachingFunctions, shardDO: namespace });
+
+            const response = await worker.fetch(new Request("https://app.example/_lunora/rest/messages/plain"), {}, fakeContext);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("cache-control")).toBeNull();
+        });
+
+        it("does not cache a rejected request (authorization denied)", async () => {
+            expect.assertions(2);
+
+            const { namespace } = echoShard();
+            const authorizeShard = vi.fn<() => Promise<boolean>>(async () => false);
+            const worker = createWorker({ authorizeShard, functions: cachingFunctions, shardDO: namespace });
+
+            const response = await worker.fetch(new Request("https://app.example/_lunora/rest/messages/list"), {}, fakeContext);
+
+            expect(response.status).toBe(403);
+            expect(response.headers.get("cache-control")).toBeNull();
+        });
+    });
 });

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -6,6 +6,7 @@ import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
 import { otlpRandomHex } from "../../../shared/otlp";
 import { relayName } from "../../../shared/relay-name";
+import type { RestExposure } from "../../../shared/rest-surface";
 import type { TraceSamplingConfig } from "../../../shared/sampling";
 import { mintWsAdminToken, verifyWsAdminToken } from "../../../shared/ws-admin-token";
 import type { AuthAdmin } from "./auth-admin-routes";
@@ -39,7 +40,6 @@ import type { FanOutSpec, QueryCoordinator } from "./query-coordinator";
 import type { DurableObjectJurisdiction, ResolvedShard, ShardNamespaceLike } from "./resolve-shard";
 import { applyJurisdiction, resolveShard } from "./resolve-shard";
 import { createResourceAttributeResolver } from "./resource-detect";
-import type { RestCacheConfigLike } from "./rest-cache";
 import type { RestInvoke, RestRateLimit } from "./rest-routes";
 import { buildRestRoutes } from "./rest-routes";
 import { buildScheduledAdminRoutes } from "./scheduled-admin-routes";
@@ -205,7 +205,7 @@ interface FunctionRegistryEntry {
      * `cache` is the optional response-caching policy the REST router turns into
      * `Cache-Control` / `Cache-Tag` / `Vary` headers (see `rest-cache`).
      */
-    expose?: { readonly cache?: RestCacheConfigLike; readonly rest?: boolean };
+    expose?: RestExposure;
 
     /**
      * The generated registry carries `"stream"` alongside query/mutation/action;

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -39,6 +39,7 @@ import type { FanOutSpec, QueryCoordinator } from "./query-coordinator";
 import type { DurableObjectJurisdiction, ResolvedShard, ShardNamespaceLike } from "./resolve-shard";
 import { applyJurisdiction, resolveShard } from "./resolve-shard";
 import { createResourceAttributeResolver } from "./resource-detect";
+import type { RestCacheConfigLike } from "./rest-cache";
 import type { RestInvoke, RestRateLimit } from "./rest-routes";
 import { buildRestRoutes } from "./rest-routes";
 import { buildScheduledAdminRoutes } from "./scheduled-admin-routes";
@@ -200,8 +201,11 @@ interface FunctionRegistryEntry {
      * routing THROUGH the procedure so auth/RLS/validators are enforced. Rides
      * along on the registered function's identity (like `fn.x402` / `fn.rls`), so
      * reading it needs no change to the generated registry shape.
+     *
+     * `cache` is the optional response-caching policy the REST router turns into
+     * `Cache-Control` / `Cache-Tag` / `Vary` headers (see `rest-cache`).
      */
-    expose?: { readonly rest?: boolean };
+    expose?: { readonly cache?: RestCacheConfigLike; readonly rest?: boolean };
 
     /**
      * The generated registry carries `"stream"` alongside query/mutation/action;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -150,6 +150,8 @@ export type {
 export { createQueryCoordinator, createStaticShardRegistry, mergeStrategyForAggregate } from "./query-coordinator";
 export type { DurableObjectJurisdiction, ResolvedShard, ShardNamespaceLike } from "./resolve-shard";
 export { applyJurisdiction, resolveShard } from "./resolve-shard";
+export type { RestCacheConfigLike } from "./rest-cache";
+export { applyRestCache, requestCarriesCredentials, restCacheHeaders } from "./rest-cache";
 export type { RateLimiterLike, RestInvoke, RestRateLimit, RestRegistryEntry, RestRegistryLike, RestRoute, RestRouteDeps } from "./rest-routes";
 export { argsFromQuery, buildRestRoutes, createRestRateLimit, readShardKey, restSurfaceFromRegistry } from "./rest-routes";
 export type { CorsOptions, CsrfOptions, ResolvedSecurity, SecurityHeadersOptions, SecurityOptions } from "./security-headers";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -150,7 +150,6 @@ export type {
 export { createQueryCoordinator, createStaticShardRegistry, mergeStrategyForAggregate } from "./query-coordinator";
 export type { DurableObjectJurisdiction, ResolvedShard, ShardNamespaceLike } from "./resolve-shard";
 export { applyJurisdiction, resolveShard } from "./resolve-shard";
-export type { RestCacheConfigLike } from "./rest-cache";
 export { applyRestCache, requestCarriesCredentials, restCacheHeaders } from "./rest-cache";
 export type { RateLimiterLike, RestInvoke, RestRateLimit, RestRegistryEntry, RestRegistryLike, RestRoute, RestRouteDeps } from "./rest-routes";
 export { argsFromQuery, buildRestRoutes, createRestRateLimit, readShardKey, restSurfaceFromRegistry } from "./rest-routes";

--- a/packages/runtime/src/rest-cache.ts
+++ b/packages/runtime/src/rest-cache.ts
@@ -9,83 +9,51 @@
  * "a per-caller response is never stored in a shared cache" structural — the
  * cost of a wrong `scope` is a missed cache hit, never a cross-user leak.
  *
- * Headers are the same trio `httpRoute(...).cacheControl()/.cacheTag()/.vary()`
- * writes (see `@lunora/server`'s `http.ts`), so a `cache.tag` declared here is
- * purgeable through the identical `ctx.cache.purge({ tags: [...] })` surface.
+ * The header VALUES are not computed here. `shared/rest-surface` owns
+ * `cacheControlValue` / `cacheVaryValue`, and the OpenAPI emitter documents the
+ * endpoint from those same two functions — so the published spec cannot drift
+ * from what this module actually sends. What lives here is only the part that
+ * needs a live `Request`: deciding the effective scope, and deciding whether the
+ * exchange is cacheable at all.
+ *
+ * Note the deliberate asymmetry with `httpRoute(...).cacheControl()` in
+ * `@lunora/server`: that writes whatever value the author passed, with no
+ * credential downgrade. It is the lower-level escape hatch; this is the guarded
+ * surface. Do not describe them as equivalent.
  */
-
-/** Mirror of `@lunora/server`'s `RestCacheConfig`, kept structural so the runtime needs no dependency on the server package. */
-interface RestCacheConfigLike {
-    readonly maxAge: number;
-    readonly scope: "private" | "public";
-    readonly staleWhileRevalidate?: number;
-    readonly tag?: string;
-    readonly vary?: string;
-}
+import type { RestCachePolicy } from "../../../shared/rest-surface";
+import { cacheControlValue, cacheVaryValue, credentialHeadersFor, mergeVary } from "../../../shared/rest-surface";
 
 /**
- * Request headers whose presence means "this response may be caller-specific".
- * `Authorization` covers bearer/basic auth; `Cookie` covers session cookies —
- * between them, every way a Lunora caller establishes identity over REST.
+ * True when the request presented credentials, i.e. the response must be treated
+ * as caller-specific. Checks the built-in identity headers plus anything the
+ * policy declares via `credentialHeaders` — an app whose `resolveIdentity` reads
+ * a bespoke header must say so, or its callers read as anonymous here.
  */
-const CREDENTIAL_HEADERS = ["authorization", "cookie"] as const;
-
-/** `Vary` names added under `scope: "public"` so a shared cache can't serve the anonymous variant to a credentialed caller. */
-const CREDENTIAL_VARY = CREDENTIAL_HEADERS;
-
-/** True when the request presented credentials, i.e. the response must be treated as caller-specific. */
-const requestCarriesCredentials = (request: Request): boolean => CREDENTIAL_HEADERS.some((header) => request.headers.has(header));
-
-/** Clamp an author-supplied seconds value to a non-negative integer; a non-finite value degrades to `0` (revalidate-always) rather than emitting `NaN`. */
-const seconds = (value: number): number => (Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0);
-
-/** Merge `Vary` header names case-insensitively, preserving first-seen order and dropping duplicates. */
-const mergeVary = (...sources: ReadonlyArray<string | undefined>): string | undefined => {
-    const names: string[] = [];
-
-    for (const source of sources) {
-        for (const raw of source?.split(",") ?? []) {
-            const name = raw.trim().toLowerCase();
-
-            if (name !== "" && !names.includes(name)) {
-                names.push(name);
-            }
-        }
-    }
-
-    return names.length === 0 ? undefined : names.join(", ");
-};
+const requestCarriesCredentials = (request: Request, policy: RestCachePolicy): boolean =>
+    credentialHeadersFor(policy).some((header) => request.headers.has(header));
 
 /**
  * Build the cache headers for one exchange, or `undefined` when the exchange
  * isn't cacheable at all (non-`GET`, or a non-2xx result — an error body must
  * never be stored as if it were the resource).
  *
- * The effective scope is `config.scope` narrowed by {@link requestCarriesCredentials};
+ * The effective scope is `policy.scope` narrowed by {@link requestCarriesCredentials};
  * `"public"` survives only for a genuinely anonymous request.
  */
-const restCacheHeaders = (config: RestCacheConfigLike, request: Request, status: number): Record<string, string> | undefined => {
+const restCacheHeaders = (policy: RestCachePolicy, request: Request, status: number): Record<string, string> | undefined => {
     if (request.method !== "GET" || status < 200 || status > 299) {
         return undefined;
     }
 
-    const scope = config.scope === "public" && !requestCarriesCredentials(request) ? "public" : "private";
-    const directives = [scope, `max-age=${String(seconds(config.maxAge))}`];
+    const effectiveScope = policy.scope === "public" && !requestCarriesCredentials(request, policy) ? "public" : "private";
+    const headers: Record<string, string> = { "cache-control": cacheControlValue(policy, effectiveScope) };
 
-    if (config.staleWhileRevalidate !== undefined) {
-        directives.push(`stale-while-revalidate=${String(seconds(config.staleWhileRevalidate))}`);
+    if (policy.tag !== undefined && policy.tag !== "") {
+        headers["cache-tag"] = policy.tag;
     }
 
-    const headers: Record<string, string> = { "cache-control": directives.join(", ") };
-
-    if (config.tag !== undefined && config.tag !== "") {
-        headers["cache-tag"] = config.tag;
-    }
-
-    // `Vary` is keyed off the DECLARED scope, not the effective one: the point is
-    // to fence the stored anonymous variant off from credentialed callers, and
-    // that fence has to be present on the anonymous response itself.
-    const vary = config.scope === "public" ? mergeVary(config.vary, ...CREDENTIAL_VARY) : mergeVary(config.vary);
+    const vary = cacheVaryValue(policy);
 
     if (vary !== undefined) {
         headers.vary = vary;
@@ -100,12 +68,12 @@ const restCacheHeaders = (config: RestCacheConfigLike, request: Request, status:
  * are carried over, the body is streamed through untouched). When the exchange
  * isn't cacheable the original response is returned as-is — no copy.
  */
-const applyRestCache = (response: Response, config: RestCacheConfigLike | undefined, request: Request): Response => {
-    if (config === undefined) {
+const applyRestCache = (response: Response, policy: RestCachePolicy | undefined, request: Request): Response => {
+    if (policy === undefined) {
         return response;
     }
 
-    const headers = restCacheHeaders(config, request, response.status);
+    const headers = restCacheHeaders(policy, request, response.status);
 
     if (headers === undefined) {
         return response;
@@ -114,11 +82,14 @@ const applyRestCache = (response: Response, config: RestCacheConfigLike | undefi
     const cached = new Response(response.body, response);
 
     for (const [name, value] of Object.entries(headers)) {
-        cached.headers.set(name, value);
+        // `Vary` is merged rather than replaced: the procedure's own response may
+        // already vary on `Accept-Language`, `Origin`, or another negotiated
+        // header, and dropping those would let a shared cache serve one variant in
+        // place of another. Every other header here is ours to state outright.
+        cached.headers.set(name, name === "vary" ? (mergeVary(cached.headers.get("vary") ?? undefined, value) ?? value) : value);
     }
 
     return cached;
 };
 
-export type { RestCacheConfigLike };
-export { applyRestCache, mergeVary, requestCarriesCredentials, restCacheHeaders };
+export { applyRestCache, requestCarriesCredentials, restCacheHeaders };

--- a/packages/runtime/src/rest-cache.ts
+++ b/packages/runtime/src/rest-cache.ts
@@ -1,0 +1,124 @@
+/**
+ * HTTP caching for the opt-in public REST surface (`.expose({ rest: true, cache })`).
+ *
+ * The whole hazard of caching a procedure-backed endpoint is that the procedure
+ * runs under `ctx.auth` and RLS, so its body is frequently caller-specific. A
+ * declared `scope` is therefore treated as a REQUEST, not a fact: this module
+ * re-derives the effective scope from the live request and downgrades
+ * `"public"` → `"private"` whenever the caller presented credentials. That makes
+ * "a per-caller response is never stored in a shared cache" structural — the
+ * cost of a wrong `scope` is a missed cache hit, never a cross-user leak.
+ *
+ * Headers are the same trio `httpRoute(...).cacheControl()/.cacheTag()/.vary()`
+ * writes (see `@lunora/server`'s `http.ts`), so a `cache.tag` declared here is
+ * purgeable through the identical `ctx.cache.purge({ tags: [...] })` surface.
+ */
+
+/** Mirror of `@lunora/server`'s `RestCacheConfig`, kept structural so the runtime needs no dependency on the server package. */
+interface RestCacheConfigLike {
+    readonly maxAge: number;
+    readonly scope: "private" | "public";
+    readonly staleWhileRevalidate?: number;
+    readonly tag?: string;
+    readonly vary?: string;
+}
+
+/**
+ * Request headers whose presence means "this response may be caller-specific".
+ * `Authorization` covers bearer/basic auth; `Cookie` covers session cookies —
+ * between them, every way a Lunora caller establishes identity over REST.
+ */
+const CREDENTIAL_HEADERS = ["authorization", "cookie"] as const;
+
+/** `Vary` names added under `scope: "public"` so a shared cache can't serve the anonymous variant to a credentialed caller. */
+const CREDENTIAL_VARY = CREDENTIAL_HEADERS;
+
+/** True when the request presented credentials, i.e. the response must be treated as caller-specific. */
+const requestCarriesCredentials = (request: Request): boolean => CREDENTIAL_HEADERS.some((header) => request.headers.has(header));
+
+/** Clamp an author-supplied seconds value to a non-negative integer; a non-finite value degrades to `0` (revalidate-always) rather than emitting `NaN`. */
+const seconds = (value: number): number => (Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0);
+
+/** Merge `Vary` header names case-insensitively, preserving first-seen order and dropping duplicates. */
+const mergeVary = (...sources: ReadonlyArray<string | undefined>): string | undefined => {
+    const names: string[] = [];
+
+    for (const source of sources) {
+        for (const raw of source?.split(",") ?? []) {
+            const name = raw.trim().toLowerCase();
+
+            if (name !== "" && !names.includes(name)) {
+                names.push(name);
+            }
+        }
+    }
+
+    return names.length === 0 ? undefined : names.join(", ");
+};
+
+/**
+ * Build the cache headers for one exchange, or `undefined` when the exchange
+ * isn't cacheable at all (non-`GET`, or a non-2xx result — an error body must
+ * never be stored as if it were the resource).
+ *
+ * The effective scope is `config.scope` narrowed by {@link requestCarriesCredentials};
+ * `"public"` survives only for a genuinely anonymous request.
+ */
+const restCacheHeaders = (config: RestCacheConfigLike, request: Request, status: number): Record<string, string> | undefined => {
+    if (request.method !== "GET" || status < 200 || status > 299) {
+        return undefined;
+    }
+
+    const scope = config.scope === "public" && !requestCarriesCredentials(request) ? "public" : "private";
+    const directives = [scope, `max-age=${String(seconds(config.maxAge))}`];
+
+    if (config.staleWhileRevalidate !== undefined) {
+        directives.push(`stale-while-revalidate=${String(seconds(config.staleWhileRevalidate))}`);
+    }
+
+    const headers: Record<string, string> = { "cache-control": directives.join(", ") };
+
+    if (config.tag !== undefined && config.tag !== "") {
+        headers["cache-tag"] = config.tag;
+    }
+
+    // `Vary` is keyed off the DECLARED scope, not the effective one: the point is
+    // to fence the stored anonymous variant off from credentialed callers, and
+    // that fence has to be present on the anonymous response itself.
+    const vary = config.scope === "public" ? mergeVary(config.vary, ...CREDENTIAL_VARY) : mergeVary(config.vary);
+
+    if (vary !== undefined) {
+        headers.vary = vary;
+    }
+
+    return headers;
+};
+
+/**
+ * Return `response` with the declared cache headers applied. A shard `Response`
+ * has immutable headers, so this rebuilds it (status/statusText/existing headers
+ * are carried over, the body is streamed through untouched). When the exchange
+ * isn't cacheable the original response is returned as-is — no copy.
+ */
+const applyRestCache = (response: Response, config: RestCacheConfigLike | undefined, request: Request): Response => {
+    if (config === undefined) {
+        return response;
+    }
+
+    const headers = restCacheHeaders(config, request, response.status);
+
+    if (headers === undefined) {
+        return response;
+    }
+
+    const cached = new Response(response.body, response);
+
+    for (const [name, value] of Object.entries(headers)) {
+        cached.headers.set(name, value);
+    }
+
+    return cached;
+};
+
+export type { RestCacheConfigLike };
+export { applyRestCache, mergeVary, requestCarriesCredentials, restCacheHeaders };

--- a/packages/runtime/src/rest-routes.ts
+++ b/packages/runtime/src/rest-routes.ts
@@ -19,10 +19,12 @@
 import type { RestExposure } from "../../../shared/rest-surface";
 import { describeRestSurface } from "../../../shared/rest-surface";
 import { methodGuard } from "./method-guard";
+import type { RestCacheConfigLike } from "./rest-cache";
+import { applyRestCache } from "./rest-cache";
 
 /** The bits of a registered function the REST router reads: its kind and its `.expose` tag. */
 interface RestRegistryEntry {
-    expose?: RestExposure;
+    expose?: RestExposure & { cache?: RestCacheConfigLike };
     kind: "action" | "mutation" | "query" | "stream";
 }
 
@@ -130,6 +132,10 @@ const buildRestRoutes = (deps: RestRouteDeps): Record<string, RestRoute> => {
     for (const entry of restSurfaceFromRegistry(functions)) {
         // A query is reachable via GET or POST; a mutation/action via POST only.
         const allowed = entry.kind === "query" ? ["GET", "POST"] : ["POST"];
+        // Read straight off the registry: the surface descriptor is the shared
+        // path/method contract with the OpenAPI emitter and deliberately carries
+        // no response policy.
+        const cache = functions[entry.functionPath]?.expose?.cache;
 
         routes[entry.path] = async (
             request: Request,
@@ -168,7 +174,7 @@ const buildRestRoutes = (deps: RestRouteDeps): Record<string, RestRoute> => {
 
             const shardKey = readShardKey(url, request);
 
-            return invoke({
+            const response = await invoke({
                 args,
                 env,
                 functionPath: entry.functionPath,
@@ -176,6 +182,12 @@ const buildRestRoutes = (deps: RestRouteDeps): Record<string, RestRoute> => {
                 ...(shardKey === undefined ? {} : { shardKey }),
                 ...(context?.waitUntil === undefined ? {} : { waitUntil: (promise: Promise<unknown>) => context.waitUntil?.(promise) }),
             });
+
+            // Applied AFTER dispatch so the effective `Cache-Control` can account
+            // for the real status (an error is never cached) and for whether the
+            // caller presented credentials (a credentialed exchange is forced
+            // `private`, see `rest-cache`).
+            return applyRestCache(response, cache, request);
         };
     }
 

--- a/packages/runtime/src/rest-routes.ts
+++ b/packages/runtime/src/rest-routes.ts
@@ -19,12 +19,11 @@
 import type { RestExposure } from "../../../shared/rest-surface";
 import { describeRestSurface } from "../../../shared/rest-surface";
 import { methodGuard } from "./method-guard";
-import type { RestCacheConfigLike } from "./rest-cache";
 import { applyRestCache } from "./rest-cache";
 
 /** The bits of a registered function the REST router reads: its kind and its `.expose` tag. */
 interface RestRegistryEntry {
-    expose?: RestExposure & { cache?: RestCacheConfigLike };
+    expose?: RestExposure;
     kind: "action" | "mutation" | "query" | "stream";
 }
 
@@ -134,8 +133,9 @@ const buildRestRoutes = (deps: RestRouteDeps): Record<string, RestRoute> => {
         const allowed = entry.kind === "query" ? ["GET", "POST"] : ["POST"];
         // Read straight off the registry: the surface descriptor is the shared
         // path/method contract with the OpenAPI emitter and deliberately carries
-        // no response policy.
-        const cache = functions[entry.functionPath]?.expose?.cache;
+        // no response policy. `entry.functionPath` came out of this same map, so
+        // the lookup cannot miss.
+        const cache = (functions[entry.functionPath] as RestRegistryEntry).expose?.cache;
 
         routes[entry.path] = async (
             request: Request,

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -1,4 +1,4 @@
-import { v,ValidationError } from "@lunora/values";
+import { v, ValidationError } from "@lunora/values";
 import { describe, expect, it } from "vitest";
 
 import { parseValidatorMap } from "../src/functions";
@@ -131,6 +131,69 @@ describe("defineListArgs — no sortable columns declared", () => {
         // than assuming the validator already ran.
         expect(fixed.toQueryArgs({ orderBy: [{ field: "passwordHash" as never }] })).not.toHaveProperty("orderBy");
         expect(spec.toQueryArgs({ orderBy: [{ field: "passwordHash" as never }, { field: "score" }] }).orderBy).toEqual([{ score: "asc" }]);
+    });
+});
+
+describe("defineListArgs — toQueryArgs hardening", () => {
+    it("drops an undeclared field handed straight to toQueryArgs, bypassing the validator", () => {
+        expect.assertions(2);
+
+        // `toQueryArgs` is exported, so it cannot assume `.input()` already ran.
+        const args = spec.toQueryArgs({ where: { secretFlag: true, status: "open" } as never });
+
+        expect(args.where).toEqual({ status: "open" });
+        expect(args.where).not.toHaveProperty("secretFlag");
+    });
+
+    it("cannot be used to reach a prototype key", () => {
+        expect.assertions(2);
+
+        const hostile = JSON.parse('{"where":{"__proto__":{"polluted":true},"constructor":{"x":1},"status":"open"}}') as { where: never };
+        const args = spec.toQueryArgs(hostile);
+
+        expect(args.where).toEqual({ status: "open" });
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it("reduces an operator object to recognised operators only", () => {
+        expect.assertions(1);
+
+        const args = spec.toQueryArgs({ where: { score: { gte: 10, sqlInjection: "1=1" } } as never });
+
+        expect(args.where).toEqual({ score: { gte: 10 } });
+    });
+
+    it("normalizes a nonsensical configured bound rather than emitting an out-of-contract limit", () => {
+        expect.assertions(3);
+
+        expect(defineListArgs({ filter: {}, maxLimit: 0, orderBy: [] }).toQueryArgs({ limit: 50 }).limit).toBe(1);
+        expect(defineListArgs({ filter: {}, maxLimit: 10.9, orderBy: [] }).toQueryArgs({ limit: 50 }).limit).toBe(10);
+        expect(defineListArgs({ filter: {}, defaultLimit: Number.NaN, orderBy: [] }).toQueryArgs({}).limit).toBe(25);
+    });
+});
+
+describe("defineListArgs — request-cost bounds", () => {
+    it("rejects an oversized `in` array, which would become one bound parameter each", () => {
+        expect.assertions(2);
+
+        expect(() => parse({ where: { status: { in: Array.from({ length: 100 }).fill("x") } } })).not.toThrow();
+        expect(() => parse({ where: { status: { in: Array.from({ length: 101 }).fill("x") } } })).toThrow(ValidationError);
+    });
+
+    it("honours a custom maxInValues", () => {
+        expect.assertions(1);
+
+        const tight = defineListArgs({ filter: { status: v.string() }, maxInValues: 2, orderBy: [] });
+
+        expect(() => parseValidatorMap(tight.args as never, { where: { status: { in: ["a", "b", "c"] } } }, "args")).toThrow(ValidationError);
+    });
+
+    it("caps how many orderBy entries reach the query", () => {
+        expect.assertions(1);
+
+        const wide = defineListArgs({ filter: {}, maxOrderBy: 2, orderBy: ["a", "b", "c"] });
+
+        expect(wide.toQueryArgs({ orderBy: [{ field: "a" }, { field: "b" }, { field: "c" }] }).orderBy).toHaveLength(2);
     });
 });
 

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -1,0 +1,146 @@
+import { v,ValidationError } from "@lunora/values";
+import { describe, expect, it } from "vitest";
+
+import { parseValidatorMap } from "../src/functions";
+import { clampLimit, defineListArgs } from "../src/list-args";
+
+const spec = defineListArgs({
+    filter: { authorId: v.string(), score: v.number(), status: v.string() },
+    orderBy: ["_creationTime", "score"],
+});
+
+/** Parse a raw argument object through the declared validator map, exactly as a procedure's `.input()` does. */
+const parse = (raw: Record<string, unknown>): Record<string, unknown> => parseValidatorMap(spec.args as never, raw, "args");
+
+describe("defineListArgs — argument shape", () => {
+    it("accepts a bare value as an equality predicate", () => {
+        expect.assertions(1);
+
+        expect(parse({ where: { status: "open" } }).where).toEqual({ status: "open" });
+    });
+
+    it("accepts the operator object mirroring the ctx.db where DSL", () => {
+        expect.assertions(1);
+
+        const parsed = parse({ where: { score: { gte: 10, lt: 100 }, status: { in: ["open", "closed"] } } });
+
+        expect(parsed.where).toEqual({ score: { gte: 10, lt: 100 }, status: { in: ["open", "closed"] } });
+    });
+
+    it("drops a predicate over an undeclared column, so a caller cannot filter on unpublished data", () => {
+        expect.assertions(2);
+
+        const parsed = parse({ where: { secretInternalFlag: true, status: "open" } }) as { where: Record<string, unknown> };
+
+        expect(parsed.where.status).toBe("open");
+        expect(parsed.where).not.toHaveProperty("secretInternalFlag");
+    });
+
+    it("rejects a value of the wrong type for a declared column", () => {
+        expect.assertions(1);
+
+        expect(() => parse({ where: { score: "not-a-number" } })).toThrow(ValidationError);
+    });
+
+    it("rejects an orderBy field outside the declared allow-list", () => {
+        expect.assertions(2);
+
+        expect(() => parse({ orderBy: [{ field: "score" }] })).not.toThrow();
+        expect(() => parse({ orderBy: [{ field: "passwordHash" }] })).toThrow(ValidationError);
+    });
+
+    it("has no offset-paging arguments — paging is keyset only", () => {
+        expect.assertions(3);
+
+        expect(Object.keys(spec.args).toSorted((a, b) => a.localeCompare(b))).toEqual(["cursor", "limit", "orderBy", "where"]);
+        expect(spec.args).not.toHaveProperty("page");
+        expect(spec.args).not.toHaveProperty("offset");
+    });
+});
+
+describe("defineListArgs — toQueryArgs", () => {
+    it("applies the default limit when the caller omits one", () => {
+        expect.assertions(1);
+
+        expect(spec.toQueryArgs({}).limit).toBe(25);
+    });
+
+    it("clamps an oversized limit down to maxLimit rather than rejecting the request", () => {
+        expect.assertions(2);
+
+        expect(spec.toQueryArgs({ limit: 5000 }).limit).toBe(100);
+        expect(defineListArgs({ filter: {}, maxLimit: 10, orderBy: [] }).toQueryArgs({ limit: 5000 }).limit).toBe(10);
+    });
+
+    it("floors a fractional limit and lifts a non-positive one to 1", () => {
+        expect.assertions(3);
+
+        expect(spec.toQueryArgs({ limit: 7.9 }).limit).toBe(7);
+        expect(spec.toQueryArgs({ limit: 0 }).limit).toBe(1);
+        expect(spec.toQueryArgs({ limit: -20 }).limit).toBe(1);
+    });
+
+    it("reshapes orderBy entries into the ctx.db `{ column: direction }[]` form, defaulting to asc", () => {
+        expect.assertions(1);
+
+        const args = spec.toQueryArgs({ orderBy: [{ direction: "desc", field: "score" }, { field: "_creationTime" }] });
+
+        expect(args.orderBy).toEqual([{ score: "desc" }, { _creationTime: "asc" }]);
+    });
+
+    it("passes cursor and where straight through — the validator already constrained them", () => {
+        expect.assertions(2);
+
+        const args = spec.toQueryArgs({ cursor: "abc", where: { status: "open" } });
+
+        expect(args.cursor).toBe("abc");
+        expect(args.where).toEqual({ status: "open" });
+    });
+
+    it("omits absent keys instead of emitting undefined values", () => {
+        expect.assertions(3);
+
+        const args = spec.toQueryArgs({});
+
+        expect(args).not.toHaveProperty("cursor");
+        expect(args).not.toHaveProperty("where");
+        expect(args).not.toHaveProperty("orderBy");
+    });
+
+    it("omits orderBy when the caller sends an empty list", () => {
+        expect.assertions(1);
+
+        expect(spec.toQueryArgs({ orderBy: [] })).not.toHaveProperty("orderBy");
+    });
+});
+
+describe("defineListArgs — no sortable columns declared", () => {
+    const fixed = defineListArgs({ filter: {}, orderBy: [] });
+
+    it("refuses every orderBy field, including any sentinel-looking value", () => {
+        expect.assertions(2);
+
+        expect(() => parseValidatorMap(fixed.args as never, { orderBy: [{ field: "anything" }] }, "args")).toThrow(ValidationError);
+        expect(() => parseValidatorMap(fixed.args as never, { orderBy: [{ field: "__never__" }] }, "args")).toThrow(ValidationError);
+    });
+
+    it("drops an unlisted orderBy field in toQueryArgs even when handed an unparsed object", () => {
+        expect.assertions(2);
+
+        // `toQueryArgs` is exported, so it re-checks the allow-list itself rather
+        // than assuming the validator already ran.
+        expect(fixed.toQueryArgs({ orderBy: [{ field: "passwordHash" as never }] })).not.toHaveProperty("orderBy");
+        expect(spec.toQueryArgs({ orderBy: [{ field: "passwordHash" as never }, { field: "score" }] }).orderBy).toEqual([{ score: "asc" }]);
+    });
+});
+
+describe("clampLimit", () => {
+    it("falls back to the default when the value is absent or non-finite", () => {
+        expect.assertions(3);
+
+        expect(clampLimit(undefined, 25, 100)).toBe(25);
+        expect(clampLimit(Number.NaN, 25, 100)).toBe(25);
+        // A default above the ceiling is itself clamped — the ceiling always wins.
+        expect(clampLimit(undefined, 500, 100)).toBe(100);
+    });
+});

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -4,13 +4,60 @@ import { describe, expect, it } from "vitest";
 import { parseValidatorMap } from "../src/functions";
 import { clampLimit, defineListArgs } from "../src/list-args";
 
-const spec = defineListArgs({
+/** Stand-in for a generated `Doc&lt;"messages">`; binding it is what makes typos compile errors. */
+interface Message {
+    _creationTime: number;
+    authorId: string;
+    score: number;
+    status: string;
+}
+
+const spec = defineListArgs<Message>()({
     filter: { authorId: v.string(), score: v.number(), status: v.string() },
     orderBy: ["_creationTime", "score"],
 });
 
 /** Parse a raw argument object through the declared validator map, exactly as a procedure's `.input()` does. */
 const parse = (raw: Record<string, unknown>): Record<string, unknown> => parseValidatorMap(spec.args as never, raw, "args");
+
+describe("defineListArgs — Doc binding (compile-time)", () => {
+    it("rejects a filter column that isn't on the document", () => {
+        expect.assertions(1);
+
+        // @ts-expect-error -- `madeUpColumn` is not a key of Message; before the Doc
+        // binding this compiled and produced a filter that could never match.
+        const bad = defineListArgs<Message>()({ filter: { madeUpColumn: v.string() }, orderBy: [] });
+
+        expect(bad.args).toBeDefined();
+    });
+
+    it("rejects an orderBy field that isn't on the document", () => {
+        expect.assertions(1);
+
+        // @ts-expect-error -- "createdAt" does not exist on Message (it is `_creationTime`).
+        const bad = defineListArgs<Message>()({ filter: {}, orderBy: ["createdAt"] });
+
+        expect(bad.args).toBeDefined();
+    });
+
+    it("rejects a validator whose type contradicts the column", () => {
+        expect.assertions(1);
+
+        // @ts-expect-error -- `score` is a number on Message, so a string validator
+        // would decode into a predicate the column can never satisfy.
+        const bad = defineListArgs<Message>()({ filter: { score: v.string() }, orderBy: [] });
+
+        expect(bad.args).toBeDefined();
+    });
+
+    it("accepts the columns the document really has", () => {
+        expect.assertions(1);
+
+        const good = defineListArgs<Message>()({ filter: { score: v.number(), status: v.string() }, orderBy: ["_creationTime"] });
+
+        expect(Object.keys(good.args).toSorted((a, b) => a.localeCompare(b))).toEqual(["cursor", "limit", "orderBy", "where"]);
+    });
+});
 
 describe("defineListArgs — argument shape", () => {
     it("accepts a bare value as an equality predicate", () => {
@@ -69,7 +116,7 @@ describe("defineListArgs — toQueryArgs", () => {
         expect.assertions(2);
 
         expect(spec.toQueryArgs({ limit: 5000 }).limit).toBe(100);
-        expect(defineListArgs({ filter: {}, maxLimit: 10, orderBy: [] }).toQueryArgs({ limit: 5000 }).limit).toBe(10);
+        expect(defineListArgs<Message>()({ filter: {}, maxLimit: 10, orderBy: [] }).toQueryArgs({ limit: 5000 }).limit).toBe(10);
     });
 
     it("floors a fractional limit and lifts a non-positive one to 1", () => {
@@ -115,7 +162,7 @@ describe("defineListArgs — toQueryArgs", () => {
 });
 
 describe("defineListArgs — no sortable columns declared", () => {
-    const fixed = defineListArgs({ filter: {}, orderBy: [] });
+    const fixed = defineListArgs<Message>()({ filter: {}, orderBy: [] });
 
     it("refuses every orderBy field, including any sentinel-looking value", () => {
         expect.assertions(2);
@@ -166,9 +213,9 @@ describe("defineListArgs — toQueryArgs hardening", () => {
     it("normalizes a nonsensical configured bound rather than emitting an out-of-contract limit", () => {
         expect.assertions(3);
 
-        expect(defineListArgs({ filter: {}, maxLimit: 0, orderBy: [] }).toQueryArgs({ limit: 50 }).limit).toBe(1);
-        expect(defineListArgs({ filter: {}, maxLimit: 10.9, orderBy: [] }).toQueryArgs({ limit: 50 }).limit).toBe(10);
-        expect(defineListArgs({ filter: {}, defaultLimit: Number.NaN, orderBy: [] }).toQueryArgs({}).limit).toBe(25);
+        expect(defineListArgs<Message>()({ filter: {}, maxLimit: 0, orderBy: [] }).toQueryArgs({ limit: 50 }).limit).toBe(1);
+        expect(defineListArgs<Message>()({ filter: {}, maxLimit: 10.9, orderBy: [] }).toQueryArgs({ limit: 50 }).limit).toBe(10);
+        expect(defineListArgs<Message>()({ filter: {}, defaultLimit: Number.NaN, orderBy: [] }).toQueryArgs({}).limit).toBe(25);
     });
 });
 
@@ -183,7 +230,7 @@ describe("defineListArgs — request-cost bounds", () => {
     it("honours a custom maxInValues", () => {
         expect.assertions(1);
 
-        const tight = defineListArgs({ filter: { status: v.string() }, maxInValues: 2, orderBy: [] });
+        const tight = defineListArgs<Message>()({ filter: { status: v.string() }, maxInValues: 2, orderBy: [] });
 
         expect(() => parseValidatorMap(tight.args as never, { where: { status: { in: ["a", "b", "c"] } } }, "args")).toThrow(ValidationError);
     });
@@ -191,7 +238,7 @@ describe("defineListArgs — request-cost bounds", () => {
     it("caps how many orderBy entries reach the query", () => {
         expect.assertions(1);
 
-        const wide = defineListArgs({ filter: {}, maxOrderBy: 2, orderBy: ["a", "b", "c"] });
+        const wide = defineListArgs<{ a: number; b: number; c: number }>()({ filter: {}, maxOrderBy: 2, orderBy: ["a", "b", "c"] });
 
         expect(wide.toQueryArgs({ orderBy: [{ field: "a" }, { field: "b" }, { field: "c" }] }).orderBy).toHaveLength(2);
     });

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -240,7 +240,8 @@ describe("defineListArgs — request-cost bounds", () => {
 
         // This is the path that exists BECAUSE toQueryArgs is reachable without
         // `.input()`, so the cap has to hold here too or it protects nothing.
-        const args = spec.toQueryArgs({ where: { status: { in: Array.from({ length: 5000 }).fill("x") } } });
+        // Mapper uses its index so eslint keeps `Array.from` (a `.fill()` rewrite types as `unknown[]`).
+        const args = spec.toQueryArgs({ where: { status: { in: Array.from({ length: 5000 }, (_, index) => String(index)) } } });
         const predicate = (args.where as { status: { in: string[] } }).status;
 
         expect(predicate.in).toHaveLength(100);

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -235,6 +235,22 @@ describe("defineListArgs — request-cost bounds", () => {
         expect(() => parseValidatorMap(tight.args as never, { where: { status: { in: ["a", "b", "c"] } } }, "args")).toThrow(ValidationError);
     });
 
+    it("caps an oversized in-array handed straight to toQueryArgs, not just through the validator", () => {
+        expect.assertions(2);
+
+        // This is the path that exists BECAUSE toQueryArgs is reachable without
+        // `.input()`, so the cap has to hold here too or it protects nothing.
+        const args = spec.toQueryArgs({ where: { status: { in: Array.from({ length: 5000 }).fill("x") } } });
+        const predicate = (args.where as { status: { in: string[] } }).status;
+
+        expect(predicate.in).toHaveLength(100);
+        expect(
+            defineListArgs<Message>()({ filter: { status: v.string() }, maxInValues: 3, orderBy: [] }).toQueryArgs({
+                where: { status: { in: ["a", "b", "c", "d"] } },
+            }).where,
+        ).toEqual({ status: { in: ["a", "b", "c"] } });
+    });
+
     it("caps how many orderBy entries reach the query", () => {
         expect.assertions(1);
 

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -240,8 +240,8 @@ describe("defineListArgs — request-cost bounds", () => {
 
         // This is the path that exists BECAUSE toQueryArgs is reachable without
         // `.input()`, so the cap has to hold here too or it protects nothing.
-        // Mapper uses its index so eslint keeps `Array.from` (a `.fill()` rewrite types as `unknown[]`).
-        const args = spec.toQueryArgs({ where: { status: { in: Array.from({ length: 5000 }, (_, index) => String(index)) } } });
+        // eslint-disable-next-line e18e/prefer-array-fill -- the `.fill("x")` rewrite infers `unknown[]`, so the mapped form is the one that type-checks
+        const args = spec.toQueryArgs({ where: { status: { in: Array.from({ length: 5000 }, () => "x") } } });
         const predicate = (args.where as { status: { in: string[] } }).status;
 
         expect(predicate.in).toHaveLength(100);

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -179,6 +179,78 @@ ordering are covered in
 the browser-side `defineMutator` / `bindMutators` live in
 [`@lunora/db`](/docs/packages/db#custom-mutators).
 
+## List endpoints
+
+`defineListArgs(config)` is the shared convention for a paginated list query: it
+returns the validator map for `.input()` plus the translation into
+`ctx.db.<table>.findMany(...)` options, so every list endpoint agrees on how
+filtering, sorting, and paging are spelled — and the generated OpenAPI describes
+them without special-casing.
+
+```ts
+const listMessages = defineListArgs({
+    filter: { authorId: v.id("users"), status: v.string() },
+    orderBy: ["_creationTime", "status"],
+    // defaultLimit: 25, maxLimit: 100
+});
+
+export const list = c.query
+    .input(listMessages.args)
+    .expose({ rest: true })
+    .query(({ args, ctx }) => ctx.db.messages.findMany(listMessages.toQueryArgs(args)));
+```
+
+Callers get `where`, `orderBy`, `cursor`, and `limit`. `where` accepts either a
+bare value (equality) or the operator object mirroring the `ctx.db` `where` DSL
+(`{ gte, lt, in, contains, isNull, … }`).
+
+Three constraints are deliberate:
+
+- **Keyset paging, not offset.** There is no `page` / `page_size`. Offset paging
+  re-scans from row 0 for every page and shifts rows between pages whenever the
+  data changes — which, under a live query, it always is.
+- **Filterable columns are enumerated.** `filter` is an allow-list. `v.object`
+  drops undeclared keys, so a caller cannot predicate on a column you didn't
+  publish. Keep the list to indexed columns; `@lunora/advisor`'s
+  `filter-without-index` lint flags the static cases.
+- **No `AND` / `OR` / `NOT` trees.** A flat field⇒predicate map keeps every
+  filter routable to an index. Compose richer logic inside the procedure.
+
+`limit` is clamped into `[1, maxLimit]` rather than rejected, and `orderBy`
+fields outside the allow-list are refused by the validator and re-checked in
+`toQueryArgs`.
+
+`lunora introspect` emits `list` procedures built on this helper — see the
+[CLI docs](/docs/packages/cli#lunora-introspect).
+
+## Caching an exposed REST endpoint
+
+`.expose({ rest: true })` publishes a procedure at
+`/_lunora/rest/<namespace>/<fn>`. Add `cache` to have the runtime answer with
+`Cache-Control` / `Cache-Tag` / `Vary`:
+
+```ts
+export const listPublicPosts = c.query
+    .input(listPosts.args)
+    .expose({ rest: true, cache: { scope: "public", maxAge: 60, staleWhileRevalidate: 300, tag: "posts" } })
+    .query(({ args, ctx }) => ctx.db.posts.findMany(listPosts.toQueryArgs(args)));
+```
+
+Caching a procedure-backed endpoint is how a REST cache turns into a data leak,
+since the procedure runs under `ctx.auth` and RLS. So `scope` is enforced, not
+trusted: **a request carrying an `Authorization` header or any `Cookie` is always
+answered `private`**, even under `scope: "public"`. A per-caller response can
+therefore never be stored in a shared or edge cache, and the worst a mis-declared
+`scope` costs you is a missed cache hit. `scope: "public"` additionally emits
+`Vary: authorization, cookie` so an intermediary can't hand the stored anonymous
+variant to a signed-in caller.
+
+Headers are only ever applied to a cacheable exchange — a `GET` (so `query`
+procedures; a `mutation` / `action` is `POST`-only) that returned 2xx. An error
+response is never cached. `tag` is purgeable through the same
+`ctx.cache.purge({ tags: [...] })` surface `httpRoute(...).cacheTag()` uses, and
+the emitted OpenAPI documents the headers a caller will observe.
+
 ## Subpaths
 
 - `@lunora/server/rls/testing` — `expectPolicy(policies)`, an in-process RLS

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -188,10 +188,12 @@ filtering, sorting, and paging are spelled — and the generated OpenAPI describ
 them without special-casing.
 
 ```ts
-const listMessages = defineListArgs({
+import type { Doc } from "./_generated/dataModel";
+
+const listMessages = defineListArgs<Doc<"messages">>()({
     filter: { authorId: v.id("users"), status: v.string() },
     orderBy: ["_creationTime", "status"],
-    // defaultLimit: 25, maxLimit: 100
+    // defaultLimit: 25, maxLimit: 100, maxInValues: 100, maxOrderBy: 8
 });
 
 export const list = c.query
@@ -203,6 +205,13 @@ export const list = c.query
 Callers get `where`, `orderBy`, `cursor`, and `limit`. `where` accepts either a
 bare value (equality) or the operator object mirroring the `ctx.db` `where` DSL
 (`{ gte, lt, in, contains, isNull, … }`).
+
+The extra `()` is what binds the table's document type. With `Doc` bound, `filter`
+keys, `orderBy` entries, and each validator's type are checked against the table's
+real columns — so a typo, or a column renamed out from under the endpoint, is a
+**compile error** rather than a predicate that silently matches nothing.
+TypeScript has no partial type-argument inference, so binding `Doc` while still
+inferring the rest from the config needs the second call.
 
 Three constraints are deliberate:
 

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -212,13 +212,18 @@ Three constraints are deliberate:
 - **Filterable columns are enumerated.** `filter` is an allow-list. `v.object`
   drops undeclared keys, so a caller cannot predicate on a column you didn't
   publish. Keep the list to indexed columns; `@lunora/advisor`'s
-  `filter-without-index` lint flags the static cases.
+  `filter-without-index` lint flags the static cases. This bounds _which_ columns
+  are reachable, not the cost of every operator: `contains` compiles to a
+  leading-wildcard `LIKE`, and `ne` / `notIn` / `isNull: false` are non-sargable
+  too, so all of them scan regardless of the index.
 - **No `AND` / `OR` / `NOT` trees.** A flat field⇒predicate map keeps every
   filter routable to an index. Compose richer logic inside the procedure.
 
 `limit` is clamped into `[1, maxLimit]` rather than rejected, and `orderBy`
 fields outside the allow-list are refused by the validator and re-checked in
-`toQueryArgs`.
+`toQueryArgs`. `in` / `notIn` arrays are capped at `maxInValues` (default 100)
+because each element becomes a bound parameter, and `orderBy` at `maxOrderBy`
+(default 8).
 
 `lunora introspect` emits `list` procedures built on this helper — see the
 [CLI docs](/docs/packages/cli#lunora-introspect).
@@ -238,12 +243,25 @@ export const listPublicPosts = c.query
 
 Caching a procedure-backed endpoint is how a REST cache turns into a data leak,
 since the procedure runs under `ctx.auth` and RLS. So `scope` is enforced, not
-trusted: **a request carrying an `Authorization` header or any `Cookie` is always
-answered `private`**, even under `scope: "public"`. A per-caller response can
-therefore never be stored in a shared or edge cache, and the worst a mis-declared
-`scope` costs you is a missed cache hit. `scope: "public"` additionally emits
-`Vary: authorization, cookie` so an intermediary can't hand the stored anonymous
-variant to a signed-in caller.
+trusted: **a request carrying `Authorization`, `Cookie`, or
+`Cf-Access-Jwt-Assertion` is always answered `private`**, even under
+`scope: "public"`. A per-caller response therefore never reaches a shared or edge
+cache, and the worst a mis-declared `scope` costs you is a missed cache hit.
+
+That check is a header list, and it cannot be exhaustive — `resolveIdentity`
+receives the whole request, so an app may authenticate on anything. **If your
+auth reads a header not in that list, declare it:**
+
+```ts
+.expose({ rest: true, cache: { scope: "public", maxAge: 60, credentialHeaders: ["x-api-key"] } })
+```
+
+Otherwise those callers read as anonymous and their responses are cached
+`public`. The emitted `Vary` also covers `x-lunora-shard-key` and
+`x-d1-bookmark`, which select _which_ rows a request sees. Treat `Vary` as a
+courtesy to well-behaved intermediaries rather than the safety mechanism —
+Cloudflare's cache honours it only for `Accept-Encoding`, so the real protection
+is the downgrade above.
 
 Headers are only ever applied to a cacheable exchange — a `GET` (so `query`
 procedures; a `mutation` / `action` is `POST`-only) that returned 2xx. An error

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -40,6 +40,8 @@ export type { DefineIdentityOptions, IdentityContract, IdentityRejectMode, Ident
 export { defineIdentity } from "./identity";
 export type { LifecycleHandler } from "./lifecycle";
 export { onConnect, onDisconnect } from "./lifecycle";
+export type { DefineListArgsConfig, ListArgsSpec, ListArgsValidators, ListArgsValue, ListFilterOperators, ListOrderByEntry, ListWhere } from "./list-args";
+export { clampLimit, DEFAULT_LIMIT, DEFAULT_MAX_LIMIT, defineListArgs } from "./list-args";
 export type { MaskColumns, MaskContext, MaskFn, MaskOptions, MaskPolicies, MaskStrategy } from "./mask/index";
 export { mask } from "./mask/index";
 export type { MigrationDefinition, MigrationDocument, MigrationTransform, RegisteredMigration } from "./migration";
@@ -143,6 +145,7 @@ export type {
     RegisteredQuery,
     RegisteredStream,
     RelationDefinition,
+    RestCacheConfig,
     ScheduledFunctionDoc,
     ScheduledJob,
     Scheduler,

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -1,0 +1,208 @@
+/**
+ * The shared convention for a paginated list endpoint.
+ *
+ * Every `.expose({ rest: true })` list query used to hand-roll its own
+ * filter/sort/page arguments, so no two endpoints agreed on a spelling and the
+ * generated OpenAPI documented whatever each author happened to invent.
+ * {@link defineListArgs} makes that one declaration:
+ *
+ * ```ts
+ * const listMessages = defineListArgs({
+ *     filter: { authorId: v.id("users"), status: v.string() },
+ *     orderBy: ["_creationTime", "status"],
+ * });
+ *
+ * export const list = c.query
+ *     .input(listMessages.args)
+ *     .expose({ rest: true })
+ *     .query(({ args, ctx }) => ctx.db.messages.findMany(listMessages.toQueryArgs(args)));
+ * ```
+ *
+ * Three deliberate departures from the REST-gateway convention (pREST et al.):
+ *
+ *   - **Keyset, not offset.** There is no `page` / `page_size`. Paging is
+ *     `cursor` + `limit`, matching `ctx.db`'s keyset reader — offset paging
+ *     re-scans from row 0 for every page and silently shifts rows between pages
+ *     whenever the underlying data changes, which under a live query it always
+ *     is.
+ *   - **Filterable fields are enumerated, never open.** `filter` is an explicit
+ *     allow-list of column → validator. `v.object` drops undeclared keys, so a
+ *     caller cannot smuggle a predicate over a column the author didn't publish.
+ *     Keep the list to indexed columns — an unindexed filter is a table scan
+ *     (`@lunora/advisor`'s `filter-without-index` lint flags the static cases).
+ *   - **No `AND` / `OR` / `NOT` trees.** A flat field⇒predicate map is what keeps
+ *     every filter routable to an index; arbitrary boolean nesting is precisely
+ *     what forces scans. Compose those server-side in the procedure instead.
+ *
+ * Because the result is an ordinary validator map, the OpenAPI emitter describes
+ * these parameters with no special-casing — the published spec and the accepted
+ * arguments are the same declaration.
+ */
+import type { ColumnValidator, Infer, Validator } from "@lunora/values";
+import { v } from "@lunora/values";
+
+import type { OrderBy, QueryArgs } from "./data-model";
+
+/** Default `limit` when the caller doesn't ask for one. */
+const DEFAULT_LIMIT = 25;
+
+/** Default ceiling on `limit`, so one request can't ask for an unbounded page. */
+const DEFAULT_MAX_LIMIT = 100;
+
+/**
+ * Per-field predicate accepted for a declared filter column — mirrors
+ * `WhereOperators` from the `ctx.db` `where` DSL exactly, so a parsed value is
+ * passed straight through with no translation step to drift.
+ */
+interface ListFilterOperators<T> {
+    contains?: string;
+    eq?: T;
+    gt?: T;
+    gte?: T;
+    in?: T[];
+    isNull?: boolean;
+    lt?: T;
+    lte?: T;
+    ne?: T;
+    notIn?: T[];
+}
+
+/** The `where` argument: each declared filter column, optionally, as a bare value or an operator object. */
+type ListWhere<F extends Record<string, Validator>> = {
+    [K in keyof F]?: Infer<F[K]> | ListFilterOperators<Infer<F[K]>>;
+};
+
+/** One `orderBy` entry. `direction` defaults to `"asc"`. */
+interface ListOrderByEntry<O extends string> {
+    direction?: "asc" | "desc";
+    field: O;
+}
+
+/** The decoded arguments a {@link defineListArgs} endpoint receives. */
+interface ListArgsValue<F extends Record<string, Validator>, O extends string> {
+    cursor?: null | string;
+    limit?: number;
+    orderBy?: ListOrderByEntry<O>[];
+    where?: ListWhere<F>;
+}
+
+interface DefineListArgsConfig<F extends Record<string, Validator>, O extends string> {
+    /** `limit` applied when the caller omits one. Defaults to 25. */
+    readonly defaultLimit?: number;
+
+    /**
+     * Allow-list of filterable columns. Publish only columns an index can serve;
+     * anything absent here is unreachable from the client.
+     */
+    readonly filter: F;
+
+    /** Ceiling on `limit`; a larger request is clamped down, not rejected. Defaults to 100. */
+    readonly maxLimit?: number;
+
+    /** Allow-list of sortable columns. Pass `[]` to fix the order server-side. */
+    readonly orderBy: ReadonlyArray<O>;
+}
+
+/** The validator map handed to `.input()`. Typed precisely so `args` infers end-to-end. */
+interface ListArgsValidators<F extends Record<string, Validator>, O extends string> {
+    cursor: ColumnValidator<null | string | undefined, null | string | undefined>;
+    limit: ColumnValidator<number | undefined, number | undefined>;
+    orderBy: ColumnValidator<ListOrderByEntry<O>[] | undefined, ListOrderByEntry<O>[] | undefined>;
+    where: ColumnValidator<ListWhere<F> | undefined, ListWhere<F> | undefined>;
+}
+
+interface ListArgsSpec<F extends Record<string, Validator>, O extends string> {
+    /** Spread into `.input(...)` — `{ cursor, limit, orderBy, where }`. */
+    readonly args: ListArgsValidators<F, O>;
+
+    /**
+     * Translate the decoded arguments into the `findMany` options object:
+     * `limit` clamped into `[1, maxLimit]`, `orderBy` reshaped from
+     * `{ field, direction }[]` into `ctx.db`'s `{ column: direction }[]`.
+     */
+    readonly toQueryArgs: <TDocument>(args: ListArgsValue<F, O>) => QueryArgs<TDocument>;
+}
+
+/** Build the operator object accepted alongside a bare value for one filter column. */
+const operatorsValidator = (value: Validator): Validator =>
+    v.object({
+        contains: v.optional(v.string()),
+        eq: v.optional(value),
+        gt: v.optional(value),
+        gte: v.optional(value),
+        in: v.optional(v.array(value)),
+        isNull: v.optional(v.boolean()),
+        lt: v.optional(value),
+        lte: v.optional(value),
+        ne: v.optional(value),
+        notIn: v.optional(v.array(value)),
+    });
+
+/** Clamp a caller-supplied `limit` into `[1, maxLimit]`; a non-finite value falls back to `fallback`. */
+const clampLimit = (limit: number | undefined, fallback: number, maxLimit: number): number => {
+    if (limit === undefined || !Number.isFinite(limit)) {
+        return Math.min(fallback, maxLimit);
+    }
+
+    return Math.min(Math.max(1, Math.floor(limit)), maxLimit);
+};
+
+/**
+ * Declare the filter / sort / page arguments for a list endpoint, plus the
+ * translation into `ctx.db.&lt;table>.findMany(...)` options. See the module docs
+ * for the shape and the reasoning behind it.
+ */
+const defineListArgs = <F extends Record<string, Validator>, O extends string>(config: DefineListArgsConfig<F, O>): ListArgsSpec<F, O> => {
+    const defaultLimit = config.defaultLimit ?? DEFAULT_LIMIT;
+    const maxLimit = config.maxLimit ?? DEFAULT_MAX_LIMIT;
+
+    const whereShape: Record<string, Validator> = {};
+
+    for (const [field, validator] of Object.entries(config.filter)) {
+        whereShape[field] = v.optional(v.union(validator, operatorsValidator(validator)));
+    }
+
+    // With no sortable columns declared the `field` slot must be unsatisfiable —
+    // `v.union` requires at least one member, and any literal sentinel would
+    // itself be an accepted value, so refute unconditionally instead.
+    const sortable = new Set<string>(config.orderBy);
+    const fieldValidator: Validator =
+        config.orderBy.length === 0
+            ? v.string().check(() => false, { message: "no sortable columns are declared for this endpoint" })
+            : v.union(...config.orderBy.map((field) => v.literal(field)));
+
+    const args = {
+        cursor: v.optional(v.union(v.string(), v.null())),
+        limit: v.optional(v.number()),
+        orderBy: v.optional(
+            v.array(
+                v.object({
+                    direction: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+                    field: fieldValidator,
+                }),
+            ),
+        ),
+        where: v.optional(v.object(whereShape)),
+    } as unknown as ListArgsValidators<F, O>;
+
+    const toQueryArgs = <TDocument>(value: ListArgsValue<F, O>): QueryArgs<TDocument> => {
+        // Re-check `field` against the allow-list rather than trusting that the
+        // validator ran: `toQueryArgs` is an exported function and nothing stops a
+        // caller handing it an unparsed object.
+        const orderBy = value.orderBy
+            ?.filter((entry) => sortable.has(entry.field))
+            .map((entry) => ({ [entry.field]: entry.direction ?? "asc" }) as OrderBy<TDocument>);
+
+        return {
+            ...(value.cursor === undefined ? {} : { cursor: value.cursor }),
+            limit: clampLimit(value.limit, defaultLimit, maxLimit),
+            ...(orderBy === undefined || orderBy.length === 0 ? {} : { orderBy }),
+            ...(value.where === undefined ? {} : { where: value.where as QueryArgs<TDocument>["where"] }),
+        };
+    };
+
+    return { args, toQueryArgs };
+};
+
+export type { DefineListArgsConfig, ListArgsSpec, ListArgsValidators, ListArgsValue, ListFilterOperators, ListOrderByEntry, ListWhere };
+export { clampLimit, DEFAULT_LIMIT, DEFAULT_MAX_LIMIT,defineListArgs };

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -30,6 +30,13 @@
  *     caller cannot smuggle a predicate over a column the author didn't publish.
  *     Keep the list to indexed columns — an unindexed filter is a table scan
  *     (`@lunora/advisor`'s `filter-without-index` lint flags the static cases).
+ *
+ *     Note what this does NOT promise: publishing only indexed columns bounds
+ *     WHICH columns are reachable, not the cost of every predicate over them.
+ *     `contains` compiles to a leading-wildcard `LIKE`, and `ne` / `notIn` /
+ *     `isNull: false` are likewise non-sargable — all of them scan whatever the
+ *     column's index would otherwise have narrowed. `maxInValues` and `maxLimit`
+ *     bound request size; they don't make a scan into a seek.
  *   - **No `AND` / `OR` / `NOT` trees.** A flat field⇒predicate map is what keeps
  *     every filter routable to an index; arbitrary boolean nesting is precisely
  *     what forces scans. Compose those server-side in the procedure instead.
@@ -41,7 +48,7 @@
 import type { ColumnValidator, Infer, Validator } from "@lunora/values";
 import { v } from "@lunora/values";
 
-import type { OrderBy, QueryArgs } from "./data-model";
+import type { OrderBy, QueryArgs, WhereOperators } from "./data-model";
 
 /** Default `limit` when the caller doesn't ask for one. */
 const DEFAULT_LIMIT = 25;
@@ -50,22 +57,25 @@ const DEFAULT_LIMIT = 25;
 const DEFAULT_MAX_LIMIT = 100;
 
 /**
- * Per-field predicate accepted for a declared filter column — mirrors
- * `WhereOperators` from the `ctx.db` `where` DSL exactly, so a parsed value is
- * passed straight through with no translation step to drift.
+ * Default ceiling on `in` / `notIn` array length.
+ *
+ * Each element becomes one bound parameter in the compiled statement, so an
+ * uncapped array turns a single ~1 MB request body into a statement with hundreds
+ * of thousands of parameters — past SQLite's variable ceiling, and expensive well
+ * before that. `limit` being carefully clamped while this stayed open was the
+ * larger hole of the two.
  */
-interface ListFilterOperators<T> {
-    contains?: string;
-    eq?: T;
-    gt?: T;
-    gte?: T;
-    in?: T[];
-    isNull?: boolean;
-    lt?: T;
-    lte?: T;
-    ne?: T;
-    notIn?: T[];
-}
+const DEFAULT_MAX_IN_VALUES = 100;
+
+/** Default ceiling on how many `orderBy` entries one request may ask for. */
+const DEFAULT_MAX_ORDER_BY = 8;
+
+/**
+ * Per-field predicate accepted for a declared filter column. An alias of the
+ * `ctx.db` `where` DSL's own operator type rather than a copy, so the two cannot
+ * drift as operators are added.
+ */
+type ListFilterOperators<T> = WhereOperators<T>;
 
 /** The `where` argument: each declared filter column, optionally, as a bare value or an operator object. */
 type ListWhere<F extends Record<string, Validator>> = {
@@ -80,7 +90,7 @@ interface ListOrderByEntry<O extends string> {
 
 /** The decoded arguments a {@link defineListArgs} endpoint receives. */
 interface ListArgsValue<F extends Record<string, Validator>, O extends string> {
-    cursor?: null | string;
+    cursor?: null | number | string;
     limit?: number;
     orderBy?: ListOrderByEntry<O>[];
     where?: ListWhere<F>;
@@ -96,8 +106,14 @@ interface DefineListArgsConfig<F extends Record<string, Validator>, O extends st
      */
     readonly filter: F;
 
+    /** Ceiling on `in` / `notIn` array length — one bound parameter each. Defaults to 100. */
+    readonly maxInValues?: number;
+
     /** Ceiling on `limit`; a larger request is clamped down, not rejected. Defaults to 100. */
     readonly maxLimit?: number;
+
+    /** Ceiling on how many `orderBy` entries a request may ask for. Defaults to 8. */
+    readonly maxOrderBy?: number;
 
     /** Allow-list of sortable columns. Pass `[]` to fix the order server-side. */
     readonly orderBy: ReadonlyArray<O>;
@@ -105,7 +121,7 @@ interface DefineListArgsConfig<F extends Record<string, Validator>, O extends st
 
 /** The validator map handed to `.input()`. Typed precisely so `args` infers end-to-end. */
 interface ListArgsValidators<F extends Record<string, Validator>, O extends string> {
-    cursor: ColumnValidator<null | string | undefined, null | string | undefined>;
+    cursor: ColumnValidator<null | number | string | undefined, null | number | string | undefined>;
     limit: ColumnValidator<number | undefined, number | undefined>;
     orderBy: ColumnValidator<ListOrderByEntry<O>[] | undefined, ListOrderByEntry<O>[] | undefined>;
     where: ColumnValidator<ListWhere<F> | undefined, ListWhere<F> | undefined>;
@@ -124,19 +140,23 @@ interface ListArgsSpec<F extends Record<string, Validator>, O extends string> {
 }
 
 /** Build the operator object accepted alongside a bare value for one filter column. */
-const operatorsValidator = (value: Validator): Validator =>
-    v.object({
+const operatorsValidator = (value: Validator, maxInValues: number): Validator => {
+    const bounded = (inner: Validator): Validator =>
+        v.optional(v.array(inner).check((items) => items.length <= maxInValues, { message: `at most ${String(maxInValues)} values` }));
+
+    return v.object({
         contains: v.optional(v.string()),
         eq: v.optional(value),
         gt: v.optional(value),
         gte: v.optional(value),
-        in: v.optional(v.array(value)),
+        in: bounded(value),
         isNull: v.optional(v.boolean()),
         lt: v.optional(value),
         lte: v.optional(value),
         ne: v.optional(value),
-        notIn: v.optional(v.array(value)),
+        notIn: bounded(value),
     });
+};
 
 /** Clamp a caller-supplied `limit` into `[1, maxLimit]`; a non-finite value falls back to `fallback`. */
 const clampLimit = (limit: number | undefined, fallback: number, maxLimit: number): number => {
@@ -148,18 +168,92 @@ const clampLimit = (limit: number | undefined, fallback: number, maxLimit: numbe
 };
 
 /**
+ * Normalize an author-supplied bound to a positive integer. `maxLimit: 0` or a
+ * fractional / `NaN` value would otherwise flow into {@link clampLimit} and
+ * produce a `limit` outside the documented `[1, maxLimit]` contract.
+ */
+const normalizeBound = (value: number | undefined, fallback: number): number => {
+    if (value === undefined || !Number.isFinite(value)) {
+        return fallback;
+    }
+
+    return Math.max(1, Math.floor(value));
+};
+
+/** The runtime spelling of `WhereOperators`' keys — the allow-list `toQueryArgs` rebuilds against. Keep in step with `data-model`'s `WhereOperators`. */
+const OPERATOR_KEYS = new Set(["contains", "eq", "gt", "gte", "in", "isNull", "lt", "lte", "ne", "notIn"]);
+
+/**
+ * Reduce a candidate predicate to recognised operators, or `undefined` when it
+ * isn't an operator object at all.
+ *
+ * The test is "does it name at least one operator", not "are all of its keys
+ * operators". Requiring all keys would let a MIXED object — `{ gte: 10, junk: … }`
+ * — fall through as a bare value and reach the where-compiler with the junk key
+ * still attached, which is precisely the case worth stopping. A plain object that
+ * names no operator at all is left alone, so an object-valued column can still be
+ * matched by equality.
+ */
+const asOperators = (value: unknown): Record<string, unknown> | undefined => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return undefined;
+    }
+
+    const source = value as Record<string, unknown>;
+    const operators: Record<string, unknown> = {};
+
+    for (const operator of OPERATOR_KEYS) {
+        if (Object.hasOwn(source, operator)) {
+            operators[operator] = source[operator];
+        }
+    }
+
+    return Object.keys(operators).length === 0 ? undefined : operators;
+};
+
+/**
+ * Rebuild `where` from the declared allow-list before it reaches `ctx.db`.
+ *
+ * The validator map already enforces this for anything arriving through
+ * `.input()`, but `toQueryArgs` is exported and nothing stops a caller passing an
+ * object that never went through it. Note the direction of the loop: fields are
+ * taken FROM the allow-list rather than from the input, so an undeclared key
+ * — including `__proto__` or `constructor` — has no path into the output at all,
+ * and operator objects are reduced to recognised operators only.
+ */
+const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<string>): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+
+    for (const field of filterable) {
+        if (!Object.hasOwn(where, field)) {
+            continue;
+        }
+
+        const value = where[field];
+        const operators = asOperators(value);
+
+        out[field] = operators ?? value;
+    }
+
+    return out;
+};
+
+/**
  * Declare the filter / sort / page arguments for a list endpoint, plus the
  * translation into `ctx.db.&lt;table>.findMany(...)` options. See the module docs
  * for the shape and the reasoning behind it.
  */
 const defineListArgs = <F extends Record<string, Validator>, O extends string>(config: DefineListArgsConfig<F, O>): ListArgsSpec<F, O> => {
-    const defaultLimit = config.defaultLimit ?? DEFAULT_LIMIT;
-    const maxLimit = config.maxLimit ?? DEFAULT_MAX_LIMIT;
+    const defaultLimit = normalizeBound(config.defaultLimit, DEFAULT_LIMIT);
+    const maxLimit = normalizeBound(config.maxLimit, DEFAULT_MAX_LIMIT);
+    const maxInValues = normalizeBound(config.maxInValues, DEFAULT_MAX_IN_VALUES);
+    const maxOrderBy = normalizeBound(config.maxOrderBy, DEFAULT_MAX_ORDER_BY);
 
+    const filterable = new Set(Object.keys(config.filter));
     const whereShape: Record<string, Validator> = {};
 
     for (const [field, validator] of Object.entries(config.filter)) {
-        whereShape[field] = v.optional(v.union(validator, operatorsValidator(validator)));
+        whereShape[field] = v.optional(v.union(validator, operatorsValidator(validator, maxInValues)));
     }
 
     // With no sortable columns declared the `field` slot must be unsatisfiable —
@@ -172,7 +266,10 @@ const defineListArgs = <F extends Record<string, Validator>, O extends string>(c
             : v.union(...config.orderBy.map((field) => v.literal(field)));
 
     const args = {
-        cursor: v.optional(v.union(v.string(), v.null())),
+        // A number is accepted because the REST router JSON-parses query-string
+        // values, so an all-digit cursor arrives as one; `toQueryArgs` restores it
+        // to the string `ctx.db` expects.
+        cursor: v.optional(v.union(v.string(), v.number(), v.null())),
         limit: v.optional(v.number()),
         orderBy: v.optional(
             v.array(
@@ -191,13 +288,18 @@ const defineListArgs = <F extends Record<string, Validator>, O extends string>(c
         // caller handing it an unparsed object.
         const orderBy = value.orderBy
             ?.filter((entry) => sortable.has(entry.field))
+            .slice(0, maxOrderBy)
             .map((entry) => ({ [entry.field]: entry.direction ?? "asc" }) as OrderBy<TDocument>);
 
+        // Same reasoning as `orderBy` above: rebuilt from the allow-list rather
+        // than trusted, because this function is reachable without the validator.
+        const where = value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable) as QueryArgs<TDocument>["where"]);
+
         return {
-            ...(value.cursor === undefined ? {} : { cursor: value.cursor }),
+            ...(value.cursor === undefined ? {} : { cursor: typeof value.cursor === "number" ? String(value.cursor) : value.cursor }),
             limit: clampLimit(value.limit, defaultLimit, maxLimit),
             ...(orderBy === undefined || orderBy.length === 0 ? {} : { orderBy }),
-            ...(value.where === undefined ? {} : { where: value.where as QueryArgs<TDocument>["where"] }),
+            ...(where === undefined ? {} : { where }),
         };
     };
 
@@ -205,4 +307,4 @@ const defineListArgs = <F extends Record<string, Validator>, O extends string>(c
 };
 
 export type { DefineListArgsConfig, ListArgsSpec, ListArgsValidators, ListArgsValue, ListFilterOperators, ListOrderByEntry, ListWhere };
-export { clampLimit, DEFAULT_LIMIT, DEFAULT_MAX_LIMIT,defineListArgs };
+export { clampLimit, DEFAULT_LIMIT, DEFAULT_MAX_IN_VALUES, DEFAULT_MAX_LIMIT, DEFAULT_MAX_ORDER_BY, defineListArgs, normalizeBound, sanitizeWhere };

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -77,9 +77,17 @@ const DEFAULT_MAX_ORDER_BY = 8;
  */
 type ListFilterOperators<T> = WhereOperators<T>;
 
+/**
+ * The filter allow-list a caller may declare: a subset of the document's own
+ * columns, each with a validator for that column's type. Constraining the KEYS to
+ * `keyof Doc` is what turns a typo'd or renamed column into a compile error
+ * instead of a predicate that silently never matches.
+ */
+type ListFilterShape<TDocument> = { [K in keyof TDocument & string]?: Validator<TDocument[K]> };
+
 /** The `where` argument: each declared filter column, optionally, as a bare value or an operator object. */
-type ListWhere<F extends Record<string, Validator>> = {
-    [K in keyof F]?: Infer<F[K]> | ListFilterOperators<Infer<F[K]>>;
+type ListWhere<F> = {
+    [K in keyof F]?: Infer<NonNullable<F[K]>> | ListFilterOperators<Infer<NonNullable<F[K]>>>;
 };
 
 /** One `orderBy` entry. `direction` defaults to `"asc"`. */
@@ -89,14 +97,14 @@ interface ListOrderByEntry<O extends string> {
 }
 
 /** The decoded arguments a {@link defineListArgs} endpoint receives. */
-interface ListArgsValue<F extends Record<string, Validator>, O extends string> {
+interface ListArgsValue<F, O extends string> {
     cursor?: null | number | string;
     limit?: number;
     orderBy?: ListOrderByEntry<O>[];
     where?: ListWhere<F>;
 }
 
-interface DefineListArgsConfig<F extends Record<string, Validator>, O extends string> {
+interface DefineListArgsConfig<F, O extends string> {
     /** `limit` applied when the caller omits one. Defaults to 25. */
     readonly defaultLimit?: number;
 
@@ -120,14 +128,14 @@ interface DefineListArgsConfig<F extends Record<string, Validator>, O extends st
 }
 
 /** The validator map handed to `.input()`. Typed precisely so `args` infers end-to-end. */
-interface ListArgsValidators<F extends Record<string, Validator>, O extends string> {
+interface ListArgsValidators<F, O extends string> {
     cursor: ColumnValidator<null | number | string | undefined, null | number | string | undefined>;
     limit: ColumnValidator<number | undefined, number | undefined>;
     orderBy: ColumnValidator<ListOrderByEntry<O>[] | undefined, ListOrderByEntry<O>[] | undefined>;
     where: ColumnValidator<ListWhere<F> | undefined, ListWhere<F> | undefined>;
 }
 
-interface ListArgsSpec<F extends Record<string, Validator>, O extends string> {
+interface ListArgsSpec<TDocument, F, O extends string> {
     /** Spread into `.input(...)` — `{ cursor, limit, orderBy, where }`. */
     readonly args: ListArgsValidators<F, O>;
 
@@ -135,8 +143,12 @@ interface ListArgsSpec<F extends Record<string, Validator>, O extends string> {
      * Translate the decoded arguments into the `findMany` options object:
      * `limit` clamped into `[1, maxLimit]`, `orderBy` reshaped from
      * `{ field, direction }[]` into `ctx.db`'s `{ column: direction }[]`.
+     *
+     * Returns `QueryArgs&lt;Doc>` — bound to the table, not free — so a mismatch
+     * between what this helper declares and what the table actually holds is a
+     * compile error at the `findMany` call site.
      */
-    readonly toQueryArgs: <TDocument>(args: ListArgsValue<F, O>) => QueryArgs<TDocument>;
+    readonly toQueryArgs: (args: ListArgsValue<F, O>) => QueryArgs<TDocument>;
 }
 
 /** Build the operator object accepted alongside a bare value for one filter column. */
@@ -242,69 +254,82 @@ const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<s
  * Declare the filter / sort / page arguments for a list endpoint, plus the
  * translation into `ctx.db.&lt;table>.findMany(...)` options. See the module docs
  * for the shape and the reasoning behind it.
+ *
+ * Curried on the document type: `defineListArgs&lt;Doc&lt;"messages">>()({ … })`. The
+ * extra `()` buys the thing that matters — with `Doc` bound, `filter` keys and
+ * `orderBy` entries are checked against the table's real columns, so a typo or a
+ * column renamed out from under the endpoint is a COMPILE error instead of a
+ * predicate that silently matches nothing. TypeScript has no partial type-argument
+ * inference, so binding `Doc` explicitly while still inferring `F` and `O` from
+ * the config requires the second call.
  */
-const defineListArgs = <F extends Record<string, Validator>, O extends string>(config: DefineListArgsConfig<F, O>): ListArgsSpec<F, O> => {
-    const defaultLimit = normalizeBound(config.defaultLimit, DEFAULT_LIMIT);
-    const maxLimit = normalizeBound(config.maxLimit, DEFAULT_MAX_LIMIT);
-    const maxInValues = normalizeBound(config.maxInValues, DEFAULT_MAX_IN_VALUES);
-    const maxOrderBy = normalizeBound(config.maxOrderBy, DEFAULT_MAX_ORDER_BY);
+const defineListArgs =
+    <TDocument>() =>
+    <F extends ListFilterShape<TDocument>, O extends keyof TDocument & string>(config: DefineListArgsConfig<F, O>): ListArgsSpec<TDocument, F, O> => {
+        const defaultLimit = normalizeBound(config.defaultLimit, DEFAULT_LIMIT);
+        const maxLimit = normalizeBound(config.maxLimit, DEFAULT_MAX_LIMIT);
+        const maxInValues = normalizeBound(config.maxInValues, DEFAULT_MAX_IN_VALUES);
+        const maxOrderBy = normalizeBound(config.maxOrderBy, DEFAULT_MAX_ORDER_BY);
 
-    const filterable = new Set(Object.keys(config.filter));
-    const whereShape: Record<string, Validator> = {};
+        const filterable = new Set(Object.keys(config.filter));
+        const whereShape: Record<string, Validator> = {};
 
-    for (const [field, validator] of Object.entries(config.filter)) {
-        whereShape[field] = v.optional(v.union(validator, operatorsValidator(validator, maxInValues)));
-    }
+        for (const [field, validator] of Object.entries(config.filter) as [string, Validator][]) {
+            whereShape[field] = v.optional(v.union(validator, operatorsValidator(validator, maxInValues)));
+        }
 
-    // With no sortable columns declared the `field` slot must be unsatisfiable —
-    // `v.union` requires at least one member, and any literal sentinel would
-    // itself be an accepted value, so refute unconditionally instead.
-    const sortable = new Set<string>(config.orderBy);
-    const fieldValidator: Validator =
-        config.orderBy.length === 0
-            ? v.string().check(() => false, { message: "no sortable columns are declared for this endpoint" })
-            : v.union(...config.orderBy.map((field) => v.literal(field)));
+        // With no sortable columns declared the `field` slot must be unsatisfiable —
+        // `v.union` requires at least one member, and any literal sentinel would
+        // itself be an accepted value, so refute unconditionally instead.
+        const sortable = new Set<string>(config.orderBy);
+        const fieldValidator: Validator =
+            config.orderBy.length === 0
+                ? v.string().check(() => false, { message: "no sortable columns are declared for this endpoint" })
+                : v.union(...config.orderBy.map((field) => v.literal(field)));
 
-    const args = {
-        // A number is accepted because the REST router JSON-parses query-string
-        // values, so an all-digit cursor arrives as one; `toQueryArgs` restores it
-        // to the string `ctx.db` expects.
-        cursor: v.optional(v.union(v.string(), v.number(), v.null())),
-        limit: v.optional(v.number()),
-        orderBy: v.optional(
-            v.array(
-                v.object({
-                    direction: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
-                    field: fieldValidator,
-                }),
+        const args = {
+            // A number is accepted because the REST router JSON-parses query-string
+            // values, so an all-digit cursor arrives as one; `toQueryArgs` restores it
+            // to the string `ctx.db` expects.
+            cursor: v.optional(v.union(v.string(), v.number(), v.null())),
+            limit: v.optional(v.number()),
+            orderBy: v.optional(
+                v.array(
+                    v.object({
+                        direction: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+                        field: fieldValidator,
+                    }),
+                ),
             ),
-        ),
-        where: v.optional(v.object(whereShape)),
-    } as unknown as ListArgsValidators<F, O>;
+            where: v.optional(v.object(whereShape)),
+        } as unknown as ListArgsValidators<F, O>;
 
-    const toQueryArgs = <TDocument>(value: ListArgsValue<F, O>): QueryArgs<TDocument> => {
-        // Re-check `field` against the allow-list rather than trusting that the
-        // validator ran: `toQueryArgs` is an exported function and nothing stops a
-        // caller handing it an unparsed object.
-        const orderBy = value.orderBy
-            ?.filter((entry) => sortable.has(entry.field))
-            .slice(0, maxOrderBy)
-            .map((entry) => ({ [entry.field]: entry.direction ?? "asc" }) as OrderBy<TDocument>);
+        const toQueryArgs = (value: ListArgsValue<F, O>): QueryArgs<TDocument> => {
+            // Re-check `field` against the allow-list rather than trusting that the
+            // validator ran: `toQueryArgs` is an exported function and nothing stops a
+            // caller handing it an unparsed object.
+            const orderBy = value.orderBy
+                ?.filter((entry) => sortable.has(entry.field))
+                .slice(0, maxOrderBy)
+                // Cast is unavoidable: a computed key widens to `{ [x: string]: … }`,
+                // which TS cannot narrow back to `OrderBy<Doc>` on its own. `field` is
+                // already constrained to `keyof Doc` and re-checked against `sortable`.
+                .map((entry) => ({ [entry.field]: entry.direction ?? "asc" }) as OrderBy<TDocument>);
 
-        // Same reasoning as `orderBy` above: rebuilt from the allow-list rather
-        // than trusted, because this function is reachable without the validator.
-        const where = value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable) as QueryArgs<TDocument>["where"]);
+            // Same reasoning as `orderBy` above: rebuilt from the allow-list rather
+            // than trusted, because this function is reachable without the validator.
+            const where = value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable) as QueryArgs<TDocument>["where"]);
 
-        return {
-            ...(value.cursor === undefined ? {} : { cursor: typeof value.cursor === "number" ? String(value.cursor) : value.cursor }),
-            limit: clampLimit(value.limit, defaultLimit, maxLimit),
-            ...(orderBy === undefined || orderBy.length === 0 ? {} : { orderBy }),
-            ...(where === undefined ? {} : { where }),
+            return {
+                ...(value.cursor === undefined ? {} : { cursor: typeof value.cursor === "number" ? String(value.cursor) : value.cursor }),
+                limit: clampLimit(value.limit, defaultLimit, maxLimit),
+                ...(orderBy === undefined || orderBy.length === 0 ? {} : { orderBy }),
+                ...(where === undefined ? {} : { where }),
+            };
         };
-    };
 
-    return { args, toQueryArgs };
-};
+        return { args, toQueryArgs };
+    };
 
 export type { DefineListArgsConfig, ListArgsSpec, ListArgsValidators, ListArgsValue, ListFilterOperators, ListOrderByEntry, ListWhere };
 export { clampLimit, DEFAULT_LIMIT, DEFAULT_MAX_IN_VALUES, DEFAULT_MAX_LIMIT, DEFAULT_MAX_ORDER_BY, defineListArgs, normalizeBound, sanitizeWhere };

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -206,7 +206,7 @@ const OPERATOR_KEYS = new Set(["contains", "eq", "gt", "gte", "in", "isNull", "l
  * names no operator at all is left alone, so an object-valued column can still be
  * matched by equality.
  */
-const asOperators = (value: unknown): Record<string, unknown> | undefined => {
+const asOperators = (value: unknown, maxInValues: number): Record<string, unknown> | undefined => {
     if (typeof value !== "object" || value === null || Array.isArray(value)) {
         return undefined;
     }
@@ -215,9 +215,17 @@ const asOperators = (value: unknown): Record<string, unknown> | undefined => {
     const operators: Record<string, unknown> = {};
 
     for (const operator of OPERATOR_KEYS) {
-        if (Object.hasOwn(source, operator)) {
-            operators[operator] = source[operator];
+        if (!Object.hasOwn(source, operator)) {
+            continue;
         }
+
+        const operand = source[operator];
+
+        // `in` / `notIn` become one bound parameter per element. `operatorsValidator`
+        // caps them for anything arriving through `.input()`, but this path exists
+        // precisely BECAUSE `toQueryArgs` is reachable without that validator — so
+        // leaving the cap off here would reopen the hole it was added to close.
+        operators[operator] = Array.isArray(operand) ? operand.slice(0, maxInValues) : operand;
     }
 
     return Object.keys(operators).length === 0 ? undefined : operators;
@@ -233,7 +241,7 @@ const asOperators = (value: unknown): Record<string, unknown> | undefined => {
  * — including `__proto__` or `constructor` — has no path into the output at all,
  * and operator objects are reduced to recognised operators only.
  */
-const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<string>): Record<string, unknown> => {
+const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<string>, maxInValues: number): Record<string, unknown> => {
     const out: Record<string, unknown> = {};
 
     for (const field of filterable) {
@@ -242,7 +250,7 @@ const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<s
         }
 
         const value = where[field];
-        const operators = asOperators(value);
+        const operators = asOperators(value, maxInValues);
 
         out[field] = operators ?? value;
     }
@@ -318,7 +326,7 @@ const defineListArgs =
 
             // Same reasoning as `orderBy` above: rebuilt from the allow-list rather
             // than trusted, because this function is reachable without the validator.
-            const where = value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable) as QueryArgs<TDocument>["where"]);
+            const where = value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable, maxInValues) as QueryArgs<TDocument>["where"]);
 
             return {
                 ...(value.cursor === undefined ? {} : { cursor: typeof value.cursor === "number" ? String(value.cursor) : value.cursor }),

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -5,6 +5,8 @@
 import type { SearchLanguage, SearchStrategy } from "@lunora/search-core";
 import type { Id, Infer, InferValidatorMap, Validator, ValidatorMap } from "@lunora/values";
 
+import type { RestCachePolicy } from "../../../shared/rest-surface";
+
 // Cache the namespace proxies and the per-function reference objects so that
 // `api.foo.bar` returns the *same* object on every access. React hooks
 // (`useMutation`, `useQuery`) put the reference in dependency arrays; a fresh
@@ -489,20 +491,14 @@ interface X402ProcedureConfig {
 }
 
 /**
- * Opt-in public-surface tag attached by the `.expose({ rest: true })` builder
- * modifier (plan 167). Marks a procedure as deliberately published over the
- * public REST surface: the runtime mints a `/_lunora/rest/&lt;namespace>/&lt;fn>` route
- * that dispatches THROUGH the procedure (so `ctx.auth` / RLS / validators are
- * enforced), and the generated OpenAPI describes it. Everything is default-closed
- * — a procedure without this tag is unreachable over REST.
- */
-
-/**
  * HTTP caching for an exposed REST endpoint, declared as
  * `.expose({ rest: true, cache: { scope: "public", maxAge: 60 } })`. The runtime
- * turns this into `Cache-Control` / `Cache-Tag` / `Vary` response headers — the
- * same header trio `httpRoute(...).cacheControl()` writes, so a `cache.tag` is
- * purgeable through the identical `ctx.cache.purge({ tags: [...] })` surface.
+ * turns this into `Cache-Control` / `Cache-Tag` / `Vary` response headers, and a
+ * `cache.tag` is purgeable through `ctx.cache.purge({ tags: [...] })`.
+ *
+ * This is NOT equivalent to `httpRoute(...).cacheControl()`, which writes whatever
+ * value the author passes with no credential downgrade. That is the unguarded
+ * escape hatch; this is the guarded surface.
  *
  * Caching a procedure whose result depends on the caller is how a REST cache
  * turns into a data leak, so `scope` is enforced at runtime rather than trusted:
@@ -517,27 +513,16 @@ interface X402ProcedureConfig {
  * Only ever applied to a cacheable exchange: a `GET` (so `query` procedures — a
  * `mutation` / `action` is `POST`-only) that produced a 2xx.
  */
-interface RestCacheConfig {
-    /** `max-age` in seconds — how long a fresh response may be reused. */
-    readonly maxAge: number;
+type RestCacheConfig = RestCachePolicy;
 
-    /**
-     * `"public"` allows shared/edge caches to store the response (only ever for
-     * an uncredentialed request, per the downgrade rule above); `"private"`
-     * restricts it to the caller's own browser cache.
-     */
-    readonly scope: "private" | "public";
-
-    /** `stale-while-revalidate` in seconds — serve stale this long while refreshing behind the request. */
-    readonly staleWhileRevalidate?: number;
-
-    /** `Cache-Tag` value for tag-based purging via `ctx.cache.purge({ tags: [...] })`. */
-    readonly tag?: string;
-
-    /** Extra `Vary` header names, merged with the ones `scope` implies. */
-    readonly vary?: string;
-}
-
+/**
+ * Opt-in public-surface tag attached by the `.expose({ rest: true })` builder
+ * modifier (plan 167). Marks a procedure as deliberately published over the
+ * public REST surface: the runtime mints a `/_lunora/rest/&lt;namespace>/&lt;fn>` route
+ * that dispatches THROUGH the procedure (so `ctx.auth` / RLS / validators are
+ * enforced), and the generated OpenAPI describes it. Everything is default-closed
+ * — a procedure without this tag is unreachable over REST.
+ */
 interface ExposeConfig {
     /** Opt this endpoint's responses into HTTP caching. Omit to leave them uncached. */
     readonly cache?: RestCacheConfig;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -496,7 +496,52 @@ interface X402ProcedureConfig {
  * enforced), and the generated OpenAPI describes it. Everything is default-closed
  * — a procedure without this tag is unreachable over REST.
  */
+
+/**
+ * HTTP caching for an exposed REST endpoint, declared as
+ * `.expose({ rest: true, cache: { scope: "public", maxAge: 60 } })`. The runtime
+ * turns this into `Cache-Control` / `Cache-Tag` / `Vary` response headers — the
+ * same header trio `httpRoute(...).cacheControl()` writes, so a `cache.tag` is
+ * purgeable through the identical `ctx.cache.purge({ tags: [...] })` surface.
+ *
+ * Caching a procedure whose result depends on the caller is how a REST cache
+ * turns into a data leak, so `scope` is enforced at runtime rather than trusted:
+ * a request that carries credentials (an `Authorization` header or any `Cookie`)
+ * is ALWAYS answered `private`, even under `scope: "public"` — see
+ * {@link https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control MDN}
+ * for what `private` forbids. So a per-user response can never be stored in a
+ * shared/edge cache, and the worst a mis-declared `scope` can cost is a missed
+ * cache hit. `scope: "public"` additionally emits `Vary: authorization, cookie`
+ * so an intermediary can't hand a stored anonymous variant to a signed-in caller.
+ *
+ * Only ever applied to a cacheable exchange: a `GET` (so `query` procedures — a
+ * `mutation` / `action` is `POST`-only) that produced a 2xx.
+ */
+interface RestCacheConfig {
+    /** `max-age` in seconds — how long a fresh response may be reused. */
+    readonly maxAge: number;
+
+    /**
+     * `"public"` allows shared/edge caches to store the response (only ever for
+     * an uncredentialed request, per the downgrade rule above); `"private"`
+     * restricts it to the caller's own browser cache.
+     */
+    readonly scope: "private" | "public";
+
+    /** `stale-while-revalidate` in seconds — serve stale this long while refreshing behind the request. */
+    readonly staleWhileRevalidate?: number;
+
+    /** `Cache-Tag` value for tag-based purging via `ctx.cache.purge({ tags: [...] })`. */
+    readonly tag?: string;
+
+    /** Extra `Vary` header names, merged with the ones `scope` implies. */
+    readonly vary?: string;
+}
+
 interface ExposeConfig {
+    /** Opt this endpoint's responses into HTTP caching. Omit to leave them uncached. */
+    readonly cache?: RestCacheConfig;
+
     /** Publish this procedure over the public REST surface. */
     readonly rest?: boolean;
 }
@@ -2128,6 +2173,7 @@ export type {
     RegisteredQuery,
     RegisteredStream,
     RelationDefinition,
+    RestCacheConfig,
     ScheduledFunctionDoc,
     ScheduledJob,
     Scheduler,

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,10 +1,13 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["node"]
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): `lint:types`
+        // is `tsc --noEmit` and the real build is packem (driven by package.json
+        // exports), so neither is load-bearing here. A set `rootDir` would raise
+        // TS6059 for the `../../../shared/rest-surface` import (a file outside this
+        // package). See shared/rest-surface.ts.
     },
     "include": ["src/**/*", "__tests__/**/*", "__bench__/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2169,6 +2169,12 @@ importers:
       magic-string:
         specifier: ^1.1.0
         version: 1.1.0
+      mysql2:
+        specifier: '*'
+        version: 3.23.1(@types/node@26.1.1)
+      pg:
+        specifier: '*'
+        version: 8.22.0
       react:
         specifier: 19.2.8
         version: 19.2.8

--- a/shared/rest-surface.ts
+++ b/shared/rest-surface.ts
@@ -18,14 +18,128 @@ const REST_PATH_PREFIX = "/_lunora/rest";
 type RestFunctionKind = "action" | "mutation" | "query";
 
 /**
+ * Request headers whose presence means the response may be caller-specific.
+ *
+ * `Authorization` covers bearer/basic auth, `Cookie` covers session cookies, and
+ * `Cf-Access-Jwt-Assertion` covers Cloudflare Access — which
+ * `@lunora/cloudflare-access` reads BEFORE its cookie, so a service-token or
+ * machine client presents the header and no cookie. Omitting it would classify
+ * those callers as anonymous.
+ *
+ * This list is not, and cannot be, exhaustive: `resolveIdentity` receives the
+ * whole `Request` and an app may authenticate on anything (`x-api-key`, a signed
+ * query parameter, …). An app doing that must declare its own header names via
+ * {@link RestCachePolicy.credentialHeaders}, or not mark the endpoint
+ * `scope: "public"`.
+ */
+const CREDENTIAL_HEADERS = ["authorization", "cf-access-jwt-assertion", "cookie"] as const;
+
+/**
+ * Headers that select WHICH data a request sees rather than who is asking, and so
+ * must key the cache even though they aren't credentials. `x-lunora-shard-key`
+ * routes to a shard (the query-string form is already in the URL, the header form
+ * is not); `x-d1-bookmark` pins read-your-writes freshness. Without these in
+ * `Vary`, one URL maps to many different bodies.
+ */
+const DATA_SELECTING_HEADERS = ["x-d1-bookmark", "x-lunora-shard-key"] as const;
+
+/**
+ * Declared HTTP caching for an exposed endpoint (`.expose({ cache })`). Lives
+ * here, alongside the path/method contract, for the same reason: the runtime
+ * WRITES these headers and the OpenAPI emitter DESCRIBES them, and the two must
+ * not be able to disagree. Deriving both from {@link cacheControlValue} /
+ * {@link cacheVaryValue} makes "the published spec matches what the runtime
+ * actually sends" structural rather than a hand-kept invariant.
+ */
+interface RestCachePolicy {
+    /**
+     * Extra request headers this app authenticates on, beyond
+     * {@link CREDENTIAL_HEADERS}. Declare these whenever `resolveIdentity` reads
+     * something else (`x-api-key`, a tenant header, …): they join both the
+     * credential check and the emitted `Vary`. Without them, a caller
+     * authenticating that way is treated as anonymous.
+     */
+    readonly credentialHeaders?: ReadonlyArray<string>;
+    readonly maxAge: number;
+    readonly scope: "private" | "public";
+    readonly staleWhileRevalidate?: number;
+    readonly tag?: string;
+    readonly vary?: string;
+}
+
+/** Every header name that must be treated as identifying for a given policy. */
+const credentialHeadersFor = (policy: RestCachePolicy): string[] => [
+    ...CREDENTIAL_HEADERS,
+    ...(policy.credentialHeaders ?? []).map((name) => name.toLowerCase()),
+];
+
+/**
  * The `.expose({ rest: true })` tag stamped onto a registered procedure (runtime,
  * as `fn.expose`) or discovered from its builder chain (codegen, onto the
  * `FunctionIR`). Presence of `rest === true` is the ONLY thing that opts a
  * procedure into the surface — everything is default-closed.
  */
 interface RestExposure {
+    cache?: RestCachePolicy;
     rest?: boolean;
 }
+
+/** Clamp an author-supplied seconds value to a non-negative integer; a non-finite value degrades to `0` rather than emitting `NaN`. */
+const cacheSeconds = (value: number): number => (Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0);
+
+/**
+ * Merge `Vary` header names case-insensitively, preserving first-seen order and
+ * dropping duplicates. Returns `undefined` when nothing survives.
+ */
+const mergeVary = (...sources: ReadonlyArray<string | undefined>): string | undefined => {
+    const names: string[] = [];
+
+    for (const source of sources) {
+        for (const raw of source?.split(",") ?? []) {
+            const name = raw.trim().toLowerCase();
+
+            if (name !== "" && !names.includes(name)) {
+                names.push(name);
+            }
+        }
+    }
+
+    return names.length === 0 ? undefined : names.join(", ");
+};
+
+/**
+ * The `Cache-Control` value for a policy under an EFFECTIVE scope — which the
+ * runtime narrows per request (a credentialed caller is always `private`) and the
+ * emitter documents as the declared best case. Both go through here, so the
+ * clamping applies identically to the served header and the published example.
+ */
+const cacheControlValue = (policy: RestCachePolicy, effectiveScope: "private" | "public"): string => {
+    const directives = [effectiveScope, `max-age=${String(cacheSeconds(policy.maxAge))}`];
+
+    if (policy.staleWhileRevalidate !== undefined) {
+        directives.push(`stale-while-revalidate=${String(cacheSeconds(policy.staleWhileRevalidate))}`);
+    }
+
+    return directives.join(", ");
+};
+
+/**
+ * The `Vary` value a policy implies. Keyed off the DECLARED scope, not the
+ * effective one: the point is to fence a stored anonymous variant off from
+ * credentialed callers, and that fence has to be present on the anonymous
+ * response itself. {@link DATA_SELECTING_HEADERS} are always included, since they
+ * change the body regardless of scope.
+ *
+ * Treat `Vary` as a courtesy to well-behaved intermediaries, NOT as the safety
+ * mechanism: Cloudflare's own cache honours `Vary` only for `Accept-Encoding`, so
+ * the real protection is the credential downgrade in `@lunora/runtime`'s
+ * `rest-cache`, which never emits `public` for an identified caller in the first
+ * place.
+ */
+const cacheVaryValue = (policy: RestCachePolicy): string | undefined =>
+    policy.scope === "public"
+        ? mergeVary(policy.vary, ...credentialHeadersFor(policy), ...DATA_SELECTING_HEADERS)
+        : mergeVary(policy.vary, ...DATA_SELECTING_HEADERS);
 
 /** One resolved REST endpoint: the transport method + URL path a procedure is reachable at. */
 interface RestSurfaceEntry {
@@ -108,5 +222,18 @@ const describeRestSurface = (
     return entries;
 };
 
-export type { RestExposure, RestFunctionKind, RestSurfaceEntry };
-export { describeRestSurface, REST_PATH_PREFIX, restMethodForKind, restPathForFunction, splitFunctionPath };
+export type { RestCachePolicy, RestExposure, RestFunctionKind, RestSurfaceEntry };
+export {
+    cacheControlValue,
+    cacheSeconds,
+    cacheVaryValue,
+    CREDENTIAL_HEADERS,
+    credentialHeadersFor,
+    DATA_SELECTING_HEADERS,
+    describeRestSurface,
+    mergeVary,
+    REST_PATH_PREFIX,
+    restMethodForKind,
+    restPathForFunction,
+    splitFunctionPath,
+};


### PR DESCRIPTION
Closes three of the six gaps found comparing [pREST](https://github.com/prest/prest) against `alpha`.

Most of pREST's surface already exists here in a stronger form (OpenAPI/OpenRPC generation, MCP with write tools, Studio, RLS, aggregate indexes, `withSearchIndex`, OTel, a rate-limited REST surface). These are the parts that genuinely didn't, and that fit Lunora's architecture.

## `.expose({ rest: true, cache })`

Declared response caching for the public REST surface, emitting the same `Cache-Control` / `Cache-Tag` / `Vary` trio `httpRoute()` already writes — so a tag is purgeable through the identical `ctx.cache.purge({ tags: [...] })`.

Caching a procedure-backed endpoint is how a REST cache turns into a data leak, since the procedure runs under `ctx.auth` and RLS. So `scope` is **enforced, not trusted**: a request carrying `Authorization` or any `Cookie` is always answered `private`, even under `scope: "public"`. A per-caller response can therefore never reach a shared or edge cache, and a mis-declared `scope` costs a cache miss instead of a cross-user leak. `scope: "public"` also emits `Vary: authorization, cookie` so an intermediary can't hand the stored anonymous variant to a signed-in caller.

Headers apply only to a cacheable exchange — a `GET` that returned 2xx. Errors are never cached. Codegen reads the literal block, so the emitted OpenAPI documents the headers a caller will actually observe, including the downgrade rule.

## `defineListArgs`

The shared filter/sort/page convention for list endpoints. One declaration yields both the `.input()` validator map and the translation into `findMany` options, so every list endpoint agrees on spelling and the generated OpenAPI describes them with no special-casing.

Three constraints are deliberate:

- **Keyset paging, not offset.** No `page` / `page_size` — offset paging re-scans from row 0 per page and shifts rows between pages whenever the data changes, which under a live query it always is.
- **Filterable columns are enumerated.** `v.object` drops undeclared keys, so a caller cannot predicate on a column the author didn't publish.
- **No `AND`/`OR`/`NOT` trees**, which is what keeps every filter routable to an index.

`limit` clamps into `[1, maxLimit]` rather than erroring; `orderBy` fields are re-checked in `toQueryArgs`, since it's exported and may be handed an unparsed object.

## `lunora introspect`

Reads an existing Postgres/MySQL database and scaffolds `lunora/schema.ts` plus a `list`/`get` module per table — the onramp pREST is built around, without giving up RLS.

Read-only against the source (`information_schema`, plus `pg_index` on Postgres for faithful multi-column index order), and it refuses to overwrite without `--force`. Query execution sits behind an injectable executor so the assembly logic is testable without a live database. `pg` / `mysql2` load on demand via `createRequire` resolved **from the user's project**, as optional peers rather than CLI dependencies.

What it emits is a scaffold the developer owns, not a gateway:

- Tables are `.global({ backend: "hyperdrive" })`, since the rows live externally.
- The source primary key becomes a unique index, because Lunora mints its own `_id`.
- Foreign keys become `v.id(target)`; an unmapped type becomes `v.any()` with a `TODO` and a reported warning.
- The procedures are **RPC-only by design** — publishing over REST stays an explicit decision made after adding auth/RLS, which `introspect` cannot infer.
- `list` is built on `defineListArgs`, so the scaffold can't hand out a full-table scan on day one.

## Deliberately not included

Recorded so they aren't re-proposed without new reasoning: table-level auto-CRUD (bypasses RLS — `rest-routes.ts` says so explicitly); offset paging; `_time_bucket` (aggregate indexes are keyed on declared columns, so a bucket over a raw timestamp can't use them); multi-database alias routing (`GlobalBackend` is one backend per app); `/_QUERIES` templated SQL endpoints; `_renderer=xml`.

Still open and judged to fit, but not attempted here: REST verbs beyond GET/POST with path params, and `.vectorIndex()` / `withVectorIndex()` mirroring the existing `.geoIndex()` companion-table pattern.

## Verification

| Check | Result |
| --- | --- |
| `build:packages` | 49 packages, green |
| `lint:types` (server, runtime, codegen, cli) | clean |
| ESLint + Prettier | clean |
| `vis sort-package-json --check` | 62/62 sorted |
| `@lunora/server` tests | 468 passed |
| `@lunora/runtime` tests | 778 passed |
| `@lunora/codegen` tests | 920 passed |
| `@lunora/cli` tests | 811 passed |

New coverage: 16 tests for `defineListArgs`, 29 across `rest-cache` + the REST surface, 23 for introspection, plus codegen cases for cache discovery and the OpenAPI headers block.

One note: `__tests__/commands/deploy.test.ts` Railpack cases are flaky against the 10s default timeout — they shell out for 5–14s, and a different case fails on each run. All 71 CLI files pass with `--testTimeout=60000`. Pre-existing and unrelated to this branch; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `lunora introspect` to scaffold `lunora/schema.ts` plus optional per-table `list`/`get` procedures from Postgres or MySQL.
  * Introspection now supports merging into an existing `lunora/schema.ts` (unless `--force`), with `--dry-run`, table selection, and read-only metadata extraction.
  * Added standardized keyset pagination for REST list endpoints via `defineListArgs`.
  * Added opt-in REST response caching (cache headers, tags, `Vary`) for exposed endpoints, including OpenAPI documentation.
* **Documentation**
  * Expanded CLI and server docs for introspection, list endpoint conventions, and REST caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->