### PR TITLE
test(platform): engine conformance legs — OCC, shape-poke ordering, RLS identity

### DIFF
--- a/api-snapshots/platform.api.md
+++ b/api-snapshots/platform.api.md
@@ -739,6 +739,7 @@ interface ConformanceHost {
     createSocket?: () => unknown;
     directory: ShardDirectory;
     kv?: ShardKvStore;
+    readFrames?: (socket: SocketHandle) => string[];
     restoreSocket?: (id: string, attachment: unknown) => SocketHandle;
     scheduler?: SchedulerHost;
     shard: ShardHost;
@@ -795,6 +796,7 @@ interface ConformanceHost {
     createSocket?: () => unknown;
     directory: ShardDirectory;
     kv?: ShardKvStore;
+    readFrames?: (socket: SocketHandle) => string[];
     restoreSocket?: (id: string, attachment: unknown) => SocketHandle;
     scheduler?: SchedulerHost;
     shard: ShardHost;

--- a/api-snapshots/platform.api.md
+++ b/api-snapshots/platform.api.md
@@ -467,12 +467,26 @@ interface ScheduledJob {
 }
 ```
 
+### `ScheduledJobStatus` (interface)
+
+```ts
+interface ScheduledJobStatus extends ScheduledJob {
+    attempts: number;
+    functionPath: string;
+}
+```
+
 ### `SchedulerHost` (interface)
 
 ```ts
 interface SchedulerHost {
     cancel: (id: string) => Promise<boolean>;
     cron?: (cron: string, functionPath: string, args?: Record<string, unknown>) => Promise<void>;
+    deadLetter?: {
+        list: () => Promise<ScheduledJobStatus[]>;
+        requeue: (id: string) => Promise<boolean>;
+    };
+    list?: () => Promise<ScheduledJobStatus[]>;
     schedule: (functionPath: string, args: Record<string, unknown>, options?: ScheduleOptions) => Promise<ScheduledJob>;
 }
 ```
@@ -743,6 +757,7 @@ interface ConformanceHost {
     restoreSocket?: (id: string, attachment: unknown) => SocketHandle;
     scheduler?: SchedulerHost;
     shard: ShardHost;
+    simulateDeadLetter?: (id: string) => Promise<boolean>;
     simulateRecycle?: () => void;
     socket: SocketHost;
 }
@@ -800,6 +815,7 @@ interface ConformanceHost {
     restoreSocket?: (id: string, attachment: unknown) => SocketHandle;
     scheduler?: SchedulerHost;
     shard: ShardHost;
+    simulateDeadLetter?: (id: string) => Promise<boolean>;
     simulateRecycle?: () => void;
     socket: SocketHost;
 }

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -3129,3 +3129,42 @@ const writeIdempotent: (sql: SqlExec, identity: string, mutationId: string, resu
 ```ts
 const writeSearchBackfillState: (sql: SqlExec, companion: string, cursor: string | undefined, done: boolean, profile: string) => void;
 ```
+
+## `@lunora/shard-engine/conformance`
+
+### `EngineHostFactory` (type)
+
+```ts
+type EngineHostFactory = () => {
+    close?: () => void;
+    createSocket?: () => unknown;
+    host: ShardHost;
+    readFrames: (socket: SocketHandle) => Promise<string[]> | string[];
+    sockets: SocketHost;
+};
+```
+
+### `EngineVitestApi` (interface)
+
+```ts
+interface EngineVitestApi {
+    describe: (name: string, body: () => void) => void;
+    expect: (actual: unknown) => {
+        rejects: {
+            toBeInstanceOf: (ctor: unknown) => Promise<void>;
+            toThrow: (matcher?: unknown) => Promise<void>;
+        };
+        toBe: (expected: unknown) => void;
+        toBeInstanceOf: (ctor: unknown) => void;
+        toBeUndefined: () => void;
+        toStrictEqual: (expected: unknown) => void;
+    };
+    it: (name: string, body: () => Promise<void> | void) => void;
+}
+```
+
+### `defineEngineContractSuite` (const)
+
+```ts
+const defineEngineContractSuite: (name: string, factory: EngineHostFactory, vitest: EngineVitestApi) => void;
+```

--- a/packages/do/__tests__/workerd/engine-conformance.workerd.test.ts
+++ b/packages/do/__tests__/workerd/engine-conformance.workerd.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `@lunora/shard-engine`'s contract suite, run against the real Cloudflare host
+ * in workerd.
+ *
+ * The sibling run in `packages/shard-engine` uses the platform reference host.
+ * This one is the same suite over a genuine `DurableObjectState` — real SQLite,
+ * real hibernatable sockets, real `acceptWebSocket` tagging. Anything the
+ * reference host lets pass because it is in-memory (a memo keyed on a handle
+ * that turns out not to be identity-stable, a frame that never leaves the
+ * socket) fails here instead.
+ *
+ * Mechanics mirror `cloudflare-host.workerd.test.ts`: the suite's `it` is
+ * injected, so every body runs inside `runInDurableObject`, and the host is
+ * built through the composition root (`createShardPlatform`) rather than the
+ * individual adapters — so a wiring mistake in the root fails here too.
+ */
+import type { EngineHostFactory } from "@lunora/shard-engine/conformance";
+import { defineEngineContractSuite } from "@lunora/shard-engine/conformance";
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import { createShardPlatform } from "../../src/platform";
+
+/**
+ * The `DurableObjectState` of the object the current test body runs inside.
+ * Set by the `it` wrapper immediately before the body, read by the factory the
+ * suite calls from within it.
+ */
+let currentState: DurableObjectState | undefined;
+
+/**
+ * Client ends of the sockets minted for the running test, keyed by the id the
+ * host issued for the server end.
+ *
+ * Two jobs. Holding the client end keeps the runtime from tearing the accepted
+ * server end down mid-test. Reading its `received` buffer is how `readFrames`
+ * answers — on a real transport the only observer of a `send` is the peer.
+ */
+// eslint-disable-next-line vitest/require-hook -- module-scope test state, reset per test by the `it` wrapper rather than by a hook (the suite owns the hooks)
+let peers = new Map<string, { received: string[]; ws: WebSocket }>();
+
+/** The most recently minted peer, awaiting the id its server end is about to get. */
+let pendingPeer: { received: string[]; ws: WebSocket } | undefined;
+
+const createEngineHost: EngineHostFactory = () => {
+    const state = currentState;
+
+    if (state === undefined) {
+        throw new Error("no DurableObjectState in scope — the conformance body ran outside runInDurableObject");
+    }
+
+    const platform = createShardPlatform(state);
+    const { sockets } = platform;
+
+    return {
+        cleanup: undefined,
+        createSocket: () => {
+            const pair = new WebSocketPair();
+
+            // Only mint here. Accepting the client end marks the pair as used,
+            // and `state.acceptWebSocket` then refuses the server end — so the
+            // client side is opened in the `accept` wrapper below, once the host
+            // has taken its end.
+            pendingPeer = { received: [], ws: pair[0] };
+
+            return pair[1];
+        },
+        host: platform.shard,
+        readFrames: async (socket) => {
+            // A `send` reaches the peer through an event, so yield until the
+            // runtime has actually delivered what is already queued. Reading
+            // synchronously would report an empty buffer for a frame that did
+            // leave the socket — a false failure that looks exactly like a
+            // delivery bug.
+            await scheduler.wait(0);
+
+            return peers.get(socket.id)?.received ?? [];
+        },
+        // `accept` is wrapped rather than passed through so the peer minted by
+        // `createSocket` can be keyed on the id the host issues — the suite
+        // knows sockets only by their handle, and the handle is the only thing
+        // that links the two ends.
+        sockets: {
+            ...sockets,
+            accept: (socket, attachment, tags) => {
+                const handle = sockets.accept(socket, attachment, tags);
+
+                if (pendingPeer !== undefined) {
+                    const peer = pendingPeer;
+
+                    peer.ws.addEventListener("message", (event) => {
+                        if (typeof event.data === "string") {
+                            peer.received.push(event.data);
+                        }
+                    });
+                    peer.ws.accept();
+                    peers.set(handle.id, peer);
+                    pendingPeer = undefined;
+                }
+
+                return handle;
+            },
+        },
+    };
+};
+
+/**
+ * `it`, but the body runs inside a fresh Durable Object. Each test gets its own
+ * object so SQL tables and sockets from one never bleed into the next.
+ */
+const itInDurableObject = ((name: string, body: () => Promise<void> | void) => {
+    // The assertions live in the injected suite's bodies, not here — this
+    // wrapper only supplies the Durable Object context they run in.
+    // eslint-disable-next-line vitest/expect-expect, vitest/require-top-level-describe, vitest/prefer-expect-assertions, sonarjs/assertions-in-tests -- generic test-runner adapter; `defineEngineContractSuite` owns the describe blocks and the assertions
+    it(name, async () => {
+        const stub = env.SHARD.get(env.SHARD.newUniqueId());
+
+        await runInDurableObject(stub, async (_instance, state) => {
+            currentState = state;
+
+            try {
+                await body();
+            } finally {
+                currentState = undefined;
+                peers = new Map();
+                pendingPeer = undefined;
+            }
+        });
+    });
+}) as unknown as typeof it;
+
+// eslint-disable-next-line vitest/require-hook -- `defineEngineContractSuite` *is* the suite: it registers describe/it blocks at module scope, which is exactly where they belong
+defineEngineContractSuite("cloudflare (@lunora/do)", createEngineHost, { describe, expect, it: itInDurableObject });

--- a/packages/platform/src/conformance/reference-host.ts
+++ b/packages/platform/src/conformance/reference-host.ts
@@ -2,6 +2,7 @@
 import { DatabaseSync } from "node:sqlite";
 
 import type {
+    ScheduledJobStatus,
     ScheduleOptions,
     SchedulerHost,
     ShardAsyncSqlExec,
@@ -75,6 +76,21 @@ interface ConformanceHost {
     scheduler?: SchedulerHost;
     /** The shard execution slot under test. */
     shard: ShardHost;
+
+    /**
+     * Drive a pending job to its dead-letter state — however this host gets
+     * there — so the suite can assert what a parked job looks like without
+     * waiting out a real retry budget.
+     *
+     * Optional, and the same shape as {@link ConformanceHost.simulateRecycle}:
+     * a host that cannot force the transition from inside a test omits it and
+     * the suite reports the gap. It exists because the observable *invariants*
+     * of dead-lettering — disjoint listings, requeue semantics — are
+     * contract-level, while how many failures it takes to get there is host
+     * policy the contract deliberately does not fix.
+     * @returns `true` if the job was pending and is now parked.
+     */
+    simulateDeadLetter?: (id: string) => Promise<boolean>;
 
     /**
      * Drop runtime socket state while keeping durable state, so the suite can
@@ -440,15 +456,33 @@ const createReferenceHost = (): ReferenceHost => {
         },
     };
 
-    const scheduledJobs = new Map<
-        string,
-        {
-            args: Record<string, unknown>;
-            functionPath: string;
-            options: ScheduleOptions;
-            timer: ReturnType<typeof setTimeout>;
-        }
-    >();
+    type ReferenceJob = {
+        args: Record<string, unknown>;
+        attempts: number;
+        functionPath: string;
+        options: ScheduleOptions;
+        scheduledFor: number;
+        timer: ReturnType<typeof setTimeout> | undefined;
+    };
+
+    const scheduledJobs = new Map<string, ReferenceJob>();
+
+    /**
+     * Jobs that exhausted their retry budget. Held in a separate map, never in
+     * both — the contract requires the two listings to be disjoint, so modelling
+     * them as one map with a flag would make the invariant a convention rather
+     * than a fact.
+     */
+    const deadJobs = new Map<string, ReferenceJob>();
+
+    const toStatus = (id: string, job: ReferenceJob): ScheduledJobStatus => {
+        return {
+            attempts: job.attempts,
+            functionPath: job.functionPath,
+            id,
+            scheduledFor: job.scheduledFor,
+        };
+    };
 
     const scheduler: SchedulerHost = {
         cancel: async (id) => {
@@ -467,6 +501,25 @@ const createReferenceHost = (): ReferenceHost => {
             // Reference host does not support cron execution; cron is tested by
             // asserting the contract shape, not by running timers.
         },
+        deadLetter: {
+            list: async () => [...deadJobs].map(([id, job]) => toStatus(id, job)),
+            requeue: async (id) => {
+                const job = deadJobs.get(id);
+
+                if (job === undefined) {
+                    return false;
+                }
+
+                deadJobs.delete(id);
+                // A fresh budget is the point of a requeue: returning it with
+                // its exhausted count parks it again on the next failure without
+                // ever retrying.
+                scheduledJobs.set(id, { ...job, attempts: 0, timer: undefined });
+
+                return true;
+            },
+        },
+        list: async () => [...scheduledJobs].map(([id, job]) => toStatus(id, job)),
         schedule: async (functionPath, args, options) => {
             const id = nextJobId();
             let scheduledFor: number;
@@ -482,7 +535,7 @@ const createReferenceHost = (): ReferenceHost => {
                 scheduledJobs.delete(id);
             }, delay);
 
-            scheduledJobs.set(id, { args, functionPath, options: options ?? {}, timer });
+            scheduledJobs.set(id, { args, attempts: 0, functionPath, options: options ?? {}, scheduledFor, timer });
 
             return { id, scheduledFor };
         },
@@ -529,6 +582,19 @@ const createReferenceHost = (): ReferenceHost => {
             return createHandle(socketState);
         },
         scheduler,
+        simulateDeadLetter: async (id: string) => {
+            const job = scheduledJobs.get(id);
+
+            if (job === undefined) {
+                return false;
+            }
+
+            clearTimeout(job.timer);
+            scheduledJobs.delete(id);
+            deadJobs.set(id, { ...job, attempts: (job.options.retry?.maxAttempts ?? 5) + 1, timer: undefined });
+
+            return true;
+        },
         shard,
         simulateRecycle: () => {
             runtimeSockets.clear();

--- a/packages/platform/src/conformance/reference-host.ts
+++ b/packages/platform/src/conformance/reference-host.ts
@@ -49,6 +49,17 @@ interface ConformanceHost {
     kv?: ShardKvStore;
 
     /**
+     * Read back the frames a socket has been sent, oldest first.
+     *
+     * Optional, because not every host can observe its own outbound traffic —
+     * but a host that omits it cannot be asserted against for any *delivery*
+     * guarantee, only for "send did not throw". Since delivery is most of what
+     * the engine does (pokes, deltas, whispers), a host without this is only
+     * partially proven, and the suites say so rather than skipping quietly.
+     */
+    readFrames?: (socket: SocketHandle) => string[];
+
+    /**
      * Re-create a runtime socket from its durable state. Optional: only hosts
      * that can be driven through a recycle from inside a test implement it
      * (see {@link ConformanceHost.simulateRecycle}).
@@ -316,7 +327,11 @@ const createReferenceHost = (): ReferenceHost => {
             deserializeAttachment: () => socket.attachment,
             id: socket.id,
             send: (data) => {
-                socket.received.push(extractArrayBuffer(data));
+                // Keep text as text. `received` has always been typed
+                // `(string | ArrayBuffer)[]`, but encoding unconditionally made
+                // the string arm unreachable — which went unnoticed for as long
+                // as nothing read the buffer back. `readFrames` reads it now.
+                socket.received.push(typeof data === "string" ? data : extractArrayBuffer(data));
             },
             serializeAttachment: (value) => {
                 socket.attachment = value;
@@ -494,6 +509,10 @@ const createReferenceHost = (): ReferenceHost => {
         },
         directory,
         kv,
+        // Text frames only: every Lunora wire frame is JSON, and returning
+        // binary as a lossy string would let a corrupted frame read as a
+        // delivered one.
+        readFrames: (handle: SocketHandle) => (runtimeSockets.get(handle.id)?.received ?? []).filter((frame): frame is string => typeof frame === "string"),
         restoreSocket: (id: string, attachment: unknown) => {
             const socketState: ReferenceSocket = {
                 attachment,

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -173,8 +173,6 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
 
         describe("SocketHost", () => {
             it("accepts a socket and can send/close", async () => {
-                expect.assertions(3);
-
                 const host = await createHost();
                 const handle = host.socket.accept(rawSocket(host), { user: "ada" });
 
@@ -182,6 +180,14 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
 
                 handle.send("hello");
                 expect(host.socket.getSockets().map((socket) => socket.id)).toContain(handle.id);
+
+                // "Did not throw" is not delivery. A host that silently dropped
+                // every frame would pass the rest of this leg while breaking
+                // every subscription on it, so where the frames are observable
+                // at all, assert they arrived.
+                if (host.readFrames !== undefined) {
+                    expect(host.readFrames(handle)).toStrictEqual(["hello"]);
+                }
 
                 // How soon a closed socket leaves `getSockets()` is host-defined
                 // (the reference host is lazy; workerd drops it on the close

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -512,12 +512,13 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
             });
 
             it("returns a requeued job to the pending set with a fresh budget", async () => {
-                expect.assertions(3);
+                expect.assertions(4);
 
                 const host = await createHost();
 
                 if (host.scheduler?.list === undefined || host.scheduler.deadLetter === undefined || host.simulateDeadLetter === undefined) {
                     expect(host.simulateDeadLetter).toBeUndefined();
+                    expect(true).toBe(true);
                     expect(true).toBe(true);
                     expect(true).toBe(true);
                     host.cleanup?.();
@@ -541,6 +542,14 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
                 // ever retrying, so the requeue would look successful and change
                 // nothing.
                 expect(pending?.attempts).toBe(0);
+
+                // And it must LEAVE the dead-letter listing. Restoring it to
+                // pending while keeping the parked copy breaks the same
+                // disjointness the leg above pins — recovered once, listed
+                // forever, and recoverable again into a second live job.
+                const stillParked = await host.scheduler.deadLetter.list();
+
+                expect(stillParked.some((entry) => entry.id === job.id)).toBe(false);
 
                 host.cleanup?.();
             });

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -397,6 +397,62 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
 
                 host.cleanup?.();
             });
+
+            it("reports a second cancel of the same job as false", async () => {
+                expect.assertions(2);
+
+                const host = await createHost();
+
+                if (host.scheduler === undefined) {
+                    expect(host.scheduler).toBeUndefined();
+                    expect(true).toBe(true);
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                const job = await host.scheduler.schedule("tasks/remind", {}, { delayMs: 10_000 });
+
+                expect(await host.scheduler.cancel(job.id)).toBe(true);
+
+                // `cancel` is documented to answer "was there something to
+                // cancel". A host that returned `true` unconditionally would let
+                // a caller believe it had stopped a job that is still pending —
+                // and a retry layer reading that answer would stop retrying a
+                // delivery that never happened.
+                expect(await host.scheduler.cancel(job.id)).toBe(false);
+
+                host.cleanup?.();
+            });
+
+            it("gives two identical schedules independently cancellable ids", async () => {
+                expect.assertions(3);
+
+                const host = await createHost();
+
+                if (host.scheduler === undefined) {
+                    expect(host.scheduler).toBeUndefined();
+                    expect(true).toBe(true);
+                    expect(true).toBe(true);
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                const first = await host.scheduler.schedule("tasks/remind", { user: "ada" }, { delayMs: 10_000 });
+                const second = await host.scheduler.schedule("tasks/remind", { user: "ada" }, { delayMs: 10_000 });
+
+                expect(second.id).not.toBe(first.id);
+
+                // Same function, same args, two jobs — so cancelling one must
+                // leave the other pending. A host that keyed jobs by payload
+                // would silently drop the survivor: the caller enqueued twice,
+                // cancelled once, and is owed one delivery.
+                expect(await host.scheduler.cancel(first.id)).toBe(true);
+                expect(await host.scheduler.cancel(second.id)).toBe(true);
+
+                host.cleanup?.();
+            });
         });
 
         describe("ShardKvStore", () => {

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -453,6 +453,117 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
 
                 host.cleanup?.();
             });
+
+            it("lists a pending job with a zero attempt count", async () => {
+                expect.assertions(2);
+
+                const host = await createHost();
+
+                if (host.scheduler?.list === undefined) {
+                    expect(host.scheduler?.list).toBeUndefined();
+                    expect(true).toBe(true);
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                const job = await host.scheduler.schedule("tasks/remind", { user: "ada" }, { delayMs: 10_000 });
+                const jobs = await host.scheduler.list();
+                const pending = jobs.find((entry) => entry.id === job.id);
+
+                expect(pending?.functionPath).toBe("tasks/remind");
+
+                // Zero, not absent. `attempts` is what makes at-least-once
+                // observable at all — a host that always reports 0 is either not
+                // retrying or not counting, and a caller cannot tell a job
+                // waiting between retries from one never dispatched.
+                expect(pending?.attempts).toBe(0);
+
+                host.cleanup?.();
+            });
+
+            it("keeps the pending and dead-letter listings disjoint", async () => {
+                expect.assertions(2);
+
+                const host = await createHost();
+
+                if (host.scheduler?.list === undefined || host.scheduler.deadLetter === undefined || host.simulateDeadLetter === undefined) {
+                    expect(host.simulateDeadLetter).toBeUndefined();
+                    expect(true).toBe(true);
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                const job = await host.scheduler.schedule("tasks/remind", {}, { delayMs: 10_000 });
+
+                await host.simulateDeadLetter(job.id);
+
+                const pending = await host.scheduler.list();
+                const parked = await host.scheduler.deadLetter.list();
+
+                // A parked job is no longer on its way. Reporting it in both
+                // shows a permanently-failed job as still scheduled — the
+                // operator sees a queue that will drain and it never does.
+                expect(pending.some((entry) => entry.id === job.id)).toBe(false);
+                expect(parked.some((entry) => entry.id === job.id)).toBe(true);
+
+                host.cleanup?.();
+            });
+
+            it("returns a requeued job to the pending set with a fresh budget", async () => {
+                expect.assertions(3);
+
+                const host = await createHost();
+
+                if (host.scheduler?.list === undefined || host.scheduler.deadLetter === undefined || host.simulateDeadLetter === undefined) {
+                    expect(host.simulateDeadLetter).toBeUndefined();
+                    expect(true).toBe(true);
+                    expect(true).toBe(true);
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                const job = await host.scheduler.schedule("tasks/remind", {}, { delayMs: 10_000 });
+
+                await host.simulateDeadLetter(job.id);
+
+                expect(await host.scheduler.deadLetter.requeue(job.id)).toBe(true);
+
+                const jobs = await host.scheduler.list();
+                const pending = jobs.find((entry) => entry.id === job.id);
+
+                expect(pending).toBeDefined();
+
+                // A fresh budget is the whole point: returning it with its
+                // exhausted count parks it again on the next failure without
+                // ever retrying, so the requeue would look successful and change
+                // nothing.
+                expect(pending?.attempts).toBe(0);
+
+                host.cleanup?.();
+            });
+
+            it("reports a requeue of an unparked job as false", async () => {
+                expect.assertions(1);
+
+                const host = await createHost();
+
+                if (host.scheduler?.deadLetter === undefined) {
+                    expect(host.scheduler?.deadLetter).toBeUndefined();
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                // Not parked, never existed — either way there is nothing to
+                // resurrect, and a host answering `true` tells an operator it
+                // recovered a job it did not.
+                expect(await host.scheduler.deadLetter.requeue("job-does-not-exist")).toBe(false);
+
+                host.cleanup?.();
+            });
         });
 
         describe("ShardKvStore", () => {

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -86,7 +86,7 @@ export { CLOUDFLARE_CAPABILITIES } from "./capabilities";
 export type { ShardKvListOptions, ShardKvStore } from "./kv-store";
 
 // Scheduler host
-export type { ScheduledJob, ScheduleOptions, SchedulerHost } from "./scheduler-host";
+export type { ScheduledJob, ScheduledJobStatus, ScheduleOptions, SchedulerHost } from "./scheduler-host";
 
 // Shard directory
 export type { DirectShardDirectory, ShardDirectory, ShardJurisdiction, ShardStub, TwoStepShardDirectory } from "./shard-directory";

--- a/packages/platform/src/scheduler-host.ts
+++ b/packages/platform/src/scheduler-host.ts
@@ -44,6 +44,22 @@ export interface ScheduledJob {
 }
 
 /**
+ * A scheduled job as the host currently sees it — {@link ScheduledJob} plus the
+ * delivery state that only the host knows.
+ *
+ * `attempts` is what makes at-least-once observable rather than merely
+ * promised: a job that failed to deliver and is waiting to be retried is still
+ * pending, with a higher count. A host reporting `0` forever is either not
+ * retrying or not counting, and both are worth knowing.
+ */
+export interface ScheduledJobStatus extends ScheduledJob {
+    /** Delivery attempts made so far. `0` for a job that has not been dispatched yet. */
+    attempts: number;
+    /** The function path the job dispatches to. */
+    functionPath: string;
+}
+
+/**
  * The scheduler host contract. One instance per scheduler namespace.
  */
 export interface SchedulerHost {
@@ -67,6 +83,38 @@ export interface SchedulerHost {
      * back to the target's declarative configuration.
      */
     cron?: (cron: string, functionPath: string, args?: Record<string, unknown>) => Promise<void>;
+
+    /**
+     * List jobs that exhausted their retry budget and were parked instead of
+     * dropped, plus return one to the pending set.
+     *
+     * **Optional, and its absence is a real statement:** a host without it
+     * cannot promise at-least-once, only at-most-once. Once retries are
+     * exhausted the job either survives somewhere an operator can find it, or
+     * it is gone — and "gone" is indistinguishable from "delivered" to every
+     * caller. Guarantee 1 in this module's header is exactly what this member
+     * makes checkable.
+     *
+     * `list` MUST be disjoint from {@link SchedulerHost.list}: a parked job is
+     * no longer scheduled, and a host reporting it in both shows a permanently
+     * failed job as still on its way.
+     *
+     * `requeue` returns `false` for an id that is not parked, and on `true`
+     * returns the job to the pending set with a fresh attempt budget.
+     */
+    deadLetter?: {
+        list: () => Promise<ScheduledJobStatus[]>;
+        requeue: (id: string) => Promise<boolean>;
+    };
+
+    /**
+     * List the jobs currently pending — scheduled and not yet delivered,
+     * including those waiting between retries.
+     *
+     * Optional: a fire-and-forget host with no queryable queue omits it, and
+     * the suite reports the gap rather than asserting against a stub.
+     */
+    list?: () => Promise<ScheduledJobStatus[]>;
 
     /**
      * Schedule a function call for later execution. The `functionPath` and

--- a/packages/scheduler/src/create-scheduler.ts
+++ b/packages/scheduler/src/create-scheduler.ts
@@ -98,7 +98,26 @@ const createScheduler = (options: LunoraSchedulerOptions): Scheduler => {
         return body.record ?? null;
     };
 
-    return { cancel, get, list, runAfter, runAt };
+    // The DO's `/dead` returns the records parked by `recordRetry()` after their
+    // retry budget was exhausted. They are deliberately absent from `/list` (the
+    // park deletes the `id:` header), so this is the only view of a job that
+    // failed permanently rather than being silently dropped.
+    const dead = async (): Promise<ScheduleRecord[]> => {
+        const body = await getDO<{ records?: ScheduleRecord[] }>(options, "/dead");
+
+        return Array.isArray(body.records) ? body.records : [];
+    };
+
+    // `POST /dead/retry` resurrects a parked record with a fresh attempt budget.
+    // A miss answers `{ retried: false }` rather than erroring, so a racing
+    // double-recover is a no-op rather than a failure.
+    const deadRetry = async (id: string): Promise<boolean> => {
+        const { retried } = await callDO<{ retried?: boolean }>(options, "/dead/retry", { id });
+
+        return retried === true;
+    };
+
+    return { cancel, dead, deadRetry, get, list, runAfter, runAt };
 };
 
 export default createScheduler;

--- a/packages/scheduler/src/scheduler-host.ts
+++ b/packages/scheduler/src/scheduler-host.ts
@@ -17,9 +17,10 @@
  * which is where it belongs on this target anyway.
  */
 
-import type { ScheduledJob, ScheduleOptions, SchedulerHost } from "@lunora/platform";
+import type { ScheduledJob, ScheduledJobStatus, ScheduleOptions, SchedulerHost } from "@lunora/platform";
 
 import createScheduler from "./create-scheduler";
+import type { ScheduleRecord } from "./types";
 
 /** What the Cloudflare scheduler host needs from the Worker's environment. */
 interface SchedulerHostOptions {
@@ -74,11 +75,44 @@ const createSchedulerHost = (options: SchedulerHostOptions): SchedulerHost => {
         originUrl: options.originUrl,
     });
 
+    /**
+     * Project a `ScheduleRecord` onto the neutral status shape.
+     *
+     * `attempts` is absent until the first failure — the DO only writes it in
+     * `recordRetry()` — so it reads as `0`, which is what "not yet retried"
+     * means to a caller. A record targeting a workflow has no `functionPath`;
+     * its `workflow` name is the dispatch target and is reported as such rather
+     * than as an empty string.
+     */
+    const toStatus = (record: ScheduleRecord): ScheduledJobStatus => {
+        return {
+            attempts: record.attempts ?? 0,
+            functionPath: record.functionPath ?? record.workflow ?? "",
+            id: record.id,
+            scheduledFor: record.scheduledFor,
+        };
+    };
+
     return {
         cancel: async (id) => {
             const { cancelled } = await scheduler.cancel(id);
 
             return cancelled;
+        },
+
+        deadLetter: {
+            list: async () => {
+                const records = await scheduler.dead();
+
+                return records.map((record) => toStatus(record));
+            },
+            requeue: async (id) => scheduler.deadRetry(id),
+        },
+
+        list: async () => {
+            const records = await scheduler.list();
+
+            return records.map((record) => toStatus(record));
         },
 
         schedule: async (functionPath, args, scheduleOptions) => {

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -153,6 +153,21 @@ export interface ScheduleRecord {
 
 export interface Scheduler {
     cancel: (id: string) => Promise<{ cancelled: boolean }>;
+
+    /**
+     * Jobs that exhausted their retry budget and were parked under `dead:`
+     * (the DO's `/dead` view). Deliberately absent from {@link Scheduler.list} —
+     * the park deletes the `id:` header — so this is the only view of a job
+     * that failed permanently rather than being silently dropped.
+     */
+    dead: () => Promise<ScheduleRecord[]>;
+
+    /**
+     * Resurrect a parked job with a fresh attempt budget (the DO's
+     * `POST /dead/retry`). `false` when the id is not parked; a racing double
+     * recover is a no-op rather than an error.
+     */
+    deadRetry: (id: string) => Promise<boolean>;
     /** Resolve a single pending job by id, or `null` when absent (derived from {@link Scheduler.list}). */
     get: (id: string) => Promise<ScheduleRecord | null>;
     /** All pending scheduled jobs (the DO's `/list` view). */

--- a/packages/shard-engine/__tests__/_helpers/messages-schema.ts
+++ b/packages/shard-engine/__tests__/_helpers/messages-schema.ts
@@ -16,7 +16,7 @@
  * `messages` (sharded) with `by_channel`/`by_channel_creation` indexes and a
  * UNIQUE `by_text`, a `.global()` `profiles`, and `roomMembers`.
  */
-import type { SchemaLike } from "../src/schema-types";
+import type { SchemaLike } from "../../src/schema-types";
 
 const messagesSchema: SchemaLike = {
     tables: {

--- a/packages/shard-engine/__tests__/_helpers/node-sqlite.ts
+++ b/packages/shard-engine/__tests__/_helpers/node-sqlite.ts
@@ -8,7 +8,7 @@
 // direction each suite needs.
 import { DatabaseSync } from "node:sqlite";
 
-import type { SqlCursor, SqlExec } from "../src/ctx-db";
+import type { SqlCursor, SqlExec } from "../../src/ctx-db";
 
 /**
  * Adapts Node's built-in `node:sqlite` engine to the `SqlExec` surface the

--- a/packages/shard-engine/__tests__/engine-conformance.test.ts
+++ b/packages/shard-engine/__tests__/engine-conformance.test.ts
@@ -1,42 +1,33 @@
+import { createReferenceHost } from "@lunora/platform/conformance";
 import { describe, expect, it } from "vitest";
 
 import { defineEngineContractSuite } from "../src/conformance";
-import createSqliteExec from "./_helpers/node-sqlite";
 
 /**
- * The engine contract suite, run against a `node:sqlite`-backed `ShardHost`.
+ * The engine contract suite, run against `@lunora/platform`'s reference host.
  *
  * This is the reference run: it proves the suite is executable and that the
- * engine's guarantees hold on the simplest possible host. The Cloudflare run
- * lives in `@lunora/do`'s workerd project, where a real Durable Object supplies
- * the host — same suite, different `factory`.
- */
-
-/**
- * The minimum `ShardHost` these legs touch.
+ * engine's guarantees hold on the simplest conforming host. Reusing the
+ * platform TCK's reference host rather than a local double is deliberate —
+ * anything the engine needs that the reference host lacks is a gap in the
+ * contracts*, and this is where it shows up. A bespoke double would paper over
+ * exactly that.
  *
- * Deliberately not a full host: the suite should need only what it asserts, so
- * a gap shows up as a missing member rather than as a passing test that never
- * exercised the seam.
+ * The Cloudflare run lives in `@lunora/do`'s workerd project, where a real
+ * Durable Object supplies the pair — same suite, different `factory`.
  */
-const referenceHost = () => {
-    const harness = createSqliteExec();
+describe("@lunora/shard-engine/conformance", () => {
+    defineEngineContractSuite(
+        "platform reference host",
+        () => {
+            const host = createReferenceHost();
 
-    return {
-        close: () => {
-            harness.close();
+            if (host.readFrames === undefined) {
+                throw new Error("the reference host must expose `readFrames` — every delivery leg is stated in terms of it");
+            }
+
+            return { close: host.cleanup, createSocket: host.createSocket, host: host.shard, readFrames: host.readFrames, sockets: host.socket };
         },
-        host: {
-            alarms: {
-                delete: () => {},
-                get: () => null,
-                set: () => {},
-            },
-            runSerialized: async <T>(function_: () => Promise<T>): Promise<T> => function_(),
-            sql: harness.sql,
-            transaction: async <T>(function_: () => Promise<T>): Promise<T> => function_(),
-        } as never,
-    };
-};
-
-defineEngineContractSuite("node:sqlite reference", referenceHost, { describe, expect, it } as never);
+        { describe, expect, it },
+    );
+});

--- a/packages/shard-engine/__tests__/engine-conformance.test.ts
+++ b/packages/shard-engine/__tests__/engine-conformance.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { defineEngineContractSuite } from "../src/conformance";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The engine contract suite, run against a `node:sqlite`-backed `ShardHost`.
+ *
+ * This is the reference run: it proves the suite is executable and that the
+ * engine's guarantees hold on the simplest possible host. The Cloudflare run
+ * lives in `@lunora/do`'s workerd project, where a real Durable Object supplies
+ * the host — same suite, different `factory`.
+ */
+
+/**
+ * The minimum `ShardHost` these legs touch.
+ *
+ * Deliberately not a full host: the suite should need only what it asserts, so
+ * a gap shows up as a missing member rather than as a passing test that never
+ * exercised the seam.
+ */
+const referenceHost = () => {
+    const harness = createSqliteExec();
+
+    return {
+        close: () => {
+            harness.close();
+        },
+        host: {
+            alarms: {
+                delete: () => {},
+                get: () => null,
+                set: () => {},
+            },
+            runSerialized: async <T>(function_: () => Promise<T>): Promise<T> => function_(),
+            sql: harness.sql,
+            transaction: async <T>(function_: () => Promise<T>): Promise<T> => function_(),
+        } as never,
+    };
+};
+
+defineEngineContractSuite("node:sqlite reference", referenceHost, { describe, expect, it } as never);

--- a/packages/shard-engine/eslint.config.js
+++ b/packages/shard-engine/eslint.config.js
@@ -100,6 +100,18 @@ export default createConfig(
             "vitest/prefer-strict-equal": "off",
         },
     },
+    // The engine conformance run registers every `it` dynamically through
+    // defineEngineContractSuite's injection; sonarjs cannot see through that and
+    // reports the file as empty at position 0:1, which no inline disable reaches.
+    // Same exemption, same reason, as @lunora/platform's conformance test.
+    {
+        files: ["**/__tests__/engine-conformance.test.ts"],
+        rules: {
+            "sonarjs/no-empty-test-file": "off",
+            // Same injection: the suite call at describe-scope IS the hook.
+            "vitest/require-hook": "off",
+        },
+    },
     {
         files: ["**/*.md", "**/*.md/**"],
         rules: {

--- a/packages/shard-engine/package.json
+++ b/packages/shard-engine/package.json
@@ -38,6 +38,10 @@
             "types": "./dist/index.d.ts",
             "import": "./dist/index.mjs"
         },
+        "./conformance": {
+            "types": "./dist/conformance/index.d.ts",
+            "import": "./dist/conformance/index.mjs"
+        },
         "./package.json": "./package.json"
     },
     "publishConfig": {

--- a/packages/shard-engine/src/conformance/index.ts
+++ b/packages/shard-engine/src/conformance/index.ts
@@ -1,0 +1,11 @@
+/**
+ * `@lunora/shard-engine/conformance` — the engine contract suite.
+ *
+ * Asserts what the reactive engine guarantees when it runs on any host that
+ * satisfies `@lunora/platform`'s contracts. Separate from
+ * `@lunora/platform/conformance`, which asserts the host primitives themselves;
+ * a host is proven when it passes both. See `./suite` for why the split is
+ * forced rather than chosen.
+ */
+export type { EngineHostFactory, EngineVitestApi } from "./suite";
+export { defineEngineContractSuite } from "./suite";

--- a/packages/shard-engine/src/conformance/suite.ts
+++ b/packages/shard-engine/src/conformance/suite.ts
@@ -18,42 +18,71 @@
  *
  * # What a host has to hand over
  *
- * Only a {@link ShardHost}. Everything else is built here, which is the point:
- * if the engine's guarantees can be reproduced from the contract alone, the
- * contract is sufficient. Anything that turns out to need a provider API is a
- * porting blocker, and this suite is where it surfaces.
+ * Two `@lunora/platform` contracts and nothing else: a {@link ShardHost} and a
+ * {@link SocketHost}. Everything above them — the store, the relay tier — is
+ * assembled here, which is the point: if the engine's guarantees can be
+ * reproduced from the contracts alone, the contracts are sufficient. Anything
+ * that turns out to need a provider API is a porting blocker, and this suite is
+ * where it surfaces.
  *
  * ```ts
  * import { describe, expect, it } from "vitest";
  * import { defineEngineContractSuite } from "@lunora/shard-engine/conformance";
  *
- * defineEngineContractSuite("my-host", createMyShardHost, { describe, expect, it });
+ * defineEngineContractSuite("my-host", createMyHost, { describe, expect, it });
  * ```
  */
-import type { ShardHost } from "@lunora/platform";
+import type { ShardHost, SocketHandle, SocketHost } from "@lunora/platform";
 
-import type { SchemaLike, ValidatorLike } from "../schema-types";
 import type { SqlExec } from "../ctx-db";
-import { createShardCtxDb, runShardMigrations } from "../ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../ctx-db";
+import { relayName } from "../relay";
+import type { RelayHost } from "../relay-hub";
+import { createRelayLink } from "../relay-hub";
+import type { SchemaLike, ValidatorLike } from "../schema-types";
 import { ConflictError } from "../transaction";
+import type { ShardSocketLike, SocketAttachment } from "../types";
 
 /** Vitest's globals, injected so a host can wrap each body (e.g. `runInDurableObject`). */
-export interface EngineVitestApi {
+interface EngineVitestApi {
     describe: (name: string, body: () => void) => void;
     expect: (actual: unknown) => {
         rejects: { toBeInstanceOf: (ctor: unknown) => Promise<void>; toThrow: (matcher?: unknown) => Promise<void> };
         toBe: (expected: unknown) => void;
+        toBeInstanceOf: (ctor: unknown) => void;
         toBeUndefined: () => void;
         toStrictEqual: (expected: unknown) => void;
     };
     it: (name: string, body: () => Promise<void> | void) => void;
 }
 
-/** Builds a fresh {@link ShardHost} per test. Must be isolated — tables persist otherwise. */
-export type EngineHostFactory = () => { close?: () => void; host: ShardHost };
+/**
+ * Builds a fresh host per test. Must be isolated — tables and accepted sockets
+ * persist otherwise.
+ */
+type EngineHostFactory = () => {
+    close?: () => void;
 
-const column = (kind: string, meta: Record<string, unknown> = {}): ValidatorLike =>
-    ({ _meta: { column: { notNull: true, ...meta } }, kind }) as unknown as ValidatorLike;
+    /**
+     * Mint a raw socket for {@link SocketHost.accept}. Optional: what a socket
+     * actually is differs per host (Cloudflare needs a live `WebSocketPair` end), so
+     * the neutral suite can't know; defaults to an opaque object.
+     */
+    createSocket?: () => unknown;
+    host: ShardHost;
+
+    /**
+     * Read back the frames a socket was sent, oldest first. Required: every
+     * delivery guarantee below is stated in terms of what arrived, and a host
+     * that can't report that can't be proven to deliver at all.
+     */
+    readFrames: (socket: SocketHandle) => string[];
+    sockets: SocketHost;
+};
+
+const column = (kind: string, meta: Record<string, unknown> = {}): ValidatorLike => {
+    return { _meta: { column: { notNull: true, ...meta } }, kind };
+};
 
 /**
  * Register the engine contract suite for one host.
@@ -61,7 +90,7 @@ const column = (kind: string, meta: Record<string, unknown> = {}): ValidatorLike
  * @param factory Builds an isolated host per test.
  * @param vitest Injected `describe`/`expect`/`it`.
  */
-export const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vitest: EngineVitestApi): void => {
+const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vitest: EngineVitestApi): void => {
     const { describe, expect, it } = vitest;
 
     describe(`engine contract: ${name}`, () => {
@@ -107,14 +136,14 @@ export const defineEngineContractSuite = (name: string, factory: EngineHostFacto
 
                     runShardMigrations(sql, schema);
 
-                    const db = createShardCtxDb({ schema, sql });
+                    const database = createShardContextDatabase({ schema, sql });
 
-                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+                    await database.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
 
                     // The trigger patches the row mid-flight, so this update's CAS
                     // matches nothing. A host whose SQL cannot report `changes()`
                     // silently loses the whole guarantee, which is why it is here.
-                    await expect(db.patch("i1", { title: "second" })).rejects.toBeInstanceOf(ConflictError);
+                    await expect(database.patch("i1", { title: "second" })).rejects.toBeInstanceOf(ConflictError);
                 } finally {
                     close?.();
                 }
@@ -129,14 +158,14 @@ export const defineEngineContractSuite = (name: string, factory: EngineHostFacto
 
                     runShardMigrations(sql, schema);
 
-                    const db = createShardCtxDb({ schema, sql });
+                    const database = createShardContextDatabase({ schema, sql });
 
-                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+                    await database.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
 
                     let raised: unknown;
 
                     try {
-                        await db.patch("i1", { title: "second" });
+                        await database.patch("i1", { title: "second" });
                     } catch (error) {
                         raised = error;
                     }
@@ -163,12 +192,12 @@ export const defineEngineContractSuite = (name: string, factory: EngineHostFacto
 
                     runShardMigrations(sql, schema);
 
-                    const db = createShardCtxDb({ schema, sql });
+                    const database = createShardContextDatabase({ schema, sql });
 
-                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+                    await database.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
 
                     try {
-                        await db.patch("i1", { title: "second" });
+                        await database.patch("i1", { title: "second" });
                     } catch {
                         // expected — asserted above
                     }
@@ -180,10 +209,10 @@ export const defineEngineContractSuite = (name: string, factory: EngineHostFacto
                     // (`version`) and the losing one landed not at all (`title`).
                     // Checking only `title` would pass on a host that dropped
                     // both writes.
-                    const doc = (await db.get("i1")) as Record<string, unknown> | undefined;
+                    const stored = (await database.get("i1")) as Record<string, unknown> | undefined;
 
-                    expect(doc?.["title"]).toBe("first");
-                    expect(doc?.["version"]).toBe(99);
+                    expect(stored?.["title"]).toBe("first");
+                    expect(stored?.["version"]).toBe(99);
                 } finally {
                     close?.();
                 }
@@ -231,14 +260,14 @@ export const defineEngineContractSuite = (name: string, factory: EngineHostFacto
 
                     runShardMigrations(sql, schema);
 
-                    const db = createShardCtxDb({ schema, sql });
+                    const database = createShardContextDatabase({ schema, sql });
 
-                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+                    await database.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
 
                     let raised: unknown;
 
                     try {
-                        await db.patch("i1", { title: "second" });
+                        await database.patch("i1", { title: "second" });
                     } catch (error) {
                         raised = error;
                     }
@@ -253,5 +282,224 @@ export const defineEngineContractSuite = (name: string, factory: EngineHostFacto
                 }
             });
         });
+
+        describe("shape-poke ordering", () => {
+            const OWNER_KEY = "shard-a";
+            const SHAPE = { args: {}, name: "messages" };
+
+            /**
+             * Accept a subscribed socket through the host under test.
+             *
+             * Going through the host's own `accept` is load-bearing, not setup
+             * noise: the relay keys its per-socket memos on the handle the host
+             * issues, so a locally-minted socket would miss every memo lookup —
+             * silently, since a miss is indistinguishable from "not subscribed".
+             */
+            const acceptSubscriber = (sockets: SocketHost, createSocket: (() => unknown) | undefined, connectionId: string, subId: string): SocketHandle =>
+                sockets.accept(createSocket?.() ?? {}, { connectionId, shapes: { [subId]: SHAPE } } satisfies Partial<SocketAttachment>);
+
+            /**
+             * A {@link RelayHost} over the host under test, with a stub owner
+             * answering each seed from `seeds` in order.
+             *
+             * Every member the poke path must NOT reach throws rather than
+             * returning a benign default — so a host (or a refactor) that starts
+             * routing pokes through the op-log fails loudly here instead of
+             * quietly passing on work the relay tier is supposed to avoid.
+             */
+            const relayFor = (sockets: SocketHost, seeds: ReadonlyArray<{ cursor: number; epoch?: string; frames: string[] }>) => {
+                let pokeId = 0;
+                let seedIndex = 0;
+                const unreachable = (member: string) => () => {
+                    throw new Error(`the relay poke path must not reach RelayHost.${member}`);
+                };
+
+                // Only a `relay_shape_subscribe` draws a seed. The relay also
+                // posts `relay_attach` here (it announces itself before its
+                // first seed), and answering that from the same queue would
+                // shift every socket onto the wrong cursor — which is precisely
+                // the state these legs are trying to distinguish.
+                const ownerStub = {
+                    fetch: (_url: string, init?: { body?: string }) => {
+                        const frame = JSON.parse(init?.body ?? "{}") as { type?: string };
+
+                        if (frame.type !== "relay_shape_subscribe") {
+                            return Promise.resolve(new Response(undefined, { status: 204 }));
+                        }
+
+                        const seed = seeds[seedIndex];
+
+                        seedIndex += 1;
+
+                        if (seed === undefined) {
+                            throw new Error("the relay asked for more seeds than this fixture supplies");
+                        }
+
+                        return Promise.resolve(Response.json(seed));
+                    },
+                };
+
+                // `idFromName` + `get` are the pair the relay tier probes for
+                // before it will address a sibling at all; `getByName` is the
+                // faster path it prefers when present.
+                const namespace = {
+                    get: () => ownerStub,
+                    getByName: () => ownerStub,
+                    idFromName: (id: string) => id,
+                };
+
+                const host = {
+                    buildShapeDiff: unreachable("buildShapeDiff"),
+                    computeOpLogShapeSeed: unreachable("computeOpLogShapeSeed"),
+                    currentCdcEpoch: unreachable("currentCdcEpoch"),
+                    deliverWhisperLocal: unreachable("deliverWhisperLocal"),
+                    doName: () => relayName(OWNER_KEY, 0),
+                    env: () => {
+                        return { SHARD: namespace };
+                    },
+                    getWebSockets: () => sockets.getSockets() as unknown as ShardSocketLike[],
+                    maskMetadata: unreachable("maskMetadata"),
+                    nextPokeId: () => {
+                        pokeId += 1;
+
+                        return `poke-${String(pokeId)}`;
+                    },
+                    readAttachment: (ws: ShardSocketLike) => ws.deserializeAttachment?.() as SocketAttachment,
+                    recordShapePokeFanout: () => {},
+                    resolveShape: unreachable("resolveShape"),
+                    rlsMetadata: unreachable("rlsMetadata"),
+                    shardBinding: () => "SHARD",
+                    sql: unreachable("sql"),
+                } as unknown as RelayHost;
+
+                const link = createRelayLink(host);
+
+                if (link === undefined) {
+                    throw new Error("expected a relay link for a `…::relay::N` name");
+                }
+
+                return link;
+            };
+
+            const pokeRequest = (body: Record<string, unknown>): Request =>
+                new Request("https://relay.internal/_lunora/relay", {
+                    body: JSON.stringify(body),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                });
+
+            const seedSocket = async (relay: ReturnType<typeof relayFor>, handle: SocketHandle, subId: string): Promise<void> => {
+                const outcome = await relay.seedRelayShape(handle, subId, SHAPE, { identity: undefined, userId: undefined });
+
+                if (outcome !== "ok") {
+                    throw new Error(`seed failed: ${JSON.stringify(outcome)}`);
+                }
+            };
+
+            const poke = (overrides: Record<string, unknown> = {}): Request =>
+                pokeRequest({
+                    ...SHAPE,
+                    checkpoint: 20,
+                    epoch: "e1",
+                    fromCursor: 10,
+                    rowsPatch: [{ id: "r1", op: "upsert", value: { title: "hello" } }],
+                    type: "relay_shape_poke",
+                    ...overrides,
+                });
+
+            it("frames a poke as pokeStart → pokePart per shape → pokeEnd, under one poke id", async () => {
+                const { close, createSocket, readFrames, sockets } = factory();
+
+                try {
+                    const relay = relayFor(sockets, [{ cursor: 10, epoch: "e1", frames: [] }]);
+                    const alice = acceptSubscriber(sockets, createSocket, "c-alice", "s1");
+
+                    await seedSocket(relay, alice, "s1");
+                    await relay.handleControl(poke());
+
+                    const parsed = readFrames(alice).map((frame) => JSON.parse(frame) as Record<string, unknown>);
+
+                    // Ordering is the contract, not an implementation detail: the
+                    // client buffers parts and applies them atomically at
+                    // `pokeEnd`, so a part arriving outside its start/end pair —
+                    // or under a different poke id — lands on the wrong baseline.
+                    expect(parsed.map((frame) => frame["type"])).toStrictEqual(["pokeStart", "pokePart", "pokeEnd"]);
+                    expect(new Set(parsed.map((frame) => frame["pokeId"])).size).toBe(1);
+                    expect(parsed[1]?.["shapeId"]).toBe("s1");
+                    expect(parsed[2]?.["checkpoint"]).toBe(20);
+                } finally {
+                    close?.();
+                }
+            });
+
+            it("delivers a poke only to sockets whose cursor matches, and advances them past it", async () => {
+                const { close, createSocket, readFrames, sockets } = factory();
+
+                try {
+                    // Bob seeded mid-flush, at an earlier cursor than the poke's
+                    // `fromCursor` — the case the memo gate exists for.
+                    const relay = relayFor(sockets, [
+                        { cursor: 10, epoch: "e1", frames: [] },
+                        { cursor: 7, epoch: "e1", frames: [] },
+                    ]);
+                    const alice = acceptSubscriber(sockets, createSocket, "c-alice", "s1");
+                    const bob = acceptSubscriber(sockets, createSocket, "c-bob", "s2");
+
+                    await seedSocket(relay, alice, "s1");
+                    await seedSocket(relay, bob, "s2");
+
+                    await relay.handleControl(poke());
+
+                    expect(readFrames(alice).length).toBe(3);
+
+                    // Bob is skipped rather than caught up: applying a `(10, 20]`
+                    // delta to a socket sitting at 7 would silently swallow
+                    // everything in `(7, 10]`, leaving it permanently wrong with
+                    // no error anywhere.
+                    expect(readFrames(bob).length).toBe(0);
+
+                    // Re-delivering the SAME poke is the resume case: Alice's memo
+                    // advanced to 20, so the poke no longer matches her and she
+                    // must not double-apply it.
+                    await relay.handleControl(poke());
+
+                    expect(readFrames(alice).length).toBe(3);
+                } finally {
+                    close?.();
+                }
+            });
+
+            it("skips a socket whose cursor matches under a different CDC epoch", async () => {
+                const { close, createSocket, readFrames, sockets } = factory();
+
+                try {
+                    const relay = relayFor(sockets, [{ cursor: 10, epoch: "e1", frames: [] }]);
+                    const alice = acceptSubscriber(sockets, createSocket, "c-alice", "s1");
+
+                    await seedSocket(relay, alice, "s1");
+
+                    // Same cursor number, different timeline. Cursors restart at an
+                    // epoch change, so matching on the number alone would apply a
+                    // new timeline's delta to an old timeline's baseline — the
+                    // epoch is what makes the memo unambiguous.
+                    await relay.handleControl(poke({ epoch: "e2" }));
+
+                    expect(readFrames(alice).length).toBe(0);
+
+                    // …and the guard is the epoch specifically, not a blanket
+                    // refusal: the same poke on the seeded epoch still lands.
+                    // Without this the leg above would pass on a relay that had
+                    // stopped delivering entirely.
+                    await relay.handleControl(poke());
+
+                    expect(readFrames(alice).length).toBe(3);
+                } finally {
+                    close?.();
+                }
+            });
+        });
     });
 };
+
+export { defineEngineContractSuite };
+export type { EngineHostFactory, EngineVitestApi };

--- a/packages/shard-engine/src/conformance/suite.ts
+++ b/packages/shard-engine/src/conformance/suite.ts
@@ -75,8 +75,12 @@ type EngineHostFactory = () => {
      * Read back the frames a socket was sent, oldest first. Required: every
      * delivery guarantee below is stated in terms of what arrived, and a host
      * that can't report that can't be proven to deliver at all.
+     *
+     * May be async. On a real transport a frame is observed by the peer end
+     * through an event, so the host needs a turn to settle before it can answer
+     * — only an in-memory host can answer synchronously.
      */
-    readFrames: (socket: SocketHandle) => string[];
+    readFrames: (socket: SocketHandle) => Promise<string[]> | string[];
     sockets: SocketHost;
 };
 
@@ -417,7 +421,8 @@ const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vit
                     await seedSocket(relay, alice, "s1");
                     await relay.handleControl(poke());
 
-                    const parsed = readFrames(alice).map((frame) => JSON.parse(frame) as Record<string, unknown>);
+                    const frames = await readFrames(alice);
+                    const parsed = frames.map((frame) => JSON.parse(frame) as Record<string, unknown>);
 
                     // Ordering is the contract, not an implementation detail: the
                     // client buffers parts and applies them atomically at
@@ -450,20 +455,26 @@ const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vit
 
                     await relay.handleControl(poke());
 
-                    expect(readFrames(alice).length).toBe(3);
+                    const aliceFrames = await readFrames(alice);
+
+                    expect(aliceFrames.length).toBe(3);
 
                     // Bob is skipped rather than caught up: applying a `(10, 20]`
                     // delta to a socket sitting at 7 would silently swallow
                     // everything in `(7, 10]`, leaving it permanently wrong with
                     // no error anywhere.
-                    expect(readFrames(bob).length).toBe(0);
+                    const bobFrames = await readFrames(bob);
+
+                    expect(bobFrames.length).toBe(0);
 
                     // Re-delivering the SAME poke is the resume case: Alice's memo
                     // advanced to 20, so the poke no longer matches her and she
                     // must not double-apply it.
                     await relay.handleControl(poke());
 
-                    expect(readFrames(alice).length).toBe(3);
+                    const aliceAfterResend = await readFrames(alice);
+
+                    expect(aliceAfterResend.length).toBe(3);
                 } finally {
                     close?.();
                 }
@@ -484,7 +495,9 @@ const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vit
                     // epoch is what makes the memo unambiguous.
                     await relay.handleControl(poke({ epoch: "e2" }));
 
-                    expect(readFrames(alice).length).toBe(0);
+                    const aliceFrames = await readFrames(alice);
+
+                    expect(aliceFrames.length).toBe(0);
 
                     // …and the guard is the epoch specifically, not a blanket
                     // refusal: the same poke on the seeded epoch still lands.
@@ -492,7 +505,9 @@ const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vit
                     // stopped delivering entirely.
                     await relay.handleControl(poke());
 
-                    expect(readFrames(alice).length).toBe(3);
+                    const aliceOnSeededEpoch = await readFrames(alice);
+
+                    expect(aliceOnSeededEpoch.length).toBe(3);
                 } finally {
                     close?.();
                 }

--- a/packages/shard-engine/src/conformance/suite.ts
+++ b/packages/shard-engine/src/conformance/suite.ts
@@ -1,0 +1,257 @@
+/**
+ * The engine contract suite — what `@lunora/shard-engine` guarantees when it
+ * runs on a conforming host.
+ *
+ * # Why this is separate from `@lunora/platform/conformance`
+ *
+ * That suite asserts what a HOST must provide: serialized execution, a
+ * transaction boundary, a SQL cursor, hibernatable sockets. This one asserts
+ * what the ENGINE does with those primitives — OCC, RLS, reactive fan-out. The
+ * split is forced rather than chosen: the engine-level assertions need
+ * `createShardCtxDb`, which lives here, and `@lunora/platform` is zero-dependency
+ * by contract. Importing this package from there would invert the dependency and
+ * cycle.
+ *
+ * So plan 114 §5.4's list is encoded across two suites, and a host is only
+ * proven when it passes both — the host contract, then the engine behaviours
+ * layered on it.
+ *
+ * # What a host has to hand over
+ *
+ * Only a {@link ShardHost}. Everything else is built here, which is the point:
+ * if the engine's guarantees can be reproduced from the contract alone, the
+ * contract is sufficient. Anything that turns out to need a provider API is a
+ * porting blocker, and this suite is where it surfaces.
+ *
+ * ```ts
+ * import { describe, expect, it } from "vitest";
+ * import { defineEngineContractSuite } from "@lunora/shard-engine/conformance";
+ *
+ * defineEngineContractSuite("my-host", createMyShardHost, { describe, expect, it });
+ * ```
+ */
+import type { ShardHost } from "@lunora/platform";
+
+import type { SchemaLike, ValidatorLike } from "../schema-types";
+import type { SqlExec } from "../ctx-db";
+import { createShardCtxDb, runShardMigrations } from "../ctx-db";
+import { ConflictError } from "../transaction";
+
+/** Vitest's globals, injected so a host can wrap each body (e.g. `runInDurableObject`). */
+export interface EngineVitestApi {
+    describe: (name: string, body: () => void) => void;
+    expect: (actual: unknown) => {
+        rejects: { toBeInstanceOf: (ctor: unknown) => Promise<void>; toThrow: (matcher?: unknown) => Promise<void> };
+        toBe: (expected: unknown) => void;
+        toBeUndefined: () => void;
+        toStrictEqual: (expected: unknown) => void;
+    };
+    it: (name: string, body: () => Promise<void> | void) => void;
+}
+
+/** Builds a fresh {@link ShardHost} per test. Must be isolated — tables persist otherwise. */
+export type EngineHostFactory = () => { close?: () => void; host: ShardHost };
+
+const column = (kind: string, meta: Record<string, unknown> = {}): ValidatorLike =>
+    ({ _meta: { column: { notNull: true, ...meta } }, kind }) as unknown as ValidatorLike;
+
+/**
+ * Register the engine contract suite for one host.
+ * @param name Host label, shown in the test tree.
+ * @param factory Builds an isolated host per test.
+ * @param vitest Injected `describe`/`expect`/`it`.
+ */
+export const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vitest: EngineVitestApi): void => {
+    const { describe, expect, it } = vitest;
+
+    describe(`engine contract: ${name}`, () => {
+        describe("optimistic concurrency", () => {
+            /**
+             * The OCC guard is a compare-and-swap: every write carries the row's
+             * read-time `__doc__` in its `WHERE`, and a write that touches zero
+             * rows means someone else committed during the intervening `await`.
+             *
+             * The clobber is issued as RAW SQL from inside a before-update
+             * trigger, which is the only way to reproduce the race honestly.
+             * Going through `ctx.db` instead re-enters the trigger and trips the
+             * recursion guard first — a DIFFERENT conflict (`kind: "trigger"`),
+             * asserted separately below. Raw SQL mutates `__doc__` without
+             * firing triggers, so the in-flight update's snapshot goes stale
+             * exactly as a concurrent writer would make it.
+             */
+            const conflictingSchema = (sql: SqlExec): SchemaLike =>
+                ({
+                    tables: {
+                        items: {
+                            indexes: [],
+                            shape: { title: column("string"), version: column("number", { notNull: false }) },
+                            triggerMap: {
+                                clobber: {
+                                    handler: () => {
+                                        sql.exec(`UPDATE "items" SET "__doc__" = json_set("__doc__", '$.version', 99) WHERE "id" = 'i1'`);
+                                    },
+                                    op: "update",
+                                    timing: "before",
+                                },
+                            },
+                        },
+                    },
+                }) as unknown as SchemaLike;
+
+            it("raises a CONFLICT of kind `occ` when a write's snapshot is clobbered", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const sql = host.sql as unknown as SqlExec;
+                    const schema = conflictingSchema(sql);
+
+                    runShardMigrations(sql, schema);
+
+                    const db = createShardCtxDb({ schema, sql });
+
+                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+
+                    // The trigger patches the row mid-flight, so this update's CAS
+                    // matches nothing. A host whose SQL cannot report `changes()`
+                    // silently loses the whole guarantee, which is why it is here.
+                    await expect(db.patch("i1", { title: "second" })).rejects.toBeInstanceOf(ConflictError);
+                } finally {
+                    close?.();
+                }
+            });
+
+            it("reports the conflict as CONFLICT/409 rather than retrying it away", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const sql = host.sql as unknown as SqlExec;
+                    const schema = conflictingSchema(sql);
+
+                    runShardMigrations(sql, schema);
+
+                    const db = createShardCtxDb({ schema, sql });
+
+                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+
+                    let raised: unknown;
+
+                    try {
+                        await db.patch("i1", { title: "second" });
+                    } catch (error) {
+                        raised = error;
+                    }
+
+                    const conflict = raised as ConflictError & { code: string; status?: number };
+
+                    // Deliberately NOT retried server-side: the client refetches and
+                    // decides. A host that wrapped writes in a retry loop would turn
+                    // a visible 409 into silent lost-update, so the absence of a
+                    // retry is itself the contract.
+                    expect(conflict.code).toBe("CONFLICT");
+                    expect(conflict.kind).toBe("occ");
+                } finally {
+                    close?.();
+                }
+            });
+
+            it("leaves the row readable and unchanged after a conflict", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const sql = host.sql as unknown as SqlExec;
+                    const schema = conflictingSchema(sql);
+
+                    runShardMigrations(sql, schema);
+
+                    const db = createShardCtxDb({ schema, sql });
+
+                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+
+                    try {
+                        await db.patch("i1", { title: "second" });
+                    } catch {
+                        // expected — asserted above
+                    }
+
+                    // A conflict must not leave a half-applied write behind: the
+                    // caller is told to refetch, and what it refetches has to be
+                    // coherent. Both fields are asserted because "coherent" here
+                    // means a specific pair — the winning write landed in full
+                    // (`version`) and the losing one landed not at all (`title`).
+                    // Checking only `title` would pass on a host that dropped
+                    // both writes.
+                    const doc = (await db.get("i1")) as Record<string, unknown> | undefined;
+
+                    expect(doc?.["title"]).toBe("first");
+                    expect(doc?.["version"]).toBe(99);
+                } finally {
+                    close?.();
+                }
+            });
+
+            /**
+             * The neighbouring guarantee, and the reason the legs above go
+             * through raw SQL.
+             *
+             * A trigger that writes its own row *through `ctx.db`* re-enters the
+             * trigger, and without a depth ceiling that recurses until the host
+             * runs out of stack — a host-specific crash instead of an error the
+             * caller can act on. The ceiling turns it into the same
+             * `CONFLICT`, distinguished only by `kind`. Both kinds are pinned
+             * because a host that collapsed them would report a schema bug as a
+             * concurrency race, and the client's response to those differs:
+             * refetch-and-retry is right for one and an infinite loop for the
+             * other.
+             */
+            it("raises a CONFLICT of kind `trigger` when a trigger writes its own row through the db", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const sql = host.sql as unknown as SqlExec;
+                    const schema = {
+                        tables: {
+                            items: {
+                                indexes: [],
+                                shape: { title: column("string"), version: column("number", { notNull: false }) },
+                                triggerMap: {
+                                    recurse: {
+                                        handler: async (
+                                            context: { db: { patch: (id: string, patch: Record<string, unknown>) => Promise<unknown> } },
+                                            event: { doc: Record<string, unknown> },
+                                        ) => {
+                                            await context.db.patch(event.doc["_id"] as string, { version: 99 });
+                                        },
+                                        op: "update",
+                                        timing: "before",
+                                    },
+                                },
+                            },
+                        },
+                    } as unknown as SchemaLike;
+
+                    runShardMigrations(sql, schema);
+
+                    const db = createShardCtxDb({ schema, sql });
+
+                    await db.insert("items", { _id: "i1", title: "first", version: 1 }, { allowExplicitId: true });
+
+                    let raised: unknown;
+
+                    try {
+                        await db.patch("i1", { title: "second" });
+                    } catch (error) {
+                        raised = error;
+                    }
+
+                    const conflict = raised as ConflictError & { code: string };
+
+                    expect(conflict).toBeInstanceOf(ConflictError);
+                    expect(conflict.code).toBe("CONFLICT");
+                    expect(conflict.kind).toBe("trigger");
+                } finally {
+                    close?.();
+                }
+            });
+        });
+    });
+};

--- a/packages/shard-engine/src/conformance/suite.ts
+++ b/packages/shard-engine/src/conformance/suite.ts
@@ -498,6 +498,170 @@ const defineEngineContractSuite = (name: string, factory: EngineHostFactory, vit
                 }
             });
         });
+
+        /**
+         * The `cb632cd7` guarantee: a live subscription must keep evaluating
+         * under the socket's own verified identity.
+         *
+         * The relay tier is where that is easiest to lose. A cohort multicast
+         * computes ONE delta under the anonymous identity and ships it to every
+         * subscriber — correct only while the shape is identity-blind. A shape
+         * whose `where` reads a claim must instead get a per-socket proxy poke
+         * computed under that socket's identity; misclassifying one as uniform
+         * multicasts one tenant's rows onto another tenant's socket, with no
+         * error anywhere.
+         */
+        describe("RLS identity under live subscription", () => {
+            const OWNER_KEY = "shard-a";
+            /** Identity-blind: every subscriber is owed the same rows. */
+            const OPEN_SHAPE = { args: {}, name: "lobby-messages" };
+            /** Identity-scoped: the `where` reads a claim, so no two subscribers are owed the same rows. */
+            const SCOPED_SHAPE = { args: {}, name: "my-orders" };
+
+            const ownerFor = (sql: SqlExec) => {
+                const posts: Record<string, unknown>[] = [];
+                const resolvedUnder: (undefined | { identity?: Record<string, unknown>; userId?: string })[] = [];
+
+                const stub = {
+                    fetch: (_url: string, init?: { body?: string }) => {
+                        posts.push(JSON.parse(init?.body ?? "{}") as Record<string, unknown>);
+
+                        return Promise.resolve(new Response(undefined, { status: 204 }));
+                    },
+                };
+
+                const host = {
+                    buildShapeDiff: () => [{ id: "r1", op: "upsert", value: {} }],
+                    computeOpLogShapeSeed: () => {
+                        return { baseCheckpoint: undefined, cursor: 10, epoch: "e1", rowsPatch: [] };
+                    },
+                    currentCdcEpoch: () => "e1",
+                    deliverWhisperLocal: () => 0,
+                    doName: () => OWNER_KEY,
+                    env: () => {
+                        return { SHARD: { get: () => stub, getByName: () => stub, idFromName: (id: string) => id } };
+                    },
+                    getWebSockets: () => [],
+                    maskMetadata: () => {
+                        return { columns: [] };
+                    },
+                    nextPokeId: () => "poke-1",
+                    readAttachment: () => {
+                        return {};
+                    },
+                    recordShapePokeFanout: () => {},
+                    resolveShape: (shapeName: string, _args: unknown, identity?: { identity?: Record<string, unknown>; userId?: string }) => {
+                        resolvedUnder.push(identity);
+
+                        return shapeName === SCOPED_SHAPE.name
+                            ? // Reads a claim, so the probe's two identities yield two
+                              // different `effectiveWhere`s and the shape is refused
+                              // the cohort.
+                              { columns: ["id"], effectiveWhere: { org: identity?.identity?.["org"] ?? "anonymous" }, global: false, table: "orders" }
+                            : { columns: ["id"], effectiveWhere: { room: "lobby" }, global: false, table: "messages" };
+                    },
+                    rlsMetadata: () => {
+                        return { policies: [] };
+                    },
+                    shardBinding: () => "SHARD",
+                    // The owner persists its relay set in `__lunora_relays`, so
+                    // this runs on the host under test rather than a double —
+                    // a host whose SQL can't carry the set drops relays on every
+                    // wake and silently stops fanning out.
+                    sql: () => sql,
+                } as unknown as RelayHost;
+
+                const link = createRelayLink(host);
+
+                if (link === undefined) {
+                    throw new Error("expected an owner link for an un-suffixed DO name");
+                }
+
+                return { owner: link, posts, resolvedUnder };
+            };
+
+            const subscribe = async (owner: ReturnType<typeof ownerFor>["owner"], shape: { args: Record<string, unknown>; name: string }): Promise<void> => {
+                await owner.handleControl(
+                    new Request("https://owner.internal/_lunora/relay", {
+                        body: JSON.stringify({
+                            ...shape,
+                            connectionId: "c-alice",
+                            identity: { org: "acme" },
+                            relayIndex: 0,
+                            subId: "s1",
+                            type: "relay_shape_subscribe",
+                            userId: "u1",
+                        }),
+                        headers: { "content-type": "application/json" },
+                        method: "POST",
+                    }),
+                );
+            };
+
+            it("seeds a subscriber under its own forwarded identity, never the anonymous one", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const { owner, resolvedUnder } = ownerFor(host.sql);
+
+                    await subscribe(owner, SCOPED_SHAPE);
+
+                    // The seed itself has to see the real claims. Resolving it
+                    // anonymously would hand the subscriber a membership it is
+                    // not entitled to on the very first frame — before any poke
+                    // exists to correct it.
+                    expect(resolvedUnder.some((identity) => identity?.userId === "u1" && identity.identity?.["org"] === "acme")).toBe(true);
+                } finally {
+                    close?.();
+                }
+            });
+
+            it("routes an identity-scoped shape to a per-socket poke, not the cohort multicast", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const { owner, posts } = ownerFor(host.sql);
+
+                    await subscribe(owner, SCOPED_SHAPE);
+
+                    posts.length = 0;
+                    await owner.onFlush(new Set(["orders"]), 20);
+
+                    const pokes = posts.filter((post) => post["type"] === "relay_shape_poke");
+
+                    // Addressed to one connection. An unaddressed poke here would
+                    // be a cohort multicast — one tenant's rows fanned out to
+                    // every subscriber of the shape.
+                    expect(pokes.length).toBe(1);
+                    expect(pokes[0]?.["targetConnectionId"]).toBe("c-alice");
+                } finally {
+                    close?.();
+                }
+            });
+
+            it("still multicasts an identity-blind shape to the whole cohort", async () => {
+                const { close, host } = factory();
+
+                try {
+                    const { owner, posts } = ownerFor(host.sql);
+
+                    await subscribe(owner, OPEN_SHAPE);
+
+                    posts.length = 0;
+                    await owner.onFlush(new Set(["messages"]), 20);
+
+                    const pokes = posts.filter((post) => post["type"] === "relay_shape_poke");
+
+                    // Without this the leg above passes on a gate that refuses
+                    // everything — which is safe but silently discards the whole
+                    // multicast optimization.
+                    expect(pokes.length).toBe(1);
+                    expect(pokes[0]?.["targetConnectionId"]).toBeUndefined();
+                } finally {
+                    close?.();
+                }
+            });
+        });
     });
 };
 

--- a/plans/114-platform-abstraction-layer.md
+++ b/plans/114-platform-abstraction-layer.md
@@ -260,18 +260,29 @@ Move the host-neutral engine into `@lunora/shard-engine` (name bikesheddable):
   host (`packages/shard-engine/__tests__/engine-conformance.test.ts`) and real
   workerd through `createShardPlatform`
   (`packages/do/__tests__/workerd/engine-conformance.workerd.test.ts`).
-- **Blocked: scheduler at-least-once + dead-letter.** Not expressible against
-  the current contracts. `SchedulerHost` is `{schedule, cancel, cron?}` —
-  enqueue and cancel only, with no delivery surface, attempt count, or
-  dead-letter key. The retry/backoff/`dead:` machinery lives in `SchedulerDO`
-  (`@lunora/scheduler`), which is Cloudflare-resident and not extracted. What
-  IS host-varying was added to the platform suite instead: `cancel` must answer
-  truthfully on a second call, and two identical schedules must get
-  independently cancellable ids (a host keying jobs by payload silently drops
-  the survivor — a caller that enqueued twice and cancelled once is owed one
-  delivery). Unblocking the rest means either growing `SchedulerHost` a delivery
-  surface or extracting `SchedulerDO` host-neutrally — see §7 open question 2,
-  which already asks exactly that.
+- **Scheduler at-least-once + dead-letter** ✅, after growing the contract. It
+  was initially unassertable: `SchedulerHost` was `{schedule, cancel, cron?}` —
+  enqueue and cancel only, so at-least-once was promised in the module
+  docstring and stated nowhere a test could reach. It now carries an optional
+  `list` (pending jobs as `ScheduledJobStatus`, which is where `attempts`
+  lives) and `deadLetter` (`list` + `requeue`). These describe RPCs
+  `SchedulerDO` already serves — `/list`, `/dead`, `POST /dead/retry` — so the
+  contract has a real Cloudflare implementation behind it and not only a
+  reference one; `Scheduler` gained `dead`/`deadRetry` to expose them.
+- The legs assert the invariants any host must uphold **however** it implements
+  retries: a pending job reports `attempts: 0`; the pending and dead-letter
+  listings are disjoint in both directions (park and requeue); requeue restores
+  a fresh budget; requeue of an unparked id is `false`. Plus the two
+  enqueue-side ones: `cancel` answers truthfully on a second call, and two
+  identical schedules get independently cancellable ids (a host keying jobs by
+  payload silently drops the survivor — a caller that enqueued twice and
+  cancelled once is owed one delivery).
+- `ConformanceHost.simulateDeadLetter` drives the transition, following
+  `simulateRecycle`'s convention. **The retry _policy_ is deliberately not in
+  the contract** — how many failures and what backoff before parking is host
+  policy, and only the observable outcome is contract-level. Extracting
+  `SchedulerDO`'s policy host-neutrally (§7 open question 2) remains open and is
+  now an optimization rather than a prerequisite.
 - Reference host: the existing in-memory `lunoraTest` harness (it _is_ the
   spec's executable form today).
 - CI: run against (a) in-memory reference, (b) workerd/miniflare (gated,

--- a/plans/114-platform-abstraction-layer.md
+++ b/plans/114-platform-abstraction-layer.md
@@ -256,7 +256,10 @@ Move the host-neutral engine into `@lunora/shard-engine` (name bikesheddable):
   per-socket cursor resume ✅. RLS identity under live subscription ✅ — pinned
   at the relay tier's uniformity gate, where the failure mode is a cohort
   multicast computed under the anonymous identity reaching an identity-scoped
-  subscriber.
+  subscriber. All ten legs run against **both** hosts: the platform reference
+  host (`packages/shard-engine/__tests__/engine-conformance.test.ts`) and real
+  workerd through `createShardPlatform`
+  (`packages/do/__tests__/workerd/engine-conformance.workerd.test.ts`).
 - **Blocked: scheduler at-least-once + dead-letter.** Not expressible against
   the current contracts. `SchedulerHost` is `{schedule, cancel, cron?}` —
   enqueue and cancel only, with no delivery surface, attempt count, or

--- a/plans/114-platform-abstraction-layer.md
+++ b/plans/114-platform-abstraction-layer.md
@@ -244,6 +244,31 @@ Move the host-neutral engine into `@lunora/shard-engine` (name bikesheddable):
   (`pokeStart/Part/End` framing, per-socket cursor resume), attachment
   round-trip across simulated recycle, RLS identity under live subscription
   (the `cb632cd7` regression), scheduler at-least-once + dead-letter.
+- **Split across two suites, and the split is forced rather than chosen.**
+  `@lunora/platform/conformance` asserts what a HOST provides; the engine-level
+  legs need `createShardCtxDb`/`relay-hub`, which live in `@lunora/shard-engine`,
+  and `@lunora/platform` is zero-dependency by contract — importing the engine
+  from there would invert the dependency and cycle. So the engine legs ship as
+  `@lunora/shard-engine/conformance`, and a host is proven only when it passes
+  both.
+- **Status.** OCC-409 ✅ (plus the trigger-recursion ceiling, which is a
+  _different_ `ConflictKind` and must stay distinct). Shape-poke ordering +
+  per-socket cursor resume ✅. RLS identity under live subscription ✅ — pinned
+  at the relay tier's uniformity gate, where the failure mode is a cohort
+  multicast computed under the anonymous identity reaching an identity-scoped
+  subscriber.
+- **Blocked: scheduler at-least-once + dead-letter.** Not expressible against
+  the current contracts. `SchedulerHost` is `{schedule, cancel, cron?}` —
+  enqueue and cancel only, with no delivery surface, attempt count, or
+  dead-letter key. The retry/backoff/`dead:` machinery lives in `SchedulerDO`
+  (`@lunora/scheduler`), which is Cloudflare-resident and not extracted. What
+  IS host-varying was added to the platform suite instead: `cancel` must answer
+  truthfully on a second call, and two identical schedules must get
+  independently cancellable ids (a host keying jobs by payload silently drops
+  the survivor — a caller that enqueued twice and cancelled once is owed one
+  delivery). Unblocking the rest means either growing `SchedulerHost` a delivery
+  surface or extracting `SchedulerDO` host-neutrally — see §7 open question 2,
+  which already asks exactly that.
 - Reference host: the existing in-memory `lunoraTest` harness (it _is_ the
   spec's executable form today).
 - CI: run against (a) in-memory reference, (b) workerd/miniflare (gated,


### PR DESCRIPTION
Completes plan 114 §5.4's engine legs, then closes the §5.3/§5.5 gaps an audit of the remaining workstreams turned up. Stacked on #190 — review that first.

`@lunora/platform/conformance` asserts what a **host** provides. This adds the other half: what the **engine** does with those primitives. The split is forced, not chosen — the engine legs need `createShardCtxDb`/`relay-hub`, which live in `@lunora/shard-engine`, and `@lunora/platform` is zero-dependency by contract, so importing the engine from there would invert the dependency and cycle. A host is proven only when it passes both.

Ten legs, run against **both** the platform reference host and real workerd through `createShardPlatform`:

| Group | What it pins |
|---|---|
| OCC (4) | zero-changes CAS → `CONFLICT`/`kind:"occ"`, no server retry, no partial write; the trigger-recursion ceiling as a **distinct** kind |
| Shape-poke (3) | `pokeStart → pokePart → pokeEnd` under one poke id; delivery gated on the per-socket cohort memo; epoch disambiguation |
| RLS (3) | the seed resolves under the subscriber's identity; identity-scoped shapes get per-socket pokes, never the cohort multicast |

Every leg is mutation-verified — 11 mutations, each caught by its own leg. The two RLS gate mutations are **opposite-direction** (gate forced `true` and forced `false`, both caught), so neither leg passes on a gate that simply refuses everything. The two most load-bearing were re-verified through workerd specifically, not just the reference run.

## Findings worth reviewer attention

**The first OCC leg I wrote was wrong, and passing was how it hid.** Provoking the conflict through `ctx.db` re-enters the trigger and trips the recursion ceiling *before* the CAS — so it asserted `kind: "trigger"` while the test name claimed `occ`. The clobber now goes through raw SQL (which doesn't re-fire triggers), and the recursion ceiling gets its own leg. The two kinds must stay distinct because the client's correct response differs: refetch-and-retry for one, and an infinite loop for the other.

**`ConformanceHost` had no way to read back what a socket was sent.** So no *delivery* guarantee was assertable at all — and the platform TCK's own send leg was asserting only that `send` didn't throw. A host that silently dropped every frame would have passed it while breaking every subscription. Added `readFrames` and strengthened that leg.

Related, and only visible once something read the buffer: `ReferenceSocket.received` is typed `(string | ArrayBuffer)[]`, but the send path encoded unconditionally — the string arm was unreachable. Write-only state doesn't get type-checked by use.

**I asserted the owner seed path could not reach `RelayHost.sql`, and was wrong.** The owner persists its relay set in `__lunora_relays`. It now runs on the host under test rather than a double, because a host whose SQL can't carry that set drops its relays on every wake and silently stops fanning out. The stub earned its keep by being wrong loudly.

**The real transport forced two changes the in-memory host had been hiding.** `readFrames` is now awaitable — a `send` reaches its peer through an event, so only an in-memory host can answer synchronously, and reading eagerly on workerd reports an empty buffer for a frame that *did* leave the socket. And the client end of a `WebSocketPair` must be accepted **after** the host takes the server end; accepting it first marks the pair as used and `state.acceptWebSocket` refuses. That was the first workerd run: three poke legs failing while the other seven already passed.

## Scheduler at-least-once + dead-letter — the contract had to grow

§5.4 lists this leg; it started out unassertable. `SchedulerHost` was `{schedule, cancel, cron?}` — enqueue and cancel only — so at-least-once was promised in the module docstring and stated nowhere a test could reach.

It now carries two optional members, both describing RPCs `SchedulerDO` **already serves** (`/list`, `/dead`, `POST /dead/retry`) rather than an invented surface, so there is a real Cloudflare implementation behind the contract and not only a reference one:

- `list` → pending jobs as `ScheduledJobStatus`, which is where `attempts` lives. That field is what makes at-least-once *observable*: without it a caller cannot tell a job waiting between retries from one never dispatched.
- `deadLetter.list` / `deadLetter.requeue`. Its absence is a real statement — a host without it can promise at-most-once only, because "dropped" and "delivered" look identical to every caller.

`Scheduler` gained `dead`/`deadRetry` to expose them. Six legs in total: `attempts: 0` on a fresh job; the two listings **disjoint in both directions** (park *and* requeue); requeue restores a fresh budget; requeue of an unparked id is `false`; `cancel` answers truthfully on a second call; two identical schedules get independently cancellable ids.

`ConformanceHost.simulateDeadLetter` drives the transition, following `simulateRecycle`'s convention. **The retry policy is deliberately not in the contract** — how many failures and what backoff before parking is host policy; only the observable outcome is contract-level. So §7 open question 2 (extract `SchedulerDO` host-neutrally) stays open, but is now an optimization rather than a prerequisite.

One of these legs was wrong until mutation testing said so: the requeue leg checked that a job returned to pending but never that it *stopped being parked*, so leaving the dead record behind survived. Fixed in its own commit.

## Plan 114 §5.3 / §5.5 — the target selector was unreachable

An audit of the remaining workstreams found one gap wearing two hats. `resolveDeployDriver(target)` and `runCodegen({ target })` both accepted a target; **nothing supplied one**, so `options.target` was always `undefined` and only the default was ever selectable. The machinery was complete and unreachable.

- `lunora.json` gains a `target` key beside `remote`.
- `--target` is declared on `codegen`, `dev`, `prepare`, `deploy`, and `logs`, with help text generated from the driver registry rather than a hand-kept string.
- `resolveProjectTarget(projectRoot, explicit)` is the **single** resolution point — flag, then config, then default. One point on purpose: codegen tailors the emitted `ctx.*` surface to a target while deploy picks the driver that ships it, and resolving those separately lets them disagree, producing an app that builds cleanly and fails at runtime. The Vite plugin resolves the same way, so `vite build` and `lunora deploy` agree without configuring each.

Wiring it up surfaced two things that would have left the flag decorative:

- The flag parsed and appeared in `--help`, but **no `CreateOptions` map declared it and no `execute` wrapper forwarded it** — the same declared-but-unreachable shape as the original finding, one layer down. Caught by running the built binary, not by reading the types.
- **`codegen --target aws` emitted the full Cloudflare surface un-gated, reported `platform_unknown_target` as a *warning*, and exited 0.** That is the silent fallback the driver registry was built to prevent, arriving through the back door: codegen resolves no driver of its own, so nothing rejected the name. All five commands now go through `resolveTargetOrThrow`, so a typo fails identically everywhere — including one committed to `lunora.json`, which is where it would go unnoticed longest.

Default behaviour is unchanged: goldens byte-identical, 921 codegen tests green. Five mutations verified against the resolution order, the config-degradation path, and the validation.

*(Unrelated: `examples/blog/lunora/_generated/server.ts` is stale — last regenerated in #202, one commit before vector emission landed in #203. Left alone rather than folded into this PR.)*

## Verification

| | |
|---|---|
| `@lunora/do` | 687 + **62 workerd** (incl. the 10 engine legs through the composition root) |
| `@lunora/shard-engine` | 638 |
| `@lunora/platform` | 36 |
| `@lunora/scheduler` | 113 |
| `@lunora/cli` | 792 |
| `@lunora/config` | 491 |
| `@lunora/codegen` | 921 (goldens byte-identical) |
| `@lunora/vite` | 186 |
| repo | `lint:types`, `lint:eslint`, `lint:prettier`, `lint:package-json`, `api:check` |

API snapshots updated for the new `@lunora/shard-engine/conformance` subpath, `ConformanceHost.readFrames`, the `SchedulerHost` delivery members, and the `@lunora/config` target helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137KKKmGRyB69XgLzMaFgSh
