### PR TITLE
fix(runtime): let http routes reach internal functions

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -30,6 +30,8 @@
         "@fuma-comment/react": "catalog:web",
         "@fumadocs/mdx-remote": "catalog:web",
         "@icons-pack/react-simple-icons": "catalog:web",
+        "@lunora/client": "workspace:*",
+        "@lunora/errors": "workspace:*",
         "@lunora/mcp": "workspace:*",
         "@lunora/ratelimit": "workspace:*",
         "@radix-ui/react-icons": "catalog:web",

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -1432,6 +1432,35 @@ describe("createWorker — HTTP actions", () => {
         expect(forwarded.args).toEqual({ body: { text: "hi" } });
     });
 
+    it("marks a route's `ctx.run*` as a trusted system dispatch, so `internal` functions are reachable", async () => {
+        expect.assertions(3);
+
+        shard.response = Response.json({ result: "cell_1" });
+
+        const worker = createWorker({
+            httpRouter: honoApp((app) =>
+                app.post("/v1/cells", async (c) => Response.json({ cellId: await c.var.lunora.runMutation({ __lunoraRef: "cells:register" }, { name: "c" }) })),
+            ),
+            resolveIdentity: () => {
+                return { userId: "user_7" };
+            },
+            shardDO: shard.namespace,
+        });
+
+        const res = await worker.fetch(new Request("https://app.example/v1/cells", { method: "POST" }), {}, fakeContext);
+
+        expect(res.status).toBe(200);
+
+        // The whole point: `handleRpc` refuses an `internal` function to any caller
+        // without this flag, so an operator/webhook/ingest route delegating to one
+        // used to fail with FUNCTION_NOT_FOUND surfaced as a 500.
+        expect(shard.calls[0]!.request.headers.get("x-lunora-system")).toBe("1");
+
+        // And it widens visibility ONLY — the caller's identity still rides along,
+        // so RLS and ownership checks inside the function are unchanged.
+        expect(shard.calls[0]!.request.headers.get("x-lunora-userid")).toBe("user_7");
+    });
+
     it("exposes resolveIdentity on c.var.lunora.auth", async () => {
         expect.assertions(1);
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -2875,7 +2875,29 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
             const forwarded = new Request("https://shard.internal/rpc", {
                 body: JSON.stringify({ args, functionPath }),
-                headers,
+                // `x-lunora-system` marks this a trusted server-initiated dispatch, so
+                // the shard will run `internal` functions — exactly as on the
+                // scheduler path above, and for the same reason.
+                //
+                // An `httpRouter` handler is app-authored worker code, not a client:
+                // the reference it passes is a literal `internal.foo.bar` from the
+                // app's own source, never a caller-supplied string, and the handler
+                // has already run whatever authorization it requires (the operator
+                // bearer on a cell-register route, a deploy-key lookup on an ingest
+                // route). Without this the route's `ctx.run*` reached the shard as an
+                // ordinary *client* RPC, and `handleRpc` — which refuses internals to
+                // anything lacking this flag — answered FUNCTION_NOT_FOUND, so every
+                // route delegating to an `internal*` function failed with a 500 that
+                // named a function the registry demonstrably contained.
+                //
+                // This widens visibility only. The shard reconstructs identity from
+                // the `x-lunora-*` headers independently of the flag, so the call
+                // still runs under the caller's RLS/ownership context; `headers` is
+                // minted by `resolveForwardContext` from a fixed allowlist that never
+                // copies `x-lunora-system` off the inbound request, so a client cannot
+                // forge it. The external client path (`/_lunora/rpc`, and SSR loaders
+                // that go through it) never passes here and stays gated.
+                headers: { ...headers, "x-lunora-system": "1" },
                 method: "POST",
             });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -923,6 +923,12 @@ importers:
       '@icons-pack/react-simple-icons':
         specifier: catalog:web
         version: 13.13.0(react@19.2.8)
+      '@lunora/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@lunora/errors':
+        specifier: workspace:*
+        version: link:../../packages/errors
       '@lunora/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp


### PR DESCRIPTION
## The bug

An `httpRouter` handler calling `ctx.runQuery`/`ctx.runMutation` on an `internal*` function **always failed**.

The action context's `run` helper (`packages/runtime/src/create-worker.ts`) forwarded the RPC to the shard without `x-lunora-system`, so the DO's `handleRpc` treated an app-authored server dispatch as an ordinary client RPC and refused it. The route received `FUNCTION_NOT_FOUND` for a function the registry demonstrably contained, which surfaced to callers as a bare 500.

Found while trying to bootstrap `apps/cloud` from a cold start:

```
POST /v1/cells   → HTTP 500   "function not registered: cells:register"
POST /v1/traces  → HTTP 500   (should be 401 for a bogus key)
```

In `apps/cloud` this broke every `/v1/*` route delegating to an internal function — OTLP traces/logs/metrics ingest, log ingest, GitHub webhooks, and cell registration, the documented operator-gated way to register a fleet cell. Six call sites in `src/deploy/router.ts`.

Not a regression from any current branch: the visibility gate has been in the cloud app's generated shard since `fff492398` (2026-06-16) and is present in that branch's pre-existing baseline.

## The fix

Set `x-lunora-system: "1"` on that dispatch, exactly as the scheduler path already does a few hundred lines above.

## Why this is safe

It widens **visibility only** — it is not an auth or RLS bypass:

- The flag's sole consumer is the internal-visibility check in the generated `handleRpc`. It gates nothing else (verified across `@lunora/do`, `@lunora/codegen`, `@lunora/testing`).
- The shard rebuilds identity from the `x-lunora-*` headers independently of the flag, so calls keep running under the caller's RLS/ownership context — the same coexistence the scheduler path documents.
- A client cannot forge it: `resolveForwardContext` mints the forwarded headers from a fixed allowlist that never copies `x-lunora-system` off the inbound request.
- The reference a route passes is an app-source literal (`internal.cells.register`), never a caller-supplied string.
- The external path is unaffected: `/_lunora/rpc` — including SSR loaders that proxy through it, such as `apps/cloud`'s preload seam — never passes through this helper and stays gated.

## Testing

New regression test in `packages/runtime/__tests__/create-worker.test.ts`, verified to fail without the source change (`expected null to be '1'`) and pass with it. It also asserts identity still rides along, pinning the visibility-only property.

- `@lunora/runtime` tests: **760 passed** (58 files)
- `lint:types`: clean
- `lint:eslint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed HTTP actions that delegate to internal procedures, preventing `FUNCTION_NOT_FOUND` errors.
  - HTTP requests now include a trusted-dispatch indicator when forwarding to the backend, ensuring delegated internal routes execute reliably.
  - Existing request headers continue to be forwarded as before.
- **Chores**
  - Updated the documentation app to include the client and errors packages via workspace-linked dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->