### PR TITLE
fix(cloud): close the React Doctor findings in the studio

### DIFF
--- a/apps/cloud/src/client/AlertsSection.tsx
+++ b/apps/cloud/src/client/AlertsSection.tsx
@@ -116,8 +116,7 @@ export const AlertsSection = ({ organizationId, preloaded }: SectionProps<Return
                 />
                 <form
                     className="inline-form"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
 
                         const run = async (): Promise<void> => {

--- a/apps/cloud/src/client/CommandPalette.tsx
+++ b/apps/cloud/src/client/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { PaletteCommand } from "./use-command-palette";
 
@@ -37,27 +37,44 @@ const PaletteDialog = ({ commands, onClose }: Omit<CommandPaletteProps, "open">)
         }
     };
 
+    // A native <dialog> opened with showModal(), rather than a div with
+    // role="dialog": the platform then owns the focus trap (tab cannot escape to
+    // the page behind), the top layer, the backdrop, and Escape-to-close. The
+    // hand-rolled version had none of those — keyboard users could tab straight out
+    // of the palette into the obscured page underneath.
+    const dialogRef = useRef<HTMLDialogElement>(null);
+
+    useEffect(() => {
+        const dialog = dialogRef.current;
+
+        dialog?.showModal();
+
+        return () => {
+            dialog?.close();
+        };
+    }, []);
+
     return (
-        <div
-            className="palette-overlay"
-            onClick={onClose}
-            onKeyDown={(event) => {
-                if (event.key === "Escape") {
+        <dialog
+            aria-label="Command palette"
+            className="palette"
+            onCancel={(event) => {
+                // The browser's Escape handling would remove the dialog from the DOM
+                // behind React's back; close through the owner instead so `open` state
+                // stays the source of truth.
+                event.preventDefault();
+                onClose();
+            }}
+            onClick={(event) => {
+                // ::backdrop clicks land on the dialog element itself, so a hit that is
+                // not inside the panel is a backdrop hit — the old overlay behaviour.
+                if (event.target === dialogRef.current) {
                     onClose();
                 }
             }}
-            role="presentation"
+            ref={dialogRef}
         >
-            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events -- the click handler only stops overlay-close propagation; keyboard flow lives on the input */}
-            <div
-                aria-label="Command palette"
-                aria-modal="true"
-                className="palette"
-                onClick={(event) => {
-                    event.stopPropagation();
-                }}
-                role="dialog"
-            >
+            <div className="palette-panel">
                 <input
                     aria-label="Search commands"
                     // eslint-disable-next-line jsx-a11y/no-autofocus -- a command palette exists to receive keyboard input the instant it opens
@@ -114,7 +131,7 @@ const PaletteDialog = ({ commands, onClose }: Omit<CommandPaletteProps, "open">)
                 </ul>
                 <div className="palette-hint muted">↑↓ navigate · ↵ run · esc close</div>
             </div>
-        </div>
+        </dialog>
     );
 };
 

--- a/apps/cloud/src/client/DashboardsSection.tsx
+++ b/apps/cloud/src/client/DashboardsSection.tsx
@@ -58,8 +58,7 @@ export const DashboardsSection = ({ organizationId, preloaded }: SectionProps<Re
                 </p>
                 <form
                     className="inline-form"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
 
                         void create

--- a/apps/cloud/src/client/DeployKeysSection.tsx
+++ b/apps/cloud/src/client/DeployKeysSection.tsx
@@ -77,8 +77,7 @@ export const DeployKeysSection = ({ organizationId, preloaded }: SectionProps<Re
                 ) : null}
                 <form
                     className="inline-form"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
 
                         void (async () => {

--- a/apps/cloud/src/client/DomainsSection.tsx
+++ b/apps/cloud/src/client/DomainsSection.tsx
@@ -151,8 +151,7 @@ export const DomainsSection = ({ organizationId, preloaded }: SectionProps<Retur
                     ) : null}
                     <form
                         className="inline-form"
-                        onSubmit={(event) => {
-                            event.preventDefault();
+                        action={() => {
                             setError(null);
                             setPending(true);
 

--- a/apps/cloud/src/client/InvitationsSection.tsx
+++ b/apps/cloud/src/client/InvitationsSection.tsx
@@ -74,8 +74,7 @@ export const InvitationsSection = ({ organizationId, preloaded }: SectionProps<R
                 ) : null}
                 <form
                     className="inline-form"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
                         setPending(true);
 

--- a/apps/cloud/src/client/Login.tsx
+++ b/apps/cloud/src/client/Login.tsx
@@ -34,8 +34,7 @@ export const Login = ({ onSignedIn }: LoginProps = {}): ReactElement => {
         <div className="auth-shell">
             <form
                 className="card auth-card"
-                onSubmit={(event) => {
-                    event.preventDefault();
+                action={() => {
                     setError(null);
                     setPending(true);
 

--- a/apps/cloud/src/client/MembersSection.tsx
+++ b/apps/cloud/src/client/MembersSection.tsx
@@ -54,8 +54,7 @@ export const MembersSection = ({ organizationId, preloaded }: SectionProps<Retur
                 <h3>Add member</h3>
                 <form
                     className="inline-form"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
 
                         void (async () => {

--- a/apps/cloud/src/client/OrganizationList.tsx
+++ b/apps/cloud/src/client/OrganizationList.tsx
@@ -95,8 +95,7 @@ export const OrganizationList = ({ onSelect, preloadedCells, preloadedOrganizati
                 ) : null}
                 <form
                     className="form-grid"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
 
                         if (!cellId) {

--- a/apps/cloud/src/client/ProjectsSection.tsx
+++ b/apps/cloud/src/client/ProjectsSection.tsx
@@ -98,8 +98,7 @@ export const ProjectsSection = ({ organizationId, preloaded }: SectionProps<Retu
                 <h3>New project</h3>
                 <form
                     className="form-grid"
-                    onSubmit={(event) => {
-                        event.preventDefault();
+                    action={() => {
                         setError(null);
 
                         void (async () => {

--- a/apps/cloud/src/client/SecretsSection.tsx
+++ b/apps/cloud/src/client/SecretsSection.tsx
@@ -81,8 +81,7 @@ export const SecretsSection = ({ organizationId, preloaded }: SectionProps<Retur
                     <h3>Set secret</h3>
                     <form
                         className="inline-form"
-                        onSubmit={(event) => {
-                            event.preventDefault();
+                        action={() => {
                             setError(null);
                             setPending(true);
 

--- a/apps/cloud/src/client/SessionsSection.tsx
+++ b/apps/cloud/src/client/SessionsSection.tsx
@@ -122,6 +122,13 @@ export const SessionsSection = ({ organizationId, preloaded }: SectionProps<Retu
                                     onClick={() => {
                                         setSessionId(session.sessionId === sessionId ? "" : session.sessionId);
                                     }}
+                                    onKeyDown={(event) => {
+                                        if (event.key === "Enter" || event.key === " ") {
+                                            event.preventDefault();
+                                            setSessionId(session.sessionId === sessionId ? "" : session.sessionId);
+                                        }
+                                    }}
+                                    tabIndex={0}
                                 >
                                     <td className="trace-id">{session.sessionId.slice(0, 16)}</td>
                                     <td>{session.turnCount}</td>

--- a/apps/cloud/src/client/TraceDetail.tsx
+++ b/apps/cloud/src/client/TraceDetail.tsx
@@ -15,7 +15,7 @@ interface TraceWaterfallProps {
 
 /** The nested span waterfall: a true span timeline (real offsets/durations), indented by depth. */
 export const TraceWaterfall = ({ onSelect, rows, selectedSpanId }: TraceWaterfallProps): ReactElement => (
-    <div className="trace-waterfall">
+    <div className="trace-waterfall" role="listbox">
         {rows.map((row) => (
             <div
                 aria-selected={row.spanId === selectedSpanId}
@@ -28,7 +28,7 @@ export const TraceWaterfall = ({ onSelect, rows, selectedSpanId }: TraceWaterfal
                         onSelect(row.spanId);
                     }
                 }}
-                role="button"
+                role="option"
                 tabIndex={0}
             >
                 <span className="trace-off">+{String(row.offsetMs)}ms</span>

--- a/apps/cloud/src/client/TracesSection.tsx
+++ b/apps/cloud/src/client/TracesSection.tsx
@@ -208,6 +208,14 @@ export const TracesSection = ({ focusTraceId, organizationId, preloaded }: Secti
                                         setSelectedSpanId("");
                                         setTraceId(trace.traceId === traceId ? "" : trace.traceId);
                                     }}
+                                    onKeyDown={(event) => {
+                                        if (event.key === "Enter" || event.key === " ") {
+                                            event.preventDefault();
+                                            setSelectedSpanId("");
+                                            setTraceId(trace.traceId === traceId ? "" : trace.traceId);
+                                        }
+                                    }}
+                                    tabIndex={0}
                                 >
                                     <td className="trace-id">
                                         {trace.traceId.slice(0, 12)}

--- a/apps/cloud/src/client/UsageSection.tsx
+++ b/apps/cloud/src/client/UsageSection.tsx
@@ -7,14 +7,7 @@ import { includedUsageFor } from "../billing/overage";
 
 import type { SectionProps } from "./tabs";
 import { formatDate, formatNumber } from "./format";
-
-/** Epoch ms for the first instant of the current UTC month. */
-/** Start of the current UTC billing month — shared with the `usage` route loader so SSR and client agree on the period. */
-export const monthStart = (): number => {
-    const now = new Date();
-
-    return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
-};
+import { monthStart } from "./usage-period";
 
 const formatBytes = (bytes: number): string => {
     const units = ["B", "KB", "MB", "GB", "TB"];

--- a/apps/cloud/src/client/styles.css
+++ b/apps/cloud/src/client/styles.css
@@ -500,26 +500,32 @@ button.link.danger {
 }
 
 /* ⌘K command palette (GAPS.md ring 3) */
-.palette-overlay {
-    align-items: flex-start;
-    background: rgba(0, 0, 0, 0.45);
-    display: flex;
-    inset: 0;
-    justify-content: center;
-    padding-top: 14vh;
-    position: fixed;
-    z-index: 60;
+/*
+ * The palette is a native <dialog> in the top layer, so it needs no overlay
+ * element, no z-index and no fixed positioning — the browser handles stacking and
+ * renders the scrim via ::backdrop. The dialog box itself is transparent and only
+ * positions the panel; the panel keeps the visible chrome.
+ */
+.palette {
+    background: transparent;
+    border: none;
+    margin: 14vh auto auto;
+    max-width: 520px;
+    padding: 0;
+    width: 92%;
 }
 
-.palette {
+.palette::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.palette-panel {
     background: #16181d;
     border: 1px solid rgba(127, 127, 127, 0.25);
     border-radius: 10px;
     box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5);
     color: #e6e8ec;
-    max-width: 520px;
     overflow: hidden;
-    width: 92%;
 }
 
 .palette-input {

--- a/apps/cloud/src/client/usage-period.ts
+++ b/apps/cloud/src/client/usage-period.ts
@@ -1,0 +1,16 @@
+/**
+ * The usage tab's billing period, in its own module.
+ *
+ * It lives here rather than in `UsageSection.tsx` because that file is a component
+ * module: exporting a plain helper alongside the component defeats React Fast
+ * Refresh (an edit to either forces a full reload instead of a component swap) and
+ * is what `react-doctor/only-export-components` flags. The route loader and the
+ * component both import it, so SSR and the client agree on the period.
+ */
+
+/** Epoch ms for the first instant of the current UTC month. */
+export const monthStart = (): number => {
+    const now = new Date();
+
+    return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+};

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -2,7 +2,7 @@ import { LunoraClient } from "@lunora/client";
 import { LunoraProvider } from "@lunora/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import { createRootRouteWithContext, HeadContent, Link, Outlet, Scripts } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
@@ -48,9 +48,9 @@ export const Route = createRootRouteWithContext<RouterContext>()({
             <div className="callout">
                 <h1>404</h1>
                 <p>This page could not be found.</p>
-                <a className="link" href="/">
+                <Link className="link" to="/">
                     Back to organizations
-                </a>
+                </Link>
             </div>
         </main>
     ),

--- a/apps/cloud/src/routes/_authed.orgs.$organizationId.usage.tsx
+++ b/apps/cloud/src/routes/_authed.orgs.$organizationId.usage.tsx
@@ -3,7 +3,8 @@ import type { ReactElement } from "react";
 
 import { api } from "../../lunora/_generated/api.js";
 import type { OrgId } from "../client/types";
-import { monthStart, UsageSection } from "../client/UsageSection";
+import { UsageSection } from "../client/UsageSection";
+import { monthStart } from "../client/usage-period";
 import { preload } from "../ssr/loader";
 
 const UsageSectionRoute = (): ReactElement => {


### PR DESCRIPTION
Closes 16 of the 20 React Doctor warnings reported on #85.

> **Base is `claude/cloud-platform-dx-ojvkmu`, not `alpha`, deliberately.** `apps/cloud` on alpha contains only `ROADMAP.md` — all 18 flagged files exist solely on the cloud branch, so a PR against alpha would present the whole app as additions and could not merge cleanly.

## Fixed

| Rule | Count | Change |
| --- | --- | --- |
| `no-prevent-default` | 10 | forms → React 19 `<form action={fn}>` |
| `click-events-have-key-events` | 2 | Enter/Space + `tabIndex` on clickable rows |
| `prefer-html-dialog` | 1 | command palette → native `<dialog>` |
| `role-supports-aria-props` | 1 | waterfall rows → `listbox`/`option` |
| `only-export-components` | 1 | `monthStart` extracted to its own module |

**Forms.** Every flagged handler used `event` exactly once — to cancel the browser's own submit — so each converted cleanly to a function action. Verified via SSR: the login form now renders with React's function-action sentinel (`action="javascript:throw new Error('React form unexpectedly submitted.')"`), confirming React owns submission rather than a cancelled native submit.

**Command palette.** This was a real accessibility hole rather than a lint nit. A `role="dialog"` div provides no focus trap, so tab moved straight out of the palette into the obscured page behind it. Opened with `showModal()`, the platform supplies the trap, the top layer, the backdrop and Escape handling. `onCancel` is intercepted so the browser cannot remove the element behind React's back, and the overlay/z-index CSS is replaced by `::backdrop`.

**Keyboard access.** The Traces and Sessions tables were mouse-only; their rows now use the same Enter/Space idiom the trace waterfall already had.

**`aria-selected` on `role="button"`** is not a supported pairing — the waterfall rows are a selectable list, so they became `listbox`/`option`.

## Deliberately not fixed: the 4 `react-compiler-no-manual-memoization` warnings

They assume React Compiler is compiling this app. It is not — `babel-plugin-react-compiler` is wired into `apps/studio`, `apps/docs` and `packages/studio`, but `apps/cloud` runs a plain `react()` with no compiler babel plugin. Removing the `useMemo`/`useCallback` they flag would delete real memoization with nothing replacing it.

The correct fix is adopting the compiler here as the sibling apps do. That changes runtime behaviour for every component and deserves its own PR.

## Verification

- 444 `@lunora/cloud` tests pass
- `tsc --noEmit` clean
- production `vite build` succeeds
- `/login` renders server-side with no error boundary

The React Doctor threads on #85 are intentionally left unresolved until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)