### PR TITLE
feat(cli): make the deploy target selectable end to end

### DIFF
--- a/api-snapshots/cli.api.md
+++ b/api-snapshots/cli.api.md
@@ -169,10 +169,10 @@ interface DevCommandOptions {
     port?: number;
     remote?: boolean;
     startCodegen?: typeof startCodegenWatch;
-    target?: string;
     startStudio?: typeof startStudioServer;
     startWorker?: WorkerSpawner;
     studio?: boolean;
+    target?: string;
     workerPort?: number;
 }
 ```

--- a/api-snapshots/cli.api.md
+++ b/api-snapshots/cli.api.md
@@ -169,6 +169,7 @@ interface DevCommandOptions {
     port?: number;
     remote?: boolean;
     startCodegen?: typeof startCodegenWatch;
+    target?: string;
     startStudio?: typeof startStudioServer;
     startWorker?: WorkerSpawner;
     studio?: boolean;

--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -1138,6 +1138,12 @@ const lintSchema: (options: LintSchemaOptions) => Finding[];
 const parseSchemaSnapshot: (content: string | undefined) => SchemaSnapshot | undefined;
 ```
 
+### `platformMatrixIds` (const)
+
+```ts
+const platformMatrixIds: () => ReadonlyArray<string>;
+```
+
 ### `readProjectTarget` (const)
 
 ```ts

--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -1138,6 +1138,12 @@ const lintSchema: (options: LintSchemaOptions) => Finding[];
 const parseSchemaSnapshot: (content: string | undefined) => SchemaSnapshot | undefined;
 ```
 
+### `readProjectTarget` (const)
+
+```ts
+const readProjectTarget: (projectRoot: string) => string | undefined;
+```
+
 ### `redact` (const)
 
 ```ts
@@ -1148,6 +1154,12 @@ const redact: (value: string) => string;
 
 ```ts
 const refreshCodegenProject: (project: Project, lunoraDirectory: string) => void;
+```
+
+### `resolveCodegenTarget` (const)
+
+```ts
+const resolveCodegenTarget: (projectRoot: string, explicit?: string) => string;
 ```
 
 ### `runCodegen` (const)

--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -1741,6 +1741,12 @@ const resolveProjectTarget: (projectRoot: string, explicit?: string) => string;
 const resolveRemoteEnabled: (inputs: RemoteEnableInputs) => boolean;
 ```
 
+### `resolveTargetOrThrow` (const)
+
+```ts
+const resolveTargetOrThrow: (projectRoot: string, explicit?: string) => string;
+```
+
 ### `scaffoldPolicyFile` (const)
 
 ```ts

--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -689,6 +689,7 @@ type LunoraLineLevel = "error" | "info" | "warn";
 ```ts
 interface LunoraProjectConfig {
     remote?: unknown;
+    target?: unknown;
 }
 ```
 
@@ -1686,6 +1687,12 @@ const readProjectDependencyNames: (root: string) => ReadonlySet<string>;
 const readProjectRemotePreference: (projectRoot: string) => RemotePreference;
 ```
 
+### `readProjectTarget` (const)
+
+```ts
+const readProjectTarget: (projectRoot: string) => string | undefined;
+```
+
 ### `readWranglerJsonc` (const)
 
 ```ts
@@ -1720,6 +1727,12 @@ const requiredSecrets: (packageNames: ReadonlyArray<string>) => SecretEntry[];
 
 ```ts
 const resolveDeployDriver: (target?: string) => DeployDriver;
+```
+
+### `resolveProjectTarget` (const)
+
+```ts
+const resolveProjectTarget: (projectRoot: string, explicit?: string) => string;
 ```
 
 ### `resolveRemoteEnabled` (const)

--- a/api-snapshots/vite.api.md
+++ b/api-snapshots/vite.api.md
@@ -78,6 +78,7 @@ interface LunoraPluginOptions {
     projectRoot?: string;
     schemaDir?: string;
     studio?: boolean;
+    target?: string;
     validateWrangler?: boolean;
 }
 ```
@@ -121,6 +122,7 @@ interface ResolvedLunoraPluginOptions {
     projectRoot: string;
     schemaDir: string;
     studio: boolean;
+    target: string;
     validateWrangler: boolean;
 }
 ```

--- a/packages/cli/__tests__/commands/codegen.test.ts
+++ b/packages/cli/__tests__/commands/codegen.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -65,12 +65,17 @@ describe("lunora codegen", () => {
         it("emits the default surface with no target given", () => {
             expect.assertions(2);
 
-            const result = runCodegenCommand({ cwd: workdir, logger: silentLogger() });
+            const before = runCodegenCommand({ cwd: workdir, logger: silentLogger() });
+            const generated = readFileSync(join(workdir, "lunora", "_generated", "server.ts"), "utf8");
 
-            // The default path must stay byte-identical for existing projects,
-            // so an absent target produces no diagnostics at all.
-            expect(result.error).toBeUndefined();
-            expect(existsSync(join(workdir, "lunora", "_generated", "server.ts"))).toBe(true);
+            expect(before.error).toBeUndefined();
+
+            // Byte-identical, not merely present: the default path is what every
+            // existing project already builds, so this asserts the target work
+            // changed nothing for them rather than just that a file exists.
+            runCodegenCommand({ cwd: workdir, logger: silentLogger(), target: "cloudflare" });
+
+            expect(readFileSync(join(workdir, "lunora", "_generated", "server.ts"), "utf8")).toBe(generated);
         });
 
         it("refuses an unregistered --target instead of emitting an un-gated surface", () => {
@@ -83,7 +88,10 @@ describe("lunora codegen", () => {
             // target that does not exist, warn, and exit 0 — the silent
             // fallback the driver registry exists to prevent.
             expect(result.error).toMatch(/unknown deploy target "aws"/);
-            expect(result.outputDirectory).toBe("");
+
+            // Nothing was written: the target is rejected before codegen runs,
+            // so a rejected run cannot leave a half-emitted surface behind.
+            expect(existsSync(join(workdir, "lunora", "_generated", "server.ts"))).toBe(false);
         });
 
         it("refuses an unregistered target from lunora.json", () => {

--- a/packages/cli/__tests__/commands/codegen.test.ts
+++ b/packages/cli/__tests__/commands/codegen.test.ts
@@ -61,6 +61,51 @@ describe("lunora codegen", () => {
         rmSync(workdir, { force: true, recursive: true });
     });
 
+    describe("deploy target", () => {
+        it("emits the default surface with no target given", () => {
+            expect.assertions(2);
+
+            const result = runCodegenCommand({ cwd: workdir, logger: silentLogger() });
+
+            // The default path must stay byte-identical for existing projects,
+            // so an absent target produces no diagnostics at all.
+            expect(result.error).toBeUndefined();
+            expect(existsSync(join(workdir, "lunora", "_generated", "server.ts"))).toBe(true);
+        });
+
+        it("refuses an unregistered --target instead of emitting an un-gated surface", () => {
+            expect.assertions(2);
+
+            const result = runCodegenCommand({ cwd: workdir, logger: silentLogger(), target: "aws" });
+
+            // Codegen resolves no driver of its own, so without the explicit
+            // validation this would emit the full Cloudflare surface for a
+            // target that does not exist, warn, and exit 0 — the silent
+            // fallback the driver registry exists to prevent.
+            expect(result.error).toMatch(/unknown deploy target "aws"/);
+            expect(result.outputDirectory).toBe("");
+        });
+
+        it("refuses an unregistered target from lunora.json", () => {
+            expect.assertions(1);
+
+            writeFileSync(join(workdir, "lunora.json"), JSON.stringify({ target: "clouflare" }), "utf8");
+
+            // A typo in the committed config must fail the same way as a typo on
+            // the command line — the config path is where it would otherwise go
+            // unnoticed for longest.
+            expect(runCodegenCommand({ cwd: workdir, logger: silentLogger() }).error).toMatch(/unknown deploy target "clouflare"/);
+        });
+
+        it("lets --target override lunora.json", () => {
+            expect.assertions(1);
+
+            writeFileSync(join(workdir, "lunora.json"), JSON.stringify({ target: "aws" }), "utf8");
+
+            expect(runCodegenCommand({ cwd: workdir, logger: silentLogger(), target: "cloudflare" }).error).toBeUndefined();
+        });
+    });
+
     describe("lunora codegen", () => {
         it("writes the three generated files", () => {
             expect.assertions(3);

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -91,6 +91,44 @@ describe("lunora deploy", () => {
     });
 
     describe("lunora deploy", () => {
+        describe("deploy target", () => {
+            it("rejects an unregistered target declared in lunora.json", async () => {
+                expect.assertions(3);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+                writeFileSync(join(workdir, "lunora.json"), `{ "target": "clouflare" }`, "utf8");
+
+                const { calls, spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, logger, secretLister: noRemoteSecrets, spawner });
+
+                // Deploy used to read only the `--target` flag, so a typo in the
+                // committed config failed `codegen`/`prepare`/`dev` and shipped
+                // fine from here — the one command where the fallback matters.
+                expect(result.code).toBe(1);
+                expect(result.error).toMatch(/unknown deploy target "clouflare"/);
+
+                // And it must abort BEFORE spawning wrangler: the resolution
+                // happens up front so nothing is written or published first.
+                expect(calls).toHaveLength(0);
+            });
+
+            it("lets --target override lunora.json", async () => {
+                expect.assertions(1);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+                writeFileSync(join(workdir, "lunora.json"), `{ "target": "clouflare" }`, "utf8");
+
+                const { spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, logger, secretLister: noRemoteSecrets, spawner, target: "cloudflare" });
+
+                expect(result.code).toBe(0);
+            });
+        });
+
         it("runs codegen, validates wrangler, then spawns `pnpm exec wrangler deploy`", async () => {
             expect.assertions(5);
 

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -299,7 +299,7 @@ describe("lunora dev lifecycle", () => {
         it("forwards --target to the daemon", async () => {
             expect.assertions(2);
 
-            let args: string[] | undefined;
+            let args: ReadonlyArray<string> | undefined;
 
             await startBackground({
                 cwd: workdir,
@@ -325,7 +325,7 @@ describe("lunora dev lifecycle", () => {
         it("omits --target when none was given", async () => {
             expect.assertions(1);
 
-            let args: string[] | undefined;
+            let args: ReadonlyArray<string> | undefined;
 
             await startBackground({
                 cwd: workdir,

--- a/packages/cli/__tests__/commands/dev-lifecycle.test.ts
+++ b/packages/cli/__tests__/commands/dev-lifecycle.test.ts
@@ -296,6 +296,55 @@ describe("lunora dev lifecycle", () => {
             expect(readDevServerState(workdir)).toBeUndefined();
         });
 
+        it("forwards --target to the daemon", async () => {
+            expect.assertions(2);
+
+            let args: string[] | undefined;
+
+            await startBackground({
+                cwd: workdir,
+                jsonLogs: false,
+                logger: recordingLogger().logger,
+                options: { target: "aws" } as DevOptions,
+                remote: false,
+                run: (options) => {
+                    args = options.command.args;
+
+                    return Promise.resolve({ code: 0 });
+                },
+            });
+
+            // The daemon is a fresh process that re-parses argv, so a flag not
+            // forwarded here is silently dropped — and `--background` is the
+            // automatic path when an AI agent runs `lunora dev`, which made this
+            // the default way to lose the flag.
+            expect(args).toContain("--target");
+            expect(args?.[(args.indexOf("--target") ?? 0) + 1]).toBe("aws");
+        });
+
+        it("omits --target when none was given", async () => {
+            expect.assertions(1);
+
+            let args: string[] | undefined;
+
+            await startBackground({
+                cwd: workdir,
+                jsonLogs: false,
+                logger: recordingLogger().logger,
+                options: {} as DevOptions,
+                remote: false,
+                run: (options) => {
+                    args = options.command.args;
+
+                    return Promise.resolve({ code: 0 });
+                },
+            });
+
+            // Absent, not empty-string: the daemon re-reads `lunora.json`, so
+            // passing `--target ""` would override a project setting with junk.
+            expect(args).not.toContain("--target");
+        });
+
         it("loses the claim to a live incumbent and reports it without spawning", async () => {
             expect.assertions(4);
 

--- a/packages/cli/__tests__/util/platform-diagnostics.test.ts
+++ b/packages/cli/__tests__/util/platform-diagnostics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { Logger } from "../../src/util/logger";
+import reportPlatformDiagnostics from "../../src/util/platform-diagnostics";
+
+interface Recording {
+    lines: { level: string; message: string }[];
+    logger: Logger;
+}
+
+const recordingLogger = (): Recording => {
+    const lines: { level: string; message: string }[] = [];
+    const push =
+        (level: string) =>
+        (message: string): void => {
+            lines.push({ level, message });
+        };
+
+    return { lines, logger: { error: push("error"), info: push("info"), success: push("success"), warn: push("warn") } };
+};
+
+const diagnostic = (level: "error" | "warn", name: string) =>
+    ({ level, message: `${name} happened`, name, remediation: "do the thing", target: "aws" }) as never;
+
+describe("reportPlatformDiagnostics", () => {
+    it("says nothing and fails nothing when there are none", () => {
+        expect.assertions(2);
+
+        const { lines, logger } = recordingLogger();
+
+        expect(reportPlatformDiagnostics([], logger)).toBeUndefined();
+        // Silence on the default target is what keeps this out of every build log.
+        expect(lines).toStrictEqual([]);
+    });
+
+    it("warns without failing when every diagnostic is warn-level", () => {
+        expect.assertions(2);
+
+        const { lines, logger } = recordingLogger();
+
+        expect(reportPlatformDiagnostics([diagnostic("warn", "platform_note")], logger)).toBeUndefined();
+        expect(lines[0]?.level).toBe("warn");
+    });
+
+    it("fails the command on an error-level diagnostic", () => {
+        expect.assertions(2);
+
+        const { lines, logger } = recordingLogger();
+
+        // Both diagnostic kinds are declared `level: "error"` because each drops
+        // or misdirects an emitted surface. Printing that as a warning with a
+        // zero exit is how an app ships built against a surface its target
+        // cannot serve, with CI green the whole way.
+        expect(reportPlatformDiagnostics([diagnostic("error", "platform_unknown_target")], logger)).toBe("platform_unknown_target happened");
+        expect(lines[0]?.level).toBe("error");
+    });
+
+    it("fails when errors are mixed in with warnings", () => {
+        expect.assertions(1);
+
+        const { logger } = recordingLogger();
+
+        expect(reportPlatformDiagnostics([diagnostic("warn", "a"), diagnostic("error", "b")], logger)).toBe("b happened");
+    });
+});

--- a/packages/cli/src/commands/build/handler.ts
+++ b/packages/cli/src/commands/build/handler.ts
@@ -21,6 +21,14 @@ interface BuildCommandOptions {
     /** Directory the bundled worker is written to (default `.lunora/build`). */
     outDir?: string;
     spawner?: Spawner;
+
+    /**
+     * Deploy target the artifact is built for. Defaults to `"target"` in
+     * `lunora.json`, then `"cloudflare"`. `build` is the artifact half of the
+     * `lunora build` → `lunora deploy --prebuilt` CI split, so without this that
+     * split can only ever produce a default-target artifact.
+     */
+    target?: string;
 }
 
 /**
@@ -40,6 +48,7 @@ const runBuildCommand = async (options: BuildCommandOptions): Promise<DeployComm
         logger: options.logger,
         outDir: outDirectory,
         spawner: options.spawner,
+        target: options.target,
     });
 
     if (result.code === 0) {
@@ -57,6 +66,7 @@ const execute: CommandHandler<BuildOptions> = defineHandler<BuildOptions>(async 
         format: options.format,
         logger,
         outDir: options.outDir,
+        target: options.target,
     });
 
     return { code: result.code };

--- a/packages/cli/src/commands/build/index.ts
+++ b/packages/cli/src/commands/build/index.ts
@@ -1,6 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 import { API_SPEC_HELP } from "../../util/api-spec";
+import { TARGET_OPTION } from "../../util/deploy-target";
 
 /**
  * `lunora build` — run codegen + all pre-deploy gates and emit the bundled
@@ -23,6 +24,7 @@ const buildCommand: Command = {
     name: "build",
     options: [
         { description: `Which API spec(s) to emit: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
+        TARGET_OPTION,
         { description: "Output format: pretty (default) or json", name: "format", type: String },
         { description: "Directory to write the bundled Worker to (default .lunora/build)", name: "out-dir", type: String },
     ],
@@ -34,4 +36,5 @@ export type BuildOptions = CreateOptions<{
     "api-spec": string | undefined;
     format: string | undefined;
     "out-dir": string | undefined;
+    target: string | undefined;
 }>;

--- a/packages/cli/src/commands/codegen/handler.ts
+++ b/packages/cli/src/commands/codegen/handler.ts
@@ -5,9 +5,10 @@ import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
-import { resolveTargetOrThrow } from "../../util/deploy-target";
+import { resolveTargetOrError } from "../../util/deploy-target";
 import type { Logger } from "../../util/logger";
 import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
+import reportPlatformDiagnostics from "../../util/platform-diagnostics";
 import type { CodegenOptions } from "./index";
 
 /** Cloudflare caps a Worker at 3 Cron Triggers (distinct cron expressions). */
@@ -20,14 +21,14 @@ interface CodegenCommandOptions {
     /** Output format: `pretty` (default) or `json`. */
     format?: string;
     logger: Logger;
-    /** Deploy target the emitted `ctx.*` surface is tailored to. Defaults to `"cloudflare"`. */
+    /** Deploy target the emitted `ctx.*` surface is tailored to. Resolved by the caller; falls back to `"target"` in `lunora.json`, then `"cloudflare"`. */
     target?: string;
 }
 
 interface CodegenCommandResult {
     advisories: ReadonlyArray<{ detail: string; level: string; name: string; remediation: string }>;
     cronTriggers: ReadonlyArray<string>;
-    /** Set when the run aborted on an invalid `--format` before codegen ran. */
+    /** Set when the run failed: an invalid `--format`, an unregistered target, or an error-level platform diagnostic. */
     error?: string;
     outputDirectory: string;
 }
@@ -47,22 +48,18 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
         return { advisories: [], cronTriggers: [], error: formatError, outputDirectory: "" };
     }
 
-    let target: string;
+    // Validated here because codegen resolves no driver of its own — an
+    // unregistered name would otherwise emit the full Cloudflare surface
+    // un-gated and exit 0.
+    const resolvedTarget = resolveTargetOrError(projectRoot, options.target);
 
-    try {
-        // Resolved through the shared helper so a `lunora.json` target applies
-        // without the flag, and the emitted surface matches what `deploy` will
-        // ship it to. Validated here because codegen resolves no driver of its
-        // own — an unregistered name would otherwise emit the full Cloudflare
-        // surface un-gated and exit 0.
-        target = resolveTargetOrThrow(projectRoot, options.target);
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
+    if (resolvedTarget.target === undefined) {
+        options.logger.error(resolvedTarget.error ?? "unknown deploy target");
 
-        options.logger.error(message);
-
-        return { advisories: [], cronTriggers: [], error: message, outputDirectory: "" };
+        return { advisories: [], cronTriggers: [], error: resolvedTarget.error ?? "unknown deploy target", outputDirectory: "" };
     }
+
+    const { target } = resolvedTarget;
 
     const result = runCodegen({
         apiSpec: options.apiSpec,
@@ -95,16 +92,10 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
         logger.warn(`${count.toString()} schema ${count === 1 ? "advisory" : "advisories"}:\n${lines.join("\n")}`);
     }
 
-    // Platform-portability diagnostics: `ctx.*` features the deploy target does
-    // not support (omitted from the emitted surface) or an unknown target.
-    // Empty on the default Cloudflare target, so this stays silent there.
-    if (result.platformDiagnostics.length > 0) {
-        const count = result.platformDiagnostics.length;
-        const lines = result.platformDiagnostics.map(
-            (diagnostic) => `  [${diagnostic.level.toUpperCase()}] ${diagnostic.name} — ${diagnostic.message}\n      ↳ ${diagnostic.remediation}`,
-        );
+    const platformError = reportPlatformDiagnostics(result.platformDiagnostics, logger);
 
-        logger.warn(`${count.toString()} platform ${count === 1 ? "diagnostic" : "diagnostics"}:\n${lines.join("\n")}`);
+    if (platformError !== undefined) {
+        commandResult.error = platformError;
     }
 
     // Distinct cron expressions map 1:1 to wrangler `triggers.crons`; Cloudflare

--- a/packages/cli/src/commands/codegen/handler.ts
+++ b/packages/cli/src/commands/codegen/handler.ts
@@ -5,6 +5,7 @@ import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { resolveTargetOrThrow } from "../../util/deploy-target";
 import type { Logger } from "../../util/logger";
 import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
 import type { CodegenOptions } from "./index";
@@ -19,6 +20,8 @@ interface CodegenCommandOptions {
     /** Output format: `pretty` (default) or `json`. */
     format?: string;
     logger: Logger;
+    /** Deploy target the emitted `ctx.*` surface is tailored to. Defaults to `"cloudflare"`. */
+    target?: string;
 }
 
 interface CodegenCommandResult {
@@ -44,7 +47,29 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
         return { advisories: [], cronTriggers: [], error: formatError, outputDirectory: "" };
     }
 
-    const result = runCodegen({ apiSpec: options.apiSpec, projectRoot, wranglerVariables: collectWranglerSecretVariables(projectRoot) });
+    let target: string;
+
+    try {
+        // Resolved through the shared helper so a `lunora.json` target applies
+        // without the flag, and the emitted surface matches what `deploy` will
+        // ship it to. Validated here because codegen resolves no driver of its
+        // own — an unregistered name would otherwise emit the full Cloudflare
+        // surface un-gated and exit 0.
+        target = resolveTargetOrThrow(projectRoot, options.target);
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        options.logger.error(message);
+
+        return { advisories: [], cronTriggers: [], error: message, outputDirectory: "" };
+    }
+
+    const result = runCodegen({
+        apiSpec: options.apiSpec,
+        projectRoot,
+        target,
+        wranglerVariables: collectWranglerSecretVariables(projectRoot),
+    });
     const commandResult: CodegenCommandResult = {
         advisories: result.advisories.map((advisory) => {
             return {
@@ -101,7 +126,7 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
 
 /** `lunora codegen` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<CodegenOptions> = defineHandler<CodegenOptions>(({ cwd, logger, options }) => {
-    const result = runCodegenCommand({ apiSpec: parseApiSpec(options.apiSpec), cwd, format: options.format, logger });
+    const result = runCodegenCommand({ apiSpec: parseApiSpec(options.apiSpec), cwd, format: options.format, logger, target: options.target });
 
     return { code: result.error === undefined ? 0 : 1 };
 });

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -1,6 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 import { API_SPEC_HELP } from "../../util/api-spec";
+import { TARGET_OPTION } from "../../util/deploy-target";
 
 const codegenCommand: Command = {
     description: "Run codegen for lunora/ functions and schema",
@@ -13,10 +14,11 @@ const codegenCommand: Command = {
     name: "codegen",
     options: [
         { description: `Which API spec(s) to emit: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
+        TARGET_OPTION,
         { description: "Output format: pretty (default) or json", name: "format", type: String },
     ],
 };
 
 export { codegenCommand };
 
-export type CodegenOptions = CreateOptions<{ "api-spec": string | undefined; format: string | undefined }>;
+export type CodegenOptions = CreateOptions<{ "api-spec": string | undefined; format: string | undefined; target: string | undefined }>;

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -1206,6 +1206,7 @@ const execute: CommandHandler<DeployOptions> = defineHandler<DeployOptions>(asyn
         // `--prebuilt` trusts a prior `lunora build`/`prepare`: skip codegen (and
         // thus the drift gate, which has no fresh snapshot to measure).
         skipCodegen: options.prebuilt === true,
+        target: options.target,
         temporary: options.temporary === true,
         updateSchemaBaseline: options.updateSchemaBaseline === true,
     });

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -31,6 +31,7 @@ import { autoLinkFromDeployOutput } from "../../util/auto-link";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
 import { renderDeploySummary } from "../../util/deploy-summary";
+import { resolveTargetOrError } from "../../util/deploy-target";
 import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { DockerProbe } from "../../util/docker";
 import { isDockerAvailable } from "../../util/docker";
@@ -136,7 +137,8 @@ interface DeployCommandOptions {
     spawner?: Spawner;
 
     /**
-     * Deploy target. Defaults to `"cloudflare"`, which selects the wrangler
+     * Deploy target. Falls back to `"target"` in `lunora.json`, then
+     * `"cloudflare"`, which selects the wrangler
      * toolchain — i.e. today's behavior for every project. An unregistered name
      * throws rather than falling back, so a typo can never ship the app to the
      * wrong provider.
@@ -379,8 +381,14 @@ const syncCronTriggers = (cwd: string, logger: Logger, cronTriggers: ReadonlyArr
  * best-effort: a failure here must not abort the deploy, since the validator
  * still reports any genuinely missing requirement.
  */
-const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> | undefined): Promise<void> => {
+const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> | undefined, target: string): Promise<void> => {
     try {
+        // Resolved for its side effect: reject an unregistered target before
+        // reconciling a config shaped for the wrong provider. `prepare` routes
+        // its provisioning through `DeployDriver.provision`; deploy still
+        // reconciles inline, so this is the narrower equivalent guard.
+        resolveDeployDriver(target);
+
         const inferred = await inferLunoraBindings({ projectRoot: cwd });
         const reconciled = reconcileWranglerBindings(cwd, inferred);
 
@@ -487,13 +495,13 @@ const resolveRequiredSecretKeys = async (cwd: string): Promise<string[]> => {
 };
 
 /** Generate + `wrangler secret put` each mintable key (sequential; stops on first failure). Returns true on full success. */
-const pushMintableSecrets = async (cwd: string, options: DeployCommandOptions, keys: ReadonlyArray<string>): Promise<boolean> => {
+const pushMintableSecrets = async (cwd: string, options: DeployCommandOptions, keys: ReadonlyArray<string>, target: string): Promise<boolean> => {
     const { logger } = options;
     const spawner = options.spawner ?? defaultSpawner;
     const manager = detectPackageManager(cwd);
     const environmentFlag = options.env === undefined ? "" : ` --env ${options.env}`;
 
-    const { toolchain } = resolveDeployDriver(options.target);
+    const { toolchain } = resolveDeployDriver(target);
 
     if (toolchain === undefined) {
         logger.error("deploy target has no command-line toolchain; cannot push secrets");
@@ -539,7 +547,7 @@ const pushMintableSecrets = async (cwd: string, options: DeployCommandOptions, k
  * secret list can't be read — we proceed rather than guess. Any pushing happens
  * BEFORE the deploy spawn so the new version boots with the secrets present.
  */
-const offerMissingSecrets = async (cwd: string, options: DeployCommandOptions, interactive: boolean): Promise<string | undefined> => {
+const offerMissingSecrets = async (cwd: string, options: DeployCommandOptions, interactive: boolean, target: string): Promise<string | undefined> => {
     if (options.dryRun === true || options.preview === true) {
         return undefined;
     }
@@ -593,7 +601,7 @@ const offerMissingSecrets = async (cwd: string, options: DeployCommandOptions, i
     if (
         await confirm(`${String(mintable.length)} required secret(s) not set on the target (${mintable.join(", ")}). Generate strong values and push them now?`)
     ) {
-        await pushMintableSecrets(cwd, options, mintable);
+        await pushMintableSecrets(cwd, options, mintable, target);
 
         return undefined;
     }
@@ -724,7 +732,13 @@ const validateMigrateDeployPreflight = (options: DeployCommandOptions): string |
  * success (the deploy needs its schema snapshot for the drift gate), or an
  * `{ error }` message on failure.
  */
-const runCodegenStep = (cwd: string, interactive: boolean, logger: Logger, apiSpec: ApiSpec | undefined): { error?: string; result?: CodegenResult } => {
+const runCodegenStep = (
+    cwd: string,
+    interactive: boolean,
+    logger: Logger,
+    apiSpec: ApiSpec | undefined,
+    target: string,
+): { error?: string; result?: CodegenResult } => {
     let codegenSpinner: Spinner | undefined;
 
     if (interactive) {
@@ -735,7 +749,7 @@ const runCodegenStep = (cwd: string, interactive: boolean, logger: Logger, apiSp
     }
 
     try {
-        const result = runCodegen({ apiSpec, projectRoot: cwd });
+        const result = runCodegen({ apiSpec, projectRoot: cwd, target });
         codegenSpinner?.succeed("codegen complete");
 
         if (!codegenSpinner) {
@@ -946,7 +960,7 @@ const runPreDeployGates = async (cwd: string, options: DeployCommandOptions): Pr
  * caller via {@link execArgsFor}. Extracted from {@link executeDeploy} to keep
  * its cognitive complexity within budget.
  */
-const buildDeployCommand = (cwd: string, options: DeployCommandOptions): ToolchainCommand => {
+const buildDeployCommand = (cwd: string, options: DeployCommandOptions, target: string): ToolchainCommand => {
     // Class-B composition: bundle the `src/worker.ts` wrapper (which the
     // framework's CF adapter can't clobber) instead of the adapter-owned `main`.
     const composedEntry = resolveComposedWorkerEntry(cwd);
@@ -976,7 +990,7 @@ const buildDeployCommand = (cwd: string, options: DeployCommandOptions): Toolcha
     // The target's own CLI decides the flags; this command only says what it
     // wants done. Logging stays here because it is the CLI's voice, not the
     // driver's.
-    const driver = resolveDeployDriver(options.target);
+    const driver = resolveDeployDriver(target);
     const request = {
         dryRun: options.dryRun,
         entry: composedEntry,
@@ -1014,10 +1028,29 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
     const cwd = options.cwd ?? process.cwd();
     const interactive = isInteractive(options);
 
+    // Resolved ONCE, and before anything writes. Deploy rewrites `_generated/*`
+    // and may mutate `wrangler.jsonc` well before it reaches the wrangler step,
+    // so validating at the point of driver use would leave those side effects
+    // behind on an unknown target. Resolving here also means `lunora.json`'s
+    // `target` reaches the driver, not just the `--target` flag.
+    const resolvedTarget = resolveTargetOrError(cwd, options.target);
+
+    if (resolvedTarget.target === undefined) {
+        const message = resolvedTarget.error ?? "unknown deploy target";
+
+        // Logged here, not just returned: the caller only prints `error` in
+        // `--format json` mode, so a bare return exits 1 in silence.
+        options.logger.error(message);
+
+        return { code: 1, descriptor: undefined, error: message, validation: { problems: [], wranglerPath: undefined } };
+    }
+
+    const { target } = resolvedTarget;
+
     let codegen: CodegenResult | undefined;
 
     if (!options.skipCodegen) {
-        const codegenStep = runCodegenStep(cwd, interactive, options.logger, options.apiSpec);
+        const codegenStep = runCodegenStep(cwd, interactive, options.logger, options.apiSpec, target);
 
         if (codegenStep.error !== undefined) {
             return {
@@ -1064,7 +1097,7 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
         reblessSchemaBaseline = gate.rebless;
     }
 
-    await provisionBindings(cwd, options.logger, codegen?.cronTriggers);
+    await provisionBindings(cwd, options.logger, codegen?.cronTriggers, target);
 
     const migratePreflightError = validateMigrateDeployPreflight(options);
 
@@ -1097,7 +1130,7 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
     // Non-interactive (CI): a missing required secret aborts rather than shipping
     // a worker that will crash. Best-effort detection — skips dry-run/preview and
     // stays quiet when the worker can't be queried yet (first deploy / not authed).
-    const secretAbort = await offerMissingSecrets(cwd, options, interactive);
+    const secretAbort = await offerMissingSecrets(cwd, options, interactive, target);
 
     if (secretAbort !== undefined) {
         options.logger.error(secretAbort);
@@ -1110,7 +1143,7 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
     // existing links are never clobbered and subsequent deploys keep full TTY output.
     const shouldAutoLink = !isJsonFormat(options.format) && options.dryRun !== true && options.preview !== true && readLinkedProject(cwd) === undefined;
 
-    const deployCommand = buildDeployCommand(cwd, options);
+    const deployCommand = buildDeployCommand(cwd, options, target);
     const exec = execArgsFor(detectPackageManager(cwd), deployCommand.tool, deployCommand.args);
     const descriptor: SpawnDescriptor = {
         args: exec.args,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -1,6 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 import { API_SPEC_HELP } from "../../util/api-spec";
+import { TARGET_OPTION } from "../../util/deploy-target";
 
 const deployCommand: Command = {
     description: "Codegen, validate wrangler, then wrangler deploy",
@@ -21,6 +22,7 @@ const deployCommand: Command = {
         { description: `Which API spec(s) to emit: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
         { description: "Validate, bundle, and run pre-deploy gates without publishing (wrangler deploy --dry-run)", name: "dry-run", type: Boolean },
         { description: "Cloudflare environment name", name: "env", type: String },
+        TARGET_OPTION,
         { description: "Output format: pretty (default) or json", name: "format", type: String },
         { description: "After a successful deploy, run pending data migrations against the live worker", name: "migrate", type: Boolean },
         {
@@ -69,6 +71,7 @@ export type DeployOptions = CreateOptions<{
     "migrate-yes": boolean | undefined;
     prebuilt: boolean | undefined;
     preview: boolean | undefined;
+    target: string | undefined;
     temporary: boolean | undefined;
     "update-schema-baseline": boolean | undefined;
 }>;

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -32,6 +32,7 @@ import {
     readProjectRemotePreference,
     readWranglerJsonc,
     resolveDeployDriver,
+    resolveProjectTarget,
     resolveRemoteEnabled,
     resolveTargetOrThrow,
     streamContainerLogs,
@@ -323,7 +324,9 @@ const planDevCommand = (options: DevCommandOptions): DevCommandPlan => {
             // The sidecar runs `--config wrangler.dev.jsonc`, not the deploy
             // `wrangler.jsonc` — check its own `dev.ip` first.
             const loopbackArgs = resolveLoopbackArgs(cwd, options.hasIpv6Loopback ?? hasIpv6Loopback, DEV_WRANGLER_CONFIG);
-            const devCommand = resolveDeployDriver().toolchain?.dev({
+            // The toolchain is the target's, not always wrangler's — resolving from the
+            // project keeps a non-default target from shelling out to the wrong CLI.
+            const devCommand = resolveDeployDriver(resolveProjectTarget(cwd)).toolchain?.dev({
                 configPath: DEV_WRANGLER_CONFIG,
                 extraArgs: [...loopbackArgs, "--var", "WORKER_ENV:development"],
             });

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -33,6 +33,7 @@ import {
     readWranglerJsonc,
     resolveDeployDriver,
     resolveRemoteEnabled,
+    resolveTargetOrThrow,
     streamContainerLogs,
     updateDevServerState,
 } from "@lunora/config";
@@ -43,7 +44,6 @@ import type { CodegenWatcherHandle } from "../../util/codegen-watch";
 import { startCodegenWatch } from "../../util/codegen-watch";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
-import { resolveTargetOrThrow } from "../../util/deploy-target";
 import { detectPackageManager, execArgsFor, runScriptCommand } from "../../util/detect-package-manager";
 import { findAvailablePort } from "../../util/free-port";
 import type { Logger } from "../../util/logger";
@@ -121,7 +121,7 @@ interface DevCommandOptions {
     startWorker?: WorkerSpawner;
     /** Disable the embedded studio server. */
     studio?: boolean;
-    /** Deploy target the emitted `ctx.*` surface is tailored to. Defaults to `"cloudflare"`. */
+    /** Deploy target the emitted `ctx.*` surface is tailored to. Resolved by the caller; falls back to `"target"` in `lunora.json`, then `"cloudflare"`. */
     target?: string;
     /** `wrangler dev` port. */
     workerPort?: number;
@@ -856,13 +856,13 @@ const startStudioBestEffort = async (
  * owns the ongoing watch, but there's a startup race. Best-effort + a no-op for
  * every single-process flavor. A failure is surfaced but non-fatal.
  */
-const ensureSidecarGenerated = (plan: DevCommandPlan, options: DevCommandOptions, cwd: string, logger: Logger): void => {
+const ensureSidecarGenerated = (plan: DevCommandPlan, options: DevCommandOptions, cwd: string, logger: Logger, target: string): void => {
     if (plan.sidecar === undefined) {
         return;
     }
 
     try {
-        runCodegen({ apiSpec: options.apiSpec, lunoraDirectory: "lunora", projectRoot: cwd });
+        runCodegen({ apiSpec: options.apiSpec, lunoraDirectory: "lunora", projectRoot: cwd, target });
     } catch (error: unknown) {
         logger.warn(`codegen (pre-sidecar) failed: ${error instanceof Error ? error.message : String(error)} — the framework dev server will retry`);
     }
@@ -878,6 +878,13 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
     const plan = await buildDevPlan(options);
     const { logger } = options;
     const cwd = plan.wrangler.cwd ?? process.cwd();
+    // Resolved for every flavor, not just the ones that run the codegen watcher:
+    // the `vite` and `framework-worker` flavors have `codegenEnabled === false`,
+    // so gating on it accepted `--target` and then used it nowhere — while
+    // `lunora codegen --target <same typo>` exited 1. Resolving here also puts
+    // the failure before the dev-vars prompt and the start-record claim, rather
+    // than after them.
+    const target = resolveTargetOrThrow(cwd, options.target);
     // Register the remote temp-config disposer up front so it's torn down on
     // every exit path — including a throw during startup below (the `finally`).
     const handles: Teardown = { remoteCleanup: plan.remote.cleanup };
@@ -941,9 +948,7 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
                 apiSpec: options.apiSpec,
                 logger,
                 projectRoot: cwd,
-                // `dev` must emit the same surface `deploy` will ship, or a
-                // feature works locally and vanishes in production.
-                target: resolveTargetOrThrow(cwd, options.target),
+                target,
             });
         }
 
@@ -956,7 +961,7 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
             logger.warn(plan.frameworkHint);
         }
 
-        ensureSidecarGenerated(plan, options, cwd, logger);
+        ensureSidecarGenerated(plan, options, cwd, logger, target);
 
         const spawn = options.startWorker ?? defaultWorkerSpawner;
         const worker = spawn(plan.wrangler, logger);

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -43,6 +43,7 @@ import type { CodegenWatcherHandle } from "../../util/codegen-watch";
 import { startCodegenWatch } from "../../util/codegen-watch";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { resolveTargetOrThrow } from "../../util/deploy-target";
 import { detectPackageManager, execArgsFor, runScriptCommand } from "../../util/detect-package-manager";
 import { findAvailablePort } from "../../util/free-port";
 import type { Logger } from "../../util/logger";
@@ -120,6 +121,8 @@ interface DevCommandOptions {
     startWorker?: WorkerSpawner;
     /** Disable the embedded studio server. */
     studio?: boolean;
+    /** Deploy target the emitted `ctx.*` surface is tailored to. Defaults to `"cloudflare"`. */
+    target?: string;
     /** `wrangler dev` port. */
     workerPort?: number;
 }
@@ -934,7 +937,14 @@ const runDevCommand = async (options: DevCommandOptions): Promise<{ code: number
         }
 
         if (plan.codegenEnabled) {
-            handles.codegen = (options.startCodegen ?? startCodegenWatch)({ apiSpec: options.apiSpec, logger, projectRoot: cwd });
+            handles.codegen = (options.startCodegen ?? startCodegenWatch)({
+                apiSpec: options.apiSpec,
+                logger,
+                projectRoot: cwd,
+                // `dev` must emit the same surface `deploy` will ship, or a
+                // feature works locally and vanishes in production.
+                target: resolveTargetOrThrow(cwd, options.target),
+            });
         }
 
         handles.studio = await startStudioBestEffort(options, plan, cwd, logger);
@@ -1034,6 +1044,7 @@ const execute: CommandHandler<DevOptions> = defineHandler<DevOptions>(async ({ a
         port: options.port,
         remote,
         studio: options.studio === false ? false : undefined,
+        target: options.target,
         workerPort: options.workerPort,
     });
 });

--- a/packages/cli/src/commands/dev/index.ts
+++ b/packages/cli/src/commands/dev/index.ts
@@ -1,6 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 import { API_SPEC_HELP } from "../../util/api-spec";
+import { TARGET_OPTION } from "../../util/deploy-target";
 
 const devCommand: Command = {
     argument: {
@@ -30,6 +31,7 @@ const devCommand: Command = {
     // must reach a `--background` daemon has to be forwarded there explicitly.
     options: [
         { description: `Which API spec(s) codegen emits: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
+        TARGET_OPTION,
         { description: "Studio server port (default 6173)", name: "port", type: Number },
         { description: "wrangler dev port (default 8787)", name: "worker-port", type: Number },
         {
@@ -58,5 +60,6 @@ export type DevOptions = CreateOptions<{
     port: number | undefined;
     remote: boolean | undefined;
     studio: boolean | undefined;
+    target: string | undefined;
     "worker-port": number | undefined;
 }>;

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -490,6 +490,14 @@ const daemonArguments = (options: DevOptions, remote: boolean): string[] => {
         args.push("--no-studio");
     }
 
+    // Forwarded explicitly, like every other flag here: the daemon is a fresh
+    // process that re-parses argv, so an unforwarded flag is silently dropped.
+    // `lunora.json`'s target still reaches it (the daemon re-reads the config),
+    // which is what makes a missing `--target` look accepted and do nothing.
+    if (options.target !== undefined) {
+        args.push("--target", options.target);
+    }
+
     if (remote) {
         args.push("--remote");
     }

--- a/packages/cli/src/commands/env/handler.ts
+++ b/packages/cli/src/commands/env/handler.ts
@@ -13,6 +13,7 @@ import {
     parseDevVariableEntries,
     requiredSecrets,
     resolveDeployDriver,
+    resolveProjectTarget,
 } from "@lunora/config";
 
 import type { CommandHandler } from "../../util/command";
@@ -320,7 +321,9 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
     const descriptors: SpawnDescriptor[] = [];
 
     for (const entry of map.values()) {
-        const secretCommand = resolveDeployDriver().toolchain?.secretPut({
+        // The toolchain is the target's, not always wrangler's — resolving from the
+        // project keeps a non-default target from shelling out to the wrong CLI.
+        const secretCommand = resolveDeployDriver(resolveProjectTarget(cwd)).toolchain?.secretPut({
             environment: options.prod === true ? "production" : undefined,
             key: entry.key,
             temporary: options.temporary,

--- a/packages/cli/src/commands/logs/handler.ts
+++ b/packages/cli/src/commands/logs/handler.ts
@@ -130,6 +130,7 @@ const execute: CommandHandler<LogsOptions> = defineHandler<LogsOptions>(({ argum
         logger,
         search: options.search,
         status: options.status,
+        target: options.target,
         temporary: options.temporary === true,
         worker: argument[0],
     });

--- a/packages/cli/src/commands/logs/handler.ts
+++ b/packages/cli/src/commands/logs/handler.ts
@@ -25,7 +25,7 @@ interface LogsCommandOptions {
     spawner?: Spawner;
     /** Filter by invocation status: `ok`, `error`, or `canceled` (forwarded as `--status`). */
     status?: string;
-    /** Deploy target whose tail command to run. Defaults to `"cloudflare"`. */
+    /** Deploy target whose tail command to run. Resolved by the caller; falls back to `"target"` in `lunora.json`, then `"cloudflare"`. */
     target?: string;
 
     /**

--- a/packages/cli/src/commands/logs/index.ts
+++ b/packages/cli/src/commands/logs/index.ts
@@ -1,5 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
+import { TARGET_OPTION } from "../../util/deploy-target";
+
 /**
  * `lunora logs [worker]` — stream live logs from a deployed Lunora Worker by
  * wrapping `wrangler tail`, OR (with `--durable`) read the persisted `ctx.log`
@@ -18,6 +20,7 @@ const logsCommand: Command = {
     name: "logs",
     options: [
         { description: "Cloudflare environment name", name: "env", type: String },
+        TARGET_OPTION,
         { description: "Output format: pretty (default) or json", name: "format", type: String },
         { description: "Substring filter on log messages", name: "search", type: String },
         { description: "Filter by invocation status: ok, error, or canceled", name: "status", type: String },
@@ -67,6 +70,7 @@ export type LogsOptions = CreateOptions<{
     since: string | undefined;
     status: string | undefined;
     table: string | undefined;
+    target: string | undefined;
     temporary: boolean | undefined;
     "trace-id": string | undefined;
     until: string | undefined;

--- a/packages/cli/src/commands/prepare/handler.ts
+++ b/packages/cli/src/commands/prepare/handler.ts
@@ -13,6 +13,7 @@ import { parseApiSpec } from "../../util/api-spec";
 import { renderCodegenFailure } from "../../util/codegen-error";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { resolveTargetOrThrow } from "../../util/deploy-target";
 import type { Logger } from "../../util/logger";
 import { runSchemaDriftGate } from "../../util/schema-drift-gate";
 import { validateWrangler } from "../../util/wrangler-validator";
@@ -105,13 +106,17 @@ const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: Read
  */
 const runPrepareCommand = async (options: PrepareCommandOptions): Promise<PrepareCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
+    // Resolved ONCE and reused for both codegen and binding provisioning. Two
+    // resolutions could disagree — emitting a surface for one target while
+    // provisioning another's bindings — and nothing downstream would notice.
+    const target = resolveTargetOrThrow(cwd, options.target);
 
     options.logger.info("running codegen");
 
     let codegen: CodegenResult;
 
     try {
-        codegen = runCodegen({ apiSpec: options.apiSpec, projectRoot: cwd });
+        codegen = runCodegen({ apiSpec: options.apiSpec, projectRoot: cwd, target });
         options.logger.success("codegen complete");
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -147,7 +152,7 @@ const runPrepareCommand = async (options: PrepareCommandOptions): Promise<Prepar
         };
     }
 
-    await provisionBindings(cwd, options.logger, codegen.cronTriggers, options.target);
+    await provisionBindings(cwd, options.logger, codegen.cronTriggers, target);
 
     const validation = validateWrangler({ projectRoot: cwd });
 
@@ -182,6 +187,7 @@ const execute: CommandHandler<PrepareOptions> = defineHandler<PrepareOptions>(({
         apiSpec: parseApiSpec(options.apiSpec),
         cwd,
         logger,
+        target: options.target,
         updateSchemaBaseline: options.updateSchemaBaseline === true,
     }),
 );

--- a/packages/cli/src/commands/prepare/handler.ts
+++ b/packages/cli/src/commands/prepare/handler.ts
@@ -6,15 +6,15 @@
  */
 import type { CodegenResult } from "@lunora/codegen";
 import { runCodegen } from "@lunora/codegen";
-import { resolveDeployDriver } from "@lunora/config";
+import { resolveDeployDriver, resolveTargetOrThrow } from "@lunora/config";
 
 import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
 import { renderCodegenFailure } from "../../util/codegen-error";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
-import { resolveTargetOrThrow } from "../../util/deploy-target";
 import type { Logger } from "../../util/logger";
+import reportPlatformDiagnostics from "../../util/platform-diagnostics";
 import { runSchemaDriftGate } from "../../util/schema-drift-gate";
 import { validateWrangler } from "../../util/wrangler-validator";
 import type { PrepareOptions } from "./index";
@@ -28,7 +28,7 @@ interface PrepareCommandOptions {
     logger: Logger;
 
     /**
-     * Deploy target, matching `deploy` and `logs`. Defaults to `"cloudflare"`.
+     * Deploy target, matching `deploy` and `logs`. Resolved by the caller; falls back to `"target"` in `lunora.json`, then `"cloudflare"`.
      * Resolved through the same registry they use so a second driver does not
      * have to be found here separately.
      */
@@ -106,9 +106,8 @@ const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: Read
  */
 const runPrepareCommand = async (options: PrepareCommandOptions): Promise<PrepareCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
-    // Resolved ONCE and reused for both codegen and binding provisioning. Two
-    // resolutions could disagree — emitting a surface for one target while
-    // provisioning another's bindings — and nothing downstream would notice.
+    // Resolved ONCE and reused for both codegen and binding provisioning, so
+    // the emitted surface and the provisioned bindings cannot disagree.
     const target = resolveTargetOrThrow(cwd, options.target);
 
     options.logger.info("running codegen");
@@ -118,6 +117,10 @@ const runPrepareCommand = async (options: PrepareCommandOptions): Promise<Prepar
     try {
         codegen = runCodegen({ apiSpec: options.apiSpec, projectRoot: cwd, target });
         options.logger.success("codegen complete");
+
+        // `prepare` is the CI entry point, so a gated surface has to be visible
+        // here rather than only in the deployed app.
+        reportPlatformDiagnostics(codegen.platformDiagnostics, options.logger);
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
 

--- a/packages/cli/src/commands/prepare/index.ts
+++ b/packages/cli/src/commands/prepare/index.ts
@@ -1,6 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 import { API_SPEC_HELP } from "../../util/api-spec";
+import { TARGET_OPTION } from "../../util/deploy-target";
 
 const prepareCommand: Command = {
     description: "Run codegen + binding reconcile + wrangler validation (no Vite) — for CI",
@@ -14,6 +15,7 @@ const prepareCommand: Command = {
     options: [
         { description: "Override the schema-drift gate (proceed even with breaking schema drift and no migration)", name: "allow-schema-drift", type: Boolean },
         { description: `Which API spec(s) to emit: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
+        TARGET_OPTION,
         {
             description: "Re-bless the committed schema baseline (lunora/.lunora-schema.json) with the current shape",
             name: "update-schema-baseline",
@@ -27,5 +29,6 @@ export { prepareCommand };
 export type PrepareOptions = CreateOptions<{
     "allow-schema-drift": boolean | undefined;
     "api-spec": string | undefined;
+    target: string | undefined;
     "update-schema-baseline": boolean | undefined;
 }>;

--- a/packages/cli/src/commands/verify/handler.ts
+++ b/packages/cli/src/commands/verify/handler.ts
@@ -8,6 +8,7 @@ import { parseApiSpec } from "../../util/api-spec";
 import { renderCodegenHint } from "../../util/codegen-error";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
+import { resolveTargetOrError } from "../../util/deploy-target";
 import { detectPackageManager, execArgsFor } from "../../util/detect-package-manager";
 import type { Logger } from "../../util/logger";
 import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
@@ -39,16 +40,25 @@ interface VerifyCommandOptions {
      * health step is skipped entirely, so `verify` stays offline-safe by default.
      */
     healthUrl?: string;
+
     logger: Logger;
     /** Injectable subprocess runner for the tsc step; defaults to the real spawner. */
     spawner?: Spawner;
+
+    /**
+     * Deploy target the drift gate's snapshot is emitted for. Defaults to
+     * `"target"` in `lunora.json`, then `"cloudflare"`. Verify never writes, but
+     * a snapshot emitted for the wrong target compares against the wrong
+     * baseline.
+     */
+    target?: string;
     /** When false, skip the TypeScript type-check step. Defaults to true. */
     typecheck?: boolean;
 }
 
 interface VerifyCommandResult {
     code: number;
-    /** Set when the run aborted on an invalid `--format` before validation ran. */
+    /** Set when the run aborted before validation ran: an invalid `--format`, or an unregistered deploy target. */
     error?: string;
     errors: ReadonlyArray<string>;
     warnings: ReadonlyArray<string>;
@@ -194,7 +204,20 @@ const runVerifyCommand = async (options: VerifyCommandOptions): Promise<VerifyCo
         // `dryRun` keeps `lunora/_generated/` untouched but still returns the
         // current schema snapshot, so the read-only drift gate can run without
         // mutating any file (verify never writes — see `readOnly: true`).
-        const codegen = runCodegen({ apiSpec: options.apiSpec, dryRun: true, projectRoot: cwd });
+        // Validated even though verify never writes: the drift gate compares a
+        // snapshot emitted for this target against the committed baseline, so
+        // an unrecognized name silently checks the wrong surface.
+        const resolvedTarget = resolveTargetOrError(cwd, options.target);
+
+        if (resolvedTarget.target === undefined) {
+            const message = resolvedTarget.error ?? "unknown deploy target";
+
+            logger.error(message);
+
+            return { code: 1, error: message, errors: [message], warnings: [], wranglerPath: undefined };
+        }
+
+        const codegen = runCodegen({ apiSpec: options.apiSpec, dryRun: true, projectRoot: cwd, target: resolvedTarget.target });
         const gate = runSchemaDriftGate({ allowDrift: options.allowSchemaDrift === true, codegen, logger, readOnly: true });
 
         if (gate.blocked) {
@@ -244,6 +267,7 @@ const execute: CommandHandler<VerifyOptions> = defineHandler<VerifyOptions>(asyn
         format: options.format,
         healthUrl: options.healthUrl,
         logger,
+        target: options.target,
         // `--no-typecheck` is declared as a `no-*` option but cerebro exposes it
         // under the negated `typecheck` key (false when passed, true when absent).
         typecheck: options.typecheck === false ? false : undefined,

--- a/packages/cli/src/commands/verify/index.ts
+++ b/packages/cli/src/commands/verify/index.ts
@@ -1,6 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 import { API_SPEC_HELP } from "../../util/api-spec";
+import { TARGET_OPTION } from "../../util/deploy-target";
 
 const verifyCommand: Command = {
     description: "Validate wrangler.jsonc + codegen dry-run + tsc --noEmit (no files written)",
@@ -18,6 +19,7 @@ const verifyCommand: Command = {
     options: [
         { description: "Treat breaking schema drift as a warning instead of a failure", name: "allow-schema-drift", type: Boolean },
         { description: `Which API spec(s) to emit: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
+        TARGET_OPTION,
         { description: "Output format: pretty (default) or json", name: "format", type: String },
         {
             description: "Probe this deployment's /_lunora/health endpoint (off by default; keeps verify offline-safe)",
@@ -37,5 +39,6 @@ export type VerifyOptions = CreateOptions<{
     "api-spec": string | undefined;
     format: string | undefined;
     "health-url": string | undefined;
+    target: string | undefined;
     typecheck: boolean | undefined;
 }>;

--- a/packages/cli/src/util/codegen-watch.ts
+++ b/packages/cli/src/util/codegen-watch.ts
@@ -20,9 +20,9 @@ const DEFAULT_DEBOUNCE_MS = 100;
 const PATH_SEGMENT_SEPARATOR = /[/\\]/u;
 
 /** Run codegen once, logging success or surfacing a parse/emit error without throwing. */
-const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenOptions["apiSpec"], logger: Logger, reason: string): void => {
+const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenOptions["apiSpec"], logger: Logger, reason: string, target?: string): void => {
     try {
-        runCodegen({ apiSpec, lunoraDirectory, projectRoot });
+        runCodegen({ apiSpec, lunoraDirectory, projectRoot, target });
 
         logger.success(`codegen: wrote ${lunoraDirectory}/_generated (${reason})`);
     } catch (error: unknown) {
@@ -42,7 +42,7 @@ export const startCodegenWatch = (options: CodegenWatcherOptions): CodegenWatche
     const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
     const { apiSpec } = options;
 
-    runOnce(options.projectRoot, lunoraDirectory, apiSpec, options.logger, "startup");
+    runOnce(options.projectRoot, lunoraDirectory, apiSpec, options.logger, "startup", options.target);
 
     let timer: NodeJS.Timeout | undefined;
     let watcher: FSWatcher | undefined;
@@ -74,7 +74,16 @@ export const startCodegenWatch = (options: CodegenWatcherOptions): CodegenWatche
                 clearTimeout(timer);
             }
 
-            timer = setTimeout(runOnce, debounceMs, options.projectRoot, lunoraDirectory, apiSpec, options.logger, `change: ${filename ?? "?"}`);
+            timer = setTimeout(
+                runOnce,
+                debounceMs,
+                options.projectRoot,
+                lunoraDirectory,
+                apiSpec,
+                options.logger,
+                `change: ${filename ?? "?"}`,
+                options.target,
+            );
         });
     } catch (error: unknown) {
         options.logger.warn(
@@ -114,6 +123,8 @@ export interface CodegenWatcherOptions {
     lunoraDirectory?: string;
     /** Project root containing the `lunora/` directory. */
     projectRoot: string;
+    /** Deploy target the emitted `ctx.*` surface is tailored to. Defaults to `"cloudflare"`. */
+    target?: string;
 }
 
 export interface CodegenWatcherHandle {

--- a/packages/cli/src/util/codegen-watch.ts
+++ b/packages/cli/src/util/codegen-watch.ts
@@ -13,18 +13,34 @@ import { runCodegen } from "@lunora/codegen";
 
 import { renderCodegenFailure } from "./codegen-error";
 import type { Logger } from "./logger";
+import reportPlatformDiagnostics from "./platform-diagnostics";
 
 const DEFAULT_DEBOUNCE_MS = 100;
 
 /** Splits a watch filename into path segments to detect `_generated` writes. */
 const PATH_SEGMENT_SEPARATOR = /[/\\]/u;
 
-/** Run codegen once, logging success or surfacing a parse/emit error without throwing. */
-const runOnce = (projectRoot: string, lunoraDirectory: string, apiSpec: CodegenOptions["apiSpec"], logger: Logger, reason: string, target?: string): void => {
+/**
+ * Run codegen once, logging success or surfacing a parse/emit error without
+ * throwing.
+ *
+ * Takes an options object rather than positionals: four of its fields are
+ * already `CodegenWatcherOptions` fields, and the positional form existed only
+ * to feed `setTimeout`'s trailing-argument passing — which a closure does just
+ * as well, without leaving an argument order for the next parameter to get
+ * wrong.
+ */
+const runOnce = (options: Pick<CodegenWatcherOptions, "apiSpec" | "logger" | "projectRoot" | "target">, lunoraDirectory: string, reason: string): void => {
+    const { apiSpec, logger, projectRoot, target } = options;
+
     try {
-        runCodegen({ apiSpec, lunoraDirectory, projectRoot, target });
+        const result = runCodegen({ apiSpec, lunoraDirectory, projectRoot, target });
 
         logger.success(`codegen: wrote ${lunoraDirectory}/_generated (${reason})`);
+
+        // The watcher is a codegen path like any other: without this the dev
+        // loop emits a gated surface and says nothing about it.
+        reportPlatformDiagnostics(result.platformDiagnostics, logger);
     } catch (error: unknown) {
         logger.error(renderCodegenFailure(error, reason));
     }
@@ -40,9 +56,8 @@ export const startCodegenWatch = (options: CodegenWatcherOptions): CodegenWatche
     const lunoraDirectory = options.lunoraDirectory ?? "lunora";
     const watchDirectory = join(options.projectRoot, lunoraDirectory);
     const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
-    const { apiSpec } = options;
 
-    runOnce(options.projectRoot, lunoraDirectory, apiSpec, options.logger, "startup", options.target);
+    runOnce(options, lunoraDirectory, "startup");
 
     let timer: NodeJS.Timeout | undefined;
     let watcher: FSWatcher | undefined;
@@ -74,16 +89,9 @@ export const startCodegenWatch = (options: CodegenWatcherOptions): CodegenWatche
                 clearTimeout(timer);
             }
 
-            timer = setTimeout(
-                runOnce,
-                debounceMs,
-                options.projectRoot,
-                lunoraDirectory,
-                apiSpec,
-                options.logger,
-                `change: ${filename ?? "?"}`,
-                options.target,
-            );
+            timer = setTimeout(() => {
+                runOnce(options, lunoraDirectory, `change: ${filename ?? "?"}`);
+            }, debounceMs);
         });
     } catch (error: unknown) {
         options.logger.warn(
@@ -123,7 +131,7 @@ export interface CodegenWatcherOptions {
     lunoraDirectory?: string;
     /** Project root containing the `lunora/` directory. */
     projectRoot: string;
-    /** Deploy target the emitted `ctx.*` surface is tailored to. Defaults to `"cloudflare"`. */
+    /** Deploy target the emitted `ctx.*` surface is tailored to. Resolved by the caller; falls back to `"target"` in `lunora.json`, then `"cloudflare"`. */
     target?: string;
 }
 

--- a/packages/cli/src/util/deploy-target.ts
+++ b/packages/cli/src/util/deploy-target.ts
@@ -1,0 +1,52 @@
+/**
+ * The `--target` flag, shared by every command that resolves a deploy target
+ * (plan 114 §5.3/§5.5).
+ *
+ * One descriptor rather than a copy per command, so the help text can list the
+ * targets actually registered instead of a hand-maintained string that drifts
+ * the moment a driver lands.
+ *
+ * A command that omits the flag is not target-neutral — it is pinned to the
+ * default. Anything that resolves a `DeployDriver` or emits a `ctx.*` surface
+ * needs it, because those two must agree: codegen tailors the surface to a
+ * target while deploy picks the driver that ships it, and an app generated for
+ * one provider and deployed to another fails at runtime with nothing in the
+ * build to explain it.
+ */
+import { DEFAULT_DEPLOY_TARGET, deployTargetIds, resolveDeployDriver, resolveProjectTarget } from "@lunora/config";
+
+/** Human-readable list of registered targets, for help text and errors. */
+const TARGET_HELP = `${deployTargetIds().join(" | ")} (default ${DEFAULT_DEPLOY_TARGET})`;
+
+/** The `--target` option descriptor, spread into a command's `options` array. */
+const TARGET_OPTION = {
+    description: `Deploy target: ${TARGET_HELP}. Also settable as "target" in lunora.json`,
+    name: "target",
+    type: String,
+} as const;
+
+/**
+ * Resolve the target for a command and reject an unregistered one.
+ *
+ * The validation is the point. `resolveProjectTarget` deliberately passes an
+ * unknown name through — a typo must not collapse into the default — and the
+ * commands that resolve a `DeployDriver` then fail on it naturally. Codegen
+ * does not resolve a driver, so without this it would emit the full Cloudflare
+ * surface un-gated for a target that does not exist, report it as a warning,
+ * and exit `0`. That is the silent fallback the registry was designed to
+ * prevent, arriving through the back door.
+ *
+ * Routing every command through here also means one error message rather than
+ * one per entry point.
+ * @throws when the resolved target names no registered driver.
+ */
+const resolveTargetOrThrow = (projectRoot: string, explicit?: string): string => {
+    const target = resolveProjectTarget(projectRoot, explicit);
+
+    // Resolved purely to validate — the driver itself is the caller's business.
+    resolveDeployDriver(target);
+
+    return target;
+};
+
+export { resolveTargetOrThrow, TARGET_HELP, TARGET_OPTION };

--- a/packages/cli/src/util/deploy-target.ts
+++ b/packages/cli/src/util/deploy-target.ts
@@ -8,15 +8,22 @@
  *
  * A command that omits the flag is not target-neutral — it is pinned to the
  * default. Anything that resolves a `DeployDriver` or emits a `ctx.*` surface
- * needs it, because those two must agree: codegen tailors the surface to a
- * target while deploy picks the driver that ships it, and an app generated for
- * one provider and deployed to another fails at runtime with nothing in the
- * build to explain it.
+ * needs it; see `resolveProjectTarget` in `@lunora/config` for why those two
+ * must agree.
  */
-import { DEFAULT_DEPLOY_TARGET, deployTargetIds, resolveDeployDriver, resolveProjectTarget } from "@lunora/config";
+import { DEFAULT_DEPLOY_TARGET, deployTargetIds, resolveTargetOrThrow } from "@lunora/config";
 
-/** Human-readable list of registered targets, for help text and errors. */
-const TARGET_HELP = `${deployTargetIds().join(" | ")} (default ${DEFAULT_DEPLOY_TARGET})`;
+/**
+ * Human-readable list of registered targets, for help text and errors.
+ *
+ * The `(default …)` suffix is dropped while only one target is registered,
+ * where it would render as the redundant `cloudflare (default cloudflare)`.
+ */
+const TARGET_HELP = (() => {
+    const ids = deployTargetIds();
+
+    return ids.length > 1 ? `${ids.join(" | ")} (default ${DEFAULT_DEPLOY_TARGET})` : ids.join(" | ");
+})();
 
 /** The `--target` option descriptor, spread into a command's `options` array. */
 const TARGET_OPTION = {
@@ -26,27 +33,23 @@ const TARGET_OPTION = {
 } as const;
 
 /**
- * Resolve the target for a command and reject an unregistered one.
+ * Resolve and validate a target, reshaped to the return-an-error idiom the CLI
+ * handlers already use (see `validateOutputFormat`) rather than throwing.
  *
- * The validation is the point. `resolveProjectTarget` deliberately passes an
- * unknown name through — a typo must not collapse into the default — and the
- * commands that resolve a `DeployDriver` then fail on it naturally. Codegen
- * does not resolve a driver, so without this it would emit the full Cloudflare
- * surface un-gated for a target that does not exist, report it as a warning,
- * and exit `0`. That is the silent fallback the registry was designed to
- * prevent, arriving through the back door.
- *
- * Routing every command through here also means one error message rather than
- * one per entry point.
- * @throws when the resolved target names no registered driver.
+ * The throwing form is right for `@lunora/config`, whose callers differ; inside
+ * a handler it forces a try/catch around what is otherwise a flat sequence of
+ * guards, which is both noisier and a different shape from the guard sitting
+ * five lines above it.
+ * @param projectRoot Directory containing `lunora.json`.
+ * @param explicit A caller-supplied target, if any.
+ * @returns the resolved target, or the message explaining why it was rejected.
  */
-const resolveTargetOrThrow = (projectRoot: string, explicit?: string): string => {
-    const target = resolveProjectTarget(projectRoot, explicit);
-
-    // Resolved purely to validate — the driver itself is the caller's business.
-    resolveDeployDriver(target);
-
-    return target;
+const resolveTargetOrError = (projectRoot: string, explicit?: string): { error?: string; target?: string } => {
+    try {
+        return { target: resolveTargetOrThrow(projectRoot, explicit) };
+    } catch (error: unknown) {
+        return { error: error instanceof Error ? error.message : String(error) };
+    }
 };
 
-export { resolveTargetOrThrow, TARGET_HELP, TARGET_OPTION };
+export { resolveTargetOrError, TARGET_HELP, TARGET_OPTION };

--- a/packages/cli/src/util/platform-diagnostics.ts
+++ b/packages/cli/src/util/platform-diagnostics.ts
@@ -1,0 +1,53 @@
+/**
+ * Reporting for codegen's platform-portability diagnostics.
+ *
+ * Every path that runs codegen has to surface these, because each one means the
+ * emitted `ctx.*` surface does not match what the target can actually provide —
+ * either a used feature was dropped, or the target has no capability matrix at
+ * all and nothing was gated. A path that runs codegen and stays silent about
+ * them ships that mismatch to production, which is the failure the whole target
+ * seam exists to prevent.
+ *
+ * Shared rather than copied because there are four such paths (`codegen`,
+ * `prepare`, the dev watcher, and the Vite plugin's own equivalent), and a
+ * reporting rule that lives in four places is a rule that ends up applied in
+ * three.
+ */
+import type { PlatformDiagnostic } from "@lunora/codegen";
+
+import type { Logger } from "./logger";
+
+/**
+ * Log every diagnostic, and report whether any of them should fail the command.
+ *
+ * Error-level diagnostics fail. Both kinds carry `level: "error"` because each
+ * "drops or misdirects an emitted surface" (see `PlatformDiagnostic`), and
+ * reporting that as a warning with a zero exit is how an app ends up built
+ * against a surface its target cannot serve while CI stays green.
+ * @param diagnostics What `runCodegen` returned.
+ * @param logger Where the lines go.
+ * @returns the first error-level message, or `undefined` when nothing failed.
+ */
+const reportPlatformDiagnostics = (diagnostics: ReadonlyArray<PlatformDiagnostic>, logger: Logger): string | undefined => {
+    if (diagnostics.length === 0) {
+        return undefined;
+    }
+
+    const lines = diagnostics.map(
+        (diagnostic) => `  [${diagnostic.level.toUpperCase()}] ${diagnostic.name} — ${diagnostic.message}\n      ↳ ${diagnostic.remediation}`,
+    );
+    const errors = diagnostics.filter((diagnostic) => diagnostic.level === "error");
+    const heading = `${String(diagnostics.length)} platform ${diagnostics.length === 1 ? "diagnostic" : "diagnostics"}:\n${lines.join("\n")}`;
+
+    if (errors.length === 0) {
+        logger.warn(heading);
+
+        return undefined;
+    }
+
+    logger.error(heading);
+
+    return errors[0]?.message ?? "platform diagnostics reported an error";
+};
+
+export default reportPlatformDiagnostics;

--- a/packages/cli/src/util/wrangler-secrets.ts
+++ b/packages/cli/src/util/wrangler-secrets.ts
@@ -9,7 +9,7 @@
  */
 import { execFile } from "node:child_process";
 
-import { resolveDeployDriver } from "@lunora/config";
+import { resolveDeployDriver, resolveProjectTarget } from "@lunora/config";
 
 import { detectPackageManager, execArgsFor } from "./detect-package-manager";
 
@@ -90,7 +90,9 @@ const parseSecretNames = (stdout: string): ReadonlyArray<string> | undefined => 
 };
 
 const listRemoteSecrets = async (inputs: ListRemoteSecretsInputs): Promise<ListRemoteSecretsResult> => {
-    const listCommand = resolveDeployDriver().toolchain?.secretList({ environment: inputs.env, temporary: inputs.temporary });
+    // The toolchain is the target's, not always wrangler's — resolving from the
+    // project keeps a non-default target from shelling out to the wrong CLI.
+    const listCommand = resolveDeployDriver(resolveProjectTarget(inputs.cwd)).toolchain?.secretList({ environment: inputs.env, temporary: inputs.temporary });
 
     if (listCommand === undefined) {
         return { error: "deploy target has no command-line toolchain", names: [], ok: false };

--- a/packages/codegen/__tests__/platform-target.test.ts
+++ b/packages/codegen/__tests__/platform-target.test.ts
@@ -1,7 +1,14 @@
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import type { PlatformCapabilities } from "@lunora/platform";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { FeatureUsage } from "../src/discover-feature-usage";
+import { readProjectTarget, resolveCodegenTarget } from "../src/platform-target";
+import { runCodegen } from "../src/run-codegen";
 
 const ALL_OFF: FeatureUsage = {
     access: false,
@@ -99,5 +106,75 @@ describe("gatePlatformFeatures", () => {
         const result = gatePlatformFeatures(usage, "cloudflare");
 
         expect(result.usage).toStrictEqual(usage);
+    });
+});
+
+describe("project-declared target", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const fixtureRoot = join(here, "fixtures", "simple");
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-target-"));
+        cpSync(join(fixtureRoot, "lunora"), join(workdir, "lunora"), { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    const writeConfig = (text: string): void => {
+        writeFileSync(join(workdir, "lunora.json"), text, "utf8");
+    };
+
+    const diagnosticNames = (target?: string): string[] =>
+        runCodegen({ projectRoot: workdir, target }).platformDiagnostics.map((diagnostic) => diagnostic.name);
+
+    it("gates against the project's declared target when the caller passes none", () => {
+        expect.assertions(2);
+
+        expect(diagnosticNames()).toStrictEqual([]);
+
+        writeConfig(`{ "target": "aws" }`);
+
+        // The point of resolving inside `runCodegen`: a call site that forgets
+        // to thread a target would otherwise emit the DEFAULT surface with no
+        // diagnostic at all, and the mismatch would only surface at runtime on
+        // the deployed app.
+        expect(diagnosticNames()).toStrictEqual(["platform_unknown_target"]);
+    });
+
+    it("reads the target as JSONC, matching how the rest of lunora.json is parsed", () => {
+        expect.assertions(1);
+
+        // `@lunora/config` parses this file with `jsonc-parser`. A second reader
+        // using plain `JSON.parse` would reject a config the CLI accepts, which
+        // is exactly the drift a shared parser exists to prevent.
+        writeConfig(`{\n    // the target we ship to\n    "target": "aws",\n}`);
+
+        expect(diagnosticNames()).toStrictEqual(["platform_unknown_target"]);
+    });
+
+    it("lets an explicit target override the project config", () => {
+        expect.assertions(1);
+
+        writeConfig(`{ "target": "aws" }`);
+
+        expect(diagnosticNames("cloudflare")).toStrictEqual([]);
+    });
+
+    it("degrades to the default on an unusable config rather than throwing", () => {
+        expect.assertions(3);
+
+        writeConfig("{ not json");
+
+        expect(readProjectTarget(workdir)).toBeUndefined();
+
+        writeConfig(`{ "target": 42 }`);
+
+        // A non-string is a shape error, not a name the user meant — unlike a
+        // misspelled string, which must reach the registry and be rejected.
+        expect(readProjectTarget(workdir)).toBeUndefined();
+        expect(resolveCodegenTarget(workdir)).toBe("cloudflare");
     });
 });

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -65,11 +65,12 @@
         "@lunora/agent": "1.0.0-alpha.30",
         "@lunora/container": "1.0.0-alpha.17",
         "@lunora/errors": "1.0.0-alpha.9",
-        "@lunora/platform": "1.0.0-alpha.1",
+        "@lunora/platform": "workspace:*",
         "@lunora/queue": "1.0.0-alpha.11",
         "@lunora/scheduler": "1.0.0-alpha.13",
         "@lunora/values": "1.0.0-alpha.12",
         "@lunora/workflow": "1.0.0-alpha.14",
+        "jsonc-parser": "catalog:vite",
         "ts-morph": "catalog:tooling"
     },
     "devDependencies": {

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -78,7 +78,7 @@ export { buildOpenApiDocument, emitOpenApi, emitOpenApiModule } from "./openapi"
 export type { OpenRpcEmitInput } from "./openrpc";
 export { buildOpenRpcDocument, emitOpenRpc, emitOpenRpcModule, OPENRPC_VERSION } from "./openrpc";
 export type { PlatformDiagnostic } from "./platform-target";
-export { DEFAULT_TARGET, readProjectTarget, resolveCodegenTarget } from "./platform-target";
+export { DEFAULT_TARGET, platformMatrixIds, readProjectTarget, resolveCodegenTarget } from "./platform-target";
 export type { CodegenOptions, CodegenResult } from "./run-codegen";
 export { createCodegenProject, refreshCodegenProject, runCodegen, SCHEMA_SNAPSHOT_FILENAME } from "./run-codegen";
 export type {

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -78,7 +78,7 @@ export { buildOpenApiDocument, emitOpenApi, emitOpenApiModule } from "./openapi"
 export type { OpenRpcEmitInput } from "./openrpc";
 export { buildOpenRpcDocument, emitOpenRpc, emitOpenRpcModule, OPENRPC_VERSION } from "./openrpc";
 export type { PlatformDiagnostic } from "./platform-target";
-export { DEFAULT_TARGET } from "./platform-target";
+export { DEFAULT_TARGET, readProjectTarget, resolveCodegenTarget } from "./platform-target";
 export type { CodegenOptions, CodegenResult } from "./run-codegen";
 export { createCodegenProject, refreshCodegenProject, runCodegen, SCHEMA_SNAPSHOT_FILENAME } from "./run-codegen";
 export type {

--- a/packages/codegen/src/platform-target.ts
+++ b/packages/codegen/src/platform-target.ts
@@ -107,6 +107,19 @@ const PLATFORM_MATRICES: Readonly<Record<string, PlatformCapabilities>> = {
     cloudflare: CLOUDFLARE_CAPABILITIES,
 };
 
+/**
+ * The target ids codegen can gate against.
+ *
+ * Exported so `@lunora/config` can assert that its driver registry and this
+ * capability-matrix registry name the same targets. They are two id spaces for one
+ * concept: a target that ships a driver but no matrix passes the CLI's
+ * validation and then emits an un-gated surface, and one with a matrix but no
+ * driver gates a surface nothing can deploy. Today both hold exactly
+ * `cloudflare`, which is why nothing has noticed.
+ * @returns the registered matrix ids, sorted.
+ */
+const platformMatrixIds = (): ReadonlyArray<string> => Object.keys(PLATFORM_MATRICES).toSorted((a, b) => a.localeCompare(b));
+
 /** A platform feature key in the `@lunora/platform` capability matrix. */
 type PlatformFeatureKey = keyof PlatformCapabilities["features"];
 
@@ -224,4 +237,4 @@ const gatePlatformFeatures = (usage: FeatureUsage, target: string): PlatformGate
 };
 
 export type { PlatformDiagnostic, PlatformGateResult };
-export { DEFAULT_TARGET, gateAgainstMatrix, gatePlatformFeatures, PROJECT_CONFIG_FILE, readProjectTarget, resolveCodegenTarget };
+export { DEFAULT_TARGET, gateAgainstMatrix, gatePlatformFeatures, platformMatrixIds, PROJECT_CONFIG_FILE, readProjectTarget, resolveCodegenTarget };

--- a/packages/codegen/src/platform-target.ts
+++ b/packages/codegen/src/platform-target.ts
@@ -22,14 +22,81 @@
  * not have.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import type { PlatformCapabilities } from "@lunora/platform";
 import { CLOUDFLARE_CAPABILITIES } from "@lunora/platform";
+import type { ParseError } from "jsonc-parser";
+import { parse as parseJsonc } from "jsonc-parser";
 
 import type { CapabilityKey } from "./capabilities";
 import type { FeatureUsage } from "./discover-feature-usage";
 
 /** The default codegen target — today's behavior, byte-identical goldens. */
 const DEFAULT_TARGET = "cloudflare";
+
+/** The project-config file the target is declared in. Same file `@lunora/config` reads for `remote`. */
+const PROJECT_CONFIG_FILE = "lunora.json";
+
+/**
+ * Read `target` from `&lt;projectRoot>/lunora.json`.
+ *
+ * This lives in `@lunora/codegen` rather than `@lunora/config` — where the rest
+ * of the `lunora.json` reading lives — because `@lunora/config` depends on
+ * `@lunora/codegen`, not the reverse. Putting it there and importing it here
+ * would invert that edge, so config delegates to this instead and there is
+ * still exactly one parser for the key.
+ *
+ * Best-effort and deliberately unvalidated: a missing file, malformed JSONC, or
+ * a non-string value all collapse to `undefined`, because those are shape
+ * errors rather than a name the user meant. An unrecognized *name* is returned
+ * as-is so the caller's registry lookup rejects it — swallowing a typo into the
+ * default would ship an app to the wrong provider.
+ * @param projectRoot Directory containing `lunora.json`.
+ * @returns the declared target, or `undefined` when none is usable.
+ */
+const readProjectTarget = (projectRoot: string): string | undefined => {
+    const configPath = join(projectRoot, PROJECT_CONFIG_FILE);
+
+    if (!existsSync(configPath)) {
+        return undefined;
+    }
+
+    let text: string;
+
+    try {
+        text = readFileSync(configPath, "utf8");
+    } catch {
+        return undefined;
+    }
+
+    const parseErrors: ParseError[] = [];
+    const parsed: unknown = parseJsonc(text, parseErrors, { allowTrailingComma: true });
+
+    if (parseErrors.length > 0 || parsed === null || typeof parsed !== "object") {
+        return undefined;
+    }
+
+    const { target } = parsed as { target?: unknown };
+
+    return typeof target === "string" && target.length > 0 ? target : undefined;
+};
+
+/**
+ * The target codegen should emit for: an explicit option wins, then
+ * `lunora.json`, then the default.
+ *
+ * `runCodegen` applies this itself so a caller that forgets to pass a target
+ * still emits the surface the project declared. That default matters more than
+ * it looks: a call site that silently omits the target emits the *default*
+ * surface with no diagnostic to notice, and the mismatch only shows up at
+ * runtime on the deployed app.
+ * @param projectRoot Directory containing `lunora.json`.
+ * @param explicit A caller-supplied target, if any.
+ * @returns the resolved target id — not guaranteed to be registered.
+ */
+const resolveCodegenTarget = (projectRoot: string, explicit?: string): string => explicit ?? readProjectTarget(projectRoot) ?? DEFAULT_TARGET;
 
 /**
  * The capability matrices codegen can gate against, keyed by target id. One
@@ -157,4 +224,4 @@ const gatePlatformFeatures = (usage: FeatureUsage, target: string): PlatformGate
 };
 
 export type { PlatformDiagnostic, PlatformGateResult };
-export { DEFAULT_TARGET, gateAgainstMatrix, gatePlatformFeatures };
+export { DEFAULT_TARGET, gateAgainstMatrix, gatePlatformFeatures, PROJECT_CONFIG_FILE, readProjectTarget, resolveCodegenTarget };

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -93,7 +93,7 @@ import type { AgentIR, ContainerIR, QueueIR, WorkflowIR, WranglerVariableIR } fr
 import { buildOpenApiDocument, emitOpenApiModule } from "./openapi";
 import { buildOpenRpcDocument, emitOpenRpcModule } from "./openrpc";
 import type { PlatformDiagnostic } from "./platform-target";
-import { DEFAULT_TARGET, gatePlatformFeatures } from "./platform-target";
+import { gatePlatformFeatures, resolveCodegenTarget } from "./platform-target";
 import type { SchemaSnapshot } from "./schema-drift";
 import { buildSchemaSnapshot, serializeSchemaSnapshot } from "./schema-drift";
 
@@ -521,7 +521,11 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // gate is the identity and the emitted surface (and goldens) is unchanged;
     // a target that lacks a used feature omits its `ctx.*` surface below and
     // reports a `platform_unsupported_feature` diagnostic.
-    const platformGate = gatePlatformFeatures(rawFeatureUsage, options.target ?? DEFAULT_TARGET);
+    // Resolved here rather than demanded of every caller: a call site that omits
+    // the target emits the DEFAULT surface with no diagnostic, so the mismatch
+    // stays invisible until the deployed app fails. Falling back to the
+    // project's declared target makes every caller correct without remembering.
+    const platformGate = gatePlatformFeatures(rawFeatureUsage, resolveCodegenTarget(options.projectRoot, options.target));
     const featureUsage = platformGate.usage;
     const hasAi = featureUsage.ai;
     const hasPayments = featureUsage.payments;

--- a/packages/config/__tests__/project-config.test.ts
+++ b/packages/config/__tests__/project-config.test.ts
@@ -2,9 +2,10 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { platformMatrixIds } from "@lunora/codegen";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { DEFAULT_DEPLOY_TARGET, resolveDeployDriver } from "../src/driver-registry";
+import { DEFAULT_DEPLOY_TARGET, deployTargetIds, resolveDeployDriver } from "../src/driver-registry";
 import { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget } from "../src/project-config";
 
 describe("interpretRemote", () => {
@@ -162,5 +163,20 @@ describe("deploy-target resolution", () => {
         // was unrecognized ships an app to the wrong provider.
         expect(resolveProjectTarget(root)).toBe("clouflare");
         expect(() => resolveDeployDriver(resolveProjectTarget(root))).toThrow(/unknown deploy target "clouflare"/);
+    });
+});
+
+describe("target registries", () => {
+    it("keeps the driver registry and codegen's capability matrices in agreement", () => {
+        expect.assertions(1);
+
+        // Two id spaces for one concept. A target with a driver but no matrix
+        // passes `resolveTargetOrThrow` and then emits an un-gated surface —
+        // reintroducing the silent fallback with the guard fully in place. One
+        // with a matrix but no driver gates a surface nothing can deploy.
+        // They agree today only because both hold exactly `cloudflare`; this is
+        // what makes the next target's omission a failing test instead of a
+        // production surprise.
+        expect(deployTargetIds()).toStrictEqual(platformMatrixIds());
     });
 });

--- a/packages/config/__tests__/project-config.test.ts
+++ b/packages/config/__tests__/project-config.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference } from "../src/project-config";
+import { DEFAULT_DEPLOY_TARGET, resolveDeployDriver } from "../src/driver-registry";
+import { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget } from "../src/project-config";
 
 describe("interpretRemote", () => {
     it("passes a boolean through unchanged", () => {
@@ -86,5 +87,80 @@ describe("readProjectRemotePreference", () => {
         writeFileSync(join(root, LUNORA_CONFIG_FILE), `{ "name": "app" }`, "utf8");
 
         expect(readProjectRemotePreference(root)).toBeUndefined();
+    });
+});
+
+describe("deploy-target resolution", () => {
+    let root: string;
+
+    beforeEach(() => {
+        root = mkdtempSync(join(tmpdir(), "lunora-project-config-"));
+    });
+
+    afterEach(() => {
+        rmSync(root, { force: true, recursive: true });
+    });
+
+    const writeConfig = (config: unknown): void => {
+        writeFileSync(join(root, LUNORA_CONFIG_FILE), JSON.stringify(config), "utf8");
+    };
+
+    it("falls back to the registry default with no flag and no config", () => {
+        expect.assertions(2);
+
+        expect(readProjectTarget(root)).toBeUndefined();
+        expect(resolveProjectTarget(root)).toBe(DEFAULT_DEPLOY_TARGET);
+    });
+
+    it("reads the target from lunora.json", () => {
+        expect.assertions(2);
+
+        writeConfig({ remote: true, target: "aws" });
+
+        expect(readProjectTarget(root)).toBe("aws");
+        expect(resolveProjectTarget(root)).toBe("aws");
+    });
+
+    it("lets an explicit target win over the config", () => {
+        expect.assertions(1);
+
+        writeConfig({ target: "aws" });
+
+        // `--target` is the per-invocation override; a project that normally
+        // ships to one provider must be able to build for another without
+        // editing the committed config.
+        expect(resolveProjectTarget(root, "cloudflare")).toBe("cloudflare");
+    });
+
+    it("ignores a non-string target", () => {
+        expect.assertions(2);
+
+        // A shape error is not a name the user meant, so it collapses to "no
+        // preference" — unlike a misspelled string, which must reach the
+        // registry and throw.
+        writeConfig({ target: 42 });
+
+        expect(readProjectTarget(root)).toBeUndefined();
+        expect(resolveProjectTarget(root)).toBe(DEFAULT_DEPLOY_TARGET);
+    });
+
+    it("degrades to the default on a malformed config rather than throwing", () => {
+        expect.assertions(1);
+
+        writeFileSync(join(root, LUNORA_CONFIG_FILE), "{ not json", "utf8");
+
+        expect(resolveProjectTarget(root)).toBe(DEFAULT_DEPLOY_TARGET);
+    });
+
+    it("carries a misspelled target through to a throwing driver lookup", () => {
+        expect.assertions(2);
+
+        writeConfig({ target: "clouflare" });
+
+        // The whole point of the resolution order: a typo must NOT be swallowed
+        // into the default. Quietly deploying to Cloudflare because the name
+        // was unrecognized ships an app to the wrong provider.
+        expect(resolveProjectTarget(root)).toBe("clouflare");
+        expect(() => resolveDeployDriver(resolveProjectTarget(root))).toThrow(/unknown deploy target "clouflare"/);
     });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -69,7 +69,7 @@ export { default as LunoraReporter } from "./lunora-reporter";
 export type { SecretEntry } from "./package-secrets-registry";
 export { PACKAGE_SECRETS_REGISTRY, secretsForPackages } from "./package-secrets-registry";
 export type { LunoraProjectConfig, RemotePreference } from "./project-config";
-export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference } from "./project-config";
+export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget } from "./project-config";
 export type { MultiSelectOption, SelectOption } from "./prompt";
 export { createConfirm, isInteractive, promptMultiSelect, promptSelect, promptText, promptYesNo } from "./prompt";
 export type { ExportGap, ReconcileBindingsResult } from "./reconcile-bindings";

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -69,7 +69,14 @@ export { default as LunoraReporter } from "./lunora-reporter";
 export type { SecretEntry } from "./package-secrets-registry";
 export { PACKAGE_SECRETS_REGISTRY, secretsForPackages } from "./package-secrets-registry";
 export type { LunoraProjectConfig, RemotePreference } from "./project-config";
-export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget } from "./project-config";
+export {
+    interpretRemote,
+    LUNORA_CONFIG_FILE,
+    readProjectRemotePreference,
+    readProjectTarget,
+    resolveProjectTarget,
+    resolveTargetOrThrow,
+} from "./project-config";
 export type { MultiSelectOption, SelectOption } from "./prompt";
 export { createConfirm, isInteractive, promptMultiSelect, promptSelect, promptText, promptYesNo } from "./prompt";
 export type { ExportGap, ReconcileBindingsResult } from "./reconcile-bindings";

--- a/packages/config/src/project-config.ts
+++ b/packages/config/src/project-config.ts
@@ -2,9 +2,10 @@
  * `lunora.json` — the optional project config file at the repo root.
  *
  * It is distinct from `wrangler.jsonc` (the Cloudflare worker config): this is
- * Lunora-level project settings the CLI + Vite plugin read. Today it carries one
- * key, `remote`, which opts the project into remote-binding dev (PLAN5 §5.3)
- * without needing the `--remote` flag or `LUNORA_REMOTE` env on every run.
+ * Lunora-level project settings the CLI + Vite plugin read. It carries `remote`,
+ * which opts the project into remote-binding dev (PLAN5 §5.3) without needing
+ * the `--remote` flag or `LUNORA_REMOTE` env on every run, and `target`, which
+ * selects the deploy target (plan 114 §5.3/§5.5).
  *
  * The file is entirely optional and best-effort: a missing file, malformed
  * JSONC, or an unexpected `remote` value all degrade to "no project preference"
@@ -15,6 +16,7 @@ import { existsSync, readFileSync } from "node:fs";
 import type { ParseError } from "jsonc-parser";
 import { parse as parseJsonc } from "jsonc-parser";
 
+import { DEFAULT_DEPLOY_TARGET } from "./driver-registry";
 import join from "./path";
 
 /** The canonical project-config filename probed at the project root. */
@@ -35,6 +37,7 @@ type RemotePreference = boolean | undefined;
 /** The structural slice of `lunora.json` Lunora reads. */
 interface LunoraProjectConfig {
     remote?: unknown;
+    target?: unknown;
 }
 
 /**
@@ -62,7 +65,7 @@ const interpretRemote = (value: unknown): RemotePreference => {
  * parse error, or unexpected shape all collapse to `undefined` so the caller
  * falls through to the env/flag layers.
  */
-const readProjectRemotePreference = (projectRoot: string): RemotePreference => {
+const readProjectConfig = (projectRoot: string): LunoraProjectConfig | undefined => {
     const configPath = join(projectRoot, LUNORA_CONFIG_FILE);
 
     if (!existsSync(configPath)) {
@@ -84,8 +87,39 @@ const readProjectRemotePreference = (projectRoot: string): RemotePreference => {
         return undefined;
     }
 
-    return interpretRemote((parsed as LunoraProjectConfig).remote);
+    return parsed;
 };
 
+const readProjectRemotePreference = (projectRoot: string): RemotePreference => interpretRemote(readProjectConfig(projectRoot)?.remote);
+
+/**
+ * Read the project's deploy `target` from `lunora.json`, or `undefined` when
+ * absent.
+ *
+ * Deliberately NOT validated here. An unknown name must reach
+ * `resolveDeployDriver`, which throws and lists the registered targets —
+ * treating a typo as "no preference" would silently deploy to Cloudflare
+ * because `"clouflare"` was not recognized, which is the one failure mode
+ * target selection must never have. Only a non-string (or absent) value
+ * collapses to `undefined`, since that is a shape error rather than a name the
+ * user meant.
+ */
+const readProjectTarget = (projectRoot: string): string | undefined => {
+    const { target } = readProjectConfig(projectRoot) ?? {};
+
+    return typeof target === "string" && target.length > 0 ? target : undefined;
+};
+
+/**
+ * Resolve the deploy target for a command: an explicit `--target` wins, then
+ * `lunora.json`, then the registry default.
+ *
+ * One resolution point on purpose. Codegen tailors the emitted `ctx.*` surface
+ * to a target while deploy picks the driver that ships it — resolving those
+ * separately lets them disagree, and an app generated for one provider and
+ * deployed to another fails at runtime with nothing in the build to explain it.
+ */
+const resolveProjectTarget = (projectRoot: string, explicit?: string): string => explicit ?? readProjectTarget(projectRoot) ?? DEFAULT_DEPLOY_TARGET;
+
 export type { LunoraProjectConfig, RemotePreference };
-export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference };
+export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget };

--- a/packages/config/src/project-config.ts
+++ b/packages/config/src/project-config.ts
@@ -13,10 +13,11 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 
+import { readProjectTarget as readCodegenProjectTarget } from "@lunora/codegen";
 import type { ParseError } from "jsonc-parser";
 import { parse as parseJsonc } from "jsonc-parser";
 
-import { DEFAULT_DEPLOY_TARGET } from "./driver-registry";
+import { DEFAULT_DEPLOY_TARGET, resolveDeployDriver } from "./driver-registry";
 import join from "./path";
 
 /** The canonical project-config filename probed at the project root. */
@@ -60,10 +61,11 @@ const interpretRemote = (value: unknown): RemotePreference => {
 };
 
 /**
- * Read the project's `remote` preference from `lunora.json`, or `undefined` when
- * there's no usable preference. Best-effort: never throws — a missing file,
- * parse error, or unexpected shape all collapse to `undefined` so the caller
- * falls through to the env/flag layers.
+ * Parse `lunora.json`, or `undefined` when there is nothing usable to read.
+ *
+ * Best-effort by design: a missing file, unreadable file, malformed JSONC, or
+ * non-object root all collapse to `undefined` so a typo in an optional config
+ * never breaks a command that would otherwise run fine without it.
  */
 const readProjectConfig = (projectRoot: string): LunoraProjectConfig | undefined => {
     const configPath = join(projectRoot, LUNORA_CONFIG_FILE);
@@ -90,36 +92,63 @@ const readProjectConfig = (projectRoot: string): LunoraProjectConfig | undefined
     return parsed;
 };
 
+/**
+ * Read the project's `remote` preference, or `undefined` when there is no
+ * usable one — the caller then falls through to the env/flag layers.
+ */
 const readProjectRemotePreference = (projectRoot: string): RemotePreference => interpretRemote(readProjectConfig(projectRoot)?.remote);
 
 /**
  * Read the project's deploy `target` from `lunora.json`, or `undefined` when
  * absent.
  *
- * Deliberately NOT validated here. An unknown name must reach
- * `resolveDeployDriver`, which throws and lists the registered targets —
- * treating a typo as "no preference" would silently deploy to Cloudflare
- * because `"clouflare"` was not recognized, which is the one failure mode
- * target selection must never have. Only a non-string (or absent) value
- * collapses to `undefined`, since that is a shape error rather than a name the
- * user meant.
+ * Delegates to `@lunora/codegen` rather than re-reading the file here.
+ * `runCodegen` has to resolve the same key without this package (config
+ * depends on codegen, not the reverse), so the parser lives there and this is a
+ * re-export — two readers of one key is exactly the kind of copy that drifts.
  */
-const readProjectTarget = (projectRoot: string): string | undefined => {
-    const { target } = readProjectConfig(projectRoot) ?? {};
-
-    return typeof target === "string" && target.length > 0 ? target : undefined;
-};
+const readProjectTarget = (projectRoot: string): string | undefined => readCodegenProjectTarget(projectRoot);
 
 /**
  * Resolve the deploy target for a command: an explicit `--target` wins, then
  * `lunora.json`, then the registry default.
  *
- * One resolution point on purpose. Codegen tailors the emitted `ctx.*` surface
- * to a target while deploy picks the driver that ships it — resolving those
- * separately lets them disagree, and an app generated for one provider and
- * deployed to another fails at runtime with nothing in the build to explain it.
+ * **This is the canonical resolution point, and the reason it is one place.**
+ * Codegen tailors the emitted `ctx.*` surface to a target while deploy picks
+ * the driver that ships it. Resolve those separately and they can disagree,
+ * producing an app that builds cleanly and fails at runtime with nothing in the
+ * build to explain it. Every caller — CLI commands, the Vite plugin,
+ * `runCodegen`'s own fallback — resolves through here or through
+ * {@link resolveTargetOrThrow}, so there is exactly one precedence order to
+ * reason about.
  */
 const resolveProjectTarget = (projectRoot: string, explicit?: string): string => explicit ?? readProjectTarget(projectRoot) ?? DEFAULT_DEPLOY_TARGET;
 
+/**
+ * Resolve the deploy target as {@link resolveProjectTarget} does, then reject
+ * one that no registered driver serves.
+ *
+ * Lives here rather than in `@lunora/cli` because nothing about it is
+ * CLI-shaped and the Vite plugin needs the same guard — a validator only the
+ * CLI could reach left `vite build` emitting the default surface for a
+ * mis-declared target, silently.
+ *
+ * Callers that go on to resolve a driver get this for free; the ones that never
+ * look a driver up — codegen, the Vite plugin — need it, because otherwise
+ * nothing in their path ever rejects the name.
+ * @param projectRoot Directory containing `lunora.json`.
+ * @param explicit A caller-supplied target, if any.
+ * @throws when the resolved target names no registered driver.
+ * @returns the resolved, registered target id.
+ */
+const resolveTargetOrThrow = (projectRoot: string, explicit?: string): string => {
+    const target = resolveProjectTarget(projectRoot, explicit);
+
+    // Resolved purely to validate — the driver itself is the caller's business.
+    resolveDeployDriver(target);
+
+    return target;
+};
+
 export type { LunoraProjectConfig, RemotePreference };
-export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget };
+export { interpretRemote, LUNORA_CONFIG_FILE, readProjectRemotePreference, readProjectTarget, resolveProjectTarget, resolveTargetOrThrow };

--- a/packages/vite/__tests__/agent-rules-hint-plugin.test.ts
+++ b/packages/vite/__tests__/agent-rules-hint-plugin.test.ts
@@ -18,6 +18,7 @@ const makeOptions = (projectRoot: string): ResolvedLunoraPluginOptions => {
         overlay: false,
         projectRoot,
         schemaDir: "lunora",
+        target: "cloudflare",
         studio: false,
         validateWrangler: false,
     };

--- a/packages/vite/__tests__/codegen-plugin.test.ts
+++ b/packages/vite/__tests__/codegen-plugin.test.ts
@@ -71,6 +71,7 @@ const makeOptions = (projectRoot: string): ResolvedLunoraPluginOptions => {
         overlay: false,
         projectRoot,
         schemaDir: "lunora",
+        target: "cloudflare",
         validateWrangler: false,
     };
 };

--- a/packages/vite/__tests__/dev-variables-plugin.test.ts
+++ b/packages/vite/__tests__/dev-variables-plugin.test.ts
@@ -17,6 +17,7 @@ const RESOLVED = (projectRoot: string) => {
         overlay: false as const,
         projectRoot,
         schemaDir: "lunora",
+        target: "cloudflare",
         studio: true,
         validateWrangler: false,
     };

--- a/packages/vite/__tests__/framework-compose-plugin.test.ts
+++ b/packages/vite/__tests__/framework-compose-plugin.test.ts
@@ -36,6 +36,7 @@ const baseOptions = (overrides: Partial<ResolvedLunoraPluginOptions> = {}): Reso
         overlay: false,
         projectRoot: "/workspace/app",
         schemaDir: "lunora",
+        target: "cloudflare",
         studio: true,
         validateWrangler: true,
         ...overrides,

--- a/packages/vite/__tests__/wrangler-validator-plugin.test.ts
+++ b/packages/vite/__tests__/wrangler-validator-plugin.test.ts
@@ -59,6 +59,7 @@ const makeOptions = (projectRoot: string): ResolvedLunoraPluginOptions => {
         overlay: false,
         projectRoot,
         schemaDir: "lunora",
+        target: "cloudflare",
         validateWrangler: true,
     };
 };

--- a/packages/vite/src/codegen-plugin.ts
+++ b/packages/vite/src/codegen-plugin.ts
@@ -176,6 +176,22 @@ const runCodegenSafely = (
             }
         }
 
+        // Platform-portability diagnostics: a `ctx.*` surface the target cannot
+        // provide, or a target with no registered capability matrix. Surfaced
+        // here for the same reason the CLI surfaces them — without this a
+        // `vite build` against a mis-declared target emits the default surface,
+        // prints nothing, and exits 0, which is the Vite-first path around the
+        // guard the CLI already has.
+        for (const diagnostic of result.platformDiagnostics) {
+            const line = advisoryLine(diagnostic.level === "error" ? "ERROR" : "WARN", diagnostic.name, diagnostic.message, diagnostic.remediation);
+
+            if (diagnostic.level === "error") {
+                logger.error(line);
+            } else {
+                logger.warn(line);
+            }
+        }
+
         // Codegen succeeded. The browser error overlay (if any was shown) is
         // cleared by the single `full-reload` the change handler sends after a
         // successful run — so there is nothing to do here. (Build mode passes no

--- a/packages/vite/src/codegen-plugin.ts
+++ b/packages/vite/src/codegen-plugin.ts
@@ -138,7 +138,7 @@ const reconcileWranglerExtras = (
  * behaviour.
  */
 const runCodegenSafely = (
-    options: Pick<ResolvedLunoraPluginOptions, "apiSpec" | "projectRoot" | "schemaDir">,
+    options: Pick<ResolvedLunoraPluginOptions, "apiSpec" | "projectRoot" | "schemaDir" | "target">,
     logger: { error: (message: string) => void; info?: (message: string) => void; warn: (message: string) => void },
     overlay?: OverlayCallbacks,
     project?: Project,
@@ -157,6 +157,7 @@ const runCodegenSafely = (
             lunoraDirectory: options.schemaDir,
             project,
             projectRoot: options.projectRoot,
+            target: options.target,
             wranglerVariables: collectWranglerSecretVariables(options.projectRoot),
         });
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "node:module";
 
 import { cloudflare } from "@cloudflare/vite-plugin";
-import { resolveProjectTarget } from "@lunora/config";
+import { resolveTargetOrThrow } from "@lunora/config";
 import errorOverlayPlugin from "@visulima/vite-overlay";
 import type { Plugin } from "vite";
 
@@ -76,10 +76,11 @@ const resolveOptions = (options: LunoraPluginOptions | undefined): ResolvedLunor
         overlay: resolveOverlayOption(input.overlay),
         projectRoot,
         schemaDir: schemaDirectory,
-        // Same resolution order as the CLI — explicit option, then
+        // Same resolution AND validation as the CLI — explicit option, then
         // `lunora.json`, then the default — so a project that sets `target`
-        // once gets it in `vite build` and `lunora deploy` alike.
-        target: resolveProjectTarget(projectRoot, input.target),
+        // once gets it in `vite build` and `lunora deploy` alike, and a typo
+        // fails here rather than emitting the default surface silently.
+        target: resolveTargetOrThrow(projectRoot, input.target),
         validateWrangler: input.validateWrangler ?? true,
     };
 };

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 
 import { cloudflare } from "@cloudflare/vite-plugin";
+import { resolveProjectTarget } from "@lunora/config";
 import errorOverlayPlugin from "@visulima/vite-overlay";
 import type { Plugin } from "vite";
 
@@ -64,6 +65,8 @@ const resolveOptions = (options: LunoraPluginOptions | undefined): ResolvedLunor
         cloudflareOption = input.cloudflare;
     }
 
+    const projectRoot = input.projectRoot ?? process.cwd();
+
     return {
         allowUnauthenticatedShardAccess: input.allowUnauthenticatedShardAccess ?? false,
         apiSpec: input.apiSpec ?? "openapi",
@@ -71,8 +74,12 @@ const resolveOptions = (options: LunoraPluginOptions | undefined): ResolvedLunor
         studio: input.studio ?? true,
         generatedDir: input.generatedDir ?? `${schemaDirectory}/_generated`,
         overlay: resolveOverlayOption(input.overlay),
-        projectRoot: input.projectRoot ?? process.cwd(),
+        projectRoot,
         schemaDir: schemaDirectory,
+        // Same resolution order as the CLI — explicit option, then
+        // `lunora.json`, then the default — so a project that sets `target`
+        // once gets it in `vite build` and `lunora deploy` alike.
+        target: resolveProjectTarget(projectRoot, input.target),
         validateWrangler: input.validateWrangler ?? true,
     };
 };

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -43,12 +43,25 @@ export interface LunoraPluginOptions {
      * Defaults to `true`.
      */
     overlay?: boolean | OverlayPluginOptions;
+
     /** Project root containing the `lunora/` directory. Defaults to `process.cwd()`. */
     projectRoot?: string;
     /** Directory name (relative to `projectRoot`) containing `schema.ts` and function files. Defaults to `"lunora"`. */
     schemaDir?: string;
     /** Serve the Lunora studio at `/__lunora` during dev. Pass `false` to opt out. Defaults to `true`. */
     studio?: boolean;
+
+    /**
+     * Deploy target the emitted `ctx.*` surface is tailored to. Defaults to
+     * `"target"` in `lunora.json`, then `"cloudflare"` — so an existing project
+     * emits byte-identical output.
+     *
+     * Set it here only to override the project config for one build. Keeping
+     * the two in sync matters: codegen tailors the surface to a target while
+     * `lunora deploy` picks the driver that ships it, and a mismatch produces
+     * an app that builds cleanly and fails at runtime.
+     */
+    target?: string;
     /** Validate that `wrangler.jsonc` declares the bindings the schema implies. Defaults to `true`. */
     validateWrangler?: boolean;
 }
@@ -63,6 +76,7 @@ export interface ResolvedLunoraPluginOptions {
     projectRoot: string;
     schemaDir: string;
     studio: boolean;
+    target: string;
     validateWrangler: boolean;
 }
 

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -56,10 +56,9 @@ export interface LunoraPluginOptions {
      * `"target"` in `lunora.json`, then `"cloudflare"` — so an existing project
      * emits byte-identical output.
      *
-     * Set it here only to override the project config for one build. Keeping
-     * the two in sync matters: codegen tailors the surface to a target while
-     * `lunora deploy` picks the driver that ships it, and a mismatch produces
-     * an app that builds cleanly and fails at runtime.
+     * Set it here only to override the project config for one build — keeping
+     * this and `lunora deploy` on the same target is what the shared resolution
+     * in `@lunora/config` exists to guarantee.
      */
     target?: string;
     /** Validate that `wrangler.jsonc` declares the bindings the schema implies. Defaults to `true`. */

--- a/plans/114-platform-abstraction-layer.md
+++ b/plans/114-platform-abstraction-layer.md
@@ -235,6 +235,18 @@ Move the host-neutral engine into `@lunora/shard-engine` (name bikesheddable):
   imports).
 - `@lunora/cli`: `deploy`/`dev` route through the driver; `--target`/config
   field selects it (default `cloudflare`, so zero behavior change).
+- **Done.** `lunora.json` gains a `target` key beside `remote`; `--target` is
+  declared on `codegen`, `dev`, `prepare`, `deploy`, and `logs`, its help text
+  generated from the driver registry. `resolveProjectTarget(projectRoot,
+explicit)` is the single resolution point — flag, then config, then default.
+  One point on purpose: codegen tailors the emitted `ctx.*` surface to a target
+  while deploy picks the driver that ships it, and resolving those separately
+  lets them disagree. The Vite plugin resolves the same way, so `vite build`
+  and `lunora deploy` agree without configuring each.
+- An unregistered target is **rejected, never defaulted** — all five commands
+  resolve through `resolveTargetOrThrow`, including codegen, which resolves no
+  driver of its own and would otherwise emit the full Cloudflare surface
+  un-gated for a nonexistent target and exit 0.
 
 ### 5.4 Conformance suite — `@lunora/platform-conformance` (M)
 
@@ -293,6 +305,9 @@ Move the host-neutral engine into `@lunora/shard-engine` (name bikesheddable):
 
 - `lunora.config` (or codegen options) gains `target: "cloudflare" | …`
   (default `"cloudflare"`; absent = today's output, byte-identical goldens).
+- **Done**, and reachable: every `runCodegen` call site (the `codegen` command,
+  `prepare`, the `dev` watcher, and the Vite plugin) now passes a resolved
+  target. See §5.3 for the shared resolution + validation.
 - Codegen consumes the target's `PlatformCapabilities`: ctx surfaces for
   unsupported features are omitted from emitted types with a diagnostic
   (`platform_unsupported_feature`, advisor-style, pointing at the matrix);

--- a/plans/114-platform-abstraction-layer.md
+++ b/plans/114-platform-abstraction-layer.md
@@ -305,9 +305,18 @@ explicit)` is the single resolution point — flag, then config, then default.
 
 - `lunora.config` (or codegen options) gains `target: "cloudflare" | …`
   (default `"cloudflare"`; absent = today's output, byte-identical goldens).
-- **Done**, and reachable: every `runCodegen` call site (the `codegen` command,
-  `prepare`, the `dev` watcher, and the Vite plugin) now passes a resolved
-  target. See §5.3 for the shared resolution + validation.
+- **Done**, and reachable — but the first attempt wired 5 of ~9 places and the
+  claim that every call site passed a target was wrong. `runCodegen` now
+  resolves the target itself from `lunora.json` when the caller passes none, so
+  a missed call site emits the project's surface rather than the default one
+  silently. The reader lives in `@lunora/codegen` (config depends on codegen,
+  not the reverse) and `@lunora/config` delegates to it.
+- Error-level diagnostics (`platform_unknown_target`,
+  `platform_unsupported_feature`) **fail the command**. Both are declared
+  `level: "error"` because each drops or misdirects an emitted surface; printing
+  them as warnings with exit 0 was the root cause the target validation had been
+  patching around. Surfaced in `codegen`, `prepare`, the dev watcher, and the
+  Vite plugin — the last of which had never read `platformDiagnostics` at all.
 - Codegen consumes the target's `PlatformCapabilities`: ctx surfaces for
   unsupported features are omitted from emitted types with a diagnostic
   (`platform_unsupported_feature`, advisor-style, pointing at the matrix);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2481,6 +2481,9 @@ importers:
       '@lunora/workflow':
         specifier: workspace:*
         version: link:../workflow
+      jsonc-parser:
+        specifier: catalog:vite
+        version: 3.3.1
       ts-morph:
         specifier: catalog:tooling
         version: 28.0.0


### PR DESCRIPTION
Closes the plan 114 **§5.3 / §5.5** gaps. Stacked on #190 — review that first.

An audit found the target machinery **complete and unreachable**: `resolveDeployDriver(target)` and `runCodegen({ target })` both accepted a target, nothing supplied one, so only the default was ever selectable. The first pass at wiring it up got 5 of ~9 places — a two-pass review caught the rest, including `deploy`.

## The invariant

Codegen tailors the emitted `ctx.*` surface to a target while deploy picks the driver that ships it. If those disagree you get an app that builds cleanly and fails at runtime with nothing in the build to explain it. So there is exactly one resolution order — flag → `lunora.json` → default — stated once at `resolveProjectTarget`.

- `lunora.json` gains a `target` key, beside `remote`.
- `--target` on `codegen`, `dev`, `prepare`, `deploy`, `logs`, `build`, and `verify`, with help text generated from the driver registry.
- The Vite plugin resolves and validates identically, so `vite build` and `lunora deploy` agree without configuring each.

**`runCodegen` resolves the target itself** when the caller passes none. This is the part that makes it hold: a call site that forgets emitted the *default* surface with no diagnostic, so nothing could catch it — not review, not CI. Defaulting from the project file makes every caller correct without remembering. The reader lives in `@lunora/codegen` because `@lunora/config` depends on it and not the reverse; config delegates there so one parser serves both, **with JSONC support** that a second copy would have silently lost.

## What review caught

**`deploy` was broken four ways** — the command whose disagreement with codegen this feature exists to prevent. It read only the `--target` flag, so `lunora.json`'s target was invisible to it: a typo'd config failed `codegen`/`prepare`/`dev` and **shipped fine from `deploy`**. It passed no target to codegen or provisioning, and resolved so late that `_generated/*` was rewritten and `wrangler.jsonc` possibly mutated before the error surfaced. It now resolves once, before anything writes.

**`dev` dropped `--target` when backgrounding** — the automatic path when an AI agent runs it — so the flag looked accepted and did nothing. It also gated resolution on `codegenEnabled`, false for the `vite` and `framework-worker` flavors, and pre-generated its sidecar with no target.

**Error-level diagnostics exited 0.** `platform_unknown_target` and `platform_unsupported_feature` both carry `level: "error"` because each "drops or misdirects an emitted surface" — and both were printed as warnings. That was the root cause the target validation had been patching around. They now fail the command, reporting is shared rather than copied across the paths, and the **Vite plugin surfaces them at all** — it had never read `platformDiagnostics`, so `vite build` against a mis-declared target emitted the default surface, printed nothing, and exited 0.

**Two id spaces for one concept.** `resolveTargetOrThrow` validates against the *driver* registry; codegen gates against the *matrix* registry. A target with a driver but no matrix passes validation and then emits an un-gated surface — the silent fallback back again, with the guard fully in place. They are now asserted equal, so the next target's omission is a failing test.

**`@lunora/codegen` pinned `@lunora/platform` to `1.0.0-alpha.1`** — a version that does not exist on the registry. Inherited from #190 and masked by the workspace overrides, it would have frozen the published dependency permanently. Now `workspace:*` like its six siblings.

Two more I introduced and caught only by running the built binary: `deploy`'s early return set `error` but never logged it, so it exited 1 in silence; and `verify` accepted `--target` without validating it. Neither was visible in the diff.

## Verification

Every fix above was verified by hand and by nothing else — which is how they broke in the first place. They are now pinned, with **eight mutations** each caught by its own test: dropping the `lunora.json` fallback, swapping JSONC for `JSON.parse`, removing the daemon forwarding, reverting deploy to the raw flag, moving deploy's resolution after codegen, degrading error diagnostics to warnings, registering a matrix with no driver, and breaking the codegen exit code.

With `{"target":"clouflare"}` in `lunora.json`, all five of codegen/prepare/build/verify/deploy exit 1 with the same message. Default path unchanged.

| | |
|---|---|
| `@lunora/cli` | 876 |
| `@lunora/config` | 495 |
| `@lunora/codegen` | 930 (goldens byte-identical) |
| `@lunora/vite` | 186 |
| repo | `lint:types`, `lint:eslint`, `lint:prettier`, `lint:package-json`, `api:check` |

*(Unrelated: `examples/blog/lunora/_generated/server.ts` is stale — last regenerated in #202, one commit before vector emission landed in #203. Left alone rather than folded in.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137KKKmGRyB69XgLzMaFgSh
