### PR TITLE
fix(do): skip validation of a null on an optional column

### DIFF
--- a/api-snapshots/do.api.md
+++ b/api-snapshots/do.api.md
@@ -3238,7 +3238,7 @@ const runReadonlySql: (sql: SqlExec, query: string) => SqlConsoleResult;
 ### `runRowValidators` (const)
 
 ```ts
-const runRowValidators: (definition: TableDefinitionLike, document: Record<string, unknown>) => void;
+const runRowValidators: (definition: TableDefinitionLike, document: Record<string, unknown>, tolerateStoredNull?: boolean) => void;
 ```
 
 ### `runShardMigrations` (const)

--- a/packages/do/__tests__/ctx-db.constraints.test.ts
+++ b/packages/do/__tests__/ctx-db.constraints.test.ts
@@ -341,5 +341,85 @@ describe("ctx-db constraints", () => {
 
             await expect(writer.replace("o1", { amount: -1, sku: "X" })).rejects.toThrow(/non-negative/u);
         });
+
+        /**
+         * A `null` on an OPTIONAL column means "no value" and must not be validated.
+         * Both backends produce one without the caller asking: `onDelete: "set null"`
+         * patches the FK to null by design, and a `.global()` read returns SQL NULL for
+         * every never-set column, which then rides along in the merged document on the
+         * next patch. A real `v.optional(x)` parser rejects null, so validating it made
+         * a patch of one field fail because of a different column nobody touched.
+         */
+        const setupNullable = () => {
+            const schema: SchemaLike = {
+                tables: {
+                    notes: {
+                        indexes: [],
+                        shape: {
+                            // Mirrors `v.optional(v.string())`: kind "optional", and a parser
+                            // that admits `undefined` but rejects `null`.
+                            note: {
+                                _meta: { column: { notNull: false } },
+                                kind: "optional",
+                                parse(value) {
+                                    if (value !== undefined && typeof value !== "string") {
+                                        throw new Error("Expected string, received null");
+                                    }
+
+                                    return value;
+                                },
+                            },
+                            title: checked("string", (v) => typeof v === "string", "title must be a string"),
+                        },
+                    },
+                },
+            };
+
+            runShardMigrations(harness.sql, schema);
+
+            return createShardContextDatabase({ clock: () => FIXED_CLOCK, schema, sql: harness.sql });
+        };
+
+        it("patch tolerates a null on an optional column it did not touch", async () => {
+            expect.assertions(2);
+
+            const writer = setupNullable();
+
+            await writer.insert("notes", { _id: "n1", title: "first" }, { allowExplicitId: true });
+            // Put the column into the state `onDelete: "set null"` and a D1 read produce.
+            await writer.patch("n1", { note: null });
+
+            // The patch below touches only `title`; before the fix the untouched `note`
+            // rode along in the merged document and failed validation.
+            await writer.patch("n1", { title: "second" });
+
+            await expect(writer.get("n1")).resolves.toMatchObject({ title: "second" });
+            await expect(writer.count("notes")).resolves.toBe(1);
+        });
+
+        it("still rejects a caller-supplied null on insert", async () => {
+            expect.assertions(1);
+
+            const writer = setupNullable();
+
+            // The patch path tolerates a null because it may be one the store itself
+            // produced (`onDelete: "set null"`, or a `.global()` read of an unset
+            // column). Insert has no such excuse — the whole document comes from the
+            // caller — so a null must not be persistable into a column the generated
+            // types promise is `string | undefined`.
+            await expect(writer.insert("notes", { note: null, title: "t" })).rejects.toThrow(/Expected string, received null/u);
+        });
+
+        it("still rejects a null on a required column", async () => {
+            expect.assertions(1);
+
+            const writer = setupNullable();
+
+            await writer.insert("notes", { _id: "n2", title: "ok" }, { allowExplicitId: true });
+
+            // `title` is required, so a null there is a genuine violation and must throw
+            // — the skip above is scoped to optional columns only.
+            await expect(writer.patch("n2", { title: null })).rejects.toThrow(/title must be a string/u);
+        });
     });
 });

--- a/packages/do/src/ctx-db.ts
+++ b/packages/do/src/ctx-db.ts
@@ -3429,7 +3429,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // Run column refinements on the merged row so a patch that flips a
             // field to an invalid value (e.g. negative amount) is rejected
             // before SQLite sees it.
-            runRowValidators(tableDefinition, merged);
+            runRowValidators(tableDefinition, merged, true);
 
             if (hasMatchingTrigger(tableName, "before", "update")) {
                 await fireTriggers("before", "update", { doc: { ...merged }, id, op: "update", previous: existing, table: tableName });

--- a/packages/do/src/relations.ts
+++ b/packages/do/src/relations.ts
@@ -444,23 +444,45 @@ const applyOnDelete = async (options: ApplyOnDeleteOptions): Promise<void> => {
  * before the row hits SQL.
  *
  * Skips fields the validator doesn't declare a `parse` for (the structural
- * fakes used in DO/D1 unit tests omit it) and skips fields absent from the
- * document. The shape is iterated, not the document, so unknown fields pass
- * through untouched — they're part of the JSON-blob shape but not part of the
- * schema's declared columns.
+ * fakes used in DO/D1 unit tests omit it), fields absent from the document, and
+ * — only when `tolerateStoredNull` is set, i.e. on the patch path — a `null` on
+ * an optional field (see below). The shape is iterated, not the document, so
+ * unknown fields pass through untouched — they're part of the JSON-blob shape
+ * but not part of the schema's declared columns.
  *
  * Lives here (alongside `applyOnDelete`) rather than in each backend's
  * `ctx-db.ts` so DO + D1 share one implementation instead of two drift-prone
  * copies. The signature is intentionally `validator.parse?` so the unit-test
  * fakes (which never carry a runtime parser) keep working.
  */
-const runRowValidators = (definition: TableDefinitionLike, document: Record<string, unknown>): void => {
+const runRowValidators = (definition: TableDefinitionLike, document: Record<string, unknown>, tolerateStoredNull = false): void => {
     for (const [field, validator] of Object.entries(definition.shape)) {
         if (!(field in document)) {
             continue;
         }
 
         if (typeof validator.parse !== "function") {
+            continue;
+        }
+
+        // A `null` on an OPTIONAL field is skipped like an absent field, but ONLY on
+        // the patch path, where the document is `{...existing, ...patch}` and the null
+        // may well be one the store itself produced: `onDelete: "set null"` writes the
+        // FK as null by design, and a `.global()` read returns SQL NULL for every
+        // column that was never set. `v.optional(x)` admits `undefined` and rejects
+        // `null`, so validating those would fail a patch of one field because of a
+        // *different* column nobody touched.
+        //
+        // Insert and replace stay strict, because there the whole document is
+        // caller-supplied — tolerating null on those paths would let a caller persist
+        // an explicit `null` into a column the generated types promise is
+        // `T | undefined`, which on the DO backend is a *distinct* stored value (the
+        // document is JSON-serialized whole, so `"x": null` is not an absent key) and
+        // would reintroduce the very null-vs-undefined hazard this guard exists for.
+        //
+        // Required fields are unaffected on every path: a null there is a genuine
+        // violation and still throws.
+        if (tolerateStoredNull && document[field] === null && validator.kind === "optional") {
             continue;
         }
 

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -2631,7 +2631,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
 
             // Refinement checks fire on the merged row so a patch that flips
             // a field to an invalid value is rejected before D1 sees it.
-            runRowValidators(definition, merged);
+            runRowValidators(definition, merged, true);
 
             if (hasMatchingTrigger(tableName, "before", "update")) {
                 await fireTriggers("before", "update", { doc: { ...merged }, id, op: "update", previous: existing, table: tableName });


### PR DESCRIPTION
## The bug

`runRowValidators` re-parses every declared column of the merged document on patch, so writing **one** field validated the whole row. A column holding `null` was validated as `null`, and `v.optional(x)` admits `undefined` but rejects it — so patching one field failed because of a **different** column the caller never touched.

Both backends produce that null without being asked:

- `onDelete: "set null"` patches the FK to null **by design** (the DO's own comment calls it "the documented semantics of the action").
- A `.global()` read returns SQL NULL for every column that was never set, which then rides along in the merged document on the next patch.

Found in the control-plane app, where it made the entire deployment lifecycle unreachable — `updateStatus` rejected its own patch with `Expected string at <root>, received null`, so a deployment could never leave `queued`, for CI as much as for a seed script.

## The fix

A `null` on an **optional** column now skips validation exactly like an absent field, gated behind an explicit `tolerateStoredNull` flag that **only the patch call sites pass**.

Insert and replace stay strict on purpose: their document is entirely caller-supplied, so tolerating null there would let a caller persist an explicit `null` into a column the generated types promise is `T | undefined` — on the DO backend a genuinely distinct stored value, since the document is JSON-serialized whole (`"x": null` is not an absent key). Required columns are unaffected on every path.

## Why here, not in a backend

DO and D1 both route through this helper. The DO reaches the same state via `onDelete: "set null"`; its existing coverage misses it only because the unit-test fakes carry no `parse`, so the validator loop skips them.

## Considered and rejected: fixing it in the decoder

Dropping SQL NULLs in `decodeGlobalRow` would make an unset column read as absent and fix this at a stroke — but it also erases the null `onDelete: "set null"` deliberately stores. SQL cannot distinguish "never set" from "explicitly set to null", so no decode-time rule is right for both, and three existing D1 tests correctly pin the behaviour that change breaks. Tried it, reverted it.

## Tests

Three, in `ctx-db.constraints.test.ts`:

1. patch tolerates a null on an optional column it did not touch
2. insert still rejects a caller-supplied null (pins the narrowed scope)
3. a null on a required column still throws

The first was verified to fail without the source change, with the production error.

## Verification

- `@lunora/do` **1311 passed**
- `@lunora/sql-store` **80 passed**
- `@lunora/d1` **237 passed** — including the three that pin `onDelete: "set null"` storing an explicit null
- `tsc --noEmit` and `eslint` clean

Extracted from the cloud app branch where it was found; it is framework code every app depends on, so it should be reviewed on its own rather than inside an app PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed patch updates involving optional fields with stored `null` values.
  * Patch validation now correctly allows these values while continuing to enforce validation for required fields and during inserts or replacements.
  * Applied the fix consistently across supported data storage environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->