### PR TITLE
ci: stop the merge queue from running PR-only checks

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -16,6 +16,16 @@
 
 "jobs":
     "semantic-pull-request":
+        # The `merge_group` trigger above exists only so this required check
+        # reports a status in the merge queue — a job skipped by `if` counts as
+        # passing, whereas a workflow that never triggers leaves the queue entry
+        # stuck on "Expected". The validation itself must not run there:
+        # amannn/action-semantic-pull-request hard-errors with "This action can
+        # only be invoked in `pull_request_target` or `pull_request` events"
+        # because a merge group has no PR to infer. The title was already
+        # validated on the PR and cannot change once queued, so re-checking it
+        # here would be redundant even if the action supported it.
+        "if": "github.event_name != 'merge_group'"
         "permissions":
             "pull-requests": "write" # to analyze PRs (amannn/action-semantic-pull-request)
             "statuses": "write" # to mark status of analyzed PR (amannn/action-semantic-pull-request)

--- a/vis.config.ts
+++ b/vis.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "@visulima/vis/config";
 
 export default defineConfig({
+    // `alpha` is the development branch, not `main`. vis only derives the
+    // affected base from CI env vars for `pull_request`/`push` events — it has
+    // no `merge_group` handling at all — so in the merge queue it falls through
+    // to `origin/<defaultBase>`. Left unset that fallback is `main`, which sits
+    // ~2340 commits behind `alpha`: every queue run then marked all 50 packages
+    // affected and `vis affected build` died with `spawn E2BIG`. This also
+    // fixes local `vis affected`, which merge-bases against the same default.
+    defaultBase: "alpha",
     namedInputs: {
         default: ["sharedGlobals", "{projectRoot}/**/*", "!{projectRoot}/**/*.md"],
         production: ["default", "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)"],


### PR DESCRIPTION
Two jobs assumed a pull_request context but were wired to `merge_group`.

Semantic Pull Request failed on 4 of 4 queue runs in ~12s with "This action can only be invoked in `pull_request_target` or `pull_request` events" — a merge group has no PR to infer. Keep the `merge_group` trigger so the required check still reports (a skipped job counts as passing; a workflow that never triggers leaves the entry on "Expected") and guard the job itself.

`vis affected` has no merge_group handling at all, so it fell through to `origin/<defaultBase>`, unset and therefore `main` — ~2340 commits behind `alpha`. The resulting changed-file list was 3535 entries / 148,105 bytes, over the 131,072-byte MAX_ARG_STRLEN, so `vis affected build` died with `spawn E2BIG`. The affected-project list saturates at all 50 packages in both cases, which is why the passing pull_request run looked identical. This crossed the limit only recently as alpha drifted from main.

<!--
Thank you for contributing to Lunora!

Please fill out the sections below so reviewers can land your change quickly.
Keep the title in conventional-commit form (e.g. `feat(cli): add migrate flag`).
-->

## Summary

<!--
Explain *why* this change is needed and *what* it does at a high level.
Link to the relevant package(s) (e.g. `@lunora/d1`, `@lunora/codegen`) so
reviewers know which Wave / area is touched.
-->

## Linked issues

<!--
- Closes #...
- Refs #...
-->

## Test plan

<!--
Bulleted checklist of what you ran locally and what reviewers should re-run:

- [ ] `pnpm lint:types` passes
- [ ] `pnpm lint:eslint` passes
- [ ] `pnpm test` passes (234+ tests)
- [ ] If schema changed: `pnpm --filter @lunora/cli run codegen` regenerated cleanly
- [ ] If Durable Object / D1 code changed: workerd-based Vitest pool tests still pass
- [ ] Manual smoke test in `apps/playground` (if user-facing)
-->

## Checklist

- [ ] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change
- [ ] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs)
- [ ] No `package.json` files in `packages/*` modified outside the touched package
- [ ] If a new package was added: `project.json` has `type:package` and a `category:*` tag
- [ ] If migration impact: noted upgrade steps in the PR description and changelog entry

## Notes for reviewers

<!--
Anything reviewers should look at first, follow-up work you deferred, screenshots
for UI changes, etc.
-->

## Contributor License Agreement

<!--
Required for external contributors. Keep the line below in your PR description
exactly as written — the CLA check (.github/workflows/cla.yml) looks for it.
Members of the @anolilab organization can omit it (the check is skipped).
-->

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflow compatibility with merge queue events.
  * Prevented unnecessary validation failures when pull request details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->