### PR TITLE
docs(studio): cite the tracking issue in the giant-component suppressions

### DIFF
--- a/packages/studio/src/features/auth/organization-detail.tsx
+++ b/packages/studio/src/features/auth/organization-detail.tsx
@@ -115,7 +115,7 @@ const ManagedTable = ({
  * the whole surface also polls via {@link useAutoRefresh} since the auth store
  * is HTTP-only with no live channel.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~551 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~550 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const OrganizationDetail = ({ organizationId, rolesEnabled, teamsEnabled }: OrganizationDetailProps): ReactElement => {
     const client = useLunora();
     const t = useT();

--- a/packages/studio/src/features/data/data-browser.tsx
+++ b/packages/studio/src/features/data/data-browser.tsx
@@ -284,7 +284,7 @@ const DataBrowserViewControls = ({
  * touches the server — pagination still flows through `readTablePage`. All of
  * that state lives in {@link useDataBrowser}; this component is just the markup.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~811 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~810 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const DataBrowser = ({
     editable = false,
     globalTableNames,

--- a/packages/studio/src/features/data/global-data-browser.tsx
+++ b/packages/studio/src/features/data/global-data-browser.tsx
@@ -85,7 +85,7 @@ const chipValue = (value: unknown): string => {
  * table sidebar + a bordered grid with a paginated footer — and gated by the
  * server's `LUNORA_ADMIN_TOKEN`.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~458 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~452 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const GlobalDataBrowser = ({
     initialTable,
     onSelectTable,

--- a/packages/studio/src/features/logs/logs-panel.tsx
+++ b/packages/studio/src/features/logs/logs-panel.tsx
@@ -381,7 +381,7 @@ const SummaryBucketRow = ({ bucket }: SummaryBucketRowProps): ReactElement => (
  * For the raw, un-attributed request firehose (which Lunora deliberately does
  * NOT re-stream), a deep-link to Cloudflare Workers Observability is provided.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~801 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~800 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => {
     const t = useT();
 

--- a/packages/studio/src/features/logs/mail-panel.tsx
+++ b/packages/studio/src/features/logs/mail-panel.tsx
@@ -111,7 +111,7 @@ const selectedMail = (visible: ReadonlyArray<CapturedMail>, selectedId: null | s
  * mail appears without a manual refresh. The HTML body is rendered in a fully
  * sandboxed iframe (no script execution) so captured markup can't run in the studio.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~424 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~423 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 const MailPanel = ({ limit = 100 }: MailPanelProps): ReactElement => {
     const client = useLunora();
     const t = useT();

--- a/packages/studio/src/features/reports/health-panel.tsx
+++ b/packages/studio/src/features/reports/health-panel.tsx
@@ -289,7 +289,7 @@ const authSeries = (auth: AuthMetrics | null | undefined): { attempts: number[];
  * on every write-flush (coalesced so a burst yields at most one in-flight pull).
  */
 // react-doctor-disable-next-line react-doctor/prefer-useReducer -- the eight values are independent reads that arrive from separate queries at separate times, so one reducer would serialise updates that genuinely are not one transition
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~641 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~640 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const HealthPanel = ({ initialShardKey }: HealthPanelProps): ReactElement => {
     const client = useLunora();
     const t = useT();

--- a/packages/studio/src/features/reports/metrics-panel.tsx
+++ b/packages/studio/src/features/reports/metrics-panel.tsx
@@ -131,7 +131,7 @@ const formatMs = (ms: number): string => {
  * sparkline. The series is capped at {@link MAX_HISTORY} points and is lost on
  * remount.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~493 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~492 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactElement => {
     const client = useLunora();
     const t = useT();

--- a/packages/studio/src/features/schema/schema-editor-overlay.tsx
+++ b/packages/studio/src/features/schema/schema-editor-overlay.tsx
@@ -52,7 +52,7 @@ interface SchemaEditorOverlayProps {
  * Mounted only when `SchemaViewer` receives `schemaEditable` (set by the
  * loopback dev hosts), so it is absent from a deployed/read-only studio.
  */
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~381 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~380 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const SchemaEditorOverlay = ({ onApplied, tableNames }: SchemaEditorOverlayProps): ReactElement => {
     const t = useT();
     const navigate = useNavigate();

--- a/packages/studio/src/features/schema/schema-viewer.tsx
+++ b/packages/studio/src/features/schema/schema-viewer.tsx
@@ -175,7 +175,7 @@ const schemaTabClass = (active: boolean): string =>
  * works.
  */
 // react-doctor-disable-next-line react-doctor/prefer-useReducer -- the six values are independent reads that arrive from separate queries at separate times, so one reducer would serialise updates that genuinely are not one transition
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~670 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~669 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const SchemaViewer = ({ initialShardKey, initialTable, schemaEditable }: SchemaViewerProps): ReactElement => {
     const client = useLunora();
     const t = useT();

--- a/packages/studio/src/features/sql/sql-editor-panel.tsx
+++ b/packages/studio/src/features/sql/sql-editor-panel.tsx
@@ -112,7 +112,7 @@ const tabClass = (selected: boolean): string =>
 /** The tab the editor opens with on a fresh browser: the first template. */
 const seedTab = (): SqlTab => makeTab(TEMPLATES[0]?.sql ?? "");
 
-// react-doctor-disable-next-line react-doctor/no-giant-component -- ~840 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately, and recorded under "Deferred" in plans/README.md's Wave 15 so it is not invisible
+// react-doctor-disable-next-line react-doctor/no-giant-component -- ~839 lines. Decomposing this is a real refactor with its own review, not a lint fix — deferred deliberately and tracked in #230, which lists all ten with their sizes and a suggested order
 export const SqlEditorPanel = ({ initialShardKey }: SqlEditorPanelProps): ReactElement => {
     const client = useLunora();
     const t = useT();

--- a/plans/README.md
+++ b/plans/README.md
@@ -149,6 +149,15 @@ commits are the record).
 | 073  | Dedup identity-independent reactive query runs across sockets  | perf      | P2  | M      | MED  | DONE — `dd340715` (#70): `isIdentityIndependent()` + `resolveReactiveOutcomeDeduped()` + flush-local `reactiveRunCache`; negative RLS test confirms no cross-identity leak |
 | 074  | Extract shared socket-pool helper (dedup poke worker pools)    | tech-debt | P3  | S      | LOW  | DONE — `dd340715` (#70): `do/src/socket-pool.ts` `runSocketPool()`; both `refreshSubscriptions`/`pokeShapeSubscribers` call it; `socket-pool.test.ts`                      |
 
+- **Deferred out of the wave: decomposing ten oversized studio panels.** The
+  react-doctor sweep that closed this wave took `packages/studio` from 232
+  findings to 0, but ten `no-giant-component` findings were suppressed rather
+  than fixed — splitting a panel is its own refactor with its own review.
+  Tracked in [#230](https://github.com/anolilab/lunora/issues/230), which lists
+  all ten with their line counts, a suggested order, and a definition of done;
+  each suppression comment cites it. `data-browser-grid.tsx` (1157 lines) is
+  above the repo's 1k guidance for the same reason and rides along.
+
 ### Recommended execution order & dependencies
 
 - **First, the quick wins (no deps):** 064, 065, 066 — small, isolated,


### PR DESCRIPTION
Follow-up to the react-doctor sweep in #229, closing the one finding from the thermo review that could not be fixed in code.

The ten `react-doctor/no-giant-component` suppressions justified themselves with a claim that was not true. First they said the debt was **"tracked separately"** — nothing tracked it. The replacement said it was recorded under "Deferred" in `plans/README.md` — an entry that was never actually written. Same failure twice: the load-bearing half of the justification was fiction, which turns real debt into invisible debt.

#230 now tracks it properly: all ten components with their line counts, a suggested order, and a definition of done ("the suppression can be deleted and the scan still reports zero"). Each suppression cites the issue by number and carries its own exact line count. The Wave 15 notes in `plans/README.md` record the deferral so the plan history and the code agree.

The suggested first step in #230 is the cheap one the sweep already set up: `use-data-browser.tsx`'s four hoisted helpers (`toPageArgs`, `toCountArgs`, `resolveStagedChanges`, `editableColumn`) are pure and hook-free, so moving them to a sibling module drops that file under the threshold at zero behavioural cost.

Comments only — no code paths change. ESLint `--max-warnings=0`, `tsc --noEmit`, 930 studio tests, Prettier, and `react-doctor` (0 findings) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal component tracking notes and size estimates across Studio panels and editors.
  * Clarified references for deferred component refactoring work.

* **Maintenance**
  * No changes to functionality, runtime behavior, public interfaces, or the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->