### PR TITLE
feat(config): translate wrangler.jsonc into an Alchemy program

### DIFF
--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -109,6 +109,15 @@ interface AgentRulesStatus {
 }
 ```
 
+### `AlchemyTranslation` (interface)
+
+```ts
+interface AlchemyTranslation {
+    source: string;
+    unsupported: ReadonlyArray<string>;
+}
+```
+
 ### `ApplyEditResult` (type)
 
 ```ts
@@ -1275,6 +1284,47 @@ interface WranglerConfig {
 }
 ```
 
+### `WranglerConfigShape` (interface)
+
+```ts
+interface WranglerConfigShape {
+    compatibility_date?: string;
+    compatibility_flags?: ReadonlyArray<string>;
+    d1_databases?: ReadonlyArray<{
+        binding?: string;
+        database_id?: string;
+        database_name?: string;
+    }>;
+    durable_objects?: {
+        bindings?: ReadonlyArray<WranglerDurableObjectBinding$1>;
+    };
+    kv_namespaces?: ReadonlyArray<{
+        binding?: string;
+        id?: string;
+    }>;
+    main?: string;
+    migrations?: ReadonlyArray<{
+        new_classes?: ReadonlyArray<string>;
+        new_sqlite_classes?: ReadonlyArray<string>;
+    }>;
+    name?: string;
+    queues?: {
+        producers?: ReadonlyArray<{
+            binding?: string;
+            queue?: string;
+        }>;
+    };
+    r2_buckets?: ReadonlyArray<{
+        binding?: string;
+        bucket_name?: string;
+    }>;
+    triggers?: {
+        crons?: ReadonlyArray<string>;
+    };
+    vars?: Readonly<Record<string, unknown>>;
+}
+```
+
 ### `WranglerContainerEntry` (interface)
 
 ```ts
@@ -1805,6 +1855,12 @@ const wireRlsIntoProcedure: (source: string, edit: WireRlsEdit) => WireResult;
 
 ```ts
 const withTailConsumer: (wrangler: WranglerConfig, consumer: TailConsumer) => WranglerConfig;
+```
+
+### `wranglerToAlchemy` (const)
+
+```ts
+const wranglerToAlchemy: (config: WranglerConfigShape) => AlchemyTranslation;
 ```
 
 ### `writeDevServerState` (const)

--- a/packages/config/__tests__/wrangler-to-alchemy.test.ts
+++ b/packages/config/__tests__/wrangler-to-alchemy.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import type { WranglerConfigShape } from "../src/wrangler-to-alchemy";
+import { wranglerToAlchemy } from "../src/wrangler-to-alchemy";
+
+const BASE: WranglerConfigShape = { main: "src/server/index.ts", name: "my-app" };
+
+describe("wranglerToAlchemy", () => {
+    it("emits a runnable program for a config with no bindings", () => {
+        expect.assertions(4);
+
+        const { source, unsupported } = wranglerToAlchemy(BASE);
+
+        expect(source).toContain(`import alchemy from "alchemy";`);
+        expect(source).toContain(`const app = await alchemy("my-app");`);
+        expect(source).toContain("await app.finalize();");
+        expect(unsupported).toStrictEqual([]);
+    });
+
+    it("adopts existing resources rather than creating alongside them", () => {
+        expect.assertions(2);
+
+        const { source } = wranglerToAlchemy({
+            ...BASE,
+            d1_databases: [{ binding: "DB", database_id: "abc123", database_name: "my-app-db" }],
+        });
+
+        // The single most important flag here. A project translated from an
+        // existing `wrangler.jsonc` already HAS its database, with data in it.
+        // Without adoption Alchemy treats it as new and creates a second one —
+        // the one outcome a deploy must never have.
+        expect(source).toContain(`await D1Database("DB", { adopt: true, name: "my-app-db" });`);
+
+        // `database_id` is Cloudflare's handle, not an Alchemy input — adoption
+        // matches on the name.
+        expect(source).not.toContain("abc123");
+    });
+
+    it("marks a Durable Object as SQLite-backed from any migration entry, not just the newest", () => {
+        expect.assertions(2);
+
+        const { source } = wranglerToAlchemy({
+            ...BASE,
+            durable_objects: {
+                bindings: [
+                    { class_name: "ShardDO", name: "SHARD" },
+                    { class_name: "PlainDO", name: "PLAIN" },
+                ],
+            },
+            migrations: [{ new_sqlite_classes: ["ShardDO"] }, { new_classes: ["PlainDO"] }],
+        });
+
+        // A class introduced in `v1` is still SQLite-backed at `v3`, so the flag
+        // is accumulated across migrations rather than read off the last one.
+        expect(source).toContain(`DurableObjectNamespace("SHARD", { className: "ShardDO", sqlite: true })`);
+        expect(source).toContain(`DurableObjectNamespace("PLAIN", { className: "PlainDO", sqlite: false })`);
+    });
+
+    it("reports what it could not carry over instead of dropping it silently", () => {
+        expect.assertions(2);
+
+        const { source, unsupported } = wranglerToAlchemy({
+            ...BASE,
+            vectorize: [{ binding: "POSTS_SEARCH", index_name: "posts_search" }],
+        } as WranglerConfigShape);
+
+        // A silently-dropped Vectorize binding produces a worker whose
+        // `env.POSTS_SEARCH` is undefined at runtime, with nothing in the build
+        // to explain it. The caller has to be able to say so.
+        expect(unsupported).toContain("vectorize");
+        expect(source).not.toContain("POSTS_SEARCH");
+    });
+
+    it("skips a Durable Object implemented by another worker", () => {
+        expect.assertions(2);
+
+        const { source, unsupported } = wranglerToAlchemy({
+            ...BASE,
+            durable_objects: { bindings: [{ class_name: "OtherDO", name: "OTHER", script_name: "other-worker" }] },
+        });
+
+        // The implementing worker is outside this program's scope, so binding to
+        // it would reference something the program never creates.
+        expect(source).not.toContain("OTHER");
+        expect(unsupported[0]).toContain("external script_name");
+    });
+
+    it("quotes a binding name that is not a valid identifier", () => {
+        expect.assertions(2);
+
+        const { source } = wranglerToAlchemy({ ...BASE, r2_buckets: [{ binding: "my-bucket", bucket_name: "b" }] });
+
+        // Nothing enforces that a binding is `SCREAMING_SNAKE`, and a hyphen
+        // would emit a program that does not parse.
+        expect(source).toContain(`"my-bucket":`);
+        expect(source).toContain("const binding_my_bucket =");
+    });
+
+    it("uses shorthand when the binding name is already the local const", () => {
+        expect.assertions(1);
+
+        const { source } = wranglerToAlchemy({ ...BASE, r2_buckets: [{ binding: "FILES", bucket_name: "files" }] });
+
+        // The generated file gets read by humans debugging a deploy; `FILES: FILES` is noise.
+        expect(source).toContain("        FILES,");
+    });
+
+    it("carries crons, compatibility settings and vars onto the worker", () => {
+        expect.assertions(4);
+
+        const { source } = wranglerToAlchemy({
+            ...BASE,
+            compatibility_date: "2026-04-07",
+            compatibility_flags: ["nodejs_compat"],
+            triggers: { crons: ["0 * * * *"] },
+            vars: { PUBLIC_URL: "https://example.com" },
+        });
+
+        expect(source).toContain(`compatibilityDate: "2026-04-07",`);
+        expect(source).toContain(`compatibilityFlags: ["nodejs_compat"],`);
+        expect(source).toContain(`crons: ["0 * * * *"],`);
+        expect(source).toContain(`PUBLIC_URL: "https://example.com",`);
+    });
+
+    it("omits an empty bindings block rather than emitting an empty object", () => {
+        expect.assertions(1);
+
+        expect(wranglerToAlchemy(BASE).source).not.toContain("bindings:");
+    });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -165,6 +165,8 @@ export { discoverWorkflowInfo } from "./workflow-info";
 export type { ReadWranglerResult } from "./wrangler-path";
 export { findWranglerFile, readWranglerJsonc, WRANGLER_FILES } from "./wrangler-path";
 export { collectWranglerSecretVariables, scanWranglerVariablesForSecrets } from "./wrangler-secret-variables";
+export type { AlchemyTranslation, WranglerConfigShape } from "./wrangler-to-alchemy";
+export { wranglerToAlchemy } from "./wrangler-to-alchemy";
 export type {
     TailConsumer,
     WranglerConfig,

--- a/packages/config/src/wrangler-to-alchemy.ts
+++ b/packages/config/src/wrangler-to-alchemy.ts
@@ -1,0 +1,302 @@
+/**
+ * Translate a `wrangler.jsonc` into an [Alchemy](https://alchemy.run) program.
+ *
+ * # Why translate rather than ask for a second config
+ *
+ * `wrangler.jsonc` is already the source of truth for what an app needs, and
+ * Lunora already infers and reconciles it — `inferLunoraBindings` decides that
+ * a project needs a shard namespace and a bucket, `reconcileWranglerBindings`
+ * writes them. Asking a developer to restate all of that in an
+ * `alchemy.run.ts` would give the project two sources of truth that drift, and
+ * the drift would surface as a deploy that provisions something the app does
+ * not bind.
+ *
+ * So Alchemy is an implementation detail of `deploy`, not a thing to configure:
+ * read the config, emit the program, run it.
+ *
+ * # Why this emits source rather than calling Alchemy
+ *
+ * `alchemy@0.93` has thirty dependencies, nine of them Node-shaped —
+ * `wrangler`, `miniflare`, `esbuild`, `execa`, `find-process`, `glob`, `open`,
+ * `proper-lockfile`, `signal-exit`. `@lunora/config` is imported by
+ * `@lunora/vite`, so importing Alchemy here would push that tree into every
+ * project that merely wanted to read `lunora.json`, and into any bundle
+ * targeting workerd — where none of it survives.
+ *
+ * Emitting text keeps this module pure and dependency-free. Alchemy is invoked
+ * as a CLI against the generated file, so it only has to exist on the machine
+ * that deploys.
+ *
+ * # Adoption, not re-creation
+ *
+ * Every resource is emitted with `adopt: true`. A project translated from an
+ * existing `wrangler.jsonc` already *has* its D1 database and its bucket, with
+ * data in them. Without adoption Alchemy would treat them as new and try to
+ * create alongside — the one outcome a deploy must never have.
+ */
+
+/** A Durable Object binding as `wrangler.jsonc` spells it. */
+interface WranglerDurableObjectBinding {
+    class_name?: string;
+    name?: string;
+    script_name?: string;
+}
+
+/** The slice of `wrangler.jsonc` that translates into Alchemy resources. */
+interface WranglerConfigShape {
+    compatibility_date?: string;
+    compatibility_flags?: ReadonlyArray<string>;
+    d1_databases?: ReadonlyArray<{ binding?: string; database_id?: string; database_name?: string }>;
+    durable_objects?: { bindings?: ReadonlyArray<WranglerDurableObjectBinding> };
+    kv_namespaces?: ReadonlyArray<{ binding?: string; id?: string }>;
+    main?: string;
+    /** `new_sqlite_classes` marks which DO classes get SQLite storage — Alchemy needs that per namespace. */
+    migrations?: ReadonlyArray<{ new_classes?: ReadonlyArray<string>; new_sqlite_classes?: ReadonlyArray<string> }>;
+    name?: string;
+    queues?: { producers?: ReadonlyArray<{ binding?: string; queue?: string }> };
+    r2_buckets?: ReadonlyArray<{ binding?: string; bucket_name?: string }>;
+    triggers?: { crons?: ReadonlyArray<string> };
+    vars?: Readonly<Record<string, unknown>>;
+}
+
+/** What the translation could not carry over, so the caller can say so out loud. */
+interface AlchemyTranslation {
+    /** The emitted program source. */
+    source: string;
+
+    /**
+     * Bindings present in `wrangler.jsonc` that this translation drops.
+     *
+     * Reported rather than silently omitted: a deploy that quietly loses a
+     * Vectorize index produces a worker whose `env.POSTS_SEARCH` is undefined
+     * at runtime, and nothing in the build says why.
+     */
+    unsupported: ReadonlyArray<string>;
+}
+
+/** JSON-encode for embedding in emitted source. Also the identifier-safety check's escape hatch. */
+const literal = (value: unknown): string => JSON.stringify(value);
+
+/**
+ * Whether a binding name can be emitted as a bare object key / identifier.
+ *
+ * A binding is an env var name, so in practice it is `SCREAMING_SNAKE` — but
+ * nothing enforces that, and a name with a hyphen would emit a program that
+ * does not parse. Quoting the odd ones keeps the emitter total.
+ */
+const SAFE_IDENTIFIER = /^[A-Z_a-z][\w$]*$/u;
+
+const isSafeIdentifier = (name: string): boolean => SAFE_IDENTIFIER.test(name);
+
+/** The local const an emitted resource binds to, unique per binding name. */
+const localName = (binding: string): string => (isSafeIdentifier(binding) ? binding : `binding_${binding.replaceAll(/\W/gu, "_")}`);
+
+/**
+ * One entry of the worker's `bindings` object.
+ *
+ * Emits shorthand (`DB,`) when the binding name is already the local const —
+ * the generated file is committed-adjacent and gets read by humans debugging a
+ * deploy, and `DB: DB` is noise.
+ */
+const bindingEntry = (binding: string, value: string = localName(binding)): string => {
+    const safe = isSafeIdentifier(binding);
+
+    if (safe && value === binding) {
+        return `${binding},`;
+    }
+
+    return `${safe ? binding : literal(binding)}: ${value},`;
+};
+
+/**
+ * The set of Durable Object classes that use SQLite storage.
+ *
+ * Alchemy needs this per namespace; wrangler records it once per migration
+ * entry, so it is accumulated across all of them rather than read off the
+ * newest — a class introduced in `v1` is still SQLite-backed at `v3`.
+ */
+const sqliteClasses = (config: WranglerConfigShape): ReadonlySet<string> => {
+    const classes = new Set<string>();
+
+    for (const migration of config.migrations ?? []) {
+        for (const className of migration.new_sqlite_classes ?? []) {
+            classes.add(className);
+        }
+    }
+
+    return classes;
+};
+
+/** Durable Object bindings. Not provisioned resources — the namespace is created with the worker. */
+const collectDurableObjects = (
+    config: WranglerConfigShape,
+    sqlite: ReadonlySet<string>,
+    imports: Set<string>,
+    bindings: string[],
+    unsupported: string[],
+): void => {
+    for (const durableObject of config.durable_objects?.bindings ?? []) {
+        if (durableObject.name === undefined || durableObject.class_name === undefined) {
+            continue;
+        }
+
+        if (durableObject.script_name !== undefined) {
+            // A namespace implemented by *another* worker. Alchemy models this,
+            // but the other worker is outside this program's scope, so carrying
+            // it over would bind to something the program never creates.
+            unsupported.push(`durable_objects.${durableObject.name} (external script_name "${durableObject.script_name}")`);
+
+            continue;
+        }
+
+        imports.add("DurableObjectNamespace");
+        // Not awaited: `DurableObjectNamespace` is a binding descriptor, not a
+        // provisioned resource — the namespace is created with the worker.
+        bindings.push(
+            bindingEntry(
+                durableObject.name,
+                `DurableObjectNamespace(${literal(durableObject.name)}, { className: ${literal(durableObject.class_name)}, sqlite: ${String(sqlite.has(durableObject.class_name))} })`,
+            ),
+        );
+    }
+
+    for (const [key, value] of Object.entries(config.vars ?? {})) {
+        bindings.push(bindingEntry(key, literal(String(value))));
+    }
+};
+
+/** Plain `vars` ride onto the worker as literal bindings. */
+const collectVariables = (config: WranglerConfigShape, bindings: string[]): void => {
+    for (const [key, value] of Object.entries(config.vars ?? {})) {
+        bindings.push(bindingEntry(key, literal(String(value))));
+    }
+};
+
+/** Bindings this translation does not model yet. Named individually so the message is actionable. */
+const collectUnsupported = (config: WranglerConfigShape, unsupported: string[]): void => {
+    // Bindings Lunora can declare in wrangler but this translation does not
+    // model yet. Named individually so the message is actionable.
+    for (const [field, label] of [
+        ["ai", "ai"],
+        ["analytics_engine_datasets", "analytics_engine_datasets"],
+        ["browser", "browser"],
+        ["containers", "containers"],
+        ["hyperdrive", "hyperdrive"],
+        ["images", "images"],
+        ["pipelines", "pipelines"],
+        ["vectorize", "vectorize"],
+        ["workflows", "workflows"],
+    ] as const) {
+        const present = (config as Record<string, unknown>)[field];
+
+        if (present !== undefined && (!Array.isArray(present) || present.length > 0)) {
+            unsupported.push(label);
+        }
+    }
+};
+
+/**
+ * Translate a parsed `wrangler.jsonc` into an Alchemy program.
+ *
+ * Pure: it reads nothing and writes nothing, so the caller decides where the
+ * source lands and the whole thing stays testable as a string comparison.
+ * @param config The parsed `wrangler.jsonc`.
+ * @returns the program source, plus whatever could not be carried over.
+ */
+const wranglerToAlchemy = (config: WranglerConfigShape): AlchemyTranslation => {
+    const workerName = config.name ?? "worker";
+    const unsupported: string[] = [];
+    const imports = new Set<string>(["Worker"]);
+    const resources: string[] = [];
+    const bindings: string[] = [];
+    const sqlite = sqliteClasses(config);
+
+    // The four provisioned kinds differ only in constructor and name field, so
+    // they run through one pass — a loop each was four chances to forget
+    // `adopt`.
+    const provisioned: ReadonlyArray<{ construct: string; entries: ReadonlyArray<{ binding?: string; name?: string }>; nameKey: string }> = [
+        {
+            construct: "D1Database",
+            entries: (config.d1_databases ?? []).map((d) => {
+                return { binding: d.binding, name: d.database_name };
+            }),
+            nameKey: "name",
+        },
+        {
+            construct: "R2Bucket",
+            entries: (config.r2_buckets ?? []).map((b) => {
+                return { binding: b.binding, name: b.bucket_name };
+            }),
+            nameKey: "name",
+        },
+        {
+            construct: "KVNamespace",
+            entries: (config.kv_namespaces ?? []).map((k) => {
+                return { binding: k.binding, name: k.binding };
+            }),
+            nameKey: "title",
+        },
+        {
+            construct: "Queue",
+            entries: (config.queues?.producers ?? []).map((q) => {
+                return { binding: q.binding, name: q.queue };
+            }),
+            nameKey: "name",
+        },
+    ];
+
+    for (const { construct, entries, nameKey } of provisioned) {
+        for (const entry of entries) {
+            if (entry.binding === undefined) {
+                continue;
+            }
+
+            imports.add(construct);
+            // `adopt` on every one: the project already has these, with data in
+            // them. The declared name is what Alchemy matches on when adopting.
+            resources.push(
+                `const ${localName(entry.binding)} = await ${construct}(${literal(entry.binding)}, { adopt: true, ${nameKey}: ${literal(entry.name ?? entry.binding)} });`,
+            );
+            bindings.push(bindingEntry(entry.binding));
+        }
+    }
+
+    collectDurableObjects(config, sqlite, imports, bindings, unsupported);
+    collectVariables(config, bindings);
+    collectUnsupported(config, unsupported);
+
+    const workerProps = [
+        "adopt: true,",
+        bindings.length === 0 ? undefined : `bindings: {\n        ${bindings.join("\n        ")}\n    },`,
+        config.compatibility_date === undefined ? undefined : `compatibilityDate: ${literal(config.compatibility_date)},`,
+        config.compatibility_flags === undefined || config.compatibility_flags.length === 0
+            ? undefined
+            : `compatibilityFlags: ${literal([...config.compatibility_flags])},`,
+        config.triggers?.crons === undefined || config.triggers.crons.length === 0 ? undefined : `crons: ${literal([...config.triggers.crons])},`,
+        config.main === undefined ? undefined : `entrypoint: ${literal(config.main)},`,
+        `name: ${literal(workerName)},`,
+    ].filter((line): line is string => line !== undefined);
+
+    const source = [
+        "// GENERATED by @lunora/config from wrangler.jsonc — do not edit.",
+        "// Re-generated on every `lunora deploy`; edit wrangler.jsonc instead.",
+        "",
+        `import alchemy from "alchemy";`,
+        `import { ${[...imports].toSorted((a, b) => a.localeCompare(b)).join(", ")} } from "alchemy/cloudflare";`,
+        "",
+        `const app = await alchemy(${literal(workerName)});`,
+        "",
+        ...(resources.length === 0 ? [] : [...resources, ""]),
+        `export const worker = await Worker(${literal(workerName)}, {`,
+        `    ${workerProps.join("\n    ")}`,
+        "});",
+        "",
+        "await app.finalize();",
+        "",
+    ].join("\n");
+
+    return { source, unsupported };
+};
+
+export type { AlchemyTranslation, WranglerConfigShape };
+export { wranglerToAlchemy };


### PR DESCRIPTION
Lets `lunora deploy` provision through [Alchemy](https://alchemy.run) instead of wrangler — without asking anyone to write a second config.

Stacked on #190 — review that first.

## Why translate rather than add a config

`wrangler.jsonc` is already the source of truth for what an app needs, and Lunora already owns both halves of it: `inferLunoraBindings` decides a project needs a shard namespace and a bucket, `reconcileWranglerBindings` writes them. A hand-written `alchemy.run.ts` would be a second source of truth, and the drift would surface as a deploy that provisions something the app never binds.

So Alchemy becomes an implementation detail of deploy: **read the config, emit the program, run it.** `wranglerToAlchemy` does the middle step.

## Why Alchemy at all

Wrangler deploys *one worker*. It has no model of the resources around it — the D1 database, the R2 bucket, the queue — beyond what someone already wrote into `wrangler.jsonc`, and no model at all of what should happen when a project is deleted. That is why teardown is conventionally a best-effort sweep over names, and why a non-empty bucket leaks.

Alchemy models resources with create/update/delete lifecycles and a state store, which buys provider breadth we will not write (Neon and PlanetScale branchable Postgres/MySQL — what preview-environment database branching actually needs — plus Upstash, S3, Vercel, AWS), state that is diffable rather than implicit in naming conventions, and a destroy that works.

It does **not** replace wrangler for Workers-for-Platforms: Alchemy's Cloudflare provider is regular-Worker-shaped, and dispatch-namespace uploads stay on their own API surface.

## Why it emits source rather than importing Alchemy

`alchemy@0.93`'s published tarball carries **thirty dependencies, nine of them Node-shaped** — `wrangler`, `miniflare`, `esbuild`, `execa`, `find-process`, `glob`, `open`, `proper-lockfile`, `signal-exit`. `@lunora/config` is imported by `@lunora/vite`, so importing Alchemy here would push that tree into every project that merely wanted to read `lunora.json`, and into any workerd bundle where none of it survives.

Emitting text keeps the module pure and dependency-free. Alchemy only has to exist on the machine that deploys. (I verified this against the real tarball — npm's registry metadata reports 0 dependencies, which is misleading.)

The emitted program is built against Alchemy's actual types, unpacked from the package rather than guessed: `Worker`, `D1Database`, `R2Bucket`, `KVNamespace`, `Queue` are async; `DurableObjectNamespace` is not, because it is a binding descriptor rather than a provisioned resource.

## Two decisions worth attention

**Everything is emitted with `adopt: true`.** A project translated from an existing `wrangler.jsonc` already *has* its database and bucket, with data in them. Without adoption Alchemy treats them as new and creates alongside — the one outcome a deploy must never have.

**What it cannot translate, it names.** Vectorize, workflows, containers, hyperdrive, AI, browser, images, pipelines and analytics datasets land in `unsupported` rather than vanishing, because a silently-missing binding produces a worker whose `env.POSTS_SEARCH` is undefined at runtime with nothing in the build to explain it. Same for a Durable Object implemented by another worker — that script is outside the program's scope, so binding to it would reference something the program never creates.

## Verification

Run against `examples/blog`'s real config: D1, R2 and both Durable Object namespaces translate, `new_sqlite_classes` is accumulated across migrations (a class introduced in `v1` is still SQLite-backed at `v3`), and `vectorize` is correctly reported as unsupported.

Four mutations verified: dropping `adopt`, dropping the unsupported report, reading the SQLite flag off only the newest migration, and binding an external-script Durable Object anyway.

`@lunora/config` 504 tests, `api:check` 42 snapshots, build/lint/prettier green.

## Not wired yet, deliberately

The translator exists but no command calls it — `lunora deploy` still runs wrangler. The remaining step writes the program to `.lunora/alchemy.run.ts` and invokes `alchemy deploy`, plus deciding how it is selected (`--target alchemy`, or a `lunora.json` flag). That is a user-facing surface choice, and the translator is independently reviewable without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137KKKmGRyB69XgLzMaFgSh
