### PR TITLE
test(auth): pin zero-config trusted origins

### DIFF
--- a/packages/auth/__tests__/forget-password-route.test.ts
+++ b/packages/auth/__tests__/forget-password-route.test.ts
@@ -1,13 +1,12 @@
 import { DatabaseSync } from "node:sqlite";
 
-import { getAuthTables } from "better-auth/db";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { lunoraAuthAdapter } from "../src/adapter";
-import { createAuth, resolveAuthOptions } from "../src/create-auth";
+import { createAuth } from "../src/create-auth";
 import { handleAuthRequest } from "../src/handler";
-import type { SqlExecutor } from "../src/sql-store";
 import { createSqlAuthStore } from "../src/sql-store";
+import { executorFor, materialiseAuthSchema } from "./helpers/sqlite-auth-db";
 
 /**
  * Reproduces the E2E `mail-reset.spec.ts` failure at the worker/auth boundary
@@ -21,40 +20,6 @@ const EMAIL = "ada@example.com";
 const PASSWORD = "correct-horse-battery-staple"; // secret-scanner:allow
 
 let database: DatabaseSync;
-
-const executorFor = (database_: DatabaseSync): SqlExecutor => {
-    return {
-        all: (sql, parameters) => Promise.resolve(database_.prepare(sql).all(...(parameters as never[])) as Record<string, unknown>[]),
-        run: (sql, parameters) => {
-            database_.prepare(sql).run(...(parameters as never[]));
-
-            return Promise.resolve();
-        },
-    };
-};
-
-const affinity = (type: ReadonlyArray<string> | string): string => {
-    if (type === "number") {
-        return "REAL";
-    }
-
-    if (type === "boolean") {
-        return "INTEGER";
-    }
-
-    return "TEXT";
-};
-
-const materialiseSchema = (database_: DatabaseSync, options: Parameters<typeof getAuthTables>[0]): void => {
-    for (const table of Object.values(getAuthTables(options))) {
-        const columns = [
-            `"id" TEXT PRIMARY KEY`,
-            ...Object.entries(table.fields).map(([field, attribute]) => `"${attribute.fieldName ?? field}" ${affinity(attribute.type)}`),
-        ];
-
-        database_.exec(`CREATE TABLE "${table.modelName}" (${columns.join(", ")})`);
-    }
-};
 
 const jsonRequest = (path: string, body: unknown): Request =>
     new Request(`http://localhost:3000${path}`, {
@@ -83,10 +48,7 @@ describe("auth — /api/auth/forget-password HTTP route", () => {
 
     beforeEach(() => {
         database = new DatabaseSync(":memory:");
-        // Materialise the schema from the SAME resolved options `createAuth` runs
-        // with (and `compileMigrationsSql` migrates from), so `getAuthTables` emits
-        // the `rateLimit` table better-auth's default-on durable limiter writes to.
-        materialiseSchema(database, resolveAuthOptions(baseOptions));
+        materialiseAuthSchema(database, baseOptions);
     });
 
     afterEach(() => {

--- a/packages/auth/__tests__/helpers/sqlite-auth-db.ts
+++ b/packages/auth/__tests__/helpers/sqlite-auth-db.ts
@@ -1,0 +1,72 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { getAuthTables } from "better-auth/db";
+
+import type { LunoraAuthOptions } from "../../src/create-auth";
+import { resolveAuthOptions } from "../../src/create-auth";
+import type { SqlExecutor } from "../../src/sql-store";
+
+/**
+ * Shared `node:sqlite` backing for the suites that drive a **real** better-auth instance
+ * over Lunora's SQL store.
+ *
+ * Shared rather than copied for the reason `helpers/do-storage.ts` gives about its own
+ * double: the copies drift on the one detail that matters. They already had —
+ * `integration.test.ts` materialised its schema from *raw* options while
+ * `forget-password-route.test.ts` used resolved ones and carried a comment explaining
+ * why raw is wrong. {@link materialiseAuthSchema} resolves internally so that divergence
+ * cannot recur.
+ */
+
+/**
+ * A {@link SqlExecutor} over an in-memory SQLite database.
+ *
+ * `DatabaseSync` is synchronous, so both methods resolve immediately; the async signature
+ * exists to satisfy the executor seam D1 (genuinely async) also implements.
+ */
+const executorFor = (database: DatabaseSync): SqlExecutor => {
+    return {
+        all: (sql, parameters) => Promise.resolve(database.prepare(sql).all(...(parameters as never[])) as Record<string, unknown>[]),
+        run: (sql, parameters) => {
+            database.prepare(sql).run(...(parameters as never[]));
+
+            return Promise.resolve();
+        },
+    };
+};
+
+/** SQLite column affinity for a better-auth field type. */
+const affinity = (type: ReadonlyArray<string> | string): string => {
+    if (type === "number") {
+        return "REAL";
+    }
+
+    if (type === "boolean") {
+        return "INTEGER";
+    }
+
+    return "TEXT";
+};
+
+/**
+ * Materialise the tables `createAuth(options)` will actually read, so the store works
+ * against real tables rather than implicit-table fakery.
+ *
+ * Takes the **caller's** options and resolves them here on purpose. The defaults
+ * `resolveAuthOptions` fills change which tables `getAuthTables` emits — most visibly the
+ * `rateLimit` table better-auth's default-on durable limiter writes to — and a missing one
+ * surfaces as an opaque SQL error much later. Folding the resolve in means no caller can
+ * pass raw options and get a subtly incomplete schema.
+ */
+const materialiseAuthSchema = (database: DatabaseSync, options: LunoraAuthOptions): void => {
+    for (const table of Object.values(getAuthTables(resolveAuthOptions(options)))) {
+        const columns = [
+            `"id" TEXT PRIMARY KEY`,
+            ...Object.entries(table.fields).map(([field, attribute]) => `"${attribute.fieldName ?? field}" ${affinity(attribute.type)}`),
+        ];
+
+        database.exec(`CREATE TABLE "${table.modelName}" (${columns.join(", ")})`);
+    }
+};
+
+export { executorFor, materialiseAuthSchema };

--- a/packages/auth/__tests__/integration.test.ts
+++ b/packages/auth/__tests__/integration.test.ts
@@ -1,13 +1,12 @@
 import { DatabaseSync } from "node:sqlite";
 
-import { getAuthTables } from "better-auth/db";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { lunoraAuthAdapter } from "../src/adapter";
 import type { LunoraAuth } from "../src/create-auth";
 import { createAuth } from "../src/create-auth";
-import type { SqlExecutor } from "../src/sql-store";
 import { createSqlAuthStore } from "../src/sql-store";
+import { executorFor, materialiseAuthSchema } from "./helpers/sqlite-auth-db";
 
 /**
  * Integration coverage (audit finding #9). The other suites in this package
@@ -33,45 +32,6 @@ const EMAIL = "ada@example.com";
 const PASSWORD = "correct-horse-battery-staple"; // secret-scanner:allow
 
 let database: DatabaseSync;
-
-const executorFor = (db: DatabaseSync): SqlExecutor => {
-    return {
-        all: (sql, parameters) => Promise.resolve(db.prepare(sql).all(...(parameters as never[])) as Record<string, unknown>[]),
-        run: (sql, parameters) => {
-            db.prepare(sql).run(...(parameters as never[]));
-
-            return Promise.resolve();
-        },
-    };
-};
-
-/** SQLite column affinity for a better-auth field type. */
-const affinity = (type: ReadonlyArray<string> | string): string => {
-    if (type === "number") {
-        return "REAL";
-    }
-
-    if (type === "boolean") {
-        return "INTEGER";
-    }
-
-    return "TEXT";
-};
-
-/**
- * Materialise the better-auth schema for `options` into the SQLite database so
- * the store reads and writes real tables (no implicit-table fakery).
- */
-const materialiseSchema = (db: DatabaseSync, options: Parameters<typeof getAuthTables>[0]): void => {
-    for (const table of Object.values(getAuthTables(options))) {
-        const columns = [
-            `"id" TEXT PRIMARY KEY`,
-            ...Object.entries(table.fields).map(([field, attribute]) => `"${attribute.fieldName ?? field}" ${affinity(attribute.type)}`),
-        ];
-
-        db.exec(`CREATE TABLE "${table.modelName}" (${columns.join(", ")})`);
-    }
-};
 
 /**
  * A signed-in session: the unsigned token (the value stored in the `session`
@@ -121,7 +81,7 @@ describe("auth integration — real better-auth over in-memory SQLite", () => {
 
     beforeEach(() => {
         database = new DatabaseSync(":memory:");
-        materialiseSchema(database, baseOptions);
+        materialiseAuthSchema(database, baseOptions);
     });
 
     afterEach(() => {

--- a/packages/auth/__tests__/trusted-origins.behaviour.test.ts
+++ b/packages/auth/__tests__/trusted-origins.behaviour.test.ts
@@ -1,0 +1,178 @@
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lunoraAuthAdapter } from "../src/adapter";
+import type { LunoraAuth, LunoraAuthOptions } from "../src/create-auth";
+import { createAuth } from "../src/create-auth";
+import { createSqlAuthStore } from "../src/sql-store";
+import { executorFor, materialiseAuthSchema } from "./helpers/sqlite-auth-db";
+
+/**
+ * Sign-in must work on a freshly deployed worker that configured **neither**
+ * `baseURL` **nor** `trustedOrigins`.
+ *
+ * That shape is the common one on Cloudflare Workers, and `create-auth.ts` documents
+ * why: `baseURL` is very often left unset so better-auth infers the origin per request.
+ * The risk is that better-auth's CSRF layer (`validateOrigin`) rejects every
+ * cookie-bearing POST with `INVALID_ORIGIN` when its trusted list is empty — which is
+ * what a naive read of `getTrustedOrigins(options)` suggests, since the context-time
+ * call passes no `request` and therefore resolves no origin at all.
+ *
+ * It does not, because `createBetterAuth`'s handler recomputes the list per request
+ * (`auth/base.mjs`: when `options.baseURL` is unset it derives the base URL from the
+ * request, then re-runs `getTrustedOrigins(trustOptions, request)`), so the origin the
+ * browser actually connected to is trusted for that request. These tests pin that
+ * behaviour: it is the reason Lunora ships no `trustedOrigins` default of its own, and
+ * it is load-bearing for zero-config sign-in after deploy. A better-auth change that
+ * moved the resolution back to context-creation time would break every deployment
+ * relying on origin inference, silently and only in production.
+ *
+ * Deliberately driven through `auth.handler(request)` rather than `auth.api.*`: the
+ * origin/CSRF middleware only runs on the HTTP path, so a direct `api` call proves
+ * nothing here.
+ *
+ * ## Why every case sets `disableOriginCheck: false`
+ *
+ * better-auth resolves `skipOriginCheck` in `context/create-context.mjs` as: the caller's
+ * `advanced.disableOriginCheck` when set, else **true** under `isTest()`. Vitest sets
+ * `NODE_ENV=test`, so without the explicit `false` the middleware returns early and every
+ * origin is accepted — the two positive cases below then pass while proving nothing, and
+ * the two negative ones fail outright. Setting it restores the production code path, the
+ * only one worth asserting on.
+ *
+ * Which is also the property that keeps this suite honest: it asserts in **both**
+ * directions, so it cannot quietly decay into a vacuous pass. An accept-everything
+ * regression breaks the negative cases; a reject-everything regression breaks the
+ * positive ones.
+ *
+ * ## Why the environment is stubbed
+ *
+ * `getBaseURL` consults `BETTER_AUTH_URL` and its framework-prefixed variants *before*
+ * falling back to the request, and `getTrustedOrigins` appends
+ * `BETTER_AUTH_TRUSTED_ORIGINS` to the list. Any of those set in the ambient shell silently
+ * changes the verdict: pointing `BETTER_AUTH_TRUSTED_ORIGINS` at the foreign origin below
+ * turns "CSRF protection is intact" red with no hint that the environment is the cause, and
+ * `BETTER_AUTH_URL` is exactly what a developer working on a better-auth app would have
+ * exported. Clearing them is what makes the run hermetic.
+ */
+
+const SECRET = "lunora-trusted-origins-secret-lunora-trusted-xx";
+const EMAIL = "ada@example.com";
+// test-only credential for an in-memory better-auth instance — never a real secret
+const PASSWORD = "correct-horse-battery-staple"; // secret-scanner:allow
+
+/** The origin the "deployment" is reached on; never configured on the auth instance. */
+const OWN_ORIGIN = "https://app.example.com";
+const FOREIGN_ORIGIN = "https://evil.example";
+
+let database: DatabaseSync;
+
+/**
+ * Every env key that can pre-empt or widen the request-derived origin — the
+ * `BETTER_AUTH_URL` family read by `getBaseURL`, plus `BETTER_AUTH_TRUSTED_ORIGINS`
+ * appended by `getTrustedOrigins`. `BASE_URL` is deliberately absent: Vitest owns that
+ * key, and stubbing it breaks the runner rather than the dependency.
+ */
+const AMBIENT_ORIGIN_KEYS = [
+    "BETTER_AUTH_URL",
+    "NEXT_PUBLIC_BETTER_AUTH_URL",
+    "PUBLIC_BETTER_AUTH_URL",
+    "NUXT_PUBLIC_BETTER_AUTH_URL",
+    "NUXT_PUBLIC_AUTH_URL",
+    "BETTER_AUTH_TRUSTED_ORIGINS",
+] as const;
+
+/**
+ * The deployment under test: no `baseURL`, no `trustedOrigins`, schema materialised to
+ * match the options it will actually run with.
+ *
+ * Rate limiting is off so a burst of cases can't turn into a 429 that masks the origin
+ * verdict — the limiter has no bearing on the origin middleware.
+ */
+const deployAuth = (): LunoraAuth => {
+    const options: LunoraAuthOptions = {
+        // Undo better-auth's `isTest()` default of skipping the origin check; see the
+        // module comment. Everything else is left at Lunora's own defaults.
+        advanced: { disableOriginCheck: false },
+        database: lunoraAuthAdapter(createSqlAuthStore(executorFor(database))),
+        emailAndPassword: { enabled: true },
+        rateLimit: { enabled: false },
+        secret: SECRET,
+    };
+
+    materialiseAuthSchema(database, options);
+
+    return createAuth(options);
+};
+
+/**
+ * A sign-in POST carrying valid credentials, so a rejection can only ever be the origin
+ * verdict. The `cookie` header matters: `validateOrigin` only engages on a request that
+ * carries cookies.
+ */
+const signInRequest = ({ callbackURL, origin }: { callbackURL?: string; origin: string }): Request =>
+    new Request(`${OWN_ORIGIN}/api/auth/sign-in/email`, {
+        body: JSON.stringify({ email: EMAIL, password: PASSWORD, ...(callbackURL === undefined ? {} : { callbackURL }) }),
+        headers: {
+            "content-type": "application/json",
+            cookie: "prior-session=1",
+            origin,
+        },
+        method: "POST",
+    });
+
+describe("trusted origins with neither baseURL nor trustedOrigins configured", () => {
+    let auth: LunoraAuth;
+
+    beforeEach(async () => {
+        for (const key of AMBIENT_ORIGIN_KEYS) {
+            vi.stubEnv(key, undefined);
+        }
+
+        database = new DatabaseSync(":memory:");
+        auth = deployAuth();
+
+        // `auth.api.*` has no Request, so this bypasses the origin middleware under test.
+        await auth.api.signUpEmail({ body: { email: EMAIL, name: "Ada", password: PASSWORD } });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        database.close();
+    });
+
+    it("accepts a sign-in from the origin the request arrived on", async () => {
+        expect.assertions(1);
+
+        const response = await auth.handler(signInRequest({ origin: OWN_ORIGIN }));
+
+        expect(response.status).toBe(200);
+    });
+
+    it("still rejects a cross-origin sign-in, so CSRF protection is intact", async () => {
+        expect.assertions(2);
+
+        const response = await auth.handler(signInRequest({ origin: FOREIGN_ORIGIN }));
+
+        expect(response.status).toBe(403);
+        await expect(response.json()).resolves.toMatchObject({ code: "INVALID_ORIGIN" });
+    });
+
+    it("accepts a callbackURL on the deployment's own origin", async () => {
+        expect.assertions(1);
+
+        const response = await auth.handler(signInRequest({ callbackURL: `${OWN_ORIGIN}/welcome`, origin: OWN_ORIGIN }));
+
+        expect(response.status).toBe(200);
+    });
+
+    it("rejects a callbackURL pointing at another origin", async () => {
+        expect.assertions(2);
+
+        const response = await auth.handler(signInRequest({ callbackURL: `${FOREIGN_ORIGIN}/steal`, origin: OWN_ORIGIN }));
+
+        expect(response.status).toBe(403);
+        await expect(response.json()).resolves.toMatchObject({ code: "INVALID_CALLBACK_URL" });
+    });
+});

--- a/packages/auth/src/adapter.ts
+++ b/packages/auth/src/adapter.ts
@@ -152,7 +152,7 @@ const lunoraAuthAdapter = (store: AuthStore, runInTransaction?: TransactionRunne
 const lunoraD1Adapter = (d1: Parameters<typeof d1Executor>[0]): ReturnType<typeof lunoraAuthAdapter> => lunoraAuthAdapter(createSqlAuthStore(d1Executor(d1)));
 
 /**
- * Prototype: a better-auth `database` backed by a Durable Object's own SQLite —
+ * A better-auth `database` backed by a Durable Object's own SQLite —
  * `lunoraAuthAdapter(createSqlAuthStore(doExecutor(storage)), doTransactionRunner(storage))`.
  *
  * Unlike `lunoraD1Adapter` this one exposes real transactions, so plugins that

--- a/packages/auth/src/create-auth.ts
+++ b/packages/auth/src/create-auth.ts
@@ -73,6 +73,17 @@ const isExplicitHttpBaseUrl = (baseURL: BetterAuthOptions["baseURL"]): boolean =
  *
  * CSRF/origin validation and `baseURL`-trusted-origins are already on by default
  * in better-auth, so we don't re-implement them here.
+ *
+ * That includes the common Workers shape with `baseURL` unset: better-auth trusts the
+ * request's own origin, recomputed per request, so sign-in works on a fresh deploy with
+ * nothing configured. CSRF still holds — the trusted origin is derived from the `Host`
+ * the browser connected to, which page JS cannot forge, so a cross-site `Origin` never
+ * matches. (The `BETTER_AUTH_URL` family and `BETTER_AUTH_TRUSTED_ORIGINS` can pre-empt
+ * or widen that list, but they are operator-set and not attacker-reachable.)
+ *
+ * Do **not** add a `trustedOrigins` default here on the assumption that the
+ * context-time list is empty — it is, and it doesn't matter. The mechanism and the
+ * pin live in `__tests__/trusted-origins.behaviour.test.ts`.
  */
 const hardenAuthOptions = (options: BetterAuthOptions): BetterAuthOptions => {
     if (isWeakSecret(options.secret)) {

--- a/packages/auth/src/do-store.ts
+++ b/packages/auth/src/do-store.ts
@@ -1,5 +1,5 @@
 /**
- * **Prototype.** better-auth over a Durable Object's own SQLite, rather than D1.
+ * better-auth over a Durable Object's own SQLite, rather than D1.
  *
  * ## Why this exists
  *
@@ -15,14 +15,31 @@
  * `ShardDO.runInTransaction` already relies on. Backing better-auth with DO storage
  * therefore satisfies SCIM without leaving Cloudflare's first-party stack.
  *
- * ## Status and the trade it makes
+ * ## Status
  *
- * This is a prototype, not a recommended default. It puts `user` / `session` (and the
- * SCIM tables) inside **one** Durable Object, which changes the shape of the system:
- * writes serialise through a single object rather than spreading across D1, the object
- * holds them in its own SQLite, and backup/export follows the DO path instead of D1's.
- * That is a deliberate architectural choice, not a drop-in swap — measure it before
- * moving an existing deployment.
+ * `@experimental`; D1 remains the recommended default. Experimental here is about the
+ * signature, not the primitive: the transaction path is covered by a workerd suite over
+ * the real `state.storage.transaction`, but `api-snapshots/auth.api.md` records the export
+ * as untracked, so its shape can churn without failing the gate that backs this package's
+ * stability guarantee.
+ *
+ * What makes it a deliberate choice rather than a drop-in swap:
+ *
+ * **Topology.** `user` / `session` and the SCIM tables live inside **one** object, so writes
+ * serialise through it, its storage limits apply, and backup/export follows the DO path
+ * rather than D1's.
+ *
+ * **No `ensureMigrated`.** better-auth's migrator is kysely-only, so the object materialises
+ * its own schema (see `authDoSchemaStatements`).
+ *
+ * **No sharding.** There is one auth object.
+ *
+ * **`authAdmin` degrades.** The studio's auth admin pages read the auth tables from the
+ * worker, which DO storage does not permit, so they report "not configured" rather than
+ * returning data. The audit feed still works — the worker reads it back over an internal
+ * route.
+ *
+ * Measure it before moving an existing deployment. Full picture: `docs/index.mdx`.
  *
  * ```ts
  * // Inside a Durable Object (`this.state` / `this.ctx`), with the constructor's


### PR DESCRIPTION
## What this pins

A worker deployed with neither `baseURL` nor `trustedOrigins` configured — the common Cloudflare Workers shape — can still sign in. Nothing in the repo pinned that, and the code reads as though it shouldn't work: better-auth's context-time `getTrustedOrigins(options)` call receives no request, so the trusted list really is empty at that point.

It works because the handler recomputes the list **per request** (`auth/base.mjs`: with no configured `baseURL` it derives one from the request, then re-runs `getTrustedOrigins(trustOptions, request)`), so the origin the browser connected to is trusted for that request. CSRF still holds, because only the request's *own* origin is added and it comes from the `Host` the browser connected to — which page JS cannot forge.

The standing risk was someone reading the context-time call, concluding the list is empty, and "fixing" it with a redundant `trustedOrigins` default. `__tests__/trusted-origins.behaviour.test.ts` now makes that regression loud, and `create-auth.ts` says explicitly not to do it.

## Why the test asserts in both directions

Four cases: the request's own origin is accepted, a cross-site origin is rejected with `INVALID_ORIGIN`, an own-origin `callbackURL` is accepted, a foreign one is rejected with `INVALID_CALLBACK_URL`. That two-directional shape is deliberate — an accept-everything regression breaks the negative cases, a reject-everything regression breaks the positive ones, so the suite cannot quietly decay into a vacuous pass.

Assertions are on the observable HTTP contract (status + error `code`), not on better-auth internals; internals appear only in comments. It is driven through `auth.handler(request)` rather than `auth.api.*`, because the origin middleware only runs on the HTTP path.

## Two traps it has to defuse

**better-auth disables origin checking under test.** `skipOriginCheck` defaults to `true` when `isTest()`, and Vitest sets `NODE_ENV=test`. Without an explicit `advanced: { disableOriginCheck: false }` the middleware returns early: the positive cases pass while proving nothing and the negative ones fail outright. Worth knowing beyond this PR — **any** future test in this repo that thinks it is asserting CSRF or origin behaviour is asserting nothing unless it sets that flag. I checked, and no pre-existing test was affected.

**Ambient env vars silently change the verdict.** `getBaseURL` reads `BETTER_AUTH_URL` and its framework-prefixed variants *before* falling back to the request, and `getTrustedOrigins` appends `BETTER_AUTH_TRUSTED_ORIGINS`. With `BETTER_AUTH_TRUSTED_ORIGINS` pointed at the foreign origin, "CSRF protection is intact" goes red with no hint that the environment is the cause — and `BETTER_AUTH_URL` is exactly what someone working on a better-auth app would have exported. They are stubbed per test. I verified the stubbing is load-bearing rather than decorative: with it removed and a hostile value exported, the two negative cases fail.

## Test-helper extraction

`__tests__/helpers/sqlite-auth-db.ts` replaces three verbatim copies of `executorFor` / `affinity` / `materialiseSchema`, which had **already drifted**: `integration.test.ts` materialised its schema from *raw* options while `forget-password-route.test.ts` used *resolved* ones and carried a comment explaining why raw is wrong. Raw options omit the `rateLimit` table better-auth's default-on durable limiter writes to, which surfaces much later as an opaque SQL error.

The helper resolves internally, so a caller cannot pass raw options and get a subtly incomplete schema. That fixes `integration.test.ts` en route. Five partial copies of `executorFor` / `affinity` remain in `sql-store`, `audit`, and `do-adapter`; consolidating those is a fair follow-up and deliberately not in scope here.

## Label normalisation

The DO-backed auth path was labelled `@experimental` in some files and "Prototype" in others. It is now `@experimental` throughout. "Prototype" undersold something that has a workerd suite over the real `state.storage.transaction`, a `vis generate lunora-auth-do` scaffold, and an advisor lint (`auth-scim-without-transactions`) naming it as the fix for SCIM-on-D1 — it is the only Cloudflare-native SCIM path, since D1 has no native transactions.

The status block in `do-store.ts` now states what experimental actually commits us to (the export is recorded as untracked in `api-snapshots/auth.api.md`, so its shape can churn) and restores the functional caveats an earlier draft had dropped: no `ensureMigrated`, no sharding, and `authAdmin` degrading to "not configured" because the studio's auth admin pages read the auth tables from the worker, which DO storage does not permit.

## Verification

- `pnpm --filter "@lunora/auth" exec vitest run` — 29 files / 320 tests pass
- `LUNORA_WORKERD_TESTS=1 … --project workerd` — 2 files / 7 tests pass, so the workerd claim now cited in `do-store.ts` is verified rather than assumed
- `lint:types`, ESLint, Prettier clean on all seven files
- `pnpm run api:check` — matches all 39 committed snapshots (the `src` edits are comment-only)

Reviewed by both thermo-nuclear passes before opening; every finding either fixed here or explicitly scoped out above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the Durable Object–backed SQLite adapter’s description and experimental status.
  - Expanded guidance on trusted-origin behavior in Cloudflare Workers, including browser host handling and test coverage.
  - Documented storage topology, serialization, backup/export considerations, differences from the D1 setup, and expected administrative behavior.
  - No runtime behavior or public API changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->