### PR TITLE
fix(auth-ui): complete the recovery flows (reset token from URL, OTP reset, backup codes, redirectTo)

### DIFF
--- a/packages/auth-ui/__tests__/core/extras.test.ts
+++ b/packages/auth-ui/__tests__/core/extras.test.ts
@@ -179,6 +179,89 @@ describe("redirectTo", () => {
     });
 });
 
+describe("redirectTo reaches every sign-in transport", () => {
+    afterEach(() => {
+        // jsdom keeps the URL across tests otherwise, and these all set it.
+        window.history.pushState({}, "", "/");
+    });
+
+    it("passes an on-origin redirectTo as the social callbackURL", async () => {
+        expect.assertions(1);
+
+        const { resolveContext, signInWithSocial } = await import("../../src/core");
+
+        window.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+
+        const social = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const context = resolveContext({
+            authClient: { getSession: vi.fn(), signIn: { social } } as never,
+            nav: { navigate: vi.fn(), replace: vi.fn() },
+        });
+
+        await signInWithSocial(context, "google");
+
+        expect(social).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: "/invite/xyz" }));
+    });
+
+    it("falls back to the configured default when redirectTo would leave the origin", async () => {
+        expect.assertions(1);
+
+        const { resolveContext, signInWithSocial } = await import("../../src/core");
+
+        window.history.pushState({}, "", "/sign-in?redirectTo=https%3A%2F%2Fevil.example");
+
+        const social = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const context = resolveContext({
+            authClient: { getSession: vi.fn(), signIn: { social } } as never,
+            nav: { navigate: vi.fn(), replace: vi.fn() },
+            redirects: { afterSignIn: "/app" },
+        });
+
+        await signInWithSocial(context, "google");
+
+        expect(social).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: "/app" }));
+    });
+
+    it("passes an on-origin redirectTo as the magic-link callbackURL", async () => {
+        expect.assertions(1);
+
+        const { createMagicLinkController, resolveContext } = await import("../../src/core");
+
+        window.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+
+        const magicLink = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const context = resolveContext({
+            authClient: { getSession: vi.fn(), signIn: { magicLink } } as never,
+            nav: { navigate: vi.fn(), replace: vi.fn() },
+        });
+
+        const controller = createMagicLinkController(context);
+
+        controller.actions.setField("email", "ada@example.com");
+        await controller.actions.submit();
+
+        expect(magicLink).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: "/invite/xyz" }));
+    });
+
+    it("passes an on-origin redirectTo as the One Tap callbackURL", async () => {
+        expect.assertions(1);
+
+        const { promptOneTap, resolveContext } = await import("../../src/core");
+
+        window.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+
+        const oneTap = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const context = resolveContext({
+            authClient: { getSession: vi.fn(), oneTap } as never,
+            nav: { navigate: vi.fn(), replace: vi.fn() },
+        });
+
+        await promptOneTap(context);
+
+        expect(oneTap).toHaveBeenCalledWith(expect.objectContaining({ callbackURL: "/invite/xyz" }));
+    });
+});
+
 describe("oauth-provider consent", () => {
     it("labels known scopes and shows unknown ones verbatim", async () => {
         expect.assertions(2);

--- a/packages/auth-ui/__tests__/core/extras.test.ts
+++ b/packages/auth-ui/__tests__/core/extras.test.ts
@@ -182,7 +182,7 @@ describe("redirectTo", () => {
 describe("redirectTo reaches every sign-in transport", () => {
     afterEach(() => {
         // jsdom keeps the URL across tests otherwise, and these all set it.
-        window.history.pushState({}, "", "/");
+        globalThis.history.pushState({}, "", "/");
     });
 
     it("passes an on-origin redirectTo as the social callbackURL", async () => {
@@ -190,7 +190,7 @@ describe("redirectTo reaches every sign-in transport", () => {
 
         const { resolveContext, signInWithSocial } = await import("../../src/core");
 
-        window.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+        globalThis.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
 
         const social = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const context = resolveContext({
@@ -208,7 +208,11 @@ describe("redirectTo reaches every sign-in transport", () => {
 
         const { resolveContext, signInWithSocial } = await import("../../src/core");
 
-        window.history.pushState({}, "", "/sign-in?redirectTo=https%3A%2F%2Fevil.example");
+        // Built rather than a literal query string: an off-origin `redirectTo` is
+        // exactly what `resolveAfterSignIn` must refuse to honour.
+        const offOrigin = new URLSearchParams({ redirectTo: "https://evil.example" });
+
+        globalThis.history.pushState({}, "", `/sign-in?${offOrigin.toString()}`);
 
         const social = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const context = resolveContext({
@@ -227,7 +231,7 @@ describe("redirectTo reaches every sign-in transport", () => {
 
         const { createMagicLinkController, resolveContext } = await import("../../src/core");
 
-        window.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+        globalThis.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
 
         const magicLink = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const context = resolveContext({
@@ -248,7 +252,7 @@ describe("redirectTo reaches every sign-in transport", () => {
 
         const { promptOneTap, resolveContext } = await import("../../src/core");
 
-        window.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+        globalThis.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
 
         const oneTap = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const context = resolveContext({

--- a/packages/auth-ui/__tests__/react/extras.test.tsx
+++ b/packages/auth-ui/__tests__/react/extras.test.tsx
@@ -11,6 +11,7 @@ import {
     ResetPasswordCard,
     ResetPasswordOtpCard,
     SignUpCard,
+    TwoFactorCard,
     TwoFactorSetupCard,
 } from "../../src/react";
 
@@ -246,6 +247,57 @@ describe("resetPasswordOtpCard", () => {
 
         await waitFor(() => {
             expect(resetPassword).toHaveBeenCalledWith({ email: "ada@example.com", otp: "123456", password: "hunter2hunter2" });
+        });
+    });
+});
+
+describe("twoFactorCard backup-code toggle", () => {
+    const renderCard = (client: AuthClient) =>
+        render(
+            <AuthUIProvider authClient={client} discover={false} nav={{ navigate: vi.fn(), replace: vi.fn() }} plugins={{ twoFactor: true }}>
+                <TwoFactorCard />
+            </AuthUIProvider>,
+        );
+
+    it("switches to the backup-code form and submits it instead of the TOTP one", async () => {
+        expect.assertions(2);
+
+        const verifyTotp = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const verifyBackupCode = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { getSession: vi.fn(), twoFactor: { verifyBackupCode, verifyTotp } } as unknown as AuthClient;
+
+        renderCard(client);
+
+        fireEvent.click(screen.getByRole("button", { name: "Use a backup code" }));
+        fireEvent.change(screen.getByLabelText("Backup code"), { target: { value: "abc-def-ghi" } });
+        fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+        await waitFor(() => {
+            expect(verifyBackupCode).toHaveBeenCalledWith(expect.objectContaining({ code: "abc-def-ghi" }));
+        });
+
+        expect(verifyTotp).not.toHaveBeenCalled();
+    });
+
+    it("switches back to the authenticator form", async () => {
+        expect.assertions(2);
+
+        const verifyTotp = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const verifyBackupCode = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { getSession: vi.fn(), twoFactor: { verifyBackupCode, verifyTotp } } as unknown as AuthClient;
+
+        renderCard(client);
+
+        fireEvent.click(screen.getByRole("button", { name: "Use a backup code" }));
+        fireEvent.click(screen.getByRole("button", { name: "Use your authenticator app instead" }));
+
+        expect(screen.getByLabelText("Verification code")).toBeDefined();
+
+        fireEvent.change(screen.getByLabelText("Verification code"), { target: { value: "123456" } });
+        fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+        await waitFor(() => {
+            expect(verifyTotp).toHaveBeenCalledWith(expect.objectContaining({ code: "123456" }));
         });
     });
 });

--- a/packages/auth-ui/__tests__/react/extras.test.tsx
+++ b/packages/auth-ui/__tests__/react/extras.test.tsx
@@ -3,7 +3,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthClient } from "../../src/core";
 import { pushToast, resetToasts } from "../../src/core";
-import { AuthUIProvider, ConsentCard, ErrorToaster, OrganizationLogoCard, ResetPasswordCard, SignUpCard, TwoFactorSetupCard } from "../../src/react";
+import {
+    AuthUIProvider,
+    ConsentCard,
+    ErrorToaster,
+    OrganizationLogoCard,
+    ResetPasswordCard,
+    ResetPasswordOtpCard,
+    SignUpCard,
+    TwoFactorSetupCard,
+} from "../../src/react";
 
 const stubClient = (): AuthClient => ({ getSession: vi.fn() }) as unknown as AuthClient;
 
@@ -212,6 +221,31 @@ describe("resetPasswordCard reads the token from the URL", () => {
 
         await waitFor(() => {
             expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "from-prop" }));
+        });
+    });
+});
+
+describe("resetPasswordOtpCard", () => {
+    it("redeems the emailed code and sets a new password", async () => {
+        expect.assertions(1);
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { emailOtp: { resetPassword }, getSession: vi.fn() } as unknown as AuthClient;
+
+        render(
+            <AuthUIProvider authClient={client} discover={false} forgotPassword={{ method: "otp" }} nav={{ navigate: vi.fn(), replace: vi.fn() }}>
+                <ResetPasswordOtpCard />
+            </AuthUIProvider>,
+        );
+
+        fireEvent.change(screen.getByLabelText("Email"), { target: { value: "ada@example.com" } });
+        fireEvent.change(screen.getByLabelText("Verification code"), { target: { value: "123456" } });
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.click(screen.getByRole("button", { name: "Set new password" }));
+
+        await waitFor(() => {
+            expect(resetPassword).toHaveBeenCalledWith({ email: "ada@example.com", otp: "123456", password: "hunter2hunter2" });
         });
     });
 });

--- a/packages/auth-ui/__tests__/react/extras.test.tsx
+++ b/packages/auth-ui/__tests__/react/extras.test.tsx
@@ -3,13 +3,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthClient } from "../../src/core";
 import { pushToast, resetToasts } from "../../src/core";
-import { AuthUIProvider, ConsentCard, ErrorToaster, OrganizationLogoCard, SignUpCard, TwoFactorSetupCard } from "../../src/react";
+import { AuthUIProvider, ConsentCard, ErrorToaster, OrganizationLogoCard, ResetPasswordCard, SignUpCard, TwoFactorSetupCard } from "../../src/react";
 
 const stubClient = (): AuthClient => ({ getSession: vi.fn() }) as unknown as AuthClient;
 
 // One cross-suite teardown hook, deliberately at the top level.
 afterEach(() => {
     resetToasts();
+    // jsdom keeps the URL across tests otherwise, and the reset-password suite
+    // below relies on a clean starting point.
+    window.history.pushState({}, "", "/");
 });
 
 describe("errorToaster", () => {
@@ -158,6 +161,57 @@ describe("two-factor setup without a password", () => {
 
         await waitFor(() => {
             expect(screen.queryByText("Set a password before turning on two-factor authentication.")).toBeNull();
+        });
+    });
+});
+
+describe("resetPasswordCard reads the token from the URL", () => {
+    const renderCard = (client: AuthClient) =>
+        render(
+            <AuthUIProvider authClient={client} discover={false} nav={{ navigate: vi.fn(), replace: vi.fn() }}>
+                <ResetPasswordCard />
+            </AuthUIProvider>,
+        );
+
+    it("submits the ?token= from the URL when no prop is passed", async () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=abc");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
+
+        renderCard(client);
+
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.click(screen.getByRole("button", { name: "Set new password" }));
+
+        await waitFor(() => {
+            expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "abc" }));
+        });
+    });
+
+    it("lets an explicit prop win over the URL", async () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=from-url");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
+
+        render(
+            <AuthUIProvider authClient={client} discover={false} nav={{ navigate: vi.fn(), replace: vi.fn() }}>
+                <ResetPasswordCard token="from-prop" />
+            </AuthUIProvider>,
+        );
+
+        fireEvent.change(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.change(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.click(screen.getByRole("button", { name: "Set new password" }));
+
+        await waitFor(() => {
+            expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "from-prop" }));
         });
     });
 });

--- a/packages/auth-ui/__tests__/react/extras.test.tsx
+++ b/packages/auth-ui/__tests__/react/extras.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
     resetToasts();
     // jsdom keeps the URL across tests otherwise, and the reset-password suite
     // below relies on a clean starting point.
-    window.history.pushState({}, "", "/");
+    globalThis.history.pushState({}, "", "/");
 });
 
 describe("errorToaster", () => {
@@ -186,7 +186,7 @@ describe("resetPasswordCard reads the token from the URL", () => {
     it("submits the ?token= from the URL when no prop is passed", async () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=abc");
+        globalThis.history.pushState({}, "", "/reset-password?token=abc");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
@@ -205,7 +205,7 @@ describe("resetPasswordCard reads the token from the URL", () => {
     it("lets an explicit prop win over the URL", async () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=from-url");
+        globalThis.history.pushState({}, "", "/reset-password?token=from-url");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;

--- a/packages/auth-ui/__tests__/solid/cards.test.tsx
+++ b/packages/auth-ui/__tests__/solid/cards.test.tsx
@@ -26,7 +26,7 @@ afterEach(() => {
     vi.restoreAllMocks();
     // jsdom keeps the URL across tests otherwise, and the reset-password suite
     // below relies on a clean starting point.
-    window.history.pushState({}, "", "/");
+    globalThis.history.pushState({}, "", "/");
 });
 
 describe("solid SignInCard", () => {
@@ -124,7 +124,7 @@ describe("solid ResetPasswordCard reads the token from the URL", () => {
     it("submits the ?token= from the URL when no prop is passed", () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=abc");
+        globalThis.history.pushState({}, "", "/reset-password?token=abc");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
@@ -141,7 +141,7 @@ describe("solid ResetPasswordCard reads the token from the URL", () => {
     it("lets an explicit prop win over the URL", () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=from-url");
+        globalThis.history.pushState({}, "", "/reset-password?token=from-url");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;

--- a/packages/auth-ui/__tests__/solid/cards.test.tsx
+++ b/packages/auth-ui/__tests__/solid/cards.test.tsx
@@ -8,9 +8,9 @@ import { fireEvent, render, screen } from "@solidjs/testing-library";
 import type { JSX } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AuthUIConfig } from "../../src/core";
+import type { AuthClient, AuthUIConfig } from "../../src/core";
 import { resetFlowWarnings } from "../../src/core";
-import { MagicLinkCard, SignInCard, SignUpCard } from "../../src/solid";
+import { MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard } from "../../src/solid";
 import { AuthUIProvider } from "../../src/solid/provider";
 import { bareClient, fakeNav, pluginClient } from "../fake-client";
 
@@ -24,6 +24,9 @@ const renderCard = (card: () => JSX.Element, authClient: AuthUIConfig["authClien
 afterEach(() => {
     resetFlowWarnings();
     vi.restoreAllMocks();
+    // jsdom keeps the URL across tests otherwise, and the reset-password suite
+    // below relies on a clean starting point.
+    window.history.pushState({}, "", "/");
 });
 
 describe("solid SignInCard", () => {
@@ -114,5 +117,41 @@ describe("solid theme", () => {
 
         expect(card.style.getPropertyValue("--primary")).toBe("rebeccapurple");
         expect(card.style.getPropertyValue("--border")).toBe("");
+    });
+});
+
+describe("solid ResetPasswordCard reads the token from the URL", () => {
+    it("submits the ?token= from the URL when no prop is passed", () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=abc");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
+
+        renderCard(() => <ResetPasswordCard />, client);
+
+        fireEvent.input(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.input(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "abc" }));
+    });
+
+    it("lets an explicit prop win over the URL", () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=from-url");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const client = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
+
+        renderCard(() => <ResetPasswordCard token="from-prop" />, client);
+
+        fireEvent.input(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.input(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "from-prop" }));
     });
 });

--- a/packages/auth-ui/__tests__/svelte/Harness.svelte
+++ b/packages/auth-ui/__tests__/svelte/Harness.svelte
@@ -7,6 +7,7 @@
     import type { AuthUIConfig } from "../../src/core";
     import AuthUIProvider from "../../src/svelte/AuthUIProvider.svelte";
     import MagicLinkCard from "../../src/svelte/MagicLinkCard.svelte";
+    import ResetPasswordCard from "../../src/svelte/ResetPasswordCard.svelte";
     import SignInCard from "../../src/svelte/SignInCard.svelte";
     import SignUpCard from "../../src/svelte/SignUpCard.svelte";
 
@@ -15,11 +16,13 @@
         card,
         nav,
         theme,
+        token,
     }: {
         authClient: AuthUIConfig["authClient"];
-        card: "magic-link" | "sign-in" | "sign-up";
+        card: "magic-link" | "reset-password" | "sign-in" | "sign-up";
         nav: AuthUIConfig["nav"];
         theme?: AuthUIConfig["theme"];
+        token?: string;
     } = $props();
 </script>
 
@@ -28,6 +31,8 @@
         <SignInCard />
     {:else if card === "sign-up"}
         <SignUpCard />
+    {:else if card === "reset-password"}
+        <ResetPasswordCard {token} />
     {:else}
         <MagicLinkCard />
     {/if}

--- a/packages/auth-ui/__tests__/svelte/cards.test.ts
+++ b/packages/auth-ui/__tests__/svelte/cards.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
     vi.restoreAllMocks();
     // jsdom keeps the URL across tests otherwise, and the reset-password suite
     // below relies on a clean starting point.
-    window.history.pushState({}, "", "/");
+    globalThis.history.pushState({}, "", "/");
 });
 
 describe("svelte SignInCard", () => {
@@ -124,7 +124,7 @@ describe("svelte ResetPasswordCard reads the token from the URL", () => {
     it("submits the ?token= from the URL when no prop is passed", async () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=abc");
+        globalThis.history.pushState({}, "", "/reset-password?token=abc");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const authClient = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
@@ -141,7 +141,7 @@ describe("svelte ResetPasswordCard reads the token from the URL", () => {
     it("lets an explicit prop win over the URL", async () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=from-url");
+        globalThis.history.pushState({}, "", "/reset-password?token=from-url");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const authClient = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;

--- a/packages/auth-ui/__tests__/svelte/cards.test.ts
+++ b/packages/auth-ui/__tests__/svelte/cards.test.ts
@@ -8,7 +8,7 @@ import { fireEvent, render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { ThemeTokens } from "../../src/core";
+import type { AuthClient, ThemeTokens } from "../../src/core";
 import { pushToast, resetFlowWarnings, resetToasts } from "../../src/core";
 import ErrorToaster from "../../src/svelte/ErrorToaster.svelte";
 import { bareClient, fakeNav, pluginClient } from "../fake-client";
@@ -20,6 +20,9 @@ afterEach(() => {
     // up in whichever test renders <ErrorToaster> next.
     resetToasts();
     vi.restoreAllMocks();
+    // jsdom keeps the URL across tests otherwise, and the reset-password suite
+    // below relies on a clean starting point.
+    window.history.pushState({}, "", "/");
 });
 
 describe("svelte SignInCard", () => {
@@ -114,6 +117,42 @@ describe("svelte theme", () => {
 
         expect(card.style.getPropertyValue("--primary")).toBe("rebeccapurple");
         expect(card.style.getPropertyValue("--border")).toBe("");
+    });
+});
+
+describe("svelte ResetPasswordCard reads the token from the URL", () => {
+    it("submits the ?token= from the URL when no prop is passed", async () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=abc");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const authClient = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
+
+        render(Harness, { props: { authClient, card: "reset-password", nav: fakeNav() } });
+
+        await fireEvent.input(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        await fireEvent.input(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "abc" }));
+    });
+
+    it("lets an explicit prop win over the URL", async () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=from-url");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const authClient = { getSession: vi.fn(), resetPassword } as unknown as AuthClient;
+
+        render(Harness, { props: { authClient, card: "reset-password", nav: fakeNav(), token: "from-prop" } });
+
+        await fireEvent.input(screen.getByLabelText("Password"), { target: { value: "hunter2hunter2" } });
+        await fireEvent.input(screen.getByLabelText("Confirm password"), { target: { value: "hunter2hunter2" } });
+        await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "from-prop" }));
     });
 });
 

--- a/packages/auth-ui/__tests__/vue/cards.test.ts
+++ b/packages/auth-ui/__tests__/vue/cards.test.ts
@@ -13,6 +13,7 @@ import { resetFlowWarnings } from "../../src/core";
 import AuthUIProvider from "../../src/vue/AuthUIProvider.vue";
 import MagicLinkCard from "../../src/vue/MagicLinkCard.vue";
 import ResetPasswordCard from "../../src/vue/ResetPasswordCard.vue";
+import ResetPasswordOtpCard from "../../src/vue/ResetPasswordOtpCard.vue";
 import SignInCard from "../../src/vue/SignInCard.vue";
 import SignUpCard from "../../src/vue/SignUpCard.vue";
 import type { FakeClient } from "../fake-client";
@@ -21,8 +22,7 @@ import { bareClient, fakeNav, pluginClient } from "../fake-client";
 const renderInProvider = (component: unknown, fake: FakeClient, extra: Record<string, unknown> = {}, componentProps: Record<string, unknown> = {}): void => {
     render(
         defineComponent({
-            render: () =>
-                h(AuthUIProvider, { authClient: fake.client, nav: fakeNav(), ...extra }, { default: () => h(component as never, componentProps) }),
+            render: () => h(AuthUIProvider, { authClient: fake.client, nav: fakeNav(), ...extra }, { default: () => h(component as never, componentProps) }),
         }),
     );
 };
@@ -170,5 +170,24 @@ describe("vue ResetPasswordCard reads the token from the URL", () => {
         await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
 
         expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "from-prop" }));
+    });
+});
+
+describe("vue ResetPasswordOtpCard", () => {
+    it("redeems the emailed code and sets a new password", async () => {
+        expect.assertions(1);
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const fake = { client: { emailOtp: { resetPassword }, getSession: vi.fn() } as unknown as AuthClient, signInEmail: vi.fn() };
+
+        renderInProvider(ResetPasswordOtpCard, fake, { discover: false, forgotPassword: { method: "otp" } });
+
+        await fireEvent.update(screen.getByLabelText("Email"), "ada@example.com");
+        await fireEvent.update(screen.getByLabelText("Verification code"), "123456");
+        await fireEvent.update(screen.getByLabelText("Password"), "hunter2hunter2");
+        await fireEvent.update(screen.getByLabelText("Confirm password"), "hunter2hunter2");
+        await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith({ email: "ada@example.com", otp: "123456", password: "hunter2hunter2" });
     });
 });

--- a/packages/auth-ui/__tests__/vue/cards.test.ts
+++ b/packages/auth-ui/__tests__/vue/cards.test.ts
@@ -16,6 +16,7 @@ import ResetPasswordCard from "../../src/vue/ResetPasswordCard.vue";
 import ResetPasswordOtpCard from "../../src/vue/ResetPasswordOtpCard.vue";
 import SignInCard from "../../src/vue/SignInCard.vue";
 import SignUpCard from "../../src/vue/SignUpCard.vue";
+import TwoFactorCard from "../../src/vue/TwoFactorCard.vue";
 import type { FakeClient } from "../fake-client";
 import { bareClient, fakeNav, pluginClient } from "../fake-client";
 
@@ -189,5 +190,50 @@ describe("vue ResetPasswordOtpCard", () => {
         await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
 
         expect(resetPassword).toHaveBeenCalledWith({ email: "ada@example.com", otp: "123456", password: "hunter2hunter2" });
+    });
+});
+
+describe("vue TwoFactorCard backup-code toggle", () => {
+    it("switches to the backup-code form and submits it instead of the TOTP one", async () => {
+        expect.assertions(2);
+
+        const verifyTotp = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const verifyBackupCode = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const fake = {
+            client: { getSession: vi.fn(), twoFactor: { verifyBackupCode, verifyTotp } } as unknown as AuthClient,
+            signInEmail: vi.fn(),
+        };
+
+        renderInProvider(TwoFactorCard, fake, { discover: false, plugins: { twoFactor: true } });
+
+        await fireEvent.click(screen.getByRole("button", { name: "Use a backup code" }));
+        await fireEvent.update(screen.getByLabelText("Backup code"), "abc-def-ghi");
+        await fireEvent.submit(screen.getByRole("button", { name: "Verify" }));
+
+        expect(verifyBackupCode).toHaveBeenCalledWith(expect.objectContaining({ code: "abc-def-ghi" }));
+        expect(verifyTotp).not.toHaveBeenCalled();
+    });
+
+    it("switches back to the authenticator form", async () => {
+        expect.assertions(2);
+
+        const verifyTotp = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const verifyBackupCode = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const fake = {
+            client: { getSession: vi.fn(), twoFactor: { verifyBackupCode, verifyTotp } } as unknown as AuthClient,
+            signInEmail: vi.fn(),
+        };
+
+        renderInProvider(TwoFactorCard, fake, { discover: false, plugins: { twoFactor: true } });
+
+        await fireEvent.click(screen.getByRole("button", { name: "Use a backup code" }));
+        await fireEvent.click(screen.getByRole("button", { name: "Use your authenticator app instead" }));
+
+        expect(screen.getByLabelText("Verification code")).toBeDefined();
+
+        await fireEvent.update(screen.getByLabelText("Verification code"), "123456");
+        await fireEvent.submit(screen.getByRole("button", { name: "Verify" }));
+
+        expect(verifyTotp).toHaveBeenCalledWith(expect.objectContaining({ code: "123456" }));
     });
 });

--- a/packages/auth-ui/__tests__/vue/cards.test.ts
+++ b/packages/auth-ui/__tests__/vue/cards.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
     vi.restoreAllMocks();
     // jsdom keeps the URL across tests otherwise, and the reset-password suite
     // below relies on a clean starting point.
-    window.history.pushState({}, "", "/");
+    globalThis.history.pushState({}, "", "/");
 });
 
 describe("vue SignInCard", () => {
@@ -142,7 +142,7 @@ describe("vue ResetPasswordCard reads the token from the URL", () => {
     it("submits the ?token= from the URL when no prop is passed", async () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=abc");
+        globalThis.history.pushState({}, "", "/reset-password?token=abc");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const fake = { client: { getSession: vi.fn(), resetPassword } as unknown as AuthClient, signInEmail: vi.fn() };
@@ -159,7 +159,7 @@ describe("vue ResetPasswordCard reads the token from the URL", () => {
     it("lets an explicit prop win over the URL", async () => {
         expect.assertions(1);
 
-        window.history.pushState({}, "", "/reset-password?token=from-url");
+        globalThis.history.pushState({}, "", "/reset-password?token=from-url");
 
         const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
         const fake = { client: { getSession: vi.fn(), resetPassword } as unknown as AuthClient, signInEmail: vi.fn() };

--- a/packages/auth-ui/__tests__/vue/cards.test.ts
+++ b/packages/auth-ui/__tests__/vue/cards.test.ts
@@ -8,19 +8,21 @@ import { fireEvent, render, screen } from "@testing-library/vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, h } from "vue";
 
-import type { ThemeTokens } from "../../src/core";
+import type { AuthClient, ThemeTokens } from "../../src/core";
 import { resetFlowWarnings } from "../../src/core";
 import AuthUIProvider from "../../src/vue/AuthUIProvider.vue";
 import MagicLinkCard from "../../src/vue/MagicLinkCard.vue";
+import ResetPasswordCard from "../../src/vue/ResetPasswordCard.vue";
 import SignInCard from "../../src/vue/SignInCard.vue";
 import SignUpCard from "../../src/vue/SignUpCard.vue";
 import type { FakeClient } from "../fake-client";
 import { bareClient, fakeNav, pluginClient } from "../fake-client";
 
-const renderInProvider = (component: unknown, fake: FakeClient, extra: Record<string, unknown> = {}): void => {
+const renderInProvider = (component: unknown, fake: FakeClient, extra: Record<string, unknown> = {}, componentProps: Record<string, unknown> = {}): void => {
     render(
         defineComponent({
-            render: () => h(AuthUIProvider, { authClient: fake.client, nav: fakeNav(), ...extra }, { default: () => h(component as never) }),
+            render: () =>
+                h(AuthUIProvider, { authClient: fake.client, nav: fakeNav(), ...extra }, { default: () => h(component as never, componentProps) }),
         }),
     );
 };
@@ -28,6 +30,9 @@ const renderInProvider = (component: unknown, fake: FakeClient, extra: Record<st
 afterEach(() => {
     resetFlowWarnings();
     vi.restoreAllMocks();
+    // jsdom keeps the URL across tests otherwise, and the reset-password suite
+    // below relies on a clean starting point.
+    window.history.pushState({}, "", "/");
 });
 
 describe("vue SignInCard", () => {
@@ -129,5 +134,41 @@ describe("vue theme", () => {
 
         expect(card.style.getPropertyValue("--primary")).toBe("rebeccapurple");
         expect(card.style.getPropertyValue("--border")).toBe("");
+    });
+});
+
+describe("vue ResetPasswordCard reads the token from the URL", () => {
+    it("submits the ?token= from the URL when no prop is passed", async () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=abc");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const fake = { client: { getSession: vi.fn(), resetPassword } as unknown as AuthClient, signInEmail: vi.fn() };
+
+        renderInProvider(ResetPasswordCard, fake);
+
+        await fireEvent.update(screen.getByLabelText("Password"), "hunter2hunter2");
+        await fireEvent.update(screen.getByLabelText("Confirm password"), "hunter2hunter2");
+        await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "abc" }));
+    });
+
+    it("lets an explicit prop win over the URL", async () => {
+        expect.assertions(1);
+
+        window.history.pushState({}, "", "/reset-password?token=from-url");
+
+        const resetPassword = vi.fn(() => Promise.resolve({ data: {}, error: null }));
+        const fake = { client: { getSession: vi.fn(), resetPassword } as unknown as AuthClient, signInEmail: vi.fn() };
+
+        renderInProvider(ResetPasswordCard, fake, {}, { token: "from-prop" });
+
+        await fireEvent.update(screen.getByLabelText("Password"), "hunter2hunter2");
+        await fireEvent.update(screen.getByLabelText("Confirm password"), "hunter2hunter2");
+        await fireEvent.submit(screen.getByRole("button", { name: "Set new password" }));
+
+        expect(resetPassword).toHaveBeenCalledWith(expect.objectContaining({ token: "from-prop" }));
     });
 });

--- a/packages/auth-ui/src/angular/auth-cards.ts
+++ b/packages/auth-ui/src/angular/auth-cards.ts
@@ -18,6 +18,8 @@ import { readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import type { ResetPasswordField } from "../core/reset-password";
 import { createResetPasswordController } from "../core/reset-password";
+import type { ResetPasswordOtpField } from "../core/reset-password-otp";
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import { createSignInController } from "../core/sign-in";
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
@@ -318,6 +320,69 @@ class ResetPasswordCardComponent implements OnInit {
     }
 }
 
+/**
+ * Redeems an emailed one-time code instead of a link — for apps that set
+ * `forgotPassword: { method: "otp" }`. Unlike {@link ResetPasswordCardComponent},
+ * the email address is a field rather than something carried from the previous
+ * screen: a code can legitimately be redeemed from a fresh tab.
+ */
+@Component({
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [AuthCardComponent, AuthFieldComponent, FormBannerComponent, SubmitButtonComponent],
+    selector: "lunora-reset-password-otp-card",
+    standalone: true,
+    template: `
+        <lunora-auth-card [title]="t.resetPassword" [description]="t.resetPasswordOtpDescription">
+            <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
+                <lunora-auth-banner [error]="state().formError" [success]="state().successMessage" />
+                <lunora-auth-field
+                    [field]="state().fields.email"
+                    [label]="t.emailLabel"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    (changed)="actions.setField('email', $event)"
+                    (blurred)="actions.blur('email')"
+                />
+                <lunora-auth-field
+                    [field]="state().fields.otp"
+                    [label]="t.codeLabel"
+                    name="otp"
+                    autoComplete="one-time-code"
+                    (changed)="actions.setField('otp', $event)"
+                    (blurred)="actions.blur('otp')"
+                />
+                <lunora-auth-field
+                    [field]="state().fields.password"
+                    [label]="t.passwordLabel"
+                    name="password"
+                    type="password"
+                    autoComplete="new-password"
+                    (changed)="actions.setField('password', $event)"
+                    (blurred)="actions.blur('password')"
+                />
+                <lunora-auth-field
+                    [field]="state().fields.confirmPassword"
+                    [label]="t.confirmPasswordLabel"
+                    name="confirmPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    (changed)="actions.setField('confirmPassword', $event)"
+                    (blurred)="actions.blur('confirmPassword')"
+                />
+                <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.resetPassword }}</lunora-auth-submit-button>
+            </form>
+        </lunora-auth-card>
+    `,
+})
+class ResetPasswordOtpCardComponent {
+    private readonly context = injectAuthUIContext();
+    protected readonly t = this.context().localization;
+    private readonly bridge = controllerSignal(createResetPasswordOtpController, { context: this.context });
+    protected readonly state: Signal<FormState<ResetPasswordOtpField>> = this.bridge.state;
+    protected readonly actions: FormActions<ResetPasswordOtpField> = this.bridge.actions;
+}
+
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [AuthCardComponent, AuthFieldComponent, AuthLinkComponent, FormBannerComponent, SubmitButtonComponent],
@@ -457,6 +522,7 @@ export {
     ForgotPasswordCardComponent,
     MagicLinkCardComponent,
     ResetPasswordCardComponent,
+    ResetPasswordOtpCardComponent,
     SignInCardComponent,
     SignUpCardComponent,
     TwoFactorCardComponent,

--- a/packages/auth-ui/src/angular/auth-cards.ts
+++ b/packages/auth-ui/src/angular/auth-cards.ts
@@ -5,9 +5,11 @@
  * standalone component binding a core controller to the shared view primitives.
  */
 import type { OnInit, Signal } from "@angular/core";
-import { ChangeDetectionStrategy, Component, computed, inject, Injector, input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject, Injector, input, signal } from "@angular/core";
 
 import { signInAnonymously } from "../core/anonymous";
+import type { BackupCodeSignInField } from "../core/backup-codes";
+import { createBackupCodeSignInController } from "../core/backup-codes";
 import { queryParameter } from "../core/browser-location";
 import type { EmailOtpActions, EmailOtpState } from "../core/email-otp";
 import { createEmailOtpController } from "../core/email-otp";
@@ -477,20 +479,41 @@ class EmailOtpCardComponent {
     standalone: true,
     template: `
         @if (enabled()) {
-            <lunora-auth-card [title]="t.twoFactor">
-                <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
-                    <lunora-auth-banner [error]="state().formError" />
-                    <lunora-auth-field
-                        [field]="state().fields.code"
-                        [label]="t.codeLabel"
-                        name="code"
-                        autoComplete="one-time-code"
-                        (changed)="actions.setField('code', $event)"
-                        (blurred)="actions.blur('code')"
-                    />
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.twoFactor }}</lunora-auth-submit-button>
-                </form>
-            </lunora-auth-card>
+            @if (useBackupCode()) {
+                <lunora-auth-card [title]="t.twoFactor" [footer]="true">
+                    <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); backupActions.submit()">
+                        <lunora-auth-banner [error]="backupState().formError" />
+                        <lunora-auth-field
+                            [field]="backupState().fields.code"
+                            [label]="t.backupCodeLabel"
+                            name="code"
+                            autoComplete="one-time-code"
+                            (changed)="backupActions.setField('code', $event)"
+                            (blurred)="backupActions.blur('code')"
+                        />
+                        <lunora-auth-submit-button [pending]="backupState().status === 'submitting'">{{ t.twoFactor }}</lunora-auth-submit-button>
+                    </form>
+                    <button lunoraAuthCardFooter class="lunora-auth-link" type="button" (click)="useBackupCode.set(false)">
+                        {{ t.twoFactorUseAuthenticator }}
+                    </button>
+                </lunora-auth-card>
+            } @else {
+                <lunora-auth-card [title]="t.twoFactor" [footer]="true">
+                    <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
+                        <lunora-auth-banner [error]="state().formError" />
+                        <lunora-auth-field
+                            [field]="state().fields.code"
+                            [label]="t.codeLabel"
+                            name="code"
+                            autoComplete="one-time-code"
+                            (changed)="actions.setField('code', $event)"
+                            (blurred)="actions.blur('code')"
+                        />
+                        <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.twoFactor }}</lunora-auth-submit-button>
+                    </form>
+                    <button lunoraAuthCardFooter class="lunora-auth-link" type="button" (click)="useBackupCode.set(true)">{{ t.backupCodeSignIn }}</button>
+                </lunora-auth-card>
+            }
         }
     `,
 })
@@ -504,6 +527,14 @@ class TwoFactorCardComponent implements OnInit {
     protected readonly t = this.context().localization;
     protected state!: Signal<FormState<TwoFactorField>>;
     protected actions!: FormActions<TwoFactorField>;
+    protected backupState!: Signal<FormState<BackupCodeSignInField>>;
+    protected backupActions!: FormActions<BackupCodeSignInField>;
+
+    /**
+     * Both controllers stay live regardless of which form is showing — a
+     * session-mutating submit must not depend on the toggle's current position.
+     */
+    protected readonly useBackupCode = signal(false);
 
     ngOnInit(): void {
         const bridge = controllerSignal((context) => createTwoFactorVerifyController(context, { method: this.method(), trustDevice: this.trustDevice() }), {
@@ -513,6 +544,14 @@ class TwoFactorCardComponent implements OnInit {
 
         this.state = bridge.state;
         this.actions = bridge.actions;
+
+        const backupBridge = controllerSignal((context) => createBackupCodeSignInController(context, { trustDevice: this.trustDevice() }), {
+            context: this.context,
+            injector: this.injector,
+        });
+
+        this.backupState = backupBridge.state;
+        this.backupActions = backupBridge.actions;
     }
 }
 

--- a/packages/auth-ui/src/angular/auth-cards.ts
+++ b/packages/auth-ui/src/angular/auth-cards.ts
@@ -8,6 +8,7 @@ import type { OnInit, Signal } from "@angular/core";
 import { ChangeDetectionStrategy, Component, computed, inject, Injector, input } from "@angular/core";
 
 import { signInAnonymously } from "../core/anonymous";
+import { queryParameter } from "../core/browser-location";
 import type { EmailOtpActions, EmailOtpState } from "../core/email-otp";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
@@ -293,7 +294,7 @@ class ForgotPasswordCardComponent implements OnInit {
     `,
 })
 class ResetPasswordCardComponent implements OnInit {
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     readonly token = input<string>();
 
     private readonly context = injectAuthUIContext();
@@ -302,8 +303,12 @@ class ResetPasswordCardComponent implements OnInit {
     protected state!: Signal<FormState<ResetPasswordField>>;
     protected actions!: FormActions<ResetPasswordField>;
 
+    // Built in ngOnInit, not a field initializer: `token()` is unbound until
+    // Angular has set the inputs, so the controller would consume the URL's
+    // token even when the caller passed one of their own.
     ngOnInit(): void {
-        const bridge = controllerSignal((context) => createResetPasswordController(context, { token: this.token() }), {
+        const resolved = this.token() ?? queryParameter("token");
+        const bridge = controllerSignal((context) => createResetPasswordController(context, { token: resolved }), {
             context: this.context,
             injector: this.injector,
         });

--- a/packages/auth-ui/src/angular/auth-view.ts
+++ b/packages/auth-ui/src/angular/auth-view.ts
@@ -17,6 +17,7 @@ import {
     ForgotPasswordCardComponent,
     MagicLinkCardComponent,
     ResetPasswordCardComponent,
+    ResetPasswordOtpCardComponent,
     SignInCardComponent,
     SignUpCardComponent,
     TwoFactorCardComponent,
@@ -136,6 +137,7 @@ class PhoneSignInCardComponent {
         ForgotPasswordCardComponent,
         MagicLinkCardComponent,
         ResetPasswordCardComponent,
+        ResetPasswordOtpCardComponent,
         SignInCardComponent,
         SignUpCardComponent,
         TwoFactorCardComponent,
@@ -173,7 +175,11 @@ class PhoneSignInCardComponent {
                 }
             }
             @case (viewPaths().resetPassword) {
-                <lunora-reset-password-card />
+                @if (forgotPasswordMethod() === "otp") {
+                    <lunora-reset-password-otp-card />
+                } @else {
+                    <lunora-reset-password-card />
+                }
             }
             @case (viewPaths().signUp) {
                 <lunora-sign-up-card />
@@ -202,6 +208,7 @@ class AuthViewComponent {
 
     /** Derived, so a discovery answer that turns a plugin off redirects to sign-in. */
     protected readonly plugins: Signal<Required<PluginFlags>> = computed(() => this.context().plugins);
+    protected readonly forgotPasswordMethod: Signal<"link" | "otp"> = computed(() => this.context().forgotPasswordMethod);
     protected readonly viewPaths: Signal<Required<ViewPaths>> = computed(() => this.context().viewPaths);
 }
 

--- a/packages/auth-ui/src/angular/index.ts
+++ b/packages/auth-ui/src/angular/index.ts
@@ -34,6 +34,7 @@ export {
     ForgotPasswordCardComponent,
     MagicLinkCardComponent,
     ResetPasswordCardComponent,
+    ResetPasswordOtpCardComponent,
     SignInCardComponent,
     SignUpCardComponent,
     TwoFactorCardComponent,

--- a/packages/auth-ui/src/core/localization.ts
+++ b/packages/auth-ui/src/core/localization.ts
@@ -133,6 +133,7 @@ interface Localization {
     remove: string;
     resetPassword: string;
     resetPasswordDone: string;
+    resetPasswordOtpDescription: string;
     revoke: string;
     revokeAccess: string;
     revokeOthers: string;
@@ -306,6 +307,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     remove: "Remove",
     resetPassword: "Set new password",
     resetPasswordDone: "Your password has been updated. You can sign in now.",
+    resetPasswordOtpDescription: "Enter the code we emailed you, then choose a new password.",
     revoke: "Revoke",
     revokeAccess: "Revoke access",
     revokeOthers: "Sign out other sessions",

--- a/packages/auth-ui/src/core/localization.ts
+++ b/packages/auth-ui/src/core/localization.ts
@@ -33,6 +33,7 @@ interface Localization {
     avatarUploadFailed: string;
     avatarWrongType: string;
     backToSignIn: string;
+    backupCodeLabel: string;
     backupCodes: string;
     backupCodeSignIn: string;
     backupCodesRegenerate: string;
@@ -166,6 +167,7 @@ interface Localization {
     twoFactorScan: string;
     twoFactorSecret: string;
     twoFactorSetup: string;
+    twoFactorUseAuthenticator: string;
     /** Fallback when a session has neither a user-agent nor an IP. */
     unknownDevice: string;
     usernameAvailable: string;
@@ -207,6 +209,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     avatarUploadFailed: "Could not upload that image. Try again.",
     avatarWrongType: "Choose a PNG, JPEG, WebP, GIF, or AVIF image.",
     backToSignIn: "Back to sign in",
+    backupCodeLabel: "Backup code",
     backupCodes: "Save these backup codes somewhere safe:",
     backupCodeSignIn: "Use a backup code",
     backupCodesRegenerate: "Regenerate backup codes",
@@ -340,6 +343,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     twoFactorScan: "Scan this with your authenticator app, then enter the 6-digit code.",
     twoFactorSecret: "Or enter this key manually:",
     twoFactorSetup: "Two-factor authentication",
+    twoFactorUseAuthenticator: "Use your authenticator app instead",
     unknownDevice: "Unknown device",
     usernameAvailable: "That username is available.",
     usernameChecking: "Checking…",

--- a/packages/auth-ui/src/core/magic-link.ts
+++ b/packages/auth-ui/src/core/magic-link.ts
@@ -2,6 +2,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import type { FormController } from "./types";
 import { email as validateEmail } from "./validators";
 
@@ -16,7 +17,7 @@ const createMagicLinkController = (context: ControllerContext): FormController<M
         submit: async (values, context_) => {
             assertOk(
                 await context_.authClient.signIn.magicLink({
-                    callbackURL: context_.redirects.afterSignIn,
+                    callbackURL: resolveAfterSignIn(context_.redirects.afterSignIn),
                     email: values.email.trim(),
                 }),
             );

--- a/packages/auth-ui/src/core/one-tap.ts
+++ b/packages/auth-ui/src/core/one-tap.ts
@@ -13,6 +13,7 @@
  * working exactly as intended, so they only reach `onError`.
  */
 import type { ControllerContext } from "./config";
+import { resolveAfterSignIn } from "./redirect-to";
 
 /**
  * Show the One Tap prompt, if the browser and the user's Google session allow.
@@ -21,7 +22,7 @@ import type { ControllerContext } from "./config";
  */
 const promptOneTap = async (context: ControllerContext): Promise<void> => {
     try {
-        await context.authClient.oneTap({ callbackURL: context.redirects.afterSignIn });
+        await context.authClient.oneTap({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn) });
         context.onSessionChange?.();
     } catch (error) {
         context.onError?.(error);

--- a/packages/auth-ui/src/core/social.ts
+++ b/packages/auth-ui/src/core/social.ts
@@ -9,10 +9,11 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInWithSocial = async (context: ControllerContext, provider: string): Promise<void> => {
     try {
-        assertOk(await context.authClient.signIn.social({ callbackURL: context.redirects.afterSignIn, provider }));
+        assertOk(await context.authClient.signIn.social({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn), provider }));
     } catch (error) {
         // A failed social redirect leaves the user on the same page with no
         // explanation, so this is one of the paths that needs a toast.

--- a/packages/auth-ui/src/react/auth-cards.tsx
+++ b/packages/auth-ui/src/react/auth-cards.tsx
@@ -3,6 +3,7 @@
 import type { ReactElement } from "react";
 
 import { signInAnonymously } from "../core/anonymous";
+import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
@@ -219,13 +220,14 @@ const ForgotPasswordCard = ({ resetPath, signInHref = "/sign-in" }: ForgotPasswo
 };
 
 interface ResetPasswordCardProps {
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     token?: string;
 }
 
 const ResetPasswordCard = ({ token }: ResetPasswordCardProps = {}): ReactElement => {
     const { localization: t } = useAuthUI();
-    const [state, actions] = useController((context) => createResetPasswordController(context, { token }), [token]);
+    const resolved = token ?? queryParameter("token");
+    const [state, actions] = useController((context) => createResetPasswordController(context, { token: resolved }), [resolved]);
 
     return (
         <AuthCard title={t.resetPassword}>

--- a/packages/auth-ui/src/react/auth-cards.tsx
+++ b/packages/auth-ui/src/react/auth-cards.tsx
@@ -10,6 +10,7 @@ import { createForgotPasswordController } from "../core/forgot-password";
 import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import { createSignInController } from "../core/sign-in";
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
@@ -265,6 +266,77 @@ const ResetPasswordCard = ({ token }: ResetPasswordCardProps = {}): ReactElement
     );
 };
 
+/**
+ * Redeems an emailed one-time code instead of a link — for apps that set
+ * `forgotPassword: { method: "otp" }`. Unlike {@link ResetPasswordCard}, the
+ * email address is a field rather than something carried from the previous
+ * screen: a code can legitimately be redeemed from a fresh tab.
+ */
+const ResetPasswordOtpCard = (): ReactElement => {
+    const { localization: t } = useAuthUI();
+    const [state, actions] = useController(createResetPasswordOtpController);
+
+    return (
+        <AuthCard description={t.resetPasswordOtpDescription} title={t.resetPassword}>
+            <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
+                <FormBanner error={state.formError} success={state.successMessage} />
+                <Field
+                    autoComplete="email"
+                    field={state.fields.email}
+                    label={t.emailLabel}
+                    name="email"
+                    onBlur={() => {
+                        actions.blur("email");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("email", value);
+                    }}
+                    type="email"
+                />
+                <Field
+                    autoComplete="one-time-code"
+                    field={state.fields.otp}
+                    label={t.codeLabel}
+                    name="otp"
+                    onBlur={() => {
+                        actions.blur("otp");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("otp", value);
+                    }}
+                />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.password}
+                    label={t.passwordLabel}
+                    name="password"
+                    onBlur={() => {
+                        actions.blur("password");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("password", value);
+                    }}
+                    type="password"
+                />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.confirmPassword}
+                    label={t.confirmPasswordLabel}
+                    name="confirmPassword"
+                    onBlur={() => {
+                        actions.blur("confirmPassword");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("confirmPassword", value);
+                    }}
+                    type="password"
+                />
+                <SubmitButton pending={state.status === "submitting"}>{t.resetPassword}</SubmitButton>
+            </form>
+        </AuthCard>
+    );
+};
+
 interface MagicLinkCardProps {
     signInHref?: string;
 }
@@ -398,4 +470,4 @@ const TwoFactorCard = ({ method, trustDevice }: TwoFactorCardProps = {}): ReactE
 };
 
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps };
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard };
+export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard };

--- a/packages/auth-ui/src/react/auth-cards.tsx
+++ b/packages/auth-ui/src/react/auth-cards.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import type { ReactElement } from "react";
+import { useState } from "react";
 
 import { signInAnonymously } from "../core/anonymous";
+import { createBackupCodeSignInController } from "../core/backup-codes";
 import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
@@ -442,13 +444,66 @@ const TwoFactorCard = ({ method, trustDevice }: TwoFactorCardProps = {}): ReactE
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = useController((context_) => createTwoFactorVerifyController(context_, { method, trustDevice }), [method, trustDevice]);
+    const [backupState, backupActions] = useController((context_) => createBackupCodeSignInController(context_, { trustDevice }), [trustDevice]);
+    // Both controllers are always live — a form's live session-mutating submit
+    // must not depend on which mode happened to be showing when it was called.
+    const [useBackupCode, setUseBackupCode] = useState(false);
 
     if (!isFlowEnabled(context, "twoFactor", "TwoFactorCard")) {
         return null;
     }
 
+    if (useBackupCode) {
+        return (
+            <AuthCard
+                footer={
+                    <button
+                        className="lunora-auth-link"
+                        onClick={() => {
+                            setUseBackupCode(false);
+                        }}
+                        type="button"
+                    >
+                        {t.twoFactorUseAuthenticator}
+                    </button>
+                }
+                title={t.twoFactor}
+            >
+                <form className="lunora-auth-form" noValidate onSubmit={onSubmit(backupActions.submit)}>
+                    <FormBanner error={backupState.formError} />
+                    <Field
+                        autoComplete="one-time-code"
+                        field={backupState.fields.code}
+                        label={t.backupCodeLabel}
+                        name="code"
+                        onBlur={() => {
+                            backupActions.blur("code");
+                        }}
+                        onChange={(value) => {
+                            backupActions.setField("code", value);
+                        }}
+                    />
+                    <SubmitButton pending={backupState.status === "submitting"}>{t.twoFactor}</SubmitButton>
+                </form>
+            </AuthCard>
+        );
+    }
+
     return (
-        <AuthCard title={t.twoFactor}>
+        <AuthCard
+            footer={
+                <button
+                    className="lunora-auth-link"
+                    onClick={() => {
+                        setUseBackupCode(true);
+                    }}
+                    type="button"
+                >
+                    {t.backupCodeSignIn}
+                </button>
+            }
+            title={t.twoFactor}
+        >
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} />
                 <Field

--- a/packages/auth-ui/src/react/auth-view.tsx
+++ b/packages/auth-ui/src/react/auth-view.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from "react";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createPhoneSignInController } from "../core/phone-number";
 import { createUsernameSignInController } from "../core/username";
-import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
 import { DeviceAuthorizationCard } from "./plugin-cards";
 import { AuthCard, Field, FormBanner, SubmitButton } from "./primitives";
 import { useAuthUI } from "./provider";
@@ -123,7 +123,7 @@ interface AuthViewProps {
 }
 
 const AuthView = ({ view }: AuthViewProps = {}): ReactElement => {
-    const { plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, viewPaths } = useAuthUI();
 
     /*
      * A lookup keyed by the resolved segment, not a `switch` over
@@ -143,7 +143,7 @@ const AuthView = ({ view }: AuthViewProps = {}): ReactElement => {
         [viewPaths.emailOtp]: () => (plugins.emailOtp ? <EmailOtpCard /> : <SignInCard />),
         [viewPaths.forgotPassword]: () => <ForgotPasswordCard />,
         [viewPaths.magicLink]: () => (plugins.magicLink ? <MagicLinkCard /> : <SignInCard />),
-        [viewPaths.resetPassword]: () => <ResetPasswordCard />,
+        [viewPaths.resetPassword]: () => (forgotPasswordMethod === "otp" ? <ResetPasswordOtpCard /> : <ResetPasswordCard />),
         [viewPaths.signUp]: () => <SignUpCard />,
         [viewPaths.twoFactor]: () => (plugins.twoFactor ? <TwoFactorCard /> : <SignInCard />),
         [viewPaths.verifyEmail]: () => <VerifyEmailCard />,

--- a/packages/auth-ui/src/react/index.ts
+++ b/packages/auth-ui/src/react/index.ts
@@ -17,7 +17,17 @@ export * from "../core";
  */
 export { AppearanceCard, AvatarCard, LinkedAccountsCard, SetUsernameCard } from "./account-cards";
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps } from "./auth-cards";
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+export {
+    AnonymousButton,
+    EmailOtpCard,
+    ForgotPasswordCard,
+    MagicLinkCard,
+    ResetPasswordCard,
+    ResetPasswordOtpCard,
+    SignInCard,
+    SignUpCard,
+    TwoFactorCard,
+} from "./auth-cards";
 export type { AuthViewProps } from "./auth-view";
 export { AuthView, PhoneSignInCard, UsernameSignInCard } from "./auth-view";
 export type { CaptchaProps, OrganizationLogoCardProps } from "./extras";

--- a/packages/auth-ui/src/solid/auth-cards.tsx
+++ b/packages/auth-ui/src/solid/auth-cards.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "solid-js";
 import { Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
+import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
@@ -217,13 +218,13 @@ const ForgotPasswordCard = (props: ForgotPasswordCardProps = {}): JSX.Element =>
 };
 
 interface ResetPasswordCardProps {
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     token?: string;
 }
 
 const ResetPasswordCard = (props: ResetPasswordCardProps = {}): JSX.Element => {
     const { localization: t } = useAuthUI();
-    const [state, actions] = createController((context) => createResetPasswordController(context, { token: props.token }));
+    const [state, actions] = createController((context) => createResetPasswordController(context, { token: props.token ?? queryParameter("token") }));
 
     return (
         <AuthCard title={t.resetPassword}>

--- a/packages/auth-ui/src/solid/auth-cards.tsx
+++ b/packages/auth-ui/src/solid/auth-cards.tsx
@@ -9,6 +9,7 @@ import { createForgotPasswordController } from "../core/forgot-password";
 import { readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import { createSignInController } from "../core/sign-in";
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
@@ -262,6 +263,77 @@ const ResetPasswordCard = (props: ResetPasswordCardProps = {}): JSX.Element => {
     );
 };
 
+/**
+ * Redeems an emailed one-time code instead of a link — for apps that set
+ * `forgotPassword: { method: "otp" }`. Unlike {@link ResetPasswordCard}, the
+ * email address is a field rather than something carried from the previous
+ * screen: a code can legitimately be redeemed from a fresh tab.
+ */
+const ResetPasswordOtpCard = (): JSX.Element => {
+    const { localization: t } = useAuthUI();
+    const [state, actions] = createController((context) => createResetPasswordOtpController(context));
+
+    return (
+        <AuthCard description={t.resetPasswordOtpDescription} title={t.resetPassword}>
+            <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
+                <FormBanner error={state.formError} success={state.successMessage} />
+                <Field
+                    autoComplete="email"
+                    field={state.fields.email}
+                    label={t.emailLabel}
+                    name="email"
+                    onBlur={() => {
+                        actions.blur("email");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("email", value);
+                    }}
+                    type="email"
+                />
+                <Field
+                    autoComplete="one-time-code"
+                    field={state.fields.otp}
+                    label={t.codeLabel}
+                    name="otp"
+                    onBlur={() => {
+                        actions.blur("otp");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("otp", value);
+                    }}
+                />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.password}
+                    label={t.passwordLabel}
+                    name="password"
+                    onBlur={() => {
+                        actions.blur("password");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("password", value);
+                    }}
+                    type="password"
+                />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.confirmPassword}
+                    label={t.confirmPasswordLabel}
+                    name="confirmPassword"
+                    onBlur={() => {
+                        actions.blur("confirmPassword");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("confirmPassword", value);
+                    }}
+                    type="password"
+                />
+                <SubmitButton pending={state.status === "submitting"}>{t.resetPassword}</SubmitButton>
+            </form>
+        </AuthCard>
+    );
+};
+
 interface MagicLinkCardProps {
     signInHref?: string;
 }
@@ -393,4 +465,4 @@ const TwoFactorCard = (props: TwoFactorCardProps = {}): JSX.Element => {
 };
 
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps };
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard };
+export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard };

--- a/packages/auth-ui/src/solid/auth-cards.tsx
+++ b/packages/auth-ui/src/solid/auth-cards.tsx
@@ -1,7 +1,8 @@
 import type { JSX } from "solid-js";
-import { Show } from "solid-js";
+import { createSignal, Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
+import { createBackupCodeSignInController } from "../core/backup-codes";
 import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
@@ -437,30 +438,84 @@ const TwoFactorCard = (props: TwoFactorCardProps = {}): JSX.Element => {
     const [state, actions] = createController((context_) =>
         createTwoFactorVerifyController(context_, { method: props.method, trustDevice: props.trustDevice }),
     );
+    // Both controllers stay live regardless of which form is showing — a
+    // session-mutating submit must not depend on the toggle's current position.
+    const [backupState, backupActions] = createController((context_) => createBackupCodeSignInController(context_, { trustDevice: props.trustDevice }));
+    const [useBackupCode, setUseBackupCode] = createSignal(false);
 
     if (!isFlowEnabled(context, "twoFactor", "TwoFactorCard")) {
         return null;
     }
 
     return (
-        <AuthCard title={t.twoFactor}>
-            <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
-                <FormBanner error={state.formError} />
-                <Field
-                    autoComplete="one-time-code"
-                    field={state.fields.code}
-                    label={t.codeLabel}
-                    name="code"
-                    onBlur={() => {
-                        actions.blur("code");
-                    }}
-                    onChange={(value) => {
-                        actions.setField("code", value);
-                    }}
-                />
-                <SubmitButton pending={state.status === "submitting"}>{t.twoFactor}</SubmitButton>
-            </form>
-        </AuthCard>
+        <Show
+            fallback={
+                <AuthCard
+                    footer={
+                        <button
+                            class="lunora-auth-link"
+                            onClick={() => {
+                                setUseBackupCode(true);
+                            }}
+                            type="button"
+                        >
+                            {t.backupCodeSignIn}
+                        </button>
+                    }
+                    title={t.twoFactor}
+                >
+                    <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
+                        <FormBanner error={state.formError} />
+                        <Field
+                            autoComplete="one-time-code"
+                            field={state.fields.code}
+                            label={t.codeLabel}
+                            name="code"
+                            onBlur={() => {
+                                actions.blur("code");
+                            }}
+                            onChange={(value) => {
+                                actions.setField("code", value);
+                            }}
+                        />
+                        <SubmitButton pending={state.status === "submitting"}>{t.twoFactor}</SubmitButton>
+                    </form>
+                </AuthCard>
+            }
+            when={useBackupCode()}
+        >
+            <AuthCard
+                footer={
+                    <button
+                        class="lunora-auth-link"
+                        onClick={() => {
+                            setUseBackupCode(false);
+                        }}
+                        type="button"
+                    >
+                        {t.twoFactorUseAuthenticator}
+                    </button>
+                }
+                title={t.twoFactor}
+            >
+                <form class="lunora-auth-form" noValidate onSubmit={onSubmit(backupActions.submit)}>
+                    <FormBanner error={backupState.formError} />
+                    <Field
+                        autoComplete="one-time-code"
+                        field={backupState.fields.code}
+                        label={t.backupCodeLabel}
+                        name="code"
+                        onBlur={() => {
+                            backupActions.blur("code");
+                        }}
+                        onChange={(value) => {
+                            backupActions.setField("code", value);
+                        }}
+                    />
+                    <SubmitButton pending={backupState.status === "submitting"}>{t.twoFactor}</SubmitButton>
+                </form>
+            </AuthCard>
+        </Show>
     );
 };
 

--- a/packages/auth-ui/src/solid/auth-view.tsx
+++ b/packages/auth-ui/src/solid/auth-view.tsx
@@ -4,7 +4,7 @@ import { Match, Show, Switch } from "solid-js";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createPhoneSignInController } from "../core/phone-number";
 import { createUsernameSignInController } from "../core/username";
-import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
 import { DeviceAuthorizationCard } from "./plugin-cards";
 import { AuthCard, Field, FormBanner, SubmitButton } from "./primitives";
 import { useAuthUI } from "./provider";
@@ -123,7 +123,7 @@ interface AuthViewProps {
 }
 
 const AuthView = (props: AuthViewProps = {}): JSX.Element => {
-    const { plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, viewPaths } = useAuthUI();
 
     /*
      * Plugin-gated views are checked here rather than left to the card's own
@@ -159,7 +159,9 @@ const AuthView = (props: AuthViewProps = {}): JSX.Element => {
                 </Show>
             </Match>
             <Match when={props.view === viewPaths.resetPassword}>
-                <ResetPasswordCard />
+                <Show fallback={<ResetPasswordCard />} when={forgotPasswordMethod === "otp"}>
+                    <ResetPasswordOtpCard />
+                </Show>
             </Match>
             <Match when={props.view === viewPaths.signUp}>
                 <SignUpCard />

--- a/packages/auth-ui/src/solid/index.ts
+++ b/packages/auth-ui/src/solid/index.ts
@@ -17,7 +17,17 @@ export * from "../core";
  */
 export { AppearanceCard, AvatarCard, LinkedAccountsCard, SetUsernameCard } from "./account-cards";
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps } from "./auth-cards";
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+export {
+    AnonymousButton,
+    EmailOtpCard,
+    ForgotPasswordCard,
+    MagicLinkCard,
+    ResetPasswordCard,
+    ResetPasswordOtpCard,
+    SignInCard,
+    SignUpCard,
+    TwoFactorCard,
+} from "./auth-cards";
 export type { AuthViewProps } from "./auth-view";
 export { AuthView, PhoneSignInCard, UsernameSignInCard } from "./auth-view";
 export type { CaptchaProps, OrganizationLogoCardProps } from "./extras";

--- a/packages/auth-ui/src/svelte/AuthView.svelte
+++ b/packages/auth-ui/src/svelte/AuthView.svelte
@@ -15,6 +15,7 @@
     import ForgotPasswordCard from "./ForgotPasswordCard.svelte";
     import MagicLinkCard from "./MagicLinkCard.svelte";
     import ResetPasswordCard from "./ResetPasswordCard.svelte";
+    import ResetPasswordOtpCard from "./ResetPasswordOtpCard.svelte";
     import SignInCard from "./SignInCard.svelte";
     import SignUpCard from "./SignUpCard.svelte";
     import TwoFactorCard from "./TwoFactorCard.svelte";
@@ -27,7 +28,7 @@
         view?: string;
     } = $props();
 
-    const { plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, viewPaths } = useAuthUI();
 </script>
 
 <!--
@@ -47,7 +48,11 @@
 {:else if view === viewPaths.magicLink && plugins.magicLink}
     <MagicLinkCard />
 {:else if view === viewPaths.resetPassword}
-    <ResetPasswordCard />
+    {#if forgotPasswordMethod === "otp"}
+        <ResetPasswordOtpCard />
+    {:else}
+        <ResetPasswordCard />
+    {/if}
 {:else if view === viewPaths.signUp}
     <SignUpCard />
 {:else if view === viewPaths.twoFactor && plugins.twoFactor}

--- a/packages/auth-ui/src/svelte/ResetPasswordCard.svelte
+++ b/packages/auth-ui/src/svelte/ResetPasswordCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { queryParameter } from "../core/browser-location";
     import { createResetPasswordController } from "../core/reset-password";
     import AuthCard from "./AuthCard.svelte";
     import { useAuthUI } from "./context";
@@ -7,11 +8,11 @@
     import FormBanner from "./FormBanner.svelte";
     import SubmitButton from "./SubmitButton.svelte";
 
-    let { token }: { token?: string } = $props();
+    let { token }: { /** Defaults to `?token=` from the URL. */ token?: string } = $props();
 
     const t = useAuthUI().localization;
     // The reset token is read once at mount; navigate to a fresh route to reset.
-    const { actions, state: form } = controllerStore((context) => createResetPasswordController(context, { token }));
+    const { actions, state: form } = controllerStore((context) => createResetPasswordController(context, { token: token ?? queryParameter("token") }));
 </script>
 
 <AuthCard title={t.resetPassword}>

--- a/packages/auth-ui/src/svelte/ResetPasswordOtpCard.svelte
+++ b/packages/auth-ui/src/svelte/ResetPasswordOtpCard.svelte
@@ -1,0 +1,83 @@
+<!--
+    Redeems an emailed one-time code instead of a link — for apps that set
+    `forgotPassword: { method: "otp" }`. Unlike ResetPasswordCard, the email
+    address is a field rather than something carried from the previous screen:
+    a code can legitimately be redeemed from a fresh tab.
+-->
+<script lang="ts">
+    import { createResetPasswordOtpController } from "../core/reset-password-otp";
+    import AuthCard from "./AuthCard.svelte";
+    import { useAuthUI } from "./context";
+    import { controllerStore } from "./controller-store";
+    import Field from "./Field.svelte";
+    import FormBanner from "./FormBanner.svelte";
+    import SubmitButton from "./SubmitButton.svelte";
+
+    const t = useAuthUI().localization;
+    const { actions, state: form } = controllerStore((context) => createResetPasswordOtpController(context));
+</script>
+
+<AuthCard description={t.resetPasswordOtpDescription} title={t.resetPassword}>
+    <form
+        class="lunora-auth-form"
+        novalidate
+        onsubmit={(event) => {
+            event.preventDefault();
+            void actions.submit();
+        }}
+    >
+        <FormBanner error={$form.formError} success={$form.successMessage} />
+        <Field
+            autoComplete="email"
+            field={$form.fields.email}
+            label={t.emailLabel}
+            name="email"
+            onBlur={() => {
+                actions.blur("email");
+            }}
+            onChange={(value) => {
+                actions.setField("email", value);
+            }}
+            type="email"
+        />
+        <Field
+            autoComplete="one-time-code"
+            field={$form.fields.otp}
+            label={t.codeLabel}
+            name="otp"
+            onBlur={() => {
+                actions.blur("otp");
+            }}
+            onChange={(value) => {
+                actions.setField("otp", value);
+            }}
+        />
+        <Field
+            autoComplete="new-password"
+            field={$form.fields.password}
+            label={t.passwordLabel}
+            name="password"
+            onBlur={() => {
+                actions.blur("password");
+            }}
+            onChange={(value) => {
+                actions.setField("password", value);
+            }}
+            type="password"
+        />
+        <Field
+            autoComplete="new-password"
+            field={$form.fields.confirmPassword}
+            label={t.confirmPasswordLabel}
+            name="confirmPassword"
+            onBlur={() => {
+                actions.blur("confirmPassword");
+            }}
+            onChange={(value) => {
+                actions.setField("confirmPassword", value);
+            }}
+            type="password"
+        />
+        <SubmitButton pending={$form.status === "submitting"}>{t.resetPassword}</SubmitButton>
+    </form>
+</AuthCard>

--- a/packages/auth-ui/src/svelte/TwoFactorCard.svelte
+++ b/packages/auth-ui/src/svelte/TwoFactorCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { createBackupCodeSignInController } from "../core/backup-codes";
     import { isFlowEnabled } from "../core/flow-gate";
     import { createTwoFactorVerifyController } from "../core/two-factor-verify";
     import AuthCard from "./AuthCard.svelte";
@@ -21,9 +22,51 @@
     const enabled = isFlowEnabled(context, "twoFactor", "TwoFactorCard");
     // `method` / `trustDevice` are read once at mount.
     const { actions, state: form } = controllerStore((context) => createTwoFactorVerifyController(context, { method, trustDevice }));
+    // Both controllers stay live regardless of which form is showing — a
+    // session-mutating submit must not depend on the toggle's current position.
+    const { actions: backupActions, state: backupForm } = controllerStore((context) => createBackupCodeSignInController(context, { trustDevice }));
+
+    let useBackupCode = $state(false);
 </script>
 
-{#if enabled}
+{#if enabled && useBackupCode}
+    <AuthCard title={t.twoFactor}>
+        <form
+            class="lunora-auth-form"
+            novalidate
+            onsubmit={(event) => {
+                event.preventDefault();
+                void backupActions.submit();
+            }}
+        >
+            <FormBanner error={$backupForm.formError} />
+            <Field
+                autoComplete="one-time-code"
+                field={$backupForm.fields.code}
+                label={t.backupCodeLabel}
+                name="code"
+                onBlur={() => {
+                    backupActions.blur("code");
+                }}
+                onChange={(value) => {
+                    backupActions.setField("code", value);
+                }}
+            />
+            <SubmitButton pending={$backupForm.status === "submitting"}>{t.twoFactor}</SubmitButton>
+        </form>
+        {#snippet footer()}
+            <button
+                class="lunora-auth-link"
+                onclick={() => {
+                    useBackupCode = false;
+                }}
+                type="button"
+            >
+                {t.twoFactorUseAuthenticator}
+            </button>
+        {/snippet}
+    </AuthCard>
+{:else if enabled}
     <AuthCard title={t.twoFactor}>
         <form
             class="lunora-auth-form"
@@ -48,5 +91,16 @@
             />
             <SubmitButton pending={$form.status === "submitting"}>{t.twoFactor}</SubmitButton>
         </form>
+        {#snippet footer()}
+            <button
+                class="lunora-auth-link"
+                onclick={() => {
+                    useBackupCode = true;
+                }}
+                type="button"
+            >
+                {t.backupCodeSignIn}
+            </button>
+        {/snippet}
     </AuthCard>
 {/if}

--- a/packages/auth-ui/src/svelte/index.ts
+++ b/packages/auth-ui/src/svelte/index.ts
@@ -75,6 +75,7 @@ export { default as PhoneSignInCard } from "./PhoneSignInCard.svelte";
 export { default as ProfileCard } from "./ProfileCard.svelte";
 export { default as ResendVerificationCard } from "./ResendVerificationCard.svelte";
 export { default as ResetPasswordCard } from "./ResetPasswordCard.svelte";
+export { default as ResetPasswordOtpCard } from "./ResetPasswordOtpCard.svelte";
 export { default as SessionsCard } from "./SessionsCard.svelte";
 export { default as SetUsernameCard } from "./SetUsernameCard.svelte";
 export { default as SignInCard } from "./SignInCard.svelte";

--- a/packages/auth-ui/src/vue/AuthView.vue
+++ b/packages/auth-ui/src/vue/AuthView.vue
@@ -16,6 +16,7 @@ import ForgotPasswordCard from "./ForgotPasswordCard.vue";
 import MagicLinkCard from "./MagicLinkCard.vue";
 import { useAuthUIContextRef } from "./provider";
 import ResetPasswordCard from "./ResetPasswordCard.vue";
+import ResetPasswordOtpCard from "./ResetPasswordOtpCard.vue";
 import SignInCard from "./SignInCard.vue";
 import SignUpCard from "./SignUpCard.vue";
 import TwoFactorCard from "./TwoFactorCard.vue";
@@ -38,7 +39,7 @@ const context = useAuthUIContextRef();
  * gate for when they are mounted directly.
  */
 const card = computed<Component>(() => {
-    const { plugins, viewPaths } = context.value;
+    const { forgotPasswordMethod, plugins, viewPaths } = context.value;
 
     switch (props.view) {
         case viewPaths.acceptInvitation: {
@@ -62,7 +63,7 @@ const card = computed<Component>(() => {
         }
 
         case viewPaths.resetPassword: {
-            return ResetPasswordCard;
+            return forgotPasswordMethod === "otp" ? ResetPasswordOtpCard : ResetPasswordCard;
         }
 
         case viewPaths.signUp: {

--- a/packages/auth-ui/src/vue/ResetPasswordCard.vue
+++ b/packages/auth-ui/src/vue/ResetPasswordCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { queryParameter } from "../core/browser-location";
 import { createResetPasswordController } from "../core/reset-password";
 import AuthCard from "./AuthCard.vue";
 import Field from "./Field.vue";
@@ -8,12 +9,15 @@ import SubmitButton from "./SubmitButton.vue";
 import { useController } from "./use-controller";
 
 const props = defineProps<{
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     token?: string;
 }>();
 
 const { localization: t } = useAuthUI();
-const { actions, state } = useController((context) => createResetPasswordController(context, { token: props.token }));
+// Captured at setup: the controller consumes the token once on creation, so a
+// token that changes afterwards means a new card, not a new state.
+const token = props.token ?? queryParameter("token");
+const { actions, state } = useController((context) => createResetPasswordController(context, { token }));
 </script>
 
 <template>

--- a/packages/auth-ui/src/vue/ResetPasswordOtpCard.vue
+++ b/packages/auth-ui/src/vue/ResetPasswordOtpCard.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+// Redeems an emailed one-time code instead of a link — for apps that set
+// `forgotPassword: { method: "otp" }`. Unlike ResetPasswordCard, the email
+// address is a field rather than something carried from the previous screen:
+// a code can legitimately be redeemed from a fresh tab.
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
+import AuthCard from "./AuthCard.vue";
+import Field from "./Field.vue";
+import FormBanner from "./FormBanner.vue";
+import { useAuthUI } from "./provider";
+import SubmitButton from "./SubmitButton.vue";
+import { useController } from "./use-controller";
+
+const { localization: t } = useAuthUI();
+const { actions, state } = useController((context) => createResetPasswordOtpController(context));
+</script>
+
+<template>
+    <AuthCard :description="t.resetPasswordOtpDescription" :title="t.resetPassword">
+        <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
+            <FormBanner :error="state.formError" :success="state.successMessage" />
+            <Field
+                :field="state.fields.email"
+                :label="t.emailLabel"
+                name="email"
+                type="email"
+                autoComplete="email"
+                @blur="actions.blur('email')"
+                @change="actions.setField('email', $event)"
+            />
+            <Field
+                :field="state.fields.otp"
+                :label="t.codeLabel"
+                name="otp"
+                autoComplete="one-time-code"
+                @blur="actions.blur('otp')"
+                @change="actions.setField('otp', $event)"
+            />
+            <Field
+                :field="state.fields.password"
+                :label="t.passwordLabel"
+                name="password"
+                type="password"
+                autoComplete="new-password"
+                @blur="actions.blur('password')"
+                @change="actions.setField('password', $event)"
+            />
+            <Field
+                :field="state.fields.confirmPassword"
+                :label="t.confirmPasswordLabel"
+                name="confirmPassword"
+                type="password"
+                autoComplete="new-password"
+                @blur="actions.blur('confirmPassword')"
+                @change="actions.setField('confirmPassword', $event)"
+            />
+            <SubmitButton :pending="state.status === 'submitting'">{{ t.resetPassword }}</SubmitButton>
+        </form>
+    </AuthCard>
+</template>

--- a/packages/auth-ui/src/vue/TwoFactorCard.vue
+++ b/packages/auth-ui/src/vue/TwoFactorCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
+import { createBackupCodeSignInController } from "../core/backup-codes";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createTwoFactorVerifyController } from "../core/two-factor-verify";
 import AuthCard from "./AuthCard.vue";
@@ -21,10 +22,33 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "twoFactor", "TwoFactorCard"));
 const { actions, state } = useController((context_) => createTwoFactorVerifyController(context_, { method: props.method, trustDevice: props.trustDevice }));
+// Both controllers stay live regardless of which form is showing — a
+// session-mutating submit must not depend on the toggle's current position.
+const { actions: backupActions, state: backupState } = useController((context_) =>
+    createBackupCodeSignInController(context_, { trustDevice: props.trustDevice }),
+);
+const useBackupCode = ref(false);
 </script>
 
 <template>
-    <AuthCard v-if="enabled" :title="t.twoFactor">
+    <AuthCard v-if="enabled && useBackupCode" :title="t.twoFactor">
+        <form class="lunora-auth-form" novalidate @submit.prevent="backupActions.submit">
+            <FormBanner :error="backupState.formError" />
+            <Field
+                :field="backupState.fields.code"
+                :label="t.backupCodeLabel"
+                name="code"
+                autoComplete="one-time-code"
+                @blur="backupActions.blur('code')"
+                @change="backupActions.setField('code', $event)"
+            />
+            <SubmitButton :pending="backupState.status === 'submitting'">{{ t.twoFactor }}</SubmitButton>
+        </form>
+        <template #footer>
+            <button class="lunora-auth-link" type="button" @click="useBackupCode = false">{{ t.twoFactorUseAuthenticator }}</button>
+        </template>
+    </AuthCard>
+    <AuthCard v-else-if="enabled" :title="t.twoFactor">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" />
             <Field
@@ -37,5 +61,8 @@ const { actions, state } = useController((context_) => createTwoFactorVerifyCont
             />
             <SubmitButton :pending="state.status === 'submitting'">{{ t.twoFactor }}</SubmitButton>
         </form>
+        <template #footer>
+            <button class="lunora-auth-link" type="button" @click="useBackupCode = true">{{ t.backupCodeSignIn }}</button>
+        </template>
     </AuthCard>
 </template>

--- a/packages/auth-ui/src/vue/index.ts
+++ b/packages/auth-ui/src/vue/index.ts
@@ -73,6 +73,7 @@ export type { AuthUIProviderProps, AuthUIVueContext } from "./provider";
 export { AUTH_UI_INJECTION_KEY, createAuthUI, provideAuthUI, useAuthUI, useAuthUIContextRef, useAuthUILink } from "./provider";
 export { default as ResendVerificationCard } from "./ResendVerificationCard.vue";
 export { default as ResetPasswordCard } from "./ResetPasswordCard.vue";
+export { default as ResetPasswordOtpCard } from "./ResetPasswordOtpCard.vue";
 export { default as SessionsCard } from "./SessionsCard.vue";
 export { default as SetUsernameCard } from "./SetUsernameCard.vue";
 export { default as SignInCard } from "./SignInCard.vue";


### PR DESCRIPTION
Four account-recovery flows were broken/incomplete across all five ports: (1) password-reset-by-link was dead — the card only took the token as a prop, no port defaulted it from `?token=`, so the emailed link always failed; (2) OTP reset was un-renderable despite being documented config; (3) backup-code sign-in was unreachable (controller existed, no port mounted it); (4) social/magic-link/One Tap dropped `redirectTo`. All four fixed in react/vue/svelte/solid/angular.

Verified: 225/225, all four lint:types sub-checks green.

⚠ ON MERGE: run `pnpm --filter @lunora/auth-ui sync:registry` to regenerate `registry/auth-ui-*` (the executor correctly withheld — outside the package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)