### PR TITLE
fix: bound container readiness probe, reject sub-minute crons, warn on missing Astro wrapper

### DIFF
--- a/api-snapshots/scheduler.api.md
+++ b/api-snapshots/scheduler.api.md
@@ -495,7 +495,7 @@ const assertValidCronExpression: (schedule: string, context?: string) => void;
 ### `compileCronSchedule` (const)
 
 ```ts
-const compileCronSchedule: (kind: CronScheduleKind, schedule: DailySchedule | HourlySchedule | IntervalSchedule | MonthlySchedule | WeeklySchedule) => string;
+const compileCronSchedule: (kind: CronScheduleKind, schedule: DailySchedule | HourlySchedule | IntervalSchedule | MonthlySchedule | WeeklySchedule, jobName?: string) => string;
 ```
 
 ### `createCronTrigger` (const)
@@ -556,4 +556,10 @@ const isValidCronExpression: (schedule: string) => boolean;
 
 ```ts
 const isWorkflowReference: (target: unknown) => target is WorkflowReference;
+```
+
+### `warnIfSecondsLeading` (const)
+
+```ts
+const warnIfSecondsLeading: (schedule: string, context: string) => void;
 ```

--- a/packages/astro/__tests__/integration.test.ts
+++ b/packages/astro/__tests__/integration.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { lunora } from "../src/integration";
+
+/** Minimal fake of the `astro:config:done` hook payload, scoped to what the hook reads. */
+interface ConfigDoneHookArgument {
+    config: { root: URL };
+    logger: { warn: (message: string) => void };
+}
 
 describe("lunora() Astro integration", () => {
     it("returns an AstroIntegration object with the package name", () => {
@@ -12,17 +23,79 @@ describe("lunora() Astro integration", () => {
         expect(typeof integration.hooks).toBe("object");
     });
 
-    it("exposes an astro:config:done hook that runs without side effects", () => {
+    it("exposes an astro:config:done hook that runs without side effects when no context is passed", () => {
         expect.assertions(1);
 
         const integration = lunora({ serverEntry: "src/custom-worker.ts" });
         const hook = integration.hooks["astro:config:done"];
 
-        // The hook is side-effect-free today (the load-bearing composition is
-        // `withLunora` at the server-entry boundary); it must not throw.
+        // Without a `config.root` to resolve against (e.g. a caller invoking the
+        // hook directly, as this test does), there is nothing to check the entry
+        // file against — the hook must stay side-effect-free rather than throw.
         expect(() => {
             (hook as () => void)();
         }).not.toThrow();
+    });
+
+    describe("serverEntry existence + withLunora check", () => {
+        let directory: string;
+
+        afterEach(() => {
+            rmSync(directory, { force: true, recursive: true });
+        });
+
+        const contextFor = (root: string, warn = vi.fn<(message: string) => void>()): ConfigDoneHookArgument => {
+            return { config: { root: pathToFileURL(`${root}/`) }, logger: { warn } };
+        };
+
+        it("warns when serverEntry does not exist", () => {
+            expect.assertions(2);
+
+            directory = mkdtempSync(join(tmpdir(), "lunora-astro-"));
+
+            const warn = vi.fn<(message: string) => void>();
+            const integration = lunora({ serverEntry: "src/worker.ts" });
+            const hook = integration.hooks["astro:config:done"] as (context: ConfigDoneHookArgument) => void;
+
+            hook(contextFor(directory, warn));
+
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn.mock.calls[0]?.[0]).toMatch(/server entry "src\/worker\.ts" not found/u);
+        });
+
+        it("warns when serverEntry exists but does not call withLunora", () => {
+            expect.assertions(2);
+
+            directory = mkdtempSync(join(tmpdir(), "lunora-astro-"));
+            writeFileSync(join(directory, "worker.ts"), "export default { fetch: () => new Response('ok') };\n");
+
+            const warn = vi.fn<(message: string) => void>();
+            const integration = lunora({ serverEntry: "worker.ts" });
+            const hook = integration.hooks["astro:config:done"] as (context: ConfigDoneHookArgument) => void;
+
+            hook(contextFor(directory, warn));
+
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn.mock.calls[0]?.[0]).toMatch(/does not call `withLunora`/u);
+        });
+
+        it("is silent when serverEntry exists and calls withLunora", () => {
+            expect.assertions(1);
+
+            directory = mkdtempSync(join(tmpdir(), "lunora-astro-"));
+            writeFileSync(
+                join(directory, "worker.ts"),
+                'import { withLunora } from "@lunora/astro/server";\nexport default withLunora(astroWorker, { shardDO: env.SHARD });\n',
+            );
+
+            const warn = vi.fn<(message: string) => void>();
+            const integration = lunora({ serverEntry: "worker.ts" });
+            const hook = integration.hooks["astro:config:done"] as (context: ConfigDoneHookArgument) => void;
+
+            hook(contextFor(directory, warn));
+
+            expect(warn).not.toHaveBeenCalled();
+        });
     });
 
     it("defaults serverEntry without requiring options", () => {

--- a/packages/astro/__tests__/integration.test.ts
+++ b/packages/astro/__tests__/integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -76,7 +76,7 @@ describe("lunora() Astro integration", () => {
             hook(contextFor(directory, warn));
 
             expect(warn).toHaveBeenCalledTimes(1);
-            expect(warn.mock.calls[0]?.[0]).toMatch(/does not call `withLunora`/u);
+            expect(warn.mock.calls[0]?.[0]).toMatch(/couldn't find a `withLunora\(\.\.\.\)` call/u);
         });
 
         it("is silent when serverEntry exists and calls withLunora", () => {
@@ -95,6 +95,46 @@ describe("lunora() Astro integration", () => {
             hook(contextFor(directory, warn));
 
             expect(warn).not.toHaveBeenCalled();
+        });
+
+        it("warns when serverEntry imports withLunora but never calls it", () => {
+            expect.assertions(2);
+
+            // Regression: `source.includes("withLunora")` was always true here
+            // because the import specifier itself contains the substring — the
+            // guard must look for an actual `withLunora(...)` call, not mere
+            // presence of the identifier.
+            directory = mkdtempSync(join(tmpdir(), "lunora-astro-"));
+            writeFileSync(join(directory, "worker.ts"), 'import { withLunora } from "@lunora/astro/server";\nexport default astroWorker;\n');
+
+            const warn = vi.fn<(message: string) => void>();
+            const integration = lunora({ serverEntry: "worker.ts" });
+            const hook = integration.hooks["astro:config:done"] as (context: ConfigDoneHookArgument) => void;
+
+            hook(contextFor(directory, warn));
+
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn.mock.calls[0]?.[0]).toMatch(/couldn't find a `withLunora\(\.\.\.\)` call/u);
+        });
+
+        it("warns (does not throw) when serverEntry exists but cannot be read", () => {
+            expect.assertions(2);
+
+            // `existsSync` passing doesn't mean `readFileSync` will succeed — a
+            // directory at that path raises EISDIR. The hook's contract is "warns,
+            // does not fail the build", so this must degrade to a warning too.
+            directory = mkdtempSync(join(tmpdir(), "lunora-astro-"));
+            mkdirSync(join(directory, "worker.ts"));
+
+            const warn = vi.fn<(message: string) => void>();
+            const integration = lunora({ serverEntry: "worker.ts" });
+            const hook = integration.hooks["astro:config:done"] as (context: ConfigDoneHookArgument) => void;
+
+            expect(() => {
+                hook(contextFor(directory, warn));
+            }).not.toThrow();
+
+            expect(warn.mock.calls[0]?.[0]).toMatch(/could not read server entry/u);
         });
     });
 

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -12,7 +12,15 @@
  * `@lunora/react`, `@lunora/solid`, `@lunora/svelte`, or `@lunora/vue` — each of
  * which ships its own `hydratePreloaded(preloaded)` for the SSR-seed → live
  * handoff. This package owns the server/composition half only.
+ *
+ * The integration is declarative-only: it does not write or modify the
+ * project's `serverEntry` file (no injection). The `withLunora` wiring at the
+ * server-entry boundary is a step the project author performs by hand; the
+ * `astro:config:done` hook below only checks that they did, and warns (mirrors
+ * `@lunora/nuxt`'s missing-`worker.ts` check) rather than failing the build.
  */
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /**
  * Structural subset of Astro's `AstroIntegration`. Declared locally (rather than
@@ -28,6 +36,31 @@ interface AstroIntegrationLike {
     };
     readonly name: string;
 }
+
+/**
+ * Structural subset of the `astro:config:done` hook payload this integration
+ * reads: `config.root` (to resolve `serverEntry` to an absolute path) and
+ * `logger` (Astro's per-integration scoped logger). Declared locally for the
+ * same decoupling reason as {@link AstroIntegrationLike} — real Astro always
+ * passes both, but every field is optional here so a caller invoking the hook
+ * directly (tests, or a future Astro major that reshapes the payload) degrades
+ * to a no-op check rather than throwing.
+ */
+interface ConfigDoneContext {
+    readonly config?: {
+        readonly root?: URL;
+    };
+    readonly logger?: {
+        readonly warn: (message: string) => void;
+    };
+}
+
+/** Copy/paste wiring snippet shown when `serverEntry` doesn't call `withLunora`. */
+const WITH_LUNORA_SNIPPET = [
+    'import { withLunora } from "@lunora/astro/server";',
+    "",
+    "export default withLunora(astroWorker, { shardDO: env.SHARD /* , … */ });",
+].join("\n");
 
 /** Options for the `lunora` integration. */
 interface LunoraIntegrationOptions {
@@ -56,34 +89,63 @@ interface LunoraIntegrationOptions {
  *
  * What it does:
  *
- * - Marks the build so the `@astrojs/cloudflare` server entry is wrapped with
- *   `withLunora` — the composed worker reserves `/_lunora/*` for Lunora realtime
- *   and forwards everything else to Astro's SSR handler (one worker, one deploy).
  * - Documents the `serverEntry` (default `src/worker.ts`) where the
  *   `withLunora(astroWorker, { shardDO: env.SHARD, … })` composition lives.
+ * - Checks, at `astro:config:done`, that `serverEntry` exists and calls
+ *   `withLunora` — and warns (does not fail the build) when it doesn't, so a
+ *   missing wrapper is caught at build time instead of shipping a worker where
+ *   `/_lunora/*` is unrouted and realtime silently 404s.
  *
- * The hook is intentionally minimal here: the load-bearing composition is the
- * `withLunora` wrapper at the server-entry boundary (see `withLunora` for the
- * `@astrojs/cloudflare` injection point). The integration object exists so the
- * wiring is declared in `astro.config` the idiomatic Astro way, and so future
- * build-time hooks (binding reconcile, dev middleware) have a home without
- * changing the public surface.
+ * This integration does NOT wrap the server entry itself — no file is written
+ * or modified. The load-bearing composition is the `withLunora` call the
+ * project author writes at the server-entry boundary (see `withLunora` for the
+ * `@astrojs/cloudflare` injection point); this object exists so the wiring is
+ * declared in `astro.config` the idiomatic Astro way, checked once at build
+ * time, and has a home for future build-time hooks (binding reconcile, dev
+ * middleware) without changing the public surface.
  */
 const lunora = (options: LunoraIntegrationOptions = {}): AstroIntegrationLike => {
     const serverEntry = (options.serverEntry ?? "src/worker.ts").trim();
 
     return {
         hooks: {
-            "astro:config:done": () => {
-                // The composition is performed by `withLunora` at the
-                // `@astrojs/cloudflare` server-entry boundary (`serverEntry`).
-                // This hook is the declared seam for future build-time wiring
-                // (wrangler binding reconcile, dev middleware mounting
-                // `/_lunora/*`). Kept side-effect-free today (it only reads the
-                // resolved entry) so the integration is safe to add before that
-                // wiring lands.
+            "astro:config:done": (context: ConfigDoneContext = {}) => {
                 if (serverEntry.length === 0) {
                     throw new TypeError("@lunora/astro: `serverEntry` must be a non-empty path.");
+                }
+
+                const root = context.config?.root;
+
+                // Without a resolvable project root (e.g. a caller invoking this
+                // hook directly outside a real Astro build) there is nothing to
+                // check the entry file against — stay side-effect-free rather
+                // than guessing a root.
+                if (root === undefined) {
+                    return;
+                }
+
+                const warn =
+                    context.logger?.warn ??
+                    ((message: string) => {
+                        // eslint-disable-next-line no-console -- no `logger` was supplied on this call; fall back so the warning is never silently dropped
+                        console.warn(message);
+                    });
+                const entryPath = fileURLToPath(new URL(serverEntry, root));
+
+                if (!existsSync(entryPath)) {
+                    warn(
+                        `@lunora/astro: server entry "${serverEntry}" not found — add it (or point \`lunora({ serverEntry })\` at the right path) and wrap the Astro worker with \`withLunora\`, or \`/_lunora/*\` (Lunora realtime) will be unrouted:\n\n${WITH_LUNORA_SNIPPET}`,
+                    );
+
+                    return;
+                }
+
+                const source = readFileSync(entryPath, "utf8");
+
+                if (!source.includes("withLunora")) {
+                    warn(
+                        `@lunora/astro: server entry "${serverEntry}" does not call \`withLunora\` — \`/_lunora/*\` (Lunora realtime) will be unrouted and subscriptions will silently 404. Wrap the Astro worker:\n\n${WITH_LUNORA_SNIPPET}`,
+                    );
                 }
             },
         },

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -62,6 +62,16 @@ const WITH_LUNORA_SNIPPET = [
     "export default withLunora(astroWorker, { shardDO: env.SHARD /* , … */ });",
 ].join("\n");
 
+/**
+ * Matches an actual `withLunora(...)` CALL — e.g. `withLunora(astroWorker, …)`,
+ * `export default withLunora(…)`, or `ns.withLunora(…)`. Deliberately does NOT
+ * match `import { withLunora } from "@lunora/astro/server";`: that specifier is
+ * followed by `}`/whitespace/`from`, never directly by `(`, so a file that
+ * imports the helper but forgets to invoke it is correctly reported as missing
+ * the wiring instead of passing on the import alone.
+ */
+const WITH_LUNORA_CALL_PATTERN = /\bwithLunora\s*\(/u;
+
 /** Options for the `lunora` integration. */
 interface LunoraIntegrationOptions {
     /**
@@ -91,10 +101,11 @@ interface LunoraIntegrationOptions {
  *
  * - Documents the `serverEntry` (default `src/worker.ts`) where the
  *   `withLunora(astroWorker, { shardDO: env.SHARD, … })` composition lives.
- * - Checks, at `astro:config:done`, that `serverEntry` exists and calls
- *   `withLunora` — and warns (does not fail the build) when it doesn't, so a
- *   missing wrapper is caught at build time instead of shipping a worker where
- *   `/_lunora/*` is unrouted and realtime silently 404s.
+ * - Checks, at `astro:config:done`, that `serverEntry` exists and contains an
+ *   actual `withLunora(...)` CALL (not merely an import of it) — and warns
+ *   (does not fail the build) when it doesn't, so a missing wrapper is caught
+ *   at build time instead of shipping a worker where `/_lunora/*` is unrouted
+ *   and realtime silently 404s.
  *
  * This integration does NOT wrap the server entry itself — no file is written
  * or modified. The load-bearing composition is the `withLunora` call the
@@ -140,11 +151,26 @@ const lunora = (options: LunoraIntegrationOptions = {}): AstroIntegrationLike =>
                     return;
                 }
 
-                const source = readFileSync(entryPath, "utf8");
+                let source: string;
 
-                if (!source.includes("withLunora")) {
+                try {
+                    source = readFileSync(entryPath, "utf8");
+                } catch (error) {
+                    // `existsSync` passing doesn't guarantee a readable regular file
+                    // (it could be a directory, permission-denied, a broken symlink
+                    // loop, …) — this hook warns rather than fails the build, so a
+                    // read failure must degrade to a warning too, not an uncaught
+                    // throw out of `astro:config:done`.
+                    const reason = error instanceof Error ? error.message : String(error);
+
+                    warn(`@lunora/astro: could not read server entry "${serverEntry}" (${reason}) — skipping the \`withLunora\` check.`);
+
+                    return;
+                }
+
+                if (!WITH_LUNORA_CALL_PATTERN.test(source)) {
                     warn(
-                        `@lunora/astro: server entry "${serverEntry}" does not call \`withLunora\` — \`/_lunora/*\` (Lunora realtime) will be unrouted and subscriptions will silently 404. Wrap the Astro worker:\n\n${WITH_LUNORA_SNIPPET}`,
+                        `@lunora/astro: couldn't find a \`withLunora(...)\` call in the server entry "${serverEntry}" — \`/_lunora/*\` (Lunora realtime) will be unrouted and subscriptions will silently 404. Wrap the Astro worker:\n\n${WITH_LUNORA_SNIPPET}`,
                     );
                 }
             },

--- a/packages/codegen/__tests__/discover-crons.test.ts
+++ b/packages/codegen/__tests__/discover-crons.test.ts
@@ -234,6 +234,85 @@ describe("discover-crons", () => {
         expect(() => discoverCrons(newProject(), workdir)).toThrow(/invalid cron expression/u);
     });
 
+    it("names the job + file:line when an interval.seconds schedule is rejected (build path)", () => {
+        expect.assertions(4);
+
+        // Regression: this call site used to pass only 2 args to
+        // `compileCronSchedule` (dropping `jobName`) and wasn't wrapped in
+        // `diagnosticAt` like its siblings, so the rejection named neither the
+        // job nor the file — the exact failure mode `wrangler deploy` produces,
+        // just earlier and worse.
+        writeSource(
+            "crons.ts",
+            `
+            import { cronJobs } from "@lunora/scheduler";
+            import { internal } from "./_generated/api.js";
+            const crons = cronJobs();
+            crons.interval("tick", { seconds: 30 }, internal.jobs.tick, {});
+            export default crons;
+        `,
+        );
+
+        const cronPath = join(workdir, "crons.ts");
+
+        let thrown: unknown;
+
+        try {
+            discoverCrons(newProject(), workdir);
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(CodegenDiagnosticError);
+
+        const diagnostic = thrown as CodegenDiagnosticError;
+
+        expect(diagnostic.file).toBe(cronPath);
+        expect(diagnostic.line).toBeGreaterThan(0);
+        // Names the job ("tick") the way `compileCronSchedule`'s own message does.
+        expect(diagnostic.message).toMatch(/cron job "tick".*one-minute floor/u);
+    });
+
+    it("warns (does not throw) during codegen when a raw 6-field .cron() is accepted (build path)", () => {
+        expect.assertions(2);
+
+        // Regression: `discover-crons.ts` validated a raw `.cron()` with
+        // `isValidCronExpression` directly and never routed the accepted
+        // 6-field case through the shared seconds-leading advisory, so codegen
+        // silently emitted a Cloudflare-incompatible trigger to wrangler.jsonc.
+        writeSource(
+            "crons.ts",
+            `
+            import { cronJobs } from "@lunora/scheduler";
+            import { internal } from "./_generated/api.js";
+            const crons = cronJobs();
+            crons.cron("sub-minute", "*/30 * * * * *", internal.jobs.tick, {});
+            export default crons;
+        `,
+        );
+
+        const warnings: string[] = [];
+        // eslint-disable-next-line no-console -- capture the seconds-leading advisory under test.
+        const originalWarn = console.warn;
+
+        // eslint-disable-next-line no-console -- temporarily intercept warnings emitted during discovery.
+        console.warn = (message: string): void => {
+            warnings.push(message);
+        };
+
+        let result: ReturnType<typeof discoverCrons>;
+
+        try {
+            result = discoverCrons(newProject(), workdir);
+        } finally {
+            // eslint-disable-next-line no-console -- restore the original implementation.
+            console.warn = originalWarn;
+        }
+
+        expect(result).toEqual([{ args: {}, cron: "*/30 * * * * *", functionPath: "jobs:tick", name: "sub-minute" }]);
+        expect(warnings.some((message) => message.includes("6-field (seconds-leading) cron expression"))).toBe(true);
+    });
+
     it("throws when a job name is not a static string literal", () => {
         expect.assertions(1);
 

--- a/packages/codegen/src/discover-crons.ts
+++ b/packages/codegen/src/discover-crons.ts
@@ -1,10 +1,10 @@
 import { LunoraError } from "@lunora/errors";
 import type { CronScheduleKind } from "@lunora/scheduler";
-import { compileCronSchedule, CRON_SCHEDULE_KINDS, isValidCronExpression } from "@lunora/scheduler";
+import { compileCronSchedule, CRON_SCHEDULE_KINDS, isValidCronExpression, warnIfSecondsLeading } from "@lunora/scheduler";
 import type { CallExpression, Identifier, ObjectLiteralExpression, Project, PropertyAccessExpression, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
-import { diagnosticAt } from "./diagnostics";
+import { CodegenDiagnosticError, diagnosticAt } from "./diagnostics";
 import { listLunoraSourceFiles } from "./discover-functions";
 import type { AgentIR, CronJobIR, WorkflowIR } from "./ir";
 import { isCronSourceModule } from "./module-specifiers";
@@ -336,6 +336,81 @@ const resolveTarget = (
     return { functionPath: functionPathFromArgument(call, index, jobName) };
 };
 
+/** Strips the `@lunora/scheduler: ` prefix a re-thrown scheduler error carries, so codegen's own prefix isn't doubled. */
+const SCHEDULER_ERROR_PREFIX_PATTERN = /^@lunora\/scheduler:\s*/u;
+
+/**
+ * Resolve the raw `.cron(name, cronExpr, ...)` escape hatch: validate the
+ * literal expression is well-formed, then route an accepted-but-6-field
+ * (seconds-leading) expression through the same shared advisory the runtime
+ * `cronJobs()` builder emits — so a hand-authored 6-field `.cron(name,
+ * cronExpr, …)` warns at build time too, not only when the app runs.
+ */
+const rawCronExpression = (call: CallExpression, name: string): string => {
+    const expression = stringArgument(call, 1);
+
+    if (expression === undefined) {
+        throw diagnosticAt(call, `Cron job "${name}" must pass a string-literal cron expression to ".cron(...)".`, {
+            code: "CRON_EXPR_NOT_STATIC",
+            name: "LunoraError",
+            status: 500,
+        });
+    }
+
+    if (!isValidCronExpression(expression)) {
+        throw diagnosticAt(call, `Cron job "${name}" has an invalid cron expression "${expression}" — expected 5 or 6 space-separated fields.`, {
+            code: "CRON_EXPR_INVALID",
+            name: "LunoraError",
+            status: 500,
+        });
+    }
+
+    warnIfSecondsLeading(expression, `cron expression for job "${name}"`);
+
+    return expression;
+};
+
+/**
+ * Resolve an ergonomic `.{daily,hourly,interval,monthly,weekly}(name, schedule,
+ * ...)` call into a compiled cron expression. `name` is passed through as
+ * `compileCronSchedule`'s `jobName` (already in scope here) so a rejection —
+ * e.g. `interval.seconds`, which `compileInterval` rejects outright — names the
+ * job, and any such rejection is re-thrown through `diagnosticAt`, like every
+ * sibling error in this module, so it also carries file:line instead of
+ * surfacing bare.
+ */
+const structuredCronExpression = (call: CallExpression, method: string, name: string): string => {
+    const scheduleArgument = call.getArguments()[1];
+
+    if (!scheduleArgument || !Node.isObjectLiteralExpression(scheduleArgument)) {
+        throw diagnosticAt(call, `Cron job "${name}" must pass an object-literal schedule to ".${method}(...)".`, {
+            code: "CRON_SCHEDULE_NOT_STATIC",
+            name: "LunoraError",
+            status: 500,
+        });
+    }
+
+    try {
+        return compileCronSchedule(method as CronScheduleKind, objectLiteralValue(scheduleArgument, name), name);
+    } catch (error) {
+        // `objectLiteralValue`/`literalValue` already throw a
+        // `CodegenDiagnosticError` (file:line included) for a non-static
+        // schedule value — let that pass through unchanged rather than
+        // double-wrapping it.
+        if (error instanceof CodegenDiagnosticError) {
+            throw error;
+        }
+
+        const detail = error instanceof Error ? error.message.replace(SCHEDULER_ERROR_PREFIX_PATTERN, "") : String(error);
+
+        throw diagnosticAt(call, detail, {
+            code: "CRON_SCHEDULE_INVALID",
+            name: "LunoraError",
+            status: 500,
+        });
+    }
+};
+
 /** Lift one `crons.method(name, schedule, fnRef, args?)` call into {@link CronJobIR}. */
 const cronFromCall = (
     call: CallExpression,
@@ -364,41 +439,7 @@ const cronFromCall = (
         });
     }
 
-    let cron: string;
-
-    if (method === "cron") {
-        const expression = stringArgument(call, 1);
-
-        if (expression === undefined) {
-            throw diagnosticAt(call, `Cron job "${name}" must pass a string-literal cron expression to ".cron(...)".`, {
-                code: "CRON_EXPR_NOT_STATIC",
-                name: "LunoraError",
-                status: 500,
-            });
-        }
-
-        if (!isValidCronExpression(expression)) {
-            throw diagnosticAt(call, `Cron job "${name}" has an invalid cron expression "${expression}" — expected 5 or 6 space-separated fields.`, {
-                code: "CRON_EXPR_INVALID",
-                name: "LunoraError",
-                status: 500,
-            });
-        }
-
-        cron = expression;
-    } else {
-        const scheduleArgument = call.getArguments()[1];
-
-        if (!scheduleArgument || !Node.isObjectLiteralExpression(scheduleArgument)) {
-            throw diagnosticAt(call, `Cron job "${name}" must pass an object-literal schedule to ".${method}(...)".`, {
-                code: "CRON_SCHEDULE_NOT_STATIC",
-                name: "LunoraError",
-                status: 500,
-            });
-        }
-
-        cron = compileCronSchedule(method as CronScheduleKind, objectLiteralValue(scheduleArgument, name));
-    }
+    const cron = method === "cron" ? rawCronExpression(call, name) : structuredCronExpression(call, method, name);
 
     const target = resolveTarget(call, 2, name, workflowsByName, agentsByName);
     const argumentsNode = call.getArguments()[3];

--- a/packages/container/__tests__/lunora-container.test.ts
+++ b/packages/container/__tests__/lunora-container.test.ts
@@ -357,6 +357,62 @@ describe("lunoraContainer lifecycle logging", () => {
         await expect(instance.onStart()).rejects.toThrow("has no port");
     });
 
+    it("aborts a readiness probe that never responds instead of hanging forever, and rejects at the deadline", async () => {
+        expect.assertions(1);
+
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        // `AbortSignal.timeout`'s real delay runs on the wall clock and isn't
+        // reachable by vitest's fake timers, so stub it to hand back an
+        // already-aborted signal — this exercises the same "the attempt was
+        // aborted" path a real timeout would take, without a real 30s wait.
+        vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
+            const controller = new AbortController();
+
+            controller.abort();
+
+            return controller.signal;
+        });
+        vi.useFakeTimers();
+
+        const context = fakeDurableObjectContext({
+            container: {
+                getTcpPort: () => {
+                    return {
+                        // A container that accepted the TCP connection but never
+                        // answers: the returned promise only ever settles via the
+                        // abort signal, exactly like a real `fetch` would.
+                        fetch: (_url: string, init?: { signal?: AbortSignal }) => {
+                            return new Promise((_resolve, reject) => {
+                                if (init?.signal?.aborted) {
+                                    reject(new Error("aborted"));
+
+                                    return;
+                                }
+
+                                init?.signal?.addEventListener("abort", () => {
+                                    reject(new Error("aborted"));
+                                });
+                            });
+                        },
+                    };
+                },
+                running: false,
+            },
+        });
+
+        const definition = defineContainer({ defaultPort: 8080, image: "./app", readyOn: [{ path: "/ready" }] });
+        const instance = new LunoraContainer(context as never, {}, definition, "transcoder");
+
+        try {
+            const assertion = expect(instance.onStart()).rejects.toThrow("did not return 200 within");
+
+            await vi.advanceTimersByTimeAsync(30_000);
+            await assertion;
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("arms a hard-timeout schedule on start, stamped with the bumped run generation", async () => {
         expect.assertions(2);
 

--- a/packages/container/src/do/index.ts
+++ b/packages/container/src/do/index.ts
@@ -342,15 +342,21 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
         const tcpPort = container.getTcpPort(port);
 
         for (;;) {
+            // A container that accepts the TCP connection but never answers must not
+            // hang this loop past the deadline — bound each attempt with an abort
+            // signal, floored at one poll interval so the final attempt still gets a
+            // fair window instead of an near-instant abort.
+            const attemptTimeoutMs = Math.max(READINESS_POLL_INTERVAL_MS, deadline - Date.now());
+
             try {
                 // eslint-disable-next-line no-await-in-loop -- sequential poll: each probe waits on the previous attempt before retrying.
-                const response = await tcpPort.fetch(`http://container${path}`);
+                const response = await tcpPort.fetch(`http://container${path}`, { signal: AbortSignal.timeout(attemptTimeoutMs) });
 
                 if (response.status === expectedStatus) {
                     return;
                 }
             } catch {
-                // Connection refused / app not up yet — fall through and retry below.
+                // Connection refused, app not up yet, or the attempt timed out — fall through and retry below.
             }
 
             if (Date.now() >= deadline) {

--- a/packages/scheduler/__tests__/cron-jobs.test.ts
+++ b/packages/scheduler/__tests__/cron-jobs.test.ts
@@ -20,17 +20,27 @@ const fnRef = (ref: string): FunctionReference => {
 
 describe("cronJobs", () => {
     it("compiles .interval into a stepped cron expression for each unit", () => {
-        expect.assertions(3);
+        expect.assertions(2);
 
         const crons = cronJobs();
 
         crons.interval("every-30-min", { minutes: 30 }, fnRef("presence.clear"));
         crons.interval("every-2-hours", { hours: 2 }, fnRef("jobs.sweep"));
-        crons.interval("every-15-seconds", { seconds: 15 }, fnRef("jobs.tick"));
 
         expect(crons.jobs()[0]?.cron).toBe("*/30 * * * *");
         expect(crons.jobs()[1]?.cron).toBe("0 */2 * * *");
-        expect(crons.jobs()[2]?.cron).toBe("*/15 * * * * *");
+    });
+
+    it("rejects interval.seconds — Cloudflare Cron Triggers have a one-minute floor", () => {
+        expect.assertions(2);
+
+        // A `{ seconds }` interval compiles to a 6-field, seconds-leading cron
+        // expression that Cloudflare's Cron Triggers don't understand — it would
+        // otherwise survive validation and codegen and only fail at
+        // `wrangler deploy`, naming neither the job nor the file.
+        expect(() => cronJobs().interval("tick", { seconds: 30 }, fnRef("jobs.tick"))).toThrow(/cron job "tick".*one-minute floor/u);
+        // The fastest cron-native cadence (once a minute) still compiles.
+        expect(cronJobs().interval("every-minute", { minutes: 1 }, fnRef("jobs.tick")).jobs()[0]?.cron).toBe("*/1 * * * *");
     });
 
     it("compiles .daily/.weekly/.monthly to fixed-UTC cron expressions", () => {
@@ -139,7 +149,7 @@ describe("cronJobs", () => {
     });
 
     it("rejects an interval value that does not evenly divide its period", () => {
-        expect.assertions(3);
+        expect.assertions(2);
 
         const crons = cronJobs();
 
@@ -147,8 +157,8 @@ describe("cronJobs", () => {
         expect(() => crons.interval("m", { minutes: 45 }, fnRef("a.b"))).toThrow(/interval\.minutes/u);
         // 7 does not divide 24: cron "0 */7" fires at 00,07,14,21 then wraps to a 3h gap.
         expect(() => crons.interval("h", { hours: 7 }, fnRef("a.b"))).toThrow(/interval\.hours/u);
-        // 25 does not divide 60 seconds.
-        expect(() => crons.interval("s", { seconds: 25 }, fnRef("a.b"))).toThrow(/interval\.seconds/u);
+        // `interval.seconds` is rejected outright (one-minute floor) before divisibility is
+        // even checked — see "rejects interval.seconds" above.
     });
 
     it("validates numeric bounds on schedule fields", () => {

--- a/packages/scheduler/__tests__/cron-parity.json
+++ b/packages/scheduler/__tests__/cron-parity.json
@@ -1,13 +1,6 @@
 {
-    "_comment": "Shared cron-schedule compile contract. Both @lunora/scheduler's compileCronSchedule (src/jobs.ts) and @lunora/codegen's mirror (src/cron-compile.ts) are asserted against this single matrix so a drift in either copy fails CI. Update this file ONLY when the cron expression format intentionally changes, and update both compilers together.",
+    "_comment": "Shared cron-schedule compile contract for @lunora/scheduler's compileCronSchedule (src/jobs.ts), which @lunora/codegen imports directly rather than mirroring. Update this file ONLY when the cron expression format intentionally changes. `interval.seconds` is deliberately absent — Cloudflare Cron Triggers have a one-minute floor, so compileCronSchedule rejects it outright (see the dedicated 'rejects interval.seconds' test above) instead of compiling to a 6-field expression.",
     "cases": [
-        {
-            "kind": "interval",
-            "schedule": {
-                "seconds": 30
-            },
-            "expected": "*/30 * * * * *"
-        },
         {
             "kind": "interval",
             "schedule": {

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -40,4 +40,4 @@ export type {
     WorkpoolOptions,
 } from "./types";
 export { isWorkflowReference } from "./types";
-export { assertValidCronExpression, isValidCronExpression } from "./validate-cron";
+export { assertValidCronExpression, isValidCronExpression, warnIfSecondsLeading } from "./validate-cron";

--- a/packages/scheduler/src/jobs.ts
+++ b/packages/scheduler/src/jobs.ts
@@ -168,8 +168,13 @@ const stepField = (value: number, label: string, period: number): string => {
  * Exactly one unit is allowed; the value is rendered as a stepped wildcard
  * (`star-slash-n`) in the corresponding cron field and must evenly divide the
  * field's period so the recurrence is truly `every n` (see {@link stepField}).
+ *
+ * `jobName` is optional so `@lunora/codegen`'s static AST-based discovery (which
+ * calls this without a resolved job name in scope) still gets a rejection — just
+ * without the job name in the message; the `cronJobs()` builder below always has
+ * a name and passes it.
  */
-const compileInterval = (schedule: IntervalSchedule): string => {
+const compileInterval = (schedule: IntervalSchedule, jobName?: string): string => {
     const units = (["seconds", "minutes", "hours"] as const).filter((unit) => schedule[unit] !== undefined);
 
     if (units.length !== 1) {
@@ -198,8 +203,17 @@ const compileInterval = (schedule: IntervalSchedule): string => {
         );
     }
 
+    // Cloudflare Cron Triggers have a one-minute floor: the platform only
+    // understands the standard 5-field (minute-granularity) grammar, so a
+    // 6-field seconds-leading expression compiles cleanly, survives codegen,
+    // and lands in the user's committed wrangler.jsonc — then fails only at
+    // `wrangler deploy`, with an error naming neither the job nor the file.
+    // Reject it here instead, where the job name is still in scope.
     if (unit === "seconds") {
-        return `*/${stepField(value, "interval.seconds", 60)} * * * * *`;
+        throw new LunoraError(
+            "INTERNAL",
+            `@lunora/scheduler: cron job${jobName ? ` "${jobName}"` : ""} uses interval.seconds (${String(value)}) — Cloudflare Cron Triggers have a one-minute floor and cannot run sub-minute schedules; \`wrangler deploy\` would reject the resulting 6-field cron expression. Use ctx.scheduler.runAfter/runAt (optionally via a workpool for bounded concurrency) for sub-minute recurrence, or crons.interval(name, { minutes: 1 }, …) for the fastest cron-native cadence.`,
+        );
     }
 
     if (unit === "minutes") {
@@ -249,11 +263,14 @@ const CRON_SCHEDULE_KINDS: ReadonlySet<CronScheduleKind> = new Set<CronScheduleK
  * Compile one of the ergonomic schedule forms into a standard cron expression.
  * Exposed as a pure function so `@lunora/codegen` can reuse the exact same
  * compilation when it statically lifts a `crons.{kind}(...)` call out of the
- * AST — codegen imports this directly (no duplicated mirror).
+ * AST — codegen imports this directly (no duplicated mirror). `jobName` is
+ * optional (see {@link compileInterval}) so codegen's existing 2-arg call site
+ * keeps working unchanged.
  */
 const compileCronSchedule = (
     kind: CronScheduleKind,
     schedule: DailySchedule | HourlySchedule | IntervalSchedule | MonthlySchedule | WeeklySchedule,
+    jobName?: string,
 ): string => {
     switch (kind) {
         case "daily": {
@@ -263,7 +280,7 @@ const compileCronSchedule = (
             return compileHourly(schedule as HourlySchedule);
         }
         case "interval": {
-            return compileInterval(schedule as IntervalSchedule);
+            return compileInterval(schedule as IntervalSchedule, jobName);
         }
         case "monthly": {
             return compileMonthly(schedule as MonthlySchedule);
@@ -365,7 +382,7 @@ const cronJobs = (): CronJobsBuilder => {
             return builder;
         },
         interval(name, schedule, function_, args) {
-            register(name, compileCronSchedule("interval", schedule), function_, args);
+            register(name, compileCronSchedule("interval", schedule, name), function_, args);
 
             return builder;
         },

--- a/packages/scheduler/src/validate-cron.ts
+++ b/packages/scheduler/src/validate-cron.ts
@@ -16,6 +16,16 @@
  * the `cronJobs()` builder (authoring) and `@lunora/codegen` (build), never by
  * the `SchedulerDO` runtime path — so with `sideEffects: false` it tree-shakes
  * out of the Worker bundle.
+ *
+ * The ergonomic `crons.interval({ seconds })` form is rejected outright by
+ * `compileInterval` in `./jobs.ts` before it ever reaches this validator. The
+ * raw `.cron()` escape hatch is different: a 6-field, seconds-leading
+ * expression is well-formed cron grammar (`cron-parser` accepts it), so it
+ * passes here — but Cloudflare Cron Triggers only understand the standard
+ * 5-field form and reject 6-field expressions at `wrangler deploy`. We warn
+ * rather than throw for that case (see {@link warnIfSecondsLeading}): the
+ * escape hatch exists precisely so callers can hand-author cron grammar this
+ * module doesn't otherwise validate against a specific platform.
  */
 import { LunoraError } from "@lunora/errors";
 import { CronExpressionParser } from "cron-parser";
@@ -35,10 +45,33 @@ const isValidCronExpression = (schedule: string): boolean => {
     }
 };
 
+/** Splits a cron expression on whitespace to count its fields. */
+const CRON_FIELD_SPLIT_PATTERN = /\s+/u;
+
+/**
+ * A 6-field (seconds-leading) cron expression is legal generic cron grammar
+ * but not a Cloudflare Cron Trigger — the platform only understands the
+ * 5-field, minute-granularity form and rejects the rest at `wrangler deploy`
+ * with a message naming neither the job nor the file. Warn here instead of
+ * staying silent, without throwing: unlike the ergonomic `.interval()` form,
+ * the raw `.cron()` escape hatch is meant to accept cron grammar this module
+ * doesn't otherwise second-guess.
+ */
+const warnIfSecondsLeading = (schedule: string, context: string): void => {
+    if (schedule.trim().split(CRON_FIELD_SPLIT_PATTERN).length === 6) {
+        // eslint-disable-next-line no-console -- deliberate authoring-time warning; no logger is available in this Node/codegen-time module
+        console.warn(
+            `@lunora/scheduler: ${context} "${schedule}" is a 6-field (seconds-leading) cron expression — Cloudflare Cron Triggers only support the standard 5-field form and will reject this at \`wrangler deploy\`. Drop the seconds field, or use ctx.scheduler.runAfter/runAt for sub-minute work.`,
+        );
+    }
+};
+
 /**
  * Assert a raw cron expression is well-formed, throwing the same shaped error
  * both cron surfaces use. The `context` prefix lets callers name the offending
- * job (`cron job "send digest"`) vs. the bare trigger.
+ * job (`cron job "send digest"`) vs. the bare trigger. Well-formed but
+ * Cloudflare-incompatible (6-field) expressions pass but log a warning — see
+ * {@link warnIfSecondsLeading}.
  */
 const assertValidCronExpression = (schedule: string, context = "cron expression"): void => {
     if (!isValidCronExpression(schedule)) {
@@ -47,6 +80,8 @@ const assertValidCronExpression = (schedule: string, context = "cron expression"
             `@lunora/scheduler: invalid ${context} "${schedule}" — expected a standard 5- or 6-field cron expression (e.g. "0 * * * *")`,
         );
     }
+
+    warnIfSecondsLeading(schedule, context);
 };
 
 export { assertValidCronExpression, isValidCronExpression };

--- a/packages/scheduler/src/validate-cron.ts
+++ b/packages/scheduler/src/validate-cron.ts
@@ -56,6 +56,13 @@ const CRON_FIELD_SPLIT_PATTERN = /\s+/u;
  * staying silent, without throwing: unlike the ergonomic `.interval()` form,
  * the raw `.cron()` escape hatch is meant to accept cron grammar this module
  * doesn't otherwise second-guess.
+ *
+ * Exported (not module-private) because it is the ONE place this advisory is
+ * written: the runtime `cronJobs()` builder reaches it via
+ * {@link assertValidCronExpression}, and `@lunora/codegen`'s static
+ * `discover-crons.ts` calls it directly after its own `isValidCronExpression`
+ * check — so a hand-authored 6-field `.cron()` warns whether it's discovered
+ * from source at build time or registered at runtime, with one shared message.
  */
 const warnIfSecondsLeading = (schedule: string, context: string): void => {
     if (schedule.trim().split(CRON_FIELD_SPLIT_PATTERN).length === 6) {
@@ -84,4 +91,4 @@ const assertValidCronExpression = (schedule: string, context = "cron expression"
     warnIfSecondsLeading(schedule, context);
 };
 
-export { assertValidCronExpression, isValidCronExpression };
+export { assertValidCronExpression, isValidCronExpression, warnIfSecondsLeading };


### PR DESCRIPTION
Three independent Cloudflare-service guards: the container readiness probe had no AbortSignal (a connected-but-silent container hung the DO start forever) → adds a deadline-bound signal; `crons.interval({ seconds })` compiled to a cron Cloudflare can't deploy (one-minute floor) and failed opaquely at deploy → now throws at authoring time naming the job; the Astro integration silently did nothing while its docblock claimed it wrapped the server entry → now warns when `withLunora` is missing.

Verified: container 139, scheduler 118, astro 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)