### PR TITLE
fix: reject control chars in signed-URL keys + explicit upload authorize gate (+ defineEventStore spike)

### DIFF
--- a/packages/bindings/__tests__/event-store/define-event-store.test.ts
+++ b/packages/bindings/__tests__/event-store/define-event-store.test.ts
@@ -1,0 +1,119 @@
+/**
+ * PROTOTYPE coverage (plan 247, design spike) — proves `defineEventStore` can
+ * type ONE schema into both a Pipelines `send()` and an r2sql `query()` over
+ * the same table, and — the load-bearing claim — that an off-schema `send()`
+ * is caught at runtime, not merely disallowed by TypeScript.
+ *
+ * Doubles mirror the package's existing per-binding tests:
+ * `PipelineBindingLike` as a plain object (see
+ * `__tests__/pipelines/create-pipelines.test.ts`), and a real `createR2Sql`
+ * client wired to a fake `fetch` (see `__tests__/r2sql/client.test.ts`) so
+ * `query().run()` exercises the real `SelectBuilder` + envelope-parsing path,
+ * not a hand-rolled stand-in.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { defineEventStore } from "../../src/event-store/define-event-store";
+import type { EventStoreRecord, EventStoreSchema } from "../../src/event-store/types";
+import { createR2Sql } from "../../src/r2sql/client";
+
+const schema = {
+    amount: "number",
+    id: "string",
+    occurredAt: "timestamp",
+} as const satisfies EventStoreSchema;
+
+type PurchaseEvent = EventStoreRecord<typeof schema>;
+
+interface FakeResponseInit {
+    body?: unknown;
+    ok?: boolean;
+    status?: number;
+}
+
+const fakeResponse = (init: FakeResponseInit = {}): Response => {
+    const { body = { result: { rows: [], schema: [] }, success: true }, ok = true, status = 200 } = init;
+
+    return {
+        json: async () => body,
+        ok,
+        status,
+        text: async () => JSON.stringify(body),
+    } as unknown as Response;
+};
+
+const setup = (responseInit?: FakeResponseInit) => {
+    const send = vi.fn<(records: unknown[]) => Promise<void>>(async () => {});
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () => fakeResponse(responseInit));
+    const r2sql = createR2Sql({ accountId: "acc", apiToken: "secret", bucket: "events", fetch: fetchImpl });
+
+    const store = defineEventStore({
+        pipeline: { send },
+        r2sql,
+        schema,
+        table: "analytics.purchases",
+    });
+
+    return { fetchImpl, send, store };
+};
+
+describe("defineEventStore (prototype)", () => {
+    it("types one schema into a working send() over the Pipelines binding-like", async () => {
+        expect.assertions(1);
+
+        const { send, store } = setup();
+        const event: PurchaseEvent = { amount: 42, id: "evt-1", occurredAt: "2026-07-31T00:00:00Z" };
+
+        await store.send(event);
+
+        expect(send).toHaveBeenCalledWith([event]);
+    });
+
+    it("types the same schema into a query() built from the real r2sql SelectBuilder over the same table", async () => {
+        expect.assertions(2);
+
+        const { fetchImpl, store } = setup({ body: { result: { rows: [{ amount: 42, id: "evt-1", occurredAt: "2026-07-31T00:00:00Z" }] }, success: true } });
+
+        const result = await store.query().where("amount > 10").orderBy("occurredAt").limit(5).run();
+
+        const sentQuery = JSON.parse(fetchImpl.mock.calls[0]?.[1]?.body as string).query as string;
+
+        // The query executed against the SAME `table` passed to `defineEventStore`
+        // — the whole point being that write and read target one physical table
+        // under one declared schema, not two independently maintained references.
+        expect(sentQuery).toBe("SELECT * FROM analytics.purchases WHERE amount > 10 ORDER BY occurredAt LIMIT 5");
+        expect(result.rows).toEqual([{ amount: 42, id: "evt-1", occurredAt: "2026-07-31T00:00:00Z" }]);
+    });
+
+    it("catches a wrong-typed field at send() time, at runtime — not just a compile-time cast", async () => {
+        expect.assertions(2);
+
+        const { send, store } = setup();
+        // A plain-JS caller (or a stale build, or an `as` cast) can hand send() a
+        // record TypeScript would otherwise reject — `amount` is a string, not
+        // the schema's declared `number`. This is the case the design doc calls
+        // out: EventStoreRecord<Schema> alone is compile-time-only.
+        const offSchema = { amount: "forty-two", id: "evt-2", occurredAt: "2026-07-31T00:00:00Z" } as unknown as PurchaseEvent;
+
+        await expect(store.send(offSchema)).rejects.toThrow(/"amount" must be a number/);
+        expect(send).not.toHaveBeenCalled();
+    });
+
+    it("catches a missing declared field at send() time", async () => {
+        expect.assertions(1);
+
+        const { store } = setup();
+        const missingField = { id: "evt-3", occurredAt: "2026-07-31T00:00:00Z" } as unknown as PurchaseEvent;
+
+        await expect(store.send(missingField)).rejects.toThrow(/"amount" must be a number/);
+    });
+
+    it("catches a field the schema does not declare (the table's columns are fixed)", async () => {
+        expect.assertions(1);
+
+        const { store } = setup();
+        const extraField = { amount: 1, id: "evt-4", occurredAt: "2026-07-31T00:00:00Z", unexpected: "nope" } as unknown as PurchaseEvent;
+
+        await expect(store.send(extraField)).rejects.toThrow(/"unexpected" is not declared in the schema/);
+    });
+});

--- a/packages/bindings/__tests__/event-store/define-event-store.test.ts
+++ b/packages/bindings/__tests__/event-store/define-event-store.test.ts
@@ -116,4 +116,24 @@ describe("defineEventStore (prototype)", () => {
 
         await expect(store.send(extraField)).rejects.toThrow(/"unexpected" is not declared in the schema/);
     });
+
+    it("catches an off-schema field named after an Object.prototype member", async () => {
+        expect.assertions(2);
+
+        // `field in schema` walks the prototype chain, so a record field named
+        // "constructor" (or "toString", "hasOwnProperty", …) would read as
+        // "declared" against ANY schema object and smuggle through unvalidated
+        // — the exact off-schema case the previous test guards against, just
+        // reached via the prototype chain instead of a plain extra key.
+        const { send, store } = setup();
+        const prototypePollution = {
+            amount: 1,
+            constructor: "nope",
+            id: "evt-5",
+            occurredAt: "2026-07-31T00:00:00Z",
+        } as unknown as PurchaseEvent;
+
+        await expect(store.send(prototypePollution)).rejects.toThrow(/"constructor" is not declared in the schema/);
+        expect(send).not.toHaveBeenCalled();
+    });
 });

--- a/packages/bindings/__tests__/images/signed-delivery-url.test.ts
+++ b/packages/bindings/__tests__/images/signed-delivery-url.test.ts
@@ -178,6 +178,22 @@ describe("buildSignedImageUrl / verifySignedImageUrl", () => {
         expect(result.key).toBe("a.png");
     });
 
+    it("rejects a key containing a raw newline at sign time (BINDINGS-01)", async () => {
+        expect.assertions(1);
+
+        // The canonical is `host\nkey\nexp\ntransform` — `key` is not its last
+        // field, so a raw \n in it could shift where `exp` re-splits on verify,
+        // letting an attacker-influenced key smuggle a different expiry under
+        // the same signature.
+        await expect(buildSignedImageUrl({ baseUrl: BASE, key: "uploads/avatar.png\n9999999999\n", secret: SECRET })).rejects.toThrow(/control character/);
+    });
+
+    it("rejects a key containing a carriage return at sign time", async () => {
+        expect.assertions(1);
+
+        await expect(buildSignedImageUrl({ baseUrl: BASE, key: "uploads/avatar\r.png", secret: SECRET })).rejects.toThrow(/control character/);
+    });
+
     it("round-trips a key that has a leading slash (canonical/URL mismatch regression)", async () => {
         // A leading-slash key was previously signed with the slash in the
         // canonical but built into the URL without it, so verify always returned

--- a/packages/bindings/src/event-store/define-event-store.ts
+++ b/packages/bindings/src/event-store/define-event-store.ts
@@ -1,0 +1,81 @@
+/**
+ * PROTOTYPE (plan 247, design spike) — see `packages/bindings/src/event-store/types.ts`
+ * and `plans/247-event-store-design.md` for the design this validates.
+ */
+import { LunoraError } from "@lunora/errors";
+
+import type { EventStore, EventStoreColumnType, EventStoreConfig, EventStoreRecord, EventStoreSchema } from "./types";
+
+/** Runtime type check for one column value against its declared {@link EventStoreColumnType}. */
+const matchesColumnType = (value: unknown, type: EventStoreColumnType): boolean => {
+    switch (type) {
+        case "boolean": {
+            return typeof value === "boolean";
+        }
+        case "number": {
+            return typeof value === "number" && Number.isFinite(value);
+        }
+        case "string": {
+            return typeof value === "string";
+        }
+        case "timestamp": {
+            return typeof value === "string" || typeof value === "number" || value instanceof Date;
+        }
+        default: {
+            // Exhaustive per `EventStoreColumnType`; a value outside it (e.g. from
+            // a plain-JS caller that bypassed the type system) fails closed.
+            return false;
+        }
+    }
+};
+
+/**
+ * Runtime guard behind `send()`. `EventStoreRecord&lt;Schema>` narrows the call
+ * site at compile time, but Pipelines' own binding takes untyped
+ * `Record&lt;string, unknown>[]` and enforces nothing server-side — so the type
+ * alone is a promise a plain-JS caller, a stale build, or an `as` cast can
+ * break silently. This is the actual enforcement: a record with a
+ * wrong-typed field, a missing field, or a field the schema doesn't declare
+ * throws here, before anything reaches Pipelines.
+ */
+const assertMatchesSchema = (schema: EventStoreSchema, record: Record<string, unknown>): void => {
+    for (const [field, type] of Object.entries(schema)) {
+        if (!matchesColumnType(record[field], type)) {
+            throw new LunoraError("VALIDATION_ERROR", `@lunora/bindings/event-store: field "${field}" must be a ${type} (got ${typeof record[field]})`);
+        }
+    }
+
+    for (const field of Object.keys(record)) {
+        if (!(field in schema)) {
+            throw new LunoraError("VALIDATION_ERROR", `@lunora/bindings/event-store: field "${field}" is not declared in the schema`);
+        }
+    }
+};
+
+/**
+ * Declare one schema that types BOTH the Pipelines write path and the r2sql
+ * read path over the same Iceberg table — modeled on `defineRag`
+ * (`@lunora/ai/rag`), which couples `ctx.ai` + `ctx.vectors` under one schema
+ * the same way. `send()` is runtime-validated against `schema`; `query()` is
+ * `r2sql.from&lt;Row>(table)` with `Row` inferred from the same `schema`, so a
+ * column can't drift between the two halves the way two hand-declared
+ * column-type lists can.
+ *
+ * This is a SPIKE prototype: it does not own R2 Data Catalog table creation
+ * (the table must already exist, matching `schema`, created out-of-band) and
+ * is not wired into `@lunora/bindings`'s public subpath exports. See
+ * `plans/247-event-store-design.md`.
+ */
+// eslint-disable-next-line import/prefer-default-export -- re-exported as a named export from index.ts; the package convention is named-only exports
+export const defineEventStore = <Schema extends EventStoreSchema>(config: EventStoreConfig<Schema>): EventStore<Schema> => {
+    const { pipeline, r2sql, schema, table } = config;
+
+    return {
+        query: () => r2sql.from<EventStoreRecord<Schema>>(table),
+        send: async (record: EventStoreRecord<Schema>): Promise<void> => {
+            assertMatchesSchema(schema, record);
+
+            await pipeline.send([record]);
+        },
+    };
+};

--- a/packages/bindings/src/event-store/define-event-store.ts
+++ b/packages/bindings/src/event-store/define-event-store.ts
@@ -46,7 +46,7 @@ const assertMatchesSchema = (schema: EventStoreSchema, record: Record<string, un
     }
 
     for (const field of Object.keys(record)) {
-        if (!(field in schema)) {
+        if (!Object.hasOwn(schema, field)) {
             throw new LunoraError("VALIDATION_ERROR", `@lunora/bindings/event-store: field "${field}" is not declared in the schema`);
         }
     }

--- a/packages/bindings/src/event-store/index.ts
+++ b/packages/bindings/src/event-store/index.ts
@@ -1,0 +1,8 @@
+/**
+ * PROTOTYPE (plan 247, design spike) — not part of `@lunora/bindings`'s public
+ * subpath exports (`package.json` "exports" has no `./event-store" entry).
+ * Kept as an internal barrel, matching the package's per-binding folder
+ * convention, so the prototype reads the same as every shipped subpath.
+ */
+export { defineEventStore } from "./define-event-store";
+export type { EventStore, EventStoreColumnType, EventStoreConfig, EventStoreRecord, EventStoreSchema } from "./types";

--- a/packages/bindings/src/event-store/types.ts
+++ b/packages/bindings/src/event-store/types.ts
@@ -1,0 +1,109 @@
+/**
+ * PROTOTYPE (plan 247, design spike) — types for `defineEventStore`, which
+ * explores whether one declared schema can drive BOTH the Pipelines write
+ * path (`ctx.pipelines`-shaped `.send()`) and the r2sql read path
+ * (`ctx.r2sql`-shaped `.query()`) over the same R2 Data Catalog / Iceberg
+ * table, the way `defineRag` (`@lunora/ai/rag`) already couples `ctx.ai` +
+ * `ctx.vectors` under one schema.
+ *
+ * Not wired into the package's public subpath exports — see
+ * `plans/247-event-store-design.md` for the open questions (table-lifecycle
+ * ownership, Analytics Engine generalization, codegen wiring) that block
+ * shipping this as `@lunora/bindings/event-store`.
+ */
+
+import type { PipelineBindingLike } from "../pipelines/types";
+import type SelectBuilder from "../r2sql/builder";
+import type { R2SqlClient } from "../r2sql/client";
+
+/**
+ * Column primitive types this prototype supports. Deliberately small — enough
+ * to prove the schema-drives-both-halves mapping, not a full mirror of
+ * Iceberg's type system (no nested/list/map/decimal types). A real
+ * implementation would need to grow this to whatever the R2 Data Catalog
+ * table actually declares.
+ */
+type EventStoreColumnType = "boolean" | "number" | "string" | "timestamp";
+
+/** Map one {@link EventStoreColumnType} to its TS representation. */
+type TsTypeOfColumn<Column extends EventStoreColumnType> = Column extends "boolean"
+    ? boolean
+    : Column extends "number"
+      ? number
+      : Column extends "string"
+        ? string
+        : Column extends "timestamp"
+          ? Date | number | string
+          : never;
+
+/**
+ * A column name → type map. This one object is the schema: it drives both
+ * `send()`'s accepted record type and `query()`'s row type, so the two
+ * can't independently drift the way two hand-written column-type lists can.
+ */
+type EventStoreSchema = Record<string, EventStoreColumnType>;
+
+/**
+ * The record shape `send()` accepts and `query()`'s rows resolve to, derived
+ * field-by-field from `Schema`.
+ */
+type EventStoreRecord<Schema extends EventStoreSchema> = { [Field in keyof Schema]: TsTypeOfColumn<Schema[Field]> };
+
+/** Config for {@link import("./define-event-store").defineEventStore | defineEventStore}. */
+interface EventStoreConfig<Schema extends EventStoreSchema> {
+    /**
+     * The Pipelines binding-like `send()` is forwarded to (the same shape
+     * `ctx.pipelines` wraps — see `@lunora/bindings/pipelines`'s
+     * `PipelineBindingLike`). Untyped at the Cloudflare API boundary; this
+     * prototype's `EventStoreRecord&lt;Schema>` narrows the call site.
+     */
+    pipeline: PipelineBindingLike<EventStoreRecord<Schema>>;
+
+    /**
+     * The r2sql client `query()` is built from (the same shape `ctx.r2sql`
+     * wraps — see `@lunora/bindings/r2sql`'s `R2SqlClient`). Only `from` is
+     * required, so a caller can inject a narrower double in tests.
+     */
+    r2sql: Pick<R2SqlClient, "from">;
+
+    /**
+     * Column name → type. The single source of truth this prototype exists
+     * to prove: it drives both `send()`'s record type and `query()`'s row
+     * type from the SAME declaration, instead of two independently
+     * maintained lists.
+     */
+    schema: Schema;
+
+    /**
+     * The Iceberg table (`namespace.table`) both halves target. **Not owned
+     * by this prototype** — see the design doc's "document, don't own"
+     * decision: the table must already exist, with a schema matching
+     * `schema`, created out-of-band (`wrangler r2 sql` / R2 Data Catalog API
+     * / Cloudflare dashboard) and kept in sync by hand.
+     */
+    table: string;
+}
+
+/** Returned by {@link import("./define-event-store").defineEventStore | defineEventStore}. */
+interface EventStore<Schema extends EventStoreSchema> {
+    /**
+     * Start a typed r2sql `SELECT` over the same table + schema — literally
+     * `r2sql.from&lt;EventStoreRecord&lt;Schema>>(table)`, so it inherits every
+     * `SelectBuilder` feature (`WHERE`, joins, window functions, set
+     * operations, …) for free; this prototype adds no query surface of its
+     * own.
+     */
+    query: () => SelectBuilder<EventStoreRecord<Schema>>;
+
+    /**
+     * Ingest one record through Pipelines. Runtime-validated against
+     * `schema` before the record reaches the binding — Pipelines ingest is
+     * otherwise fire-and-forget with zero server-side schema enforcement
+     * (see the design doc), so `EventStoreRecord&lt;Schema>` alone would only be
+     * a compile-time promise a plain-JS caller (or an `as` cast) could break
+     * silently.
+     */
+    send: (record: EventStoreRecord<Schema>) => Promise<void>;
+}
+
+export type { EventStore, EventStoreColumnType, EventStoreConfig, EventStoreRecord, EventStoreSchema };

--- a/packages/bindings/src/images/signed-delivery-url.ts
+++ b/packages/bindings/src/images/signed-delivery-url.ts
@@ -12,7 +12,7 @@
  * Pure WebCrypto, no binding I/O → deterministic, safe to call from any handler.
  */
 
-import { extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical } from "../../../../shared/hmac-url";
+import { assertCanonicalSafe, extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical } from "../../../../shared/hmac-url";
 import type { TransformOptions } from "./types";
 
 // Hoisted to module scope so the literal isn't recompiled on every call. The
@@ -111,6 +111,13 @@ export const buildSignedImageUrl = async (options: SignedImageUrlOptions): Promi
     // the URL path so signing and verification always agree, even when the
     // caller passes a key with a leading slash.
     const normalizedKey = options.key.replace(LEADING_SLASH_RE, "");
+
+    // The canonical is newline-delimited and `key` is not its last field, so a
+    // key containing a raw CR/LF could shift `exp` (and `transform`) on
+    // re-split — reject it here rather than minting a URL two different keys
+    // could both satisfy. See `shared/hmac-url.ts#assertCanonicalSafe`.
+    assertCanonicalSafe(normalizedKey);
+
     const sig = await signCanonical(options.secret, canonicalize(host, normalizedKey, exp, transform));
 
     const base = options.baseUrl.endsWith("/") ? options.baseUrl.slice(0, -1) : options.baseUrl;
@@ -172,6 +179,9 @@ export const verifySignedImageUrl = async (input: string | URL, secret: string, 
             .split("/")
             .map((segment) => decodeURIComponent(segment))
             .join("/");
+        // A percent-decoded key carrying a raw CR/LF is rejected the same as a
+        // decode failure — see the build-side comment on `assertCanonicalSafe`.
+        assertCanonicalSafe(key);
         sigBytes = fromBase64Url(sig);
     } catch {
         return { reason: "malformed", valid: false };

--- a/packages/storage/__tests__/create-storage.test.ts
+++ b/packages/storage/__tests__/create-storage.test.ts
@@ -206,6 +206,8 @@ describe("createStorage", () => {
         ["/leading", /must not start with/u],
         ["nul\0byte", /NUL byte/u],
         ["", /non-empty/u],
+        ["cr\rlf", /control character/u],
+        ["new\nline", /control character/u],
     ])("upload() rejects an unsafe key %s before touching the bucket", async (key, pattern) => {
         expect.assertions(2);
 

--- a/packages/storage/__tests__/signed-url.test.ts
+++ b/packages/storage/__tests__/signed-url.test.ts
@@ -294,4 +294,28 @@ describe("signedUrl", () => {
         await expect(verifySignedUrl(rewritten.toString(), "shh")).resolves.toMatchObject({ reason: "bad_signature", valid: false });
         await expect(verifySignedUrl(rewritten.toString(), "shh", { expectedHost: "https://cdn.example.com" })).resolves.toMatchObject({ valid: true });
     });
+
+    it("rejects a key containing a raw newline at sign time (BINDINGS-01)", async () => {
+        expect.assertions(1);
+
+        // The canonical is `method\nhost\nkey\nexp[\nct]` — `key` is not its
+        // last field, so a raw \n could shift where `exp` re-splits on verify.
+        await expect(buildSignedUrl({ baseUrl: "https://cdn.test", key: "uploads/x\n9999999999\nGET", secret: "shh" })).rejects.toThrow(/control character/);
+    });
+
+    it("rejects a key containing a carriage return at sign time", async () => {
+        expect.assertions(1);
+
+        await expect(buildSignedUrl({ baseUrl: "https://cdn.test", key: "uploads/x\ry", secret: "shh" })).rejects.toThrow(/control character/);
+    });
+
+    it("still signs and verifies a normal key unaffected by the control-char guard", async () => {
+        expect.assertions(2);
+
+        const url = await buildSignedUrl({ baseUrl: "https://cdn.test", key: "uploads/x.png", secret: "shh" });
+        const result = await verifySignedUrl(url, "shh");
+
+        expect(result.valid).toBe(true);
+        expect(result.key).toBe("uploads/x.png");
+    });
 });

--- a/packages/storage/__tests__/upload-handler.test.ts
+++ b/packages/storage/__tests__/upload-handler.test.ts
@@ -13,7 +13,7 @@ import { createTusAdapter, UploadControl } from "@visulima/storage-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UploadAuthzContext } from "../src/upload-handler";
-import { createUploadHandler } from "../src/upload-handler";
+import { createUploadHandler, DEFAULT_MAX_UPLOAD_BYTES } from "../src/upload-handler";
 
 const ENDPOINT = "https://test.local/upload";
 const B64 = (value: string): string => Buffer.from(value).toString("base64");
@@ -100,7 +100,10 @@ describe("createUploadHandler (RLS-gated, non-admin)", () => {
     let handler: ReturnType<typeof createUploadHandler>;
 
     beforeEach(() => {
-        handler = createUploadHandler({ storage: new MemoryStorage({ path: "/upload" }) });
+        // `silent` keeps these upload-flow tests (unrelated to the authorize
+        // warning below) quiet — see the dedicated "default-open authorize"
+        // describe block for coverage of the warning itself.
+        handler = createUploadHandler({ silent: true, storage: new MemoryStorage({ path: "/upload" }) });
     });
 
     afterEach(() => {
@@ -276,6 +279,92 @@ describe("createUploadHandler (RLS-gated, non-admin)", () => {
             await expect(adapter.upload(makeFile(50_000))).rejects.toThrow(/403/u);
 
             wire.restore();
+        });
+    });
+
+    describe("default-open authorize warning", () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it("warns once (at construction, not per request) when authorize is omitted", async () => {
+            expect.hasAssertions();
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+            const openHandler = createUploadHandler({ storage: new MemoryStorage({ path: "/upload" }) });
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0]?.[0]).toMatch(/no `authorize`/u);
+
+            // Multiple requests against the SAME handler must not add more warnings.
+            await openHandler.fetch(new Request(ENDPOINT, { headers: { "Tus-Resumable": "1.0.0", "Upload-Length": "10" }, method: "POST" }));
+            await openHandler.fetch(new Request(ENDPOINT, { headers: { "Tus-Resumable": "1.0.0", "Upload-Length": "10" }, method: "POST" }));
+
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not warn when `silent: true` is passed", () => {
+            expect.hasAssertions();
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+            createUploadHandler({ silent: true, storage: new MemoryStorage({ path: "/upload" }) });
+
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not warn when `public: true` is passed", () => {
+            expect.hasAssertions();
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+            createUploadHandler({ public: true, storage: new MemoryStorage({ path: "/upload" }) });
+
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not warn when `authorize` is provided", () => {
+            expect.hasAssertions();
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+            createUploadHandler({ authorize: () => true, storage: new MemoryStorage({ path: "/upload" }) });
+
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("default upload size cap", () => {
+        it("rejects an upload above the default cap (no maxFileSize configured)", async () => {
+            expect.hasAssertions();
+
+            const openHandler = createUploadHandler({ silent: true, storage: new MemoryStorage({ path: "/upload" }) });
+
+            // TUS declares the total size up-front via `Upload-Length` on the
+            // `create` (POST) request, so this rejects before any body bytes
+            // would need to be sent.
+            const response = await openHandler.fetch(
+                new Request(ENDPOINT, {
+                    headers: { "Tus-Resumable": "1.0.0", "Upload-Length": String(DEFAULT_MAX_UPLOAD_BYTES + 1) },
+                    method: "POST",
+                }),
+            );
+
+            expect(response.status).toBe(413);
+        });
+
+        it("honors an explicit maxFileSize below the default, both rejecting and accepting relative to it", async () => {
+            expect.hasAssertions();
+
+            const tight = createUploadHandler({ maxFileSize: 1024, silent: true, storage: new MemoryStorage({ path: "/upload" }) });
+
+            const tooBig = await tight.fetch(new Request(ENDPOINT, { headers: { "Tus-Resumable": "1.0.0", "Upload-Length": "2048" }, method: "POST" }));
+
+            expect(tooBig.status).toBe(413);
+
+            const withinCap = await tight.fetch(new Request(ENDPOINT, { headers: { "Tus-Resumable": "1.0.0", "Upload-Length": "512" }, method: "POST" }));
+
+            expect(withinCap.status).toBe(201);
         });
     });
 });

--- a/packages/storage/src/create-storage.ts
+++ b/packages/storage/src/create-storage.ts
@@ -23,6 +23,16 @@ type UploadBody = ReadableStream | ArrayBuffer | Blob;
 /** R2's documented key-length ceiling. */
 const MAX_KEY_LENGTH = 1024;
 
+// Matches any C0 control character (codes 0-31), which includes CR and LF —
+// built from code points rather than a `\u` escape range so the regex source
+// can't be mistaken for (or mangled into) a literal control byte sitting in
+// this file. Mirrors `shared/hmac-url.ts#assertCanonicalSafe`, which guards
+// the same class of value once it reaches the HMAC canonical; this guard runs
+// earlier, at the point a caller-supplied key first enters `@lunora/storage`
+// (uploads, not just signed-URL minting).
+const CONTROL_CHAR_CODES: number[] = Array.from({ length: 32 }, (_, index) => index);
+const CONTROL_CHAR_RE = new RegExp(`[${CONTROL_CHAR_CODES.map((code) => String.fromCodePoint(code)).join("")}]`, "u");
+
 /** R2's documented per-page list ceiling. */
 const MAX_LIST_LIMIT = 1000;
 
@@ -214,6 +224,14 @@ const validateKey = (key: string): void => {
 
     if (key.includes("\0")) {
         throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: key contains NUL byte");
+    }
+
+    // CR/LF (and other C0 controls) in a key would let a signed-URL canonical
+    // (`shared/hmac-url.ts`, host\nkey\nexp\n...) re-split so a different
+    // `exp` reads back for the same signature — reject at the point the key
+    // enters storage, not just when a signed URL happens to be minted for it.
+    if (CONTROL_CHAR_RE.test(key)) {
+        throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: key contains a control character (including CR/LF)");
     }
 
     if (key.startsWith("/")) {

--- a/packages/storage/src/create-storage.ts
+++ b/packages/storage/src/create-storage.ts
@@ -1,5 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 
+import { hasControlChar } from "../../../shared/hmac-url";
 import { toHex, trimTrailingSlashes } from "./internal";
 import { buildPresignedUrl } from "./presigned-url";
 import { buildSignedUrl } from "./signed-url";
@@ -22,16 +23,6 @@ type UploadBody = ReadableStream | ArrayBuffer | Blob;
 
 /** R2's documented key-length ceiling. */
 const MAX_KEY_LENGTH = 1024;
-
-// Matches any C0 control character (codes 0-31), which includes CR and LF —
-// built from code points rather than a `\u` escape range so the regex source
-// can't be mistaken for (or mangled into) a literal control byte sitting in
-// this file. Mirrors `shared/hmac-url.ts#assertCanonicalSafe`, which guards
-// the same class of value once it reaches the HMAC canonical; this guard runs
-// earlier, at the point a caller-supplied key first enters `@lunora/storage`
-// (uploads, not just signed-URL minting).
-const CONTROL_CHAR_CODES: number[] = Array.from({ length: 32 }, (_, index) => index);
-const CONTROL_CHAR_RE = new RegExp(`[${CONTROL_CHAR_CODES.map((code) => String.fromCodePoint(code)).join("")}]`, "u");
 
 /** R2's documented per-page list ceiling. */
 const MAX_LIST_LIMIT = 1000;
@@ -230,7 +221,10 @@ const validateKey = (key: string): void => {
     // (`shared/hmac-url.ts`, host\nkey\nexp\n...) re-split so a different
     // `exp` reads back for the same signature — reject at the point the key
     // enters storage, not just when a signed URL happens to be minted for it.
-    if (CONTROL_CHAR_RE.test(key)) {
+    // `hasControlChar` is the canonical detector from `shared/hmac-url.ts`, so
+    // this stays in lockstep with the HMAC canonical's own guard instead of a
+    // byte-similar copy that can drift.
+    if (hasControlChar(key)) {
         throw new LunoraError("VALIDATION_ERROR", "@lunora/storage: key contains a control character (including CR/LF)");
     }
 

--- a/packages/storage/src/signed-url.ts
+++ b/packages/storage/src/signed-url.ts
@@ -17,7 +17,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
-import { extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical } from "../../../shared/hmac-url";
+import { assertCanonicalSafe, extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical } from "../../../shared/hmac-url";
 import { trimTrailingSlashes } from "./internal";
 import type { SignedUrlOptions } from "./types";
 
@@ -76,6 +76,12 @@ export const buildSignedUrl = async (
     // contentType is a PUT-only pin: a GET URL has no request body to constrain,
     // so drop it for GET to keep GET canonicals unchanged.
     const contentType = method === "PUT" ? args.contentType : undefined;
+
+    // The canonical is newline-delimited and `key` is not its last field, so a
+    // key containing a raw CR/LF could shift `exp` (and `contentType`) on
+    // re-split — reject it here rather than minting a URL two different keys
+    // could both satisfy. See `shared/hmac-url.ts#assertCanonicalSafe`.
+    assertCanonicalSafe(args.key);
 
     const exp = Math.floor(Date.now() / 1000) + expiresInSeconds;
     const host = extractHost(args.baseUrl);
@@ -165,6 +171,9 @@ export const verifySignedUrl = async (input: string | URL, secret: string, optio
             .split("/")
             .map((segment) => decodeURIComponent(segment))
             .join("/");
+        // A percent-decoded key carrying a raw CR/LF is rejected the same as a
+        // decode failure — see the build-side comment on `assertCanonicalSafe`.
+        assertCanonicalSafe(key);
         sigBytes = fromBase64Url(sig);
     } catch {
         return { reason: "malformed", valid: false };

--- a/packages/storage/src/upload-handler.ts
+++ b/packages/storage/src/upload-handler.ts
@@ -24,6 +24,14 @@ import { AwsLightStorage } from "@visulima/storage/provider/aws-light";
 /** Resumable upload wire protocols the handler can speak. */
 type UploadProtocol = "chunked-rest" | "multipart" | "tus";
 
+/**
+ * Default ceiling applied to `maxFileSize` when the caller doesn't supply one
+ * (100 MiB). Without SOME cap, an unauthenticated or loosely-authorized
+ * handler accepts an unbounded request body — pass an explicit `maxFileSize`
+ * to raise or lower this for your app.
+ */
+const DEFAULT_MAX_UPLOAD_BYTES: number = 100 * 1024 * 1024;
+
 // Derive the visulima handler option/storage types from the class constructors
 // so we never import `@visulima/storage`'s internal `BaseStorage` / `UploadFile`
 // symbols (they are not part of the fetch-handler entry's public surface).
@@ -55,12 +63,35 @@ interface CreateUploadHandlerOptions {
      * returning `false` **or throwing** yields a `403`. Omit only for a fully
      * public bucket — the whole point of this handler over the admin path is
      * that uploads are gated by *your* per-user policy, not an admin token.
+     *
+     * Omitting it mounts an unauthenticated, unbounded-write endpoint, so
+     * doing so logs a one-time warning (per handler) unless `silent`/`public`
+     * says the omission is intentional.
      */
     authorize?: (context: UploadAuthzContext) => boolean | Promise<boolean>;
-    /** Maximum accepted file size in bytes (forwarded to the multipart parser). */
+
+    /**
+     * Maximum accepted file size in bytes. Forwarded to the multipart parser
+     * (protocol `"multipart"`) and, for `"tus"`/`"chunked-rest"`, enforced by
+     * this handler itself against the request's declared size (`Upload-Length`
+     * / `Content-Length`) — see {@link declaredUploadSize}. Defaults to
+     * {@link DEFAULT_MAX_UPLOAD_BYTES} (100 MiB) — pass this to raise or lower
+     * the ceiling; there is no unbounded option.
+     */
     maxFileSize?: number;
     /** Which protocol to speak. Default `"tus"` (the resumable, pause/resume-capable one). */
     protocol?: UploadProtocol;
+
+    /**
+     * Set when omitting `authorize` is intentional (a fully public upload
+     * bucket) — suppresses the one-time "no authorize gate" warning that would
+     * otherwise print when the handler is constructed. Has no effect when
+     * `authorize` is provided.
+     */
+    public?: boolean;
+
+    /** Suppress the one-time default-open-authorize warning. Alias of `public`. */
+    silent?: boolean;
     /** The storage provider the bytes land in (R2 in prod, memory in tests). */
     storage: UploadStorage;
 }
@@ -118,6 +149,59 @@ const denyResponse = (protocol: UploadProtocol): Response => {
     return Response.json({ error: { code: "FORBIDDEN", message: "Upload denied by authorization policy", name: "ForbiddenError" } }, { headers, status: 403 });
 };
 
+const tooLargeResponse = (protocol: UploadProtocol): Response => {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+
+    if (protocol === "tus") {
+        headers["Tus-Resumable"] = TUS_RESUMABLE;
+    }
+
+    return Response.json(
+        { error: { code: "REQUEST_ENTITY_TOO_LARGE", message: "Upload exceeds the configured maxFileSize", name: "RequestEntityTooLargeError" } },
+        { headers, status: 413 },
+    );
+};
+
+/**
+ * Best-effort declared upload size read off the request, checked against
+ * `maxFileSize` before the request reaches the underlying protocol handler.
+ *
+ * Why not lean on `@visulima/storage` itself? Its `UploadOptions.maxFileSize`
+ * only bounds the multipart-form parser (protocol `"multipart"`); the
+ * `"tus"`/`"chunked-rest"` protocols instead validate against the storage
+ * provider's own `maxUploadSize` — captured into a validator closure once, at
+ * STORAGE construction time. `createUploadHandler` receives an
+ * already-constructed `storage`, so it cannot tighten that cap after the
+ * fact; this pre-check is what actually enforces `maxFileSize` for those two
+ * protocols. TUS's create (`POST`) declares the total size via
+ * `Upload-Length`; REST/other single-shot requests carry it in
+ * `Content-Length`.
+ *
+ * Deliberately skipped for `"multipart"`: there, `Content-Length` covers the
+ * whole multipart body (boundaries + field headers, not just file bytes), so
+ * comparing it to `maxFileSize` would false-reject a file that's actually
+ * within the cap — the library's own accurate `maxFileSize` forwarding
+ * already covers that protocol.
+ *
+ * Known gap: a TUS upload created with `Upload-Defer-Length` (no declared
+ * total up front) is not covered by this pre-check.
+ */
+const declaredUploadSize = (request: Request, protocol: UploadProtocol): number | undefined => {
+    if (protocol === "multipart") {
+        return undefined;
+    }
+
+    const raw = request.headers.get("Upload-Length") ?? request.headers.get("Content-Length");
+
+    if (raw === null) {
+        return undefined;
+    }
+
+    const parsed = Number(raw);
+
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
 const instantiateHandler = (protocol: UploadProtocol, handlerOptions: UploadHandlerOptions): { fetch: (request: Request) => Promise<Response> } => {
     if (protocol === "chunked-rest") {
         return new Rest(handlerOptions);
@@ -137,17 +221,33 @@ const instantiateHandler = (protocol: UploadProtocol, handlerOptions: UploadHand
  */
 const createUploadHandler = (options: CreateUploadHandlerOptions): UploadHandler => {
     const protocol = options.protocol ?? "tus";
+    const maxFileSize = options.maxFileSize ?? DEFAULT_MAX_UPLOAD_BYTES;
 
     const handlerOptions: UploadHandlerOptions = {
+        maxFileSize,
         storage: options.storage,
-        ...(options.maxFileSize === undefined ? {} : { maxFileSize: options.maxFileSize }),
     };
 
     const handler = instantiateHandler(protocol, handlerOptions);
 
     const { authorize } = options;
 
+    if (authorize === undefined && !options.silent && !options.public) {
+        // One-time warning per handler instance — mirrors `@lunora/notify`'s
+        // one-time unsafe-default warn (`packages/notify/src/notify.ts`).
+        // eslint-disable-next-line no-console -- one-time misconfiguration warning, mirrors other unsafe-default fallbacks
+        console.warn(
+            "@lunora/storage: createUploadHandler() has no `authorize` — this mounts an unauthenticated, unbounded-write endpoint. Pass an RLS `authorize` gate, or set `public: true` (or `silent: true`) to confirm this bucket is intentionally open.",
+        );
+    }
+
     const fetch = async (request: Request): Promise<Response> => {
+        const declaredSize = declaredUploadSize(request, protocol);
+
+        if (declaredSize !== undefined && declaredSize > maxFileSize) {
+            return tooLargeResponse(protocol);
+        }
+
         if (authorize !== undefined) {
             try {
                 const allowed = await authorize({ method: request.method, protocol, request, url: new URL(request.url) });
@@ -189,4 +289,4 @@ const createR2UploadStorage = (options: R2UploadStorageOptions & { secretAccessK
     });
 
 export type { CreateUploadHandlerOptions, R2UploadStorageOptions, UploadAuthzContext, UploadHandler, UploadProtocol, UploadStorage };
-export { createR2UploadStorage, createUploadHandler };
+export { createR2UploadStorage, createUploadHandler, DEFAULT_MAX_UPLOAD_BYTES };

--- a/packages/storage/src/upload.ts
+++ b/packages/storage/src/upload.ts
@@ -7,4 +7,4 @@
  * `@lunora/react` / `@lunora/vue` / … `useUpload` re-exports) on the client.
  */
 export type { CreateUploadHandlerOptions, R2UploadStorageOptions, UploadAuthzContext, UploadHandler, UploadProtocol, UploadStorage } from "./upload-handler";
-export { createR2UploadStorage, createUploadHandler } from "./upload-handler";
+export { createR2UploadStorage, createUploadHandler, DEFAULT_MAX_UPLOAD_BYTES } from "./upload-handler";

--- a/plans/247-event-store-design.md
+++ b/plans/247-event-store-design.md
@@ -1,0 +1,282 @@
+# Plan 247 — `defineEventStore`: couple Pipelines write + R2 SQL query under one typed schema (design spike)
+
+**Baseline:** `2829e33ec` (2026-07-31)
+**Status:** SPIKE COMPLETE — prototype + recommendation below; not ratified for a shipping package/subpath.
+
+## 0. Headline finding
+
+Pipelines (write) and R2 SQL (read) both target the same physical thing — an
+Apache Iceberg table in R2 Data Catalog — but share no type today.
+`PipelineBindingLike.send` takes untyped `Record<string, unknown>[]`
+(`packages/bindings/src/pipelines/types.ts:16`), and `R2SqlClient.from<Row>`
+takes a caller-declared `Row` with no relationship to what was ever written
+(`packages/bindings/src/r2sql/client.ts:80`). A dev who wants both ends up
+hand-declaring the column list twice — once as whatever shape they pass to
+`send()`, once as the `Row` type argument to `from<Row>()` — and nothing
+stops the two from drifting.
+
+`defineEventStore(schema)` proves one schema CAN drive both halves at the
+TypeScript level, and — the part that actually matters, since Pipelines
+enforces nothing server-side — a runtime guard in front of `send()` catches
+an off-schema record before it reaches Pipelines. The prototype does **not**
+attempt to own the Iceberg table itself; see §4 for why.
+
+## 1. Current state (audit)
+
+- **Pipelines — write-only, untyped.** `packages/bindings/src/pipelines/types.ts:10-18`:
+  `PipelineRecord = Record<string, unknown>`; `PipelineBindingLike<T>.send(records: T[])`.
+  `packages/bindings/src/pipelines/create-pipelines.ts` wraps it as `ctx.pipelines`
+  — "fire-and-forget", "no in-handler read-back" (its own doc comment).
+- **R2 SQL — query-only, over Iceberg.** `packages/bindings/src/r2sql/types.ts` +
+  `client.ts`: `createR2Sql(config)` → `R2SqlClient`. `from<Row>(table)` returns a
+  `SelectBuilder<Row>` (`packages/bindings/src/r2sql/builder.ts`) — a real chainable
+  query builder (`WHERE`, joins, window functions, set operations), but `Row` is
+  purely a caller-side cast; nothing checks it against the table.
+- **No DDL/table-lifecycle code anywhere in this repo.** `grep`-ing
+  `packages/bindings/src` for `CREATE TABLE`/schema-management turns up nothing —
+  Iceberg tables are created out-of-band today (`wrangler r2 sql` / the R2 Data
+  Catalog REST API / the dashboard), and neither Pipelines nor R2 SQL bindings
+  expose a way to create or introspect a table's column list from inside a
+  Worker.
+- **Precedent this is modeled on:** `packages/ai/src/rag/define-rag.ts`. One
+  `RagConfig` couples `ctx.ai` (embed) + `ctx.vectors` (write AND read) under one
+  declared shape, returning a per-bound-ctx factory (`{ index, retrieve, remove, asTool }`).
+  Notably `defineRag` does not own Vectorize INDEX creation either — the index name
+  is a config string, and creating/dimensioning the index is a `wrangler vectorize`
+  step outside the library. That is the same "document, don't own" boundary this
+  plan reaches for the Iceberg table (§4).
+- **Adjacent precedent: Analytics Engine already half-solves this differently.**
+  `packages/bindings/src/analytics/types.ts` + `create-analytics.ts`:
+  `AnalyticsClient.track(name, event)` maps named `{ dimensions, metrics, index }`
+  fields to AE's positional `blobN`/`doubleN`/`index1` columns and **returns** a
+  `TrackSchema` (the field→column mapping) from every call — but there is no
+  single declared schema up front; the mapping is inferred per-call from the
+  event's own key order, and the read side (raw SQL over AE's SQL API) never
+  consumes `TrackSchema` to type its rows. So AE independently arrived at
+  "return a mapping instead of hand-declaring types twice," which is a lighter
+  version of the same problem this plan addresses for Pipelines/r2sql — see §7.
+
+## 2. Existing seams (do not reinvent)
+
+- **`SelectBuilder<Row>`** already IS the typed query builder — `query()` in the
+  prototype is nothing more than `r2sql.from<Row>(table)` with `Row` inferred
+  from the schema. No new query surface was built; reinventing one would
+  duplicate `WHERE`/joins/window functions/set-ops for no reason.
+- **`PipelineBindingLike<T>`** already accepts a generic record type — the
+  prototype narrows `T` to the schema-derived record instead of inventing a new
+  binding shape.
+- **`LunoraError` / `VALIDATION_ERROR`** (`@lunora/errors`, already a
+  `@lunora/bindings` dependency) is the existing error vocabulary for a
+  caller-input rejection; the runtime guard uses it rather than a bespoke error
+  type.
+
+## 3. The API
+
+```ts
+const purchases = defineEventStore({
+    pipeline: env.PURCHASE_EVENTS, // PipelineBindingLike<EventStoreRecord<Schema>>
+    r2sql: createR2Sql({ accountId, apiToken, bucket }), // needs only `.from`
+    schema: {
+        id: "string",
+        amount: "number",
+        occurredAt: "timestamp",
+    },
+    table: "analytics.purchases", // must already exist with a matching column set
+});
+
+// Write — runtime-validated against `schema` before it reaches Pipelines:
+await purchases.send({ id: "evt-1", amount: 42, occurredAt: new Date().toISOString() });
+
+// Read — the SAME schema types the row shape, over the SAME table:
+const recent = await purchases.query().where("amount > 10").orderBy(desc("occurredAt")).limit(50).run();
+```
+
+`EventStoreRecord<Schema>` is a mapped type (`{ [K in keyof Schema]: TsTypeOf<Schema[K]> }`)
+derived from the column-type map, exactly the way `defineRag`'s config shapes
+derive `IndexInput`/`RetrieveResult` from one `RagConfig`. `query()` returns the
+real `SelectBuilder<EventStoreRecord<Schema>>` unmodified — every existing
+builder method works, typed against the same row shape `send()` accepts.
+
+Prototype: `packages/bindings/src/event-store/{types,define-event-store,index}.ts`,
+tests at `packages/bindings/__tests__/event-store/define-event-store.test.ts`.
+
+## 4. Design decisions
+
+### 4.1 Table lifecycle: **document, don't own**
+
+**Decision:** `defineEventStore` takes `table` as a plain string and assumes it
+already exists with columns matching `schema`. It does not call any table-creation
+or table-introspection API.
+
+**Alternative rejected: own table creation** (e.g. `defineEventStore` calls the
+R2 Data Catalog API on first use to `CREATE TABLE IF NOT EXISTS` from `schema`).
+Rejected because:
+
+- **No existing seam.** Nothing in `@lunora/bindings` talks to the R2 Data
+  Catalog control plane (table DDL) today — only the R2 SQL _query_ REST
+  endpoint and the Pipelines _write_ binding, neither of which does schema
+  management. Owning creation means a THIRD Cloudflare API surface (bearer
+  token scope, endpoint, error handling) added specifically for this facade.
+- **Type reconciliation is not solvable client-side.** Pipelines ingests JSON
+  and Cloudflare's pipeline-to-Iceberg mapping decides the actual Iceberg
+  column types (and does its own type coercion/widening) — this prototype's
+  4-type `EventStoreColumnType` (`boolean` / `number` / `string` / `timestamp`)
+  is a deliberately small approximation, not a mirror of Iceberg's real type
+  system (no `decimal`, no nested `struct`/`list`/`map`, no explicit
+  int-width/precision). A `CREATE TABLE` generated from `schema` could produce
+  a column type that doesn't match what Pipelines actually writes for a given
+  JSON value, and there is no in-repo way to verify that reconciliation short
+  of running a real ingest against a real table and diffing the catalog's
+  reported schema — out of scope for a client library, and squarely the kind
+  of drift this plan exists to prevent, not reproduce one level down.
+- **Blast radius of getting it wrong.** A table is a durable, billed, org-wide
+  resource. Auto-creating it from application code (implicitly, on first
+  `send()`) is a much bigger commitment than the read/write coupling this spike
+  set out to prove, and reversing a wrong auto-created schema means a manual
+  Iceberg migration.
+
+So: the design **documents** the requirement (`table` must pre-exist,
+matching `schema`, created via `wrangler r2 sql` / the Data Catalog API /
+dashboard) rather than **coupling** the facade to table ownership. This
+mirrors `defineRag`'s own boundary (Vectorize index creation/dimensioning is
+also out-of-band) and matches the STOP condition in the originating plan:
+_"the R2 Data Catalog table schema can't be reconciled between Pipelines
+ingest format and r2sql column types without owning table creation — document
+the mismatch and stop at 'document, don't couple.'"_ That is the exact outcome
+here.
+
+### 4.2 Schema → both-halves mapping
+
+One `EventStoreSchema` (`Record<string, "boolean"|"number"|"string"|"timestamp">`)
+is the single source of truth:
+
+- `EventStoreRecord<Schema>` (a mapped type) is used as BOTH `send()`'s
+  parameter type and `SelectBuilder`'s `Row` type argument for `query()`. There
+  is exactly one place a column name/type is written down.
+- At runtime, `send()` is checked field-by-field against `schema` before
+  forwarding to the Pipelines binding (§4.3) — the compile-time mapping alone
+  cannot be trusted given how `send()` can be reached (see below).
+
+### 4.3 Runtime enforcement is client-side, and is honest about its limits
+
+**The originating plan's STOP text is correct and worth restating precisely:**
+_"Pipelines ingest is fire-and-forget with no schema enforcement — state the
+typed `send` is compile-time-only honestly."_ This prototype goes one step
+further than a pure type-level wrapper — `assertMatchesSchema` in
+`define-event-store.ts` DOES run a real runtime check (field presence, no
+extra fields, primitive-type match) before calling `pipeline.send()` — proven
+by the "catches a wrong-typed field / missing field / undeclared field"
+tests. But two honesty notes:
+
+1. This check runs in the calling Worker, in front of the SDK boundary. It
+   catches a bad call from JS (no compiler), a stale build, or an `as` cast —
+   the realistic ways a typed `send()` gets bypassed. It does **not** validate
+   against the Iceberg table's actual, authoritative schema (Cloudflare-side),
+   because nothing in this client library can read that schema back (§4.1).
+   A `schema` that has drifted from the real table columns will pass this
+   check and still fail (or silently coerce) downstream in Cloudflare's
+   pipeline.
+2. The 4-type vocabulary is intentionally coarse. It cannot express Iceberg's
+   fuller type system, so "passes `assertMatchesSchema`" is necessary but not
+   sufficient for "matches the Iceberg column type."
+
+Net: the typed `send()` here is a real improvement over "cast and hope,"
+not a full write-time schema-enforcement guarantee.
+
+## 5. Prototype — what the test proves
+
+`packages/bindings/__tests__/event-store/define-event-store.test.ts`, five cases:
+
+1. `send()` forwards a schema-valid record to the (double) Pipelines binding
+   unchanged.
+2. `query()` is a real `SelectBuilder` over the SAME `table` — `.where()`/
+   `.orderBy()`/`.limit()`/`.run()` all work, exercised against `createR2Sql`
+   wired to a fake `fetch` (mirrors `__tests__/r2sql/client.test.ts`'s pattern),
+   not a hand-rolled stand-in for the query engine.
+3. **The load-bearing case:** a record cast past the type system
+   (`as unknown as PurchaseEvent`) with a wrong-typed field is REJECTED by
+   `send()` at runtime, and the underlying Pipelines `send` mock is never
+   called — proving the enforcement is not merely a compile-time convenience
+   wrapper.
+4. Same, for a record missing a declared field.
+5. Same, for a record carrying a field the schema doesn't declare.
+
+Doubles: `PipelineBindingLike` as a plain object literal (matching
+`__tests__/pipelines/create-pipelines.test.ts`'s existing pattern), and the
+real `createR2Sql` factory with an injected fake `fetch` (matching
+`__tests__/r2sql/client.test.ts`'s pattern) — so the read half runs through
+the actual `SelectBuilder` + envelope-parsing code, not a fake query engine.
+
+`pnpm --filter "@lunora/bindings" run test` and `lint:types` both pass; the
+existing `pipelines`/`r2sql` test files are untouched, so the untyped
+`ctx.pipelines.send` / raw `r2sql.query()` paths are provably unaffected.
+
+## 6. Does the façade generalize to Analytics Engine?
+
+Partially, and not for free. AE's write path (`createAnalytics` /
+`AnalyticsClient.track`) already derives a per-call `TrackSchema` mapping
+(§1) — narrower than `defineEventStore`'s upfront declared schema, but
+solving an adjacent problem (named fields → AE's positional `blobN`/`doubleN`
+layout). Generalizing `defineEventStore` to AE would mean:
+
+- A `defineEventStore`-style wrapper COULD accept a schema, call `track()` for
+  writes, and use the _returned_ `TrackSchema` to type a query helper — but
+  AE's read side (`packages/bindings/src/analytics/sql-api.ts`) is raw SQL
+  over the Workers Analytics Engine SQL API, not `r2sql`'s typed
+  `SelectBuilder`; there is no chainable query builder to plug a `Row` type
+  into today. Building one is a separate, non-trivial scope addition — out of
+  scope for this spike (the originating plan explicitly says "mention it,"
+  not build it).
+- AE's `TrackSchema` mapping is inherently per-call (key insertion order
+  decides the positional columns), which is a fundamentally different
+  contract than "one schema, declared once, used for every write" — merging
+  the two designs cleanly is itself an open question, not a mechanical port.
+
+**Conclusion:** plausible future direction, not a small follow-up. Left as an
+open question (§8), not attempted here.
+
+## 7. Codegen / DX story
+
+Not addressed — the originating plan puts "wire codegen" out of scope. The
+schema in the prototype is a plain object literal passed directly to
+`defineEventStore` at the call site (mirroring `defineRag`'s `RagConfig`,
+which also has no codegen involvement) — there is no `lunora/eventStores.ts`
+declarative file, no `_generated/*` emission, and no `ctx.eventStores.*`
+surface. If this ships for real, the DX question of "does the schema live in
+`lunora/schema.ts` (reusing `defineTable`'s column vocabulary) or its own
+declaration file" is open — see §8.
+
+## 8. Open questions (answer before shipping past the spike)
+
+1. **Table-lifecycle ownership.** Confirmed here as "document, don't own"
+   (§4.1) for the spike — but is that the permanent answer, or does demand
+   justify a later, carefully-scoped table-creation helper (e.g. thin
+   `CREATE TABLE IF NOT EXISTS` from `schema`, run explicitly via a CLI command
+   rather than implicitly on first `send()`)? Needs real usage signal.
+2. **Is Analytics Engine in scope for a generalized facade**, and if so, does
+   AE need its own typed query builder first (a much larger, separate
+   project) before a shared `defineEventStore`-style wrapper makes sense?
+3. **Where does the schema live?** A plain object literal at the call site
+   (this prototype) vs. reusing `defineTable`'s column-type vocabulary from
+   `lunora/schema.ts` vs. a new declaration file. Each has different codegen
+   implications (§7).
+4. **Type vocabulary completeness.** Is the 4-type `EventStoreColumnType`
+   enough for real event-store use cases, or does it need to grow (nested
+   objects, arrays, explicit numeric width) before this is usable beyond a
+   spike — and if it grows, does the runtime guard's coverage grow with it or
+   quietly fall behind?
+5. **Multi-tenancy.** Neither Pipelines nor r2sql have a namespace/tenant
+   concept the way Vectorize does (`defineRag`'s `namespace` parameter) — is
+   per-tenant isolation a column in `schema` (app-level `WHERE tenant_id = ?`)
+   or does it need a first-class parameter the way `defineRag` has one?
+
+## 9. STOP / GO
+
+**GO** on the design pattern (schema → both `send()` type and `query()` row
+type is proven, with real runtime enforcement on the write side) — the
+prototype's test suite demonstrates the core claim cleanly.
+
+**STOP** on shipping `@lunora/bindings/event-store` as a public subpath until
+open questions §8.1–§8.3 have real answers; the prototype intentionally stays
+un-exported (no `package.json` "exports" entry) so nothing depends on an
+unratified surface.

--- a/shared/hmac-url.ts
+++ b/shared/hmac-url.ts
@@ -125,6 +125,15 @@ const assertCanonicalSafe = (value: string): void => {
     }
 };
 
+/**
+ * Predicate form of the same C0-control-character check `assertCanonicalSafe`
+ * throws on. The canonical home for "is this value canonical-unsafe" so
+ * callers that need a boolean (rather than a thrown `TypeError`) — e.g.
+ * `@lunora/storage`'s `validateKey`, which raises its own `LunoraError` — share
+ * this single detector instead of re-deriving `CONTROL_CHAR_RE` from scratch.
+ */
+const hasControlChar = (value: string): boolean => CONTROL_CHAR_RE.test(value);
+
 /** Sign `canonical` with the secret's HMAC key, returning the base64url signature. */
 const signCanonical = async (secret: string, canonical: string): Promise<string> => {
     const cryptoKey = await importHmacKey(secret);
@@ -145,4 +154,4 @@ const verifyCanonical = async (secret: string, canonical: string, sigBytes: Uint
     return crypto.subtle.verify("HMAC", cryptoKey, sigBytes as unknown as BufferSource, textEncoder.encode(canonical));
 };
 
-export { assertCanonicalSafe, extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical };
+export { assertCanonicalSafe, extractHost, fromBase64Url, hasControlChar, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical };

--- a/shared/hmac-url.ts
+++ b/shared/hmac-url.ts
@@ -35,6 +35,14 @@ const MAX_SIGNED_URL_TTL_SECONDS: number = 7 * 24 * 60 * 60;
 // Hoisted to module scope so the literal isn't recompiled on every call.
 const SCHEME_PREFIX_RE = /^[a-z][a-z0-9+\-.]*:\/\//i;
 
+// Matches any C0 control character (codes 0-31 inclusive), which covers CR and
+// LF among others. Built from code points rather than a \u escape literal in
+// the regex source, so the intent stays unambiguous in review and no
+// editor/tool can silently turn the escape text into a literal control byte
+// sitting inside this source file.
+const CONTROL_CHAR_CODES: number[] = Array.from({ length: 32 }, (_, index) => index);
+const CONTROL_CHAR_RE = new RegExp(`[${CONTROL_CHAR_CODES.map((code) => String.fromCodePoint(code)).join("")}]`, "u");
+
 const toBase64Url = (bytes: Uint8Array): string => {
     // A SHA-256 HMAC is a fixed 32 bytes, well under the argument-spread limit,
     // so building the binary string in one `fromCodePoint` call is safe and
@@ -99,6 +107,24 @@ const extractHost = (input: string): string => {
     }
 };
 
+/**
+ * Reject a free-text value bound into an HMAC canonical if it contains any C0
+ * control character (codes 0-31), which includes CR and LF. The canonical is
+ * newline-delimited (`field\nfield\n...`), so a non-terminal free-text field
+ * (e.g. a signed-URL `key`) that itself contains a raw newline can shift where
+ * later fields (e.g. `exp`) get re-split on verify: two different `(key, exp)`
+ * pairs can then canonicalize to byte-identical strings under the SAME valid
+ * signature. Call this on every non-terminal free-text canonical field before
+ * signing, and again on the decoded value before verifying (inside the
+ * existing malformed-input `catch`, so a rejected value surfaces as
+ * `"malformed"` rather than an uncaught throw).
+ */
+const assertCanonicalSafe = (value: string): void => {
+    if (CONTROL_CHAR_RE.test(value)) {
+        throw new TypeError("hmac-url: value must not contain control characters (including CR/LF)");
+    }
+};
+
 /** Sign `canonical` with the secret's HMAC key, returning the base64url signature. */
 const signCanonical = async (secret: string, canonical: string): Promise<string> => {
     const cryptoKey = await importHmacKey(secret);
@@ -119,4 +145,4 @@ const verifyCanonical = async (secret: string, canonical: string, sigBytes: Uint
     return crypto.subtle.verify("HMAC", cryptoKey, sigBytes as unknown as BufferSource, textEncoder.encode(canonical));
 };
 
-export { extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical };
+export { assertCanonicalSafe, extractHost, fromBase64Url, MAX_SIGNED_URL_TTL_SECONDS, signCanonical, verifyCanonical };


### PR DESCRIPTION
The signed-URL HMAC canonical is newline-delimited with an unbounded trailing field, so a key containing `\n` could produce an ambiguous canonical (a non-expiring URL under the same signature) → rejects CR/LF/C0 controls at sign+verify. The upload handler's authorize gate was default-open with no size cap → warns once + a 100 MiB default (via a request-declared-size pre-check, since `maxFileSize` is a no-op on the default tus protocol). Plus a `defineEventStore` design spike (isolated prototype coupling Pipelines write + R2 SQL query under one schema).

Verified: bindings 228, storage 105. shared/hmac-url.ts confirmed clean (no literal control bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)