### PR TITLE
fix(notify): page the push-broadcast audience + bound subscription metadata (+ in-app inbox spike)

### DIFF
--- a/packages/notify/__tests__/helpers.ts
+++ b/packages/notify/__tests__/helpers.ts
@@ -99,6 +99,15 @@ interface FakeRow {
     user_id: string | null;
 }
 
+/** Ascending `id` comparator — mirrors the real store's `ORDER BY id ASC`. */
+const compareById = (a: { id: string }, b: { id: string }): number => {
+    if (a.id < b.id) {
+        return -1;
+    }
+
+    return a.id > b.id ? 1 : 0;
+};
+
 /**
  * A minimal functional fake of the D1 slice the subscription store uses. Branches
  * on the statement text (CREATE/INSERT…ON CONFLICT/SELECT/DELETE/UPDATE) against
@@ -127,8 +136,8 @@ const fakeD1 = (options: FakeD1Options = {}): D1Like => {
 
                 let results = [...rows.values()];
                 // Consume bindings in the same order the store appends them:
-                // [kind?, userId?, limit?]. A cursor keeps the filters correct even
-                // when a trailing `LIMIT ?` binding is present.
+                // [kind?, userId?, after?, limit?]. A cursor keeps the filters
+                // correct even when a trailing `LIMIT ?` binding is present.
                 let cursor = 0;
 
                 if (sql.includes("kind = ?")) {
@@ -145,6 +154,17 @@ const fakeD1 = (options: FakeD1Options = {}): D1Like => {
 
                     cursor += 1;
                     results = results.filter((row) => row.user_id === userId);
+                }
+
+                if (sql.includes("id > ?")) {
+                    const after = bound[cursor] as string;
+
+                    cursor += 1;
+                    results = results.filter((row) => row.id > after);
+                }
+
+                if (sql.includes("ORDER BY id ASC")) {
+                    results = results.toSorted(compareById);
                 }
 
                 if (sql.includes("LIMIT ?")) {
@@ -231,4 +251,4 @@ const fakeD1 = (options: FakeD1Options = {}): D1Like => {
     return { prepare: prepared };
 };
 
-export { fakeD1, mockChatProvider, mockEngine, mockPushProvider, mockThrowingPushProvider };
+export { compareById, fakeD1, mockChatProvider, mockEngine, mockPushProvider, mockThrowingPushProvider };

--- a/packages/notify/__tests__/inbox.test.ts
+++ b/packages/notify/__tests__/inbox.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import { memoryInboxStore } from "../src/inbox/memory-store";
+
+describe("memoryInboxStore (plan 241 spike — read half prototype)", () => {
+    it("append 3 -> unreadCount 3", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        await store.append({ payload: { body: "one" }, userId: "u1" });
+        await store.append({ payload: { body: "two" }, userId: "u1" });
+        await store.append({ payload: { body: "three" }, userId: "u1" });
+
+        await expect(store.unreadCount("u1")).resolves.toBe(3);
+    });
+
+    it("markRead(one) -> unreadCount 2", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        const first = await store.append({ payload: { body: "one" }, userId: "u1" });
+
+        await store.append({ payload: { body: "two" }, userId: "u1" });
+        await store.append({ payload: { body: "three" }, userId: "u1" });
+
+        await store.markRead(first.id);
+
+        await expect(store.unreadCount("u1")).resolves.toBe(2);
+
+        const [readItem] = await store.list("u1", { limit: 1, unreadOnly: false });
+
+        expect(readItem?.id).not.toBe(first.id); // newest-first: the just-appended "three" leads, not "one"
+    });
+
+    it("markRead is idempotent (marking an already-read item again is a no-op)", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+        const item = await store.append({ payload: { body: "one" }, userId: "u1" });
+
+        await store.markRead(item.id);
+
+        const [afterFirst] = await store.list("u1");
+        const firstReadAt = afterFirst?.readAt;
+
+        await store.markRead(item.id);
+
+        const [afterSecond] = await store.list("u1");
+
+        expect(afterSecond?.readAt).toBe(firstReadAt);
+        await expect(store.unreadCount("u1")).resolves.toBe(0);
+    });
+
+    it("markRead on an unknown id is a safe no-op", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        await expect(store.markRead("inbox_does_not_exist")).resolves.toBeUndefined();
+    });
+
+    it("listInbox returns newest-first", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        const first = await store.append({ payload: { body: "first" }, userId: "u1" });
+        const second = await store.append({ payload: { body: "second" }, userId: "u1" });
+        const third = await store.append({ payload: { body: "third" }, userId: "u1" });
+
+        const listed = await store.list("u1");
+
+        expect(listed.map((item) => item.id)).toStrictEqual([third.id, second.id, first.id]);
+    });
+
+    it("listInbox pages with an exclusive `after` cursor, newest-first, no skip/duplicate", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+        const appended: string[] = [];
+
+        for (let index = 0; index < 7; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential append in a test
+            const item = await store.append({ payload: { body: `item-${index.toString()}` }, userId: "u1" });
+
+            appended.push(item.id);
+        }
+
+        // Newest-first order is the reverse of append order.
+        const expectedOrder = appended.toReversed();
+
+        const seen: string[] = [];
+        let cursor: string | undefined;
+
+        for (;;) {
+            // eslint-disable-next-line no-await-in-loop -- pages are inherently sequential in this walk
+            const page = await store.list("u1", { after: cursor, limit: 3 });
+
+            if (page.length === 0) {
+                break;
+            }
+
+            seen.push(...page.map((item) => item.id));
+            cursor = page[page.length - 1]?.id;
+
+            if (page.length < 3) {
+                break;
+            }
+        }
+
+        expect(seen).toStrictEqual(expectedOrder);
+    });
+
+    it("unreadOnly filters out read items", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+        const first = await store.append({ payload: { body: "one" }, userId: "u1" });
+
+        await store.append({ payload: { body: "two" }, userId: "u1" });
+        await store.markRead(first.id);
+
+        const unread = await store.list("u1", { unreadOnly: true });
+
+        expect(unread).toHaveLength(1);
+        expect(unread[0]?.id).not.toBe(first.id);
+    });
+
+    it("markAllRead -> unreadCount 0, and returns the count changed", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        await store.append({ payload: { body: "one" }, userId: "u1" });
+        await store.append({ payload: { body: "two" }, userId: "u1" });
+        await store.append({ payload: { body: "three" }, userId: "u1" });
+
+        const changed = await store.markAllRead("u1");
+
+        expect(changed).toBe(3);
+        await expect(store.unreadCount("u1")).resolves.toBe(0);
+
+        // Idempotent: nothing left to change on a second call.
+        await expect(store.markAllRead("u1")).resolves.toBe(0);
+    });
+
+    it("isolates items per user — one user's append/read never touches another's", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        await store.append({ payload: { body: "for u1" }, userId: "u1" });
+        await store.append({ payload: { body: "for u2 (a)" }, userId: "u2" });
+        await store.append({ payload: { body: "for u2 (b)" }, userId: "u2" });
+
+        await expect(store.unreadCount("u1")).resolves.toBe(1);
+        await expect(store.unreadCount("u2")).resolves.toBe(2);
+
+        const changed = await store.markAllRead("u1");
+
+        expect(changed).toBe(1);
+        await expect(store.unreadCount("u2")).resolves.toBe(2);
+
+        const u1Items = await store.list("u1");
+        const u2Items = await store.list("u2");
+
+        expect(u1Items).toHaveLength(1);
+        expect(u2Items).toHaveLength(2);
+    });
+
+    it("round-trips payload, category and groupKey", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+        const stored = await store.append({
+            category: "billing",
+            groupKey: "invoice:42",
+            payload: { body: "Your invoice is ready", title: "Invoice #42" },
+            userId: "u1",
+        });
+
+        expect(stored).toMatchObject({
+            category: "billing",
+            groupKey: "invoice:42",
+            payload: { body: "Your invoice is ready", title: "Invoice #42" },
+            userId: "u1",
+        });
+        expect(stored.readAt).toBeUndefined();
+        expect(typeof stored.createdAt).toBe("number");
+
+        const [listed] = await store.list("u1");
+
+        expect(listed).toStrictEqual(stored);
+    });
+
+    it("respects `limit` without a cursor", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        for (let index = 0; index < 5; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential append in a test
+            await store.append({ payload: { body: `item-${index.toString()}` }, userId: "u1" });
+        }
+
+        const page = await store.list("u1", { limit: 2 });
+
+        expect(page).toHaveLength(2);
+    });
+
+    it("an empty inbox lists empty and reports zero unread", async () => {
+        expect.hasAssertions();
+
+        const store = memoryInboxStore();
+
+        await expect(store.list("nobody")).resolves.toStrictEqual([]);
+        await expect(store.unreadCount("nobody")).resolves.toBe(0);
+        await expect(store.markAllRead("nobody")).resolves.toBe(0);
+    });
+});

--- a/packages/notify/__tests__/notify.test.ts
+++ b/packages/notify/__tests__/notify.test.ts
@@ -173,6 +173,33 @@ describe("ctx.push.broadcast pagination (plan 222 / NOTIFY-01)", () => {
         expect(listSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
     });
 
+    it("broadcast({ limit }) caps the CUMULATIVE audience across pages, not per page", async () => {
+        expect.hasAssertions();
+
+        const { push, store } = setupPaged();
+        const total = pageSize + 10; // audience bigger than the cap, spanning multiple pages
+        const limit = pageSize + 2; // bigger than one page, so the walk must still span >= 2 pages
+
+        for (let index = 0; index < total; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await push.register({ subscription: { endpoint: `https://push.example/cap/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } });
+        }
+
+        const result = await push.broadcast({ body: "capped", title: "t" }, { limit });
+
+        // Reaches EXACTLY `limit` subscriptions overall — not `limit` PER PAGE
+        // (which would deliver to the whole `total` audience across pages).
+        expect(result.total).toBe(limit);
+        expect(result.sent).toBe(limit);
+
+        const ids = result.outcomes.map((outcome) => outcome.id);
+
+        expect(new Set(ids).size).toBe(limit);
+
+        // The rest of the audience was registered but never delivered to.
+        await expect(store.list()).resolves.toHaveLength(total);
+    });
+
     it("broadcastPage returns one bounded page plus a resumable nextCursor", async () => {
         expect.hasAssertions();
 

--- a/packages/notify/__tests__/notify.test.ts
+++ b/packages/notify/__tests__/notify.test.ts
@@ -140,6 +140,130 @@ describe("ctx.push.broadcast", () => {
     });
 });
 
+describe("ctx.push.broadcast pagination (plan 222 / NOTIFY-01)", () => {
+    const pageSize = 5;
+
+    const setupPaged = () => {
+        const store = memorySubscriptionStore();
+        const push = mockPushProvider();
+        const engine = mockEngine({ push: push.provider });
+        const facade = createNotify(baseDefinition(store), {}, { broadcastPageSize: pageSize, engine, silent: true });
+
+        return { ...facade, engine, sends: push.sends, store };
+    };
+
+    it("a broadcast over pageSize + 10 fakes visits every one across >= 2 pages", async () => {
+        expect.hasAssertions();
+
+        const { push, store } = setupPaged();
+        const total = pageSize + 10;
+
+        for (let index = 0; index < total; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await push.register({ subscription: { endpoint: `https://push.example/bulk/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } });
+        }
+
+        const listSpy = vi.spyOn(store, "list");
+        const result = await push.broadcast({ body: "bulk", title: "t" });
+
+        expect(result.total).toBe(total);
+        expect(result.sent).toBe(total);
+        // A single page (pageSize=5) could never cover `total`=15 fakes — proves
+        // the walk spanned multiple pages, not one big unbounded list().
+        expect(listSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("broadcastPage returns one bounded page plus a resumable nextCursor", async () => {
+        expect.hasAssertions();
+
+        const { push } = setupPaged();
+
+        for (let index = 0; index < pageSize + 2; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await push.register({ subscription: { endpoint: `https://push.example/page/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } });
+        }
+
+        const first = await push.broadcastPage({ body: "p1" });
+
+        expect(first.result.total).toBe(pageSize);
+        expect(first.nextCursor).toBeDefined();
+
+        const second = await push.broadcastPage({ body: "p2" }, { after: first.nextCursor });
+
+        expect(second.result.total).toBe(2);
+        expect(second.nextCursor).toBeUndefined();
+
+        // No overlap between the two pages' delivered subscription ids.
+        const firstIds = new Set(first.result.outcomes.map((outcome) => outcome.id));
+
+        for (const outcome of second.result.outcomes) {
+            expect(firstIds.has(outcome.id)).toBe(false);
+        }
+    });
+
+    it("a job carrying a cursor (job.filter.after) resumes exactly where the previous page left off", async () => {
+        expect.hasAssertions();
+
+        const { push } = setupPaged();
+
+        for (let index = 0; index < pageSize + 3; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await push.register({ subscription: { endpoint: `https://push.example/resume/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } });
+        }
+
+        const firstPage = await push.broadcastPage({ body: "hi" });
+
+        expect(firstPage.nextCursor).toBeDefined();
+
+        // Simulate a queue job carrying the cursor forward (see `runPushBroadcastJob`).
+        const resumed = await push.broadcastPage({ body: "hi" }, { after: firstPage.nextCursor });
+
+        expect(resumed.result.total).toBe(3);
+        expect(resumed.nextCursor).toBeUndefined();
+    });
+
+    it("a store that ignores `after` (unpaged fallback) terminates and never double-delivers", async () => {
+        expect.hasAssertions();
+
+        const backing = memorySubscriptionStore();
+        // A non-cursoring store: `list` always returns the same (from-the-top)
+        // window regardless of `filter.after` — the documented fallback case.
+        // `broadcastPage`'s defensive re-filter is what has to keep this correct.
+        const nonCursoringStore = {
+            ...backing,
+            list: (filter?: Parameters<typeof backing.list>[0]) => backing.list({ kind: filter?.kind, limit: filter?.limit, userId: filter?.userId }),
+        };
+
+        const providerMock = mockPushProvider();
+        const { push } = createNotify(
+            baseDefinition(nonCursoringStore),
+            {},
+            { broadcastPageSize: pageSize, engine: mockEngine({ push: providerMock.provider }), silent: true },
+        );
+
+        const total = pageSize + 10;
+
+        for (let index = 0; index < total; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await push.register({ subscription: { endpoint: `https://push.example/nocursor/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } });
+        }
+
+        // Must resolve (not hang/loop forever) — the real assertion is that the
+        // promise settles at all within the test's timeout.
+        const result = await push.broadcast({ body: "hi" });
+
+        // A non-cursoring store can't be trusted to deliver the FULL matched
+        // audience (see `SubscriptionFilter.after`'s documented fallback limit),
+        // but it must never double-deliver: every delivered id is distinct, and
+        // it can't exceed the registered total.
+        const ids = result.outcomes.map((outcome) => outcome.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(result.total).toBeGreaterThan(0);
+        expect(result.total).toBeLessThanOrEqual(total);
+    });
+});
+
 describe("ctx.push.broadcast fault-tolerance", () => {
     const webPushSub = (suffix: string) => {
         return { endpoint: `https://push.example/${suffix}`, keys: { auth: "a", p256dh: "p" } };

--- a/packages/notify/__tests__/queue.test.ts
+++ b/packages/notify/__tests__/queue.test.ts
@@ -20,25 +20,25 @@ describe("queue-backed fan-out", () => {
         expect(sent).toStrictEqual([{ filter: { userId: "u1" }, payload: { body: "hi", title: "t" }, type: "lunora.push.broadcast" }]);
     });
 
-    it("runs an enqueued job through push.broadcast", async () => {
+    it("runs an enqueued job through push.broadcastPage (ONE bounded page, not the whole audience)", async () => {
         expect.hasAssertions();
 
-        const broadcast = vi.fn().mockResolvedValue({ failed: 0, outcomes: [], pruned: 0, sent: 0, total: 0 });
-        const push = { broadcast } as unknown as LunoraPush;
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: undefined, result: { failed: 0, outcomes: [], pruned: 0, sent: 0, total: 0 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
         const job: PushBroadcastJob = { payload: { body: "hi" }, type: "lunora.push.broadcast" };
 
         await runPushBroadcastJob(push, job);
 
-        expect(broadcast).toHaveBeenCalledWith(job.payload, undefined);
+        expect(broadcastPage).toHaveBeenCalledWith(job.payload, undefined);
     });
 
-    it("rejects a job with a transient failure so the queue retries", async () => {
+    it("rejects a job with a transient failure so the queue retries JUST this page", async () => {
         expect.hasAssertions();
 
-        // Any `failed > 0` is a transient batch failure worth another attempt —
-        // re-thrown so the queue does NOT ack it.
-        const broadcast = vi.fn().mockResolvedValue({ failed: 2, outcomes: [], pruned: 0, sent: 0, total: 2 });
-        const push = { broadcast } as unknown as LunoraPush;
+        // Any `result.failed > 0` is a transient page failure worth another
+        // attempt — re-thrown so the queue does NOT ack it.
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: undefined, result: { failed: 2, outcomes: [], pruned: 0, sent: 0, total: 2 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
         const job: PushBroadcastJob = { payload: { body: "hi" }, type: "lunora.push.broadcast" };
 
         await expect(runPushBroadcastJob(push, job)).rejects.toThrow(/transient failure/u);
@@ -47,35 +47,61 @@ describe("queue-backed fan-out", () => {
     it("rejects a partial success that still had a transient failure", async () => {
         expect.hasAssertions();
 
-        // `sent > 0` but `failed > 0`: the failed recipients are worth a retry, so the
-        // whole batch is re-thrown (retry re-runs the full, non-idempotent broadcast).
-        const broadcast = vi.fn().mockResolvedValue({ failed: 1, outcomes: [], pruned: 0, sent: 1, total: 2 });
-        const push = { broadcast } as unknown as LunoraPush;
+        // `sent > 0` but `failed > 0`: the failed recipients are worth a retry, so
+        // this page's job is re-thrown (retry re-runs the page, not the whole broadcast).
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: undefined, result: { failed: 1, outcomes: [], pruned: 0, sent: 1, total: 2 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
         const job: PushBroadcastJob = { payload: { body: "hi" }, type: "lunora.push.broadcast" };
 
         await expect(runPushBroadcastJob(push, job)).rejects.toThrow(/transient failure/u);
     });
 
-    it("does NOT throw when the whole audience was pruned (a successful prune, not a failure)", async () => {
+    it("does NOT throw when the whole page was pruned (a successful prune, not a failure)", async () => {
         expect.hasAssertions();
 
-        // Every device had unsubscribed: `sent:0`, `failed:0`, `pruned:N`. That is a
-        // SUCCESSFUL prune of a fully-unsubscribed audience — throwing on it would
-        // spuriously retry and pressure the DLQ, so it must resolve (ack).
-        const broadcast = vi.fn().mockResolvedValue({ failed: 0, outcomes: [], pruned: 3, sent: 0, total: 3 });
-        const push = { broadcast } as unknown as LunoraPush;
+        // Every device on this page had unsubscribed: `sent:0`, `failed:0`, `pruned:N`.
+        // That is a SUCCESSFUL prune, not a failure, so throwing on it would
+        // spuriously retry and pressure the DLQ — it must resolve (ack).
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: undefined, result: { failed: 0, outcomes: [], pruned: 3, sent: 0, total: 3 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
         const job: PushBroadcastJob = { payload: { body: "hi" }, type: "lunora.push.broadcast" };
 
-        await expect(runPushBroadcastJob(push, job)).resolves.toMatchObject({ pruned: 3, sent: 0 });
+        await expect(runPushBroadcastJob(push, job)).resolves.toMatchObject({ result: { pruned: 3, sent: 0 } });
     });
 
-    it("resolves for an empty audience — nothing to retry", async () => {
+    it("resolves for an empty page — nothing to retry", async () => {
         expect.hasAssertions();
 
-        const broadcast = vi.fn().mockResolvedValue({ failed: 0, outcomes: [], pruned: 0, sent: 0, total: 0 });
-        const push = { broadcast } as unknown as LunoraPush;
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: undefined, result: { failed: 0, outcomes: [], pruned: 0, sent: 0, total: 0 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
         const job: PushBroadcastJob = { payload: { body: "hi" }, type: "lunora.push.broadcast" };
 
-        await expect(runPushBroadcastJob(push, job)).resolves.toMatchObject({ total: 0 });
+        await expect(runPushBroadcastJob(push, job)).resolves.toMatchObject({ result: { total: 0 } });
+    });
+
+    it("surfaces nextCursor so the caller can enqueue the continuation page", async () => {
+        expect.hasAssertions();
+
+        const broadcastPage = vi
+            .fn()
+            .mockResolvedValue({ nextCursor: "wp2_deadbeefdeadbeef", result: { failed: 0, outcomes: [], pruned: 0, sent: 5, total: 5 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
+        const job: PushBroadcastJob = { payload: { body: "hi" }, type: "lunora.push.broadcast" };
+
+        const outcome = await runPushBroadcastJob(push, job);
+
+        expect(outcome.nextCursor).toBe("wp2_deadbeefdeadbeef");
+    });
+
+    it("a job carrying a cursor resumes broadcastPage with that cursor as `filter.after`", async () => {
+        expect.hasAssertions();
+
+        const broadcastPage = vi.fn().mockResolvedValue({ nextCursor: undefined, result: { failed: 0, outcomes: [], pruned: 0, sent: 1, total: 1 } });
+        const push = { broadcastPage } as unknown as LunoraPush;
+        const job: PushBroadcastJob = { filter: { after: "wp2_1111111111111111", userId: "u1" }, payload: { body: "hi" }, type: "lunora.push.broadcast" };
+
+        await runPushBroadcastJob(push, job);
+
+        expect(broadcastPage).toHaveBeenCalledWith(job.payload, { after: "wp2_1111111111111111", userId: "u1" });
     });
 });

--- a/packages/notify/__tests__/subscriptions.test.ts
+++ b/packages/notify/__tests__/subscriptions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { d1SubscriptionStore } from "../src/subscriptions/d1-store";
 import { memorySubscriptionStore } from "../src/subscriptions/memory-store";
 import { fcmId, isGoneError, legacyFcmId, legacyWebPushId, normalizeRegisterInput, targetOf, webPushId } from "../src/subscriptions/normalize";
-import { fakeD1 } from "./helpers";
+import { compareById, fakeD1 } from "./helpers";
 
 const webPushSub = { endpoint: "https://push.example/abc", keys: { auth: "AUTHKEY", p256dh: "P256KEY" } };
 
@@ -52,6 +52,69 @@ describe("normalizeRegisterInput", () => {
 
         expect(stored).toMatchObject({ id: fcmId("device-token-1"), kind: "fcm", token: "device-token-1" });
         expect(() => normalizeRegisterInput({ kind: "fcm", token: "" })).toThrow(/non-empty `token`/u);
+    });
+});
+
+describe("normalizeRegisterInput metadata validation (NOTIFY-02)", () => {
+    it("round-trips realistic small metadata", () => {
+        expect.hasAssertions();
+
+        const metadata = { deviceName: "Pixel 9", locale: "en-US", topics: ["news", "offers"] };
+        const stored = normalizeRegisterInput({ kind: "fcm", metadata, token: "device-token-1" });
+
+        expect(stored.metadata).toStrictEqual(metadata);
+    });
+
+    it("allows omitted metadata", () => {
+        expect.hasAssertions();
+
+        const stored = normalizeRegisterInput({ kind: "fcm", token: "device-token-1" });
+
+        expect(stored.metadata).toBeUndefined();
+    });
+
+    it("rejects a non-plain-object metadata (array, string, number)", () => {
+        expect.hasAssertions();
+
+        for (const bad of [["x"], "oops", 42, null]) {
+            expect(() => normalizeRegisterInput({ kind: "fcm", metadata: bad as never, token: "t" }), JSON.stringify(bad)).toThrow(/plain object/u);
+        }
+    });
+
+    it("rejects metadata exceeding the byte cap", () => {
+        expect.hasAssertions();
+
+        const metadata = { blob: "x".repeat(10_000) };
+
+        expect(() => normalizeRegisterInput({ kind: "fcm", metadata, token: "t" })).toThrow(/exceeding the .*-byte cap/u);
+    });
+
+    it("rejects non-JSON-serialisable metadata (BigInt)", () => {
+        expect.hasAssertions();
+
+        const metadata = { amount: 10n } as unknown as Record<string, unknown>;
+
+        expect(() => normalizeRegisterInput({ kind: "fcm", metadata, token: "t" })).toThrow(/not JSON-serialisable/u);
+    });
+
+    it("rejects a circular metadata object", () => {
+        expect.hasAssertions();
+
+        const metadata: Record<string, unknown> = { name: "loop" };
+
+        metadata.self = metadata;
+
+        expect(() => normalizeRegisterInput({ kind: "fcm", metadata, token: "t" })).toThrow(/not JSON-serialisable/u);
+    });
+
+    it("applies the same validation to web-push registrations", () => {
+        expect.hasAssertions();
+
+        expect(() => normalizeRegisterInput({ metadata: ["bad"] as never, subscription: webPushSub })).toThrow(/plain object/u);
+
+        const stored = normalizeRegisterInput({ metadata: { locale: "de-DE" }, subscription: webPushSub });
+
+        expect(stored.metadata).toStrictEqual({ locale: "de-DE" });
     });
 });
 
@@ -233,6 +296,16 @@ describe("d1SubscriptionStore", () => {
         await expect(store.get(wp.id)).resolves.toBeUndefined();
     });
 
+    it("round-trips validated metadata without the store's own JSON.stringify throwing", async () => {
+        expect.hasAssertions();
+
+        const store = d1SubscriptionStore(fakeD1());
+        const metadata = { deviceName: "Pixel 9", topics: ["news"] };
+        const stored = await store.put(normalizeRegisterInput({ kind: "fcm", metadata, token: "meta-tok" }));
+
+        await expect(store.get(stored.id)).resolves.toMatchObject({ metadata });
+    });
+
     it("rejects an unsafe table name", () => {
         expect.hasAssertions();
 
@@ -301,6 +374,137 @@ describe("legacy-id migration eviction (memory + D1)", () => {
         expect(current.id).toBe(fcmId(token));
         await expect(store.get(legacyId)).resolves.toBeUndefined();
         await expect(store.list()).resolves.toHaveLength(1);
+    });
+});
+
+describe("keyset pagination via `after` (memory + D1 parity)", () => {
+    const stores: ReadonlyArray<readonly [string, () => ReturnType<typeof memorySubscriptionStore>]> = [
+        ["memory", () => memorySubscriptionStore()],
+        ["d1", () => d1SubscriptionStore(fakeD1())],
+    ];
+
+    it.each(stores)("orders ascending by id and pages with an exclusive cursor (%s)", async (_name, makeStore) => {
+        expect.hasAssertions();
+
+        const store = makeStore();
+
+        for (let index = 0; index < 10; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await store.put(
+                normalizeRegisterInput({ subscription: { endpoint: `https://push.example/page/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } }),
+            );
+        }
+
+        const all = await store.list();
+
+        expect(all).toHaveLength(10);
+
+        const expectedIds = all.toSorted(compareById).map((s) => s.id);
+
+        // Walk the whole store in pages of 3, an exclusive `after` cursor each time.
+        const seen: string[] = [];
+        let cursor: string | undefined;
+
+        for (;;) {
+            // eslint-disable-next-line no-await-in-loop -- pages are inherently sequential in this walk
+            const page = await store.list({ after: cursor, limit: 3 });
+
+            if (page.length === 0) {
+                break;
+            }
+
+            // Ascending order within the page.
+            for (let index = 1; index < page.length; index += 1) {
+                const previousId = page[index - 1]?.id as string;
+                const currentId = page[index]?.id as string;
+
+                // eslint-disable-next-line vitest/prefer-comparison-matcher -- `toBeGreaterThan` is typed number|bigint only; these are string ids
+                expect(currentId > previousId).toBe(true);
+            }
+
+            seen.push(...page.map((s) => s.id));
+            cursor = page[page.length - 1]?.id;
+
+            if (page.length < 3) {
+                break;
+            }
+        }
+
+        // Every row visited exactly once, in ascending id order overall — no
+        // skip and no double-delivery across the page boundary.
+        expect(seen).toStrictEqual(expectedIds);
+    });
+
+    it.each(stores)("a cursor is exclusive — the boundary row is not repeated (%s)", async (_name, makeStore) => {
+        expect.hasAssertions();
+
+        const store = makeStore();
+
+        for (let index = 0; index < 4; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            await store.put(
+                normalizeRegisterInput({ subscription: { endpoint: `https://push.example/excl/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } }),
+            );
+        }
+
+        const firstPage = await store.list({ limit: 2 });
+        const boundary = firstPage[1]?.id as string;
+        const secondPage = await store.list({ after: boundary, limit: 2 });
+
+        expect(secondPage.map((s) => s.id)).not.toContain(boundary);
+        expect(secondPage.every((s) => s.id > boundary)).toBe(true);
+    });
+
+    it.each(stores)("stays stable under a concurrent register mid-walk — the already-consumed page is unaffected (%s)", async (_name, makeStore) => {
+        expect.hasAssertions();
+
+        const store = makeStore();
+        const originalIds: string[] = [];
+
+        for (let index = 0; index < 3; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential registration in a test
+            const stored = await store.put(
+                normalizeRegisterInput({ subscription: { endpoint: `https://push.example/concurrent/${index.toString()}`, keys: { auth: "a", p256dh: "p" } } }),
+            );
+
+            originalIds.push(stored.id);
+        }
+
+        const firstPage = await store.list({ limit: 2 });
+
+        expect(firstPage).toHaveLength(2);
+
+        // A new device registers BETWEEN the first and second page fetch — must
+        // not retroactively appear in a page already walked (firstPage is fixed,
+        // already returned), nor cause an already-seen row to be skipped or
+        // repeated in the next page. Whether the NEW device itself lands before
+        // or after the cursor depends on its id's hash position — both are
+        // correct keyset-pagination outcomes, so this only asserts what's
+        // deterministic: the 3 PRE-EXISTING ids are exactly accounted for once
+        // each, and the new device never causes a duplicate/skip among them.
+        await store.put(normalizeRegisterInput({ subscription: { endpoint: "https://push.example/concurrent/new", keys: { auth: "a", p256dh: "p" } } }));
+
+        const cursor = firstPage[1]?.id as string;
+        const secondPage = await store.list({ after: cursor, limit: 10 });
+
+        const firstIds = new Set(firstPage.map((s) => s.id));
+
+        for (const subscription of secondPage) {
+            // Exclusive cursor: nothing already returned in firstPage reappears.
+            expect(firstIds.has(subscription.id)).toBe(false);
+            // eslint-disable-next-line vitest/prefer-comparison-matcher -- `toBeGreaterThan` is typed number|bigint only; these are string ids
+            expect(subscription.id > cursor).toBe(true);
+        }
+
+        // Every pre-existing id appears in exactly one of the two pages — the
+        // cursor boundary is exclusive and stable regardless of the concurrent
+        // register (the 3rd pre-existing id, being the largest of the original
+        // 3, is guaranteed > cursor and so always surfaces in secondPage).
+        const combinedIds = new Set([...firstPage.map((s) => s.id), ...secondPage.map((s) => s.id)]);
+
+        for (const id of originalIds) {
+            expect(combinedIds.has(id)).toBe(true);
+        }
     });
 });
 

--- a/packages/notify/src/inbox/memory-store.ts
+++ b/packages/notify/src/inbox/memory-store.ts
@@ -1,0 +1,116 @@
+import type { AppendInboxInput, InboxItem, InboxStore, ListInboxFilter } from "./types";
+
+/** Descending `id` comparator (newest-first — ids are monotonically increasing, see `nextId`). */
+const compareByIdDescending = (a: InboxItem, b: InboxItem): number => {
+    if (a.id < b.id) {
+        return 1;
+    }
+
+    return a.id > b.id ? -1 : 0;
+};
+
+/**
+ * Zero-pad a monotonically increasing counter into a fixed-width, lexically
+ * sortable id. 12 digits comfortably outlives any single isolate's lifetime
+ * (10^12 appends) while keeping ids short and diffable in test output.
+ */
+const nextId = (counter: number): string => `inbox_${counter.toString().padStart(12, "0")}`;
+
+/**
+ * An in-memory {@link InboxStore} — the plan 241 spike's ONLY implementation
+ * so far (a D1 backend is design-only, see `plans/241-inapp-inbox-design.md`).
+ * Mirrors `memorySubscriptionStore`'s shape: not durable, suitable for tests
+ * and prototyping the query/receipt surface before committing to a durable
+ * schema.
+ *
+ * ID SCHEME: ids are minted from a per-store monotonically increasing
+ * counter (see {@link nextId}), so insertion order and id order always agree
+ * — unlike the subscription store's content-hash ids, an inbox item has no
+ * natural stable key (an in-app notification isn't "the same" across
+ * re-sends the way a device subscription is), so a counter is simpler and
+ * sufficient here.
+ */
+const memoryInboxStore = (): InboxStore => {
+    const items: InboxItem[] = [];
+    let counter = 0;
+
+    const append = (input: AppendInboxInput): Promise<InboxItem> => {
+        counter += 1;
+
+        const item: InboxItem = {
+            createdAt: Date.now(),
+            id: nextId(counter),
+            payload: input.payload,
+            userId: input.userId,
+            ...(input.category === undefined ? {} : { category: input.category }),
+            ...(input.groupKey === undefined ? {} : { groupKey: input.groupKey }),
+        };
+
+        items.push(item);
+
+        return Promise.resolve(item);
+    };
+
+    const list = (userId: string, filter?: ListInboxFilter): Promise<InboxItem[]> => {
+        // Newest-first: ids are monotonically increasing (see `nextId`), so
+        // descending id order is descending chronological order.
+        let matching = items.filter((item) => item.userId === userId).toSorted(compareByIdDescending);
+
+        if (filter?.unreadOnly === true) {
+            matching = matching.filter((item) => item.readAt === undefined);
+        }
+
+        // `after` is exclusive and means "strictly OLDER than this cursor" in
+        // newest-first order — i.e. a smaller id (see `ListInboxFilter.after`).
+        if (filter?.after !== undefined) {
+            const { after } = filter;
+
+            matching = matching.filter((item) => item.id < after);
+        }
+
+        const capped = filter?.limit !== undefined && filter.limit > 0 ? matching.slice(0, Math.trunc(filter.limit)) : matching;
+
+        return Promise.resolve(capped);
+    };
+
+    const unreadCount = (userId: string): Promise<number> => {
+        let count = 0;
+
+        for (const item of items) {
+            if (item.userId === userId && item.readAt === undefined) {
+                count += 1;
+            }
+        }
+
+        return Promise.resolve(count);
+    };
+
+    const markRead = (id: string): Promise<void> => {
+        const item = items.find((candidate) => candidate.id === id);
+
+        if (item !== undefined && item.readAt === undefined) {
+            item.readAt = Date.now();
+        }
+
+        return Promise.resolve();
+    };
+
+    const markAllRead = (userId: string): Promise<number> => {
+        let changed = 0;
+        const now = Date.now();
+
+        for (const item of items) {
+            if (item.userId === userId && item.readAt === undefined) {
+                item.readAt = now;
+                changed += 1;
+            }
+        }
+
+        return Promise.resolve(changed);
+    };
+
+    return { append, list, markAllRead, markRead, unreadCount };
+};
+
+// eslint-disable-next-line import/prefer-default-export -- named export by repo convention (no default exports)
+export { memoryInboxStore };

--- a/packages/notify/src/inbox/types.ts
+++ b/packages/notify/src/inbox/types.ts
@@ -1,0 +1,90 @@
+import type { InAppPayload } from "@visulima/notification";
+
+/**
+ * SPIKE (plan 241): types for the in-app inbox READ half's prototype store.
+ * This is a design/prototype seam, not yet wired into `createNotify` /
+ * `ctx.notify` — see `plans/241-inapp-inbox-design.md` for the write-coupling,
+ * query surface, and open questions (D1 backend, live delivery, retention)
+ * this prototype deliberately leaves unresolved. Only a MEMORY backend exists
+ * so far; do not treat this as a stable public surface yet.
+ */
+
+/**
+ * An in-app inbox payload: an {@link InAppPayload} without `to` — the owning
+ * {@link InboxItem.userId} already carries the recipient, mirroring how
+ * `PushContent` drops `PushPayload.to` for the same reason (`../types.ts`).
+ */
+export type InboxContent = Omit<InAppPayload, "to">;
+
+/**
+ * One persisted in-app notification. `id` is a store-assigned, monotonically
+ * SORTABLE identifier (ascending = chronological) — the memory store mints a
+ * zero-padded counter; a real backend would use an equivalent (ULID, a D1
+ * autoincrement rowid, …). Sortability is what lets `listInbox` page
+ * newest-first with an exclusive cursor, mirroring plan 222's
+ * `SubscriptionFilter.after` keyset-pagination shape.
+ */
+export interface InboxItem {
+    /** Optional coarse category for filtering (e.g. `"billing"`, `"social"`). Grouping/collapsing policy is an open question — see the design doc. */
+    category?: string;
+    /** Unix-ms time the item was appended. */
+    createdAt: number;
+    /** Optional key for client-side collapsing of related items (e.g. `"comment:42"`). Not interpreted by the store itself. */
+    groupKey?: string;
+    /** Store-assigned, sortable identifier. */
+    id: string;
+    /** The in-app content (title/body/data/actions). */
+    payload: InboxContent;
+    /** Unix-ms time the item was read, or `undefined` while unread. */
+    readAt?: number;
+    /** The owning user — unlike a device subscription, an inbox item always has a specific, non-anonymous recipient. */
+    userId: string;
+}
+
+/** Input to {@link InboxStore.append}. */
+export interface AppendInboxInput {
+    /** Optional coarse category (see {@link InboxItem.category}). */
+    category?: string;
+    /** Optional client-collapsing key (see {@link InboxItem.groupKey}). */
+    groupKey?: string;
+    /** The in-app content to persist. */
+    payload: InboxContent;
+    /** The owning user. */
+    userId: string;
+}
+
+/**
+ * Filter/pagination for {@link InboxStore.list}. Reuses plan 222's cursor
+ * shape (`after` + `limit`) but the ORDER is reversed: `listInbox` is
+ * newest-first (a notification center shows recent items on top), so `after`
+ * means "strictly OLDER than this cursor" — the id of the last item on the
+ * previous page — rather than "greater than", matching what a `list`-then-
+ * "load older" pagination UI needs.
+ */
+export interface ListInboxFilter {
+    /** Cursor: return only items older than this item id (exclusive), newest-first order. */
+    after?: string;
+    /** Cap the number of rows returned. A non-positive/absent value means "no cap". */
+    limit?: number;
+    /** Restrict to unread items only (`readAt === undefined`). */
+    unreadOnly?: boolean;
+}
+
+/**
+ * Persistence for the in-app inbox READ half (plan 241 spike). A MEMORY
+ * implementation exists ({@link import("./memory-store").memoryInboxStore});
+ * a D1 (or other durable) backend is design-only for now — see
+ * `plans/241-inapp-inbox-design.md`.
+ */
+export interface InboxStore {
+    /** Persist a new in-app notification for `input.userId` and return the stored item. */
+    append: (input: AppendInboxInput) => Promise<InboxItem>;
+    /** List `userId`'s items, newest-first, optionally filtered/paged (see {@link ListInboxFilter}). */
+    list: (userId: string, filter?: ListInboxFilter) => Promise<InboxItem[]>;
+    /** Mark all of `userId`'s currently-unread items as read; returns how many were changed. */
+    markAllRead: (userId: string) => Promise<number>;
+    /** Mark one item as read by id (idempotent — a no-op if already read or unknown). */
+    markRead: (id: string) => Promise<void>;
+    /** Count `userId`'s unread items. */
+    unreadCount: (userId: string) => Promise<number>;
+}

--- a/packages/notify/src/notify.ts
+++ b/packages/notify/src/notify.ts
@@ -7,6 +7,7 @@ import { memorySubscriptionStore } from "./subscriptions/memory-store";
 import { isGoneError, normalizeRegisterInput, targetOf } from "./subscriptions/normalize";
 import type {
     BroadcastOutcome,
+    BroadcastPageResult,
     BroadcastResult,
     LunoraNotify,
     LunoraPush,
@@ -22,6 +23,15 @@ import type {
     SubscriptionFilter,
     SubscriptionStore,
 } from "./types";
+
+/**
+ * Default page size for `push.broadcast`'s internal keyset pagination (see
+ * `CreateNotifyOptions`'s `broadcastPageSize`). A few hundred keeps one
+ * page's store round trip + fan-out comfortably inside Worker CPU/wall
+ * limits while still being large enough that a typical small app's
+ * broadcast completes in one page.
+ */
+const DEFAULT_BROADCAST_PAGE_SIZE = 250;
 
 const resolveMaybeFactory = <T>(value: T | ((env: NotifyEnv) => T | undefined) | undefined, env: NotifyEnv): T | undefined =>
     typeof value === "function" ? (value as (env: NotifyEnv) => T | undefined)(env) : value;
@@ -119,6 +129,17 @@ const runtimeFor = (definition: NotifyDefinition, env: NotifyEnv): NotifyRuntime
 
 /** Options for {@link createNotify}. */
 export interface CreateNotifyOptions {
+    /**
+     * Page size for `push.broadcast`'s internal keyset pagination over the
+     * subscription store (default {@link DEFAULT_BROADCAST_PAGE_SIZE}, 250).
+     * Each page is fetched, delivered, and counted independently before the
+     * next page's store round trip, so a huge audience is never materialized
+     * wholesale in the isolate. Also the per-message bound `push.broadcastPage`
+     * (and so `runPushBroadcastJob`) uses. A test/tuning seam — most apps never
+     * need to set this.
+     */
+    broadcastPageSize?: number;
+
     /** Max concurrent sends during a `broadcast` (default 10). */
     concurrency?: number;
 
@@ -203,6 +224,7 @@ export const createNotify = (definition: NotifyDefinition, env: NotifyEnv, optio
 
     const subscriptionStore = store;
     const concurrency = Math.max(1, options.concurrency ?? 10);
+    const broadcastPageSize = Math.max(1, options.broadcastPageSize ?? DEFAULT_BROADCAST_PAGE_SIZE);
     const { log, metrics } = options;
 
     /**
@@ -341,62 +363,146 @@ export const createNotify = (definition: NotifyDefinition, env: NotifyEnv, optio
         return { error, receipt, status };
     };
 
+    /**
+     * Deliver `payload` to exactly the given (already-paged) `subscriptions`
+     * batch, bounded by `concurrency`, and fold the outcomes into one
+     * {@link BroadcastResult}. Shared by `broadcastPage` (one page) and, via
+     * its page-walk loop, `broadcast` (the whole audience) — the bucketed
+     * metric-count / outcome-shaping logic that used to live inline in
+     * `broadcast` lives here once instead of twice.
+     */
+    const deliverPage = async (payload: PushContent, subscriptions: StoredSubscription[]): Promise<BroadcastResult> => {
+        const rows = await mapWithConcurrency(subscriptions, concurrency, async (subscription) => {
+            // `deliver` is total (it never rejects — a throwing recipient
+            // becomes a `failed` outcome inside it), so the bounded `Promise.all`
+            // pool in `mapWithConcurrency` can never be rejected by one bad send.
+            const { error, status } = await deliver(subscription, payload, false);
+
+            return { error, kind: subscription.kind, status, subscription };
+        });
+
+        // Fold the per-recipient statuses into one metric count per (kind,
+        // status) bucket — at most kinds×3 emits — instead of one durable
+        // SQLite write per recipient. (The per-recipient FAILURE LOGS already
+        // fired inside `deliver`.)
+        const buckets = new Map<string, { count: number; kind: string; status: NotifyDeliveryStatus }>();
+
+        for (const { kind, status } of rows) {
+            const key = `${kind} ${status}`;
+            const bucket = buckets.get(key);
+
+            if (bucket === undefined) {
+                buckets.set(key, { count: 1, kind, status });
+            } else {
+                bucket.count += 1;
+            }
+        }
+
+        for (const { count, kind, status } of buckets.values()) {
+            countSend("push", kind, status, count);
+        }
+
+        const outcomes: BroadcastOutcome[] = rows.map(({ error, status, subscription }) => {
+            if (status === "accepted") {
+                return { id: subscription.id, status: "ok" };
+            }
+
+            return status === "gone" ? { error, id: subscription.id, status: "expired" } : { error, id: subscription.id, status: "failed" };
+        });
+
+        return {
+            failed: outcomes.filter((outcome) => outcome.status === "failed").length,
+            outcomes,
+            pruned: outcomes.filter((outcome) => outcome.status === "expired").length,
+            sent: outcomes.filter((outcome) => outcome.status === "ok").length,
+            total: outcomes.length,
+        };
+    };
+
+    /**
+     * Fetch and deliver ONE bounded page of `filter`'s matching subscriptions
+     * (see {@link LunoraPush.broadcastPage}). Pages are keyset-paginated on
+     * `id` (`filter.after`, exclusive): the store is asked for `pageSize + 1`
+     * rows so an exactly-full page can be told apart from the true last page
+     * without a second (empty) round trip — the `+1`th row, when present, is
+     * trimmed off and its predecessor's `id` becomes `nextCursor`.
+     *
+     * DEFENSIVE RE-FILTER: `filter.after` is OPTIONAL for a `SubscriptionStore`
+     * to honor (see {@link SubscriptionFilter.after}'s documented "unpaged if
+     * unsupported" fallback). Rather than trust the store, the fetched rows are
+     * re-filtered here to `id > filter.after` unconditionally — a compliant
+     * store's rows already all satisfy this (the filter is then a no-op cost),
+     * while a store that ignores `after` and keeps returning its same unpaged
+     * window gets its stale (already-delivered) rows dropped before they reach
+     * `deliverPage`. This is what makes `broadcast`'s page-walk both
+     * NEVER-DOUBLE-DELIVER and guaranteed to terminate against such a store:
+     * `nextCursor` only ever advances (each page's eligible rows are, by
+     * construction, all greater than the cursor just used), so the "new since
+     * cursor" window against a fixed-size store response shrinks every
+     * iteration until it empties out.
+     */
+    const broadcastPage = async (payload: PushContent, filter?: SubscriptionFilter): Promise<BroadcastPageResult> => {
+        // `filter.limit`, when set, is an OVERALL cap (see its JSDoc) — never
+        // let a single page exceed it even when the configured page size is larger.
+        const cap = filter?.limit !== undefined && filter.limit > 0 ? Math.trunc(filter.limit) : undefined;
+        const pageSize = cap === undefined ? broadcastPageSize : Math.min(cap, broadcastPageSize);
+
+        const rows = await subscriptionStore.list({ after: filter?.after, kind: filter?.kind, limit: pageSize + 1, userId: filter?.userId });
+        const eligible = filter?.after === undefined ? rows : rows.filter((row) => row.id > (filter.after as string));
+        const hasMore = eligible.length > pageSize;
+        const page = hasMore ? eligible.slice(0, pageSize) : eligible;
+
+        if (page.length === 0 && filter?.after === undefined) {
+            // A broadcast that matched nobody on its FIRST page — surface the
+            // no-op rather than a silent all-zero result (per-send metrics never
+            // fire). Only on the first page so a legitimately-exhausted later
+            // page of an otherwise-nonempty broadcast doesn't also count as a skip.
+            observeSkip("push", "no-subscriptions-matched");
+        }
+
+        const result = await deliverPage(payload, page);
+        const nextCursor = hasMore ? page[page.length - 1]?.id : undefined;
+
+        return { nextCursor, result };
+    };
+
+    /**
+     * Walk every page of `filter`'s matching audience (see
+     * {@link LunoraPush.broadcast}), merging each page's {@link BroadcastResult}
+     * into one aggregate. Stops when a page reports no `nextCursor` — the
+     * normal end, which `broadcastPage`'s defensive re-filter also guarantees
+     * to eventually reach even against a `SubscriptionStore` that ignores
+     * `filter.after` (see its doc comment). The `nextCursor === cursor` check
+     * is an extra backstop against a pathological store whose `nextCursor`
+     * somehow fails to advance despite reporting more rows remain.
+     */
+    const broadcast = async (payload: PushContent, filter?: SubscriptionFilter): Promise<BroadcastResult> => {
+        const aggregate: BroadcastResult = { failed: 0, outcomes: [], pruned: 0, sent: 0, total: 0 };
+        let cursor = filter?.after;
+
+        for (;;) {
+            // eslint-disable-next-line no-await-in-loop -- pages are inherently sequential: page N's cursor comes from page N-1's result
+            const { nextCursor, result } = await broadcastPage(payload, { ...filter, after: cursor });
+
+            aggregate.failed += result.failed;
+            aggregate.pruned += result.pruned;
+            aggregate.sent += result.sent;
+            aggregate.total += result.total;
+            aggregate.outcomes.push(...result.outcomes);
+
+            if (nextCursor === undefined || nextCursor === cursor) {
+                break;
+            }
+
+            cursor = nextCursor;
+        }
+
+        return aggregate;
+    };
+
     const push: LunoraPush = {
-        broadcast: async (payload: PushContent, filter?: SubscriptionFilter): Promise<BroadcastResult> => {
-            const subscriptions = await subscriptionStore.list(filter);
-
-            if (subscriptions.length === 0) {
-                // A broadcast that matched nobody — surface the no-op rather than
-                // returning a silent all-zero result (per-send metrics never fire).
-                observeSkip("push", "no-subscriptions-matched");
-            }
-
-            const rows = await mapWithConcurrency(subscriptions, concurrency, async (subscription) => {
-                // `deliver` is total (it never rejects — a throwing recipient
-                // becomes a `failed` outcome inside it), so the bounded `Promise.all`
-                // pool in `mapWithConcurrency` can never be rejected by one bad send.
-                const { error, status } = await deliver(subscription, payload, false);
-
-                return { error, kind: subscription.kind, status, subscription };
-            });
-
-            // Fold the per-recipient statuses into one metric count per (kind,
-            // status) bucket — at most kinds×3 emits — instead of one durable
-            // SQLite write per recipient. (The per-recipient FAILURE LOGS already
-            // fired inside `deliver`.)
-            const buckets = new Map<string, { count: number; kind: string; status: NotifyDeliveryStatus }>();
-
-            for (const { kind, status } of rows) {
-                const key = `${kind} ${status}`;
-                const bucket = buckets.get(key);
-
-                if (bucket === undefined) {
-                    buckets.set(key, { count: 1, kind, status });
-                } else {
-                    bucket.count += 1;
-                }
-            }
-
-            for (const { count, kind, status } of buckets.values()) {
-                countSend("push", kind, status, count);
-            }
-
-            const outcomes: BroadcastOutcome[] = rows.map(({ error, status, subscription }) => {
-                if (status === "accepted") {
-                    return { id: subscription.id, status: "ok" };
-                }
-
-                return status === "gone" ? { error, id: subscription.id, status: "expired" } : { error, id: subscription.id, status: "failed" };
-            });
-
-            return {
-                failed: outcomes.filter((outcome) => outcome.status === "failed").length,
-                outcomes,
-                pruned: outcomes.filter((outcome) => outcome.status === "expired").length,
-                sent: outcomes.filter((outcome) => outcome.status === "ok").length,
-                total: outcomes.length,
-            };
-        },
+        broadcast,
+        broadcastPage,
         list: (filter?: SubscriptionFilter): Promise<PushSubscriptionDevice[]> => listProjected(filter),
         register: (input: RegisterInput): Promise<StoredSubscription> => {
             // A web-push registration accepts a client-controlled endpoint — the SSRF

--- a/packages/notify/src/notify.ts
+++ b/packages/notify/src/notify.ts
@@ -475,20 +475,37 @@ export const createNotify = (definition: NotifyDefinition, env: NotifyEnv, optio
      * `filter.after` (see its doc comment). The `nextCursor === cursor` check
      * is an extra backstop against a pathological store whose `nextCursor`
      * somehow fails to advance despite reporting more rows remain.
+     *
+     * `filter.limit`, when set, is a CUMULATIVE cap across the whole walk (see
+     * its JSDoc) — `broadcastPage` itself only enforces `limit` as a per-page
+     * cap, so each page here is handed the shrinking REMAINING budget
+     * (`overallLimit - aggregate.total`) rather than the original `filter.limit`
+     * unmodified; forwarding it verbatim would let every page reach up to
+     * `limit` MORE subscriptions instead of the whole broadcast topping out
+     * there. The walk also stops as soon as the cumulative total meets the cap,
+     * even if more pages remain.
      */
     const broadcast = async (payload: PushContent, filter?: SubscriptionFilter): Promise<BroadcastResult> => {
         const aggregate: BroadcastResult = { failed: 0, outcomes: [], pruned: 0, sent: 0, total: 0 };
         let cursor = filter?.after;
+        const overallLimit = filter?.limit;
 
         for (;;) {
+            const pageFilter: SubscriptionFilter | undefined =
+                overallLimit === undefined ? { ...filter, after: cursor } : { ...filter, after: cursor, limit: overallLimit - aggregate.total };
+
             // eslint-disable-next-line no-await-in-loop -- pages are inherently sequential: page N's cursor comes from page N-1's result
-            const { nextCursor, result } = await broadcastPage(payload, { ...filter, after: cursor });
+            const { nextCursor, result } = await broadcastPage(payload, pageFilter);
 
             aggregate.failed += result.failed;
             aggregate.pruned += result.pruned;
             aggregate.sent += result.sent;
             aggregate.total += result.total;
             aggregate.outcomes.push(...result.outcomes);
+
+            if (overallLimit !== undefined && aggregate.total >= overallLimit) {
+                break;
+            }
 
             if (nextCursor === undefined || nextCursor === cursor) {
                 break;

--- a/packages/notify/src/queue.ts
+++ b/packages/notify/src/queue.ts
@@ -1,14 +1,16 @@
 import { LunoraError } from "@lunora/errors";
 
-import type { BroadcastResult, LunoraPush, PushContent, SubscriptionFilter } from "./types";
+import type { BroadcastPageResult, LunoraPush, PushContent, SubscriptionFilter } from "./types";
 
 /**
  * A broadcast job body — the JSON-serialisable payload enqueued for off-request
  * fan-out. Shaped to travel through a `@lunora/queue` producer/consumer without
  * `@lunora/notify` depending on `@lunora/queue` (the seam stays structural).
+ * `filter.after`, when set, resumes a broadcast partway through (see
+ * {@link runPushBroadcastJob}'s continuation semantics).
  */
 export interface PushBroadcastJob {
-    /** Subscription filter (which devices/users to target). */
+    /** Subscription filter (which devices/users to target; `filter.after` resumes a paged broadcast). */
     filter?: SubscriptionFilter;
     /** The push payload to deliver (the `to` target is derived per subscription). */
     payload: PushContent;
@@ -24,7 +26,8 @@ export interface QueueProducerLike {
 /**
  * Enqueue a fan-out broadcast for background delivery through a `@lunora/queue`
  * queue instead of blocking the request. Pair with {@link runPushBroadcastJob} in
- * the queue consumer.
+ * the queue consumer — see its doc comment for how a large audience continues
+ * across MULTIPLE messages (one bounded page per message), not one.
  *
  * ```ts
  * // in a mutation/action:
@@ -32,7 +35,18 @@ export interface QueueProducerLike {
  *
  * // in lunora/queues.ts consumer:
  * export const push = defineQueue({ async handler(batch, ctx) {
- *     for (const message of batch.messages) await runPushBroadcastJob(ctx.push, message.body);
+ *     for (const message of batch.messages) {
+ *         const { nextCursor } = await runPushBroadcastJob(ctx.push, message.body);
+ *
+ *         if (nextCursor !== undefined) {
+ *             // More pages remain — enqueue the continuation. Each message still
+ *             // does only ONE bounded page of work.
+ *             await enqueuePushBroadcast(ctx.queues.push, {
+ *                 payload: message.body.payload,
+ *                 filter: { ...message.body.filter, after: nextCursor },
+ *             });
+ *         }
+ *     }
  * }});
  * ```
  */
@@ -40,31 +54,50 @@ export const enqueuePushBroadcast = (queue: QueueProducerLike, job: Omit<PushBro
     queue.send({ ...job, type: "lunora.push.broadcast" });
 
 /**
- * Run an enqueued broadcast job on the consumer side, delivering through the push
- * facade (which reuses the engine's retry + circuit-breaker middleware and prunes
- * gone subscriptions).
+ * Run ONE bounded page of an enqueued broadcast job on the consumer side,
+ * delivering through the push facade's {@link LunoraPush.broadcastPage} (which
+ * reuses the engine's retry + circuit-breaker middleware and prunes gone
+ * subscriptions).
  *
- * RETRY SEMANTICS: retry is gated on `failed` — the count of TRANSIENT delivery
- * errors (a provider 5xx / network fault worth another attempt). When at least one
- * recipient `failed`, the job is RE-THROWN so the queue does NOT ack it and its
- * normal retry/backoff (and, on exhaustion, dead-letter) applies. A broadcast with
- * zero `failed` resolves and is acked — this includes the all-`pruned` case (every
- * device had unsubscribed: `sent:0`, `failed:0`, `pruned:N`), which is a SUCCESSFUL
- * prune, not a failure, so throwing on it would spuriously retry and pressure the
- * DLQ; and the empty audience (zero `total`), which has nothing to retry. Note a
- * retry re-runs the WHOLE broadcast, re-sending to the already-delivered recipients
- * (broadcast is not idempotent) — the accepted cost of getting the transiently
- * failed ones redelivered.
+ * RETRY / CONTINUATION SEMANTICS (rewritten for plan 222 / NOTIFY-01 — a
+ * broadcast job used to process the WHOLE audience in one message, which could
+ * exceed Worker CPU/wall limits for a large audience and made a retry re-run
+ * everything):
+ *
+ * - A job now processes exactly ONE bounded page (see `CreateNotifyOptions`'s
+ * page-size option, default 250, or `job.filter.limit` when smaller),
+ * keyset-paginated on the subscription `id` (see `SubscriptionFilter.after`)
+ * — so per-message work is bounded regardless of total audience size.
+ * - Retry is still gated on `result.failed` — the count of TRANSIENT delivery
+ * errors (a provider 5xx / network fault worth another attempt). When at
+ * least one recipient in THIS PAGE `failed`, the job is RE-THROWN so the
+ * queue does NOT ack it and its normal retry/backoff (and, on exhaustion,
+ * dead-letter) applies — to just this page, not the whole broadcast.
+ * - A page with zero `failed` resolves and is acked — this includes the
+ * all-`pruned` case (every device on the page had unsubscribed:
+ * `sent:0`, `failed:0`, `pruned:N`), which is a SUCCESSFUL prune, not a
+ * failure, so throwing on it would spuriously retry and pressure the DLQ;
+ * and the empty-page case (zero `total`), which has nothing to retry.
+ * - The returned `nextCursor` is set when more pages remain. `@lunora/notify`
+ * does NOT enqueue the continuation itself — it has no `@lunora/queue`
+ * dependency (the seam stays structural) and no reference to the producer
+ * that enqueued this message — so the CALLER (the `lunora/queues.ts`
+ * consumer) is responsible for re-enqueueing with `filter.after: nextCursor`
+ * when present. See the consumer example on {@link enqueuePushBroadcast}.
+ * - A retry of a page redelivers only that page's already-delivered recipients
+ * on a transient partial failure (a page is not individually idempotent) —
+ * the accepted cost of getting the transiently failed ones redelivered, now
+ * scoped to one page instead of the whole broadcast.
  */
-export const runPushBroadcastJob = async (push: LunoraPush, job: PushBroadcastJob): Promise<BroadcastResult> => {
-    const result = await push.broadcast(job.payload, job.filter);
+export const runPushBroadcastJob = async (push: LunoraPush, job: PushBroadcastJob): Promise<BroadcastPageResult> => {
+    const page = await push.broadcastPage(job.payload, job.filter);
 
-    if (result.failed > 0) {
+    if (page.result.failed > 0) {
         throw new LunoraError(
             "INTERNAL",
-            `@lunora/notify: push broadcast had ${result.failed.toString()} transient failure(s) of ${result.total.toString()} subscription(s) (${result.sent.toString()} sent, ${result.pruned.toString()} pruned) — throwing so the queue retries`,
+            `@lunora/notify: push broadcast page had ${page.result.failed.toString()} transient failure(s) of ${page.result.total.toString()} subscription(s) (${page.result.sent.toString()} sent, ${page.result.pruned.toString()} pruned) — throwing so the queue retries this page`,
         );
     }
 
-    return result;
+    return page;
 };

--- a/packages/notify/src/subscriptions/d1-store.ts
+++ b/packages/notify/src/subscriptions/d1-store.ts
@@ -169,6 +169,14 @@ const d1SubscriptionStore = (database: D1Like, options: D1StoreOptions = {}): Su
                 subscription.keys?.auth ?? null,
                 subscription.token ?? null,
                 subscription.userId ?? null,
+                // A `StoredSubscription.metadata` built via `normalizeRegisterInput`
+                // has already round-tripped through `JSON.stringify` once at
+                // validation time (see `validateMetadata`, NOTIFY-02), so this
+                // re-serialisation of the same pure, unchanged object cannot throw
+                // mid-write for a subscription that reached `register()` — only a
+                // hand-built `StoredSubscription` bypassing normalize (a test, or a
+                // caller writing directly to the store) could still supply a
+                // non-serialisable value here.
                 subscription.metadata === undefined ? null : JSON.stringify(subscription.metadata),
                 subscription.createdAt,
                 subscription.lastSeenAt,
@@ -225,7 +233,19 @@ const d1SubscriptionStore = (database: D1Like, options: D1StoreOptions = {}): Su
             }
         }
 
+        if (filter?.after !== undefined) {
+            // Keyset pagination cursor: only rows strictly past the last id of the
+            // previous page. Paired with `ORDER BY id ASC` below — see
+            // `SubscriptionFilter.after`.
+            bindings.push(filter.after);
+            clauses.push(`id > ?${bindings.length.toString()}`);
+        }
+
         const where = clauses.length === 0 ? "" : ` WHERE ${clauses.join(" AND ")}`;
+        // Deterministic ascending order by `id` is required for `after` to page
+        // correctly (and for parity with the memory store's explicit sort) —
+        // without it, D1/SQLite gives no ordering guarantee across pages.
+        const orderBy = " ORDER BY id ASC";
 
         let limit = "";
 
@@ -237,7 +257,7 @@ const d1SubscriptionStore = (database: D1Like, options: D1StoreOptions = {}): Su
         }
 
         const { results } = await database
-            .prepare(`SELECT * FROM ${table}${where}${limit}`)
+            .prepare(`SELECT * FROM ${table}${where}${orderBy}${limit}`)
             .bind(...bindings)
             .all<Row>();
 

--- a/packages/notify/src/subscriptions/memory-store.ts
+++ b/packages/notify/src/subscriptions/memory-store.ts
@@ -1,6 +1,15 @@
 import type { StoredSubscription, SubscriptionFilter, SubscriptionStatus, SubscriptionStore } from "../types";
 import { legacyIdFor } from "./normalize";
 
+/** Ascending `id` comparator — pairs with the D1 store's `ORDER BY id ASC`. */
+const compareById = (a: StoredSubscription, b: StoredSubscription): number => {
+    if (a.id < b.id) {
+        return -1;
+    }
+
+    return a.id > b.id ? 1 : 0;
+};
+
 const matches = (subscription: StoredSubscription, filter?: SubscriptionFilter): boolean => {
     if (filter === undefined) {
         return true;
@@ -42,9 +51,18 @@ const memorySubscriptionStore = (): SubscriptionStore => {
                 }
             }
 
+            // Keyset-paginate: sort ascending by `id` (Map iteration order is
+            // INSERTION order, not `id` order, so this is required for a stable,
+            // deterministic page boundary — see `SubscriptionFilter.after`), then
+            // drop everything at/before the cursor. Mirrors the D1 store's
+            // `ORDER BY id ASC` + `id > ?`.
+            result.sort(compareById);
+
+            const paged = filter?.after === undefined ? result : result.filter((subscription) => subscription.id > (filter.after as string));
+
             // Honor `limit` for parity with the D1 store's `LIMIT` (a non-positive
             // value means "no cap").
-            const capped = filter?.limit !== undefined && filter.limit > 0 ? result.slice(0, Math.trunc(filter.limit)) : result;
+            const capped = filter?.limit !== undefined && filter.limit > 0 ? paged.slice(0, Math.trunc(filter.limit)) : paged;
 
             return Promise.resolve(capped);
         },

--- a/packages/notify/src/subscriptions/normalize.ts
+++ b/packages/notify/src/subscriptions/normalize.ts
@@ -9,6 +9,68 @@ interface LooseSubscription {
     keys?: { auth?: unknown; p256dh?: unknown };
 }
 
+/**
+ * Cap on a `register()` input's serialised `metadata` size (NOTIFY-02): a
+ * client controls this field end-to-end, and it is `JSON.stringify`'d
+ * straight into the D1 row with no prior shape/size check, so an
+ * unbounded value lets a client persist an arbitrarily large blob per
+ * subscription. A few KB is comfortably enough for the documented use
+ * (device name, locale, topic tags) while bounding worst-case row growth.
+ */
+const MAX_METADATA_BYTES = 4096;
+
+/**
+ * Validate a `register()` input's `metadata` (NOTIFY-02) before it is
+ * STORED: must be a plain object (not an array, class instance, or
+ * primitive — those are legal `typeof "object"` values a client could send
+ * despite the `Record&lt;string, unknown&gt;` type, since the input crosses an RPC
+ * boundary untyped at runtime), must be JSON-serialisable (a circular
+ * reference or a `BigInt` value makes `JSON.stringify` throw), and its
+ * serialised form must not exceed {@link MAX_METADATA_BYTES}.
+ *
+ * Serialising here — ONCE, at validation time — rather than leaving it to
+ * the store means the later `JSON.stringify(subscription.metadata)` inside
+ * `d1SubscriptionStore.put` (a pure, deterministic re-serialisation of the
+ * SAME already-proven-serialisable object) can no longer throw mid-write: by
+ * the time a `StoredSubscription` reaches any store, its `metadata` has
+ * already round-tripped through `JSON.stringify` successfully once here.
+ */
+const validateMetadata = (metadata: unknown): Record<string, unknown> | undefined => {
+    if (metadata === undefined) {
+        return undefined;
+    }
+
+    const prototype: unknown = typeof metadata === "object" && metadata !== null ? Object.getPrototypeOf(metadata) : undefined;
+    const isPlainObject =
+        typeof metadata === "object" && metadata !== null && !Array.isArray(metadata) && (prototype === Object.prototype || prototype === null);
+
+    if (!isPlainObject) {
+        throw new LunoraError("BAD_REQUEST", "@lunora/notify: register() `metadata` must be a plain object");
+    }
+
+    let serialized: string;
+
+    try {
+        serialized = JSON.stringify(metadata);
+    } catch (error) {
+        throw new LunoraError(
+            "BAD_REQUEST",
+            `@lunora/notify: register() \`metadata\` is not JSON-serialisable: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+
+    const byteLength = new TextEncoder().encode(serialized).length;
+
+    if (byteLength > MAX_METADATA_BYTES) {
+        throw new LunoraError(
+            "BAD_REQUEST",
+            `@lunora/notify: register() \`metadata\` is ${byteLength.toString()} bytes, exceeding the ${MAX_METADATA_BYTES.toString()}-byte cap`,
+        );
+    }
+
+    return metadata as Record<string, unknown>;
+};
+
 /** One 16-bit limb of a 64-bit hash as 4 lowercase hex digits. */
 const hex4 = (limb: number): string => limb.toString(16).padStart(4, "0");
 
@@ -210,7 +272,8 @@ const assertPushEndpoint = (endpoint: string, allowedPushOrigins?: string[]): vo
  * Normalise a `register(...)` input into a {@link StoredSubscription}. Validates
  * the shape (a web-push subscription needs `endpoint` + `keys.{p256dh,auth}`; an
  * FCM entry needs a non-empty `token`), enforces the anti-SSRF endpoint boundary
- * (see {@link assertPushEndpoint}), and stamps `createdAt`/`lastSeenAt`.
+ * (see {@link assertPushEndpoint}), validates `metadata` (see
+ * {@link validateMetadata}), and stamps `createdAt`/`lastSeenAt`.
  */
 const normalizeRegisterInput = (input: RegisterInput, now: number = Date.now(), options: NormalizeOptions = {}): StoredSubscription => {
     if ("token" in input) {
@@ -220,7 +283,15 @@ const normalizeRegisterInput = (input: RegisterInput, now: number = Date.now(), 
             throw new LunoraError("BAD_REQUEST", "@lunora/notify: register() fcm input requires a non-empty `token`");
         }
 
-        return { createdAt: now, id: fcmId(token), kind: "fcm", lastSeenAt: now, metadata: input.metadata, token, userId: input.userId ?? null };
+        return {
+            createdAt: now,
+            id: fcmId(token),
+            kind: "fcm",
+            lastSeenAt: now,
+            metadata: validateMetadata(input.metadata),
+            token,
+            userId: input.userId ?? null,
+        };
     }
 
     const subscription = parseSubscription(input.subscription);
@@ -241,7 +312,7 @@ const normalizeRegisterInput = (input: RegisterInput, now: number = Date.now(), 
         keys: { auth, p256dh },
         kind: "web-push",
         lastSeenAt: now,
-        metadata: input.metadata,
+        metadata: validateMetadata(input.metadata),
         userId: input.userId ?? null,
     };
 };

--- a/packages/notify/src/types.ts
+++ b/packages/notify/src/types.ts
@@ -69,6 +69,31 @@ export type RegisterInput =
 
 /** Filter narrowing which stored subscriptions a `list`/`broadcast` targets. */
 export interface SubscriptionFilter {
+    /**
+     * Keyset pagination cursor: return only rows with `id` strictly GREATER
+     * than this value, ordered ascending by `id`. `id` is a stable,
+     * content-derived hash (see `webPushId`/`fcmId`), so ordering by it is
+     * immune to concurrent inserts/deletes elsewhere in the table — a page
+     * already walked never re-delivers or skips a row when another device
+     * registers mid-broadcast (the reviewer-flagged "stable under concurrent
+     * registers" property). `broadcastPage`/`broadcast` set this internally to
+     * walk pages; a direct `list()` caller may also page through results with
+     * it.
+     *
+     * OPTIONAL for a reason: `SubscriptionStore` is implementable outside this
+     * package. An external store that does not support cursoring may ignore
+     * `after` entirely and keep returning its (from-the-top) unpaged result —
+     * `broadcastPage` defensively re-filters whatever the store returns down
+     * to `id > after` itself, so a non-cursoring store can never cause a
+     * double-send or an infinite page-walk (each page's result only ever
+     * contains ids the previous page didn't already deliver), but it also
+     * cannot deliver the FULL matched audience beyond whatever the store's own
+     * (unpaged) response window happens to contain — implement `after`
+     * (ordered ascending by `id`, exclusive) to get real, complete pagination
+     * over a large audience.
+     */
+    after?: string;
+
     /** Restrict to a delivery kind. */
     kind?: SubscriptionKind;
 
@@ -76,8 +101,15 @@ export interface SubscriptionFilter {
      * Cap the number of rows returned (a `LIMIT`). Applied server-side by the
      * store, so a large audience never materializes wholesale in the isolate.
      * A non-positive/absent value means "no cap"; a fractional value is truncated.
-     * `broadcast` deliberately leaves this unset (it must reach every matched
-     * device); admin/list reads set it to bound the page.
+     *
+     * For `list`/admin reads this bounds the returned page as before. For
+     * `broadcast`, this is now an OVERALL cap on the total number of
+     * subscriptions reached across every internally-walked page (still
+     * deliberately left unset by default — it must reach every matched
+     * device); the PER-PAGE batch size is a separate, independent knob (see
+     * `CreateNotifyOptions`'s `broadcastPageSize`, default 250) so a caller
+     * that sets `limit` to bound the audience doesn't also have to reason
+     * about page sizing.
      */
     limit?: number;
     /** Restrict to a single owning user. */
@@ -94,7 +126,14 @@ export interface SubscriptionStore {
     delete: (id: string) => Promise<void>;
     /** Read a subscription by id, or `undefined`. */
     get: (id: string) => Promise<StoredSubscription | undefined>;
-    /** List subscriptions, optionally filtered. */
+
+    /**
+     * List subscriptions, optionally filtered. When `filter.after` is set,
+     * results are keyset-paginated: only rows with `id` strictly greater than
+     * `filter.after` are returned, ordered ascending by `id`. Implementing
+     * `after` is OPTIONAL (see {@link SubscriptionFilter.after}) — a store
+     * that ignores it may keep returning its unpaged result.
+     */
     list: (filter?: SubscriptionFilter) => Promise<StoredSubscription[]>;
     /** Record the latest delivery outcome for a subscription (best-effort). */
     markStatus: (id: string, status: SubscriptionStatus, error?: string) => Promise<void>;
@@ -124,6 +163,19 @@ export interface BroadcastResult {
     sent: number;
     /** Total subscriptions attempted. */
     total: number;
+}
+
+/**
+ * Result of `broadcastPage` — one bounded page of a fan-out, plus the cursor
+ * to fetch the next page. `nextCursor` is `undefined` when this was the last
+ * page (or the store doesn't support cursoring — see
+ * {@link SubscriptionFilter.after}'s documented unpaged fallback).
+ */
+export interface BroadcastPageResult {
+    /** Cursor for the next page (pass as `filter.after`), or `undefined` when done. */
+    nextCursor?: string;
+    /** The delivery outcome for just this page. */
+    result: BroadcastResult;
 }
 
 /**
@@ -184,8 +236,29 @@ export interface LunoraPush {
      * Reuses the engine's retry/circuit-breaker middleware; prunes subscriptions
      * the push service reports as gone (HTTP 404/410, FCM `UNREGISTERED`). The `to`
      * target is derived from each subscription, so it is omitted from the payload.
+     *
+     * Internally walks the audience in bounded pages (via {@link LunoraPush.broadcastPage},
+     * keyset-paginated on the subscription `id`) so a huge audience is never
+     * materialized wholesale in the isolate — see `CreateNotifyOptions`'s
+     * `broadcastPageSize`. This call still processes the WHOLE matched
+     * audience in one request/queue message; use {@link LunoraPush.broadcastPage}
+     * directly (as `runPushBroadcastJob` does) to bound a single queue message
+     * to one page.
      */
     broadcast: (payload: PushContent, filter?: SubscriptionFilter) => Promise<BroadcastResult>;
+
+    /**
+     * Fan-out a push to ONE bounded page of stored subscriptions matching
+     * `filter` (page size: `CreateNotifyOptions`'s `broadcastPageSize`, default
+     * 250, capped by `filter.limit` when set). Same delivery semantics as
+     * {@link LunoraPush.broadcast} (retry/circuit-breaker, gone-pruning) but
+     * scoped to a single page; returns the page's own {@link BroadcastResult}
+     * plus a `nextCursor` to fetch the next page (`undefined` when done).
+     * Backs `runPushBroadcastJob` so one queue message does bounded work
+     * regardless of audience size — most app code should call
+     * {@link LunoraPush.broadcast} instead.
+     */
+    broadcastPage: (payload: PushContent, filter?: SubscriptionFilter) => Promise<BroadcastPageResult>;
 
     /**
      * List stored subscriptions (optionally filtered), with the delivery

--- a/plans/241-inapp-inbox-design.md
+++ b/plans/241-inapp-inbox-design.md
@@ -1,0 +1,313 @@
+# Plan 241 — In-app inbox read half (design spike)
+
+**Baseline:** `2d4f71511`
+**Status:** SPIKE COMPLETE — memory prototype shipped; D1 backend and the
+reactive `useInbox` client hook are design-only, pending the STOP-gated
+decision in §5.
+
+## 0. Headline finding
+
+`@lunora/notify` can SEND an in-app notification (`ctx.notify.inApp(payload)`
+dispatches through the `inApp` provider) but a user can never READ their
+notification center back — there is no persisted inbox, no unread count, no
+read receipt. The package says so verbatim at `packages/notify/src/types.ts`
+(`NotifyDeliveryStatus`'s doc comment): "The one place a later `seen`/`read`
+is real is the in-app inbox, where the client posts a read receipt back — out
+of scope here." This spike scopes the READ half: persist, list, unread count,
+mark-read.
+
+## 1. Current state (audit)
+
+- `packages/notify/src/providers.ts:82,107-108` — `inApp` is wired into the
+  `@visulima/notification` engine as a plain dispatch provider
+  (`providers.inapp = resolved.inApp`), same as chat/webhook. It sends and
+  forgets; nothing persists the payload.
+- `packages/notify/src/notify.ts` — `notify.inApp(payload)` calls
+  `sendToChannel("inapp", payload)`, which counts a metric and returns a
+  `Receipt`. No store is touched.
+- `packages/notify/src/subscriptions/` holds the **device**-subscription
+  store (`StoredSubscription`: Web Push endpoint / FCM token, keyed by a
+  content-hash id) — this backs push DELIVERY targets, not inbox CONTENT. It
+  has no `userId`-scoped content list, no read state.
+- `packages/notify/src/queue.ts` (plan 222) established the
+  `after`/`limit` keyset-pagination shape (`SubscriptionFilter`) this spike's
+  `ListInboxFilter` deliberately reuses the field names of, for a consistent
+  package-wide pagination vocabulary — see §4.4 for why the ORDER differs.
+- `InAppPayload` (`@visulima/notification`) already carries `to: string`
+  ("Subscriber id the notification belongs to"), `title?`, `body`, `data?`,
+  `actions?` — i.e. it already IS shaped like an inbox item's content plus a
+  recipient. See §2.
+
+## 2. Existing seams (do not reinvent)
+
+- **`SubscriptionStore` pattern** (`packages/notify/src/types.ts`,
+  `subscriptions/{memory,d1}-store.ts`): a small persistence interface with a
+  memory default + a D1-backed implementation, wired into `defineNotify` via
+  an optional `store: (env) => SubscriptionStore` factory, falling back to a
+  non-durable memory store with a one-time dev warning when unset. The
+  prototype in this spike (`packages/notify/src/inbox/`) mirrors this shape
+  exactly (`InboxStore`, `memoryInboxStore()`) so a future `d1InboxStore()`
+  slots in the same way — see §4.1.
+- **Plan 222's keyset cursor** (`SubscriptionFilter.after`/`limit`): ascending
+  by a sortable `id`, exclusive cursor, page-size independent of the "total
+  cap" `limit`. `ListInboxFilter` reuses the `{ after, limit }` field names
+  for a consistent vocabulary but the ORDER is reversed (newest-first) — see
+  §4.4, this is a deliberate divergence, not an oversight.
+- **`PushContent = Omit<PushPayload, "to">`** (`packages/notify/src/types.ts`):
+  the existing pattern for "the engine payload minus the recipient, because
+  the recipient is carried by the surrounding call/record instead." This
+  spike's `InboxContent = Omit<InAppPayload, "to">` is the same move applied
+  to `InAppPayload` — see §4.1.
+- **Lunora's reactive query pipeline** (`ctx.db` tables +
+  `useQuery`/`useSubscription`, `@lunora/do`'s per-shard SQLite + OCC +
+  hibernated WS subscriptions): the ONLY mechanism in this codebase that
+  already delivers "the client sees a new row without polling." Central to
+  §5's live-delivery recommendation — do not invent a second live-delivery
+  mechanism if this one reaches.
+
+## 3. The behavioural contract to preserve
+
+- `packages/notify/src/types.ts`'s `NotifyDeliveryStatus` doc comment's
+  "out of scope here" note for read receipts must be either reconciled (this
+  spike does NOT remove it — see §7, it stays accurate: `notify.inApp` itself
+  still doesn't touch read state, only a configured `InboxStore` would) or
+  updated in the same change that wires the receipt into `notify.inApp`.
+  **Not done in this spike** — `send`/`broadcast` are explicitly out of scope
+  (SCOPE note in the originating plan).
+- `notify.inApp(payload)`'s current behavior (dispatch-only, returns a
+  `Receipt`, no persistence) must be UNCHANGED by this spike. Verified: no
+  edits to `notify.ts`, `providers.ts`, or `queue.ts`; `packages/notify/__tests__/notify.test.ts`'s
+  existing suite passes unmodified (108 tests total across the package, up
+  from 96 after plan 222 — the +12 are the new `inbox.test.ts`).
+
+## 4. Design decisions
+
+### 4.1 Store shape
+
+```ts
+interface InboxItem {
+    id: string; // store-assigned, monotonically sortable
+    userId: string; // owning user — always present, never anonymous
+    payload: InboxContent; // Omit<InAppPayload, "to"> — title/body/data/actions
+    category?: string; // coarse filter tag, e.g. "billing" | "social"
+    groupKey?: string; // client-collapsing key, e.g. "comment:42" — NOT interpreted by the store (§4.5)
+    createdAt: number; // unix-ms
+    readAt?: number; // unix-ms, undefined while unread
+}
+```
+
+Relation to the device-subscription store: **none at the storage level, only
+at the call-site level.** `SubscriptionStore` answers "which physical
+devices/browsers does this user have, and how do I push to them" (many rows
+per user, content-hash keyed, no notion of "read"). `InboxStore` answers
+"what has this user been told, and have they seen it" (one row per
+notification, counter-keyed, no notion of a device). A future combined
+send helper could write to BOTH stores for one logical notification (push a
+device alert AND persist an inbox row), but that is a `send`/`broadcast`
+change and is explicitly out of scope here (see the originating plan's
+SCOPE note).
+
+Rejected alternative: folding inbox rows into `StoredSubscription` (add
+`readAt`/`payload` fields there). Rejected because a subscription is
+PER-DEVICE (a user with 3 browsers has 3 subscription rows) while an inbox
+item is PER-EVENT PER-USER — conflating them would multiply inbox rows by
+device count for no reason, and complicate the subscription store's already
+delicate legacy-id-migration logic (`normalize.ts`) with unrelated fields.
+
+### 4.2 Write-coupling: does `ctx.notify.inApp(...)` persist?
+
+**Recommendation: yes, but opt-in — only when an inbox store is
+configured**, mirroring `defineNotify`'s existing `store?: (env) =>
+SubscriptionStore` pattern:
+
+```ts
+export default defineNotify({
+    inApp: (env) => someInAppProvider(env),
+    inboxStore: (env) => d1InboxStore(env.DB), // NEW, optional
+});
+```
+
+When `inboxStore` is configured, `notify.inApp(payload)` would ALSO call
+`inboxStore.append({ userId: payload.to, payload: rest, category, groupKey })`
+after (or alongside) the provider dispatch — `payload.to` already carries the
+recipient, so no new parameter is needed at the call site. When unset,
+`inApp` keeps today's dispatch-only behavior byte-for-byte (no behavior
+change for an app that hasn't opted in).
+
+Rejected alternative: always persist unconditionally. Rejected because (a) it
+would force every `@lunora/notify` consumer into owning inbox storage/rows
+even if they never show a notification center, and (b) it breaks the
+"unconfigured falls back safely" pattern the rest of `defineNotify` follows
+(`store` unset → memory + warning, never a silent behavior change on an
+unrelated call).
+Rejected alternative: a separate explicit `ctx.inbox.append(...)` call site
+instead of piggybacking on `notify.inApp`. Rejected because it would require
+every call site to remember to call both — the coupling is exactly the kind
+of "forget once, it's silently broken" gap this spike exists to close, and
+the WHY section's motivating gap ("send but can't read back") is specifically
+about `inApp` sends not becoming inbox rows.
+
+### 4.3 Query surface
+
+```ts
+listInbox(userId: string, filter?: { after?: string; limit?: number; unreadOnly?: boolean }): Promise<InboxItem[]>
+unreadCount(userId: string): Promise<number>
+```
+
+Reuses plan 222's `{ after, limit }` field names for a consistent
+package-wide pagination vocabulary. `unreadOnly` is new (no push-subscription
+equivalent — a device subscription has no "unread").
+
+### 4.4 Why `after` is reversed from plan 222
+
+Plan 222's `SubscriptionFilter.after` pages ASCENDING by id — appropriate for
+a `broadcast` walking a whole audience in some order, order doesn't matter to
+the sender. An inbox is a notification CENTER: a user expects the newest
+item on top, exactly like every inbox/feed UI. So `listInbox` is
+**newest-first**, and `after` means "strictly OLDER than this cursor" (a
+smaller id in this scheme) rather than "greater than." The prototype's ids
+are a monotonically increasing per-store counter (`inbox_000000000042`), so
+descending-id order IS descending-chronological order; a real backend would
+use an equivalent sortable scheme (ULID, a D1 autoincrement rowid, a
+`(createdAt, id)` compound key). This is documented in
+`packages/notify/src/inbox/types.ts` on `ListInboxFilter.after` directly, so
+a reader hitting one cursor shape after the other doesn't assume they match.
+
+### 4.5 Receipt
+
+```ts
+markRead(id: string): Promise<void>       // idempotent — no-op if already read or unknown id
+markAllRead(userId: string): Promise<number>  // returns count actually changed
+```
+
+No `markUnread` — flagged as an open question (§6.1), not decided here.
+
+### 4.6 Reactive delivery mechanism
+
+This is the load-bearing decision this spike exists to make **a
+recommendation, not a build**, on (see the STOP condition in the originating
+plan). Three options considered:
+
+**Option A — Lunora-native reactive table (recommended).** `@lunora/notify`
+ships a schema-merge helper (an `inboxTable()` fragment an app splices into
+its own `defineSchema`, or a `vis generate lunora-inbox` scaffold mirroring
+the other generators) plus generated `listInbox`/`unreadCount` queries and a
+`markRead` mutation. Reactivity is then **free** — it comes from the exact
+same `ctx.db` + per-shard SQLite/OCC + `useQuery`/`useSubscription` pipeline
+every other live Lunora read already uses (`packages/do`'s `ShardDO`). No new
+live-delivery mechanism to design, build, or maintain.
+Cost: this is an architectural expansion of `@lunora/notify`'s footprint — it
+currently owns ONLY its own D1 tables outside the app's reactive schema graph
+(lazily `CREATE TABLE IF NOT EXISTS`'d by `d1SubscriptionStore`), the same
+shape this spike's `d1InboxStore` (not built) would naturally take if it just
+mirrored `d1SubscriptionStore`. Option A means the inbox does NOT mirror that
+pattern — it becomes the first `@lunora/notify` feature backed by an
+app-schema table instead of a package-private one, which is a real
+precedent-setting change, not a routine store addition.
+
+**Option B — Poll-based `useInbox`.** No new mechanism: `useInbox()` polls
+`listInbox`/`unreadCount` on an interval or on window focus/visibility
+change. Works with ANY backend, including a package-private D1 store
+(`d1InboxStore` mirroring `d1SubscriptionStore` exactly, zero schema-graph
+change). Con: not truly live (visible staleness up to the poll interval),
+adds steady request volume proportional to connected clients.
+
+**Option C — Piggyback the existing WS connection with a custom event.** The
+client already holds a live per-shard WebSocket for query subscriptions
+(`@lunora/do`'s hibernated WS subscriptions, `@lunora/client`). The server
+could push an out-of-band `"inbox:new"` message over that socket when
+`notify.inApp()` fires for a session known to be connected, and `useInbox()`
+listens and refetches/patches locally. Con: needs `@lunora/notify` to reach
+into `@lunora/do`'s session/WS registry — a new cross-package coupling
+(structurally similar in spirit to the `@lunora/queue` seam from plan 222,
+but for OUTBOUND delivery into a live connection rather than a triggered
+job) that does not exist today and would need its own design pass.
+
+**Recommendation: Option A for the eventual 1.0-quality inbox** (reuses
+proven, already-hardened infrastructure — no new live-delivery mechanism is
+ever the safer choice when one already reaches). **Option B as the pragmatic
+interim** if Option A's schema-graph footprint expansion is rejected or
+deferred — it is strictly less work and compatible with the D1-store
+prototype shape already sketched in §4.1/§2. **Option C is not recommended**
+unless both A and B are ruled out; it is the most bespoke and highest-risk of
+the three.
+
+**This spike stops here, at the recommendation** — no reactive delivery
+mechanism is implemented, and the memory prototype in
+`packages/notify/src/inbox/` deliberately says nothing about which option a
+D1 backend will eventually pick (it is a query/receipt-surface proof, not a
+delivery-mechanism proof).
+
+## 5. STOP condition reached
+
+Per the originating plan: **"live inbox delivery requires a mechanism notify
+can't reach (it would need to own a Lunora table + subscription) — document
+the options and stop at the recommendation, don't force one."** §4.6's Option
+A is exactly this case — a live inbox that reuses Lunora's reactive pipeline
+requires `@lunora/notify` to either own (part of) the app's schema or
+generate code into it, which today it does not do anywhere else in the
+package. This is documented above with a recommendation; it is intentionally
+NOT implemented in this spike.
+
+## 6. Open questions (answer during execution)
+
+1. **Dispatch-persists vs. explicit opt-in call.** §4.2 recommends
+   `inboxStore` config gates automatic persistence on `notify.inApp()`
+   (opt-in AT THE `defineNotify` LEVEL, but automatic once configured, not a
+   second call site). Confirm this is the desired ergonomics before building
+   the D1 store — an app author who wants inbox rows only for SOME `inApp`
+   sends (not all) would need an escape hatch this design doesn't yet have.
+2. **Live delivery mechanism — Option A vs B vs C (§4.6).** Blocks the
+   `useInbox` hook's contract (a thin `useQuery` wrapper under Option A looks
+   nothing like a polling hook under Option B). Needs a decision before any
+   client-hook work starts.
+3. **Retention / cap.** An inbox is unbounded by construction (every send
+   appends). Options: (a) TTL-based expiry (cron-swept, needs
+   `@lunora/scheduler`), (b) a per-user row cap (evict oldest beyond N on
+   append, no cron needed, bounded storage cost), (c) no built-in cap
+   (document it as the app's responsibility, maybe an `@lunora/advisor` lint
+   for an inbox table past some row-count threshold). Leaning (b) as the
+   safer default with (a) as an optional additional layer, but there's no
+   usage data yet to size N or a TTL against.
+4. **Grouping/collapsing.** `groupKey` exists on `InboxItem` (§4.1) but the
+   prototype does not collapse/merge on it — every `append` is a new row even
+   with a repeated `groupKey`. Does a real backend upsert-by-`groupKey` (e.g.
+   bump a `count` field, refresh `createdAt`) so "3 people liked your post"
+   collapses server-side, or does every event get its own row and the CLIENT
+   collapses for display (grouping by `groupKey` in the `useInbox` render
+   layer)? Leaning client-side collapsing (keeps the store simple, more
+   flexible UI, no lossy server merge) but not decided.
+5. **`markUnread`?** No use case identified yet (unlike email, an in-app
+   notification center rarely needs unmarking) — left out of `InboxStore` on
+   purpose; add if a concrete need shows up rather than speculatively.
+6. **`useInbox` hook contract.** Sketch, pending Q2's decision:
+   `useInbox({ limit? }) => { items, unreadCount, markRead(id), markAllRead(), loadMore(), isLoading }`,
+   mirroring the existing `useQuery`/`useMutation` family shapes. Under
+   Option A this is close to a thin wrapper generated alongside the
+   `listInbox` query; under Option B it needs its own polling/interval
+   internals; under Option C it needs a WS-event listener. Not buildable
+   until Q2 resolves.
+7. **Does a category/`unreadOnly` combination need its own index thinking for
+   D1**, or is a straightforward `WHERE user_id = ? AND read_at IS NULL
+ORDER BY id DESC` (mirroring `d1SubscriptionStore`'s existing
+   `user_id`/`kind` index pattern) sufficient at expected inbox volumes? Not
+   answerable without the retention decision (Q3) bounding table size first.
+
+## 7. What shipped in this spike
+
+- `packages/notify/src/inbox/types.ts` — `InboxItem`, `InboxContent`,
+  `AppendInboxInput`, `ListInboxFilter`, `InboxStore`.
+- `packages/notify/src/inbox/memory-store.ts` — `memoryInboxStore()`, the
+  only `InboxStore` implementation so far.
+- `packages/notify/__tests__/inbox.test.ts` — 12 tests: append/unreadCount,
+  markRead (incl. idempotence and unknown-id), newest-first listing incl.
+  paged cursor walk (no skip/duplicate), `unreadOnly` filtering,
+  `markAllRead` (incl. the count-changed return and idempotence), per-user
+  isolation, payload/category/groupKey round-trip, plain `limit`, and the
+  empty-inbox case.
+- **Deliberately NOT shipped:** a D1 `InboxStore` implementation, the
+  `useInbox` client hook, any change to `notify.inApp`/`send`/`broadcast`,
+  and any schema/codegen integration (§4.6 Option A). The prototype is
+  intentionally unexported from `packages/notify/src/index.ts` — it is not
+  yet a stable public surface; tests import it by relative path, the same way
+  the subscription-store tests do for internal-only helpers.


### PR DESCRIPTION
`push.broadcast()` with no filter materialized every subscription into one isolate and fanned out in a single request/queue message (a hard kill past a few thousand devices; retries re-sent to everyone) → keyset pagination with a per-page `broadcastPageSize` and per-page queue jobs. Client-supplied subscription `metadata` was unbounded → rejected/capped with `BAD_REQUEST`. Plus an in-app-inbox design spike + memory-store prototype (the read half the package's own docstring says is 'out of scope here').

Verified: 108/108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)