### PR TITLE
fix(cli): close deploy-safety gaps (env-scoped wrangler validation, diagnostic gating, --env secrets, migrate-URL scoping)

### DIFF
--- a/api-snapshots/cli.api.md
+++ b/api-snapshots/cli.api.md
@@ -127,6 +127,7 @@ interface DeployCommandOptions {
     secretLister?: (inputs: ListRemoteSecretsInputs) => Promise<ListRemoteSecretsResult>;
     skipCodegen?: boolean;
     spawner?: Spawner;
+    strictAdvisories?: boolean;
     target?: string;
     temporary?: boolean;
     updateSchemaBaseline?: boolean;
@@ -512,6 +513,7 @@ interface SpawnDescriptor {
     args: ReadonlyArray<string>;
     captureStderr?: boolean;
     captureStdout?: boolean;
+    captureStdoutSilently?: boolean;
     command: string;
     cwd?: string;
     env?: Readonly<Record<string, string>>;

--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -852,6 +852,15 @@ const buildSchemaSnapshot: (schema: SchemaIR, migrationIds: ReadonlyArray<string
 const createCodegenProject: (lunoraDirectory: string) => Project;
 ```
 
+### `describeErrorLevelFindings` (const)
+
+```ts
+const describeErrorLevelFindings: (result: Pick<CodegenResult, "advisories" | "platformDiagnostics">) => {
+    advisoryNames: ReadonlyArray<string>;
+    platformDiagnosticNames: ReadonlyArray<string>;
+};
+```
+
 ### `diagnosticAt` (const)
 
 ```ts
@@ -1117,6 +1126,18 @@ const emitWorkflows: (workflows: ReadonlyArray<WorkflowIR>) => string;
 
 ```ts
 const emitWranglerCronTriggers: (crons: ReadonlyArray<CronJobIR>) => string[];
+```
+
+### `errorAdvisoryNames` (const)
+
+```ts
+const errorAdvisoryNames: (advisories: ReadonlyArray<Pick<Finding, "level" | "name">>) => ReadonlyArray<string>;
+```
+
+### `errorPlatformDiagnosticNames` (const)
+
+```ts
+const errorPlatformDiagnosticNames: (platformDiagnostics: ReadonlyArray<Pick<PlatformDiagnostic, "level" | "name">>) => ReadonlyArray<string>;
 ```
 
 ### `evaluateSchemaDrift` (const)

--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -1594,6 +1594,7 @@ interface WranglerConfig {
     durable_objects?: {
         bindings?: ReadonlyArray<WranglerDurableObjectBinding>;
     };
+    env?: Record<string, WranglerConfig>;
     exports?: Record<string, {
         cache?: {
             enabled?: boolean;
@@ -1735,6 +1736,7 @@ interface WranglerContainerEntry {
 
 ```ts
 interface WranglerProjectValidationOptions {
+    environment?: string;
     projectRoot: string;
     schemaDir?: string;
 }
@@ -1822,7 +1824,7 @@ const readWranglerJsonc: <T = unknown>(wranglerPath: string) => ReadWranglerResu
 ### `reconcileWranglerBindings` (const)
 
 ```ts
-const reconcileWranglerBindings: (projectRoot: string, inferred: InferredBindings) => ReconcileBindingsResult;
+const reconcileWranglerBindings: (projectRoot: string, inferred: InferredBindings, environment?: string) => ReconcileBindingsResult;
 ```
 
 ### `reconcileWranglerCompatibilityDate` (const)
@@ -1858,7 +1860,7 @@ const validateWrangler: typeof validateWranglerConfig;
 ### `validateWranglerConfig` (const)
 
 ```ts
-const validateWranglerConfig: (wrangler: WranglerConfig | undefined, schema?: SchemaInfo) => WranglerValidationReport;
+const validateWranglerConfig: (wranglerInput: WranglerConfig | undefined, schema?: SchemaInfo, environment?: string) => WranglerValidationReport;
 ```
 
 ### `validateWranglerProject` (const)

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { CodegenResult, PlatformDiagnostic } from "@lunora/codegen";
+import { runCodegen } from "@lunora/codegen";
 import { parse as parseJsonc } from "jsonc-parser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,6 +12,19 @@ import { runDeployCommand } from "../../src/commands/deploy/handler";
 import type { FetchLike } from "../../src/commands/run/handler";
 import type { Logger } from "../../src/util/logger";
 import { createRecordingSpawner } from "../../src/util/spawn";
+
+// A pass-through wrapper around the real `runCodegen` — every existing test in
+// this file runs the genuine codegen pass unmodified. Only the platform-
+// diagnostics / advisory gate tests below override a single call's result (via
+// `mockImplementationOnce`, layered on the REAL result so the rest of the
+// deploy pipeline still gets a valid `CodegenResult`) to exercise a diagnostic
+// shape the shipped `cloudflare` capability matrix can never actually produce
+// (it rates every feature `native`/`emulated`, never `unsupported`).
+vi.mock("@lunora/codegen", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@lunora/codegen")>();
+
+    return { ...actual, runCodegen: vi.fn(actual.runCodegen) };
+});
 
 // Keep the deploy suite hermetic: the deploy-time missing-secret gate lists the
 // target's remote secrets via `wrangler secret list`, which would shell out to a
@@ -1011,6 +1026,108 @@ export const backfillNames = defineMigration({
 
                 expect(result.code).toBe(1);
                 expect(errors.some((line) => line.includes("lunora env push --yes --env staging") && !line.includes("--prod"))).toBe(true);
+            });
+        });
+
+        describe("platform-diagnostics / advisory gate", () => {
+            /** Append an index referencing a column that doesn't exist — `index_references_unknown_field` is an ERROR-level advisory. */
+            const addBogusIndexToSchema = (dir: string): void => {
+                const schemaPath = join(dir, "lunora", "schema.ts");
+                const schema = readFileSync(schemaPath, "utf8");
+                const patched = schema.replace(
+                    `.searchIndex("by_text", { field: "text", filterFields: ["channelId"] }),`,
+                    `.searchIndex("by_text", { field: "text", filterFields: ["channelId"] })\n        .index("by_bogus", ["doesNotExist"]),`,
+                );
+
+                expect(patched).not.toBe(schema);
+                writeFileSync(schemaPath, patched, "utf8");
+            };
+
+            it("deploys a clean project with the gate in place", async () => {
+                expect.assertions(1);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+
+                const { spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, logger, secretLister: noRemoteSecrets, spawner, strictAdvisories: true });
+
+                expect(result.code).toBe(0);
+            });
+
+            it("aborts a strict deploy on an ERROR-level codegen advisory", async () => {
+                expect.assertions(5);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+                addBogusIndexToSchema(workdir);
+
+                const { calls, spawner } = createRecordingSpawner();
+                const { errors, logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, logger, secretLister: noRemoteSecrets, spawner, strictAdvisories: true });
+
+                expect(result.code).toBe(1);
+                expect(calls).toHaveLength(0);
+                expect(result.error).toContain("ERROR-level");
+                expect(errors.some((line) => line.includes("index_references_unknown_field"))).toBe(true);
+            });
+
+            it("--no-strict-advisories deploys anyway despite the same ERROR-level advisory", async () => {
+                expect.assertions(2);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+                addBogusIndexToSchema(workdir);
+
+                const { spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, logger, secretLister: noRemoteSecrets, spawner, strictAdvisories: false });
+
+                expect(result.code).toBe(0);
+            });
+
+            it("aborts on an error-level platform diagnostic even with the advisory opt-out set", async () => {
+                expect.assertions(4);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+
+                // The shipped `cloudflare` capability matrix rates every feature
+                // native/emulated — never unsupported — so a real project can't
+                // produce this diagnostic today. Layer it onto the REAL codegen
+                // result (one call only) so the rest of the pipeline still sees a
+                // valid `CodegenResult`.
+                const actual = await vi.importActual<typeof import("@lunora/codegen")>("@lunora/codegen");
+                const diagnostic: PlatformDiagnostic = {
+                    level: "error",
+                    message: `ctx.ai is used, but target "cloudflare" does not support it`,
+                    name: "platform_unsupported_feature",
+                    remediation: "remove the usage, or choose a target that supports it",
+                    target: "cloudflare",
+                };
+
+                vi.mocked(runCodegen).mockImplementationOnce(
+                    (options): CodegenResult => ({ ...actual.runCodegen(options), platformDiagnostics: [diagnostic] }),
+                );
+
+                const { calls, spawner } = createRecordingSpawner();
+                const { errors, logger } = silentLogger();
+
+                const result = await runDeployCommand({
+                    cwd: workdir,
+                    logger,
+                    secretLister: noRemoteSecrets,
+                    spawner,
+                    // The opt-out downgrades ERROR advisories, never platform
+                    // diagnostics — those mean the emitted surface doesn't match
+                    // what the target can actually serve.
+                    strictAdvisories: false,
+                });
+
+                expect(result.code).toBe(1);
+                expect(calls).toHaveLength(0);
+                expect(result.error).toContain("ctx.ai");
+                expect(errors.some((line) => line.includes("platform_unsupported_feature"))).toBe(true);
             });
         });
     });

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -991,6 +991,27 @@ export const backfillNames = defineMigration({
                 expect(calls.some((call) => call.descriptor.args.join(" ").includes("wrangler deploy"))).toBe(false);
                 expect(errors.some((line) => line.includes("missing required secret"))).toBe(true);
             });
+
+            it("a staging deploy's missing-secret remediation names --env staging, not --prod", async () => {
+                expect.assertions(2);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+
+                const { spawner } = createRecordingSpawner();
+                const { errors, logger } = silentLogger();
+
+                const result = await runDeployCommand({
+                    cwd: workdir,
+                    env: "staging",
+                    interactive: false,
+                    logger,
+                    secretLister: () => Promise.resolve({ names: [], ok: true }),
+                    spawner,
+                });
+
+                expect(result.code).toBe(1);
+                expect(errors.some((line) => line.includes("lunora env push --yes --env staging") && !line.includes("--prod"))).toBe(true);
+            });
         });
     });
 });

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -908,6 +908,31 @@ export const backfillNames = defineMigration({
                 expect(argv.some((line) => line.includes("wrangler deploy"))).toBe(true);
             });
 
+            it("aborts an interactive deploy when the confirmed secret push fails instead of deploying anyway", async () => {
+                expect.assertions(3);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+
+                // Every spawn (including the confirmed `wrangler secret put`) fails.
+                const { calls, spawner } = createRecordingSpawner(1);
+                const { errors, logger } = silentLogger();
+
+                const result = await runDeployCommand({
+                    cwd: workdir,
+                    interactive: true,
+                    logger,
+                    secretConfirm: () => Promise.resolve(true),
+                    secretLister: () => Promise.resolve({ names: [], ok: true }),
+                    spawner,
+                });
+
+                expect(result.code).toBe(1);
+                // Never reached the wrangler deploy spawn — a failed secret push must
+                // not fall through to shipping a worker still missing that secret.
+                expect(calls.some((call) => call.descriptor.args.join(" ").includes("wrangler deploy"))).toBe(false);
+                expect(errors.some((line) => line.includes("failed to push required secret"))).toBe(true);
+            });
+
             it("launches wrangler through npx (secret-push + deploy) when the project declares npm", async () => {
                 expect.assertions(5);
 

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -20,10 +20,11 @@ import { createRecordingSpawner } from "../../src/util/spawn";
 // deploy pipeline still gets a valid `CodegenResult`) to exercise a diagnostic
 // shape the shipped `cloudflare` capability matrix can never actually produce
 // (it rates every feature `native`/`emulated`, never `unsupported`).
+// eslint-disable-next-line vitest/prefer-import-in-mock -- `vi.mock(import("@lunora/codegen"), ...)` type-checks the mock's shape against the module's `default`-bearing type, which this partial re-export doesn't satisfy
 vi.mock("@lunora/codegen", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@lunora/codegen")>();
 
-    return { ...actual, runCodegen: vi.fn(actual.runCodegen) };
+    return { ...actual, runCodegen: vi.fn<typeof actual.runCodegen>(actual.runCodegen) };
 });
 
 // Keep the deploy suite hermetic: the deploy-time missing-secret gate lists the
@@ -72,6 +73,36 @@ const VALID_WRANGLER = `{
         "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }]
     },
     "d1_databases": [{ "binding": "DB", "database_name": "x", "database_id": "real-db-id-abc123" }]
+}
+`;
+
+/**
+ * `VALID_WRANGLER` plus a declared `env.&lt;name>` block repeating the same
+ * (non-inheritable) bindings — real wrangler only WARNS on an undeclared
+ * `--env &lt;name>` and then deploys with NO bindings at all (confirmed against
+ * wrangler 4.114.0: `wrangler deploy --dry-run --env doesnotexist` prints
+ * "No bindings found."), which is exactly the silent failure mode the deploy
+ * validator's env-scoping gate exists to turn into a loud one — so any test
+ * exercising a real `--env &lt;name>` deploy needs a matching declared block,
+ * same as a correctly-configured project would have.
+ */
+const validWranglerWithEnv = (name: string): string => `{
+    "name": "lunora-app",
+    "main": "src/index.ts",
+    "compatibility_date": "2026-04-07",
+    "compatibility_flags": ["nodejs_compat"],
+    "durable_objects": {
+        "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }]
+    },
+    "d1_databases": [{ "binding": "DB", "database_name": "x", "database_id": "real-db-id-abc123" }],
+    "env": {
+        "${name}": {
+            "durable_objects": {
+                "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }]
+            },
+            "d1_databases": [{ "binding": "DB", "database_name": "x-${name}", "database_id": "real-db-id-${name}" }]
+        }
+    }
 }
 `;
 
@@ -400,7 +431,7 @@ export const transcoder = defineContainer({ image: "./containers/transcoder" });
         it("forwards --env to wrangler", async () => {
             expect.assertions(2);
 
-            writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+            writeFileSync(join(workdir, "wrangler.jsonc"), validWranglerWithEnv("production"), "utf8");
 
             const { calls, spawner } = createRecordingSpawner();
             const { logger } = silentLogger();
@@ -411,6 +442,69 @@ export const transcoder = defineContainer({ image: "./containers/transcoder" });
 
             expect(args).toContain("--env");
             expect(args).toContain("production");
+        });
+
+        describe("env-scoped wrangler validation (CONFIG-02)", () => {
+            it("blocks --env production when the SHARD binding exists only at the top level (env.production has none)", async () => {
+                expect.assertions(3);
+
+                // Top-level-only bindings, `env.production` declares nothing —
+                // the exact shape a `deploy --env production` gate used to wave
+                // through despite wrangler deploying with NO bindings at all for
+                // that environment (durable_objects is non-inheritable).
+                writeFileSync(
+                    join(workdir, "wrangler.jsonc"),
+                    `{
+    "name": "lunora-app",
+    "main": "src/index.ts",
+    "compatibility_date": "2026-04-07",
+    "durable_objects": { "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }] },
+    "d1_databases": [{ "binding": "DB", "database_name": "x", "database_id": "real-db-id-abc123" }],
+    "env": { "production": {} }
+}
+`,
+                    "utf8",
+                );
+
+                const { calls, spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, env: "production", logger, secretLister: noRemoteSecrets, spawner });
+
+                expect(result.code).toBe(1);
+                expect(result.error).toBe("wrangler validation failed");
+                // Never reached the wrangler spawn.
+                expect(calls).toHaveLength(0);
+            });
+
+            it("deploys once env.production repeats its own bindings", async () => {
+                expect.assertions(1);
+
+                writeFileSync(join(workdir, "wrangler.jsonc"), validWranglerWithEnv("production"), "utf8");
+
+                const { spawner } = createRecordingSpawner();
+                const { logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, env: "production", logger, secretLister: noRemoteSecrets, spawner });
+
+                expect(result.code).toBe(0);
+            });
+
+            it("blocks --env <name> that names no declared environment", async () => {
+                expect.assertions(3);
+
+                // No "env" block at all in the config.
+                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+
+                const { calls, spawner } = createRecordingSpawner();
+                const { errors, logger } = silentLogger();
+
+                const result = await runDeployCommand({ cwd: workdir, env: "canary", logger, secretLister: noRemoteSecrets, spawner });
+
+                expect(result.code).toBe(1);
+                expect(calls).toHaveLength(0);
+                expect(errors.some((line) => line.includes("names no environment declared"))).toBe(true);
+            });
         });
 
         it("forwards --temporary to wrangler", async () => {
@@ -1010,7 +1104,7 @@ export const backfillNames = defineMigration({
             it("a staging deploy's missing-secret remediation names --env staging, not --prod", async () => {
                 expect.assertions(2);
 
-                writeFileSync(join(workdir, "wrangler.jsonc"), VALID_WRANGLER, "utf8");
+                writeFileSync(join(workdir, "wrangler.jsonc"), validWranglerWithEnv("staging"), "utf8");
 
                 const { spawner } = createRecordingSpawner();
                 const { errors, logger } = silentLogger();
@@ -1040,6 +1134,7 @@ export const backfillNames = defineMigration({
                 );
 
                 expect(patched).not.toBe(schema);
+
                 writeFileSync(schemaPath, patched, "utf8");
             };
 
@@ -1106,9 +1201,9 @@ export const backfillNames = defineMigration({
                     target: "cloudflare",
                 };
 
-                vi.mocked(runCodegen).mockImplementationOnce(
-                    (options): CodegenResult => ({ ...actual.runCodegen(options), platformDiagnostics: [diagnostic] }),
-                );
+                vi.mocked(runCodegen).mockImplementationOnce((options): CodegenResult => {
+                    return { ...actual.runCodegen(options), platformDiagnostics: [diagnostic] };
+                });
 
                 const { calls, spawner } = createRecordingSpawner();
                 const { errors, logger } = silentLogger();

--- a/packages/cli/__tests__/commands/env.test.ts
+++ b/packages/cli/__tests__/commands/env.test.ts
@@ -360,6 +360,35 @@ describe("lunora env", () => {
             expect(calls[0]?.descriptor.args).toContain("production");
         });
 
+        it("push --env staging adds --env staging", async () => {
+            expect.assertions(2);
+
+            const { logger } = recordingLogger();
+
+            writeFileSync(join(workdir, ".dev.vars"), "OK=1\n", "utf8");
+
+            const { calls, spawner } = createRecordingSpawner();
+
+            await runEnvCommand({ cwd: workdir, env: "staging", logger, spawner, subcommand: "push", yes: true });
+
+            expect(calls[0]?.descriptor.args).toContain("--env");
+            expect(calls[0]?.descriptor.args).toContain("staging");
+        });
+
+        it("push --env wins over --prod when both are set", async () => {
+            expect.assertions(1);
+
+            const { logger } = recordingLogger();
+
+            writeFileSync(join(workdir, ".dev.vars"), "OK=1\n", "utf8");
+
+            const { calls, spawner } = createRecordingSpawner();
+
+            await runEnvCommand({ cwd: workdir, env: "staging", logger, prod: true, spawner, subcommand: "push", yes: true });
+
+            expect(calls[0]?.descriptor.args).toContain("staging");
+        });
+
         it("push --temporary adds --temporary to each secret put", async () => {
             expect.assertions(2);
 
@@ -469,6 +498,23 @@ describe("lunora env", () => {
             const result = await runEnvCommand({ cwd: workdir, logger, secretLister: stubLister([], false), subcommand: "diff" });
 
             expect(result.code).toBe(1);
+        });
+
+        it("diff --env staging targets staging rather than production", async () => {
+            expect.assertions(1);
+
+            let seenEnv: string | undefined;
+            const lister = async (inputs: { env?: string }): Promise<{ names: string[]; ok: boolean }> => {
+                seenEnv = inputs.env;
+
+                return { names: [], ok: true };
+            };
+
+            const { logger } = recordingLogger();
+
+            await runEnvCommand({ cwd: workdir, env: "staging", logger, secretLister: lister, subcommand: "diff" });
+
+            expect(seenEnv).toBe("staging");
         });
 
         it("diff reports local-only and remote-only keys", async () => {

--- a/packages/cli/__tests__/util/resolve-target.test.ts
+++ b/packages/cli/__tests__/util/resolve-target.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeLinkedProject } from "@lunora/config";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveProductionWorkerUrl, resolveWorkerUrl } from "../../src/util/resolve-target";
+
+describe("resolveWorkerUrl", () => {
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-resolve-target-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("returns the explicit --url flag even when it would otherwise resolve differently", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { env: "production", workerUrl: "https://linked.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: "production", url: "https://explicit.example.com" })).toBe("https://explicit.example.com");
+    });
+
+    it("treats an empty-string --url as absent and falls through to the link", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { workerUrl: "https://linked.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: undefined, url: "" })).toBe("https://linked.workers.dev");
+    });
+
+    it("returns undefined when no link exists and no --url was passed", () => {
+        expect.assertions(1);
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: undefined })).toBeUndefined();
+    });
+
+    it("returns the link's URL when the link's env matches the requested (top-level) env", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { workerUrl: "https://linked.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: undefined })).toBe("https://linked.workers.dev");
+    });
+
+    it("returns the link's URL when the link's env matches the requested scoped env", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { env: "staging", workerUrl: "https://staging.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: "staging" })).toBe("https://staging.workers.dev");
+    });
+
+    it("returns undefined when a production-linked checkout is targeted with --env staging", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { env: "production", workerUrl: "https://prod.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: "staging" })).toBeUndefined();
+    });
+
+    it("returns undefined when a scoped link is targeted at the top level (no --env)", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { env: "staging", workerUrl: "https://staging.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: undefined })).toBeUndefined();
+    });
+
+    it("returns undefined when a top-level link is targeted with a named --env", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { workerUrl: "https://top-level.workers.dev" });
+
+        expect(resolveWorkerUrl({ cwd: workdir, env: "production" })).toBeUndefined();
+    });
+});
+
+describe("resolveProductionWorkerUrl", () => {
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-resolve-target-prod-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("returns the explicit --url flag regardless of --prod", () => {
+        expect.assertions(1);
+
+        expect(resolveProductionWorkerUrl({ cwd: workdir, prod: false, url: "https://explicit.example.com" })).toBe("https://explicit.example.com");
+    });
+
+    it("returns undefined without --prod even when a production link exists", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { workerUrl: "https://prod.workers.dev" });
+
+        expect(resolveProductionWorkerUrl({ cwd: workdir, prod: false })).toBeUndefined();
+    });
+
+    it("returns the link's URL with --prod when the link is unscoped (top-level)", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { workerUrl: "https://prod.workers.dev" });
+
+        expect(resolveProductionWorkerUrl({ cwd: workdir, prod: true })).toBe("https://prod.workers.dev");
+    });
+
+    it("returns the link's URL with --prod when the link is explicitly scoped to production", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { env: "production", workerUrl: "https://prod.workers.dev" });
+
+        expect(resolveProductionWorkerUrl({ cwd: workdir, prod: true })).toBe("https://prod.workers.dev");
+    });
+
+    it("returns undefined with --prod when the link is scoped to a non-production environment", () => {
+        expect.assertions(1);
+
+        writeLinkedProject(workdir, { env: "staging", workerUrl: "https://staging.workers.dev" });
+
+        expect(resolveProductionWorkerUrl({ cwd: workdir, prod: true })).toBeUndefined();
+    });
+
+    it("returns undefined with --prod when no link exists", () => {
+        expect.assertions(1);
+
+        expect(resolveProductionWorkerUrl({ cwd: workdir, prod: true })).toBeUndefined();
+    });
+});

--- a/packages/cli/__tests__/util/spawn.test.ts
+++ b/packages/cli/__tests__/util/spawn.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { spawnShellCompat } from "../../src/util/spawn";
+import { defaultSpawner, spawnShellCompat } from "../../src/util/spawn";
 
 describe("spawnShellCompat", () => {
     it("passes through untouched on POSIX", () => {
@@ -86,5 +86,55 @@ describe("spawnShellCompat", () => {
             command: "pnpm",
             shell: true,
         });
+    });
+});
+
+describe("defaultSpawner", () => {
+    // Regression test for the `lunora deploy --format json` corruption bug:
+    // `offerMissingSecrets` shells out to `wrangler secret list --format json`
+    // on every real deploy via `captureStdoutSilently`. If that capture ever
+    // teed to the parent's stdout again, the secret-list JSON would print
+    // ahead of the final deploy JSON and break `JSON.parse(stdout)` in CI.
+    it("captures a child's stdout without writing it to the parent's stdout when captureStdoutSilently is set", async () => {
+        expect.assertions(3);
+
+        const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+        try {
+            const result = await defaultSpawner({
+                args: ["-e", "process.stdout.write('secret-list-json-payload')"],
+                captureStdoutSilently: true,
+                command: process.execPath,
+            });
+
+            expect(result.code).toBe(0);
+            expect(result.stdout).toBe("secret-list-json-payload");
+            expect(writeSpy).not.toHaveBeenCalled();
+        } finally {
+            writeSpy.mockRestore();
+        }
+    });
+
+    // `captureStdout` (used by deploy's auto-link URL capture) must keep
+    // teeing so interactive users still see live progress — only the silent
+    // variant added for parsed-not-displayed output changes behavior.
+    it("still tees to the parent's stdout when the caller asks for captureStdout", async () => {
+        expect.assertions(3);
+
+        const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+        try {
+            const result = await defaultSpawner({
+                args: ["-e", "process.stdout.write('deploy-progress')"],
+                captureStdout: true,
+                command: process.execPath,
+            });
+
+            expect(result.code).toBe(0);
+            expect(result.stdout).toBe("deploy-progress");
+            expect(writeSpy).toHaveBeenCalledWith(Buffer.from("deploy-progress"));
+        } finally {
+            writeSpy.mockRestore();
+        }
     });
 });

--- a/packages/cli/__tests__/util/wrangler-secrets.test.ts
+++ b/packages/cli/__tests__/util/wrangler-secrets.test.ts
@@ -114,7 +114,7 @@ describe("listRemoteSecrets", () => {
     it("passes the resolved command through to the runner (env + package-manager aware)", async () => {
         expect.assertions(1);
 
-        let seenArgs: readonly string[] | undefined;
+        let seenArgs: ReadonlyArray<string> | undefined;
 
         await listRemoteSecrets({
             cwd: workdir,

--- a/packages/cli/__tests__/util/wrangler-secrets.test.ts
+++ b/packages/cli/__tests__/util/wrangler-secrets.test.ts
@@ -1,0 +1,131 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { listRemoteSecrets, parseSecretNames } from "../../src/util/wrangler-secrets";
+
+describe("parseSecretNames", () => {
+    it("parses a valid `wrangler secret list --format json` payload into sorted names", () => {
+        expect.assertions(1);
+
+        const stdout = JSON.stringify([
+            { name: "STRIPE_KEY", type: "secret_text" },
+            { name: "AUTH_SECRET", type: "secret_text" },
+        ]);
+
+        expect(parseSecretNames(stdout)).toStrictEqual(["AUTH_SECRET", "STRIPE_KEY"]);
+    });
+
+    it("returns undefined for malformed JSON", () => {
+        expect.assertions(1);
+
+        expect(parseSecretNames("not json")).toBeUndefined();
+    });
+
+    it("returns undefined when the payload is not an array", () => {
+        expect.assertions(1);
+
+        expect(parseSecretNames(JSON.stringify({ name: "AUTH_SECRET" }))).toBeUndefined();
+    });
+
+    it("returns undefined for null input JSON", () => {
+        expect.assertions(1);
+
+        expect(parseSecretNames("null")).toBeUndefined();
+    });
+
+    it("filters out entries with a missing or non-string name", () => {
+        expect.assertions(1);
+
+        const stdout = JSON.stringify([{ name: "AUTH_SECRET" }, { type: "secret_text" }, { name: 42 }, { name: "" }, null]);
+
+        expect(parseSecretNames(stdout)).toStrictEqual(["AUTH_SECRET"]);
+    });
+
+    it("returns an empty array (not undefined) for an empty array payload", () => {
+        expect.assertions(1);
+
+        expect(parseSecretNames("[]")).toStrictEqual([]);
+    });
+});
+
+describe("listRemoteSecrets", () => {
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-wrangler-secrets-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("reports failure when the injected runner exits non-zero", async () => {
+        expect.assertions(3);
+
+        const result = await listRemoteSecrets({
+            cwd: workdir,
+            runner: () => Promise.resolve({ code: 1, stderr: "not authenticated", stdout: "" }),
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.names).toStrictEqual([]);
+        expect(result.error).toBe("not authenticated");
+    });
+
+    it("falls back to a generic error when a non-zero exit has no stderr", async () => {
+        expect.assertions(1);
+
+        const result = await listRemoteSecrets({
+            cwd: workdir,
+            runner: () => Promise.resolve({ code: 3, stderr: "", stdout: "" }),
+        });
+
+        expect(result.error).toBe("wrangler secret list exited 3");
+    });
+
+    it("reports failure when the runner's stdout can't be parsed as the expected JSON shape", async () => {
+        expect.assertions(3);
+
+        const result = await listRemoteSecrets({
+            cwd: workdir,
+            runner: () => Promise.resolve({ code: 0, stderr: "", stdout: "not json" }),
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.names).toStrictEqual([]);
+        expect(result.error).toBe("could not parse `wrangler secret list --format json` output");
+    });
+
+    it("returns sorted names on success", async () => {
+        expect.assertions(2);
+
+        const result = await listRemoteSecrets({
+            cwd: workdir,
+            runner: () => Promise.resolve({ code: 0, stderr: "", stdout: JSON.stringify([{ name: "B" }, { name: "A" }]) }),
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.names).toStrictEqual(["A", "B"]);
+    });
+
+    it("passes the resolved command through to the runner (env + package-manager aware)", async () => {
+        expect.assertions(1);
+
+        let seenArgs: readonly string[] | undefined;
+
+        await listRemoteSecrets({
+            cwd: workdir,
+            env: "staging",
+            runner: (_command, args) => {
+                seenArgs = args;
+
+                return Promise.resolve({ code: 0, stderr: "", stdout: "[]" });
+            },
+        });
+
+        expect(seenArgs?.join(" ")).toContain("--env staging");
+    });
+});

--- a/packages/cli/src/commands/codegen/handler.ts
+++ b/packages/cli/src/commands/codegen/handler.ts
@@ -1,6 +1,8 @@
+import type { Finding } from "@lunora/codegen";
 import { runCodegen } from "@lunora/codegen";
 import { collectWranglerSecretVariables } from "@lunora/config/cloudflare";
 
+import { evaluateAdvisoryGate, resolveStrictAdvisories } from "../../util/advisory-gate";
 import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
 import type { CommandHandler } from "../../util/command";
@@ -33,7 +35,7 @@ interface CodegenCommandOptions {
 }
 
 interface CodegenCommandResult {
-    advisories: ReadonlyArray<{ detail: string; level: string; name: string; remediation: string }>;
+    advisories: ReadonlyArray<{ detail: string; level: Finding["level"]; name: string; remediation: string }>;
     cronTriggers: ReadonlyArray<string>;
     /** Set when the run failed: an invalid `--format`, an unregistered target, or an error-level platform diagnostic. */
     error?: string;
@@ -59,7 +61,7 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
 
     // CI is the default gate: a pipeline should fail on an ERROR advisory, a
     // local run should not have its workflow interrupted by one.
-    const strictAdvisories = options.strictAdvisories ?? (process.env["CI"] !== undefined && process.env["CI"] !== "");
+    const strictAdvisories = resolveStrictAdvisories(options);
 
     // Validated here because codegen resolves no driver of its own — an
     // unregistered name would otherwise emit the full Cloudflare surface
@@ -122,11 +124,9 @@ const runCodegenCommand = (options: CodegenCommandOptions): CodegenCommandResult
     // that prompted this read "the call throws at runtime". Exiting 0 on those
     // meant three workflows could deploy and fail on first use with a green
     // build. WARN and INFO stay non-blocking.
-    const errorAdvisories = commandResult.advisories.filter((advisory) => advisory.level === "ERROR");
+    const { errorAdvisories, names, shouldBlock } = evaluateAdvisoryGate(commandResult.advisories, strictAdvisories);
 
-    if (errorAdvisories.length > 0 && strictAdvisories) {
-        const names = [...new Set(errorAdvisories.map((advisory) => advisory.name))].toSorted((a, b) => a.localeCompare(b));
-
+    if (shouldBlock) {
         logger.error(
             `${errorAdvisories.length.toString()} ERROR-level ${errorAdvisories.length === 1 ? "advisory" : "advisories"} (${names.join(", ")}). ` +
                 `Codegen wrote its output; this exit code is the gate. Pass --no-strict-advisories to downgrade it to a warning.`,

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -309,6 +309,15 @@ const isInteractive = (options: DeployCommandOptions): boolean => {
 };
 
 /**
+ * Same CI-detection default `lunora codegen` uses: strict in CI, advisory
+ * locally, so a legitimately-partial target can still be shipped by hand.
+ * Extracted (rather than inlined in `executeDeploy`) purely to keep that
+ * function's cognitive complexity within the repo's lint budget.
+ */
+const resolveStrictAdvisories = (options: DeployCommandOptions): boolean =>
+    options.strictAdvisories ?? (process.env["CI"] !== undefined && process.env["CI"] !== "");
+
+/**
  * Return the name of any D1 binding that still carries the placeholder
  * database_id written by `reconcileWranglerBindings`. Returns `undefined`
  * when no placeholder is found (or when wrangler.jsonc is absent/unparseable —
@@ -396,7 +405,13 @@ const syncCronTriggers = (cwd: string, logger: Logger, cronTriggers: ReadonlyArr
  * best-effort: a failure here must not abort the deploy, since the validator
  * still reports any genuinely missing requirement.
  */
-const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: ReadonlyArray<string> | undefined, target: string): Promise<void> => {
+const provisionBindings = async (
+    cwd: string,
+    logger: Logger,
+    cronTriggers: ReadonlyArray<string> | undefined,
+    target: string,
+    environment: string | undefined,
+): Promise<void> => {
     try {
         // Resolved for its side effect: reject an unregistered target before
         // reconciling a config shaped for the wrong provider. `prepare` routes
@@ -405,7 +420,7 @@ const provisionBindings = async (cwd: string, logger: Logger, cronTriggers: Read
         resolveDeployDriver(target);
 
         const inferred = await inferLunoraBindings({ projectRoot: cwd });
-        const reconciled = reconcileWranglerBindings(cwd, inferred);
+        const reconciled = reconcileWranglerBindings(cwd, inferred, environment);
 
         if (reconciled.changed) {
             logger.success(`provisioned bindings: ${reconciled.added.join(", ")} → ${reconciled.wranglerPath ?? "wrangler.jsonc"}`);
@@ -1092,9 +1107,7 @@ const reportWranglerProblems = (validation: { problems: ReadonlyArray<string> },
 const executeDeploy = async (options: DeployCommandOptions): Promise<DeployCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
     const interactive = isInteractive(options);
-    // Same CI-detection default `lunora codegen` uses: strict in CI, advisory
-    // locally, so a legitimately-partial target can still be shipped by hand.
-    const strictAdvisories = options.strictAdvisories ?? (process.env["CI"] !== undefined && process.env["CI"] !== "");
+    const strictAdvisories = resolveStrictAdvisories(options);
 
     // Resolved ONCE, and before anything writes. Deploy rewrites `_generated/*`
     // and may mutate `wrangler.jsonc` well before it reaches the wrangler step,
@@ -1175,7 +1188,7 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
         reblessSchemaBaseline = gate.rebless;
     }
 
-    await provisionBindings(cwd, options.logger, codegen?.cronTriggers, target);
+    await provisionBindings(cwd, options.logger, codegen?.cronTriggers, target, options.env);
 
     const migratePreflightError = validateMigrateDeployPreflight(options);
 
@@ -1192,7 +1205,11 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
         return { code: 1, descriptor: undefined, error: preflightError, validation: { problems: [], wranglerPath: undefined } };
     }
 
-    const validation = validateWrangler({ projectRoot: cwd });
+    // `--env <name>` validates the env-scoped view — a binding present only
+    // at the top level is a real gap for that environment (non-inheritable;
+    // see wrangler-validator.ts's NON_INHERITABLE_KEYS), and the deploy that
+    // follows targets exactly this environment via `wrangler deploy --env`.
+    const validation = validateWrangler({ environment: options.env, projectRoot: cwd });
 
     if (reportWranglerProblems(validation, options.logger)) {
         return { code: 1, descriptor: undefined, error: "wrangler validation failed", validation };

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -39,6 +39,7 @@ import type { DockerProbe } from "../../util/docker";
 import { isDockerAvailable } from "../../util/docker";
 import type { Logger } from "../../util/logger";
 import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
+import reportPlatformDiagnostics from "../../util/platform-diagnostics";
 import { runPostCodegenHook } from "../../util/post-codegen-hook";
 import { buildRailpackImages } from "../../util/railpack";
 import { resolveWorkerUrl } from "../../util/resolve-target";
@@ -138,6 +139,17 @@ interface DeployCommandOptions {
     secretLister?: (inputs: ListRemoteSecretsInputs) => Promise<ListRemoteSecretsResult>;
     skipCodegen?: boolean;
     spawner?: Spawner;
+
+    /**
+     * Fail the deploy when codegen reports an ERROR-level advisory. Same
+     * option `lunora codegen` exposes as `--no-strict-advisories`; defaults to
+     * CI detection (on in CI, off locally) so a legitimately-partial target
+     * can still be shipped interactively. Does NOT gate platform diagnostics
+     * (`platform_unsupported_feature` / `platform_unknown_target`), which
+     * always block — those mean the emitted `ctx.*` surface does not match
+     * what the target can serve, not merely a style nit.
+     */
+    strictAdvisories?: boolean;
 
     /**
      * Deploy target. Falls back to `"target"` in `lunora.json`, then
@@ -750,6 +762,7 @@ const runCodegenStep = async (
     target: string,
     spawner: Spawner | undefined,
     jsonOutput: boolean,
+    strictAdvisories: boolean,
 ): Promise<{ error?: string; result?: CodegenResult }> => {
     let codegenSpinner: Spinner | undefined;
 
@@ -766,6 +779,34 @@ const runCodegenStep = async (
 
         if (!codegenSpinner) {
             logger.success("codegen complete");
+        }
+
+        // Portability diagnostics (`platform_unsupported_feature` /
+        // `platform_unknown_target`) mean the emitted `ctx.*` surface does not
+        // match what the deploy target can actually serve — always blocking,
+        // no opt-out, same as every other codegen caller
+        // (`reportPlatformDiagnostics` is shared for exactly this reason).
+        const platformError = reportPlatformDiagnostics(result.platformDiagnostics, logger);
+
+        if (platformError !== undefined) {
+            return { error: platformError };
+        }
+
+        // ERROR-level schema advisories ("the call throws at runtime") gate on
+        // the same `--no-strict-advisories` opt-out `lunora codegen` uses, so a
+        // legitimately-partial target can still ship interactively while CI
+        // stays strict by default.
+        const errorAdvisories = result.advisories.filter((advisory) => advisory.level === "ERROR");
+
+        if (errorAdvisories.length > 0 && strictAdvisories) {
+            const names = [...new Set(errorAdvisories.map((advisory) => advisory.name))].toSorted((a, b) => a.localeCompare(b));
+            const message =
+                `${errorAdvisories.length.toString()} ERROR-level ${errorAdvisories.length === 1 ? "advisory" : "advisories"} (${names.join(", ")}). ` +
+                `Pass --no-strict-advisories to downgrade this to a warning and deploy anyway.`;
+
+            logger.error(message);
+
+            return { error: message };
         }
 
         // Codegen ran in-process, not through the project's own `codegen`
@@ -1051,6 +1092,9 @@ const reportWranglerProblems = (validation: { problems: ReadonlyArray<string> },
 const executeDeploy = async (options: DeployCommandOptions): Promise<DeployCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
     const interactive = isInteractive(options);
+    // Same CI-detection default `lunora codegen` uses: strict in CI, advisory
+    // locally, so a legitimately-partial target can still be shipped by hand.
+    const strictAdvisories = options.strictAdvisories ?? (process.env["CI"] !== undefined && process.env["CI"] !== "");
 
     // Resolved ONCE, and before anything writes. Deploy rewrites `_generated/*`
     // and may mutate `wrangler.jsonc` well before it reaches the wrangler step,
@@ -1074,7 +1118,16 @@ const executeDeploy = async (options: DeployCommandOptions): Promise<DeployComma
     let codegen: CodegenResult | undefined;
 
     if (!options.skipCodegen) {
-        const codegenStep = await runCodegenStep(cwd, interactive, options.logger, options.apiSpec, target, options.spawner, isJsonFormat(options.format));
+        const codegenStep = await runCodegenStep(
+            cwd,
+            interactive,
+            options.logger,
+            options.apiSpec,
+            target,
+            options.spawner,
+            isJsonFormat(options.format),
+            strictAdvisories,
+        );
 
         if (codegenStep.error !== undefined) {
             return {
@@ -1267,6 +1320,7 @@ const execute: CommandHandler<DeployOptions> = defineHandler<DeployOptions>(asyn
         // `--prebuilt` trusts a prior `lunora build`/`prepare`: skip codegen (and
         // thus the drift gate, which has no fresh snapshot to measure).
         skipCodegen: options.prebuilt === true,
+        strictAdvisories: options.strictAdvisories,
         target: options.target,
         temporary: options.temporary === true,
         updateSchemaBaseline: options.updateSchemaBaseline === true,

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -604,7 +604,14 @@ const offerMissingSecrets = async (cwd: string, options: DeployCommandOptions, i
     if (
         await confirm(`${String(mintable.length)} required secret(s) not set on the target (${mintable.join(", ")}). Generate strong values and push them now?`)
     ) {
-        await pushMintableSecrets(cwd, options, mintable, target);
+        // `pushMintableSecrets` returns `false` the moment any `secret put` fails
+        // (e.g. auth expired mid-push). Discarding that result used to deploy
+        // anyway, shipping a worker still missing the secret it just failed to
+        // set — the exact outcome the non-interactive branch above refuses to
+        // risk.
+        if (!(await pushMintableSecrets(cwd, options, mintable, target))) {
+            return "failed to push required secret(s) — set them manually and re-deploy";
+        }
 
         return undefined;
     }

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -585,7 +585,7 @@ const offerMissingSecrets = async (cwd: string, options: DeployCommandOptions, i
         return (
             `missing required secret(s) on the deploy target: ${missing.join(", ")}. ` +
             `Set them with \`wrangler secret put <KEY>${environmentFlag}\` ` +
-            `(or \`lunora env generate --set\` then \`lunora env push --yes${options.env === undefined ? "" : " --prod"}\`), then re-deploy.`
+            `(or \`lunora env generate --set\` then \`lunora env push --yes${options.env === undefined ? "" : ` --env ${options.env}`}\`), then re-deploy.`
         );
     }
 
@@ -618,7 +618,7 @@ const offerMissingSecrets = async (cwd: string, options: DeployCommandOptions, i
 
     logger.warn(
         `${String(mintable.length)} required secret(s) not set on the target: ${mintable.join(", ")}. ` +
-            `Generate + push with \`lunora env generate --set\` then \`lunora env push --yes${options.env === undefined ? "" : " --prod"}\`.`,
+            `Generate + push with \`lunora env generate --set\` then \`lunora env push --yes${options.env === undefined ? "" : ` --env ${options.env}`}\`.`,
     );
 
     return undefined;

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -1250,8 +1250,11 @@ const execute: CommandHandler<DeployOptions> = defineHandler<DeployOptions>(asyn
         migrate: options.migrate === true,
         migrateToken: options.migrateToken,
         // Fall back to the `.lunora/project.json` link so a linked checkout no
-        // longer needs --migrate-url repeated on every `deploy --migrate`.
-        migrateUrl: resolveWorkerUrl({ cwd, url: options.migrateUrl }),
+        // longer needs --migrate-url repeated on every `deploy --migrate`. The
+        // link is only trusted when it was recorded for THIS `--env` — a
+        // production-linked checkout must not silently supply its URL to a
+        // `--env staging --migrate` run (see resolveWorkerUrl's env guard).
+        migrateUrl: resolveWorkerUrl({ cwd, env: options.env, url: options.migrateUrl }),
         migrateYes: options.migrateYes === true,
         preview: options.preview === true,
         // `--prebuilt` trusts a prior `lunora build`/`prepare`: skip codegen (and

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -27,6 +27,7 @@ import { join } from "@visulima/path";
 import { Spinner } from "@visulima/spinner";
 import { Project } from "ts-morph";
 
+import { evaluateAdvisoryGate, resolveStrictAdvisories } from "../../util/advisory-gate";
 import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
 import { autoLinkFromDeployOutput } from "../../util/auto-link";
@@ -307,15 +308,6 @@ const isInteractive = (options: DeployCommandOptions): boolean => {
 
     return process.stdout.isTTY && !process.env.CI;
 };
-
-/**
- * Same CI-detection default `lunora codegen` uses: strict in CI, advisory
- * locally, so a legitimately-partial target can still be shipped by hand.
- * Extracted (rather than inlined in `executeDeploy`) purely to keep that
- * function's cognitive complexity within the repo's lint budget.
- */
-const resolveStrictAdvisories = (options: DeployCommandOptions): boolean =>
-    options.strictAdvisories ?? (process.env["CI"] !== undefined && process.env["CI"] !== "");
 
 /**
  * Return the name of any D1 binding that still carries the placeholder
@@ -811,10 +803,9 @@ const runCodegenStep = async (
         // the same `--no-strict-advisories` opt-out `lunora codegen` uses, so a
         // legitimately-partial target can still ship interactively while CI
         // stays strict by default.
-        const errorAdvisories = result.advisories.filter((advisory) => advisory.level === "ERROR");
+        const { errorAdvisories, names, shouldBlock } = evaluateAdvisoryGate(result.advisories, strictAdvisories);
 
-        if (errorAdvisories.length > 0 && strictAdvisories) {
-            const names = [...new Set(errorAdvisories.map((advisory) => advisory.name))].toSorted((a, b) => a.localeCompare(b));
+        if (shouldBlock) {
             const message =
                 `${errorAdvisories.length.toString()} ERROR-level ${errorAdvisories.length === 1 ? "advisory" : "advisories"} (${names.join(", ")}). ` +
                 `Pass --no-strict-advisories to downgrade this to a warning and deploy anyway.`;

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -37,6 +37,16 @@ const deployCommand: Command = {
             type: String,
         },
         { description: "Confirm running the production data migration triggered by --migrate (required with --migrate)", name: "migrate-yes", type: Boolean },
+        // Declared as a `no-*` option, like `lunora codegen`'s identically-named
+        // flag: cerebro only synthesizes a negation for options declared that
+        // way, so a positive `strict-advisories` would have made the advertised
+        // `--no-strict-advisories` an unknown-option error.
+        {
+            description:
+                "Don't fail the deploy on ERROR-level codegen advisories (the gate defaults to on in CI, off locally). Never downgrades platform diagnostics.",
+            name: "no-strict-advisories",
+            type: Boolean,
+        },
         {
             description: "Upload a preview version (wrangler versions upload) instead of going live — prints a preview URL; doesn't shift production traffic",
             name: "preview",
@@ -71,6 +81,7 @@ export type DeployOptions = CreateOptions<{
     "migrate-yes": boolean | undefined;
     prebuilt: boolean | undefined;
     preview: boolean | undefined;
+    "strict-advisories": boolean | undefined;
     target: string | undefined;
     temporary: boolean | undefined;
     "update-schema-baseline": boolean | undefined;

--- a/packages/cli/src/commands/env/handler.ts
+++ b/packages/cli/src/commands/env/handler.ts
@@ -30,6 +30,12 @@ type EnvSubcommand = "diff" | "doctor" | "generate" | "get" | "list" | "push" | 
 
 interface EnvCommandOptions {
     cwd?: string;
+    /**
+     * Cloudflare environment name for `push`/`diff` (`wrangler … --env <name>`).
+     * `prod` is a boolean-only alias for `env: "production"` kept for backward
+     * compatibility — when both are set, `env` wins.
+     */
+    env?: string;
     /** Required for `set`. Required (positional) for `get`/`unset`. */
     key?: string;
     logger: Logger;
@@ -188,6 +194,13 @@ interface EnvContext {
     options: EnvCommandOptions;
 }
 
+/**
+ * The Cloudflare environment `push`/`diff` should target: the explicit
+ * `--env <name>` wins; `--prod` is kept as a boolean-only alias for
+ * `--env production`; otherwise `undefined` (top-level config).
+ */
+const resolveEnvironment = (options: EnvCommandOptions): string | undefined => options.env ?? (options.prod === true ? "production" : undefined);
+
 const runEnvList = (context: EnvContext): EnvCommandResult => {
     const map = loadDevVariables(context.devVariablesPath);
 
@@ -319,12 +332,13 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
     const manager = detectPackageManager(cwd);
     const descriptors: SpawnDescriptor[] = [];
+    const environment = resolveEnvironment(options);
 
     for (const entry of map.values()) {
         // The toolchain is the target's, not always wrangler's — resolving from the
         // project keeps a non-default target from shelling out to the wrong CLI.
         const secretCommand = resolveDeployDriver(resolveProjectTarget(cwd)).toolchain?.secretPut({
-            environment: options.prod === true ? "production" : undefined,
+            environment,
             key: entry.key,
             temporary: options.temporary,
         });
@@ -347,7 +361,7 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
         };
 
         descriptors.push(descriptor);
-        logger.info(`pushing ${entry.key} -> wrangler secret${options.prod ? " (production)" : ""}`);
+        logger.info(`pushing ${entry.key} -> wrangler secret${environment === undefined ? "" : ` (${environment})`}`);
 
         // eslint-disable-next-line no-await-in-loop -- secrets push sequentially so a failure aborts.
         const result = await spawner(descriptor);
@@ -364,13 +378,13 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
     return { code: 0, descriptors };
 };
 
-/** List the deployed Worker's secret names for `diff` (prod env when `--prod`). */
+/** List the deployed Worker's secret names for `diff` (the resolved --env/--prod target). */
 const fetchRemoteSecretNames = (context: EnvContext): Promise<ListRemoteSecretsResult> => {
     const lister = context.options.secretLister ?? listRemoteSecrets;
 
     return lister({
         cwd: context.cwd,
-        env: context.options.prod ? "production" : undefined,
+        env: resolveEnvironment(context.options),
         temporary: context.options.temporary,
     });
 };
@@ -612,6 +626,7 @@ const execute: CommandHandler<EnvOptions> = defineHandler<EnvOptions>(({ argumen
 
     return runEnvCommand({
         cwd,
+        env: options.env,
         key: argument[1],
         logger,
         prod: options.prod === true,

--- a/packages/cli/src/commands/env/handler.ts
+++ b/packages/cli/src/commands/env/handler.ts
@@ -30,8 +30,9 @@ type EnvSubcommand = "diff" | "doctor" | "generate" | "get" | "list" | "push" | 
 
 interface EnvCommandOptions {
     cwd?: string;
+
     /**
-     * Cloudflare environment name for `push`/`diff` (`wrangler … --env <name>`).
+     * Cloudflare environment name for `push`/`diff` (`wrangler … --env &lt;name>`).
      * `prod` is a boolean-only alias for `env: "production"` kept for backward
      * compatibility — when both are set, `env` wins.
      */
@@ -196,7 +197,7 @@ interface EnvContext {
 
 /**
  * The Cloudflare environment `push`/`diff` should target: the explicit
- * `--env <name>` wins; `--prod` is kept as a boolean-only alias for
+ * `--env &lt;name>` wins; `--prod` is kept as a boolean-only alias for
  * `--env production`; otherwise `undefined` (top-level config).
  */
 const resolveEnvironment = (options: EnvCommandOptions): string | undefined => options.env ?? (options.prod === true ? "production" : undefined);

--- a/packages/cli/src/commands/env/index.ts
+++ b/packages/cli/src/commands/env/index.ts
@@ -18,7 +18,8 @@ const envCommand: Command = {
         }),
     name: "env",
     options: [
-        { description: "Target production for `push` (passes --env production to wrangler)", name: "prod", type: Boolean },
+        { description: "Target this Cloudflare environment for `push`/`diff` (passes --env <name> to wrangler)", name: "env", type: String },
+        { description: "Alias for --env production", name: "prod", type: Boolean },
         { description: "For `generate` — write the generated secrets into .dev.vars instead of printing them", name: "set", type: Boolean },
         {
             description:
@@ -32,4 +33,10 @@ const envCommand: Command = {
 
 export { envCommand };
 
-export type EnvOptions = CreateOptions<{ prod: boolean | undefined; set: boolean | undefined; temporary: boolean | undefined; yes: boolean | undefined }>;
+export type EnvOptions = CreateOptions<{
+    env: string | undefined;
+    prod: boolean | undefined;
+    set: boolean | undefined;
+    temporary: boolean | undefined;
+    yes: boolean | undefined;
+}>;

--- a/packages/cli/src/util/advisory-gate.ts
+++ b/packages/cli/src/util/advisory-gate.ts
@@ -1,0 +1,59 @@
+/**
+ * The ERROR-advisory gate shared by `lunora codegen` and `lunora deploy`:
+ * both fail the run on an ERROR-level schema advisory the same way, opting
+ * out via the same `--no-strict-advisories` flag that defaults off CI
+ * detection. The two copies had already drifted once — this file exists so a
+ * third drift needs a deliberate second implementation, not a silent copy.
+ *
+ * Platform diagnostics are NOT this gate's concern: they stay on
+ * `reportPlatformDiagnostics` (`./platform-diagnostics.ts`), which is always
+ * blocking (no strict opt-out) and returns the diagnostic's own message
+ * rather than a name-list summary — a different, non-optional contract this
+ * gate must not fold into.
+ */
+import type { Finding } from "@lunora/advisor";
+import { errorAdvisoryNames } from "@lunora/codegen";
+
+interface AdvisoryGateOptions {
+    /** The command's own `--strict-advisories`/`--no-strict-advisories` option; `undefined` falls back to CI detection. */
+    strictAdvisories?: boolean;
+}
+
+interface AdvisoryGateResult<TAdvisory extends Pick<Finding, "level" | "name">> {
+    /** Every ERROR-level advisory found, regardless of `strict` — callers report the count even when not blocking. */
+    errorAdvisories: ReadonlyArray<TAdvisory>;
+    /** Deduplicated, sorted names of `errorAdvisories`, ready to join into a message. */
+    names: ReadonlyArray<string>;
+    /** True when `errorAdvisories` is non-empty AND the gate is strict — the caller's abort signal. */
+    shouldBlock: boolean;
+}
+
+/**
+ * CI is the default gate: a pipeline should fail on an ERROR advisory, a
+ * local run should not have its workflow interrupted by one.
+ */
+const resolveStrictAdvisories = (options: AdvisoryGateOptions): boolean =>
+    options.strictAdvisories ?? (process.env["CI"] !== undefined && process.env["CI"] !== "");
+
+/**
+ * Filter, dedup+sort names, and decide whether `strict` mode should block the
+ * run. Callers append their own remediation tail to the message they build
+ * from `names`/`errorAdvisories.length` — this only owns the part that had
+ * already drifted once between `lunora codegen` and `lunora deploy`.
+ *
+ * Generic over the advisory shape (rather than pinned to `@lunora/advisor`'s
+ * full `Finding`) because `lunora codegen`'s own result type re-maps
+ * `Finding` down to a plain `{ detail, level, name, remediation }` for its
+ * JSON output — this only ever reads `level`/`name`, so it accepts either.
+ */
+const evaluateAdvisoryGate = <TAdvisory extends Pick<Finding, "level" | "name">>(
+    advisories: ReadonlyArray<TAdvisory>,
+    strict: boolean,
+): AdvisoryGateResult<TAdvisory> => {
+    const errorAdvisories = advisories.filter((advisory) => advisory.level === "ERROR");
+
+    return { errorAdvisories, names: errorAdvisoryNames(advisories), shouldBlock: errorAdvisories.length > 0 && strict };
+};
+
+export { evaluateAdvisoryGate, resolveStrictAdvisories };
+export type { AdvisoryGateOptions, AdvisoryGateResult };

--- a/packages/cli/src/util/resolve-target.ts
+++ b/packages/cli/src/util/resolve-target.ts
@@ -16,7 +16,7 @@ import { readLinkedProject } from "@lunora/config";
 
 interface ResolveWorkerUrlInputs {
     cwd: string;
-    /** The `--env <name>` the caller is targeting, when scoped. `undefined` means top-level (no `--env`). */
+    /** The `--env &lt;name>` the caller is targeting, when scoped. `undefined` means top-level (no `--env`). */
     env?: string;
     /** Explicit `--url` flag value, when the caller passed one. */
     url?: string;

--- a/packages/cli/src/util/resolve-target.ts
+++ b/packages/cli/src/util/resolve-target.ts
@@ -16,21 +16,36 @@ import { readLinkedProject } from "@lunora/config";
 
 interface ResolveWorkerUrlInputs {
     cwd: string;
+    /** The `--env <name>` the caller is targeting, when scoped. `undefined` means top-level (no `--env`). */
+    env?: string;
     /** Explicit `--url` flag value, when the caller passed one. */
     url?: string;
 }
 
 /**
  * Resolve the worker URL: the explicit `--url` flag wins, else the linked
- * project's `workerUrl`, else `undefined` (the caller supplies its own default,
- * typically `http://localhost:8787`).
+ * project's `workerUrl` — but ONLY when the link was recorded for the SAME
+ * environment the caller is targeting now. `lunora link` writes `env` for the
+ * environment it was run against (`undefined` for the top-level config); a link
+ * scoped to `production` must never stand in for a `--env staging` command (or
+ * vice versa) — that would run e.g. a data migration meant for staging against
+ * the production worker's URL. When the environments don't match, this returns
+ * `undefined` so the caller keeps its own default (typically
+ * `http://localhost:8787`, or — for `--migrate` — a hard refusal demanding
+ * `--migrate-url`).
  */
-const resolveWorkerUrl = ({ cwd, url }: ResolveWorkerUrlInputs): string | undefined => {
+const resolveWorkerUrl = ({ cwd, env, url }: ResolveWorkerUrlInputs): string | undefined => {
     if (url !== undefined && url !== "") {
         return url;
     }
 
-    return readLinkedProject(cwd)?.workerUrl;
+    const link = readLinkedProject(cwd);
+
+    if (link === undefined || link.env !== env) {
+        return undefined;
+    }
+
+    return link.workerUrl;
 };
 
 interface ResolveProductionWorkerUrlInputs {
@@ -44,16 +59,32 @@ interface ResolveProductionWorkerUrlInputs {
 /**
  * Resolve the worker URL for a bulk/destructive command gated by `--prod`. The
  * explicit `--url` flag always wins; otherwise the linked project's `workerUrl`
- * is used ONLY when `--prod` is set. Without `--prod` (and without `--url`) this
- * returns `undefined` so the caller keeps defaulting to localhost — a prod link
- * never silently becomes the target of an unguarded write/export.
+ * is used ONLY when `--prod` is set AND the link was recorded for production
+ * (`env` unset, or explicitly `"production"`). Without `--prod` (and without
+ * `--url`) this returns `undefined` so the caller keeps defaulting to
+ * localhost — a prod link never silently becomes the target of an unguarded
+ * write/export.
+ *
+ * Same bug class as {@link resolveWorkerUrl}'s environment guard: a link
+ * scoped to a non-production environment (`lunora link --env staging`) is not
+ * a production link, so `--prod` must not silently borrow its URL.
  */
 const resolveProductionWorkerUrl = ({ cwd, prod, url }: ResolveProductionWorkerUrlInputs): string | undefined => {
     if (url !== undefined && url !== "") {
         return url;
     }
 
-    return prod ? readLinkedProject(cwd)?.workerUrl : undefined;
+    if (!prod) {
+        return undefined;
+    }
+
+    const link = readLinkedProject(cwd);
+
+    if (link === undefined || (link.env !== undefined && link.env !== "production")) {
+        return undefined;
+    }
+
+    return link.workerUrl;
 };
 
 export type { ResolveProductionWorkerUrlInputs, ResolveWorkerUrlInputs };

--- a/packages/cli/src/util/spawn.ts
+++ b/packages/cli/src/util/spawn.ts
@@ -31,9 +31,21 @@ export interface SpawnDescriptor {
      * Capture the child's stdout (in addition to streaming it to the parent), so
      * the caller can parse it — used by `deploy` to read the deployed URL from
      * `wrangler deploy` output. Each chunk is still teed to the parent's stdout
-     * so the user sees live progress. Mutually exclusive with `stdoutToStderr`.
+     * so the user sees live progress. Mutually exclusive with `stdoutToStderr`
+     * and `captureStdoutSilently`.
      */
     captureStdout?: boolean;
+
+    /**
+     * Capture the child's stdout WITHOUT teeing it to the parent's stdout —
+     * for output that is parsed, never displayed (e.g. `wrangler secret list
+     * --format json`). Unlike `captureStdout`, nothing is written to
+     * `process.stdout`, so it can't interleave with — and corrupt — a
+     * caller's own stdout (notably `lunora deploy --format json`, which must
+     * emit exactly one JSON document). Mutually exclusive with `captureStdout`
+     * and `stdoutToStderr`.
+     */
+    captureStdoutSilently?: boolean;
     command: string;
     cwd?: string;
     env?: Readonly<Record<string, string>>;
@@ -58,7 +70,7 @@ export interface SpawnResult {
     code: number;
     /** The captured stderr, present only when the descriptor set `captureStderr`. */
     stderr?: string;
-    /** The captured stdout, present only when the descriptor set `captureStdout`. */
+    /** The captured stdout, present only when the descriptor set `captureStdout` or `captureStdoutSilently`. */
     stdout?: string;
 }
 
@@ -122,15 +134,17 @@ export const defaultSpawner: Spawner = (descriptor) =>
     new Promise<SpawnResult>((resolve, reject) => {
         const hasInput = typeof descriptor.input === "string";
         const wantCapture = descriptor.captureStdout === true;
+        const wantSilentCapture = descriptor.captureStdoutSilently === true;
         // When the caller pipes input we need a writable stdin handle — "inherit"
         // gives us the parent's stdin which we can't write to. stderr always stays
         // inherited so errors land where the user can see them. stdout is normally
         // inherited; in `--format json` mode it is mapped to the parent's stderr fd
         // (2) so the child's human output never pollutes the JSON on stdout; and in
-        // capture mode it is piped so we can buffer + tee it.
+        // either capture mode it is piped so we can buffer it (and, for
+        // `captureStdout` only, tee it to the parent too).
         let stdout: "inherit" | "pipe" | number = "inherit";
 
-        if (wantCapture) {
+        if (wantCapture || wantSilentCapture) {
             stdout = "pipe";
         } else if (descriptor.stdoutToStderr) {
             stdout = 2;
@@ -154,11 +168,16 @@ export const defaultSpawner: Spawner = (descriptor) =>
             });
         }
 
-        if (wantCapture && child.stdout) {
+        if ((wantCapture || wantSilentCapture) && child.stdout) {
             child.stdout.on("data", (chunk: Buffer) => {
                 captured += chunk.toString("utf8");
-                // Tee to the parent so the user still sees live deploy progress.
-                process.stdout.write(chunk);
+
+                if (wantCapture) {
+                    // Tee to the parent so the user still sees live deploy progress.
+                    process.stdout.write(chunk);
+                }
+                // `captureStdoutSilently`: buffer only — this output is parsed,
+                // never displayed, and must never reach the parent's stdout.
             });
         }
 
@@ -173,7 +192,7 @@ export const defaultSpawner: Spawner = (descriptor) =>
             resolve({
                 code: code ?? (signal ? 1 : 0),
                 stderr: descriptor.captureStderr === true ? capturedError : undefined,
-                stdout: wantCapture ? captured : undefined,
+                stdout: wantCapture || wantSilentCapture ? captured : undefined,
             });
         });
 

--- a/packages/cli/src/util/wrangler-secrets.ts
+++ b/packages/cli/src/util/wrangler-secrets.ts
@@ -49,10 +49,17 @@ interface ListRemoteSecretsResult {
  * hardening. A spawn error (the child never started) is reported as a failed
  * result rather than a thrown rejection, matching the previous `execFile`-based
  * runner's contract.
+ *
+ * Uses `captureStdoutSilently`, not `captureStdout`: this output is parsed
+ * (secret *names* only — Cloudflare never returns values), never displayed, so
+ * it must not be teed to the parent's stdout. `offerMissingSecrets` runs this
+ * on every real deploy, including `--format json`, where the parent process
+ * writes a single JSON document to stdout — a teed `secret list` payload ahead
+ * of it would corrupt that document for CI's `JSON.parse(stdout)`.
  */
 const defaultRunner: SecretListRunner = async (command, args, cwd) => {
     try {
-        const result = await defaultSpawner({ args, captureStderr: true, captureStdout: true, command, cwd });
+        const result = await defaultSpawner({ args, captureStderr: true, captureStdoutSilently: true, command, cwd });
 
         return { code: result.code, stderr: result.stderr ?? "", stdout: result.stdout ?? "" };
     } catch (error: unknown) {

--- a/packages/cli/src/util/wrangler-secrets.ts
+++ b/packages/cli/src/util/wrangler-secrets.ts
@@ -7,18 +7,10 @@
  * reconcile against and `env diff` needs to compare. The command runner is
  * injectable so tests can stub the wrangler invocation.
  */
-import { execFile } from "node:child_process";
-
 import { resolveDeployDriver, resolveProjectTarget } from "@lunora/config";
 
 import { detectPackageManager, execArgsFor } from "./detect-package-manager";
-
-/**
- * The shape of an `execFile` callback error we care about. `@types/node`'s
- * `ExecFileException` covers this but is now deprecated; we only read `code`
- * (a number, or an `errno` string like `ENOENT`), so type it structurally.
- */
-type ExecFileError = Error & { code?: number | string | null };
+import { defaultSpawner } from "./spawn";
 
 interface SecretListRunnerResult {
     code: number;
@@ -48,21 +40,25 @@ interface ListRemoteSecretsResult {
     ok: boolean;
 }
 
-/** Map an execFile error to an exit code (0 on success, the child's code, else 1). */
-const execCode = (error: ExecFileError | null): number => {
-    if (!error) {
-        return 0;
+/**
+ * Runs `wrangler secret list` through {@link defaultSpawner} rather than a bare
+ * `execFile`, so it gets the same Windows `.cmd`-shim handling every other
+ * spawned command in this CLI relies on ({@link spawnShellCompat} inside
+ * `defaultSpawner`) — `execFile` on a package-manager shim (`pnpm`/`npx`/`yarn`/
+ * `bun`) fails outright on Windows (`EINVAL`/`ENOENT`, no PID) since Node's
+ * CVE-2024-27980 hardening. A spawn error (the child never started) is reported
+ * as a failed result rather than a thrown rejection, matching the previous
+ * `execFile`-based runner's contract.
+ */
+const defaultRunner: SecretListRunner = async (command, args, cwd) => {
+    try {
+        const result = await defaultSpawner({ args, captureStderr: true, captureStdout: true, command, cwd });
+
+        return { code: result.code, stderr: result.stderr ?? "", stdout: result.stdout ?? "" };
+    } catch (error: unknown) {
+        return { code: 1, stderr: error instanceof Error ? error.message : String(error), stdout: "" };
     }
-
-    return typeof error.code === "number" ? error.code : 1;
 };
-
-const defaultRunner: SecretListRunner = (command, args, cwd) =>
-    new Promise<SecretListRunnerResult>((resolve) => {
-        execFile(command, [...args], { cwd }, (error, stdout, stderr) => {
-            resolve({ code: execCode(error), stderr, stdout });
-        });
-    });
 
 /**
  * Parse `wrangler secret list --format json` output into a sorted name list.

--- a/packages/cli/src/util/wrangler-secrets.ts
+++ b/packages/cli/src/util/wrangler-secrets.ts
@@ -42,13 +42,13 @@ interface ListRemoteSecretsResult {
 
 /**
  * Runs `wrangler secret list` through {@link defaultSpawner} rather than a bare
- * `execFile`, so it gets the same Windows `.cmd`-shim handling every other
- * spawned command in this CLI relies on ({@link spawnShellCompat} inside
- * `defaultSpawner`) — `execFile` on a package-manager shim (`pnpm`/`npx`/`yarn`/
- * `bun`) fails outright on Windows (`EINVAL`/`ENOENT`, no PID) since Node's
- * CVE-2024-27980 hardening. A spawn error (the child never started) is reported
- * as a failed result rather than a thrown rejection, matching the previous
- * `execFile`-based runner's contract.
+ * `execFile`, so it gets the same Windows `.cmd`-shim handling (`spawnShellCompat`,
+ * used inside `defaultSpawner`) every other spawned command in this CLI relies
+ * on — `execFile` on a package-manager shim (`pnpm`/`npx`/`yarn`/`bun`) fails
+ * outright on Windows (`EINVAL`/`ENOENT`, no PID) since Node's CVE-2024-27980
+ * hardening. A spawn error (the child never started) is reported as a failed
+ * result rather than a thrown rejection, matching the previous `execFile`-based
+ * runner's contract.
  */
 const defaultRunner: SecretListRunner = async (command, args, cwd) => {
     try {

--- a/packages/codegen/src/blocking.ts
+++ b/packages/codegen/src/blocking.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared "which findings are ERROR-level" read for a {@link CodegenResult}.
+ *
+ * Every caller that gates a run on codegen's output — `lunora codegen`,
+ * `lunora deploy`, and the Vite plugin's `vite build` — needs the same
+ * deduplicated, sorted name list for its ERROR-level advisories and platform
+ * diagnostics. Before this file existed each of the three computed it inline
+ * with `[...new Set(...)].toSorted(...)`, and they had already drifted:
+ * `codegen-plugin.ts`'s copy left the names unsorted. Presentation (message
+ * wording, whether the two categories are folded into one combined message,
+ * strict/CI opt-outs) stays each caller's own job — this only owns the
+ * filter + dedup + sort so that part can't drift again.
+ */
+import type { Finding } from "@lunora/advisor";
+
+import type { PlatformDiagnostic } from "./platform-target";
+import type { CodegenResult } from "./run-codegen";
+
+const sortedUniqueNames = (names: Iterable<string>): ReadonlyArray<string> => [...new Set(names)].toSorted((a, b) => a.localeCompare(b));
+
+/** Deduplicated, sorted names of every ERROR-level advisory in `advisories`. */
+const errorAdvisoryNames = (advisories: ReadonlyArray<Pick<Finding, "level" | "name">>): ReadonlyArray<string> =>
+    sortedUniqueNames(advisories.filter((advisory) => advisory.level === "ERROR").map((advisory) => advisory.name));
+
+/** Deduplicated, sorted names of every error-level platform diagnostic in `platformDiagnostics`. */
+const errorPlatformDiagnosticNames = (platformDiagnostics: ReadonlyArray<Pick<PlatformDiagnostic, "level" | "name">>): ReadonlyArray<string> =>
+    sortedUniqueNames(platformDiagnostics.filter((diagnostic) => diagnostic.level === "error").map((diagnostic) => diagnostic.name));
+
+/**
+ * Convenience read combining both categories from a full {@link CodegenResult}
+ * — the shape the Vite plugin's `buildBlockingMessage` needs, which (unlike
+ * the CLI's `lunora codegen`/`lunora deploy`) folds ERROR-level advisories and
+ * platform diagnostics into a single blocking message with no strict/CI
+ * opt-out.
+ */
+const describeErrorLevelFindings = (
+    result: Pick<CodegenResult, "advisories" | "platformDiagnostics">,
+): { advisoryNames: ReadonlyArray<string>; platformDiagnosticNames: ReadonlyArray<string> } => {
+    return {
+        advisoryNames: errorAdvisoryNames(result.advisories),
+        platformDiagnosticNames: errorPlatformDiagnosticNames(result.platformDiagnostics),
+    };
+};
+
+export { describeErrorLevelFindings, errorAdvisoryNames, errorPlatformDiagnosticNames };

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -14,6 +14,7 @@ export type {
 export { diffSchemaSnapshots, SCHEMA_SNAPSHOT_VERSION, serializeSchemaSnapshot } from "../../../shared/schema-snapshot";
 export type { LintSchemaOptions } from "./advisor";
 export { formatAdvisories, lintSchema, toAdvisorContext } from "./advisor";
+export { describeErrorLevelFindings, errorAdvisoryNames, errorPlatformDiagnosticNames } from "./blocking";
 export { CodegenDiagnosticError, diagnosticAt } from "./diagnostics";
 export { AGENTS_FILENAME, discoverAgents } from "./discover-agents";
 export { default as discoverAuthApiCalls } from "./discover-authapi-calls";

--- a/packages/config/__tests__/reconcile-bindings.test.ts
+++ b/packages/config/__tests__/reconcile-bindings.test.ts
@@ -78,6 +78,67 @@ describe("reconcileWranglerBindings", () => {
         expect(result.reason).toContain("in sync");
     });
 
+    describe("environment argument (advisory only — does not change WHERE bindings are written)", () => {
+        it("still writes only to the top level when environment is passed", () => {
+            expect.assertions(2);
+
+            writeFileSync(
+                join(root, "wrangler.jsonc"),
+                `{
+    "name": "lunora-app",
+    "compatibility_date": "2026-04-07",
+    "durable_objects": { "bindings": [] },
+    "env": { "production": {} },
+}
+`,
+                "utf8",
+            );
+
+            const result = reconcileWranglerBindings(root, baseInferred(), "production");
+
+            expect(result.changed).toBe(true);
+            // The write landed at the top level, not inside env.production —
+            // the pipeline has no env-scoped write path (see the doc comment).
+            expect(readConfig().durable_objects.bindings).toContainEqual({ class_name: "ShardDO", name: "SHARD" });
+        });
+
+        it("warns that env.production has its own non-inheritable bindings needing manual reconciliation", () => {
+            expect.assertions(1);
+
+            writeFileSync(
+                join(root, "wrangler.jsonc"),
+                `{
+    "name": "lunora-app",
+    "compatibility_date": "2026-04-07",
+    "durable_objects": { "bindings": [] },
+    "env": { "production": {} },
+}
+`,
+                "utf8",
+            );
+
+            const result = reconcileWranglerBindings(root, baseInferred(), "production");
+
+            expect(result.warnings.some((line) => line.includes("env.production") && line.includes("top level"))).toBe(true);
+        });
+
+        it("warns distinctly when the requested environment isn't declared at all", () => {
+            expect.assertions(1);
+
+            const result = reconcileWranglerBindings(root, baseInferred(), "production");
+
+            expect(result.warnings.some((line) => line.includes('no "env.production" block'))).toBe(true);
+        });
+
+        it("does not warn about environments when none was requested (unchanged default)", () => {
+            expect.assertions(1);
+
+            const result = reconcileWranglerBindings(root, baseInferred());
+
+            expect(result.warnings.some((line) => line.includes("env."))).toBe(false);
+        });
+    });
+
     it("turns on observability when the key is absent (not just for container apps)", () => {
         expect.assertions(3);
 

--- a/packages/config/__tests__/wrangler-validator.test.ts
+++ b/packages/config/__tests__/wrangler-validator.test.ts
@@ -375,6 +375,257 @@ describe("wrangler-validator", () => {
         });
     });
 
+    describe("validateWranglerConfig — environment-scoped (env.<name>)", () => {
+        /** A top level with every binding this suite exercises, valid on its own. */
+        const topLevel = (): WranglerConfig => {return {
+            compatibility_date: REQUIRED_COMPATIBILITY_DATE,
+            compatibility_flags: [REQUIRED_FLAG],
+            d1_databases: [{ binding: "DB" }],
+            durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
+            kv_namespaces: [{ binding: "CACHE", id: "top-level-kv-id" }],
+            observability: { enabled: true },
+            queues: { producers: [{ binding: "EMAILS", queue: "emails" }] },
+            r2_buckets: [{ binding: "UPLOADS" }],
+            vars: { LUNORA_ENV: "shared" },
+        }};
+
+        it("ignores env entirely when environment is not requested (unchanged default)", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: {} };
+
+            expect(validateWranglerConfig(wrangler).valid).toBe(true);
+        });
+
+        it("errors distinctly when --env names an undeclared environment", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { staging: {} };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            expect(report.valid).toBe(false);
+            expect(report.errors.some((line) => line.includes('names no environment declared') && line.includes("staging"))).toBe(true);
+        });
+
+        it("errors the same way when no env block is declared at all", () => {
+            expect.assertions(2);
+
+            const report = validateWranglerConfig(topLevel(), undefined, "production");
+
+            expect(report.valid).toBe(false);
+            expect(report.errors.some((line) => line.includes("no environments are declared"))).toBe(true);
+        });
+
+        // durable_objects — NON-inheritable: a SHARD binding at the top level
+        // must NOT satisfy env.production when that environment doesn't repeat
+        // it — wrangler deploys env.production with no SHARD binding at all.
+        it("durable_objects: a top-level-only SHARD binding fails env.production validation", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: {} };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            expect(report.valid).toBe(false);
+            expect(report.errors.some((line) => SHARD_BINDING_ERROR_RE.test(line))).toBe(true);
+        });
+
+        it("durable_objects: passes once env.production repeats its own SHARD binding", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
+
+            expect(validateWranglerConfig(wrangler, undefined, "production").valid).toBe(true);
+        });
+
+        // d1_databases — inferred non-inheritable (see NON_INHERITABLE_KEYS doc
+        // comment): a schema with a .global() table needs env.production's OWN DB
+        // binding, not the top level's.
+        it("d1_databases: a top-level-only DB binding fails env.production when the schema has a .global() table", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
+
+            const report = validateWranglerConfig(wrangler, { hasGlobalTable: true }, "production");
+
+            expect(report.valid).toBe(false);
+            expect(report.errors.some((line) => line.includes('d1_databases must include a binding named "DB"'))).toBe(true);
+        });
+
+        it("d1_databases: passes once env.production repeats its own DB binding", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = {
+                production: { d1_databases: [{ binding: "DB" }], durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } },
+            };
+
+            expect(validateWranglerConfig(wrangler, { hasGlobalTable: true }, "production").valid).toBe(true);
+        });
+
+        // kv_namespaces — NON-inheritable, hint-only (warns on a missing id,
+        // doesn't error): env.production's OWN (id-less) entry must be what
+        // gets validated — the top level's entry (which DOES have an id) must
+        // not silently paper over it.
+        it("kv_namespaces: env.production's own id-less entry warns, even though the top level's has an id", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = {
+                production: {
+                    durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
+                    kv_namespaces: [{ binding: "CACHE" }],
+                },
+            };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            // Still valid (kv_namespaces is a hint, not a hard error) — but the
+            // warning must fire, proving the merged view used env.production's
+            // id-less entry rather than the top level's complete one.
+            expect(report.valid).toBe(true);
+            expect(report.warnings.some((line) => line.toLowerCase().includes("kv") && line.includes("id"))).toBe(true);
+        });
+
+        // r2_buckets — NON-inheritable, self-describing (shape-only, no remote
+        // id to warn about) — this asserts the merge drops the top-level entry
+        // rather than that anything currently errors on a missing one.
+        it("r2_buckets: env.production's merged view has no bucket when it doesn't declare one", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
+
+            // No direct assertion surface on r2_buckets in the report (shape-only,
+            // self-describing) — exercised via vars below instead, which DOES
+            // have an observable effect (the CORS lint).
+            expect(validateWranglerConfig(wrangler, undefined, "production").valid).toBe(true);
+        });
+
+        // vars — NON-inheritable: a CORS-unsafe combination declared ONLY under
+        // env.production must still be caught; the top level's (safe) vars must
+        // not mask it.
+        it("vars: env.production's own (unsafe) vars are validated, not the top level's (safe) ones", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = {
+                production: {
+                    durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
+                    vars: { LUNORA_ALLOWED_ORIGINS: "*", LUNORA_CORS_ALLOW_CREDENTIALS: "true" },
+                },
+            };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            expect(report.valid).toBe(false);
+            expect(report.errors.some((line) => line.includes("wildcard"))).toBe(true);
+        });
+
+        it("vars: the top level's unsafe vars do NOT leak into an env.production that declares its own safe vars", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.vars = { LUNORA_ALLOWED_ORIGINS: "*", LUNORA_CORS_ALLOW_CREDENTIALS: "true" };
+            wrangler.env = {
+                production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] }, vars: { LUNORA_ALLOWED_ORIGINS: "https://app.example.com" } },
+            };
+
+            expect(validateWranglerConfig(wrangler, undefined, "production").valid).toBe(true);
+        });
+
+        // queues — NON-inheritable: exercised for shape only (no direct error
+        // surface here), asserting the merge behavior via warnings/valid stays
+        // sane rather than throwing.
+        it("queues: env.production without its own producers/consumers does not crash and stays valid", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
+
+            expect(validateWranglerConfig(wrangler, undefined, "production").valid).toBe(true);
+        });
+
+        // compatibility_date / observability — INHERITABLE: env.production
+        // inherits the top level's value when it doesn't override it.
+        it("compatibility_date: inherits the top level's value into env.production", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
+
+            // The top level's REQUIRED_COMPATIBILITY_DATE is >= the minimum, so
+            // this only passes if it was actually carried over into the merged view.
+            expect(validateWranglerConfig(wrangler, undefined, "production").errors.some((line) => line.includes("compatibility_date must be"))).toBe(false);
+        });
+
+        it("compatibility_date: env.production's own override is used over the top level's", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = {
+                production: { compatibility_date: "2020-01-01", durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } },
+            };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            expect(report.valid).toBe(false);
+            expect(report.errors.some((line) => line.includes("compatibility_date must be"))).toBe(true);
+        });
+
+        it("observability: inherits the top level's enabled:true into env.production (no cache/observability error)", () => {
+            expect.assertions(1);
+
+            const wrangler = topLevel();
+
+            wrangler.env = { production: { durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] } } };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            expect(report.errors.some((line) => line.toLowerCase().includes("observability"))).toBe(false);
+        });
+
+        it("warns once (not per-key) when env.production overrides a key with no verified inheritance rule", () => {
+            expect.assertions(2);
+
+            const wrangler = topLevel();
+
+            wrangler.env = {
+                production: {
+                    durable_objects: { bindings: [{ class_name: "ShardDO", name: "SHARD" }] },
+                    // `hyperdrive` is a real WranglerConfig key with no verified
+                    // entry in either NON_INHERITABLE_KEYS or INHERITABLE_KEYS.
+                    hyperdrive: [{ binding: "HYPERDRIVE", id: "env-only-id" }],
+                },
+            };
+
+            const report = validateWranglerConfig(wrangler, undefined, "production");
+
+            expect(report.warnings.some((line) => line.includes("hyperdrive") && line.includes("TOP-LEVEL value only"))).toBe(true);
+            // Exactly one such warning, not one per unverified key.
+            expect(report.warnings.filter((line) => line.includes("TOP-LEVEL value only"))).toHaveLength(1);
+        });
+    });
+
     describe("withTailConsumer", () => {
         it("appends a tail consumer when none is wired", () => {
             expect.assertions(2);
@@ -427,6 +678,82 @@ describe("wrangler-validator", () => {
             expect(result.problems).toEqual([]);
             expect(result.report.valid).toBe(true);
             expect(result.wranglerPath).toBe(join(workdir, "wrangler.jsonc"));
+        });
+
+        describe("environment argument (env.<name>)", () => {
+            // Top level declares everything (so a top-level-only validation
+            // passes); env.production and env.staging each declare their OWN
+            // (non-inheritable) durable_objects — staging's is deliberately
+            // missing the SHARD binding to prove the merge is per-environment.
+            const MULTI_ENV_WRANGLER = `{
+    "name": "lunora-app",
+    "main": "src/index.ts",
+    "compatibility_date": "${REQUIRED_COMPATIBILITY_DATE}",
+    "compatibility_flags": ["nodejs_compat", "${REQUIRED_FLAG}"],
+    "durable_objects": {
+        "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }]
+    },
+    "d1_databases": [{ "binding": "DB", "database_name": "lunora-global", "database_id": "top-level-only" }],
+    "env": {
+        "production": {
+            "durable_objects": {
+                "bindings": [{ "name": "SHARD", "class_name": "ShardDO" }]
+            },
+            "d1_databases": [{ "binding": "DB", "database_name": "lunora-prod", "database_id": "prod-id" }]
+        },
+        "staging": {
+            "vars": { "LUNORA_ENV": "staging" }
+        }
+    }
+}
+`;
+
+            it("validating the top level (no --environment) still passes — unchanged default", () => {
+                expect.assertions(1);
+
+                writeSchema(SCHEMA_WITH_GLOBAL);
+                writeFileSync(join(workdir, "wrangler.jsonc"), MULTI_ENV_WRANGLER, "utf8");
+
+                expect(validateWranglerProject({ projectRoot: workdir }).report.valid).toBe(true);
+            });
+
+            it("validating --env production inspects env.production's own bindings and passes", () => {
+                expect.assertions(1);
+
+                writeSchema(SCHEMA_WITH_GLOBAL);
+                writeFileSync(join(workdir, "wrangler.jsonc"), MULTI_ENV_WRANGLER, "utf8");
+
+                const result = validateWranglerProject({ environment: "production", projectRoot: workdir });
+
+                expect(result.report.valid).toBe(true);
+            });
+
+            it("validating --env staging fails — a missing SHARD there errors even though the top level has one", () => {
+                expect.assertions(3);
+
+                writeSchema(SCHEMA_WITH_GLOBAL);
+                writeFileSync(join(workdir, "wrangler.jsonc"), MULTI_ENV_WRANGLER, "utf8");
+
+                const result = validateWranglerProject({ environment: "staging", projectRoot: workdir });
+
+                expect(result.report.valid).toBe(false);
+                expect(result.problems.some((line) => SHARD_BINDING_ERROR_RE.test(line))).toBe(true);
+                // Also missing its own DB binding (schema has a .global() table).
+                expect(result.problems.some((line) => line.includes('d1_databases must include a binding named "DB"'))).toBe(true);
+            });
+
+            it("an undeclared --env errors distinctly, without running the rest of validation", () => {
+                expect.assertions(3);
+
+                writeSchema(SCHEMA_WITH_GLOBAL);
+                writeFileSync(join(workdir, "wrangler.jsonc"), MULTI_ENV_WRANGLER, "utf8");
+
+                const result = validateWranglerProject({ environment: "canary", projectRoot: workdir });
+
+                expect(result.report.valid).toBe(false);
+                expect(result.problems).toHaveLength(1);
+                expect(result.problems[0]).toContain('names no environment declared');
+            });
         });
 
         describe("durable object / workflow classes the entry does not export", () => {

--- a/packages/config/src/cloudflare/reconcile-bindings.ts
+++ b/packages/config/src/cloudflare/reconcile-bindings.ts
@@ -77,6 +77,9 @@ interface WranglerShape {
     containers?: ReadonlyArray<ContainerEntry>;
     d1_databases?: ReadonlyArray<{ binding?: string }>;
     durable_objects?: { bindings?: ReadonlyArray<DurableObjectBinding> };
+    // Presence-only: read here just to tell whether a requested `--env <name>`
+    // is declared at all, for the advisory warning below. Never written into.
+    env?: Record<string, unknown>;
     // Hint-only: the `app_id` is a remote Flagship app Lunora can't mint — warned, never written.
     flagship?: ReadonlyArray<{ app_id?: string; binding?: string }>;
     // Hint-only: the `id` is a remote Hyperdrive resource Lunora can't mint — warned, never written.
@@ -687,8 +690,21 @@ const reconcileQueues = (text: string, parsed: WranglerShape, queues: ReadonlyAr
  *
  * Writes only when something is missing; returns `changed: false` when the
  * config already satisfies the inferred needs.
+ *
+ * `environment`, when passed, does NOT change where this writes — every step
+ * below still only touches the TOP-LEVEL config; wrangler's `env.&lt;name>`
+ * blocks have no auto-provisioning path today. It is used only to emit an
+ * advisory warning, because bindings (`durable_objects`, `d1_databases`, …)
+ * are non-inheritable (see `wrangler-validator.ts`'s `NON_INHERITABLE_KEYS`):
+ * a `--env production` deploy needs its OWN copy of each one, and silently
+ * writing only to the top level would leave that gap unmentioned. Extending
+ * the JSONC writer itself to target `env.&lt;name>.*` idempotently for every
+ * binding kind here is a separate, larger change (each of the ~10 pipeline
+ * steps below reads AND writes the top-level path) that this fix does not
+ * attempt — `lunora deploy --env &lt;name>` now VALIDATES the env-scoped view
+ * (closing the reported gap), it just doesn't yet auto-provision it.
  */
-const reconcileWranglerBindings = (projectRoot: string, inferred: InferredBindings): ReconcileBindingsResult => {
+const reconcileWranglerBindings = (projectRoot: string, inferred: InferredBindings, environment?: string): ReconcileBindingsResult => {
     const wranglerPath = findWranglerFile(projectRoot);
 
     const exportGaps = collectExportGaps(inferred);
@@ -713,6 +729,19 @@ const reconcileWranglerBindings = (projectRoot: string, inferred: InferredBindin
 
     // Hints are filtered against the existing config so a wired-up project is quiet.
     const warnings = collectWarnings(inferred, projectRoot, parsed);
+
+    // See the doc comment above: auto-provisioning has no env-scoped write
+    // path, so a `--env <name>` deploy is told plainly rather than silently
+    // getting top-level-only bindings its non-inheritable ones won't reach.
+    if (environment !== undefined) {
+        const envBlockDeclared = parsed.env?.[environment] !== undefined;
+
+        warnings.push(
+            envBlockDeclared
+                ? `auto-provisioned bindings are written to the top level of wrangler.jsonc only — "env.${environment}" has its own (non-inheritable) bindings and must be reconciled by hand; \`lunora deploy --env ${environment}\` now validates them, so a gap here will be reported at deploy time.`
+                : `--env "${environment}" was requested but wrangler.jsonc declares no "env.${environment}" block — auto-provisioned bindings are written to the top level only and will not apply to that environment.`,
+        );
+    }
 
     // Only exported container classes are provisionable — wrangler rejects a
     // class_name the worker doesn't export. Their DO bindings + migration

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -110,6 +110,12 @@ interface WranglerConfig {
     // `validateDispatchNamespaces`.
     dispatch_namespaces?: ReadonlyArray<{ binding?: string; namespace?: string; outbound?: unknown } | null | undefined>;
     durable_objects?: { bindings?: ReadonlyArray<WranglerDurableObjectBinding> };
+    // Per-environment overrides (`env.<name>` in wrangler.jsonc). Which keys a
+    // declared environment inherits from the top level vs must redeclare is
+    // NOT uniform — see `NON_INHERITABLE_KEYS` / `INHERITABLE_KEYS` /
+    // `mergeWranglerEnvironment`. Recursive by the same shape (minus its own
+    // `env`, which wrangler does not support nesting).
+    env?: Record<string, WranglerConfig>;
     // Per-entrypoint cache control for named `WorkerEntrypoint`s. Lunora apps
     // typically use a single `export default` entrypoint, so this is passthrough.
     // Parsed from untrusted JSONC, so the map or any entry may be `null`;
@@ -185,6 +191,137 @@ interface WranglerValidationReport {
     valid: boolean;
     warnings: string[];
 }
+
+/**
+ * `env.&lt;name>` keys confirmed NON-inheritable by the current Cloudflare docs
+ * (`workers/wrangler/configuration/`, "Non-inheritable keys" section, checked
+ * 2026-07-31): wrangler does NOT fall back to the top-level value for these
+ * when a declared environment omits one — each must be redeclared per
+ * environment or it is simply absent there. Every entry below except
+ * `d1_databases` is named verbatim in that section's list.
+ *
+ * `d1_databases` is not in the docs' literal enumeration, but every OTHER
+ * binding-shaped key in that same list (`durable_objects`, `kv_namespaces`,
+ * `r2_buckets`, `vectorize`, `services`, `queues`, `workflows`,
+ * `tail_consumers`, `secrets_store_secrets`) is confirmed non-inheritable,
+ * and the section's own framing is general — "Bindings, such as `vars` or
+ * `kv_namespaces`, are not inheritable and need to be defined explicitly." A
+ * D1 binding is a binding by every definition Cloudflare uses elsewhere in
+ * the same document, so treating it the same as its siblings here is a
+ * same-pattern inference from a direct quote, not a guess. Flagged so a
+ * future reviewer can re-check it if Cloudflare's docs are ever updated to
+ * state it explicitly (or to contradict this).
+ */
+const NON_INHERITABLE_KEYS = [
+    "d1_databases",
+    "durable_objects",
+    "kv_namespaces",
+    "queues",
+    "r2_buckets",
+    "secrets_store_secrets",
+    "services",
+    "tail_consumers",
+    "vars",
+    "vectorize",
+    "workflows",
+] as const satisfies ReadonlyArray<keyof WranglerConfig>;
+
+/**
+ * `env.&lt;name>` keys confirmed INHERITABLE by the same docs section: an
+ * environment that does not override one still gets the top-level value.
+ * Limited to the keys this validator actually reads — the docs' "Inheritable
+ * keys" list is longer (`name`, `route`, `triggers`, …) but this project does
+ * not validate those fields, so extending the table to cover them would add
+ * surface with nothing exercising it.
+ */
+const INHERITABLE_KEYS = [
+    "assets",
+    "compatibility_date",
+    "exports",
+    "logpush",
+    "main",
+    "migrations",
+    "observability",
+    "placement",
+] as const satisfies ReadonlyArray<keyof WranglerConfig>;
+
+interface WranglerEnvironmentMerge {
+    /** Set when `environment` names no `env.&lt;name>` block declared in the config — the caller should treat this as a hard validation failure. */
+    error?: string;
+    /** The env-scoped view: `wrangler` unchanged when `environment` is `undefined`, otherwise merged per {@link NON_INHERITABLE_KEYS} / {@link INHERITABLE_KEYS}. */
+    merged: WranglerConfig;
+
+    /**
+     * Keys the env block overrides whose inheritance status this validator
+     * cannot verify (not in either table above) — validated against the
+     * TOP-LEVEL value only, per the "do not guess" rule; the override is
+     * silently ignored for validation purposes. The caller logs this ONCE
+     * (not per key) so an unusual `env.&lt;name>` block doesn't spam warnings.
+     */
+    unverifiedKeys: string[];
+}
+
+/**
+ * Resolve the config view `wrangler deploy --env &lt;environment>` will actually
+ * use. Undefined `environment` returns `wrangler` unchanged — the top-level
+ * config is what a plain `wrangler deploy` reads, same as today.
+ *
+ * Deliberately independent of any other merge in this module: called fresh
+ * from the ORIGINAL `wrangler` each time (see both call sites), so there is
+ * no risk of merging an already-merged config and silently losing the
+ * top-level fallback a second merge pass would no longer have access to.
+ */
+const mergeWranglerEnvironment = (wrangler: WranglerConfig, environment: string | undefined): WranglerEnvironmentMerge => {
+    if (environment === undefined) {
+        return { merged: wrangler, unverifiedKeys: [] };
+    }
+
+    const envBlock = wrangler.env?.[environment];
+
+    if (envBlock === undefined) {
+        const declared = Object.keys(wrangler.env ?? {}).toSorted((a, b) => a.localeCompare(b));
+        const declaredSuffix = declared.length > 0 ? ` (declared: ${declared.join(", ")}).` : " (no environments are declared).";
+
+        return {
+            error: `--env "${environment}" names no environment declared in wrangler.jsonc's "env" block${declaredSuffix}`,
+            merged: wrangler,
+            unverifiedKeys: [],
+        };
+    }
+
+    // Baseline: the top-level config, `env` included — harmless since nothing
+    // downstream reads `merged.env`, and this function is always called fresh
+    // from the ORIGINAL `wrangler` (see both call sites), never from an
+    // already-merged result, so there is no risk of a stale `env` block
+    // confusing a later merge. A key the env block never mentions — inheritable,
+    // non-inheritable, or unverified alike — keeps its top-level value here,
+    // which is correct for all three cases EXCEPT when the env block DOES
+    // override an inheritable or non-inheritable key, handled below.
+    const merged: WranglerConfig = { ...wrangler };
+    const envBlockKeys = Object.keys(envBlock).filter((key) => key !== "env") as ReadonlyArray<keyof WranglerConfig>;
+
+    for (const key of envBlockKeys) {
+        if ((INHERITABLE_KEYS as ReadonlyArray<keyof WranglerConfig>).includes(key)) {
+            // Env overrides top-level when present — exactly what "inheritable"
+            // means: absent, it already fell through from the baseline above.
+            (merged as Record<string, unknown>)[key] = (envBlock as Record<string, unknown>)[key];
+        }
+    }
+
+    // Non-inheritable: use ONLY the env block's value, even when the block
+    // doesn't set it (making it `undefined`) — a declared environment that
+    // doesn't repeat a binding does NOT inherit the top level's, which is
+    // exactly the gap this closes (a missing SHARD binding at the top level
+    // is a false negative for `--env production` if that env has its own).
+    for (const key of NON_INHERITABLE_KEYS) {
+        (merged as Record<string, unknown>)[key] = (envBlock as Record<string, unknown>)[key];
+    }
+
+    const knownKeys = new Set<string>([...NON_INHERITABLE_KEYS, ...INHERITABLE_KEYS]);
+    const unverifiedKeys = envBlockKeys.filter((key) => !knownKeys.has(key)).map(String);
+
+    return { merged, unverifiedKeys };
+};
 
 /**
  * Schema-declared vector indexes must each have a matching `vectorize` binding.
@@ -1018,15 +1155,52 @@ const validateCorsVariables = (wrangler: WranglerConfig, errors: string[]): void
 };
 
 /**
+ * Resolve the env-scoped view for {@link validateWranglerConfig} and fold in
+ * its "unverified key" warning. Pulled out purely to keep
+ * `validateWranglerConfig`'s cognitive complexity within the repo's lint
+ * budget — no behavior change from inlining it.
+ */
+const resolveEnvironmentView = (wrangler: WranglerConfig, environment: string | undefined, warnings: string[]): { error?: string; wrangler: WranglerConfig } => {
+    const { error, merged, unverifiedKeys } = mergeWranglerEnvironment(wrangler, environment);
+
+    if (error !== undefined) {
+        return { error, wrangler: merged };
+    }
+
+    if (unverifiedKeys.length > 0) {
+        warnings.push(
+            `env.${String(environment)} overrides ${unverifiedKeys.join(", ")}, which this validator doesn't have a verified inheritance rule for — validated against the TOP-LEVEL value only. Double-check ${unverifiedKeys.length === 1 ? "it" : "them"} by hand for "${String(environment)}".`,
+        );
+    }
+
+    return { wrangler: merged };
+};
+
+/**
  * Pure validator: given a parsed `WranglerConfig` object and an optional
  * `SchemaInfo`, produce a structured report. Performs no I/O.
+ *
+ * `environment`, when set, validates the `env.&lt;environment>` view
+ * ({@link mergeWranglerEnvironment}) instead of the top-level config — e.g. a
+ * `durable_objects` binding present only at the top level is a validation
+ * FAILURE for `--env production` if `env.production` doesn't repeat it,
+ * because `durable_objects` is non-inheritable and wrangler will not carry it
+ * over. Omit `environment` to validate the top level only (unchanged default).
  */
-const validateWranglerConfig = (wrangler: WranglerConfig | undefined, schema?: SchemaInfo): WranglerValidationReport => {
+const validateWranglerConfig = (wranglerInput: WranglerConfig | undefined, schema?: SchemaInfo, environment?: string): WranglerValidationReport => {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    if (!wrangler || typeof wrangler !== "object") {
+    if (!wranglerInput || typeof wranglerInput !== "object") {
         errors.push("wrangler config is not a valid object");
+
+        return { errors, valid: false, warnings };
+    }
+
+    const { error: environmentError, wrangler } = resolveEnvironmentView(wranglerInput, environment, warnings);
+
+    if (environmentError !== undefined) {
+        errors.push(environmentError);
 
         return { errors, valid: false, warnings };
     }
@@ -1121,6 +1295,13 @@ const validateWranglerConfig = (wrangler: WranglerConfig | undefined, schema?: S
 const validateWrangler: typeof validateWranglerConfig = validateWranglerConfig;
 
 interface WranglerProjectValidationOptions {
+    /**
+     * Cloudflare environment to validate against `env.&lt;name>` in
+     * wrangler.jsonc. See {@link mergeWranglerEnvironment} for which keys
+     * inherit the top-level value vs must be redeclared per environment.
+     * Omit to validate the top-level config only (unchanged default).
+     */
+    environment?: string;
     projectRoot: string;
     schemaDir?: string;
 }
@@ -1444,10 +1625,26 @@ const validateWranglerProject = (options: WranglerProjectValidationOptions): Wra
         };
     }
 
+    // Resolved ONCE for the FS-aware checks below, straight from the raw
+    // `wrangler` — kept independent of `validateWranglerConfig`'s own
+    // equivalent merge (called with `options.environment` a few lines down)
+    // rather than fed this result, so there is exactly one merge input
+    // (`wrangler` unmerged) and no risk of double-merging an already-merged
+    // config, which would look up `merged.env` and find nothing.
+    const { error: environmentError, merged: resolvedWrangler } = mergeWranglerEnvironment(wrangler, options.environment);
+
+    if (environmentError !== undefined) {
+        return {
+            problems: [environmentError],
+            report: { errors: [environmentError], valid: false, warnings: [] },
+            wranglerPath,
+        };
+    }
+
     // Surface a parse failure as a warning rather than swallowing it — codegen
     // reports the actionable error elsewhere, but a complete miss is hard to debug.
     const { error: schemaError, info: schemaInfo } = discoverSchemaInfo(options.projectRoot, schemaDirectory);
-    const report = validateWranglerConfig(wrangler, schemaInfo);
+    const report = validateWranglerConfig(wrangler, schemaInfo, options.environment);
 
     if (schemaError !== undefined) {
         report.warnings.push(`schema parse failed in ${schemaDirectory}/schema.ts: ${schemaError}`);
@@ -1458,7 +1655,7 @@ const validateWranglerProject = (options: WranglerProjectValidationOptions): Wra
     // references are left to wrangler — pure shape checks already ran above.
     const configDirectory = dirname(wranglerPath);
 
-    report.errors.push(...collectContainerImageErrors(wrangler.containers ?? [], configDirectory, wranglerPath));
+    report.errors.push(...collectContainerImageErrors(resolvedWrangler.containers ?? [], configDirectory, wranglerPath));
 
     // FS-aware: every declared Durable Object / Workflow class must be exported
     // by the worker entry, or wrangler refuses to bundle.
@@ -1474,13 +1671,13 @@ const validateWranglerProject = (options: WranglerProjectValidationOptions): Wra
     // Warning still closes the reported gap: `verify` and `doctor` used to print
     // a clean bill of health on a tree that cannot deploy, and now they say so.
     // The authoritative check remains wrangler's own, which `lunora build` runs.
-    report.warnings.push(...collectUnexportedClassErrors(wrangler, options.projectRoot, wranglerPath));
+    report.warnings.push(...collectUnexportedClassErrors(resolvedWrangler, options.projectRoot, wranglerPath));
 
     // FS-aware: `assets.directory` is created by the client build, so it may
     // legitimately not exist at validation time (pre-build). Surface a *warning*
     // (never an error) so pre-build validation flows aren't broken — mirrors the
     // container-image existence check above, but downgraded to a warning.
-    const assetsDirectory = wrangler.assets?.directory;
+    const assetsDirectory = resolvedWrangler.assets?.directory;
 
     if (typeof assetsDirectory === "string" && assetsDirectory.length > 0) {
         const resolved = assetsDirectory.startsWith("/") ? assetsDirectory : join(configDirectory, assetsDirectory);

--- a/packages/vite/__tests__/codegen-plugin.test.ts
+++ b/packages/vite/__tests__/codegen-plugin.test.ts
@@ -120,6 +120,69 @@ describe("codegen-plugin", () => {
             expect(dataModel).toContain("export interface Doc_users");
         });
 
+        it("vite build fails when codegen reports an ERROR-level advisory (index_references_unknown_field)", async () => {
+            expect.assertions(2);
+
+            writeFixture(workdir);
+
+            const badSchema = SCHEMA_SOURCE.replace(
+                `.index("by_channel", ["channelId"]),`,
+                `.index("by_channel", ["channelId"])\n        .index("by_bogus", ["doesNotExist"]),`,
+            );
+
+            expect(badSchema).not.toBe(SCHEMA_SOURCE);
+            writeFileSync(join(workdir, "lunora", "schema.ts"), badSchema, "utf8");
+
+            const plugin = codegenPlugin(makeOptions(workdir));
+
+            // Vite calls `config` (with the resolved command) before `buildStart` on
+            // every run — this is how the plugin tells a `vite build` apart from a
+            // `vite dev` inside `buildStart`, which fires for both.
+            (plugin.config as (userConfig: unknown, env: { command: "build" | "serve" }) => void)(undefined, { command: "build" });
+
+            const buildContext = { error: (message: string): never => { throw new Error(message); } };
+
+            await expect(
+                (plugin.buildStart as (this: typeof buildContext) => Promise<void>).call(buildContext),
+            ).rejects.toThrow(/ERROR-level.*index_references_unknown_field/u);
+        });
+
+        it("vite dev only logs the same ERROR-level advisory (never throws)", async () => {
+            expect.assertions(3);
+
+            writeFixture(workdir);
+
+            const badSchema = SCHEMA_SOURCE.replace(
+                `.index("by_channel", ["channelId"]),`,
+                `.index("by_channel", ["channelId"])\n        .index("by_bogus", ["doesNotExist"]),`,
+            );
+
+            writeFileSync(join(workdir, "lunora", "schema.ts"), badSchema, "utf8");
+
+            const errors: string[] = [];
+            // eslint-disable-next-line no-console -- capturing console refs to restore after the test
+            const originalError = console.error;
+
+            // eslint-disable-next-line no-console
+            console.error = (message: string) => errors.push(message);
+
+            try {
+                const plugin = codegenPlugin(makeOptions(workdir));
+
+                (plugin.config as (userConfig: unknown, env: { command: "build" | "serve" }) => void)(undefined, { command: "serve" });
+
+                // No `this.error`-capable context is even needed: dev never reaches it.
+                await expect((plugin.buildStart as (this: unknown) => Promise<void>).call(undefined)).resolves.toBeUndefined();
+
+                expect(errors.some((line) => line.includes("index_references_unknown_field"))).toBe(true);
+                // Codegen still wrote its output — dev is log-only, not blocking.
+                expect(existsSync(join(workdir, "lunora", "_generated", "api.ts"))).toBe(true);
+            } finally {
+                // eslint-disable-next-line no-console
+                console.error = originalError;
+            }
+        });
+
         it("buildStart logs a warning when schema.ts is missing (does not crash)", () => {
             expect.assertions(2);
 

--- a/packages/vite/__tests__/codegen-plugin.test.ts
+++ b/packages/vite/__tests__/codegen-plugin.test.ts
@@ -131,6 +131,7 @@ describe("codegen-plugin", () => {
             );
 
             expect(badSchema).not.toBe(SCHEMA_SOURCE);
+
             writeFileSync(join(workdir, "lunora", "schema.ts"), badSchema, "utf8");
 
             const plugin = codegenPlugin(makeOptions(workdir));

--- a/packages/vite/src/codegen-plugin.ts
+++ b/packages/vite/src/codegen-plugin.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
 
+import type { CodegenResult } from "@lunora/codegen";
 import { CodegenDiagnosticError, createCodegenProject, refreshCodegenProject, runCodegen } from "@lunora/codegen";
 import { inferLunoraBindings, LUNORA_CONFIG_FILE } from "@lunora/config";
 import type { ExportGap } from "@lunora/config/cloudflare";
@@ -136,6 +137,29 @@ interface CodegenSafelyResult {
 }
 
 /**
+ * The `blockingMessage` for {@link runCodegenSafely}'s result: one aggregated
+ * line naming every ERROR-level advisory/platform diagnostic, or `undefined`
+ * when none. Extracted purely to keep `runCodegenSafely`'s cognitive
+ * complexity within the repo's lint budget — no behavior change from inlining
+ * it.
+ */
+const buildBlockingMessage = (result: Pick<CodegenResult, "advisories" | "platformDiagnostics">): string | undefined => {
+    const blockingNames = [
+        ...result.advisories.filter((advisory) => advisory.level === "ERROR").map((advisory) => advisory.name),
+        ...result.platformDiagnostics.filter((diagnostic) => diagnostic.level === "error").map((diagnostic) => diagnostic.name),
+    ];
+
+    if (blockingNames.length === 0) {
+        return undefined;
+    }
+
+    const names = [...new Set(blockingNames)].join(", ");
+    const noun = blockingNames.length === 1 ? "issue" : "issues";
+
+    return `${LUNORA_TAG} ${String(blockingNames.length)} ERROR-level ${noun} (${names}) — see the log above for detail.`;
+};
+
+/**
  * Run codegen, returning the absolute directory codegen actually wrote to
  * (so callers can invalidate the *real* output, not an independently-guessed
  * path) and — when any advisory/platform diagnostic is ERROR-level — an
@@ -210,16 +234,8 @@ const runCodegenSafely = (
         // platform diagnostic says the emitted surface doesn't match the
         // target) — `vite dev` never does, matching `lunora codegen`'s own
         // advisory-outside-CI default.
-        const blockingNames = [
-            ...result.advisories.filter((advisory) => advisory.level === "ERROR").map((advisory) => advisory.name),
-            ...result.platformDiagnostics.filter((diagnostic) => diagnostic.level === "error").map((diagnostic) => diagnostic.name),
-        ];
-
         return {
-            blockingMessage:
-                blockingNames.length > 0
-                    ? `${LUNORA_TAG} ${String(blockingNames.length)} ERROR-level ${blockingNames.length === 1 ? "issue" : "issues"} (${[...new Set(blockingNames)].join(", ")}) — see the log above for detail.`
-                    : undefined,
+            blockingMessage: buildBlockingMessage(result),
             outputDirectory: resolve(result.outputDirectory),
         };
     } catch (error: unknown) {

--- a/packages/vite/src/codegen-plugin.ts
+++ b/packages/vite/src/codegen-plugin.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { basename, join, resolve, sep } from "node:path";
 
 import type { CodegenResult } from "@lunora/codegen";
-import { CodegenDiagnosticError, createCodegenProject, refreshCodegenProject, runCodegen } from "@lunora/codegen";
+import { CodegenDiagnosticError, createCodegenProject, describeErrorLevelFindings, refreshCodegenProject, runCodegen } from "@lunora/codegen";
 import { inferLunoraBindings, LUNORA_CONFIG_FILE } from "@lunora/config";
 import type { ExportGap } from "@lunora/config/cloudflare";
 import { collectWranglerSecretVariables, reconcileWranglerBindings, reconcileWranglerCompatibilityDate, WRANGLER_FILES } from "@lunora/config/cloudflare";
@@ -139,24 +139,25 @@ interface CodegenSafelyResult {
 /**
  * The `blockingMessage` for {@link runCodegenSafely}'s result: one aggregated
  * line naming every ERROR-level advisory/platform diagnostic, or `undefined`
- * when none. Extracted purely to keep `runCodegenSafely`'s cognitive
- * complexity within the repo's lint budget — no behavior change from inlining
- * it.
+ * when none. The name list itself comes from `@lunora/codegen`'s
+ * `describeErrorLevelFindings` — the same filter+dedup+sort the CLI's
+ * `lunora codegen`/`lunora deploy` gate uses — so this only owns folding the
+ * two categories into one combined, sorted message; it used to compute an
+ * unsorted list inline, which is what let it drift from the CLI's. Extracted
+ * purely to keep `runCodegenSafely`'s cognitive complexity within the repo's
+ * lint budget — no other behavior change from inlining it.
  */
 const buildBlockingMessage = (result: Pick<CodegenResult, "advisories" | "platformDiagnostics">): string | undefined => {
-    const blockingNames = [
-        ...result.advisories.filter((advisory) => advisory.level === "ERROR").map((advisory) => advisory.name),
-        ...result.platformDiagnostics.filter((diagnostic) => diagnostic.level === "error").map((diagnostic) => diagnostic.name),
-    ];
+    const { advisoryNames, platformDiagnosticNames } = describeErrorLevelFindings(result);
+    const blockingNames = [...new Set([...advisoryNames, ...platformDiagnosticNames])].toSorted((a, b) => a.localeCompare(b));
 
     if (blockingNames.length === 0) {
         return undefined;
     }
 
-    const names = [...new Set(blockingNames)].join(", ");
-    const noun = blockingNames.length === 1 ? "issue" : "issues";
+    const noun = blockingNames.length === 1 ? "advisory/platform diagnostic" : "advisories/platform diagnostics";
 
-    return `${LUNORA_TAG} ${String(blockingNames.length)} ERROR-level ${noun} (${names}) — see the log above for detail.`;
+    return `${LUNORA_TAG} ${String(blockingNames.length)} ERROR-level ${noun} (${blockingNames.join(", ")}) — see the log above for detail.`;
 };
 
 /**

--- a/packages/vite/src/codegen-plugin.ts
+++ b/packages/vite/src/codegen-plugin.ts
@@ -122,27 +122,40 @@ const reconcileWranglerExtras = (
     }
 };
 
+/** {@link runCodegenSafely}'s result. */
+interface CodegenSafelyResult {
+    /**
+     * Set when codegen reported at least one ERROR-level advisory or
+     * platform diagnostic — one message aggregating all of them, ready to
+     * fail a `vite build` with. Every level is still logged unconditionally
+     * above; this is only the caller's signal for whether to escalate.
+     */
+    blockingMessage?: string;
+    /** Absolute directory codegen actually wrote to; `undefined` when codegen was skipped or failed. */
+    outputDirectory?: string;
+}
+
 /**
  * Run codegen, returning the absolute directory codegen actually wrote to
  * (so callers can invalidate the *real* output, not an independently-guessed
- * path), or `undefined` when codegen was skipped or failed.
+ * path) and — when any advisory/platform diagnostic is ERROR-level — an
+ * aggregated `blockingMessage` the caller can escalate.
  *
  * Pass `overlay` to surface fatal failures in the Vite error overlay during
- * dev. Omit it (build mode) to keep the current log-and-return-undefined
- * behaviour.
+ * dev. Omit it (build mode) to keep the current log-and-return behaviour.
  */
 const runCodegenSafely = (
     options: Pick<ResolvedLunoraPluginOptions, "apiSpec" | "projectRoot" | "schemaDir" | "target">,
     logger: { error: (message: string) => void; info?: (message: string) => void; warn: (message: string) => void },
     overlay?: OverlayCallbacks,
     project?: Project,
-): string | undefined => {
+): CodegenSafelyResult => {
     const schemaPath = join(options.projectRoot, options.schemaDir, "schema.ts");
 
     if (!existsSync(schemaPath)) {
         logger.warn(`${LUNORA_TAG} schema.ts not found at ${schemaPath} — codegen skipped`);
 
-        return undefined;
+        return {};
     }
 
     try {
@@ -191,7 +204,24 @@ const runCodegenSafely = (
         // successful run — so there is nothing to do here. (Build mode passes no
         // overlay at all.)
 
-        return resolve(result.outputDirectory);
+        // Every level above is already logged; this only decides whether the
+        // caller escalates. `vite build` gates on it (same reason `lunora
+        // deploy` does: an ERROR advisory says a call throws at runtime, and a
+        // platform diagnostic says the emitted surface doesn't match the
+        // target) — `vite dev` never does, matching `lunora codegen`'s own
+        // advisory-outside-CI default.
+        const blockingNames = [
+            ...result.advisories.filter((advisory) => advisory.level === "ERROR").map((advisory) => advisory.name),
+            ...result.platformDiagnostics.filter((diagnostic) => diagnostic.level === "error").map((diagnostic) => diagnostic.name),
+        ];
+
+        return {
+            blockingMessage:
+                blockingNames.length > 0
+                    ? `${LUNORA_TAG} ${String(blockingNames.length)} ERROR-level ${blockingNames.length === 1 ? "issue" : "issues"} (${[...new Set(blockingNames)].join(", ")}) — see the log above for detail.`
+                    : undefined,
+            outputDirectory: resolve(result.outputDirectory),
+        };
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
 
@@ -201,7 +231,7 @@ const runCodegenSafely = (
         // user sees it immediately without leaving the browser.
         overlay?.onError(error, message);
 
-        return undefined;
+        return {};
     }
 };
 
@@ -316,7 +346,18 @@ const codegenPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
     let configBaselineSettled = false;
     let restartInFlight = false;
 
+    // Captured via the `config` hook (fires before `buildStart`), same idiom as
+    // `createCommandProbe` in `dev-worker-env.ts`. `buildStart` runs for BOTH
+    // `vite build` and `vite dev` — the presence/absence of the `overlay`
+    // callbacks below is NOT a build/dev signal (build mode's `buildStart` call
+    // also omits it), so without this a `vite build` against a mis-declared
+    // target logs an ERROR line and still exits 0.
+    let command: "build" | "serve" | undefined;
+
     return {
+        config(_userConfig, env) {
+            command = env.command;
+        },
         async buildStart() {
             const logger = {
                 error: (message: string): void => {
@@ -334,10 +375,21 @@ const codegenPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
             };
 
             // Build mode: no devServer, no overlay callbacks.
-            const outputDirectory = runCodegenSafely(options, logger);
+            const { blockingMessage, outputDirectory } = runCodegenSafely(options, logger);
 
             if (outputDirectory !== undefined) {
                 absoluteGeneratedDirectory = outputDirectory;
+            }
+
+            // `vite build` fails on an ERROR-level advisory/platform diagnostic —
+            // silence here is how an app ships built against a surface its target
+            // can't serve, or a call known to throw at runtime, with CI green the
+            // whole way (the same gap `lunora deploy` closed for the CLI path).
+            // `vite dev` stays log-only, matching `lunora codegen`'s own
+            // advisory-outside-CI default — interrupting the dev server on every
+            // ERROR-level advisory would be a worse loop than the terminal warning.
+            if (command === "build" && blockingMessage !== undefined) {
+                this.error(blockingMessage);
             }
 
             // Auto-provision the bindings the code implies. Done once at startup
@@ -525,7 +577,11 @@ const codegenPlugin = (options: ResolvedLunoraPluginOptions): Plugin => {
                         refreshCodegenProject(cachedProject, absoluteSchemaDirectory);
                     }
 
-                    const outputDirectory = runCodegenSafely(options, serverLogger, overlay, cachedProject);
+                    // `blockingMessage` (an ERROR-level advisory/platform
+                    // diagnostic) is intentionally ignored here: dev stays
+                    // log-only (already logged inside runCodegenSafely) —
+                    // only `vite build`, in buildStart above, escalates it.
+                    const { outputDirectory } = runCodegenSafely(options, serverLogger, overlay, cachedProject);
 
                     if (outputDirectory === undefined) {
                         // Codegen was skipped or threw — drop the (possibly partially


### PR DESCRIPTION
Six fixes to the least-guarded command. `deploy --env production` validated the top-level wrangler block then shipped `env.production` whose non-inheritable bindings may be missing → env-scoped validation with an explicit inheritable/non-inheritable key table (sourced from live Cloudflare docs). `deploy --env staging --migrate` in a prod-linked checkout ran the prod migration → migrate-URL now scoped to the deployed env. deploy/`vite build` didn't gate on codegen platform diagnostics/ERROR advisories → now do (with a `--no-strict-advisories` opt-out). `env push/diff` got a real `--env`; the interactive secret-push failure now aborts; `wrangler secret list` routed through the hardened spawner.

Verified: cli 983, config + vite green; full repo lint:affected/test:affected green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)