### PR TITLE
fix(mcp): fail closed on an unparseable paid-tool body + publish OpenRPC/OpenAPI as MCP resources

### DIFF
--- a/packages/mcp/__tests__/local.test.ts
+++ b/packages/mcp/__tests__/local.test.ts
@@ -1,10 +1,14 @@
 import type { FunctionDescriptor } from "@lunora/client";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { ListResourcesRequestSchema, ReadResourceRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it, vi } from "vitest";
 
 import type { LocalDeployment } from "../src/local";
-import { localTools, NO_DEPLOYMENT_MESSAGE } from "../src/local";
+import { createLocalMcpServer, localTools, NO_DEPLOYMENT_MESSAGE, OPENAPI_RESOURCE_URI, OPENRPC_RESOURCE_URI } from "../src/local";
 
 const FUNCTIONS: FunctionDescriptor[] = [{ args: [], kind: "query", path: "messages:list" }];
+const OPENRPC_SPEC = { info: { title: "test", version: "1.0.0" }, methods: [{ name: "messages.list" }], openrpc: "1.3.2" } as const;
+const OPENAPI_SPEC = { info: { title: "test", version: "1.0.0" }, openapi: "3.1.0", paths: {} } as const;
 
 /**
  * A `fetch` double standing in for both the docs site and a Lunora deployment,
@@ -22,13 +26,50 @@ const stubFetch = (): { asFetch: typeof fetch; urls: string[] } => {
             return Response.json({ functions: FUNCTIONS }, { headers: { "content-type": "application/json" }, status: 200 });
         }
 
+        if (url.includes("/_lunora/admin/openrpc")) {
+            return Response.json(OPENRPC_SPEC, { headers: { "content-type": "application/json" }, status: 200 });
+        }
+
+        if (url.includes("/_lunora/admin/openapi")) {
+            return Response.json(OPENAPI_SPEC, { headers: { "content-type": "application/json" }, status: 200 });
+        }
+
         return new Response("[]", { headers: { "content-type": "application/json" }, status: 200 });
     }) as unknown as typeof fetch;
 
     return { asFetch, urls };
 };
 
+/** A `fetch` double whose openrpc/openapi routes 404 — everything else (e.g. docs) still 200s. */
+const stubFetchSpecNotFound = (): typeof fetch =>
+    vi.fn<(input: string | URL) => Promise<Response>>(async (input) => {
+        const url = typeof input === "string" ? input : input.href;
+
+        if (url.includes("/_lunora/admin/openrpc") || url.includes("/_lunora/admin/openapi")) {
+            return Response.json({ error: { code: "NOT_FOUND", message: "not found" } }, { status: 404 });
+        }
+
+        return new Response("[]", { headers: { "content-type": "application/json" }, status: 200 });
+    }) as unknown as typeof fetch;
+
 const namesOf = (tools: ReadonlyArray<{ definition: { name: string } }>): string[] => tools.map((tool) => tool.definition.name);
+
+/**
+ * The low-level SDK `Server` stores request handlers in a private map keyed by
+ * request method. We don't drive a transport here; we reach the handlers the
+ * same way the SDK does — by looking them up via the request schema's method.
+ */
+const handlerFor = (server: Server, method: string): ((request: Record<string, unknown>) => unknown) => {
+    // eslint-disable-next-line no-underscore-dangle -- reach into the SDK's private handler map; there is no public accessor for registered handlers.
+    const handlers = (server as unknown as { _requestHandlers: Map<string, (request: unknown, extra: unknown) => unknown> })._requestHandlers;
+    const handler = handlers.get(method);
+
+    if (handler === undefined) {
+        throw new Error(`no handler registered for ${method}`);
+    }
+
+    return (request: Record<string, unknown>) => handler({ method, ...request }, { signal: new AbortController().signal });
+};
 
 describe("localTools", () => {
     it("serves documentation tools even with no deployment", () => {
@@ -125,5 +166,91 @@ describe("localTools", () => {
         const names = namesOf(localTools({ deployment: () => undefined, extraTools: [extra] }));
 
         expect(names.indexOf("lunora_search_docs")).toBeLessThan(names.indexOf("custom"));
+    });
+});
+
+describe("deployment spec resources", () => {
+    it("lists the OpenRPC/OpenAPI resources alongside docs when a deployment is configured", async () => {
+        expect.assertions(1);
+
+        const { asFetch } = stubFetch();
+        const server = createLocalMcpServer({ deployment: { url: "https://worker.example" }, fetch: asFetch });
+
+        const listed = (await handlerFor(server, ListResourcesRequestSchema.shape.method.value)({ params: {} })) as {
+            resources: { name: string; uri: string }[];
+        };
+
+        const uris = listed.resources.map((resource) => resource.uri);
+
+        expect(uris).toStrictEqual(expect.arrayContaining([OPENRPC_RESOURCE_URI, OPENAPI_RESOURCE_URI]));
+    });
+
+    it("reads the OpenRPC resource back with the fetched spec", async () => {
+        expect.assertions(2);
+
+        const { asFetch } = stubFetch();
+        const server = createLocalMcpServer({ deployment: { url: "https://worker.example" }, fetch: asFetch });
+
+        const read = (await handlerFor(server, ReadResourceRequestSchema.shape.method.value)({ params: { uri: OPENRPC_RESOURCE_URI } })) as {
+            contents: { mimeType?: string; text: string }[];
+        };
+
+        expect(read.contents[0]?.mimeType).toBe("application/json");
+        expect(JSON.parse(read.contents[0]?.text ?? "{}")).toStrictEqual(OPENRPC_SPEC);
+    });
+
+    it("omits the spec resources without error when the deployment doesn't serve them (404)", async () => {
+        expect.assertions(2);
+
+        const server = createLocalMcpServer({ deployment: { url: "https://worker.example" }, fetch: stubFetchSpecNotFound() });
+
+        const listed = (await handlerFor(server, ListResourcesRequestSchema.shape.method.value)({ params: {} })) as {
+            resources: { uri: string }[];
+        };
+        const uris = listed.resources.map((resource) => resource.uri);
+
+        expect(uris).not.toContain(OPENRPC_RESOURCE_URI);
+        expect(uris).not.toContain(OPENAPI_RESOURCE_URI);
+    });
+
+    it("omits the spec resources when no deployment is configured", async () => {
+        expect.assertions(1);
+
+        // Docs stay enabled (stubbed, so no real network) — the resources
+        // capability exists via the docs provider; only the deployment side is
+        // absent, and that's what this test asserts stays unlisted.
+        const { asFetch } = stubFetch();
+        const server = createLocalMcpServer({ fetch: asFetch });
+
+        const listed = (await handlerFor(server, ListResourcesRequestSchema.shape.method.value)({ params: {} })) as {
+            resources: { uri: string }[];
+        };
+
+        expect(listed.resources.map((resource) => resource.uri)).not.toContain(OPENRPC_RESOURCE_URI);
+    });
+
+    it("reads through the same admin-gated client the tools use (bearer token forwarded)", async () => {
+        expect.assertions(1);
+
+        let sawAuthorization = false;
+
+        const asFetch = vi.fn<(input: string | URL, init?: RequestInit) => Promise<Response>>(async (input, init) => {
+            const url = typeof input === "string" ? input : input.href;
+            const headers = new Headers(init?.headers);
+
+            if (url.includes("/_lunora/admin/openrpc")) {
+                sawAuthorization = headers.get("authorization") === "Bearer secret-token";
+
+                return Response.json(OPENRPC_SPEC, { headers: { "content-type": "application/json" }, status: 200 });
+            }
+
+            return new Response("[]", { headers: { "content-type": "application/json" }, status: 200 });
+        }) as unknown as typeof fetch;
+
+        const server = createLocalMcpServer({ deployment: { token: "secret-token", url: "https://worker.example" }, fetch: asFetch });
+
+        await handlerFor(server, ReadResourceRequestSchema.shape.method.value)({ params: { uri: OPENRPC_RESOURCE_URI } });
+
+        expect(sawAuthorization).toBe(true);
     });
 });

--- a/packages/mcp/__tests__/paid.test.ts
+++ b/packages/mcp/__tests__/paid.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { serveStateless } from "../src/http";
 import { createPaidMcpServer } from "../src/paid";
 import type { ToolResult } from "../src/tools";
+
+vi.mock(import("../src/http"), async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return { ...actual, serveStateless: vi.fn<typeof actual.serveStateless>(actual.serveStateless) };
+});
 
 /** The worker-level x402 charge vocabulary shared by every paid tool. */
 const charge = {
@@ -50,6 +57,14 @@ const mcpRequest = (body: unknown, headers: Record<string, string> = {}): Reques
         method: "POST",
     });
 
+/** A Streamable-HTTP client POST carrying a raw (possibly unparseable) body. */
+const rawMcpRequest = (rawBody: string, headers: Record<string, string> = {}): Request =>
+    new Request("https://worker.example/mcp", {
+        body: rawBody,
+        headers: { accept: "application/json, text/event-stream", "content-type": "application/json", ...headers },
+        method: "POST",
+    });
+
 const initializeBody = {
     id: 1,
     jsonrpc: "2.0",
@@ -68,6 +83,7 @@ const text = (value: string): ToolResult => {
 describe("createPaidMcpServer", () => {
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.mocked(serveStateless).mockClear();
     });
 
     it("challenges an unpaid paid-tool call with 402 and never runs the handler", async () => {
@@ -155,6 +171,40 @@ describe("createPaidMcpServer", () => {
         expect(response.status).toBe(400);
         // Refused before any facilitator or dispatch work.
         expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("fails closed on an unparseable body when a tool is priced — never dispatches", async () => {
+        expect.assertions(3);
+
+        const fetchMock = stubFacilitator();
+
+        const mcp = createPaidMcpServer({ charge });
+        mcp.paidTool({ description: "paid", inputSchema: NO_INPUT, name: "premium_report", price: "$0.05" }, () => text("secret"));
+
+        const response = await mcp.fetchHandler(rawMcpRequest("{not json"));
+
+        expect(response.status).toBe(400);
+        // The underlying SDK transport (serveStateless) is never reached — this
+        // module can't tell whether the unparseable body targeted the paid tool,
+        // so it refuses before dispatch rather than let the transport's own
+        // re-parse decide.
+        expect(serveStateless).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("dispatches an unparseable body unchanged when no tool is priced", async () => {
+        expect.assertions(1);
+
+        stubFacilitator();
+
+        const mcp = createPaidMcpServer({ charge });
+        mcp.tool({ description: "echo", inputSchema: NO_INPUT, name: "ping" }, () => text("pong"));
+
+        await mcp.fetchHandler(rawMcpRequest("{not json"));
+
+        // No paid tools registered → the parse-miss guard never applies, so the
+        // request still reaches the SDK transport exactly as before this change.
+        expect(serveStateless).toHaveBeenCalledTimes(1);
     });
 
     it("rejects registering the same tool name twice", () => {

--- a/packages/mcp/src/local.ts
+++ b/packages/mcp/src/local.ts
@@ -21,7 +21,7 @@ import { LunoraClient } from "@lunora/client";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-import type { McpTool } from "./compose";
+import type { McpResourceProvider, McpResourceSummary, McpTool } from "./compose";
 import { createToolServer } from "./compose";
 import { createRemoteDocsIndex } from "./docs/remote-index";
 import { docsResources } from "./docs/resources";
@@ -144,6 +144,130 @@ const lazyDeploymentTools = (source: LocalDeploymentSource, allowWrites: boolean
     });
 };
 
+/** URI for the deployment's generated OpenRPC 1.x document (the RPC-native spec: a `methods` array). */
+const OPENRPC_RESOURCE_URI = "lunora-spec:openrpc";
+
+/** URI for the deployment's generated OpenAPI 3.1 document. */
+const OPENAPI_RESOURCE_URI = "lunora-spec:openapi";
+
+/** One deployment spec this server can offer as a resource, and how to fetch it. */
+interface SpecResourceEntry {
+    description: string;
+    fetch: (client: LunoraClient) => Promise<Record<string, unknown>>;
+    name: string;
+    uri: string;
+}
+
+const SPEC_RESOURCE_ENTRIES: ReadonlyArray<SpecResourceEntry> = [
+    {
+        description:
+            "The deployment's generated OpenRPC 1.x document — every RPC function's path, kind, and argument schema in one read, instead of list_functions plus one get_function_schema call per function.",
+        fetch: async (client) => client.fetchOpenRpc(),
+        name: "OpenRPC specification",
+        uri: OPENRPC_RESOURCE_URI,
+    },
+    {
+        description: "The deployment's generated OpenAPI 3.1 document.",
+        fetch: async (client) => client.fetchOpenApi(),
+        name: "OpenAPI specification",
+        uri: OPENAPI_RESOURCE_URI,
+    },
+];
+
+/**
+ * The deployment's generated OpenRPC/OpenAPI spec documents, as MCP resources.
+ *
+ * The narrow `lunora_list_functions` / `lunora_get_function_schema` tools make
+ * an agent discover the deployment's surface one function at a time — a
+ * `list_functions` call plus one `get_function_schema` round trip per
+ * function. The worker already serves the whole surface in one document (the
+ * admin-gated `GET /_lunora/admin/openrpc` / `/openapi` endpoints codegen
+ * emits); publishing it as a resource lets an agent read the entire API in one
+ * request instead.
+ *
+ * Resolved lazily, exactly like {@link lazyDeploymentTools}: the deployment may
+ * not be running yet when this server is built (an editor spawns it before
+ * `lunora dev`), so both `list` and `read` re-resolve the source and re-fetch
+ * on every call rather than caching a spec captured at server-build time.
+ *
+ * A deployment that isn't reachable, has no spec wired, or predates the
+ * openrpc/openapi endpoints (an older worker build) fails the admin fetch;
+ * that entry is simply left out of `list()` and its `read()` returns
+ * `undefined` — resources are meant to be browsed, so one that would always
+ * error on read is worse than one that's silently absent. A worker WITH the
+ * endpoint but no spec configured still resolves 200 with an empty document,
+ * so it stays listed — only a hard failure omits it.
+ */
+const deploymentSpecResources = (source: LocalDeploymentSource, fetchImplementation: typeof fetch | undefined): McpResourceProvider => {
+    const resolve = typeof source === "function" ? source : (): LocalDeployment => source;
+    const clientFor = createClientCache(fetchImplementation);
+
+    /** The live document for `entry`, or `undefined` when the deployment can't serve it. */
+    const fetchEntry = async (entry: SpecResourceEntry): Promise<Record<string, unknown> | undefined> => {
+        const deployment = resolve();
+
+        if (deployment === undefined) {
+            return undefined;
+        }
+
+        try {
+            return await entry.fetch(clientFor(deployment));
+        } catch {
+            return undefined;
+        }
+    };
+
+    return {
+        list: async (): Promise<ReadonlyArray<McpResourceSummary>> => {
+            const summaries = await Promise.all(
+                SPEC_RESOURCE_ENTRIES.map(async (entry): Promise<McpResourceSummary | undefined> => {
+                    const spec = await fetchEntry(entry);
+
+                    return spec === undefined ? undefined : { description: entry.description, mimeType: "application/json", name: entry.name, uri: entry.uri };
+                }),
+            );
+
+            return summaries.filter((summary): summary is McpResourceSummary => summary !== undefined);
+        },
+
+        read: async (uri: string): Promise<{ mimeType?: string; text: string } | undefined> => {
+            const entry = SPEC_RESOURCE_ENTRIES.find((candidate) => candidate.uri === uri);
+
+            if (entry === undefined) {
+                return undefined;
+            }
+
+            const spec = await fetchEntry(entry);
+
+            return spec === undefined ? undefined : { mimeType: "application/json", text: JSON.stringify(spec, undefined, 2) };
+        },
+    };
+};
+
+/** Merge several resource providers into one — `list()` concatenates, `read()` tries each in order. */
+const combineResourceProviders = (providers: ReadonlyArray<McpResourceProvider>): McpResourceProvider => {
+    return {
+        list: async (): Promise<ReadonlyArray<McpResourceSummary>> => {
+            const lists = await Promise.all(providers.map(async (provider) => provider.list()));
+
+            return lists.flat();
+        },
+
+        read: async (uri: string): Promise<{ mimeType?: string; text: string } | undefined> => {
+            for (const provider of providers) {
+                // eslint-disable-next-line no-await-in-loop -- sequential by design: the first provider that recognizes `uri` wins, and providers are few (docs + spec).
+                const found = await provider.read(uri);
+
+                if (found !== undefined) {
+                    return found;
+                }
+            }
+
+            return undefined;
+        },
+    };
+};
+
 /**
  * Assemble the tool list, in the order it is advertised: docs first (the
  * surface that always works), then the caller's extras, then the deployment
@@ -185,10 +309,23 @@ const createLocalMcpServer = (options: LocalMcpServerOptions = {}): Server => {
                   ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
               });
 
+    const resourceProviders: McpResourceProvider[] = [];
+
+    if (index !== undefined) {
+        resourceProviders.push(docsResources(index));
+    }
+
+    // Only offer the spec resources when a deployment is configured at all —
+    // mirrors the docs-index check above (the whole surface is opt-in, not a
+    // live probe at server-build time).
+    if (options.deployment !== undefined) {
+        resourceProviders.push(deploymentSpecResources(options.deployment, options.fetch));
+    }
+
     return createToolServer(
         { name: LOCAL_SERVER_NAME, version: options.version ?? "0.0.0" },
         localTools(options),
-        index === undefined ? undefined : docsResources(index),
+        resourceProviders.length === 0 ? undefined : combineResourceProviders(resourceProviders),
     );
 };
 
@@ -206,4 +343,4 @@ const connectLocalStdio = async (options: LocalMcpServerOptions = {}): Promise<S
 };
 
 export type { LocalDeployment, LocalDeploymentSource, LocalMcpServerOptions };
-export { connectLocalStdio, createLocalMcpServer, LOCAL_SERVER_NAME, localTools, NO_DEPLOYMENT_MESSAGE };
+export { connectLocalStdio, createLocalMcpServer, LOCAL_SERVER_NAME, localTools, NO_DEPLOYMENT_MESSAGE, OPENAPI_RESOURCE_URI, OPENRPC_RESOURCE_URI };

--- a/packages/mcp/src/paid.ts
+++ b/packages/mcp/src/paid.ts
@@ -180,6 +180,17 @@ const refuseBatch = (): Response =>
     Response.json({ error: "A JSON-RPC batch may not reference a paid MCP tool; send paid tools/call requests individually." }, { status: 400 });
 
 /**
+ * Refuse a POST body this module couldn't parse when any tool is priced. This
+ * module decides "is this a priced `tools/call`?" from its own parse of the
+ * body; on a parse miss it can't tell, and handing the original request to the
+ * SDK transport (which re-reads/re-parses it independently) would let a paid
+ * tool dispatch with no `X-PAYMENT` check. Fail closed instead — mirrors
+ * {@link refuseBatch}'s envelope/status.
+ */
+const refuseUnparseableBody = (): Response =>
+    Response.json({ error: "The request body could not be parsed as JSON; a priced MCP tool is registered, so the call cannot be gated." }, { status: 400 });
+
+/**
  * Create a paid MCP server. Register free tools with `tool()` and priced tools
  * with `paidTool()` (they coexist), then serve `fetchHandler` over HTTP.
  *
@@ -282,6 +293,13 @@ const createPaidMcpServer = (config: PaidMcpServerConfig): PaidMcpServer => {
         // Hand the already-parsed body to the transport so it doesn't re-read the
         // consumed stream; fall back to letting it read `request` on a parse miss.
         const dispatch = (): Promise<Response> => serveStateless(buildServer(), request, parsedBody === undefined ? undefined : { parsedBody });
+
+        // Scoped to POST: GET (SSE stream open) and DELETE (session termination)
+        // carry no body by spec and reach this same handler, so a method-blind
+        // check would 400 every legitimate handshake.
+        if (parsedBody === undefined && prices.size > 0 && request.method === "POST") {
+            return refuseUnparseableBody();
+        }
 
         if (Array.isArray(parsedBody)) {
             return parsedBody.some((message) => prices.has(callToolName(message) ?? "")) ? refuseBatch() : dispatch();


### PR DESCRIPTION
The x402 paid-MCP paywall decided 'is this a priced tools/call?' from its own JSON.parse but on a parse miss handed the request to the SDK transport to re-parse — a body this module couldn't parse but the SDK could dispatched a paid tool unpaid. Now fails closed (400) on a parse miss when any tool is priced (POST-only, verified against the SDK's GET/DELETE handshake paths). Plus: publishes the deployment's already-emitted OpenRPC + OpenAPI spec as lazy, admin-gated MCP resources so agents load the whole surface in one read instead of N per-function probes.

Verified: 145/145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)