### PR TITLE
perf(sql-store): add a batch exec seam; proxy the queue capture Message

### DIFF
--- a/examples/blog/lunora/_generated/app.ts
+++ b/examples/blog/lunora/_generated/app.ts
@@ -464,23 +464,39 @@ class AppBuilder<Env extends object> {
     }
 }
 
-/** Adapt the raw D1 binding to `@lunora/d1`'s `D1Exec` (reads via `all`, writes via `run`). */
-const buildExec = (database: D1DatabaseLike): D1Exec => ({
-    all: async (sql, parameters) => {
-        const result = await database
-            .prepare(sql)
-            .bind(...parameters)
-            .all<Record<string, unknown>>();
+/** Adapt the raw D1 binding to `@lunora/d1`'s `D1Exec` (reads via `all`, writes via `run`, and — when the binding exposes it — several writes in one round trip via `batch`). */
+const buildExec = (database: D1DatabaseLike): D1Exec => {
+    const nativeBatch = database.batch;
 
-        return result.results;
-    },
-    run: async (sql, parameters) => {
-        await database
-            .prepare(sql)
-            .bind(...parameters)
-            .run();
-    },
-});
+    return {
+        all: async (sql, parameters) => {
+            const result = await database
+                .prepare(sql)
+                .bind(...parameters)
+                .all<Record<string, unknown>>();
+
+            return result.results;
+        },
+        // D1's own `batch` runs the whole array as one atomic SQLite
+        // transaction. Guarded because `D1DatabaseLike.batch` is optional in
+        // the structural type (test doubles may omit it) — real D1 always has
+        // it; a double without it still works through the store's sequential
+        // fallback.
+        batch: nativeBatch
+            ? async (statements) => {
+                  await nativeBatch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
+
+                  return statements.map(() => ({ rowsAffected: 0 }));
+              }
+            : undefined,
+        run: async (sql, parameters) => {
+            await database
+                .prepare(sql)
+                .bind(...parameters)
+                .run();
+        },
+    };
+};
 
 /** Introspect `.global()` (D1-backed) tables for the studio's global data browser. */
 const buildGlobalIntrospector = (database: D1DatabaseLike): GlobalIntrospector => {

--- a/examples/blog/lunora/_generated/app.ts
+++ b/examples/blog/lunora/_generated/app.ts
@@ -466,7 +466,7 @@ class AppBuilder<Env extends object> {
 
 /** Adapt the raw D1 binding to `@lunora/d1`'s `D1Exec` (reads via `all`, writes via `run`, and — when the binding exposes it — several writes in one round trip via `batch`). */
 const buildExec = (database: D1DatabaseLike): D1Exec => {
-    const nativeBatch = database.batch;
+    const hasBatch = typeof database.batch === "function";
 
     return {
         all: async (sql, parameters) => {
@@ -481,12 +481,13 @@ const buildExec = (database: D1DatabaseLike): D1Exec => {
         // transaction. Guarded because `D1DatabaseLike.batch` is optional in
         // the structural type (test doubles may omit it) — real D1 always has
         // it; a double without it still works through the store's sequential
-        // fallback.
-        batch: nativeBatch
+        // fallback. Called as `database.batch(...)`, not through a detached
+        // reference — the real workerd `D1Database` dereferences `this` inside
+        // `batch`, so a standalone capture throws `TypeError: Illegal
+        // invocation` the first time it runs.
+        batch: hasBatch
             ? async (statements) => {
-                  await nativeBatch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
-
-                  return statements.map(() => ({ rowsAffected: 0 }));
+                  await database.batch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
               }
             : undefined,
         run: async (sql, parameters) => {

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
@@ -309,23 +309,39 @@ class AppBuilder<Env extends object> {
     }
 }
 
-/** Adapt the raw D1 binding to `@lunora/d1`'s `D1Exec` (reads via `all`, writes via `run`). */
-const buildExec = (database: D1DatabaseLike): D1Exec => ({
-    all: async (sql, parameters) => {
-        const result = await database
-            .prepare(sql)
-            .bind(...parameters)
-            .all<Record<string, unknown>>();
+/** Adapt the raw D1 binding to `@lunora/d1`'s `D1Exec` (reads via `all`, writes via `run`, and — when the binding exposes it — several writes in one round trip via `batch`). */
+const buildExec = (database: D1DatabaseLike): D1Exec => {
+    const nativeBatch = database.batch;
 
-        return result.results;
-    },
-    run: async (sql, parameters) => {
-        await database
-            .prepare(sql)
-            .bind(...parameters)
-            .run();
-    },
-});
+    return {
+        all: async (sql, parameters) => {
+            const result = await database
+                .prepare(sql)
+                .bind(...parameters)
+                .all<Record<string, unknown>>();
+
+            return result.results;
+        },
+        // D1's own `batch` runs the whole array as one atomic SQLite
+        // transaction. Guarded because `D1DatabaseLike.batch` is optional in
+        // the structural type (test doubles may omit it) — real D1 always has
+        // it; a double without it still works through the store's sequential
+        // fallback.
+        batch: nativeBatch
+            ? async (statements) => {
+                  await nativeBatch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
+
+                  return statements.map(() => ({ rowsAffected: 0 }));
+              }
+            : undefined,
+        run: async (sql, parameters) => {
+            await database
+                .prepare(sql)
+                .bind(...parameters)
+                .run();
+        },
+    };
+};
 
 /** Introspect `.global()` (D1-backed) tables for the studio's global data browser. */
 const buildGlobalIntrospector = (database: D1DatabaseLike): GlobalIntrospector => {

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
@@ -311,7 +311,7 @@ class AppBuilder<Env extends object> {
 
 /** Adapt the raw D1 binding to `@lunora/d1`'s `D1Exec` (reads via `all`, writes via `run`, and — when the binding exposes it — several writes in one round trip via `batch`). */
 const buildExec = (database: D1DatabaseLike): D1Exec => {
-    const nativeBatch = database.batch;
+    const hasBatch = typeof database.batch === "function";
 
     return {
         all: async (sql, parameters) => {
@@ -326,12 +326,13 @@ const buildExec = (database: D1DatabaseLike): D1Exec => {
         // transaction. Guarded because `D1DatabaseLike.batch` is optional in
         // the structural type (test doubles may omit it) — real D1 always has
         // it; a double without it still works through the store's sequential
-        // fallback.
-        batch: nativeBatch
+        // fallback. Called as `database.batch(...)`, not through a detached
+        // reference — the real workerd `D1Database` dereferences `this` inside
+        // `batch`, so a standalone capture throws `TypeError: Illegal
+        // invocation` the first time it runs.
+        batch: hasBatch
             ? async (statements) => {
-                  await nativeBatch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
-
-                  return statements.map(() => ({ rowsAffected: 0 }));
+                  await database.batch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
               }
             : undefined,
         run: async (sql, parameters) => {

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -838,23 +838,39 @@ const buildStorageHelpers = (hasStorage: boolean): string =>
 const buildGlobalHelpers = (hasGlobal: boolean): string =>
     hasGlobal
         ? `
-/** Adapt the raw D1 binding to \`@lunora/d1\`'s \`D1Exec\` (reads via \`all\`, writes via \`run\`). */
-const buildExec = (database: D1DatabaseLike): D1Exec => ({
-    all: async (sql, parameters) => {
-        const result = await database
-            .prepare(sql)
-            .bind(...parameters)
-            .all<Record<string, unknown>>();
+/** Adapt the raw D1 binding to \`@lunora/d1\`'s \`D1Exec\` (reads via \`all\`, writes via \`run\`, and — when the binding exposes it — several writes in one round trip via \`batch\`). */
+const buildExec = (database: D1DatabaseLike): D1Exec => {
+    const nativeBatch = database.batch;
 
-        return result.results;
-    },
-    run: async (sql, parameters) => {
-        await database
-            .prepare(sql)
-            .bind(...parameters)
-            .run();
-    },
-});
+    return {
+        all: async (sql, parameters) => {
+            const result = await database
+                .prepare(sql)
+                .bind(...parameters)
+                .all<Record<string, unknown>>();
+
+            return result.results;
+        },
+        // D1's own \`batch\` runs the whole array as one atomic SQLite
+        // transaction. Guarded because \`D1DatabaseLike.batch\` is optional in
+        // the structural type (test doubles may omit it) — real D1 always has
+        // it; a double without it still works through the store's sequential
+        // fallback.
+        batch: nativeBatch
+            ? async (statements) => {
+                  await nativeBatch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
+
+                  return statements.map(() => ({ rowsAffected: 0 }));
+              }
+            : undefined,
+        run: async (sql, parameters) => {
+            await database
+                .prepare(sql)
+                .bind(...parameters)
+                .run();
+        },
+    };
+};
 
 /** Introspect \`.global()\` (D1-backed) tables for the studio's global data browser. */
 const buildGlobalIntrospector = (database: D1DatabaseLike): GlobalIntrospector => {

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -840,7 +840,7 @@ const buildGlobalHelpers = (hasGlobal: boolean): string =>
         ? `
 /** Adapt the raw D1 binding to \`@lunora/d1\`'s \`D1Exec\` (reads via \`all\`, writes via \`run\`, and — when the binding exposes it — several writes in one round trip via \`batch\`). */
 const buildExec = (database: D1DatabaseLike): D1Exec => {
-    const nativeBatch = database.batch;
+    const hasBatch = typeof database.batch === "function";
 
     return {
         all: async (sql, parameters) => {
@@ -855,12 +855,13 @@ const buildExec = (database: D1DatabaseLike): D1Exec => {
         // transaction. Guarded because \`D1DatabaseLike.batch\` is optional in
         // the structural type (test doubles may omit it) — real D1 always has
         // it; a double without it still works through the store's sequential
-        // fallback.
-        batch: nativeBatch
+        // fallback. Called as \`database.batch(...)\`, not through a detached
+        // reference — the real workerd \`D1Database\` dereferences \`this\` inside
+        // \`batch\`, so a standalone capture throws \`TypeError: Illegal
+        // invocation\` the first time it runs.
+        batch: hasBatch
             ? async (statements) => {
-                  await nativeBatch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
-
-                  return statements.map(() => ({ rowsAffected: 0 }));
+                  await database.batch(statements.map(({ params, sql }) => database.prepare(sql).bind(...params)));
               }
             : undefined,
         run: async (sql, parameters) => {

--- a/packages/hyperdrive/__tests__/global-dialect.test.ts
+++ b/packages/hyperdrive/__tests__/global-dialect.test.ts
@@ -147,8 +147,8 @@ describe("exec adapters", () => {
         expect(result).toEqual({ rowsAffected: 0 });
     });
 
-    it("buildPgExec.batch dispatches every statement (concurrently, not one-per-round-trip) and reports rowsAffected: 0 per statement", async () => {
-        expect.assertions(2);
+    it("buildPgExec.batch dispatches every statement (concurrently, not one-per-round-trip)", async () => {
+        expect.assertions(1);
 
         const calls: { params: ReadonlyArray<unknown>; sql: string }[] = [];
         const exec = buildPgExec({
@@ -159,7 +159,7 @@ describe("exec adapters", () => {
             },
         });
 
-        const result = await exec.batch?.([
+        await exec.batch?.([
             { params: ["a"], sql: "INSERT INTO t (x) VALUES ($1)" },
             { params: ["b"], sql: "INSERT INTO t (x) VALUES ($1)" },
         ]);
@@ -168,30 +168,25 @@ describe("exec adapters", () => {
             { params: ["a"], sql: "INSERT INTO t (x) VALUES ($1)" },
             { params: ["b"], sql: "INSERT INTO t (x) VALUES ($1)" },
         ]);
-        expect(result).toEqual([{ rowsAffected: 0 }, { rowsAffected: 0 }]);
     });
 
-    it("buildMysqlExec.batch dispatches every statement and reports each statement's affectedRows, in order", async () => {
-        expect.assertions(2);
+    it("buildMysqlExec.batch dispatches every statement", async () => {
+        expect.assertions(1);
 
         const calls: { params: ReadonlyArray<unknown>; sql: string }[] = [];
         const exec = buildMysqlExec({
             execute: async (text, params = []) => {
                 calls.push({ params, sql: text });
 
-                // Reply with a distinct affectedRows per statement so a
-                // shuffled dispatch order would be caught by the ordered
-                // assertion below.
                 return [{ affectedRows: params[0] === "a" ? 1 : 2 }, undefined];
             },
         });
 
-        const result = await exec.batch?.([
+        await exec.batch?.([
             { params: ["a"], sql: "INSERT INTO `t` (`x`) VALUES (?)" },
             { params: ["b"], sql: "INSERT INTO `t` (`x`) VALUES (?)" },
         ]);
 
         expect(calls).toHaveLength(2);
-        expect(result).toEqual([{ rowsAffected: 1 }, { rowsAffected: 2 }]);
     });
 });

--- a/packages/hyperdrive/__tests__/global-dialect.test.ts
+++ b/packages/hyperdrive/__tests__/global-dialect.test.ts
@@ -146,4 +146,52 @@ describe("exec adapters", () => {
 
         expect(result).toEqual({ rowsAffected: 0 });
     });
+
+    it("buildPgExec.batch dispatches every statement (concurrently, not one-per-round-trip) and reports rowsAffected: 0 per statement", async () => {
+        expect.assertions(2);
+
+        const calls: { params: ReadonlyArray<unknown>; sql: string }[] = [];
+        const exec = buildPgExec({
+            query: async (text, params = []) => {
+                calls.push({ params, sql: text });
+
+                return [];
+            },
+        });
+
+        const result = await exec.batch?.([
+            { params: ["a"], sql: "INSERT INTO t (x) VALUES ($1)" },
+            { params: ["b"], sql: "INSERT INTO t (x) VALUES ($1)" },
+        ]);
+
+        expect(calls).toEqual([
+            { params: ["a"], sql: "INSERT INTO t (x) VALUES ($1)" },
+            { params: ["b"], sql: "INSERT INTO t (x) VALUES ($1)" },
+        ]);
+        expect(result).toEqual([{ rowsAffected: 0 }, { rowsAffected: 0 }]);
+    });
+
+    it("buildMysqlExec.batch dispatches every statement and reports each statement's affectedRows, in order", async () => {
+        expect.assertions(2);
+
+        const calls: { params: ReadonlyArray<unknown>; sql: string }[] = [];
+        const exec = buildMysqlExec({
+            execute: async (text, params = []) => {
+                calls.push({ params, sql: text });
+
+                // Reply with a distinct affectedRows per statement so a
+                // shuffled dispatch order would be caught by the ordered
+                // assertion below.
+                return [{ affectedRows: params[0] === "a" ? 1 : 2 }, undefined];
+            },
+        });
+
+        const result = await exec.batch?.([
+            { params: ["a"], sql: "INSERT INTO `t` (`x`) VALUES (?)" },
+            { params: ["b"], sql: "INSERT INTO `t` (`x`) VALUES (?)" },
+        ]);
+
+        expect(calls).toHaveLength(2);
+        expect(result).toEqual([{ rowsAffected: 1 }, { rowsAffected: 2 }]);
+    });
 });

--- a/packages/hyperdrive/src/global-exec.ts
+++ b/packages/hyperdrive/src/global-exec.ts
@@ -39,21 +39,16 @@ export type Mysql2Execute = Mysql2Like;
  * connections instead of serializing one full round trip at a time; against a
  * single connection it still removes the sequential *await*, though the
  * underlying driver may itself queue the sends. Either way it stays
- * non-atomic and at-least-once, same as the sequential fallback — safe only
- * for statements whose effects don't depend on each other, which is what
- * every current caller batches (distinct-keyed companion rows).
+ * non-atomic, at-least-once, and unordered between elements, same as the
+ * sequential fallback minus the ordering — safe only for statements whose
+ * effects don't depend on each other, which is what every current caller
+ * batches (distinct-keyed companion rows).
  */
 export const buildPgExec = (client: RowClient): SqlExec => {
     return {
         all: (sql, params) => client.query(sql, params),
         batch: async (statements) => {
             await Promise.all(statements.map((statement) => client.query(statement.sql, statement.params)));
-
-            // Same reporting contract as `run`: PG's OCC goes through
-            // `RETURNING` (read via `all`), so no caller consumes these counts.
-            return statements.map(() => {
-                return { rowsAffected: 0 };
-            });
         },
         run: async (sql, params): Promise<SqlRunResult> => {
             await client.query(sql, params);
@@ -79,9 +74,9 @@ export const buildPgExec = (client: RowClient): SqlExec => {
  * `batch` dispatches every statement concurrently (`Promise.all`), same
  * rationale as {@link buildPgExec}'s `batch` — `Mysql2Like` only exposes a
  * single-statement `execute`, so this is "spread across a pool's connections"
- * rather than one wire-level multi-statement command; still non-atomic and
- * at-least-once, safe only for statements with no cross-effect (what every
- * current caller batches).
+ * rather than one wire-level multi-statement command; still non-atomic,
+ * at-least-once, and unordered between elements, safe only for statements
+ * with no cross-effect (what every current caller batches).
  */
 export const buildMysqlExec = (connection: Mysql2Execute): SqlExec => {
     return {
@@ -91,11 +86,7 @@ export const buildMysqlExec = (connection: Mysql2Execute): SqlExec => {
             return rows as Record<string, unknown>[];
         },
         batch: async (statements) => {
-            const results = await Promise.all(statements.map((statement) => connection.execute(statement.sql, statement.params)));
-
-            return results.map(([result]) => {
-                return { rowsAffected: (result as { affectedRows?: number }).affectedRows ?? 0 };
-            });
+            await Promise.all(statements.map((statement) => connection.execute(statement.sql, statement.params)));
         },
         run: async (sql, params): Promise<SqlRunResult> => {
             const [result] = await connection.execute(sql, params);

--- a/packages/hyperdrive/src/global-exec.ts
+++ b/packages/hyperdrive/src/global-exec.ts
@@ -30,10 +30,31 @@ export type Mysql2Execute = Mysql2Like;
  * `fromNodePg`) as a {@link SqlExec}. The core already renders `$N` placeholders
  * for Postgres, so `all`/`run` forward verbatim. Postgres uses `RETURNING` for
  * OCC (read via `all`), so `run` reports no affected-row count.
+ *
+ * `batch` dispatches every statement concurrently (`Promise.all`) over `client`
+ * rather than awaiting each `query` call in turn — `RowClient` only exposes a
+ * single-statement `query`, so there is no wire-level multi-statement command
+ * to reach for. When `client` is backed by a pool (the common production
+ * shape), this genuinely spreads the statements across multiple physical
+ * connections instead of serializing one full round trip at a time; against a
+ * single connection it still removes the sequential *await*, though the
+ * underlying driver may itself queue the sends. Either way it stays
+ * non-atomic and at-least-once, same as the sequential fallback — safe only
+ * for statements whose effects don't depend on each other, which is what
+ * every current caller batches (distinct-keyed companion rows).
  */
 export const buildPgExec = (client: RowClient): SqlExec => {
     return {
         all: (sql, params) => client.query(sql, params),
+        batch: async (statements) => {
+            await Promise.all(statements.map((statement) => client.query(statement.sql, statement.params)));
+
+            // Same reporting contract as `run`: PG's OCC goes through
+            // `RETURNING` (read via `all`), so no caller consumes these counts.
+            return statements.map(() => {
+                return { rowsAffected: 0 };
+            });
+        },
         run: async (sql, params): Promise<SqlRunResult> => {
             await client.query(sql, params);
 
@@ -54,6 +75,13 @@ export const buildPgExec = (client: RowClient): SqlExec => {
  * (mysql2: `createPool({ flags: ["FOUND_ROWS"] })`). Without it, `affectedRows`
  * counts *changed* rows, so an idempotent `patch`/`replace` that re-writes the
  * same values reports 0 and the OCC guard raises a spurious conflict.
+ *
+ * `batch` dispatches every statement concurrently (`Promise.all`), same
+ * rationale as {@link buildPgExec}'s `batch` — `Mysql2Like` only exposes a
+ * single-statement `execute`, so this is "spread across a pool's connections"
+ * rather than one wire-level multi-statement command; still non-atomic and
+ * at-least-once, safe only for statements with no cross-effect (what every
+ * current caller batches).
  */
 export const buildMysqlExec = (connection: Mysql2Execute): SqlExec => {
     return {
@@ -61,6 +89,13 @@ export const buildMysqlExec = (connection: Mysql2Execute): SqlExec => {
             const [rows] = await connection.execute(sql, params);
 
             return rows as Record<string, unknown>[];
+        },
+        batch: async (statements) => {
+            const results = await Promise.all(statements.map((statement) => connection.execute(statement.sql, statement.params)));
+
+            return results.map(([result]) => {
+                return { rowsAffected: (result as { affectedRows?: number }).affectedRows ?? 0 };
+            });
         },
         run: async (sql, params): Promise<SqlRunResult> => {
             const [result] = await connection.execute(sql, params);

--- a/packages/queue/__tests__/dispatch.test.ts
+++ b/packages/queue/__tests__/dispatch.test.ts
@@ -362,6 +362,54 @@ describe("dispatchQueueBatch capture", () => {
         );
     });
 
+    it("forwards a message property the MessageLike type doesn't declare (dev/prod parity)", async () => {
+        expect.assertions(1);
+
+        // A real workerd Message may carry more than the four `MessageLike`
+        // declares. The old capture wrapper rebuilt each message from an
+        // object literal listing exactly those four (plus ack/retry), so an
+        // undeclared property like this one read `undefined` under capture
+        // but its real value with capture off — the bug this test guards.
+        const withExtra = { ...captureMessage({ n: 1 }), region: "wnam" };
+        let seenRegion: unknown;
+        const queue = defineQueue({
+            handler: (_context, b) => {
+                seenRegion = (b.messages[0] as unknown as { region: string }).region;
+            },
+        });
+
+        await dispatchQueueBatch(
+            batch("q", [withExtra as unknown as MessageLike]),
+            { q: { definition: queue, exportName: "q" } },
+            { capture: vi.fn<QueueCaptureSink>(), env: {} },
+        );
+
+        expect(seenRegion).toBe("wnam");
+    });
+
+    it("forwards a batch property MessageBatchLike doesn't declare, alongside messages/queue", async () => {
+        expect.assertions(3);
+
+        const rawBatch = batch("q", [captureMessage({ n: 1 })]);
+        const withExtra = { ...rawBatch, region: "wnam" };
+        let seenRegion: unknown;
+        let seenQueue: unknown;
+        let seenMessageCount: unknown;
+        const queue = defineQueue({
+            handler: (_context, b) => {
+                seenRegion = (b as unknown as { region: string }).region;
+                seenQueue = b.queue;
+                seenMessageCount = b.messages.length;
+            },
+        });
+
+        await dispatchQueueBatch(withExtra, { q: { definition: queue, exportName: "q" } }, { capture: vi.fn<QueueCaptureSink>(), env: {} });
+
+        expect(seenRegion).toBe("wnam");
+        expect(seenQueue).toBe("q");
+        expect(seenMessageCount).toBe(1);
+    });
+
     it("logs a warning when the capture sink rejects (observability of the observability feature)", async () => {
         expect.assertions(2);
 

--- a/packages/queue/src/dispatch.ts
+++ b/packages/queue/src/dispatch.ts
@@ -115,39 +115,91 @@ interface CaptureHarness {
 }
 
 /**
- * Build a {@link CaptureHarness} over `batch`. Message objects are wrapped (not
- * mutated) because a real workerd `Message` is a non-extensible host object —
- * reassigning `message.ack` would throw. The wrapped messages delegate every
- * accessor to the original and merely observe `ack`/`retry`.
+ * Wrap one message so `ack`/`retry` record their disposition (keyed by the
+ * REAL, un-proxied `message` — the same key {@link buildCaptureRecords} looks
+ * up against `harness.originals`) before delegating to the real method. Every
+ * OTHER property — `attempts`/`body`/`id`/`timestamp`, and anything a real
+ * workerd `Message` carries beyond the four the structural `MessageLike` type
+ * declares — forwards through `Reflect.get`, so an undeclared property reads
+ * its real value under capture exactly like it would with capture off.
+ *
+ * A `Proxy` over `message` (not a rebuilt object literal, and not
+ * `Object.create(message)`) is required for that "anything else" case: a
+ * hand-picked property list is exactly the bug this fixes, and
+ * `Object.create` can't fix the same problem because an inherited accessor
+ * looked up through a prototype chain still runs with the WRAPPER as `this`.
+ * The `get` trap sidesteps that by pinning the receiver to `message` itself —
+ * a workerd `Message` is a host object, and an accessor invoked with a
+ * non-genuine `this` can throw ("illegal invocation") — so every forwarded
+ * read runs against the real instance, never the proxy.
+ */
+const wrapMessage = (message: MessageLike, dispositions: Map<MessageLike, QueueMessageOutcome>): MessageLike =>
+    new Proxy(message, {
+        get: (target, property): unknown => {
+            if (property === "ack") {
+                return (): void => {
+                    dispositions.set(target, "ack");
+                    target.ack();
+                };
+            }
+
+            if (property === "retry") {
+                return (options?: QueueRetryOptions): void => {
+                    dispositions.set(target, "retry");
+                    target.retry(options);
+                };
+            }
+
+            return Reflect.get(target, property, target);
+        },
+    });
+
+/**
+ * Wrap the batch itself, same rationale as {@link wrapMessage}: `ackAll` /
+ * `retryAll` observe the disposition fill and `messages` answers with the
+ * WRAPPED messages (so a handler iterating `batch.messages` gets instrumented
+ * ones), but `queue` and any other property the real `MessageBatch` carries
+ * forward through `Reflect.get` against the real batch.
+ */
+const wrapBatch = (
+    batch: MessageBatchLike,
+    wrappedMessages: ReadonlyArray<MessageLike>,
+    fillUndecided: (outcome: QueueMessageOutcome) => void,
+): MessageBatchLike =>
+    new Proxy(batch, {
+        get: (target, property): unknown => {
+            if (property === "ackAll") {
+                return (): void => {
+                    fillUndecided("ack");
+                    target.ackAll();
+                };
+            }
+
+            if (property === "retryAll") {
+                return (options?: QueueRetryOptions): void => {
+                    fillUndecided("retry");
+                    target.retryAll(options);
+                };
+            }
+
+            if (property === "messages") {
+                return wrappedMessages;
+            }
+
+            return Reflect.get(target, property, target);
+        },
+    });
+
+/**
+ * Build a {@link CaptureHarness} over `batch`. Message and batch objects are
+ * wrapped (not mutated) because a real workerd `Message`/`MessageBatch` is a
+ * non-extensible host object — reassigning `message.ack` would throw.
  */
 const instrumentBatch = (batch: MessageBatchLike): CaptureHarness => {
     const dispositions = new Map<MessageLike, QueueMessageOutcome>();
     const originals = batch.messages;
 
-    const wrappedMessages = originals.map((message): MessageLike => {
-        return {
-            ack: (): void => {
-                dispositions.set(message, "ack");
-                message.ack();
-            },
-            get attempts(): number {
-                return message.attempts;
-            },
-            get body(): unknown {
-                return message.body;
-            },
-            get id(): string {
-                return message.id;
-            },
-            retry: (options?: QueueRetryOptions): void => {
-                dispositions.set(message, "retry");
-                message.retry(options);
-            },
-            get timestamp(): Date {
-                return message.timestamp;
-            },
-        };
-    });
+    const wrappedMessages = originals.map((message) => wrapMessage(message, dispositions));
 
     /** Fill the disposition for every message the handler didn't explicitly decide. */
     const fillUndecided = (outcome: QueueMessageOutcome): void => {
@@ -158,18 +210,7 @@ const instrumentBatch = (batch: MessageBatchLike): CaptureHarness => {
         }
     };
 
-    const wrappedBatch: MessageBatchLike = {
-        ackAll: (): void => {
-            fillUndecided("ack");
-            batch.ackAll();
-        },
-        messages: wrappedMessages,
-        queue: batch.queue,
-        retryAll: (options?: QueueRetryOptions): void => {
-            fillUndecided("retry");
-            batch.retryAll(options);
-        },
-    };
+    const wrappedBatch = wrapBatch(batch, wrappedMessages, fillUndecided);
 
     return { dispositions, originals, wrappedBatch };
 };

--- a/packages/sql-store/__tests__/ctx-db.test.ts
+++ b/packages/sql-store/__tests__/ctx-db.test.ts
@@ -534,6 +534,94 @@ describe("createSqlCtxDb — indexed groupBy honours a partial where", () => {
     });
 });
 
+/** A `notes` table carrying both an aggregate and a rank index, so one backfill pass exercises both companion-tally loops. */
+const backfillSchema: SchemaLike = {
+    tables: {
+        notes: {
+            aggregateIndexes: [{ by: ["archived"], name: "byArchived", on: "notes", op: "count" }],
+            indexes: [],
+            rankIndexes: [{ name: "byPriority", on: "notes", partitionBy: ["archived"], sortBy: [{ direction: "desc", field: "priority" }] }],
+            shape: {
+                archived: col("boolean"),
+                priority: col("number"),
+                slug: col("string"),
+            },
+            shardMode: { kind: "global" },
+        },
+    },
+} as never;
+
+describe("createSqlCtxDb — aggregate + rank backfills route through batch when the exec supports it", () => {
+    it("issues one batch call per companion backfill (not one run() per row) when rebuilding from pre-existing rows", async () => {
+        expect.assertions(3);
+
+        const database = new DatabaseSync(":memory:");
+        const all = (query: string, parameters: ReadonlyArray<unknown>): Record<string, unknown>[] => database.prepare(query).all(...(parameters as never[]));
+
+        const plainExec: SqlCtxExec = {
+            all: (query, parameters) => Promise.resolve(all(query, parameters)),
+            run: (query, parameters) => {
+                all(query, parameters);
+
+                return Promise.resolve();
+            },
+        };
+
+        let batchCalls = 0;
+        const batchingExec: SqlCtxExec = {
+            all: (query, parameters) => Promise.resolve(all(query, parameters)),
+            batch: (statements) => {
+                batchCalls += 1;
+
+                for (const statement of statements) {
+                    all(statement.sql, statement.params);
+                }
+
+                return Promise.resolve(statements.map(() => undefined));
+            },
+            run: (query, parameters) => {
+                all(query, parameters);
+
+                return Promise.resolve();
+            },
+        };
+
+        try {
+            // Seed the base table (and migrate the companions) through a plain
+            // writer, five rows, so a from-scratch backfill has more than one
+            // tally/tuple to insert.
+            const seeder = createSqlCtxDb({ clock: () => 1, dialect: makeSqliteDialect(), exec: plainExec, schema: backfillSchema });
+
+            for (const [index, slug] of ["a", "b", "c", "d", "e"].entries()) {
+                // eslint-disable-next-line no-await-in-loop -- deterministic seeding
+                await seeder.insert("notes", { archived: false, priority: index, slug });
+            }
+
+            // A SECOND writer over the SAME database, with its own empty
+            // backfill cache: its first write re-derives both companions from
+            // scratch — the historical backfill path both loops share — this
+            // time through the batching exec.
+            const rebuilder = createSqlCtxDb({ clock: () => 2, dialect: makeSqliteDialect(), exec: batchingExec, schema: backfillSchema });
+
+            await rebuilder.insert("notes", { archived: false, priority: 99, slug: "f" });
+
+            // One batch call for the aggregate tally backfill, one for the rank
+            // tuple backfill — never a run()-per-row loop.
+            expect(batchCalls).toBe(2);
+
+            const groups = await rebuilder.groupBy("notes", { agg: { op: "count" }, by: ["archived"] });
+
+            expect(groups[0]?.value).toBe(6);
+
+            const page = await rebuilder.rankPage("notes", "byPriority", { take: 10 });
+
+            expect(page.page).toHaveLength(6);
+        } finally {
+            database.close();
+        }
+    });
+});
+
 describe("createSqlCtxDb — cross-dialect SQL rendering", () => {
     /** A recording exec that captures every rendered statement and answers reads from a fixed row set. */
     const recordingExec = (rows: Record<string, unknown>[]): { exec: SqlCtxExec; statements: string[] } => {

--- a/packages/sql-store/__tests__/ctx-db.test.ts
+++ b/packages/sql-store/__tests__/ctx-db.test.ts
@@ -577,7 +577,7 @@ describe("createSqlCtxDb — aggregate + rank backfills route through batch when
                     all(statement.sql, statement.params);
                 }
 
-                return Promise.resolve(statements.map(() => undefined));
+                return Promise.resolve();
             },
             run: (query, parameters) => {
                 all(query, parameters);

--- a/packages/sql-store/__tests__/search-layout.test.ts
+++ b/packages/sql-store/__tests__/search-layout.test.ts
@@ -105,6 +105,53 @@ const createHarness = (): { close: () => void; exec: SqlCtxExec; raw: (query: st
     };
 };
 
+/**
+ * A real `node:sqlite`-backed exec that additionally implements `batch`,
+ * running every statement in the array against the same database and
+ * counting how many times `batch` itself was called (vs `run`). Exercises the
+ * write paths' batch seam against a genuine engine rather than a stub, so a
+ * test asserting "one batch call" also proves the batched rows actually land.
+ */
+const createBatchingHarness = (): {
+    batchCalls: () => number;
+    close: () => void;
+    exec: SqlCtxExec;
+    raw: (query: string, ...parameters: unknown[]) => Record<string, unknown>[];
+    runCalls: () => number;
+} => {
+    const database = new DatabaseSync(":memory:");
+    const all = (query: string, parameters: ReadonlyArray<unknown>): Record<string, unknown>[] => database.prepare(query).all(...(parameters as never[]));
+    let batches = 0;
+    let runs = 0;
+
+    return {
+        batchCalls: () => batches,
+        close: () => {
+            database.close();
+        },
+        exec: {
+            all: (query, parameters) => Promise.resolve(all(query, parameters)),
+            batch: (statements) => {
+                batches += 1;
+
+                for (const statement of statements) {
+                    all(statement.sql, statement.params);
+                }
+
+                return Promise.resolve(statements.map(() => undefined));
+            },
+            run: (query, parameters) => {
+                runs += 1;
+                all(query, parameters);
+
+                return Promise.resolve();
+            },
+        },
+        raw: (query, ...parameters) => all(query, parameters),
+        runCalls: () => runs,
+    };
+};
+
 /** An exec that records the SQL it is handed and returns nothing — for the rendering assertions. */
 const recordingExec = (): { exec: SqlCtxExec; statements: string[] } => {
     const statements: string[] = [];
@@ -360,6 +407,34 @@ describe("search layouts", () => {
             await invertedLayout.indexDocument(harness.exec, dialect, companion, "big", { body }, byBody);
 
             expect(companionRows()).toHaveLength(260);
+        });
+
+        it("issues one batch call (not one per chunk) when the exec supports batch", async () => {
+            expect.assertions(3);
+
+            const batching = createBatchingHarness();
+
+            try {
+                // 260 tokens spans 6 chunks at INSERT_CHUNK_ROWS = 50; without
+                // the batch seam this would be 6 sequential `run()` calls.
+                const body = Array.from({ length: 260 }, (_, index) => `token${String(index)}`).join(" ");
+
+                await invertedLayout.ensureCompanion(batching.exec, dialect, companion);
+
+                // ensureCompanion's DDL goes through `run`; `indexDocument`
+                // itself still purges the old rows via `run` (a single
+                // DELETE) before the chunked insert loop, which is the one
+                // expected to move to `batch`.
+                const runsBeforeIndexing = batching.runCalls();
+
+                await invertedLayout.indexDocument(batching.exec, dialect, companion, "big", { body }, byBody);
+
+                expect(batching.batchCalls()).toBe(1);
+                expect(batching.raw(`SELECT "__token__" FROM "notes__fts_by_body" ORDER BY "__token__"`)).toHaveLength(260);
+                expect(batching.runCalls()).toBe(runsBeforeIndexing + 1);
+            } finally {
+                batching.close();
+            }
         });
 
         it("caps how many tokens one oversized document contributes", async () => {

--- a/packages/sql-store/__tests__/search-layout.test.ts
+++ b/packages/sql-store/__tests__/search-layout.test.ts
@@ -138,7 +138,7 @@ const createBatchingHarness = (): {
                     all(statement.sql, statement.params);
                 }
 
-                return Promise.resolve(statements.map(() => undefined));
+                return Promise.resolve();
             },
             run: (query, parameters) => {
                 runs += 1;

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -101,7 +101,7 @@ import { migrateSearchState } from "./ctx-db-search-state";
 import type { SqlDialect } from "./dialect";
 import { createPointReadBatcher } from "./point-read-batcher";
 import type { SqlCtxExec } from "./sql-exec";
-import { columnRefSql, createIndexIfNotExists, decodeRow, decodeRows, forEachRowPaged, queryAll, queryRun, serializeColumnValue } from "./sql-exec";
+import { columnRefSql, createIndexIfNotExists, decodeRow, decodeRows, forEachRowPaged, queryAll, queryBatch, queryRun, serializeColumnValue } from "./sql-exec";
 import { effectiveColumnKind } from "./value-codec";
 
 /** Order fields that already provide a stable tiebreak (no extra `id ASC` needed). */
@@ -1160,14 +1160,18 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
 
         await queryRun(exec, dialect, sql`DELETE FROM ${sql.identifier(aggTable)}`);
 
+        const inserts: SQL[] = [];
+
         for (const [encoded, tally] of tallies) {
-            // eslint-disable-next-line no-await-in-loop -- counter rows are inserted sequentially on the single shared D1 connection; SqlCtxExec exposes no batch API here.
-            await queryRun(
-                exec,
-                dialect,
+            inserts.push(
                 sql`INSERT INTO ${sql.identifier(aggTable)} (${sql.identifier("__key__")}, ${sql.identifier("__value__")}, ${sql.identifier("__count__")}) VALUES (${encoded}, ${tally.value}, ${tally.count})`,
             );
         }
+
+        // One round trip for the whole backfill when the exec exposes `batch`
+        // (rows are keyed by distinct `__key__`, so order across them doesn't
+        // matter); a sequential `run()` loop otherwise.
+        await queryBatch(exec, dialect, inserts);
 
         backfilled.set(cacheKey, true);
 
@@ -1542,15 +1546,19 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
             rankTuples.push([document["_id"], partitionKey, ...sortValues]);
         });
 
-        for (const tuple of rankTuples) {
+        const inserts = rankTuples.map((tuple) => {
             const valueList = sql.join(
                 tuple.map((value) => sql`${value}`),
                 sql`, `,
             );
 
-            // eslint-disable-next-line no-await-in-loop -- rank rows are inserted sequentially on the single shared D1 connection; SqlCtxExec exposes no batch API here.
-            await queryRun(exec, dialect, sql`INSERT INTO ${sql.identifier(rankTable)} (${insertColumnList}) VALUES (${valueList})`);
-        }
+            return sql`INSERT INTO ${sql.identifier(rankTable)} (${insertColumnList}) VALUES (${valueList})`;
+        });
+
+        // One round trip for the whole backfill when the exec exposes `batch`
+        // (rows are keyed by distinct `__id__`, so order across them doesn't
+        // matter); a sequential `run()` loop otherwise.
+        await queryBatch(exec, dialect, inserts);
 
         rankBackfilled.set(cacheKey, true);
 

--- a/packages/sql-store/src/dialect.ts
+++ b/packages/sql-store/src/dialect.ts
@@ -39,25 +39,26 @@ export interface SqlExec {
 
     /**
      * Optional: run several write statements as one round trip instead of
-     * `run()` called once per statement in sequence. Statements execute in the
-     * given array ORDER — callers rely on that for e.g. a purge-then-insert
-     * pair, so an implementation must never reorder or parallelize across
-     * elements in a way that could observe them out of order.
+     * `run()` called once per statement in sequence. Statements MUST be
+     * mutually independent — an implementation MAY reorder or parallelize
+     * across elements, so callers must never rely on array order between
+     * elements (e.g. a purge-then-insert pair belongs in separate sequential
+     * `queryRun`/`run` calls, not one `batch`).
      *
      * Absent, the store core falls back to its historical sequential `run()`
      * loop, so an exec that doesn't implement this keeps working unchanged.
      *
      * D1's `client.batch` executes the whole array atomically (all-or-nothing)
-     * in one request — an actual atomicity improvement over the sequential
-     * fallback, not just a round-trip one. The Hyperdrive `postgres`/`pg`
-     * adapters instead dispatch every statement concurrently (`Promise.all`)
-     * over the same connection/pool rather than awaiting each in turn — still
-     * "at-least-once, non-atomic" like the fallback, but no longer serialized
-     * one full RTT at a time. Safe only for statements whose effects don't
-     * depend on each other (distinct-keyed rows), which is what every current
-     * caller batches.
+     * in one request, preserving array order — an actual atomicity improvement
+     * over the sequential fallback, not just a round-trip one. The Hyperdrive
+     * `postgres`/`pg` adapters instead dispatch every statement concurrently
+     * (`Promise.all`) over the same connection/pool rather than awaiting each
+     * in turn — still "at-least-once, non-atomic" like the fallback, but no
+     * longer serialized one full RTT at a time, and with no ordering between
+     * elements. Safe only for statements whose effects don't depend on each
+     * other (distinct-keyed rows), which is what every current caller batches.
      */
-    batch?: (statements: ReadonlyArray<{ params: ReadonlyArray<unknown>; sql: string }>) => Promise<SqlRunResult[]>;
+    batch?: (statements: ReadonlyArray<{ params: ReadonlyArray<unknown>; sql: string }>) => Promise<void>;
     run: (sql: string, params: ReadonlyArray<unknown>) => Promise<SqlRunResult>;
 }
 

--- a/packages/sql-store/src/dialect.ts
+++ b/packages/sql-store/src/dialect.ts
@@ -36,6 +36,28 @@ export interface SqlRunResult {
  */
 export interface SqlExec {
     all: (sql: string, params: ReadonlyArray<unknown>) => Promise<Record<string, unknown>[]>;
+
+    /**
+     * Optional: run several write statements as one round trip instead of
+     * `run()` called once per statement in sequence. Statements execute in the
+     * given array ORDER — callers rely on that for e.g. a purge-then-insert
+     * pair, so an implementation must never reorder or parallelize across
+     * elements in a way that could observe them out of order.
+     *
+     * Absent, the store core falls back to its historical sequential `run()`
+     * loop, so an exec that doesn't implement this keeps working unchanged.
+     *
+     * D1's `client.batch` executes the whole array atomically (all-or-nothing)
+     * in one request — an actual atomicity improvement over the sequential
+     * fallback, not just a round-trip one. The Hyperdrive `postgres`/`pg`
+     * adapters instead dispatch every statement concurrently (`Promise.all`)
+     * over the same connection/pool rather than awaiting each in turn — still
+     * "at-least-once, non-atomic" like the fallback, but no longer serialized
+     * one full RTT at a time. Safe only for statements whose effects don't
+     * depend on each other (distinct-keyed rows), which is what every current
+     * caller batches.
+     */
+    batch?: (statements: ReadonlyArray<{ params: ReadonlyArray<unknown>; sql: string }>) => Promise<SqlRunResult[]>;
     run: (sql: string, params: ReadonlyArray<unknown>) => Promise<SqlRunResult>;
 }
 

--- a/packages/sql-store/src/search-layout.ts
+++ b/packages/sql-store/src/search-layout.ts
@@ -38,7 +38,7 @@ import { sql } from "drizzle-orm";
 
 import type { SqlDialect } from "./dialect";
 import type { SqlCtxExec } from "./sql-exec";
-import { columnRefSql, createIndexIfNotExists, decodeRows, queryAll, queryRun, serializeColumnValue } from "./sql-exec";
+import { columnRefSql, createIndexIfNotExists, decodeRows, queryAll, queryBatch, queryRun, serializeColumnValue } from "./sql-exec";
 
 /** The staged `.withSearchIndex().search()` query a layout executes. */
 interface SearchStage {
@@ -361,6 +361,7 @@ const invertedLayout: SearchLayout = {
             [FTS_TOKEN_COLUMN, FTS_ID_COLUMN, FTS_COUNT_COLUMN].map((column) => sql.identifier(column)),
             sql`, `,
         );
+        const chunks: SQL[] = [];
 
         for (let start = 0; start < rows.length; start += INSERT_CHUNK_ROWS) {
             const values = sql.join(
@@ -368,9 +369,14 @@ const invertedLayout: SearchLayout = {
                 sql`, `,
             );
 
-            // eslint-disable-next-line no-await-in-loop -- companion writes run sequentially on the single shared connection, like every other write path here.
-            await queryRun(exec, dialect, sql`INSERT INTO ${sql.identifier(companion)} (${columns}) VALUES ${values}`);
+            chunks.push(sql`INSERT INTO ${sql.identifier(companion)} (${columns}) VALUES ${values}`);
         }
+
+        // One round trip per document write when the exec exposes `batch`
+        // (still chunked at INSERT_CHUNK_ROWS, so the bound-parameter count of
+        // any one statement stays far under every engine's cap); a per-chunk
+        // sequential `run()` loop otherwise.
+        await queryBatch(exec, dialect, chunks);
     },
     name: "inverted",
     runSearch: runInvertedSearch,

--- a/packages/sql-store/src/sql-exec.ts
+++ b/packages/sql-store/src/sql-exec.ts
@@ -48,6 +48,34 @@ const queryRun = (exec: SqlCtxExec, dialect: SqlDialect, query: SQL): Promise<Sq
 };
 
 /**
+ * Run several write statements as one round trip when the exec exposes
+ * {@link SqlCtxExec.batch}, in the given array ORDER; falls back to the
+ * historical sequential `run()`-per-statement loop when it doesn't, so an
+ * exec built before `batch` existed keeps working unchanged.
+ *
+ * The one place that renders and dispatches a companion write batch — the
+ * search-index chunk insert, the aggregate tally backfill, and the rank-tuple
+ * backfill all route through this instead of each re-deriving the
+ * has-`batch`-or-fall-back branch.
+ */
+const queryBatch = async (exec: SqlCtxExec, dialect: SqlDialect, queries: ReadonlyArray<SQL>): Promise<void> => {
+    if (queries.length === 0) {
+        return;
+    }
+
+    if (!exec.batch) {
+        for (const query of queries) {
+            // eslint-disable-next-line no-await-in-loop -- fallback path: this exec has no batch seam, so statements run sequentially like every write did before batch existed.
+            await queryRun(exec, dialect, query);
+        }
+
+        return;
+    }
+
+    await exec.batch(queries.map((query) => renderSql(dialect.name, query)));
+};
+
+/**
  * Create an index idempotently across engines. SQLite/Postgres support
  * `CREATE [UNIQUE] INDEX IF NOT EXISTS`; **MySQL does not** (only `CREATE TABLE`
  * takes `IF NOT EXISTS`), so it creates unconditionally and swallows the
@@ -87,6 +115,13 @@ const createIndexIfNotExists = async (
  */
 interface SqlCtxExec {
     all: (sql: string, parameters: ReadonlyArray<unknown>) => Promise<Record<string, unknown>[]>;
+    // Optional, mirroring `SqlExec.batch` (see dialect.ts): run several write
+    // statements as one round trip, in array order. `| void` for the same
+    // reason `run` below is unioned — a D1/node:sqlite double may not report
+    // per-statement results. Absent it, `queryBatch` falls back to the
+    // sequential `run()` loop every companion write used before this existed.
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- `void` is intentional: accepts a batch that reports no per-statement results
+    batch?: (statements: ReadonlyArray<{ params: ReadonlyArray<unknown>; sql: string }>) => Promise<(SqlRunResult | void)[]>;
     // `void` for D1/node:sqlite (the result is ignored on those paths); a
     // `SqlRunResult` ({ rowsAffected }) for engines whose OCC needs the affected
     // count (MySQL, which has no `RETURNING`). The union lets a PlanetScale
@@ -251,6 +286,7 @@ export {
     forEachRowPaged,
     physicalColumn,
     queryAll,
+    queryBatch,
     queryRun,
     serializeColumnValue,
 };

--- a/packages/sql-store/src/sql-exec.ts
+++ b/packages/sql-store/src/sql-exec.ts
@@ -115,13 +115,13 @@ const createIndexIfNotExists = async (
  */
 interface SqlCtxExec {
     all: (sql: string, parameters: ReadonlyArray<unknown>) => Promise<Record<string, unknown>[]>;
-    // Optional, mirroring `SqlExec.batch` (see dialect.ts): run several write
-    // statements as one round trip, in array order. `| void` for the same
-    // reason `run` below is unioned — a D1/node:sqlite double may not report
-    // per-statement results. Absent it, `queryBatch` falls back to the
-    // sequential `run()` loop every companion write used before this existed.
-    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- `void` is intentional: accepts a batch that reports no per-statement results
-    batch?: (statements: ReadonlyArray<{ params: ReadonlyArray<unknown>; sql: string }>) => Promise<(SqlRunResult | void)[]>;
+    // Optional, mirroring `SqlExec.batch` (see dialect.ts): run several
+    // mutually-independent write statements as one round trip. No caller
+    // consumes a return value — some engines dispatch these concurrently, so
+    // there's no ordered result to report — hence `void`. Absent it,
+    // `queryBatch` falls back to the sequential `run()` loop every companion
+    // write used before this existed.
+    batch?: (statements: ReadonlyArray<{ params: ReadonlyArray<unknown>; sql: string }>) => Promise<void>;
     // `void` for D1/node:sqlite (the result is ignored on those paths); a
     // `SqlRunResult` ({ rowsAffected }) for engines whose OCC needs the affected
     // count (MySQL, which has no `RETURNING`). The union lets a PlanetScale


### PR DESCRIPTION
A single insert/patch on a `.global()` table with search-index + aggregate/rank companions cost a double-digit count of sequential Hyperdrive round trips. Adds an optional `batch` to the exec seam (atomic on D1, pipelined on Hyperdrive) routing the companion loops through it with a sequential fallback. Also: the queue capture harness re-shaped `Message` through a fixed property allowlist (dev-only divergence — unlisted properties read undefined) → now a Proxy forwarding everything except ack/retry.

Verified: sql-store 92, queue 40, codegen 973 (goldens byte-identical).

⚠ Wires D1 batch through codegen/emit-app.ts + a golden + examples/blog — merge-order vs #243/#244/#256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)