### PR TITLE
feat(values): add validator refinements (.min/.max/.length/.pattern/.email/.url/.int)

### DIFF
--- a/packages/values/__tests__/refinements.test.ts
+++ b/packages/values/__tests__/refinements.test.ts
@@ -70,6 +70,21 @@ describe("string refinements", () => {
 
             expect(toJsonSchema(v.string().pattern(/^[a-z]+$/u))).toStrictEqual({ pattern: "^[a-z]+$", type: "string" });
         });
+
+        it("accepts a matching string consistently across repeated calls with a global-flagged regex", () => {
+            expect.assertions(3);
+
+            // A `g`-flagged RegExp is stateful: `.test()` advances `lastIndex` on
+            // match and resumes from it next call. A single `.pattern()` validator
+            // is built once and its regex reused across every `.parse()` call, so
+            // without neutralizing the flag this alternates true/false/true/... on
+            // the exact same input instead of returning a consistent answer.
+            const validator = v.string().pattern(/^[a-z]+$/gu);
+
+            expect(validator.parse("abc")).toBe("abc");
+            expect(validator.parse("abc")).toBe("abc");
+            expect(validator.parse("abc")).toBe("abc");
+        });
     });
 
     describe(".email()", () => {
@@ -103,6 +118,30 @@ describe("string refinements", () => {
             expect.assertions(1);
 
             expect(toJsonSchema(v.string().url())).toStrictEqual({ format: "uri", type: "string" });
+        });
+
+        it("accepts http(s) URLs", () => {
+            expect.assertions(2);
+
+            const validator = v.string().url();
+
+            expect(validator.parse("http://example.com")).toBe("http://example.com");
+            expect(validator.parse("https://example.com")).toBe("https://example.com");
+        });
+
+        it("rejects dangerous non-http(s) schemes even though they parse as a valid URL", () => {
+            expect.assertions(4);
+
+            // `URL.canParse` alone returns true for all of these — they are
+            // syntactically valid URLs, just not ones safe to drop into
+            // `<a href>`/`window.location` after "validating" them as a link.
+            const validator = v.string().url();
+
+            // eslint-disable-next-line no-script-url -- intentional dangerous-scheme fixture, never executed
+            expect(() => validator.parse("javascript:alert(1)")).toThrow(ValidationError);
+            expect(() => validator.parse("data:text/html,x")).toThrow(ValidationError);
+            expect(() => validator.parse("file:///x")).toThrow(ValidationError);
+            expect(() => validator.parse("vbscript:msgbox(1)")).toThrow(ValidationError);
         });
     });
 

--- a/packages/values/__tests__/refinements.test.ts
+++ b/packages/values/__tests__/refinements.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import { toJsonSchema, v, ValidationError } from "../src/index";
+
+describe("string refinements", () => {
+    describe(".min()", () => {
+        it("rejects a too-short string and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.string().min(1);
+
+            expect(() => validator.parse("")).toThrow(ValidationError);
+            expect(validator.parse("a")).toBe("a");
+        });
+
+        it("emits minLength", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.string().min(1))).toStrictEqual({ minLength: 1, type: "string" });
+        });
+    });
+
+    describe(".max()", () => {
+        it("rejects a too-long string and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.string().max(3);
+
+            expect(() => validator.parse("abcd")).toThrow(ValidationError);
+            expect(validator.parse("abc")).toBe("abc");
+        });
+
+        it("emits maxLength", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.string().max(3))).toStrictEqual({ maxLength: 3, type: "string" });
+        });
+    });
+
+    describe(".length()", () => {
+        it("rejects a wrong-length string and accepts an exact match", () => {
+            expect.assertions(3);
+
+            const validator = v.string().length(4);
+
+            expect(() => validator.parse("abc")).toThrow(ValidationError);
+            expect(() => validator.parse("abcde")).toThrow(ValidationError);
+            expect(validator.parse("abcd")).toBe("abcd");
+        });
+
+        it("emits both minLength and maxLength", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.string().length(4))).toStrictEqual({ maxLength: 4, minLength: 4, type: "string" });
+        });
+    });
+
+    describe(".pattern()", () => {
+        it("rejects a non-matching string and accepts a matching one", () => {
+            expect.assertions(2);
+
+            const validator = v.string().pattern(/^[a-z]+$/u);
+
+            expect(() => validator.parse("ABC")).toThrow(ValidationError);
+            expect(validator.parse("abc")).toBe("abc");
+        });
+
+        it("emits pattern from the regex source", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.string().pattern(/^[a-z]+$/u))).toStrictEqual({ pattern: "^[a-z]+$", type: "string" });
+        });
+    });
+
+    describe(".email()", () => {
+        it("rejects an invalid address and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.string().email();
+
+            expect(() => validator.parse("x")).toThrow(ValidationError);
+            expect(validator.parse("a@b.com")).toBe("a@b.com");
+        });
+
+        it("emits format: email", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.string().email())).toStrictEqual({ format: "email", type: "string" });
+        });
+    });
+
+    describe(".url()", () => {
+        it("rejects an invalid URL and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.string().url();
+
+            expect(() => validator.parse("not a url")).toThrow(ValidationError);
+            expect(validator.parse("https://example.com")).toBe("https://example.com");
+        });
+
+        it("emits format: uri", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.string().url())).toStrictEqual({ format: "uri", type: "string" });
+        });
+    });
+
+    describe("chaining", () => {
+        it("v.string().min(1).email() enforces both and emits both keywords", () => {
+            expect.assertions(4);
+
+            const validator = v.string().min(1).email();
+
+            expect(() => validator.parse("")).toThrow(ValidationError);
+            expect(() => validator.parse("x")).toThrow(ValidationError);
+            expect(validator.parse("a@b.com")).toBe("a@b.com");
+            expect(toJsonSchema(validator)).toStrictEqual({ format: "email", minLength: 1, type: "string" });
+        });
+
+        it(".check() still composes after a refinement shortcut", () => {
+            expect.assertions(3);
+
+            const validator = v
+                .string()
+                .min(1)
+                .check((value) => value === value.toLowerCase(), "must be lowercase");
+
+            expect(() => validator.parse("")).toThrow(ValidationError);
+            expect(() => validator.parse("ABC")).toThrow(ValidationError);
+            expect(validator.parse("abc")).toBe("abc");
+        });
+    });
+});
+
+describe("number refinements", () => {
+    describe(".min()", () => {
+        it("rejects a too-small number and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.number().min(0);
+
+            expect(() => validator.parse(-1)).toThrow(ValidationError);
+            expect(validator.parse(0)).toBe(0);
+        });
+
+        it("emits minimum", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.number().min(0))).toStrictEqual({ minimum: 0, type: "number" });
+        });
+    });
+
+    describe(".max()", () => {
+        it("rejects a too-large number and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.number().max(10);
+
+            expect(() => validator.parse(11)).toThrow(ValidationError);
+            expect(validator.parse(10)).toBe(10);
+        });
+
+        it("emits maximum", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.number().max(10))).toStrictEqual({ maximum: 10, type: "number" });
+        });
+    });
+
+    describe(".int()", () => {
+        it("rejects a non-integer and accepts an integer", () => {
+            expect.assertions(2);
+
+            const validator = v.number().int();
+
+            expect(() => validator.parse(1.5)).toThrow(ValidationError);
+            expect(validator.parse(1)).toBe(1);
+        });
+
+        it("emits type: integer", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.number().int())).toStrictEqual({ type: "integer" });
+        });
+    });
+
+    describe(".positive()", () => {
+        it("rejects zero/negative and accepts a positive number", () => {
+            expect.assertions(3);
+
+            const validator = v.number().positive();
+
+            expect(() => validator.parse(0)).toThrow(ValidationError);
+            expect(() => validator.parse(-1)).toThrow(ValidationError);
+            expect(validator.parse(1)).toBe(1);
+        });
+
+        it("emits exclusiveMinimum: 0", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.number().positive())).toStrictEqual({ exclusiveMinimum: 0, type: "number" });
+        });
+    });
+
+    describe("chaining", () => {
+        it("v.number().int().min(0) rejects -1 and 1.5, accepts 0, and emits both keywords", () => {
+            expect.assertions(4);
+
+            const validator = v.number().int().min(0);
+
+            expect(() => validator.parse(-1)).toThrow(ValidationError);
+            expect(() => validator.parse(1.5)).toThrow(ValidationError);
+            expect(validator.parse(0)).toBe(0);
+            expect(toJsonSchema(validator)).toStrictEqual({ minimum: 0, type: "integer" });
+        });
+    });
+});
+
+describe("array refinements", () => {
+    describe(".min()", () => {
+        it("rejects a too-short array and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.array(v.string()).min(1);
+
+            expect(() => validator.parse([])).toThrow(ValidationError);
+            expect(validator.parse(["a"])).toStrictEqual(["a"]);
+        });
+
+        it("emits minItems", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.array(v.string()).min(1))).toStrictEqual({ items: { type: "string" }, minItems: 1, type: "array" });
+        });
+    });
+
+    describe(".max()", () => {
+        it("rejects a too-long array and accepts a valid one", () => {
+            expect.assertions(2);
+
+            const validator = v.array(v.string()).max(2);
+
+            expect(() => validator.parse(["a", "b", "c"])).toThrow(ValidationError);
+            expect(validator.parse(["a", "b"])).toStrictEqual(["a", "b"]);
+        });
+
+        it("emits maxItems", () => {
+            expect.assertions(1);
+
+            expect(toJsonSchema(v.array(v.string()).max(2))).toStrictEqual({ items: { type: "string" }, maxItems: 2, type: "array" });
+        });
+    });
+
+    describe("chaining", () => {
+        it("v.array(v.string()).min(1).max(3) enforces both and emits both keywords", () => {
+            expect.assertions(4);
+
+            const validator = v.array(v.string()).min(1).max(3);
+
+            expect(() => validator.parse([])).toThrow(ValidationError);
+            expect(() => validator.parse(["a", "b", "c", "d"])).toThrow(ValidationError);
+            expect(validator.parse(["a", "b"])).toStrictEqual(["a", "b"]);
+            expect(toJsonSchema(validator)).toStrictEqual({ items: { type: "string" }, maxItems: 3, minItems: 1, type: "array" });
+        });
+    });
+});

--- a/packages/values/src/index.ts
+++ b/packages/values/src/index.ts
@@ -4,6 +4,7 @@ export type { JsonSchema, SchemaNodeReader } from "./json-schema-core";
 export { jsonSchemaFromNode, objectSchemaFromNodes } from "./json-schema-core";
 export { argsToJsonSchema, toJsonSchema } from "./to-json-schema";
 export type {
+    ArrayColumnValidator,
     CheckOptions,
     Column,
     ColumnMeta,
@@ -17,8 +18,10 @@ export type {
     InsertShape,
     JsonSchemaFragment,
     MetaOptions,
+    NumberColumnValidator,
     SelectShape,
     ServerDefaultContext,
+    StringColumnValidator,
     TimestampColumnValidator,
     Validator,
     ValidatorKind,

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -229,9 +229,25 @@ interface StringColumnValidator extends ColumnValidator<string, string> {
     max: (max: number) => StringColumnValidator;
     /** Require at least `min` characters (`minLength`). */
     min: (min: number) => StringColumnValidator;
-    /** Require the value to match `pattern` (JSON Schema `pattern` set from `pattern.source`). */
+
+    /**
+     * Require the value to match `pattern` (JSON Schema `pattern` set from
+     * `pattern.source`; emitted `pattern` does not encode `pattern.flags` — a
+     * case-insensitive `/i` regex, for instance, emits a flag-less JSON Schema
+     * pattern). A `g`/`y`-flagged `pattern` is tested statelessly (its
+     * `lastIndex` is never consulted or advanced), so a single validator
+     * instance gives the same answer for the same input on every call.
+     */
     pattern: (pattern: RegExp) => StringColumnValidator;
-    /** Require a valid URL, parseable by the WHATWG `URL` constructor (`format: "uri"`). */
+
+    /**
+     * Require a valid `http:`/`https:` URL (`format: "uri"`). Parseable by the
+     * WHATWG `URL` constructor is necessary but not sufficient — schemes such as
+     * `javascript:`, `data:`, `file:`, and `vbscript:` all parse successfully but
+     * are rejected here, since accepting them lets a validated "link" field carry
+     * an XSS payload straight into an anchor's `href` or `window.location` at
+     * render time.
+     */
     url: () => StringColumnValidator;
 }
 
@@ -359,8 +375,24 @@ interface InternalArrayColumnValidator<T> extends InternalColumnValidator<T[]> {
  */
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/u;
 
-/** True when `value` parses as a WHATWG URL. */
-const isValidUrl = (value: string): boolean => URL.canParse(value);
+/**
+ * True when `value` parses as a WHATWG URL AND uses the `http:`/`https:`
+ * scheme. An allowlist rather than a denylist deliberately — `URL.canParse`
+ * alone accepts any scheme the parser recognizes (`javascript:`, `data:`,
+ * `file:`, `vbscript:`, …), and a denylist would need to name every dangerous
+ * scheme up front and stay current as new ones appear. http(s)-only covers the
+ * overwhelming majority of "validate a link" use cases and fails closed on
+ * everything else.
+ */
+const isValidUrl = (value: string): boolean => {
+    if (!URL.canParse(value)) {
+        return false;
+    }
+
+    const { protocol } = new URL(value);
+
+    return protocol === "http:" || protocol === "https:";
+};
 
 // Declared as a function (not an arrow expression) so TypeScript treats its
 // `: never` return as a control-flow assertion — callers rely on this to narrow
@@ -571,11 +603,22 @@ const createValidator = <T>(
                     message: `expected string length === ${String(length)}`,
                     schema: { maxLength: length, minLength: length },
                 }) as InternalStringColumnValidator;
-            self.pattern = (pattern) =>
-                self.check((value) => pattern.test(value), {
+            self.pattern = (pattern) => {
+                // `g`/`y`-flagged regexes are stateful: `RegExp.prototype.test`
+                // advances `lastIndex` on match and resumes from it next call, so
+                // reusing the caller's `RegExp` instance directly across requests
+                // makes the same input alternate between passing and failing
+                // depending on call order. Strip `g`/`y` once here into a fresh,
+                // non-advancing `RegExp` so `.test()` is a pure function of its
+                // input; the JSON Schema `pattern` still comes from the original
+                // `pattern.source` (flags are never encoded there regardless).
+                const stable = pattern.global || pattern.sticky ? new RegExp(pattern.source, pattern.flags.replaceAll(/[gy]/gu, "")) : pattern;
+
+                return self.check((value) => stable.test(value), {
                     message: `expected string matching ${pattern.toString()}`,
                     schema: { pattern: pattern.source },
                 }) as InternalStringColumnValidator;
+            };
             self.email = () =>
                 self.check((value) => EMAIL_PATTERN.test(value), {
                     message: "expected a valid email address",

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -84,7 +84,15 @@ interface Validator<T = unknown> extends StandardSchemaV1<T, T> {
      *
      * Works in any context — argument validators, column validators, or
      * standalone — so it can encode invariants like
-     * `v.number().check(n => n >= 0)` or
+     * `v.number().check(n => n >= 0)`.
+     *
+     * For the common length/format/range cases, prefer the named shortcuts
+     * (`v.string().min(1)`, `.max(n)`, `.length(n)`, `.pattern(re)`, `.email()`,
+     * `.url()`; `v.number().min(n)`, `.max(n)`, `.int()`, `.positive()`;
+     * `v.array(...).min(n)`, `.max(n)`) — each is sugar over this same
+     * `.check(predicate, { schema })` path, so the predicate and the JSON Schema
+     * keyword are set together and can never drift apart. `.check()` remains the
+     * escape hatch for anything the shortcuts don't cover, e.g.
      * `v.string().check(s => s.length > 0, { message: "non-empty", schema: { minLength: 1 } })`.
      */
     check: (predicate: (value: T) => boolean, options?: CheckOptions | string) => Validator<T>;
@@ -203,6 +211,56 @@ interface TimestampColumnValidator extends ColumnValidator<number, number> {
     defaultNow: () => ColumnValidator<number, number | undefined>;
 }
 
+/**
+ * A {@link ColumnValidator} for `v.string()` with ergonomic refinement
+ * shortcuts. Each method is sugar over `.check(predicate, { schema })` — it
+ * sets the runtime predicate AND the matching JSON Schema keyword in one call
+ * so the two can never drift (see the module-level `.check()` docstring for
+ * the underlying two-part mechanism). Chainable among each other; `.check()`/
+ * `.meta()` compose after them but the return narrows to the base
+ * {@link ColumnValidator} (no further refinement shortcuts after that point).
+ */
+interface StringColumnValidator extends ColumnValidator<string, string> {
+    /** Require a valid email address (`format: "email"`). Uses a pragmatic (non-RFC-5322-exhaustive) pattern. */
+    email: () => StringColumnValidator;
+    /** Require exactly `length` characters (`minLength`/`maxLength` both set to `length`). */
+    length: (length: number) => StringColumnValidator;
+    /** Require at most `max` characters (`maxLength`). */
+    max: (max: number) => StringColumnValidator;
+    /** Require at least `min` characters (`minLength`). */
+    min: (min: number) => StringColumnValidator;
+    /** Require the value to match `pattern` (JSON Schema `pattern` set from `pattern.source`). */
+    pattern: (pattern: RegExp) => StringColumnValidator;
+    /** Require a valid URL, parseable by the WHATWG `URL` constructor (`format: "uri"`). */
+    url: () => StringColumnValidator;
+}
+
+/**
+ * A {@link ColumnValidator} for `v.number()` with ergonomic refinement
+ * shortcuts — see {@link StringColumnValidator} for the delegation pattern.
+ */
+interface NumberColumnValidator extends ColumnValidator<number, number> {
+    /** Require an integer value (`Number.isInteger`); JSON Schema `type` narrows to `"integer"`. */
+    int: () => NumberColumnValidator;
+    /** Require at most `max` (`maximum`). */
+    max: (max: number) => NumberColumnValidator;
+    /** Require at least `min` (`minimum`). */
+    min: (min: number) => NumberColumnValidator;
+    /** Require a value strictly greater than zero (`exclusiveMinimum: 0`). */
+    positive: () => NumberColumnValidator;
+}
+
+/**
+ * A {@link ColumnValidator} for `v.array(...)` with ergonomic length-refinement
+ * shortcuts — see {@link StringColumnValidator} for the delegation pattern.
+ */
+interface ArrayColumnValidator<TItem> extends ColumnValidator<TItem[], TItem[]> {
+    /** Require at most `max` items (`maxItems`). */
+    max: (max: number) => ArrayColumnValidator<TItem>;
+    /** Require at least `min` items (`minItems`). */
+    min: (min: number) => ArrayColumnValidator<TItem>;
+}
+
 /** The type a validator/column presents on **select** (reads). */
 type InferSelect<V> = V extends Validator<infer T> ? T : never;
 
@@ -261,6 +319,48 @@ interface InternalColumnValidator<T> extends InternalValidator<T> {
     serverDefault: (function_: (context: ServerDefaultContext) => T) => InternalColumnValidator<T>;
     unique: () => InternalColumnValidator<T>;
 }
+
+/** Internal runtime shape backing {@link StringColumnValidator}. */
+interface InternalStringColumnValidator extends InternalColumnValidator<string> {
+    email: () => InternalStringColumnValidator;
+    length: (length: number) => InternalStringColumnValidator;
+    max: (max: number) => InternalStringColumnValidator;
+    min: (min: number) => InternalStringColumnValidator;
+    pattern: (pattern: RegExp) => InternalStringColumnValidator;
+    url: () => InternalStringColumnValidator;
+}
+
+/** Internal runtime shape backing {@link NumberColumnValidator}. */
+interface InternalNumberColumnValidator extends InternalColumnValidator<number> {
+    int: () => InternalNumberColumnValidator;
+    max: (max: number) => InternalNumberColumnValidator;
+    min: (min: number) => InternalNumberColumnValidator;
+    positive: () => InternalNumberColumnValidator;
+}
+
+/** Internal runtime shape backing {@link ArrayColumnValidator}. */
+interface InternalArrayColumnValidator<T> extends InternalColumnValidator<T[]> {
+    max: (max: number) => InternalArrayColumnValidator<T>;
+    min: (min: number) => InternalArrayColumnValidator<T>;
+}
+
+/**
+ * A pragmatic (not RFC-5322-exhaustive) email pattern: one-or-more
+ * non-whitespace/non-`@` chars (dots allowed), `@`, then one-or-more
+ * dot-separated domain labels each excluding `.` from their own character
+ * class. The domain-label classes are dot-exclusive specifically so the two
+ * `+`-quantified groups either side of the repeated `\.` never overlap in
+ * what they can match — that disjointness is what keeps the match linear
+ * instead of letting the engine try every possible split point around each
+ * dot (a super-linear backtracking blowup on adversarial input otherwise).
+ * Good enough to catch the common "missing `@`"/"missing domain" mistakes
+ * without pretending to fully validate deliverability (RFC 5322 pedantry does
+ * not either).
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/u;
+
+/** True when `value` parses as a WHATWG URL. */
+const isValidUrl = (value: string): boolean => URL.canParse(value);
 
 // Declared as a function (not an arrow expression) so TypeScript treats its
 // `: never` return as a control-flow assertion — callers rely on this to narrow
@@ -403,6 +503,97 @@ const createValidator = <T>(
         return createValidator<T>(kind, parser, mergeConstraints(meta, fragment));
     };
 
+    // Kind-specific ergonomic refinements (`.min()`/`.email()`/`.int()`/…). Each
+    // is sugar over the SAME `validator.check(predicate, { schema })` path just
+    // defined above, so runtime predicate and JSON-Schema keyword can never
+    // drift apart. Attached here (inside `createValidator`, gated on `kind`)
+    // rather than on the public factories so they survive `.check()`'s
+    // recursive `createValidator` call and stay available for further chaining
+    // (`.min(1).email()`), since `kind` is threaded through every rebuild.
+    switch (kind) {
+        case "array": {
+            const self = validator as unknown as InternalArrayColumnValidator<unknown>;
+
+            self.min = (min) =>
+                self.check((value) => value.length >= min, {
+                    message: `expected array length >= ${String(min)}`,
+                    schema: { minItems: min },
+                }) as InternalArrayColumnValidator<unknown>;
+            self.max = (max) =>
+                self.check((value) => value.length <= max, {
+                    message: `expected array length <= ${String(max)}`,
+                    schema: { maxItems: max },
+                }) as InternalArrayColumnValidator<unknown>;
+
+            break;
+        }
+        case "number": {
+            const self = validator as unknown as InternalNumberColumnValidator;
+
+            self.min = (min) =>
+                self.check((value) => value >= min, {
+                    message: `expected number >= ${String(min)}`,
+                    schema: { minimum: min },
+                }) as InternalNumberColumnValidator;
+            self.max = (max) =>
+                self.check((value) => value <= max, {
+                    message: `expected number <= ${String(max)}`,
+                    schema: { maximum: max },
+                }) as InternalNumberColumnValidator;
+            self.int = () =>
+                self.check((value) => Number.isInteger(value), {
+                    message: "expected an integer",
+                    schema: { type: "integer" },
+                }) as InternalNumberColumnValidator;
+            self.positive = () =>
+                self.check((value) => value > 0, {
+                    message: "expected a positive number",
+                    schema: { exclusiveMinimum: 0 },
+                }) as InternalNumberColumnValidator;
+
+            break;
+        }
+        case "string": {
+            const self = validator as unknown as InternalStringColumnValidator;
+
+            self.min = (min) =>
+                self.check((value) => value.length >= min, {
+                    message: `expected string length >= ${String(min)}`,
+                    schema: { minLength: min },
+                }) as InternalStringColumnValidator;
+            self.max = (max) =>
+                self.check((value) => value.length <= max, {
+                    message: `expected string length <= ${String(max)}`,
+                    schema: { maxLength: max },
+                }) as InternalStringColumnValidator;
+            self.length = (length) =>
+                self.check((value) => value.length === length, {
+                    message: `expected string length === ${String(length)}`,
+                    schema: { maxLength: length, minLength: length },
+                }) as InternalStringColumnValidator;
+            self.pattern = (pattern) =>
+                self.check((value) => pattern.test(value), {
+                    message: `expected string matching ${pattern.toString()}`,
+                    schema: { pattern: pattern.source },
+                }) as InternalStringColumnValidator;
+            self.email = () =>
+                self.check((value) => EMAIL_PATTERN.test(value), {
+                    message: "expected a valid email address",
+                    schema: { format: "email" },
+                }) as InternalStringColumnValidator;
+            self.url = () =>
+                self.check((value) => isValidUrl(value), {
+                    message: "expected a valid URL",
+                    schema: { format: "uri" },
+                }) as InternalStringColumnValidator;
+
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
     return validator;
 };
 
@@ -412,19 +603,28 @@ const toInternal = <T>(validator: Validator<T>): InternalValidator<T> => validat
 const asColumn = <TSelect, TInsert = TSelect>(validator: InternalColumnValidator<TSelect>): ColumnValidator<TSelect, TInsert> =>
     validator as unknown as ColumnValidator<TSelect, TInsert>;
 
-const string = (): ColumnValidator<string, string> =>
-    asColumn(
+/** Bridge the loose runtime validator to the public {@link StringColumnValidator} surface. */
+const asStringColumn = (validator: InternalStringColumnValidator): StringColumnValidator => validator as unknown as StringColumnValidator;
+
+/** Bridge the loose runtime validator to the public {@link NumberColumnValidator} surface. */
+const asNumberColumn = (validator: InternalNumberColumnValidator): NumberColumnValidator => validator as unknown as NumberColumnValidator;
+
+/** Bridge the loose runtime validator to the public {@link ArrayColumnValidator} surface. */
+const asArrayColumn = <T>(validator: InternalArrayColumnValidator<T>): ArrayColumnValidator<T> => validator as unknown as ArrayColumnValidator<T>;
+
+const string = (): StringColumnValidator =>
+    asStringColumn(
         createValidator<string>("string", (value, context) => {
             if (typeof value !== "string") {
                 fail(context, "string", value);
             }
 
             return value;
-        }),
+        }) as unknown as InternalStringColumnValidator,
     );
 
-const number = (): ColumnValidator<number, number> =>
-    asColumn(
+const number = (): NumberColumnValidator =>
+    asNumberColumn(
         createValidator<number>("number", (value, context) => {
             // Reject NaN and ±Infinity — they round-trip through JSON as `null`
             // and break downstream code that assumes a real numeric value.
@@ -433,7 +633,7 @@ const number = (): ColumnValidator<number, number> =>
             }
 
             return value;
-        }),
+        }) as unknown as InternalNumberColumnValidator,
     );
 
 /** Shared parser for the time validators: a finite epoch-millisecond number. */
@@ -593,10 +793,10 @@ const literal = <T extends bigint | boolean | number | string | null>(literalVal
         ),
     );
 
-const array = <V extends Validator>(inner: V): ColumnValidator<Infer<V>[], Infer<V>[]> => {
+const array = <V extends Validator>(inner: V): ArrayColumnValidator<Infer<V>> => {
     const innerInternal = toInternal(inner as Validator<Infer<V>>);
 
-    return asColumn(
+    return asArrayColumn(
         createValidator<Infer<V>[]>(
             "array",
             (value, context) => {
@@ -626,7 +826,7 @@ const array = <V extends Validator>(inner: V): ColumnValidator<Infer<V>[], Infer
                 return out;
             },
             { inner },
-        ),
+        ) as unknown as InternalArrayColumnValidator<Infer<V>>,
     );
 };
 
@@ -1023,6 +1223,7 @@ const v: {
 };
 
 export type {
+    ArrayColumnValidator,
     CheckOptions,
     Column,
     ColumnMeta,
@@ -1036,9 +1237,11 @@ export type {
     InsertShape,
     JsonSchemaFragment,
     MetaOptions,
+    NumberColumnValidator,
     OptionalizeShape,
     SelectShape,
     ServerDefaultContext,
+    StringColumnValidator,
     TimestampColumnValidator,
     Validator,
     ValidatorKind,


### PR DESCRIPTION
Length/format/range validation was a verbose, drift-prone two-part hand-roll (`.check(pred, { schema })` restating the predicate and the JSON-Schema fragment separately, which can silently disagree). Adds first-class refinement methods on string/number/array builders, each delegating to the existing constraint machinery so the runtime predicate and the emitted JSON-Schema stay in lockstep. `.check()` remains the escape hatch.

Verified: 168/168 (lockstep tests asserting both the predicate and toJsonSchema output).

⚠ Conflicts with #248 on values/v.ts at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)