### PR TITLE
[spike] agent durable run queue + channel reply-out (design + isolated prototypes)

### DIFF
--- a/packages/agent/__tests__/reply.prototype.test.ts
+++ b/packages/agent/__tests__/reply.prototype.test.ts
@@ -1,0 +1,107 @@
+import type { MailTransport, SendPayload } from "@lunora/mail";
+import { createMailer } from "@lunora/mail";
+import type { InboundEmail } from "@lunora/mail/inbound";
+import { describe, expect, it } from "vitest";
+
+import { buildReferences, captureEmailReplyRef, replyToEmail } from "../src/reply.prototype";
+
+/** Minimal `InboundEmail` builder — fills only the fields the prototype reads. */
+const fakeInboundEmail = (overrides: Partial<InboundEmail> = {}): InboundEmail => {
+    return {
+        attachments: [],
+        authentication: { dkim: "pass", dmarc: "pass", spf: "pass" },
+        from: "customer@example.com",
+        headers: {},
+        to: ["support@lunora.sh"],
+        ...overrides,
+    };
+};
+
+/** Records every payload handed to `send` — the fake mail sender. */
+const fakeMailTransport = (): { sent: SendPayload[]; transport: MailTransport } => {
+    const sent: SendPayload[] = [];
+
+    return {
+        sent,
+        transport: {
+            send: async (payload) => {
+                sent.push(payload);
+
+                return { id: `sent-${String(sent.length)}` };
+            },
+        },
+    };
+};
+
+describe("reply prototype (plan 242 spike)", () => {
+    it("captures a reply ref from an inbound email and threads the reply's In-Reply-To/References", async () => {
+        const { sent, transport } = fakeMailTransport();
+        const mailer = createMailer({ from: "support@lunora.sh", transport });
+
+        const inbound = fakeInboundEmail({
+            from: "customer@example.com",
+            messageId: "<abc123@example.com>",
+        });
+
+        const replyRef = captureEmailReplyRef(inbound);
+
+        expect(replyRef).toStrictEqual({
+            channel: "email",
+            from: "customer@example.com",
+            messageId: "<abc123@example.com>",
+            to: ["support@lunora.sh"],
+        });
+
+        // "Run the agent" — stands in for the real runAgentLoop's final answer.
+        const answer = "Your order #4821 ships tomorrow.";
+
+        await replyToEmail(mailer, replyRef as NonNullable<typeof replyRef>, { subject: "Re: Order status", text: answer });
+
+        expect(sent).toHaveLength(1);
+        expect(sent[0]).toMatchObject({
+            headers: { "In-Reply-To": "<abc123@example.com>", References: "<abc123@example.com>" },
+            text: answer,
+            to: "customer@example.com",
+        });
+    });
+
+    it("appends to an existing References chain rather than replacing it", async () => {
+        const { sent, transport } = fakeMailTransport();
+        const mailer = createMailer({ from: "support@lunora.sh", transport });
+
+        const inbound = fakeInboundEmail({
+            from: "customer@example.com",
+            messageId: "<third@example.com>",
+            references: "<first@example.com> <second@example.com>",
+        });
+
+        const replyRef = captureEmailReplyRef(inbound);
+
+        expect(replyRef?.references).toBe("<first@example.com> <second@example.com>");
+        expect(buildReferences(replyRef as NonNullable<typeof replyRef>)).toBe("<first@example.com> <second@example.com> <third@example.com>");
+
+        await replyToEmail(mailer, replyRef as NonNullable<typeof replyRef>, { subject: "Re: Order status", text: "reply body" });
+
+        expect(sent[0]?.headers?.["References"]).toBe("<first@example.com> <second@example.com> <third@example.com>");
+        expect(sent[0]?.headers?.["In-Reply-To"]).toBe("<third@example.com>");
+    });
+
+    it("declines to reply when the inbound message carried no Message-ID (nothing to thread against)", () => {
+        const inbound = fakeInboundEmail({ from: "customer@example.com" });
+
+        expect(captureEmailReplyRef(inbound)).toBeUndefined();
+    });
+
+    it("threads a real reply through the mailer's own address/header validation (not a hand-rolled assertion)", async () => {
+        const { sent, transport } = fakeMailTransport();
+        const mailer = createMailer({ from: "support@lunora.sh", transport });
+
+        const replyRef = captureEmailReplyRef(fakeInboundEmail({ from: "customer@example.com", messageId: "<msg@example.com>" }));
+
+        await replyToEmail(mailer, replyRef as NonNullable<typeof replyRef>, { subject: "Re: hi", text: "hello" });
+
+        // The mailer's buildPayload ran (from defaulted, addresses validated) —
+        // proof this went through the real @lunora/mail send path, not a stub.
+        expect(sent[0]?.from).toBe("support@lunora.sh");
+    });
+});

--- a/packages/agent/__tests__/run-queue.prototype.test.ts
+++ b/packages/agent/__tests__/run-queue.prototype.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+
+import type { PrototypeDatabase, PrototypeIndexBuilder, PrototypeIndexQuery, PrototypeRow } from "../src/run-queue.prototype";
+import { completeRunAndDequeue, ensureThreadOrQueue, MAX_QUEUE_DEPTH, QueueConflictError } from "../src/run-queue.prototype";
+
+const QUEUE_FULL_PATTERN = /run queue is full/u;
+const IN_FLIGHT_PATTERN = /already has a run in flight/u;
+
+/** Same fields the prototype's two indexes order by. */
+const ORDER_FIELDS: Record<string, string> = { byThread: "position" };
+
+const collectConditions = (build: (q: PrototypeIndexBuilder) => unknown): [string, unknown][] => {
+    const conditions: [string, unknown][] = [];
+    const builder: PrototypeIndexBuilder = {
+        eq: (field, value) => {
+            conditions.push([field, value]);
+
+            return builder;
+        },
+    };
+
+    build(builder);
+
+    return conditions;
+};
+
+const matchesConditions = (row: PrototypeRow, conditions: [string, unknown][]): boolean => conditions.every(([field, value]) => row[field] === value);
+
+const sortByField = (rows: PrototypeRow[], field: string | undefined, indexName: string, direction: "asc" | "desc"): PrototypeRow[] => {
+    if (field === undefined) {
+        throw new Error(`test double: .order() is only modeled for a known-keyed index, not "${indexName}"`);
+    }
+
+    return rows.toSorted((a, b) => {
+        const delta = ((a[field] as number | undefined) ?? 0) - ((b[field] as number | undefined) ?? 0);
+
+        return direction === "desc" ? -delta : delta;
+    });
+};
+
+const makePrototypeIndexQuery = (allRows: PrototypeRow[], indexName: string, conditions: [string, unknown][]): PrototypeIndexQuery => {
+    const matches = (): PrototypeRow[] => allRows.filter((row) => matchesConditions(row, conditions));
+
+    return {
+        collect: async () => matches(),
+        first: async () => matches()[0] ?? null,
+        order: (direction: "asc" | "desc") => {
+            return {
+                collect: async () => sortByField(matches(), ORDER_FIELDS[indexName], indexName, direction),
+            };
+        },
+    };
+};
+
+/**
+ * Minimal `ctx.db` double for the prototype — same shape as
+ * `__tests__/component.test.ts`'s `fakeDatabase`, extended with `remove` (the
+ * prototype needs to delete a dequeued queue row).
+ */
+const fakePrototypeDatabase = (): { db: PrototypeDatabase; rows: Map<string, PrototypeRow[]> } => {
+    const rows = new Map<string, PrototypeRow[]>();
+    let nextId = 0;
+
+    const tableRows = (table: string): PrototypeRow[] => {
+        const existing = rows.get(table);
+
+        if (existing) {
+            return existing;
+        }
+
+        const created: PrototypeRow[] = [];
+
+        rows.set(table, created);
+
+        return created;
+    };
+
+    const db: PrototypeDatabase = {
+        insert: async (table, document) => {
+            const id = `id-${String(nextId)}`;
+
+            nextId += 1;
+            tableRows(table).push({ ...document, _id: id });
+
+            return id;
+        },
+        patch: async (id, patch) => {
+            for (const tableContent of rows.values()) {
+                const row = tableContent.find((candidate) => candidate["_id"] === id);
+
+                if (row) {
+                    Object.assign(row, patch);
+                }
+            }
+        },
+        query: (table) => {
+            return {
+                withIndex: (name, build) => makePrototypeIndexQuery(tableRows(table), name, collectConditions(build)),
+            };
+        },
+        remove: async (id) => {
+            for (const tableContent of rows.values()) {
+                const index = tableContent.findIndex((candidate) => candidate["_id"] === id);
+
+                if (index !== -1) {
+                    tableContent.splice(index, 1);
+                }
+            }
+        },
+    };
+
+    return { db, rows };
+};
+
+describe("run-queue prototype (plan 240 spike)", () => {
+    it("parks B instead of rejecting it, then resumes B in order when A completes", async () => {
+        const { db } = fakePrototypeDatabase();
+
+        // A starts and is running.
+        await expect(ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" })).resolves.toStrictEqual({ created: true });
+
+        // B starts while A is in flight, with onConcurrentRun: "queue" — must
+        // park, not throw CONFLICT.
+        const parked = await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1", onConcurrentRun: "queue" });
+
+        expect(parked).toStrictEqual({ created: false, position: 0, queued: true });
+
+        // A completes — dequeue-and-handoff must return B's instance id and
+        // stamp the thread over to B atomically.
+        const handoff = await completeRunAndDequeue(db, { instanceId: "wf-a", key: "t-1", terminalStatus: "idle" });
+
+        expect(handoff).toStrictEqual({ dequeued: "wf-b" });
+    });
+
+    it("preserves A -> B -> C ordering: C parks behind B, and dequeues follow FIFO position, not completion order", async () => {
+        const { db, rows } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" });
+
+        const parkedB = await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1", onConcurrentRun: "queue" });
+        const parkedC = await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-c", key: "t-1", onConcurrentRun: "queue" });
+
+        expect(parkedB).toStrictEqual({ created: false, position: 0, queued: true });
+        expect(parkedC).toStrictEqual({ created: false, position: 1, queued: true });
+
+        // A completes -> hands off to B (the head, position 0).
+        const ownershipSequence: string[] = ["wf-a"];
+        const firstHandoff = await completeRunAndDequeue(db, { instanceId: "wf-a", key: "t-1", terminalStatus: "idle" });
+
+        expect(firstHandoff).toStrictEqual({ dequeued: "wf-b" });
+
+        ownershipSequence.push("wf-b");
+
+        expect(rows.get("proto_agent_threads")?.[0]?.["instanceId"]).toBe("wf-b");
+
+        // B completes -> hands off to C (the only one left).
+        const secondHandoff = await completeRunAndDequeue(db, { instanceId: "wf-b", key: "t-1", terminalStatus: "idle" });
+
+        expect(secondHandoff).toStrictEqual({ dequeued: "wf-c" });
+
+        ownershipSequence.push("wf-c");
+
+        expect(rows.get("proto_agent_threads")?.[0]?.["instanceId"]).toBe("wf-c");
+
+        // C completes -> nobody left, thread goes terminal.
+        const thirdHandoff = await completeRunAndDequeue(db, { instanceId: "wf-c", key: "t-1", terminalStatus: "idle" });
+
+        expect(thirdHandoff).toStrictEqual({ dequeued: undefined });
+        expect(rows.get("proto_agent_threads")?.[0]?.["status"]).toBe("idle");
+
+        expect(ownershipSequence).toStrictEqual(["wf-a", "wf-b", "wf-c"]);
+        expect(rows.get("proto_agent_run_queue")).toHaveLength(0);
+    });
+
+    it("a replay of B's still-parked bootstrap does not duplicate its queue entry or change its position", async () => {
+        const { db, rows } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" });
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1", onConcurrentRun: "queue" });
+        // A THIRD run parks behind B before B replays, so a mis-ordered
+        // duplicate would be observable as a position/count change.
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-c", key: "t-1", onConcurrentRun: "queue" });
+
+        expect(rows.get("proto_agent_run_queue")).toHaveLength(2);
+
+        // B's workflow replays (re-executes ensureThread for real, since it
+        // runs outside step.do) while still parked, before A has completed.
+        const replay = await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1", onConcurrentRun: "queue" });
+
+        expect(replay).toStrictEqual({ created: false, position: 0, queued: true });
+        expect(rows.get("proto_agent_run_queue")).toHaveLength(2);
+
+        // Ordering still resolves B then C — the replay didn't reshuffle anything.
+        const firstHandoff = await completeRunAndDequeue(db, { instanceId: "wf-a", key: "t-1", terminalStatus: "idle" });
+
+        expect(firstHandoff).toStrictEqual({ dequeued: "wf-b" });
+
+        const secondHandoff = await completeRunAndDequeue(db, { instanceId: "wf-b", key: "t-1", terminalStatus: "idle" });
+
+        expect(secondHandoff).toStrictEqual({ dequeued: "wf-c" });
+    });
+
+    it("a replay of A's own completion does not double-dequeue and skip C's turn", async () => {
+        const { db } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" });
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1", onConcurrentRun: "queue" });
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-c", key: "t-1", onConcurrentRun: "queue" });
+
+        const firstCall = await completeRunAndDequeue(db, { instanceId: "wf-a", key: "t-1", terminalStatus: "idle" });
+
+        expect(firstCall).toStrictEqual({ dequeued: "wf-b" });
+
+        // A REPLAYS its own completion step (e.g. the workflow re-runs after a
+        // crash before the step was durably recorded as done). The thread no
+        // longer belongs to "wf-a", so this must be a no-op — NOT a second
+        // dequeue that would hand C the thread out from under B.
+        const replayedCall = await completeRunAndDequeue(db, { instanceId: "wf-a", key: "t-1", terminalStatus: "idle" });
+
+        expect(replayedCall).toStrictEqual({ dequeued: undefined });
+
+        // C is still parked, waiting for B — not skipped.
+        const secondCall = await completeRunAndDequeue(db, { instanceId: "wf-b", key: "t-1", terminalStatus: "idle" });
+
+        expect(secondCall).toStrictEqual({ dequeued: "wf-c" });
+    });
+
+    it("enforces the queue depth bound, rejecting past the cap instead of growing unbounded durable state", async () => {
+        const { db, rows } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" });
+
+        for (let index = 0; index < MAX_QUEUE_DEPTH; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- each enqueue depends on the prior one's committed depth
+            await ensureThreadOrQueue(db, { agent: "support", instanceId: `wf-q${String(index)}`, key: "t-1", onConcurrentRun: "queue" });
+        }
+
+        expect(rows.get("proto_agent_run_queue")).toHaveLength(MAX_QUEUE_DEPTH);
+
+        await expect(ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-overflow", key: "t-1", onConcurrentRun: "queue" })).rejects.toThrow(
+            QUEUE_FULL_PATTERN,
+        );
+
+        // The overflowing attempt left no trace.
+        expect(rows.get("proto_agent_run_queue")).toHaveLength(MAX_QUEUE_DEPTH);
+    });
+
+    it("still throws CONFLICT for the default (reject) policy — unchanged from today", async () => {
+        const { db } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" });
+
+        await expect(ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1" })).rejects.toThrow(IN_FLIGHT_PATTERN);
+        await expect(ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-b", key: "t-1", onConcurrentRun: "reject" })).rejects.toThrow(
+            IN_FLIGHT_PATTERN,
+        );
+    });
+
+    it("still replaces (terminating the in-flight run's ownership) — unchanged from today", async () => {
+        const { db, rows } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-old", key: "t-1" });
+
+        const result = await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-new", key: "t-1", onConcurrentRun: "replace" });
+
+        expect(result).toStrictEqual({ created: false, priorInstanceId: "wf-old", replaced: true });
+        expect(rows.get("proto_agent_threads")?.[0]?.["instanceId"]).toBe("wf-new");
+    });
+
+    it("rejects an id-less dispatch under queue policy rather than parking an un-wakeable run", async () => {
+        const { db } = fakePrototypeDatabase();
+
+        await ensureThreadOrQueue(db, { agent: "support", instanceId: "wf-a", key: "t-1" });
+
+        await expect(ensureThreadOrQueue(db, { agent: "support", key: "t-1", onConcurrentRun: "queue" })).rejects.toThrow(QueueConflictError);
+    });
+});

--- a/packages/agent/src/reply.prototype.ts
+++ b/packages/agent/src/reply.prototype.ts
@@ -1,0 +1,92 @@
+/**
+ * DESIGN-SPIKE PROTOTYPE — see `plans/242-agent-reply-design.md`.
+ *
+ * NOT wired into `component.ts`, `agent-loop.ts`, `inbound.ts`, `channels.ts`,
+ * or `types.ts`, and NOT exported from `./index`. This proves out the
+ * capture -> run -> threaded-reply round trip for the ONE channel (email)
+ * this spike prototypes; production wiring (if this direction is ratified)
+ * belongs in `types.ts` (`AgentReplyRef`, `AgentEmailRun.replyRef`) and
+ * `agent-loop.ts` (an `onReply` hook on the terminal turn), not here.
+ *
+ * Deliberately reuses the REAL `@lunora/mail` `Mailer` contract rather than
+ * a hand-rolled stand-in, so the prototype exercises the package's actual
+ * address/header validation — a fake mail transport only replaces the final
+ * network hop.
+ * @experimental
+ */
+import type { Mailer } from "@lunora/mail";
+import type { InboundEmail } from "@lunora/mail/inbound";
+
+/**
+ * The email variant of the design doc's `AgentReplyRef` union — captured at
+ * `onEmail` mapper time from fields `@lunora/mail/inbound`'s
+ * `parseInboundEmail` already produced, not re-parsed from anything raw.
+ */
+interface EmailReplyRef {
+    channel: "email";
+    /** Who to reply TO — the original sender. */
+    from: string;
+    /** Becomes the reply's `In-Reply-To` header. */
+    messageId: string;
+    /** The inbound message's own `References` chain, if any — appended to, not replaced. */
+    references?: string;
+    /** Who the reply comes FROM — the original recipient(s) (mailbox that received it). */
+    to: string[];
+}
+
+/**
+ * Capture a reply reference from an already-parsed inbound email. Returns
+ * `undefined` when the message carries no `Message-ID` — there is nothing to
+ * thread a reply against, so (mirroring plan 240's honest-reject-over-
+ * silent-misbehavior stance) the caller should decline to reply rather than
+ * send an unthreaded one.
+ */
+const captureEmailReplyRef = (email: InboundEmail): EmailReplyRef | undefined => {
+    if (email.messageId === undefined) {
+        return undefined;
+    }
+
+    return {
+        channel: "email",
+        from: email.from,
+        messageId: email.messageId,
+        to: email.to,
+        ...(email.references === undefined ? {} : { references: email.references }),
+    };
+};
+
+/** RFC 5322 threading: append the replied-to id to any existing `References` chain. */
+const buildReferences = (replyRef: EmailReplyRef): string => {
+    if (replyRef.references === undefined) {
+        return replyRef.messageId;
+    }
+
+    return `${replyRef.references} ${replyRef.messageId}`;
+};
+
+interface ReplyBody {
+    subject: string;
+    text: string;
+}
+
+/**
+ * Send a threaded reply for a captured email ref through a REAL `Mailer`.
+ * Standing in for what an `onReply` hook (design doc, not implemented here)
+ * would call once a run's final answer is ready.
+ *
+ * `replyRef.to` (the mailbox the inbound message was addressed to) is
+ * captured but unused here — this minimal prototype always sends from the
+ * mailer's configured default `from`. A multi-alias app that wants the reply
+ * to come from the SAME address that received it would pass `from:
+ * replyRef.to[0]` explicitly; that's a real-wiring decision, not a spike one.
+ */
+const replyToEmail = async (mailer: Mailer, replyRef: EmailReplyRef, body: ReplyBody): Promise<{ id: string }> =>
+    mailer.send({
+        headers: { "In-Reply-To": replyRef.messageId, References: buildReferences(replyRef) },
+        subject: body.subject,
+        text: body.text,
+        to: replyRef.from,
+    });
+
+export { buildReferences, captureEmailReplyRef, replyToEmail };
+export type { EmailReplyRef, ReplyBody };

--- a/packages/agent/src/run-queue.prototype.ts
+++ b/packages/agent/src/run-queue.prototype.ts
@@ -1,0 +1,248 @@
+/**
+ * DESIGN-SPIKE PROTOTYPE — see `plans/240-agent-run-queue-design.md`.
+ *
+ * NOT wired into `component.ts`, `agent-loop.ts`, or any trigger path, and
+ * NOT exported from `./index`. This proves out the ordering + seq-claim
+ * correctness of a durable per-thread run queue for
+ * `defineAgent({ onConcurrentRun: "queue" })` — today that value silently
+ * degrades to `"reject"` (`component.ts`'s `agentEnsureThread`). It is a
+ * throwaway artifact of the spike, not a shipped feature; production wiring
+ * (if this direction is ratified) belongs in `component.ts` alongside the
+ * real `agentEnsureThread`/`agentPatchThread` mutations, not here.
+ *
+ * Mirrors just enough of `agentEnsureThread`'s existing reject/replace logic
+ * to add a third, `"queue"` branch, plus the completion-side dequeue that
+ * `agent-loop.ts` would call instead of its current terminal `patchThread`.
+ * Both mutations assume the same single-threaded-per-DO execution model the
+ * real component relies on — see the design doc's "Ordering + seq claim"
+ * section for why that's what makes the handoff race-free.
+ * @experimental
+ */
+
+/** Bounded queue depth — see design doc open question #1 (no config surface yet). */
+const MAX_QUEUE_DEPTH = 5;
+
+/** Minimal `ctx.db` shape this prototype needs — same shape `component.ts`'s mutations use. */
+interface PrototypeRow extends Record<string, unknown> {
+    _id: string;
+}
+
+interface PrototypeIndexQuery {
+    collect: () => Promise<PrototypeRow[]>;
+    first: () => Promise<PrototypeRow | null>;
+    order: (direction: "asc" | "desc") => { collect: () => Promise<PrototypeRow[]> };
+}
+
+interface PrototypeIndexBuilder {
+    eq: (field: string, value: unknown) => PrototypeIndexBuilder;
+}
+
+interface PrototypeDatabase {
+    insert: (table: string, document: Record<string, unknown>) => Promise<string>;
+    patch: (id: string, patch: Record<string, unknown>) => Promise<void>;
+    query: (table: string) => { withIndex: (name: string, build: (q: PrototypeIndexBuilder) => unknown) => PrototypeIndexQuery };
+    remove: (id: string) => Promise<void>;
+}
+
+const THREADS_TABLE = "proto_agent_threads";
+const QUEUE_TABLE = "proto_agent_run_queue";
+
+interface EnsureThreadOrQueueArgs {
+    agent: string;
+    instanceId?: string;
+    key: string;
+    onConcurrentRun?: "queue" | "reject" | "replace";
+}
+
+type EnsureThreadOrQueueResult =
+    { created: true } | { created: false } | { created: false; priorInstanceId: string; replaced: true } | { created: false; position: number; queued: true };
+
+/** Thrown in place of the real `LunoraError("CONFLICT", ...)` — message-compatible enough for tests to pattern-match. */
+class QueueConflictError extends Error {}
+
+/**
+ * The `"queue"` branch, split out of `ensureThreadOrQueue` to keep that
+ * function's branching within the repo's cognitive-complexity budget. Called
+ * only once `isConcurrentRun` is already known true and `policy === "queue"`.
+ */
+const enqueueOrThrow = async (
+    database: PrototypeDatabase,
+    args: EnsureThreadOrQueueArgs & { instanceId: string },
+    existing: PrototypeRow,
+    now: number,
+): Promise<EnsureThreadOrQueueResult> => {
+    // Idempotent enqueue: a replay of a still-parked run's bootstrap must
+    // return its existing position, not create a duplicate row.
+    const alreadyQueued = await database
+        .query(QUEUE_TABLE)
+        .withIndex("byThreadInstance", (q) => q.eq("threadKey", args.key).eq("instanceId", args.instanceId))
+        .first();
+
+    if (alreadyQueued) {
+        return { created: false, position: alreadyQueued["position"] as number, queued: true };
+    }
+
+    const queuedRows = await database
+        .query(QUEUE_TABLE)
+        .withIndex("byThread", (q) => q.eq("threadKey", args.key))
+        .collect();
+
+    if (queuedRows.length >= MAX_QUEUE_DEPTH) {
+        throw new QueueConflictError(
+            `@lunora/agent: thread "${args.key}" run queue is full (depth ${String(MAX_QUEUE_DEPTH)}) — rejecting instance "${args.instanceId}"`,
+        );
+    }
+
+    const position = existing["nextPosition"] as number;
+
+    await database.patch(existing["_id"], { nextPosition: position + 1 });
+    await database.insert(QUEUE_TABLE, {
+        agent: args.agent,
+        enqueuedAt: now,
+        instanceId: args.instanceId,
+        position,
+        threadKey: args.key,
+    });
+
+    return { created: false, position, queued: true };
+};
+
+/**
+ * Mirrors `component.ts`'s `agentEnsureThread`, with the `"queue"` branch
+ * implemented instead of degraded to reject. See the design doc for why
+ * idempotent-by-`(threadKey, instanceId)` enqueue is required (a workflow
+ * replay of a still-parked run re-executes this mutation for real, since
+ * `ensureThread` — like the production one — runs outside `step.do`).
+ */
+const ensureThreadOrQueue = async (database: PrototypeDatabase, args: EnsureThreadOrQueueArgs, now = Date.now()): Promise<EnsureThreadOrQueueResult> => {
+    const existing = await database
+        .query(THREADS_TABLE)
+        .withIndex("byKey", (q) => q.eq("key", args.key))
+        .first();
+
+    if (!existing) {
+        await database.insert(THREADS_TABLE, {
+            agent: args.agent,
+            key: args.key,
+            nextPosition: 0,
+            status: "running",
+            updatedAt: now,
+            ...(args.instanceId === undefined ? {} : { instanceId: args.instanceId }),
+        });
+
+        return { created: true };
+    }
+
+    const priorInstanceId = existing["instanceId"] as string | undefined;
+    const isConcurrentRun =
+        (existing["status"] === "running" || existing["status"] === "awaiting_input") &&
+        priorInstanceId !== undefined &&
+        (args.instanceId === undefined || args.instanceId !== priorInstanceId);
+
+    if (!isConcurrentRun) {
+        // Replay (same instance) or a resumed idle/errored/cancelled thread.
+        await database.patch(existing["_id"], {
+            status: "running",
+            updatedAt: now,
+            ...(args.instanceId === undefined ? {} : { instanceId: args.instanceId }),
+        });
+
+        return { created: false };
+    }
+
+    const policy = args.onConcurrentRun ?? "reject";
+
+    if (policy === "replace") {
+        await database.patch(existing["_id"], {
+            status: "running",
+            updatedAt: now,
+            ...(args.instanceId === undefined ? {} : { instanceId: args.instanceId }),
+        });
+
+        return { created: false, priorInstanceId, replaced: true };
+    }
+
+    if (policy === "queue") {
+        if (args.instanceId === undefined) {
+            // The id-less inbound-email/inbound-channel dispatch path can't be
+            // told apart from anyone else later, so it can't be parked and
+            // dequeued by instance id — same honest-reject fallback as an
+            // overflowing queue.
+            throw new QueueConflictError(
+                `@lunora/agent: thread "${args.key}" already has a run in flight (instance "${priorInstanceId}") — cannot queue an id-less dispatch`,
+            );
+        }
+
+        return enqueueOrThrow(database, { ...args, instanceId: args.instanceId }, existing, now);
+    }
+
+    // "reject" (default)
+    throw new QueueConflictError(
+        `@lunora/agent: thread "${args.key}" already has a run in flight (instance "${priorInstanceId}") — onConcurrentRun="${policy}"`,
+    );
+};
+
+interface CompleteRunArgs {
+    instanceId: string;
+    key: string;
+    terminalStatus: "cancelled" | "error" | "idle";
+}
+
+type CompleteRunResult = { dequeued: undefined } | { dequeued: string };
+
+/**
+ * Mirrors what `agent-loop.ts`'s terminal `patchThread` call would become:
+ * instead of unconditionally setting the terminal status, check the queue
+ * first and — inside this SAME mutation — hand the thread straight to the
+ * next parked instance if one is waiting. See the design doc for why doing
+ * both in one mutation is what makes the handoff race-free (no window where
+ * a third caller can observe an ownerless thread).
+ *
+ * Idempotent under a replay of the FINISHING run's own completion: guarded on
+ * `thread.instanceId === args.instanceId` first, so a second call (after
+ * ownership has already moved to the dequeued instance) is a no-op rather
+ * than dequeuing a second entry and skipping someone's turn.
+ */
+const completeRunAndDequeue = async (database: PrototypeDatabase, args: CompleteRunArgs, now = Date.now()): Promise<CompleteRunResult> => {
+    const thread = await database
+        .query(THREADS_TABLE)
+        .withIndex("byKey", (q) => q.eq("key", args.key))
+        .first();
+
+    if (thread?.["instanceId"] !== args.instanceId) {
+        // Already handed off (a replay of this same completion) or unknown —
+        // either way, not this call's job to touch it again.
+        return { dequeued: undefined };
+    }
+
+    const queuedRows = await database
+        .query(QUEUE_TABLE)
+        .withIndex("byThread", (q) => q.eq("threadKey", args.key))
+        .order("asc")
+        .collect();
+
+    const head = queuedRows[0];
+
+    if (!head) {
+        await database.patch(thread["_id"], { status: args.terminalStatus, updatedAt: now });
+
+        return { dequeued: undefined };
+    }
+
+    await database.remove(head["_id"]);
+    await database.patch(thread["_id"], { instanceId: head["instanceId"], status: "running", updatedAt: now });
+
+    return { dequeued: head["instanceId"] as string };
+};
+
+export { completeRunAndDequeue, ensureThreadOrQueue, MAX_QUEUE_DEPTH, QueueConflictError };
+export type {
+    CompleteRunArgs,
+    CompleteRunResult,
+    EnsureThreadOrQueueArgs,
+    EnsureThreadOrQueueResult,
+    PrototypeDatabase,
+    PrototypeIndexBuilder,
+    PrototypeIndexQuery,
+    PrototypeRow,
+};

--- a/plans/240-agent-run-queue-design.md
+++ b/plans/240-agent-run-queue-design.md
@@ -1,0 +1,267 @@
+# Plan 240 — Durable run queue for `onConcurrentRun: "queue"` (design spike)
+
+- **Category**: correctness (silent feature degradation)
+- **Status**: SPIKE — design + single-surface prototype only, no production wiring
+- **Baseline**: `2d4f71511` (drift check passed — no changes to `packages/agent/src` since)
+- **Goal**: decide how a durable per-thread run queue would work for
+  `defineAgent({ onConcurrentRun: "queue" })`, which today silently degrades to
+  `"reject"` (`packages/agent/src/component.ts:228-230`). Produce a design +
+  a test-only prototype proving the ordering/seq-claim correctness holds. Do
+  **not** wire the real thing into `agentEnsureThread` or any trigger path.
+
+## Current state (verified)
+
+- `packages/agent/src/types.ts:579-592` documents `onConcurrentRun: "queue" |
+  "reject" | "replace"` and says `"queue"` is "reserved for a future durable
+  queue; currently degrades to `reject`."
+- `packages/agent/src/component.ts:184-250` (`agentEnsureThread`) is the actual
+  guard: it detects a genuine second run (different, live `instanceId` on a
+  `"running"`/`"awaiting_input"` thread) and either throws `CONFLICT`
+  (`"reject"`, the default, and today also `"queue"`) or takes the thread over
+  (`"replace"`, `component.ts:237-249`).
+- `packages/agent/src/agent-loop.ts:983-997` calls `ensureThread` at the very
+  top of `runAgentLoop`, **outside** `step.do` — the comment there explains why:
+  "get-or-create; keyed append ... so a replay converges" without needing
+  Workflow-level memoization. A `CONFLICT` throws before any message is
+  persisted, so a rejected/queued run never touches the winning run's thread.
+- The HITL approval pause (`packages/agent/src/agent-loop.ts:207-241`,
+  `awaitApproval`) is the existing precedent for "durably park a workflow
+  instance and wake it selectively": it persists a marker, patches the thread
+  to `"awaiting_input"`, then calls `step.waitForEvent<ApprovalDecision>(
+  `approval:${call.id}`, { type: `agent-approval:${call.id}` })`. Resolution
+  (`component.ts:512-557`, `agentResolveApproval`) calls
+  `ctx.agents[agent].sendEvent(instanceId, { type: `agent-approval:${toolCallId}`,
+  payload })` — the SAME `AgentHandle.sendEvent` producer
+  (`types.ts:1161-1187`) a queue resume would use.
+- `packages/scheduler/src/create-workpool.ts:24-34` is explicit about its own
+  boundary: "Why not Cloudflare Queues? ... do NOT grow multi-step
+  orchestration on top of this — that's Cloudflare **Workflows** (`step.do` /
+  `step.sleep` / `step.waitForEvent`)." A workpool is a bounded-concurrency
+  **action dispatcher** (fire-and-report-completion via `POST /complete`) with
+  no notion of "this specific already-created workflow instance is paused,
+  wake exactly it, and hand it durable state." An agent run **is** the
+  multi-step orchestration the workpool's own doc tells callers to keep off
+  it.
+
+## Recommendation: park on the agent's own DO table + `step.waitForEvent`, not the scheduler workpool
+
+Do **not** route `"queue"` through `@lunora/scheduler`'s workpool. Two reasons,
+both load-bearing:
+
+1. **Wrong unit of work.** The workpool dispatches a `FunctionReference` call
+   and waits for `POST /complete`; it has no concept of "resume workflow
+   instance `wf-b` at its `waitForEvent` point." Fitting a park/resume queue
+   onto it means building exactly the orchestration primitive
+   `create-workpool.ts` says belongs in Workflows — i.e. reimplementing
+   `step.waitForEvent` on top of a tool whose doc comment says not to.
+2. **Wrong ownership boundary.** The seq-claim correctness (below) depends on
+   the dequeue-and-handoff happening in the *same* DO mutation that frees the
+   thread, so no third party can observe a briefly-ownerless thread. That
+   mutation already lives on the agent's own `agent_threads` table inside the
+   shard DO. Routing through a second DO (`SchedulerDO`) would split that
+   atomic step across two storage backends and reopen the exact race the
+   design has to close.
+
+Instead: add a bounded, per-thread durable queue **table** to the same schema
+extension `agent_threads`/`agent_messages` already live in
+(`packages/agent/src/component.ts:35-132`), and drive parking with
+`step.waitForEvent` — the same primitive the HITL approval path already
+proves out end-to-end (persist marker → patch status → wait on a scoped event
+type → resume → patch status back).
+
+### Shape (not implemented outside the prototype)
+
+```ts
+// A NEW bare table alongside "threads"/"messages" in the same extension.
+const RUN_QUEUE_BARE_TABLE = "run_queue";
+
+defineTable({
+    agent: v.string(),
+    enqueuedAt: v.number(),
+    instanceId: v.string(),
+    // Monotonic per-thread position — see "ordering" below for why this beats
+    // sorting by `enqueuedAt` alone.
+    position: v.number(),
+    threadKey: v.string(),
+})
+    .index("byThread", ["threadKey", "position"]) // FIFO dequeue
+    .index("byThreadInstance", ["threadKey", "instanceId"], { unique: true }) // idempotent enqueue
+    .public();
+```
+
+## Ordering + seq claim — the correctness core
+
+The STOP condition this plan was written under is: *"the per-thread seq
+counter can't be claimed by a resuming run without racing the in-flight
+run."* Working through it: **it doesn't race**, provided both halves of the
+handoff stay inside the DO's existing single-threaded mutation serialization
+— the same property that already makes today's `"reject"`/`"replace"` branches
+race-free.
+
+**Enqueue (on conflict, policy `"queue"`).** Inside the *same* mutation that
+today throws `CONFLICT` (`component.ts:230-235`), instead:
+
+- Look up an existing queue row for `(threadKey, instanceId)` (the
+  `byThreadInstance` unique index). If found, return its existing `position`
+  — **do not** insert a second row. This is the fix for the replay hazard
+  (below): `ensureThread` runs outside `step.do`, so a workflow replay of a
+  still-parked run re-executes this mutation for real, and it must be a
+  no-op, not a duplicate enqueue.
+- Otherwise, if the queue is at its depth bound, throw `CONFLICT` (the same
+  message shape as `"reject"` today) — see "Bound + overflow" below.
+- Otherwise, insert `{ threadKey, instanceId, agent, enqueuedAt: now,
+  position: nextPosition }`, where `nextPosition` is a per-thread counter
+  (stored on the thread row, incremented like `messageCount` already is) —
+  **not** `Date.now()`. Two runs parking in the same millisecond must still
+  get a strict, unambiguous order; a counter allocated inside the same
+  serialized mutation gives that for free, the same way `messageCount` already
+  gives `seq` its ordering.
+- Return `{ created: false, queued: true, position }` instead of throwing.
+
+**Resume (on completion).** Inside the *same* mutation that today patches the
+finishing thread to `"idle"`/`"error"`/`"cancelled"` (there is no such
+mutation yet — today's `patchThreadByKey` in `agent-loop.ts` just sets
+`status`; the prototype adds the "check the queue" step to that call site):
+
+- Guard on `thread.instanceId === callerInstanceId` first — the same
+  ownership check `agentResolveApproval` already applies
+  (`component.ts:533-537`). This makes the dequeue step idempotent under a
+  replay of the *finishing* run's own completion: a second execution sees the
+  thread's `instanceId` has already moved to the dequeued run and no-ops
+  rather than dequeuing the *next* entry too.
+- Query `byThread` ordered by `position` ascending, take the first row (FIFO).
+- If none: patch the thread to the terminal status as today.
+- If found: **in the same mutation**, delete the queue row and patch the
+  thread to `{ instanceId: head.instanceId, status: "running", updatedAt:
+  now }` — i.e. skip the terminal-status write entirely; ownership transfers
+  directly from the finishing instance to the head of the queue. Return
+  `{ dequeued: head.instanceId }` to the caller (the finishing run's
+  workflow), which then calls `ctx.agents[agent].sendEvent(head.instanceId,
+  { type: `agent-dequeue:${threadKey}:${head.instanceId}`, payload: {} })`.
+
+Because both enqueue and dequeue-and-handoff are single mutations on a
+single-threaded DO, there is no window where the thread is observably
+"free": a third run — genuinely new, or a replay of anyone else — either
+sees the thread still owned by the run that's about to finish, or already
+owned by the dequeued instance. Nobody can wedge in between. The resumed run
+never re-claims anything for its first message: by the time its
+`waitForEvent` resolves, `thread.instanceId` already names it, so it goes
+straight to `agentAppendMessage` (which — same as today — isn't itself
+instance-gated; the gate is entirely "who is allowed to become `running`").
+
+## Resume trigger
+
+`step.waitForEvent` on a queue-entry-scoped type: `agent-dequeue:<threadKey>:
+<instanceId>` — mirrors the HITL approval's `agent-approval:<toolCallId>`
+scoping exactly (`agent-loop.ts:216-220`'s reasoning applies verbatim: native
+CF Workflows matches a waiter by `type`, so an unscoped type would let one
+parked run's wake event resolve a different one). No alarm or cron: delivery
+piggybacks on the finishing run's own completion step, which already has a
+workflow context to call `sendEvent` from (same call site `agentResolveApproval`
+already demonstrates is reachable via `ctx.agents`).
+
+Open question (below): what happens if the DB mutation commits (ownership
+already transferred) but the subsequent `sendEvent` RPC fails or the process
+dies before making it — the dequeued run then owns the thread but is never
+told to wake up.
+
+## Replay safety
+
+- **A parked run's own replay never double-enqueues** — the
+  `byThreadInstance` unique lookup makes enqueue idempotent (see above).
+- **A REPLAY re-entering under the same instance id is never treated as a new
+  parked run** — inherited unchanged from the existing guard: `isConcurrentRun`
+  in `component.ts:220-223` already excludes `args.instanceId === priorInstanceId`,
+  and that check runs *before* the queue branch, so it never fires for a
+  replay of the run that currently owns the thread.
+- **A finishing run's own replay never double-dequeues** — the
+  `thread.instanceId === callerInstanceId` guard on the completion mutation
+  (above) makes the handoff idempotent, same pattern as
+  `agentResolveApproval`'s instance check.
+
+## Prototype (test-only)
+
+`packages/agent/src/run-queue.prototype.ts` implements exactly the two
+mutations described above (`ensureThreadOrQueue`, `completeRunAndDequeue`)
+against the SAME minimal `ctx.db` shape `__tests__/component.test.ts`'s
+`fakeDatabase` already models (`insert`/`patch`/`query().withIndex().first()/
+.collect()`) — **not** wired into `component.ts`, `agent-loop.ts`, or any
+trigger path. It exists to prove the ordering/replay claims above, not to
+ship.
+
+`packages/agent/__tests__/run-queue.prototype.test.ts` drives:
+
+- A starts and runs (`"running"`).
+- B starts with `onConcurrentRun: "queue"` while A is in flight → parks
+  (`queued: true`, not rejected — `CONFLICT` is never thrown).
+- C starts the same way while A and B are both ahead of it → parks behind B
+  (`position` strictly greater than B's).
+- A completes → dequeue-and-handoff returns B's instance id; the thread now
+  shows `instanceId: B`, `status: "running"`; the queue now holds only C.
+- B completes → dequeue-and-handoff returns C's instance id; ordering
+  A → B → C is asserted end to end via the sequence of `instanceId` values
+  the thread took on, not just the two happy-path hops.
+- A REPLAY of B's bootstrap while B is still parked (before A completes) does
+  **not** create a second queue row and does **not** change B's `position`.
+- A REPLAY of A's completion (called twice with the same finishing instance
+  id) dequeues B only once — the second call is a no-op, not a double-dequeue
+  that would skip C's turn.
+- The queue enforces its depth bound: parking past the cap throws `CONFLICT`
+  (the honest fallback), not an unbounded row count.
+
+## Bound + overflow
+
+The prototype hardcodes a small constant (`MAX_QUEUE_DEPTH = 5`) rather than
+inventing a config surface — see open questions. Overflow throws the same
+`CONFLICT` shape `"reject"` already throws today, so a caller that floods a
+thread past the cap gets an honest, immediate failure instead of unbounded
+durable rows or a run that silently never gets its turn.
+
+## Open questions (unresolved by this spike)
+
+1. **Queue depth + overflow policy as a real config surface.** The prototype
+   hardcodes 5. Production needs this as a per-agent (or per-`onConcurrentRun`)
+   knob — e.g. `onConcurrentRun: { mode: "queue", maxDepth: 5 }` — which is a
+   breaking shape change to the current flat string literal union in
+   `AgentConfig` (`types.ts:592`). Whether overflow should always be `"reject"`
+   or itself configurable (e.g. drop-oldest) is unresolved.
+2. **Wake-delivery failure.** If the completion mutation commits the
+   ownership handoff but the follow-up `ctx.agents[agent].sendEvent(...)` call
+   fails or never runs (crash between the two), the dequeued instance owns the
+   thread but sits hibernating forever with nothing to wake it. The HITL
+   approval path has the same theoretical gap today (an approval mutation that
+   commits `sendEvent` failure) but it's user-triggered and retryable from a
+   client; a queue resume has no user in the loop to retry it. Needs either a
+   reconciliation sweep (an alarm that re-sends to any thread whose owner has
+   been "running" with zero messages appended for N minutes) or a stronger
+   guarantee that the mutation and the `sendEvent` call succeed atomically —
+   both out of scope for a spike.
+3. **What a client observes while parked.** `AgentThreadStatus` today is
+   `"awaiting_input" | "cancelled" | "error" | "idle" | "running"` — none of
+   these mean "your run is queued behind another." While B is parked, the
+   thread it would attach to still shows A's status (`"running"`), since
+   ownership hasn't transferred. Does the *caller* of the queued run (which
+   dispatched a workflow that's now parked, not the thread's live subscriber)
+   need a way to observe `{ queued: true, position }`? The prototype's queue
+   table could back a query, but adding a public query is a real feature
+   decision, not a spike deliverable.
+4. **Interaction with `"replace"`.** If a thread has A running and B, C parked
+   behind it (`"queue"`), and a fourth run D calls with `onConcurrentRun:
+   "replace"`, does D take over from A only (leaving B, C to resume after D
+   finishes — B/C queued behind a run they never knew about), or does replace
+   flush the queue (terminate B and C too, since they were waiting for A
+   specifically)? Both are defensible; this spike takes no position.
+5. **Durable-state cost.** Each parked run is a live Cloudflare Workflow
+   instance hibernating on `waitForEvent` for the parked duration — bounded by
+   the depth cap, but a cap of 5 during a real burst is still 5 concurrently
+   billed, paused Workflow instances per busy thread. Whether the default cap
+   in question 1 should be smaller (e.g. 2-3) pending real usage data is
+   unresolved.
+
+## Non-goals (this spike)
+
+- Wiring `"queue"` into `agentEnsureThread`/`agent-loop.ts` for real.
+- Changing `"reject"`/`"replace"` behavior or their tests.
+- Adding a `queueDepth` (or similar) field to `AgentConfig`/`defineAgent`.
+- A client-facing "queued" status or query.
+- The reply-out path (plan 242) — unrelated surface.

--- a/plans/242-agent-reply-design.md
+++ b/plans/242-agent-reply-design.md
@@ -1,0 +1,266 @@
+# Plan 242 — Reply-out path for triggered agent runs (design spike)
+
+- **Category**: capability gap (inbound trigger, no outbound reply)
+- **Status**: SPIKE — design + single-channel prototype only, no production wiring
+- **Baseline**: `2d4f71511` (drift check passed — `channels.ts`/`inbound.ts`/`types.ts`
+  unchanged since; the only diff under `packages/agent/src` is plan 240's own
+  new prototype file)
+- **Goal**: decide how a `defineAgent`-declared agent, triggered by an inbound
+  Slack mention / GitHub comment / Discord message / email, delivers its
+  answer back to the SAME thread/channel/conversation it was triggered from.
+  Produce a design + a single-channel (email) prototype proving capture → run
+  → threaded reply. Do **not** build the other three channels' outbound
+  adapters or wire anything into `component.ts`/`agent-loop.ts`/`inbound.ts`.
+
+## Current state (verified)
+
+- **Inbound is fully built, outbound does not exist.** `packages/agent/src/channels.ts`
+  verifies Slack (HMAC over `v0:timestamp:body`), GitHub (HMAC over the body),
+  and Discord (Ed25519 over `timestamp+body`) webhook signatures
+  (`verifySlack`/`verifyGithub`/`verifyDiscord`, `channels.ts:66-126`), then
+  offers the parsed, verified event to each agent's `onInbound.map` mapper
+  (`channels.ts:311-371`, `dispatchAgentChannel`). `packages/agent/src/inbound.ts`
+  does the email equivalent: DKIM/SPF/DMARC-gated, dispatching to `onEmail`
+  (`inbound.ts:67-112`, `dispatchAgentEmail`).
+- **Grep confirms the gap.** `reply|respond|postMessage|sendEmail|outbound|threadTs|replyTo`
+  matches nothing in `channels.ts` or `inbound.ts` — there is no code path
+  from a finished run back to the channel it came from. The run's answer only
+  ever lands in `agent_messages` (the live-subscription thread the mapper's
+  OWN caller, if any, can read) — never posted back to Slack/GitHub/Discord,
+  never emailed back.
+- **The reply handle is available at map time, not dropped by verification.**
+  This matters for the STOP condition this plan was written under
+  ("capturing the reply reference requires re-parsing the raw inbound payload
+  the verifier already consumed"). Checked directly:
+  - Email: `packages/mail/src/inbound/parse.ts:65-96` (`InboundEmail`) already
+    carries `messageId`, `from`, `to`, `inReplyTo`, `references` — CR/LF-checked,
+    fully parsed — and the WHOLE object is handed to `AgentEmailMapper`
+    (`types.ts:462`) unmodified. No re-parse is needed; the ref is one field
+    read away from where the mapper already stands.
+  - Channels: `InboundChannelEvent` (`types.ts:474-483`) hands the mapper
+    `headers` and a `json()` accessor over the ALREADY-VERIFIED raw body
+    (`channels.ts:328`, built once per request, after signature check). A
+    Slack `event_callback`'s `event.channel`/`event.ts` (or `thread_ts` for a
+    threaded reply), a GitHub `issue_comment`'s `repository`/`issue.number`/
+    `comment.id`, and a Discord message's `channel_id`/`id` are all fields on
+    that same parsed body — again, no re-parse and no signature-verification
+    change required to read them.
+  - **Conclusion: this STOP condition does not trigger for any of the four
+    channels.** The gap is that nothing captures these fields into the
+    RETURNED run shape (`AgentEmailRun`/`AgentChannelRun`,
+    `types.ts:433-448`/`468`) — both are `{ input, owner?, threadKey, title? }`
+    today, with no room for a reply reference. That's a type/shape gap at the
+    map→run boundary, not a re-parsing problem.
+- `packages/mail/src/types.ts:33-44` (`SendOptions`) already accepts arbitrary
+  `headers?: Record<string, string>` on `mailer.send(...)` — so `In-Reply-To`/
+  `References` threading is just two header entries, no new mail-package
+  capability needed. `@lunora/mail` is already a direct dependency of
+  `@lunora/agent` (`packages/agent/package.json:93`).
+- `plans/README.md:627` — plan 132 ("Outbound webhook delivery on
+  queue/scheduler/dispatch") spiked Standard-Webhooks-over-`SchedulerDO`
+  delivery: signed, retried, dead-lettered dispatch to a table of REGISTERED
+  SUBSCRIBER endpoints. That is a fan-out primitive for "notify N URLs an
+  event happened," with machinery (endpoint table, redrive UX) sized for that
+  problem. A reply targets exactly ONE destination the inbound event already
+  named (one thread, one comment, one Message-ID) — there is no subscriber
+  list, no fan-out, and (per channel) a different, provider-specific delivery
+  call (Slack `chat.postMessage`, GitHub "create issue comment", `@lunora/mail`
+  send) rather than a generic signed webhook POST.
+
+## `AgentReplyRef` per channel
+
+A discriminated union, one variant per trigger, threaded through the run
+shape (not the event — the event is already fully available to the mapper;
+the ref is what survives PAST the mapper, into the run and eventually to
+wherever a reply is composed):
+
+```ts
+type AgentReplyRef =
+    | { channel: "discord"; channelId: string; messageId?: string }
+    | { channel: "email"; from: string; messageId: string; references?: string; to: string[] }
+    | { channel: "github"; commentId?: number; issueNumber: number; owner: string; repo: string }
+    | { channel: "slack"; channelId: string; threadTs: string };
+```
+
+- **Email** — `from`/`to` swap for the reply (reply goes back to the sender,
+  from whichever mailbox received it); `messageId` becomes `In-Reply-To`;
+  `references` (the inbound message's OWN `References` header, if any) plus
+  its `messageId` becomes the reply's `References` — standard RFC 2822/5322
+  threading, the same convention every mail client already implements.
+- **Slack** — `channelId` + `threadTs` (the root message's `ts`, or the event's
+  own `ts` if it's the first reply) is exactly what `chat.postMessage`'s
+  `thread_ts` parameter wants.
+- **GitHub** — `owner`/`repo`/`issueNumber` addresses "create a comment on this
+  issue/PR"; `commentId` is carried for a possible future "reply to this
+  specific review comment" (GraphQL reply-to-comment), not needed for a
+  top-level issue comment.
+- **Discord** — `channelId` alone posts a new channel message; a genuine
+  threaded reply (Discord's `message_reference`) additionally wants the
+  triggering message's `id`. See the open question below — Discord's actual
+  reply mechanism doesn't fit this shape as cleanly as the other three (below).
+
+Capture point: each channel's mapper populates `replyRef` on ITS OWN turn,
+from data it already has:
+
+- `onEmail: (email) => ({ ..., replyRef: email.messageId === undefined ? undefined : { channel: "email", from: email.from, messageId: email.messageId, references: email.references, to: email.to } })`
+- `onInbound.map: (event) => { const body = event.json() as SlackEventBody; return { ..., replyRef: { channel: "slack", channelId: body.event.channel, threadTs: body.event.thread_ts ?? body.event.ts } }; }`
+
+Both are ORDINARY application code the mapper author writes — `AgentReplyRef`
+just needs to be a valid field on `AgentEmailRun`/`AgentChannelRun` for it to
+type-check and flow through to wherever a reply is triggered. This plan does
+not itself change `types.ts` (see Non-goals); it establishes the shape a real
+change would add.
+
+## Reply API: automatic callback, not a tool
+
+Two shapes considered:
+
+1. **`defineAgent({ onReply: async (result, replyRef) => {...} })`** — a new
+   per-agent callback, mirroring the existing `onStepFinish` (`types.ts:609`)
+   in how it's wired: invoked once, automatically, at the same point
+   `agent-loop.ts`'s terminal turn persists the final assistant message and
+   patches the thread status (`agent-loop.ts` — `handleTurn`'s "final answer"
+   branch, `~828-870`). The run doesn't need to know or care it was
+   triggered externally; `onReply` only fires when `replyRef` is present
+   (i.e., the thread WAS started from an inbound trigger, not a normal
+   in-app `ctx.agents.<name>.run` call).
+2. **A reply tool** — give the model an explicit `reply` tool it calls
+   mid-conversation (like any other tool call), so the agent can post
+   more than once (a "still working on it" ack, then a final answer) or
+   choose NOT to reply.
+
+**Recommendation: (1), the automatic callback, as the default; leave (2) as a
+future extension, not a competing default.** A triggered agent's whole point
+is "answer where you were asked" — making that automatic is the same reasoning
+that makes email threading automatic in a mail client, and it needs no prompt
+engineering to make the model remember to call a tool. A tool-based path is
+still worth having LATER for agents that want multiple/partial replies (open
+question below), layered on top of `onReply` rather than replacing it — a tool
+call can itself just invoke the same reply primitive `onReply` would use.
+
+## Transport decision: build directly, not over plan 132
+
+**Build a direct, per-channel outbound call — do not route through plan 132's
+Standard-Webhooks-over-scheduler transport.** Same reasoning as plan 240's
+workpool rejection, mirrored:
+
+- Plan 132 solves "deliver a signed payload to N registered subscriber
+  endpoints, with retry/dead-letter/redrive for a fan-out audience." A reply
+  has exactly one destination, already named by the inbound event (a
+  `threadTs`, a `Message-ID`, an issue number) — there is no subscriber table
+  to look up and no generic payload to sign, because the destination isn't a
+  registered webhook URL at all; it's a provider API call (`chat.postMessage`,
+  "create comment," an outbound email).
+- The four channels don't share a wire format the way plan 132's subscribers
+  do (one Standard-Webhooks POST shape for everyone). Reply delivery is
+  necessarily per-channel: `@lunora/mail` for email (already a dependency),
+  a Slack Web API call for Slack, GitHub's REST/GraphQL API for GitHub, and
+  Discord's REST API (or the interaction followup-webhook token) for Discord.
+  Forcing these through a shared signed-webhook transport buys nothing; each
+  needs its own SDK/fetch call and its own auth anyway.
+- Retry IS still a real need (a transient Slack/GitHub/mail failure
+  shouldn't silently drop the answer), but that's a much smaller ask than
+  plan 132's full delivery framework — likely `step.do`'s existing at-least-
+  once retry (the run is already inside a Cloudflare Workflow) is enough,
+  not a new endpoint-table/dead-letter subsystem.
+
+## Per-channel auth
+
+- **Email — already has a home.** The reply goes out through the app's
+  existing `@lunora/mail` `Mailer` (`createMailer`/`createMailerFromEnv`),
+  configured once for the whole app (API key or Cloudflare Email Workers
+  `send_email` binding). No new credential surface: `onReply` for an
+  email-triggered run just needs a `Mailer` in scope, exactly like any other
+  server-side send already in the app.
+- **Slack/GitHub/Discord — no home yet; reporting the gap, not inventing a
+  store.** `AgentInboundChannel` (`types.ts:501-513`) already carries an
+  INBOUND `secret: string | ((env) => string | undefined)` for verifying
+  signatures — but there is nothing analogous for an OUTBOUND credential (a
+  Slack bot token, a GitHub App installation token, a Discord bot token).
+  `ctx.secrets` (Cloudflare Secrets Store, per `@lunora/server`'s package
+  description) is the obvious place such a token would eventually live, and
+  an `AgentInboundChannel.replyToken` field mirroring the existing `secret`
+  shape is the obvious API shape — but neither exists today, and this spike
+  does not add either. This is a real gap a follow-up plan needs to close
+  before Slack/GitHub/Discord replies can ship, independent of the queue/
+  transport decisions above.
+
+## Prototype (test-only, email channel)
+
+`packages/agent/src/reply.prototype.ts` — NOT wired into `inbound.ts`,
+`component.ts`, `agent-loop.ts`, or `types.ts`, and NOT exported from
+`./index`:
+
+- `EmailReplyRef` (the email variant of `AgentReplyRef` above).
+- `captureEmailReplyRef(email: InboundEmail): EmailReplyRef | undefined` —
+  reads `messageId`/`from`/`to`/`references` straight off the ALREADY-PARSED
+  `InboundEmail` from `@lunora/mail/inbound` (no re-parsing); returns
+  `undefined` when the inbound message had no `Message-ID` (nothing to thread
+  against — same "can't queue an id-less run" honesty pattern as plan 240's
+  overflow case).
+- `replyToEmail(mailer, replyRef, body)` — sends via the REAL `Mailer` contract
+  from `@lunora/mail` (`mailer.send(...)`), addressed back to `replyRef.from`,
+  with `headers: { "In-Reply-To": replyRef.messageId, References: <references
+  + messageId, space-joined> }` — standard RFC 5322 threading.
+
+`packages/agent/__tests__/reply.prototype.test.ts` builds a fake `MailTransport`
+(records what it was asked to send, matching the pattern `component.test.ts`'s
+`fakeAgents()` already uses for recording calls) and a REAL `createMailer`
+from `@lunora/mail` on top of it — proving the prototype's payload passes the
+package's actual address/header validation, not just a hand-rolled assertion.
+The test drives: capture a ref from a synthetic inbound email (with a prior
+`References` header, so the round-trip must APPEND rather than replace) → "run"
+the agent (a stub answer string, standing in for `runAgentLoop`'s real output)
+→ reply → assert the fake transport recorded a message `to` the original
+sender, `In-Reply-To` the original `Message-ID`, `References` containing BOTH
+the prior chain and the original id, and the run's answer as the body. A
+second case proves a message with NO `Message-ID` yields `undefined` (declines
+to reply) rather than sending an unthreaded reply.
+
+`channels.ts`/`inbound.ts` are untouched by this plan — running the full
+`@lunora/agent` suite (which includes the existing Slack/GitHub/Discord
+signature-verification tests) is itself the proof inbound verification is
+unaffected.
+
+## Open questions (unresolved by this spike)
+
+1. **`AgentReplyRef` as a real field.** This spike defines the shape but does
+   not add it to `AgentEmailRun`/`AgentChannelRun`/`InboundChannelEvent` in
+   `types.ts` — a real change needs to decide whether `AgentChannelRun`
+   (today `= AgentEmailRun`, `types.ts:468`) keeps that type alias (forcing
+   `AgentReplyRef` to be one union covering all channels, as drafted above) or
+   diverges into its own type now that channels and email need different
+   reply shapes.
+2. **Per-channel outbound token storage.** Reported above as a gap, not
+   designed here: Slack/GitHub/Discord need a credential surface on
+   `AgentInboundChannel` (or elsewhere) that doesn't exist yet.
+3. **Automatic vs. explicit reply.** The recommended `onReply` callback fires
+   once, automatically, on the final answer. Does any real use case need
+   multiple replies (an early ack, a follow-up), and if so is that a SECOND
+   automatic hook, or the tool-based path noted above layered on top?
+4. **Partial-failure behavior.** The run succeeds and persists its answer to
+   the thread, but the reply POST/send fails (rate limit, revoked token,
+   transient network). Today's `agentAppendMessage`/thread state has no
+   "answered but couldn't tell them" status — does this need a new
+   `AgentThreadStatus` value, a retry (and if so, how many/how durable — see
+   the transport decision above), or is "the answer is safely in the thread,
+   the reply is best-effort" an acceptable default?
+5. **Discord's reply mechanism doesn't fit the shared shape.** Slack/GitHub/
+   email all reply via a persistent bot/API token to a durable
+   channel/issue/mailbox address. Discord INTERACTIONS (the inbound trigger
+   `channels.ts` verifies) instead hand back a time-limited followup-webhook
+   token scoped to that one interaction — a different, narrower credential
+   than "a bot token that can post to any channel." Whether Discord reply
+   support uses that followup-webhook token (simpler auth, but expires) or a
+   full bot token (persistent, but a bigger credential to provision) is
+   unresolved and may need its own mini-spike.
+
+## Non-goals (this spike)
+
+- Adding `AgentReplyRef`/`onReply`/`replyToken` to `types.ts`, or wiring
+  `onReply` into `agent-loop.ts`'s terminal-turn handling.
+- Slack, GitHub, or Discord outbound adapters (only email is prototyped).
+- Any token/secret storage productization (`ctx.secrets` wiring, a new
+  `AgentInboundChannel` field).
+- Changing `channels.ts`'s or `inbound.ts`'s verification logic.
+- The durable run queue (plan 240) — unrelated surface.


### PR DESCRIPTION
Two direction spikes for `@lunora/agent` (design doc + isolated prototype each, nothing wired into production): (240) the durable run queue that `onConcurrentRun: "queue"` already advertises but silently degrades to reject — DO-table + waitForEvent, the seq-claim ordering worked out; (242) the reply-out path back to the triggering Slack/GitHub/Discord/email thread (the inbound half exists; the reply handle is dropped at the boundary) — email prototyped end-to-end through real @lunora/mail with correct In-Reply-To/References threading.

Verified: 297/297; prototypes confirmed not imported by production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)