### PR TITLE
fix(runtime): base64url-encode the forwarded identity header (non-Latin-1 claims break every RPC)

### DIFF
--- a/packages/agent/__tests__/voice-turn.test.ts
+++ b/packages/agent/__tests__/voice-turn.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { encodeIdentityHeader } from "../../../shared/identity-header";
 import { defineAgent } from "../src/define-agent";
 import { agentBindingName, voiceBindingName, voiceClassName } from "../src/naming";
 import { DEFAULT_AGENT_FUNCTION_PATHS } from "../src/paths";
 import type { AgentFunctionReference, AgentRunFunction, AgentStreamGenerate } from "../src/types";
 import type { VoiceServerFrame, VoiceSynthesize } from "../src/voice-turn";
-import { runVoiceTurn } from "../src/voice-turn";
+import { parseIdentity, runVoiceTurn } from "../src/voice-turn";
 
 /** An in-memory model of the shared agent thread functions the voice turn dispatches to. */
 const createThreadStore = (): { calls: { args: Record<string, unknown>; path: string }[]; run: AgentRunFunction } => {
@@ -276,5 +277,30 @@ describe(runVoiceTurn, () => {
         const patches = store.calls.filter((call) => call.path === paths.patchThread);
 
         expect(patches.at(-1)?.args).toMatchObject({ key: "t1", status: "idle" });
+    });
+});
+
+describe(parseIdentity, () => {
+    it("decodes a base64url-encoded x-lunora-identity header (delegates to decodeIdentityHeader)", () => {
+        expect.assertions(1);
+
+        const claims = { name: "名前 🎌" };
+
+        expect(parseIdentity(encodeIdentityHeader(claims))).toStrictEqual(claims);
+    });
+
+    it("still decodes a legacy raw-JSON header value", () => {
+        expect.assertions(1);
+
+        const claims = { email: "user@example.com" };
+
+        expect(parseIdentity(JSON.stringify(claims))).toStrictEqual(claims);
+    });
+
+    it("returns undefined for null/malformed input rather than throwing", () => {
+        expect.assertions(2);
+
+        expect(parseIdentity(null)).toBeUndefined();
+        expect(parseIdentity("{not json")).toBeUndefined();
     });
 });

--- a/packages/agent/src/voice-do.ts
+++ b/packages/agent/src/voice-do.ts
@@ -4,6 +4,7 @@ import { createAi } from "@lunora/ai";
 import { createDispatchRunner } from "@lunora/dispatch";
 
 import { toBase64 } from "../../../shared/base64";
+import { decodeUserIdHeader } from "../../../shared/identity-header";
 import { createStreamGenerate } from "./generate";
 import { DEFAULT_AGENT_FUNCTION_PATHS, toFunctionReference } from "./paths";
 import type { AgentDefinition, AgentFunctionPaths, AgentRunFunction, AgentStreamGenerate } from "./types";
@@ -136,7 +137,7 @@ class VoiceSessionDO {
         // eslint-disable-next-line n/no-unsupported-features/node-builtins -- workerd provides the Web Crypto global; this DO never runs under Node
         const connectionId = crypto.randomUUID();
         const identity = parseIdentity(request.headers.get("x-lunora-identity"));
-        const userId = request.headers.get("x-lunora-userid") ?? undefined;
+        const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
 
         (server as unknown as HibernatableWebSocket).serializeAttachment?.({
             connectionId,

--- a/packages/agent/src/voice-turn.ts
+++ b/packages/agent/src/voice-turn.ts
@@ -1,4 +1,5 @@
 import { fromBase64 } from "../../../shared/base64";
+import { decodeIdentityHeader } from "../../../shared/identity-header";
 import { buildModelMessages } from "./model-messages";
 import { toFunctionReference } from "./paths";
 import type { AgentDefinition, AgentFunctionPaths, AgentMessageRow, AgentRunFunction, AgentStreamGenerate } from "./types";
@@ -394,20 +395,12 @@ const runVoiceTurn = async (options: RunVoiceTurnOptions): Promise<VoiceTurnResu
     }
 };
 
-/** Parse the JSON identity envelope forwarded on the `x-lunora-identity` upgrade header. */
-const parseIdentity = (raw: string | null): Record<string, unknown> | undefined => {
-    if (!raw) {
-        return undefined;
-    }
-
-    try {
-        const parsed: unknown = JSON.parse(raw);
-
-        return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : undefined;
-    } catch {
-        return undefined;
-    }
-};
+/**
+ * Parse the identity envelope forwarded on the `x-lunora-identity` upgrade
+ * header. Delegates to {@link decodeIdentityHeader} (base64url-encoded, with a
+ * fail-soft sniffing fallback for a legacy raw-JSON header value).
+ */
+const parseIdentity = (raw: string | null): Record<string, unknown> | undefined => decodeIdentityHeader(raw);
 
 /** Read the `.text` field off a Workers AI transcription result, tolerating shape drift. */
 const readTranscriptionText = (result: unknown): string => {

--- a/packages/dispatch/__tests__/dispatch-runner-behavior.test.ts
+++ b/packages/dispatch/__tests__/dispatch-runner-behavior.test.ts
@@ -1,6 +1,7 @@
 import { isLunoraError } from "@lunora/errors";
 import { describe, expect, it, vi } from "vitest";
 
+import { decodeIdentityHeader, encodeIdentityHeader } from "../../../shared/identity-header";
 import { createDispatchLogger } from "../src/create-dispatch-logger";
 import { createDispatchRunner } from "../src/create-dispatch-runner";
 
@@ -72,7 +73,7 @@ describe("createDispatchRunner request shape", () => {
 });
 
 describe("createDispatchRunner identity forwarding", () => {
-    it("forwards x-lunora-userid and JSON-encoded claims when an identity is configured", async () => {
+    it("forwards x-lunora-userid and base64url-encoded claims when an identity is configured", async () => {
         expect.assertions(2);
 
         const fetchImpl = vi.fn<typeof fetch>(okJson);
@@ -83,7 +84,29 @@ describe("createDispatchRunner identity forwarding", () => {
         const { headers } = captureCall(fetchImpl);
 
         expect(headers["x-lunora-userid"]).toBe("user_1");
-        expect(JSON.parse(headers["x-lunora-identity"] as string)).toStrictEqual({ role: "admin", sub: "user_1" });
+        expect(decodeIdentityHeader(headers["x-lunora-identity"] as string)).toStrictEqual({ role: "admin", sub: "user_1" });
+    });
+
+    it("encodes non-Latin-1 claims so the header value stays a valid ByteString", async () => {
+        expect.assertions(2);
+
+        const fetchImpl = vi.fn<typeof fetch>(okJson);
+        const identity = { claims: { name: "名前 🎌" }, userId: "user_1" };
+
+        await createDispatchRunner({ env: ENV, fetchImpl, identity, label: "@lunora/queue" })(REF);
+
+        const { headers } = captureCall(fetchImpl);
+        const identityHeader = headers["x-lunora-identity"] as string;
+        let isByteStringSafe = identityHeader.length > 0;
+
+        for (let index = 0; index < identityHeader.length; index += 1) {
+            if ((identityHeader.codePointAt(index) ?? 0) > 255) {
+                isByteStringSafe = false;
+            }
+        }
+
+        expect(isByteStringSafe).toBe(true);
+        expect(identityHeader).toBe(encodeIdentityHeader({ name: "名前 🎌" }));
     });
 
     it("sends only the userId header when no claims are given", async () => {

--- a/packages/dispatch/__tests__/dispatch-runner-behavior.test.ts
+++ b/packages/dispatch/__tests__/dispatch-runner-behavior.test.ts
@@ -1,7 +1,7 @@
 import { isLunoraError } from "@lunora/errors";
 import { describe, expect, it, vi } from "vitest";
 
-import { decodeIdentityHeader, encodeIdentityHeader } from "../../../shared/identity-header";
+import { decodeIdentityHeader, encodeIdentityHeader, isByteStringSafe } from "../../../shared/identity-header";
 import { createDispatchLogger } from "../src/create-dispatch-logger";
 import { createDispatchRunner } from "../src/create-dispatch-runner";
 
@@ -97,15 +97,8 @@ describe("createDispatchRunner identity forwarding", () => {
 
         const { headers } = captureCall(fetchImpl);
         const identityHeader = headers["x-lunora-identity"] as string;
-        let isByteStringSafe = identityHeader.length > 0;
 
-        for (let index = 0; index < identityHeader.length; index += 1) {
-            if ((identityHeader.codePointAt(index) ?? 0) > 255) {
-                isByteStringSafe = false;
-            }
-        }
-
-        expect(isByteStringSafe).toBe(true);
+        expect(isByteStringSafe(identityHeader)).toBe(true);
         expect(identityHeader).toBe(encodeIdentityHeader({ name: "名前 🎌" }));
     });
 

--- a/packages/dispatch/src/create-dispatch-runner.ts
+++ b/packages/dispatch/src/create-dispatch-runner.ts
@@ -10,6 +10,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
+import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
 import type { ArgsOf, DispatchRunFunction, FunctionReference, RunFunctionOptions } from "./types";
 
 /** The reserved worker endpoint that re-dispatches a server-initiated function call to its shard. */
@@ -116,11 +117,13 @@ export const createDispatchRunner = (options: DispatchRunnerOptions): DispatchRu
         // shard reconstructs identity from these headers independently of the
         // system flag, so a server dispatch can still carry a userId for RLS.
         if (options.identity?.userId !== undefined) {
-            headers["x-lunora-userid"] = options.identity.userId;
+            // Base64url-encoded when non-Latin-1 (HTTP header values are WebIDL
+            // `ByteString`s); see shared/identity-header.ts.
+            headers["x-lunora-userid"] = encodeUserIdHeader(options.identity.userId);
         }
 
         if (options.identity?.claims !== undefined) {
-            headers["x-lunora-identity"] = JSON.stringify(options.identity.claims);
+            headers["x-lunora-identity"] = encodeIdentityHeader(options.identity.claims);
         }
 
         const response = await fetchImpl(url, {

--- a/packages/dispatch/tsconfig.json
+++ b/packages/dispatch/tsconfig.json
@@ -1,10 +1,13 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["node"]
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): `lint:types`
+        // is `tsc --noEmit` and the real build is packem (driven by package.json
+        // exports), so neither is load-bearing here. A set `rootDir` would raise
+        // TS6059 for the inlined `../../../shared/identity-header` import (a file
+        // outside this package, bundled in at build time). See shared/identity-header.ts.
     },
     "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -1,6 +1,7 @@
 import type { MutationDelta, SocketAttachment, SubscriptionEnvelope } from "@lunora/shard-engine";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
 import { encodeWire } from "../../../shared/wire-codec";
 import type { ShardDOState, SubscriptionOutcome } from "../src/shard-do";
 import { ROOT_DO_SIZE_WARN_BYTES, ROOT_SHARD_NAME, ShardDO, subscriptionListDeltas } from "../src/shard-do";
@@ -618,6 +619,22 @@ describe("shardDO identity capture", () => {
         expect(shard.observedUserId).toBe("user_42");
     });
 
+    it("decodes a base64url-encoded x-lunora-userid (non-Latin-1) back to the original id via getCurrentUserId()", async () => {
+        expect.assertions(1);
+
+        const userId = "田中太郎";
+
+        await shard.fetch(
+            new Request("https://shard.internal/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                headers: { "content-type": "application/json", "x-lunora-userid": encodeUserIdHeader(userId) },
+                method: "POST",
+            }),
+        );
+
+        expect(shard.observedUserId).toBe(userId);
+    });
+
     it("parses x-lunora-identity JSON envelope into a plain object", async () => {
         expect.assertions(1);
 
@@ -649,6 +666,47 @@ describe("shardDO identity capture", () => {
 
         expect(response.status).toBe(200);
         expect(shard.observedIdentity).toBeUndefined();
+    });
+
+    it("parses a base64url-encoded x-lunora-identity to the SAME object the legacy raw-JSON header produces (rollout order-independence)", async () => {
+        expect.assertions(2);
+
+        // Latin-1-only claims deliberately: a raw (unencoded) legacy header can
+        // only ever carry Latin-1-safe content in the first place — that's the
+        // bug this plan fixes — so the equivalence is only meaningful for content
+        // both forms can actually transport.
+        const claims = { email: "user@example.com", roles: ["admin"] };
+
+        const legacyResponse = shard.fetch(
+            new Request("https://shard.internal/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                headers: {
+                    "content-type": "application/json",
+                    "x-lunora-identity": JSON.stringify(claims),
+                    "x-lunora-userid": "user_42",
+                },
+                method: "POST",
+            }),
+        );
+
+        await legacyResponse;
+
+        const legacyObserved = shard.observedIdentity;
+
+        const encodedResponse = await shard.fetch(
+            new Request("https://shard.internal/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                headers: {
+                    "content-type": "application/json",
+                    "x-lunora-identity": encodeIdentityHeader(claims),
+                    "x-lunora-userid": encodeUserIdHeader("user_42"),
+                },
+                method: "POST",
+            }),
+        );
+
+        expect(encodedResponse.status).toBe(200);
+        expect(shard.observedIdentity).toEqual(legacyObserved);
     });
 
     it("clears identity headers between requests so they don't leak across clients", async () => {

--- a/packages/do/src/admin-rpc-args.ts
+++ b/packages/do/src/admin-rpc-args.ts
@@ -31,6 +31,8 @@ import type {
 } from "@lunora/shard-engine";
 import { ADMIN_FUNCTION_PREFIX, tableFromDepKey } from "@lunora/shard-engine";
 
+import { decodeIdentityHeader } from "../../../shared/identity-header";
+
 /** Recovers the process exit code embedded in a container `stop` message as `(exit &lt;n>)`. */
 const CONTAINER_EXIT_CODE_PATTERN = /\(exit (\d+)\)/;
 
@@ -1086,28 +1088,19 @@ const parseCdcSyncArgs = (args: Record<string, unknown>): RunShardCdcSyncArgs =>
 const bookmarkHeaders = (bookmark: string | undefined): Record<string, string> | undefined => (bookmark ? { "x-d1-bookmark": bookmark } : undefined);
 
 /**
- * Decode the JSON envelope shipped on the `x-lunora-identity` header.
- * Malformed payloads collapse to `undefined` rather than throwing — the
- * shard should still serve requests whose identity claims didn't round-trip.
+ * Decode the envelope shipped on the `x-lunora-identity` header. Malformed
+ * payloads collapse to `undefined` rather than throwing — the shard should
+ * still serve requests whose identity claims didn't round-trip.
+ *
+ * Delegates to {@link decodeIdentityHeader} (base64url-encoded, with a
+ * fail-soft sniffing fallback for a legacy raw-JSON header value — see
+ * shared/identity-header.ts). Kept as a named wrapper — rather than importing
+ * `decodeIdentityHeader` directly at call sites — so this file's own
+ * name/signature stays the stable public surface for `shard-do.ts` and
+ * anything else depending on it.
  * @returns the decoded identity object, or `undefined` when the header is absent or malformed
  */
-const parseIdentityHeader = (raw: string | null): Record<string, unknown> | undefined => {
-    if (!raw) {
-        return undefined;
-    }
-
-    try {
-        const parsed = JSON.parse(raw) as unknown;
-
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            return parsed as Record<string, unknown>;
-        }
-    } catch {
-        // fall through to undefined
-    }
-
-    return undefined;
-};
+const parseIdentityHeader = (raw: string | null): Record<string, unknown> | undefined => decodeIdentityHeader(raw);
 
 /**
  * Parse the `x-lunora-client-seq` header into a positive integer mutation

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -203,6 +203,7 @@ import type { BatchEntry } from "../../../shared/batch-wire";
 import { MAX_BATCH_ENTRIES } from "../../../shared/batch-wire";
 import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
+import { decodeUserIdHeader } from "../../../shared/identity-header";
 import { jsonResponse } from "../../../shared/json-response";
 import type { LogSinkContext } from "../../../shared/log-event";
 import type { LogFields } from "../../../shared/log-fields";
@@ -3952,7 +3953,10 @@ abstract class ShardDO {
         // values. Cleared on exit so the next request starts fresh.
         this.currentRequestBookmark = request.headers.get("x-d1-bookmark") ?? undefined;
         this.currentResponseBookmark = undefined;
-        this.currentRequestUserId = request.headers.get("x-lunora-userid") ?? undefined;
+        // `decodeUserIdHeader` inverts the runtime's `encodeUserIdHeader`: a
+        // Latin-1-safe id is forwarded unchanged, a non-Latin-1 one arrives
+        // base64url-encoded behind a leading `=` sentinel. See shared/identity-header.ts.
+        this.currentRequestUserId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
         this.currentRequestMutationId = request.headers.get("x-lunora-mutation-id") ?? undefined;
         // Custom-mutator push identity: a stable per-device client id plus a
         // monotonic per-client sequence. Present only on custom-mutator pushes;
@@ -8444,7 +8448,7 @@ abstract class ShardDO {
         // hibernation and can be replayed to the connection-lifecycle hooks at
         // connect/close — including `webSocketClose`, when the socket carries no
         // request of its own.
-        const userId = request.headers.get("x-lunora-userid") ?? undefined;
+        const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
         const identity = parseIdentityHeader(request.headers.get("x-lunora-identity"));
         // Optional credential expiry (epoch ms) forwarded by the runtime. A
         // malformed value is ignored (the socket simply never auto-expires).

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -2,6 +2,7 @@ import { LunoraError } from "@lunora/errors";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { decodeIdentityHeader } from "../../../shared/identity-header";
 import type { ExecutionContextLike, HttpActionContext, HttpRouterLike, Route } from "../src/create-worker";
 import { composeWorker, createLunoraHandler, createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
@@ -585,7 +586,7 @@ describe("createWorker", () => {
         const identityHeader = shard.calls[0]!.request.headers.get("x-lunora-identity");
 
         expect(identityHeader).not.toBeNull();
-        expect(JSON.parse(identityHeader!)).toEqual({ email: "u@example.com", roles: ["admin"] });
+        expect(decodeIdentityHeader(identityHeader)).toEqual({ email: "u@example.com", roles: ["admin"] });
     });
 
     it("does not invoke resolveIdentity when fanOut request would 400 (no coordinator)", async () => {
@@ -655,7 +656,7 @@ describe("createWorker", () => {
         const { headers } = fanOut.mock.calls[0]![1];
 
         expect(headers["x-lunora-userid"]).toBe("user_42");
-        expect(JSON.parse(headers["x-lunora-identity"]!)).toEqual({ email: "u@example.com" });
+        expect(decodeIdentityHeader(headers["x-lunora-identity"])).toEqual({ email: "u@example.com" });
     });
 
     it("denies fan-out by default when authorizeShard is set without authorizeFanOut", async () => {

--- a/packages/runtime/__tests__/identity-header.test.ts
+++ b/packages/runtime/__tests__/identity-header.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
+
+/** `true` when every UTF-16 code unit of `value` is &lt;= 255 (a valid WebIDL `ByteString`). */
+const isByteStringSafe = (value: string): boolean => {
+    for (let index = 0; index < value.length; index += 1) {
+        if ((value.codePointAt(index) ?? 0) > 255) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+describe("encodeIdentityHeader / decodeIdentityHeader", () => {
+    it("round-trips ASCII claims", () => {
+        expect.assertions(2);
+
+        const claims = { email: "user@example.com", roles: ["admin", "member"] };
+        const encoded = encodeIdentityHeader(claims);
+
+        expect(isByteStringSafe(encoded)).toBe(true);
+        expect(decodeIdentityHeader(encoded)).toStrictEqual(claims);
+    });
+
+    it("round-trips CJK claims as a valid ByteString header value", () => {
+        expect.assertions(2);
+
+        const claims = { name: "名前" };
+        const encoded = encodeIdentityHeader(claims);
+
+        expect(isByteStringSafe(encoded)).toBe(true);
+        expect(decodeIdentityHeader(encoded)).toStrictEqual(claims);
+    });
+
+    it("round-trips emoji claims as a valid ByteString header value", () => {
+        expect.assertions(2);
+
+        const claims = { status: "名前 🎌" };
+        const encoded = encodeIdentityHeader(claims);
+
+        expect(isByteStringSafe(encoded)).toBe(true);
+        expect(decodeIdentityHeader(encoded)).toStrictEqual(claims);
+    });
+
+    it("a real Request can be constructed with the encoded header value (the actual bug)", () => {
+        expect.assertions(1);
+
+        const encoded = encodeIdentityHeader({ name: "名前 🎌", roles: ["admin"] });
+
+        // Before this codec, setting this header to raw `JSON.stringify(claims)`
+        // made `new Request(...)` throw a TypeError (WebIDL ByteString violation)
+        // for any non-Latin-1 claim. This is the actual failure mode the codec fixes.
+        expect(() => new Request("https://shard.internal/rpc", { headers: { "x-lunora-identity": encoded } })).not.toThrow();
+    });
+
+    it("decodes a legacy raw-JSON header value (pre-encoding rollout / Latin-1-only claims sent raw)", () => {
+        expect.assertions(1);
+
+        const claims = { email: "user@example.com" };
+
+        expect(decodeIdentityHeader(JSON.stringify(claims))).toStrictEqual(claims);
+    });
+
+    it.each([null, undefined, ""])("returns undefined for %p", (raw) => {
+        expect.assertions(1);
+
+        expect(decodeIdentityHeader(raw)).toBeUndefined();
+    });
+
+    it("returns undefined for garbage base64url that doesn't decode to JSON", () => {
+        expect.assertions(1);
+
+        expect(decodeIdentityHeader("not-valid-base64url-json!!!")).toBeUndefined();
+    });
+
+    it("returns undefined for malformed legacy JSON", () => {
+        expect.assertions(1);
+
+        expect(decodeIdentityHeader("{not json")).toBeUndefined();
+    });
+
+    it("returns undefined when the decoded JSON is an array, not an object", () => {
+        expect.assertions(1);
+
+        const encodedArray = btoa("[1,2,3]").replaceAll("+", "-").replaceAll("/", "_");
+
+        expect(decodeIdentityHeader(encodedArray)).toBeUndefined();
+    });
+
+    it("returns undefined when the decoded JSON is a primitive, not an object", () => {
+        expect.assertions(1);
+
+        const encodedNumber = btoa("42").replaceAll("+", "-").replaceAll("/", "_");
+
+        expect(decodeIdentityHeader(encodedNumber)).toBeUndefined();
+    });
+});
+
+describe("encodeUserIdHeader / decodeUserIdHeader", () => {
+    it("forwards a Latin-1-safe userId unchanged", () => {
+        expect.assertions(2);
+
+        const encoded = encodeUserIdHeader("user_42");
+
+        expect(encoded).toBe("user_42");
+        expect(decodeUserIdHeader(encoded)).toBe("user_42");
+    });
+
+    it("round-trips a CJK userId as a valid ByteString header value", () => {
+        expect.assertions(3);
+
+        const userId = "田中太郎";
+        const encoded = encodeUserIdHeader(userId);
+
+        expect(isByteStringSafe(encoded)).toBe(true);
+        expect(encoded.startsWith("=")).toBe(true);
+        expect(decodeUserIdHeader(encoded)).toBe(userId);
+    });
+
+    it("round-trips an emoji userId as a valid ByteString header value", () => {
+        expect.assertions(2);
+
+        const userId = "user_🎌";
+        const encoded = encodeUserIdHeader(userId);
+
+        expect(isByteStringSafe(encoded)).toBe(true);
+        expect(decodeUserIdHeader(encoded)).toBe(userId);
+    });
+
+    it("a real Request can be constructed with the encoded userId header value (the actual bug)", () => {
+        expect.assertions(1);
+
+        const encoded = encodeUserIdHeader("田中太郎 🎌");
+
+        expect(() => new Request("https://shard.internal/rpc", { headers: { "x-lunora-userid": encoded } })).not.toThrow();
+    });
+
+    it("encodes a Latin-1-safe userId that happens to start with the `=` sentinel, to avoid ambiguity", () => {
+        expect.assertions(2);
+
+        const userId = "=weird-but-latin1-id";
+        const encoded = encodeUserIdHeader(userId);
+
+        expect(encoded).not.toBe(userId);
+        expect(decodeUserIdHeader(encoded)).toBe(userId);
+    });
+
+    it.each([null, undefined, ""])("returns undefined for %p", (raw) => {
+        expect.assertions(1);
+
+        expect(decodeUserIdHeader(raw)).toBeUndefined();
+    });
+
+    it("returns undefined for a malformed encoded userId", () => {
+        expect.assertions(1);
+
+        expect(decodeUserIdHeader("=not-valid-base64url!!!")).toBeUndefined();
+    });
+});

--- a/packages/runtime/__tests__/identity-header.test.ts
+++ b/packages/runtime/__tests__/identity-header.test.ts
@@ -1,17 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
-
-/** `true` when every UTF-16 code unit of `value` is &lt;= 255 (a valid WebIDL `ByteString`). */
-const isByteStringSafe = (value: string): boolean => {
-    for (let index = 0; index < value.length; index += 1) {
-        if ((value.codePointAt(index) ?? 0) > 255) {
-            return false;
-        }
-    }
-
-    return true;
-};
+import { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader, isByteStringSafe } from "../../../shared/identity-header";
 
 describe("encodeIdentityHeader / decodeIdentityHeader", () => {
     it("round-trips ASCII claims", () => {

--- a/packages/runtime/__tests__/identity-integration.test.ts
+++ b/packages/runtime/__tests__/identity-integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration-shaped regression test for the ByteString identity-header bug
+ * (plan 213): a `resolveIdentity` returning non-Latin-1 claims used to make
+ * `new Request(...)` throw a `TypeError` before the shard was ever reached,
+ * turning into an opaque INTERNAL 500 for every RPC.
+ *
+ * Unlike the rest of `@lunora/runtime`'s worker suite — which passes a
+ * hand-rolled `ShardNamespaceLike` double that never constructs a real
+ * `Request` — this drives a REAL `ShardDO` instance (from `@lunora/do`)
+ * through a REAL `createWorker(...)`, so the encode (runtime) and decode (DO)
+ * halves of the fix are exercised together across the actual package
+ * boundary, with a genuine `new Request(...)` in between (see
+ * `admin-roundtrip.test.ts` for the precedent of a runtime test driving a
+ * real `ShardDO`). Node's `fetch`/`Request`/`Headers` (undici) enforce the
+ * same WebIDL `ByteString` constraint workerd does, so this reproduces the
+ * exact failure mode without needing the gated `LUNORA_WORKERD_TESTS=1` suite
+ * (`packages/runtime/__tests__/workerd/`, which has no identity-specific test
+ * to extend today — noted here rather than standing up new workerd infra for
+ * this one case, per plan 213).
+ */
+import type { ShardDOState } from "@lunora/do";
+import { ShardDO } from "@lunora/do";
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionContextLike, ResolvedIdentity } from "../src/create-worker";
+import { createWorker } from "../src/create-worker";
+import type { ShardNamespaceLike } from "../src/resolve-shard";
+
+/** A `ShardDO` whose `handleRpc` bypasses all storage and just echoes back what `ctx.auth` sees. */
+class IdentityEchoShard extends ShardDO {
+    public override async handleRpc(): Promise<unknown> {
+        return { identity: this.getCurrentIdentity(), userId: this.getCurrentUserId() };
+    }
+}
+
+const createRealShardNamespace = (): ShardNamespaceLike => {
+    const state: ShardDOState = {
+        acceptWebSocket() {},
+        getWebSockets() {
+            return [];
+        },
+        // `handleRpc` never touches storage, so a real SQLite backing isn't needed —
+        // mirrors `shard-do.test.ts`'s `createFakeState`.
+        storage: { sql: undefined as never },
+    };
+    const shard = new IdentityEchoShard(state, {});
+
+    return {
+        get: () => {
+            return { fetch: (request: Request) => shard.fetch(request) };
+        },
+        idFromName: (name) => name,
+    };
+};
+
+const fakeContext: ExecutionContextLike = {
+    passThroughOnException: () => undefined,
+    waitUntil: () => undefined,
+};
+
+describe("identity header integration (worker -> real ShardDO)", () => {
+    it("dispatches a CJK + emoji identity end-to-end and ctx.auth sees it intact", async () => {
+        expect.assertions(3);
+
+        const worker = createWorker({
+            resolveIdentity: (): ResolvedIdentity => {
+                return { name: "名前 🎌", userId: "user_42" };
+            },
+            shardDO: createRealShardNamespace(),
+        });
+
+        const response = await worker.fetch(
+            new Request("https://app.example/_lunora/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                method: "POST",
+            }),
+            {},
+            fakeContext,
+        );
+
+        expect(response.status).toBe(200);
+
+        const body: { result: { identity: Record<string, unknown>; userId: string } } = await response.json();
+
+        expect(body.result.userId).toBe("user_42");
+        expect(body.result.identity).toStrictEqual({ name: "名前 🎌" });
+    });
+
+    it("dispatches a non-Latin-1 userId end-to-end and ctx.auth sees it intact", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({
+            resolveIdentity: (): ResolvedIdentity => {
+                return { userId: "田中太郎" };
+            },
+            shardDO: createRealShardNamespace(),
+        });
+
+        const response = await worker.fetch(
+            new Request("https://app.example/_lunora/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "messages:list" }),
+                method: "POST",
+            }),
+            {},
+            fakeContext,
+        );
+
+        expect(response.status).toBe(200);
+
+        const body: { result: { userId: string } } = await response.json();
+
+        expect(body.result.userId).toBe("田中太郎");
+    });
+});

--- a/packages/runtime/__tests__/identity-layer.test.ts
+++ b/packages/runtime/__tests__/identity-layer.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { decodeIdentityHeader } from "../../../shared/identity-header";
 import type { ExecutionContextLike, ResolvedIdentity } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
 import type { IdentityContractLike, IdentityResolver } from "../src/identity-resolvers";
@@ -212,7 +213,7 @@ describe("identity contract trust boundary", () => {
         await worker.fetch(rpc(), {}, fakeContext);
 
         expect(shard.calls[0]!.request.headers.get("x-lunora-userid")).toBe("user_42");
-        expect(JSON.parse(shard.calls[0]!.request.headers.get("x-lunora-identity")!)).toEqual({ tenantId: "t_1" });
+        expect(decodeIdentityHeader(shard.calls[0]!.request.headers.get("x-lunora-identity"))).toEqual({ tenantId: "t_1" });
     });
 
     it("downgrades a contract-violating identity to anonymous (onInvalid: 'anonymous')", async () => {

--- a/packages/runtime/__tests__/server-query.test.ts
+++ b/packages/runtime/__tests__/server-query.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { encodeIdentityHeader } from "../../../shared/identity-header";
 import type { ExecutionContextLike, ResolvedIdentity } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
@@ -133,7 +134,7 @@ describe("serverQuery — in-process fast-path (PLAN4 §2.2 / §5.3)", () => {
             result: {
                 args: {},
                 functionPath: "messages:list",
-                identity: JSON.stringify({ email: "u@example.com" }),
+                identity: encodeIdentityHeader({ email: "u@example.com" }),
                 shardKey: "__root__",
                 userId: "user_42",
             },

--- a/packages/runtime/__tests__/shard-client.test.ts
+++ b/packages/runtime/__tests__/shard-client.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { encodeIdentityHeader } from "../../../shared/identity-header";
+import { encodeIdentityHeader, isByteStringSafe } from "../../../shared/identity-header";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
 import type { ShardFunctionReference } from "../src/shard-client";
 import { createShardClient } from "../src/shard-client";
@@ -119,18 +119,11 @@ describe("createShardClient", () => {
             .call("mcp:listNodes", {});
 
         const identityHeader = calls[0]?.headers["x-lunora-identity"] ?? "";
-        let isByteStringSafe = identityHeader.length > 0;
-
-        for (let index = 0; index < identityHeader.length; index += 1) {
-            if ((identityHeader.codePointAt(index) ?? 0) > 255) {
-                isByteStringSafe = false;
-            }
-        }
 
         // Every code unit must be <= 255 (WebIDL `ByteString`-safe) — this is the
         // literal property `new Request(...)` enforces at the real fetch call below;
         // a raw `JSON.stringify({ name: "名前 🎌" })` would violate it.
-        expect(isByteStringSafe).toBe(true);
+        expect(isByteStringSafe(identityHeader)).toBe(true);
         expect(identityHeader).toBe(encodeIdentityHeader({ name: "名前 🎌" }));
     });
 

--- a/packages/runtime/__tests__/shard-client.test.ts
+++ b/packages/runtime/__tests__/shard-client.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { encodeIdentityHeader } from "../../../shared/identity-header";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
 import type { ShardFunctionReference } from "../src/shard-client";
 import { createShardClient } from "../src/shard-client";
@@ -104,7 +105,33 @@ describe("createShardClient", () => {
         // reach `internal*`, the identity so RLS/ownership sees the real user.
         expect(calls[0]?.headers["x-lunora-system"]).toBe("1");
         expect(calls[0]?.headers["x-lunora-userid"]).toBe("u1");
-        expect(calls[0]?.headers["x-lunora-identity"]).toBe(JSON.stringify({ email: "a@b.c" }));
+        expect(calls[0]?.headers["x-lunora-identity"]).toBe(encodeIdentityHeader({ email: "a@b.c" }));
+    });
+
+    it("encodes non-Latin-1 `.as()` claims so the header value stays a valid ByteString", async () => {
+        expect.assertions(2);
+
+        const { calls, namespace } = createNamespace(() => ok(null));
+
+        await createShardClient(namespace)
+            .as({ claims: { name: "名前 🎌" }, userId: "u1" })
+            .forShard("u1")
+            .call("mcp:listNodes", {});
+
+        const identityHeader = calls[0]?.headers["x-lunora-identity"] ?? "";
+        let isByteStringSafe = identityHeader.length > 0;
+
+        for (let index = 0; index < identityHeader.length; index += 1) {
+            if ((identityHeader.codePointAt(index) ?? 0) > 255) {
+                isByteStringSafe = false;
+            }
+        }
+
+        // Every code unit must be <= 255 (WebIDL `ByteString`-safe) — this is the
+        // literal property `new Request(...)` enforces at the real fetch call below;
+        // a raw `JSON.stringify({ name: "名前 🎌" })` would violate it.
+        expect(isByteStringSafe).toBe(true);
+        expect(identityHeader).toBe(encodeIdentityHeader({ name: "名前 🎌" }));
     });
 
     it("drops the system flag when the caller opts out", async () => {

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -5,6 +5,7 @@ import type { BatchEntry } from "../../../shared/batch-wire";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
+import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
 import { otlpRandomHex } from "../../../shared/otlp";
 import { relayName } from "../../../shared/relay-name";
 import type { RestExposure } from "../../../shared/rest-surface";
@@ -1429,6 +1430,15 @@ const REQUIRE_EPHEMERAL_ENV_VALUES = new Set(["1", "enabled", "on", "true", "yes
  * Read the optional caller identity a server-initiated dispatch may forward on
  * the `x-lunora-userid` / `x-lunora-identity` headers, returning the shape
  * `dispatchToShard` threads to the shard (or `undefined` when neither is set).
+ *
+ * Deliberately opaque: both values are captured as raw strings and later copied
+ * verbatim back onto the outbound shard request's headers (see the
+ * `dispatchToShard` header block below) without being decoded here. The inbound
+ * request is itself `@lunora/dispatch`'s own `fetch` to this worker, which
+ * already encodes via `encodeUserIdHeader`/`encodeIdentityHeader` — so the
+ * string captured here is already `ByteString`-safe and needs no
+ * decode-then-re-encode round trip; it's the shard's `parseIdentityHeader` /
+ * voice DO's identity parser that ultimately decode it.
  */
 const readForwardedIdentity = (request: Request): { identity?: string; userId?: string } | undefined => {
     const forwardedUserId = request.headers.get("x-lunora-userid");
@@ -1666,7 +1676,11 @@ const resolveForwardContext = async (request: Request, env: unknown, resolveIden
         return { claims: null, headers, identity: null, userId: null };
     }
 
-    headers["x-lunora-userid"] = identity.userId;
+    // Base64url-encoded when `userId` has any non-Latin-1 code unit — otherwise
+    // forwarded unchanged. HTTP header values are WebIDL `ByteString`s, so a raw
+    // id containing e.g. a CJK/emoji character would throw on `new Request(...)`
+    // at the shard fetch below; see shared/identity-header.ts.
+    headers["x-lunora-userid"] = encodeUserIdHeader(identity.userId);
 
     // Forward an optional token-expiry so the DO can drop a socket whose
     // credential has lapsed (the client then reconnects, re-resolving identity).
@@ -1686,7 +1700,12 @@ const resolveForwardContext = async (request: Request, env: unknown, resolveIden
     const claims = Object.keys(extra).length > 0 ? extra : null;
 
     if (claims) {
-        headers["x-lunora-identity"] = JSON.stringify(claims);
+        // UTF-8 -> base64url so any non-Latin-1 claim (a CJK/Cyrillic/Arabic name,
+        // an emoji, …) stays a valid WebIDL `ByteString` header value. Decoded on
+        // the shard side by `parseIdentityHeader` (delegates to
+        // `decodeIdentityHeader`, which also still accepts a legacy raw-JSON
+        // value). See shared/identity-header.ts.
+        headers["x-lunora-identity"] = encodeIdentityHeader(claims);
     }
 
     return { claims, headers, identity, userId };

--- a/packages/runtime/src/cross-shard-relations.ts
+++ b/packages/runtime/src/cross-shard-relations.ts
@@ -37,6 +37,7 @@
 // `@lunora/do` while reusing its canonical writer types (see the alias note).
 import type { DatabaseWriterLike } from "@lunora/shard-engine";
 
+import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
 import { LunoraError } from "./errors";
 
 /**
@@ -84,11 +85,13 @@ const buildIdentityHeaders = (options: CrossShardRelationOptions): Record<string
     const headers: Record<string, string> = { "content-type": "application/json" };
 
     if (options.userId !== undefined && options.userId.length > 0) {
-        headers["x-lunora-userid"] = options.userId;
+        // Base64url-encoded when non-Latin-1 (HTTP header values are WebIDL
+        // `ByteString`s); see shared/identity-header.ts.
+        headers["x-lunora-userid"] = encodeUserIdHeader(options.userId);
     }
 
     if (options.identity !== undefined) {
-        headers["x-lunora-identity"] = JSON.stringify(options.identity);
+        headers["x-lunora-identity"] = encodeIdentityHeader(options.identity);
     }
 
     return headers;

--- a/packages/runtime/src/shard-client.ts
+++ b/packages/runtime/src/shard-client.ts
@@ -42,6 +42,7 @@
 
 import { LunoraError } from "@lunora/errors";
 
+import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { DurableObjectJurisdiction, ShardNamespaceLike } from "./resolve-shard";
 import { applyJurisdiction, resolveShard } from "./resolve-shard";
@@ -220,10 +221,14 @@ const createShardClient = (namespace: ShardNamespaceLike, options: ShardClientOp
             // `ctx.auth` from these headers independently of the system flag, so the
             // call can be trusted AND carry the user's RLS/ownership context.
             if (options.as) {
-                headers["x-lunora-userid"] = options.as.userId;
+                // HTTP header values are WebIDL `ByteString`s, so a raw non-Latin-1
+                // userId/claim (CJK/Cyrillic/Arabic name, emoji, …) would throw on
+                // `new Request(...)` below; base64url-encode when needed. See
+                // shared/identity-header.ts.
+                headers["x-lunora-userid"] = encodeUserIdHeader(options.as.userId);
 
                 if (options.as.claims) {
-                    headers["x-lunora-identity"] = JSON.stringify(options.as.claims);
+                    headers["x-lunora-identity"] = encodeIdentityHeader(options.as.claims);
                 }
             }
 

--- a/shared/base64.ts
+++ b/shared/base64.ts
@@ -7,6 +7,10 @@
  * Both use a fixed-size chunk so a large buffer — a multi-megabyte audio utterance
  * or a `v.bytes()` payload — never overflows the argument-count ceiling of
  * `String.fromCharCode` (nor blows the call stack) via a single spread.
+ *
+ * `toBase64Url`/`fromBase64Url` are the URL-safe, unpadded variant built on top
+ * of the two above; `shared/identity-header.ts` imports them from here as the
+ * canonical base64url home rather than hand-rolling its own.
  */
 
 /** Base64-encode bytes. */
@@ -33,4 +37,15 @@ const fromBase64 = (base64: string): Uint8Array => {
     return bytes;
 };
 
-export { fromBase64, toBase64 };
+/** Base64 (from {@link toBase64}) -> URL-safe, unpadded base64url. */
+const toBase64Url = (bytes: Uint8Array): string => toBase64(bytes).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+
+/** URL-safe base64url -> bytes, via {@link fromBase64} (which expects standard padded base64). */
+const fromBase64Url = (value: string): Uint8Array => {
+    const restored = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = restored + "=".repeat((4 - (restored.length % 4)) % 4);
+
+    return fromBase64(padded);
+};
+
+export { fromBase64, fromBase64Url, toBase64, toBase64Url };

--- a/shared/identity-header.ts
+++ b/shared/identity-header.ts
@@ -47,24 +47,13 @@
  * Consumers must drop `outDir`/`rootDir` from their `tsconfig.json` (a set
  * `rootDir` raises TS6059 for this out-of-package file under `tsc --noEmit`).
  */
-import { fromBase64, toBase64 } from "./base64";
+import { fromBase64Url, toBase64Url } from "./base64";
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
 
 /** Sentinel prefix marking an `x-lunora-userid` value as base64url-encoded UTF-8. */
 const USERID_ENCODED_PREFIX = "=";
-
-/** Base64 (from {@link toBase64}) -> URL-safe, unpadded base64url. */
-const toBase64Url = (bytes: Uint8Array): string => toBase64(bytes).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
-
-/** URL-safe base64url -> bytes, via {@link fromBase64} (which expects standard padded base64). */
-const fromBase64Url = (value: string): Uint8Array => {
-    const restored = value.replaceAll("-", "+").replaceAll("_", "/");
-    const padded = restored + "=".repeat((4 - (restored.length % 4)) % 4);
-
-    return fromBase64(padded);
-};
 
 /** `true` when every UTF-16 code unit of `value` is <= 255 (safe as a WebIDL `ByteString`). */
 const isByteStringSafe = (value: string): boolean => {
@@ -130,6 +119,12 @@ const encodeUserIdHeader = (userId: string): string => {
  * returned unchanged (the common, unencoded case); a value with it is
  * base64url-decoded -> UTF-8. A malformed encoded value -> `undefined`
  * (fail-soft, matching {@link decodeIdentityHeader}).
+ *
+ * Mixed-rollout edge: this sentinel scheme assumes a raw (pre-{@link encodeUserIdHeader})
+ * userId never itself starts with `=` — true for UUIDs/emails/JWT `sub`s, but not
+ * guaranteed in general. A new consumer decoding a legacy raw userId that does start
+ * with `=` would misinterpret it as encoded. Deploy this decoder no earlier than every
+ * producer that could emit such a raw id has picked up the `=`-encoding it now expects.
  */
 const decodeUserIdHeader = (raw: null | string | undefined): string | undefined => {
     if (!raw) {
@@ -147,4 +142,4 @@ const decodeUserIdHeader = (raw: null | string | undefined): string | undefined 
     }
 };
 
-export { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader };
+export { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader, isByteStringSafe };

--- a/shared/identity-header.ts
+++ b/shared/identity-header.ts
@@ -1,0 +1,150 @@
+/**
+ * Codec for the `x-lunora-userid` / `x-lunora-identity` headers the worker
+ * forwards to a shard as verified caller identity.
+ *
+ * HTTP header values are WebIDL `ByteString`s: `new Request(...)`/`Headers`
+ * throws a `TypeError` for any code unit above 255. The worker used to set
+ * `x-lunora-identity` to raw `JSON.stringify(claims)` and `x-lunora-userid` to
+ * the raw id string, so a `resolveIdentity` returning any claim (or id) with a
+ * non-Latin-1 character — a CJK/Cyrillic/Arabic name, an emoji, an IDN — made
+ * the `Request` construction throw before the shard was ever reached, turning
+ * into an opaque INTERNAL 500 for every RPC/batch/fan-out/REST/dispatch call
+ * for that user. Latin-1-only text (including accented Latin letters) survives
+ * unencoded, which is why local testing with ASCII-ish names misses this.
+ *
+ * `encodeIdentityHeader` UTF-8-encodes the claims JSON and base64url-encodes
+ * the bytes, so the header value is always plain ASCII (every code unit <=
+ * 127, well under the 255 ceiling) regardless of what the claims contain.
+ * `decodeIdentityHeader` sniffs the encoding: `raw[0] === "{"` means an
+ * unencoded legacy value (forwarded by a worker that hasn't picked up this
+ * codec yet, or a Latin-1-only claims set that happened to be sent raw before
+ * this change) and is parsed as JSON directly; anything else is treated as
+ * base64url and decoded first. This makes rollout order-independent — an old
+ * producer and a new consumer (or vice versa) both still work.
+ *
+ * `encodeUserIdHeader` / `decodeUserIdHeader` do the equivalent for the bare
+ * `x-lunora-userid` string, which has no JSON envelope to sniff a `{` on. A
+ * userId is Latin-1-safe in the overwhelming common case (opaque ids, emails,
+ * UUIDs), so it is forwarded byte-for-byte unchanged whenever every code unit
+ * is <= 255 AND it doesn't already start with `=` (the encoded-form sentinel
+ * below) — keeping the header human-readable and avoiding a size regression
+ * for the common path. Only a userId that needs encoding (a non-Latin-1
+ * character, or one that would collide with the sentinel) is prefixed with
+ * `=` and base64url-encoded; `decodeUserIdHeader` inverts this by checking for
+ * the leading `=`.
+ *
+ * Every decode fails soft to `undefined` on malformed input — no `raw[0] ===
+ * "{"` legacy JSON, no valid base64url, or a decoded-but-non-object JSON value
+ * — mirroring `parseIdentityHeader`'s pre-existing posture in
+ * `packages/do/src/admin-rpc-args.ts` (a garbled/absent identity header
+ * degrades the caller to anonymous rather than throwing).
+ *
+ * Deliberately **not** a package: consumers (`@lunora/runtime`,
+ * `@lunora/dispatch`, `@lunora/do`, `@lunora/agent`) import this file by
+ * relative path and the bundler (packem/rollup) inlines it — no runtime
+ * dependency edge between otherwise-unrelated packages. Keep it genuinely
+ * zero-dependency (only relative/built-in imports) or inlining breaks.
+ * Consumers must drop `outDir`/`rootDir` from their `tsconfig.json` (a set
+ * `rootDir` raises TS6059 for this out-of-package file under `tsc --noEmit`).
+ */
+import { fromBase64, toBase64 } from "./base64";
+
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+/** Sentinel prefix marking an `x-lunora-userid` value as base64url-encoded UTF-8. */
+const USERID_ENCODED_PREFIX = "=";
+
+/** Base64 (from {@link toBase64}) -> URL-safe, unpadded base64url. */
+const toBase64Url = (bytes: Uint8Array): string => toBase64(bytes).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+
+/** URL-safe base64url -> bytes, via {@link fromBase64} (which expects standard padded base64). */
+const fromBase64Url = (value: string): Uint8Array => {
+    const restored = value.replaceAll("-", "+").replaceAll("_", "/");
+    const padded = restored + "=".repeat((4 - (restored.length % 4)) % 4);
+
+    return fromBase64(padded);
+};
+
+/** `true` when every UTF-16 code unit of `value` is <= 255 (safe as a WebIDL `ByteString`). */
+const isByteStringSafe = (value: string): boolean => {
+    for (let index = 0; index < value.length; index += 1) {
+        if (value.charCodeAt(index) > 255) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+/**
+ * Encode identity claims for the `x-lunora-identity` header: UTF-8 JSON ->
+ * base64url. The result is always ASCII, so it is always a valid header value
+ * regardless of what `claims` contains.
+ */
+const encodeIdentityHeader = (claims: Record<string, unknown>): string => toBase64Url(textEncoder.encode(JSON.stringify(claims)));
+
+/**
+ * Decode an `x-lunora-identity` header value. `null`/empty -> `undefined`.
+ * Sniffs legacy unencoded values (`raw[0] === "{"`) and parses them as JSON
+ * directly; otherwise base64url-decodes -> UTF-8 -> `JSON.parse`s. Any
+ * failure, or a successfully parsed non-object (array/primitive), -> `undefined`
+ * — fail-soft, matching `parseIdentityHeader`'s pre-existing behavior.
+ */
+const decodeIdentityHeader = (raw: null | string | undefined): Record<string, unknown> | undefined => {
+    if (!raw) {
+        return undefined;
+    }
+
+    try {
+        const json = raw[0] === "{" ? raw : textDecoder.decode(fromBase64Url(raw));
+        const parsed = JSON.parse(json) as unknown;
+
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+    } catch {
+        // fall through to undefined
+    }
+
+    return undefined;
+};
+
+/**
+ * Encode a userId for the `x-lunora-userid` header. Returned unchanged when
+ * every code unit is <= 255 (WebIDL `ByteString`-safe) AND it doesn't already
+ * start with the `=` encoded-form sentinel; otherwise UTF-8-encoded,
+ * base64url-encoded, and prefixed with `=`.
+ */
+const encodeUserIdHeader = (userId: string): string => {
+    if (!userId.startsWith(USERID_ENCODED_PREFIX) && isByteStringSafe(userId)) {
+        return userId;
+    }
+
+    return `${USERID_ENCODED_PREFIX}${toBase64Url(textEncoder.encode(userId))}`;
+};
+
+/**
+ * Decode an `x-lunora-userid` header value produced by {@link encodeUserIdHeader}.
+ * `null`/empty -> `undefined`. A value without the leading `=` sentinel is
+ * returned unchanged (the common, unencoded case); a value with it is
+ * base64url-decoded -> UTF-8. A malformed encoded value -> `undefined`
+ * (fail-soft, matching {@link decodeIdentityHeader}).
+ */
+const decodeUserIdHeader = (raw: null | string | undefined): string | undefined => {
+    if (!raw) {
+        return undefined;
+    }
+
+    if (!raw.startsWith(USERID_ENCODED_PREFIX)) {
+        return raw;
+    }
+
+    try {
+        return textDecoder.decode(fromBase64Url(raw.slice(USERID_ENCODED_PREFIX.length)));
+    } catch {
+        return undefined;
+    }
+};
+
+export { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader };


### PR DESCRIPTION
The worker forwards verified identity to the shard as HTTP headers (`x-lunora-userid`, `x-lunora-identity` = raw `JSON.stringify(claims)`). HTTP header values are WebIDL ByteStrings — workerd/undici throw TypeError for any code unit > 255 — so a `resolveIdentity` returning any claim with a non-Latin-1 char (a CJK/Cyrillic/Arabic name, an emoji, an IDN) makes `new Request(...)` throw before the shard is reached, becoming an opaque INTERNAL 500 for **every** RPC/batch/fan-out/REST/dispatch for that user (Latin-1 accents survive, which is why local testing misses it).

Adds a zero-dep `shared/identity-header.ts` (UTF-8 → base64url, with a sniffing decoder for order-independent rollout) and routes all **four** producer sites (create-worker, cross-shard-relations, dispatch-runner, and shard-client's `.as()` path — the last two found via repo-wide grep, not in the original inventory) plus every consumer (parseIdentityHeader, voice-turn's parseIdentity, and the raw userId reads in shard-do/voice-do) through it. Legacy raw-JSON headers still decode during a mixed-version deploy.

Verified: runtime 814, dispatch 23, do 503, agent 288; a real createWorker→ShardDO integration test with CJK/emoji claims + a non-Latin-1 userId (reproduces the ByteString TypeError pre-fix).

⚠ Touches runtime/create-worker.ts + do/shard-do.ts — merge-order vs #248 (226 create-worker), #243 (206-207 shard-do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)