### PR TITLE
fix(studio): data-browser view re-seed, truncated bulk-delete signal, per-tab SQL busy state

### DIFF
--- a/packages/studio/__tests__/features/data/data-browser.test.tsx
+++ b/packages/studio/__tests__/features/data/data-browser.test.tsx
@@ -1439,3 +1439,168 @@ describe("dataBrowser — facets", () => {
         expect(screen.getByTestId("db-row").textContent).toContain("again");
     });
 });
+
+interface ShardSwitchRow {
+    __id__: string;
+    text: string;
+}
+
+/**
+ * Two independent shard fixtures — `""` (the default/root shard) serving table
+ * `inbox`, and `"s2"` serving a DIFFERENT table `archive` — so a test can drive
+ * an atomic table+shard switch (the shape a saved-query apply or a cross-shard
+ * deep link produces: table, shard, and search all change in ONE URL push) and
+ * tell which shard a request actually reached from `options.shardKey`.
+ */
+const SHARD_SWITCH_FIXTURES: Record<string, { rows: ShardSwitchRow[]; table: string }> = {
+    "": { rows: [{ __id__: "a1", text: "alpha-hello" }], table: "inbox" },
+    s2: { rows: [{ __id__: "b1", text: "beta-world" }], table: "archive" },
+};
+
+const createShardSwitchClient = (): MockClientHooks =>
+    createMockClient({
+        query: (reference, args, options): unknown => {
+            const shard = (options as { shardKey?: string } | undefined)?.shardKey ?? "";
+            const fixture = SHARD_SWITCH_FIXTURES[shard];
+
+            if (fixture === undefined) {
+                throw new Error(`unknown shard: ${shard}`);
+            }
+
+            if (reference === ADMIN_FUNCTIONS.listTables) {
+                return [{ name: fixture.table, rowCount: fixture.rows.length }];
+            }
+
+            if (reference === ADMIN_FUNCTIONS.writeRow) {
+                const { id, op } = args as { id?: string; op: string };
+
+                if (op === "delete" && id !== undefined) {
+                    fixture.rows = fixture.rows.filter((row) => row["__id__"] !== id);
+                }
+
+                return { id: id ?? null, op };
+            }
+
+            // readTablePage
+            const { search = "", table } = args as { search?: string; table: string };
+
+            if (table !== fixture.table) {
+                throw new Error(`unknown table "${table}" on shard "${shard}"`);
+            }
+
+            const needle = search.trim().toLowerCase();
+            const matched = needle === "" ? fixture.rows : fixture.rows.filter((row) => row.text.toLowerCase().includes(needle));
+
+            return { columns: ["__id__", "text"], rows: matched, total: matched.length };
+        },
+    });
+
+/**
+ * Test host that can drive an ATOMIC table+shard+search switch — `table`,
+ * `search`, and `shardKey` all change inside ONE event handler (one React
+ * commit), the way the real Table editor's "apply saved query" flow pushes a
+ * saved view's table, shard, and search as a single URL update.
+ * `onSelectTable` (a plain in-app table click) deliberately leaves the shard
+ * alone, matching production.
+ */
+const ShardSwitchDataBrowser = ({ pageSize }: { pageSize?: number }): ReactElement => {
+    const [table, setTable] = useState<string | undefined>(undefined);
+    const [search, setSearch] = useState<string | undefined>(undefined);
+    const [shardKey, setShardKey] = useState<string | undefined>(undefined);
+
+    const onSelectTable = (next: string, options?: { search?: string }): void => {
+        setTable(next);
+        setSearch(options?.search);
+    };
+
+    const applyShardSwitch = (): void => {
+        setTable("archive");
+        setSearch(undefined);
+        setShardKey("s2");
+    };
+
+    return (
+        <>
+            <button data-testid="apply-shard-switch" onClick={applyShardSwitch} type="button">
+                apply saved query
+            </button>
+            <DataBrowser editable initialSearch={search} initialShardKey={shardKey} onSelectTable={onSelectTable} pageSize={pageSize} tableParam={table} />
+        </>
+    );
+};
+
+describe("dataBrowser — table switch reset (STUDIO-01)", () => {
+    it("issues the first read for the new table with ITS OWN search, not the previous table's leftover search", async () => {
+        expect.assertions(1);
+
+        const mock = createShardSwitchClient();
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <ShardSwitchDataBrowser pageSize={10} />
+            </LunoraProvider>,
+        );
+
+        fireEvent.click(await screen.findByTestId("db-table-inbox"));
+        await screen.findByText("alpha-hello");
+
+        // Type a search for table A, then switch WITHOUT waiting for its 300ms
+        // debounce to settle — the reset must discard it outright, not merely win
+        // a race against it.
+        fireEvent.change(screen.getByTestId("db-filter"), { target: { value: "alpha" } });
+        fireEvent.click(screen.getByTestId("apply-shard-switch"));
+
+        await screen.findByText("beta-world");
+
+        const archiveRead = mock.query.mock.calls.find(
+            (call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage && (call[1] as { table: string }).table === "archive",
+        ) as [unknown, { search?: string; table: string }, unknown] | undefined;
+
+        // The very first read for the new table already carries ITS search
+        // ("") — never table A's leftover "alpha".
+        expect(archiveRead?.[1].search).toBe("");
+    });
+
+    it("targets the NEW shard for a delete issued right after a switch that also changes shard", async () => {
+        expect.assertions(1);
+
+        const mock = createShardSwitchClient();
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <ShardSwitchDataBrowser pageSize={10} />
+            </LunoraProvider>,
+        );
+
+        fireEvent.click(await screen.findByTestId("db-table-inbox"));
+        await screen.findByText("alpha-hello");
+
+        fireEvent.click(screen.getByTestId("apply-shard-switch"));
+        await screen.findByText("beta-world");
+
+        // Select and delete the new table's row as soon as it's on screen — the
+        // earliest an operator could possibly click after the switch.
+        fireEvent.click(screen.getByTestId("db-select-all"));
+        await screen.findByTestId("grid-selection-count");
+
+        fireEvent.click(screen.getByTestId("grid-selection-delete"));
+        fireEvent.click(screen.getByTestId("grid-selection-delete-confirm"));
+
+        await waitFor(() => {
+            const deletes = mock.query.mock.calls.filter(
+                (call) => call[0].__lunoraRef === ADMIN_FUNCTIONS.writeRow && (call[1] as { op: string }).op === "delete",
+            );
+
+            if (deletes.length === 0) {
+                throw new Error("delete not issued yet");
+            }
+        });
+
+        const deletes = mock.query.mock.calls.filter((call) => call[0].__lunoraRef === ADMIN_FUNCTIONS.writeRow && (call[1] as { op: string }).op === "delete");
+
+        // Every delete targets the NEW shard ("s2") — the old code's own comment
+        // claimed this couldn't happen, and it could: the debounced shard used to
+        // lag the table-derived selection by up to 400ms.
+        expect(deletes.every((call) => (call[2] as { shardKey?: string } | undefined)?.shardKey === "s2")).toBe(true);
+    });
+});

--- a/packages/studio/__tests__/features/data/data-browser.test.tsx
+++ b/packages/studio/__tests__/features/data/data-browser.test.tsx
@@ -1604,3 +1604,123 @@ describe("dataBrowser — table switch reset (STUDIO-01)", () => {
         expect(deletes.every((call) => (call[2] as { shardKey?: string } | undefined)?.shardKey === "s2")).toBe(true);
     });
 });
+
+// Mirrors `MAX_BULK_DELETE_BATCHES` in `use-data-browser.tsx` (not exported —
+// this test drives the client-side loop-exhaustion path directly).
+const MAX_BULK_DELETE_BATCHES = 200;
+
+/**
+ * A `messages` table pre-loaded with more matching rows than
+ * `MAX_BULK_DELETE_BATCHES × bulkCap` can drain in one bulk-delete run, so the
+ * client's own batch loop runs out before the server ever reports
+ * `hasMore: false` — exercising the STUDIO-02 truncation path, distinct from
+ * `createFilterableClient`'s ordinary (server-completes) multi-batch drain.
+ */
+const createCapExhaustingClient = (rowCount: number, bulkCap: number): MockClientHooks => {
+    let rows = Array.from({ length: rowCount }, (_, index) => {
+        return { __id__: `m${index.toString()}`, status: "active", text: `row-${index.toString()}` };
+    });
+
+    return createMockClient({
+        query: (reference, args): unknown => {
+            if (reference === ADMIN_FUNCTIONS.listTables) {
+                return [{ name: "messages", rowCount: rows.length }];
+            }
+
+            if (reference === ADMIN_FUNCTIONS.deleteRows) {
+                const batch = rows.slice(0, bulkCap);
+                const doomed = new Set(batch.map((row) => row["__id__"]));
+
+                rows = rows.filter((row) => !doomed.has(row["__id__"]));
+
+                return { deleted: batch.length, hasMore: rows.length > 0 };
+            }
+
+            const { limit = 50, offset = 0, table } = args as { limit?: number; offset?: number; table: string };
+
+            if (table !== "messages") {
+                throw new Error(`unknown table: ${table}`);
+            }
+
+            return { columns: ["__id__", "status", "text"], rows: rows.slice(offset, offset + limit), total: rows.length };
+        },
+    });
+};
+
+describe("dataBrowser — bulk delete cap exhaustion (STUDIO-02)", () => {
+    it("surfaces a truncation message when the client's batch cap is hit before the server reports done", async () => {
+        expect.assertions(3);
+
+        // 205 matching rows, capped at 1 row/call → needs 205 round-trips to
+        // finish; the client stops itself at 200.
+        const mock = createCapExhaustingClient(MAX_BULK_DELETE_BATCHES + 5, 1);
+
+        render(renderBrowser(mock, { editable: true, pageSize: 10 }));
+
+        fireEvent.click(await screen.findByTestId("db-table-messages"));
+        await screen.findByTestId("db-page");
+
+        fireEvent.click(screen.getByTestId("db-add-filter"));
+        fireEvent.change(await screen.findByTestId("db-filter-column"), { target: { value: "status" } });
+        fireEvent.change(await screen.findByTestId("db-filter-value"), { target: { value: "active" } });
+
+        await waitFor(() => {
+            if (screen.queryAllByTestId("db-row").length === 0) {
+                throw new Error("filter not applied yet");
+            }
+        });
+
+        fireEvent.click(screen.getByTestId("db-bulk-delete"));
+        fireEvent.click(screen.getByTestId("db-bulk-delete-confirm"));
+
+        const errorElement = await screen.findByTestId("db-write-error");
+
+        expect(errorElement.textContent).toBe("Stopped after 200 batches — rows still match this delete. Run it again to remove the rest.");
+
+        const bulk = mock.query.mock.calls.filter((call) => call[0].__lunoraRef === ADMIN_FUNCTIONS.deleteRows);
+
+        expect(bulk).toHaveLength(MAX_BULK_DELETE_BATCHES);
+
+        // 205 rows − 200×1 deleted = 5 left; the refetch this triggers shows them
+        // rather than a page that quietly still looks "done".
+        await waitFor(() => {
+            if (screen.getAllByTestId("db-row").length !== 5) {
+                throw new Error("page not refetched yet");
+            }
+        });
+
+        expect(screen.getAllByTestId("db-row")).toHaveLength(5);
+    });
+
+    it("still reports clean success (no writeError) when the delete finishes under the cap", async () => {
+        expect.assertions(1);
+
+        const mock = createFilterableClient(1);
+
+        render(renderBrowser(mock, { editable: true, pageSize: 10 }));
+
+        fireEvent.click(await screen.findByTestId("db-table-messages"));
+        await screen.findByTestId("db-page");
+
+        fireEvent.click(screen.getByTestId("db-add-filter"));
+        fireEvent.change(await screen.findByTestId("db-filter-column"), { target: { value: "status" } });
+        fireEvent.change(await screen.findByTestId("db-filter-value"), { target: { value: "active" } });
+
+        await waitFor(() => {
+            if (screen.getAllByTestId("db-row").length !== 2) {
+                throw new Error("filter not applied yet");
+            }
+        });
+
+        fireEvent.click(screen.getByTestId("db-bulk-delete"));
+        fireEvent.click(screen.getByTestId("db-bulk-delete-confirm"));
+
+        await waitFor(() => {
+            if (screen.queryAllByTestId("db-row").length > 0) {
+                throw new Error("rows not deleted yet");
+            }
+        });
+
+        expect(screen.queryByTestId("db-write-error")).toBeNull();
+    });
+});

--- a/packages/studio/__tests__/features/sql/sql-editor-panel.test.tsx
+++ b/packages/studio/__tests__/features/sql/sql-editor-panel.test.tsx
@@ -483,4 +483,76 @@ describe("sqlEditorPanel", () => {
 
         expect(within(screen.getByTestId("sql-tab-strip")).getAllByTestId(/^sql-tab-select-/u)).toHaveLength(1);
     });
+
+    it("keeps `running` scoped per tab: a slow query in one tab never disables/spins another tab's Run button (STUDIO-11)", async () => {
+        expect.assertions(4);
+
+        let resolveSlow: ((value: SqlConsoleResult) => void) | undefined;
+
+        const mock = createMockClient({
+            query: (reference, args): unknown => {
+                if (reference !== ADMIN_FUNCTIONS.runSql) {
+                    return { columns: [], rowCount: 0, rows: [], truncated: false };
+                }
+
+                const { sql } = args as { sql: string };
+
+                // Tab A's query never resolves on its own — held open until the test
+                // calls `resolveSlow` explicitly, so it can assert on the state while
+                // it's still in flight.
+                if (sql.includes("SLOW")) {
+                    return new Promise<SqlConsoleResult>((resolve) => {
+                        resolveSlow = resolve;
+                    });
+                }
+
+                return { columns: ["name"], rowCount: 1, rows: [{ name: "fast" }], truncated: false };
+            },
+        });
+
+        render(renderPanel(mock));
+
+        // Tab A: start the slow query.
+        typeInEditor("SELECT 'SLOW'");
+        fireEvent.click(screen.getByTestId("sql-run"));
+
+        await waitFor(() => {
+            if (!screen.getByTestId<HTMLButtonElement>("sql-run").disabled) {
+                throw new Error("tab A hasn't started running yet");
+            }
+        });
+
+        // Open a second tab — it becomes active. Tab A stays first in the strip
+        // (`addTab` appends), so its id is captured before switching away.
+        fireEvent.click(screen.getByTestId("sql-tab-add"));
+
+        const tabAId =
+            (within(screen.getByTestId("sql-tab-strip")).getAllByTestId(/^sql-tab-select-/u)[0] as HTMLElement).dataset.testid?.replace(
+                "sql-tab-select-",
+                "",
+            ) ?? "";
+
+        // Tab B's Run is enabled — tab A's in-flight query hasn't disabled/spun it,
+        // the way a single panel-level `running` flag used to.
+        expect(screen.getByTestId<HTMLButtonElement>("sql-run").disabled).toBe(false);
+        expect(screen.getByTestId("sql-run").textContent).not.toContain("Running");
+
+        // Land tab A's query while tab B is still the active tab.
+        resolveSlow?.({ columns: ["name"], rowCount: 1, rows: [{ name: "slow-result" }], truncated: false });
+
+        // Tab B is unaffected by tab A's query landing.
+        expect(screen.getByTestId<HTMLButtonElement>("sql-run").disabled).toBe(false);
+
+        // Switch back to tab A: its own spinner cleared (not tab B's), and its
+        // result is the one that landed while it was in the background.
+        fireEvent.click(screen.getByTestId(`sql-tab-select-${tabAId}`));
+
+        await waitFor(() => {
+            if (screen.getByTestId<HTMLButtonElement>("sql-run").disabled) {
+                throw new Error("tab A's running flag never cleared");
+            }
+        });
+
+        expect(screen.getByTestId("sql-rows").textContent).toContain("slow-result");
+    });
 });

--- a/packages/studio/src/features/data/hooks/use-data-browser.tsx
+++ b/packages/studio/src/features/data/hooks/use-data-browser.tsx
@@ -344,11 +344,10 @@ const useDataBrowser = ({
     // are all in scope.
     const [filter, setFilter] = useState<string>(initialSearch ?? "");
 
-    // Structured column filters. Held in a ref too so a write's bulk-delete reads
-    // the current value without threading it through; the page query reads the
-    // state directly via `pageArgs`.
+    // Structured column filters. `bulkDelete` / `toggleFacet` read this state
+    // directly (both are recreated every render and read it synchronously, never
+    // across an `await`), same as the page query via `pageArgs`.
     const [filters, setFilters] = useState<EditableFilter[]>(() => toEditableFilters(initialFilters ?? []));
-    const filtersRef = useMirroredRef<EditableFilter[]>(filters);
 
     // Facets (Datasette-style per-column value/count summaries): the columns the
     // operator has toggled into the facet sidebar, each with its loaded summary.
@@ -412,7 +411,6 @@ const useDataBrowser = ({
         const nextFilters = toEditableFilters(initialFilters ?? []);
 
         setFilters(nextFilters);
-        filtersRef.current = nextFilters;
         // Re-seed the shard from the new URL too, so a switch that also changes
         // shard (a saved query / cross-shard deep link) points reads AND writes
         // at the URL's shard instead of leaving the previous table's shard live.
@@ -552,7 +550,7 @@ const useDataBrowser = ({
     // drops it entirely. With no table selected the hook seeds the slot without
     // fetching (a null fetcher).
     const toggleFacet = (column: string): void => {
-        toggleFacetColumn(column, selectedTable === null ? null : facetFetcher(debouncedShard, selectedTable, filtersRef.current, search));
+        toggleFacetColumn(column, selectedTable === null ? null : facetFetcher(debouncedShard, selectedTable, filters, search));
     };
 
     // Clicking a facet value adds an `eq` filter for that column/value, narrowing
@@ -731,9 +729,9 @@ const useDataBrowser = ({
     // whatever DID get deleted) while leaving the operator with no signal that
     // more rows are still out there, so this reports the outcome and surfaces a
     // truncation notice on `writeError` instead of staying silent.
-    const drainBulk = async (ref: typeof DELETE_ROWS, args: Record<string, unknown>): Promise<BulkDrainOutcome | undefined> => {
+    const drainBulk = async (ref: typeof DELETE_ROWS, args: Record<string, unknown>): Promise<void> => {
         if (selectedTable === null) {
-            return undefined;
+            return;
         }
 
         setWriteError(null);
@@ -757,12 +755,8 @@ const useDataBrowser = ({
             if (outcome === "cap-hit") {
                 setWriteError(`Stopped after ${MAX_BULK_DELETE_BATCHES.toString()} batches — rows still match this delete. Run it again to remove the rest.`);
             }
-
-            return outcome;
         } catch (error) {
             setWriteError((error as Error).message);
-
-            return undefined;
         }
     };
 
@@ -823,7 +817,7 @@ const useDataBrowser = ({
     };
 
     const bulkDelete = (): void => {
-        fireAndForget(drainBulk(DELETE_ROWS, { filters: toFilterClauses(filtersRef.current), search, table: selectedTable }));
+        fireAndForget(drainBulk(DELETE_ROWS, { filters: toFilterClauses(filters), search, table: selectedTable }));
     };
 
     const emptyTable = (): void => {

--- a/packages/studio/src/features/data/hooks/use-data-browser.tsx
+++ b/packages/studio/src/features/data/hooks/use-data-browser.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { OnChangeFn, SortingState } from "@tanstack/react-table";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAdminQuery } from "../../../hooks/use-admin-query";
 import useDebounced from "../../../hooks/use-debounced";
@@ -332,18 +332,10 @@ const useDataBrowser = ({
     // selections.
     const [sorting, setSorting] = useState<SortingState>(() => fromOrderBy(initialOrderBy));
 
-    // Search box value. Debounced into a server-side `search` (filters across the
-    // WHOLE table, not just the loaded page), which re-fetches from offset 0.
+    // Search box value; debounced (below, into `search`) after the structured
+    // filters / facets / staged-edit state it resets alongside on a table switch
+    // are all in scope.
     const [filter, setFilter] = useState<string>(initialSearch ?? "");
-    const search = useDebounced(filter.trim(), 300);
-
-    // The shard the reads target, debounced so typing a key settles before
-    // refetching the table list + page rather than firing per keystroke. Page-bound
-    // actions (preview, facet fetch, row write/delete, bulk delete) target this same
-    // settled shard so a write can never hit a different shard than the one whose
-    // rows are on screen during the debounce window. The live `shardKey` is only the
-    // input value + the share-link descriptor.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
 
     // Structured column filters. Held in a ref too so a write's bulk-delete reads
     // the current value without threading it through; the page query reads the
@@ -371,6 +363,84 @@ const useDataBrowser = ({
     const stagedEdits = useStagedEdits();
     const [editingCell, setEditingCell] = useState<null | { column: string; rowId: string }>(null);
     const [committing, setCommitting] = useState<boolean>(false);
+
+    // Tracks the table the local view has been (re-)seeded for. Seeded with the
+    // mount `tableParam` so the first render is a no-op (the `useState`
+    // initializers above already hydrated from the URL).
+    const [seededTableParameter, setSeededTableParameter] = useState<string | undefined>(tableParam);
+    const isTableSwitch = tableParam !== seededTableParameter;
+
+    // Re-seed the per-table local view state whenever the open table changes — an
+    // in-app switch, an FK-nav, a deep link, or browser back/forward. The new
+    // values come from the new URL (empty on a plain switch, the id on an FK-nav,
+    // the saved view on a deep link), so the table and its view never disagree.
+    //
+    // Done RENDER-TIME (the "adjusting state when a prop changes" pattern), not in
+    // an effect: an effect — even a synchronous one, even one that skips the old
+    // `queueMicrotask` hop — always lets render N commit with the PREVIOUS table's
+    // state before it can reset anything for render N+1, and a delete clicked in
+    // that committed window reads the previous table's `debouncedShard`. Calling
+    // these setters here makes React discard this render and retry synchronously
+    // with the reset state already applied, so `pageArgs`/`countArgs` and
+    // `debouncedShard` below are correct on the first render that ever commits
+    // after a switch — no write-window where a click can still reach the old
+    // table/shard.
+    //
+    // `selectedTable` is derived from `tableParam`, so there is no separate
+    // reconcile/"select the URL's table" step — opening the URL's table is
+    // implicit. Reads `initialFilters`/`initialOrderBy`/`initialSearch`/
+    // `initialShardKey` DIRECTLY (this render's props), not through a mirrored
+    // ref: unlike the effect this replaces, this block is gated by a plain
+    // condition re-evaluated every render (`tableParam !== seededTableParameter`)
+    // rather than an effect dependency array, so it can only ever fire on a real
+    // `tableParam` change. The URL-mirror round trip from the user's OWN typing
+    // (which changes `initialSearch` etc. without changing `tableParam`) can't
+    // retrigger it, so there is no staleness hazard here to route around with a
+    // ref the way the mirror effect below still has to.
+    if (isTableSwitch) {
+        setSeededTableParameter(tableParam);
+        setSorting(fromOrderBy(initialOrderBy));
+        setFilter(initialSearch ?? "");
+
+        const nextFilters = toEditableFilters(initialFilters ?? []);
+
+        setFilters(nextFilters);
+        filtersRef.current = nextFilters;
+        // Re-seed the shard from the new URL too, so a switch that also changes
+        // shard (a saved query / cross-shard deep link) points reads AND writes
+        // at the URL's shard instead of leaving the previous table's shard live.
+        setShardKey(initialShardKey ?? "");
+        clearFacets();
+        stagedEdits.clear();
+        setEditingCell(null);
+        setOffset(0);
+    }
+
+    // The raw input each debounced mirror below reflects for THIS render: on a
+    // table switch, the new table's URL values directly — the `filter`/`shardKey`
+    // STATE above only catches up once React retries this render, and feeding
+    // `useDebounced` the stale state on THIS pass would bake the stale value into
+    // its own internal (persistent) `debounced` state via its `resetKey` snap (see
+    // `useDebounced`'s doc comment). Otherwise, the live state as usual.
+    const filterInput = isTableSwitch ? (initialSearch ?? "") : filter;
+    const shardInput = isTableSwitch ? (initialShardKey ?? "") : shardKey;
+
+    // Search box value, debounced into a server-side `search` (filters across the
+    // WHOLE table, not just the loaded page), which re-fetches from offset 0.
+    //
+    // The shard the reads target, debounced so typing a key settles before
+    // refetching the table list + page rather than firing per keystroke. Page-bound
+    // actions (preview, facet fetch, row write/delete, bulk delete) target this same
+    // settled shard so a write can never hit a different shard than the one whose
+    // rows are on screen during the debounce window. The live `shardKey` is only the
+    // input value + the share-link descriptor.
+    //
+    // Both key their `resetKey` on `tableParam`: a table switch snaps them straight
+    // to the new table's values (via `filterInput`/`shardInput` above) with NO
+    // trailing debounce window, instead of continuing to serve the previous
+    // table's search predicate / shard for up to 300–400ms after the switch.
+    const search = useDebounced(filterInput.trim(), 300, tableParam);
+    const debouncedShard = useDebounced(shardInput.trim(), 400, tableParam);
 
     // ── Reads via TanStack Query: a one-shot fetch plus a live WS push into the
     // cache (the same model as every other studio panel). The table list follows
@@ -518,24 +588,19 @@ const useDataBrowser = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps -- same reason: `useMirroredRef` handles are stable, and listing them would say this effect depends on identities it deliberately does not
     }, [debouncedShard, selectedTable, filters, search]);
 
-    // Tracks the table the local view has been (re-)seeded for. Declared before the
-    // mirror effect below so that effect can tell whether the view it's about to
-    // mirror belongs to the current `tableParam` yet. Seeded with the mount
-    // `tableParam` so the first run is a no-op (the `useState` initializers already
-    // hydrated from the URL); the re-seed effect advances it on each table change.
-    const seededTableRef = useRef(tableParam);
-
     // Mirror the active view (shard / search / filters / sort) to the host so it can
     // write it into the URL — making every view a real, shareable link. The shard /
     // search are debounced, so it tracks the displayed view; the table itself is
     // mirrored separately by `onSelectTable`.
     useEffect(() => {
         // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- the URL is a projection of the active view (a value, not a discrete event); mirroring it when the view changes is the correct pattern.
-        if (selectedTable === null || onViewChangeRef.current === undefined || seededTableRef.current !== tableParam) {
-            // On a `tableParam` change this effect runs (via `selectedTable`) BEFORE
-            // the re-seed effect below has cleared the previous table's
-            // filters/sort/search. Skipping until the re-seed for this table has run
-            // stops us writing the stale view back into the clean / FK-nav URL.
+        if (selectedTable === null || onViewChangeRef.current === undefined || seededTableParameter !== tableParam) {
+            // The render-time reset above keeps `seededTableParameter` in lockstep with
+            // `tableParam` on every COMMITTED render, so this branch is a defensive
+            // invariant rather than a live gate now (there's no longer a committed
+            // render where a switch has landed but the reset hasn't) — kept so a
+            // future change to the reset can't silently reintroduce the stale-URL-
+            // write hazard the two-effect version had to route around.
             return;
         }
 
@@ -548,56 +613,7 @@ const useDataBrowser = ({
         // Fire on the displayed view; `onViewChange` is read via `onViewChangeRef` (see above).
         // react-doctor-disable-next-line react-doctor/exhaustive-deps -- the ref is a `useMirroredRef` handle — stable by construction; depending on `onViewChange` itself is what caused the navigate loop this pattern exists to avoid
         // eslint-disable-next-line react-hooks/exhaustive-deps -- same reason: the ref handle is stable, and depending on `onViewChange` is exactly the loop this avoids
-    }, [selectedTable, tableParam, filters, sorting, search, debouncedShard]);
-
-    // The URL's view params, mirrored to refs so the re-seed effect can read the
-    // CURRENT values while depending on `tableParam` alone (depending on the params
-    // themselves would re-seed — wiping a half-typed filter — every time the user's
-    // own edit mirrors back to the URL).
-    const initialFiltersRef = useMirroredRef(initialFilters);
-    const initialOrderByRef = useMirroredRef(initialOrderBy);
-    const initialSearchRef = useMirroredRef(initialSearch);
-    const initialShardKeyRef = useMirroredRef(initialShardKey);
-
-    // Re-seed the per-table local view state whenever the open table changes — an
-    // in-app switch, an FK-nav, a deep link, or browser back/forward. The new
-    // values come from the new URL (empty on a plain switch, the id on an FK-nav,
-    // the saved view on a deep link), so the table and its view never disagree.
-    // Skipped on first mount (the `useState` initializers already hydrated from the
-    // URL); `seededTableRef` (declared above, seeded with the mount `tableParam`)
-    // makes the first run a no-op.
-    //
-    // `selectedTable` is derived from `tableParam`, so there is no separate
-    // reconcile/"select the URL's table" step — opening the URL's table is implicit.
-    useEffect(() => {
-        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- URL → view sync: when the open table (a URL value, not a user event) changes, re-seed the per-table view from the new URL. It can't be a render-time computation: `filter` is debounced input state and the resets span several `useState`s + the facet/staged hooks.
-        if (seededTableRef.current === tableParam) {
-            return;
-        }
-
-        seededTableRef.current = tableParam;
-
-        // Defer out of the effect's synchronous run (the resets touch several state
-        // setters across hooks) — matching the prior reconcile pattern.
-        queueMicrotask(() => {
-            const nextFilters = toEditableFilters(initialFiltersRef.current ?? []);
-
-            setSorting(fromOrderBy(initialOrderByRef.current));
-            setFilter(initialSearchRef.current ?? "");
-            setFilters(nextFilters);
-            filtersRef.current = nextFilters;
-            // Re-seed the shard from the new URL too, so a switch that also changes
-            // shard (a saved query / cross-shard deep link) points reads AND writes
-            // at the URL's shard instead of leaving the previous table's shard live.
-            setShardKey(initialShardKeyRef.current ?? "");
-            clearFacets();
-            stagedEdits.clear();
-            setEditingCell(null);
-            setOffset(0);
-        });
-        // Fire only on a real `tableParam` change; the URL params are read via refs above.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tableParam]);
+    }, [selectedTable, tableParam, seededTableParameter, filters, sorting, search, debouncedShard]);
 
     const goToPage = (nextOffset: number): void => {
         if (selectedTable === null) {

--- a/packages/studio/src/features/data/hooks/use-data-browser.tsx
+++ b/packages/studio/src/features/data/hooks/use-data-browser.tsx
@@ -264,6 +264,13 @@ const resolveStagedChanges = (page: TablePage | null, staged: StagedEditsModel["
 /** Whether a column is editable in place — every column but the meta ones. */
 const editableColumn = (column: string): boolean => !META_COLUMNS.has(column);
 
+/**
+ * Why `drainBulk` stopped: `"completed"` when the server reported no more
+ * matching rows; `"cap-hit"` when the client's own `MAX_BULK_DELETE_BATCHES`
+ * loop ran out first — matching rows may still remain.
+ */
+type BulkDrainOutcome = "cap-hit" | "completed";
+
 const useDataBrowser = ({
     initialFilters,
     initialOrderBy,
@@ -716,27 +723,46 @@ const useDataBrowser = ({
     // call; the loop is bounded by `MAX_BULK_DELETE_BATCHES` so it can never run
     // unbounded. Sequential by design: each call's deletes shrink the set the
     // next read sees, so the round-trips can't be parallelised.
-    const drainBulk = async (ref: typeof DELETE_ROWS, args: Record<string, unknown>): Promise<void> => {
+    //
+    // Running out of batches before the server reports `hasMore: false` means
+    // rows still match the predicate — the loop just stopped asking. Falling
+    // through to the same `setOffset(0); pageQuery.refetch();` as a clean finish
+    // would look like success (the visible page empties or shrinks along with
+    // whatever DID get deleted) while leaving the operator with no signal that
+    // more rows are still out there, so this reports the outcome and surfaces a
+    // truncation notice on `writeError` instead of staying silent.
+    const drainBulk = async (ref: typeof DELETE_ROWS, args: Record<string, unknown>): Promise<BulkDrainOutcome | undefined> => {
         if (selectedTable === null) {
-            return;
+            return undefined;
         }
 
         setWriteError(null);
 
         try {
+            let outcome: BulkDrainOutcome = "cap-hit";
+
             for (let batch = 0; batch < MAX_BULK_DELETE_BATCHES; batch += 1) {
                 // eslint-disable-next-line no-await-in-loop -- batches are inherently sequential (each call reflects the prior batch's deletes)
                 const result = (await client.query(ref, args, callOptions(debouncedShard))) as BulkDeleteResult;
 
                 if (!result.hasMore) {
+                    outcome = "completed";
                     break;
                 }
             }
 
             setOffset(0);
             pageQuery.refetch();
+
+            if (outcome === "cap-hit") {
+                setWriteError(`Stopped after ${MAX_BULK_DELETE_BATCHES.toString()} batches — rows still match this delete. Run it again to remove the rest.`);
+            }
+
+            return outcome;
         } catch (error) {
             setWriteError((error as Error).message);
+
+            return undefined;
         }
     };
 

--- a/packages/studio/src/features/sql/hooks/use-sql-editor-tabs.tsx
+++ b/packages/studio/src/features/sql/hooks/use-sql-editor-tabs.tsx
@@ -27,10 +27,18 @@ interface TabOutput {
     readonly failed?: { error: string; sql: string };
     readonly pane: ResultTab;
     readonly result: null | SqlConsoleResult;
+
+    /**
+     * Whether THIS tab has a query in flight. Per-tab (not panel-wide) for the
+     * same reason as `failed`/`chart`: a slow query in tab A must not disable or
+     * spin tab B's Run button, and A's own spinner must clear when A's query
+     * lands — not whenever the panel's active tab happens to change.
+     */
+    readonly running: boolean;
 }
 
 /** A tab's output before it has run anything. */
-const DEFAULT_TAB_OUTPUT: TabOutput = { error: null, pane: "results", result: null };
+const DEFAULT_TAB_OUTPUT: TabOutput = { error: null, pane: "results", result: null, running: false };
 
 /** The right-clicked tab's context menu: the target tab id + cursor position. */
 interface TabMenu {

--- a/packages/studio/src/features/sql/sql-editor-panel.tsx
+++ b/packages/studio/src/features/sql/sql-editor-panel.tsx
@@ -61,11 +61,10 @@ export const SqlEditorPanel = ({ initialShardKey }: SqlEditorPanelProps): ReactE
     const { recordHistory, updateQuerySql } = library;
     const draft = activeTab.sql;
     const { activeId } = activeTab;
-    const { chart: inferredChart, error, failed: failedRun, result } = output;
+    const { chart: inferredChart, error, failed: failedRun, result, running } = output;
     const tab = output.pane;
 
     const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
-    const [running, setRunning] = useState<boolean>(false);
     // Editor↔results layout: stacked (default) or side-by-side, persisted across reloads.
     const [splitView, setSplitView] = usePersistedValue<boolean>(SPLIT_VIEW_KEY, false);
 
@@ -107,23 +106,34 @@ export const SqlEditorPanel = ({ initialShardKey }: SqlEditorPanelProps): ReactE
             return;
         }
 
-        setRunning(true);
+        // `patchActiveOutput` closes over the tab that's active AT THIS CALL —
+        // the same closure used below to land the result, even if the operator
+        // switches to a different tab while this query is in flight. That's what
+        // keeps `running` (and the result it guards) scoped to the tab that
+        // actually ran the query, not whichever tab happens to be active when the
+        // response lands.
+        patchActiveOutput({ running: true });
         const sql = mode === "explain" ? `EXPLAIN QUERY PLAN ${draft}` : draft;
 
         try {
             const next = (await client.query(RUN_SQL, { sql }, callOptions(shardKey))) as SqlConsoleResult;
 
-            patchActiveOutput({ chart: undefined, error: null, failed: undefined, pane: mode, result: next });
+            patchActiveOutput({ chart: undefined, error: null, failed: undefined, pane: mode, result: next, running: false });
             recordShard(shardKey);
             recordHistory(sql);
         } catch (error_: unknown) {
             // Capture the statement that actually failed. "Fix this" previously
             // read the live draft, so any edit after the failure asked the model
             // to repair text that never ran, against an error it never produced.
-            patchActiveOutput({ chart: undefined, error: errorMessage(error_), failed: { error: errorMessage(error_), sql }, pane: mode, result: null });
+            patchActiveOutput({
+                chart: undefined,
+                error: errorMessage(error_),
+                failed: { error: errorMessage(error_), sql },
+                pane: mode,
+                result: null,
+                running: false,
+            });
         }
-
-        setRunning(false);
     };
 
     const onRun = (): void => {

--- a/packages/studio/src/hooks/use-debounced.ts
+++ b/packages/studio/src/hooks/use-debounced.ts
@@ -4,9 +4,29 @@ import { useEffect, useState } from "react";
  * Debounced mirror of `value`: returns the latest value only after it has been
  * stable for `delayMs`. Used so a per-keystroke search box drives at most one
  * server round-trip per pause, instead of one request per character.
+ *
+ * `resetKey` is an optional escape hatch from the trailing delay: when it
+ * changes relative to the PREVIOUS call, the mirror snaps to `value`
+ * immediately — no `delayMs` window at all. It exists for callers that key a
+ * debounced input (a search box, a shard key) to a coarser identity (e.g. the
+ * open table): on that identity's change the caller usually re-seeds `value`
+ * itself in the same render, and without `resetKey` the debounced mirror would
+ * still trail the OLD value behind its own timer for up to `delayMs`, ignoring
+ * the reseed. The snap happens render-time (the "adjusting state when a prop
+ * changes" pattern): calling the setters below makes React discard this render
+ * and retry synchronously with the caught-up state, so the returned value is
+ * already correct on the render that reads it — no extra commit, no trailing
+ * window. Omit `resetKey` (the default) to keep the original always-debounced
+ * behavior; every other caller in the codebase does this.
  */
-const useDebounced = function <T>(value: T, delayMs = 300): T {
+const useDebounced = function <T>(value: T, delayMs = 300, resetKey?: unknown): T {
     const [debounced, setDebounced] = useState<T>(value);
+    const [seededResetKey, setSeededResetKey] = useState<unknown>(resetKey);
+
+    if (resetKey !== undefined && resetKey !== seededResetKey) {
+        setSeededResetKey(resetKey);
+        setDebounced(value);
+    }
 
     useEffect(() => {
         const id = setTimeout(() => {


### PR DESCRIPTION
Three Studio admin-surface bugs. (STUDIO-01) switching tables deferred the view reset into queueMicrotask AND read through 300/400ms debounced mirrors with no leading edge, so the first reads after a switch carried the previous table's search/filters/shard — and on a shard-changing switch, a delete clicked in that window targeted the OLD shard (the code's own invariant comment said this can't happen). Now a synchronous render-time reset + a resettable debounce. (STUDIO-02) 'Delete N matching' stopped after 200 batches and fell through to a success-looking refetch → now surfaces a truncation notice. (STUDIO-11) the SQL editor's `running` flag was panel-level while output is per-tab, so a slow query in tab A spun tab B's Run button → moved to per-tab `TabOutput`.

Verified: studio 965/965, lint:types + lint:eslint clean. The STUDIO-01 test exercises the shard-changing switch (a delete after the switch targets the new shard).

⚠ Merge-order vs plan 228/230/231 (also touch studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)