### PR TITLE
fix(client): six lifecycle bugs — cross-tab overlay leak, pong watchdog, offline-queue cap, complete-frame, RN/SSR guards

### DIFF
--- a/api-snapshots/client.api.md
+++ b/api-snapshots/client.api.md
@@ -1354,7 +1354,7 @@ class TabCoordinator {
     get isRunning(): boolean;
     broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string): void;
     broadcastSubscriptionError(key: string, error: SubscriptionError): void;
-    broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string): void;
+    broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number): void;
 }
 ```
 

--- a/api-snapshots/client.api.md
+++ b/api-snapshots/client.api.md
@@ -1352,8 +1352,9 @@ class TabCoordinator {
     get leaderTabId(): string | undefined;
     get id(): string;
     get isRunning(): boolean;
-    broadcastSubscriptionData(key: string, data: unknown): void;
+    broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string): void;
     broadcastSubscriptionError(key: string, error: SubscriptionError): void;
+    broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string): void;
 }
 ```
 

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TabCoordinator } from "../src/cross-tab";
+import { LunoraClient } from "../src/lunora-client";
+import { SubscriptionRegistry } from "../src/subscription";
+import type { FunctionReference } from "../src/types";
 
 /** Wire shape mirrored from `cross-tab.ts`'s internal message union, for raw test-side sends. */
 type RawMessage = { tabId: string; ts: number; type: "claim-leadership" | "heartbeat" };
+
+/** Wire shape of a leader's `subscription-data` / `subscription-settled` broadcast, for raw test-side sends simulating a leader tab. */
+type RawLeaderMessage =
+    | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
+    | { cursor?: number; epoch?: string; key: string; tabId: string; type: "subscription-settled" };
+
+const fnRef = (ref: string): FunctionReference => {
+    return { __lunoraRef: ref };
+};
+
+const jsonResponse = (body: unknown): Response => Response.json(body, { headers: { "content-type": "application/json" }, status: 200 });
 
 // Real `TabCoordinator` ids always start with `"tab_"` (see `cross-tab.ts`). These
 // fabricated ids are chosen to sort deterministically on either side of that
@@ -150,6 +164,160 @@ describe("tabCoordinator — leader demotion / health (CLIENT-02)", () => {
         } finally {
             rogue.close();
             coordinator.stop();
+        }
+    });
+});
+
+describe("tabCoordinator — subscription-data/subscription-settled wire frames (CLIENT-01)", () => {
+    it("broadcastSubscriptionData/broadcastSubscriptionSettled carry cursor/epoch on the wire when supplied, and omit them when not", async () => {
+        expect.assertions(4);
+
+        const channelName = `test-cross-tab-${crypto.randomUUID()}`;
+        const coordinator = new TabCoordinator({ channelName, heartbeatInterval: HEARTBEAT_INTERVAL_MS, leaderTimeout: LEADER_TIMEOUT_MS });
+        const rogue = new BroadcastChannel(channelName);
+        const received: RawLeaderMessage[] = [];
+
+        rogue.addEventListener("message", (event: MessageEvent<RawLeaderMessage>): void => {
+            received.push(event.data);
+        });
+
+        try {
+            coordinator.start();
+
+            // Solo boot: self-promotes to leader once the leader-timeout window
+            // elapses (mirrors the other tests in this file).
+            await delay(LEADER_TIMEOUT_MS + 20);
+
+            coordinator.broadcastSubscriptionData("q:1::{}::", { hello: "world" }, 10, "epoch-1");
+            coordinator.broadcastSubscriptionSettled("q:1::{}::", 12, "epoch-2");
+            // No cursor/epoch supplied — a CDC-off shard, or a leader relaying a
+            // frame it never got a cursor for.
+            coordinator.broadcastSubscriptionData("q:2::{}::", 1);
+
+            await delay(20);
+
+            const dataFrame = received.find((m) => m.type === "subscription-data" && m.key === "q:1::{}::");
+            const settledFrame = received.find((m) => m.type === "subscription-settled");
+            const bareFrame = received.find((m) => m.type === "subscription-data" && m.key === "q:2::{}::");
+
+            expect(dataFrame).toMatchObject({ cursor: 10, epoch: "epoch-1" });
+            expect(settledFrame).toMatchObject({ cursor: 12, epoch: "epoch-2" });
+            // Omitted cursor/epoch aren't sent as `undefined` properties on the
+            // wire — a stale receiver checking `"cursor" in message` (rather than
+            // `!== undefined`) must see it absent, not present-but-undefined.
+            expect(bareFrame).toBeDefined();
+            expect(bareFrame && "cursor" in bareFrame).toBe(false);
+        } finally {
+            rogue.close();
+            coordinator.stop();
+        }
+    });
+});
+
+describe("lunoraClient — cross-tab follower drops confirmed optimistic layers (CLIENT-01)", () => {
+    it("a follower drops a per-call optimistic layer once a leader-broadcast cursor reaches its commit cursor", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const received: unknown[] = [];
+
+            client.subscribe(fnRef("counter:get"), {}, (value) => received.push(value));
+
+            // Per-call optimistic write. The RPC response echoes commitCursor 10;
+            // this (non-leader, cross-tab) client's socket never opens — see
+            // `ensureSocket`'s cross-tab leader gate — so the layer stays pending
+            // until a leader frame confirms it.
+            await client.mutation(fnRef("counter:get"), {}, { optimistic: (current) => (typeof current === "number" ? current + 1 : 1) });
+
+            expect(received.at(-1)).toBe(1);
+
+            // The leader tab broadcasts a `subscription-data` frame whose cursor
+            // has reached the write's commit cursor.
+            const key = SubscriptionRegistry.key("counter:get", {});
+
+            rogue.postMessage({ cursor: 10, data: 11, key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+
+            await delay(30);
+
+            // The overlay is dropped; the leader's authoritative value shows —
+            // not 12 (which a still-applied +1 layer would fold on top of 11).
+            expect(received.at(-1)).toBe(11);
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("a follower's setQuery overlay is released once a leader-broadcast cursor reaches its commit cursor", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const received: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, (value) => received.push(value));
+
+            await client.mutation(fnRef("m:set"), {}, {
+                optimisticUpdate: (store) => {
+                    store.setQuery(fnRef("q:list"), {}, 42);
+                },
+            });
+
+            // The constant `setQuery` layer masks the (still-unknown) server value.
+            expect(received.at(-1)).toBe(42);
+
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            rogue.postMessage({ cursor: 10, data: 99, key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+
+            await delay(30);
+
+            // The overlay is released; the leader's authoritative value shows.
+            expect(received.at(-1)).toBe(99);
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("a cursor-less subscription-data frame (mixed-version leader) keeps the historical fold-without-drop behavior", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const received: unknown[] = [];
+
+            client.subscribe(fnRef("counter:get"), {}, (value) => received.push(value));
+
+            await client.mutation(fnRef("counter:get"), {}, { optimistic: (current) => (typeof current === "number" ? current + 1 : 1) });
+
+            expect(received.at(-1)).toBe(1);
+
+            // A mixed-version leader (no CLIENT-01 cursor on the wire) — the layer
+            // stays folded on top instead of being dropped.
+            const key = SubscriptionRegistry.key("counter:get", {});
+
+            rogue.postMessage({ data: 5, key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+
+            await delay(30);
+
+            // 5 (new base) folded through the still-active +1 layer = 6, not the
+            // raw leader value — the historical no-cursor behavior, preserved for
+            // backward compat with a mixed-version deploy.
+            expect(received.at(-1)).toBe(6);
+        } finally {
+            rogue.close();
+            client.close();
         }
     });
 });

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -11,7 +11,7 @@ type RawMessage = { tabId: string; ts: number; type: "claim-leadership" | "heart
 /** Wire shape of a leader's `subscription-data` / `subscription-settled` broadcast, for raw test-side sends simulating a leader tab. */
 type RawLeaderMessage =
     | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
-    | { cursor?: number; epoch?: string; key: string; tabId: string; type: "subscription-settled" };
+    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" };
 
 const fnRef = (ref: string): FunctionReference => {
     return { __lunoraRef: ref };
@@ -212,6 +212,42 @@ describe("tabCoordinator — subscription-data/subscription-settled wire frames 
             coordinator.stop();
         }
     });
+
+    it("broadcastSubscriptionSettled carries lastMutationId on the wire when supplied, and omits it when not", async () => {
+        expect.assertions(2);
+
+        const channelName = `test-cross-tab-${crypto.randomUUID()}`;
+        const coordinator = new TabCoordinator({ channelName, heartbeatInterval: HEARTBEAT_INTERVAL_MS, leaderTimeout: LEADER_TIMEOUT_MS });
+        const rogue = new BroadcastChannel(channelName);
+        const received: RawLeaderMessage[] = [];
+
+        rogue.addEventListener("message", (event: MessageEvent<RawLeaderMessage>): void => {
+            received.push(event.data);
+        });
+
+        try {
+            coordinator.start();
+            await delay(LEADER_TIMEOUT_MS + 20);
+
+            // A custom-mutator watermark rides along so a follower's `@lunora/db`
+            // `onCheckpoint` gate can advance too, not just cursor/epoch.
+            coordinator.broadcastSubscriptionSettled("q:1::{}::", 12, "epoch-2", 7);
+            // No `lastMutationId` supplied — a plain `useQuery` subscription with
+            // no custom-mutator watermark to forward.
+            coordinator.broadcastSubscriptionSettled("q:2::{}::", 1);
+
+            await delay(20);
+
+            const withId = received.find((m) => m.type === "subscription-settled" && m.key === "q:1::{}::");
+            const withoutId = received.find((m) => m.type === "subscription-settled" && m.key === "q:2::{}::");
+
+            expect(withId).toMatchObject({ lastMutationId: 7 });
+            expect(withoutId && "lastMutationId" in withoutId).toBe(false);
+        } finally {
+            rogue.close();
+            coordinator.stop();
+        }
+    });
 });
 
 describe("lunoraClient — cross-tab follower drops confirmed optimistic layers (CLIENT-01)", () => {
@@ -264,11 +300,15 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
 
             client.subscribe(fnRef("q:list"), {}, (value) => received.push(value));
 
-            await client.mutation(fnRef("m:set"), {}, {
-                optimisticUpdate: (store) => {
-                    store.setQuery(fnRef("q:list"), {}, 42);
+            await client.mutation(
+                fnRef("m:set"),
+                {},
+                {
+                    optimisticUpdate: (store) => {
+                        store.setQuery(fnRef("q:list"), {}, 42);
+                    },
                 },
-            });
+            );
 
             // The constant `setQuery` layer masks the (still-unknown) server value.
             expect(received.at(-1)).toBe(42);
@@ -315,6 +355,42 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
             // raw leader value — the historical no-cursor behavior, preserved for
             // backward compat with a mixed-version deploy.
             expect(received.at(-1)).toBe(6);
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("a follower's onCheckpoint fires with the leader-broadcast lastMutationId on a subscription-settled frame", async () => {
+        expect.assertions(1);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const checkpoints: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, () => undefined, { onCheckpoint: (watermark) => checkpoints.push(watermark) });
+
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            // The leader relays a `settled` frame (no value change, cursor advanced)
+            // carrying the custom-mutator watermark it already applied — without
+            // forwarding `lastMutationId`, a follower's `@lunora/db` `onCheckpoint`
+            // gate would never see this confirmed write and would hang.
+            rogue.postMessage({
+                cursor: 10,
+                epoch: "epoch-1",
+                key,
+                lastMutationId: 7,
+                tabId: "leader-tab",
+                type: "subscription-settled",
+            } satisfies RawLeaderMessage);
+
+            await delay(30);
+
+            expect(checkpoints).toStrictEqual([{ checkpoint: 10, mutationId: 7 }]);
         } finally {
             rogue.close();
             client.close();

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -782,6 +782,80 @@ describe("lunoraClient", () => {
             client.close();
         });
 
+        it("force-closes a half-open socket once no frame has arrived for heartbeatIntervalMs * 2.5, and arms reconnect (CLIENT-02)", () => {
+            expect.assertions(4);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({
+                fetch: vi.fn<typeof fetch>(),
+                heartbeatIntervalMs: 1000,
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            client.subscribe(fnRef("messages:list"), {}, () => undefined);
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            expect(client.connectionStatus()).toBe("connected");
+
+            // Two heartbeat ticks pass with no reply at all (not even a pong) —
+            // still under the 2.5x window (2500ms), so the socket stays open and
+            // a ping keeps going out each tick.
+            vi.advanceTimersByTime(2000);
+
+            expect(socket.readyState).toBe(1);
+
+            // The third tick crosses `heartbeatIntervalMs * 2.5`: the far end has
+            // gone quiet without the socket ever firing `close` (a half-open
+            // socket — a swallowed RST, a stuck proxy) — the watchdog force-closes
+            // it instead of leaving it reporting "open" forever while every live
+            // query on it silently stales, and the normal reconnect/backoff arms.
+            vi.advanceTimersByTime(1000);
+
+            expect(socket.readyState).toBe(3);
+            expect(client.connectionStatus()).toBe("offline");
+
+            client.close();
+        });
+
+        it("a socket that keeps receiving ANY frame (even the non-JSON lunora-pong) is never force-closed by the watchdog (CLIENT-02)", () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({
+                fetch: vi.fn<typeof fetch>(),
+                heartbeatIntervalMs: 1000,
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            client.subscribe(fnRef("messages:list"), {}, () => undefined);
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            // The server answers every ping with `lunora-pong` — a plain,
+            // non-JSON string the `handleServerMessage` JSON.parse guard drops —
+            // but it must still reset the watchdog (it proves the socket is
+            // alive). Five ticks span 5000ms, well past the 2500ms window, so a
+            // watchdog that ignored the pong would have force-closed by now.
+            for (let tick = 0; tick < 5; tick += 1) {
+                vi.advanceTimersByTime(1000);
+                socket.receive("lunora-pong");
+            }
+
+            expect(socket.readyState).toBe(1);
+            expect(client.connectionStatus()).toBe("connected");
+
+            client.close();
+        });
+
         it("does not send keepalive pings when the heartbeat is disabled", () => {
             expect.assertions(1);
 

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -1091,6 +1091,57 @@ describe("lunoraClient", () => {
             expect(errors).toEqual([{ code: "ADMIN_FORBIDDEN", message: "admin gate not cleared" }]);
         });
 
+        it("a complete frame for a live subscription surfaces SUBSCRIPTION_CANCELLED and re-subscribes on the next reconnect instead of freezing (CLIENT-04)", () => {
+            expect.assertions(4);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({
+                fetch: vi.fn<typeof fetch>(),
+                reconnect: { initialDelayMs: 10, jitter: false, maxDelayMs: 10 },
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const errors: { code?: string; message: string }[] = [];
+            const data: unknown[] = [];
+
+            client.subscribe(fnRef("messages:list"), {}, (d) => data.push(d), { onError: (error) => errors.push(error) });
+
+            const first = latestSocket();
+
+            first.open();
+
+            const subId = firstSub(first).id as string;
+
+            // A subscription-scoped `complete` frame — today's server only sends
+            // `complete` for stream ids (see the source comment on
+            // `handleCompleteMessage`), but this pins the defensive behavior for
+            // a `sub_*` id in case a future/subclassed `ShardDO` ever cancels a
+            // subscription this way. The historical behavior removed the state
+            // from the registry entirely, so it never resubscribed on ANY future
+            // reconnect and the query froze forever.
+            first.receive({ id: subId, type: "complete" });
+
+            expect(errors).toEqual([{ code: "SUBSCRIPTION_CANCELLED", message: "subscription was cancelled by the server" }]);
+
+            // The socket drops and reconnects.
+            first.triggerClose();
+            vi.advanceTimersByTime(15);
+
+            const second = latestSocket();
+
+            second.open();
+
+            // Non-destructive: the subscription is still registered and gets
+            // re-sent on the fresh socket instead of having silently vanished.
+            expect(second).not.toBe(first);
+            expect(firstSub(second)?.query?.functionPath).toBe("messages:list");
+            expect(data).toHaveLength(0);
+
+            vi.useRealTimers();
+        });
+
         it("re-sends an admin subscription with its token on reconnect", () => {
             expect.assertions(3);
 

--- a/packages/client/__tests__/offline-queue.test.ts
+++ b/packages/client/__tests__/offline-queue.test.ts
@@ -244,6 +244,72 @@ describe("offlineQueue — persistence", () => {
         expect(drained.map((d) => d.functionPath)).toEqual(["old-session-write", "boot-time-write"]);
     });
 
+    it("hydrate respects maxItems — evicts the oldest restored entries down to the cap (CLIENT-03)", async () => {
+        expect.assertions(4);
+
+        const persistence = createInMemoryPersistence();
+
+        // Persist maxItems(3) + 5 = 8 records, oldest ("m0") first.
+        for (let index = 0; index < 8; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- deterministic FIFO persist order across records is the point of this fixture
+            await persistence.append({ args: {}, functionPath: `m${String(index)}`, id: `id-${String(index)}` });
+        }
+
+        const onEvict = vi.fn<(entry: { functionPath: string }, error: Error & { code?: string }) => void>();
+        const queue = new OfflineQueue({ maxItems: 3 }, { onEvict, persistence });
+
+        await queue.hydrate();
+
+        // The in-memory queue never exceeds maxItems, regardless of how many
+        // records the durable store held.
+        expect(queue.size).toBe(3);
+
+        // The evicted ones are the OLDEST (m0..m4) — FIFO order preserved, the
+        // newest 3 (m5, m6, m7) survive.
+        const drained = queue.drain();
+
+        expect(drained.map((d) => d.functionPath)).toEqual(["m5", "m6", "m7"]);
+
+        // Each eviction fired onEvict with OFFLINE_QUEUE_OVERFLOW, oldest-first.
+        expect(onEvict).toHaveBeenCalledTimes(5);
+        expect(onEvict.mock.calls.map((call) => call[0].functionPath)).toEqual(["m0", "m1", "m2", "m3", "m4"]);
+    });
+
+    it("hydrate overflow un-persists the evicted entries, and a subsequent enqueue overflows exactly once more (CLIENT-03)", async () => {
+        expect.assertions(4);
+
+        const persistence = createInMemoryPersistence();
+
+        for (let index = 0; index < 5; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- deterministic FIFO persist order across records is the point of this fixture
+            await persistence.append({ args: {}, functionPath: `m${String(index)}`, id: `id-${String(index)}` });
+        }
+
+        const queue = new OfflineQueue({ maxItems: 2 }, { persistence });
+
+        await queue.hydrate();
+
+        expect(queue.size).toBe(2);
+
+        // The 3 evicted records (m0, m1, m2) are gone from durable storage too —
+        // only the surviving pair remains.
+        const persisted = await persistence.load();
+
+        expect(persisted.map((m) => m.functionPath).toSorted((a, b) => a.localeCompare(b))).toEqual(["m3", "m4"]);
+
+        // A single live enqueue past the (already-at-cap) queue evicts exactly
+        // one MORE entry (the oldest surviving one, "m3") — the cap holds going
+        // forward, no double-counting or leftover slack from the hydrate-time
+        // trim, and no spurious extra eviction beyond the one this enqueue causes.
+        queue.enqueue({ args: {}, functionPath: "new", reject: () => undefined, resolve: () => undefined });
+
+        expect(queue.size).toBe(2);
+
+        const drained = queue.drain();
+
+        expect(drained.map((d) => d.functionPath)).toEqual(["m4", "new"]);
+    });
+
     it("hydrate re-appends nothing and skips ids already queued", async () => {
         expect.assertions(1);
 

--- a/packages/client/__tests__/offline-queue.test.ts
+++ b/packages/client/__tests__/offline-queue.test.ts
@@ -215,6 +215,30 @@ describe("offlineQueue — persistence", () => {
         expect(drained.map((d) => d.functionPath)).toEqual(["a", "b", "c"]);
     });
 
+    it("hydrate omits the shard key of a restored mutation that eviction dropped", async () => {
+        expect.assertions(2);
+
+        const persistence = createInMemoryPersistence();
+
+        // Two shards, one restored mutation each — "room-1" is the older
+        // (oldest-first) record, so it's the one `evictOverflow` drops once
+        // `maxItems: 1` caps the restored set down to a single surviving entry.
+        await persistence.append({ args: {}, functionPath: "a", id: "1", shardKey: "room-1" });
+        await persistence.append({ args: {}, functionPath: "b", id: "2", shardKey: "room-2" });
+
+        const queue = new OfflineQueue({ maxItems: 1 }, { persistence });
+        const shardKeys = await queue.hydrate();
+
+        // Without a shard key for "room-1" left in the queue, a caller that
+        // called `ensureSocket()` for every returned shard key would open a
+        // socket for a shard with nothing left to flush.
+        expect(shardKeys).toEqual(["room-2"]);
+
+        const drained = queue.drain();
+
+        expect(drained.map((d) => d.functionPath)).toEqual(["b"]);
+    });
+
     it("hydrate splices restored prior-session writes ahead of a mutation enqueued during boot-time hydration (CLIENT-03)", async () => {
         expect.assertions(1);
 

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -64,9 +64,11 @@ interface TabCoordinatorOptions {
      * too — otherwise a `setQuery`/per-call optimistic overlay that a
      * byte-identical write just confirmed stays masked on follower tabs until
      * the next VISIBLE data frame arrives, even though the leader already
-     * dropped it.
+     * dropped it. `lastMutationId` rides along the same way so a follower's
+     * `@lunora/db` `onCheckpoint` gate advances too, instead of waiting on a
+     * confirmed write the leader already acknowledged.
      */
-    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string) => void;
+    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string, lastMutationId?: number) => void;
 }
 
 type WsFollowerMessage =
@@ -75,7 +77,7 @@ type WsFollowerMessage =
 type WsLeaderMessage =
     | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
     | { error: SubscriptionError; key: string; tabId: string; type: "subscription-error" }
-    | { cursor?: number; epoch?: string; key: string; tabId: string; type: "subscription-settled" };
+    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" };
 
 type TabCoordinatorMessage = WsFollowerMessage | WsLeaderMessage;
 
@@ -115,7 +117,7 @@ class TabCoordinator {
     private readonly onStopBeingLeader: (() => void) | undefined;
     private readonly onSubscriptionData: ((key: string, data: unknown, cursor?: number, epoch?: string) => void) | undefined;
     private readonly onSubscriptionError: ((key: string, error: SubscriptionError) => void) | undefined;
-    private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string) => void) | undefined;
+    private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string, lastMutationId?: number) => void) | undefined;
 
     public constructor(options: TabCoordinatorOptions = {}) {
         // A random UUID suffix makes `tabId` globally unique across tabs/realms,
@@ -289,7 +291,7 @@ class TabCoordinator {
      * (no value change, but the resume cursor/epoch moved — see
      * `LunoraClient.handleSettledMessage`). Only the leader should call this.
      */
-    public broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string): void {
+    public broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number): void {
         if (!this.leader) {
             return;
         }
@@ -300,6 +302,7 @@ class TabCoordinator {
             key,
             ...(cursor === undefined ? {} : { cursor }),
             ...(epoch === undefined ? {} : { epoch }),
+            ...(lastMutationId === undefined ? {} : { lastMutationId }),
         });
     }
 
@@ -351,7 +354,7 @@ class TabCoordinator {
                     break;
                 }
 
-                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch);
+                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch, message.lastMutationId);
 
                 break;
             }

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -44,22 +44,38 @@ interface TabCoordinatorOptions {
     onStopBeingLeader?: () => void;
 
     /**
-     * Called when the leader broadcasts subscription data.
+     * Called when the leader broadcasts subscription data. `cursor`/`epoch`
+     * ride along when the leader is CLIENT-01-aware, so the follower can drop
+     * its own confirmed optimistic layers instead of just displaying the raw
+     * value; both are absent on a mixed-version leader that hasn't shipped the
+     * cursor yet (the follower falls back to its historical behavior — see
+     * `lunora-client.ts`'s `onSubscriptionData` wiring).
      */
-    onSubscriptionData?: (key: string, data: unknown) => void;
+    onSubscriptionData?: (key: string, data: unknown, cursor?: number, epoch?: string) => void;
 
     /**
      * Called when the leader broadcasts a subscription error.
      */
     onSubscriptionError?: (key: string, error: SubscriptionError) => void;
+
+    /**
+     * Called when the leader broadcasts a `settled` frame's checkpoint advance
+     * (no value change, but the resume cursor moved). A follower needs this
+     * too — otherwise a `setQuery`/per-call optimistic overlay that a
+     * byte-identical write just confirmed stays masked on follower tabs until
+     * the next VISIBLE data frame arrives, even though the leader already
+     * dropped it.
+     */
+    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string) => void;
 }
 
 type WsFollowerMessage =
     { tabId: string; ts: number; type: "heartbeat" } | { tabId: string; ts: number; type: "claim-leadership" } | { tabId: string; type: "yield-leadership" };
 
 type WsLeaderMessage =
-    | { data: unknown; key: string; tabId: string; type: "subscription-data" }
-    | { error: SubscriptionError; key: string; tabId: string; type: "subscription-error" };
+    | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
+    | { error: SubscriptionError; key: string; tabId: string; type: "subscription-error" }
+    | { cursor?: number; epoch?: string; key: string; tabId: string; type: "subscription-settled" };
 
 type TabCoordinatorMessage = WsFollowerMessage | WsLeaderMessage;
 
@@ -97,8 +113,9 @@ class TabCoordinator {
     /** Callbacks set via constructor options. */
     private readonly onBecomeLeader: (() => void) | undefined;
     private readonly onStopBeingLeader: (() => void) | undefined;
-    private readonly onSubscriptionData: ((key: string, data: unknown) => void) | undefined;
+    private readonly onSubscriptionData: ((key: string, data: unknown, cursor?: number, epoch?: string) => void) | undefined;
     private readonly onSubscriptionError: ((key: string, error: SubscriptionError) => void) | undefined;
+    private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string) => void) | undefined;
 
     public constructor(options: TabCoordinatorOptions = {}) {
         // A random UUID suffix makes `tabId` globally unique across tabs/realms,
@@ -114,6 +131,7 @@ class TabCoordinator {
         this.onStopBeingLeader = options.onStopBeingLeader;
         this.onSubscriptionData = options.onSubscriptionData;
         this.onSubscriptionError = options.onSubscriptionError;
+        this.onSubscriptionSettled = options.onSubscriptionSettled;
 
         // BroadcastChannel is browser-only — no-op in SSR/Node/React Native.
         if (typeof BroadcastChannel === "undefined") {
@@ -234,14 +252,24 @@ class TabCoordinator {
 
     /**
      * Broadcast subscription data to all follower tabs. Only the leader should
-     * call this.
+     * call this. `cursor`/`epoch` are omitted from the wire frame when
+     * `undefined` (e.g. a CDC-off shard) — a follower on ANY version treats a
+     * missing `cursor` as "no confirmed-layer drop this frame", so omitting it
+     * here is equivalent to sending it as `undefined`.
      */
-    public broadcastSubscriptionData(key: string, data: unknown): void {
+    public broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string): void {
         if (!this.leader) {
             return;
         }
 
-        this.broadcast({ type: "subscription-data", tabId: this.tabId, key, data });
+        this.broadcast({
+            type: "subscription-data",
+            tabId: this.tabId,
+            key,
+            data,
+            ...(cursor === undefined ? {} : { cursor }),
+            ...(epoch === undefined ? {} : { epoch }),
+        });
     }
 
     /**
@@ -254,6 +282,25 @@ class TabCoordinator {
         }
 
         this.broadcast({ type: "subscription-error", tabId: this.tabId, key, error });
+    }
+
+    /**
+     * Broadcast a `settled` frame's checkpoint advance to all follower tabs
+     * (no value change, but the resume cursor/epoch moved — see
+     * `LunoraClient.handleSettledMessage`). Only the leader should call this.
+     */
+    public broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string): void {
+        if (!this.leader) {
+            return;
+        }
+
+        this.broadcast({
+            type: "subscription-settled",
+            tabId: this.tabId,
+            key,
+            ...(cursor === undefined ? {} : { cursor }),
+            ...(epoch === undefined ? {} : { epoch }),
+        });
     }
 
     // -----------------------------------------------------------------------
@@ -284,7 +331,7 @@ class TabCoordinator {
                     break; // ignore our own broadcasts
                 }
 
-                this.onSubscriptionData?.(message.key, message.data);
+                this.onSubscriptionData?.(message.key, message.data, message.cursor, message.epoch);
 
                 break;
             }
@@ -295,6 +342,16 @@ class TabCoordinator {
                 }
 
                 this.onSubscriptionError?.(message.key, message.error);
+
+                break;
+            }
+
+            case "subscription-settled": {
+                if (this.leader || message.tabId === this.tabId) {
+                    break;
+                }
+
+                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch);
 
                 break;
             }

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -928,26 +928,51 @@ class LunoraClient {
                         this.connections.delete(key);
                     }
                 },
-                onSubscriptionData: (key, data) => {
+                onSubscriptionData: (key, data, cursor, epoch) => {
                     // A follower tab received the authoritative server value from
                     // the leader. Update serverBase and re-fold any local optimistic
                     // layers so the displayed value reflects both the new base and
                     // the follower's own pending writes.
                     const state = this.subscriptions.get(key);
 
-                    if (state) {
-                        state.serverBase = data;
+                    if (!state) {
+                        return;
+                    }
 
-                        const folded = state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers);
+                    state.serverBase = data;
 
-                        state.lastValue = folded;
+                    // `cursor` rides the broadcast only from a CLIENT-01-aware
+                    // leader tab. When present, advance this follower's own resume
+                    // cursor/epoch and run the SAME confirmed-layer drop + notify
+                    // tail `handleDataMessage` uses on the leader — so a follower's
+                    // optimistic overlay (per-call or `setQuery`) is released the
+                    // moment the confirming frame arrives instead of staying masked
+                    // forever (CLIENT-01). A mixed-version deploy where the leader
+                    // hasn't shipped the cursor yet falls through to the historical
+                    // fold-and-notify-without-drop behavior below — backward
+                    // compatible with a cursor-less wire frame.
+                    if (cursor !== undefined) {
+                        state.serverCursor = cursor;
 
-                        for (const callback of state.callbacks) {
-                            try {
-                                callback(folded);
-                            } catch {
-                                /* user callback threw — ignore */
-                            }
+                        if (epoch !== undefined) {
+                            state.serverEpoch = epoch;
+                        }
+
+                        dropConfirmedLayers(state, cursor);
+                        notifySubscription(state, state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers));
+
+                        return;
+                    }
+
+                    const folded = state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers);
+
+                    state.lastValue = folded;
+
+                    for (const callback of state.callbacks) {
+                        try {
+                            callback(folded);
+                        } catch {
+                            /* user callback threw — ignore */
                         }
                     }
                 },
@@ -962,6 +987,18 @@ class LunoraClient {
                                 /* user callback threw — ignore */
                             }
                         }
+                    }
+                },
+                onSubscriptionSettled: (key, cursor, epoch) => {
+                    // The leader's `settled` checkpoint advanced with no value
+                    // change — reuse the exact same tail the leader itself runs
+                    // (ack + advance cursor/epoch + drop confirmed layers +
+                    // notify) so a follower's `setQuery`/per-call overlay a
+                    // byte-identical write just confirmed gets released here too.
+                    const state = this.subscriptions.get(key);
+
+                    if (state) {
+                        this.ackAndAdvanceCursor(state, cursor, epoch);
                     }
                 },
             });
@@ -4875,7 +4912,7 @@ class LunoraClient {
         if (this.tabCoordinator?.isLeader()) {
             const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
 
-            this.tabCoordinator.broadcastSubscriptionData(key, payload);
+            this.tabCoordinator.broadcastSubscriptionData(key, payload, state.serverCursor, state.serverEpoch);
         }
     }
 
@@ -4926,6 +4963,16 @@ class LunoraClient {
         // checkpoint callback never (un)subscribes to this same state mid-flush.
         for (const onCheckpoint of state.checkpointCallbacks) {
             onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
+        }
+
+        // Cross-tab: propagate the checkpoint advance to follower tabs too, or a
+        // `setQuery`/per-call optimistic overlay this byte-identical write just
+        // confirmed would stay masked on a follower until the next VISIBLE data
+        // frame (see `onSubscriptionSettled` in the constructor).
+        if (this.tabCoordinator?.isLeader()) {
+            const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
+
+            this.tabCoordinator.broadcastSubscriptionSettled(key, state.serverCursor, state.serverEpoch);
         }
     }
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -5124,11 +5124,24 @@ class LunoraClient {
         this.tokenExpiredListeners.emit();
     }
 
+    /**
+     * CLIENT-04: `type: "complete"` today is sent ONLY by `@lunora/do`'s
+     * `handleStream` (see `shard-do.ts`), gated to the `stream` envelope type
+     * and minting only `stream_*` ids — the `subscribe` path never sends it, so
+     * a live SUBSCRIPTION provably never receives `complete` from the current
+     * server. But `ServerCompleteMessage` is a generic `id`-keyed frame and
+     * `ShardDO` is user-subclassable, so this stays defensive rather than
+     * assuming a `sub_*` id can never reach here: unlike the historical
+     * `subscriptions.remove(state)`, which dropped the state out of
+     * `subscriptions.all()` — the set the reconnect resubscribe loop walks
+     * (`ensureSocket`'s `open` handler) — and so froze the query forever across
+     * every future reconnect, this fans a cancellation error to any listener
+     * and marks the registration un-acked instead. Non-destructive: the state
+     * stays in the registry, so the very next reconnect resubscribes it. The
+     * two id-spaces don't overlap (`sub_*` vs `stream_*`), so the stream and
+     * subscription lookups below are mutually exclusive.
+     */
     private handleCompleteMessage(id: string): void {
-        // Streams complete normally — close the iterator. Subscriptions
-        // can also receive `complete` (cancelled server-side); remove them
-        // from the registry. The two id-spaces don't overlap (`sub_*` vs
-        // `stream_*`) so the two lookups are mutually exclusive.
         const stream = this.streams.get(id);
 
         if (stream) {
@@ -5141,7 +5154,8 @@ class LunoraClient {
         const state = this.subscriptions.getById(id);
 
         if (state) {
-            this.subscriptions.remove(state);
+            state.acked = false;
+            fanSubscriptionError(state.errorCallbacks, { code: "SUBSCRIPTION_CANCELLED", message: "subscription was cancelled by the server" });
         }
     }
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -979,27 +979,13 @@ class LunoraClient {
 
                     const folded = state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers);
 
-                    state.lastValue = folded;
-
-                    for (const callback of state.callbacks) {
-                        try {
-                            callback(folded);
-                        } catch {
-                            /* user callback threw — ignore */
-                        }
-                    }
+                    notifySubscription(state, folded);
                 },
                 onSubscriptionError: (key, error) => {
                     const state = this.subscriptions.get(key);
 
                     if (state) {
-                        for (const callback of state.errorCallbacks) {
-                            try {
-                                callback(error);
-                            } catch {
-                                /* user callback threw — ignore */
-                            }
-                        }
+                        fanSubscriptionError(state.errorCallbacks, error);
                     }
                 },
                 onSubscriptionSettled: (key, cursor, epoch) => {

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -988,7 +988,7 @@ class LunoraClient {
                         fanSubscriptionError(state.errorCallbacks, error);
                     }
                 },
-                onSubscriptionSettled: (key, cursor, epoch) => {
+                onSubscriptionSettled: (key, cursor, epoch, lastMutationId) => {
                     // The leader's `settled` checkpoint advanced with no value
                     // change — reuse the exact same tail the leader itself runs
                     // (ack + advance cursor/epoch + drop confirmed layers +
@@ -998,6 +998,19 @@ class LunoraClient {
 
                     if (state) {
                         this.ackAndAdvanceCursor(state, cursor, epoch);
+
+                        if (lastMutationId !== undefined) {
+                            state.lastMutationId = lastMutationId;
+                        }
+
+                        // Fan out to every registered checkpoint subscriber, same
+                        // as the leader's own `handleSettledMessage` tail — a
+                        // `@lunora/db` `onCheckpoint` gate on a follower tab must
+                        // advance too, or it hangs on a confirmed write the leader
+                        // already acknowledged.
+                        for (const onCheckpoint of state.checkpointCallbacks) {
+                            onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
+                        }
                     }
                 },
             });
@@ -4423,6 +4436,15 @@ class LunoraClient {
         });
 
         socket.addEventListener("message", (event: MessageEvent): void => {
+            // Ignore a late message from a socket the connection already moved
+            // past (see `open`/`close`/`error` above) — `handleServerMessage`
+            // looks the connection up by shard key, not by socket identity, so
+            // without this guard a stale socket's frame would stamp the newer
+            // socket's `lastFrameAt` and defeat the heartbeat watchdog.
+            if (conn.socket !== socket) {
+                return;
+            }
+
             this.handleServerMessage(event.data, shardKey);
         });
 
@@ -5009,7 +5031,7 @@ class LunoraClient {
         if (this.tabCoordinator?.isLeader()) {
             const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
 
-            this.tabCoordinator.broadcastSubscriptionSettled(key, state.serverCursor, state.serverEpoch);
+            this.tabCoordinator.broadcastSubscriptionSettled(key, state.serverCursor, state.serverEpoch, state.lastMutationId);
         }
     }
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -377,6 +377,19 @@ interface ShardConnection {
     connectTimer: ReturnType<typeof setTimeout> | undefined;
     /** Active keepalive interval while the socket is open; cleared on disconnect/close. */
     heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+    /**
+     * Wall-clock time (`Date.now()`) of the most recently received frame on
+     * this connection's socket — ANY frame, including the plain-string
+     * `lunora-pong` keepalive reply, which never reaches `handleServerMessage`'s
+     * JSON parsing. Reset on every `open` so a fresh (re)connect starts its
+     * watchdog window clean. The heartbeat tick force-closes a socket that's
+     * gone quiet for more than `heartbeatIntervalMs * 2.5` despite reporting
+     * `wsState === "open"` — a half-open socket (a proxy that swallowed the
+     * close, a hibernation edge case) that would otherwise never fire `close`
+     * and silently stale every live query bound to it forever.
+     */
+    lastFrameAt: number;
     /** Stream-start frames buffered while the socket was (re)connecting. Flushed on `open`. */
     pendingStreams?: ClientMessage[];
     /** Unsubscribes that couldn't be sent while the socket was down, each tagged with its wire type so a shape sub is torn down as `shape_unsubscribe`, never the legacy `unsubscribe`. */
@@ -3951,6 +3964,7 @@ class LunoraClient {
             conn = {
                 connectTimer: undefined,
                 heartbeatTimer: undefined,
+                lastFrameAt: 0,
                 pendingUnsubscribes: [],
                 reconnect: createReconnect(this.reconnectOptions),
                 reconnectTimer: undefined,
@@ -4357,6 +4371,10 @@ class LunoraClient {
             conn.wsState = "open";
             conn.wasEverConnected = true;
             conn.reconnect.reset();
+            // Fresh (re)connect — start the half-open watchdog window clean
+            // rather than carrying over a stale timestamp from before a
+            // disconnect/reconnect cycle (see `ShardConnection.lastFrameAt`).
+            conn.lastFrameAt = Date.now();
             this.emitConnectionStatus();
 
             // Announce the connection (and its app context) before resubscribing,
@@ -4518,7 +4536,12 @@ class LunoraClient {
     }
 
     /**
-     * Begin the keepalive heartbeat on an open connection. Each tick sends a
+     * Begin the keepalive heartbeat on an open connection. Each tick first
+     * checks the half-open watchdog (see {@link ShardConnection.lastFrameAt}):
+     * if no frame at all has arrived within `heartbeatIntervalMs * 2.5`, the far
+     * end has gone quiet without the socket ever firing `close` — force it
+     * closed so `handleDisconnect` arms the normal reconnect/backoff instead of
+     * every live query on it silently staling forever. Otherwise it sends a
      * {@link WS_KEEPALIVE_PING} text frame the server answers from its
      * hibernation auto-response without waking the DO. A no-op when the
      * heartbeat is disabled (an interval of zero or less); idempotent — any
@@ -4537,8 +4560,25 @@ class LunoraClient {
                 return;
             }
 
+            const { socket } = conn;
+
+            if (Date.now() - conn.lastFrameAt > this.heartbeatIntervalMs * 2.5) {
+                // Mirrors the fail-fast connect-timeout pattern in `ensureSocket`:
+                // a stuck socket may throw on close, but the disconnect call
+                // below still arms reconnect either way.
+                try {
+                    socket.close();
+                } catch {
+                    /* a stuck socket may throw on close — the disconnect below still arms reconnect */
+                }
+
+                this.handleDisconnect(conn);
+
+                return;
+            }
+
             try {
-                conn.socket.send(WS_KEEPALIVE_PING);
+                socket.send(WS_KEEPALIVE_PING);
             } catch {
                 // A send race against a closing socket is harmless — the close
                 // handler will tear the heartbeat down.
@@ -4623,6 +4663,17 @@ class LunoraClient {
     }
 
     private handleServerMessage(raw: unknown, shardKey?: string): void {
+        // Any inbound frame — including the plain-string `lunora-pong` keepalive
+        // reply, which the JSON.parse guard below silently drops — proves the
+        // socket is still alive. Stamp it unconditionally, before the parsing
+        // below, so the heartbeat watchdog (see `startHeartbeat`) can tell a
+        // half-open socket from a healthy one.
+        const conn = this.getConnection(shardKey);
+
+        if (conn) {
+            conn.lastFrameAt = Date.now();
+        }
+
         const text = decodeServerFrame(raw);
 
         if (text === undefined) {

--- a/packages/client/src/offline-queue.ts
+++ b/packages/client/src/offline-queue.ts
@@ -166,26 +166,7 @@ class OfflineQueue {
                 reportPersistenceError(this.onPersistenceError, "append", error, item.id);
             });
 
-        while (this.items.length > this.maxItems) {
-            const dropped = this.items.shift();
-
-            if (dropped) {
-                if (dropped.id) {
-                    this.persistence?.remove(dropped.id).catch((error: unknown) => {
-                        reportPersistenceError(this.onPersistenceError, "remove", error, dropped.id);
-                    });
-                }
-
-                const error = new Error("offline queue overflow");
-
-                (error as Error & { code?: string }).code = "OFFLINE_QUEUE_OVERFLOW";
-                dropped.reject(error);
-                // Also surface on the client's terminal-verdict observer: a
-                // hydrated entry's `reject` is a no-op, so without this an
-                // overflow eviction would silently drop a durable write.
-                this.onEvict?.(dropped, error);
-            }
-        }
+        this.evictOverflow();
 
         this.notifySize();
     }
@@ -253,6 +234,14 @@ class OfflineQueue {
         }
 
         this.items.unshift(...restored);
+
+        // A durable store holding more than `maxItems` records (e.g. `maxItems`
+        // was lowered between sessions, or writes piled up while the app was
+        // fully offline across restarts) must not bypass the cap — evict from
+        // the front (the oldest restored entries) exactly as `enqueue` does, so
+        // the in-memory queue never exceeds `maxItems` regardless of how it got
+        // there (CLIENT-03).
+        this.evictOverflow();
 
         this.notifySize();
 
@@ -353,6 +342,37 @@ class OfflineQueue {
 
         this.items.length = 0;
         this.notifySize();
+    }
+
+    /**
+     * Evict entries from the FRONT of `items` (the oldest — FIFO order) until
+     * the queue is at or under `maxItems`, rejecting each with
+     * `OFFLINE_QUEUE_OVERFLOW`, un-persisting it, and firing `onEvict`. Shared
+     * by `enqueue` (a live write pushes past capacity) and `hydrate` (a durable
+     * store restored more than `maxItems` records — CLIENT-03) so an overflow
+     * always drops the same way regardless of which caller triggered it.
+     */
+    private evictOverflow(): void {
+        while (this.items.length > this.maxItems) {
+            const dropped = this.items.shift();
+
+            if (dropped) {
+                if (dropped.id) {
+                    this.persistence?.remove(dropped.id).catch((error: unknown) => {
+                        reportPersistenceError(this.onPersistenceError, "remove", error, dropped.id);
+                    });
+                }
+
+                const error = new Error("offline queue overflow");
+
+                (error as Error & { code?: string }).code = "OFFLINE_QUEUE_OVERFLOW";
+                dropped.reject(error);
+                // Also surface on the client's terminal-verdict observer: a
+                // hydrated entry's `reject` is a no-op, so without this an
+                // overflow eviction would silently drop a durable write.
+                this.onEvict?.(dropped, error);
+            }
+        }
     }
 
     /** Notify the size observer (the client's pending-sync count) after any change. */

--- a/packages/client/src/offline-queue.ts
+++ b/packages/client/src/offline-queue.ts
@@ -203,7 +203,6 @@ class OfflineQueue {
             throw error;
         }
 
-        const shardKeys = new Set<string | undefined>();
         const restored: QueuedMutation[] = [];
 
         for (const mutation of persisted) {
@@ -230,7 +229,6 @@ class OfflineQueue {
                 resolve: () => undefined,
                 shardKey: mutation.shardKey,
             });
-            shardKeys.add(mutation.shardKey);
         }
 
         this.items.unshift(...restored);
@@ -244,6 +242,20 @@ class OfflineQueue {
         this.evictOverflow();
 
         this.notifySize();
+
+        // Compute shard keys AFTER eviction, from whichever restored entries
+        // actually survived: `evictOverflow` drops from the front of `items`
+        // (the oldest restored entries first), so a shard key gathered before
+        // eviction can point at a mutation that no longer exists — the caller
+        // would then call `ensureSocket()` for a shard with nothing queued.
+        const survivingItems = new Set(this.items);
+        const shardKeys = new Set<string | undefined>();
+
+        for (const mutation of restored) {
+            if (survivingItems.has(mutation)) {
+                shardKeys.add(mutation.shardKey);
+            }
+        }
 
         return [...shardKeys];
     }

--- a/packages/react/__tests__/use-presence.test.tsx
+++ b/packages/react/__tests__/use-presence.test.tsx
@@ -1,6 +1,7 @@
 import type { FunctionReference } from "@lunora/client";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
+import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LunoraProvider } from "../src/lunora-provider";
@@ -119,6 +120,56 @@ describe("usePresence", () => {
             expect(id).toMatch(/^sess-/);
         } finally {
             Object.defineProperty(globalThis, "crypto", { configurable: true, value: originalCrypto });
+        }
+    });
+
+    it("mounts and still heartbeats on an interval when `document` is unavailable, e.g. React Native (RN-01)", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient();
+
+        // React Native has no `document` global at all — not even `undefined`,
+        // the identifier is simply never declared. A bare `document.visibilityState`
+        // read (or `document.addEventListener`) throws a ReferenceError on mount
+        // without the `typeof document !== "undefined"` guard. `react-dom`
+        // creates elements via the container's `ownerDocument`, not the bare
+        // global, so rendering into a container created BEFORE deleting the
+        // global still works here — letting this test isolate exactly the
+        // hook's own (formerly unguarded) `document` reads.
+        const container = globalThis.document.createElement("div");
+
+        globalThis.document.body.append(container);
+
+        const originalDocument = globalThis.document;
+
+        // @ts-expect-error -- intentionally deleting a required global to simulate React Native
+        delete globalThis.document;
+
+        const root = createRoot(container);
+
+        try {
+            expect(() => {
+                // eslint-disable-next-line testing-library/no-unnecessary-act -- this is raw `react-dom/client`'s `root.render`, not an RTL util call (the rule name-matches "render" regardless of origin); `act` here is load-bearing so the mount's effects (the heartbeat) flush synchronously before the assertion below.
+                act(() => {
+                    root.render(
+                        <LunoraProvider client={mock.asClient}>
+                            <Roster />
+                        </LunoraProvider>,
+                    );
+                });
+            }).not.toThrow();
+
+            // The interval heartbeat (not the visibility-driven one, which is
+            // itself guarded and simply skipped) fires synchronously as part of
+            // mount — asserted here, before `document` is restored, so this
+            // stays proof of the mount-time behavior specifically. (Skip RTL's
+            // `waitFor`: it resolves its own default container from `document`,
+            // which is exactly what this test has deleted.)
+            expect(mock.mutation).toHaveBeenCalledTimes(1);
+        } finally {
+            Object.defineProperty(globalThis, "document", { configurable: true, value: originalDocument, writable: true });
+            root.unmount();
+            container.remove();
         }
     });
 

--- a/packages/react/src/use-presence.ts
+++ b/packages/react/src/use-presence.ts
@@ -127,22 +127,34 @@ export const usePresence = <H extends HeartbeatReference, L extends ListPresentR
 
     // Heartbeat: immediately, on an interval, and whenever the tab regains
     // visibility. Cleared on unmount so no timer leaks.
+    //
+    // `document` is guarded (`typeof document !== "undefined"`, matching
+    // vue/solid/svelte/angular's presence) rather than read bare: React Native
+    // has no `document` global at all, so an unguarded read throws a
+    // ReferenceError on mount (RN-01) instead of just skipping the
+    // visibility-driven heartbeat, which is a web-only refinement anyway (the
+    // interval heartbeat still covers RN).
     useEffect(() => {
         sendHeartbeat();
 
         const handle = setInterval(sendHeartbeat, intervalMs);
 
         const onVisible = (): void => {
-            if (document.visibilityState === "visible") {
+            if (typeof document !== "undefined" && document.visibilityState === "visible") {
                 sendHeartbeat();
             }
         };
 
-        document.addEventListener("visibilitychange", onVisible);
+        if (typeof document !== "undefined") {
+            document.addEventListener("visibilitychange", onVisible);
+        }
 
         return () => {
             clearInterval(handle);
-            document.removeEventListener("visibilitychange", onVisible);
+
+            if (typeof document !== "undefined") {
+                document.removeEventListener("visibilitychange", onVisible);
+            }
         };
     }, [sendHeartbeat, intervalMs]);
 

--- a/packages/svelte/__tests__/agent-chat.test.ts
+++ b/packages/svelte/__tests__/agent-chat.test.ts
@@ -260,4 +260,29 @@ describe(agentChat, () => {
         }).not.toThrow();
         expect(fake.unsubscribeSpy).not.toHaveBeenCalled();
     });
+
+    it("does not open the eager token stream during SSR (no window) (SVELTE-01)", () => {
+        const fake = createFakeClient();
+
+        // Same server-render scenario as above, but with a `stream` reference
+        // configured — the eager `stream(...).chunks.subscribe(...)` call must
+        // be gated on `isBrowser` too, or it opens (and leaks) a live stream
+        // during `renderToString` just like an ungated history/thread
+        // subscription would.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const handle = agentChat(fake.client, {
+            api: buildApi(),
+            send: makeRef(SEND_REF) as FunctionReference<"mutation">,
+            stream: makeStreamRef(STREAM_REF),
+            threadKey: "t1",
+        });
+
+        expect(fake.streamCalls).toHaveLength(0);
+        expect(get(handle.streamingText)).toBe("");
+
+        expect(() => {
+            handle.teardown();
+        }).not.toThrow();
+    });
 });

--- a/packages/svelte/__tests__/agent-chat.test.ts
+++ b/packages/svelte/__tests__/agent-chat.test.ts
@@ -1,6 +1,6 @@
 import type { FunctionReference } from "@lunora/client";
 import { get } from "svelte/store";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { AgentChatApi, AgentLiveEvent } from "../src/agent-chat";
 import { agentChat } from "../src/agent-chat";
@@ -33,6 +33,18 @@ const buildApi = (): AgentChatApi =>
     }) as unknown as AgentChatApi;
 
 describe(agentChat, () => {
+    beforeEach(() => {
+        // `agentChat` gates its history/thread subscriptions on a browser
+        // `window` (SVELTE-01); the vitest env is `node` (no `window`), so
+        // define one for these client-path tests. The SSR test below removes
+        // it to exercise the guard, mirroring `presence.test.ts`.
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("surfaces durable history and live status over the agents:* subscriptions", () => {
         const fake = createFakeClient();
         const handle = agentChat(fake.client, { api: buildApi(), send: makeRef(SEND_REF) as FunctionReference<"mutation">, threadKey: "t1" });
@@ -223,5 +235,29 @@ describe(agentChat, () => {
         await expect(handle.approve("call-1")).rejects.toThrow("no in-flight run");
 
         handle.teardown();
+    });
+
+    it("does not open the history/thread subscriptions during SSR (no window) (SVELTE-01)", () => {
+        const fake = createFakeClient();
+
+        // Simulate the server render: no browser `window` (this package pairs
+        // with `@lunora/nuxt`'s server rendering, where a component's init runs
+        // inside `renderToString` with no `window`). Opening a live WS
+        // subscription there fires during `renderToString` with no
+        // corresponding `onDestroy` to close it — every server render would
+        // leak a subscription.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const handle = agentChat(fake.client, { api: buildApi(), send: makeRef(SEND_REF) as FunctionReference<"mutation">, threadKey: "t1" });
+
+        expect(fake.subscribeCalls).toHaveLength(0);
+        expect(get(handle.messages)).toStrictEqual([]);
+        expect(get(handle.status)).toBeUndefined();
+
+        // Teardown itself must not throw with nothing live to unsubscribe.
+        expect(() => {
+            handle.teardown();
+        }).not.toThrow();
+        expect(fake.unsubscribeSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/svelte/__tests__/presence.test.ts
+++ b/packages/svelte/__tests__/presence.test.ts
@@ -106,10 +106,16 @@ const flushAsync = async (): Promise<void> => {
 describe("presence (Svelte)", () => {
     beforeEach(() => {
         vi.useFakeTimers({ shouldAdvanceTime: true });
+        // `presence` gates its heartbeat/interval/listener/connection-context wiring
+        // on a browser `window` (SVELTE-01); the vitest env is `node` (no `window`),
+        // so define one for these client-path tests. The SSR test below removes it
+        // to exercise the guard, mirroring `@lunora/vue`'s `use-presence.test.ts`.
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
     });
 
     afterEach(() => {
         vi.useRealTimers();
+        Reflect.deleteProperty(globalThis, "window");
     });
 
     it("heartbeats on mount and again on each interval tick", async () => {
@@ -270,5 +276,49 @@ describe("presence (Svelte)", () => {
         first.teardown();
 
         expect(fake.currentConnectionContext()).toBeUndefined();
+    });
+
+    it("does not heartbeat, open an interval, subscribe, or acquire connection context during SSR (no window) (SVELTE-01)", async () => {
+        const fake = createPresenceFakeClient();
+
+        // Simulate the server render: no browser `window` (this package pairs
+        // with `@lunora/nuxt`'s server rendering, where a component's init runs
+        // inside `renderToString` with no `window`).
+        Reflect.deleteProperty(globalThis, "window");
+
+        const handle = presence(fake.client, "room-1", {
+            heartbeat: HEARTBEAT,
+            intervalMs: 500,
+            listPresent: LIST_PRESENT,
+            sessionId: "sess-fixed",
+        });
+
+        // Reading the store ("rendering" it) must not trigger a live WS
+        // subscription server-side either.
+        const stopPresent = handle.present.subscribe(() => undefined);
+
+        await flushAsync();
+
+        // No setup-time heartbeat write, no live subscription, no connection
+        // context acquired.
+        expect(fake.mutationCalls).toHaveLength(0);
+        expect(fake.subscribeCalls).toHaveLength(0);
+        expect(fake.currentConnectionContext()).toBeUndefined();
+
+        // No leaked interval: advancing time fires no further heartbeats.
+        await vi.advanceTimersByTimeAsync(2000);
+        await flushAsync();
+
+        expect(fake.mutationCalls).toHaveLength(0);
+
+        // The store stays at its inert initial value.
+        expect(get(handle.present)).toBeUndefined();
+
+        stopPresent();
+
+        // Teardown itself must not throw with nothing to release/clear.
+        expect(() => {
+            handle.teardown();
+        }).not.toThrow();
     });
 });

--- a/packages/svelte/src/agent-chat.ts
+++ b/packages/svelte/src/agent-chat.ts
@@ -260,16 +260,30 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
         recomputeStreamingText();
     });
 
+    // The history/thread subscriptions below are client-only side effects: a
+    // component's init can run server-side (this package pairs with
+    // `@lunora/nuxt`'s server rendering) with no `window`, and opening a live
+    // WS subscription there would fire during `renderToString` with no
+    // corresponding `onDestroy` to close it — every server render would leak
+    // a subscription (SVELTE-01, mirrors the `presence.ts` guard). Skip them
+    // server-side; `messages`/`status` stay at their inert initial values
+    // until the component hydrates and `teardown` becomes a no-op.
+    const isBrowser = (globalThis as { window?: unknown }).window !== undefined;
+
     const historyArgs = limit === undefined ? { key: threadKey } : { key: threadKey, limit };
-    const unsubscribeHistory = client.subscribe(api.agents.agentMessages, historyArgs, (value) => {
-        durable = value as unknown as ReadonlyArray<AgentChatMessage>;
-        recompute();
-        recomputeStreamingText();
-    });
-    const unsubscribeThread = client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
-        latestThread = value as AgentThreadRecord | undefined;
-        statusStore.set(latestThread?.status);
-    });
+    const unsubscribeHistory = isBrowser
+        ? client.subscribe(api.agents.agentMessages, historyArgs, (value) => {
+              durable = value as unknown as ReadonlyArray<AgentChatMessage>;
+              recompute();
+              recomputeStreamingText();
+          })
+        : (): void => undefined;
+    const unsubscribeThread = isBrowser
+        ? client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
+              latestThread = value as AgentThreadRecord | undefined;
+              statusStore.set(latestThread?.status);
+          })
+        : (): void => undefined;
 
     const send = async (input: string, arguments_?: Record<string, unknown>): Promise<void> => {
         const id = nextId;

--- a/packages/svelte/src/agent-chat.ts
+++ b/packages/svelte/src/agent-chat.ts
@@ -249,26 +249,29 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
         streamingTextStore.set(text);
     };
 
+    // The subscriptions below are client-only side effects: a component's init
+    // can run server-side (this package pairs with `@lunora/nuxt`'s server
+    // rendering) with no `window`, and opening a live WS subscription there
+    // would fire during `renderToString` with no corresponding `onDestroy` to
+    // close it — every server render would leak a subscription (SVELTE-01,
+    // mirrors the `presence.ts` guard). Skip them server-side; `messages`/
+    // `status`/`streamingText` stay at their inert initial values until the
+    // component hydrates and `teardown` becomes a no-op.
+    const isBrowser = (globalThis as { window?: unknown }).window !== undefined;
+
     // The token stream is optional: with no reference we pass the sentinel + "skip"
     // so `stream` never opens a stream (and `streamingText` stays empty). Subscribed
     // eagerly (matching the history/thread subscriptions) so the stream opens with
-    // the handle and closes on `teardown`.
+    // the handle and closes on `teardown` — but only in the browser; `stream(...)`'s
+    // `chunks` store opens the underlying stream on its first subscriber, so calling
+    // it unconditionally here would open (and leak) a live stream during SSR too.
     const streamArguments = streamReference === undefined ? "skip" : { key: threadKey };
-    const streamHandle = stream(client, streamReference ?? NO_STREAM_REF, streamArguments);
-    const unsubscribeStream = streamHandle.chunks.subscribe((value) => {
-        liveEvents = value;
-        recomputeStreamingText();
-    });
-
-    // The history/thread subscriptions below are client-only side effects: a
-    // component's init can run server-side (this package pairs with
-    // `@lunora/nuxt`'s server rendering) with no `window`, and opening a live
-    // WS subscription there would fire during `renderToString` with no
-    // corresponding `onDestroy` to close it — every server render would leak
-    // a subscription (SVELTE-01, mirrors the `presence.ts` guard). Skip them
-    // server-side; `messages`/`status` stay at their inert initial values
-    // until the component hydrates and `teardown` becomes a no-op.
-    const isBrowser = (globalThis as { window?: unknown }).window !== undefined;
+    const unsubscribeStream = isBrowser
+        ? stream(client, streamReference ?? NO_STREAM_REF, streamArguments).chunks.subscribe((value) => {
+              liveEvents = value;
+              recomputeStreamingText();
+          })
+        : (): void => undefined;
 
     const historyArgs = limit === undefined ? { key: threadKey } : { key: threadKey, limit };
     const unsubscribeHistory = isBrowser

--- a/packages/svelte/src/presence.ts
+++ b/packages/svelte/src/presence.ts
@@ -86,28 +86,53 @@ const createPresenceHandle = <H extends HeartbeatReference, L extends ListPresen
         sendHeartbeat();
     };
 
-    sendHeartbeat();
-    const intervalHandle = setInterval(sendHeartbeat, intervalMs);
-
     const onVisible = (): void => {
         if (typeof document !== "undefined" && document.visibilityState === "visible") {
             sendHeartbeat();
         }
     };
 
-    if (typeof document !== "undefined") {
-        document.addEventListener("visibilitychange", onVisible);
+    let intervalHandle: ReturnType<typeof setInterval> | undefined;
+    let releaseConnectionContext: (() => void) | undefined;
+
+    // The heartbeat, interval, visibility listener, connection-context, and
+    // live subscription below are all client-only side effects. During SSR
+    // (this package pairs with `@lunora/nuxt`'s server rendering) a
+    // component's init runs inside `renderToString` with no `window`: firing a
+    // heartbeat there writes a ghost presence row under a throwaway session
+    // id, and the render scope never stops — so the auto-`onDestroy` below
+    // never fires and every server render would leak a live `setInterval`
+    // handle (SVELTE-01). Skip the whole client wiring server-side, mirroring
+    // `@lunora/vue`'s `use-presence.ts` guard; the returned store stays inert
+    // until the component hydrates.
+    const isBrowser = (globalThis as { window?: unknown }).window !== undefined;
+
+    if (isBrowser) {
+        sendHeartbeat();
+        intervalHandle = setInterval(sendHeartbeat, intervalMs);
+
+        if (typeof document !== "undefined") {
+            document.addEventListener("visibilitychange", onVisible);
+        }
+
+        // Register connection context so server can drop the row on socket disconnect.
+        // Use the refcounted acquire (not the last-writer-wins setter) so a second
+        // presence store on the same client/shard doesn't clobber this one's context
+        // when either tears down.
+        releaseConnectionContext = client.acquireConnectionContext({ roomId, sessionId }, { shardKey });
     }
 
-    // Register connection context so server can drop the row on socket disconnect.
-    // Use the refcounted acquire (not the last-writer-wins setter) so a second
-    // presence store on the same client/shard doesn't clobber this one's context
-    // when either tears down.
-    const releaseConnectionContext = client.acquireConnectionContext({ roomId, sessionId }, { shardKey });
-
-    // Subscribe to the live present-list; expose as a Readable store.
+    // Subscribe to the live present-list; expose as a Readable store. Also
+    // gated: `readable`'s start callback only runs once the store gets its
+    // first subscriber, but a server-rendered page that reads `$present`
+    // during `renderToString` WOULD trigger it — so guard it too rather than
+    // open a live WS subscription server-side.
     const present = readable<ReturnOf<L> | undefined>(undefined, (set) => {
-        const unsubscribe = client.subscribe(
+        if (!isBrowser) {
+            return undefined;
+        }
+
+        return client.subscribe(
             listPresent,
             { roomId } as ArgsOf<L>,
             (value) => {
@@ -115,8 +140,6 @@ const createPresenceHandle = <H extends HeartbeatReference, L extends ListPresen
             },
             { shardKey },
         );
-
-        return unsubscribe;
     });
 
     let torndown = false;
@@ -131,13 +154,15 @@ const createPresenceHandle = <H extends HeartbeatReference, L extends ListPresen
 
         torndown = true;
 
-        clearInterval(intervalHandle);
+        if (intervalHandle !== undefined) {
+            clearInterval(intervalHandle);
+        }
 
         if (typeof document !== "undefined") {
             document.removeEventListener("visibilitychange", onVisible);
         }
 
-        releaseConnectionContext();
+        releaseConnectionContext?.();
     };
 
     // Auto-teardown on component destruction so a consumer who forgets


### PR DESCRIPTION
Six independent client-layer lifecycle bugs: (CLIENT-01) cross-tab follower tabs never dropped confirmed optimistic layers → a "+1" write showed +2/+3 forever and a setQuery overlay masked the query until reload — the BroadcastChannel frame now carries cursor/epoch and the follower drops confirmed layers via the same tail the leader uses (backward-compatible with cursor-less frames). (CLIENT-02) the WS heartbeat was send-only → a half-open socket stayed open forever; added a pong watchdog (`lastFrameAt` + force-close past 2.5× the interval). (CLIENT-03) `OfflineQueue.hydrate()` bypassed the maxItems cap → now trims. (CLIENT-04) a server `complete` frame silently killed a subscription → now surfaces SUBSCRIPTION_CANCELLED + keeps it re-subscribable (streams-only today, but ShardDO is subclassable). (RN-01) React `usePresence` crashed on React Native reading `document` unguarded → guarded. (SVELTE-01) Svelte presence/agent-chat fired network side effects at SSR init → guarded.

Verified: client 485(+1 expected-fail), react 141, svelte 89, lint:types clean; api:update ran for the new TabCoordinator surface.

⚠ Touches lunora-client.ts — merge-order vs plan 231 (socket-lifecycle extraction) + 237 (admin-auth hooks) when those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved cross-tab synchronization so subscription progress and settled updates remain consistent across browser tabs.
  - Added automatic recovery for stalled connections and improved reconnect handling after server-cancelled subscriptions.

- **Bug Fixes**
  - Offline queues now enforce capacity limits when restored, removing excess entries consistently.
  - Presence and chat features no longer trigger browser-only behavior during server-side rendering.
  - Improved presence cleanup when connections or browser visibility change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->