### PR TITLE
fix(platform): honest + observable contract — fail-closed capability gate, emulated scheduler, stable idFor, TCK, refresh signal

### DIFF
--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -492,7 +492,7 @@ interface PlatformDiagnostic {
     feature?: CapabilityKey;
     level: "error" | "warn";
     message: string;
-    name: "platform_unknown_target" | "platform_unsupported_feature";
+    name: "platform_undeclared_feature" | "platform_unknown_target" | "platform_unsupported_feature";
     remediation: string;
     target: string;
 }

--- a/packages/codegen/__tests__/platform-target.test.ts
+++ b/packages/codegen/__tests__/platform-target.test.ts
@@ -81,6 +81,36 @@ describe("gatePlatformFeatures", () => {
         ]);
     });
 
+    it("fails closed on a feature the matrix omits, under its own diagnostic name", async () => {
+        expect.assertions(5);
+
+        // A partial matrix that RATES `ai` but says nothing about `browser` — the
+        // shape a WIP second host ships mid-implementation. `browser` must not
+        // silently pass through just because the key is absent: every `features`
+        // key is optional, so an omission is indistinguishable from "unsupported"
+        // unless the gate treats it as such.
+        const partialTarget: PlatformCapabilities = {
+            id: "partial",
+            name: "Partial Host",
+            features: {
+                ai: { level: "native" },
+            },
+        };
+
+        const { gateAgainstMatrix } = await import("../src/platform-target");
+        const usage: FeatureUsage = { ...ALL_OFF, ai: true, browser: true };
+
+        const result = gateAgainstMatrix(usage, partialTarget, "partial");
+
+        // Fails closed: the surface is omitted exactly as an explicit "unsupported" would be.
+        expect(result.usage.browser).toBe(false);
+        expect(result.usage.ai).toBe(true);
+
+        expect(result.diagnostics).toHaveLength(1);
+        expect(result.diagnostics[0]?.name).toBe("platform_undeclared_feature");
+        expect(result.diagnostics[0]?.feature).toBe("browser");
+    });
+
     it("reports an unknown target and leaves the surface un-gated", async () => {
         expect.assertions(3);
 

--- a/packages/codegen/src/platform-target.ts
+++ b/packages/codegen/src/platform-target.ts
@@ -9,7 +9,12 @@
  * `@lunora/platform` {@link PlatformCapabilities} matrix): a feature the app
  * uses that the target marks `unsupported` is dropped from the emitted surface
  * and reported as a {@link PlatformDiagnostic}, so a portability gap is a
- * build-time signal rather than a runtime surprise.
+ * build-time signal rather than a runtime surprise. A feature the app uses
+ * that the matrix does not rate AT ALL — every `features` key is optional —
+ * is treated the same way (dropped, diagnosed) rather than left in: an
+ * un-rated feature fails closed under its own `platform_undeclared_feature`
+ * name, so a partial matrix from a WIP second host cannot silently emit a
+ * surface for a primitive it never claimed to support.
  *
  * `native` and `emulated` both emit as-is — `emulated` means Lunora builds the
  * feature on lower-level primitives, which is still a working surface.
@@ -149,12 +154,12 @@ const CAPABILITY_TO_FEATURE: Partial<Record<CapabilityKey, PlatformFeatureKey>> 
 interface PlatformDiagnostic {
     /** The codegen capability this concerns, when it is feature-specific. */
     feature?: CapabilityKey;
-    /** Severity. `platform_unsupported_feature` and `platform_unknown_target` are both errors — each drops or misdirects an emitted surface. */
+    /** Severity. All three names are errors — each drops or misdirects an emitted surface. */
     level: "error" | "warn";
     /** Human-readable explanation of the gap. */
     message: string;
-    /** The lint id: `platform_unsupported_feature` or `platform_unknown_target`. */
-    name: "platform_unknown_target" | "platform_unsupported_feature";
+    /** The lint id: `platform_unsupported_feature`, `platform_undeclared_feature`, or `platform_unknown_target`. */
+    name: "platform_undeclared_feature" | "platform_unknown_target" | "platform_unsupported_feature";
     /** How to resolve it. */
     remediation: string;
     /** The requested deploy target. */
@@ -195,6 +200,25 @@ const gateAgainstMatrix = (usage: FeatureUsage, matrix: PlatformCapabilities, ta
                 message: `${matrix.name} does not support "${capability}" (ctx.${capability}). Its surface was omitted from the generated types.`,
                 name: "platform_unsupported_feature",
                 remediation: `Remove the ctx.${capability} usage, or deploy to a target whose capability matrix marks "${featureKey}" as native or emulated.`,
+                target,
+            });
+        } else if (level === undefined) {
+            // Every `features` key is optional (`Capability | undefined`), so a
+            // matrix that OMITS a key — the shape a WIP second host ships while its
+            // capability matrix is still partial — would otherwise fall through
+            // this `if` entirely and leave `gated` (and the emitted surface)
+            // untouched: fail OPEN. An omitted rating is not evidence of support,
+            // so it is treated the same as an explicit `"unsupported"` for gating
+            // purposes, but reported under its own name — the fix is different
+            // (rate the feature) from an explicit unsupported (remove the usage or
+            // change target), and collapsing them would send the wrong remediation.
+            gated[capability] = false;
+            diagnostics.push({
+                feature: capability,
+                level: "error",
+                message: `${matrix.name}'s capability matrix does not declare a support level for "${capability}" (ctx.${capability}). Treated as unsupported and its surface was omitted from the generated types.`,
+                name: "platform_undeclared_feature",
+                remediation: `Rate "${featureKey}" in the ${matrix.name} capability matrix as "native", "emulated", or "unsupported" — an undeclared feature fails closed rather than shipping a surface the host may not provide.`,
                 target,
             });
         }

--- a/packages/do/__tests__/subscription-refresh.integration.test.ts
+++ b/packages/do/__tests__/subscription-refresh.integration.test.ts
@@ -24,6 +24,7 @@
  * `webSocketMessage`, and `fetch` seams exposed by ShardDO.
  */
 import type { SocketAttachment, SubscriptionEnvelope } from "@lunora/shard-engine";
+import { ADMIN_FUNCTIONS } from "@lunora/shard-engine";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { ShardDOState, SubscriptionOutcome } from "../src/shard-do";
@@ -189,6 +190,35 @@ const subscribeSocket = (shard: SubscriptionRefreshShard, ws: FakeWebSocket, sub
         query: { args: {}, functionPath },
         type: "subscribe",
     });
+
+/**
+ * Shared by both the isolation test and the DO-01 counter/log test: a shard
+ * whose `messages:broken` subscription seeds cleanly (first call) then throws
+ * on every subsequent refresh, while every other functionPath behaves like
+ * the base `SubscriptionRefreshShard`.
+ */
+class BrokenRefreshShard extends SubscriptionRefreshShard {
+    // Track whether we are on the first call (seed) to each functionPath.
+    private readonly firstCall = new Set<string>();
+
+    protected override executeSubscription(functionPath: string, args: Record<string, unknown>): Promise<SubscriptionOutcome | null> {
+        if (functionPath === "messages:broken") {
+            if (!this.firstCall.has(functionPath)) {
+                // First call = seed: return null so no memo is set and no
+                // initial push is sent. The broken subscription is "registered"
+                // but has no memo.
+                this.firstCall.add(functionPath);
+
+                return Promise.resolve(null);
+            }
+
+            // Subsequent calls = refresh: throw to exercise the error path.
+            return Promise.reject(new Error("broken subscription"));
+        }
+
+        return super.executeSubscription(functionPath, args);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Test suite
@@ -447,29 +477,6 @@ describe("shardDO: mutation → subscription-refresh pipeline", () => {
     it("a failing subscription does not abort the refresh of its siblings on the same socket", async () => {
         expect.assertions(3);
 
-        class BrokenRefreshShard extends SubscriptionRefreshShard {
-            // Track whether we are on the first call (seed) to each functionPath.
-            private readonly firstCall = new Set<string>();
-
-            protected override executeSubscription(functionPath: string, args: Record<string, unknown>): Promise<SubscriptionOutcome | null> {
-                if (functionPath === "messages:broken") {
-                    if (!this.firstCall.has(functionPath)) {
-                        // First call = seed: return null so no memo is set and
-                        // no initial push is sent. The broken subscription is
-                        // "registered" but has no memo.
-                        this.firstCall.add(functionPath);
-
-                        return Promise.resolve(null);
-                    }
-
-                    // Subsequent calls = refresh: throw to exercise the error path.
-                    return Promise.reject(new Error("broken subscription"));
-                }
-
-                return super.executeSubscription(functionPath, args);
-            }
-        }
-
         const brokenShard = new BrokenRefreshShard(state, {});
         const ws = createFakeWebSocket();
 
@@ -515,6 +522,66 @@ describe("shardDO: mutation → subscription-refresh pipeline", () => {
         const brokenFrames = subFrames(ws, "sub-broken");
 
         expect(brokenFrames).toHaveLength(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // DO-01 — a swallowed refresh error is counted and logged, not silent.
+    //
+    // Same broken/healthy pairing as the case above, but asserting the
+    // observability side rather than just "siblings still refresh": the
+    // `catch { continue; }` in `refreshSubscriptions` used to discard the error
+    // outright, so a live query that threw deterministically went silently
+    // stale for the life of the socket with nothing an operator could see.
+    // -------------------------------------------------------------------------
+    it("a failing subscription refresh increments subscriptionRefreshErrors and logs once, without blocking its sibling", async () => {
+        expect.assertions(6);
+
+        const adminToken = "s3cret-admin";
+        const adminRequest = (functionPath: string): Request =>
+            new Request("https://shard.internal/rpc", {
+                body: JSON.stringify({ args: {}, functionPath }),
+                headers: { authorization: `Bearer ${adminToken}`, "content-type": "application/json" },
+                method: "POST",
+            });
+
+        const brokenShard = new BrokenRefreshShard(state, { LUNORA_ADMIN_TOKEN: adminToken });
+        const ws = createFakeWebSocket();
+
+        brokenShard.registerSocket(ws);
+
+        await subscribeSocket(brokenShard, ws, "sub-broken", "messages:broken");
+
+        brokenShard.outcomes.set("messages:list", { result: [{ _id: "m1" }], tables: new Set(["messages"]) });
+        await subscribeSocket(brokenShard, ws, "sub-healthy", "messages:list");
+
+        brokenShard.outcomes.set("messages:list", { result: [{ _id: "m1" }, { _id: "m2" }], tables: new Set(["messages"]) });
+        brokenShard.changedTableOnRpc = "messages";
+
+        // Two mutations ⇒ the broken subscription's refresh throws TWICE — the
+        // counter and log entries must track both, and the sibling must keep
+        // refreshing on the second pass too, not just the first.
+        await brokenShard.writeRpc();
+        await brokenShard.writeRpc();
+
+        // Sibling still refreshes on both passes — same shape as the case above,
+        // asserted again here so a future change can't decouple "counted" from
+        // "siblings unaffected".
+        expect(subFrames(ws, "sub-healthy").slice(1).length).toBeGreaterThan(0);
+        expect(subFrames(ws, "sub-broken")).toHaveLength(0);
+
+        const metricsResponse = await brokenShard.fetch(adminRequest(ADMIN_FUNCTIONS.getMetrics));
+        const metricsBody = await metricsResponse.json<{ result: { subscriptionRefreshErrors: number } }>();
+
+        expect(metricsResponse.status).toBe(200);
+        expect(metricsBody.result.subscriptionRefreshErrors).toBe(2);
+
+        const logsResponse = await brokenShard.fetch(adminRequest(ADMIN_FUNCTIONS.getLogs));
+        const logsBody = await logsResponse.json<{
+            result: { entries: { functionPath?: string; level: string; message: string }[] };
+        }>();
+
+        expect(logsResponse.status).toBe(200);
+        expect(logsBody.result.entries.filter((entry) => entry.functionPath === "messages:broken" && entry.level === "error")).toHaveLength(2);
     });
 
     // -------------------------------------------------------------------------

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -7180,20 +7180,25 @@ abstract class ShardDO {
      *
      * `lastTelemetrySink` (not a threaded `sink`) because both flush workers run
      * with no `ctx` — the same stand-in `flushTelemetry` uses.
+     *
+     * `error` is a caught INTERNAL failure surfaced from a background
+     * refresh/poke pass, not a value a developer chose to log via `ctx.log` —
+     * so `recordUserLog`'s "args are not redacted" contract (see its
+     * docstring) does not apply here: a thrown value can carry an arbitrary
+     * `cause`, stack, or custom own property (a handler can `throw
+     * Object.assign(new Error(...), { row })`), and `args` rides raw into any
+     * `sink.onLog` an operator has configured. Route it through the same
+     * `toErrorBody` envelope every other error-crossing boundary in this file
+     * uses (see `errorToResponse`, the shape-seed catches above) so only a
+     * bounded `{ code, message }` — not the raw error — reaches the sink.
      */
     private recordSubscriptionRefreshError(functionPath: string, error: unknown, fields: Record<string, unknown>): void {
         this.metrics.subscriptionRefreshErrors += 1;
 
         try {
-            this.recordUserLog(
-                functionPath,
-                "error",
-                [error],
-                error instanceof Error ? error.message : String(error),
-                fields,
-                this.lastTelemetrySink,
-                "subscriptionRefreshError",
-            );
+            const { body } = toErrorBody(error, { fallbackCode: "SUBSCRIPTION_REFRESH_FAILED", redactedMessage: "subscription refresh failed" });
+
+            this.recordUserLog(functionPath, "error", [body], body.message, fields, this.lastTelemetrySink, "subscriptionRefreshError");
         } catch {
             // Best-effort, matching every other telemetry call on this path.
         }
@@ -7656,9 +7661,10 @@ abstract class ShardDO {
      * the results into the poke parts to send and the per-shape memo advances. A
      * `.global()` shape (driven by the alarm poll loop, not this flush) and a shape
      * whose table didn't change are skipped; a shape whose resolve/diff throws is
-     * logged and skipped with its memo unadvanced so a later flush retries. Empty
-     * diffs advance unconditionally; part-bearing shapes advance only once the
-     * caller confirms the poke was delivered.
+     * counted and logged via `recordSubscriptionRefreshError` (DO-01) and skipped
+     * with its memo unadvanced so a later flush retries. Empty diffs advance
+     * unconditionally; part-bearing shapes advance only once the caller confirms
+     * the poke was delivered.
      */
     private collectShapePokeParts(
         ws: ShardSocketLike,
@@ -7691,7 +7697,13 @@ abstract class ShardDO {
                     emptyAdvanced.push(subId);
                 }
             } catch (error) {
-                this.recordShapeError(`shape:poke:${subId}`, error);
+                // Counted and logged like the socket-level catch in the caller
+                // (see `recordSubscriptionRefreshError`) so a resolve/diff
+                // failure contained to one shape still shows up on
+                // `metrics.subscriptionRefreshErrors` and the structured
+                // telemetry event — not just the socket-level failures that
+                // escape this loop entirely.
+                this.recordSubscriptionRefreshError(`${ADMIN_FUNCTION_PREFIX}pokeShapeSubscribers`, error, { subId });
             }
         }
 

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1146,8 +1146,15 @@ abstract class ShardDO {
      * RPC. In-memory only — they reset when the DO hibernates or restarts, which
      * is the right granularity for a "since this instance woke" health readout
      * (durable aggregation would be a separate, heavier feature).
+     *
+     * `subscriptionRefreshErrors` (DO-01) rides along the same lifetime/in-memory
+     * shape: incremented, alongside a structured log, wherever a live-query
+     * refresh or shape poke swallows a per-subscription/per-socket error so its
+     * siblings can keep flushing (`refreshSubscriptions`, `pokeShapeSubscribers`
+     * via `recordSubscriptionRefreshError`). It IS on the `getMetrics` wire
+     * response (`collectMetrics`); a studio panel charting it is a follow-up.
      */
-    private readonly metrics = { errors: 0, requests: 0, sinceMs: Date.now() };
+    private readonly metrics = { errors: 0, requests: 0, sinceMs: Date.now(), subscriptionRefreshErrors: 0 };
 
     /**
      * Running fan-out cost counters surfaced by the
@@ -4706,6 +4713,13 @@ abstract class ShardDO {
      * fields. `indexHits` is shaped exactly as the advisor's `AdvisorIndexHit`
      * (`{ table, index, reads }`), so the studio passes it straight to
      * `runLints({ ..., indexHits })` after summing the per-shard arrays.
+     *
+     * `subscriptionRefreshErrors` (DO-01) rides along the same way: an
+     * in-memory-only lifetime count (no durable table, unlike `requests`/
+     * `errors`), incremented by `recordSubscriptionRefreshError` whenever a live
+     * query refresh or shape poke swallows a per-subscription error to protect
+     * its siblings. The field is on the wire so it is queryable/testable now;
+     * charting it in the studio's metrics panel is a follow-up.
      */
     private collectMetrics(): {
         cache: null | { bytes: number; entries: number; evictions: number; hits: number; misses: number };
@@ -4718,6 +4732,7 @@ abstract class ShardDO {
         requests: number;
         shard: string;
         sinceMs: number;
+        subscriptionRefreshErrors: number;
         uptimeMs: number;
     } {
         const size = this.shardHost.sql.databaseSize;
@@ -4771,6 +4786,7 @@ abstract class ShardDO {
             requests,
             shard: this.runner.shardKey ?? ROOT_SHARD_NAME,
             sinceMs: this.metrics.sinceMs,
+            subscriptionRefreshErrors: this.metrics.subscriptionRefreshErrors,
             uptimeMs: Date.now() - this.metrics.sinceMs,
         };
     }
@@ -7150,6 +7166,39 @@ abstract class ShardDO {
      * high-fanout shards rather than bolt a second, semantically-divergent dedup
      * into this loop.
      */
+
+    /**
+     * Count and log a subscription-delivery error that its caller is about to
+     * swallow (DO-01) — `refreshSubscriptions`' per-`(socket, sub)` catch and
+     * `pokeShapeSubscribers`' per-socket catch both call this instead of a bare
+     * `catch { continue; }`, so a live query or shape poke that throws
+     * DETERMINISTICALLY on every flush is counted on `metrics.subscriptionRefreshErrors`
+     * and shows up in the studio's Live Logs, rather than repeating silently for
+     * the life of the socket. Factored out because both call sites need the
+     * identical counter-then-best-effort-log shape, and duplicating it inline
+     * pushed each closure over the file's cognitive-complexity budget.
+     *
+     * `lastTelemetrySink` (not a threaded `sink`) because both flush workers run
+     * with no `ctx` — the same stand-in `flushTelemetry` uses.
+     */
+    private recordSubscriptionRefreshError(functionPath: string, error: unknown, fields: Record<string, unknown>): void {
+        this.metrics.subscriptionRefreshErrors += 1;
+
+        try {
+            this.recordUserLog(
+                functionPath,
+                "error",
+                [error],
+                error instanceof Error ? error.message : String(error),
+                fields,
+                this.lastTelemetrySink,
+                "subscriptionRefreshError",
+            );
+        } catch {
+            // Best-effort, matching every other telemetry call on this path.
+        }
+    }
+
     private async refreshSubscriptions(changed: Set<string>, changedKeys?: Map<string, IndexKeyEntry[] | undefined>): Promise<void> {
         const sockets = [...this.runner.sockets()];
 
@@ -7238,12 +7287,18 @@ abstract class ShardDO {
                     await awaitWsDrain(ws);
 
                     this.pushSubscriptionData(ws, subId, outcome, frameCursor, frameEpoch);
-                } catch {
+                } catch (error) {
                     // A throwing subscription must not abort the refresh of its
                     // siblings, nor fail the mutation that triggered it. The memo
                     // is left untouched ("unknown deps"), so this subscription
-                    // re-runs on the next flush.
-                    /* refresh error contained to this subscription */ continue;
+                    // re-runs on the next flush — but until now that failure was
+                    // silent (DO-01): a subscription whose refresh throws
+                    // DETERMINISTICALLY (a bad handler cast, say) repeated
+                    // unnoticed for the life of the socket with no signal an
+                    // operator could see anywhere. See `recordSubscriptionRefreshError`.
+                    this.recordSubscriptionRefreshError(functionPath, error, { subId });
+
+                    continue;
                 }
             }
         };
@@ -7567,13 +7622,17 @@ abstract class ShardDO {
                         }
                     }
                 }
-            } catch {
+            } catch (error) {
                 // A throwing socket (e.g. awaitWsDrain/sendPoke rejecting on a dead
                 // connection) must not abort the poke fan-out to its siblings — the
                 // bounded pool runs sockets in parallel and one bad socket would
                 // otherwise reject the whole Promise.all. Memos are left untouched,
-                // so the next flush re-pokes this socket. Mirrors refreshSubscriptions.
-                /* poke error contained to this socket */
+                // so the next flush re-pokes this socket. Mirrors refreshSubscriptions,
+                // including the DO-01 fix — see `recordSubscriptionRefreshError`. No
+                // single `functionPath` applies to a shape poke (one socket can hold
+                // several shapes), so the log is tagged with the admin-namespaced
+                // pseudo-path below and the live shape ids.
+                this.recordSubscriptionRefreshError(`${ADMIN_FUNCTION_PREFIX}pokeShapeSubscribers`, error, { shapeIds: Object.keys(shapes) });
             }
         };
 

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.sockets.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.sockets.test.ts
@@ -256,6 +256,27 @@ describe("createSocketHost handleFor ownership", () => {
         expect(host.handleFor(stranger)).toBeUndefined();
     });
 
+    it("keeps idFor stable across repeated calls on a socket it never accepted (PLATCF-01)", () => {
+        expect.assertions(2);
+
+        // A socket the runtime hands back that this host never accepted — the
+        // same "stranger" scenario as ownership, but for identity. `idFor`
+        // used to mint a FRESH counter-based id on every call for exactly this
+        // case (no id tag, no fallbackIds entry), so two callers holding the
+        // same unowned socket disagreed about its identity — three behaviours
+        // for one call, per the SocketHost.idFor contract this now honours.
+        const live: FakeSocket[] = [];
+        const host = createSocketHost(stateWith(live) as never);
+        const stranger = new FakeSocket();
+
+        const first = host.idFor(stranger);
+        const second = host.idFor(stranger);
+
+        expect(second).toBe(first);
+        // A DIFFERENT unowned socket must not collide with the first one's id.
+        expect(host.idFor(new FakeSocket())).not.toBe(first);
+    });
+
     it("answers ownership for a stream of unknown sockets without re-walking per call", () => {
         expect.assertions(23);
 

--- a/packages/platform-cloudflare/__tests__/worker-platform.test.ts
+++ b/packages/platform-cloudflare/__tests__/worker-platform.test.ts
@@ -36,6 +36,26 @@ describe("createWorkerPlatform", () => {
         expect(() => createWorkerPlatform({}).directory("SHARD")).toThrow(/no Durable Object namespace bound as "SHARD"/);
     });
 
+    // A binding wrangler left unresolved can surface as `null`, not just absent
+    // from `env` — the guard used to be `undefined`-only, which let `null` fall
+    // through to `createShardDirectory` and fail several calls later as an
+    // unrelated TypeError instead of this actionable message (PLATCF-02).
+    it("throws the same actionable message for a null binding, not a downstream TypeError", () => {
+        expect.assertions(1);
+
+        expect(() => createWorkerPlatform({ SHARD: null }).directory("SHARD")).toThrow(/no Durable Object namespace bound as "SHARD"/);
+    });
+
+    // This package does not depend on `@lunora/do` — the error used to say
+    // `@lunora/do:` from inside `@lunora/platform-cloudflare`, naming a package
+    // this one has no edge to, which sends a reader debugging the message to
+    // the wrong source.
+    it("names @lunora/platform-cloudflare in the error, not @lunora/do", () => {
+        expect.assertions(1);
+
+        expect(() => createWorkerPlatform({}).directory("SHARD")).toThrow(/^@lunora\/platform-cloudflare:/);
+    });
+
     it("omits the scheduler when no scheduler wiring is supplied", () => {
         expect.assertions(1);
 

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -207,6 +207,21 @@ const ID_TAG_PREFIX = "lunora-socket:";
 /** Fallback ids for doubles without `getTags`, stable only within one wake. */
 const fallbackIds = new WeakMap<WebSocket, string>();
 
+/**
+ * Read-only fallback ids for a socket this host never accepted (or a double
+ * with no `getTags`, once `fallbackIds` has already been checked).
+ *
+ * A separate map from `fallbackIds` on purpose: `fallbackIds` is ownership
+ * evidence written only by `accept`, and `handleFor` trusts membership in it
+ * to mean "ours". `idFor` must answer *some* caller holding a socket this
+ * host never saw (a whisper sender in another pool, a relay-tier peer) — the
+ * contract requires a stable answer, not a thrown error, per `SocketHost.idFor`
+ * — but that answer must never be able to promote the socket into `fallbackIds`
+ * and launder it into ownership. Keeping the two maps distinct is what makes
+ * that impossible: this one is consulted only by `idFor`, never by `handleFor`.
+ */
+const readOnlyIds = new WeakMap<WebSocket, string>();
+
 let fallbackCounter = 0;
 
 /**
@@ -254,13 +269,27 @@ const readSocketId = (state: DurableObjectState, ws: WebSocket): string => {
         return existing;
     }
 
+    // A socket with no id tag and no fallback-id entry: either a test double
+    // with no `getTags` and no accept-time record, or a socket this host never
+    // accepted at all. `idFor` still has to answer, and it has to answer the
+    // SAME string every time for the SAME socket object — a fresh mint per call
+    // was the bug (PLATCF-01): three different callers holding the same
+    // unowned socket would get three different "ids" for what the engine has
+    // to treat as one identity. Cache into `readOnlyIds` — NOT `fallbackIds`,
+    // see that map's docstring for why the two must stay separate.
+    const cached = readOnlyIds.get(ws);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
     fallbackCounter += 1;
 
-    // Deliberately NOT recorded in `fallbackIds`. That map is ownership evidence
-    // consulted by `handleFor`, and `accept` is its only legitimate writer — a
-    // read-only id lookup that wrote to it would let `idFor(x)` on a foreign
-    // socket turn a cached "not ours" into "ours" on the next `handleFor(x)`.
-    return `cf-socket-${String(fallbackCounter)}`;
+    const minted = `cf-socket-${String(fallbackCounter)}`;
+
+    readOnlyIds.set(ws, minted);
+
+    return minted;
 };
 
 /**

--- a/packages/platform-cloudflare/src/platform.ts
+++ b/packages/platform-cloudflare/src/platform.ts
@@ -129,8 +129,15 @@ export const createWorkerPlatform = (env: unknown, options: WorkerPlatformOption
     const directory = (binding: string): ShardDirectory => {
         const namespace = bindings[binding];
 
-        if (namespace === undefined) {
-            throw new Error(`@lunora/do: no Durable Object namespace bound as "${binding}" — add it to wrangler.jsonc's durable_objects.bindings`);
+        // Guards `null` too, not just `undefined`: a binding wrangler left
+        // unresolved can surface as `null` rather than simply absent from
+        // `env`, and that case must fail with this same actionable message,
+        // not fall through to `createShardDirectory` and surface as an
+        // unrelated TypeError several calls downstream.
+        if (namespace === undefined || namespace === null) {
+            throw new Error(
+                `@lunora/platform-cloudflare: no Durable Object namespace bound as "${binding}" — add it to wrangler.jsonc's durable_objects.bindings`,
+            );
         }
 
         return createShardDirectory(namespace as Parameters<typeof createShardDirectory>[0]);

--- a/packages/platform/src/capabilities.ts
+++ b/packages/platform/src/capabilities.ts
@@ -94,7 +94,7 @@ export const CLOUDFLARE_CAPABILITIES: PlatformCapabilities = {
         crossShardFanout: { level: "emulated", note: "Lunora query coordinator + relay tier over Durable Objects" },
         queues: { level: "native", note: "Cloudflare Queues" },
         workflows: { level: "native", note: "Cloudflare Workflows" },
-        scheduler: { level: "native", note: "SchedulerDO + Cron Triggers" },
+        scheduler: { level: "emulated", note: "SchedulerDO (Lunora, on DO alarms) + declarative Cron Triggers; no runtime cron registration" },
         objectStorage: { level: "native", note: "R2" },
         keyValueStore: { level: "native", note: "Workers KV" },
         vectorStore: { level: "native", note: "Vectorize" },

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -240,6 +240,52 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
                 host.cleanup?.();
             });
 
+            // `SocketHost.idFor` is documented to answer the SAME string for
+            // the SAME socket, not a fresh value per call — the property every
+            // caller (fan-out dedup, subscription reassociation) relies on.
+            it("keeps idFor stable across repeated calls within a wake", async () => {
+                expect.assertions(1);
+
+                const host = await createHost();
+                const handle = host.socket.accept(rawSocket(host), {});
+
+                const first = host.socket.idFor(handle);
+                const second = host.socket.idFor(handle);
+
+                expect(second).toBe(first);
+
+                host.cleanup?.();
+            });
+
+            // Same leg as "round-trips attachments across a recycle" above, for
+            // identity rather than payload: the engine reassociates a rehydrated
+            // socket with the subscription state it owned before the wake BY id,
+            // so a host whose id drifts across a recycle breaks that lookup even
+            // though the attachment round-trips fine.
+            it("keeps idFor stable across a recycle", async () => {
+                expect.assertions(1);
+
+                const host = await createHost();
+
+                if (host.simulateRecycle === undefined || host.restoreSocket === undefined) {
+                    expect(true).toBe(true);
+                    host.cleanup?.();
+
+                    return;
+                }
+
+                const attachment = { roomId: "room-1", roles: ["admin"] };
+                const handle = host.socket.accept(rawSocket(host), attachment);
+                const idBeforeRecycle = host.socket.idFor(handle);
+
+                host.simulateRecycle();
+                const restored = host.restoreSocket(idBeforeRecycle, attachment);
+
+                expect(host.socket.idFor(restored)).toBe(idBeforeRecycle);
+
+                host.cleanup?.();
+            });
+
             // A tagged `getSockets` must return *exactly* the tagged sockets.
             // Length alone would pass a host that returns the wrong socket, and
             // a superset would fan shape updates out to unrelated (possibly

--- a/packages/platform/src/socket-host.ts
+++ b/packages/platform/src/socket-host.ts
@@ -127,6 +127,31 @@ export interface SocketHost {
      * recycle, since the engine uses it to reassociate a rehydrated socket with
      * its subscription state. Callers outside the O(subscribers) loops are the
      * intended consumers; do not reach for this per socket per frame.
+     *
+     * **A socket this host never {@link SocketHost.accept}ed** (a foreign socket
+     * the runtime hands back — a whisper sender in another pool, a relay peer)
+     * is outside that "own socket" contract, but a host must still pick ONE
+     * consistent answer for it, never a fresh value per call:
+     *
+     * - Throw, when a `SocketHandle` from this host can *only* ever originate
+     * from this host's own `accept`/`recycle` — an unrecognized handle then
+     * means caller error (a handle crossed from a different host instance),
+     * and failing loud beats returning a plausible-looking wrong id. This is
+     * the reference host's choice, since its `SocketHandle` is an opaque
+     * object it mints itself.
+     * - Mint and cache a read-only fallback id, when `SocketHandle` doubles as
+     * the provider's own transport socket (see {@link SocketHandle}'s "not a
+     * wrapper" rationale) — a foreign-but-genuine socket then structurally
+     * satisfies the type without ever going through `accept`, so throwing
+     * would fire on legitimate traffic, not just caller error. This is the
+     * Cloudflare host's choice: it caches into a separate map from its
+     * accept-time ownership evidence, so an `idFor` lookup can never promote
+     * a socket into "ours" for {@link SocketHost.handleFor}.
+     *
+     * Either is a valid implementation as long as it is consistent: what is not
+     * valid is minting a new id on every call for a socket the host does not
+     * recognize, which defeats the "same string for the same socket" property
+     * every caller of `idFor` — owned or not — depends on.
      */
     idFor: (socket: SocketHandle) => string;
 


### PR DESCRIPTION
Six fixes making the platform contract (what codegen trusts to decide if an app can target a host, and the spec a second host implements against) honest and observable — all no-ops for Cloudflare today; the value is correctness for the SECOND host. (PLATFORM-02) the capability gate failed OPEN on an omitted feature key → now treats undefined as unsupported under a distinct `platform_undeclared_feature` diagnostic. (PLATFORM-01) `scheduler` was rated `native` though SchedulerDO is Lunora's own DO → `emulated`. (PLATCF-01/03) `cloudflare-host.idFor` minted a fresh id per call for an unowned socket → stable `readOnlyIds` fallback, contract documented (both hosts agree), TCK `idFor`-stability cases verified against the reference host AND the real workerd host. (PLATCF-02) `createWorkerPlatform`'s error misattributed to `@lunora/do` + a null binding slipped the guard → fixed. (DO-01) a failing subscription refresh was silently swallowed → now increments a `subscriptionRefreshErrors` counter (wired into getMetrics) + logs; siblings still refresh.

Verified: codegen 974 (goldens byte-identical), platform 38, platform-cloudflare 19, do 502 (566 w/ workerd). api-snapshot updated for the new diagnostic name.

⚠ Touches codegen/platform-target.ts + do/shard-do.ts — merge-order vs the other codegen/shard-do PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform configurations now safely disable undeclared capabilities and provide actionable diagnostics.
  * Socket identifiers remain stable during repeated lookups and socket recovery.
  * Missing Cloudflare Durable Object bindings are detected more reliably with clearer setup guidance.
  * Subscription refresh and shape-update failures are tracked without interrupting processing or retries.

* **Improvements**
  * Cloudflare Scheduler support is now accurately represented as an emulated capability.
  * Expanded platform guidance clarifies behavior for unrecognized sockets and fallback identifiers.

* **Tests**
  * Added coverage for socket identifier stability across wake, recycle, and restore scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->