### PR TITLE
chore(templates): ignore .dev.vars and .env*.local in scaffold gitignores

### DIFF
--- a/templates/analog/.gitignore
+++ b/templates/analog/.gitignore
@@ -7,3 +7,7 @@ dist
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.env*.local
+.dev.vars

--- a/templates/astro/.gitignore
+++ b/templates/astro/.gitignore
@@ -6,3 +6,7 @@ dist
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.env*.local
+.dev.vars

--- a/templates/next/.gitignore
+++ b/templates/next/.gitignore
@@ -6,3 +6,7 @@ dist
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.env*.local
+.dev.vars

--- a/templates/nuxt/.gitignore
+++ b/templates/nuxt/.gitignore
@@ -7,3 +7,7 @@ dist
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.env*.local
+.dev.vars

--- a/templates/react-router/.gitignore
+++ b/templates/react-router/.gitignore
@@ -9,3 +9,6 @@ dist
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.dev.vars

--- a/templates/standalone/.gitignore
+++ b/templates/standalone/.gitignore
@@ -3,3 +3,7 @@ node_modules
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.env*.local
+.dev.vars

--- a/templates/sveltekit/.gitignore
+++ b/templates/sveltekit/.gitignore
@@ -6,3 +6,7 @@ dist
 .lunora/
 .lunora-cache
 lunora/_generated
+
+# local env files
+.env*.local
+.dev.vars

--- a/templates/tanstack-start-react/.gitignore
+++ b/templates/tanstack-start-react/.gitignore
@@ -10,3 +10,6 @@ dist
 .lunora-cache
 lunora/_generated
 src/routeTree.gen.ts
+
+# local env files
+.dev.vars

--- a/templates/tanstack-start-solid/.gitignore
+++ b/templates/tanstack-start-solid/.gitignore
@@ -14,3 +14,6 @@ dist-ssr
 __unconfig*
 lunora/_generated
 src/routeTree.gen.ts
+
+# local env files
+.dev.vars


### PR DESCRIPTION
## What

Adds `.dev.vars` (and `.env*.local` where it was also absent) to the nine scaffold-template `.gitignore` files that lacked it. Only `expo` already had it — it's the exemplar and is left untouched.

## Why

`lunora dev` / wrangler read local secrets from a `.dev.vars` file. Every template is a whole-project scaffold fetched by `lunora init` (`giget` from `gh:anolilab/lunora/templates/<type>#alpha`), and the user's first move after scaffolding is typically `git init`. Without `.dev.vars` in the template's `.gitignore`, the first `git add -A && git commit` stages the developer's local secrets into their new repo. The remote scaffold is the highest-blast-radius place this omission can live.

## Safety

- The pattern is **exact** `.dev.vars`, not `.dev.vars*`, so the committed non-secret `.dev.vars.example` placeholders stay tracked (verified: `git check-ignore` exits 1 for every existing `.dev.vars.example`).
- No template had a real `.dev.vars`/`.env` file committed — only `.example` placeholders are tracked, so this is a pure preventative fix (nothing to untrack/rotate).
- `.env*.local` added only to the six templates that lacked local-env coverage; react-router and the two tanstack-start templates already ignored it, so they got only the `.dev.vars` line.

## Verification

- All ten templates now ignore `.dev.vars` (grep loop all `ok`).
- `git diff --stat`: nine `.gitignore` files, 33 insertions, 0 deletions — nothing else touched.

Must land on `alpha` to reach new projects (the end-user impact is entirely in the remote scaffold). Mergeable independently of every other open PR.

Plan: `plans/249-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)