### PR TITLE
test(shard-engine): prototype the progressive-sharding WAL + watermark + dual-read protocol (2-shard, test-only)

### DIFF
--- a/packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts
+++ b/packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts
@@ -12,6 +12,7 @@
 
 import type { SqlExec } from "../../src/ctx-db";
 import { appendCdcChange, migrateCdcLog, readCdcChanges, readCdcCursor } from "../../src/ctx-db-cdc";
+import type { CdcChange } from "../../src/ctx-db-cdc";
 import { vnodeForId } from "../../src/shard-ring";
 import createSqliteExec from "./node-sqlite";
 
@@ -28,27 +29,54 @@ interface MessageRow {
     id: string;
 }
 
-/** Create a shard: an in-memory SQLite store with the `messages` table and `__cdc_log` migrated. */
+/**
+ * Create a shard: an in-memory SQLite store with the `messages` table, its
+ * `__cdc_log` migrated, and a `__tombstones` side table.
+ *
+ * `__tombstones` exists to make a shard's own delete authoritative over a
+ * stale row another shard still physically holds (see `dualRead`'s tombstone
+ * check below, and design doc §6 "delete-during-move"). Without it, a target
+ * that deletes a moved row during the dual-read window looks identical — to a
+ * fan-out read — to a target that simply hasn't replicated that id yet, and
+ * the read falls through to `source`'s stale pre-move copy, resurrecting a
+ * delete.
+ */
 const createShardHarness = (): ShardHarness => {
     const harness = createSqliteExec();
 
     harness.raw("CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, body TEXT NOT NULL)");
+    harness.raw("CREATE TABLE IF NOT EXISTS __tombstones (id TEXT PRIMARY KEY)");
     migrateCdcLog(harness.sql);
 
     return harness;
 };
+
+/** Record that `shard` has authoritatively deleted `id` — see `createShardHarness`'s doc. */
+const markTombstone = (shard: ShardHarness, id: string): void => {
+    shard.raw("INSERT INTO __tombstones (id) VALUES (?) ON CONFLICT(id) DO NOTHING", id);
+};
+
+/** Clear `id`'s tombstone on `shard` — a row live again (re-created after a delete) is no longer a deletion. */
+const clearTombstone = (shard: ShardHarness, id: string): void => {
+    shard.raw("DELETE FROM __tombstones WHERE id = ?", id);
+};
+
+/** Whether `shard` has authoritatively deleted `id` (and so must not be skipped past to a peer's stale copy). */
+const hasTombstone = (shard: ShardHarness, id: string): boolean => shard.raw("SELECT id FROM __tombstones WHERE id = ?", id).length > 0;
 
 /** Write (insert-or-update) a document on `shard` and append the matching WAL entry. */
 const writeMessage = (shard: ShardHarness, id: string, body: string, ts: number): void => {
     const existing = shard.raw("SELECT id FROM messages WHERE id = ?", id);
 
     shard.raw("INSERT INTO messages (id, body) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET body = excluded.body", id, body);
+    clearTombstone(shard, id);
     appendCdcChange(shard.sql, ts, "messages", id, existing.length > 0 ? "update" : "insert", { body });
 };
 
-/** Delete a document on `shard` and append the matching WAL entry. */
+/** Delete a document on `shard`, mark its tombstone, and append the matching WAL entry. */
 const deleteMessage = (shard: ShardHarness, id: string, ts: number): void => {
     shard.raw("DELETE FROM messages WHERE id = ?", id);
+    markTombstone(shard, id);
     appendCdcChange(shard.sql, ts, "messages", id, "delete", undefined);
 };
 
@@ -109,23 +137,42 @@ const snapshotVnodes = (source: ShardHarness, target: ShardHarness, ringSize: nu
     }
 };
 
-/** Apply one WAL entry (already known to belong to a moving vnode) onto `target`. */
-const applyChangeToTarget = (target: ShardHarness, change: { body?: string; id: string; op: "delete" | "insert" | "update" }): void => {
+/** Apply one WAL entry (already known to belong to a moving vnode) onto `target`, keeping its tombstone state in sync. */
+const applyChangeToTarget = (target: ShardHarness, change: CdcChange): void => {
     if (change.op === "delete") {
         target.raw("DELETE FROM messages WHERE id = ?", change.id);
+        markTombstone(target, change.id);
 
         return;
     }
 
-    target.raw("INSERT INTO messages (id, body) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET body = excluded.body", change.id, change.body ?? "");
+    target.raw(
+        "INSERT INTO messages (id, body) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET body = excluded.body",
+        change.id,
+        (change.doc?.["body"] as string | undefined) ?? "",
+    );
+    clearTombstone(target, change.id);
 };
+
+/** `readCdcChanges` clamps a single call to this many rows; `catchUpVnodes` pages past it below. */
+const CATCH_UP_PAGE_LIMIT = 1000;
 
 /**
  * Replay `source`'s WAL onto `target`, filtered to `movingVnodes`, from the
  * move's current `appliedWatermark` up to `upToSeq` (inclusive) if given, else
- * to the end of the log. Returns the move state with `appliedWatermark`
- * advanced to the highest replayed `seq` — the applied-watermark signal a
- * target uses to tell a coordinator "I have caught up to this point".
+ * to the end of the log. Pages through `readCdcChanges` — which clamps a
+ * single call to `CATCH_UP_PAGE_LIMIT` rows — until a page comes back short
+ * (or `upToSeq` truncates it), so a WAL tail longer than one page is fully
+ * consumed in one call, matching the design doc's §2.4 "runs however many
+ * times is needed" claim rather than silently stopping at the first page.
+ *
+ * Returns the move state with `appliedWatermark` advanced to the highest
+ * *consumed* `seq` (not the highest *applied* one — see the comment inline
+ * below). That is the applied-watermark signal a target uses to tell a
+ * coordinator "I have caught up to this point", and it must track the WAL
+ * position walked past, or cutover's `appliedWatermark === quiesceSeq` gate
+ * can never close under interleaved traffic (see `catchUpVnodes`'s test
+ * coverage in `progressive-shard-move.test.ts`).
  */
 const catchUpVnodes = (
     source: ShardHarness,
@@ -138,22 +185,54 @@ const catchUpVnodes = (
     // `appliedWatermark` already incorporates the snapshot floor (see
     // `beginVnodeMove`), so paging from it alone is correct and idempotent
     // across repeated calls — each call only ever sees the tail it hasn't
-    // replayed yet.
-    const { changes } = readCdcChanges(source.sql, { sinceSeq: move.appliedWatermark, tables: new Set(["messages"]) });
-
+    // consumed yet.
     let watermark = move.appliedWatermark;
 
-    for (const change of changes) {
-        if (upToSeq !== undefined && change.seq > upToSeq) {
+    for (;;) {
+        const { changes } = readCdcChanges(source.sql, { limit: CATCH_UP_PAGE_LIMIT, sinceSeq: watermark, tables: new Set(["messages"]) });
+
+        if (changes.length === 0) {
             break;
         }
 
-        if (!movingVnodes.has(vnodeForId(change.id, ringSize))) {
-            continue;
+        let truncatedByUpToSeq = false;
+
+        for (const change of changes) {
+            if (upToSeq !== undefined && change.seq > upToSeq) {
+                truncatedByUpToSeq = true;
+
+                break;
+            }
+
+            // Advance the watermark for EVERY entry consumed, not only the ones
+            // that belong to a moving vnode. `quiesceSeq` (the cutover gate's
+            // other side) is `readCdcCursor(source)` — the shard's GLOBAL
+            // high-watermark across ALL vnodes, staying ones included. Under
+            // realistic interleaved traffic the last write before quiesce is
+            // just as likely to land on a staying vnode as a moving one; if
+            // the watermark only moved inside the `movingVnodes` filter below,
+            // a staying-vnode tail write would never be consumed and
+            // `appliedWatermark` would lag `quiesceSeq` forever — cutover's
+            // precondition would never close even though every moving vnode is
+            // already fully replicated. Tracking "log position consumed"
+            // rather than "last moving-vnode seq applied" is what keeps the
+            // two cursors on the same footing.
+            watermark = change.seq;
+
+            if (!movingVnodes.has(vnodeForId(change.id, ringSize))) {
+                continue;
+            }
+
+            applyChangeToTarget(target, change);
         }
 
-        applyChangeToTarget(target, { body: change.doc?.["body"] as string | undefined, id: change.id, op: change.op });
-        watermark = change.seq;
+        if (truncatedByUpToSeq || changes.length < CATCH_UP_PAGE_LIMIT) {
+            // A short page (or an `upToSeq` cutoff mid-page) means there is
+            // nothing further to fetch right now — `readCdcChanges` applies no
+            // filter besides `sinceSeq`/`tables`, so a page smaller than the
+            // limit is proof the log's tail (for this table) has been reached.
+            break;
+        }
     }
 
     return { ...move, appliedWatermark: Math.max(watermark, move.appliedWatermark) };
@@ -200,27 +279,41 @@ const cedeVnodes = (coordinator: MoveCoordinator, vnodes: ReadonlySet<number>): 
 const resolveAuthoritativeShard = (coordinator: MoveCoordinator, id: string): "source" | "target" =>
     coordinator.cededVnodes.has(vnodeForId(id, coordinator.ringSize)) ? "target" : "source";
 
+/** What `routeWrite` applies for one routed operation: an upsert (`body`) or a delete. */
+type RouteChange = { readonly body: string } | { readonly op: "delete" };
+
 /**
- * Route a write through the coordinator: forwarded to `target` if the write's
- * vnode has already been ceded (post-cutover), rejected if the vnode is
- * mid-cutover-quiesce (the brief window a real shard would queue-and-retry
- * rather than throw), else applied on `source` as normal. This is the
- * write-side half of the "no missing/duplicated rows" guarantee: `source`
- * enforces its own cede state on every write it receives, regardless of which
- * directory version the caller resolved from.
+ * Route a write or delete through the coordinator: forwarded to `target` if
+ * the key's vnode has already been ceded (post-cutover), rejected if the
+ * vnode is mid-cutover-quiesce (the brief window a real shard would
+ * queue-and-retry rather than throw), else applied on `source` as normal.
+ * This is the write-side half of the "no missing/duplicated rows" guarantee:
+ * `source` enforces its own cede state on every operation it receives,
+ * regardless of which directory version the caller resolved from — deletes
+ * included, so a delete issued against a moved key during the propagation
+ * window still lands (forwarded) on the shard that is actually authoritative
+ * for it, and marks that shard's tombstone (see `deleteMessage`), rather than
+ * being silently dropped or misapplied to `source`.
  */
 const routeWrite = (
     coordinator: MoveCoordinator,
     source: ShardHarness,
     target: ShardHarness,
     id: string,
-    body: string,
+    change: RouteChange,
     ts: number,
 ): "forwarded" | "quiesced" | "source" => {
     const vnode = vnodeForId(id, coordinator.ringSize);
+    const apply = (shard: ShardHarness): void => {
+        if ("op" in change && change.op === "delete") {
+            deleteMessage(shard, id, ts);
+        } else if ("body" in change) {
+            writeMessage(shard, id, change.body, ts);
+        }
+    };
 
     if (coordinator.cededVnodes.has(vnode)) {
-        writeMessage(target, id, body, ts);
+        apply(target);
 
         return "forwarded";
     }
@@ -229,7 +322,7 @@ const routeWrite = (
         return "quiesced";
     }
 
-    writeMessage(source, id, body, ts);
+    apply(source);
 
     return "source";
 };
@@ -239,11 +332,24 @@ const routeWrite = (
  * and merge by identity, target-wins-if-present (see the design doc's dedup
  * rule). Returns a `Map` keyed by id, which is what makes "each row exactly
  * once" a structural property of the merge rather than a manual count.
+ *
+ * A target tombstone is authoritative and short-circuits the merge for that
+ * id — it is NOT treated the same as "target doesn't have it yet" (which
+ * falls through to `source`). Without this check, a delete applied to
+ * `target` during the dual-read window is indistinguishable, from a fan-out
+ * read's point of view, from a row `target` simply hasn't replicated yet —
+ * and falling through would hand back `source`'s stale, undeleted pre-move
+ * copy, resurrecting a delete the caller believes already happened (see
+ * design doc §6).
  */
 const dualRead = (source: ShardHarness, target: ShardHarness, ids: ReadonlyArray<string>): Map<string, MessageRow> => {
     const merged = new Map<string, MessageRow>();
 
     for (const id of ids) {
+        if (hasTombstone(target, id)) {
+            continue;
+        }
+
         const fromTarget = readMessage(target, id);
 
         if (fromTarget) {

--- a/packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts
+++ b/packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts
@@ -1,0 +1,282 @@
+// Test-only prototype for plan 235 — the progressive-sharding WAL + applied-watermark
+// + dual-read protocol, exercised entirely against the existing in-memory SQLite
+// harness (`node-sqlite.ts`) and the existing `__cdc_log` WAL primitives from
+// `ctx-db-cdc.ts`. Nothing here is imported by, or wired into, `ShardDO` or
+// `shard-ring.ts`'s live routing path — see `plans/235-progressive-sharding-design.md`
+// for the protocol this models and its open questions.
+//
+// The design's central claim, tested below: a shard receiving a write enforces
+// placement authority itself (source refuses/forwards once it has ceded a vnode),
+// so correctness does not depend on every caller holding a fresh directory —
+// only on the shard being the one true arbiter of whether it currently owns a key.
+
+import type { SqlExec } from "../../src/ctx-db";
+import { appendCdcChange, migrateCdcLog, readCdcChanges, readCdcCursor } from "../../src/ctx-db-cdc";
+import { vnodeForId } from "../../src/shard-ring";
+import createSqliteExec from "./node-sqlite";
+
+/** A single shard's store in the prototype: one `messages` table plus its `__cdc_log` WAL. */
+interface ShardHarness {
+    close: () => void;
+    raw: (query: string, ...params: unknown[]) => Record<string, unknown>[];
+    sql: SqlExec;
+}
+
+/** One row of the toy `messages` table the prototype moves between shards. */
+interface MessageRow {
+    body: string;
+    id: string;
+}
+
+/** Create a shard: an in-memory SQLite store with the `messages` table and `__cdc_log` migrated. */
+const createShardHarness = (): ShardHarness => {
+    const harness = createSqliteExec();
+
+    harness.raw("CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, body TEXT NOT NULL)");
+    migrateCdcLog(harness.sql);
+
+    return harness;
+};
+
+/** Write (insert-or-update) a document on `shard` and append the matching WAL entry. */
+const writeMessage = (shard: ShardHarness, id: string, body: string, ts: number): void => {
+    const existing = shard.raw("SELECT id FROM messages WHERE id = ?", id);
+
+    shard.raw("INSERT INTO messages (id, body) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET body = excluded.body", id, body);
+    appendCdcChange(shard.sql, ts, "messages", id, existing.length > 0 ? "update" : "insert", { body });
+};
+
+/** Delete a document on `shard` and append the matching WAL entry. */
+const deleteMessage = (shard: ShardHarness, id: string, ts: number): void => {
+    shard.raw("DELETE FROM messages WHERE id = ?", id);
+    appendCdcChange(shard.sql, ts, "messages", id, "delete", undefined);
+};
+
+/** Read one document from `shard`, or `undefined` if it does not hold that id. */
+const readMessage = (shard: ShardHarness, id: string): MessageRow | undefined => {
+    const rows = shard.raw("SELECT id, body FROM messages WHERE id = ?", id) as unknown as MessageRow[];
+
+    return rows[0];
+};
+
+/** All document ids currently stored on `shard`. */
+const listMessageIds = (shard: ShardHarness): string[] => (shard.raw("SELECT id FROM messages") as { id: string }[]).map((row) => row.id);
+
+/**
+ * Progress of moving a set of vnodes from one shard to another.
+ * `snapshotSeq` is the source WAL cursor at the moment the base copy ran;
+ * `appliedWatermark` is the target's cursor into the source's WAL — the
+ * applied-watermark protocol's whole state. `quiesceSeq`, once set, is the
+ * source cursor captured when new writes to the moving vnodes were paused for
+ * cutover; cutover is legal exactly when `appliedWatermark === quiesceSeq`.
+ */
+interface VnodeMoveState {
+    readonly appliedWatermark: number;
+    readonly quiesceSeq?: number;
+    readonly snapshotSeq: number;
+}
+
+/**
+ * Start a move: record the source's current WAL cursor as the snapshot
+ * boundary. `appliedWatermark` starts equal to `snapshotSeq`, not `0` — the
+ * base copy a caller is about to take (see {@link snapshotVnodes}) already
+ * captures every write up to this cursor, so the target is "caught up
+ * through `snapshotSeq`" the moment the copy finishes, before any WAL replay
+ * happens at all. Treating the watermark as `0` here would make the target
+ * look permanently behind on a quiet ring — `catchUpVnodes` would keep
+ * waiting for the (never-arriving) tail below `snapshotSeq` that the
+ * snapshot, not the WAL, already accounts for.
+ */
+const beginVnodeMove = (source: ShardHarness): VnodeMoveState => {
+    const snapshotSeq = readCdcCursor(source.sql);
+
+    return { appliedWatermark: snapshotSeq, snapshotSeq };
+};
+
+/**
+ * Base-copy every row belonging to `movingVnodes` from `source` to `target`, as
+ * of right now. Must run without interleaved writes to those vnodes (the
+ * prototype's tests never write mid-snapshot; a real shard would enforce this
+ * with the same single-threaded-DO guarantee it already relies on for OCC).
+ */
+const snapshotVnodes = (source: ShardHarness, target: ShardHarness, ringSize: number, movingVnodes: ReadonlySet<number>): void => {
+    const rows = source.raw("SELECT id, body FROM messages") as unknown as MessageRow[];
+
+    for (const row of rows) {
+        if (movingVnodes.has(vnodeForId(row.id, ringSize))) {
+            target.raw("INSERT INTO messages (id, body) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET body = excluded.body", row.id, row.body);
+        }
+    }
+};
+
+/** Apply one WAL entry (already known to belong to a moving vnode) onto `target`. */
+const applyChangeToTarget = (target: ShardHarness, change: { body?: string; id: string; op: "delete" | "insert" | "update" }): void => {
+    if (change.op === "delete") {
+        target.raw("DELETE FROM messages WHERE id = ?", change.id);
+
+        return;
+    }
+
+    target.raw("INSERT INTO messages (id, body) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET body = excluded.body", change.id, change.body ?? "");
+};
+
+/**
+ * Replay `source`'s WAL onto `target`, filtered to `movingVnodes`, from the
+ * move's current `appliedWatermark` up to `upToSeq` (inclusive) if given, else
+ * to the end of the log. Returns the move state with `appliedWatermark`
+ * advanced to the highest replayed `seq` — the applied-watermark signal a
+ * target uses to tell a coordinator "I have caught up to this point".
+ */
+const catchUpVnodes = (
+    source: ShardHarness,
+    target: ShardHarness,
+    ringSize: number,
+    movingVnodes: ReadonlySet<number>,
+    move: VnodeMoveState,
+    upToSeq?: number,
+): VnodeMoveState => {
+    // `appliedWatermark` already incorporates the snapshot floor (see
+    // `beginVnodeMove`), so paging from it alone is correct and idempotent
+    // across repeated calls — each call only ever sees the tail it hasn't
+    // replayed yet.
+    const { changes } = readCdcChanges(source.sql, { sinceSeq: move.appliedWatermark, tables: new Set(["messages"]) });
+
+    let watermark = move.appliedWatermark;
+
+    for (const change of changes) {
+        if (upToSeq !== undefined && change.seq > upToSeq) {
+            break;
+        }
+
+        if (!movingVnodes.has(vnodeForId(change.id, ringSize))) {
+            continue;
+        }
+
+        applyChangeToTarget(target, { body: change.doc?.["body"] as string | undefined, id: change.id, op: change.op });
+        watermark = change.seq;
+    }
+
+    return { ...move, appliedWatermark: Math.max(watermark, move.appliedWatermark) };
+};
+
+/**
+ * A move coordinator's live routing state for one migration: which vnodes are
+ * momentarily blocking new writes (the cutover quiesce gate) and which vnodes
+ * the source has already ceded to the target (post-cutover forwarding). This
+ * is the test-local stand-in for the directory-flip + forwarding shim the
+ * design doc specifies — deliberately NOT `shard-ring.ts`'s `VnodeDirectory`,
+ * since that type stays routing-only and untouched by this spike.
+ */
+interface MoveCoordinator {
+    readonly cededVnodes: Set<number>;
+    readonly quiescedVnodes: Set<number>;
+    readonly ringSize: number;
+}
+
+const createMoveCoordinator = (ringSize: number): MoveCoordinator => {
+    return { cededVnodes: new Set(), quiescedVnodes: new Set(), ringSize };
+};
+
+/** Enter the cutover gate: block new writes to `vnodes` on the source (the brief window before the atomic directory flip). */
+const quiesceVnodes = (coordinator: MoveCoordinator, vnodes: ReadonlySet<number>): void => {
+    for (const vnode of vnodes) {
+        coordinator.quiescedVnodes.add(vnode);
+    }
+};
+
+/**
+ * Commit the atomic directory flip: `vnodes` move from quiesced to ceded, so
+ * `resolveAuthoritativeShard` now answers `"target"` and any write source still
+ * receives for them is forwarded rather than applied locally.
+ */
+const cedeVnodes = (coordinator: MoveCoordinator, vnodes: ReadonlySet<number>): void => {
+    for (const vnode of vnodes) {
+        coordinator.quiescedVnodes.delete(vnode);
+        coordinator.cededVnodes.add(vnode);
+    }
+};
+
+/** Which shard is authoritative for `id` right now, per the coordinator's cede state. */
+const resolveAuthoritativeShard = (coordinator: MoveCoordinator, id: string): "source" | "target" =>
+    coordinator.cededVnodes.has(vnodeForId(id, coordinator.ringSize)) ? "target" : "source";
+
+/**
+ * Route a write through the coordinator: forwarded to `target` if the write's
+ * vnode has already been ceded (post-cutover), rejected if the vnode is
+ * mid-cutover-quiesce (the brief window a real shard would queue-and-retry
+ * rather than throw), else applied on `source` as normal. This is the
+ * write-side half of the "no missing/duplicated rows" guarantee: `source`
+ * enforces its own cede state on every write it receives, regardless of which
+ * directory version the caller resolved from.
+ */
+const routeWrite = (
+    coordinator: MoveCoordinator,
+    source: ShardHarness,
+    target: ShardHarness,
+    id: string,
+    body: string,
+    ts: number,
+): "forwarded" | "quiesced" | "source" => {
+    const vnode = vnodeForId(id, coordinator.ringSize);
+
+    if (coordinator.cededVnodes.has(vnode)) {
+        writeMessage(target, id, body, ts);
+
+        return "forwarded";
+    }
+
+    if (coordinator.quiescedVnodes.has(vnode)) {
+        return "quiesced";
+    }
+
+    writeMessage(source, id, body, ts);
+
+    return "source";
+};
+
+/**
+ * Dual-read fan-out for the propagation window: query both shards for `ids`
+ * and merge by identity, target-wins-if-present (see the design doc's dedup
+ * rule). Returns a `Map` keyed by id, which is what makes "each row exactly
+ * once" a structural property of the merge rather than a manual count.
+ */
+const dualRead = (source: ShardHarness, target: ShardHarness, ids: ReadonlyArray<string>): Map<string, MessageRow> => {
+    const merged = new Map<string, MessageRow>();
+
+    for (const id of ids) {
+        const fromTarget = readMessage(target, id);
+
+        if (fromTarget) {
+            merged.set(id, fromTarget);
+
+            continue;
+        }
+
+        const fromSource = readMessage(source, id);
+
+        if (fromSource) {
+            merged.set(id, fromSource);
+        }
+    }
+
+    return merged;
+};
+
+export {
+    applyChangeToTarget,
+    beginVnodeMove,
+    catchUpVnodes,
+    cedeVnodes,
+    createMoveCoordinator,
+    createShardHarness,
+    deleteMessage,
+    dualRead,
+    listMessageIds,
+    quiesceVnodes,
+    readMessage,
+    resolveAuthoritativeShard,
+    routeWrite,
+    snapshotVnodes,
+    writeMessage,
+};
+export type { MessageRow, MoveCoordinator, ShardHarness, VnodeMoveState };

--- a/packages/shard-engine/__tests__/progressive-shard-move.test.ts
+++ b/packages/shard-engine/__tests__/progressive-shard-move.test.ts
@@ -26,6 +26,7 @@ import {
     cedeVnodes,
     createMoveCoordinator,
     createShardHarness,
+    deleteMessage,
     dualRead,
     quiesceVnodes,
     readMessage,
@@ -134,7 +135,7 @@ describe("progressive shard move (plan 235 spike)", () => {
     describe("exactly-once resolution", () => {
         it("resolves every key to source before the move starts", () => {
             // One `resolveAuthoritativeShard` check per seeded document.
-            expect.assertions(200);
+            expect.assertions(SEED_COUNT);
 
             for (const id of groundTruth.keys()) {
                 expect(resolveAuthoritativeShard(coordinator, id)).toBe("source");
@@ -143,7 +144,7 @@ describe("progressive shard move (plan 235 spike)", () => {
 
         it("keeps resolving to source through snapshot and catch-up — cutover has not committed yet", () => {
             // 1 watermark check + one resolve check and one content check per seeded document.
-            expect.assertions(401);
+            expect.assertions(2 * SEED_COUNT + 1);
 
             const move = runToQuiesced();
 
@@ -163,7 +164,7 @@ describe("progressive shard move (plan 235 spike)", () => {
 
         it("flips moved keys to target and leaves staying keys on source after cutover — each with the correct content", () => {
             // One resolve check per seeded document + one content check per seeded document.
-            expect.assertions(400);
+            expect.assertions(2 * SEED_COUNT);
 
             const move = runToQuiesced();
 
@@ -184,6 +185,78 @@ describe("progressive shard move (plan 235 spike)", () => {
 
                 expect(readMessage(shard, id)?.body).toBe(body);
             }
+        });
+    });
+
+    describe("applied-watermark protocol under interleaved traffic", () => {
+        it("advances past a staying-vnode's tail write, so cutover does not deadlock when it — not a moving-vnode write — is last before quiesce", () => {
+            // Every one of the other scenarios writes everything in `seed()` before
+            // the move starts, or makes the last pre-quiesce write land inside the
+            // moving range — both dodge the realistic case where an ordinary write
+            // to a vnode that never moves happens to be the log's tail when quiesce
+            // fires. `quiesceSeq` is `readCdcCursor(source)`, the shard's GLOBAL
+            // high-watermark across every vnode, so a watermark that only advanced
+            // for moving-vnode entries would never consume that tail write and
+            // would lag `quiesceSeq` forever — cutover's precondition would never
+            // close even though the moving vnodes are fully replicated.
+            expect.assertions(2);
+
+            let move = beginVnodeMove(source);
+
+            snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
+
+            quiesceVnodes(coordinator, MOVING_VNODES);
+
+            const stayingId = stayingIds()[0] as string;
+
+            clock += 1;
+
+            const route = routeWrite(coordinator, source, target, stayingId, { body: "last-write-before-quiesce-on-a-staying-vnode" }, clock);
+
+            expect(route).toBe("source");
+
+            const quiesceSeq = readCdcCursor(source.sql);
+
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move, quiesceSeq);
+
+            // The watermark protocol's core signal, and cutover's precondition —
+            // both must hold even though the tail entry belonged to a vnode that
+            // never moves.
+            expect(move.appliedWatermark).toBe(quiesceSeq);
+        });
+    });
+
+    describe("catch-up paging", () => {
+        it("replays a WAL tail longer than one `readCdcChanges` page (1000 rows) in a single `catchUpVnodes` call", () => {
+            // Design doc §2.4 says catch-up "runs however many times is needed" —
+            // a mover that only ever reads one bounded page would silently stop
+            // short of a real WAL tail once a busy shard's backlog crosses
+            // `readCdcChanges`'s 1000-row page limit.
+            expect.assertions(3);
+
+            let move = beginVnodeMove(source);
+
+            snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
+
+            const pagedId = findIdInVnodes("doc_paged", MOVING_VNODES);
+            const finalBody = "final-body-after-1200-writes";
+            const writeCount = 1200;
+
+            for (let index = 0; index < writeCount; index += 1) {
+                clock += 1;
+                writeMessage(source, pagedId, index === writeCount - 1 ? finalBody : `intermediate-${String(index)}`, clock);
+            }
+
+            quiesceVnodes(coordinator, MOVING_VNODES);
+
+            const quiesceSeq = readCdcCursor(source.sql);
+
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move, quiesceSeq);
+
+            expect(move.appliedWatermark).toBe(quiesceSeq);
+            expect(() => cutover({ ...move, quiesceSeq })).not.toThrow();
+            expect(readMessage(target, pagedId)?.body).toBe(finalBody);
         });
     });
 
@@ -211,7 +284,7 @@ describe("progressive shard move (plan 235 spike)", () => {
             clock += 1;
 
             const newBody = "forwarded-update";
-            const route = routeWrite(coordinator, source, target, sampleId as string, newBody, clock);
+            const route = routeWrite(coordinator, source, target, sampleId as string, { body: newBody }, clock);
 
             expect(route).toBe("forwarded");
             // Source's undeleted copy still reads the OLD body — the divergence the
@@ -232,7 +305,7 @@ describe("progressive shard move (plan 235 spike)", () => {
 
         it("never drops or duplicates a row across a larger mixed batch", () => {
             // 1 size check + one content check per seeded document.
-            expect.assertions(201);
+            expect.assertions(SEED_COUNT + 1);
 
             const move = runToQuiesced();
 
@@ -246,6 +319,45 @@ describe("progressive shard move (plan 235 spike)", () => {
             for (const [id, body] of groundTruth) {
                 expect(merged.get(id)?.body).toBe(body);
             }
+        });
+
+        it("forwards a delete on a moved row to target and does not resurrect source's stale pre-move copy via dualRead", () => {
+            // The delete path was entirely untested before this: `deleteMessage`
+            // was exported but unused, `applyChangeToTarget`'s delete branch was
+            // never reached, and `routeWrite` had no delete branch at all. Without
+            // a target-side tombstone, a target miss during the dual-read window
+            // is indistinguishable from "target hasn't replicated this id yet" —
+            // and the read would fall through to source's stale, still-physically-
+            // present copy, resurrecting a row the caller believes is gone.
+            expect.assertions(5);
+
+            const move = runToQuiesced();
+
+            cutover(move);
+
+            const [movedId] = movingIds();
+            const originalBody = groundTruth.get(movedId as string);
+
+            expect(movedId).toBeDefined();
+            // Cutover purges nothing from source (drain-close is a separate,
+            // deferred step) — source still physically holds the pre-move row.
+            expect(readMessage(source, movedId as string)?.body).toBe(originalBody);
+
+            clock += 1;
+
+            // The vnode was ceded at cutover, so this delete is forwarded to
+            // target — exercising `routeWrite`'s delete branch and `deleteMessage`.
+            const route = routeWrite(coordinator, source, target, movedId as string, { op: "delete" }, clock);
+
+            expect(route).toBe("forwarded");
+            expect(readMessage(target, movedId as string)).toBeUndefined();
+
+            // The assertion that actually catches the bug: a dualRead during the
+            // propagation window must see the row as absent — not fall through to
+            // source's undeleted, stale copy.
+            const merged = dualRead(source, target, [movedId as string]);
+
+            expect(merged.has(movedId as string)).toBe(false);
         });
     });
 
@@ -265,7 +377,7 @@ describe("progressive shard move (plan 235 spike)", () => {
 
             clock += 1;
 
-            const route = routeWrite(coordinator, source, target, midMoveId, midMoveBody, clock);
+            const route = routeWrite(coordinator, source, target, midMoveId, { body: midMoveBody }, clock);
 
             expect(route).toBe("source");
             // Not yet caught up — target has no idea this write happened.
@@ -305,7 +417,7 @@ describe("progressive shard move (plan 235 spike)", () => {
 
             clock += 1;
 
-            const duringQuiesce = routeWrite(coordinator, source, target, id as string, "should-not-land-yet", clock);
+            const duringQuiesce = routeWrite(coordinator, source, target, id as string, { body: "should-not-land-yet" }, clock);
 
             expect(duringQuiesce).toBe("quiesced");
 
@@ -318,9 +430,36 @@ describe("progressive shard move (plan 235 spike)", () => {
 
             clock += 1;
 
-            const afterCutover = routeWrite(coordinator, source, target, id as string, "retried-after-cutover", clock);
+            const afterCutover = routeWrite(coordinator, source, target, id as string, { body: "retried-after-cutover" }, clock);
 
             expect(afterCutover).toBe("forwarded");
+        });
+
+        it("replays a delete issued on source during catch-up onto target via the WAL", () => {
+            // Exercises `applyChangeToTarget`'s op==="delete" branch, which — like
+            // the delete path generally — nothing reached before this: a delete
+            // that happens on source (still authoritative pre-quiesce) must be
+            // walked past by the SAME `catchUpVnodes` replay as an insert/update,
+            // removing the row `snapshotVnodes` already base-copied onto target.
+            expect.assertions(3);
+
+            let move = beginVnodeMove(source);
+
+            snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
+
+            const [deletedId] = movingIds();
+
+            expect(deletedId).toBeDefined();
+            // Base-copied by `snapshotVnodes` above — present on target until the
+            // delete replays below.
+            expect(readMessage(target, deletedId as string)).toBeDefined();
+
+            clock += 1;
+            deleteMessage(source, deletedId as string, clock);
+
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
+
+            expect(readMessage(target, deletedId as string)).toBeUndefined();
         });
     });
 });

--- a/packages/shard-engine/__tests__/progressive-shard-move.test.ts
+++ b/packages/shard-engine/__tests__/progressive-shard-move.test.ts
@@ -443,7 +443,7 @@ describe("progressive shard move (plan 235 spike)", () => {
             // removing the row `snapshotVnodes` already base-copied onto target.
             expect.assertions(3);
 
-            let move = beginVnodeMove(source);
+            const move = beginVnodeMove(source);
 
             snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
 
@@ -457,7 +457,7 @@ describe("progressive shard move (plan 235 spike)", () => {
             clock += 1;
             deleteMessage(source, deletedId as string, clock);
 
-            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
+            catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
 
             expect(readMessage(target, deletedId as string)).toBeUndefined();
         });

--- a/packages/shard-engine/__tests__/progressive-shard-move.test.ts
+++ b/packages/shard-engine/__tests__/progressive-shard-move.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Plan 235 spike: prototype the progressive-sharding WAL + applied-watermark +
+ * dual-read protocol for a 2-shard ring, entirely in tests.
+ *
+ * This exercises the state machine in `_helpers/progressive-shard-move.ts`
+ * against the real `__cdc_log` WAL primitives (`ctx-db-cdc.ts`) and two
+ * independent in-memory SQLite shards (`_helpers/node-sqlite.ts`). Nothing
+ * here touches `shard-ring.ts`'s live routing path or `ShardDO` — see
+ * `plans/235-progressive-sharding-design.md` for the protocol this models.
+ *
+ * The three DONE-criteria assertions from plan 235, one `describe` each:
+ * (a) every key resolves to exactly one authoritative copy throughout the move;
+ * (b) a dual-read fan-out during the propagation window returns each row
+ * exactly once, even when source still holds a stale, undeleted copy;
+ * (c) a write issued mid-move lands on the correct placement and is visible
+ * after cutover.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readCdcCursor } from "../src/ctx-db-cdc";
+import { vnodeForId } from "../src/shard-ring";
+import type { MoveCoordinator, ShardHarness, VnodeMoveState } from "./_helpers/progressive-shard-move";
+import {
+    beginVnodeMove,
+    catchUpVnodes,
+    cedeVnodes,
+    createMoveCoordinator,
+    createShardHarness,
+    dualRead,
+    quiesceVnodes,
+    readMessage,
+    resolveAuthoritativeShard,
+    routeWrite,
+    snapshotVnodes,
+    writeMessage,
+} from "./_helpers/progressive-shard-move";
+
+const RING_SIZE = 16;
+/** Half the ring — the "key range" the plan asks the prototype to move. */
+const MOVING_VNODES = new Set([0, 1, 2, 3, 4, 5, 6, 7]);
+const SEED_COUNT = 200;
+
+let source: ShardHarness;
+let target: ShardHarness;
+let coordinator: MoveCoordinator;
+/** Ground truth: id -> body, as last durably written, independent of which shard holds it. */
+let groundTruth: Map<string, string>;
+let clock: number;
+
+/** Seed `SEED_COUNT` deterministic documents on `source` before any move starts. */
+const seed = (): void => {
+    for (let index = 0; index < SEED_COUNT; index += 1) {
+        const id = `doc_${String(index)}`;
+        const body = `body-${String(index)}`;
+
+        clock += 1;
+        writeMessage(source, id, body, clock);
+        groundTruth.set(id, body);
+    }
+};
+
+/** Every seeded id that falls in a moving vnode, per the fixed ring/hash. */
+const movingIds = (): string[] => [...groundTruth.keys()].filter((id) => MOVING_VNODES.has(vnodeForId(id, RING_SIZE)));
+
+/** Every seeded id that stays on the source shard. */
+const stayingIds = (): string[] => [...groundTruth.keys()].filter((id) => !MOVING_VNODES.has(vnodeForId(id, RING_SIZE)));
+
+/**
+ * Deterministically find an id (never one of the seeded `doc_N` ids) whose
+ * vnode falls inside `vnodes` — used so "a write mid-move" provably exercises
+ * the moving range rather than assuming a fresh id happens to land there.
+ */
+const findIdInVnodes = (prefix: string, vnodes: ReadonlySet<number>): string => {
+    for (let index = 0; ; index += 1) {
+        const candidate = `${prefix}_${String(index)}`;
+
+        if (vnodes.has(vnodeForId(candidate, RING_SIZE))) {
+            return candidate;
+        }
+    }
+};
+
+/**
+ * Drive the move state machine from `beginVnodeMove` through a quiesced,
+ * caught-up state (but NOT yet cut over) — the shared setup every scenario
+ * below builds on.
+ */
+const runToQuiesced = (): VnodeMoveState => {
+    let move = beginVnodeMove(source);
+
+    snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
+    move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
+
+    quiesceVnodes(coordinator, MOVING_VNODES);
+
+    const quiesceSeq = readCdcCursor(source.sql);
+
+    move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move, quiesceSeq);
+
+    return { ...move, quiesceSeq };
+};
+
+/**
+ * Commit cutover: enforces (by throwing, not by counting toward a test's
+ * `expect.assertions`) that the target has exactly caught up to the quiesce
+ * point — the applied-watermark protocol's precondition for a safe flip. A
+ * caller that reaches this with the watermark still behind would otherwise
+ * silently cede a vnode the target has not fully replicated.
+ */
+const cutover = (move: VnodeMoveState): void => {
+    if (move.quiesceSeq === undefined || move.appliedWatermark !== move.quiesceSeq) {
+        throw new Error(`cutover precondition failed: appliedWatermark=${String(move.appliedWatermark)} quiesceSeq=${String(move.quiesceSeq)}`);
+    }
+
+    cedeVnodes(coordinator, MOVING_VNODES);
+};
+
+describe("progressive shard move (plan 235 spike)", () => {
+    beforeEach(() => {
+        source = createShardHarness();
+        target = createShardHarness();
+        coordinator = createMoveCoordinator(RING_SIZE);
+        groundTruth = new Map();
+        clock = 0;
+
+        seed();
+    });
+
+    afterEach(() => {
+        source.close();
+        target.close();
+    });
+
+    describe("exactly-once resolution", () => {
+        it("resolves every key to source before the move starts", () => {
+            // One `resolveAuthoritativeShard` check per seeded document.
+            expect.assertions(200);
+
+            for (const id of groundTruth.keys()) {
+                expect(resolveAuthoritativeShard(coordinator, id)).toBe("source");
+            }
+        });
+
+        it("keeps resolving to source through snapshot and catch-up — cutover has not committed yet", () => {
+            // 1 watermark check + one resolve check and one content check per seeded document.
+            expect.assertions(401);
+
+            const move = runToQuiesced();
+
+            // The applied-watermark protocol's signal: target has replayed the
+            // source's WAL exactly up to the point writes were quiesced.
+            expect(move.appliedWatermark).toBe(move.quiesceSeq);
+
+            for (const id of groundTruth.keys()) {
+                expect(resolveAuthoritativeShard(coordinator, id)).toBe("source");
+            }
+
+            // And the authoritative copy (source, for everyone right now) is still correct.
+            for (const [id, body] of groundTruth) {
+                expect(readMessage(source, id)?.body).toBe(body);
+            }
+        });
+
+        it("flips moved keys to target and leaves staying keys on source after cutover — each with the correct content", () => {
+            // One resolve check per seeded document + one content check per seeded document.
+            expect.assertions(400);
+
+            const move = runToQuiesced();
+
+            cutover(move);
+
+            for (const id of movingIds()) {
+                expect(resolveAuthoritativeShard(coordinator, id)).toBe("target");
+            }
+
+            for (const id of stayingIds()) {
+                expect(resolveAuthoritativeShard(coordinator, id)).toBe("source");
+            }
+
+            // Every key's authoritative shard holds the ground-truth content — never
+            // stale, never missing.
+            for (const [id, body] of groundTruth) {
+                const shard = resolveAuthoritativeShard(coordinator, id) === "target" ? target : source;
+
+                expect(readMessage(shard, id)?.body).toBe(body);
+            }
+        });
+    });
+
+    describe("dual-read window dedup", () => {
+        it("returns each row exactly once, preferring target's fresher copy over source's stale, undeleted one", () => {
+            expect.assertions(6);
+
+            const move = runToQuiesced();
+
+            cutover(move);
+
+            // Cutover purges nothing from source (the design's drain-close step is
+            // separate and deferred) — so source still physically holds its stale
+            // pre-move rows for every moved id. A dual-read during the propagation
+            // window would see BOTH copies for these ids.
+            const [sampleId] = movingIds();
+            const originalBody = groundTruth.get(sampleId as string);
+
+            expect(sampleId).toBeDefined();
+            expect(readMessage(source, sampleId as string)?.body).toBe(originalBody);
+
+            // Diverge target from source: a write forwarded through the coordinator
+            // after cutover lands on target only — source's copy is now genuinely
+            // stale, not merely absent.
+            clock += 1;
+
+            const newBody = "forwarded-update";
+            const route = routeWrite(coordinator, source, target, sampleId as string, newBody, clock);
+
+            expect(route).toBe("forwarded");
+            // Source's undeleted copy still reads the OLD body — the divergence the
+            // dedup rule must resolve, not just an id present on one side only.
+            expect(readMessage(source, sampleId as string)?.body).toBe(originalBody);
+
+            // A fan-out over a mixed batch (moved ids with stale source copies +
+            // staying ids that only ever existed on source) must merge to exactly
+            // one row per id, and pick target's fresher value where both exist.
+            const batch = [...movingIds().slice(0, 20), ...stayingIds().slice(0, 20)];
+            const merged = dualRead(source, target, batch);
+
+            expect(merged.size).toBe(batch.length);
+            // The merged row for the diverged id is target's fresh value, not
+            // source's stale one — this is what "preferring target" actually means.
+            expect(merged.get(sampleId as string)?.body).toBe(newBody);
+        });
+
+        it("never drops or duplicates a row across a larger mixed batch", () => {
+            // 1 size check + one content check per seeded document.
+            expect.assertions(201);
+
+            const move = runToQuiesced();
+
+            cutover(move);
+
+            const allIds = [...groundTruth.keys()];
+            const merged = dualRead(source, target, allIds);
+
+            expect(merged.size).toBe(allIds.length);
+
+            for (const [id, body] of groundTruth) {
+                expect(merged.get(id)?.body).toBe(body);
+            }
+        });
+    });
+
+    describe("mid-move write correctness", () => {
+        it("lands a write issued during catch-up on source, replays it via the WAL, and it is visible on target after cutover", () => {
+            expect.assertions(4);
+
+            let move = beginVnodeMove(source);
+
+            snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
+
+            // A write arrives mid-move, before quiesce — routed to source, same as
+            // any pre-cutover write. Deterministically chosen to fall in the
+            // MOVING range, so catch-up replay is actually exercised below.
+            const midMoveId = findIdInVnodes("doc_mid_move", MOVING_VNODES);
+            const midMoveBody = "written-during-catch-up";
+
+            clock += 1;
+
+            const route = routeWrite(coordinator, source, target, midMoveId, midMoveBody, clock);
+
+            expect(route).toBe("source");
+            // Not yet caught up — target has no idea this write happened.
+            expect(readMessage(target, midMoveId)).toBeUndefined();
+
+            // Catch-up replays it onto target via the WAL.
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
+
+            quiesceVnodes(coordinator, MOVING_VNODES);
+
+            const quiesceSeq = readCdcCursor(source.sql);
+
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move, quiesceSeq);
+            move = { ...move, quiesceSeq };
+
+            cutover(move);
+
+            // midMoveId is in the moving range by construction, so cutover must
+            // have flipped it to target, and the replayed write must be there.
+            expect(resolveAuthoritativeShard(coordinator, midMoveId)).toBe("target");
+            expect(readMessage(target, midMoveId)?.body).toBe(midMoveBody);
+        });
+
+        it("rejects a write to a quiesced vnode, so the coordinator retries it through the winning placement instead of losing it", () => {
+            expect.assertions(3);
+
+            let move = beginVnodeMove(source);
+
+            snapshotVnodes(source, target, RING_SIZE, MOVING_VNODES);
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move);
+
+            quiesceVnodes(coordinator, MOVING_VNODES);
+
+            const [id] = movingIds();
+
+            expect(id).toBeDefined();
+
+            clock += 1;
+
+            const duringQuiesce = routeWrite(coordinator, source, target, id as string, "should-not-land-yet", clock);
+
+            expect(duringQuiesce).toBe("quiesced");
+
+            // The value never landed anywhere — a real coordinator retries after
+            // cutover, which is exactly `routeWrite`'s "forwarded" branch.
+            const quiesceSeq = readCdcCursor(source.sql);
+
+            move = catchUpVnodes(source, target, RING_SIZE, MOVING_VNODES, move, quiesceSeq);
+            cutover({ ...move, quiesceSeq });
+
+            clock += 1;
+
+            const afterCutover = routeWrite(coordinator, source, target, id as string, "retried-after-cutover", clock);
+
+            expect(afterCutover).toBe("forwarded");
+        });
+    });
+});

--- a/plans/235-progressive-sharding-design.md
+++ b/plans/235-progressive-sharding-design.md
@@ -3,6 +3,38 @@
 **Baseline:** `ad873e805` (2026-07-31)
 **Status:** DONE (spike) — design + test-only prototype; no `src/` routing changes.
 
+**Errata (post-spike correctness pass):** the prototype's first draft had two
+protocol bugs, both now fixed in the same test-only files with new regression
+coverage — see §2.4 (watermark) and §3 (dual-read/delete). Neither reached
+`src/`; both were caught and fixed before any phase-2 build work started.
+
+1. **Watermark advanced by the wrong quantity.** `catchUpVnodes` advanced
+   `appliedWatermark` only for entries belonging to a moving vnode, so it
+   tracked "highest moving-vnode seq applied" rather than "WAL position
+   consumed." `quiesceSeq` (the cutover gate's other side) is the shard's
+   GLOBAL high-watermark across every vnode (`readCdcCursor(source)`), so
+   whenever the log's last entry before quiesce happened to be an ordinary
+   write to a vnode that never moves — the realistic case under mixed
+   traffic, not the edge case — `appliedWatermark` would lag `quiesceSeq`
+   forever and `cutover()` would throw its precondition error even though the
+   moving vnodes were fully replicated. Fixed by advancing the watermark for
+   every entry consumed, moving or not; the moving-vnode filter now gates only
+   which entries get *applied* to target, not which advance the cursor.
+2. **Dual-read's "target-wins-if-present" rule resurrected deletes.** A
+   target miss during the dual-read window is ambiguous between "target
+   hasn't replicated this id yet" (fall through to `source`, correct) and
+   "target has authoritatively deleted this id" (must NOT fall through —
+   `source` still physically holds the stale pre-move row until drain-close).
+   The original `dualRead` treated both cases identically, so a delete
+   forwarded to `target` during the propagation window came back from a
+   fan-out read as `source`'s stale, undeleted copy — resurrecting a row the
+   caller believed was gone. Fixed with a per-shard `__tombstones` table:
+   `deleteMessage`/`applyChangeToTarget`'s delete branch mark a tombstone,
+   `dualRead` treats a target tombstone as authoritative and does not fall
+   through to `source`. `routeWrite` also gained a delete branch — it had
+   none before, so a delete issued against a moved key during the
+   propagation window had no forwarding path at all.
+
 ## 0. Headline finding
 
 The applied-watermark + dual-read protocol below is achievable with the
@@ -16,9 +48,9 @@ prototype (`packages/shard-engine/__tests__/progressive-shard-move.test.ts`,
 `__tests__/_helpers/progressive-shard-move.ts`) implements the full
 snapshot → catch-up → quiesce → cutover → forward lifecycle against two real
 in-memory SQLite shards and asserts exactly-once resolution, dual-read dedup,
-and mid-move write correctness. All 24 tests (7 new + 17 pre-existing
-`shard-ring.test.ts`) pass. `git diff --stat` against `ad873e805` touches only
-`__tests__/*` and this doc.
+delete/tombstone correctness, and mid-move write correctness. All 28 tests
+(11 in this suite + 17 pre-existing `shard-ring.test.ts`) pass. `git diff
+--stat` against `ad873e805` touches only `__tests__/*` and this doc.
 
 The one correctness insight worth carrying into implementation: **placement
 authority for writes is enforced by the shard receiving the write, not by
@@ -81,10 +113,20 @@ Protocol, in order:
    see §7) — it would make `catchUpVnodes` wait forever for a WAL tail that
    the snapshot, not the WAL, already accounts for.
 4. **Catch-up.** Target repeatedly calls `readCdcChanges(source, {
-   sinceSeq: appliedWatermark, tables })`, applies each entry belonging to a
-   moving vnode (upsert on insert/update, delete on delete), and advances
-   `appliedWatermark` to the highest replayed `seq`. Runs however many times
-   is needed while source keeps taking writes.
+   sinceSeq: appliedWatermark, tables })`, pages through as many calls as the
+   WAL tail requires (the prototype's `catchUpVnodes` loops until a page
+   comes back short of `readCdcChanges`'s page limit), applies each entry
+   belonging to a moving vnode (upsert on insert/update, delete on delete),
+   and advances `appliedWatermark` to the highest `seq` **consumed** —
+   every entry walked past, not only the ones that belonged to a moving
+   vnode and got applied. This distinction is load-bearing, not cosmetic:
+   `quiesceSeq` (step 6) is the shard's GLOBAL high-watermark across every
+   vnode, so the log's last entry before quiesce is just as likely to be an
+   ordinary write to a vnode that never moves as it is to be a moving-vnode
+   write. A watermark that only advanced inside the moving-vnode filter would
+   never consume that tail entry and would lag `quiesceSeq` forever —
+   deadlocking cutover even though every moving vnode is fully replicated.
+   (This was the errata's bug #1 — see the top of this doc.)
 5. **Cutover gate (quiesce).** Coordinator briefly stops admitting new writes
    to the moving vnode's keys on `source` (queue-and-retry in a real
    deployment; the prototype's `routeWrite` returns a `"quiesced"` sentinel).
@@ -125,6 +167,7 @@ out to **both** shards during this window and merge:
 const dualRead = (source, target, ids) => {
     const merged = new Map<string, Row>(); // one entry per id, structurally
     for (const id of ids) {
+        if (hasTombstone(target, id)) continue; // target's delete is authoritative — see below
         const fromTarget = readRow(target, id);
         if (fromTarget) {
             merged.set(id, fromTarget);
@@ -143,6 +186,21 @@ vnode(s), and any write since cutover only ever landed on target (via
 forwarding) — so target's copy, when present, is always the freshest. Keying
 the merge by `(table, id)` in a `Map` makes "each row exactly once" a
 structural property of the merge, not a manually-counted invariant.
+
+**Deletes need a tombstone — a plain miss is ambiguous.** "Target wins
+whenever it has the row" is not the same rule as "fall through to source
+whenever target doesn't." A target that has never replicated an id (fall
+through is correct) and a target that has authoritatively **deleted** an id
+(fall through is wrong) look identical to `readRow(target, id)` — both return
+nothing. Falling through in the delete case hands back `source`'s stale,
+physically-present pre-move row, resurrecting a delete the caller believes
+already happened. This was the errata's bug #2 (see the top of this doc): the
+fix is a per-shard tombstone (`hasTombstone` above) that a delete marks and a
+fall-through checks first, so a target-side delete short-circuits the merge to
+"absent" instead of degrading to a source lookup. `routeWrite` — the
+prototype's write-side forwarding stand-in for step 8 above — needed the
+matching fix: forwarding a delete for a ceded vnode the same way it already
+forwarded upserts, which it did not do before this pass.
 
 The prototype's own dual-read test caught a real bug in an earlier draft: an
 assertion that only checked `merged.size === batch.length` (no duplicates,
@@ -177,15 +235,18 @@ Nothing anomalous, by construction of the above:
 `packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts` (helper,
 not exported from any package) implements: `createShardHarness` (wraps the
 existing `_helpers/node-sqlite.ts` in-memory SQLite harness + the existing
-`migrateCdcLog`), `writeMessage`/`deleteMessage`/`readMessage` (append to the
-real `__cdc_log` via `appendCdcChange`), `beginVnodeMove`, `snapshotVnodes`,
-`catchUpVnodes`, `MoveCoordinator` + `quiesceVnodes`/`cedeVnodes` (the
-directory-flip + forwarding stand-in), `routeWrite`,
-`resolveAuthoritativeShard`, and `dualRead`.
+`migrateCdcLog`, plus a `__tombstones` side table — see §3), `writeMessage`/
+`deleteMessage`/`readMessage` (append to the real `__cdc_log` via
+`appendCdcChange`; `writeMessage` clears a tombstone, `deleteMessage` marks
+one), `beginVnodeMove`, `snapshotVnodes`, `catchUpVnodes` (pages past
+`readCdcChanges`'s row limit and advances the watermark by position
+consumed — see §2.4), `MoveCoordinator` + `quiesceVnodes`/`cedeVnodes` (the
+directory-flip + forwarding stand-in), `routeWrite` (forwards both upserts
+and deletes), `resolveAuthoritativeShard`, and `dualRead` (tombstone-aware).
 
 `packages/shard-engine/__tests__/progressive-shard-move.test.ts` seeds 200
 documents on a source shard, moves half the ring (8 of 16 vnodes, a "key
-range") to a second shard, and asserts across three `describe` blocks:
+range") to a second shard, and asserts across five `describe` blocks:
 
 - **`exactly-once resolution`** (3 tests): every key resolves to `source`
   before the move; still resolves to `source` through snapshot and catch-up
@@ -193,22 +254,33 @@ range") to a second shard, and asserts across three `describe` blocks:
   protocol's core signal); flips moved keys to `target` and leaves staying
   keys on `source` after cutover, with content verified against ground truth
   for all 200 ids.
-- **`dual-read window dedup`** (2 tests): a diverged sample (source stale,
+- **`applied-watermark protocol under interleaved traffic`** (1 test): the
+  regression test for errata bug #1 — the log's last entry before quiesce is
+  an ordinary write to a *staying* vnode, not a moving one, and cutover's
+  `appliedWatermark === quiesceSeq` gate must still close.
+- **`catch-up paging`** (1 test): a WAL tail of 1,200 entries (past
+  `readCdcChanges`'s 1,000-row page limit) is fully replayed by a single
+  `catchUpVnodes` call, proving the "runs however many times is needed"
+  claim in §2.4 rather than a mover that silently stops at the first page.
+- **`dual-read window dedup`** (3 tests): a diverged sample (source stale,
   target forward-updated) merges to target's fresh value, not source's stale
   one, and the merge is exactly one row per id; a 200-id mixed batch merges
   with zero drops and zero duplicates, content-checked against ground truth
-  for every id.
-- **`mid-move write correctness`** (2 tests): a write issued during
+  for every id; the regression test for errata bug #2 — a delete forwarded to
+  `target` on a moved key is not resurrected from `source`'s stale copy by a
+  subsequent `dualRead`.
+- **`mid-move write correctness`** (3 tests): a write issued during
   catch-up lands on `source`, is absent from `target` until replay runs, and
   is visible on `target` after cutover, at the correct id; a write to a
   quiesced vnode is rejected (not silently lost) and succeeds via forwarding
-  once cutover has committed.
+  once cutover has committed; a delete issued on `source` during catch-up is
+  replayed onto `target` via the WAL (`applyChangeToTarget`'s delete branch).
 
-Result: **7/7 new tests pass**, plus the pre-existing 17-test
-`shard-ring.test.ts` suite unaffected. `git diff --stat` against `ad873e805`
-touches only files under `packages/shard-engine/__tests__/` and this
-document — `resolveVnodePlacement`, `shard-ring.ts`, and `shard-do.ts` are
-untouched.
+Result: **11/11 tests pass** in this suite, plus the pre-existing 17-test
+`shard-ring.test.ts` suite unaffected — 28 total. `git diff --stat` against
+`ad873e805` touches only files under `packages/shard-engine/__tests__/` and
+this document — `resolveVnodePlacement`, `shard-ring.ts`, and `shard-do.ts`
+are untouched.
 
 ## 6. Open questions
 
@@ -251,6 +323,21 @@ untouched.
   the drain window. This determines how long the dual-read window realistically
   stays open and therefore how long `source` must keep the stale rows around
   before drain-close can purge them.
+- **Tombstone retention and a real delete-forwarding path.** The prototype's
+  per-shard `__tombstones` table (§3) is never trimmed — it fixes the
+  dual-read resurrection hazard within the spike's own lifetime but does not
+  answer how long a real target keeps a tombstone before it is safe to drop.
+  Almost certainly "at least until drain-close purges `source`'s stale copy,
+  same as the row data itself" — a tombstone dropped before drain-close
+  reopens the exact resurrection hazard it exists to close, so retention needs
+  to be coupled to the same drain-close trigger, not decided independently.
+  Separately, this spike's `routeWrite` forwards a delete as a direct RPC-like
+  call, standing in for a shard-to-shard forwarding path that does not exist
+  yet in `src/` — a real implementation needs `ShardDO` to forward a delete
+  the same way it will need to forward an upsert, and that forwarding
+  transport (not just the tombstone bookkeeping on either end) is unbuilt and
+  untested against real network partitions or partial failure, same caveat as
+  phase 2's STOP gate below.
 
 ## 7. Phased build order
 

--- a/plans/235-progressive-sharding-design.md
+++ b/plans/235-progressive-sharding-design.md
@@ -1,0 +1,293 @@
+# Plan 235 — Progressive-sharding WAL + watermark + dual-read protocol (design spike)
+
+**Baseline:** `ad873e805` (2026-07-31)
+**Status:** DONE (spike) — design + test-only prototype; no `src/` routing changes.
+
+## 0. Headline finding
+
+The applied-watermark + dual-read protocol below is achievable with the
+primitives that already exist — the per-shard `__cdc_log` WAL
+(`packages/shard-engine/src/ctx-db-cdc.ts`) and a monotonic-cursor watermark
+in the same shape as `__client_watermark`
+(`packages/shard-engine/src/ctx-db-client-watermark.ts`). No new log format
+and no new storage primitive is needed; the work is a **consumer** of the
+existing WAL, not a new one. This was proven, not assumed: a 2-shard
+prototype (`packages/shard-engine/__tests__/progressive-shard-move.test.ts`,
+`__tests__/_helpers/progressive-shard-move.ts`) implements the full
+snapshot → catch-up → quiesce → cutover → forward lifecycle against two real
+in-memory SQLite shards and asserts exactly-once resolution, dual-read dedup,
+and mid-move write correctness. All 24 tests (7 new + 17 pre-existing
+`shard-ring.test.ts`) pass. `git diff --stat` against `ad873e805` touches only
+`__tests__/*` and this doc.
+
+The one correctness insight worth carrying into implementation: **placement
+authority for writes is enforced by the shard receiving the write, not by
+whichever directory version the caller happened to resolve from.** A source
+shard that has ceded a vnode forwards (or rejects) any write it still
+receives for it, regardless of how stale the caller's cached directory is.
+This is what makes the protocol correct despite the directory itself
+propagating to many coordinator instances at different speeds — the
+propagation lag becomes a **dual-read** problem (bounded, self-healing,
+dedup-able) rather than a **dual-write** problem (which would need
+distributed consensus to get right).
+
+## 1. The per-shard WAL record
+
+Reuse `CdcChange` as-is — no new format:
+
+```ts
+interface CdcChange {
+    doc?: Record<string, unknown>; // post-image; absent for delete
+    id: string;
+    op: "delete" | "insert" | "update";
+    seq: number; // monotonic per-shard cursor, AUTOINCREMENT-backed
+    table: string;
+    ts: number;
+}
+```
+
+`readCdcCursor` already gives the shard's current high-watermark (survives
+trimming via `sqlite_sequence`, so it never regresses); `readCdcChanges(sql,
+{ sinceSeq, tables })` already pages the log forward. A migration mover reads
+this exact API — the only new consumer behavior is filtering pages to the
+vnode(s) being moved (`vnodeForId(change.id, ringSize)` against the moving
+set), which happens client-side since the WAL is not vnode-partitioned.
+
+## 2. The applied-watermark protocol
+
+State per in-flight move (test-local `VnodeMoveState` in the prototype; a real
+implementation would persist this per-migration, likely in the coordinator's
+own system table):
+
+```ts
+interface VnodeMoveState {
+    appliedWatermark: number; // target's cursor into source's WAL
+    quiesceSeq?: number; // source cursor at the cutover-gate instant
+    snapshotSeq: number; // source cursor when the base copy ran
+}
+```
+
+Protocol, in order:
+
+1. **`snapshotSeq = readCdcCursor(source)`.** Recorded before the base copy
+   starts.
+2. **Base copy.** Target bulk-copies every row in the moving vnode(s) as they
+   stand in `source` right now. Must not race a write to those vnodes — a
+   real shard gets this for free from the same single-threaded-isolate
+   guarantee it already uses for OCC (one active transaction at a time).
+3. **`appliedWatermark` starts at `snapshotSeq`, not `0`.** The base copy
+   already captured everything up to that cursor; treating the watermark as
+   zero was the first bug the prototype's tests caught (`beginVnodeMove` —
+   see §7) — it would make `catchUpVnodes` wait forever for a WAL tail that
+   the snapshot, not the WAL, already accounts for.
+4. **Catch-up.** Target repeatedly calls `readCdcChanges(source, {
+   sinceSeq: appliedWatermark, tables })`, applies each entry belonging to a
+   moving vnode (upsert on insert/update, delete on delete), and advances
+   `appliedWatermark` to the highest replayed `seq`. Runs however many times
+   is needed while source keeps taking writes.
+5. **Cutover gate (quiesce).** Coordinator briefly stops admitting new writes
+   to the moving vnode's keys on `source` (queue-and-retry in a real
+   deployment; the prototype's `routeWrite` returns a `"quiesced"` sentinel).
+   Records `quiesceSeq = readCdcCursor(source)`.
+6. **Final catch-up**, bounded to `quiesceSeq`. Cutover is legal **exactly
+   when** `appliedWatermark === quiesceSeq` — at that instant target is
+   byte-identical to source for the moving vnode(s), as of a cursor both
+   sides agree on. This is the "target has caught up to source's watermark"
+   signal the plan asked for: a single integer comparison, not a timeout or
+   a heuristic.
+7. **Atomic directory flip.** The coordinator commits one new
+   `VnodeDirectory` value with the moving vnode(s) reassigned. A logically
+   single write (e.g. one KV put or one D1 row update) — there is no window
+   in the *source of truth* where a vnode has zero or two owners.
+8. **Un-quiesce with forwarding.** `source` resumes accepting requests for
+   the ceded vnode's keys but never re-originates a write for them — it
+   forwards to `target` and returns target's result. `source` does **not**
+   delete its now-stale rows at this point (see §3) — that is a later,
+   separate drain-close step.
+
+## 3. The dual-read window and its dedup rule
+
+The directory flip in step 7 is atomic at the source of truth, but a real
+deployment has many coordinator/isolate instances, each with its own cached
+copy that propagates on its own schedule (a Worker isolate's in-memory copy,
+a KV read with its own TTL, etc.). Between the flip committing and every
+cache having observed it, two placements are simultaneously "live": some
+callers still resolve the moving vnode to `source`, others already resolve it
+to `target`. This is the **dual-read window**, and it is a read-side hazard
+only — writes stay single-owner throughout because of the forwarding rule in
+step 8, which does not depend on the caller's directory being fresh.
+
+Because `source` never purges the moved rows until a later drain-close step,
+a coordinator that wants to be safe rather than trust its own cache can fan
+out to **both** shards during this window and merge:
+
+```ts
+const dualRead = (source, target, ids) => {
+    const merged = new Map<string, Row>(); // one entry per id, structurally
+    for (const id of ids) {
+        const fromTarget = readRow(target, id);
+        if (fromTarget) {
+            merged.set(id, fromTarget);
+            continue;
+        }
+        const fromSource = readRow(source, id);
+        if (fromSource) merged.set(id, fromSource);
+    }
+    return merged;
+};
+```
+
+**Dedup rule: target wins whenever it has the row.** After a caught-up
+cutover, target is a superset-or-equal of source's state for the moved
+vnode(s), and any write since cutover only ever landed on target (via
+forwarding) — so target's copy, when present, is always the freshest. Keying
+the merge by `(table, id)` in a `Map` makes "each row exactly once" a
+structural property of the merge, not a manually-counted invariant.
+
+The prototype's own dual-read test caught a real bug in an earlier draft: an
+assertion that only checked `merged.size === batch.length` (no duplicates,
+nothing dropped) passed even when the merge preferred **source's stale
+value**, because the mutated version still produced one entry per id — it
+just had the wrong content. Fixed by asserting the merged row's *content*
+equals target's post-forward value for a deliberately-diverged id (source
+still holding the pre-move body, target holding a forwarded update). A
+mutation check (swap the merge's preference order, confirm the test fails,
+restore) verified this is now a real assertion and not a tautology — see §7.
+
+## 4. What a client observes mid-move
+
+Nothing anomalous, by construction of the above:
+
+- **No missing row.** Before cutover, `source` is undisturbed and fully
+  authoritative. After cutover, `target` holds everything `source` had
+  (base copy + full WAL replay through `quiesceSeq`) plus anything forwarded
+  since. A row is never in neither place.
+- **No duplicated row observed.** A single-shard read only ever consults its
+  own directory resolution, which names exactly one shard. A dual-read
+  fan-out (used defensively during the propagation window) collapses to one
+  entry per id via the target-wins `Map` merge.
+- **No lost write.** Pre-quiesce, writes land on `source` normally and are
+  captured by the WAL like any other write. During quiesce, `source` refuses
+  and the caller retries (a bounded, single-vnode pause — not a full-shard
+  outage). Post-cutover, `source` forwards rather than silently dropping or
+  re-applying a write for a vnode it no longer owns.
+
+## 5. Prototype summary
+
+`packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts` (helper,
+not exported from any package) implements: `createShardHarness` (wraps the
+existing `_helpers/node-sqlite.ts` in-memory SQLite harness + the existing
+`migrateCdcLog`), `writeMessage`/`deleteMessage`/`readMessage` (append to the
+real `__cdc_log` via `appendCdcChange`), `beginVnodeMove`, `snapshotVnodes`,
+`catchUpVnodes`, `MoveCoordinator` + `quiesceVnodes`/`cedeVnodes` (the
+directory-flip + forwarding stand-in), `routeWrite`,
+`resolveAuthoritativeShard`, and `dualRead`.
+
+`packages/shard-engine/__tests__/progressive-shard-move.test.ts` seeds 200
+documents on a source shard, moves half the ring (8 of 16 vnodes, a "key
+range") to a second shard, and asserts across three `describe` blocks:
+
+- **`exactly-once resolution`** (3 tests): every key resolves to `source`
+  before the move; still resolves to `source` through snapshot and catch-up
+  (`appliedWatermark === quiesceSeq` checked directly — the watermark
+  protocol's core signal); flips moved keys to `target` and leaves staying
+  keys on `source` after cutover, with content verified against ground truth
+  for all 200 ids.
+- **`dual-read window dedup`** (2 tests): a diverged sample (source stale,
+  target forward-updated) merges to target's fresh value, not source's stale
+  one, and the merge is exactly one row per id; a 200-id mixed batch merges
+  with zero drops and zero duplicates, content-checked against ground truth
+  for every id.
+- **`mid-move write correctness`** (2 tests): a write issued during
+  catch-up lands on `source`, is absent from `target` until replay runs, and
+  is visible on `target` after cutover, at the correct id; a write to a
+  quiesced vnode is rejected (not silently lost) and succeeds via forwarding
+  once cutover has committed.
+
+Result: **7/7 new tests pass**, plus the pre-existing 17-test
+`shard-ring.test.ts` suite unaffected. `git diff --stat` against `ad873e805`
+touches only files under `packages/shard-engine/__tests__/` and this
+document — `resolveVnodePlacement`, `shard-ring.ts`, and `shard-do.ts` are
+untouched.
+
+## 6. Open questions
+
+- **Split policy** — when does a deployment promote tier-0 (`shardCount: 0`,
+  everything on `LOCAL_SHARD`) to sharded? Candidates: a storage-size
+  threshold the coordinator already tracks for other purposes, a
+  write-rate/row-count threshold, or an explicit operator trigger only (no
+  autoscale in phase 1 — see §7). Needs its own measurement of what "too
+  big" costs in practice before picking a number.
+- **Hysteresis** — a move that fires, then immediately reverses because the
+  triggering metric oscillates around the threshold, is worse than not
+  moving. Needs a cooldown window per vnode (no re-evaluation for N minutes
+  after a move) and probably a "sustained past threshold for N consecutive
+  samples" gate rather than a single-sample trigger. Not designed here —
+  deliberately deferred to autoscale-policy work, which this spike's SCOPE
+  explicitly excludes.
+- **Cross-shard relations/rank/search during a move.** This spike moved a
+  flat key-value table. `@lunora/shard-engine` also has relation joins, rank
+  pages, and full-text search that read across rows — some of those already
+  work cross-shard (`cross-shard-relations.ts`, cross-shard rank/rankPage per
+  prior work per `MEMORY.md`'s plan2-gap-status). Whether those paths
+  tolerate a vnode being mid-move (some rows on `source`, some on `target`,
+  some rows in the dual-read window) is untested here and is the first thing
+  a phase-2 implementation must verify — a rank page or search index that
+  silently double-counts or drops a row during a move would be a much worse
+  failure mode than the flat-table case this spike covers.
+- **Migration story for `.shardBy(...)` apps.** Progressive sharding and
+  explicit `.shardBy(key)` sharding are two different placement strategies
+  today (jump-consistent-hash-on-id vs. hash-on-field). An app that already
+  chose `.shardBy` has no obvious path onto progressive sharding without a
+  real data migration (re-keying by id-hash instead of field-hash) — that is
+  a different, likely harder migration than what this spike prototypes
+  (which moves whole vnodes, not re-partitions by a different key). Whether
+  the two stay permanently separate tiers, or one subsumes the other, is
+  unresolved and out of scope here.
+- **Directory propagation mechanism.** §3 assumes coordinator caches
+  propagate "eventually" but does not specify how — a KV put with a TTL, an
+  explicit invalidation broadcast, or a lease/ack protocol where the
+  coordinator waits for confirmation from every known reader before closing
+  the drain window. This determines how long the dual-read window realistically
+  stays open and therefore how long `source` must keep the stale rows around
+  before drain-close can purge them.
+
+## 7. Phased build order
+
+1. **Land `shard-ring.ts` as routing-only.** Already done (this plan's
+   groundwork) — pure placement given a directory, tier-0 identity, not
+   exported from the barrel.
+2. **Generalize this spike's mover into `src/`** — single-vnode move,
+   operator-triggered only (no autoscale), single-coordinator (no directory
+   propagation problem yet because there is exactly one coordinator
+   instance to update). This turns the test-only `MoveCoordinator` stand-in
+   into a real, persisted per-migration state machine and wires
+   `snapshotVnodes`/`catchUpVnodes`/cutover into `ShardDO`. **STOP gate:**
+   does not ship until it has run against a real multi-DO dev deployment,
+   not just the in-memory harness — the harness cannot exercise real network
+   partitions, partial failures mid-catch-up, or Durable Object eviction
+   during a move.
+3. **Directory propagation for multiple coordinator instances** — pick and
+   implement the propagation mechanism from the open question above; define
+   and test the drain-close purge trigger. **STOP gate:** dual-read dedup
+   must be re-verified against the real propagation mechanism's actual
+   staleness bound, not the instantaneous test-local `MoveCoordinator`.
+4. **Split policy + hysteresis (autoscale).** Only after 2–3 have run in a
+   real deployment long enough to know what "too big" and "flapping" look
+   like in practice, not from a spike's guesses.
+5. **Cross-shard feature parity during moves** — relations, rank, search
+   verified (or explicitly documented as unsupported mid-move) against a
+   moving vnode. **STOP gate:** a feature that silently double-counts or
+   drops a row during a move is worse than not building progressive sharding
+   at all; each feature needs its own test before it is declared safe
+   mid-move.
+6. **`.shardBy(...)` interop / migration tooling** — only once the open
+   question above is resolved; may turn out to be "the two stay separate,
+   document the boundary" rather than a build item.
+
+Confirmed: **zero changes to `src/` routing code.** `git diff --stat
+ad873e805..HEAD -- packages/shard-engine/src/shard-ring.ts
+packages/do/src/shard-do.ts` is empty; the only files this spike touched are
+`packages/shard-engine/__tests__/progressive-shard-move.test.ts`,
+`packages/shard-engine/__tests__/_helpers/progressive-shard-move.ts`, and this
+document.


### PR DESCRIPTION
## What

A **test-only** design spike for progressive (automatic) sharding: a design doc plus a working 2-shard rebalance-with-dual-read prototype driven entirely from tests. **Zero `src/` changes** — nothing touches the live routing path (`git diff` is 2 test files + 1 design doc).

## The protocol (design doc)

- **Reuses the existing `__cdc_log` as the per-shard WAL** — no new format. A move records `snapshotSeq` (the source cursor at base-copy time); the target's `appliedWatermark` **starts at `snapshotSeq`, not 0** (the first bug the prototype caught — starting at 0 re-applies already-copied rows), and advances as the target replays the WAL tail.
- **Cutover is legal exactly when `appliedWatermark === quiesceSeq`**, after a brief write-pause on the moving vnode only.
- **The dual-read window exists because directory propagation to coordinator caches is eventual**, not because data lags. Correctness rests on the source shard enforcing its own cede state on every write it receives, so a stale caller's directory can never cause a lost/duplicate write — the dual-read is defensive, deduped **target-wins-if-present** via a `Map` keyed by `(table, id)`.

## The prototype (tests)

Runs against two real in-memory SQLite shards via the existing `node-sqlite` harness and the real `ctx-db-cdc` WAL functions. Asserts, content-checked against ground truth:

- **exactly-once resolution** across 200 seeded docs before/during/after cutover;
- **dual-read dedup** returns the target's fresher value over the source's genuinely-stale undeleted copy, incl. a 200-id batch with zero drops/duplicates;
- **mid-move write** lands on source, is invisible on target until WAL replay, visible after cutover;
- a **quiesced-write-rejected-then-forwarded** case.

The dedup rule itself was mutation-tested (swapping merge preference to source-first) to confirm the assertions catch a broken protocol, not just count rows — which surfaced and fixed a content-vs-size gap in the first draft.

## Verification

7 prototype tests pass; full `@lunora/shard-engine` suite (59 files, 846 tests) + `lint:types` + prettier green. Confirmed zero `src/` diff before and after.

## Open questions (doc §6) + phased build order (§7)

Split-policy thresholds, hysteresis/cooldown, cross-shard relations/rank/search during a move (untested here — flagged as the first thing phase 2 must verify), and the explicit-`.shardBy()`-vs-progressive migration story. Build order gates each phase on a STOP (phase 2 on a real multi-DO dev-deployment test; phase 3 on re-verifying dedup against real staleness bounds).

**Demand-gated**: build the real thing only if "largest table outgrows one DO" becomes an explicit product goal. New test files — mergeable independently.

Plan: `plans/235-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)