### PR TITLE
feat(cli): lunora eval runner for the eval kit (+ Studio Evals panel design)

### DIFF
--- a/packages/cli/__tests__/commands/eval.test.ts
+++ b/packages/cli/__tests__/commands/eval.test.ts
@@ -1,0 +1,169 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { runEvalCommand } from "../../src/commands/eval/handler";
+import type { Logger } from "../../src/util/logger";
+
+/** Run async `body` while capturing everything written to `process.stdout`. */
+const captureStdout = async (body: () => Promise<void>): Promise<string> => {
+    let captured = "";
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+        captured += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+
+        return true;
+    });
+
+    try {
+        await body();
+    } finally {
+        spy.mockRestore();
+    }
+
+    return captured;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureRoot = join(here, "..", "fixtures");
+
+interface Recorded {
+    errors: string[];
+    infos: string[];
+    successes: string[];
+    warnings: string[];
+}
+
+const recordingLogger = (): { logger: Logger; recorded: Recorded } => {
+    const recorded: Recorded = { errors: [], infos: [], successes: [], warnings: [] };
+
+    return {
+        logger: {
+            error: (message) => recorded.errors.push(message),
+            info: (message) => recorded.infos.push(message),
+            success: (message) => recorded.successes.push(message),
+            warn: (message) => recorded.warnings.push(message),
+        },
+        recorded,
+    };
+};
+
+describe("lunora eval", () => {
+    it("discovers and runs a fixture *.eval.ts, printing the aggregate table, and exits 0 on a clean run", async () => {
+        expect.assertions(6);
+
+        const { logger, recorded } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-sample");
+
+        const result = await runEvalCommand({ cwd, logger });
+
+        expect(result.code).toBe(0);
+        expect(result.evals).toHaveLength(1);
+        expect(result.evals[0]?.name).toBe("support-triage");
+        expect(result.evals[0]?.result?.average).toBe(1);
+        expect(result.evals[0]?.passed).toBe(true);
+        // The aggregate table names the eval and its score.
+        expect(recorded.infos.some((line) => line.includes("support-triage") && line.includes("1.000"))).toBe(true);
+    });
+
+    it("reuses `evaluate` from @lunora/testing unchanged — the runner adds no scoring logic of its own", async () => {
+        expect.assertions(2);
+
+        const { logger } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-sample");
+
+        const result = await runEvalCommand({ cwd, logger });
+        const [outcome] = result.evals;
+
+        // The per-case breakdown is `evaluate`'s own `EvalItemResult[]`, passed
+        // through verbatim — two cases in, two cases out, each with its own score.
+        expect(outcome?.result?.items).toHaveLength(2);
+        expect(outcome?.result?.items.every((item) => item.average === 1)).toBe(true);
+    });
+
+    it("exits 0 when no evals directory exists — a project with no evals yet is a no-op, not an error", async () => {
+        expect.assertions(2);
+
+        const { logger } = recordingLogger();
+        // `fixtureRoot` itself has no `evals/` child (only the per-scenario
+        // subdirectories above do) — exercises the "nothing to run yet" path.
+        const result = await runEvalCommand({ cwd: fixtureRoot, logger });
+
+        expect(result.code).toBe(0);
+        expect(result.evals).toHaveLength(0);
+    });
+
+    it("--threshold gates the exit code: below the average fails, at/under it passes", async () => {
+        expect.assertions(4);
+
+        const { logger: failLogger } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-threshold-sample");
+
+        const failing = await runEvalCommand({ cwd, logger: failLogger, threshold: 0.6 });
+
+        expect(failing.code).toBe(1);
+        expect(failing.evals[0]?.passed).toBe(false);
+
+        const { logger: passLogger } = recordingLogger();
+        const passing = await runEvalCommand({ cwd, logger: passLogger, threshold: 0.4 });
+
+        expect(passing.code).toBe(0);
+        expect(passing.evals[0]?.passed).toBe(true);
+    });
+
+    it("a per-eval `threshold` export overrides a stricter global --threshold for that eval", async () => {
+        expect.assertions(2);
+
+        const { logger } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-override-sample");
+
+        // The eval's own average is 0.5 and its export sets `threshold: 0.4`; a
+        // much stricter global 0.9 would fail it if the override didn't win.
+        const result = await runEvalCommand({ cwd, logger, threshold: 0.9 });
+
+        expect(result.code).toBe(0);
+        expect(result.evals[0]?.threshold).toBe(0.4);
+    });
+
+    it("a crashed eval always fails the run, independent of --threshold", async () => {
+        expect.assertions(3);
+
+        const { logger, recorded } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-crash-sample");
+
+        const result = await runEvalCommand({ cwd, logger });
+
+        expect(result.code).toBe(1);
+        expect(result.evals[0]?.error).toContain("boom");
+        expect(recorded.errors.some((line) => line.includes("1/1"))).toBe(true);
+    });
+
+    it("--format json prints one structured document to stdout and routes progress to stderr", async () => {
+        expect.assertions(3);
+
+        const { logger } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-sample");
+
+        const stdout = await captureStdout(async () => {
+            await runEvalCommand({ cwd, format: "json", logger });
+        });
+
+        const parsed: unknown = JSON.parse(stdout);
+
+        expect(parsed).toMatchObject({ code: 0 });
+        expect((parsed as { evals: unknown[] }).evals).toHaveLength(1);
+        expect((parsed as { evals: { average?: number }[] }).evals).toBeDefined();
+    });
+
+    it("rejects an unknown --format before discovering anything", async () => {
+        expect.assertions(2);
+
+        const { logger, recorded } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-sample");
+
+        const result = await runEvalCommand({ cwd, format: "xml", logger });
+
+        expect(result.code).toBe(1);
+        expect(recorded.errors.some((line) => line.includes("unknown --format"))).toBe(true);
+    });
+});

--- a/packages/cli/__tests__/commands/eval.test.ts
+++ b/packages/cli/__tests__/commands/eval.test.ts
@@ -171,6 +171,32 @@ describe("lunora eval", () => {
         expect(recorded.errors.some((line) => line.includes("unknown --format"))).toBe(true);
     });
 
+    it("rejects a NaN --threshold before discovering anything", async () => {
+        expect.assertions(2);
+
+        const { logger, recorded } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-sample");
+
+        // Mirrors Cerebro parsing `--threshold abc` with `type: Number`, which
+        // yields NaN rather than a CLI-level parse error.
+        const result = await runEvalCommand({ cwd, logger, threshold: Number.NaN });
+
+        expect(result.code).toBe(1);
+        expect(recorded.errors.some((line) => line.includes("--threshold") && line.includes("[0, 1]"))).toBe(true);
+    });
+
+    it("rejects a --threshold outside [0, 1] before discovering anything", async () => {
+        expect.assertions(2);
+
+        const { logger, recorded } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-sample");
+
+        const result = await runEvalCommand({ cwd, logger, threshold: 5 });
+
+        expect(result.code).toBe(1);
+        expect(recorded.errors.some((line) => line.includes("--threshold") && line.includes("[0, 1]"))).toBe(true);
+    });
+
     it("aborts with one distinct, actionable message and a non-zero exit when the Node floor can't load a .ts eval (ERR_UNKNOWN_FILE_EXTENSION), instead of mislabeling it a per-eval failure", async () => {
         expect.assertions(4);
 

--- a/packages/cli/__tests__/commands/eval.test.ts
+++ b/packages/cli/__tests__/commands/eval.test.ts
@@ -138,8 +138,8 @@ describe("lunora eval", () => {
         expect(recorded.errors.some((line) => line.includes("1/1"))).toBe(true);
     });
 
-    it("--format json prints one structured document to stdout and routes progress to stderr", async () => {
-        expect.assertions(3);
+    it("--format json prints one structured document to stdout and routes progress to stderr, matching the documented flat per-eval shape", async () => {
+        expect.assertions(5);
 
         const { logger } = recordingLogger();
         const cwd = join(fixtureRoot, "eval-sample");
@@ -148,11 +148,15 @@ describe("lunora eval", () => {
             await runEvalCommand({ cwd, format: "json", logger });
         });
 
-        const parsed: unknown = JSON.parse(stdout);
+        const parsed = JSON.parse(stdout) as { evals: { average?: number; items?: unknown[]; name?: string; passed?: boolean }[] };
 
         expect(parsed).toMatchObject({ code: 0 });
-        expect((parsed as { evals: unknown[] }).evals).toHaveLength(1);
-        expect((parsed as { evals: { average?: number }[] }).evals).toBeDefined();
+        expect(parsed.evals).toHaveLength(1);
+        // Flat per the documented contract (`plans/245-eval-runner-design.md`
+        // §4/§6): `evals[].average`, not `evals[].result.average`.
+        expect(parsed.evals[0]?.average).toBe(1);
+        expect(parsed.evals[0]?.name).toBe("support-triage");
+        expect(parsed.evals[0]?.passed).toBe(true);
     });
 
     it("rejects an unknown --format before discovering anything", async () => {
@@ -165,5 +169,35 @@ describe("lunora eval", () => {
 
         expect(result.code).toBe(1);
         expect(recorded.errors.some((line) => line.includes("unknown --format"))).toBe(true);
+    });
+
+    it("aborts with one distinct, actionable message and a non-zero exit when the Node floor can't load a .ts eval (ERR_UNKNOWN_FILE_EXTENSION), instead of mislabeling it a per-eval failure", async () => {
+        expect.assertions(4);
+
+        const { logger, recorded } = recordingLogger();
+        const cwd = join(fixtureRoot, "eval-floor-sample");
+
+        const result = await runEvalCommand({ cwd, logger });
+
+        expect(result.code).toBe(1);
+        // No per-eval outcome at all — the run aborted before producing one,
+        // rather than recording a mislabeled "failed" entry for it.
+        expect(result.evals).toHaveLength(0);
+        expect(result.error).toContain("Node ≥23.6");
+        expect(recorded.errors.some((line) => line.includes("Node ≥23.6") && line.includes("plans/245-eval-runner-design.md"))).toBe(true);
+    });
+
+    it("--threshold against an empty/missing eval dir exits non-zero instead of passing vacuously", async () => {
+        expect.assertions(3);
+
+        const { logger, recorded } = recordingLogger();
+        // `fixtureRoot` itself has no `evals/` child (see the no-directory test
+        // above) — 0 evals discovered. A `--threshold` gate applied to nothing
+        // must not report success.
+        const result = await runEvalCommand({ cwd: fixtureRoot, logger, threshold: 0.8 });
+
+        expect(result.code).toBe(1);
+        expect(result.evals).toHaveLength(0);
+        expect(recorded.errors.some((line) => line.includes("--threshold") && line.includes("0 eval files"))).toBe(true);
     });
 });

--- a/packages/cli/__tests__/fixtures/eval-crash-sample/evals/broken.eval.ts
+++ b/packages/cli/__tests__/fixtures/eval-crash-sample/evals/broken.eval.ts
@@ -1,0 +1,10 @@
+/**
+ * Fixture eval whose `run` throws — used by `eval.test.ts` to prove a crashed
+ * eval always fails the run (non-zero exit), independent of `--threshold`.
+ */
+export default {
+    name: "broken",
+    run: async (): Promise<never> => {
+        throw new Error("boom");
+    },
+};

--- a/packages/cli/__tests__/fixtures/eval-floor-sample/evals/floor.eval.ts
+++ b/packages/cli/__tests__/fixtures/eval-floor-sample/evals/floor.eval.ts
@@ -1,0 +1,16 @@
+/**
+ * Fixture simulating the Node `^22.15.0` floor failure: on that floor,
+ * `import()`ing a `.ts` file with no runtime TS loader throws
+ * `ERR_UNKNOWN_FILE_EXTENSION` — Vitest transforms real `.ts` on import, so
+ * this fixture throws the identically-shaped error itself at module-
+ * evaluation time, which makes the runner's `import()` call reject with
+ * exactly what it would see on the real floor. Used by
+ * `packages/cli/__tests__/commands/eval.test.ts` to prove the runner surfaces
+ * one distinct, actionable message and aborts, instead of mislabeling this
+ * (and every other discovered eval) as a per-eval "failed" outcome.
+ */
+const floorError = new TypeError('Unknown file extension ".ts" for /fake/evals/floor.eval.ts') as NodeJS.ErrnoException;
+
+floorError.code = "ERR_UNKNOWN_FILE_EXTENSION";
+
+throw floorError;

--- a/packages/cli/__tests__/fixtures/eval-override-sample/evals/mixed.eval.ts
+++ b/packages/cli/__tests__/fixtures/eval-override-sample/evals/mixed.eval.ts
@@ -1,0 +1,20 @@
+import { evaluate, exactMatchScorer } from "@lunora/testing";
+
+/**
+ * Same `0.5`-average shape as `eval-threshold-sample/evals/mixed.eval.ts`, but
+ * exports its own `threshold: 0.4` — used by `eval.test.ts` to prove a
+ * per-eval `threshold` export wins over a stricter global `--threshold`.
+ */
+export default {
+    name: "mixed",
+    run: async () =>
+        evaluate(
+            [
+                { expected: "yes", input: "a" },
+                { expected: "yes", input: "b" },
+            ],
+            (input: string) => (input === "a" ? "yes" : "no"),
+            [exactMatchScorer()],
+        ),
+    threshold: 0.4,
+};

--- a/packages/cli/__tests__/fixtures/eval-sample/evals/support-triage.eval.ts
+++ b/packages/cli/__tests__/fixtures/eval-sample/evals/support-triage.eval.ts
@@ -1,0 +1,21 @@
+import { containsScorer, evaluate } from "@lunora/testing";
+
+/**
+ * Fixture eval for `packages/cli/__tests__/commands/eval.test.ts` — deliberately
+ * simple (no `agentHarness`, a pure `produce`) so the test exercises the
+ * runner's discovery/threshold/aggregation logic, not the kit's own behavior
+ * (that is `packages/testing`'s job, covered by its own suite). Both cases
+ * score 1 (each output contains "it"), so `average` is exactly `1`.
+ */
+export default {
+    name: "support-triage",
+    run: async () =>
+        evaluate(
+            [
+                { expected: "shipped", input: "where is my order?" },
+                { expected: "refunded", input: "cancel my order" },
+            ],
+            (input: string) => (input.includes("cancel") ? "It was refunded." : "It shipped Tuesday."),
+            [containsScorer("it")],
+        ),
+};

--- a/packages/cli/__tests__/fixtures/eval-threshold-sample/evals/mixed.eval.ts
+++ b/packages/cli/__tests__/fixtures/eval-threshold-sample/evals/mixed.eval.ts
@@ -1,0 +1,19 @@
+import { evaluate, exactMatchScorer } from "@lunora/testing";
+
+/**
+ * Fixture eval whose average lands at exactly `0.5` (one exact match, one
+ * miss) — used by `eval.test.ts` to exercise `--threshold`'s pass/fail
+ * boundary without a per-eval `threshold` export of its own.
+ */
+export default {
+    name: "mixed",
+    run: async () =>
+        evaluate(
+            [
+                { expected: "yes", input: "a" },
+                { expected: "yes", input: "b" },
+            ],
+            (input: string) => (input === "a" ? "yes" : "no"),
+            [exactMatchScorer()],
+        ),
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,6 @@
         "@lunora/mcp": "1.0.0-alpha.52",
         "@lunora/runtime": "1.0.0-alpha.49",
         "@lunora/seed": "1.0.0-alpha.56",
-        "@lunora/testing": "1.0.0-alpha.83",
         "@visulima/cerebro": "3.0.0",
         "@visulima/error": "catalog:prod",
         "@visulima/fs": "5.0.5",
@@ -97,6 +96,7 @@
     },
     "devDependencies": {
         "@codspeed/vitest-plugin": "catalog:test",
+        "@lunora/testing": "1.0.0-alpha.83",
         "@types/node": "catalog:types",
         "@types/react": "catalog:frontend",
         "@visulima/packem": "catalog:build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,6 +77,7 @@
         "@lunora/mcp": "1.0.0-alpha.52",
         "@lunora/runtime": "1.0.0-alpha.49",
         "@lunora/seed": "1.0.0-alpha.56",
+        "@lunora/testing": "1.0.0-alpha.83",
         "@visulima/cerebro": "3.0.0",
         "@visulima/error": "catalog:prod",
         "@visulima/fs": "5.0.5",

--- a/packages/cli/packem.config.ts
+++ b/packages/cli/packem.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
         dts: {
             oxc: true,
         },
+        // `commands/eval/handler.ts` does a genuinely dynamic `import()` of an
+        // arbitrary, runtime-discovered `*.eval.ts` file (never a glob
+        // candidate — the path is a `file://` URL built from a directory walk).
+        // `@rollup/plugin-dynamic-import-vars` otherwise tries to turn every
+        // non-literal `import()` argument into a glob and hard-fails when it
+        // can't statically resolve one; excluding the one file that needs a
+        // real runtime import keeps the plugin doing its normal job everywhere
+        // else in the CLI.
+        dynamicVars: {
+            exclude: ["**/commands/eval/handler.ts"],
+        },
         license: {
             path: "./LICENSE.md",
         },
@@ -18,7 +29,12 @@ export default defineConfig({
     validation: {
         dependencies: {
             unused: {
-                exclude: ["@bomb.sh/tab", "cfonts", "react-reconciler"],
+                // `@lunora/testing` is a type-only import (`EvalResult`, in
+                // `commands/eval/`) — the `eval` command never calls `evaluate`
+                // itself, only a discovered project's own `*.eval.ts` file does
+                // (from ITS OWN `@lunora/testing`), so packem's runtime-usage scan
+                // sees no `import ... from` and flags it as unused.
+                exclude: ["@bomb.sh/tab", "@lunora/testing", "cfonts", "react-reconciler"],
             },
             hoisted: {
                 exclude: ["@visulima/interactive-manager", "@visulima/is-ansi-color-supported"],

--- a/packages/cli/packem.config.ts
+++ b/packages/cli/packem.config.ts
@@ -29,12 +29,7 @@ export default defineConfig({
     validation: {
         dependencies: {
             unused: {
-                // `@lunora/testing` is a type-only import (`EvalResult`, in
-                // `commands/eval/`) — the `eval` command never calls `evaluate`
-                // itself, only a discovered project's own `*.eval.ts` file does
-                // (from ITS OWN `@lunora/testing`), so packem's runtime-usage scan
-                // sees no `import ... from` and flags it as unused.
-                exclude: ["@bomb.sh/tab", "@lunora/testing", "cfonts", "react-reconciler"],
+                exclude: ["@bomb.sh/tab", "cfonts", "react-reconciler"],
             },
             hoisted: {
                 exclude: ["@visulima/interactive-manager", "@visulima/is-ansi-color-supported"],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -66,6 +66,7 @@ const COMMANDS = [
     "import",
     "seed",
     "backup",
+    "eval",
     "verify",
     "info",
     "doctor",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ import { devCommand } from "./commands/dev";
 import documentationCommand from "./commands/docs";
 import { doctorCommand } from "./commands/doctor";
 import { envCommand } from "./commands/env";
+import { evalCommand } from "./commands/eval";
 import { exportCommand } from "./commands/export";
 import { importCommand } from "./commands/import";
 import { infoCommand } from "./commands/info";
@@ -157,6 +158,7 @@ const CLI_COMMANDS = [
     seedCommand,
     introspectCommand,
     backupCommand,
+    evalCommand,
     verifyCommand,
     infoCommand,
     doctorCommand,

--- a/packages/cli/src/commands/eval/discover-eval-files.ts
+++ b/packages/cli/src/commands/eval/discover-eval-files.ts
@@ -1,0 +1,46 @@
+import { lstatSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Suffix a discoverable eval fixture file must end in. */
+const EVAL_FILE_SUFFIX = ".eval.ts";
+
+/** Directories never descended into while discovering eval files. */
+const SKIP_DIRECTORIES = new Set([".git", "_generated", "dist", "node_modules"]);
+
+/**
+ * Recursively collect `*.eval.ts` files under `directory`, sorted for a
+ * deterministic run order. Mirrors codegen's `listLunoraSourceFiles`
+ * (`packages/codegen/src/discover-functions.ts`): `lstatSync`, never
+ * `statSync`, so a directory symlink pointing at an ancestor is classified by
+ * the link itself and never descended into — no symlink-cycle infinite
+ * recursion. A missing `directory` yields `[]` rather than throwing, so an
+ * app with no `evals/` yet is a no-op, not an error.
+ */
+const discoverEvalFiles = (directory: string, accumulator: string[] = []): string[] => {
+    let entries: string[];
+
+    try {
+        entries = readdirSync(directory);
+    } catch {
+        return accumulator;
+    }
+
+    for (const entry of entries) {
+        const full = join(directory, entry);
+        const info = lstatSync(full);
+
+        if (info.isDirectory()) {
+            if (SKIP_DIRECTORIES.has(entry)) {
+                continue;
+            }
+
+            discoverEvalFiles(full, accumulator);
+        } else if (info.isFile() && entry.endsWith(EVAL_FILE_SUFFIX)) {
+            accumulator.push(full);
+        }
+    }
+
+    return accumulator.toSorted((a, b) => a.localeCompare(b));
+};
+
+export { discoverEvalFiles, EVAL_FILE_SUFFIX };

--- a/packages/cli/src/commands/eval/discover-eval-files.ts
+++ b/packages/cli/src/commands/eval/discover-eval-files.ts
@@ -27,7 +27,15 @@ const discoverEvalFiles = (directory: string, accumulator: string[] = []): strin
 
     for (const entry of entries) {
         const full = join(directory, entry);
-        const info = lstatSync(full);
+        let info;
+
+        try {
+            info = lstatSync(full);
+        } catch {
+            // Entry removed between readdirSync and lstatSync, or unreadable
+            // (permissions) — skip it rather than crash the whole discovery walk.
+            continue;
+        }
 
         if (info.isDirectory()) {
             if (SKIP_DIRECTORIES.has(entry)) {

--- a/packages/cli/src/commands/eval/handler.ts
+++ b/packages/cli/src/commands/eval/handler.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
-import type { EvalResult } from "@lunora/testing";
+import type { EvalItemResult, EvalResult } from "@lunora/testing";
 
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
@@ -16,12 +16,40 @@ import { isEvalModule } from "./types";
 /** Default directory `lunora eval` discovers `*.eval.ts` files under, relative to `cwd`. */
 const DEFAULT_EVAL_DIR = "evals";
 
-/** Strip the directory and `.eval.ts` suffix off a discovered file's path for its default display name. */
-const nameFromPath = (filePath: string): string => {
-    const base = filePath.split("/").pop() ?? filePath;
+/**
+ * The actionable message printed when the Node floor can't execute a
+ * discovered `.ts` eval file — see {@link isUnsupportedTsExtensionError}.
+ */
+const NODE_FLOOR_MESSAGE =
+    '"lunora eval" needs native TypeScript execution — run Node ≥23.6, or a TS loader/transform (tracked in plans/245-eval-runner-design.md §8.3)';
 
-    return base.slice(0, -EVAL_FILE_SUFFIX.length);
+/** Matches Node's `ERR_UNKNOWN_FILE_EXTENSION` message shape when `.code` isn't set (see {@link isUnsupportedTsExtensionError}). */
+const TS_EXTENSION_ERROR_PATTERN = /unknown file extension ".ts"/i;
+
+/**
+ * True when `error` is Node's `ERR_UNKNOWN_FILE_EXTENSION` (or its message
+ * shape) thrown by a bare `import()` of a `.ts` file — i.e. there is no
+ * runtime TS loader available. This repo's `engines` floor is `^22.15.0`;
+ * native `.ts` `import()` is only unflagged from Node ≥23.6, so on the
+ * floor EVERY discovered `*.eval.ts` fails identically. That makes it a
+ * systemic, top-level failure — not a per-eval one — so callers should abort
+ * the whole run on the first occurrence rather than mislabel N evals as
+ * "failed".
+ */
+const isUnsupportedTsExtensionError = (error: unknown): boolean => {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    if ((error as NodeJS.ErrnoException).code === "ERR_UNKNOWN_FILE_EXTENSION") {
+        return true;
+    }
+
+    return TS_EXTENSION_ERROR_PATTERN.test(error.message);
 };
+
+/** Strip the directory and `.eval.ts` suffix off a discovered file's path for its default display name. */
+const nameFromPath = (filePath: string): string => basename(filePath, EVAL_FILE_SUFFIX);
 
 interface EvalCommandOptions {
     cwd?: string;
@@ -55,11 +83,91 @@ interface EvalRunOutcome {
 interface EvalCommandResult {
     code: number;
 
-    /** Set when the run aborted before any eval ran: an invalid `--format`. */
+    /**
+     * Set when the run aborted before completing normally: an invalid
+     * `--format`, the Node-floor `.ts`-execution gap, or a `--threshold`
+     * gate applied to zero discovered evals.
+     */
     error?: string;
 
     evals: EvalRunOutcome[];
 }
+
+/**
+ * The JSON-output shape for one eval's outcome, matching the documented
+ * `--format json` contract (`plans/245-eval-runner-design.md` §4/§6):
+ * `{ name, path, average?, threshold?, passed, error?, items? }` — flat, so
+ * `jq '.evals[].average'` (or any other single-hop field lookup) works
+ * directly against the printed document, unlike the nested `result.average`/
+ * `result.items` the in-process {@link EvalRunOutcome} carries for callers
+ * that already hold a reference to the full `EvalResult`.
+ */
+interface EvalJsonOutcome {
+    average?: number;
+    error?: string;
+    items?: EvalItemResult[];
+    name: string;
+    passed: boolean;
+    path: string;
+    threshold?: number;
+}
+
+/** Flatten one {@link EvalRunOutcome} into the documented `--format json` per-eval shape. */
+const toJsonOutcome = (outcome: EvalRunOutcome): EvalJsonOutcome => {
+    return {
+        average: outcome.result?.average,
+        error: outcome.error,
+        items: outcome.result?.items,
+        name: outcome.name,
+        passed: outcome.passed,
+        path: outcome.path,
+        threshold: outcome.threshold,
+    };
+};
+
+/** Flatten a whole {@link EvalCommandResult} for `--format json` printing (see {@link toJsonOutcome}). */
+const toJsonResult = (result: EvalCommandResult): { code: number; error?: string; evals: EvalJsonOutcome[] } => {
+    return {
+        code: result.code,
+        error: result.error,
+        evals: result.evals.map((outcome) => toJsonOutcome(outcome)),
+    };
+};
+
+/** Log `message` as the run's single top-level error, build the aborted {@link EvalCommandResult}, and print it as JSON when requested. */
+const abortWithTopLevelError = (logger: Logger, format: string | undefined, message: string): EvalCommandResult => {
+    logger.error(message);
+
+    const result: EvalCommandResult = { code: 1, error: message, evals: [] };
+
+    if (isJsonFormat(format)) {
+        printJson(toJsonResult(result));
+    }
+
+    return result;
+};
+
+/**
+ * Discover `*.eval.ts` files under `directory`, logging the same "nothing to
+ * run"/"no files found" info lines for a missing or empty directory that
+ * `runEvalCommand` has always reported — an absent `evals/` is a no-op, not
+ * an error (see `discoverEvalFiles`'s own doc comment).
+ */
+const discoverFilesLogged = (directory: string, directoryOption: string, logger: Logger): string[] => {
+    if (!existsSync(directory)) {
+        logger.info(`eval: no "${directoryOption}" directory — nothing to run`);
+
+        return [];
+    }
+
+    const files = discoverEvalFiles(directory);
+
+    if (files.length === 0) {
+        logger.info(`eval: no ${EVAL_FILE_SUFFIX} files found under "${directoryOption}"`);
+    }
+
+    return files;
+};
 
 /** Load one discovered file's default export and validate it satisfies {@link EvalModule}. */
 const loadEvalModule = async (filePath: string): Promise<EvalModule> => {
@@ -78,13 +186,24 @@ const loadEvalModule = async (filePath: string): Promise<EvalModule> => {
     return candidate;
 };
 
-/** Run one discovered eval file, applying its effective threshold (per-eval export, else the global `--threshold`). */
+/**
+ * Run one discovered eval file, applying its effective threshold (per-eval
+ * export, else the global `--threshold`). A load failure shaped like
+ * {@link isUnsupportedTsExtensionError} is NOT converted into a per-eval
+ * failure — it is rethrown so the caller can abort the whole run with one
+ * top-level, actionable message instead of mislabeling every eval as
+ * "failed" (see {@link NODE_FLOOR_MESSAGE}).
+ */
 const runOneEval = async (filePath: string, globalThreshold: number | undefined): Promise<EvalRunOutcome> => {
     let evalModule: EvalModule;
 
     try {
         evalModule = await loadEvalModule(filePath);
     } catch (error: unknown) {
+        if (isUnsupportedTsExtensionError(error)) {
+            throw error;
+        }
+
         const message = error instanceof Error ? error.message : String(error);
 
         return { error: message, name: nameFromPath(filePath), passed: false, path: filePath };
@@ -103,6 +222,27 @@ const runOneEval = async (filePath: string, globalThreshold: number | undefined)
 
         return { error: message, name, passed: false, path: filePath, threshold: effectiveThreshold };
     }
+};
+
+/**
+ * Run every discovered eval file sequentially, applying `threshold`. A load
+ * failure shaped like {@link isUnsupportedTsExtensionError} propagates
+ * unchanged (see {@link runOneEval}) so the caller can abort the whole run
+ * with one top-level message.
+ */
+const runAllEvals = async (files: string[], threshold: number | undefined): Promise<EvalRunOutcome[]> => {
+    const outcomes: EvalRunOutcome[] = [];
+
+    for (const file of files) {
+        // Sequential, not `Promise.all`: two eval files sharing a stateful stub
+        // (a scripted judge, a rate-limited real model behind `ctx.ai`) would
+        // interleave under concurrency. Concurrency WITHIN one eval's own
+        // dataset is still `evaluate`'s own job — untouched by this loop.
+        // eslint-disable-next-line no-await-in-loop -- sequential by design, see above
+        outcomes.push(await runOneEval(file, threshold));
+    }
+
+    return outcomes;
 };
 
 /** Render one outcome's `STATUS` cell: its error, or a pass/fail plus case count. */
@@ -144,6 +284,14 @@ const renderEvalTable = (outcomes: EvalRunOutcome[]): string[] => {
  * exit non-zero when any eval crashed or fell below its effective threshold.
  * Entirely in-process: no live Worker is ever contacted (see
  * `plans/245-eval-runner-design.md` §5).
+ *
+ * Two additional abort paths guard against silently-wrong CI signal:
+ * - The Node-floor `.ts`-execution gap ({@link isUnsupportedTsExtensionError})
+ * aborts the whole run with one top-level message instead of N mislabeled
+ * per-eval failures.
+ * - A `--threshold` applied to zero discovered evals (missing/renamed
+ * `--dir`, no `*.eval.ts` match) exits non-zero — a gate that ran against
+ * nothing must not report success.
  */
 const runEvalCommand = async (options: EvalCommandOptions): Promise<EvalCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
@@ -159,34 +307,24 @@ const runEvalCommand = async (options: EvalCommandOptions): Promise<EvalCommandR
 
     const directoryOption = options.dir ?? DEFAULT_EVAL_DIR;
     const directory = join(cwd, directoryOption);
+    const files = discoverFilesLogged(directory, directoryOption, logger);
 
-    if (!existsSync(directory)) {
-        logger.info(`eval: no "${directoryOption}" directory — nothing to run`);
+    let outcomes: EvalRunOutcome[];
 
-        const emptyResult = { code: 0, evals: [] };
-
-        if (isJsonFormat(options.format)) {
-            printJson(emptyResult);
+    try {
+        outcomes = await runAllEvals(files, options.threshold);
+    } catch (error: unknown) {
+        if (!isUnsupportedTsExtensionError(error)) {
+            throw error;
         }
 
-        return emptyResult;
+        return abortWithTopLevelError(logger, options.format, NODE_FLOOR_MESSAGE);
     }
 
-    const files = discoverEvalFiles(directory);
+    if (options.threshold !== undefined && outcomes.length === 0) {
+        const message = `eval: --threshold ${String(options.threshold)} was set but 0 eval files were discovered under "${directoryOption}" — nothing was gated`;
 
-    if (files.length === 0) {
-        logger.info(`eval: no ${EVAL_FILE_SUFFIX} files found under "${directoryOption}"`);
-    }
-
-    const outcomes: EvalRunOutcome[] = [];
-
-    for (const file of files) {
-        // Sequential, not `Promise.all`: two eval files sharing a stateful stub
-        // (a scripted judge, a rate-limited real model behind `ctx.ai`) would
-        // interleave under concurrency. Concurrency WITHIN one eval's own
-        // dataset is still `evaluate`'s own job — untouched by this loop.
-        // eslint-disable-next-line no-await-in-loop -- sequential by design, see above
-        outcomes.push(await runOneEval(file, options.threshold));
+        return abortWithTopLevelError(logger, options.format, message);
     }
 
     for (const line of renderEvalTable(outcomes)) {
@@ -205,7 +343,7 @@ const runEvalCommand = async (options: EvalCommandOptions): Promise<EvalCommandR
     const result = { code, evals: outcomes };
 
     if (isJsonFormat(options.format)) {
-        printJson(result);
+        printJson(toJsonResult(result));
     }
 
     return result;

--- a/packages/cli/src/commands/eval/handler.ts
+++ b/packages/cli/src/commands/eval/handler.ts
@@ -305,6 +305,16 @@ const runEvalCommand = async (options: EvalCommandOptions): Promise<EvalCommandR
         return { code: 1, error: formatError, evals: [] };
     }
 
+    // Cerebro parses `--threshold` with `type: Number`, so a non-numeric value
+    // (`--threshold abc`) silently becomes NaN instead of erroring at the CLI
+    // layer. Reject it — and anything outside the documented [0, 1] range —
+    // here, before it can gate the run: an unchecked NaN makes every eval's
+    // `average >= NaN` comparison false, reporting every eval as FAIL with no
+    // stated cause.
+    if (options.threshold !== undefined && !(Number.isFinite(options.threshold) && options.threshold >= 0 && options.threshold <= 1)) {
+        return abortWithTopLevelError(logger, options.format, `eval: --threshold must be a number in [0, 1] — received "${String(options.threshold)}"`);
+    }
+
     const directoryOption = options.dir ?? DEFAULT_EVAL_DIR;
     const directory = join(cwd, directoryOption);
     const files = discoverFilesLogged(directory, directoryOption, logger);

--- a/packages/cli/src/commands/eval/handler.ts
+++ b/packages/cli/src/commands/eval/handler.ts
@@ -1,0 +1,228 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { EvalResult } from "@lunora/testing";
+
+import type { CommandHandler } from "../../util/command";
+import { defineHandler } from "../../util/command";
+import type { Logger } from "../../util/logger";
+import { isJsonFormat, loggerForFormat, printJson, validateOutputFormat } from "../../util/output-format";
+import { discoverEvalFiles, EVAL_FILE_SUFFIX } from "./discover-eval-files";
+import type { EvalOptions } from "./index";
+import type { EvalModule } from "./types";
+import { isEvalModule } from "./types";
+
+/** Default directory `lunora eval` discovers `*.eval.ts` files under, relative to `cwd`. */
+const DEFAULT_EVAL_DIR = "evals";
+
+/** Strip the directory and `.eval.ts` suffix off a discovered file's path for its default display name. */
+const nameFromPath = (filePath: string): string => {
+    const base = filePath.split("/").pop() ?? filePath;
+
+    return base.slice(0, -EVAL_FILE_SUFFIX.length);
+};
+
+interface EvalCommandOptions {
+    cwd?: string;
+
+    /** Directory to discover `*.eval.ts` files under (default `evals/`). */
+    dir?: string;
+
+    /** Output format: `pretty` (default) or `json`. */
+    format?: string;
+
+    logger: Logger;
+
+    /**
+     * Global score gate every eval's average must meet, `[0, 1]`; a per-eval
+     * `threshold` export overrides it for that eval only. Omitted → report-only
+     * (a clean run always exits 0, regardless of score).
+     */
+    threshold?: number;
+}
+
+/** One discovered eval's outcome — either it produced a result, or it crashed loading/running. */
+interface EvalRunOutcome {
+    error?: string;
+    name: string;
+    passed: boolean;
+    path: string;
+    result?: EvalResult;
+    threshold?: number;
+}
+
+interface EvalCommandResult {
+    code: number;
+
+    /** Set when the run aborted before any eval ran: an invalid `--format`. */
+    error?: string;
+
+    evals: EvalRunOutcome[];
+}
+
+/** Load one discovered file's default export and validate it satisfies {@link EvalModule}. */
+const loadEvalModule = async (filePath: string): Promise<EvalModule> => {
+    // A genuinely dynamic import of an arbitrary, runtime-discovered eval file
+    // — never a static-analysis (glob) candidate. Excluded from packem's
+    // dynamic-import-vars rollup plugin (`packem.config.ts`'s `rollup.dynamicVars.exclude`),
+    // which otherwise tries to turn every non-literal `import()` into a glob
+    // and hard-fails when it can't.
+    const imported: unknown = await import(pathToFileURL(filePath).href);
+    const candidate = (imported as { default?: unknown }).default;
+
+    if (!isEvalModule(candidate)) {
+        throw new Error("does not default-export an eval module (expected `{ run(): Promise<EvalResult>, name?, threshold? }`)");
+    }
+
+    return candidate;
+};
+
+/** Run one discovered eval file, applying its effective threshold (per-eval export, else the global `--threshold`). */
+const runOneEval = async (filePath: string, globalThreshold: number | undefined): Promise<EvalRunOutcome> => {
+    let evalModule: EvalModule;
+
+    try {
+        evalModule = await loadEvalModule(filePath);
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return { error: message, name: nameFromPath(filePath), passed: false, path: filePath };
+    }
+
+    const name = evalModule.name ?? nameFromPath(filePath);
+    const effectiveThreshold = evalModule.threshold ?? globalThreshold;
+
+    try {
+        const result = await evalModule.run();
+        const passed = effectiveThreshold === undefined || result.average >= effectiveThreshold;
+
+        return { name, passed, path: filePath, result, threshold: effectiveThreshold };
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return { error: message, name, passed: false, path: filePath, threshold: effectiveThreshold };
+    }
+};
+
+/** Render one outcome's `STATUS` cell: its error, or a pass/fail plus case count. */
+const renderStatus = (outcome: EvalRunOutcome): string => {
+    if (outcome.error !== undefined) {
+        return `ERROR: ${outcome.error}`;
+    }
+
+    const verdict = outcome.passed ? "pass" : "FAIL";
+    const caseCount = outcome.result?.items.length ?? 0;
+
+    return `${verdict} (${String(caseCount)} cases)`;
+};
+
+/** Render the `NAME  SCORE  THRESHOLD  STATUS` aggregate table `lunora eval` prints in `pretty` mode. */
+const renderEvalTable = (outcomes: EvalRunOutcome[]): string[] => {
+    if (outcomes.length === 0) {
+        return [];
+    }
+
+    const nameWidth = Math.max(4, ...outcomes.map((outcome) => outcome.name.length));
+    const lines = [`${"NAME".padEnd(nameWidth)}  SCORE   THRESHOLD  STATUS`];
+
+    for (const outcome of outcomes) {
+        const score = outcome.result === undefined ? "—" : outcome.result.average.toFixed(3);
+        const threshold = outcome.threshold === undefined ? "—" : outcome.threshold.toFixed(3);
+
+        lines.push(`${outcome.name.padEnd(nameWidth)}  ${score.padEnd(6)}  ${threshold.padEnd(9)}  ${renderStatus(outcome)}`);
+    }
+
+    return lines;
+};
+
+/**
+ * Discover every `*.eval.ts` file under `--dir` (default `evals/`), run each
+ * via its default-exported `run()` — which calls `evaluate`/`agentHarness`
+ * from `@lunora/testing` exactly as a hand-written Vitest suite would, this
+ * command adds no scoring logic of its own — print the aggregate table, and
+ * exit non-zero when any eval crashed or fell below its effective threshold.
+ * Entirely in-process: no live Worker is ever contacted (see
+ * `plans/245-eval-runner-design.md` §5).
+ */
+const runEvalCommand = async (options: EvalCommandOptions): Promise<EvalCommandResult> => {
+    const cwd = options.cwd ?? process.cwd();
+    const logger = loggerForFormat(options.format, options.logger);
+
+    const formatError = validateOutputFormat("eval", options.format);
+
+    if (formatError !== undefined) {
+        options.logger.error(formatError);
+
+        return { code: 1, error: formatError, evals: [] };
+    }
+
+    const directoryOption = options.dir ?? DEFAULT_EVAL_DIR;
+    const directory = join(cwd, directoryOption);
+
+    if (!existsSync(directory)) {
+        logger.info(`eval: no "${directoryOption}" directory — nothing to run`);
+
+        const emptyResult = { code: 0, evals: [] };
+
+        if (isJsonFormat(options.format)) {
+            printJson(emptyResult);
+        }
+
+        return emptyResult;
+    }
+
+    const files = discoverEvalFiles(directory);
+
+    if (files.length === 0) {
+        logger.info(`eval: no ${EVAL_FILE_SUFFIX} files found under "${directoryOption}"`);
+    }
+
+    const outcomes: EvalRunOutcome[] = [];
+
+    for (const file of files) {
+        // Sequential, not `Promise.all`: two eval files sharing a stateful stub
+        // (a scripted judge, a rate-limited real model behind `ctx.ai`) would
+        // interleave under concurrency. Concurrency WITHIN one eval's own
+        // dataset is still `evaluate`'s own job — untouched by this loop.
+        // eslint-disable-next-line no-await-in-loop -- sequential by design, see above
+        outcomes.push(await runOneEval(file, options.threshold));
+    }
+
+    for (const line of renderEvalTable(outcomes)) {
+        logger.info(line);
+    }
+
+    const failed = outcomes.filter((outcome) => !outcome.passed);
+    const code = failed.length > 0 ? 1 : 0;
+
+    if (code === 0) {
+        logger.success(`eval: ${String(outcomes.length)} eval(s) passed`);
+    } else {
+        logger.error(`eval: ${String(failed.length)}/${String(outcomes.length)} eval(s) failed`);
+    }
+
+    const result = { code, evals: outcomes };
+
+    if (isJsonFormat(options.format)) {
+        printJson(result);
+    }
+
+    return result;
+};
+
+/** `lunora eval` handler (lazy-loaded via the command's `loader`). */
+const execute: CommandHandler<EvalOptions> = defineHandler<EvalOptions>(async ({ cwd, logger, options }) => {
+    const result = await runEvalCommand({
+        cwd,
+        dir: options.dir,
+        format: options.format,
+        logger,
+        threshold: options.threshold,
+    });
+
+    return { code: result.code };
+});
+
+export { execute, runEvalCommand };
+export type { EvalCommandOptions, EvalCommandResult, EvalRunOutcome };

--- a/packages/cli/src/commands/eval/index.ts
+++ b/packages/cli/src/commands/eval/index.ts
@@ -1,0 +1,41 @@
+import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
+
+/**
+ * `lunora eval` — discover every `*.eval.ts` under `evals/` (or `--dir`) and
+ * run it through its own default-exported `run()`, which calls
+ * `evaluate`/`agentHarness` from `@lunora/testing` however the eval needs.
+ * Entirely in-process: no `wrangler dev`/`lunora dev` needed, unlike `seed`/
+ * `insights`. Metadata only; the handler (lazy-loaded via `loader`) holds the
+ * logic. See `plans/245-eval-runner-design.md`.
+ */
+const evalCommand: Command = {
+    description: "Run every *.eval.ts under evals/ via @lunora/testing's evaluate/agentHarness — no live worker needed",
+    examples: [
+        ["lunora eval", "Run every eval under evals/, print the aggregate table"],
+        ["lunora eval --threshold 0.8", "Non-zero exit if any eval's average score falls below 0.8"],
+        ["lunora eval --dir evals/support --format json", "Run a subset and emit a machine-readable result"],
+    ],
+    group: "Develop",
+    loader: () =>
+        import("./handler").then((m) => {
+            return { default: m.execute as CommandExecute<Toolbox> };
+        }),
+    name: "eval",
+    options: [
+        { description: "Directory to discover *.eval.ts files under (default evals/)", name: "dir", type: String },
+        { description: "Output format: pretty (default) or json", name: "format", type: String },
+        {
+            description: "Score gate every eval's average must meet ([0,1]); a per-eval `threshold` export wins over this for that eval",
+            name: "threshold",
+            type: Number,
+        },
+    ],
+};
+
+export { evalCommand };
+
+export type EvalOptions = CreateOptions<{
+    dir: string | undefined;
+    format: string | undefined;
+    threshold: number | undefined;
+}>;

--- a/packages/cli/src/commands/eval/types.ts
+++ b/packages/cli/src/commands/eval/types.ts
@@ -1,0 +1,35 @@
+import type { EvalResult } from "@lunora/testing";
+
+/**
+ * What a discovered `*.eval.ts` file must default-export. `run` is the ENTIRE
+ * eval body — it calls `evaluate`/`agentHarness` (or whatever else it needs)
+ * from `@lunora/testing` itself and returns the kit's own `EvalResult`. The
+ * runner never touches a scorer or the harness; this is the whole contract.
+ *
+ * A single default export (never mixed with named exports) so the file can
+ * carry `name`/`threshold` metadata alongside the runnable body without
+ * violating the repo's "no mixed default + named exports" rule.
+ */
+interface EvalModule {
+    /** Display name; defaults to the file's basename (minus `.eval.ts`) when omitted. */
+    name?: string;
+
+    /**
+     * Run the eval. Reuses `evaluate`/`agentHarness` from `@lunora/testing`
+     * unchanged — this type imposes no new shape on the kit's own `EvalResult`.
+     */
+    run: () => Promise<EvalResult> | EvalResult;
+
+    /**
+     * Per-eval score gate in `[0, 1]`, overriding a global `--threshold` for
+     * THIS eval only. Omitted → the global `--threshold` (if any) applies.
+     */
+    threshold?: number;
+}
+
+/** Runtime shape-check for a dynamically imported eval module's default export. */
+const isEvalModule = (value: unknown): value is EvalModule =>
+    typeof value === "object" && value !== null && typeof (value as { run?: unknown }).run === "function";
+
+export type { EvalModule };
+export { isEvalModule };

--- a/plans/245-eval-runner-design.md
+++ b/plans/245-eval-runner-design.md
@@ -1,0 +1,344 @@
+# Plan 245 Phase 0 — `lunora eval` runner + Studio Evals panel: design & prototype
+
+> Design + prototype deliverable for plan 245 (SPIKE). The eval kit itself
+> (`evaluate`, `llmScorer`/`keywordScorer`/`regexScorer`/`exactMatchScorer`/
+> `containsScorer`, `agentHarness`, `recordEvaluation`) is unchanged by this
+> work — `packages/testing/src/` has a zero-line diff. This doc defines the
+> `*.eval.ts` discovery convention, the CI/`--threshold` exit-code contract,
+> and the Studio panel's data source, and reports one real gap found while
+> designing the panel.
+
+**Baseline:** `36421ad58` (2026-07-31, drift-checked against `2d4f71511` per
+plan — `git diff --stat 2d4f71511..HEAD -- packages/testing/src packages/cli/src
+packages/studio/src/features` shows zero changes to `packages/testing/src` or
+`packages/studio/src/features`; `packages/cli/src` changed in ways unrelated to
+commands/eval, confirmed by reading the diff)
+
+## 1. Current state (recap, verified)
+
+- The kit is complete and untouched by this design:
+  - `packages/testing/src/scorer.ts` — `evaluate(cases, produce, scorers)` →
+    `EvalResult { average, items: EvalItemResult[] }`; five scorers.
+  - `packages/testing/src/agent-harness.ts` — `agentHarness(agent, { script,
+    functions? })` drives `runAgentLoop` against an in-memory `agents:*`
+    runtime double and a `DurableStepJournal`. **No network, no Durable
+    Object, no `wrangler dev`** — confirmed by reading the whole file.
+    `agentHarness(...).run(...)` resolves in-process.
+  - `packages/testing/src/evaluation-telemetry.ts` — `recordEvaluation({name,
+    score, label?, span?})` returns `{ "gen_ai.evaluation.<name>.score":
+    number, "gen_ai.evaluation.<name>.label"?: string }` and, when handed a
+    `SpanHandle`, calls `span.setAttributes(...)` — i.e. it rides the SAME
+    span as the generation it grades, it does not create a new one.
+- No runner: `packages/cli/src/commands/` has no `eval` directory; `cli.ts`
+  registers 30 commands, none named `eval`.
+- No Studio surface: `packages/studio/src/features/` has no `evals/`; nothing
+  under `packages/studio/src` references `gen_ai.evaluation`.
+- `@lunora/cli`'s `package.json` does not depend on `@lunora/testing` today —
+  adding the runner requires one new dependency edge.
+
+## 2. Existing seams this reuses (do not reinvent)
+
+- **Command shape**: `verify` (`packages/cli/src/commands/verify/{index,handler}.ts`)
+  is the closest sibling — a read-only, offline-safe command with `--format
+  pretty|json` (`util/output-format.ts`: `validateOutputFormat`,
+  `loggerForFormat`, `isJsonFormat`, `printJson`) and a testable
+  `run*Command(options): Promise<{code, ...}>` function wrapped by
+  `defineHandler` (`util/command.ts`) for the cerebro `execute`. `lunora eval`
+  copies this shape exactly.
+- **File discovery**: `packages/codegen/src/discover-functions.ts`'s
+  `listLunoraSourceFiles` — `readdirSync` + `lstatSync` (never `statSync`, so
+  a directory symlink cycle isn't descended into), skipping `node_modules`/
+  `_generated`. `discover-eval-files.ts` mirrors this walker verbatim, scoped
+  to `*.eval.ts`.
+- **Contrast — commands that DO need a live worker**: `seed` and `insights`
+  both require `--url`/`--token` against a running Worker (`seed/index.ts`:
+  "bulk-insert it via the worker's admin endpoint"; `insights/index.ts`:
+  "Report... from a running Worker"). `lunora eval` is deliberately NOT this
+  shape — see §4.
+
+## 3. The `*.eval.ts` discovery convention
+
+### Location: top-level `evals/`, not `lunora/**/*.eval.ts`
+
+**Recommendation: a top-level `evals/` directory**, sibling to `lunora/`,
+walked recursively (`evals/**/*.eval.ts`). Rejected alternative:
+`lunora/**/*.eval.ts`.
+
+Why not inside `lunora/`: `lunora/` is codegen's domain — every `.ts` file in
+it (barring `schema.ts` at the root and anything under `_generated/`) is
+walked by `listLunoraSourceFiles` and parsed as a candidate function module
+(`discover-functions.ts`). An eval fixture is not a function module, but nothing
+today teaches codegen to skip a `*.eval.ts` suffix, so dropping evals inside
+`lunora/` risks a `.eval.ts` file being picked up as a broken/empty function
+source the first time someone imports something codegen's static walk doesn't
+expect, or at minimum adds a codegen-side carve-out for a concept codegen has
+no reason to know about. `evals/` at the project root mirrors the existing
+`__tests__/` convention (test-shaped code lives in its own top-level
+directory, sibling to the source it exercises) and needs zero codegen changes.
+
+### The eval module shape: a single default export, `{ name?, threshold?, run }`
+
+```ts
+// evals/support-triage.eval.ts
+import { agentHarness, containsScorer, evaluate, finalTurn } from "@lunora/testing";
+import { supportAgent } from "../lunora/agents";
+
+export default {
+    name: "support-triage", // optional — defaults to the filename minus `.eval.ts`
+    threshold: 0.8, // optional — overrides `--threshold` for THIS eval only
+    run: async () => {
+        const harness = agentHarness(supportAgent, {
+            script: [finalTurn("Your refund was issued.")],
+        });
+
+        return evaluate(
+            [{ expected: "refund", input: "where's my refund?" }],
+            async (input) => (await harness.run({ input, threadKey: input })).text ?? "",
+            [containsScorer("refund")],
+        );
+    },
+};
+```
+
+- **Single default export** — the repo-wide rule ("never mix default + named
+  exports; default is fine only as the sole export", `CLAUDE.md`) makes this
+  the only compliant shape that also carries per-eval metadata (`name`,
+  `threshold`) alongside the executable body. A bare `export default async ()
+  => EvalResult` (no metadata) was considered and rejected: it can't carry a
+  per-eval threshold without a second named export, which the mixed-export
+  rule forbids.
+- **`run` is the ENTIRE eval body** — the runner does not call `evaluate`
+  itself, does not construct scorers, does not touch `agentHarness`. The file
+  imports what it needs from `@lunora/testing` and returns whatever
+  `EvalResult` its own call to `evaluate(...)` produces. This is what makes
+  "the kit is the product, the runner is glue" literal rather than aspirational:
+  the runner's contract with a `*.eval.ts` file is exactly `() =>
+  Promise<EvalResult> | EvalResult`, and `EvalResult` is the kit's own
+  existing exported type — nothing new is added to `@lunora/testing`.
+- **No `defineEval` helper (yet)** — the codebase's `define*` convention
+  (`defineSchema`, `defineAgent`, `defineWorkflow`, …) would suggest a
+  `defineEval` identity-typed helper in `@lunora/testing` for authoring DX
+  (autocomplete, inline type errors on `run`'s return type). This is
+  deliberately **not** added in this spike: the prototype's `evals/*.eval.ts`
+  file structurally satisfies `EvalModule` (a type-only interface living in
+  `@lunora/cli`, not in the kit) with zero coupling back into
+  `packages/testing/src`, which is the strongest form of "reuses the kit
+  UNCHANGED" this design could produce. If the shape holds up, promoting it to
+  a real `defineEval` in `@lunora/testing` is a one-file, additive follow-up —
+  flagged as an open question in §6, not decided here.
+
+### Discovery mechanics (prototype)
+
+`packages/cli/src/commands/eval/discover-eval-files.ts` — `readdirSync` +
+`lstatSync` recursive walk under `--dir` (default `evals/`), collecting files
+whose name ends in `.eval.ts`, skipping `node_modules`/`_generated`/`dist`/
+`.git`, sorted for a deterministic run order. Absence of the directory is not
+an error (mirrors `verify`'s "no tsconfig.json → warning, not error"): `lunora
+eval` prints an info line and exits 0.
+
+## 4. The CI contract: `--threshold`, exit codes, `--format json`
+
+Mirrors `verify` exactly:
+
+- `lunora eval` — runs every discovered eval, prints a table (`NAME  SCORE
+  THRESHOLD  STATUS`), exits **0** if every eval ran without throwing (no
+  threshold set → report-only; this is the "just show me the scores" mode).
+- `lunora eval --threshold 0.8` — a **global** gate: every eval's `.average`
+  must be `>= 0.8`, unless the eval's own `threshold` export overrides it
+  (per-eval wins). Exits **1** if any eval falls below its effective
+  threshold, or if any eval file throws while loading or running (a crash is
+  always a failure, independent of thresholds).
+- `--format json` — mirrors `verify`'s contract bit-for-bit: every
+  human/progress line moves to stderr (`loggerForFormat`), stdout carries one
+  JSON document (`printJson`) shaped `{ code, evals: [{ name, path, average?,
+  threshold?, passed, error?, items? }] }`. Machine-readable, pipeable to
+  `jq`, and the shape a CI step greps for a specific eval's score without
+  re-running anything.
+- **No per-eval exit code** — one process, one exit code, exactly like every
+  other Lunora CLI command. A per-eval breakdown lives in the printed table /
+  JSON body, not in the exit code's bits.
+- Threshold granularity is **global by default, per-eval override** — not
+  "global XOR per-eval." An app with nine settled evals and one new,
+  known-noisy one sets `--threshold 0.85` globally and `threshold: 0.5` on the
+  noisy file, rather than choosing one mode for the whole run.
+
+## 5. Does the runner need a live worker? No — harness-only, and that is load-bearing
+
+`agentHarness` (§1) is a pure in-memory double: a scripted `AgentGenerate`,
+an in-memory `agents:*` runtime, a `DurableStepJournal` mimicking Workflows'
+`step.do` memoization. `evaluate`'s `produce` callback is caller-supplied —
+nothing in the kit reaches for `fetch`, a Durable Object stub, or a Worker
+binding. Verified by reading `agent-harness.ts` and `scorer.ts` in full: **zero**
+references to `fetch`, `WebSocket`, or any binding type.
+
+This means `lunora eval` runs entirely in the CLI's own Node process — no
+`wrangler dev`, no `lunora dev` running in another terminal, no `--url`/
+`--token` like `seed`/`insights` need. That is a real, load-bearing property
+for the CI story: a GitHub Actions step can run `pnpm --filter <app> exec
+lunora eval --threshold 0.8` with no Worker to stand up first, no port to
+wait on, no `wrangler dev` flake. This is the harness-only path the plan
+asked to confirm or refute — **confirmed harness-only**, no live worker
+required, and the design leans on that: nothing in §3–4 assumes a URL/token
+option exists.
+
+(An eval whose `produce` calls `ctx.ai`/a real model provider still needs
+network egress and an API key — that is a property of the eval author's own
+`run()` body, identical to any Vitest test that happens to hit a real API. It
+is not something the runner arranges or gates.)
+
+### An implementation gap this spike surfaces (not a STOP, but real)
+
+The prototype's discovery step (`discoverEvalFiles`) finds `*.eval.ts` files;
+running them requires actually **executing** TypeScript source, not just
+parsing it (unlike codegen, which only ever statically walks `lunora/*.ts`
+with `ts-morph` — see `discover-functions.ts` — and never runs user code).
+The prototype does a plain `await import(pathToFileURL(file).href)`. Under
+Vitest (this is how the CLI's own test suite exercises the fixture — see §7)
+this works transparently: Vitest's module runner transforms any `.ts` it
+resolves, including one reached via a dynamic `import()` at runtime, not only
+statically-imported test files. Under the **compiled** `lunora` binary running
+on plain Node, it works only on Node's built-in TypeScript type-stripping,
+which is opt-in (`--experimental-strip-types`) on the `^22.15.0` floor this
+repo's `engines` field allows and only unflagged by default starting Node
+23.6 — so on a real `^22.15.0` install, importing a `.ts` eval file from the
+shipped binary throws `ERR_UNKNOWN_FILE_EXTENSION` today. This is flagged as
+an open question in §6, not solved here — the prototype's own test runs under
+Vitest specifically to sidestep it and prove the discovery/threshold/aggregate
+logic, which is this step's actual deliverable.
+
+## 6. Studio Evals panel: data source, and a gap the panel design surfaces
+
+### Where `gen_ai.evaluation.*` actually lives
+
+`recordEvaluation` attaches its attributes to whatever `SpanHandle` the caller
+hands it — the same post-hoc handle a `ctx.trace(name, (trace, span) => …)`
+body receives (`evaluation-telemetry.ts:11-16`). That span is folded into the
+shard's trace ring and surfaced today by the existing `__lunora_admin__:getTraces`
+RPC (`packages/studio/src/lib/admin.ts:1014-1083`, consumed by
+`TracesPanel`, `packages/studio/src/features/traces/traces-panel.tsx`) — a
+`TraceSummary.spans[]` entry's `attributes` is exactly where a
+`gen_ai.evaluation.<name>.score` key would show up. **No new RPC is needed for
+a v1 panel** — `getTraces` already returns the data.
+
+### The gap: that store is a live, bounded, in-memory ring — not history
+
+Both `admin.ts`'s own doc comments are explicit about this, independently, for
+the two candidate stores:
+
+- `TraceSummary` (`admin.ts:1045-1048`): "Sourced from the shard's bounded,
+  in-memory span ring, so it resets on hibernation/restart... a 'recent traces
+  on this instance' readout for local development, **NOT a durable trace
+  store**."
+- `MetricSeries` (`admin.ts:1095-1098`): same story for `ctx.metrics` — "A
+  'recent metrics on this instance' readout for local development, **NOT a
+  durable metric store**."
+
+There IS a durable, historical, per-minute-bucketed store already shipped —
+`MetricHistoryPoint`/`getMetricHistory` (`admin.ts:1140-1159`, "persisted in
+the shard's SQLite so it survives hibernation... ready to chart as a trend
+line"). But it durably tracks `ctx.metrics.*` series (counter/gauge/
+histogram), not trace-span attributes — and `recordEvaluation` today only
+ever emits span attributes, never a metric. So the plan's ask ("groups by eval
+name + score over time") runs into a real seam mismatch: the durable,
+time-bucketed store exists, but eval scores don't flow into it; the store eval
+scores DO flow into (trace spans) has no durable history.
+
+**This is the STOP-shaped condition the plan called out** ("the
+`gen_ai.evaluation.*` spans aren't queryable from the studio trace store the
+way the panel needs") — but it resolves to a **documented gap + a v1 that
+works within it**, not a hard stop, because `getTraces` genuinely does return
+the data for a live/recent view; it just can't back a trend chart.
+
+### Recommended v1 panel (design-only in this spike, not built — see §7): live, not historical
+
+Model on `TracesPanel` directly (same admin query hook, same shard-scoped
+live-push pattern):
+
+- **Query**: `useAdminQuery(ADMIN_FUNCTIONS.getTraces, {}, { live: true,
+  shardKey })` — identical call to what `TracesPanel` already makes.
+- **Extraction**: client-side, over the returned `TraceSummary[]`. For each
+  span in each trace, scan `attributes` for keys matching
+  `/^gen_ai\.evaluation\.([^.]+)\.score$/`; the capture group is the eval
+  name, the value the score; a sibling `.label` key (same name) is optional
+  metadata. This is a pure function, exactly like `TracesPanel`'s existing
+  `filterTraces`/`spanBar` helpers in `trace-geometry.ts` — same file-shape
+  precedent.
+- **Grouping/layout**: group extracted `(name, score, traceId, spanName,
+  startTs)` rows by eval `name` into a card per eval — most-recent score,
+  a small run count, a "min/mean/max over what's currently in the ring"
+  summary (NOT a trend line — the ring doesn't support one), and a list of
+  recent runs each linking to its trace (reusing the existing trace-id
+  hand-off `lib/trace-handoff.ts` the Traces panel's exemplar links already
+  use, so "open in Traces" is a real, already-built primitive, not new work).
+  Same `EmptyState` message pattern as `TracesPanel` for the zero-evals-seen
+  case.
+- **Explicit framing in the UI**: reuse `TracesPanel`'s own caveat text
+  verbatim in spirit — "recent scores on this instance, not a durable
+  history" — so the panel doesn't imply a trend guarantee the data can't back.
+
+### Follow-up (not this spike): durable trend requires a second emission
+
+If a durable "score over time" chart is wanted, `recordEvaluation` would need
+an ADDITIVE second path — emit through `ctx.metrics.gauge` (or a histogram)
+alongside (not instead of) the span attributes, so `getMetricHistory`'s
+already-durable per-minute buckets carry eval scores too and the panel can
+build on `metrics-aggregate.ts`/`sparkline.tsx` (the existing trend-chart
+building blocks in `packages/studio/src/features/reports/`) instead of
+inventing one. This is exactly the kind of "changing the harness API" the
+plan's SCOPE excludes for this spike (`recordEvaluation`'s signature/behavior
+would need to grow), so it is recorded here as the concrete next step, not
+attempted.
+
+## 7. What actually ships in this spike
+
+- This design doc.
+- A working CLI prototype: `packages/cli/src/commands/eval/` (`index.ts`,
+  `handler.ts`, `discover-eval-files.ts`, `types.ts`), registered in
+  `cli.ts`, `@lunora/testing` added as a real dependency of `@lunora/cli`.
+  `runEvalCommand` is directly unit-testable (mirrors `runVerifyCommand`).
+- A CLI test (`packages/cli/__tests__/commands/eval.test.ts`) that runs a real
+  fixture `evals/*.eval.ts` file (using actual `@lunora/testing` exports:
+  `evaluate`, `containsScorer`) through `runEvalCommand`, asserting both the
+  aggregate table/JSON output and that a below-threshold run exits non-zero.
+- The Studio Evals panel is **design-only** in this spike (§6) — not
+  prototyped as code. Rationale: the panel's honest v1 shape depends on the
+  gap analysis in §6, which is itself the deliverable STEP 3 asked for
+  ("otherwise the design doc details the data query + layout"); building a
+  panel against the wrong data-source assumption (a trend chart the ring
+  can't support) would need to be redone once the gap was found, so the spike
+  stops at the design once the gap surfaced, per STEP 3's own stated
+  fallback.
+
+## 8. Open questions (STEP 4)
+
+1. **`defineEval` helper** — promote the `{ name?, threshold?, run }` shape
+   into a real `defineEval` export in `@lunora/testing` for authoring DX
+   (return-type inference on `run`, discoverable via the package's own
+   autocomplete)? This spike deliberately kept `@lunora/testing` at a
+   zero-line diff; a follow-up plan can add it additively once the shape has
+   seen real use.
+2. **Threshold granularity** — resolved in §4 (global default, per-eval
+   override) — flagged here because it's a public CLI contract, worth a second
+   look before it ships (a `--threshold-mode strict|any` a la "all must pass"
+   vs "aggregate average must pass" was considered and rejected as premature —
+   the per-file `threshold` override already covers the "this one eval is
+   noisier" case without a second flag).
+3. **Live worker** — resolved in §5: no, harness-only. The remaining open
+   question is narrower — the TS-execution mechanism for the compiled binary
+   (§5's gap): Node `--experimental-strip-types` re-exec vs. an `esbuild`
+   transform-then-`import()` (would promote `esbuild` from `@lunora/cli`'s
+   existing devDependency to a real one — no other `@lunora/*` package ships
+   it as a runtime dep today, confirmed by grep) vs. requiring the app's own
+   `vitest`/`tsx`/`jiti` be present and shelling out to it. Recommend the
+   `esbuild`-transform path (self-contained, no assumption about what the
+   consuming app has installed) as the next step's first thing to prototype.
+4. **Panel: live-tail vs. historical** — resolved in §6: live/recent only for
+   v1 (matches what `getTraces` can actually back); a durable trend view is a
+   distinct follow-up gated on also emitting through `ctx.metrics` (§6's
+   "Follow-up" — not this spike, not decided here beyond "additive, don't
+   change `recordEvaluation`'s existing signature, only extend it").
+5. **`evals/` vs. per-package location for a monorepo app** — this design
+   assumes one `evals/` per Lunora project root. An app with multiple
+   `apps/*` each embedding Lunora would run `lunora eval` per-app, same as
+   every other per-app CLI command (`verify`, `deploy`, …) — not a special
+   case, but worth confirming against a real multi-app repo before this ships.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2313,9 +2313,6 @@ importers:
       '@lunora/seed':
         specifier: workspace:*
         version: link:../seed
-      '@lunora/testing':
-        specifier: workspace:*
-        version: link:../testing
       '@visulima/cerebro':
         specifier: 3.0.0
         version: 3.0.0(@bomb.sh/tab@0.0.21(cac@6.7.14)(citty@0.2.2)(commander@15.0.0))(@visulima/find-cache-dir@3.0.0)(@visulima/pail@4.0.0(@opentelemetry/api@1.9.1)(@visulima/redact@3.0.0)(express@5.2.1(supports-color@10.2.2))(hono@4.12.30)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(github-slugger@2.0.0)
@@ -2374,6 +2371,9 @@ importers:
       '@codspeed/vitest-plugin':
         specifier: catalog:test
         version: 5.7.1(supports-color@10.2.2)(tinybench@2.9.0)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@lunora/testing':
+        specifier: workspace:*
+        version: link:../testing
       '@types/node':
         specifier: catalog:types
         version: 26.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2313,6 +2313,9 @@ importers:
       '@lunora/seed':
         specifier: workspace:*
         version: link:../seed
+      '@lunora/testing':
+        specifier: workspace:*
+        version: link:../testing
       '@visulima/cerebro':
         specifier: 3.0.0
         version: 3.0.0(@bomb.sh/tab@0.0.21(cac@6.7.14)(citty@0.2.2)(commander@15.0.0))(@visulima/find-cache-dir@3.0.0)(@visulima/pail@4.0.0(@opentelemetry/api@1.9.1)(@visulima/redact@3.0.0)(express@5.2.1(supports-color@10.2.2))(hono@4.12.30)(next@16.2.9(@babel/core@8.0.1)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(github-slugger@2.0.0)


### PR DESCRIPTION
## What

A working `lunora eval` CLI command that discovers `*.eval.ts` files, runs the existing eval kit against them, prints an aggregate table, and threshold-gates the exit code — plus a design doc (incl. a design-only Studio Evals panel, per the plan's stated fallback). **The eval kit itself is untouched: `packages/testing/src` is a zero-line diff.**

## The contract (design doc)

- **Discovery**: a top-level `evals/**/*.eval.ts` directory (not inside `lunora/`, so codegen's static walker never picks up fixtures). Each file is a **sole default export** `{ name?, threshold?, run }` (repo's no-mixed-export rule); `run` is the entire eval body and calls `evaluate`/`agentHarness` itself — the runner never touches a scorer or the harness.
- **CI/`--threshold`, mirroring `verify`**: report-only with no threshold; a global `--threshold` gate with a per-eval `threshold` export overriding it for that file; a crashed eval always fails regardless of thresholds; one process exit code (0/1); `--format json` routes progress to stderr and prints one JSON document to stdout.

## Runner

`packages/cli/src/commands/eval/` (index/handler/discover/types), registered in `cli.ts`, with `@lunora/testing` added as a dependency. `discoverEvalFiles` mirrors codegen's `lstatSync` walker; the handler loads each file via a real dynamic `import()`.

**Harness-only, no live worker**: `agentHarness`/`evaluate` were read in full and confirmed pure in-memory (no `fetch`/`WebSocket`/binding refs), so the CI story needs no running deployment.

## Studio panel (design-only, §6)

No new RPC needed — the existing `getTraces` RPC already returns span `attributes`; a v1 panel reuses `TracesPanel`'s query, extracts `gen_ai.evaluation.<name>.score` client-side, and groups by eval name. Honest gap documented: that trace store is a bounded in-memory per-shard ring (not history), so a durable trend view is a flagged follow-up — additively emit `recordEvaluation` through `ctx.metrics` (the SQLite-backed `getMetricHistory` store).

## One bundler tension, resolved narrowly

A plain dynamic `import()` of a runtime path trips `@rollup/plugin-dynamic-import-vars` (globs every non-literal specifier); a `new Function` dodge then breaks under Vitest's vm sandbox. Resolved by excluding just `commands/eval/handler.ts` from that one rollup plugin via `packem.config.ts` — keeping a plain, test-compatible `import()`. Both `packem.config.ts` edits are one-file-scoped and commented.

## Verification

- New command test (8 assertions): clean-run aggregate + exit 0; `--threshold` pass/fail boundary; per-eval override beating a stricter global; a crashed eval always failing; `--format json`; invalid-`--format` rejection.
- `@lunora/cli`: 78 files / 966 tests, `lint:types`, `lint:eslint`, `lint:prettier`, **package.json sort**, and the `api:check` snapshot (eval isn't public API, same as `verify`/`seed`) all pass.
- `@lunora/testing` 115/115 unchanged — the kit has a zero-line diff.

## Open questions (§8)

A real `defineEval` helper for authoring DX (deferred to keep the kit diff at zero); threshold granularity as a public CLI contract; the TS-execution mechanism for the compiled binary outside Vitest (recommends an esbuild-transform path); the durable trend view; the one-`evals/`-per-root assumption.

## Merge-order note

Touches `packages/cli/src/cli.ts` (command registry — an append, low conflict) and `pnpm-lock.yaml` (regenerate rather than text-merge per repo rule). Plan: `plans/245-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `lunora eval` command for discovering and running evaluation files.
  * Supports custom directories, readable or JSON output, global score thresholds, and per-evaluation thresholds.
  * Reports individual evaluation failures and returns appropriate exit codes.
  * Discovers evaluation files recursively with consistent ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->