### PR TITLE
perf(observability,do,studio): take the metrics hot-path off always-throwing DDL/COUNT, bound the sample buffer, signal truncation, batch Studio index enum

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -3391,11 +3391,27 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `DanglingReference` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `DanglingReferenceResult` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `DatabaseInstrumentation` (type)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
 ### `DatabaseTally` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `DatabaseTelemetryDeps` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `ErrorIssue` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
@@ -3447,6 +3463,10 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `FoldedTraces` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `FunctionMetricBucket` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
@@ -3459,7 +3479,15 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `HostSpanLike` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `HostTracingLike` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `HostTracingResolver` (type)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
@@ -3527,6 +3555,10 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `MetricEvent` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `MetricHistoryOptions` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
@@ -3535,7 +3567,15 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `MetricHistoryResult` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `MetricHistorySeries` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `MetricKind` (type)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
@@ -3547,11 +3587,31 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `QueryInsightBucket` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `QueryInsightEntry` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `QueryInsightsResult` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `QueryStatEntry` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
 ### `REQUEST_LOG_TABLE` (const)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `ReadIssuesOptions` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `ReadRequestLogOptions` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
@@ -3563,11 +3623,19 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `RequestLogEntry` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `RequestLogResult` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
 ### `RequestLogWriteOptions` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `RequestOutcome` (type)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
@@ -3599,7 +3667,27 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `SpanEvent` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `SpanEventPoint` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `SpanHandle` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `SpanKind` (type)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `SpanLink` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `SpanOptions` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
@@ -3612,6 +3700,10 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
 ### `TraceSummary` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
+### `TracedFetchDeps` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -3451,6 +3451,10 @@ Re-exported from `@lunora/observability` — signature tracked at its source.
 
 Re-exported from `@lunora/observability` — signature tracked at its source.
 
+### `FunctionMetricBucketsResult` (interface)
+
+Re-exported from `@lunora/observability` — signature tracked at its source.
+
 ### `FunctionMetricIndexHit` (interface)
 
 Re-exported from `@lunora/observability` — signature tracked at its source.

--- a/api-snapshots/observability.api.md
+++ b/api-snapshots/observability.api.md
@@ -225,6 +225,17 @@ interface FunctionMetricBucket {
 }
 ```
 
+### `FunctionMetricBucketsResult` (interface)
+
+```ts
+interface FunctionMetricBucketsResult {
+    buckets: (FunctionMetricBucket & {
+        path: string;
+    })[];
+    truncated: boolean;
+}
+```
+
 ### `FunctionMetricIndexHit` (interface)
 
 ```ts
@@ -799,9 +810,7 @@ const readErrorIssues: (sql: SqlExec, options?: ReadIssuesOptions) => ErrorIssue
 ### `readFunctionMetricBuckets` (const)
 
 ```ts
-const readFunctionMetricBuckets: (sql: SqlExec, path?: string) => (FunctionMetricBucket & {
-    path: string;
-})[];
+const readFunctionMetricBuckets: (sql: SqlExec, path?: string) => FunctionMetricBucketsResult;
 ```
 
 ### `readFunctionMetricIndexHits` (const)

--- a/api-snapshots/observability.api.md
+++ b/api-snapshots/observability.api.md
@@ -878,7 +878,7 @@ const recordMetricHistory: (sql: SqlExec, event: MetricEvent, exemplarTraceId?: 
 ### `recordQueryMetric` (const)
 
 ```ts
-const recordQueryMetric: (sql: SqlExec, rawSql: string, durationMs: number, rowsRead: number, rowsWritten: number, now?: number) => void;
+const recordQueryMetric: (sql: SqlExec, rawSql: string, durationMs: number, rowsRead: number, rowsWritten: number, now?: number, execCount?: number) => void;
 ```
 
 ### `resolveTraceAnchor` (const)

--- a/api-snapshots/observability.api.md
+++ b/api-snapshots/observability.api.md
@@ -117,6 +117,27 @@ type ContextTracer = <T>(name: string, function_: (trace: ContextTracer, span: S
 const DEFAULT_EXPLAIN_ISSUE_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 ```
 
+### `DanglingReference` (interface)
+
+```ts
+interface DanglingReference {
+    column: string;
+    id: string;
+    key: string;
+    table: string;
+}
+```
+
+### `DanglingReferenceResult` (interface)
+
+```ts
+interface DanglingReferenceResult {
+    references: DanglingReference[];
+    scanned: number;
+    truncated: boolean;
+}
+```
+
 ### `DatabaseInstrumentation` (type)
 
 ```ts
@@ -133,6 +154,38 @@ interface DatabaseTally {
     perOperation: Record<string, number>;
     spansEmitted: number;
     spansTruncated: boolean;
+}
+```
+
+### `DatabaseTelemetryDeps` (interface)
+
+```ts
+interface DatabaseTelemetryDeps {
+    anchor: TraceAnchor;
+    functionPath: string;
+    mode: DatabaseInstrumentation;
+    record: (span: SpanEvent) => void;
+    shardKey: string | undefined;
+    tally: DatabaseTally;
+    userId: () => string | undefined;
+}
+```
+
+### `ErrorIssue` (interface)
+
+```ts
+interface ErrorIssue {
+    assignee?: string;
+    count: number;
+    culprit: string;
+    firstSeen: number;
+    hash: string;
+    lastSeen: number;
+    sampleMessage: string;
+    severity?: IssueSeverity;
+    stateUpdatedAt?: number;
+    status: IssueStatus;
+    title: string;
 }
 ```
 
@@ -215,6 +268,15 @@ const FUNCTION_METRICS_SCANS_TABLE = "__lunora_metrics_scans";
 const FUNCTION_METRICS_TABLE = "__lunora_metrics";
 ```
 
+### `FoldedTraces` (interface)
+
+```ts
+interface FoldedTraces {
+    total: number;
+    traces: TraceSummary[];
+}
+```
+
 ### `FunctionMetricBucket` (interface)
 
 ```ts
@@ -246,12 +308,27 @@ interface FunctionMetricIndexHit {
 }
 ```
 
+### `HostSpanLike` (interface)
+
+```ts
+interface HostSpanLike {
+    readonly isTraced: boolean;
+    setAttribute: (key: string, value: boolean | number | string | undefined) => void;
+}
+```
+
 ### `HostTracingLike` (interface)
 
 ```ts
 interface HostTracingLike {
     enterSpan: <T>(name: string, callback: (span: HostSpanLike) => T) => T;
 }
+```
+
+### `HostTracingResolver` (type)
+
+```ts
+type HostTracingResolver = () => HostTracingLike | Promise<HostTracingLike | undefined> | undefined;
 ```
 
 ### `ISSUE_SEVERITIES` (const)
@@ -386,6 +463,21 @@ class MetricBuffer {
 }
 ```
 
+### `MetricEvent` (interface)
+
+```ts
+interface MetricEvent {
+    attributes?: LogFields;
+    functionPath: string;
+    kind: MetricKind;
+    name: string;
+    shardKey?: string;
+    traceId?: string;
+    ts: number;
+    value: number;
+}
+```
+
 ### `MetricHistoryOptions` (interface)
 
 ```ts
@@ -409,6 +501,14 @@ interface MetricHistoryPoint {
 }
 ```
 
+### `MetricHistoryResult` (interface)
+
+```ts
+interface MetricHistoryResult {
+    series: MetricHistorySeries[];
+}
+```
+
 ### `MetricHistorySeries` (interface)
 
 ```ts
@@ -420,6 +520,12 @@ interface MetricHistorySeries {
     points: MetricHistoryPoint[];
     shardKey?: string;
 }
+```
+
+### `MetricKind` (type)
+
+```ts
+type MetricKind = "counter" | "gauge" | "histogram";
 ```
 
 ### `MetricSeries` (interface)
@@ -452,6 +558,42 @@ interface MetricsDeps {
 }
 ```
 
+### `QueryInsightBucket` (interface)
+
+```ts
+interface QueryInsightBucket {
+    avgDurationMs: number;
+    bucketMs: number;
+    execCount: number;
+}
+```
+
+### `QueryInsightEntry` (interface)
+
+```ts
+interface QueryInsightEntry {
+    avgDurationMs: number;
+    execCount: number;
+    normalizedSql: string;
+    p50DurationMs: number;
+    p95DurationMs: number;
+    rowsRead: number;
+    rowsWritten: number;
+    totalDurationMs: number;
+}
+```
+
+### `QueryInsightsResult` (interface)
+
+```ts
+interface QueryInsightsResult {
+    buckets: QueryInsightBucket[];
+    capped: boolean;
+    entries: QueryInsightEntry[];
+    trackedStatements: number;
+}
+```
+
 ### `QueryStatEntry` (interface)
 
 ```ts
@@ -468,6 +610,32 @@ interface QueryStatEntry {
 
 ```ts
 const REQUEST_LOG_TABLE = "__lunora_reqlog__";
+```
+
+### `ReadIssuesOptions` (interface)
+
+```ts
+interface ReadIssuesOptions {
+    functionPathPrefix?: string;
+    limit?: number;
+    shardKey?: string;
+    status?: IssueStatus;
+    userId?: string;
+}
+```
+
+### `ReadRequestLogOptions` (interface)
+
+```ts
+interface ReadRequestLogOptions {
+    functionPathPrefix?: string;
+    limit?: number;
+    outcome?: RequestOutcome;
+    shardKey?: string;
+    sinceSeq?: number;
+    tableTouched?: string;
+    userId?: string;
+}
 ```
 
 ### `RecordAuthEventInput` (interface)
@@ -494,6 +662,27 @@ interface RecordFunctionMetricInput {
 }
 ```
 
+### `RequestLogEntry` (interface)
+
+```ts
+interface RequestLogEntry {
+    cacheHit?: boolean;
+    durationMs: number;
+    errorMessage?: string;
+    functionPath: string;
+    identity?: Record<string, unknown>;
+    outcome: RequestOutcome;
+    redactedArgs?: unknown;
+    seq: number;
+    shardKey?: string;
+    subscriptionsReRun: number;
+    tablesRead: string[];
+    tablesWritten: string[];
+    ts: number;
+    userId?: string;
+}
+```
+
 ### `RequestLogResult` (interface)
 
 ```ts
@@ -509,6 +698,12 @@ interface RequestLogWriteOptions {
     captureRaw?: boolean;
     retention?: number;
 }
+```
+
+### `RequestOutcome` (type)
+
+```ts
+type RequestOutcome = "error" | "ok";
 ```
 
 ### `SecurityAuditResult` (interface)
@@ -573,6 +768,42 @@ interface SpanCollector {
 }
 ```
 
+### `SpanEvent` (interface)
+
+```ts
+interface SpanEvent {
+    attributes?: LogFields;
+    durationMs: number;
+    events?: SpanEventPoint[];
+    error?: {
+        message: string;
+        type: string;
+    };
+    functionPath: string;
+    kind?: OtlpSpanKind;
+    links?: SpanLink[];
+    name: string;
+    ok: boolean;
+    parentSpanId: string;
+    dispatch?: boolean;
+    shardKey?: string;
+    spanId: string;
+    startTs: number;
+    traceId: string;
+    userId?: string;
+}
+```
+
+### `SpanEventPoint` (interface)
+
+```ts
+interface SpanEventPoint {
+    attributes?: LogFields;
+    name: string;
+    ts: number;
+}
+```
+
 ### `SpanHandle` (interface)
 
 ```ts
@@ -587,6 +818,32 @@ interface SpanHandle {
         spanId: string;
         traceId: string;
     };
+}
+```
+
+### `SpanKind` (type)
+
+```ts
+type OtlpSpanKind = "client" | "consumer" | "internal" | "producer" | "server";
+```
+
+### `SpanLink` (interface)
+
+```ts
+interface SpanLink {
+    attributes?: LogFields;
+    spanId: string;
+    traceId: string;
+}
+```
+
+### `SpanOptions` (interface)
+
+```ts
+interface SpanOptions {
+    attributes?: LogFields;
+    kind?: OtlpSpanKind;
+    links?: SpanLink[];
 }
 ```
 
@@ -631,6 +888,19 @@ interface TraceSummary {
     spans: TraceSpan[];
     startTs: number;
     traceId: string;
+}
+```
+
+### `TracedFetchDeps` (interface)
+
+```ts
+interface TracedFetchDeps {
+    anchor: TraceAnchor;
+    functionPath: string;
+    propagate?: ((url: URL) => boolean) | boolean;
+    record: (span: SpanEvent) => void;
+    shardKey: string | undefined;
+    userId: () => string | undefined;
 }
 ```
 

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -43,6 +43,7 @@ const ADMIN_FUNCTIONS: {
     readonly getMetricSeries: "__lunora_admin__:getMetricSeries";
     readonly listSubscriptions: "__lunora_admin__:listSubscriptions";
     readonly listTableIndexes: "__lunora_admin__:listTableIndexes";
+    readonly listTablesIndexes: "__lunora_admin__:listTablesIndexes";
     readonly getLogs: "__lunora_admin__:getLogs";
     readonly getMetrics: "__lunora_admin__:getMetrics";
     readonly getPitrBookmark: "__lunora_admin__:getPitrBookmark";
@@ -2617,6 +2618,14 @@ interface TableReaderLike {
 ```ts
 interface TablesColumnsResult {
     columnsByTable: Record<string, ColumnMeta[]>;
+}
+```
+
+### `TablesIndexesResult` (interface)
+
+```ts
+interface TablesIndexesResult {
+    indexesByTable: Record<string, TableIndexInfo[]>;
 }
 ```
 

--- a/api-snapshots/studio.api.md
+++ b/api-snapshots/studio.api.md
@@ -44,6 +44,7 @@ const ADMIN_FUNCTIONS: {
     readonly listQueues: "__lunora_admin__:listQueues";
     readonly listSubscriptions: "__lunora_admin__:listSubscriptions";
     readonly listTableIndexes: "__lunora_admin__:listTableIndexes";
+    readonly listTablesIndexes: "__lunora_admin__:listTablesIndexes";
     readonly listWorkflows: "__lunora_admin__:listWorkflows";
     readonly getLogs: "__lunora_admin__:getLogs";
     readonly getMetricHistory: "__lunora_admin__:getMetricHistory";

--- a/packages/do/__tests__/function-metrics.test.ts
+++ b/packages/do/__tests__/function-metrics.test.ts
@@ -1,4 +1,5 @@
 import {
+    ensureFunctionMetricsTables,
     FUNCTION_METRICS_BUCKET_MS,
     FUNCTION_METRICS_BUCKETS_TABLE,
     FUNCTION_METRICS_INDEX_TABLE,
@@ -178,7 +179,7 @@ describe("function-metrics module", () => {
             recordFunctionMetric(database.sql, { durationMs: 1, errored: true, errorMessage: "x", path: "f:a", ts: base + 1 });
             recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "f:a", ts: base + FUNCTION_METRICS_BUCKET_MS });
 
-            const buckets = readFunctionMetricBuckets(database.sql, "f:a");
+            const { buckets } = readFunctionMetricBuckets(database.sql, "f:a");
 
             // Two distinct minute windows.
             expect(buckets).toHaveLength(2);
@@ -318,7 +319,7 @@ describe("function-metrics module", () => {
 
         try {
             expect(readFunctionMetrics(database.sql)).toEqual([]);
-            expect(readFunctionMetricBuckets(database.sql)).toEqual([]);
+            expect(readFunctionMetricBuckets(database.sql)).toEqual({ buckets: [], truncated: false });
             expect(readFunctionMetricScans(database.sql).size).toBe(0);
             expect(readFunctionMetricIndexHits(database.sql)).toEqual([]);
             expect(readFunctionMetricsTotals(database.sql)).toEqual({ errors: 0, requests: 0 });
@@ -364,6 +365,30 @@ describe("function-metrics module", () => {
             }
 
             expect(readFunctionMetrics(database.sql)).toHaveLength(FUNCTION_METRICS_READ_LIMIT);
+        } finally {
+            database.close();
+        }
+    });
+
+    it("reports truncated on the all-paths bucket read once the LIMIT cuts it (OBS-03)", () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            ensureFunctionMetricsTables(database.sql);
+
+            for (let index = 0; index < FUNCTION_METRICS_READ_LIMIT + 50; index += 1) {
+                database.raw(
+                    `INSERT INTO "${FUNCTION_METRICS_BUCKETS_TABLE}" (path, bucket_ms, calls, errors) VALUES ('fn:a', ?, 1, 0)`,
+                    index * FUNCTION_METRICS_BUCKET_MS,
+                );
+            }
+
+            const { buckets, truncated } = readFunctionMetricBuckets(database.sql);
+
+            expect(buckets).toHaveLength(FUNCTION_METRICS_READ_LIMIT);
+            expect(truncated).toBe(true);
         } finally {
             database.close();
         }
@@ -539,6 +564,38 @@ describe("shardDO persisted metrics", () => {
             expect(body.result.errors).toBe(1);
             expect(body.result.cache).toBeNull();
             expect(body.result.shard).toBeTypeOf("string");
+        } finally {
+            database.close();
+        }
+    });
+
+    it("surfaces historyTruncated on getMetrics once the durable bucket table exceeds the read limit (OBS-03)", async () => {
+        expect.assertions(2);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new CountingShard(makeState(database), { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+
+            ensureFunctionMetricsTables(database.sql);
+
+            // Seed past the read limit directly — reaching it through real
+            // dispatches would mean thousands of fetch() round-trips for what
+            // is purely a read-path assertion.
+            for (let index = 0; index < FUNCTION_METRICS_READ_LIMIT + 50; index += 1) {
+                database.raw(
+                    `INSERT INTO "${FUNCTION_METRICS_BUCKETS_TABLE}" (path, bucket_ms, calls, errors) VALUES ('messages:list', ?, 1, 0)`,
+                    index * FUNCTION_METRICS_BUCKET_MS,
+                );
+            }
+
+            const response = await shard.fetch(adminRequest("__lunora_admin__:getMetrics"));
+            const body = await response.json<{ result: { history: unknown[]; historyTruncated: boolean } }>();
+
+            expect(body.result.history).toHaveLength(FUNCTION_METRICS_READ_LIMIT);
+            // The chart's window silently shrinking as the app grows is exactly
+            // what this field exists to make visible to the studio panel.
+            expect(body.result.historyTruncated).toBe(true);
         } finally {
             database.close();
         }

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -321,6 +321,9 @@ const userRequest = (functionPath: string): Request =>
         method: "POST",
     });
 
+/** Test-stub shape for a `tableIndexes` override, shared by the single-table and batched `listTablesIndexes` tests below. */
+type TestTableIndexInfo = { fields: string[]; name: string; type: "index" | "rank" | "search" | "vector"; unique?: boolean }[];
+
 describe("shardDO admin introspection", () => {
     let database: ReturnType<typeof createSqliteExec>;
     let state: ShardDOState;
@@ -403,9 +406,7 @@ describe("shardDO admin introspection", () => {
         // The codegen subclass overrides `tableIndexes` from the schema; mimic it.
         class IndexedShard extends AdminShard {
             // eslint-disable-next-line class-methods-use-this -- test stub mirroring the codegen override
-            protected override tableIndexes(
-                table: string,
-            ): { fields: string[]; name: string; type: "index" | "rank" | "search" | "vector"; unique?: boolean }[] {
+            protected override tableIndexes(table: string): TestTableIndexInfo {
                 return table === "messages" ? [{ fields: ["author"], name: "by_author", type: "index", unique: true }] : [];
             }
         }
@@ -496,6 +497,40 @@ describe("shardDO admin introspection", () => {
                         { name: "text", optional: false, type: "string" },
                     ],
                     users: [{ name: "_id", optional: false, pk: true, type: "id" }],
+                },
+            },
+        });
+    });
+
+    it("returns indexes for several tables in one listTablesIndexes call (STUDIO-04)", async () => {
+        expect.assertions(2);
+
+        class IndexedShard extends AdminShard {
+            // eslint-disable-next-line class-methods-use-this -- test stub mirroring the codegen override
+            protected override tableIndexes(table: string): TestTableIndexInfo {
+                if (table === "messages") {
+                    return [{ fields: ["author"], name: "by_author", type: "index", unique: true }];
+                }
+
+                return table === "users" ? [{ fields: ["email"], name: "by_email", type: "index" }] : [];
+            }
+        }
+
+        const shard = new IndexedShard(state, { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+
+        // Base hook still reports nothing per-table for an unknown table.
+        const base = new AdminShard(state, { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+        const baseResponse = await base.fetch(adminRequest(ADMIN_FUNCTIONS.listTablesIndexes, { tables: ["messages"] }, ADMIN_TOKEN));
+
+        await expect(baseResponse.json()).resolves.toEqual({ result: { indexesByTable: { messages: [] } } });
+
+        const response = await shard.fetch(adminRequest(ADMIN_FUNCTIONS.listTablesIndexes, { tables: ["messages", "users"] }, ADMIN_TOKEN));
+
+        await expect(response.json()).resolves.toEqual({
+            result: {
+                indexesByTable: {
+                    messages: [{ fields: ["author"], name: "by_author", type: "index", unique: true }],
+                    users: [{ fields: ["email"], name: "by_email", type: "index" }],
                 },
             },
         });

--- a/packages/do/__tests__/stmt-samples.test.ts
+++ b/packages/do/__tests__/stmt-samples.test.ts
@@ -1,0 +1,179 @@
+/**
+ * OBS-04: the per-dispatch SQL statement-sample buffer (`currentStmtSamples`,
+ * backing the query-metrics leaderboard) folds repeats of the same statement
+ * into a running entry rather than appending one array element per raw
+ * execution, and bounds the number of DISTINCT statement shapes a single
+ * dispatch can accumulate. Exercises the instrumented `sql` getter and
+ * `flushStmtSamples` directly through a real `.fetch()` dispatch, backed by a
+ * real SQLite handle so the durable `__lunora_metrics_queries` table can be
+ * read back afterwards.
+ */
+import { readQueryMetrics } from "@lunora/observability";
+import type { SqlExec } from "@lunora/shard-engine";
+import { ADMIN_FUNCTIONS } from "@lunora/shard-engine";
+import { describe, expect, it } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+const ADMIN_TOKEN = "stmt-samples-admin-token-long-enough";
+
+// Not re-exported from the `@lunora/observability` barrel (query-metrics.ts's
+// table-name constant is package-internal); mirrors the reserved name in
+// `packages/observability/src/query-metrics.ts`.
+const QUERY_METRICS_TABLE = "__lunora_metrics_queries";
+
+/** A shard state backed by a real in-memory SQLite, so the durable query-metrics path is exercised for real. */
+const sqliteStateDouble = (database: ReturnType<typeof createSqliteExec>): ShardDOState => {
+    return {
+        acceptWebSocket() {},
+        getWebSockets() {
+            return [];
+        },
+        storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+    };
+};
+
+/**
+ * Drives the instrumented `this.sql` getter directly from `handleRpc`,
+ * bypassing the generated function-context wiring a real app would go
+ * through — the same technique `tracing.test.ts`'s `TracingShard` uses for
+ * `makeTracer`.
+ *
+ * `distinctQueries` issues that many UNIQUELY-texted `SELECT`s (each its own
+ * statement shape); `repeatsOfFirst` issues that many MORE executions of the
+ * exact same statement text as the first query, exercising the in-dispatch
+ * fold. `attachSpan` mirrors what a handler using `ctx.span` does — forcing a
+ * `SpanCollector` to exist for this dispatch so `recordDispatchRootSpan`
+ * records an attributed root span the test can read back via `getTraces`.
+ */
+class StmtSampleShard extends ShardDO {
+    public attachSpan = true;
+
+    public distinctQueries = 0;
+
+    public repeatsOfFirst = 0;
+
+    public override async handleRpc(): Promise<unknown> {
+        if (this.attachSpan) {
+            const anchor = this.getCurrentTrace();
+
+            if (anchor !== undefined) {
+                this.makeDispatchSpan(anchor).setAttribute("probe", true);
+            }
+        }
+
+        const sql = this.sql as SqlExec;
+
+        for (let index = 0; index < this.distinctQueries; index += 1) {
+            sql.exec(`SELECT ${String(index)} AS x`).toArray();
+        }
+
+        for (let index = 0; index < this.repeatsOfFirst; index += 1) {
+            sql.exec(`SELECT 0 AS x`).toArray();
+        }
+
+        return { ok: true };
+    }
+}
+
+const userRequest = (functionPath: string): Request =>
+    new Request("https://shard.internal/rpc", {
+        body: JSON.stringify({ args: {}, functionPath }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+    });
+
+const adminRequest = (functionPath: string): Request =>
+    new Request("https://shard.internal/rpc", {
+        body: JSON.stringify({ args: {}, functionPath }),
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}`, "content-type": "application/json" },
+        method: "POST",
+    });
+
+describe("statement sample buffer (OBS-04)", () => {
+    it("folds many repeats of the same statement into one durable row with the real exec_count", async () => {
+        expect.assertions(3);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new StmtSampleShard(sqliteStateDouble(database), { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+
+            shard.attachSpan = false;
+            shard.repeatsOfFirst = 250;
+
+            await shard.fetch(userRequest("probe:query"));
+
+            // One statement shape → one physical row, not 250.
+            expect(database.raw(`SELECT COUNT(*) AS c FROM "${QUERY_METRICS_TABLE}"`)).toEqual([{ c: 1 }]);
+
+            const [row] = readQueryMetrics(database.sql);
+
+            // Every real execution still counted — folding must not silently drop them.
+            expect(row?.execCount).toBe(250);
+            expect(row?.normalizedSql).toBe("SELECT ? AS x");
+        } finally {
+            database.close();
+        }
+    });
+
+    it("bounds the per-dispatch buffer at the distinct-statement cap and sets db.stmt_samples_truncated on the wide event", async () => {
+        expect.assertions(3);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new StmtSampleShard(sqliteStateDouble(database), { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+
+            // Comfortably past the 200-distinct-statement cap (see
+            // `MAX_STMT_SAMPLES_PER_DISPATCH` in `shard-do.ts`) — each iteration is
+            // its own statement shape, so none of these fold together.
+            shard.distinctQueries = 250;
+
+            await shard.fetch(userRequest("probe:query"));
+
+            // The in-memory buffer dropped brand-new shapes past the cap, so the
+            // durable table only ever saw the first 200 distinct statements.
+            const rows = readQueryMetrics(database.sql);
+
+            expect(rows.length).toBeLessThanOrEqual(200);
+            expect(rows.length).toBeGreaterThan(0);
+
+            const tracesResponse = await shard.fetch(adminRequest(ADMIN_FUNCTIONS.getTraces));
+            const body = await tracesResponse.json<{
+                result: { traces: { spans: { attributes?: Record<string, unknown>; depth: number }[] }[] };
+            }>();
+            const root = body.result.traces[0]?.spans.find((entry) => entry.depth === 0);
+
+            expect(root?.attributes?.["db.stmt_samples_truncated"]).toBe(true);
+        } finally {
+            database.close();
+        }
+    });
+
+    it("does not set db.stmt_samples_truncated when the dispatch stays under the cap", async () => {
+        expect.assertions(1);
+
+        const database = createSqliteExec();
+
+        try {
+            const shard = new StmtSampleShard(sqliteStateDouble(database), { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN });
+
+            shard.distinctQueries = 5;
+
+            await shard.fetch(userRequest("probe:query"));
+
+            const tracesResponse = await shard.fetch(adminRequest(ADMIN_FUNCTIONS.getTraces));
+            const body = await tracesResponse.json<{
+                result: { traces: { spans: { attributes?: Record<string, unknown>; depth: number }[] }[] };
+            }>();
+            const root = body.result.traces[0]?.spans.find((entry) => entry.depth === 0);
+
+            expect(root?.attributes?.["db.stmt_samples_truncated"]).toBeUndefined();
+        } finally {
+            database.close();
+        }
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -558,6 +558,20 @@ interface ShapeMemo {
 }
 
 /**
+ * One distinct statement's folded activity within a dispatch — see
+ * {@link ShardDO.currentStmtSamples}. `count` is how many raw executions
+ * folded into this entry; `totalDurationMs`/`rowsRead`/`rowsWritten` are sums
+ * across all of them, so `totalDurationMs / count` recovers the per-execution
+ * average `recordQueryMetric`'s bucket histogram places the entry by.
+ */
+interface StmtSample {
+    count: number;
+    rowsRead: number;
+    rowsWritten: number;
+    totalDurationMs: number;
+}
+
+/**
  * Classification of a watermarked custom-mutator push against the shard's
  * `__client_watermark`: `expected` is the next in-order sequence, `kind`
  * whether the push is a replay (`"already"`), the next one (`"next"`), or an
@@ -691,6 +705,19 @@ const MAX_TRACKED_DISPATCH_SPANS = 256;
  * runaway single trace, not a working set.
  */
 const MAX_HELD_SPANS_PER_TRACE = 500;
+
+/**
+ * Bound on distinct normalised statements folded into
+ * {@link ShardDO.currentStmtSamples} per dispatch. Mirrors
+ * `database-telemetry.ts`'s `MAX_DB_SPANS_PER_CTX`: a handler that queries in a
+ * loop already folds repeats of the SAME statement into one running entry (see
+ * `sql` getter), so this only bounds the number of DISTINCT statement shapes one
+ * dispatch can accumulate before {@link ShardDO.flushStmtSamples} starts
+ * dropping brand-new ones — a handler building ad-hoc SQL per iteration
+ * (dynamic column lists, generated `IN (...)` clauses) would otherwise grow the
+ * buffer, and the flush that drains it, without bound.
+ */
+const MAX_STMT_SAMPLES_PER_DISPATCH = 200;
 
 /**
  * `event.name` of the per-dispatch wide event. Namespaced so it never collides
@@ -1277,19 +1304,39 @@ abstract class ShardDO {
     private currentRequestReadTables: Set<string> | undefined;
 
     /**
-     * Per-statement SQL samples collected during the current `/rpc` dispatch by
-     * the instrumented `sql` getter. Drained into the durable
-     * `__lunora_metrics_queries` table after the handler returns (same pattern as
-     * `currentScannedTables` / `currentIndexHits`). `undefined` when no dispatch
-     * is in flight; allocated fresh per dispatch so a previous request's samples
-     * never leak into the next one.
+     * Per-DISTINCT-statement SQL samples collected during the current `/rpc`
+     * dispatch by the instrumented `sql` getter, keyed by the raw query text.
+     * Drained into the durable `__lunora_metrics_queries` table after the
+     * handler returns (same pattern as `currentScannedTables` /
+     * `currentIndexHits`). `undefined` when no dispatch is in flight; allocated
+     * fresh per dispatch so a previous request's samples never leak into the
+     * next one.
      *
-     * Each entry is `[rawSql, durationMs, rowsRead, rowsWritten]`. DML rows
-     * written is always 0 here — the ctx-db adapter doesn't expose a
+     * Keyed by the raw query string rather than a growing array: a handler
+     * that queries in a loop reuses the SAME prepared-statement text on every
+     * iteration (bind parameters travel separately via `...params`, never
+     * inlined into `query`), so folding each call into its entry as it lands
+     * collapses the loop to one entry — {@link ShardDO.flushStmtSamples} then
+     * pays one upsert per DISTINCT statement instead of one per raw execution.
+     * Bounded at {@link MAX_STMT_SAMPLES_PER_DISPATCH} distinct entries; past
+     * that, a brand-new statement shape (ad-hoc SQL built per iteration) is
+     * dropped and `currentStmtSamplesTruncated` is set — already-tracked
+     * statements keep folding regardless.
+     *
+     * `rowsWritten` is always 0 here — the ctx-db adapter doesn't expose a
      * `changes()` count through the structural `SqlExec` surface, so we
      * attribute only SELECT result sizes as `rowsRead`.
      */
-    private currentStmtSamples: [string, number, number, number][] | undefined;
+    private currentStmtSamples: Map<string, StmtSample> | undefined;
+
+    /**
+     * Set when `currentStmtSamples` hit {@link MAX_STMT_SAMPLES_PER_DISPATCH}
+     * distinct statements and a brand-new shape was dropped this dispatch.
+     * Folded onto the dispatch's wide event as `db.stmt_samples_truncated`
+     * (mirrors `database-telemetry.ts`'s `db.spans_truncated`) so a truncated
+     * leaderboard contribution reads as partial rather than complete.
+     */
+    private currentStmtSamplesTruncated: boolean | undefined;
 
     /** Whether the current dispatch's cached query was served from cache; `undefined` until `runCachedQuery` resolves one. */
     private currentRequestCacheHit: boolean | undefined;
@@ -1543,7 +1590,7 @@ abstract class ShardDO {
 
     /**
      * Instrumented SQL handle. Wraps `state.storage.sql` so that every `exec`
-     * call during a user RPC dispatch is timed and its result size captured into
+     * call during a user RPC dispatch is timed and its result size folded into
      * `currentStmtSamples`. The samples are flushed to the durable
      * `__lunora_metrics_queries` table after the handler returns (same lifecycle
      * as `currentScannedTables`/`currentIndexHits`).
@@ -1574,6 +1621,36 @@ abstract class ShardDO {
             return rawSql;
         }
 
+        // Fold one execution's timing/result-size into its statement's running
+        // entry (keyed by the raw query text — see `currentStmtSamples`), rather
+        // than appending a new array entry per execution. A handler that queries
+        // in a loop reuses the same prepared-statement text every iteration, so
+        // this collapses the loop to one entry that `flushStmtSamples` drains
+        // with a single upsert. Bounded at `MAX_STMT_SAMPLES_PER_DISPATCH`
+        // DISTINCT entries; a brand-new statement shape past that cap is
+        // dropped and `currentStmtSamplesTruncated` is set — already-tracked
+        // statements keep folding regardless of the cap.
+        const foldSample = (query: string, durationMs: number, rowsRead: number, rowsWritten: number): void => {
+            const existing = samples.get(query);
+
+            if (existing !== undefined) {
+                existing.count += 1;
+                existing.totalDurationMs += durationMs;
+                existing.rowsRead += rowsRead;
+                existing.rowsWritten += rowsWritten;
+
+                return;
+            }
+
+            if (samples.size >= MAX_STMT_SAMPLES_PER_DISPATCH) {
+                this.currentStmtSamplesTruncated = true;
+
+                return;
+            }
+
+            samples.set(query, { count: 1, rowsRead, rowsWritten, totalDurationMs: durationMs });
+        };
+
         const instrumentedExec = (query: string, ...params: unknown[]): unknown => {
             const start = Date.now();
             const cursor = (rawExec as (...args: unknown[]) => unknown).call(rawSql, query, ...params);
@@ -1591,7 +1668,7 @@ abstract class ShardDO {
                         const rows = (originalToArray as () => unknown[])();
                         const durationMs = Date.now() - start;
 
-                        samples.push([query, durationMs, rows.length, 0]);
+                        foldSample(query, durationMs, rows.length, 0);
 
                         return rows;
                     };
@@ -1605,7 +1682,7 @@ abstract class ShardDO {
                         const row = (originalOne as () => unknown)();
                         const durationMs = Date.now() - start;
 
-                        samples.push([query, durationMs, 1, 0]);
+                        foldSample(query, durationMs, 1, 0);
 
                         return row;
                     };
@@ -1615,20 +1692,20 @@ abstract class ShardDO {
                 // DDL / DML that the caller discards without iterating), record
                 // a zero-rows sample immediately so the statement still appears
                 // in the leaderboard. The `toArray`/`one` overrides above take
-                // priority when they are used — they push their own samples and
+                // priority when they are used — they fold their own samples and
                 // the caller never reaches a point where this fallback fires
                 // again for the same execution.
                 if (typeof c["toArray"] !== "function" && typeof c["one"] !== "function") {
                     const durationMs = Date.now() - start;
 
-                    samples.push([query, durationMs, 0, 0]);
+                    foldSample(query, durationMs, 0, 0);
                 }
             } else {
                 // Non-object return (shouldn't happen with workerd's SqlStorage
                 // but guard defensively).
                 const durationMs = Date.now() - start;
 
-                samples.push([query, durationMs, 0, 0]);
+                foldSample(query, durationMs, 0, 0);
             }
 
             return cursor;
@@ -4017,9 +4094,10 @@ abstract class ShardDO {
         // Collect per-statement SQL samples from the instrumented `sql`
         // getter so `flushStmtSamples` can persist them to the durable
         // `__lunora_metrics_queries` table after the handler resolves.
-        // Allocating a fresh array here activates the instrumentation (the
+        // Allocating a fresh map here activates the instrumentation (the
         // `sql` getter only wraps when this field is defined).
-        this.currentStmtSamples = [];
+        this.currentStmtSamples = new Map<string, StmtSample>();
+        this.currentStmtSamplesTruncated = undefined;
 
         // Outcome of the dispatch, for the synthetic root span recorded in the
         // `finally` below. A sentinel rather than a boolean so the `catch` can
@@ -4231,6 +4309,7 @@ abstract class ShardDO {
             this.currentRequestReadTables = undefined;
             this.currentRequestCacheHit = undefined;
             this.currentStmtSamples = undefined;
+            this.currentStmtSamplesTruncated = undefined;
         }
     }
 
@@ -4432,10 +4511,17 @@ abstract class ShardDO {
         // Auto-instrumentation counters ride whatever root span is being recorded;
         // they never cause one (see `instrumentDb`).
         const databaseAttributes = wide?.dbTally === undefined || wide.dbTally.calls === 0 ? undefined : formatTally(wide.dbTally);
+        // Mirrors `db.spans_truncated`: the per-dispatch statement-sample buffer
+        // (see `currentStmtSamples`) hit its distinct-statement cap, so the
+        // query-metrics leaderboard's contribution from this dispatch is partial.
+        const stmtSamplesAttributes: LogFields | undefined = this.currentStmtSamplesTruncated ? { "db.stmt_samples_truncated": true } : undefined;
         const collected =
             wide?.collector === undefined
                 ? undefined
-                : { ...wide.collector.collected, attributes: { ...databaseAttributes, ...wide.collector.collected.attributes } };
+                : {
+                      ...wide.collector.collected,
+                      attributes: { ...databaseAttributes, ...stmtSamplesAttributes, ...wide.collector.collected.attributes },
+                  };
 
         try {
             this.spans.push(
@@ -4875,9 +4961,16 @@ abstract class ShardDO {
     }
 
     /**
-     * Flush per-statement SQL samples accumulated during the current dispatch
-     * into the durable `__lunora_metrics_queries` table. Called after
-     * `recordFunctionCall` on both the success and error paths.
+     * Flush the per-DISTINCT-statement SQL samples accumulated during the
+     * current dispatch into the durable `__lunora_metrics_queries` table.
+     * Called after `recordFunctionCall` on both the success and error paths.
+     *
+     * Already folded by the instrumented `sql` getter (see
+     * `currentStmtSamples`), so this pays exactly one `recordQueryMetric` call
+     * — one accumulator upsert plus one bucket upsert — per distinct statement
+     * the dispatch ran, however many times it actually ran. `count` carries the
+     * real execution count through so the durable `exec_count`/`total_duration_ms`
+     * still reflect every execution, not just one.
      *
      * Best-effort: a SQL failure (e.g. a test double without a usable `sql`
      * handle) must never fail the response, so every call is swallowed.
@@ -4888,16 +4981,16 @@ abstract class ShardDO {
     private flushStmtSamples(): void {
         const samples = this.currentStmtSamples;
 
-        if (!samples || samples.length === 0) {
+        if (!samples || samples.size === 0) {
             return;
         }
 
         try {
             const sqlHandle = this.shardHost.sql as unknown as SqlExec;
 
-            for (const [rawSql, durationMs, rowsRead, rowsWritten] of samples) {
+            for (const [rawSql, sample] of samples) {
                 try {
-                    recordQueryMetric(sqlHandle, rawSql, durationMs, rowsRead, rowsWritten);
+                    recordQueryMetric(sqlHandle, rawSql, sample.totalDurationMs, sample.rowsRead, sample.rowsWritten, Date.now(), sample.count);
                 } catch {
                     // Per-statement failures are swallowed so a bad statement
                     // never breaks the whole flush.

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -6349,14 +6349,32 @@ abstract class ShardDO {
     }
 
     /**
+     * Shared shape behind `describeTables` and `listTablesIndexes`: read the
+     * `tables` arg, run `lookup` (a cheap, synchronous, schema-sourced `this.*()`
+     * hook) over each, and report the requested set as the read's table
+     * dependency (or the {@link ADMIN_WILDCARD} sentinel when none were named).
+     * Factored out so `readAdminTableSignal` states each batched RPC as one line
+     * rather than duplicating the array-filter/fan-out shape per sibling.
+     */
+    // eslint-disable-next-line class-methods-use-this -- kept as an instance method alongside `readAdminTableSignal` (its only caller) even though `lookup` is injected rather than read off `this`; a bare module function would read as unrelated to the admin-signal resolvers it exists for
+    private batchedTableLookup<T>(args: Record<string, unknown>, lookup: (table: string) => T): { byTable: Record<string, T>; tables: Set<string> } {
+        const requested = Array.isArray(args["tables"]) ? args["tables"].filter((table): table is string => typeof table === "string") : [];
+        const byTable: Record<string, T> = Object.fromEntries(requested.map((table) => [table, lookup(table)]));
+
+        return { byTable, tables: new Set(requested.length === 0 ? [ADMIN_WILDCARD] : requested) };
+    }
+
+    /**
      * Resolve the table-scoped introspection reads whose payload is a single
      * `this.*()` lookup keyed by an optional `table` arg — `listTableIndexes`
      * (declared indexes), `describeTable` (declared columns) and `migrationStatus`
-     * (the migration ledger). The first two carry their `table` (or the
-     * {@link ADMIN_WILDCARD} sentinel when unscoped); `migrationStatus` is
-     * deployment-wide, so it always carries the wildcard. Returns `undefined` for
-     * any other path so {@link readAdminOp} falls through; folded into one helper
-     * to keep that dispatcher under its complexity budget.
+     * (the migration ledger); plus their batched siblings `describeTables` and
+     * `listTablesIndexes` (one RPC for N tables via {@link batchedTableLookup}).
+     * The single-table pair carries its `table` (or the {@link ADMIN_WILDCARD}
+     * sentinel when unscoped); `migrationStatus` is deployment-wide, so it always
+     * carries the wildcard. Returns `undefined` for any other path so
+     * {@link readAdminOp} falls through; folded into one helper to keep that
+     * dispatcher under its complexity budget.
      * @returns the read result and its table-dependency set, or `undefined` when the path is not owned by this resolver
      */
     private readAdminTableSignal(functionPath: string, sql: SqlExec, args: Record<string, unknown>): undefined | { result: unknown; tables: Set<string> } {
@@ -6368,10 +6386,18 @@ abstract class ShardDO {
         }
 
         if (functionPath === ADMIN_FUNCTIONS.describeTables) {
-            const requested = Array.isArray(args["tables"]) ? args["tables"].filter((table): table is string => typeof table === "string") : [];
-            const columnsByTable: Record<string, ColumnMeta[]> = Object.fromEntries(requested.map((table) => [table, this.tableColumns(table)]));
+            const { byTable: columnsByTable, tables } = this.batchedTableLookup(args, (table) => this.tableColumns(table));
 
-            return { result: { columnsByTable }, tables: new Set(requested.length === 0 ? [ADMIN_WILDCARD] : requested) };
+            return { result: { columnsByTable }, tables };
+        }
+
+        // Batched sibling of `listTableIndexes` — one admin RPC for N tables
+        // instead of N, following `describeTables`'s exact shape: the fan-out
+        // this collapses used to cost a full admin RPC PER table.
+        if (functionPath === ADMIN_FUNCTIONS.listTablesIndexes) {
+            const { byTable: indexesByTable, tables } = this.batchedTableLookup(args, (table) => this.tableIndexes(table));
+
+            return { result: { indexesByTable }, tables };
         }
 
         if (functionPath === ADMIN_FUNCTIONS.migrationStatus) {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -10,6 +10,7 @@ import type {
     DatabaseInstrumentation,
     DatabaseTally,
     FunctionMetricBucket,
+    FunctionMetricBucketsResult,
     FunctionMetricIndexHit,
     HostTracingLike,
     IndexHit,
@@ -4799,6 +4800,15 @@ abstract class ShardDO {
         errors: number;
         functions: FunctionCallStat[];
         history: (FunctionMetricBucket & { path: string })[];
+
+        /**
+         * True when the durable bucket table held more rows than
+         * {@link readFunctionMetricBuckets}'s read limit could return, so
+         * `history` is a partial (newest) window rather than the app's full
+         * retained history. Additive — absent on a worker predating the signal,
+         * so an older studio build simply never renders the notice.
+         */
+        historyTruncated: boolean;
         indexHits: FunctionMetricIndexHit[];
         queryStats: QueryStatEntry[];
         requests: number;
@@ -4844,6 +4854,8 @@ abstract class ShardDO {
             // No durable query-metrics table yet — report an empty feed.
         }
 
+        const historyResult = this.collectFunctionMetricBuckets();
+
         return {
             // eslint-disable-next-line unicorn/no-null -- metrics wire shape: `cache` is `null | {...}`, null reported when the reactive cache is disabled
             cache: this.reactiveCache ? this.reactiveCache.stats() : null,
@@ -4851,7 +4863,8 @@ abstract class ShardDO {
             databaseSize: typeof size === "number" ? size : null,
             errors,
             functions: this.collectFunctionStats().functions,
-            history: this.collectFunctionMetricBuckets(),
+            history: historyResult.buckets,
+            historyTruncated: historyResult.truncated,
             indexHits,
             queryStats,
             requests,
@@ -5029,14 +5042,14 @@ abstract class ShardDO {
     /**
      * Per-function coarse time-series served additively by the metrics RPC, so
      * the studio can chart call/error history. Reads the durable
-     * `__lunora_metrics_buckets` table; returns `[]` when persistence is
-     * unavailable so the response stays well-formed.
+     * `__lunora_metrics_buckets` table; returns an empty, non-truncated result
+     * when persistence is unavailable so the response stays well-formed.
      */
-    private collectFunctionMetricBuckets(): (FunctionMetricBucket & { path: string })[] {
+    private collectFunctionMetricBuckets(): FunctionMetricBucketsResult {
         try {
             return readFunctionMetricBuckets(this.shardHost.sql);
         } catch {
-            return [];
+            return { buckets: [], truncated: false };
         }
     }
 

--- a/packages/observability/__tests__/_helpers/fresh-handle.ts
+++ b/packages/observability/__tests__/_helpers/fresh-handle.ts
@@ -1,0 +1,31 @@
+import type { SqlExec } from "@lunora/shard-engine";
+
+import type createSqliteExec from "./node-sqlite";
+
+/**
+ * A brand-new `SqlExec` object bound to the SAME underlying storage as
+ * `harness` — simulating a fresh isolate reattaching to a durable shard after
+ * hibernation. Object identity differs from `harness.sql`, so any
+ * `WeakSet`/`WeakMap` memoization keyed on the handle starts cold, while the
+ * SQL it runs lands in the same tables `harness.sql` already wrote.
+ */
+const freshHandleOver = (harness: ReturnType<typeof createSqliteExec>): SqlExec =>
+    ({
+        exec: (query: string, ...parameters: unknown[]) => {
+            const rows = harness.raw(query, ...parameters);
+
+            return {
+                one: () => {
+                    if (rows.length !== 1) {
+                        throw new Error(`expected exactly one row, received ${String(rows.length)}`);
+                    }
+
+                    return rows[0]!;
+                },
+                [Symbol.iterator]: () => rows[Symbol.iterator](),
+                toArray: () => rows,
+            };
+        },
+    }) as unknown as SqlExec;
+
+export default freshHandleOver;

--- a/packages/observability/__tests__/function-metrics.test.ts
+++ b/packages/observability/__tests__/function-metrics.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import type { SqlExec } from "@lunora/shard-engine";
+import { describe, expect, it, vi } from "vitest";
 
 import {
     ensureFunctionMetricsTables,
@@ -22,6 +23,31 @@ import createSqliteExec from "./_helpers/node-sqlite";
 const dispatch = (overrides: Partial<Parameters<typeof recordFunctionMetric>[1]> = {}) => {
     return { durationMs: 10, errored: false, path: "posts:list", ts: 1_000_000, ...overrides };
 };
+
+/**
+ * A brand-new `SqlExec` object bound to the SAME underlying storage as
+ * `harness` — simulating a fresh isolate reattaching to a durable shard after
+ * hibernation. Object identity differs from `harness.sql`, so any
+ * `WeakSet`/`WeakMap` memoization keyed on the handle starts cold, while the
+ * SQL it runs lands in the same tables `harness.sql` already wrote.
+ */
+const freshHandleOver = (harness: ReturnType<typeof createSqliteExec>): SqlExec => ({
+        exec: (query: string, ...parameters: unknown[]) => {
+            const rows = harness.raw(query, ...parameters);
+
+            return {
+                one: () => {
+                    if (rows.length !== 1) {
+                        throw new Error(`expected exactly one row, received ${String(rows.length)}`);
+                    }
+
+                    return rows[0]!;
+                },
+                [Symbol.iterator]: () => rows[Symbol.iterator](),
+                toArray: () => rows,
+            };
+        },
+    } as unknown as SqlExec);
 
 describe("ensureFunctionMetricsTables", () => {
     it("is idempotent, so read and write paths can both call it defensively", () => {
@@ -460,6 +486,79 @@ describe("bounded reads", () => {
         expect(buckets.at(-1)?.bucketMs).toBe((FUNCTION_METRICS_READ_LIMIT + 49) * 60_000);
         // Still oldest-first, so it plots left to right.
         expect(buckets[0]!.bucketMs).toBeLessThan(buckets.at(-1)!.bucketMs);
+    });
+});
+
+describe("per-handle memoization (OBS-02)", () => {
+    it("issues no ALTER TABLE and no COUNT(*) on the second dispatch for an already-seen path", () => {
+        expect.assertions(2);
+
+        const harness = createSqliteExec();
+        const { sql } = harness;
+
+        // Warm the handle: creates the tables, backfills columns, and marks
+        // "posts:list" as a known path.
+        recordFunctionMetric(sql, dispatch({ path: "posts:list" }));
+
+        const original = sql.exec.bind(sql);
+        const seen: string[] = [];
+
+        vi.spyOn(sql, "exec").mockImplementation((query: string, ...parameters: unknown[]) => {
+            seen.push(query);
+
+             
+            return (original as any)(query, ...parameters);
+        });
+
+        recordFunctionMetric(sql, dispatch({ path: "posts:list" }));
+
+        expect(seen.some((query) => query.includes("ALTER TABLE"))).toBe(false);
+        expect(seen.some((query) => query.includes("COUNT(*)"))).toBe(false);
+    });
+
+    it("re-ensures and re-verifies against durable state on a fresh post-hibernation handle", () => {
+        expect.assertions(2);
+
+        const harness = createSqliteExec();
+
+        // First "isolate".
+        recordFunctionMetric(harness.sql, dispatch({ path: "posts:list" }));
+
+        // Second "isolate": a brand-new handle over the same storage. The
+        // WeakSet/WeakMap caches from the first handle must not leak across —
+        // a stale memo here would skip a needed CREATE on genuinely fresh
+        // storage, or (worse) admit a path without re-checking the cap.
+        const fresh = freshHandleOver(harness);
+
+        expect(() => {
+            recordFunctionMetric(fresh, dispatch({ path: "posts:list" }));
+        }).not.toThrow();
+
+        // Both dispatches landed in the SAME durable row.
+        const [row] = readFunctionMetrics(fresh);
+
+        expect(row?.calls).toBe(2);
+    });
+
+    it("re-verifies the distinct-path cap against durable state on a fresh post-hibernation handle", () => {
+        expect.assertions(1);
+
+        const harness = createSqliteExec();
+
+        ensureFunctionMetricsTables(harness.sql);
+
+        for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path) VALUES (?)`, `seed:${String(index)}`);
+        }
+
+        // A fresh handle has no local cache of what's tracked — it must fall
+        // back to the durable count rather than assuming an empty local cache
+        // means the cap hasn't been reached.
+        const fresh = freshHandleOver(harness);
+
+        recordFunctionMetric(fresh, dispatch({ path: "attacker:random" }));
+
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'attacker:random'`)).toStrictEqual([]);
     });
 });
 

--- a/packages/observability/__tests__/function-metrics.test.ts
+++ b/packages/observability/__tests__/function-metrics.test.ts
@@ -334,7 +334,7 @@ describe("recordFunctionMetric", () => {
         // The satellites matter as much as the accumulator: a guard that only
         // protected the accumulator would leave the bucket, scan and index tables
         // growing without bound, which is the whole reason the cap exists.
-        expect(readFunctionMetricBuckets(sql, "attacker:random")).toStrictEqual([]);
+        expect(readFunctionMetricBuckets(sql, "attacker:random")).toStrictEqual({ buckets: [], truncated: false });
         expect(readFunctionMetricScans(sql).get("attacker:random")).toBeUndefined();
     });
 
@@ -363,7 +363,7 @@ describe("recordFunctionMetric", () => {
 
 describe("time-series buckets", () => {
     it("groups dispatches within one window into a single bucket", () => {
-        expect.assertions(3);
+        expect.assertions(4);
 
         const harness = createSqliteExec();
         const { sql } = harness;
@@ -373,11 +373,12 @@ describe("time-series buckets", () => {
         recordFunctionMetric(sql, dispatch({ ts: base + 1 }));
         recordFunctionMetric(sql, dispatch({ errored: true, ts: base + 500 }));
 
-        const buckets = readFunctionMetricBuckets(sql, "posts:list");
+        const { buckets, truncated } = readFunctionMetricBuckets(sql, "posts:list");
 
         expect(buckets).toHaveLength(1);
         expect(buckets[0]?.calls).toBe(2);
         expect(buckets[0]?.errors).toBe(1);
+        expect(truncated).toBe(false);
     });
 
     it("floors each bucket to its window start so samples land on one grid", () => {
@@ -392,7 +393,7 @@ describe("time-series buckets", () => {
 
         // Charting depends on a fixed grid; an unfloored timestamp gives every
         // call its own bucket and the retention trim never coalesces.
-        expect(readFunctionMetricBuckets(sql, "posts:list")[0]?.bucketMs).toBe(base);
+        expect(readFunctionMetricBuckets(sql, "posts:list").buckets[0]?.bucketMs).toBe(base);
     });
 
     it("returns buckets oldest-first so a chart plots left to right", () => {
@@ -406,7 +407,10 @@ describe("time-series buckets", () => {
         recordFunctionMetric(sql, dispatch({ ts: base + FUNCTION_METRICS_BUCKET_MS * 2 }));
         recordFunctionMetric(sql, dispatch({ ts: base }));
 
-        expect(readFunctionMetricBuckets(sql, "posts:list").map((bucket) => bucket.bucketMs)).toStrictEqual([base, base + FUNCTION_METRICS_BUCKET_MS * 2]);
+        expect(readFunctionMetricBuckets(sql, "posts:list").buckets.map((bucket) => bucket.bucketMs)).toStrictEqual([
+            base,
+            base + FUNCTION_METRICS_BUCKET_MS * 2,
+        ]);
     });
 
     it("trims buckets older than the retention window", () => {
@@ -420,7 +424,7 @@ describe("time-series buckets", () => {
         recordFunctionMetric(sql, dispatch({ ts: 0 }));
         recordFunctionMetric(sql, dispatch({ ts: recent }));
 
-        const buckets = readFunctionMetricBuckets(sql, "posts:list");
+        const { buckets } = readFunctionMetricBuckets(sql, "posts:list");
 
         // Unbounded history is how a per-minute series eventually fills the
         // shard's SQLite store alongside the app's real data.
@@ -441,8 +445,8 @@ describe("time-series buckets", () => {
         // the subquery's scope — a global subquery still passes this. Kept because
         // the property is worth pinning: writing one path must never evict
         // another's history, however the trim is expressed.
-        expect(readFunctionMetricBuckets(sql, "old:fn")).toHaveLength(1);
-        expect(readFunctionMetricBuckets(sql, "new:fn")).toHaveLength(1);
+        expect(readFunctionMetricBuckets(sql, "old:fn").buckets).toHaveLength(1);
+        expect(readFunctionMetricBuckets(sql, "new:fn").buckets).toHaveLength(1);
     });
 
     it("returns every path's buckets when no path is given", () => {
@@ -456,15 +460,15 @@ describe("time-series buckets", () => {
 
         expect(
             readFunctionMetricBuckets(sql)
-                .map((bucket) => bucket.path)
+                .buckets.map((bucket) => bucket.path)
                 .toSorted((a, b) => a.localeCompare(b)),
         ).toStrictEqual(["a:fn", "b:fn"]);
     });
 });
 
 describe("bounded reads", () => {
-    it("caps the all-paths bucket read and keeps the most recent window", () => {
-        expect.assertions(3);
+    it("caps the all-paths bucket read, keeps the most recent window, and reports truncated", () => {
+        expect.assertions(4);
 
         const harness = createSqliteExec();
         const { sql } = harness;
@@ -478,7 +482,7 @@ describe("bounded reads", () => {
             harness.raw(`INSERT INTO "${FUNCTION_METRICS_BUCKETS_TABLE}" (path, bucket_ms, calls, errors) VALUES ('posts:list', ?, 1, 0)`, index * 60_000);
         }
 
-        const buckets = readFunctionMetricBuckets(sql);
+        const { buckets, truncated } = readFunctionMetricBuckets(sql);
 
         expect(buckets).toHaveLength(FUNCTION_METRICS_READ_LIMIT);
         // Newest window kept, not the stalest one — a chart of the oldest 1000
@@ -486,6 +490,30 @@ describe("bounded reads", () => {
         expect(buckets.at(-1)?.bucketMs).toBe((FUNCTION_METRICS_READ_LIMIT + 49) * 60_000);
         // Still oldest-first, so it plots left to right.
         expect(buckets[0]!.bucketMs).toBeLessThan(buckets.at(-1)!.bucketMs);
+        // The chart's window silently shrinking is exactly what `truncated` exists
+        // to make visible rather than leaving the caller to infer it.
+        expect(truncated).toBe(true);
+    });
+
+    it("does not report truncated when the read ends exactly at the row count", () => {
+        expect.assertions(2);
+
+        const harness = createSqliteExec();
+        const { sql } = harness;
+
+        ensureFunctionMetricsTables(sql);
+
+        // Fewer rows than the cap — the boundary case a LIMIT+1 probe must not
+        // misreport as truncated just because the app happens to have a lot of
+        // history.
+        for (let index = 0; index < FUNCTION_METRICS_READ_LIMIT; index += 1) {
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_BUCKETS_TABLE}" (path, bucket_ms, calls, errors) VALUES ('posts:list', ?, 1, 0)`, index * 60_000);
+        }
+
+        const { buckets, truncated } = readFunctionMetricBuckets(sql);
+
+        expect(buckets).toHaveLength(FUNCTION_METRICS_READ_LIMIT);
+        expect(truncated).toBe(false);
     });
 });
 
@@ -572,7 +600,7 @@ describe("reads on a never-called shard", () => {
         // Every read calls `ensureFunctionMetricsTables` first for exactly this
         // reason: the studio opens these panels before any function has run.
         expect(readFunctionMetrics(sql)).toStrictEqual([]);
-        expect(readFunctionMetricBuckets(sql)).toStrictEqual([]);
+        expect(readFunctionMetricBuckets(sql)).toStrictEqual({ buckets: [], truncated: false });
         expect(readFunctionMetricScans(sql).size).toBe(0);
         expect(readFunctionMetricIndexHits(sql)).toStrictEqual([]);
         expect(readFunctionMetricsTotals(sql)).toStrictEqual({ errors: 0, requests: 0 });

--- a/packages/observability/__tests__/function-metrics.test.ts
+++ b/packages/observability/__tests__/function-metrics.test.ts
@@ -1,4 +1,3 @@
-import type { SqlExec } from "@lunora/shard-engine";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -17,37 +16,13 @@ import {
     readFunctionMetricsTotals,
     recordFunctionMetric,
 } from "../src/function-metrics";
+import freshHandleOver from "./_helpers/fresh-handle";
 import createSqliteExec from "./_helpers/node-sqlite";
 
 /** A dispatch with every field the recorder reads, so each test varies only what it is about. */
 const dispatch = (overrides: Partial<Parameters<typeof recordFunctionMetric>[1]> = {}) => {
     return { durationMs: 10, errored: false, path: "posts:list", ts: 1_000_000, ...overrides };
 };
-
-/**
- * A brand-new `SqlExec` object bound to the SAME underlying storage as
- * `harness` — simulating a fresh isolate reattaching to a durable shard after
- * hibernation. Object identity differs from `harness.sql`, so any
- * `WeakSet`/`WeakMap` memoization keyed on the handle starts cold, while the
- * SQL it runs lands in the same tables `harness.sql` already wrote.
- */
-const freshHandleOver = (harness: ReturnType<typeof createSqliteExec>): SqlExec => ({
-        exec: (query: string, ...parameters: unknown[]) => {
-            const rows = harness.raw(query, ...parameters);
-
-            return {
-                one: () => {
-                    if (rows.length !== 1) {
-                        throw new Error(`expected exactly one row, received ${String(rows.length)}`);
-                    }
-
-                    return rows[0]!;
-                },
-                [Symbol.iterator]: () => rows[Symbol.iterator](),
-                toArray: () => rows,
-            };
-        },
-    } as unknown as SqlExec);
 
 describe("ensureFunctionMetricsTables", () => {
     it("is idempotent, so read and write paths can both call it defensively", () => {
@@ -534,7 +509,6 @@ describe("per-handle memoization (OBS-02)", () => {
         vi.spyOn(sql, "exec").mockImplementation((query: string, ...parameters: unknown[]) => {
             seen.push(query);
 
-             
             return (original as any)(query, ...parameters);
         });
 

--- a/packages/observability/__tests__/query-metrics.test.ts
+++ b/packages/observability/__tests__/query-metrics.test.ts
@@ -1,5 +1,5 @@
 import type { SqlExec } from "@lunora/shard-engine";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
     normalizeSql,
@@ -13,6 +13,31 @@ import {
     recordQueryMetric,
 } from "../src/query-metrics";
 import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * A brand-new `SqlExec` object bound to the SAME underlying storage as
+ * `harness` — simulating a fresh isolate reattaching to a durable shard after
+ * hibernation. Object identity differs from `harness.sql`, so any
+ * `WeakSet`/`WeakMap` memoization keyed on the handle starts cold, while the
+ * SQL it runs lands in the same tables `harness.sql` already wrote.
+ */
+const freshHandleOver = (harness: ReturnType<typeof createSqliteExec>): SqlExec => ({
+        exec: (query: string, ...parameters: unknown[]) => {
+            const rows = harness.raw(query, ...parameters);
+
+            return {
+                one: () => {
+                    if (rows.length !== 1) {
+                        throw new Error(`expected exactly one row, received ${String(rows.length)}`);
+                    }
+
+                    return rows[0]!;
+                },
+                [Symbol.iterator]: () => rows[Symbol.iterator](),
+                toArray: () => rows,
+            };
+        },
+    } as unknown as SqlExec);
 
 describe("normalizeSql", () => {
     it("strips single-quoted string literals", () => {
@@ -250,6 +275,73 @@ describe("recordQueryMetric + readQueryMetrics", () => {
 
         expect(QUERY_METRICS_TABLE).toBe("__lunora_metrics_queries");
     });
+});
+
+describe("per-handle memoization (OBS-02)", () => {
+    it("issues no CREATE TABLE and no COUNT(*) on the second execution of an already-seen statement", () => {
+        expect.assertions(2);
+
+        const { sql } = createSqliteExec();
+
+        // Warm the handle: creates both tables and marks the statement known.
+        recordQueryMetric(sql, "SELECT * FROM posts WHERE id = 1", 5, 1, 0);
+
+        const original = sql.exec.bind(sql);
+        const seen: string[] = [];
+
+        vi.spyOn(sql, "exec").mockImplementation((query: string, ...parameters: unknown[]) => {
+            seen.push(query);
+
+             
+            return (original as any)(query, ...parameters);
+        });
+
+        recordQueryMetric(sql, "SELECT * FROM posts WHERE id = 2", 6, 1, 0);
+
+        expect(seen.some((query) => query.includes("CREATE TABLE"))).toBe(false);
+        expect(seen.some((query) => query.includes("COUNT(*)"))).toBe(false);
+    });
+
+    it("re-ensures and re-verifies against durable state on a fresh post-hibernation handle", () => {
+        expect.assertions(2);
+
+        const harness = createSqliteExec();
+
+        recordQueryMetric(harness.sql, "SELECT * FROM posts WHERE id = 1", 5, 1, 0);
+
+        // A brand-new handle over the same storage — the WeakSet/WeakMap
+        // caches from the first handle must not leak across.
+        const fresh = freshHandleOver(harness);
+
+        expect(() => {
+            recordQueryMetric(fresh, "SELECT * FROM posts WHERE id = 2", 6, 1, 0);
+        }).not.toThrow();
+
+        const rows = readQueryMetrics(fresh);
+
+        expect(rows[0]?.execCount).toBe(2);
+    });
+
+    it("re-verifies the distinct-statement cap against durable state on a fresh post-hibernation handle", () => {
+        expect.assertions(1);
+
+        const harness = createSqliteExec();
+
+        for (let index = 0; index < QUERY_METRICS_MAX_STATEMENTS; index += 1) {
+            recordQueryMetric(harness.sql, `SELECT col${String(index)} FROM t`, 1, 0, 0);
+        }
+
+        // A fresh handle has no local cache of what's tracked — it must fall
+        // back to the durable count rather than assuming an empty local cache
+        // means the cap hasn't been reached.
+        const fresh = freshHandleOver(harness);
+
+        recordQueryMetric(fresh, "SELECT extra_col FROM t", 999, 0, 0);
+
+        const rows = readQueryMetrics(fresh);
+
+        expect(rows.some((row) => row.normalizedSql.includes("extra_col"))).toBe(false);
+    }, 15_000);
 });
 
 describe("time-bucketed query insights", () => {

--- a/packages/observability/__tests__/query-metrics.test.ts
+++ b/packages/observability/__tests__/query-metrics.test.ts
@@ -12,32 +12,8 @@ import {
     readQueryMetrics,
     recordQueryMetric,
 } from "../src/query-metrics";
+import freshHandleOver from "./_helpers/fresh-handle";
 import createSqliteExec from "./_helpers/node-sqlite";
-
-/**
- * A brand-new `SqlExec` object bound to the SAME underlying storage as
- * `harness` — simulating a fresh isolate reattaching to a durable shard after
- * hibernation. Object identity differs from `harness.sql`, so any
- * `WeakSet`/`WeakMap` memoization keyed on the handle starts cold, while the
- * SQL it runs lands in the same tables `harness.sql` already wrote.
- */
-const freshHandleOver = (harness: ReturnType<typeof createSqliteExec>): SqlExec => ({
-        exec: (query: string, ...parameters: unknown[]) => {
-            const rows = harness.raw(query, ...parameters);
-
-            return {
-                one: () => {
-                    if (rows.length !== 1) {
-                        throw new Error(`expected exactly one row, received ${String(rows.length)}`);
-                    }
-
-                    return rows[0]!;
-                },
-                [Symbol.iterator]: () => rows[Symbol.iterator](),
-                toArray: () => rows,
-            };
-        },
-    } as unknown as SqlExec);
 
 describe("normalizeSql", () => {
     it("strips single-quoted string literals", () => {
@@ -292,7 +268,6 @@ describe("per-handle memoization (OBS-02)", () => {
         vi.spyOn(sql, "exec").mockImplementation((query: string, ...parameters: unknown[]) => {
             seen.push(query);
 
-             
             return (original as any)(query, ...parameters);
         });
 

--- a/packages/observability/src/context-telemetry.ts
+++ b/packages/observability/src/context-telemetry.ts
@@ -102,7 +102,11 @@ const resolveSpanOptions = (options: LogFields | SpanOptions | undefined): SpanO
     return isSpanOptions(options) ? options : { attributes: options };
 };
 
-export type { SpanEventPoint, SpanHandle, SpanKind, SpanLink, SpanOptions } from "../../../shared/span-event";
+// Both re-exported straight from their source module (also imported above for
+// local use in `MetricsDeps`/`TracerDeps` etc.) — `export…from` keeps the
+// single source of truth per `unicorn/prefer-export-from`.
+export type { MetricEvent, MetricKind } from "../../../shared/metric-event";
+export type { SpanEvent, SpanEventPoint, SpanHandle, SpanKind, SpanLink, SpanOptions } from "../../../shared/span-event";
 
 /**
  * Structural shape of the `ctx.trace` span factory (see the server

--- a/packages/observability/src/function-metrics.ts
+++ b/packages/observability/src/function-metrics.ts
@@ -193,6 +193,22 @@ const dedupeIndexHits = (hits: ReadonlyArray<IndexHit>): IndexHit[] => {
 };
 
 /**
+ * SQL handles whose four reserved tables (and, for `__lunora_metrics`, its
+ * back-filled columns) have already been ensured this instance. Every read
+ * and write path calls {@link ensureFunctionMetricsTables} defensively, and
+ * `recordFunctionMetric` runs once per RPC dispatch — without memoizing,
+ * every dispatch re-ran `CREATE TABLE IF NOT EXISTS` four times plus the two
+ * back-fill `ALTER TABLE`s below, and the `ALTER`s throw `duplicate column
+ * name` on every call after the first (a column that already exists cannot be
+ * re-added), so two SQLite errors were being constructed and swallowed per
+ * dispatch forever. Memoizing per handle drops all of that off the hot path
+ * after the first call. A `WeakSet` so a torn-down shard's handle is
+ * collectable; a fresh handle (a new isolate after hibernation) re-ensures,
+ * which is correct — mirrors `metric-history.ts`'s `ensuredHandles`.
+ */
+const ensuredHandles = new WeakSet<SqlExec>();
+
+/**
  * Create the four reserved metrics tables. Idempotent, so the read and write
  * paths can call it defensively. The accumulator table is keyed by `path` (one
  * row per function); the bucket table by `(path, bucketMs)` (one row per
@@ -204,9 +220,15 @@ const dedupeIndexHits = (hits: ReadonlyArray<IndexHit>): IndexHit[] => {
  * than baked into the `CREATE` so a shard whose `__lunora_metrics` predates the
  * causal-attribution feature gains the column on the next call without a
  * migration. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the duplicate-column
- * error from a re-run is swallowed.
+ * error from a re-run is swallowed. Both the `CREATE`s and the back-fill only
+ * run once per handle (see {@link ensuredHandles}) — a handle already marked
+ * ensured returns immediately.
  */
 const ensureFunctionMetricsTables = (sql: SqlExec): void => {
+    if (ensuredHandles.has(sql)) {
+        return;
+    }
+
     runSql(
         sql,
         `CREATE TABLE IF NOT EXISTS "${FUNCTION_METRICS_TABLE}" (
@@ -266,6 +288,72 @@ const ensureFunctionMetricsTables = (sql: SqlExec): void => {
             PRIMARY KEY (table_name, index_name)
         )`,
     );
+
+    ensuredHandles.add(sql);
+};
+
+/**
+ * Paths this handle has confirmed are already tracked in the accumulator
+ * table — once a path is in here, {@link admitPath} skips the cap check
+ * entirely on every later dispatch for it. Bounded implicitly by
+ * {@link FUNCTION_METRICS_MAX_PATHS}: a path is only ever added once it's
+ * confirmed tracked (admitted-under-the-cap or found already present), and a
+ * rejected path is never added, so this can't grow past the cap itself. A
+ * `WeakMap` so a torn-down shard's handle is collectable; a fresh handle (a
+ * new isolate after hibernation) starts cold and re-verifies.
+ */
+const knownPaths = new WeakMap<SqlExec, Set<string>>();
+
+const knownPathsFor = (sql: SqlExec): Set<string> => {
+    let set = knownPaths.get(sql);
+
+    if (set === undefined) {
+        set = new Set<string>();
+        knownPaths.set(sql, set);
+    }
+
+    return set;
+};
+
+/**
+ * Admit `path` against the distinct-path cap without an unconditional
+ * `SELECT COUNT(*)` on every dispatch. Mirrors `metric-history.ts`'s
+ * series-cap check. A path this handle has already confirmed tracked
+ * ({@link knownPaths}) is admitted with no SQL at all — the steady-path case
+ * once every registered function has been seen once. A first-sight path pays
+ * one indexed PK lookup to tell "already tracked" (admitted, no count needed
+ * — an existing path always keeps accumulating past the cap) from "genuinely
+ * new to this shard". Only a genuinely new path reaches the actual
+ * `COUNT(*)` gate, which is the rare case after warm-up (a few thousand
+ * registered functions is already far beyond any real app). This is what
+ * keeps the cap honest: a cache that instead guessed at the row count
+ * without re-verifying a first-sight path against the table would let a
+ * steady trickle of new paths slip past the limit indefinitely.
+ */
+const admitPath = (sql: SqlExec, path: string): boolean => {
+    const known = knownPathsFor(sql);
+
+    if (known.has(path)) {
+        return true;
+    }
+
+    const alreadyTracked = runSql<{ c: number }>(sql, `SELECT 1 AS c FROM "${FUNCTION_METRICS_TABLE}" WHERE path = ? LIMIT 1`, path).toArray().length > 0;
+
+    if (alreadyTracked) {
+        known.add(path);
+
+        return true;
+    }
+
+    const pathCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`).one();
+
+    if (pathCountRow.n >= FUNCTION_METRICS_MAX_PATHS) {
+        return false;
+    }
+
+    known.add(path);
+
+    return true;
 };
 
 /**
@@ -286,16 +374,11 @@ const recordFunctionMetric = (sql: SqlExec, input: RecordFunctionMetricInput): v
     // Distinct-path cap (mirrors `query-metrics.ts`): when the accumulator is at
     // the limit and this `path` isn't tracked yet, skip the write entirely so a
     // flood of unregistered/random paths can't grow the metrics tables without
-    // bound. The check is a single cheap PK `COUNT(*)`; an already-tracked path
-    // (the normal registered-function case) still records past the cap.
-    const pathCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`).one();
-
-    if (pathCountRow.n >= FUNCTION_METRICS_MAX_PATHS) {
-        const tracked = runSql<{ c: number }>(sql, `SELECT COUNT(*) AS c FROM "${FUNCTION_METRICS_TABLE}" WHERE path = ?`, input.path).one();
-
-        if (tracked.c === 0) {
-            return;
-        }
+    // bound. An already-tracked path (the normal registered-function case)
+    // still records past the cap. See `admitPath` for how this avoids the
+    // unconditional `COUNT(*)` the old version paid on every single dispatch.
+    if (!admitPath(sql, input.path)) {
+        return;
     }
 
     // Dedupe defensively: a handler can stamp the same table's SCAN_DEP more

--- a/packages/observability/src/function-metrics.ts
+++ b/packages/observability/src/function-metrics.ts
@@ -113,6 +113,22 @@ interface FunctionMetricBucket {
     errors: number;
 }
 
+/** {@link readFunctionMetricBuckets} result: the time-series window plus whether the read limit cut it short. */
+interface FunctionMetricBucketsResult {
+    buckets: (FunctionMetricBucket & { path: string })[];
+
+    /**
+     * True when more rows existed than {@link FUNCTION_METRICS_READ_LIMIT} could
+     * return, so `buckets` is a partial (newest) window rather than the app's
+     * full retained history. Mirrors `readQueryInsights`'s `capped` and
+     * `foldTraces`'s `total`: a silently truncated read looks identical to a
+     * complete one to a caller that doesn't check for it — the Metrics chart's
+     * window would appear to shrink as the app grows, with a wrong leftmost
+     * bar, and nothing would say why.
+     */
+    truncated: boolean;
+}
+
 /** One declared index a dispatch exercised (used to narrow a read). */
 interface IndexHit {
     /** The declared index name. */
@@ -616,9 +632,9 @@ const readFunctionMetrics = (sql: SqlExec): FunctionCallStat[] => {
 /**
  * Read the coarse time-series buckets for `path` (every path when omitted),
  * oldest-bucket first so a chart can plot them left-to-right. Creates the table
- * first so reads on a never-called shard return `[]`.
+ * first so reads on a never-called shard return `{ buckets: [], truncated: false }`.
  */
-const readFunctionMetricBuckets = (sql: SqlExec, path?: string): (FunctionMetricBucket & { path: string })[] => {
+const readFunctionMetricBuckets = (sql: SqlExec, path?: string): FunctionMetricBucketsResult => {
     ensureFunctionMetricsTables(sql);
 
     // Bounded like the other reads, and for the same reason: the all-paths arm is
@@ -630,21 +646,32 @@ const readFunctionMetricBuckets = (sql: SqlExec, path?: string): (FunctionMetric
     // most recent, then reversed to restore the oldest-first order a chart plots
     // left-to-right. Ordering the scan ASC and limiting would have kept the
     // stalest window and thrown away what the panel is actually for.
+    //
+    // LIMIT is one past the real cap so a full page of results (exactly
+    // `FUNCTION_METRICS_READ_LIMIT + 1` rows back) is distinguishable from a read
+    // that happened to end exactly at the cap — the extra row is trimmed below
+    // and never returned, it only flips `truncated`.
     const rows =
         path === undefined
             ? runSql<{ bucket_ms: number; calls: number; errors: number; path: string }>(
                   sql,
-                  `SELECT path, bucket_ms, calls, errors FROM "${FUNCTION_METRICS_BUCKETS_TABLE}" ORDER BY bucket_ms DESC, path ASC LIMIT ${String(FUNCTION_METRICS_READ_LIMIT)}`,
+                  `SELECT path, bucket_ms, calls, errors FROM "${FUNCTION_METRICS_BUCKETS_TABLE}" ORDER BY bucket_ms DESC, path ASC LIMIT ${String(FUNCTION_METRICS_READ_LIMIT + 1)}`,
               ).toArray()
             : runSql<{ bucket_ms: number; calls: number; errors: number; path: string }>(
                   sql,
-                  `SELECT path, bucket_ms, calls, errors FROM "${FUNCTION_METRICS_BUCKETS_TABLE}" WHERE path = ? ORDER BY bucket_ms DESC LIMIT ${String(FUNCTION_METRICS_READ_LIMIT)}`,
+                  `SELECT path, bucket_ms, calls, errors FROM "${FUNCTION_METRICS_BUCKETS_TABLE}" WHERE path = ? ORDER BY bucket_ms DESC LIMIT ${String(FUNCTION_METRICS_READ_LIMIT + 1)}`,
                   path,
               ).toArray();
 
-    return rows.toReversed().map((row) => {
-        return { bucketMs: row.bucket_ms, calls: row.calls, errors: row.errors, path: row.path };
-    });
+    const truncated = rows.length > FUNCTION_METRICS_READ_LIMIT;
+    const kept = truncated ? rows.slice(0, FUNCTION_METRICS_READ_LIMIT) : rows;
+
+    return {
+        buckets: kept.toReversed().map((row) => {
+            return { bucketMs: row.bucket_ms, calls: row.calls, errors: row.errors, path: row.path };
+        }),
+        truncated,
+    };
 };
 
 /**
@@ -682,4 +709,4 @@ export {
     readFunctionMetricsTotals,
     recordFunctionMetric,
 };
-export type { FunctionMetricBucket, FunctionMetricIndexHit, IndexHit, RecordFunctionMetricInput };
+export type { FunctionMetricBucket, FunctionMetricBucketsResult, FunctionMetricIndexHit, IndexHit, RecordFunctionMetricInput };

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -42,7 +42,7 @@ export type {
 export { createMetrics, createSpanCollector, createTracedFetch, createTracer, dispatchRootSpan } from "./context-telemetry";
 export type { DatabaseInstrumentation, DatabaseTally } from "./database-telemetry";
 export { createDatabaseTally, formatTally, instrumentDatabase } from "./database-telemetry";
-export type { FunctionMetricBucket, FunctionMetricIndexHit, IndexHit, RecordFunctionMetricInput } from "./function-metrics";
+export type { FunctionMetricBucket, FunctionMetricBucketsResult, FunctionMetricIndexHit, IndexHit, RecordFunctionMetricInput } from "./function-metrics";
 export {
     ensureFunctionMetricsTables,
     FUNCTION_METRICS_BUCKET_MS,

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -31,16 +31,26 @@ export type {
     ContextFetch,
     ContextMetrics,
     ContextTracer,
+    HostSpanLike,
     HostTracingLike,
+    HostTracingResolver,
+    MetricEvent,
+    MetricKind,
     MetricsDeps,
     SpanCollection,
     SpanCollector,
+    SpanEvent,
+    SpanEventPoint,
     SpanHandle,
+    SpanKind,
+    SpanLink,
+    SpanOptions,
     TraceAnchor,
+    TracedFetchDeps,
     TracerDeps,
 } from "./context-telemetry";
 export { createMetrics, createSpanCollector, createTracedFetch, createTracer, dispatchRootSpan } from "./context-telemetry";
-export type { DatabaseInstrumentation, DatabaseTally } from "./database-telemetry";
+export type { DatabaseInstrumentation, DatabaseTally, DatabaseTelemetryDeps } from "./database-telemetry";
 export { createDatabaseTally, formatTally, instrumentDatabase } from "./database-telemetry";
 export type { FunctionMetricBucket, FunctionMetricBucketsResult, FunctionMetricIndexHit, IndexHit, RecordFunctionMetricInput } from "./function-metrics";
 export {
@@ -69,11 +79,23 @@ export type { LogEntry, LogLevel } from "./log-buffer";
 export { LogBuffer } from "./log-buffer";
 export type { MetricSeries } from "./metric-buffer";
 export { MetricBuffer } from "./metric-buffer";
-export type { MetricHistoryOptions, MetricHistoryPoint, MetricHistorySeries } from "./metric-history";
+export type { MetricHistoryOptions, MetricHistoryPoint, MetricHistoryResult, MetricHistorySeries } from "./metric-history";
 export { readMetricHistory, recordMetricHistory } from "./metric-history";
-export type { QueryStatEntry } from "./query-metrics";
+export type { QueryInsightBucket, QueryInsightEntry, QueryInsightsResult, QueryStatEntry } from "./query-metrics";
 export { readQueryInsights, readQueryMetrics, recordQueryMetric } from "./query-metrics";
-export type { AppendRequestLogEntry, ContextLogLevel, IssuesResult, LogEventInput, RequestLogResult, RequestLogWriteOptions } from "./request-log";
+export type {
+    AppendRequestLogEntry,
+    ContextLogLevel,
+    ErrorIssue,
+    IssuesResult,
+    LogEventInput,
+    ReadIssuesOptions,
+    ReadRequestLogOptions,
+    RequestLogEntry,
+    RequestLogResult,
+    RequestLogWriteOptions,
+    RequestOutcome,
+} from "./request-log";
 export {
     appendRequestLogEntry,
     emitLogEvent,
@@ -86,7 +108,8 @@ export {
 } from "./request-log";
 export type { SecurityAuditResult, SecurityFinding, SecurityFindingKind, SecurityFindingLevel } from "./security-audit";
 export { buildSecurityAudit, MIN_ADMIN_TOKEN_LENGTH, MIN_AUTH_SECRET_LENGTH } from "./security-audit";
-export type { TraceSpan, TraceSummary } from "./span-buffer";
+export type { FoldedTraces, TraceSpan, TraceSummary } from "./span-buffer";
 export { foldTraces, SpanBuffer } from "./span-buffer";
+export type { DanglingReference, DanglingReferenceResult } from "./storage-correlation";
 export { findDanglingReferences } from "./storage-correlation";
 export { resolveTraceAnchor } from "./trace-context";

--- a/packages/observability/src/query-metrics.ts
+++ b/packages/observability/src/query-metrics.ts
@@ -126,11 +126,27 @@ const normalizeSql = (sql: string): string => {
 };
 
 /**
+ * SQL handles whose reserved tables have already been ensured this instance.
+ * `recordQueryMetric` runs once per instrumented statement — potentially many
+ * times per dispatch — so without memoizing, a query-in-a-loop handler re-ran
+ * `CREATE TABLE IF NOT EXISTS` (twice, counting the bucket table) on every
+ * single execution. A `WeakSet` so a torn-down shard's handle is collectable;
+ * a fresh handle (a new isolate after hibernation) re-ensures, which is
+ * correct — mirrors `metric-history.ts`'s `ensuredHandles` and
+ * `function-metrics.ts`'s twin.
+ */
+const ensuredMetricsHandles = new WeakSet<SqlExec>();
+
+/**
  * Create the reserved query-metrics table. Idempotent — safe to call on every
  * hot path; SQLite's `CREATE TABLE IF NOT EXISTS` is a no-op when the table
- * already exists.
+ * already exists. Only runs once per handle (see {@link ensuredMetricsHandles}).
  */
 const ensureQueryMetricsTable = (sql: SqlExec): void => {
+    if (ensuredMetricsHandles.has(sql)) {
+        return;
+    }
+
     runSql(
         sql,
         `CREATE TABLE IF NOT EXISTS "${QUERY_METRICS_TABLE}" (
@@ -141,6 +157,8 @@ const ensureQueryMetricsTable = (sql: SqlExec): void => {
             rows_written   INTEGER NOT NULL DEFAULT 0
         )`,
     );
+
+    ensuredMetricsHandles.add(sql);
 };
 
 /**
@@ -190,8 +208,21 @@ const latencyBucketIndex = (durationMs: number): number => {
 /** Column name for one histogram bucket. */
 const latencyColumn = (index: number): string => `lat_${String(index)}`;
 
-/** Create the bucket table. Idempotent; one column per histogram bucket plus the overflow. */
+/**
+ * SQL handles whose bucket table has already been ensured this instance.
+ * Separate from {@link ensuredMetricsHandles} because `recordQueryBucket`
+ * fires per statement execution too, and the two tables are independently
+ * idempotent — memoized the same way for the same reason (see
+ * {@link ensuredMetricsHandles}).
+ */
+const ensuredBucketsHandles = new WeakSet<SqlExec>();
+
+/** Create the bucket table. Idempotent; one column per histogram bucket plus the overflow. Only runs once per handle (see {@link ensuredBucketsHandles}). */
 const ensureQueryBucketsTable = (sql: SqlExec): void => {
+    if (ensuredBucketsHandles.has(sql)) {
+        return;
+    }
+
     const latencyColumns = Array.from({ length: LATENCY_BUCKET_EDGES.length + 1 }, (_, index) => `${latencyColumn(index)} INTEGER NOT NULL DEFAULT 0`).join(
         ", ",
     );
@@ -209,6 +240,8 @@ const ensureQueryBucketsTable = (sql: SqlExec): void => {
             PRIMARY KEY (sql_hash, bucket_ms)
         )`,
     );
+
+    ensuredBucketsHandles.add(sql);
 };
 
 /**
@@ -404,12 +437,69 @@ const readQueryInsights = (sql: SqlExec, rangeMs: number, now: number = Date.now
 };
 
 /**
+ * Normalised statements this handle has confirmed are already tracked in the
+ * lifetime table — once a statement is in here, {@link admitStatement} skips
+ * the cap check entirely on every later execution of it. Bounded implicitly
+ * by {@link QUERY_METRICS_MAX_STATEMENTS} for the same reason
+ * `function-metrics.ts`'s `knownPaths` is: a statement is only ever added
+ * once confirmed tracked, and a rejected one is never added. A `WeakMap` so a
+ * torn-down shard's handle is collectable; a fresh handle (a new isolate
+ * after hibernation) starts cold and re-verifies.
+ */
+const knownStatements = new WeakMap<SqlExec, Set<string>>();
+
+const knownStatementsFor = (sql: SqlExec): Set<string> => {
+    let set = knownStatements.get(sql);
+
+    if (set === undefined) {
+        set = new Set<string>();
+        knownStatements.set(sql, set);
+    }
+
+    return set;
+};
+
+/**
+ * Admit `normalized` against the distinct-statement cap without an
+ * unconditional `SELECT COUNT(*)` on every execution. Same shape as
+ * `function-metrics.ts`'s `admitPath`: a known statement is free, a
+ * first-sight one pays one indexed PK lookup to tell "already tracked" from
+ * "genuinely new", and only a genuinely new statement reaches the actual
+ * `COUNT(*)` gate — the rare case once the leaderboard has warmed up.
+ */
+const admitStatement = (sql: SqlExec, normalized: string): boolean => {
+    const known = knownStatementsFor(sql);
+
+    if (known.has(normalized)) {
+        return true;
+    }
+
+    const alreadyTracked = runSql<{ c: number }>(sql, `SELECT 1 AS c FROM "${QUERY_METRICS_TABLE}" WHERE normalized_sql = ? LIMIT 1`, normalized).toArray().length > 0;
+
+    if (alreadyTracked) {
+        known.add(normalized);
+
+        return true;
+    }
+
+    const countRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${QUERY_METRICS_TABLE}"`).one();
+
+    if (countRow.n >= QUERY_METRICS_MAX_STATEMENTS) {
+        return false;
+    }
+
+    known.add(normalized);
+
+    return true;
+};
+
+/**
  * Record one statement execution. Creates the table on first call. Silently
  * skips recording when the normalised statement is empty (shouldn't happen
  * in practice) or when the table is already at the
  * {@link QUERY_METRICS_MAX_STATEMENTS} cap and the statement is not yet
- * tracked. The cap check is a single cheap `COUNT(*)` on the primary-key
- * index, so the hot-path cost is minimal.
+ * tracked. See `admitStatement` for how the cap check avoids an unconditional
+ * `COUNT(*)` on every execution.
  */
 const recordQueryMetric = (sql: SqlExec, rawSql: string, durationMs: number, rowsRead: number, rowsWritten: number, now: number = Date.now()): void => {
     const normalized = normalizeSql(rawSql);
@@ -420,17 +510,8 @@ const recordQueryMetric = (sql: SqlExec, rawSql: string, durationMs: number, row
 
     ensureQueryMetricsTable(sql);
 
-    // Cap guard: if the table is at the limit and this statement is new, skip.
-    const countRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${QUERY_METRICS_TABLE}"`).one();
-    const count = countRow.n;
-
-    if (count >= QUERY_METRICS_MAX_STATEMENTS) {
-        // Only skip if the statement isn't tracked yet.
-        const existing = runSql<{ c: number }>(sql, `SELECT COUNT(*) AS c FROM "${QUERY_METRICS_TABLE}" WHERE normalized_sql = ?`, normalized).one();
-
-        if (existing.c === 0) {
-            return;
-        }
+    if (!admitStatement(sql, normalized)) {
+        return;
     }
 
     // eslint-disable-next-line no-secrets/no-secrets -- SQL keyword "CONFLICT" triggers the entropy scanner; this is plain DDL, not a secret

--- a/packages/observability/src/query-metrics.ts
+++ b/packages/observability/src/query-metrics.ts
@@ -254,26 +254,33 @@ const pruneQueryBuckets = (sql: SqlExec, now: number): void => {
 };
 
 /**
- * Record one execution into its time bucket. Best-effort: a failure here must
- * never break the lifetime counters, which are the older and more load-bearing
- * of the two.
+ * Record one or more executions into their time bucket. `execCount` (default
+ * 1) lets a caller that already folded several same-statement executions into
+ * one aggregate — `shard-do.ts`'s per-dispatch statement-sample folding — flush
+ * them as a single upsert instead of one call per execution: `durationMs` is
+ * then the SUM across `execCount` executions, and the histogram places the
+ * whole entry by the per-execution AVERAGE rather than the sum, so a folded
+ * batch of many fast calls doesn't read as one enormous slow one. Best-effort:
+ * a failure here must never break the lifetime counters, which are the older
+ * and more load-bearing of the two.
  */
-const recordQueryBucket = (sql: SqlExec, normalized: string, durationMs: number, rowsRead: number, rowsWritten: number, now: number): void => {
+const recordQueryBucket = (sql: SqlExec, normalized: string, durationMs: number, rowsRead: number, rowsWritten: number, now: number, execCount: number = 1): void => {
     try {
         ensureQueryBucketsTable(sql);
 
-        const column = latencyColumn(latencyBucketIndex(durationMs));
+        const avgDurationMs = execCount > 0 ? durationMs / execCount : durationMs;
+        const column = latencyColumn(latencyBucketIndex(avgDurationMs));
 
         const upsert = `INSERT INTO "${QUERY_BUCKETS_TABLE}" (sql_hash, bucket_ms, exec_count, total_duration_ms, rows_read, rows_written, ${column})
-             VALUES (?, ?, 1, ?, ?, ?, 1)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(sql_hash, bucket_ms) DO UPDATE SET
-                 exec_count = exec_count + 1,
+                 exec_count = exec_count + excluded.exec_count,
                  total_duration_ms = total_duration_ms + excluded.total_duration_ms,
                  rows_read = rows_read + excluded.rows_read,
                  rows_written = rows_written + excluded.rows_written,
-                 ${column} = ${column} + 1`;
+                 ${column} = ${column} + excluded.${column}`;
 
-        runSql(sql, upsert, hashStatement(normalized), bucketFloor(now), durationMs, rowsRead, rowsWritten);
+        runSql(sql, upsert, hashStatement(normalized), bucketFloor(now), execCount, durationMs, rowsRead, rowsWritten, execCount);
 
         // Prune once per WINDOW, detected by the bucket changing rather than by
         // sampling a 50ms slice of it. In a DO `Date.now()` is pinned to the last
@@ -494,14 +501,31 @@ const admitStatement = (sql: SqlExec, normalized: string): boolean => {
 };
 
 /**
- * Record one statement execution. Creates the table on first call. Silently
+ * Record one statement's activity. Creates the table on first call. Silently
  * skips recording when the normalised statement is empty (shouldn't happen
  * in practice) or when the table is already at the
  * {@link QUERY_METRICS_MAX_STATEMENTS} cap and the statement is not yet
  * tracked. See `admitStatement` for how the cap check avoids an unconditional
  * `COUNT(*)` on every execution.
+ *
+ * `execCount` (default 1) lets a caller fold several executions of the SAME
+ * statement into one call — `shard-do.ts` does this per dispatch so a
+ * query-in-a-loop handler pays one upsert here instead of one per raw
+ * execution. `durationMs`/`rowsRead`/`rowsWritten` are then the SUM across
+ * `execCount` executions, exactly as `exec_count`/`total_duration_ms` already
+ * accumulate sums across separate calls — folding before calling is
+ * indistinguishable, from this table's point of view, from `execCount`
+ * separate calls with the same totals.
  */
-const recordQueryMetric = (sql: SqlExec, rawSql: string, durationMs: number, rowsRead: number, rowsWritten: number, now: number = Date.now()): void => {
+const recordQueryMetric = (
+    sql: SqlExec,
+    rawSql: string,
+    durationMs: number,
+    rowsRead: number,
+    rowsWritten: number,
+    now: number = Date.now(),
+    execCount: number = 1,
+): void => {
     const normalized = normalizeSql(rawSql);
 
     if (normalized.length === 0) {
@@ -516,15 +540,15 @@ const recordQueryMetric = (sql: SqlExec, rawSql: string, durationMs: number, row
 
     // eslint-disable-next-line no-secrets/no-secrets -- SQL keyword "CONFLICT" triggers the entropy scanner; this is plain DDL, not a secret
     const upsertSql = `INSERT INTO "${QUERY_METRICS_TABLE}" (normalized_sql, exec_count, total_duration_ms, rows_read, rows_written)
-         VALUES (?, 1, ?, ?, ?)
+         VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(normalized_sql) DO UPDATE SET
-             exec_count = exec_count + 1,
+             exec_count = exec_count + excluded.exec_count,
              total_duration_ms = total_duration_ms + excluded.total_duration_ms,
              rows_read = rows_read + excluded.rows_read,
              rows_written = rows_written + excluded.rows_written`;
 
-    runSql(sql, upsertSql, normalized, durationMs, rowsRead, rowsWritten);
-    recordQueryBucket(sql, normalized, durationMs, rowsRead, rowsWritten, now);
+    runSql(sql, upsertSql, normalized, execCount, durationMs, rowsRead, rowsWritten);
+    recordQueryBucket(sql, normalized, durationMs, rowsRead, rowsWritten, now, execCount);
 };
 
 /**

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -151,6 +151,7 @@ export type {
     TableInfo,
     TablePage,
     TablesColumnsResult,
+    TablesIndexesResult,
     WorkflowMetadata,
     WorkflowsResult,
 } from "./introspect";

--- a/packages/shard-engine/src/introspect.ts
+++ b/packages/shard-engine/src/introspect.ts
@@ -78,6 +78,7 @@ const ADMIN_FUNCTIONS = {
     getMetricSeries: "__lunora_admin__:getMetricSeries",
     listSubscriptions: "__lunora_admin__:listSubscriptions",
     listTableIndexes: "__lunora_admin__:listTableIndexes",
+    listTablesIndexes: "__lunora_admin__:listTablesIndexes",
     getLogs: "__lunora_admin__:getLogs",
     getMetrics: "__lunora_admin__:getMetrics",
     getPitrBookmark: "__lunora_admin__:getPitrBookmark",
@@ -254,6 +255,18 @@ interface TableIndexInfo {
 /** Payload of a `__lunora_admin__:listTableIndexes` call: every declared index on the table. */
 interface TableIndexesResult {
     indexes: TableIndexInfo[];
+}
+
+/**
+ * Payload of a `__lunora_admin__:listTablesIndexes` call: declared indexes per
+ * requested table, keyed by table name. The batched sibling of
+ * {@link TableIndexesResult}, mirroring {@link TablesColumnsResult}'s relation
+ * to {@link TableColumnsResult} — one admin RPC for N tables instead of N,
+ * since `tableIndexes` is a cheap, synchronous, schema-sourced lookup (no SQL
+ * query per table to amortize away).
+ */
+interface TablesIndexesResult {
+    indexesByTable: Record<string, TableIndexInfo[]>;
 }
 
 /**
@@ -1706,6 +1719,7 @@ export type {
     TableInfo,
     TablePage,
     TablesColumnsResult,
+    TablesIndexesResult,
     WorkflowInstanceState,
     WorkflowInstanceStatusResult,
     WorkflowMetadata,

--- a/packages/studio/__tests__/features/advisors/insights-panel.test.tsx
+++ b/packages/studio/__tests__/features/advisors/insights-panel.test.tsx
@@ -1,5 +1,5 @@
 import { LunoraProvider } from "@lunora/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { InsightsPanel } from "../../../src/features/advisors/insights-panel";
@@ -222,6 +222,160 @@ describe("insightsPanel", () => {
 
         expect(view.textContent).toContain("Index utilization");
         expect(view.textContent).toContain('Index "byTitle" on table "posts" has recorded no reads');
+    });
+
+    it("batches the index enumeration into one listTablesIndexes call for several tables (STUDIO-04)", async () => {
+        expect.assertions(3);
+
+        const metrics: MetricsSnapshot = { ...HEALTHY, indexHits: [{ index: "byAuthor", reads: 5, table: "posts" }] };
+        const mock = createMockClient({
+            query: (reference): unknown => {
+                if (reference === ADMIN_FUNCTIONS.getMetrics) {
+                    return metrics;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getFunctionStats) {
+                    return EMPTY_STATS;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getAdvisories) {
+                    return { advisories: [] };
+                }
+
+                if (reference === ADMIN_FUNCTIONS.listTables) {
+                    return [
+                        { name: "posts", rowCount: 3 },
+                        { name: "users", rowCount: 2 },
+                    ];
+                }
+
+                if (reference === ADMIN_FUNCTIONS.listTablesIndexes) {
+                    return {
+                        indexesByTable: {
+                            posts: [
+                                { fields: ["authorId"], name: "byAuthor", type: "index" },
+                                { fields: ["title"], name: "byTitle", type: "index" },
+                            ],
+                            users: [],
+                        },
+                    };
+                }
+
+                // The per-table RPC must NOT fire when the batched call succeeds —
+                // reaching here means the panel fell back unnecessarily.
+                throw new Error(`unexpected ${reference}`);
+            },
+        });
+
+        render(renderPanel(mock));
+
+        // The same dead-index reconciliation as the per-table test above, this
+        // time answered entirely from the batched response.
+        fireEvent.click(await screen.findByTestId("lunora-insights-tab-info"));
+        await screen.findByText("Index utilization");
+
+        const view = screen.getByTestId("lunora-insights");
+
+        expect(view.textContent).toContain("Index utilization");
+        expect(view.textContent).toContain('Index "byTitle" on table "posts" has recorded no reads');
+
+        // One call covering both tables, not one per table.
+        const batchedCalls = mock.query.mock.calls.filter(
+            (call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.listTablesIndexes,
+        );
+
+        expect(batchedCalls).toHaveLength(1);
+    });
+
+    it("degrades a stale batched reply once a shard change supersedes it (stale-shard guard)", async () => {
+        expect.assertions(2);
+
+        // shardA's listTablesIndexes reply is deferred — resolved only after
+        // shardB's own enumeration has already completed — proving a late-arriving
+        // reply for a superseded shard can't clobber the current shard's state.
+        let resolveStaleReply: (value: unknown) => void = (_value: unknown) => undefined;
+        const staleReply = new Promise((resolve) => {
+            resolveStaleReply = resolve;
+        });
+
+        const mock = createMockClient({
+            query: (reference, _args, options): unknown => {
+                const shard = (options as { shardKey?: string } | undefined)?.shardKey ?? "";
+
+                if (reference === ADMIN_FUNCTIONS.getMetrics) {
+                    return { ...HEALTHY, indexHits: [] };
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getFunctionStats) {
+                    return EMPTY_STATS;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getAdvisories) {
+                    return { advisories: [] };
+                }
+
+                if (reference === ADMIN_FUNCTIONS.listTables) {
+                    return shard === "shardA" ? [{ name: "legacy", rowCount: 1 }] : [{ name: "posts", rowCount: 1 }];
+                }
+
+                if (reference === ADMIN_FUNCTIONS.listTablesIndexes) {
+                    return shard === "shardA" ? staleReply : { indexesByTable: { posts: [] } };
+                }
+
+                throw new Error(`unexpected ${reference}`);
+            },
+        });
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <InsightsPanel initialShardKey="shardA" />
+            </LunoraProvider>,
+        );
+
+        // Wait for shardA's batched call to have been issued (and left pending)
+        // before switching shards.
+        await waitFor(() => {
+            const issued = mock.query.mock.calls.some((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.listTablesIndexes);
+
+            if (!issued) {
+                throw new Error("shardA's listTablesIndexes not yet issued");
+            }
+        });
+
+        // Switch to shardB before shardA's reply lands (debounced 400ms).
+        fireEvent.change(screen.getByTestId("in-shard-input"), { target: { value: "shardB" } });
+
+        await waitFor(
+            () => {
+                const started = mock.query.mock.calls.some(
+                    (call) =>
+                        (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.listTables &&
+                        (call[2] as { shardKey?: string } | undefined)?.shardKey === "shardB",
+                );
+
+                if (!started) {
+                    throw new Error("shardB enumeration not yet started");
+                }
+            },
+            { timeout: 2000 },
+        );
+
+        // NOW resolve shardA's stale reply, well after shardB has taken over —
+        // it names a table/index shardB's enumeration never reported.
+        resolveStaleReply({ indexesByTable: { legacy: [{ fields: ["x"], name: "stale_index", type: "index" }] } });
+
+        // Give the stale promise's continuation a tick to run — if the guard were
+        // broken, this is where it would overwrite `declaredIndexes`.
+        await new Promise((resolve) => {
+            setTimeout(resolve, 50);
+        });
+
+        const empty = await screen.findByTestId("lunora-insights-empty");
+
+        // shardB's clean state survived: no dead-index advisory at all, and
+        // specifically nothing naming the stale shardA index.
+        expect(empty.textContent).toContain("No errors detected");
+        expect(screen.queryByText(/stale_index/)).toBeNull();
     });
 
     it("auto-refreshes advisories when the tab regains focus (no manual Refresh)", async () => {

--- a/packages/studio/__tests__/features/reports/health-panel.test.tsx
+++ b/packages/studio/__tests__/features/reports/health-panel.test.tsx
@@ -168,6 +168,46 @@ describe("healthPanel SLO view", () => {
         expect(screen.getByTestId("hl-spark-requests")).toBeDefined();
     });
 
+    it("shows a notice when the durable history was truncated by the read limit", async () => {
+        expect.assertions(1);
+
+        const mock = withConnection(
+            createMockClient({
+                query: (reference): unknown => {
+                    if (reference === ADMIN_FUNCTIONS.getLogs) {
+                        return { entries: ENTRIES };
+                    }
+
+                    if (reference === ADMIN_FUNCTIONS.getMetrics) {
+                        return { ...SNAPSHOT, historyTruncated: true };
+                    }
+
+                    if (reference === ADMIN_FUNCTIONS.getFunctionStats) {
+                        return { functions: [] };
+                    }
+
+                    throw new Error(`unexpected ${reference}`);
+                },
+            }),
+        );
+
+        render(renderPanel(mock));
+
+        await screen.findByTestId("hl-history-truncated");
+
+        expect(screen.getByTestId("hl-history-truncated")).toBeDefined();
+    });
+
+    it("does not show the truncation notice when the durable history fits within the read limit", async () => {
+        expect.assertions(1);
+
+        render(renderPanel(sloClient()));
+
+        await screen.findByTestId("hl-spark-requests");
+
+        expect(screen.queryByTestId("hl-history-truncated")).toBeNull();
+    });
+
     it("degrades each SLO tile to — when its read fails, without blanking the panel", async () => {
         expect.assertions(2);
 

--- a/packages/studio/__tests__/features/reports/slo-aggregate.test.ts
+++ b/packages/studio/__tests__/features/reports/slo-aggregate.test.ts
@@ -4,8 +4,8 @@ import type { ShardSloResult } from "../../../src/features/reports/slo-aggregate
 import { dedupeMigrations, mergeFunctionStats, sumShardMetrics } from "../../../src/features/reports/slo-aggregate";
 import type { FunctionCallStat, MetricsSnapshot, MigrationStatusRow } from "../../../src/lib/admin";
 
-const snapshot = (requests: number, errors: number, history: MetricsSnapshot["history"] = []): MetricsSnapshot => {
-    return { cache: null, databaseSize: null, errors, history, requests, shard: "", sinceMs: 0, uptimeMs: 0 };
+const snapshot = (requests: number, errors: number, history: MetricsSnapshot["history"] = [], historyTruncated?: boolean): MetricsSnapshot => {
+    return { cache: null, databaseSize: null, errors, history, historyTruncated, requests, shard: "", sinceMs: 0, uptimeMs: 0 };
 };
 
 const stat = (path: string, calls: number, errors: number): FunctionCallStat => {
@@ -41,6 +41,22 @@ describe("sumShardMetrics", () => {
         ]);
 
         expect(totals.history).toHaveLength(2);
+    });
+
+    it("reports historyTruncated when ANY reachable shard's history was cut", () => {
+        expect.assertions(1);
+
+        const totals = sumShardMetrics([result({ metrics: snapshot(10, 0, [], false) }), result({ metrics: snapshot(20, 0, [], true) })]);
+
+        expect(totals.historyTruncated).toBe(true);
+    });
+
+    it("does not report historyTruncated when no shard was cut", () => {
+        expect.assertions(1);
+
+        const totals = sumShardMetrics([result({ metrics: snapshot(10, 0, [], false) }), result({ metrics: snapshot(20, 0) })]);
+
+        expect(totals.historyTruncated).toBe(false);
     });
 });
 

--- a/packages/studio/src/features/advisors/insights-panel.tsx
+++ b/packages/studio/src/features/advisors/insights-panel.tsx
@@ -20,6 +20,7 @@ import type {
     ShardTrafficResult,
     TableIndexesResult,
     TableInfo,
+    TablesIndexesResult,
 } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
 import { adminRef, callOptions, fireAndForget } from "../../lib/internal";
@@ -50,6 +51,7 @@ interface InsightsPanelProps {
 
 const LIST_TABLES = adminRef(ADMIN_FUNCTIONS.listTables);
 const LIST_TABLE_INDEXES = adminRef(ADMIN_FUNCTIONS.listTableIndexes);
+const LIST_TABLES_INDEXES = adminRef(ADMIN_FUNCTIONS.listTablesIndexes);
 
 /** A 0–1 rate as a one-decimal percentage. */
 const percent = (rate: number): string => `${(rate * 100).toFixed(1)}%`;
@@ -233,15 +235,40 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
         }
     };
 
-    // Enumerate the declared indexes (listTables + listTableIndexes per table) and
-    // fan out the cross-shard traffic feed for `shard` — the two imperative,
-    // multi-step flows that don't fit a single live read. The live `metricsQuery`
-    // already owns the recorded-reads (`indexHits`) half of the dead-index
-    // reconciliation; this supplies the declared-index half. Best-effort and
-    // independent of the metrics reads — a worker without listTables /
-    // listTableIndexes (or without an admin token for them) just yields no declared
-    // indexes, so the dead-index check stays quiet rather than failing the panel.
-    // `recordShard` runs only on a successful read, mirroring the old refresh.
+    // Per-table fan-out fallback: one `listTableIndexes` call per table, kept
+    // for a worker predating the batched `listTablesIndexes` RPC. `Promise.allSettled`
+    // so ONE table's rejected call doesn't drop every other table's declared
+    // indexes — a partial reply degrades gracefully rather than going dormant.
+    const fetchDeclaredIndexesPerTable = async (tableNames: ReadonlyArray<string>, shard: string): Promise<DeclaredIndex[]> => {
+        const indexResults = await Promise.allSettled(
+            tableNames.map(
+                async (name) => [name, (await client.query(LIST_TABLE_INDEXES, { table: name }, callOptions(shard))) as TableIndexesResult] as const,
+            ),
+        );
+
+        const declared: DeclaredIndex[] = [];
+
+        for (const result of indexResults) {
+            if (result.status === "fulfilled") {
+                const [name, payload] = result.value;
+
+                declared.push(...declaredIndexesFor(name, payload.indexes));
+            }
+        }
+
+        return declared;
+    };
+
+    // Enumerate the declared indexes (listTables + one batched listTablesIndexes
+    // call) and fan out the cross-shard traffic feed for `shard` — the two
+    // imperative, multi-step flows that don't fit a single live read. The live
+    // `metricsQuery` already owns the recorded-reads (`indexHits`) half of the
+    // dead-index reconciliation; this supplies the declared-index half.
+    // Best-effort and independent of the metrics reads — a worker without
+    // listTables / listTablesIndexes (or without an admin token for them) just
+    // yields no declared indexes, so the dead-index check stays quiet rather than
+    // failing the panel. `recordShard` runs only on a successful read, mirroring
+    // the old refresh.
     const enumerateShard = useCallback(
         async (shard: string): Promise<void> => {
             // Claim this as the latest enumeration; any earlier in-flight call now
@@ -260,24 +287,30 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
                 recordShard(shard);
                 tableNames = tables.map((table) => table.name);
 
-                const indexResults = await Promise.allSettled(
-                    tables.map(
-                        async (table) =>
-                            [table.name, (await client.query(LIST_TABLE_INDEXES, { table: table.name }, callOptions(shard))) as TableIndexesResult] as const,
-                    ),
-                );
+                let declared: DeclaredIndex[] = [];
 
-                if (latestEnumeratedShard.current !== shard) {
-                    return;
-                }
+                if (tableNames.length > 0) {
+                    try {
+                        // One RPC for every table instead of one per table — the
+                        // fan-out this collapses used to cost a full admin RPC PER
+                        // table on every shard change and `visibilitychange` refresh.
+                        const batched = (await client.query(LIST_TABLES_INDEXES, { tables: tableNames }, callOptions(shard))) as TablesIndexesResult;
 
-                const declared: DeclaredIndex[] = [];
+                        if (latestEnumeratedShard.current !== shard) {
+                            return;
+                        }
 
-                for (const result of indexResults) {
-                    if (result.status === "fulfilled") {
-                        const [name, payload] = result.value;
+                        for (const [name, indexes] of Object.entries(batched.indexesByTable)) {
+                            declared.push(...declaredIndexesFor(name, indexes));
+                        }
+                    } catch {
+                        // Older worker without listTablesIndexes — fall back to the
+                        // per-table fan-out so the dead-index check still works.
+                        declared = await fetchDeclaredIndexesPerTable(tableNames, shard);
 
-                        declared.push(...declaredIndexesFor(name, payload.indexes));
+                        if (latestEnumeratedShard.current !== shard) {
+                            return;
+                        }
                     }
                 }
 
@@ -292,9 +325,10 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
 
             await loadShardTrafficFeed(tableNames, shard);
         },
-        // `fanShardTraffic`/`loadShardTrafficFeed` are render-fresh closures; the
-        // enumeration only needs to re-run on a shard change (or a manual visibility
-        // refresh), so they're intentionally excluded from the cache key.
+        // `fanShardTraffic`/`loadShardTrafficFeed`/`fetchDeclaredIndexesPerTable` are
+        // render-fresh closures; the enumeration only needs to re-run on a shard
+        // change (or a manual visibility refresh), so they're intentionally
+        // excluded from the cache key.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [client],
     );

--- a/packages/studio/src/features/advisors/insights-panel.tsx
+++ b/packages/studio/src/features/advisors/insights-panel.tsx
@@ -269,78 +269,84 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
     // yields no declared indexes, so the dead-index check stays quiet rather than
     // failing the panel. `recordShard` runs only on a successful read, mirroring
     // the old refresh.
-    const enumerateShard = useCallback(
-        async (shard: string): Promise<void> => {
-            // Claim this as the latest enumeration; any earlier in-flight call now
-            // sees a ref mismatch after its awaits and drops its (stale) writes.
-            latestEnumeratedShard.current = shard;
+    //
+    // AN EFFECT EVENT, not a `useCallback`: it reads `fanShardTraffic` /
+    // `loadShardTrafficFeed` / `fetchDeclaredIndexesPerTable`, render-fresh
+    // closures over `loadShardTraffic` and `client`. A memoized callback pinned
+    // to `[client]` would keep whichever of those closures was in scope the
+    // render it was (re)created — so an injected `loadShardTraffic` override
+    // changing later, with `client` unchanged, would silently keep fanning out
+    // through the STALE override. An effect event always resolves through the
+    // latest committed closures without becoming a reactive dependency itself,
+    // so callers (the effect below, and `refreshOnVisible`) don't re-run just
+    // because it was called.
+    const enumerateShard = useEffectEvent(async (shard: string): Promise<void> => {
+        // Claim this as the latest enumeration; any earlier in-flight call now
+        // sees a ref mismatch after its awaits and drops its (stale) writes.
+        latestEnumeratedShard.current = shard;
 
-            let tableNames: string[] = [];
+        let tableNames: string[] = [];
 
-            try {
-                const tables = (await client.query(LIST_TABLES, {}, callOptions(shard))) as TableInfo[];
+        try {
+            const tables = (await client.query(LIST_TABLES, {}, callOptions(shard))) as TableInfo[];
 
-                if (latestEnumeratedShard.current !== shard) {
-                    return;
-                }
+            if (latestEnumeratedShard.current !== shard) {
+                return;
+            }
 
-                recordShard(shard);
-                tableNames = tables.map((table) => table.name);
+            recordShard(shard);
+            tableNames = tables.map((table) => table.name);
 
-                let declared: DeclaredIndex[] = [];
+            let declared: DeclaredIndex[] = [];
 
-                if (tableNames.length > 0) {
-                    try {
-                        // One RPC for every table instead of one per table — the
-                        // fan-out this collapses used to cost a full admin RPC PER
-                        // table on every shard change and `visibilitychange` refresh.
-                        const batched = (await client.query(LIST_TABLES_INDEXES, { tables: tableNames }, callOptions(shard))) as TablesIndexesResult;
+            if (tableNames.length > 0) {
+                try {
+                    // One RPC for every table instead of one per table — the
+                    // fan-out this collapses used to cost a full admin RPC PER
+                    // table on every shard change and `visibilitychange` refresh.
+                    const batched = (await client.query(LIST_TABLES_INDEXES, { tables: tableNames }, callOptions(shard))) as TablesIndexesResult;
 
-                        if (latestEnumeratedShard.current !== shard) {
-                            return;
-                        }
-
-                        for (const [name, indexes] of Object.entries(batched.indexesByTable)) {
-                            declared.push(...declaredIndexesFor(name, indexes));
-                        }
-                    } catch {
-                        // Older worker without listTablesIndexes — fall back to the
-                        // per-table fan-out so the dead-index check still works.
-                        declared = await fetchDeclaredIndexesPerTable(tableNames, shard);
-
-                        if (latestEnumeratedShard.current !== shard) {
-                            return;
-                        }
+                    if (latestEnumeratedShard.current !== shard) {
+                        return;
                     }
-                }
 
-                setDeclaredIndexes(declared);
-            } catch {
-                // listTables unavailable (older worker / no admin token) — no
-                // declared-index enumeration, so the dead-index check is dormant.
-                if (latestEnumeratedShard.current === shard) {
-                    setDeclaredIndexes(null);
+                    for (const [name, indexes] of Object.entries(batched.indexesByTable)) {
+                        declared.push(...declaredIndexesFor(name, indexes));
+                    }
+                } catch {
+                    // Older worker without listTablesIndexes — fall back to the
+                    // per-table fan-out so the dead-index check still works.
+                    declared = await fetchDeclaredIndexesPerTable(tableNames, shard);
+
+                    if (latestEnumeratedShard.current !== shard) {
+                        return;
+                    }
                 }
             }
 
-            await loadShardTrafficFeed(tableNames, shard);
-        },
-        // `fanShardTraffic`/`loadShardTrafficFeed`/`fetchDeclaredIndexesPerTable` are
-        // render-fresh closures; the enumeration only needs to re-run on a shard
-        // change (or a manual visibility refresh), so they're intentionally
-        // excluded from the cache key.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [client],
-    );
+            setDeclaredIndexes(declared);
+        } catch {
+            // listTables unavailable (older worker / no admin token) — no
+            // declared-index enumeration, so the dead-index check is dormant.
+            if (latestEnumeratedShard.current === shard) {
+                setDeclaredIndexes(null);
+            }
+        }
+
+        await loadShardTrafficFeed(tableNames, shard);
+    });
 
     // Drive the imperative enumeration + traffic fan-out on the debounced shard —
     // the live reads (metrics/function-stats/advisories) re-fetch via their own
     // cache key. Previously the panel only reloaded on mount + visibility change, so
     // typing a different shard key never re-fetched the enumeration either.
+    // `enumerateShard` is an effect event, so it's deliberately omitted below —
+    // listing it would be listing a value that's stable by construction and
+    // exists precisely so it ISN'T a reactive dependency.
     useEffect(() => {
         // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- drives an imperative enumeration over the debounced shard — an async load, not derived state
         fireAndForget(enumerateShard(debouncedShard));
-    }, [debouncedShard, enumerateShard]);
+    }, [debouncedShard]);
 
     // Auto-refresh when the tab regains focus. The studio is a standalone app
     // (not a Vite HMR client), so it can't hear codegen reloads directly — but

--- a/packages/studio/src/features/reports/health-panel.tsx
+++ b/packages/studio/src/features/reports/health-panel.tsx
@@ -478,6 +478,11 @@ export const HealthPanel = ({ initialShardKey }: HealthPanelProps): ReactElement
                         {metricsError}
                     </div>
                 )}
+                {metricsError === null && totals?.historyTruncated === true && (
+                    <div className="border-t border-border bg-warning/5 px-4 py-2 text-sm text-muted-foreground" data-testid="hl-history-truncated">
+                        {t("Showing a partial request/error history — one or more shards have more data than the trend chart can display.")}
+                    </div>
+                )}
             </Card>
 
             {/* Service-level KPIs — status-coloured, with trend sparklines. */}

--- a/packages/studio/src/features/reports/slo-aggregate.ts
+++ b/packages/studio/src/features/reports/slo-aggregate.ts
@@ -21,6 +21,13 @@ interface SloTotals {
     failed: number;
     /** Every shard's per-function buckets, concatenated; collapse on `bucketMs` for the trend sparkline. */
     history: MetricsHistoryBucket[];
+
+    /**
+     * True when ANY reachable shard's `history` was cut by its read limit — one
+     * truncated shard is enough to make the app-wide trend a partial window, so
+     * this is an OR across shards, not a per-shard flag the caller re-derives.
+     */
+    historyTruncated: boolean;
     /** Shards that returned a snapshot. */
     reachable: number;
     requests: number;
@@ -37,6 +44,7 @@ const sumShardMetrics = (results: ReadonlyArray<ShardSloResult>): SloTotals => {
     let errors = 0;
     let reachable = 0;
     let failed = 0;
+    let historyTruncated = false;
     const history: MetricsHistoryBucket[] = [];
 
     for (const { metrics } of results) {
@@ -50,9 +58,10 @@ const sumShardMetrics = (results: ReadonlyArray<ShardSloResult>): SloTotals => {
         requests += metrics.requests;
         errors += metrics.errors;
         history.push(...(metrics.history ?? []));
+        historyTruncated ||= metrics.historyTruncated === true;
     }
 
-    return { errors, failed, history, reachable, requests };
+    return { errors, failed, history, historyTruncated, reachable, requests };
 };
 
 /**

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -64,6 +64,7 @@ export const ADMIN_FUNCTIONS = {
     listQueues: "__lunora_admin__:listQueues",
     listSubscriptions: "__lunora_admin__:listSubscriptions",
     listTableIndexes: "__lunora_admin__:listTableIndexes",
+    listTablesIndexes: "__lunora_admin__:listTablesIndexes",
     listWorkflows: "__lunora_admin__:listWorkflows",
     getLogs: "__lunora_admin__:getLogs",
     getMetricHistory: "__lunora_admin__:getMetricHistory",
@@ -400,6 +401,16 @@ export interface TableIndexInfo {
 /** Payload of a `__lunora_admin__:listTableIndexes` call, mirroring `@lunora/do`'s `TableIndexesResult`. */
 export interface TableIndexesResult {
     indexes: TableIndexInfo[];
+}
+
+/**
+ * Payload of a `__lunora_admin__:listTablesIndexes` call, mirroring
+ * `@lunora/do`'s `TablesIndexesResult` — the batched sibling of
+ * {@link TableIndexesResult}, one RPC for every requested table instead of one
+ * per table (mirrors `TablesColumnsResult`'s relation to `TableColumnsResult`).
+ */
+export interface TablesIndexesResult {
+    indexesByTable: Record<string, TableIndexInfo[]>;
 }
 
 /**

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -290,6 +290,14 @@ export interface QueryStatEntry {
 export interface MetricsSnapshot extends ShardMetrics {
     functions?: FunctionCallStat[];
     history?: MetricsHistoryBucket[];
+
+    /**
+     * True when the DO's durable bucket table held more rows than the read
+     * limit could return, so `history` is a partial (newest) window rather
+     * than the shard's full retained history. Absent on a worker predating
+     * the signal — treat a missing value the same as `false`.
+     */
+    historyTruncated?: boolean;
     /** Per-declared-index recorded reads; absent on a worker predating the dead-index feed. */
     indexHits?: MetricsIndexHit[];
 

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -1041,6 +1041,7 @@ const MESSAGE_IDS = [
     "One or more service levels are breached.",
     "Some service levels need attention.",
     "All service levels are within target.",
+    "Showing a partial request/error history — one or more shards have more data than the trend chart can display.",
     // Analytics Engine usage panel.
     "Analytics",
     "Analytics is not configured.",


### PR DESCRIPTION
Five independent fixes (one commit each) across the metrics/telemetry path.

## A — OBS-02: metrics DDL/COUNT off the hot path
`recordFunctionMetric` (once per RPC dispatch) called `ensureFunctionMetricsTables` unconditionally — two `ALTER TABLE ADD COLUMN` in try/catch that **throw `duplicate column name` on every call after the first** (two swallowed SQLite errors per invocation forever, hiding any real error), plus an unconditional `SELECT COUNT(*)` (no O(1) count on DO SQLite — a PK scan billed rows-read, growing with cardinality). Now: `ensure*` memoized per SQL handle via `WeakSet` (mirrors `metric-history.ts`); the `COUNT(*)` replaced with an `admitPath`/`admitStatement` known-key cache (cheap PK lookup, full count only on a genuinely new key). Same in `query-metrics.ts`.

**Post-hibernation safety** (the reviewer concern): all caches are keyed by SQL-handle object identity (`WeakSet`/`WeakMap`), so a fresh handle after hibernation starts cold and re-ensures — never skips a `CREATE`. Explicit regression tests in both `function-metrics.test.ts` and `query-metrics.test.ts` wrap the same storage in a brand-new handle and prove the DDL re-ensure and cap re-verification survive a simulated restart.

## B — OBS-04: bound + dedupe the statement sample buffer
`currentStmtSamples` was an unbounded array (full raw SQL per entry); a query-in-a-loop handler accumulated one string per query then paid ~5× amplification draining it. Now a `Map` folded by raw text, capped at 200 distinct entries, one `recordQueryMetric` per distinct statement; `db.stmt_samples_truncated` set on the wide event when capped. `recordQueryMetric`/`recordQueryBucket` gained an additive `execCount` param (default 1) so a folded batch's `exec_count`/`total_duration_ms` and the latency histogram stay accurate.

## C — OBS-03: truncation signal on the metric-bucket read
The all-paths bucket read truncated at `LIMIT 1000` with no signal, silently shrinking the Metrics window as the app grows. Now `readFunctionMetricBuckets` uses a `LIMIT+1` probe and returns `{ buckets, truncated }`, threaded through `getMetrics` → the Studio's cross-shard `SloTotals.historyTruncated` (OR across shards) → a notice on the health panel.

## D — OBS-05: export the barrel's types
Re-exported every barrel function's param/return types (audited all, not just the plan's examples): `MetricHistoryResult`, `QueryInsight*`, `DanglingReference*`, `ReadRequestLogOptions`/`RequestLogEntry`/`ErrorIssue`/`ReadIssuesOptions`, `Span*`, `HostSpanLike`, `MetricEvent`/`MetricKind`, etc. — so a second host can write a typed wrapper.

## E — STUDIO-04: batch the Insights index enumeration
The advisors Insights panel issued one `listTableIndexes` RPC **per table** (41 RPCs on a 40-table app), re-run on every shard change + `visibilitychange`. Added a batched `listTablesIndexes` admin RPC (sibling of `listTableIndexes`, mirroring the existing `describeTable`→`describeTables` batching precedent exactly) and collapsed the fan-out to one call, keeping the per-table fallback behind the existing catch for older workers. A research pass confirmed `ADMIN_FUNCTIONS` is a hand-maintained string-constant object with no codegen/allowlist coupling, so the server-RPC path (not the client-side fallback) was the low-risk choice.

## Verification
observability 202, do (stmt-samples + function-metrics + shard-do.admin) 134, studio (insights + health + slo-aggregate) 28 — all green. `lint:types` clean; **api-surface gate passes (43/43 snapshots)** after regenerating `observability`/`lunora`/`shard-engine` **and `studio`** (the last was regenerated during review — the new `listTablesIndexes` key needed pinning in `studio.api.md`).

## Scope note
Section B touched `query-metrics.ts` (the additive `execCount` param) — one file outside B's literal scope but necessary to keep `exec_count`/duration/histogram correct under folding; minimal and backward-compatible.

## Merge-order notes
Touches hot files shared with other open PRs — individually mergeable vs `alpha`:
- `packages/do/src/shard-do.ts` (also in the shard-engine/DO PRs #243, #262) — the edits here are the metrics/admin paths; resolve by keeping both sides.
- `packages/shard-engine/src/index.ts` (also #267) — both append exports; keep both.
- observability (#263) and studio (#264) overlaps are in different files/regions.

Plan: `plans/228-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added batched table-index inspection to improve schema loading in Studio.
  - Expanded observability exports for telemetry, query insights, request logs, metrics, and storage diagnostics.
  - SQL telemetry now tracks execution counts, totals, and distinct statements.

- **Bug Fixes**
  - Improved metrics history handling with truncation detection.
  - Studio now warns when request and error trends are incomplete.
  - Optimized repeated metrics and schema lookups for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->