### PR TITLE
refactor: collapse dedup-drift risks (constantTimeEqual, error catalog, concurrency loops, umbrella exports, Studio shard-key hook)

### DIFF
--- a/packages/errors/__tests__/catalog-registration.test.ts
+++ b/packages/errors/__tests__/catalog-registration.test.ts
@@ -1,0 +1,103 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ERROR_CATALOG } from "../src";
+
+// Repo root, three levels up from packages/errors/__tests__.
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+const PACKAGES_ROOT = join(REPO_ROOT, "packages");
+
+const SKIP_DIRECTORIES = new Set([
+    ".git",
+    ".history",
+    ".vis",
+    ".wrangler",
+    "__fixtures__",
+    "__tests__",
+    "coverage",
+    "dist",
+    "fixtures",
+    "node_modules",
+    "test-results",
+]);
+
+// Matches the two shapes a Lunora package mints an error code in: the
+// `{ code: "X", ... }` structured-error/options shape, and a direct
+// `new LunoraError("X", ...)` first-argument literal. Deliberately textual
+// (not AST-based) — this is meant to catch a *future* uncatalogued code the
+// same cheap way a reviewer would grep for one.
+const CODE_PATTERN = /code:\s*"([A-Z][A-Z0-9_]*)"|new LunoraError\(\s*"([A-Z][A-Z0-9_]*)"/g;
+
+/** Recursively collect `.ts`/`.tsx` source files under `dir`, skipping build/vendor/test directories. */
+const collectSourceFiles = (dir: string): string[] => {
+    const entries = readdirSync(dir);
+    const files: string[] = [];
+
+    for (const entry of entries) {
+        if (SKIP_DIRECTORIES.has(entry)) {
+            continue;
+        }
+
+        const fullPath = join(dir, entry);
+        const stats = statSync(fullPath);
+
+        /* eslint-disable vitest/no-conditional-tests -- filesystem walk, not a test-behavior branch; the file-type check is inherent to recursing a directory tree */
+        if (stats.isDirectory()) {
+            files.push(...collectSourceFiles(fullPath));
+        } else if (/\.tsx?$/.test(entry) && !entry.endsWith(".d.ts")) {
+            files.push(fullPath);
+        }
+        /* eslint-enable vitest/no-conditional-tests */
+    }
+
+    return files;
+};
+
+/** Every `packages/&lt;name>/src` directory in the monorepo. */
+const packageSourceDirs = (): string[] => {
+    const dirs: string[] = [];
+
+    for (const packageDirectory of readdirSync(PACKAGES_ROOT)) {
+        const srcDir = join(PACKAGES_ROOT, packageDirectory, "src");
+
+        try {
+            if (statSync(srcDir).isDirectory()) {
+                dirs.push(srcDir);
+            }
+        } catch {
+            // No src/ directory for this package — nothing to scan.
+        }
+    }
+
+    return dirs;
+};
+
+describe("error catalog registration", () => {
+    it("every minted SCREAMING_SNAKE_CASE error code across packages/*/src is a catalog key", () => {
+        expect.assertions(1);
+
+        const catalogKeys = new Set(Object.keys(ERROR_CATALOG));
+        const missing = new Map<string, string>();
+
+        for (const srcDir of packageSourceDirs()) {
+            for (const filePath of collectSourceFiles(srcDir)) {
+                const content = readFileSync(filePath, "utf8");
+
+                for (const match of content.matchAll(CODE_PATTERN)) {
+                    const code = match[1] ?? match[2];
+
+                    if (code !== undefined && !catalogKeys.has(code) && !missing.has(code)) {
+                        missing.set(code, filePath.replace(`${REPO_ROOT}/`, ""));
+                    }
+                }
+            }
+        }
+
+        expect(
+            [...missing.entries()].map(([code, file]) => `${code} (first seen in ${file})`),
+            "Found error code(s) minted outside ERROR_CATALOG. Register each with a status/title (and internal: true if its message can carry backend detail) in packages/errors/src/catalog.ts.",
+        ).toStrictEqual([]);
+    });
+});

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -174,6 +174,164 @@ export const ERROR_CATALOG = {
     ANALYTICS_SQL_ERROR: { status: 502, title: "Analytics Engine SQL API error" },
     R2_SQL_ERROR: { status: 502, title: "R2 SQL API error" },
     WORKFLOWS_REST_ERROR: { status: 502, title: "Cloudflare Workflows REST API error" },
+
+    /**
+     * Admin-gated `/_lunora/admin/*` and `__lunora_admin__:*` codes. Registered
+     * here (plan 230, ERRORS-01) after an audit found them minted with `code:`
+     * but never added to the catalog — `isInternalCode` fails OPEN for an
+     * unregistered code, so each was already echoing its message unredacted.
+     * Below is that audit's verdict per code, not a blanket allow: most of these
+     * are deliberately actionable ("you forgot to configure X") and stay
+     * client-safe; the ones that can carry backend detail are flagged
+     * `internal: true` individually, with the reason noted alongside.
+     */
+    ADMIN_FORBIDDEN: { status: 403, title: "Admin access forbidden" },
+    ADMIN_TOKEN_NOT_CONFIGURED: { status: 400, title: "Admin token not configured" },
+    AUTH_NOT_CONFIGURED: { status: 400, title: "Auth admin not configured" },
+    AUTH_OP_NOT_SUPPORTED: { status: 400, title: "Auth admin operation not supported" },
+    BACKUP_NOT_CONFIGURED: { status: 500, title: "Scheduled backup not configured" },
+    CRON_JOBS_NOT_CONFIGURED: { status: 400, title: "Cron jobs not configured" },
+    CRON_JOB_NOT_FOUND: { status: 404, title: "Cron job not found" },
+    EXPORT_TAP_NOT_CONFIGURED: { status: 400, title: "Export tap not configured" },
+    FUNCTIONS_NOT_CONFIGURED: { status: 400, title: "Functions registry not configured" },
+    GLOBALS_NOT_CONFIGURED: { status: 400, title: "Global-table introspector not configured" },
+    KV_NOT_CONFIGURED: { status: 400, title: "KV introspector not configured" },
+    MIGRATION_ID_REQUIRED: { status: 400, title: "Migration id required" },
+    PITR_UNAVAILABLE: { status: 409, title: "Point-in-time recovery unavailable" },
+    SCHEDULER_NOT_CONFIGURED: { status: 400, title: "Scheduler not configured" },
+    STORAGE_DELETE_NOT_CONFIGURED: { status: 400, title: "Storage delete not configured" },
+    STORAGE_NOT_CONFIGURED: { status: 400, title: "Storage not configured" },
+    STORAGE_UPLOAD_NOT_CONFIGURED: { status: 400, title: "Storage upload not configured" },
+    STORAGE_URL_NOT_CONFIGURED: { status: 400, title: "Storage signed URL not configured" },
+    VECTORS_NOT_CONFIGURED: { status: 400, title: "Vector index introspector not configured" },
+    VECTOR_QUERY_UNSUPPORTED: { status: 400, title: "Vector index querying not enabled" },
+    WORKFLOWS_NOT_CONFIGURED: { status: 501, title: "Workflows not configured" },
+
+    /** The auth/security audit read plane (`__lunora_admin__:getAuthAuditLog`). */
+    AUTH_AUDIT_NOT_CONFIGURED: { status: 400, title: "Auth audit reader not configured" },
+
+    /**
+     * Backend/DB failure reading the auth audit store. The throw site already
+     * keeps the message generic and logs the real error server-side only — flagged
+     * `internal: true` anyway as the deliberate posture for "a backend read
+     * failed", so a future edit that inlines the driver error can't leak it.
+     */
+    AUTH_AUDIT_READ_FAILED: { internal: true, status: 500, title: "Auth audit read failed" },
+
+    /**
+     * Cron-job codes. The `*_NOT_STATIC` / `_INVALID` family are codegen
+     * build-time diagnostics — like `CODEGEN_DIAGNOSTIC`, they're thrown as plain
+     * messages into the CLI/Vite-overlay output, never cross the RPC wire, and are
+     * deliberately not `internal` (the message IS the fix). `CRON_JOB_FAILED` is
+     * the one runtime-reachable code in this family — its message interpolates
+     * binding/function/job names from the deployment, so it is flagged internal.
+     */
+    CRON_EXPR_INVALID: { status: 500, title: "Invalid cron expression" },
+    CRON_EXPR_NOT_STATIC: { status: 500, title: "Cron expression is not statically analyzable" },
+    CRON_JOB_FAILED: { internal: true, status: 500, title: "Cron job failed" },
+    CRON_NAME_NOT_STATIC: { status: 500, title: "Cron job name is not statically analyzable" },
+    CRON_NON_STATIC_FN: { status: 500, title: "Cron function reference is not statically analyzable" },
+    CRON_NON_STATIC_VALUE: { status: 500, title: "Cron value is not statically analyzable" },
+    CRON_SCHEDULE_NOT_STATIC: { status: 500, title: "Cron schedule is not statically analyzable" },
+    DUPLICATE_CRON_NAME: { status: 500, title: "Duplicate cron job name" },
+
+    /** More codegen build-time diagnostics — see the cron-family comment above; same reasoning applies. */
+    DUPLICATE_AGENT_BINDING: { status: 500, title: "Duplicate agent binding" },
+    DUPLICATE_AGENT_CLASS: { status: 500, title: "Duplicate agent generated class name" },
+    DUPLICATE_AGENT_NAME: { status: 500, title: "Duplicate agent name" },
+    DUPLICATE_MIGRATION_ID: { status: 500, title: "Duplicate migration id" },
+    DUPLICATE_QUEUE_BINDING: { status: 500, title: "Duplicate queue binding" },
+    DUPLICATE_QUEUE_NAME: { status: 500, title: "Duplicate queue name" },
+    DUPLICATE_WORKFLOW_CLASS: { status: 500, title: "Duplicate workflow generated class name" },
+    MIGRATION_ID_NOT_STATIC: { status: 500, title: "Migration id is not statically analyzable" },
+    NAMESPACE_COLLISION: { status: 500, title: "Function namespace collision" },
+
+    /**
+     * `@lunora/runtime`'s dispatch/security-boundary codes — RPC/HTTP entry, not
+     * admin-gated. Fixed, non-sensitive messages throughout, so none are `internal`.
+     */
+    BAD_ROW: { status: 400, title: "Malformed import row" },
+    BAD_SUBSCRIPTION_ARGS: { status: 400, title: "Invalid subscription arguments" },
+    BATCH_LIMIT_EXCEEDED: { status: 400, title: "Batch limit exceeded" },
+    CROSS_SHARD_RANK_UNSUPPORTED: { status: 400, title: "Cross-shard rank() is unsupported" },
+    FORBIDDEN_FANOUT: { status: 403, title: "Fan-out forbidden" },
+    FORBIDDEN_ORIGIN: { status: 403, title: "Origin forbidden" },
+    FORBIDDEN_SHARD: { status: 403, title: "Shard access forbidden" },
+    GLOBAL_NOT_CONFIGURED: { status: 400, title: "Global table import not configured" },
+    INVALID_INPUT: { status: 400, title: "Invalid input" },
+    RATE_LIMITED: { status: 429, title: "Rate limited" },
+    /** Thrown by `@lunora/auth` (Turnstile) and `@lunora/ratelimit` — an upstream dependency didn't respond. Fixed, safe message. */
+    SERVICE_UNAVAILABLE: { status: 503, title: "Service unavailable" },
+    SHAPE_CROSS_SHARD_JOIN: { status: 400, title: "Shape cross-shard join is unsupported" },
+    UNAUTHENTICATED: { status: 401, title: "Unauthenticated" },
+    UNKNOWN_COLUMN: { status: 404, title: "Unknown column" },
+
+    /**
+     * `@lunora/do`'s ShardDO — WebSocket-frame codes and SQLite-in-DO invariants.
+     * `NESTED_TRANSACTION` and `SQL_UNAVAILABLE` are "should never happen" state
+     * invariants (mirrors `RUN_DEPTH_EXCEEDED`'s posture above): today's message
+     * is static and safe, but flagged internal so a future edit that adds
+     * diagnostic detail can't accidentally start leaking it.
+     */
+    EXPIRED: { status: 404, title: "Session expired" },
+    NESTED_TRANSACTION: { internal: true, status: 500, title: "Nested transaction" },
+    OUT_OF_ORDER: { status: 409, title: "Out-of-order mutation" },
+    SHAPE_GLOBAL_TOO_LARGE: { status: 413, title: "Global shape too large" },
+    SHAPE_NOT_FOUND: { status: 404, title: "Shape not found" },
+    SQL_UNAVAILABLE: { internal: true, status: 500, title: "SQL storage unavailable" },
+    TOKEN_EXPIRED: { status: 401, title: "Authentication token expired" },
+    TOO_MANY_STREAMS: { status: 429, title: "Too many streams" },
+    UNKNOWN_ADMIN_OP: { status: 404, title: "Unknown admin operation" },
+
+    /**
+     * `@lunora/shard-engine`'s relay hub (cross-shard shape relay coordination).
+     * Mirrors `SHARD_ERROR`/`SHARD_UNAVAILABLE` above: operational status for an
+     * app's own relay topology, not a secret — not `internal`.
+     */
+    RELAY_CANNOT_SEED: { status: 500, title: "Relay cannot seed" },
+    RELAY_MISCONFIGURED: { status: 500, title: "Relay misconfigured" },
+    RELAY_SEED_FAILED: { status: 502, title: "Relay seed failed" },
+
+    /**
+     * A worker option required by the request path is absent (a deploy-config
+     * gap, not a caller error) — the fixed message names the missing option, so
+     * it's actionable and echoed. `MISCONFIGURED` is the one exception: its
+     * message interpolates the caller-supplied `functionPath`, and it's the code
+     * this plan's audit found live-leaking (`create-worker.ts`'s x402 gate).
+     */
+    MISCONFIGURED: { internal: true, status: 500, title: "Worker misconfigured" },
+
+    /** `@lunora/nuxt`'s Nitro bridge: the request carried no Cloudflare bindings. Fixed, safe message. */
+    LUNORA_RUNTIME_UNAVAILABLE: { status: 500, title: "Lunora runtime unavailable" },
+
+    /**
+     * `@lunora/replica`'s event-log Durable Object: generic request-handler
+     * catch-all, mirroring `INTERNAL`/`INTERNAL_SERVER_ERROR`/`RPC_FAILED` above
+     * — the real error is logged server-side only, never in this code's message.
+     */
+    INTERNAL_ERROR: { internal: true, status: 500, title: "Internal error" },
+
+    /**
+     * Client-SDK-only codes (`@lunora/client`), thrown locally in the browser/app
+     * process rather than by the server — `internal`'s wire-redaction semantics
+     * don't apply the same way here, since the "wire" is the app's own code
+     * catching its own client's exception. Kept in the catalog for the client's
+     * `code`-discrimination union and Studio/CLI rendering consistency.
+     */
+    BROWSER_TIMEOUT: { status: 504, title: "Browser operation timed out" },
+    CLIENT_CLOSED: { status: 400, title: "Client is closed" },
+    HTTP_STREAM_BAD_CHUNK: { status: 502, title: "Malformed HTTP stream chunk" },
+    HTTP_STREAM_INTERRUPTED: { status: 502, title: "HTTP stream interrupted" },
+    HTTP_STREAM_MISSING_PARAM: { status: 400, title: "HTTP stream missing path parameter" },
+    HTTP_STREAM_NO_BODY: { status: 502, title: "HTTP stream response has no body" },
+    HTTP_STREAM_STATUS: { status: 502, title: "HTTP stream request failed" },
+    HTTP_STREAM_TRANSPORT: { status: 502, title: "HTTP stream transport error" },
+    STREAM_BACKPRESSURE: { status: 429, title: "Stream backpressure" },
+    STREAM_DISCONNECTED: { status: 503, title: "Stream disconnected" },
+    STREAM_QUEUE_OVERFLOW: { status: 429, title: "Stream queue overflow" },
+
+    /** `@lunora/db`'s offline outbox: a queued write targeted a collection removed/renamed in a later deploy. */
+    UNKNOWN_MUTATION_FN: { status: 404, title: "Unknown mutation function" },
 } as const;
 
 // Shape validation kept as a standalone statement: `as const satisfies …` is not

--- a/packages/lunora/__tests__/re-exports.test.ts
+++ b/packages/lunora/__tests__/re-exports.test.ts
@@ -1,49 +1,142 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const monorepoPackagesRoot = join(packageRoot, "..");
 
 const sorted = (keys: ReadonlyArray<string>): ReadonlyArray<string> => [...keys].toSorted((a, b) => a.localeCompare(b));
 
-// The umbrella is a pure re-export surface: each subpath must forward the
-// upstream package's public API unchanged. These smoke tests guard against a
-// subpath silently dropping its barrel (e.g. a typo in `export *`) or the
-// export map drifting from the underlying package's surface.
+interface UpstreamManifest {
+    exports?: Record<string, unknown>;
+    name: string;
+}
 
-// [umbrella specifier, upstream specifier]. The default entry (`lunorash`)
-// mirrors `@lunora/server`; every other subpath forwards its namesake.
-const reExports: ReadonlyArray<readonly [string, string]> = [
-    ["lunorash", "@lunora/server"],
-    ["lunorash/server", "@lunora/server"],
-    ["lunorash/server/types", "@lunora/server/types"],
-    ["lunorash/server/data-model", "@lunora/server/data-model"],
-    ["lunorash/server/drizzle", "@lunora/server/drizzle"],
-    ["lunorash/server/rls/testing", "@lunora/server/rls/testing"],
-    ["lunorash/values", "@lunora/values"],
-    ["lunorash/runtime", "@lunora/runtime"],
-    ["lunorash/do", "@lunora/do"],
-    ["lunorash/platform", "@lunora/platform"],
-    ["lunorash/observability", "@lunora/observability"],
-    ["lunorash/client", "@lunora/client"],
-    ["lunorash/client/query", "@lunora/client/query"],
-    ["lunorash/client/auth", "@lunora/client/auth"],
-    ["lunorash/client/pagination", "@lunora/client/pagination"],
-    ["lunorash/client/ssr", "@lunora/client/ssr"],
-    ["lunorash/errors", "@lunora/errors"],
-    ["lunorash/ratelimit", "@lunora/ratelimit"],
-    ["lunorash/flags", "@lunora/flags"],
-    // The flags providers are re-exported under a flattened alias: the umbrella
-    // exposes `lunorash/flags/<provider>` for `@lunora/flags/providers/<provider>`.
-    ["lunorash/flags/env", "@lunora/flags/providers/env"],
-    ["lunorash/flags/flagship", "@lunora/flags/providers/flagship"],
-    ["lunorash/flags/memory", "@lunora/flags/providers/memory"],
-    ["lunorash/flags/web", "@lunora/flags/web"],
+const readManifest = (packageDirName: string): UpstreamManifest =>
+    JSON.parse(readFileSync(join(monorepoPackagesRoot, packageDirName, "package.json"), "utf8")) as UpstreamManifest;
+
+const umbrellaManifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as UpstreamManifest;
+const umbrellaSubpaths = new Set(Object.keys(umbrellaManifest.exports ?? {}));
+
+// Every upstream package the umbrella re-exports from, and the `packages/<dir>`
+// its manifest lives in. `@lunora/server`'s "." also aliases to the bare
+// `lunorash` default export (see `packages/lunora/src/index.ts`) — everything
+// else maps 1:1 onto `lunorash/<the upstream package's own unscoped name>`.
+const UPSTREAM_PACKAGE_DIRS: ReadonlyArray<string> = [
+    "server",
+    "values",
+    "errors",
+    "runtime",
+    "do",
+    "platform",
+    "observability",
+    "client",
+    "flags",
+    "ratelimit",
 ];
 
+// Key shared by OPT_OUT/ALIAS_SUFFIX below and the lookup in buildReExportCases:
+// the upstream package name with its subpath appended verbatim (subpath's
+// leading "." dropped, so "." itself contributes nothing) — e.g. "@lunora/flags/providers/env".
+const upstreamKey = (packageName: string, upstreamSubpath: string): string => `${packageName}${upstreamSubpath.slice(1)}`;
+
+/**
+ * Upstream subpaths deliberately NOT re-exported by the umbrella, with the
+ * reason each is excluded. Anything upstream not covered by this list or by
+ * {@link ALIAS_SUFFIX} must resolve to a real `lunorash/*` subpath — that's
+ * the parity check below. Add a new opt-out here (with a reason) rather than
+ * letting a future upstream subpath silently fall through the umbrella.
+ */
+const OPT_OUT = new Map<string, string>([
+    [
+        upstreamKey("@lunora/platform", "./conformance"),
+        "the behavioural TCK versions in lockstep with the @lunora/platform contracts it asserts, not the umbrella's opinionated re-export surface — a host author consumes @lunora/platform/conformance directly",
+    ],
+    [upstreamKey("@lunora/platform", "./conformance/suite"), "same as ./conformance above — the workerd-safe pure suite is part of the same TCK"],
+]);
+
+/**
+ * Upstream subpaths the umbrella re-exports under a DIFFERENT suffix than the
+ * upstream's own subpath — `@lunora/flags`'s `./providers/&lt;name>` collapses
+ * to `lunorash/flags/&lt;name>`, the umbrella's own naming choice. Maps
+ * `&lt;upstream package name>&lt;upstream subpath>` to the umbrella suffix (the
+ * part after `lunorash/&lt;prefix>`) it resolves to instead of the verbatim
+ * upstream subpath.
+ */
+const ALIAS_SUFFIX = new Map<string, string>([
+    [upstreamKey("@lunora/flags", "./providers/env"), "/env"],
+    [upstreamKey("@lunora/flags", "./providers/flagship"), "/flagship"],
+    [upstreamKey("@lunora/flags", "./providers/memory"), "/memory"],
+]);
+
+interface ReExportCase {
+    umbrellaSpecifier: string;
+    umbrellaSubpath: string;
+    upstreamSpecifier: string;
+}
+
+const buildReExportCases = (): ReExportCase[] => {
+    const cases: ReExportCase[] = [];
+
+    for (const dir of UPSTREAM_PACKAGE_DIRS) {
+        const manifest = readManifest(dir);
+        const prefix = manifest.name.replace(/^@lunora\//, "");
+
+        for (const upstreamSubpath of Object.keys(manifest.exports ?? {})) {
+            if (upstreamSubpath === "./package.json") {
+                continue;
+            }
+
+            const key = upstreamKey(manifest.name, upstreamSubpath);
+
+            if (OPT_OUT.has(key)) {
+                continue;
+            }
+
+            // `.` (upstream root) maps to `lunorash/<prefix>` with no suffix;
+            // every other upstream subpath appends its own segment (aliased or not).
+            const suffix = ALIAS_SUFFIX.get(key) ?? (upstreamSubpath === "." ? "" : upstreamSubpath.slice(1));
+            const umbrellaSubpath = `./${prefix}${suffix}`;
+
+            cases.push({
+                umbrellaSpecifier: `lunorash${umbrellaSubpath.slice(1)}`,
+                umbrellaSubpath,
+                upstreamSpecifier: upstreamSubpath === "." ? manifest.name : `${manifest.name}${upstreamSubpath.slice(1)}`,
+            });
+        }
+    }
+
+    // `@lunora/server`'s root additionally aliases to the bare umbrella default
+    // export (`import { query } from "lunorash"`), not just `lunorash/server`.
+    cases.push({ umbrellaSpecifier: "lunorash", umbrellaSubpath: ".", upstreamSpecifier: "@lunora/server" });
+
+    return cases;
+};
+
+const reExportCases = buildReExportCases();
+
 describe("lunora umbrella re-exports", () => {
-    it.each(reExports)("forwards %s from %s", async (umbrella, upstream) => {
-        expect.assertions(1);
+    it("has a mapping for every upstream subpath (deliberate opt-outs excepted)", () => {
+        expect.hasAssertions();
 
-        const viaUmbrella = await import(umbrella);
-        const direct = await import(upstream);
-
-        expect(sorted(Object.keys(viaUmbrella))).toStrictEqual(sorted(Object.keys(direct)));
+        for (const { umbrellaSubpath, upstreamSpecifier } of reExportCases) {
+            expect(umbrellaSubpaths.has(umbrellaSubpath), `${upstreamSpecifier} has no matching ${umbrellaSubpath} entry in packages/lunora/package.json`).toBe(
+                true,
+            );
+        }
     });
+
+    it.each(reExportCases.map(({ umbrellaSpecifier, upstreamSpecifier }): [string, string] => [umbrellaSpecifier, upstreamSpecifier]))(
+        "forwards %s from %s",
+        async (umbrella, upstream) => {
+            expect.assertions(1);
+
+            const viaUmbrella = await import(umbrella);
+            const direct = await import(upstream);
+
+            expect(sorted(Object.keys(viaUmbrella))).toStrictEqual(sorted(Object.keys(direct)));
+        },
+    );
 });

--- a/packages/lunora/package.json
+++ b/packages/lunora/package.json
@@ -62,6 +62,10 @@
             "types": "./dist/server/rls/testing.d.ts",
             "import": "./dist/server/rls/testing.mjs"
         },
+        "./server/otel": {
+            "types": "./dist/server/otel.d.ts",
+            "import": "./dist/server/otel.mjs"
+        },
         "./values": {
             "types": "./dist/values.d.ts",
             "import": "./dist/values.mjs"
@@ -105,6 +109,10 @@
         "./client/ssr": {
             "types": "./dist/client/ssr.d.ts",
             "import": "./dist/client/ssr.mjs"
+        },
+        "./client/upload": {
+            "types": "./dist/client/upload.d.ts",
+            "import": "./dist/client/upload.mjs"
         },
         "./flags": {
             "types": "./dist/flags.d.ts",

--- a/packages/lunora/src/client/upload.ts
+++ b/packages/lunora/src/client/upload.ts
@@ -1,0 +1,1 @@
+export * from "@lunora/client/upload";

--- a/packages/lunora/src/server/otel.ts
+++ b/packages/lunora/src/server/otel.ts
@@ -1,0 +1,1 @@
+export * from "@lunora/server/otel";

--- a/packages/runtime/__tests__/constant-time-equal-dedup.test.ts
+++ b/packages/runtime/__tests__/constant-time-equal-dedup.test.ts
@@ -1,0 +1,79 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// Repo root, three levels up from packages/runtime/__tests__.
+const REPO_ROOT = join(__dirname, "..", "..", "..");
+
+const CANONICAL_FILE = "shared/constant-time-equal.ts";
+
+// Known pre-existing copy, tracked as a deliberate follow-up (plan 230,
+// SHARED-01) rather than fixed here — payment webhook verification predates
+// the canonical `shared/constant-time-equal.ts` and is out of scope for this
+// change. Do not add further entries: any *new* local redeclaration should
+// fail this test and import the canonical helper instead.
+const KNOWN_COPIES = new Set(["packages/payment/src/webhook.ts"]);
+
+const SKIP_DIRECTORIES = new Set([".git", ".history", ".vis", ".wrangler", "__fixtures__", "coverage", "dist", "fixtures", "node_modules", "test-results"]);
+
+const DECLARATION_PATTERN = /(?:const|function)\s+constantTimeEqual\s*[=(]/;
+
+/** Recursively collect `.ts`/`.tsx` source files under `dir`, skipping build/vendor directories. */
+const collectSourceFiles = (dir: string): string[] => {
+    const entries = readdirSync(dir);
+    const files: string[] = [];
+
+    for (const entry of entries) {
+        if (SKIP_DIRECTORIES.has(entry)) {
+            continue;
+        }
+
+        const fullPath = join(dir, entry);
+        const stats = statSync(fullPath);
+
+        /* eslint-disable vitest/no-conditional-tests -- filesystem walk, not a test-behavior branch; the file-type check is inherent to recursing a directory tree */
+        if (stats.isDirectory()) {
+            files.push(...collectSourceFiles(fullPath));
+        } else if (/\.tsx?$/.test(entry) && !entry.endsWith(".d.ts")) {
+            files.push(fullPath);
+        }
+        /* eslint-enable vitest/no-conditional-tests */
+    }
+
+    return files;
+};
+
+describe("constantTimeEqual dedup guard", () => {
+    it("has exactly one canonical definition, plus only the documented known copies", () => {
+        expect.assertions(1);
+
+        const sourceRoots = ["shared", "packages"].map((directory) => join(REPO_ROOT, directory));
+        const offenders: string[] = [];
+
+        for (const root of sourceRoots) {
+            for (const filePath of collectSourceFiles(root)) {
+                const relativePath = relative(REPO_ROOT, filePath).split("\\").join("/");
+
+                if (relativePath === CANONICAL_FILE || KNOWN_COPIES.has(relativePath)) {
+                    continue;
+                }
+
+                if (relativePath.includes("/__tests__/") || relativePath.includes("/__fixtures__/")) {
+                    continue;
+                }
+
+                const content = readFileSync(filePath, "utf8");
+
+                if (DECLARATION_PATTERN.test(content)) {
+                    offenders.push(relativePath);
+                }
+            }
+        }
+
+        expect(
+            offenders,
+            'Found a local `constantTimeEqual` declaration outside the canonical shared/ file and the documented known copies. Import { constantTimeEqual } from "shared/constant-time-equal" instead of redeclaring it.',
+        ).toStrictEqual([]);
+    });
+});

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -2,6 +2,7 @@ import { isLunoraError, toErrorBody } from "@lunora/errors";
 
 import { asBucketStorage } from "../../../shared/as-bucket-storage";
 import type { BatchEntry } from "../../../shared/batch-wire";
+import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
@@ -1957,30 +1958,6 @@ const resolveShardBindingName = (env: unknown, namespace: ShardNamespaceLike): s
  * `Authorization` header handling is also plain — the per-shard gate is what
  * provides the constant-time check downstream.
  */
-
-/**
- * Length-independent constant-time string compare for token checks.
- *
- * Keep in sync with `packages/do/src/shard-do.ts` constantTimeEqual — the
- * two packages don't import from each other to avoid a circular dep.
- */
-const constantTimeEqual = (expected: string, supplied: string): boolean => {
-    const max = Math.max(expected.length, supplied.length);
-    // Bitwise XOR/OR are load-bearing for the branch-free constant-time
-    // comparison that protects token/HMAC checks from timing side channels.
-    // eslint-disable-next-line no-bitwise
-    let diff = expected.length ^ supplied.length;
-
-    for (let index = 0; index < max; index += 1) {
-        const expectedCode = index < expected.length ? (expected.codePointAt(index) ?? 0) : 0;
-        const suppliedCode = index < supplied.length ? (supplied.codePointAt(index) ?? 0) : 0;
-
-        // eslint-disable-next-line no-bitwise
-        diff |= expectedCode ^ suppliedCode;
-    }
-
-    return diff === 0;
-};
 
 /**
  * Verify an HMAC-SHA-256 (base64url, unpadded) signature over `body` against

--- a/packages/runtime/src/query-coordinator.ts
+++ b/packages/runtime/src/query-coordinator.ts
@@ -1245,19 +1245,28 @@ const callOneShard = async (namespace: ShardNamespaceLike, shardKey: string, pre
     }
 };
 
-const runBoundedFanOut = async (
-    namespace: ShardNamespaceLike,
-    keys: ReadonlyArray<string>,
-    request: ShardRpcRequest,
-    maxConcurrency: number,
-    timeoutMs: number,
-): Promise<ReadonlyArray<ShardRpcOutcome>> => {
-    if (keys.length === 0) {
+/**
+ * Run `jobs` through `run`, with at most `concurrency` of them in flight at
+ * once. A shared cursor lets each of the (at most `concurrency`) workers pull
+ * the next unclaimed job, so a fast job doesn't sit idle waiting for a slow
+ * sibling started in the same "batch" — the bounded-fan-out shape every
+ * multi-shard orchestrator in this file needs, whether every job shares the
+ * same request (`runBoundedFanOut`) or each carries its own args/cursor
+ * (`orchestrateCdcSync`, `orchestrateImport`, `orchestrateApplyCdc`,
+ * `orchestrateRankPage`). Results land at the same index as their job,
+ * regardless of completion order.
+ *
+ * `jobs` must not contain `undefined` — every caller here passes shard keys or
+ * pre-bucketed batch objects, never a sparse/optional array, and a literal
+ * `undefined` element would be indistinguishable from "past the end" and end
+ * the worker early.
+ */
+const runBoundedJobs = async <T, R>(jobs: ReadonlyArray<T>, concurrency: number, run: (job: T, index: number) => Promise<R>): Promise<R[]> => {
+    if (jobs.length === 0) {
         return [];
     }
 
-    const prepared = prepareShardRpc(request);
-    const outcomes: ShardRpcOutcome[] = Array.from({ length: keys.length });
+    const results: R[] = Array.from({ length: jobs.length });
     let cursor = 0;
 
     const worker = async (): Promise<void> => {
@@ -1267,22 +1276,34 @@ const runBoundedFanOut = async (
 
             cursor += 1;
 
-            const shardKey = keys[index];
+            const job = jobs[index];
 
-            if (index >= keys.length || shardKey === undefined) {
+            if (index >= jobs.length || job === undefined) {
                 return;
             }
 
-            // eslint-disable-next-line no-await-in-loop -- intentional: each worker processes shards sequentially while `concurrency` workers run in parallel
-            outcomes[index] = await callOneShard(namespace, shardKey, prepared, timeoutMs);
+            // eslint-disable-next-line no-await-in-loop -- intentional: each worker processes jobs sequentially while `concurrency` workers run in parallel
+            results[index] = await run(job, index);
         }
     };
 
-    const concurrency = Math.min(maxConcurrency, keys.length);
+    const workerCount = Math.min(concurrency, jobs.length);
 
-    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
-    return outcomes;
+    return results;
+};
+
+const runBoundedFanOut = async (
+    namespace: ShardNamespaceLike,
+    keys: ReadonlyArray<string>,
+    request: ShardRpcRequest,
+    maxConcurrency: number,
+    timeoutMs: number,
+): Promise<ReadonlyArray<ShardRpcOutcome>> => {
+    const prepared = prepareShardRpc(request);
+
+    return runBoundedJobs(keys, maxConcurrency, async (shardKey) => callOneShard(namespace, shardKey, prepared, timeoutMs));
 };
 
 /**
@@ -1630,45 +1651,23 @@ const createQueryCoordinator = (options: QueryCoordinatorOptions): QueryCoordina
 
             const shardKeys = [...union];
             const cursors = request.cursors ?? {};
-            const results: { outcome: ShardRpcOutcome; sinceSeq: number }[] = Array.from({ length: shardKeys.length });
-            let cursor = 0;
 
-            const concurrency = Math.min(maxConcurrency, shardKeys.length);
+            const results = await runBoundedJobs(shardKeys, maxConcurrency, async (shardKey) => {
+                const sinceSeq = cursors[shardKey] ?? 0;
 
-            const worker = async (): Promise<void> => {
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- bounded-concurrency worker loops until the shared cursor is exhausted (guarded below)
-                while (true) {
-                    const index = cursor;
+                const outcome = await callOneShard(
+                    namespace,
+                    shardKey,
+                    prepareShardRpc({
+                        args: { limit: request.limit, sinceSeq },
+                        functionPath: "__lunora_admin__:cdcSync",
+                        headers: request.headers,
+                    }),
+                    perShardTimeoutMs,
+                );
 
-                    cursor += 1;
-
-                    const shardKey = shardKeys[index];
-
-                    if (index >= shardKeys.length || shardKey === undefined) {
-                        return;
-                    }
-
-                    const sinceSeq = cursors[shardKey] ?? 0;
-
-                    // eslint-disable-next-line no-await-in-loop -- intentional: each worker processes shards sequentially while `concurrency` workers run in parallel
-                    const outcome = await callOneShard(
-                        namespace,
-                        shardKey,
-                        prepareShardRpc({
-                            args: { limit: request.limit, sinceSeq },
-                            functionPath: "__lunora_admin__:cdcSync",
-                            headers: request.headers,
-                        }),
-                        perShardTimeoutMs,
-                    );
-
-                    results[index] = { outcome, sinceSeq };
-                }
-            };
-
-            if (concurrency > 0) {
-                await Promise.all(Array.from({ length: concurrency }, () => worker()));
-            }
+                return { outcome, sinceSeq };
+            });
 
             return rollUpCdcSync(results);
         },
@@ -1678,41 +1677,19 @@ const createQueryCoordinator = (options: QueryCoordinatorOptions): QueryCoordina
             // every shard. The structure mirrors it: bounded `Promise.all`
             // workers pulling jobs off a shared cursor.
             const { batches } = request;
-            const outcomes: ShardRpcOutcome[] = Array.from({ length: batches.length });
-            let cursor = 0;
 
-            const concurrency = Math.min(maxConcurrency, batches.length);
-
-            const worker = async (): Promise<void> => {
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- bounded-concurrency worker loops until the shared cursor is exhausted (guarded below)
-                while (true) {
-                    const index = cursor;
-
-                    cursor += 1;
-
-                    const batch = batches[index];
-
-                    if (index >= batches.length || batch === undefined) {
-                        return;
-                    }
-
-                    // eslint-disable-next-line no-await-in-loop -- intentional: each worker processes batches sequentially while `concurrency` workers run in parallel
-                    outcomes[index] = await callOneShard(
-                        namespace,
-                        batch.shardKey,
-                        prepareShardRpc({
-                            args: { rows: [...batch.rows], startLine: batch.startLine ?? 1 },
-                            functionPath: "__lunora_admin__:importShard",
-                            headers: request.headers,
-                        }),
-                        perShardTimeoutMs,
-                    );
-                }
-            };
-
-            if (concurrency > 0) {
-                await Promise.all(Array.from({ length: concurrency }, () => worker()));
-            }
+            const outcomes = await runBoundedJobs(batches, maxConcurrency, async (batch) =>
+                callOneShard(
+                    namespace,
+                    batch.shardKey,
+                    prepareShardRpc({
+                        args: { rows: [...batch.rows], startLine: batch.startLine ?? 1 },
+                        functionPath: "__lunora_admin__:importShard",
+                        headers: request.headers,
+                    }),
+                    perShardTimeoutMs,
+                ),
+            );
 
             return rollUpImport(outcomes);
         },
@@ -1721,41 +1698,19 @@ const createQueryCoordinator = (options: QueryCoordinatorOptions): QueryCoordina
             // orchestrateImport (each shard gets distinct args, so we can't use
             // runBoundedFanOut's same-args-to-all model).
             const { batches } = request;
-            const outcomes: ShardRpcOutcome[] = Array.from({ length: batches.length });
-            let cursor = 0;
 
-            const concurrency = Math.min(maxConcurrency, batches.length);
-
-            const worker = async (): Promise<void> => {
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- bounded-concurrency worker loops until the shared cursor is exhausted (guarded below)
-                while (true) {
-                    const index = cursor;
-
-                    cursor += 1;
-
-                    const batch = batches[index];
-
-                    if (index >= batches.length || batch === undefined) {
-                        return;
-                    }
-
-                    // eslint-disable-next-line no-await-in-loop -- intentional: each worker processes batches sequentially while `concurrency` workers run in parallel
-                    outcomes[index] = await callOneShard(
-                        namespace,
-                        batch.shardKey,
-                        prepareShardRpc({
-                            args: { changes: [...batch.changes] },
-                            functionPath: "__lunora_admin__:applyCdc",
-                            headers: request.headers,
-                        }),
-                        perShardTimeoutMs,
-                    );
-                }
-            };
-
-            if (concurrency > 0) {
-                await Promise.all(Array.from({ length: concurrency }, () => worker()));
-            }
+            const outcomes = await runBoundedJobs(batches, maxConcurrency, async (batch) =>
+                callOneShard(
+                    namespace,
+                    batch.shardKey,
+                    prepareShardRpc({
+                        args: { changes: [...batch.changes] },
+                        functionPath: "__lunora_admin__:applyCdc",
+                        headers: request.headers,
+                    }),
+                    perShardTimeoutMs,
+                ),
+            );
 
             return rollUpApplyCdc(outcomes);
         },
@@ -1802,64 +1757,39 @@ const createQueryCoordinator = (options: QueryCoordinatorOptions): QueryCoordina
             // `take`; the shard-local reader internally `LIMIT take + 1`s so its
             // `hasMore` is observable even when the returned slice is exactly
             // `take` long, but the merge only ever emits up to the GLOBAL `take`.
-            const outcomes: ShardRankPageOutcome[] = Array.from({ length: keys.length });
-            let cursor = 0;
+            const outcomes = await runBoundedJobs(keys, maxConcurrency, async (shardKey): Promise<ShardRankPageOutcome> => {
+                const shardCursorKey = cursorState.perShard[shardKey];
+                const args: Record<string, unknown> = {
+                    index: request.index,
+                    table: request.table,
+                    take,
+                };
 
-            const concurrency = Math.min(maxConcurrency, keys.length);
-
-            const worker = async (): Promise<void> => {
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- bounded-concurrency worker loops until the shared cursor is exhausted (guarded below)
-                while (true) {
-                    const index = cursor;
-
-                    cursor += 1;
-
-                    const shardKey = keys[index];
-
-                    if (index >= keys.length || shardKey === undefined) {
-                        return;
-                    }
-
-                    const shardCursorKey = cursorState.perShard[shardKey];
-                    const args: Record<string, unknown> = {
-                        index: request.index,
-                        table: request.table,
-                        take,
-                    };
-
-                    if (request.partitionKey !== undefined) {
-                        args["partitionKey"] = request.partitionKey;
-                    }
-
-                    if (shardCursorKey !== undefined) {
-                        // Forward the prior page's resume key for THIS shard so
-                        // it pages strictly-after the last globally-consumed row.
-                        args["after"] = shardCursorKey;
-                    }
-
-                    // eslint-disable-next-line no-await-in-loop -- intentional: each worker processes shards sequentially while `concurrency` workers run in parallel
-                    const outcome = await callOneShard(
-                        namespace,
-                        shardKey,
-                        prepareShardRpc({ args, functionPath: "__lunora_admin__:rankPage", headers: request.headers }),
-                        perShardTimeoutMs,
-                    );
-
-                    if (outcome.kind === "err") {
-                        outcomes[index] = { error: { message: outcome.message, timedOut: outcome.timedOut }, shardKey };
-
-                        continue;
-                    }
-
-                    const payload = readRankPageResult(unwrapResult(outcome.value));
-
-                    outcomes[index] = { directions: payload.directions, hasMore: payload.hasMore, rows: payload.rows, shardKey };
+                if (request.partitionKey !== undefined) {
+                    args["partitionKey"] = request.partitionKey;
                 }
-            };
 
-            if (concurrency > 0) {
-                await Promise.all(Array.from({ length: concurrency }, () => worker()));
-            }
+                if (shardCursorKey !== undefined) {
+                    // Forward the prior page's resume key for THIS shard so
+                    // it pages strictly-after the last globally-consumed row.
+                    args["after"] = shardCursorKey;
+                }
+
+                const outcome = await callOneShard(
+                    namespace,
+                    shardKey,
+                    prepareShardRpc({ args, functionPath: "__lunora_admin__:rankPage", headers: request.headers }),
+                    perShardTimeoutMs,
+                );
+
+                if (outcome.kind === "err") {
+                    return { error: { message: outcome.message, timedOut: outcome.timedOut }, shardKey };
+                }
+
+                const payload = readRankPageResult(unwrapResult(outcome.value));
+
+                return { directions: payload.directions, hasMore: payload.hasMore, rows: payload.rows, shardKey };
+            });
 
             const slices: ShardSlice[] = [];
             let ok = 0;

--- a/packages/studio/__tests__/hooks/use-shard-key.test.tsx
+++ b/packages/studio/__tests__/hooks/use-shard-key.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useShardKey } from "../../src/hooks/use-shard-key";
@@ -14,7 +15,13 @@ const Probe = ({
 }): React.ReactElement => {
     const { queryShardKey, setShardKey, shardKey } = useShardKey(initial, delayMs);
 
-    onReady(setShardKey);
+    // Hand the setter back to the test via an effect, not during render — render
+    // must stay pure (React can replay or discard it), so the callback fires
+    // from a committed effect instead.
+    useEffect(() => {
+        // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent -- test harness: the hook must run inside a component, so the effect is the only channel to surface its setter to the test.
+        onReady(setShardKey);
+    });
 
     return (
         <div>

--- a/packages/studio/__tests__/hooks/use-shard-key.test.tsx
+++ b/packages/studio/__tests__/hooks/use-shard-key.test.tsx
@@ -1,0 +1,199 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useShardKey } from "../../src/hooks/use-shard-key";
+
+const Probe = ({
+    delayMs,
+    initial,
+    onReady,
+}: {
+    delayMs?: number;
+    initial: string | undefined;
+    onReady: (setShardKey: (value: string) => void) => void;
+}): React.ReactElement => {
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initial, delayMs);
+
+    onReady(setShardKey);
+
+    return (
+        <div>
+            <span data-testid="raw">{shardKey}</span>
+            <span data-testid="query">{queryShardKey}</span>
+        </div>
+    );
+};
+
+describe("useShardKey", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("seeds both shardKey and queryShardKey from initial immediately", () => {
+        expect.assertions(2);
+
+        render(<Probe initial="alpha" onReady={() => {}} />);
+
+        expect(screen.getByTestId("raw").textContent).toBe("alpha");
+        expect(screen.getByTestId("query").textContent).toBe("alpha");
+    });
+
+    it("defaults to the empty string when initial is undefined", () => {
+        expect.assertions(2);
+
+        render(<Probe initial={undefined} onReady={() => {}} />);
+
+        expect(screen.getByTestId("raw").textContent).toBe("");
+        expect(screen.getByTestId("query").textContent).toBe("");
+    });
+
+    it("debounces setShardKey edits: queryShardKey trails until delayMs elapses", () => {
+        expect.assertions(2);
+
+        let setShardKey: ((value: string) => void) | undefined;
+
+        render(
+            <Probe
+                delayMs={400}
+                initial=""
+                onReady={(set) => {
+                    setShardKey = set;
+                }}
+            />,
+        );
+
+        act(() => {
+            setShardKey?.("tenant-1");
+        });
+
+        expect(screen.getByTestId("query").textContent).toBe("");
+
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(screen.getByTestId("query").textContent).toBe("tenant-1");
+    });
+
+    it("a burst of edits only settles queryShardKey on the last value", () => {
+        expect.assertions(1);
+
+        let setShardKey: ((value: string) => void) | undefined;
+
+        render(
+            <Probe
+                delayMs={400}
+                initial=""
+                onReady={(set) => {
+                    setShardKey = set;
+                }}
+            />,
+        );
+
+        act(() => {
+            setShardKey?.("t");
+        });
+        act(() => {
+            vi.advanceTimersByTime(100);
+        });
+        act(() => {
+            setShardKey?.("te");
+        });
+        act(() => {
+            vi.advanceTimersByTime(100);
+        });
+        act(() => {
+            setShardKey?.("ten");
+        });
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(screen.getByTestId("query").textContent).toBe("ten");
+    });
+
+    it("trims whitespace into queryShardKey", () => {
+        expect.assertions(1);
+
+        let setShardKey: ((value: string) => void) | undefined;
+
+        render(
+            <Probe
+                delayMs={400}
+                initial=""
+                onReady={(set) => {
+                    setShardKey = set;
+                }}
+            />,
+        );
+
+        act(() => {
+            setShardKey?.("  padded  ");
+        });
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(screen.getByTestId("query").textContent).toBe("padded");
+    });
+
+    it("resets queryShardKey synchronously (no debounce wait) when initial changes", () => {
+        expect.assertions(4);
+
+        let setShardKey: ((value: string) => void) | undefined;
+        const onReady = (set: (value: string) => void): void => {
+            setShardKey = set;
+        };
+
+        const { rerender } = render(<Probe delayMs={400} initial="shard-a" onReady={onReady} />);
+
+        act(() => {
+            setShardKey?.("still-typing-shard-a-edit");
+        });
+
+        // Mid-debounce: the raw input reflects the edit, the settled query value
+        // still trails the last COMMITTED shard.
+        expect(screen.getByTestId("raw").textContent).toBe("still-typing-shard-a-edit");
+        expect(screen.getByTestId("query").textContent).toBe("shard-a");
+
+        // A caller-driven reset (e.g. a table switch) — new `initial` — must land
+        // on BOTH raw and query state immediately, without waiting `delayMs`,
+        // discarding the in-flight edit above rather than letting its pending
+        // timer resolve into the new shard's `queryShardKey` later.
+        rerender(<Probe delayMs={400} initial="shard-b" onReady={onReady} />);
+
+        expect(screen.getByTestId("raw").textContent).toBe("shard-b");
+        expect(screen.getByTestId("query").textContent).toBe("shard-b");
+    });
+
+    it("a stale pending debounce from before a reset cannot overwrite the reset", () => {
+        expect.assertions(1);
+
+        let setShardKey: ((value: string) => void) | undefined;
+        const onReady = (set: (value: string) => void): void => {
+            setShardKey = set;
+        };
+
+        const { rerender } = render(<Probe delayMs={400} initial="shard-a" onReady={onReady} />);
+
+        act(() => {
+            setShardKey?.("shard-a-typo");
+        });
+        act(() => {
+            vi.advanceTimersByTime(200);
+        });
+
+        rerender(<Probe delayMs={400} initial="shard-b" onReady={onReady} />);
+
+        // Let the pre-reset timer's original deadline pass.
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(screen.getByTestId("query").textContent).toBe("shard-b");
+    });
+});

--- a/packages/studio/src/features/advisors/insights-panel.tsx
+++ b/packages/studio/src/features/advisors/insights-panel.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } fro
 import { ShardInput } from "../../components/shard-input";
 import { Button } from "../../components/ui/button";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import type { TFunction } from "../../i18n/i18n-context";
 import { useT } from "../../i18n/i18n-context";
 import type {
@@ -139,7 +139,7 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
     const navigate = useNavigate();
     const t = useT();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
 
     // Runtime-lint inputs the dead-index advisory reconciles: every declared index
     // from listTables + listTableIndexes. Best-effort — absent on an older worker,
@@ -149,11 +149,6 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
     // out on demand (not on the metrics hot path) and best-effort — null when
     // the worker predates the shard-traffic endpoint, so hot_shard stays quiet.
     const [shardTraffic, setShardTraffic] = useState<AdvisorShardTraffic[] | null>(null);
-
-    // The shard the reads target, debounced so typing a key settles before
-    // re-fetching (and re-subscribing) rather than firing per keystroke — the
-    // shard-seed protocol the audit/metrics panels share.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
 
     // The most recently requested enumeration shard. `enumerateShard` runs
     // fire-and-forget from both the shard-change effect and the visibility handler,
@@ -166,9 +161,9 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
     // without a manual refresh. `metrics`/`functions`/`advisories` are best-effort:
     // a partial snapshot still yields useful insights, so a single failure doesn't
     // blank the panel — only a failure of BOTH runtime reads surfaces a hard error.
-    const metricsQuery = useAdminQuery<MetricsSnapshot>(ADMIN_FUNCTIONS.getMetrics, {}, { live: true, shardKey: debouncedShard });
-    const functionsQuery = useAdminQuery<FunctionStatsResult>(ADMIN_FUNCTIONS.getFunctionStats, {}, { live: true, shardKey: debouncedShard });
-    const advisoriesQuery = useAdminQuery<AdvisoriesResult>(ADMIN_FUNCTIONS.getAdvisories, {}, { live: true, shardKey: debouncedShard });
+    const metricsQuery = useAdminQuery<MetricsSnapshot>(ADMIN_FUNCTIONS.getMetrics, {}, { live: true, shardKey: queryShardKey });
+    const functionsQuery = useAdminQuery<FunctionStatsResult>(ADMIN_FUNCTIONS.getFunctionStats, {}, { live: true, shardKey: queryShardKey });
+    const advisoriesQuery = useAdminQuery<AdvisoriesResult>(ADMIN_FUNCTIONS.getAdvisories, {}, { live: true, shardKey: queryShardKey });
 
     const metrics: MetricsSnapshot | null = metricsQuery.data ?? null;
     const functions: FunctionCallStat[] | null = functionsQuery.data?.functions ?? null;
@@ -305,8 +300,8 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
     // typing a different shard key never re-fetched the enumeration either.
     useEffect(() => {
         // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- drives an imperative enumeration over the debounced shard — an async load, not derived state
-        fireAndForget(enumerateShard(debouncedShard));
-    }, [debouncedShard, enumerateShard]);
+        fireAndForget(enumerateShard(queryShardKey));
+    }, [queryShardKey, enumerateShard]);
 
     // Auto-refresh when the tab regains focus. The studio is a standalone app
     // (not a Vite HMR client), so it can't hear codegen reloads directly — but
@@ -322,7 +317,7 @@ export const InsightsPanel = ({ initialShardKey, loadShardTraffic }: InsightsPan
         metricsQuery.refetch();
         functionsQuery.refetch();
         advisoriesQuery.refetch();
-        fireAndForget(enumerateShard(debouncedShard));
+        fireAndForget(enumerateShard(queryShardKey));
     });
 
     useEffect(() => {

--- a/packages/studio/src/features/data/hooks/use-data-browser.tsx
+++ b/packages/studio/src/features/data/hooks/use-data-browser.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useAdminQuery } from "../../../hooks/use-admin-query";
 import useDebounced from "../../../hooks/use-debounced";
 import { useMirroredRef } from "../../../hooks/use-mirrored-ref";
+import { useShardKey } from "../../../hooks/use-shard-key";
 import type { BulkDeleteResult, FacetResult, FilterClause, TableInfo, TablePage, WriteRowResult } from "../../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../../lib/admin";
 import { adminRef, callOptions, fireAndForget } from "../../../lib/internal";
@@ -316,7 +317,16 @@ const useDataBrowser = ({
     // prop seeds the initial value. Changing it re-fetches the first page.
     const [pageSize, setPageSize] = useState<number>(initialPageSize);
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    // `initial` is the LIVE `initialShardKey` prop (not a mount-only capture), so a
+    // shard-only external change (browser back/forward, a saved-query deep link)
+    // resets `queryShardKey` synchronously via the hook — see `useShardKey`. This is
+    // narrower than (and coexists with) the full per-table re-seed effect below,
+    // which also resets filters/sort/search/facets/staged-edits and deliberately
+    // reads its URL params through refs so the debounced shard's own write-back
+    // (`onViewChange`) can't retrigger IT — that loop concern doesn't apply here:
+    // by the time a shard mirrors to the URL it already equals `shardKey`, so this
+    // hook's reset is a no-op echo, not a fresh wipe.
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
 
     // The open table is DERIVED from the URL — the single source of truth. There is
     // no optimistic local `selectedTable` state mirrored back to the URL: that
@@ -337,13 +347,10 @@ const useDataBrowser = ({
     const [filter, setFilter] = useState<string>(initialSearch ?? "");
     const search = useDebounced(filter.trim(), 300);
 
-    // The shard the reads target, debounced so typing a key settles before
-    // refetching the table list + page rather than firing per keystroke. Page-bound
-    // actions (preview, facet fetch, row write/delete, bulk delete) target this same
-    // settled shard so a write can never hit a different shard than the one whose
-    // rows are on screen during the debounce window. The live `shardKey` is only the
-    // input value + the share-link descriptor.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
+    // `queryShardKey` (above) is what page-bound actions (preview, facet fetch, row
+    // write/delete, bulk delete) target too, so a write can never hit a different
+    // shard than the one whose rows are on screen during the debounce window. The
+    // live `shardKey` is only the input value + the share-link descriptor.
 
     // Structured column filters. Held in a ref too so a write's bulk-delete reads
     // the current value without threading it through; the page query reads the
@@ -376,7 +383,7 @@ const useDataBrowser = ({
     // cache (the same model as every other studio panel). The table list follows
     // the debounced shard; the page read's args ARE the view, so selecting a table
     // or paginating / searching / filtering / sorting transparently refetches.
-    const tablesQuery = useAdminQuery<TableInfo[]>(ADMIN_FUNCTIONS.listTables, NO_ARGS, { live: true, shardKey: debouncedShard });
+    const tablesQuery = useAdminQuery<TableInfo[]>(ADMIN_FUNCTIONS.listTables, NO_ARGS, { live: true, shardKey: queryShardKey });
     const tables = tablesQuery.data ?? null;
     const tablesError = tablesQuery.error;
 
@@ -394,14 +401,14 @@ const useDataBrowser = ({
     const countArgs = toCountArgs({ filters, search, table: selectedTable ?? "" });
 
     // `keepPreviousData` is off: the placeholder isn't identity-aware, so holding
-    // the last page across a `selectedTable` / `debouncedShard` change would render
+    // the last page across a `selectedTable` / `queryShardKey` change would render
     // the prior table's/shard's rows while edits and deletes already target the new
     // one. `live` streams writes in. Disabled until a table is open.
     const pageQuery = useAdminQuery<TablePage>(ADMIN_FUNCTIONS.readTablePage, pageArgs, {
         enabled: selectedTable !== null,
         keepPreviousData: false,
         live: true,
-        shardKey: debouncedShard,
+        shardKey: queryShardKey,
     });
     const page = pageQuery.data ?? null;
     const pageError = pageQuery.error;
@@ -412,15 +419,15 @@ const useDataBrowser = ({
     const countQuery = useAdminQuery<TablePage>(ADMIN_FUNCTIONS.readTablePage, countArgs, {
         enabled: selectedTable !== null,
         live: true,
-        shardKey: debouncedShard,
+        shardKey: queryShardKey,
     });
 
     // Record the browsed shard into recent-shards history once its tables resolve.
     useEffect(() => {
         if (tablesQuery.data !== undefined) {
-            recordShard(debouncedShard);
+            recordShard(queryShardKey);
         }
-    }, [tablesQuery.data, debouncedShard]);
+    }, [tablesQuery.data, queryShardKey]);
 
     // Select a table = navigate the URL to it (the host drops the previous
     // filters/sort/search so the new table opens clean). The selection itself is
@@ -449,7 +456,7 @@ const useDataBrowser = ({
             const result = (await client.query(
                 READ_TABLE_PAGE,
                 { filters: [], limit: PREVIEW_CANDIDATES, offset: 0, search: id, table: targetTable },
-                callOptions(debouncedShard),
+                callOptions(queryShardKey),
             )) as TablePage;
 
             return result.rows.find((row) => rowId(row) === id) ?? null;
@@ -475,7 +482,7 @@ const useDataBrowser = ({
     // drops it entirely. With no table selected the hook seeds the slot without
     // fetching (a null fetcher).
     const toggleFacet = (column: string): void => {
-        toggleFacetColumn(column, selectedTable === null ? null : facetFetcher(debouncedShard, selectedTable, filtersRef.current, search));
+        toggleFacetColumn(column, selectedTable === null ? null : facetFetcher(queryShardKey, selectedTable, filtersRef.current, search));
     };
 
     // Clicking a facet value adds an `eq` filter for that column/value, narrowing
@@ -512,11 +519,11 @@ const useDataBrowser = ({
 
         // `refetchFacets` re-runs only the already-open facets (read off the hook's
         // ref); toggling a single facet on is handled by `toggleFacet`'s own fetch.
-        refetchFacetsRef.current(facetFetcherRef.current(debouncedShard, selectedTable, filters, search));
+        refetchFacetsRef.current(facetFetcherRef.current(queryShardKey, selectedTable, filters, search));
         // Fire on the active view; the facet callbacks are read via refs (see above).
         // react-doctor-disable-next-line react-doctor/exhaustive-deps -- the refs are `useMirroredRef` handles — stable by construction, and reading them is the whole point: the effect keys on the VIEW values so it fires when the view changes, not when a callback identity churns
         // eslint-disable-next-line react-hooks/exhaustive-deps -- same reason: `useMirroredRef` handles are stable, and listing them would say this effect depends on identities it deliberately does not
-    }, [debouncedShard, selectedTable, filters, search]);
+    }, [queryShardKey, selectedTable, filters, search]);
 
     // Tracks the table the local view has been (re-)seeded for. Declared before the
     // mirror effect below so that effect can tell whether the view it's about to
@@ -543,12 +550,12 @@ const useDataBrowser = ({
             filters: toFilterClauses(filters),
             orderBy: toOrderBy(sorting),
             search,
-            shard: debouncedShard,
+            shard: queryShardKey,
         });
         // Fire on the displayed view; `onViewChange` is read via `onViewChangeRef` (see above).
         // react-doctor-disable-next-line react-doctor/exhaustive-deps -- the ref is a `useMirroredRef` handle — stable by construction; depending on `onViewChange` itself is what caused the navigate loop this pattern exists to avoid
         // eslint-disable-next-line react-hooks/exhaustive-deps -- same reason: the ref handle is stable, and depending on `onViewChange` is exactly the loop this avoids
-    }, [selectedTable, tableParam, filters, sorting, search, debouncedShard]);
+    }, [selectedTable, tableParam, filters, sorting, search, queryShardKey]);
 
     // The URL's view params, mirrored to refs so the re-seed effect can read the
     // CURRENT values while depending on `tableParam` alone (depending on the params
@@ -630,7 +637,7 @@ const useDataBrowser = ({
         try {
             for (const [id, columns] of Object.entries(stagedEdits.staged)) {
                 // eslint-disable-next-line no-await-in-loop -- one patch per edited row; sequential so a failure pins the offending row
-                (await client.query(WRITE_ROW, { doc: columns, id, op: "patch", table: selectedTable }, callOptions(debouncedShard))) as WriteRowResult;
+                (await client.query(WRITE_ROW, { doc: columns, id, op: "patch", table: selectedTable }, callOptions(queryShardKey))) as WriteRowResult;
             }
 
             stagedEdits.clear();
@@ -683,7 +690,7 @@ const useDataBrowser = ({
             (await client.query(
                 WRITE_ROW,
                 { doc: parsedDocument, id: id ?? undefined, op, table: selectedTable },
-                callOptions(debouncedShard),
+                callOptions(queryShardKey),
             )) as WriteRowResult;
             setEditing(null);
             pageQuery.refetch();
@@ -710,7 +717,7 @@ const useDataBrowser = ({
         try {
             for (let batch = 0; batch < MAX_BULK_DELETE_BATCHES; batch += 1) {
                 // eslint-disable-next-line no-await-in-loop -- batches are inherently sequential (each call reflects the prior batch's deletes)
-                const result = (await client.query(ref, args, callOptions(debouncedShard))) as BulkDeleteResult;
+                const result = (await client.query(ref, args, callOptions(queryShardKey))) as BulkDeleteResult;
 
                 if (!result.hasMore) {
                     break;
@@ -881,7 +888,7 @@ const useDataBrowser = ({
         try {
             for (const id of ids) {
                 // eslint-disable-next-line no-await-in-loop -- one delete per selected row; sequential so a failure pins the offending row
-                (await client.query(WRITE_ROW, { id, op: "delete", table: selectedTable }, callOptions(debouncedShard))) as WriteRowResult;
+                (await client.query(WRITE_ROW, { id, op: "delete", table: selectedTable }, callOptions(queryShardKey))) as WriteRowResult;
             }
 
             pageQuery.refetch();
@@ -934,9 +941,9 @@ const useDataBrowser = ({
         previewRef,
         pageError,
         pageSize,
+        queryShardKey,
         rangeEnd,
         rangeStart,
-        queryShardKey: debouncedShard,
         saveEdit,
         selectedTable,
         selectTable,

--- a/packages/studio/src/features/database/migrations.tsx
+++ b/packages/studio/src/features/database/migrations.tsx
@@ -14,7 +14,7 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { MigrationDirection, MigrationRunResult, MigrationStatusRow } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -42,7 +42,7 @@ export const MigrationsPanel = ({ initialShardKey }: MigrationsPanelProps): Reac
     const client = useLunora();
     const t = useT();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
 
     const [migrationId, setMigrationId] = useState<string>("");
     const [direction, setDirection] = useState<MigrationDirection>("up");
@@ -51,15 +51,11 @@ export const MigrationsPanel = ({ initialShardKey }: MigrationsPanelProps): Reac
     const [runResult, setRunResult] = useState<MigrationRunResult | null>(null);
     const [runError, setRunError] = useState<null | string>(null);
 
-    // The shard the read targets, debounced so typing a key settles before
-    // refetching (and re-subscribing) rather than firing per keystroke.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
-
-    // The status query (and its post-run `refetch`) is keyed by `debouncedShard`,
+    // The status query (and its post-run `refetch`) is keyed by `queryShardKey`,
     // while a run targets the live `shardKey`. Until the debounce catches up the two
     // can disagree, so running would hit one shard while the table refreshes another.
     // Gate the run on the displayed shard being settled.
-    const shardSettled = shardKey.trim() === debouncedShard;
+    const shardSettled = shardKey.trim() === queryShardKey;
 
     // One-shot read + always-on live subscription for the committed shard. Each
     // server push refreshes the run-state table so an in-progress migration's
@@ -70,7 +66,7 @@ export const MigrationsPanel = ({ initialShardKey }: MigrationsPanelProps): Reac
         {},
         {
             live: true,
-            shardKey: debouncedShard,
+            shardKey: queryShardKey,
         },
     );
 
@@ -81,9 +77,9 @@ export const MigrationsPanel = ({ initialShardKey }: MigrationsPanelProps): Reac
     // Record the browsed shard into recent-shards history once its status resolves.
     useEffect(() => {
         if (statusQuery.data !== undefined) {
-            recordShard(debouncedShard);
+            recordShard(queryShardKey);
         }
-    }, [statusQuery.data, debouncedShard]);
+    }, [statusQuery.data, queryShardKey]);
 
     const run = async (): Promise<void> => {
         const id = migrationId.trim();

--- a/packages/studio/src/features/functions/function-stats.tsx
+++ b/packages/studio/src/features/functions/function-stats.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from "../../components/ui/card";
 import { EmptyState } from "../../components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { FunctionCallStat, FunctionStatsResult } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -98,12 +98,8 @@ const SORTERS: Record<SortKey, (a: FunctionCallStat, b: FunctionCallStat) => num
 export const FunctionStatsPanel = ({ functions, initialShardKey }: FunctionStatsPanelProps): ReactElement => {
     const t = useT();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
     const [sortKey, setSortKey] = useState<SortKey>("recent");
-
-    // The shard the read targets, debounced so typing a key settles before
-    // refetching (and re-subscribing) rather than firing per keystroke.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
 
     // One-shot read + always-on live subscription for the committed shard. Each
     // server push updates the table as mutations land; `liveError` holds a
@@ -114,7 +110,7 @@ export const FunctionStatsPanel = ({ functions, initialShardKey }: FunctionStats
         {},
         {
             live: true,
-            shardKey: debouncedShard,
+            shardKey: queryShardKey,
         },
     );
 

--- a/packages/studio/src/features/issues/issues-panel.tsx
+++ b/packages/studio/src/features/issues/issues-panel.tsx
@@ -14,7 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useAdminQuery } from "../../hooks/use-admin-query";
 import { useAsyncSubmit } from "../../hooks/use-async-submit";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { ErrorIssue, ExplainIssueArgs, ExplainIssueResult, IssueSeverity, IssuesResult, IssueStatus } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -425,7 +425,7 @@ export const IssuesPanel = ({ initialShardKey }: IssuesPanelProps): ReactElement
     const t = useT();
     const client = useLunora();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
     const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
     // Busy + error state are keyed BY ISSUE HASH, not global: two overlapping triage
     // writes must disable only their own row's buttons, and the first to complete
@@ -434,13 +434,9 @@ export const IssuesPanel = ({ initialShardKey }: IssuesPanelProps): ReactElement
     const [busyHashes, setBusyHashes] = useState<ReadonlySet<string>>(() => new Set<string>());
     const [actionErrors, setActionErrors] = useState<ReadonlyMap<string, string>>(() => new Map<string, string>());
 
-    // Debounced so typing a key settles before refetching (and re-subscribing)
-    // rather than firing per keystroke — mirrors the Metrics panel.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
-
     const { data, error, liveError } = useAdminQuery<IssuesResult>(ADMIN_FUNCTIONS.getIssues, statusFilter === "all" ? {} : { status: statusFilter }, {
         live: true,
-        shardKey: debouncedShard,
+        shardKey: queryShardKey,
     });
 
     const loaded = data !== undefined;
@@ -470,7 +466,7 @@ export const IssuesPanel = ({ initialShardKey }: IssuesPanelProps): ReactElement
         setBusyHashes((previous) => new Set(previous).add(hash));
 
         try {
-            await client.query(reference, { ...args, hash }, callOptions(debouncedShard));
+            await client.query(reference, { ...args, hash }, callOptions(queryShardKey));
         } catch (error_) {
             const message = errorMessage(error_);
 
@@ -562,7 +558,7 @@ export const IssuesPanel = ({ initialShardKey }: IssuesPanelProps): ReactElement
                                         key={issue.hash}
                                         rowError={actionErrors.get(issue.hash)}
                                         runTriage={runTriage}
-                                        shardKey={debouncedShard}
+                                        shardKey={queryShardKey}
                                     />
                                 ))}
                             </TableBody>

--- a/packages/studio/src/features/logs/audit-panel.tsx
+++ b/packages/studio/src/features/logs/audit-panel.tsx
@@ -12,7 +12,7 @@ import { EmptyState } from "../../components/ui/empty-state";
 import { Input } from "../../components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { AuditEntry, AuditLogResult } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -72,12 +72,8 @@ const observeViewportRect = (instance: Virtualizer<HTMLDivElement, Element>, cal
 const AuditPanel = ({ initialShardKey }: AuditPanelProps): ReactElement => {
     const t = useT();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
     const [search, setSearch] = useState<string>("");
-
-    // The shard the read targets, debounced so typing a key settles before
-    // refetching (and re-subscribing) rather than firing per keystroke.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
 
     // One-shot read + always-on live subscription for the committed shard. `live`
     // streams each server write-flush into the cache so new entries appear without
@@ -86,7 +82,7 @@ const AuditPanel = ({ initialShardKey }: AuditPanelProps): ReactElement => {
     const { data, error, errorSource, isLoading, liveError } = useAdminQuery<AuditLogResult>(
         ADMIN_FUNCTIONS.getAuditLog,
         {},
-        { live: true, shardKey: debouncedShard },
+        { live: true, shardKey: queryShardKey },
     );
 
     const entries = useMemo<AuditEntry[]>(() => data?.entries ?? [], [data]);

--- a/packages/studio/src/features/logs/logs-panel.tsx
+++ b/packages/studio/src/features/logs/logs-panel.tsx
@@ -11,7 +11,7 @@ import { ErrorAlert } from "../../components/error-alert";
 import { Badge } from "../../components/ui/badge";
 import { EmptyState } from "../../components/ui/empty-state";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { LogEntry, LogLevel, RequestLogEntry, RequestLogQuery, RequestOutcome } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -319,7 +319,7 @@ export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => 
     const t = useT();
 
     const [view, setView] = useState<LogsView>("requests");
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
     const [search, setSearch] = useState<string>("");
     // Errors-view client-side filters: a level allow-set (empty = all levels), a
     // function-path substring, and a relative time window. AND-composed.
@@ -335,10 +335,6 @@ export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => 
     const [tableFilter, setTableFilter] = useState<string>("");
     const [outcomeFilter, setOutcomeFilter] = useState<string>("all");
 
-    // The shard the reads target, debounced so typing a key settles before
-    // refetching (and re-subscribing) rather than firing per keystroke.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
-
     // Typed as a plain record too, so it satisfies the `useAdminQuery` args
     // surface (`Record<string, unknown>`) without a per-call-site cast. Folding it
     // into the query args means changing a correlation filter re-fetches the
@@ -352,7 +348,7 @@ export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => 
     const requestsQuery = useAdminQuery<{ entries?: unknown }>(ADMIN_FUNCTIONS.getRequestLog, requestQuery, {
         enabled: view === "requests",
         live: true,
-        shardKey: debouncedShard,
+        shardKey: queryShardKey,
     });
 
     const errorsQuery = useAdminQuery<{ entries?: unknown }>(
@@ -361,7 +357,7 @@ export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => 
         {
             enabled: view === "errors",
             live: true,
-            shardKey: debouncedShard,
+            shardKey: queryShardKey,
         },
     );
 
@@ -379,9 +375,9 @@ export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => 
     useEffect(() => {
         // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- recording the browsed shard is derived from the resolved read (a value, not a discrete event); writing it when the data lands is the correct pattern.
         if (activeQuery.data !== undefined) {
-            recordShard(debouncedShard);
+            recordShard(queryShardKey);
         }
-    }, [activeQuery.data, debouncedShard]);
+    }, [activeQuery.data, queryShardKey]);
 
     // AND-composed client-side filter for the Errors view (level allow-set,
     // function-path substring, message substring, relative time window), derived
@@ -548,7 +544,7 @@ export const LogsPanel = ({ initialShardKey }: LogsPanelProps): ReactElement => 
                 with the readout state machine — so it's gated once, not negated on every
                 `readout` branch. */}
             {view === "archive" ? (
-                <ArchiveFeed shardKey={debouncedShard} />
+                <ArchiveFeed shardKey={queryShardKey} />
             ) : (
                 <>
                     {readout === "error" && <ErrorAlert error={errorSource} testId="lg-error" />}

--- a/packages/studio/src/features/logs/subscriptions-panel.tsx
+++ b/packages/studio/src/features/logs/subscriptions-panel.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import { useState } from "react";
 
 import { ErrorAlert } from "../../components/error-alert";
 import { ShardInput } from "../../components/shard-input";
@@ -9,7 +8,7 @@ import { EmptyState } from "../../components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useAdminQuery } from "../../hooks/use-admin-query";
 import { useAutoRefresh } from "../../hooks/use-auto-refresh";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { SubscriptionConnection, SubscriptionInfo, SubscriptionsResult } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -86,11 +85,7 @@ const DASH = <span className="text-muted-foreground">—</span>;
 const SubscriptionsPanel = ({ initialShardKey }: SubscriptionsPanelProps): ReactElement => {
     const t = useT();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
-
-    // Re-read on the debounced shard key so typing a shard applies once it settles
-    // (no Refresh button) without querying a half-typed value.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
 
     // A point-in-time DO read (no write-flush fires on socket connect/disconnect),
     // so a one-shot read keyed by the debounced shard; the poll below keeps it
@@ -101,7 +96,7 @@ const SubscriptionsPanel = ({ initialShardKey }: SubscriptionsPanelProps): React
         error,
         errorSource,
         refetch,
-    } = useAdminQuery<SubscriptionsResult>(ADMIN_FUNCTIONS.listSubscriptions, {}, { keepPreviousData: true, shardKey: debouncedShard });
+    } = useAdminQuery<SubscriptionsResult>(ADMIN_FUNCTIONS.listSubscriptions, {}, { keepPreviousData: true, shardKey: queryShardKey });
 
     // No write-flush fires on socket connect/disconnect, so poll the committed
     // shard to keep the snapshot current without a manual refresh.

--- a/packages/studio/src/features/reports/fanout-panel.tsx
+++ b/packages/studio/src/features/reports/fanout-panel.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import { useState } from "react";
 
 import { ErrorAlert } from "../../components/error-alert";
 import { ShardInput } from "../../components/shard-input";
@@ -10,7 +9,7 @@ import { EmptyState } from "../../components/ui/empty-state";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../components/ui/table";
 import { useAdminQuery } from "../../hooks/use-admin-query";
 import { useAutoRefresh } from "../../hooks/use-auto-refresh";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import type { TFunction } from "../../i18n/i18n-context";
 import { useT } from "../../i18n/i18n-context";
 import type { FanoutMetricsResult, FanoutPathCounters } from "../../lib/admin";
@@ -75,18 +74,14 @@ const PathCounters = ({
 const FanoutPanel = ({ initialShardKey }: FanoutPanelProps): ReactElement => {
     const t = useT();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
-
-    // Re-read on the debounced shard key so typing a shard applies once it settles
-    // without querying a half-typed value.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
 
     const {
         data: result,
         error,
         errorSource,
         refetch,
-    } = useAdminQuery<FanoutMetricsResult>(ADMIN_FUNCTIONS.getFanoutMetrics, {}, { keepPreviousData: true, shardKey: debouncedShard });
+    } = useAdminQuery<FanoutMetricsResult>(ADMIN_FUNCTIONS.getFanoutMetrics, {}, { keepPreviousData: true, shardKey: queryShardKey });
 
     // Point-in-time DO read — poll to keep the snapshot current without a manual refresh.
     useAutoRefresh(refetch, true);

--- a/packages/studio/src/features/reports/metrics-panel.tsx
+++ b/packages/studio/src/features/reports/metrics-panel.tsx
@@ -7,7 +7,7 @@ import { LiveError } from "../../components/live-status";
 import { ShardInput } from "../../components/shard-input";
 import { Button } from "../../components/ui/button";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { MetricsSnapshot, ShardMetrics } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -61,7 +61,7 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
     const t = useT();
     const navigate = useNavigate();
 
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
     /** Active panel tab: "overview" (default) or "query-insights" (shown when queryStats present). */
     const [activeTab, setActiveTab] = useState<"overview" | "query-insights">("overview");
     const [history, setHistory] = useState<ReadonlyArray<number>>([]);
@@ -83,16 +83,12 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
         };
     }, []);
 
-    // The shard the read targets, debounced so typing a key settles before
-    // refetching (and re-subscribing) rather than firing per keystroke.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
-
     // Exemplar drill-down: stash the trace id — and the shard the series was queried
     // on, so the Traces panel searches the right ring rather than the root — for the
     // Traces panel to pick up and pre-filter on mount, then navigate there. A
     // one-shot handoff keeps the two panels decoupled from the router's search schema.
     const openTrace = (traceId: string): void => {
-        writePendingTraceFilter({ shardKey: debouncedShard, traceId });
+        writePendingTraceFilter({ shardKey: queryShardKey, traceId });
         fireAndForget(navigate({ to: "/traces" }));
     };
 
@@ -100,7 +96,7 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
     // server push folds in like a refresh; `liveError` holds a rejection message
     // (e.g. missing admin token) so the panel can say why it stopped updating. The
     // one-shot read remains the source of truth.
-    const { data, error, liveError } = useAdminQuery<ShardMetrics>(ADMIN_FUNCTIONS.getMetrics, {}, { live: true, shardKey: debouncedShard });
+    const { data, error, liveError } = useAdminQuery<ShardMetrics>(ADMIN_FUNCTIONS.getMetrics, {}, { live: true, shardKey: queryShardKey });
 
     const metrics = data ?? null;
 
@@ -117,7 +113,7 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
             return;
         }
 
-        recordShard(debouncedShard);
+        recordShard(queryShardKey);
 
         const next = data;
         const previous = lastRequestsRef.current;
@@ -138,7 +134,7 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
         if (previous !== null && next.requests >= previous) {
             setHistory((prior) => [...prior, next.requests - previous].slice(-MAX_HISTORY));
         }
-    }, [data, debouncedShard]);
+    }, [data, queryShardKey]);
 
     // Cross-shard aggregate: per-shard results for the shards we know about
     // (root + current + recently-visited). `null` = aggregate view not loaded.
@@ -280,7 +276,7 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
             )}
 
             {/* Query Insights tab — rendered only when present and selected. */}
-            {effectiveTab === "query-insights" && queryStats !== undefined && <QueryInsightsRange shardKey={debouncedShard} />}
+            {effectiveTab === "query-insights" && queryStats !== undefined && <QueryInsightsRange shardKey={queryShardKey} />}
 
             {effectiveTab === "overview" && metrics !== null && (
                 <MetricsOverviewStats
@@ -299,7 +295,7 @@ export const MetricsPanel = ({ initialShardKey }: MetricsPanelProps): ReactEleme
              * this shard. Self-contained (its own live read), renders nothing until a
              * series exists, and sits below the shard-health cards on the overview.
              */}
-            {effectiveTab === "overview" && <InstrumentsTable onOpenTrace={openTrace} shardKey={debouncedShard} />}
+            {effectiveTab === "overview" && <InstrumentsTable onOpenTrace={openTrace} shardKey={queryShardKey} />}
 
             {effectiveTab === "overview" && aggregate !== null && shardResults !== null && (
                 <MetricsAggregateView aggregate={aggregate} shardResults={shardResults} />

--- a/packages/studio/src/features/schema/hooks/use-schema-explorer.tsx
+++ b/packages/studio/src/features/schema/hooks/use-schema-explorer.tsx
@@ -74,7 +74,7 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
     const [tables, setTables] = useState<TableInfo[] | null>(null);
     const [error, setError] = useState<null | string>(null);
     const [columns, setColumns] = useState<Record<string, string[]>>({});
-    // Declared indexes per `${shardKey}:${table}`, loaded lazily alongside columns on expand.
+    // Declared indexes per `${queryShardKey}:${table}`, loaded lazily alongside columns on expand.
     const [indexes, setIndexes] = useState<Record<string, TableIndexInfo[]>>({});
     const [expanded, setExpanded] = useState<null | string>(null);
 
@@ -153,8 +153,9 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
             // Key the column cache by shard + table so editing the shard input
             // (before the debounced re-load settles) and then expanding a table
             // can't return a previous shard's columns; the probe below uses the
-            // same shardKey.
-            const cacheKey = `${shardKey}:${table}`;
+            // same queryShardKey — the settled shard the displayed tables/columns
+            // actually belong to, not the live keystroke-by-keystroke input.
+            const cacheKey = `${queryShardKey}:${table}`;
 
             if (columns[cacheKey] !== undefined) {
                 return;
@@ -164,8 +165,8 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
             // older worker without `listTableIndexes` (or one without an admin
             // token for that read) still shows the column list.
             const [page, indexResult] = await Promise.allSettled([
-                client.query(READ_TABLE_PAGE, { limit: 1, offset: 0, table }, callOptions(shardKey)) as Promise<TablePage>,
-                client.query(LIST_TABLE_INDEXES, { table }, callOptions(shardKey)) as Promise<TableIndexesResult>,
+                client.query(READ_TABLE_PAGE, { limit: 1, offset: 0, table }, callOptions(queryShardKey)) as Promise<TablePage>,
+                client.query(LIST_TABLE_INDEXES, { table }, callOptions(queryShardKey)) as Promise<TableIndexesResult>,
             ]);
 
             if (page.status === "fulfilled") {
@@ -182,7 +183,7 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
                 });
             }
         },
-        [client, columns, expanded, shardKey],
+        [client, columns, expanded, queryShardKey],
     );
 
     const toggleGlobal = async (table: string): Promise<void> => {
@@ -297,25 +298,27 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
     // When the graph opens (or the shard switches) probe every table's columns
     // once per shard. List view never probes, so the graph cost is opt-in. This is
     // a genuine lazy data-load, not a click handler: it must also re-run when the
-    // shard's `tables` change (after a re-seed) or `shardKey` switches, so it stays
-    // an effect keyed on those values rather than firing from the toggle's onClick.
+    // shard's `tables` change (after a re-seed) or `queryShardKey` switches, so it
+    // stays an effect keyed on those values rather than firing from the toggle's
+    // onClick. Keyed on `queryShardKey` (not the live `shardKey`) so the probe
+    // targets the same settled shard `tables`/`globalTables` were loaded for.
     // It waits for global discovery to resolve (success or failure) so the probe
     // covers global table names too.
     useEffect(() => {
         // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- lazy data-load gated on view + shard, not an event handler
-        if (view !== "graph" || tables === null || (globalTables === null && globalError === null) || shardColumns[shardKey] !== undefined) {
+        if (view !== "graph" || tables === null || (globalTables === null && globalError === null) || shardColumns[queryShardKey] !== undefined) {
             return;
         }
 
         fireAndForget(
             // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- lazy column probe gated on view + shard, not derived state
             probeSchema(
-                shardKey,
+                queryShardKey,
                 tables.map((table) => table.name),
                 (globalTables ?? []).map((table) => table.name),
             ),
         );
-    }, [view, tables, globalTables, globalError, shardKey, shardColumns, probeSchema]);
+    }, [view, tables, globalTables, globalError, queryShardKey, shardColumns, probeSchema]);
 
     // The unified diagram model: every table across both tiers, tagged with its
     // storage tier and carrying the columns probed for this shard (schema-typed
@@ -323,7 +326,7 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
     // A shard column referencing a global table resolves to a real node, so the
     // cross-tier FK edge can render.
     const diagramTables = useMemo<DiagramTable[]>(() => {
-        const columnsForShard = shardColumns[shardKey] ?? EMPTY_COLUMNS;
+        const columnsForShard = shardColumns[queryShardKey] ?? EMPTY_COLUMNS;
         const shardOnes = (tables ?? []).map((table): DiagramTable => {
             return { columns: columnsForShard[table.name] ?? EMPTY_COLUMN_META, name: table.name, tier: "shard" };
         });
@@ -332,7 +335,7 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
         });
 
         return [...shardOnes, ...globalOnes];
-    }, [tables, globalTables, shardColumns, shardKey]);
+    }, [tables, globalTables, shardColumns, queryShardKey]);
 
     // Substring filter (case-insensitive) over each tier's table names, applied
     // only in the list view. An empty filter shows every table.

--- a/packages/studio/src/features/schema/hooks/use-schema-explorer.tsx
+++ b/packages/studio/src/features/schema/hooks/use-schema-explorer.tsx
@@ -2,7 +2,7 @@ import type { GlobalTableInfo } from "@lunora/client";
 import { useLunora } from "@lunora/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import useDebounced from "../../../hooks/use-debounced";
+import { useShardKey } from "../../../hooks/use-shard-key";
 import type { ColumnMeta, TableIndexesResult, TableIndexInfo, TableInfo, TablePage, TablesColumnsResult } from "../../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../../lib/admin";
 import { adminRef, callOptions, errorMessage, fireAndForget } from "../../../lib/internal";
@@ -69,7 +69,7 @@ interface SchemaExplorer {
 const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?: string; initialTable?: string }): SchemaExplorer => {
     const client = useLunora();
     const [view, setView] = useState<SchemaView>("graph");
-    const [shardKey, setShardKey] = useState<string>(initialShardKey ?? "");
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(initialShardKey);
     const [tableFilter, setTableFilter] = useState<string>("");
     const [tables, setTables] = useState<TableInfo[] | null>(null);
     const [error, setError] = useState<null | string>(null);
@@ -134,13 +134,11 @@ const useSchemaExplorer = ({ initialShardKey, initialTable }: { initialShardKey?
     // Re-read on the debounced shard key so switching shards re-loads the schema
     // once the value settles (no Refresh button). Schema is static between
     // codegen/migrations, so there's no live channel or poll — just this re-load.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
-
     useEffect(() => {
         // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- async schema load, re-run when the debounced shard settles
-        fireAndForget(refresh(debouncedShard));
+        fireAndForget(refresh(queryShardKey));
         fireAndForget(refreshGlobal());
-    }, [refresh, refreshGlobal, debouncedShard]);
+    }, [refresh, refreshGlobal, queryShardKey]);
 
     const toggle = useCallback(
         async (table: string): Promise<void> => {

--- a/packages/studio/src/features/traces/traces-panel.tsx
+++ b/packages/studio/src/features/traces/traces-panel.tsx
@@ -11,7 +11,7 @@ import { Badge } from "../../components/ui/badge";
 import { EmptyState } from "../../components/ui/empty-state";
 import { Input } from "../../components/ui/input";
 import { useAdminQuery } from "../../hooks/use-admin-query";
-import useDebounced from "../../hooks/use-debounced";
+import { useShardKey } from "../../hooks/use-shard-key";
 import { useT } from "../../i18n/i18n-context";
 import type { TraceSpan, TracesResult, TraceSummary } from "../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../lib/admin";
@@ -215,7 +215,9 @@ export const TracesPanel = ({ initialShardKey }: TracesPanelProps): ReactElement
     // clear lives in the mount effect below, not here.
     const [pending] = useState<PendingTraceFilter | undefined>(peekPendingTraceFilter);
 
-    const [shardKey, setShardKey] = useState<string>(pending?.shardKey !== undefined && pending.shardKey !== "" ? pending.shardKey : (initialShardKey ?? ""));
+    const { queryShardKey, setShardKey, shardKey } = useShardKey(
+        pending?.shardKey !== undefined && pending.shardKey !== "" ? pending.shardKey : (initialShardKey ?? ""),
+    );
     const [search, setSearch] = useState<string>(pending?.traceId ?? "");
     const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
 
@@ -227,14 +229,10 @@ export const TracesPanel = ({ initialShardKey }: TracesPanelProps): ReactElement
         clearPendingTraceFilter();
     }, []);
 
-    // Debounced so typing a key settles before refetching (and re-subscribing)
-    // rather than firing per keystroke — mirrors the Logs and Issues panels.
-    const debouncedShard = useDebounced(shardKey.trim(), 400);
-
     const { data, error, errorSource, isLoading, liveError } = useAdminQuery<TracesResult>(
         ADMIN_FUNCTIONS.getTraces,
         {},
-        { live: true, shardKey: debouncedShard },
+        { live: true, shardKey: queryShardKey },
     );
 
     // Record the browsed shard into recent-shards history once the read resolves,
@@ -242,9 +240,9 @@ export const TracesPanel = ({ initialShardKey }: TracesPanelProps): ReactElement
     // matching the nine other shard-scoped panels.
     useEffect(() => {
         if (data !== undefined) {
-            recordShard(debouncedShard);
+            recordShard(queryShardKey);
         }
-    }, [data, debouncedShard]);
+    }, [data, queryShardKey]);
 
     const traces = tracesOf(data);
     // The RPC returns only the newest `DEFAULT_TRACE_LIMIT` traces; `total` is how

--- a/packages/studio/src/hooks/use-shard-key.ts
+++ b/packages/studio/src/hooks/use-shard-key.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseShardKeyResult {
+    /** The debounced shard key an admin read/subscription should key on. */
+    queryShardKey: string;
+    /** Update the raw input value (per keystroke). */
+    setShardKey: (value: string) => void;
+    /** The raw, un-debounced input value — bind this to the `ShardInput`. */
+    shardKey: string;
+}
+
+/**
+ * Shard-key input state for an admin panel: the raw (per-keystroke) `shardKey`
+ * plus a `queryShardKey` debounced by `delayMs` (400ms by default) so a read
+ * or live subscription settles once the operator stops typing instead of
+ * re-firing on every keystroke. Consolidates the
+ * `useState` + `useDebounced(shardKey.trim(), 400)` preamble that was
+ * copy-pasted across every Studio panel with a shard-key input.
+ *
+ * Debounces with its own `setTimeout` effect (mirroring `useDebounced`'s
+ * shape) rather than composing `useDebounced` itself, so it can reset that
+ * timer atomically with the state below — composing the two hooks would let
+ * `useDebounced`'s still-old internal value win a render over this hook's own
+ * synchronous reset.
+ *
+ * `initial` is tracked across renders, not just read once on mount. When the
+ * CALLER's `initial` changes — the operator switches table/tab and the panel
+ * re-seeds from a new URL/selection — that is a discrete reset, not a
+ * keystroke that should settle: `queryShardKey` snaps to the new value
+ * immediately (synchronously, during render — no `useEffect` round trip, so
+ * there is no flash of the stale value) rather than waiting out the debounce.
+ * Without this, a switch kept `queryShardKey` pointed at the PREVIOUS shard
+ * for up to `delayMs`, so a query/subscription keyed on it kept reading (and
+ * the view kept showing) the previous shard's data until the debounce caught
+ * up. Typing into the input via `setShardKey` still debounces normally.
+ */
+const useShardKey = (initial: string | undefined, delayMs = 400): UseShardKeyResult => {
+    const seed = (initial ?? "").trim();
+
+    const [shardKey, setShardKeyState] = useState<string>(seed);
+    const [queryShardKey, setQueryShardKey] = useState<string>(seed);
+
+    // The `initial` this hook is currently seeded from — compared against the
+    // live `initial` argument below so a change is caught exactly once per
+    // transition. Calling both setters here is React's sanctioned "adjust
+    // state while rendering" pattern: it discards this in-progress render and
+    // immediately restarts the component function with the new state, so
+    // `shardKey`/`queryShardKey` are already settled by the time this render
+    // commits — no extra frame, no flash of the stale shard.
+    const seededFromRef = useRef(initial);
+
+    if (seededFromRef.current !== initial) {
+        seededFromRef.current = initial;
+        setShardKeyState(seed);
+        setQueryShardKey(seed);
+    }
+
+    const trimmed = shardKey.trim();
+
+    // Settles `queryShardKey` onto `trimmed` after `delayMs` of no further
+    // edits. The reset above changes `shardKey` in the same render restart, so
+    // this effect's dependency already reflects the reset — it only ever
+    // re-confirms the (already-set) reset value, never overwrites it with a
+    // stale one.
+    useEffect(() => {
+        const id = setTimeout(() => {
+            setQueryShardKey(trimmed);
+        }, delayMs);
+
+        return () => {
+            clearTimeout(id);
+        };
+    }, [trimmed, delayMs]);
+
+    const setShardKey = (value: string): void => {
+        setShardKeyState(value);
+    };
+
+    return { queryShardKey, setShardKey, shardKey };
+};
+
+export { useShardKey };
+export type { UseShardKeyResult };


### PR DESCRIPTION
Five independent dedup/tech-debt fixes, one commit each.

## A — runtime `constantTimeEqual` → the canonical `shared/` copy
The runtime carried a private reimplementation (using `codePointAt` where the canonical uses `charCodeAt`) with a stale "keep in sync with shard-do.ts" comment — but shard-do already imports from `shared/`. A security primitive with two definitions is exactly what drifts. Now imports `shared/constant-time-equal`; the local copy + stale comment are gone. Added a dedup-guard test that greps `packages/*/src` + `shared/` for a redeclared `constantTimeEqual` (with a documented allowlist for the one remaining out-of-scope payment copy → follow-up).

## B — catalog every minted error code (close the fail-open leak)
`isInternalCode` fails **open** for any code not in `ERROR_CATALOG`, so an uncatalogued 500-class code echoes its message to the client with nothing failing. A two-pattern, multi-line-aware grep found **81** uncatalogued codes (the plan's "27" was an example list) — all now registered with correct statuses. **6 flagged `internal: true`, each audited individually**: `AUTH_AUDIT_READ_FAILED`, `CRON_JOB_FAILED`, `MISCONFIGURED` (the named live-leak on the public RPC path), `NESTED_TRANSACTION`, `SQL_UNAVAILABLE`, `INTERNAL_ERROR` — all carry backend detail. The `*_NOT_CONFIGURED` family, codegen build-time diagnostics, and client-SDK/WS codes stayed non-internal (static, actionable messages — not over-flagged). Added a repo-level registration test that fails on any future uncatalogued code.

## C — one bounded-concurrency helper
Five hand-rolled bounded-fan-out loops in `query-coordinator.ts` (with already-divergent guards) collapsed into `runBoundedJobs<T,R>(jobs, concurrency, run)`; `runBoundedFanOut` and the cdcSync/import/applyCdc/rankPage orchestrators call it, unified on the early-return-when-empty guard. The `query-coordinator.*.test.ts` suite pins the semantics.

## D — complete + data-drive the umbrella exports
`lunorash` was missing `server/otel` and `client/upload`, so a one-install app couldn't reach two shipped features. Added both re-exports + export-map entries, and rewrote the parity test to **read each upstream package's own `exports` map** and assert a `lunorash/*` mapping for every subpath — with an explicit opt-out list (`@lunora/platform`'s `./conformance*`) and an alias table (`flags/providers/*`→`flags/*`). It now fails on the next upstream subpath drift instead of needing a hand-maintained array.

## E — `useShardKey` hook (12 duplicated preambles → 1)
The shard-key + 400ms-debounce preamble was copy-pasted in 12 panels. Extracted `useShardKey(initial, delayMs)` → `{ shardKey, setShardKey, queryShardKey }` with the debounce + **synchronous reset** semantics. It uses its **own** `setTimeout` debounce rather than composing the shared `useDebounced` — composing let a stale pending debounce clobber a synchronous reset (caught by a regression test), and keeping the diff out of `use-debounced.ts` means **zero overlap with #264's edit to that file**.

## Verification
runtime 791, errors 528, lunorash 117, studio 967 (hook: 7 tests incl. synchronous-reset + stale-timer). All `lint:types`/`lint:eslint`/`lint:package-json` green; full `build:packages` (53 projects) passes.

## Merge-order notes (all individually mergeable vs alpha)
- `studio/features/advisors/insights-panel.tsx` overlaps #272 — this touches only the shard-key preamble; #272's index-enumeration body is left untouched, so the conflict is trivial context lines (keep both).
- studio panels vs #264 — designed for clean merge either order (no `use-debounced.ts` edit here; `use-data-browser.tsx`'s reset is additive to its existing re-seed effect).
- `runtime/create-worker.ts` + `query-coordinator.ts` — resolve against any other runtime PR by keeping both regions.

Plan: `plans/230-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader, clearer error coverage with appropriate status and diagnostic handling.
  * Exposed server telemetry and client upload capabilities through the main package.
  * Added consistent shard-key selection and settling across Studio data, logs, reports, migrations, schema, traces, and issue views.

* **Improvements**
  * Improved reliability and consistency when running concurrent data operations.
  * Standardized shard-scoped queries and actions to reduce inconsistent results while users edit shard keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->