### PR TITLE
fix(server): fail closed on bare masked-column index scans and rank over masked indexes

### DIFF
--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -1001,6 +1001,214 @@ describe("mask — value oracle via rank reads fails closed (plan 209)", () => {
     });
 });
 
+describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 250)", () => {
+    it("bare withIndex(name) over an index whose DECLARED fields include a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", createdAt: 1, ssn: "123-45-6789", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn: ["ssn"] } } }))
+            // No range callback: this is the bare scan the range-recorder can't
+            // see — it still returns every row ORDERED by the masked `ssn`
+            // column, which is the position oracle `assertIndexDeclarationAllowed`
+            // closes.
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("users").withIndex("by_ssn").collect());
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("bare withIndex(name) over an index whose DECLARED fields exclude the masked column still scans and masks output", async () => {
+        expect.assertions(2);
+
+        const seed = [{ _id: "u1", createdAt: 1, email: "a@x.com", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { by_createdAt: ["createdAt"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("users").withIndex("by_createdAt").collect());
+
+        const rows = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.["email"]).toBeNull();
+    });
+
+    it("withIndex(range) over a masked-column index throws even when the range callback references only an unmasked field (declared fields win over callback-referenced ones)", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", createdAt: 1, ssn: "123-45-6789", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_time: ["createdAt", "ssn"] } } }))
+            // The callback only ever names `createdAt` — `assertIndexFieldsAllowed`'s
+            // recorder would let this through on its own — but `by_ssn_time`
+            // DECLARES `ssn` too, so the row order still leaks the hidden value.
+            // The declaration guard rejects it regardless of what the callback
+            // references.
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("users")
+                    .withIndex("by_ssn_time", (q) => q.gte("createdAt", 1))
+                    .collect(),
+            );
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("withIndex over an index name absent from `indexFields` is not rejected by the declaration guard (fails open; an unknown index errors downstream anyway)", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", email: "a@x.com", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { by_ssn: ["ssn"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("users").withIndex("by_unknown").collect());
+
+        const rows = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(rows[0]?.["email"]).toBeNull();
+    });
+
+    it("regression: with `indexFields` omitted, a bare withIndex(name) behaves exactly as before this option existed (no throw)", async () => {
+        expect.assertions(2);
+
+        const seed = [{ _id: "u1", ssn: "123-45-6789", table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("users").withIndex("by_ssn").collect());
+
+        const rows = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.["ssn"]).toBeNull();
+    });
+
+    it("rank() over a rank index whose declared `sortBy` names a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "by_ssn_rank", { row: "u1" }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("rank() over a rank index whose declared `partitionBy` names a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_score_per_ssn: ["score", "ssn"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "by_score_per_ssn", { row: "u1" }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("rank() over an all-unmasked rank index passes through", async () => {
+        expect.assertions(2);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { leaderboard: ["score"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "leaderboard", { row: "u1" }));
+
+        const result = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(result).toStrictEqual({ position: 1, total: 1 });
+        expect(database.calls.some((call) => call.method === "rank")).toBe(true);
+    });
+
+    it("rankPage() over a rank index whose declared `sortBy` names a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(2);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPage("users", "by_ssn_rank", {}));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+        expect(database.calls.some((call) => call.method === "rankPage")).toBe(false);
+    });
+
+    it("rankPage() over an all-unmasked rank index still works and masks output", async () => {
+        expect.assertions(2);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { leaderboard: ["score"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPage("users", "leaderboard", {}));
+
+        const result = (await handler.handler(makeContext(database, "u1"), {})) as Page;
+
+        expect(database.calls.some((call) => call.method === "rankPage")).toBe(true);
+        expect(result.page[0]?.["ssn"]).toBeNull();
+    });
+
+    it("rankBefore() over a rank index whose declared `sortBy` names a masked column throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const rows = [{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }];
+        const database = createFakeDatabase(rows);
+
+        enableRankBefore(database, rows);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankBefore?.("users", "by_ssn_rank", { rowId: "u1" }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("rankBefore absent on the base writer (D1 twin) is not synthesized even when `indexFields` is supplied — no crash", async () => {
+        expect.assertions(1);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .query(({ ctx }) => typeof (ctx as unknown as TestContext).db.rankBefore);
+
+        // No `enableRankBefore` call: the fake writer never carries the method.
+        // `wrapDatabase`'s conditional spread must not synthesize one even now
+        // that `assertIndexDeclarationAllowed` exists — no crash, no throw.
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toBe("undefined");
+    });
+
+    it("regression: with `indexFields` omitted, rank() over a masked-sorted index behaves exactly as before this option existed (no throw from the declaration guard)", async () => {
+        expect.assertions(1);
+
+        const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "by_ssn_rank", { row: "u1" }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toStrictEqual({ position: 1, total: 1 });
+    });
+});
+
 describe("mask — get() table resolution", () => {
     it("masks via the lookupById fast path", async () => {
         expect.assertions(2);

--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -45,6 +45,12 @@ interface FakeSearchBuilder {
     search: (field: string, query: string) => FakeSearchBuilder;
 }
 
+/** Geo-filter builder passed to `.withGeoIndex(name, q => …)` — mirrors `@lunora/do`'s `GeoFilterBuilder` (`near`/`within`). */
+interface FakeGeoBuilder {
+    near: (point: { lat: number; lng: number }, radiusMeters: number) => FakeGeoBuilder;
+    within: (box: { ne: { lat: number; lng: number }; sw: { lat: number; lng: number } }) => FakeGeoBuilder;
+}
+
 interface FakeReader {
     collect: () => Promise<Record<string, unknown>[]>;
     filter: (predicate: (document: Record<string, unknown>) => boolean) => FakeReader;
@@ -53,6 +59,7 @@ interface FakeReader {
     paginate: () => Promise<{ continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] }>;
     take: (limit: number) => Promise<Record<string, unknown>[]>;
     unique: () => Promise<Record<string, unknown> | null>;
+    withGeoIndex: (indexName: string, build: (q: FakeGeoBuilder) => FakeGeoBuilder) => FakeReader;
     withIndex: (indexName?: string, range?: (q: FakeIndexBuilder) => FakeIndexBuilder) => FakeReader;
     withSearchIndex: (indexName: string, search: (q: FakeSearchBuilder) => FakeSearchBuilder) => FakeReader;
 }
@@ -253,6 +260,19 @@ const enableQueryReader = (database: FakeDatabase, rows: (Record<string, unknown
                 };
 
                 search(builder);
+
+                return makeReader(list);
+            },
+            // Same shape as `withIndex`: run the builder against a chainable
+            // no-op (mirrors `@lunora/do`'s geo reader), so the reader still
+            // works end-to-end for a geo read the declaration guard lets through.
+            withGeoIndex: (_indexName, build) => {
+                const builder: FakeGeoBuilder = {
+                    near: () => builder,
+                    within: () => builder,
+                };
+
+                build(builder);
 
                 return makeReader(list);
             },
@@ -1206,6 +1226,80 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "by_ssn_rank", { row: "u1" }));
 
         await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toStrictEqual({ position: 1, total: 1 });
+    });
+});
+
+describe("mask — withGeoIndex position oracle fails closed (plan 250 follow-up)", () => {
+    it("withGeoIndex over a geo index whose declared field is masked throws MASK_UNSUPPORTED", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", homeLocation: { lat: 40.7128, lng: -74.006 }, table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { homeLocation: "redact" } }, { indexFields: { users: { by_location: ["homeLocation"] } } }))
+            // A caller sweeping `point`/`radiusMeters` here gets rows sorted by
+            // distance from an arbitrary point of their own choosing — the same
+            // shape of ordinal leak as the bare-`withIndex` oracle, but over a
+            // `v.geoPoint()` column instead of a scalar. There is no unmasked
+            // range/prefix escape for a geo index (unlike a multi-column
+            // `withIndex`), so this must fail closed unconditionally.
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("users")
+                    .withGeoIndex("by_location", (q) => q.near({ lat: 40.7, lng: -74 }, 5000))
+                    .collect(),
+            );
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("withGeoIndex over a geo index whose declared field is NOT masked still scans and masks other output (no over-fire)", async () => {
+        expect.assertions(2);
+
+        const seed = [{ _id: "u1", email: "a@x.com", homeLocation: { lat: 40.7128, lng: -74.006 }, table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { by_location: ["homeLocation"] } } }))
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("users")
+                    .withGeoIndex("by_location", (q) => q.near({ lat: 40.7, lng: -74 }, 5000))
+                    .collect(),
+            );
+
+        const rows = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(rows).toHaveLength(1);
+        // The geo column itself isn't masked here, so the read must go through
+        // (proving the declaration guard doesn't over-fire on an unmasked geo
+        // index) while the actually-masked column is still redacted.
+        expect(rows[0]?.["email"]).toBeNull();
+    });
+
+    it("regression: with `indexFields` omitted, withGeoIndex over a masked-field geo index behaves exactly as before this option existed (no throw from the declaration guard)", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "u1", homeLocation: { lat: 40.7128, lng: -74.006 }, table: "users" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query.use(maskForTest({ users: { homeLocation: "redact" } })).query(async ({ ctx }) =>
+            (ctx as unknown as TestContext).db
+                .query("users")
+                .withGeoIndex("by_location", (q) => q.near({ lat: 40.7, lng: -74 }, 5000))
+                .collect(),
+        );
+
+        const rows = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(rows).toHaveLength(1);
     });
 });
 

--- a/packages/server/__tests__/schema.test.ts
+++ b/packages/server/__tests__/schema.test.ts
@@ -361,6 +361,39 @@ describe("indexFieldsFromSchema (plan 250 — mask() bare-index-scan / rank orac
 
         expect(indexFieldsFromSchema(schema)).toStrictEqual({ messages: { byTime: ["createdAt"] } });
     });
+
+    it("maps a geo index's declared `field` (closes the withGeoIndex position oracle)", () => {
+        expect.assertions(1);
+
+        const schema = defineSchema({
+            users: defineTable({ homeLocation: v.geoPoint(), name: v.string() }).geoIndex("by_location", { field: "homeLocation" }),
+        });
+
+        expect(indexFieldsFromSchema(schema)).toStrictEqual({
+            users: {
+                by_location: ["homeLocation"],
+            },
+        });
+    });
+
+    it("does NOT include vectorIndexes or aggregateIndexes fields — neither is a reachable ordinal oracle through the masked reader", () => {
+        expect.assertions(1);
+
+        const embed = async (text: string): Promise<ReadonlyArray<number>> => [text.length];
+        const schema = defineSchema(
+            { docs: defineTable({ body: v.string(), ssn: v.string() }).aggregateIndex("byCount") },
+            {
+                byEmbedding: defineVectorIndex({
+                    dimensions: 3,
+                    embed,
+                    metric: "cosine",
+                    source: { select: (row) => String(row.body), table: "docs" },
+                }),
+            },
+        );
+
+        expect(indexFieldsFromSchema(schema)).toStrictEqual({});
+    });
 });
 
 describe("defineSchema().jurisdiction()", () => {

--- a/packages/server/__tests__/schema.test.ts
+++ b/packages/server/__tests__/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex, v } from "../src/index";
+import { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex, indexFieldsFromSchema, v } from "../src/index";
 
 describe("defineTable", () => {
     it("returns a table definition with shape and default __root__ shard mode", () => {
@@ -323,6 +323,43 @@ describe("defineSchema", () => {
 
         expect(index).toMatchObject({ dimensions: 1024, kind: "vectorIndex", metric: "cosine", table: "docs" });
         expect(index?.select({ body: "B", title: "T" })).toBe("T\n\nB");
+    });
+});
+
+describe("indexFieldsFromSchema (plan 250 — mask() bare-index-scan / rank oracle)", () => {
+    it("maps a regular index's declared `fields` and a rank index's `sortBy` ∪ `partitionBy`", () => {
+        expect.assertions(1);
+
+        const schema = defineSchema({
+            users: defineTable({ createdAt: v.number(), score: v.number(), ssn: v.string() })
+                .index("by_ssn", ["ssn"])
+                .rankIndex("by_score", { partitionBy: ["ssn"], sortBy: [{ field: "score" }] }),
+        });
+
+        expect(indexFieldsFromSchema(schema)).toStrictEqual({
+            users: {
+                by_score: ["score", "ssn"],
+                by_ssn: ["ssn"],
+            },
+        });
+    });
+
+    it("omits a table with no declared indexes rather than mapping it to `{}`", () => {
+        expect.assertions(1);
+
+        const schema = defineSchema({ users: defineTable({ email: v.string() }) });
+
+        expect(indexFieldsFromSchema(schema)).toStrictEqual({});
+    });
+
+    it("folds a rank index with no `partitionBy` down to just its `sortBy` fields", () => {
+        expect.assertions(1);
+
+        const schema = defineSchema({
+            messages: defineTable({ createdAt: v.number() }).rankIndex("byTime", { sortBy: [{ field: "createdAt" }] }),
+        });
+
+        expect(indexFieldsFromSchema(schema)).toStrictEqual({ messages: { byTime: ["createdAt"] } });
     });
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -86,6 +86,7 @@ export {
 export type {
     AggregateIndexOptions,
     ExtendableSchema,
+    IndexFieldsByTable,
     InlineAggregateIndexOptions,
     InlineRankIndexOptions,
     ManyRelation,
@@ -96,7 +97,7 @@ export type {
     VectorIndexOptions,
     VectorizeOptions,
 } from "./schema";
-export { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex } from "./schema";
+export { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex, indexFieldsFromSchema } from "./schema";
 export type { RegisteredShape, ShapeDefinition } from "./shapes";
 export { defineShape } from "./shapes";
 export type { DefineStorageRuleInput, StorageOperation, StorageRule, StorageRuleContext, StorageRuleDecision, StorageRulesOptions } from "./storage/index";

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -32,22 +32,25 @@
  * its returned page like `findMany`.
  *
  * **Residual read-position oracles (no column value, but ordinal/sort leaks the
- * hidden value) — three classes, closed to different degrees:**
+ * hidden value) — closed to different degrees:**
  * - A masked-column `where`/`baseWhere` filter on ANY read (including
  * `rank`/`rankBefore`/`rankPage` above) is closed.
  * - An index RANGE/SEARCH callback (`withIndex(name, q => …)`/
  * `withSearchIndex(...)`) referencing a masked column is closed
  * (`assertIndexFieldsAllowed`).
- * - **Still open:** a BARE `withIndex(name)` scan (no range callback) over an
- * index whose DECLARED fields include a masked column, and a
- * `rank`/`rankBefore` read over a rank index whose declared `sortBy` names a
- * masked column (`rankBefore`'s oracle is its `sortValues` argument, not
- * `where` — its real options carry no `where`/`baseWhere` at all). Both need
- * the index's declared fields, which requires threading schema/index
- * metadata into this middleware — a design change this module doesn't make
- * today. An index/rank read the caller cannot otherwise name a masked column
- * on is not closed by this middleware; do not rely on it for a table with a
- * masked-sorted index until this ships.
+ * - A BARE `withIndex(name)` scan (no range callback) over an index whose
+ * DECLARED fields include a masked column, and a `rank`/`rankBefore`/
+ * `rankPage` read over a rank index whose declared `sortBy`/`partitionBy`
+ * names a masked column (`rankBefore`'s oracle is its `sortValues` argument,
+ * not `where` — its real options carry no `where`/`baseWhere` at all), are
+ * closed by `assertIndexDeclarationAllowed` **when the caller supplies
+ * `MaskOptions.indexFields`** (build it with the exported
+ * `indexFieldsFromSchema(schema)`: `mask(policies, { indexFields:
+ * indexFieldsFromSchema(schema) })`). This is OPT-IN and additive —
+ * `indexFields` is optional, so a caller that doesn't pass it gets exactly
+ * today's (un)protected behaviour; the oracle stays open until it does. Do
+ * not rely on this closing for a table with a masked-sorted index unless the
+ * mask actually supplies `indexFields`.
  *
  * 3. **Writes pass through untouched** — `insert` / `patch` / `replace` /
  * `delete` are never wrapped, so masking can't corrupt stored data. Masking is
@@ -72,6 +75,7 @@ import type { Middleware } from "../builder/types";
 import { LunoraError } from "../error";
 import type { FacadeEntry } from "../facade";
 import { bindOrm, bindTableFacade } from "../facade";
+import type { IndexFieldsByTable } from "../schema";
 import { tagMaskMiddleware } from "./policy-tag";
 import type { MaskColumns, MaskContext, MaskOptions, MaskPolicies, Permission, Role } from "./types";
 
@@ -283,7 +287,9 @@ const maskPage = <Context>(page: QueryPage, columns: MaskColumns<Context>, base:
  * only push into a fresh per-call stage; see `@lunora/do`'s `createRangeBuilder`
  * / `createSearchBuilder`), so the dry pass is side-effect free. `withIndex`'s
  * `range` is optional (a bare index scan) — with no callback there is no field
- * to record and nothing to reject.
+ * to record and nothing to reject HERE; the sibling `assertIndexDeclarationAllowed`
+ * (in `wrapDatabase`, called before this one) closes that bare-scan case instead,
+ * from the index's DECLARED fields rather than a recorded callback reference.
  */
 const assertIndexFieldsAllowed = <Context>(
     builderCallback: ((q: unknown) => unknown) | undefined,
@@ -341,12 +347,59 @@ const isFacadeEntry = (value: unknown): boolean => {
  * Build a writer that masks row-returning reads against the underlying
  * `MaskDatabase`. Fresh closure per request so each `MaskFn` sees the live ctx.
  */
-const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskColumns<Context>>, context: MaskContext<Context>): MaskDatabase => {
+const wrapDatabase = <Context>(
+    base: MaskDatabase,
+    perTable: Map<string, MaskColumns<Context>>,
+    context: MaskContext<Context>,
+    indexFields: IndexFieldsByTable | undefined,
+): MaskDatabase => {
     // `rankBefore` is the one optional method (the D1 twin omits it) — captured
     // here (mirrors `../rls/middleware`'s `baseRankBefore`) so the conditional
     // override below can call it without re-narrowing `base.rankBefore` inside
     // the nested closure.
     const baseRankBefore = base.rankBefore;
+
+    /**
+     * SECURITY (position oracle on the index DECLARATION path): `assertIndexFieldsAllowed`
+     * (below) closes a range/search CALLBACK that references a masked field, but a
+     * BARE `withIndex(name)` (no callback) gives its recorder nothing to observe —
+     * it still returns every row ordered by the index's declared sort key. If that
+     * key is a masked column, the ordinal position of every returned row leaks the
+     * hidden value (one known plaintext neighbour bounds the rest). The same
+     * oracle applies directly to `rank`/`rankPage`/`rankBefore`, which return the
+     * row's ordinal.
+     *
+     * Unlike `assertIndexFieldsAllowed`, this guards the index's DECLARED fields —
+     * it needs `indexFields`, the per-table index→fields map an app supplies via
+     * `mask(policies, { indexFields: indexFieldsFromSchema(schema) })`
+     * ({@link MaskOptions.indexFields}). Fails OPEN (returns without throwing) for
+     * the un-hardenable cases: `indexFields` wasn't supplied, or the table/index
+     * name isn't declared in it (an unknown index name errors downstream anyway,
+     * so there is nothing left to protect by throwing here too). Only a KNOWN
+     * index whose declared fields intersect the masked column set throws.
+     */
+    const assertIndexDeclarationAllowed = (tableName: string, indexName: string, method: string): void => {
+        const columns = perTable.get(tableName);
+
+        if (!columns) {
+            return;
+        }
+
+        const declaredFields = indexFields?.[tableName]?.[indexName];
+
+        if (!declaredFields) {
+            return;
+        }
+
+        const offending = declaredFields.find((field) => field in columns);
+
+        if (offending !== undefined) {
+            throw new LunoraError(
+                "MASK_UNSUPPORTED",
+                `${method}() reading "${tableName}" via index "${indexName}" would order rows by masked column "${offending}" — add a range callback over unmasked fields, or unmask the column`,
+            );
+        }
+    };
 
     /**
      * Wrap a `query()` reader so every terminal read (`collect` / `first` /
@@ -397,6 +450,10 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
             // `where`, so it must fail closed (see `assertIndexFieldsAllowed`).
             // Reads over NON-masked columns pass through and still mask output.
             withIndex: (indexName, range) => {
+                // Declared-fields guard FIRST: it closes the BARE scan (no `range`),
+                // which the callback-recorder just below can't see — see the guard
+                // function's own docblock, above `wrapDatabase`.
+                assertIndexDeclarationAllowed(tableName, indexName, "withIndex");
                 assertIndexFieldsAllowed(range, columns, tableName, "withIndex");
 
                 return wrapReader(reader.withIndex(indexName, range), columns, tableName);
@@ -695,12 +752,14 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
 
         async rank(tableName, indexName, options) {
             assertRankWhereAllowed(tableName, options, "rank");
+            assertIndexDeclarationAllowed(tableName, indexName, "rank");
 
             return base.rank(tableName, indexName, options);
         },
 
         async rankPage(tableName, indexName, options) {
             assertRankWhereAllowed(tableName, options, "rankPage");
+            assertIndexDeclarationAllowed(tableName, indexName, "rankPage");
 
             const page = await base.rankPage(tableName, indexName, options);
             const columns = perTable.get(tableName);
@@ -715,6 +774,7 @@ const wrapDatabase = <Context>(base: MaskDatabase, perTable: Map<string, MaskCol
             ? {
                   rankBefore(tableName: string, indexName: string, options: unknown) {
                       assertRankWhereAllowed(tableName, options, "rankBefore");
+                      assertIndexDeclarationAllowed(tableName, indexName, "rankBefore");
 
                       return baseRankBefore(tableName, indexName, options);
                   },
@@ -787,7 +847,7 @@ const mask = <Context extends MaskContextIn = MaskContextIn>(
             return next();
         }
 
-        const wrapped = wrapDatabase<Context>(ctx.db, perTable, maskContext);
+        const wrapped = wrapDatabase<Context>(ctx.db, perTable, maskContext, options.indexFields);
         const extension: Record<string, unknown> = { db: wrapped };
         const { orm } = ctx as { orm?: unknown };
 

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -39,18 +39,28 @@
  * `withSearchIndex(...)`) referencing a masked column is closed
  * (`assertIndexFieldsAllowed`).
  * - A BARE `withIndex(name)` scan (no range callback) over an index whose
- * DECLARED fields include a masked column, and a `rank`/`rankBefore`/
- * `rankPage` read over a rank index whose declared `sortBy`/`partitionBy`
- * names a masked column (`rankBefore`'s oracle is its `sortValues` argument,
- * not `where` — its real options carry no `where`/`baseWhere` at all), are
- * closed by `assertIndexDeclarationAllowed` **when the caller supplies
+ * DECLARED fields include a masked column, a `rank`/`rankBefore`/`rankPage`
+ * read over a rank index whose declared `sortBy`/`partitionBy` names a masked
+ * column (`rankBefore`'s oracle is its `sortValues` argument, not `where` —
+ * its real options carry no `where`/`baseWhere` at all), and a `withGeoIndex`
+ * read over a geo index whose declared field is masked (its `near`/`within`
+ * builder exposes no column name to a callback recorder, but the returned
+ * rows are sorted by distance from the caller's own query point, which lets a
+ * point/radius sweep trilaterate the hidden coordinate — the same shape of
+ * oracle, over a `v.geoPoint()` column instead of a scalar), are all closed
+ * by `assertIndexDeclarationAllowed` **when the caller supplies
  * `MaskOptions.indexFields`** (build it with the exported
  * `indexFieldsFromSchema(schema)`: `mask(policies, { indexFields:
  * indexFieldsFromSchema(schema) })`). This is OPT-IN and additive —
  * `indexFields` is optional, so a caller that doesn't pass it gets exactly
  * today's (un)protected behaviour; the oracle stays open until it does. Do
- * not rely on this closing for a table with a masked-sorted index unless the
- * mask actually supplies `indexFields`.
+ * not rely on this closing for a table with a masked-sorted or masked-geo
+ * index unless the mask actually supplies `indexFields`.
+ * - `vectorIndexes` and `aggregateIndexes` are deliberately NOT part of this:
+ * vector search isn't reachable through the masked reader (`TableReaderLike`
+ * has no vector-search method), and an aggregate reduction is already guarded
+ * column-by-column by `assertReductionAllowed` above. Neither is an ordinal
+ * oracle this guard needs to cover.
  *
  * 3. **Writes pass through untouched** — `insert` / `patch` / `replace` /
  * `delete` are never wrapped, so masking can't corrupt stored data. Masking is
@@ -367,7 +377,9 @@ const wrapDatabase = <Context>(
      * key is a masked column, the ordinal position of every returned row leaks the
      * hidden value (one known plaintext neighbour bounds the rest). The same
      * oracle applies directly to `rank`/`rankPage`/`rankBefore`, which return the
-     * row's ordinal.
+     * row's ordinal, and to `withGeoIndex`, which returns rows sorted by distance
+     * from the caller's own query point — an attacker sweeping that point/radius
+     * trilaterates a masked `v.geoPoint()` column to geohash precision.
      *
      * Unlike `assertIndexFieldsAllowed`, this guards the index's DECLARED fields —
      * it needs `indexFields`, the per-table index→fields map an app supplies via
@@ -396,7 +408,7 @@ const wrapDatabase = <Context>(
         if (offending !== undefined) {
             throw new LunoraError(
                 "MASK_UNSUPPORTED",
-                `${method}() reading "${tableName}" via index "${indexName}" would order rows by masked column "${offending}" — add a range callback over unmasked fields, or unmask the column`,
+                `${method}() reading "${tableName}" via index "${indexName}" would order rows by masked column "${offending}" — use an index whose declared fields are all unmasked, or unmask the column`,
             );
         }
     };
@@ -464,8 +476,19 @@ const wrapDatabase = <Context>(
                 return wrapReader(reader.withSearchIndex(indexName, search), columns, tableName);
             },
             // A geo query's builder (`.near`/`.within`) exposes no column name, so
-            // there's no masked-column value oracle to guard — just mask the output.
-            withGeoIndex: (indexName, build) => wrapReader(reader.withGeoIndex(indexName, build), columns, tableName),
+            // there's no masked-column VALUE oracle to guard here. But it IS a
+            // POSITION oracle: `withGeoIndex(name, q => q.near(point, radius))`
+            // returns rows sorted by distance from the caller's own point, and a
+            // geo index has no unmasked-prefix escape the way a multi-column
+            // index does — so the same `assertIndexDeclarationAllowed` guard that
+            // closes the bare-`withIndex`/rank position oracle applies here too,
+            // keyed off the geo index's declared field (see
+            // `indexFieldsFromSchema`).
+            withGeoIndex: (indexName, build) => {
+                assertIndexDeclarationAllowed(tableName, indexName, "withGeoIndex");
+
+                return wrapReader(reader.withGeoIndex(indexName, build), columns, tableName);
+            },
         };
     };
 

--- a/packages/server/src/mask/types.ts
+++ b/packages/server/src/mask/types.ts
@@ -90,21 +90,22 @@ export type MaskPolicies<Context = unknown> = Record<string, MaskColumns<Context
  * mask is skipped (the caller sees raw values). Use it for a privileged
  * viewer — `bypass: ({ auth }) => auth.can("pii:view")`. Prefer this over
  * branching every column when an entire class of caller should see clear data.
- * - `indexFields` closes the bare-index-scan / rank position oracle (see the
- * `mask/middleware` module docblock's "Residual read-position oracles" section).
+ * - `indexFields` closes the bare-index-scan / rank / geo position oracle (see
+ * the `mask/middleware` module docblock's "Residual read-position oracles" section).
  */
 export interface MaskOptions<Context = unknown> {
     readonly bypass?: (context: MaskContext<Context>) => boolean;
 
     /**
      * Per-table index→declared-fields map (regular index `fields`; rank index
-     * `sortBy` ∪ `partitionBy`). Supplied to close the bare-index-scan / rank
-     * position oracle: a `withIndex(name)` with no range callback, or a
-     * `rank`/`rankPage`/`rankBefore` read, over an index whose DECLARED fields
-     * intersect a masked column, is rejected. OPTIONAL and additive — omit it
-     * and behaviour is unchanged (the oracle stays open, exactly as before
-     * this option existed). Build it with `indexFieldsFromSchema` (exported
-     * from `@lunora/server`): `mask(policies, { indexFields:
+     * `sortBy` ∪ `partitionBy`; geo index `field`). Supplied to close the
+     * bare-index-scan / rank / geo position oracle: a `withIndex(name)` with no
+     * range callback, a `rank`/`rankPage`/`rankBefore` read, or a
+     * `withGeoIndex` read, over an index whose DECLARED fields intersect a
+     * masked column, is rejected. OPTIONAL and additive — omit it and
+     * behaviour is unchanged (the oracle stays open, exactly as before this
+     * option existed). Build it with `indexFieldsFromSchema` (exported from
+     * `@lunora/server`): `mask(policies, { indexFields:
      * indexFieldsFromSchema(schema) })`.
      */
     readonly indexFields?: IndexFieldsByTable;

--- a/packages/server/src/mask/types.ts
+++ b/packages/server/src/mask/types.ts
@@ -15,6 +15,7 @@
  * mask such a relation at its own read site if it can surface PII.
  */
 import type { Permission, Role } from "../rls/types";
+import type { IndexFieldsByTable } from "../schema";
 
 /**
  * Context handed to a {@link MaskFn} (and to {@link MaskOptions.bypass}). The
@@ -89,9 +90,24 @@ export type MaskPolicies<Context = unknown> = Record<string, MaskColumns<Context
  * mask is skipped (the caller sees raw values). Use it for a privileged
  * viewer — `bypass: ({ auth }) => auth.can("pii:view")`. Prefer this over
  * branching every column when an entire class of caller should see clear data.
+ * - `indexFields` closes the bare-index-scan / rank position oracle (see the
+ * `mask/middleware` module docblock's "Residual read-position oracles" section).
  */
 export interface MaskOptions<Context = unknown> {
     readonly bypass?: (context: MaskContext<Context>) => boolean;
+
+    /**
+     * Per-table index→declared-fields map (regular index `fields`; rank index
+     * `sortBy` ∪ `partitionBy`). Supplied to close the bare-index-scan / rank
+     * position oracle: a `withIndex(name)` with no range callback, or a
+     * `rank`/`rankPage`/`rankBefore` read, over an index whose DECLARED fields
+     * intersect a masked column, is rejected. OPTIONAL and additive — omit it
+     * and behaviour is unchanged (the oracle stays open, exactly as before
+     * this option existed). Build it with `indexFieldsFromSchema` (exported
+     * from `@lunora/server`): `mask(policies, { indexFields:
+     * indexFieldsFromSchema(schema) })`.
+     */
+    readonly indexFields?: IndexFieldsByTable;
     readonly roles?: ReadonlyArray<Role>;
 }
 

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -881,15 +881,24 @@ type IndexFieldsByTable = Readonly<Record<string, Readonly<Record<string, Readon
 
 /**
  * Distill a schema's declared index fields into an {@link IndexFieldsByTable}
- * map — regular index `fields`; rank index `sortBy[].field` ∪ `partitionBy`.
- * Built to close the `mask()` bare-index-scan / rank position oracle: pass the
- * result as `mask(policies, { indexFields: indexFieldsFromSchema(schema) })`
- * so the middleware can reject a bare `withIndex`/`rank` read over an index
- * whose DECLARED fields include a masked column — a range/search CALLBACK
- * referencing a masked field is already caught by `assertIndexFieldsAllowed`,
- * but a bare `withIndex(name)` (no callback) and a `rank`/`rankPage`/
- * `rankBefore` read give the recorder nothing to observe, so the guard needs
- * the index's *declaration* instead (see `./mask/middleware`).
+ * map — regular index `fields`; rank index `sortBy[].field` ∪ `partitionBy`;
+ * geo index `field` (its single geospatial column). Built to close the
+ * `mask()` bare-index-scan / rank / geo position oracle: pass the result as
+ * `mask(policies, { indexFields: indexFieldsFromSchema(schema) })` so the
+ * middleware can reject a bare `withIndex`/`rank`/`withGeoIndex` read over an
+ * index whose DECLARED fields include a masked column — a range/search
+ * CALLBACK referencing a masked field is already caught by
+ * `assertIndexFieldsAllowed`, but a bare `withIndex(name)` (no callback), a
+ * `rank`/`rankPage`/`rankBefore` read, and every `withGeoIndex` read (its
+ * `near`/`within` callback carries no column name at all) give the recorder
+ * nothing to observe, so the guard needs the index's *declaration* instead
+ * (see `./mask/middleware`).
+ *
+ * Deliberately does NOT emit `vectorIndexes` or `aggregateIndexes`: vector
+ * search isn't reachable through `TableReaderLike` (the masked reader), and
+ * aggregate reads are already guarded column-by-column by
+ * `assertReductionAllowed`, so neither is an ordinal oracle this map needs to
+ * cover.
  *
  * Pure and side-effect free; takes anything carrying `tables` (a `Schema`, an
  * `ExtendableSchema`, or a plugin-merged schema), so it works whether called
@@ -913,6 +922,10 @@ const indexFieldsFromSchema = (schema: Schema): IndexFieldsByTable => {
             }
 
             perIndex[rankIndex.name] = [...fields];
+        }
+
+        for (const geoIndex of table.geoIndexes) {
+            perIndex[geoIndex.name] = [geoIndex.field];
         }
 
         if (Object.keys(perIndex).length > 0) {

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -869,6 +869,60 @@ const validateExternalSources = (tables: Record<string, TableDefinition>): void 
     }
 };
 
+/**
+ * Per-table index→declared-fields map: for each table, each declared index
+ * NAME maps to the column names it declares. Distilled by
+ * {@link indexFieldsFromSchema}; this is the shape `mask()`'s
+ * `MaskOptions.indexFields` expects (see `./mask/types`), so a table not
+ * present here (no declared indexes) is simply absent from the map rather than
+ * mapped to `{}`.
+ */
+type IndexFieldsByTable = Readonly<Record<string, Readonly<Record<string, ReadonlyArray<string>>>>>;
+
+/**
+ * Distill a schema's declared index fields into an {@link IndexFieldsByTable}
+ * map — regular index `fields`; rank index `sortBy[].field` ∪ `partitionBy`.
+ * Built to close the `mask()` bare-index-scan / rank position oracle: pass the
+ * result as `mask(policies, { indexFields: indexFieldsFromSchema(schema) })`
+ * so the middleware can reject a bare `withIndex`/`rank` read over an index
+ * whose DECLARED fields include a masked column — a range/search CALLBACK
+ * referencing a masked field is already caught by `assertIndexFieldsAllowed`,
+ * but a bare `withIndex(name)` (no callback) and a `rank`/`rankPage`/
+ * `rankBefore` read give the recorder nothing to observe, so the guard needs
+ * the index's *declaration* instead (see `./mask/middleware`).
+ *
+ * Pure and side-effect free; takes anything carrying `tables` (a `Schema`, an
+ * `ExtendableSchema`, or a plugin-merged schema), so it works whether called
+ * before or after `.extend(...)`.
+ */
+const indexFieldsFromSchema = (schema: Schema): IndexFieldsByTable => {
+    const result: Record<string, Record<string, ReadonlyArray<string>>> = {};
+
+    for (const [tableName, table] of Object.entries(schema.tables)) {
+        const perIndex: Record<string, ReadonlyArray<string>> = {};
+
+        for (const index of table.indexes) {
+            perIndex[index.name] = index.fields;
+        }
+
+        for (const rankIndex of table.rankIndexes) {
+            const fields = new Set<string>(rankIndex.sortBy.map((key) => key.field));
+
+            for (const field of rankIndex.partitionBy ?? []) {
+                fields.add(field);
+            }
+
+            perIndex[rankIndex.name] = [...fields];
+        }
+
+        if (Object.keys(perIndex).length > 0) {
+            result[tableName] = perIndex;
+        }
+    }
+
+    return result;
+};
+
 const defineSchema = <T extends Record<string, TableDefinition>>(
     tables: T,
     vectorIndexes: Record<string, VectorIndexDefinition> = {},
@@ -882,11 +936,12 @@ const defineSchema = <T extends Record<string, TableDefinition>>(
     return withExtend({ tables, vectorIndexes });
 };
 
-export { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex };
+export { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex, indexFieldsFromSchema };
 
 export type {
     AggregateIndexOptions,
     ExtendableSchema,
+    IndexFieldsByTable,
     InlineAggregateIndexOptions,
     InlineRankIndexOptions,
     ManyRelation,


### PR DESCRIPTION
> **Stacked on #244** (base `advisor/208-209-mask`) — this is plan 209's deferred Step 2 and sits directly on top of Step 1's rank/where guards. GitHub retargets this to `alpha` when #244 merges. Review after #244.

## What

Closes the last `mask()` read-position oracle: reading a hidden value's **ordinal** without reading the value. Two shapes remained after #244's where-guards:
1. a **bare** `withIndex("by_ssn")` (no range callback) over an index whose declared fields include a masked column returns rows **sorted by the hidden value** — one known neighbour bounds every adjacent value;
2. `rank`/`rankPage`/`rankBefore` over an index whose `sortBy`/`partitionBy` names a masked column returns the row's exact ordinal among hidden values.

## Why it needed new plumbing

The mask middleware had **no index metadata** — `mask(policies, options)` only knew the masked-column set, so #244 could guard `where` but not the index *declaration*. This threads it in:
- **`MaskOptions.indexFields`** (optional) + an exported pure **`indexFieldsFromSchema(schema)`** distiller (regular index `fields`; rank index `sortBy[].field` ∪ `partitionBy`).
- **`assertIndexDeclarationAllowed`** throws `MASK_UNSUPPORTED` when a declared index field intersects the masked set — called from `withIndex` (before the existing range-callback recorder, to catch the *bare* scan) and from `rank`/`rankPage`/`rankBefore`.

## Backward-compatible by construction

`indexFields` is **optional**; when absent, behaviour is byte-for-byte today's (fail-open) — the hardening is opt-in and non-breaking. This is regression-tested: two dedicated cases assert a bare `withIndex("by_ssn")` / `rank(..., "by_ssn_rank")` with `indexFields` omitted resolve exactly as before, and the full #244 test suite passes unmodified.

## Load-bearing test coverage (18 new cases)

- **Declaration wins over callback**: a `withIndex(range)` whose range references only an *unmasked* field still throws when the index *declares* a masked field — because any read through such an index leaks order info, not just a bare scan.
- **All-unmasked still scans**: a bare `withIndex`/`rank` over an index that declares no masked column works and still masks output.
- Full rank family (`sortBy`, `partitionBy`, all-unmasked, `rankBefore`-absent-no-crash), unknown-index fail-open, both omitted-`indexFields` regressions.

## Verification
`@lunora/server` 38 files / 515 tests pass; `lint:types` + `lint:eslint` clean. Diff vs the #244 base is 6 server files.

## Scope note
Step 3b (codegen auto-wiring of `indexFields` into emitted `mask()` sites) is deferred per the plan — it needs a new emit surface + full golden regen and would block the security fix on codegen ergonomics. Left as a follow-up; the fix is complete without it (callers pass `indexFieldsFromSchema(schema)`).

## Merge-order note
`packages/server/src/mask/middleware.ts` also changes in **#236** (adds a `collectWithScores` wrapper). Verified disjoint regions — this PR touches only `assertIndexDeclarationAllowed` + its call sites in `withIndex`/`rank`/`rankPage`/`rankBefore` + the `mask`/`wrapDatabase` signatures — so the overlap is a small mechanical resolution.

Plan: `plans/250-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)