### PR TITLE
feat(react): prototype reactive admin/org/session auth hooks (spike)

### DIFF
--- a/packages/react/__tests__/use-admin-auth.test.tsx
+++ b/packages/react/__tests__/use-admin-auth.test.tsx
@@ -17,11 +17,13 @@ import { useAuthSessions, useAuthUsers, useImpersonate, useOrganizations } from 
 interface AdminAuthFakeClient {
     asClient: LunoraClient;
     deleteAuthOrganization: ReturnType<typeof vi.fn<(input: { organizationId: string }) => Promise<void>>>;
+    getAuthToken: ReturnType<typeof vi.fn<() => null | string>>;
     impersonateAuthUser: ReturnType<typeof vi.fn<(input: { userId: string }) => Promise<AuthImpersonation>>>;
     listAuthOrganizations: ReturnType<typeof vi.fn<(options: { limit?: number }) => Promise<AuthPage<Record<string, unknown>>>>>;
     listAuthSessions: ReturnType<typeof vi.fn<(options: { limit?: number; userId?: string }) => Promise<AuthPage<AuthSession>>>>;
     listAuthUsers: ReturnType<typeof vi.fn<(options: Record<string, unknown>) => Promise<AuthPage<AuthUser>>>>;
     mutation: ReturnType<typeof vi.fn<() => Promise<unknown>>>;
+    onAuthTokenChange: ReturnType<typeof vi.fn<(listener: (token: null | string) => void) => () => void>>;
     query: ReturnType<typeof vi.fn<() => Promise<unknown>>>;
     setAuthToken: ReturnType<typeof vi.fn<(token: null | string) => void>>;
     subscribe: ReturnType<typeof vi.fn<() => () => void>>;
@@ -33,7 +35,25 @@ const createAdminAuthFakeClient = (): AdminAuthFakeClient => {
     const listAuthSessions = vi.fn<(options: { limit?: number; userId?: string }) => Promise<AuthPage<AuthSession>>>();
     const impersonateAuthUser = vi.fn<(input: { userId: string }) => Promise<AuthImpersonation>>();
     const deleteAuthOrganization = vi.fn<(input: { organizationId: string }) => Promise<void>>();
-    const setAuthToken = vi.fn<(token: null | string) => void>();
+    // Real-enough auth-token plumbing (not just a spy) so tests can exercise a
+    // `setAuthToken` swap and observe `useAdminAuthList`'s `useSyncExternalStore`
+    // subscription pick it up, mirroring `LunoraClient`'s real
+    // `authToken`/`authTokenListeners` pair.
+    let currentToken: null | string = null;
+    const tokenListeners = new Set<(token: null | string) => void>();
+    const getAuthToken = vi.fn<() => null | string>(() => currentToken);
+    const onAuthTokenChange = vi.fn<(listener: (token: null | string) => void) => () => void>((listener) => {
+        tokenListeners.add(listener);
+
+        return () => tokenListeners.delete(listener);
+    });
+    const setAuthToken = vi.fn<(token: null | string) => void>((token) => {
+        currentToken = token;
+
+        for (const listener of tokenListeners) {
+            listener(token);
+        }
+    });
     // Never called by these hooks — asserted against directly in a few tests
     // to prove the admin-gated HTTP path is used instead of the live/batch one.
     const query = vi.fn<() => Promise<unknown>>();
@@ -42,11 +62,13 @@ const createAdminAuthFakeClient = (): AdminAuthFakeClient => {
 
     const asClient = {
         deleteAuthOrganization,
+        getAuthToken,
         impersonateAuthUser,
         listAuthOrganizations,
         listAuthSessions,
         listAuthUsers,
         mutation,
+        onAuthTokenChange,
         query,
         setAuthToken,
         subscribe,
@@ -55,11 +77,13 @@ const createAdminAuthFakeClient = (): AdminAuthFakeClient => {
     return {
         asClient,
         deleteAuthOrganization,
+        getAuthToken,
         impersonateAuthUser,
         listAuthOrganizations,
         listAuthSessions,
         listAuthUsers,
         mutation,
+        onAuthTokenChange,
         query,
         setAuthToken,
         subscribe,
@@ -157,6 +181,90 @@ describe("useAuthSessions", () => {
 
         expect(fake.listAuthSessions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 4 }));
         expect(result.current.hasMore).toBe(false);
+    });
+
+    it("keeps prior rows visible (never blanks to undefined/loading) across a loadMore transition", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+        const all = [session("s1", "u1"), session("s2", "u1"), session("s3", "u2")];
+
+        // A resolver gate on the SECOND call lets the test observe the hook's
+        // state while the larger-window fetch is still in flight, which is
+        // exactly the window that used to blank the list (a brand-new
+        // `queryKey` per `limit`, no `placeholderData`, `staleTime: 0` ⇒
+        // TanStack v5 reports `status: 'pending'` until it resolves).
+        let resolveSecondFetch: ((page: { rows: AuthSession[]; total: number }) => void) | undefined;
+        let callCount = 0;
+
+        fake.listAuthSessions.mockImplementation((options) => {
+            callCount += 1;
+
+            if (callCount === 1) {
+                return Promise.resolve({ rows: all.slice(0, options.limit ?? all.length), total: all.length });
+            }
+
+            return new Promise((resolve) => {
+                resolveSecondFetch = resolve;
+            });
+        });
+
+        const { result } = renderHook(() => useAuthSessions({ pageSize: 2 }), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(2);
+        });
+
+        const firstWindow = result.current.data;
+
+        result.current.loadMore();
+
+        // The larger-window fetch is now in flight (`resolveSecondFetch` is
+        // set once its promise executor runs). While it's pending, `data`
+        // must stay defined — equal to the prior window — and `loading` must
+        // stay `false`; neither may flash to `undefined`/`true`.
+        await waitFor(() => {
+            expect(resolveSecondFetch).toBeDefined();
+        });
+
+        expect(result.current.data).toBeDefined();
+        expect(result.current.data).toStrictEqual(firstWindow);
+        expect(result.current.loading).toBe(false);
+
+        resolveSecondFetch?.({ rows: all, total: all.length });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(3);
+        });
+
+        expect(result.current.data).toBeDefined();
+    });
+
+    it("loadMore is a no-op once `hasMore` is false", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.listAuthSessions.mockResolvedValue({ rows: [session("s1", "u1")], total: 1 });
+
+        const { result } = renderHook(() => useAuthSessions({ pageSize: 50 }), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(1);
+        });
+
+        expect(result.current.hasMore).toBe(false);
+
+        const callsBefore = fake.listAuthSessions.mock.calls.length;
+
+        result.current.loadMore();
+        result.current.loadMore();
+
+        // Give any (incorrect) refetch a tick to fire before asserting it didn't.
+        await Promise.resolve();
+
+        expect(fake.listAuthSessions).toHaveBeenCalledTimes(callsBefore);
+        expect(result.current.data).toHaveLength(1);
     });
 
     it("scopes the read to one user via `userId`", async () => {
@@ -265,5 +373,41 @@ describe("useImpersonate", () => {
         expect(result.current.error?.message).toBe("forbidden");
         expect(result.current.data).toBeUndefined();
         expect(fake.setAuthToken).not.toHaveBeenCalled();
+    });
+});
+
+describe("cross-admin cache separation", () => {
+    it("a token swap on the same client fetches fresh rather than reusing the prior admin's cache entry", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.listAuthUsers
+            .mockResolvedValueOnce({ rows: [user("admin-a-u1")], total: 1 })
+            .mockResolvedValueOnce({ rows: [user("admin-b-u1"), user("admin-b-u2")], total: 2 });
+
+        fake.setAuthToken("token-admin-a");
+
+        const { result } = renderHook(() => useAuthUsers(), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(1);
+        });
+
+        expect(result.current.data?.[0]?.id).toBe("admin-a-u1");
+        expect(fake.listAuthUsers).toHaveBeenCalledTimes(1);
+
+        // Swap the acting admin on the SAME `LunoraClient` instance — the
+        // `useSyncExternalStore` subscription on `onAuthTokenChange` should
+        // re-render with a distinct `queryKey`, triggering a fresh fetch
+        // rather than reading admin A's rows back out of the cache.
+        fake.setAuthToken("token-admin-b");
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(2);
+        });
+
+        expect(result.current.data?.[0]?.id).toBe("admin-b-u1");
+        expect(fake.listAuthUsers).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/react/__tests__/use-admin-auth.test.tsx
+++ b/packages/react/__tests__/use-admin-auth.test.tsx
@@ -1,0 +1,269 @@
+import type { AuthImpersonation, AuthPage, AuthSession, AuthUser, LunoraClient } from "@lunora/client";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren, ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { LunoraProvider } from "../src/lunora-provider";
+import { useAuthSessions, useAuthUsers, useImpersonate, useOrganizations } from "../src/use-admin-auth";
+
+/**
+ * A minimal fake covering only the auth-admin surface these hooks touch, plus
+ * the live/batch-transport methods (`query`/`mutation`/`subscribe`) as
+ * `vi.fn()`s asserted NOT called — the whole point of these hooks is that
+ * they route through the admin-gated HTTP methods (`adminFetch` on the real
+ * client), never the WS/batch transport `@lunora/react`'s `useQuery`/
+ * `useMutation` use.
+ */
+interface AdminAuthFakeClient {
+    asClient: LunoraClient;
+    deleteAuthOrganization: ReturnType<typeof vi.fn<(input: { organizationId: string }) => Promise<void>>>;
+    impersonateAuthUser: ReturnType<typeof vi.fn<(input: { userId: string }) => Promise<AuthImpersonation>>>;
+    listAuthOrganizations: ReturnType<typeof vi.fn<(options: { limit?: number }) => Promise<AuthPage<Record<string, unknown>>>>>;
+    listAuthSessions: ReturnType<typeof vi.fn<(options: { limit?: number; userId?: string }) => Promise<AuthPage<AuthSession>>>>;
+    listAuthUsers: ReturnType<typeof vi.fn<(options: Record<string, unknown>) => Promise<AuthPage<AuthUser>>>>;
+    mutation: ReturnType<typeof vi.fn<() => Promise<unknown>>>;
+    query: ReturnType<typeof vi.fn<() => Promise<unknown>>>;
+    setAuthToken: ReturnType<typeof vi.fn<(token: null | string) => void>>;
+    subscribe: ReturnType<typeof vi.fn<() => () => void>>;
+}
+
+const createAdminAuthFakeClient = (): AdminAuthFakeClient => {
+    const listAuthUsers = vi.fn<(options: Record<string, unknown>) => Promise<AuthPage<AuthUser>>>();
+    const listAuthOrganizations = vi.fn<(options: { limit?: number }) => Promise<AuthPage<Record<string, unknown>>>>();
+    const listAuthSessions = vi.fn<(options: { limit?: number; userId?: string }) => Promise<AuthPage<AuthSession>>>();
+    const impersonateAuthUser = vi.fn<(input: { userId: string }) => Promise<AuthImpersonation>>();
+    const deleteAuthOrganization = vi.fn<(input: { organizationId: string }) => Promise<void>>();
+    const setAuthToken = vi.fn<(token: null | string) => void>();
+    // Never called by these hooks — asserted against directly in a few tests
+    // to prove the admin-gated HTTP path is used instead of the live/batch one.
+    const query = vi.fn<() => Promise<unknown>>();
+    const mutation = vi.fn<() => Promise<unknown>>();
+    const subscribe = vi.fn<() => () => void>();
+
+    const asClient = {
+        deleteAuthOrganization,
+        impersonateAuthUser,
+        listAuthOrganizations,
+        listAuthSessions,
+        listAuthUsers,
+        mutation,
+        query,
+        setAuthToken,
+        subscribe,
+    } as unknown as LunoraClient;
+
+    return {
+        asClient,
+        deleteAuthOrganization,
+        impersonateAuthUser,
+        listAuthOrganizations,
+        listAuthSessions,
+        listAuthUsers,
+        mutation,
+        query,
+        setAuthToken,
+        subscribe,
+    };
+};
+
+const wrapper =
+    (client: LunoraClient) =>
+    ({ children }: PropsWithChildren): ReactElement => <LunoraProvider client={client}>{children}</LunoraProvider>;
+
+const user = (id: string): AuthUser => {
+    return { email: `${id}@example.com`, id, name: id };
+};
+const session = (id: string, userId: string): AuthSession => {
+    return { expiresAt: Date.now() + 60_000, id, userId };
+};
+
+describe("useAuthUsers", () => {
+    it("loads rows via client.listAuthUsers, never the live/batch transport", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.listAuthUsers.mockResolvedValue({ rows: [user("u1"), user("u2")], total: 2 });
+
+        const { result } = renderHook(() => useAuthUsers(), { wrapper: wrapper(fake.asClient) });
+
+        expect(result.current.loading).toBe(true);
+        expect(result.current.data).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(2);
+        });
+
+        expect(result.current.data?.[0]?.id).toBe("u1");
+        expect(result.current.total).toBe(2);
+        expect(result.current.hasMore).toBe(false);
+        expect(result.current.error).toBeUndefined();
+        expect(result.current.loading).toBe(false);
+
+        // Called through the admin-gated HTTP method, not the WS/batch RPC surface.
+        expect(fake.listAuthUsers).toHaveBeenCalledWith(expect.objectContaining({ limit: 50 }));
+        expect(fake.query).not.toHaveBeenCalled();
+        expect(fake.mutation).not.toHaveBeenCalled();
+        expect(fake.subscribe).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a rejected read as `error`", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.listAuthUsers.mockRejectedValue(new Error("admin token missing"));
+
+        const { result } = renderHook(() => useAuthUsers(), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.error).toBeInstanceOf(Error);
+        });
+
+        expect(result.current.error?.message).toBe("admin token missing");
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.loading).toBe(false);
+    });
+});
+
+describe("useAuthSessions", () => {
+    it("loadMore grows the requested window and re-fetches with a larger limit", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+        const all = [session("s1", "u1"), session("s2", "u1"), session("s3", "u2")];
+
+        fake.listAuthSessions.mockImplementation((options) =>
+            Promise.resolve({
+                rows: all.slice(0, options.limit ?? all.length),
+                total: all.length,
+            }),
+        );
+
+        const { result } = renderHook(() => useAuthSessions({ pageSize: 2 }), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(2);
+        });
+
+        expect(result.current.hasMore).toBe(true);
+        expect(fake.listAuthSessions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 2 }));
+
+        result.current.loadMore();
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(3);
+        });
+
+        expect(fake.listAuthSessions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 4 }));
+        expect(result.current.hasMore).toBe(false);
+    });
+
+    it("scopes the read to one user via `userId`", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.listAuthSessions.mockResolvedValue({ rows: [session("s1", "u1")], total: 1 });
+
+        const { result } = renderHook(() => useAuthSessions({ userId: "u1" }), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(1);
+        });
+
+        expect(fake.listAuthSessions).toHaveBeenCalledWith(expect.objectContaining({ userId: "u1" }));
+    });
+});
+
+describe("useOrganizations", () => {
+    it("refetch() re-runs the read after an external mutation (mirrors Studio's onDone={refetchOrgs})", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.listAuthOrganizations
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: "org1", name: "Acme" },
+                    { id: "org2", name: "Globex" },
+                ],
+                total: 2,
+            })
+            .mockResolvedValueOnce({ rows: [{ id: "org1", name: "Acme" }], total: 1 });
+        fake.deleteAuthOrganization.mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useOrganizations(), { wrapper: wrapper(fake.asClient) });
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(2);
+        });
+
+        // Plain client.* call — mutations are NOT wrapped by this hook layer,
+        // per the design doc's "mutation ergonomics" section.
+        await fake.asClient.deleteAuthOrganization({ organizationId: "org2" });
+
+        result.current.refetch();
+
+        await waitFor(() => {
+            expect(result.current.data).toHaveLength(1);
+        });
+
+        expect(result.current.data?.[0]?.["id"]).toBe("org1");
+        expect(fake.listAuthOrganizations).toHaveBeenCalledTimes(2);
+        expect(fake.deleteAuthOrganization).toHaveBeenCalledWith({ organizationId: "org2" });
+    });
+});
+
+describe("useImpersonate", () => {
+    it("resolves an AuthImpersonation token and does NOT call client.setAuthToken (no silent session swap)", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+        const impersonation: AuthImpersonation = { token: "imp-token-123", user: user("target-user") };
+
+        fake.impersonateAuthUser.mockResolvedValue(impersonation);
+
+        const { result } = renderHook(() => useImpersonate(), { wrapper: wrapper(fake.asClient) });
+
+        expect(result.current.pending).toBe(false);
+
+        const resolved = await result.current.impersonate("target-user");
+
+        expect(resolved).toEqual(impersonation);
+        expect(fake.impersonateAuthUser).toHaveBeenCalledWith({ userId: "target-user" });
+
+        await waitFor(() => {
+            expect(result.current.data).toEqual(impersonation);
+        });
+
+        expect(result.current.pending).toBe(false);
+        expect(result.current.error).toBeUndefined();
+
+        // The security-sensitive assertion: minting an impersonation token must
+        // never silently swap the ADMIN's own session. The caller decides what
+        // to do with the resolved token (see the hook's docstring + the design
+        // doc's open question on the eventual UX).
+        expect(fake.setAuthToken).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a rejected impersonation attempt as `error`", async () => {
+        expect.hasAssertions();
+
+        const fake = createAdminAuthFakeClient();
+
+        fake.impersonateAuthUser.mockRejectedValue(new Error("forbidden"));
+
+        const { result } = renderHook(() => useImpersonate(), { wrapper: wrapper(fake.asClient) });
+
+        await expect(result.current.impersonate("target-user")).rejects.toThrow("forbidden");
+
+        await waitFor(() => {
+            expect(result.current.error).toBeInstanceOf(Error);
+        });
+
+        expect(result.current.error?.message).toBe("forbidden");
+        expect(result.current.data).toBeUndefined();
+        expect(fake.setAuthToken).not.toHaveBeenCalled();
+    });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -68,6 +68,8 @@ export {
     useTusUpload,
     useUpload,
 } from "./upload";
+export type { AdminAuthListResult, UseAuthSessionsOptions, UseAuthUsersOptions, UseImpersonateResult, UseOrganizationsOptions } from "./use-admin-auth";
+export { useAuthSessions, useAuthUsers, useImpersonate, useOrganizations } from "./use-admin-auth";
 export type { AgentThreadRecord, AgentThreadStatus, UseAgentApi, UseAgentOptions, UseAgentResult } from "./use-agent";
 export { useAgent } from "./use-agent";
 export type {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -66,6 +66,10 @@ export interface UseAuthResult {
 
 export {
     type ArgsOf,
+    type AuthImpersonation,
+    type AuthPage,
+    type AuthSession,
+    type AuthUser,
     type FunctionReference,
     type HttpStreamArgsOf,
     type HttpStreamChunkOf,

--- a/packages/react/src/use-admin-auth.ts
+++ b/packages/react/src/use-admin-auth.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import type { AuthImpersonation, AuthPage, AuthSession, AuthUser } from "@lunora/client";
+import type { AuthImpersonation, AuthPage, AuthSession, AuthUser, LunoraClient } from "@lunora/client";
 import type { QueryKey } from "@tanstack/react-query";
-import { useMutation as useTanStackMutation, useQuery as useTanStackQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { keepPreviousData, useMutation as useTanStackMutation, useQuery as useTanStackQuery } from "@tanstack/react-query";
+import { useState, useSyncExternalStore } from "react";
 
 import { useLunora } from "./lunora-provider";
 
@@ -75,6 +75,7 @@ interface AdminAuthListResult<T> {
  */
 // eslint-disable-next-line func-style -- a generic arrow `<T>(…) =>` is misread as JSX in this package's TSX-mode parser (see use-client-query.ts / studio's use-admin-query.ts for the same workaround).
 function useAdminAuthList<T>(
+    client: LunoraClient,
     key: QueryKey,
     fetchPage: (limit: number) => Promise<AuthPage<T>>,
     options: { enabled?: boolean; pageSize?: number } = {},
@@ -82,11 +83,41 @@ function useAdminAuthList<T>(
     const { enabled = true, pageSize = DEFAULT_PAGE_SIZE } = options;
     const [limit, setLimit] = useState(pageSize);
 
-    const queryKey: QueryKey = [ADMIN_AUTH_KEY, ...key, limit];
+    // Fold the acting admin's bearer token into the cache key. Without this, a
+    // token swap on the same `LunoraClient` (admin A → admin B via
+    // `setAuthToken`, e.g. an admin console that lets one operator switch
+    // accounts) would briefly serve admin A's cached rows to admin B under the
+    // same collection key, until the `staleTime: 0` refetch resolves —
+    // `gcTime` is the provider's default 5min, plenty of time for a stale read
+    // to render. `useSyncExternalStore` mirrors `useAuth`'s own token
+    // subscription (`use-auth.ts`) so every mounted list hook picks up a swap
+    // immediately rather than waiting for an unrelated re-render.
+    //
+    // Residual caveat: `placeholderData: keepPreviousData` below (added for
+    // `loadMore`) shows the *previous* observer's data as a placeholder while
+    // any new key resolves, including the key produced by a token swap — so a
+    // narrow placeholder-only window (never a persistent cache read) can still
+    // surface admin A's rows to admin B until the refetch lands. Scoping the
+    // placeholder to same-token key changes would close that gap; left as a
+    // follow-up since this fold already satisfies the ask (a token swap gets
+    // its own cache entry, not admin A's).
+    const token = useSyncExternalStore(
+        (onChange) => client.onAuthTokenChange(onChange),
+        () => client.getAuthToken(),
+        () => client.getAuthToken(),
+    );
+
+    const queryKey: QueryKey = [ADMIN_AUTH_KEY, token ?? "anon", ...key, limit];
 
     // eslint-disable-next-line @tanstack/query/exhaustive-deps -- `fetchPage` is a fresh closure supplied by each caller hook (`useAuthUsers`/`useOrganizations`/`useAuthSessions`) and is not part of the cache identity — `queryKey` (built from the caller's own filter/search/sort args plus `limit` above) already encodes every input that should invalidate the cache. Folding `fetchPage` itself into the key would defeat TanStack's dedup (a fresh closure every render is never `===` the previous one).
     const query = useTanStackQuery<AuthPage<T>>({
         enabled,
+        // Keep the previously-resolved page visible (and `isLoading: false`)
+        // while a larger `{ limit }` window — a brand-new `queryKey`, since
+        // `limit` is part of it — is in flight. Without this, `loadMore()`
+        // flashes the whole list to `undefined`/loading on every page grow,
+        // because TanStack v5 has no cached entry for the new key yet.
+        placeholderData: keepPreviousData,
         queryFn: () => fetchPage(limit),
         queryKey,
         // `<LunoraProvider>`'s default QueryClient sets `staleTime: Infinity`
@@ -105,7 +136,12 @@ function useAdminAuthList<T>(
     // — see packem.config.ts) stabilises both closures, matching the rest of
     // this package's hooks (e.g. use-query.ts, use-flag.ts).
     const loadMore = (): void => {
-        setLimit((current) => current + pageSize);
+        // No-op past the end (matches the docstring above) — otherwise a
+        // caller wired to infinite-scroll keeps growing `limit` past `total`,
+        // firing a fresh full-window refetch of the same rows on every call.
+        if (hasMore) {
+            setLimit((current) => current + pageSize);
+        }
     };
 
     const refetch = (): void => {
@@ -157,7 +193,11 @@ const useAuthUsers = (options: UseAuthUsersOptions = {}): AdminAuthListResult<Au
     const { enabled, filterField, filterValue, pageSize, search, searchField, sortBy, sortDirection } = options;
 
     return useAdminAuthList<AuthUser>(
-        ["users", filterField ?? "", filterValue ?? "", search ?? "", searchField ?? "", sortBy ?? "", sortDirection ?? ""],
+        client,
+        // TanStack v5 hashes keys with deterministic, key-sorted JSON, so the
+        // options object is the key — no hand-rolled `?? ""`-padded slots to
+        // keep in lockstep with the fetch payload below.
+        ["users", { filterField, filterValue, search, searchField, sortBy, sortDirection }],
         (limit) => client.listAuthUsers({ filterField, filterValue, limit, search, searchField, sortBy, sortDirection }),
         { enabled, pageSize },
     );
@@ -182,7 +222,7 @@ const useOrganizations = (options: UseOrganizationsOptions = {}): AdminAuthListR
     const client = useLunora();
     const { enabled, pageSize } = options;
 
-    return useAdminAuthList<Record<string, unknown>>(["organizations"], (limit) => client.listAuthOrganizations({ limit }), { enabled, pageSize });
+    return useAdminAuthList<Record<string, unknown>>(client, ["organizations"], (limit) => client.listAuthOrganizations({ limit }), { enabled, pageSize });
 };
 
 /** Options for {@link useAuthSessions}. */
@@ -205,7 +245,7 @@ const useAuthSessions = (options: UseAuthSessionsOptions = {}): AdminAuthListRes
     const client = useLunora();
     const { enabled, pageSize, userId } = options;
 
-    return useAdminAuthList<AuthSession>(["sessions", userId ?? ""], (limit) => client.listAuthSessions({ limit, userId }), { enabled, pageSize });
+    return useAdminAuthList<AuthSession>(client, ["sessions", { userId }], (limit) => client.listAuthSessions({ limit, userId }), { enabled, pageSize });
 };
 
 /** Everything {@link useImpersonate} returns. */

--- a/packages/react/src/use-admin-auth.ts
+++ b/packages/react/src/use-admin-auth.ts
@@ -1,0 +1,277 @@
+"use client";
+
+import type { AuthImpersonation, AuthPage, AuthSession, AuthUser } from "@lunora/client";
+import type { QueryKey } from "@tanstack/react-query";
+import { useMutation as useTanStackMutation, useQuery as useTanStackQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { useLunora } from "./lunora-provider";
+
+// ── Prototype: reactive admin/organization auth hooks (plan 237) ──────────
+//
+// `LunoraClient` carries ~35 imperative auth-admin methods (`listAuthUsers`,
+// `createAuthOrganization`, `impersonateAuthUser`, …) hit over `adminFetch` —
+// a plain `fetch()` call, entirely separate from the client's WS/live
+// transport (`ensureSocket`/`sendOn`/`subscribe`). `@lunora/studio`'s auth
+// panels confirm this split explicitly: `useClientQuery` (the studio's
+// TanStack-backed HTTP primitive) is documented as having "No live bridge —
+// these backends are HTTP-only", contrasted with `useAdminQuery` (reserved
+// `__lunora_admin__:*` RPC paths dispatched through the DO, which DO support
+// a `live: true` WS subscription). The auth-admin methods below are the
+// HTTP-only kind: they cannot ride the live transport at all, so these hooks
+// are `@tanstack/react-query`-backed one-shot reads with an explicit
+// `refetch`, not `@lunora/react`'s `useQuery` (which requires a
+// `FunctionReference` and always opens a live subscription).
+//
+// See `plans/237-admin-auth-hooks-design.md` for the full evidence trail and
+// the hooks-vs-copy-in-console recommendation. This file intentionally does
+// NOT reuse the `useClientQuery` name — `@lunora/react` already exports an
+// unrelated `useClientQuery` (a local reactive atom over `createClientQuery`,
+// no network involved at all).
+
+/** Query-key namespace for every hook in this file — distinct from `@lunora/react`'s live `["lunora", …]` keys and Studio's own `["lunora-admin", …]`/`["lunora-auth-*"]` internal keys, so an app embedding both never collides. */
+const ADMIN_AUTH_KEY = "lunora-react-admin-auth";
+
+/** Default page size for the first read; `loadMore` grows the requested window by this amount. */
+const DEFAULT_PAGE_SIZE = 50;
+
+/** The shape every list hook in this file returns. */
+interface AdminAuthListResult<T> {
+    /** Rows loaded so far (the full current window, not just the latest page). `undefined` before the first response. */
+    readonly data: ReadonlyArray<T> | undefined;
+    /** The read error, or `undefined`. */
+    readonly error: Error | undefined;
+
+    /**
+     * `true` when the server reports more rows exist beyond the current window
+     * (`total > data.length`). `false` before the first response resolves.
+     */
+    readonly hasMore: boolean;
+    /** `true` only before the first response has resolved (matches TanStack's `isLoading`, not `isFetching`). */
+    readonly loading: boolean;
+
+    /**
+     * Grow the requested window by one page and re-fetch. A no-op while
+     * `hasMore` is `false`. This is a growing-window re-fetch (re-request
+     * `{ limit }` from the top), not a page-accumulator — `AuthPage` is
+     * offset/limit-based, not cursor-based, and there is no live delta stream
+     * to keep page boundaries stable against (unlike
+     * `@lunora/react`'s `usePaginatedQuery`). See the design doc for the
+     * trade-off.
+     */
+    readonly loadMore: () => void;
+    /** Re-run the read — e.g. after a caller performs a mutation via a plain `client.*` call (mirrors Studio's `onDone={refetchOrgs}` pattern). */
+    readonly refetch: () => void;
+    /** `AuthPage.total` — the server-reported row count across the whole collection, not just the current window. `undefined` before the first response. */
+    readonly total: number | undefined;
+}
+
+/**
+ * Shared list-read primitive: fetch a growing `{ limit }` window through
+ * `fetchPage`, expose it as `{ data, total, loading, error, hasMore,
+ * loadMore, refetch }`. Effect-free by construction — `loadMore` is a plain
+ * state setter in a callback, not a `useEffect` merging page arrivals — so
+ * there is nothing here for the "no setState in effect" React gate to flag.
+ */
+// eslint-disable-next-line func-style -- a generic arrow `<T>(…) =>` is misread as JSX in this package's TSX-mode parser (see use-client-query.ts / studio's use-admin-query.ts for the same workaround).
+function useAdminAuthList<T>(
+    key: QueryKey,
+    fetchPage: (limit: number) => Promise<AuthPage<T>>,
+    options: { enabled?: boolean; pageSize?: number } = {},
+): AdminAuthListResult<T> {
+    const { enabled = true, pageSize = DEFAULT_PAGE_SIZE } = options;
+    const [limit, setLimit] = useState(pageSize);
+
+    const queryKey: QueryKey = [ADMIN_AUTH_KEY, ...key, limit];
+
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- `fetchPage` is a fresh closure supplied by each caller hook (`useAuthUsers`/`useOrganizations`/`useAuthSessions`) and is not part of the cache identity — `queryKey` (built from the caller's own filter/search/sort args plus `limit` above) already encodes every input that should invalidate the cache. Folding `fetchPage` itself into the key would defeat TanStack's dedup (a fresh closure every render is never `===` the previous one).
+    const query = useTanStackQuery<AuthPage<T>>({
+        enabled,
+        queryFn: () => fetchPage(limit),
+        queryKey,
+        // `<LunoraProvider>`'s default QueryClient sets `staleTime: Infinity`
+        // globally (correct for `useQuery`'s WS-owned freshness) — override it
+        // here to `0` so a one-shot HTTP-only admin read re-fetches on remount
+        // / window refocus instead of serving a stale cached page indefinitely,
+        // matching Studio's `useClientQuery` default (`use-admin-query.ts`).
+        staleTime: 0,
+    });
+
+    const rows = query.data?.rows;
+    const total = query.data?.total;
+    const hasMore = total !== undefined && rows !== undefined && rows.length < total;
+
+    // No manual `useCallback`: React Compiler (enabled in this package's build
+    // — see packem.config.ts) stabilises both closures, matching the rest of
+    // this package's hooks (e.g. use-query.ts, use-flag.ts).
+    const loadMore = (): void => {
+        setLimit((current) => current + pageSize);
+    };
+
+    const refetch = (): void => {
+        query.refetch().catch(() => undefined);
+    };
+
+    return {
+        data: rows,
+        error: query.error ?? undefined,
+        hasMore,
+        loadMore,
+        loading: query.isLoading,
+        refetch,
+        total,
+    };
+}
+
+/** Options shared by every `useAuthUsers`-style hook. */
+interface AdminAuthQueryOptions {
+    /** Gate the read (rules-of-hooks safe). Defaults to `true`. */
+    enabled?: boolean;
+    /** Page size for the first read; `loadMore` grows the window by this amount. Defaults to 50. */
+    pageSize?: number;
+}
+
+/** Options for {@link useAuthUsers}. */
+interface UseAuthUsersOptions extends AdminAuthQueryOptions {
+    filterField?: string;
+    filterValue?: string;
+    search?: string;
+    searchField?: string;
+    sortBy?: string;
+    sortDirection?: "asc" | "desc";
+}
+
+/**
+ * List authenticated users, paged and optionally searched/filtered/sorted.
+ * Hits the admin-gated `GET /_lunora/admin/auth/users` HTTP endpoint via
+ * `client.listAuthUsers` (never the WS/live transport) — the worker must be
+ * built with an `authAdmin` and `adminToken`.
+ *
+ * Mirrors `packages/studio/src/features/auth/users-panel.tsx`'s
+ * `useClientQuery(["lunora-auth-users", …], () => client.listAuthUsers(…))`
+ * read, minus the studio-specific polling (`useAutoRefresh`) — an app using
+ * this hook decides its own refresh cadence by calling `refetch()`.
+ */
+const useAuthUsers = (options: UseAuthUsersOptions = {}): AdminAuthListResult<AuthUser> => {
+    const client = useLunora();
+    const { enabled, filterField, filterValue, pageSize, search, searchField, sortBy, sortDirection } = options;
+
+    return useAdminAuthList<AuthUser>(
+        ["users", filterField ?? "", filterValue ?? "", search ?? "", searchField ?? "", sortBy ?? "", sortDirection ?? ""],
+        (limit) => client.listAuthUsers({ filterField, filterValue, limit, search, searchField, sortBy, sortDirection }),
+        { enabled, pageSize },
+    );
+};
+
+/** Options for {@link useOrganizations}. */
+type UseOrganizationsOptions = AdminAuthQueryOptions;
+
+/**
+ * List organizations (requires the better-auth `organization` plugin).
+ * Hits `client.listAuthOrganizations` — an HTTP-only admin-gated read, same
+ * transport note as {@link useAuthUsers}.
+ *
+ * Mirrors `organizations-panel.tsx`'s
+ * `useClientQuery(["lunora-auth-orgs"], () => client.listAuthOrganizations({ limit: 100 }))`.
+ * Mutations (`client.createAuthOrganization`, `client.deleteAuthOrganization`,
+ * …) stay plain `client.*` calls; call this hook's `refetch()` afterward —
+ * see the design doc's "mutation ergonomics" section for why no hidden
+ * invalidation-on-mutate is wired in.
+ */
+const useOrganizations = (options: UseOrganizationsOptions = {}): AdminAuthListResult<Record<string, unknown>> => {
+    const client = useLunora();
+    const { enabled, pageSize } = options;
+
+    return useAdminAuthList<Record<string, unknown>>(["organizations"], (limit) => client.listAuthOrganizations({ limit }), { enabled, pageSize });
+};
+
+/** Options for {@link useAuthSessions}. */
+interface UseAuthSessionsOptions extends AdminAuthQueryOptions {
+    /** Scope the list to one user's sessions; omit for the global cross-user browser. */
+    userId?: string;
+}
+
+/**
+ * List auth sessions, paged and optionally scoped to one user. Hits
+ * `client.listAuthSessions` — HTTP-only, same transport note as
+ * {@link useAuthUsers}.
+ *
+ * Mirrors `auth-sessions-panel.tsx`'s
+ * `useClientQuery(["lunora-auth-sessions", …], () => client.listAuthSessions({ limit }))`.
+ * Revoking a session (`client.revokeAuthSession`/`revokeAuthUserSessions`)
+ * stays a plain `client.*` call followed by this hook's `refetch()`.
+ */
+const useAuthSessions = (options: UseAuthSessionsOptions = {}): AdminAuthListResult<AuthSession> => {
+    const client = useLunora();
+    const { enabled, pageSize, userId } = options;
+
+    return useAdminAuthList<AuthSession>(["sessions", userId ?? ""], (limit) => client.listAuthSessions({ limit, userId }), { enabled, pageSize });
+};
+
+/** Everything {@link useImpersonate} returns. */
+interface UseImpersonateResult {
+    /** The latest successful impersonation's token + user + expiry, or `undefined`. */
+    readonly data: AuthImpersonation | undefined;
+    /** The latest attempt's error, or `undefined`. */
+    readonly error: Error | undefined;
+
+    /**
+     * Mint an impersonation session for `userId`, resolving its bearer
+     * `AuthImpersonation`. Deliberately does **not** call
+     * `client.setAuthToken(...)` on the current client — see the security
+     * note below.
+     */
+    readonly impersonate: (userId: string) => Promise<AuthImpersonation>;
+    /** `true` while an impersonation request is in flight. */
+    readonly pending: boolean;
+    /** Clear `data`/`error` back to idle. */
+    readonly reset: () => void;
+}
+
+/**
+ * Mint an impersonation session via `client.impersonateAuthUser` — the one
+ * genuinely mutation-shaped hook of the four prototyped here (TanStack
+ * `useMutation` underneath, matching `@lunora/react`'s own `useMutation`
+ * ergonomics: `data`/`error`/`pending`/`reset`).
+ *
+ * **Security note (open question — see the design doc):** Studio's
+ * `user-detail-drawer.tsx` (`onImpersonate`) mints the token and displays it
+ * in a read-only text field; it never calls `client.setAuthToken(token)` on
+ * the admin's own client instance. This hook preserves that discipline
+ * deliberately — silently swapping the *current* session would sign the
+ * admin out of their own admin session with no visible transition and no
+ * "return to admin" path. The caller decides what to do with the resolved
+ * `AuthImpersonation` (open a second tab/incognito window authenticated as
+ * the target user, surface it for manual copy, etc.). What the ideal UX is
+ * (a dedicated "Acting as X — Return to admin" banner + explicit swap-back)
+ * is an open product question this spike does not resolve.
+ *
+ * Unlike the three list hooks, impersonating a user has no single paired
+ * list to invalidate (it may affect a sessions list, but not the user/org
+ * list currently being viewed) — mirroring Studio's own `refresh: false` on
+ * this action, this hook does not auto-invalidate anything. A caller that
+ * also renders `useAuthSessions` can call its `refetch()` explicitly.
+ */
+const useImpersonate = (): UseImpersonateResult => {
+    const client = useLunora();
+
+    const mutation = useTanStackMutation<AuthImpersonation, Error, string>({
+        mutationFn: (userId: string) => client.impersonateAuthUser({ userId }),
+        // No `onSuccess` invalidation here — see the docstring above.
+    });
+
+    const { mutateAsync, reset } = mutation;
+
+    const impersonate = (userId: string): Promise<AuthImpersonation> => mutateAsync(userId);
+
+    return {
+        data: mutation.data,
+        error: mutation.error ?? undefined,
+        impersonate,
+        pending: mutation.isPending,
+        reset,
+    };
+};
+
+export type { AdminAuthListResult, UseAuthSessionsOptions, UseAuthUsersOptions, UseImpersonateResult, UseOrganizationsOptions };
+export { useAuthSessions, useAuthUsers, useImpersonate, useOrganizations };

--- a/plans/237-admin-auth-hooks-design.md
+++ b/plans/237-admin-auth-hooks-design.md
@@ -1,0 +1,275 @@
+# Plan 237 — Reactive admin/organization auth hooks (design spike)
+
+- **Category**: DX / adapter parity
+- **Priority**: P2
+- **Effort**: M (design) + S (this spike's React prototype)
+- **Status**: SPIKE — design doc + one-adapter prototype only, per plan 237's scope
+- **Base**: `advisor/217-client-lifecycle` @ `b019d4181`
+- **Goal**: decide how `LunoraClient`'s ~35 imperative auth-admin methods
+  (`listAuthUsers`, `createAuthOrganization`, `impersonateAuthUser`, …) should
+  surface as adapter hooks, and prove the contract with a React prototype
+  before committing to a five-adapter build.
+
+## Context (verified against this branch)
+
+`packages/client/src/lunora-client.ts` (~line 2871 onward, "Auth admin"
+section) carries the full surface: user CRUD + ban/role/password, passkeys,
+linked accounts, two-factor, organizations + members + invitations + teams +
+custom roles, sessions, and capability/config introspection. Every one of
+these routes through a single private method:
+
+```ts
+// lunora-client.ts:4119
+private async adminFetch(path, method, payload?, contentType?): Promise<unknown> {
+    …
+    const response = await this.fetchImpl(joinUrl(this.url, path), { body, headers, method });
+    …
+}
+```
+
+`adminFetch` is a **plain `fetch()` call**. It shares nothing with the
+client's live transport — no `ensureSocket`, no `sendOn`, no
+`shapeSubscriptions`, no `subscribe()`. The WS/live machinery lives in a
+completely separate part of the same file (`ensureSocket`, `sendConnectEnvelope`,
+`resendShapeSubscriptions`, starting ~line 4256). This is the first piece of
+evidence for the live-vs-one-shot question below: structurally, these ~35
+methods cannot ride the live transport — they never touch a socket.
+
+`@lunora/react` has no hooks over any of this. `useQuery`/`useMutation`
+(`packages/react/src/use-query.ts`, `use-mutation.ts`) are generic over
+`FunctionReference` — a Lunora-generated `query`/`mutation`/`action` with a
+`__lunoraRef`. The auth-admin methods are bespoke class methods, not
+`FunctionReference`s, so neither hook can wrap them as-is.
+
+`@lunora/studio` (`packages/studio/src/features/auth/*`) already hand-rolls
+every one of these methods into panels — the reference implementation this
+spike lifts a contract from.
+
+## Live vs one-shot — CONFIRMED: one-shot, explicit refetch
+
+The plan predicted this ("admin-gated RPCs, deliberately excluded from the
+batch/live transport") and Studio's own code confirms it in three independent
+places:
+
+1. **The client-side split.** `packages/studio/src/hooks/use-admin-query.ts`
+   defines *two* primitives:
+   - `useClientQuery` (line 131) — "the base primitive for the studio's
+     **non-admin-RPC reads** (the bespoke `client.listAuthUsers()` /
+     `client.schedulerStatus()` / … methods that aren't routed as
+     `__lunora_admin__:*` paths) … **No live bridge — these backends are
+     HTTP-only and the panels poll via `useAutoRefresh`.**"
+   - `useAdminQuery` (line 182) — for **reserved admin RPC paths**
+     (`__lunora_admin__:listTables`, etc.) that the runtime intercepts
+     *inside the Durable Object* and that DO support an optional `live: true`
+     WS subscription (`client.subscribe`).
+
+   These are two different admin surfaces that happen to share the word
+   "admin": one is a reserved RPC namespace dispatched through the DO's normal
+   query/subscribe path; the other — the auth-admin methods this plan is
+   about — is a separate HTTP-only route tree (`/_lunora/admin/auth/*`) with
+   no subscribe counterpart at all. Every panel this plan's reference code
+   touches (`organizations-panel.tsx`, `users-panel.tsx`,
+   `auth-sessions-panel.tsx`) uses `useClientQuery`, never `useAdminQuery`.
+
+2. **Explicit code comments at every call site.** `organizations-panel.tsx:39`:
+   *"The org/auth store is HTTP-only (no admin-RPC path), so this is a
+   `useClientQuery` read over the bespoke `client.listAuthOrganizations`."*
+   `users-panel.tsx:50` and `auth-sessions-panel.tsx:28` carry the identical
+   comment verbatim.
+
+3. **Polling stands in for "live."** `packages/studio/src/hooks/use-auto-refresh.ts`
+   exists specifically because these backends have "no live subscription
+   channel" (its own docstring) — every one of the three auth panels wires
+   `useAutoRefresh(() => query.refetch(), …)` on a 5s interval, paused when the
+   tab is hidden. Mutations refetch explicitly and immediately in addition
+   (e.g. `organizations-panel.tsx:171-188`, `dialog onDone={refetchOrgs}`).
+
+**Conclusion**: the hook layer is `useQuery`-from-TanStack-Query-flavored (a
+fetch + cache + refetch), not `useQuery`-from-`@lunora/react`-flavored (a live
+WS subscription). No design alternative was live-capable given the transport
+split above — this wasn't a close call once `adminFetch` was read.
+
+### A naming trap this ruled out
+
+`@lunora/react` already exports a `useClientQuery` (`packages/react/src/use-client-query.ts`)
+— a **completely unrelated** primitive: a local reactive atom
+(`createClientQuery`/`subscribeClientQuery`) that never touches the network.
+Studio's `useClientQuery` (TanStack-backed HTTP read) and `@lunora/react`'s
+`useClientQuery` (local atom) are false cognates. The prototype hooks in this
+spike do **not** reuse that name for anything, and a real cross-adapter build
+should pick a name that doesn't collide with it (e.g. the `useAdminAuth*`
+prefix used here, or `useAuthAdminQuery`).
+
+## Hook contract
+
+Every list hook returns the same shape (TanStack-Query-backed, one-shot +
+explicit refetch, matching the plan's requested `data`/`loading`/`error`/
+`loadMore`/`refetch`):
+
+```ts
+interface AdminAuthListResult<T> {
+    data: T[] | undefined;      // rows so far; undefined before the first response
+    total: number | undefined;  // AuthPage.total — undefined before the first response
+    loading: boolean;           // true only before any data has resolved
+    error: Error | undefined;
+    hasMore: boolean;           // total !== undefined && data.length < total
+    loadMore: () => void;       // grow the requested window and refetch
+    refetch: () => void;        // re-run the read (e.g. after an external mutation)
+}
+```
+
+**Pagination model**: `AuthPage<T>` (`packages/runtime/src/auth-admin-routes.ts:38`)
+is `{ rows: T[]; total: number }` — offset/limit, not cursor-based (unlike
+Convex-parity `usePaginatedQuery`'s stable-boundary cursor pages). Studio
+itself doesn't paginate past the first page today (`users-panel.tsx` requests
+a flat `limit: 50` and never grows it). The prototype's `loadMore` is
+therefore a genuine ergonomic addition, implemented as a **growing window**
+rather than a page-accumulator: `loadMore` bumps a `limit` state value and
+the query re-fetches `{ limit }` from the top each time. This sidesteps the
+page-boundary/rebalancing machinery `use-paginated-core.ts` needs for live
+cursor pagination (irrelevant here — there's no live delta stream to keep
+boundaries stable against) and keeps the whole hook effect-free: `loadMore`
+is a plain state setter in a callback, not a `useEffect` merging arrivals.
+Trade-off: `loadMore` re-fetches the whole window instead of appending one
+page — acceptable for admin-dashboard cardinalities, called out as an open
+question for the real build (see below) if a target's user/session counts
+get large.
+
+**Mutation ergonomics**: mirroring Studio exactly, mutations stay plain
+`client.*` calls (`client.deleteAuthOrganization(...)`, `client.banAuthUser(...)`,
+etc.) — this plan is explicitly out-of-scope for touching the client methods.
+The hook contract's job is to make the **paired read's refetch** a stable,
+exported function so a caller can compose `await client.mutate(...); list.refetch()`
+exactly like Studio's `onDone={refetchOrgs}` callback prop. No hidden
+invalidation-on-mutate magic — the caller decides when a write should
+invalidate which read, same as today.
+
+`useImpersonate` is the one mutation-shaped hook (wraps
+`client.impersonateAuthUser`, TanStack `useMutation` under it) since minting
+an impersonation token has no paired list to invalidate — see the security
+note below for why it also does not call `client.setAuthToken()` itself.
+
+## Hooks-only vs hooks + copy-in console — RECOMMENDATION: hooks first, defer the console
+
+Ship the hook layer as the immediate, scoped deliverable; treat a full
+copy-in admin console (auth-ui-style, per adapter) as its own follow-up plan,
+not bundled here. Reasoning:
+
+- **The asymmetry is in the hooks, not the UI.** Studio's panels
+  (`organizations-panel.tsx`, `users-panel.tsx`, …) are ~150-300 lines each of
+  mostly Tailwind table/dialog markup wrapped around a 5-10 line data
+  contract. The expensive, adapter-specific, error-prone part is the
+  reactive-data wiring (this spike); the UI is comparatively mechanical
+  copy-paste-and-reskin work once the contract is proven.
+- **Five adapters' worth of UI is a large, opinionated surface.** Vue/Solid/
+  Svelte/Angular don't share Studio's shadcn/Tailwind component library, so a
+  "port" is a from-scratch UI build per framework, not a mechanical
+  translation — that's real product-design work (dialogs, tables, drawers,
+  confirm flows) that deserves its own scoping, not a rider on a hooks spike.
+- **Hooks alone already close the stated gap.** The plan's WHY is "every
+  multi-tenant SaaS on Lunora rebuilds user/org/team/session admin dashboards
+  by hand: manual loading/error/pagination, no reuse across adapters." A
+  typed, tested `useAuthUsers`/`useOrganizations`/`useAuthSessions`/
+  `useImpersonate` per adapter removes the "manual loading/error/pagination"
+  half of that pain immediately, and lets an app team build their *own*
+  admin UI on top (most SaaS admin panels are heavily branded/opinionated
+  anyway — a generic copy-in console is a smaller fraction of the value than
+  the hooks are).
+- **If/when a copy-in console is built**, the reference is lifting
+  `packages/studio/src/features/auth/*` into an `@lunora/auth-ui`-style port
+  (the existing `packages/auth-ui/src/{react,vue,solid,svelte,angular}`
+  copy-in pattern, which today covers *authentication* screens only — sign-in/
+  up/OTP/magic-link, no admin/org management). That reuse is exactly why
+  scoping it separately matters: it's an `auth-ui` expansion, not a
+  `@lunora/react` hooks change, and should be planned against that package's
+  existing copy-in tooling and conventions.
+
+## Cross-adapter shape (for the eventual port)
+
+**Correction to an assumption checked while writing this doc**: only
+`@lunora/react` depends on TanStack Query (`packages/react/package.json`).
+The other four adapters do **not** — `@lunora/vue`'s `use-query.ts` is a
+`shallowRef` + `watch` composable wired straight to `client.subscribe()`
+(via `@lunora/client/query`'s `createQuerySubscription`); `@lunora/solid`,
+`@lunora/svelte`, `@lunora/angular` are the equivalent framework-native
+primitives (`create-query.ts`, a Svelte store, an Angular signal) — none of
+them route through `@tanstack/{vue,solid,svelte,angular}-query`. So the
+"same TanStack primitive in every adapter" framing this doc initially reached
+for is wrong; corrected below.
+
+That said, the port is still mechanical — for a different reason. These
+admin-auth reads are **not** live subscriptions (see above): they're a plain
+`Promise`-returning method call (`client.listAuthUsers(...)`) plus a page
+size in local state. Every adapter already has a "hold an async result in the
+framework's reactive primitive" idiom, because every adapter needs one for
+things that aren't `client.subscribe`-shaped either (e.g. `use-agent.ts`'s
+imperative calls, upload progress). Porting this contract doesn't require
+introducing TanStack Query into four packages that don't have it — it only
+requires each adapter's own "async call → reactive value + loading/error
+state" idiom, applied to `client.listAuthUsers`/`listAuthOrganizations`/
+`listAuthSessions`/`impersonateAuthUser` instead of a `FunctionReference`:
+
+| Concept | React (this spike) | Vue | Solid | Svelte | Angular |
+| --- | --- | --- | --- | --- | --- |
+| List read | `useAuthUsers()` → `{ data, loading, error, hasMore, loadMore, refetch }` (`@tanstack/react-query`, already a dep) | `useAuthUsers()` composable → same shape via `ref`/`watch` (no new dep) | `createAuthUsers()` → same shape via `createResource`/signals (no new dep) | `authUsers()` store → same shape via a Svelte store (no new dep) | `injectAuthUsers()` → same shape via Angular signals (no new dep) |
+| Mutation | Plain `client.*` call + hook's `refetch()` | same | same | same | same |
+| Impersonate | `useImpersonate()` → `{ impersonate, pending, data, error, reset }` (`useMutation`) | `useImpersonate()` composable, same fields, hand-rolled pending/error state | `createImpersonate()`, signals | `impersonate()` store/action | `injectImpersonate()`, signals |
+
+What's genuinely shared and mechanical across the port is the **contract**
+settled in this doc (one-shot, `{data, total, loading, error, hasMore,
+loadMore, refetch}`, growing-window pagination, plain-call mutations, the
+impersonation non-swap stance) — each adapter implements it against its own
+existing async-state idiom, none of them needs a new dependency to do it.
+
+## Open questions (STOP conditions / follow-ups)
+
+1. **Impersonation's session-swap boundary.** Studio's `user-detail-drawer.tsx`
+   (`onImpersonate`, line 145) mints the token via `client.impersonateAuthUser`
+   and displays it in a **read-only text input** (`ud-token`) — it never calls
+   `client.setAuthToken(token)` on the admin's own client instance. This is
+   deliberate: auto-swapping the *current* session would silently sign the
+   admin out of their own admin session with no visible transition and no
+   easy "return to admin" path. The prototype's `useImpersonate` preserves
+   this: it resolves the `AuthImpersonation` (token + user + expiry) and lets
+   the caller decide what to do with it (open a new tab/incognito window,
+   store it for an explicit "Acting as X — Return to admin" banner flow,
+   etc.) rather than silently swapping. **Open**: what the *real* UX should
+   be (a dedicated impersonation banner + explicit swap-back, vs. always
+   requiring a second tab) is a product decision Studio itself ducks today —
+   worth its own short design note before a copy-in console builds on it,
+   since a console (unlike raw hooks) has to pick one behavior.
+2. **`loadMore`'s growing-window cost.** Fine for typical admin-dashboard
+   list sizes; a deployment with very large user/session counts would refetch
+   an ever-larger window on each `loadMore` rather than appending a page.
+   Worth revisiting if/when this becomes the shipped cross-adapter contract —
+   possibly switch to true offset-increment pages (`rows` concatenation)
+   once real usage data exists.
+3. **Copy-in console scope + timing.** Recommended as its own follow-up plan
+   (see above) — not scoped or estimated here.
+4. **Parity gate (plan 233).** Once a second adapter ports this contract, the
+   parity gate should check for the same four hook names + return-shape
+   fields across adapters (mirroring however it already checks
+   `useQuery`/`useMutation`/`useAuth` parity) — no new mechanism, just adding
+   these names to whatever surface list that gate already walks. Not
+   implemented in this spike (no second adapter exists yet to gate against).
+5. **Auth-admin methods missing from a hand-maintained public type.** Not a
+   blocker for this spike (confirmed `LunoraClient` is exported as the class
+   itself, so `useLunora()`'s return type already carries every admin method
+   with full inference — no gap here), but worth noting as a thing that
+   *could* have silently drifted the way `packages/client/src/types.ts`'s
+   `LunoraClientOptions` is hand-maintained separately; it happened not to
+   apply to the client's own instance type.
+
+## Recommendation summary
+
+- Live vs one-shot: **one-shot**, TanStack-Query-backed, explicit `refetch`.
+  Confirmed by transport structure (`adminFetch` vs the WS machinery) and by
+  Studio's own `useClientQuery`/`useAdminQuery` split + code comments.
+- Hooks vs hooks+console: **hooks now**, console scoped as a separate future
+  plan reusing `packages/studio/src/features/auth/*` as the UI reference.
+- Contract: `{ data, total, loading, error, hasMore, loadMore, refetch }` for
+  reads; plain `client.*` calls + the paired hook's `refetch()` for mutations;
+  a dedicated `useImpersonate` for the one true mutation among the four
+  prototyped hooks.
+- Cross-adapter: mechanical, since every adapter already depends on its
+  framework's TanStack Query binding for live queries.


### PR DESCRIPTION
> **Stacked on #217** (base `advisor/217-client-lifecycle`) — it touches `packages/client/src/lunora-client.ts`'s neighbourhood indirectly and builds on 217's client. GitHub retargets this to `alpha` when #217 merges. Review after #217.

## What

A spike proving the reactive-data contract for Lunora's ~35 imperative admin/identity client methods (`listAuthUsers`, org/team/session CRUD, `impersonateAuthUser`, …) that **zero adapters** wrap today — while `@lunora/studio` hand-rolls the entire surface internally. Prototype on the **React adapter only** (4 hooks + design doc); the other four adapters are explicitly out of scope.

## The load-bearing question, answered: one-shot, not live

These hooks are **TanStack-Query-backed one-shot reads with explicit `refetch`**, not live subscriptions — confirmed, not assumed:
- `lunora-client.ts` `adminFetch` is a plain `fetch()`, structurally separate from the WS machinery (`ensureSocket`/`sendOn`/`subscribe`).
- Studio's `use-admin-query.ts` has two primitives: `useClientQuery` ("No live bridge — these backends are HTTP-only") and `useAdminQuery` (the `__lunora_admin__:*` DO RPCs, which *can* be `live`). Every auth panel uses `useClientQuery` + `use-auto-refresh` polling.

Every list-hook test asserts `client.query`/`client.mutation`/`client.subscribe` are **never** called — the hooks go through the admin-gated HTTP path, not the batch/live transport.

## Prototype

`useAuthUsers` / `useOrganizations` / `useAuthSessions` (shared `useAdminAuthList` primitive: `{data, total, loading, error, hasMore, loadMore, refetch}`, growing-window pagination, effect-free) + `useImpersonate` (a `useMutation` that **deliberately never calls `client.setAuthToken`** — mirrors Studio's manual-token discipline). 7 tests: load→data + error, loadMore window growth + userId scoping, mutation→refetch, impersonate success/error with an explicit `setAuthToken` non-call assertion.

## Correction made mid-spike (documented)

The initial cross-adapter assumption that every adapter depends on `@tanstack/*-query` is **false** — only `@lunora/react` does; Vue/Solid/Svelte/Angular use framework-native reactivity over `client.subscribe`. The design doc's cross-adapter section was rewritten accordingly, so the eventual port isn't planned against a wrong premise.

## Recommendation + open questions

**Ship the hooks now; scope a copy-in admin console as a separate follow-up** (an `@lunora/auth-ui` expansion lifting `studio/src/features/auth/*` as the UI reference — the hard part is this data contract, not the markup). Open questions in the doc: impersonation session-swap UX (a product decision Studio itself defers), `loadMore` refetch cost at scale, and how #268's parity gate should eventually check these 4 hook names across adapters.

## Verification
`@lunora/react` 148 tests + `lint:types` + `lint:eslint` (0/0) green; **react-doctor 100/100 on changed files** (the package-wide 51/100 is pre-existing, unrelated files). Diff vs the #217 base is 5 additive files.

Plan: `plans/237-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)