### PR TITLE
fix(codegen): scope vector write-sync by the shard key so .vectorize() can't cross-tenant-leak

### DIFF
--- a/packages/bindings/__tests__/vectors/end-to-end.test.ts
+++ b/packages/bindings/__tests__/vectors/end-to-end.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { createContextVectors } from "../../src/vectors/context";
+import type { SchemaLike } from "../../src/vectors/context";
+import { createContextVectors, createVectorSyncHook } from "../../src/vectors/context";
 import createVectors from "../../src/vectors/create-vectors";
 import type {
     VectorizeDeleteMutation,
@@ -221,5 +222,48 @@ describe("upsert -> query end-to-end against a structural Vectorize fake", () =>
         const matches = await context.query("docs", { topK: 1, vector: embed("hello") });
 
         expect(matches.matches[0]?.id).toBe("row-1");
+    });
+});
+
+describe("createVectorSyncHook: cross-shard namespace isolation (codegen write path)", () => {
+    it("scopes each shard's auto-synced upsert to its own namespace so a second shard's query can't see it", async () => {
+        expect.assertions(3);
+
+        // One account-global Vectorize index shared by every shard DO — exactly
+        // the topology `.vectorize()` + `.shardBy()` produces. `vectors` here is
+        // the SAME `VectorSearchLike` the codegen emit hands to
+        // `createVectorSyncHook({ namespace, schema, vectors })`.
+        const index = createStatefulVectorizeIndex();
+        const vectors = createContextVectors(createVectors({ indexes: { docs: index } }));
+        const schema: SchemaLike = {
+            tables: { docs: { vectorIndexes: [{ embed, field: "body", name: "docs" }] } },
+            vectorIndexes: {},
+        };
+
+        // Mirrors `emit.ts`'s `buildCtx`: each shard DO builds its OWN onWrite
+        // hook, scoped by ITS OWN shard key — never a shared, namespace-less hook.
+        const shardAHook = createVectorSyncHook({ namespace: "shard-a", schema, vectors });
+        const shardBHook = createVectorSyncHook({ namespace: "shard-b", schema, vectors });
+
+        await shardAHook({ doc: { body: "hello from tenant A" }, id: "row-1", op: "insert", table: "docs" });
+        await shardBHook({ doc: { body: "hello from tenant B" }, id: "row-2", op: "insert", table: "docs" });
+
+        const shardAView = await vectors.query("docs", { embed, input: "hello", namespace: "shard-a" });
+        const shardBView = await vectors.query("docs", { embed, input: "hello", namespace: "shard-b" });
+
+        // The actual isolation assertion: each shard's namespaced query returns
+        // ONLY its own row — the other tenant's vector is invisible, not merely
+        // "a namespace was passed" on the write call.
+        expect(shardAView.matches.map((match) => match.id)).toEqual(["row-1"]);
+        expect(shardBView.matches.map((match) => match.id)).toEqual(["row-2"]);
+
+        // Sanity check on the fake itself: an unnamespaced query (today's
+        // `.withVectorIndex()` reader, plan 238) still sees both tenants' rows in
+        // the same account-global index — confirming the isolation above comes
+        // from the namespace filter, not from the fake accidentally partitioning
+        // storage some other way.
+        const unscoped = await vectors.query("docs", { embed, input: "hello" });
+
+        expect(unscoped.matches.map((match) => match.id).toSorted((a, b) => a.localeCompare(b))).toEqual(["row-1", "row-2"]);
     });
 });

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2628,6 +2628,74 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             expect(output).toContain("vectors,");
         });
 
+        it("emits the bare (namespace-less) createVectorSyncHook call for an unsharded (root) vectorized table", () => {
+            expect.assertions(4);
+
+            const schema: SchemaIR = {
+                tables: [
+                    {
+                        indexes: [],
+                        name: "docs",
+                        rankIndexes: [],
+                        relations: [],
+                        searchIndexes: [],
+                        shape: { body: { kind: "string" } },
+                        shardMode: "root",
+                        vectorIndexes: [{ field: "body", name: "by_body", table: "docs" }],
+                    },
+                ],
+                vectorIndexes: [{ field: "body", name: "by_body", table: "docs" }],
+            };
+
+            const output = emitShard({ schema });
+
+            // A `root`-mode vectorized table has exactly one canonical copy — no
+            // shard key to scope by — so the emit must stay byte-identical to
+            // today: no `namespace`, no `ROOT_SHARD_NAME` import, no shard-key read.
+            expect(output).toContain("onWrite = createVectorSyncHook({ schema: schema as unknown as VectorSchemaLike, vectors });");
+            expect(output).not.toContain("namespace:");
+            expect(output).not.toContain("ROOT_SHARD_NAME");
+            expect(output).not.toContain("currentShardKey");
+        });
+
+        it("scopes the createVectorSyncHook auto-sync by the DO's shard key when the vectorized table is .shardBy()'d", () => {
+            expect.assertions(5);
+
+            const schema: SchemaIR = {
+                tables: [
+                    {
+                        indexes: [],
+                        name: "docs",
+                        rankIndexes: [],
+                        relations: [],
+                        searchIndexes: [],
+                        shape: { body: { kind: "string" } },
+                        shardMode: { field: "tenantId", kind: "shardBy" },
+                        vectorIndexes: [{ field: "body", name: "by_body", table: "docs" }],
+                    },
+                ],
+                vectorIndexes: [{ field: "body", name: "by_body", table: "docs" }],
+            };
+
+            const output = emitShard({ schema });
+
+            // Vectorize indexes are account-global: a `.shardBy()`'d vectorized
+            // table MUST pass the owning DO's shard key as `namespace`, or every
+            // tenant's auto-synced vectors land in one shared namespace (the
+            // cross-tenant leak this plan closes). `ROOT_SHARD_NAME` maps the
+            // single-DO sentinel back to `undefined` so a root-mode write on the
+            // same schema (a mixed app) still stays namespace-less.
+            expect(output).toContain(
+                "import { applyCdcChanges, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, ROOT_SHARD_NAME, runDataMigration",
+            );
+            expect(output).toContain("const vectorShardKey = this.currentShardKey();");
+            expect(output).toContain(
+                "onWrite = createVectorSyncHook({ namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, schema: schema as unknown as VectorSchemaLike, vectors });",
+            );
+            expect(output).toContain("vectors,");
+            expect(output).toContain("onWrite,");
+        });
+
         it("omits @lunora/bindings/vectors entirely when the schema declares no vectors", () => {
             expect.assertions(4);
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2685,9 +2685,45 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             // cross-tenant leak this plan closes). `ROOT_SHARD_NAME` maps the
             // single-DO sentinel back to `undefined` so a root-mode write on the
             // same schema (a mixed app) still stays namespace-less.
+            expect(output).toContain("ROOT_SHARD_NAME, ");
+            expect(output).toContain("const vectorShardKey = this.currentShardKey();");
             expect(output).toContain(
-                "import { applyCdcChanges, createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, ROOT_SHARD_NAME, runDataMigration",
+                "onWrite = createVectorSyncHook({ namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, schema: schema as unknown as VectorSchemaLike, vectors });",
             );
+            expect(output).toContain("vectors,");
+            expect(output).toContain("onWrite,");
+        });
+
+        it("scopes the createVectorSyncHook auto-sync by the DO's shard key when the vectorized table is indexed via a standalone defineVectorIndex (Shape B), not inline .vectorize()", () => {
+            expect.assertions(5);
+
+            const schema: SchemaIR = {
+                tables: [
+                    {
+                        indexes: [],
+                        name: "docs",
+                        rankIndexes: [],
+                        relations: [],
+                        searchIndexes: [],
+                        shape: { body: { kind: "string" } },
+                        shardMode: { field: "tenantId", kind: "shardBy" },
+                        // Shape B: the table itself carries no vector indexes — a standalone
+                        // `defineVectorIndex(...)` never gets hoisted onto `table.vectorIndexes`
+                        // (that only happens for inline `.vectorize()`, Shape A). The index is
+                        // discoverable only via the schema-level `vectorIndexes` array below,
+                        // keyed back to its owner through `VectorIndexIR.table`.
+                        vectorIndexes: [],
+                    },
+                ],
+                vectorIndexes: [{ name: "by_body", table: "docs" }],
+            };
+
+            const output = emitShard({ schema });
+
+            // Gating on `table.vectorIndexes.length > 0` alone would miss this schema
+            // entirely (it's empty for `docs`) and silently skip the namespace scoping,
+            // reintroducing the cross-tenant leak for standalone-indexed sharded tables.
+            expect(output).toContain("ROOT_SHARD_NAME, ");
             expect(output).toContain("const vectorShardKey = this.currentShardKey();");
             expect(output).toContain(
                 "onWrite = createVectorSyncHook({ namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, schema: schema as unknown as VectorSchemaLike, vectors });",

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -4121,6 +4121,17 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
     const { constant: workflowsMetadataConst, override: workflowsMetadataOverride } = emitWorkflowsMetadataFragments(workflows);
     const { constant: queuesMetadataConst, override: queuesMetadataOverride } = emitQueuesMetadataFragments(queues);
     const hasVectors = schema.vectorIndexes.length > 0;
+    // Cross-tenant leak guard: Vectorize indexes are account-global, so a
+    // `.vectorize()` table that is ALSO `.shardBy()`'d must scope its
+    // auto-sync upserts by the owning DO's shard key, or every tenant's
+    // vectors land in one shared namespace. A vectorized table that stays
+    // `root`/`global` has exactly one canonical copy — no shard key to scope
+    // by — so this must stay `false` for those, keeping their emitted
+    // `shard.ts` (and goldens) byte-identical to the namespace-less form.
+    // `TableIR["shardMode"]` has exactly one object-typed member (`{ field, kind:
+    // "shardBy" }`), so `typeof === "object"` alone (no further `.kind` check)
+    // is what discriminates `.shardBy()` from `"root"`/`"global"`.
+    const hasShardedVectors = schema.tables.some((table) => table.vectorIndexes.length > 0 && typeof table.shardMode === "object");
     const hasGlobalTables = schema.tables.some((table) => table.shardMode === "global");
     // Which `.global()` backend(s) the schema uses. A `.global()` table defaults
     // to D1; `.global({ backend: "hyperdrive" })` routes it to a Postgres/MySQL
@@ -4252,7 +4263,7 @@ const LUNORA_RLS_READ_REGISTRY = buildRlsReadRegistry(Object.values(LUNORA_FUNCT
 
     const importLines = [
         `import type { ${doTypeImports.join(", ")} } from "${base.do}";`,
-        `import { applyCdcChanges, ${shapeGuardImport}createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, ${hasSourcedTables ? "isSourceDue, pullExternalSourceIncrementalTick, pullExternalSourceTick, " : ""}runDataMigration, runShardMigrations, ${relationFanout.importFragment}ShardDO as ShardDOBase } from "${base.do}";`,
+        `import { applyCdcChanges, ${shapeGuardImport}createReadFootprint, createShardCtxDb, exportShardRows, importShardRows, ${hasSourcedTables ? "isSourceDue, pullExternalSourceIncrementalTick, pullExternalSourceTick, " : ""}${hasShardedVectors ? "ROOT_SHARD_NAME, " : ""}runDataMigration, runShardMigrations, ${relationFanout.importFragment}ShardDO as ShardDOBase } from "${base.do}";`,
         ...(hasSourcedTables ? [`import type { ExternalSourceLike, SourceClientLike } from "${base.do}";`] : []),
         // `asBucketStorage` (the bucket-aware `ctx.storage` wrapper) and
         // `createSecrets` (the `ctx.secrets` core built-in) live in
@@ -4408,6 +4419,21 @@ const vectorsStub: VectorSearchLike = {
 `
         : "";
 
+    // Vectorize indexes are account-global — a `.shardBy()` table's auto-sync
+    // must scope upserts by this DO's own shard key (its tenant identity), or
+    // every tenant's vectors land in one shared, unpartitioned namespace.
+    // `currentShardKey()` returns the real key for a per-tenant DO instance and
+    // the `ROOT_SHARD_NAME` sentinel for the single default DO, so mapping the
+    // sentinel back to `undefined` keeps a root-mode write on this same schema
+    // (e.g. a mixed app where only SOME vectorized tables are `.shardBy()`)
+    // namespace-less, same as today. Gated on `hasShardedVectors` so a schema
+    // with no `.shardBy()`'d vector table emits the bare call, unchanged.
+    const vectorNamespaceField = hasShardedVectors
+        ? `
+                const vectorShardKey = this.currentShardKey();
+`
+        : "";
+    const vectorNamespaceOption = hasShardedVectors ? "namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, " : "";
     const vectorsBuild = hasVectors
         ? `
             let vectors: VectorSearchLike;
@@ -4415,9 +4441,9 @@ const vectorsStub: VectorSearchLike = {
 
             if (config.vectors) {
                 const lunora = createVectors({ indexes: config.vectors(env) });
-
+${vectorNamespaceField}
                 vectors = createContextVectors(lunora);
-                onWrite = createVectorSyncHook({ schema: schema as unknown as VectorSchemaLike, vectors });
+                onWrite = createVectorSyncHook({ ${vectorNamespaceOption}schema: schema as unknown as VectorSchemaLike, vectors });
             } else {
                 vectors = vectorsStub;
                 onWrite = undefined;

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -4122,16 +4122,33 @@ const LUNORA_SCHEMA_SNAPSHOT: { hash: string; json: string } = { hash: ${JSON.st
     const { constant: queuesMetadataConst, override: queuesMetadataOverride } = emitQueuesMetadataFragments(queues);
     const hasVectors = schema.vectorIndexes.length > 0;
     // Cross-tenant leak guard: Vectorize indexes are account-global, so a
-    // `.vectorize()` table that is ALSO `.shardBy()`'d must scope its
-    // auto-sync upserts by the owning DO's shard key, or every tenant's
-    // vectors land in one shared namespace. A vectorized table that stays
-    // `root`/`global` has exactly one canonical copy — no shard key to scope
-    // by — so this must stay `false` for those, keeping their emitted
-    // `shard.ts` (and goldens) byte-identical to the namespace-less form.
-    // `TableIR["shardMode"]` has exactly one object-typed member (`{ field, kind:
-    // "shardBy" }`), so `typeof === "object"` alone (no further `.kind` check)
-    // is what discriminates `.shardBy()` from `"root"`/`"global"`.
-    const hasShardedVectors = schema.tables.some((table) => table.vectorIndexes.length > 0 && typeof table.shardMode === "object");
+    // vector index owned by a `.shardBy()`'d table must scope its auto-sync
+    // upserts by the owning DO's shard key, or every tenant's vectors land in
+    // one shared namespace. A vectorized table that stays `root`/`global` has
+    // exactly one canonical copy — no shard key to scope by — so this must
+    // stay `false` for those, keeping their emitted `shard.ts` (and goldens)
+    // byte-identical to the namespace-less form.
+    //
+    // Gated on `schema.vectorIndexes` (not `table.vectorIndexes`) because only
+    // inline `.vectorize()` (Shape A) indexes get hoisted onto their owning
+    // `TableIR.vectorIndexes`; standalone `defineVectorIndex(...)` (Shape B —
+    // the `defineSchema` 2nd-arg map, and extension-contributed ones) live
+    // only in the schema-level `vectorIndexes` array, keyed back to their
+    // owner via `VectorIndexIR.table`. Checking `table.vectorIndexes.length`
+    // alone misses those and leaves a sharded Shape-B index syncing into one
+    // unpartitioned namespace — the same cross-tenant leak this guard exists
+    // to close.
+    // `TableIR["shardMode"]` has exactly one object-typed member today, so
+    // `.kind === "shardBy"` below is a no-op under the current type — kept
+    // explicit (over bare `typeof === "object"`) so this still discriminates
+    // correctly if the union ever grows a second object-shaped shard mode.
+    const shardedTableNames = new Set(
+        schema.tables
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment above
+            .filter((table) => typeof table.shardMode === "object" && table.shardMode.kind === "shardBy")
+            .map((table) => table.name),
+    );
+    const hasShardedVectors = schema.vectorIndexes.some((index) => shardedTableNames.has(index.table));
     const hasGlobalTables = schema.tables.some((table) => table.shardMode === "global");
     // Which `.global()` backend(s) the schema uses. A `.global()` table defaults
     // to D1; `.global({ backend: "hyperdrive" })` routes it to a Postgres/MySQL


### PR DESCRIPTION
## What

Closes a silent cross-tenant leak: `.vectorize()`'s auto write-sync was emitted **unscoped**. `emit.ts` called `createVectorSyncHook({ schema, vectors })` with **no `namespace`**, so in a multi-tenant sharded app every tenant's vectors landed in one shared, unpartitioned Vectorize namespace — any tenant's query without a namespace filter could then read another's vectors. The only prior mitigation was a one-time dev `console.warn`, which is not a security control.

## The fix

The hook already supported scoping (`createVectorSyncHook`'s optional `namespace`, whose docblock says the caller MUST pass the shard/tenant key) — the gap was purely in the emit. And the shard key is reachable at the emission site with **zero plumbing**: `vectorsBuild` is inlined in the emitted `ShardDO` subclass's `buildCtx()`, so `this.currentShardKey()` (already `protected` on `ShardDOBase`, returning `runner.shardKey ?? ROOT_SHARD_NAME`) is directly callable — no `ShardHost`/ctx contract change needed.

emit.ts now threads `namespace: this.currentShardKey() === ROOT_SHARD_NAME ? undefined : this.currentShardKey()` into the `createVectorSyncHook(...)` call, gated on a new codegen-time `hasShardedVectors` flag (a vector-indexed table **and** `.shardBy()`).

## Single-tenant stays byte-identical

An unsharded/single-tenant app emits the **bare** (namespace-less) call exactly as before — `define-rag.ts` documents namespace-less single-tenant as a legitimate mode. Proven two ways: a codegen test that **negative-asserts** `namespace:`/`ROOT_SHARD_NAME`/`currentShardKey` for an unsharded vectorized table, and **zero golden/example delta** on regeneration (the only vectorized example, `examples/blog`, is unsharded, so it exercises exactly the unchanged branch).

## Verification

- `@lunora/codegen` 975 tests, **no golden drift**; `@lunora/bindings` 222. `lint:types`/`lint:eslint` clean; `build:packages` green.
- Goldens + all `examples/*/_generated` regenerated via the documented flow → **zero delta everywhere** (confirmed correct, not coincidental — see above).
- **Cross-shard isolation test** (`bindings/__tests__/vectors/end-to-end.test.ts`): two hooks (namespace `shard-a`/`shard-b`) against one shared namespace-partitioning Vectorize fake; asserts each shard's query returns only its own row, plus an unnamespaced query sees both (proving isolation comes from the filter, not the fake's layout) — a real cross-namespace assertion, not just "a namespace was passed."
- The sharded+vectorized combo has no real example (none combines `.shardBy()` + `.vectorize()`), so it's covered by the new unit test rather than a golden.

## Context

This is plan 238's shippable prerequisite — a scoped `.withVectorIndex()` reader (#274) over an unscoped write path buys nothing; this makes the write side agree.

## Merge-order note
`packages/codegen/src/emit.ts` is also edited by **#243** (alarm codegen). My change is localized to the vector-index block (~lines 4123–4460); expect a trivial keep-both merge.

Plan: `plans/251-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector synchronization for tables configured with `.shardBy()`.
  * Generated shard contexts now use the appropriate shard key for vector namespaces.
  * Root shards continue to operate without a namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->