### PR TITLE
test: characterize the untested cores + close adapter surface gaps (search-core, shard-engine, studio, angular/svelte)

### DIFF
--- a/packages/angular/__tests__/auth.test.ts
+++ b/packages/angular/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import type { User } from "@lunora/client";
 import { describe, expect, it } from "vitest";
 
-import { auth } from "../src/auth";
+import { auth, authGate } from "../src/auth";
 import { createFakeClient, createFakeDestroyRef } from "./fake-client";
 
 const flushAsync = (): Promise<void> =>
@@ -86,5 +86,70 @@ describe(auth, () => {
 
         // Store's per-client refresh listener remains; auth's token updater is removed
         expect(fake.tokenListeners).toHaveLength(1);
+    });
+});
+
+describe(authGate, () => {
+    it("is neither loading nor authenticated before a token is set (signed out)", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { isAuthenticated, isLoading } = authGate({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        expect(isAuthenticated()).toBe(false);
+        expect(isLoading()).toBe(false);
+    });
+
+    it("is loading once a token is set but the user hasn't resolved yet", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { isAuthenticated, isLoading } = authGate({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        fake.asClient.setAuthToken("jwt-abc");
+        fake.emitAuthTokenChange();
+
+        expect(isLoading()).toBe(true);
+        expect(isAuthenticated()).toBe(false);
+    });
+
+    it("is authenticated once the token is set and the user has resolved", async () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const testUser: User = { id: "u1", name: "Alice" };
+
+        fake.setCurrentUser(testUser);
+
+        const { isAuthenticated, isLoading } = authGate({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        fake.asClient.setAuthToken("jwt-abc");
+        fake.emitAuthTokenChange();
+        await flushAsync();
+
+        expect(isAuthenticated()).toBe(true);
+        expect(isLoading()).toBe(false);
+    });
+
+    it("returns to signed out (neither authenticated nor loading) on sign-out", async () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+        const testUser: User = { id: "u1", name: "Alice" };
+
+        fake.setCurrentUser(testUser);
+
+        const { isAuthenticated, isLoading } = authGate({ client: fake.asClient, destroyRef: destroy.asDestroyRef });
+
+        fake.asClient.setAuthToken("jwt-abc");
+        fake.emitAuthTokenChange();
+        await flushAsync();
+
+        expect(isAuthenticated()).toBe(true);
+
+        fake.asClient.setAuthToken(null);
+        fake.emitAuthTokenChange();
+        await flushAsync();
+
+        expect(isAuthenticated()).toBe(false);
+        expect(isLoading()).toBe(false);
     });
 });

--- a/packages/angular/__tests__/upload.test.ts
+++ b/packages/angular/__tests__/upload.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Coverage for `@lunora/angular/upload`.
+ *
+ * The full resumable client-to-server flow — progress, pause/resume, resume
+ * after a dropped connection, RLS enforcement — is proven against the real
+ * `@visulima/storage-client` adapter in `@lunora/storage`'s
+ * `upload-handler.test.ts` (and transitively via `@lunora/client/upload`).
+ * Here we assert the Angular layer only: that `upload()` mounts with the
+ * documented signal surface and correctly wires the adapter's callback-based
+ * lifecycle into signals — mirroring `@lunora/react/upload`'s test scope,
+ * which defers the real network flow the same way.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createFakeDestroyRef } from "./fake-client";
+
+type ProgressCallback = ((progress: number, offset: number) => void) | undefined;
+type ResultCallback = ((result: { key: string }) => void) | undefined;
+type ErrorCallback = ((error: Error) => void) | undefined;
+
+interface FakeAdapter {
+    abort: ReturnType<typeof vi.fn>;
+    isPaused: () => boolean;
+    onError: ErrorCallback;
+    onFinish: ResultCallback;
+    onProgress: ProgressCallback;
+    onStart: (() => void) | undefined;
+    pause: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    setOnError: (callback: ErrorCallback) => void;
+    setOnFinish: (callback: ResultCallback) => void;
+    setOnProgress: (callback: ProgressCallback) => void;
+    setOnStart: (callback: (() => void) | undefined) => void;
+    upload: ReturnType<typeof vi.fn>;
+}
+
+const createFakeAdapter = (): FakeAdapter => {
+    const adapter: FakeAdapter = {
+        abort: vi.fn<() => void>(),
+        isPaused: () => false,
+        onError: undefined,
+        onFinish: undefined,
+        onProgress: undefined,
+        onStart: undefined,
+        pause: vi.fn<() => void>(),
+        resume: vi.fn<() => Promise<void>>(async () => undefined),
+        setOnError: (callback) => {
+            adapter.onError = callback;
+        },
+        setOnFinish: (callback) => {
+            adapter.onFinish = callback;
+        },
+        setOnProgress: (callback) => {
+            adapter.onProgress = callback;
+        },
+        setOnStart: (callback) => {
+            adapter.onStart = callback;
+        },
+        upload: vi.fn<(file: File) => Promise<{ key: string }>>(async () => {
+            return { key: "uploads/test" };
+        }),
+    };
+
+    return adapter;
+};
+
+let fakeAdapter: FakeAdapter;
+
+// `FakeAdapter` is deliberately narrower than the real `TusAdapter`/
+// `ChunkedRestAdapter` union (no `clear`/`getOffset` — `upload.ts`'s own
+// `ResumableUploadAdapter` doesn't use them either), so the typed
+// `vi.mock(import(...), factory)` form's structural check against the real
+// module doesn't apply cleanly here; the untyped string form says exactly
+// what's being replaced without the mismatch.
+// eslint-disable-next-line vitest/prefer-import-in-mock -- see above
+vi.mock("@lunora/client/upload", () => {
+    return {
+        createUpload: (): FakeAdapter => fakeAdapter,
+    };
+});
+
+// Imported after the mock so `upload.ts`'s `import { createUpload }` binds to
+// the fake above rather than the real TUS/chunked-REST network adapter.
+const { upload } = await import("../src/upload");
+
+const flushAsync = (): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, 0);
+    });
+
+describe(upload, () => {
+    it("mounts with idle status, zero progress, and no result/error", () => {
+        expect.assertions(6);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+
+        expect(handle.status()).toBe("idle");
+        expect(handle.progress()).toBe(0);
+        expect(handle.result()).toBeUndefined();
+        expect(handle.error()).toBeUndefined();
+        expect(handle.isPaused()).toBe(false);
+        expect(handle.start).toBeTypeOf("function");
+    });
+
+    it("wires the adapter's start/progress/finish callbacks into the status/progress/result signals", () => {
+        expect.assertions(4);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+
+        fakeAdapter.onStart?.();
+
+        expect(handle.status()).toBe("uploading");
+
+        fakeAdapter.onProgress?.(42, 4200);
+
+        expect(handle.progress()).toBe(42);
+
+        fakeAdapter.onFinish?.({ key: "uploads/test" });
+
+        expect(handle.status()).toBe("success");
+        expect(handle.result()).toStrictEqual({ key: "uploads/test" });
+    });
+
+    it("wires the adapter's error callback into the error/status signals", () => {
+        expect.assertions(2);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+
+        fakeAdapter.onError?.(new Error("upload failed"));
+
+        expect(handle.status()).toBe("error");
+        expect(handle.error()?.message).toBe("upload failed");
+    });
+
+    it("start() delegates to the adapter's upload(file)", async () => {
+        expect.assertions(2);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+        const file = new File(["hello"], "hello.txt");
+
+        await expect(handle.start(file)).resolves.toStrictEqual({ key: "uploads/test" });
+        expect(fakeAdapter.upload).toHaveBeenCalledWith(file);
+    });
+
+    it("pause()/resume() delegate to the adapter and flip isPaused/status", async () => {
+        expect.assertions(4);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+
+        handle.pause();
+
+        expect(fakeAdapter.pause).toHaveBeenCalledTimes(1);
+        expect(handle.isPaused()).toBe(true);
+        expect(handle.status()).toBe("paused");
+
+        handle.resume();
+        await flushAsync();
+
+        expect(handle.isPaused()).toBe(false);
+    });
+
+    it("aborts the adapter when the owning DestroyRef fires", () => {
+        expect.assertions(1);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+
+        destroy.destroy();
+
+        expect(fakeAdapter.abort).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -39,6 +39,10 @@
             "types": "./dist/index.d.ts",
             "import": "./dist/index.mjs"
         },
+        "./upload": {
+            "types": "./dist/upload.d.ts",
+            "import": "./dist/upload.mjs"
+        },
         "./package.json": "./package.json"
     },
     "publishConfig": {
@@ -57,7 +61,8 @@
     },
     "dependencies": {
         "@lunora/client": "1.0.0-alpha.35",
-        "@lunora/ratelimit": "1.0.0-alpha.14"
+        "@lunora/ratelimit": "1.0.0-alpha.14",
+        "@visulima/storage-client": "catalog:storage"
     },
     "devDependencies": {
         "@angular/core": "^22.0.8",

--- a/packages/angular/src/auth.ts
+++ b/packages/angular/src/auth.ts
@@ -1,5 +1,5 @@
 import type { Signal } from "@angular/core";
-import { DestroyRef, inject, signal } from "@angular/core";
+import { computed, DestroyRef, inject, signal } from "@angular/core";
 import type { LunoraClient, User } from "@lunora/client";
 import { getIdentityStore } from "@lunora/client/auth";
 
@@ -74,4 +74,40 @@ export const auth = (options: AuthOptions = {}): AuthResult => {
     };
 
     return { setToken, token: token.asReadonly(), user: user.asReadonly() };
+};
+
+/**
+ * `AuthGateResult` is part of the experimental `@lunora/angular` API and may change without a major version bump.
+ * @experimental
+ */
+export interface AuthGateResult {
+    /** `true` once a token is set and the user has resolved. */
+    isAuthenticated: Signal<boolean>;
+
+    /** `true` while a token is set but the user hasn't resolved yet. */
+    isLoading: Signal<boolean>;
+}
+
+/**
+ * Derived auth-gate signals for template gating (Angular's `\@if` control
+ * flow), built on {@link auth}. Angular has no JSX-style `Authenticated` slot
+ * component the way React/Vue/Solid do, so this exposes the same three-state
+ * logic as two booleans instead: a token with no resolved user yet is
+ * `isLoading`; a token with a resolved user is `isAuthenticated`; no token is
+ * neither (the signed-out state a template checks for with a plain `\@else`).
+ *
+ * Call from an injection context (component/service field or constructor):
+ * ```ts
+ * protected readonly authState = authGate();
+ * // template: \@if (authState.isAuthenticated()) { ... } \@else if (authState.isLoading()) { ... }
+ * ```
+ * @experimental
+ */
+export const authGate = (options: AuthOptions = {}): AuthGateResult => {
+    const { token, user } = auth(options);
+
+    const isLoading = computed(() => token() !== null && user() === null);
+    const isAuthenticated = computed(() => token() !== null && user() !== null);
+
+    return { isAuthenticated, isLoading };
 };

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -16,8 +16,8 @@ export type { AgentStateApi, AgentStateOptions, AgentStateResult } from "./agent
 export { agentState } from "./agent-state";
 export type { AgentToolEvent, AgentToolEventsApi, AgentToolEventsOptions, AgentToolEventsResult } from "./agent-tool-events";
 export { agentToolEvents } from "./agent-tool-events";
-export type { AuthOptions, AuthResult } from "./auth";
-export { auth } from "./auth";
+export type { AuthGateResult, AuthOptions, AuthResult } from "./auth";
+export { auth, authGate } from "./auth";
 
 /**
  * The Angular adapter for Lunora.

--- a/packages/angular/src/upload.ts
+++ b/packages/angular/src/upload.ts
@@ -20,26 +20,19 @@
  */
 import type { Signal } from "@angular/core";
 import { DestroyRef, inject, signal } from "@angular/core";
-import type { CreateUploadOptions, UploadProtocol, UploadResult } from "@lunora/client/upload";
+import type { ChunkedRestAdapter, CreateUploadOptions, TusAdapter, UploadProtocol, UploadResult } from "@lunora/client/upload";
 import { createUpload } from "@lunora/client/upload";
 
 /**
- * The resumable-adapter surface {@link upload} drives — the members TUS and
- * chunked-REST share identically. Multipart's adapter has a different shape
- * (`uploadBatch`, per-item abort) and is intentionally excluded from
- * {@link UploadOptions.protocol}, so this interface never needs to describe it.
+ * The resumable-adapter surface {@link upload} drives — `TusAdapter` and
+ * `ChunkedRestAdapter` share the members this module calls (`abort`, `isPaused`,
+ * `pause`, `resume`, `setOnError`/`setOnFinish`/`setOnProgress`/`setOnStart`,
+ * `upload`) identically, so the union stands in directly instead of a bespoke
+ * interface drifting from the real types. `MultipartAdapter` has a different
+ * shape (`uploadBatch`, per-item abort) and is intentionally excluded from
+ * {@link UploadOptions.protocol}, so it never enters this union.
  */
-interface ResumableUploadAdapter {
-    abort: () => void;
-    isPaused: () => boolean;
-    pause: () => void;
-    resume: () => Promise<void>;
-    setOnError: (callback: ((error: Error) => void) | undefined) => void;
-    setOnFinish: (callback: ((result: UploadResult) => void) | undefined) => void;
-    setOnProgress: (callback: ((progress: number, offset: number) => void) | undefined) => void;
-    setOnStart: (callback: (() => void) | undefined) => void;
-    upload: (file: File) => Promise<UploadResult>;
-}
+type ResumableUploadAdapter = ChunkedRestAdapter | TusAdapter;
 
 /** The lifecycle of an {@link upload} primitive. */
 export type UploadStatus = "error" | "idle" | "paused" | "success" | "uploading";
@@ -105,24 +98,20 @@ export interface UploadApi {
  * @experimental
  */
 export const upload = (options: UploadOptions): UploadApi => {
-    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+    // Rest-destructure rather than enumerate `CreateUploadOptions` fields by hand: the
+    // type does the work of stripping the Angular-only `destroyRef`, so a future field
+    // added to `CreateUploadOptions` flows through automatically instead of being
+    // silently dropped by a stale field list.
+    const { destroyRef: explicitDestroyRef, ...createOptions } = options;
 
-    const createOptions: CreateUploadOptions = {
-        chunkSize: options.chunkSize,
-        control: options.control,
-        endpoint: options.endpoint,
-        headers: options.headers,
-        maxRetries: options.maxRetries,
-        metadata: options.metadata,
-        protocol: options.protocol,
-        restrictions: options.restrictions,
-        retry: options.retry,
-    };
+    const destroyRef = explicitDestroyRef ?? inject(DestroyRef);
 
     // Safe: `UploadOptions.protocol` excludes "multipart" at the type level, so
     // `createUpload` can only ever return the resumable (TUS / chunked-REST)
-    // member of its union here.
-    const adapter = createUpload(createOptions) as unknown as ResumableUploadAdapter;
+    // member of its union here. `ResumableUploadAdapter` is a subset of
+    // `createUpload`'s real return union (`ChunkedRestAdapter | MultipartAdapter |
+    // TusAdapter`), so a single assertion narrows it without an `unknown` hop.
+    const adapter = createUpload(createOptions) as ResumableUploadAdapter;
 
     const progress = signal(0);
     const status = signal<UploadStatus>("idle");
@@ -160,18 +149,18 @@ export const upload = (options: UploadOptions): UploadApi => {
         // `adapter.resume()` is async (it may re-probe the upload offset before
         // resuming); route failure into the same `error`/`status` signals a
         // failed `start()` would, rather than an unhandled rejection.
-        (async () => {
-            try {
-                await adapter.resume();
+        adapter
+            .resume()
+            .then(() => {
                 isPaused.set(false);
                 status.set("uploading");
-            } catch (resumeError) {
+
+                return undefined;
+            })
+            .catch((resumeError: unknown) => {
                 error.set(resumeError instanceof Error ? resumeError : new Error(String(resumeError)));
                 status.set("error");
-            }
-        })().catch(() => {
-            // Unreachable: the IIFE's own try/catch already routes errors into the signals.
-        });
+            });
     };
 
     const abort = (): void => {

--- a/packages/angular/src/upload.ts
+++ b/packages/angular/src/upload.ts
@@ -1,0 +1,218 @@
+/**
+ * `@lunora/angular/upload` — end-user file-upload signals.
+ *
+ * The admin `uploadStorageObject` path on `LunoraClient` is a one-shot PUT gated
+ * by an `adminToken` — right for the Studio file browser, wrong for end users.
+ * This module gives end-user browsers progress, pause/resume, large-file
+ * resumable uploads and per-part retry by wrapping `@lunora/client/upload` (the
+ * framework-neutral core, itself a re-export of `@visulima/storage-client` —
+ * Lunora does not hand-roll the uploader) in Angular signals. Point {@link upload}
+ * at a route backed by `@lunora/storage/upload`'s RLS-gated handler — end-user
+ * uploads gated by _your_ per-user policy, not an `adminToken`.
+ *
+ * Unlike the React/Vue/Solid/Svelte adapters, this one is hand-written rather
+ * than a re-export: `@visulima/storage-client` ships no `/angular` entry. It
+ * wraps the TUS / chunked-REST surface (identical shape on both — progress,
+ * pause, resume, abort) that `createUpload` defaults to; batch multipart
+ * uploads have a different shape (`uploadBatch`, per-item abort) and aren't
+ * wrapped here — call `createMultipartAdapter` (re-exported below) directly
+ * for that.
+ */
+import type { Signal } from "@angular/core";
+import { DestroyRef, inject, signal } from "@angular/core";
+import type { CreateUploadOptions, UploadProtocol, UploadResult } from "@lunora/client/upload";
+import { createUpload } from "@lunora/client/upload";
+
+/**
+ * The resumable-adapter surface {@link upload} drives — the members TUS and
+ * chunked-REST share identically. Multipart's adapter has a different shape
+ * (`uploadBatch`, per-item abort) and is intentionally excluded from
+ * {@link UploadOptions.protocol}, so this interface never needs to describe it.
+ */
+interface ResumableUploadAdapter {
+    abort: () => void;
+    isPaused: () => boolean;
+    pause: () => void;
+    resume: () => Promise<void>;
+    setOnError: (callback: ((error: Error) => void) | undefined) => void;
+    setOnFinish: (callback: ((result: UploadResult) => void) | undefined) => void;
+    setOnProgress: (callback: ((progress: number, offset: number) => void) | undefined) => void;
+    setOnStart: (callback: (() => void) | undefined) => void;
+    upload: (file: File) => Promise<UploadResult>;
+}
+
+/** The lifecycle of an {@link upload} primitive. */
+export type UploadStatus = "error" | "idle" | "paused" | "success" | "uploading";
+
+/**
+ * `UploadOptions` is part of the experimental `@lunora/angular` API and may change without a major version bump.
+ * @experimental
+ */
+export interface UploadOptions extends Omit<CreateUploadOptions, "protocol"> {
+    /** `DestroyRef` whose `onDestroy` aborts any upload still in flight. Defaults to `inject(DestroyRef)`. */
+    destroyRef?: DestroyRef;
+
+    /** Which resumable protocol to speak. Default `"tus"`. Multipart isn't wrapped here — call `createMultipartAdapter` directly. */
+    protocol?: Exclude<UploadProtocol, "multipart">;
+}
+
+/**
+ * `UploadApi` is part of the experimental `@lunora/angular` API and may change without a major version bump.
+ * @experimental
+ */
+export interface UploadApi {
+    /** Abort the in-flight upload. Safe to call at any point, including after success. */
+    abort: () => void;
+
+    /** The upload error, or `undefined`. */
+    error: Signal<Error | undefined>;
+
+    /** Whether the upload is currently paused. */
+    isPaused: Signal<boolean>;
+
+    /** Pause the in-flight upload (TUS / chunked-REST only support this mid-upload). */
+    pause: () => void;
+
+    /** Upload progress, as the adapter reports it (0–100). */
+    progress: Signal<number>;
+
+    /** The resolved upload result, or `undefined` before it finishes. */
+    result: Signal<UploadResult | undefined>;
+
+    /** Resume a paused upload. */
+    resume: () => void;
+
+    /** Start (or restart) the upload for `file`. Also resolves/rejects with the same result the `result`/`error` signals settle to. */
+    start: (file: File) => Promise<UploadResult>;
+
+    /** The upload lifecycle. */
+    status: Signal<UploadStatus>;
+}
+
+/**
+ * Drive a resumable (TUS / chunked-REST) upload as Angular signals: `progress`,
+ * `status`, `result` and `error`, plus `start` / `pause` / `resume` / `abort`
+ * actions. Defaults to TUS — the resumable path that survives pause/resume and
+ * a dropped connection.
+ *
+ * Call from an injection context (component/service field or constructor):
+ * ```ts
+ * protected readonly upload = upload({ endpoint: "/api/upload" });
+ * onFileSelected(file: File) {
+ *     this.upload.start(file).catch(() => undefined); // errors also land in `error`
+ * }
+ * ```
+ * @experimental
+ */
+export const upload = (options: UploadOptions): UploadApi => {
+    const destroyRef = options.destroyRef ?? inject(DestroyRef);
+
+    const createOptions: CreateUploadOptions = {
+        chunkSize: options.chunkSize,
+        control: options.control,
+        endpoint: options.endpoint,
+        headers: options.headers,
+        maxRetries: options.maxRetries,
+        metadata: options.metadata,
+        protocol: options.protocol,
+        restrictions: options.restrictions,
+        retry: options.retry,
+    };
+
+    // Safe: `UploadOptions.protocol` excludes "multipart" at the type level, so
+    // `createUpload` can only ever return the resumable (TUS / chunked-REST)
+    // member of its union here.
+    const adapter = createUpload(createOptions) as unknown as ResumableUploadAdapter;
+
+    const progress = signal(0);
+    const status = signal<UploadStatus>("idle");
+    const result = signal<UploadResult | undefined>(undefined);
+    const error = signal<Error | undefined>(undefined);
+    const isPaused = signal(false);
+
+    adapter.setOnStart(() => {
+        status.set("uploading");
+    });
+
+    adapter.setOnProgress((value) => {
+        progress.set(value);
+    });
+
+    adapter.setOnFinish((value) => {
+        result.set(value);
+        status.set("success");
+    });
+
+    adapter.setOnError((uploadError) => {
+        error.set(uploadError);
+        status.set("error");
+    });
+
+    const start = (file: File): Promise<UploadResult> => adapter.upload(file);
+
+    const pause = (): void => {
+        adapter.pause();
+        isPaused.set(true);
+        status.set("paused");
+    };
+
+    const resume = (): void => {
+        // `adapter.resume()` is async (it may re-probe the upload offset before
+        // resuming); route failure into the same `error`/`status` signals a
+        // failed `start()` would, rather than an unhandled rejection.
+        (async () => {
+            try {
+                await adapter.resume();
+                isPaused.set(false);
+                status.set("uploading");
+            } catch (resumeError) {
+                error.set(resumeError instanceof Error ? resumeError : new Error(String(resumeError)));
+                status.set("error");
+            }
+        })().catch(() => {
+            // Unreachable: the IIFE's own try/catch already routes errors into the signals.
+        });
+    };
+
+    const abort = (): void => {
+        adapter.abort();
+    };
+
+    destroyRef.onDestroy(abort);
+
+    return {
+        abort,
+        error: error.asReadonly(),
+        isPaused: isPaused.asReadonly(),
+        pause,
+        progress: progress.asReadonly(),
+        result: result.asReadonly(),
+        resume,
+        start,
+        status: status.asReadonly(),
+    };
+};
+
+// Re-exported so an Angular-only consumer gets everything from one import,
+// matching the other framework adapters' `/upload` entries.
+export type {
+    ChunkedRestAdapter,
+    ChunkedRestAdapterOptions,
+    FingerprintFunction,
+    HeadersResolver,
+    MultipartAdapter,
+    MultipartAdapterOptions,
+    OnBeforeRequest,
+    RequestOptions,
+    TusAdapter,
+    TusAdapterOptions,
+    UploadAdapter,
+    UploadRestrictions,
+    UploadResult,
+} from "@lunora/client/upload";
+export { createChunkedRestAdapter, createMultipartAdapter, createTusAdapter, createUpload, RestrictionError, UploadError } from "@lunora/client/upload";
+// `UploadControl` re-exports type-only out of the rolled-up `@lunora/client/upload`
+// declaration bundle (a packem/rollup-dts artifact — the runtime export is a class,
+// same as `UploadError`/`RestrictionError`, which roll up fine), so it's re-exported
+// from its origin instead, exactly like `@lunora/react/upload` and friends already do.
+export { UploadControl } from "@visulima/storage-client";

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -28,6 +28,8 @@ interface MockSocket {
     send: (data: string) => void;
     sent: string[];
     triggerClose: () => void;
+    /** Fire a bare `error` event with no follow-up `close` — some WS implementations do this. */
+    triggerError: () => void;
     url: string;
 }
 
@@ -80,6 +82,11 @@ const createMockWebSocket = (): typeof WebSocket => {
             this.readyState = 3;
             this.onclose?.();
             this.dispatch("close");
+        }
+
+        public triggerError(): void {
+            this.onerror?.();
+            this.dispatch("error");
         }
 
         public send(data: string): void {
@@ -3107,6 +3114,120 @@ describe("lunoraClient", () => {
 
             expect(second).not.toBe(first);
             expect(second?.url).toContain("token=eph-2");
+
+            unsubscribe();
+            vi.useRealTimers();
+        });
+
+        // `subscribeScheduledJobs` runs a second, hand-rolled socket-lifecycle
+        // implementation alongside the shard path's (`ensureSocket`/`openSocket`/
+        // `handleDisconnect`/`startHeartbeat`) — the class of duplication plan 231
+        // asks to close by extracting a shared `openManagedSocket` helper. The
+        // shard path is a single, long-lived `ShardConnection` record threaded
+        // through dozens of call sites in this file (subscribe/unsubscribe
+        // dispatch, shape subscriptions, the offline queue, stream teardown,
+        // connection-status reporting); safely generalizing it behind a shared
+        // helper without changing its behavior is a substantial refactor of
+        // load-bearing code, not something to do blind in the same change as
+        // these characterization tests. The three tests below pin the concrete,
+        // currently-provable gaps this closure has relative to the shard path —
+        // the follow-up extraction should close all three at once.
+        it("never fails a hung handshake fast — unlike the shard socket, there is no connect-timeout (gap: plan 231 openManagedSocket follow-up)", () => {
+            expect.assertions(2);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({
+                // Set on the client to show it has no effect here — this option
+                // only ever reaches the shard path's `openSocket`.
+                connectTimeoutMs: 5000,
+                fetch: async () => jsonResponse({ result: null }),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+                wsToken: "adm1n",
+            });
+
+            const unsubscribe = client.subscribeScheduledJobs(() => undefined);
+
+            const socket = latestSocket();
+
+            // Handshake hangs forever: `open` never fires. The shard path's
+            // equivalent test force-closes at `connectTimeoutMs`; this socket is
+            // still sitting in `connecting` state ten minutes later.
+            vi.advanceTimersByTime(600_000);
+
+            expect(socket.readyState).toBe(0);
+            // No fail-fast means no reconnect either — still exactly one socket.
+            expect(sockets.filter((s) => s.url.includes("/scheduled/ws"))).toHaveLength(1);
+
+            unsubscribe();
+            vi.useRealTimers();
+        });
+
+        it("never recycles an open-but-silent socket — unlike the shard socket, there is no heartbeat/watchdog (gap: plan 231 openManagedSocket follow-up)", () => {
+            expect.assertions(3);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({
+                fetch: async () => jsonResponse({ result: null }),
+                // Set on the client to show it has no effect here — this option
+                // only ever reaches the shard path's `startHeartbeat`.
+                heartbeatIntervalMs: 1000,
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+                wsToken: "adm1n",
+            });
+
+            const unsubscribe = client.subscribeScheduledJobs(() => undefined);
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            // Ten minutes with the far end silent (no `jobs` push, no anything).
+            // The shard path's heartbeat would have sent keepalive pings and, had
+            // none been answered, force-closed and reconnected by
+            // `heartbeatIntervalMs * 2.5`. This socket never sends a ping — there
+            // is no keepalive concept here at all — and stays "open" regardless.
+            vi.advanceTimersByTime(600_000);
+
+            expect(socket.sent).toHaveLength(0);
+            expect(socket.readyState).toBe(1);
+            expect(sockets.filter((s) => s.url.includes("/scheduled/ws"))).toHaveLength(1);
+
+            unsubscribe();
+            vi.useRealTimers();
+        });
+
+        it("a bare error event with no follow-up close never arms a reconnect — the subscription goes silently dead (gap: plan 231 openManagedSocket follow-up)", () => {
+            expect.assertions(1);
+
+            vi.useFakeTimers();
+
+            const client = new LunoraClient({
+                fetch: async () => jsonResponse({ result: null }),
+                reconnect: { initialDelayMs: 10, jitter: false, maxDelayMs: 10 },
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+                wsToken: "adm1n",
+            });
+
+            const unsubscribe = client.subscribeScheduledJobs(() => undefined);
+
+            const socket = latestSocket();
+
+            socket.open();
+            // The shard path treats a standalone `error` (no `close` follow-up —
+            // some WS implementations and proxies do this) as a disconnect and
+            // arms reconnect itself; this closure's `error` listener is a no-op
+            // that assumes `close` always follows. It doesn't here.
+            socket.triggerError();
+
+            vi.advanceTimersByTime(600_000);
+
+            // No reconnect ever fires: still exactly the one socket from `open()`.
+            expect(sockets.filter((s) => s.url.includes("/scheduled/ws"))).toHaveLength(1);
 
             unsubscribe();
             vi.useRealTimers();

--- a/packages/search-core/__tests__/query.test.ts
+++ b/packages/search-core/__tests__/query.test.ts
@@ -1,0 +1,373 @@
+import { LunoraError } from "@lunora/errors";
+import { describe, expect, it } from "vitest";
+
+import { createSearchAnalyzer } from "../src/analyzer";
+import type { SearchStageLike } from "../src/query";
+import {
+    assertSearchWithinCap,
+    buildFtsMatch,
+    createSearchBuilder,
+    encodeSearchCursor,
+    finishSearchPage,
+    MAX_SEARCH_FILTERS,
+    MAX_SEARCH_SCAN,
+    MAX_SEARCH_TERMS,
+    parseSearchCursor,
+    planSearchPage,
+    resolveSearchScan,
+    scoreDocument,
+    searchPageScan,
+    searchTermRange,
+} from "../src/query";
+
+/**
+ * The read side of `.searchIndex()`: caps, the builder's guards, ranking and the
+ * paging algebra. Shared by every backend, so these pin the one behaviour both
+ * engines must reproduce rather than either implementation.
+ */
+
+describe("caps", () => {
+    it("matches Convex's documented limits", () => {
+        expect.assertions(3);
+
+        expect(MAX_SEARCH_TERMS).toBe(16);
+        expect(MAX_SEARCH_FILTERS).toBe(8);
+        expect(MAX_SEARCH_SCAN).toBe(1024);
+    });
+});
+
+describe("search cursors", () => {
+    it("round-trips an offset through encode/decode", () => {
+        expect.assertions(3);
+
+        expect(parseSearchCursor(encodeSearchCursor(0))).toBe(0);
+        expect(parseSearchCursor(encodeSearchCursor(42))).toBe(42);
+        expect(parseSearchCursor(encodeSearchCursor(MAX_SEARCH_SCAN))).toBe(MAX_SEARCH_SCAN);
+    });
+
+    it("reads a bare 'search:' prefix (no digits) as offset 0", () => {
+        expect.assertions(1);
+
+        // Number("") === 0, and 0 is a valid integer offset — so a cursor whose
+        // numeric suffix is empty decodes to the start of the result window
+        // rather than being rejected.
+        const bareCursor = btoa("search:");
+
+        expect(parseSearchCursor(bareCursor)).toBe(0);
+    });
+
+    it("rejects a cursor that isn't base64 at all", () => {
+        expect.assertions(1);
+
+        expect(parseSearchCursor("not valid base64!!")).toBeUndefined();
+    });
+
+    it("rejects a cursor with the wrong prefix", () => {
+        expect.assertions(1);
+
+        expect(parseSearchCursor(btoa("keyset:5"))).toBeUndefined();
+    });
+
+    it("rejects a negative or non-integer offset", () => {
+        expect.assertions(2);
+
+        expect(parseSearchCursor(btoa("search:-1"))).toBeUndefined();
+        expect(parseSearchCursor(btoa("search:1.5"))).toBeUndefined();
+    });
+});
+
+describe(finishSearchPage, () => {
+    it("is terminal when numItems is 0, even with rows in the window", () => {
+        expect.assertions(1);
+
+        expect(finishSearchPage([{ id: 1 }, { id: 2 }, { id: 3 }], { numItems: 0, offset: 0 })).toStrictEqual({
+            continueCursor: null,
+            isDone: true,
+            page: [],
+        });
+    });
+
+    it("reports hasMore when the window holds a row past the page", () => {
+        expect.assertions(1);
+
+        const window = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+        expect(finishSearchPage(window, { numItems: 2, offset: 0 })).toStrictEqual({
+            continueCursor: encodeSearchCursor(2),
+            isDone: false,
+            page: [{ id: 1 }, { id: 2 }],
+        });
+    });
+
+    it("is terminal when the window ends exactly at the page boundary", () => {
+        expect.assertions(1);
+
+        const window = [{ id: 1 }, { id: 2 }];
+
+        expect(finishSearchPage(window, { numItems: 2, offset: 0 })).toStrictEqual({
+            continueCursor: null,
+            isDone: true,
+            page: [{ id: 1 }, { id: 2 }],
+        });
+    });
+});
+
+describe(resolveSearchScan, () => {
+    it("reads an absent limit as one past the cap, so a capped read is detectable", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchScan(undefined)).toBe(MAX_SEARCH_SCAN + 1);
+    });
+
+    it("clamps a non-finite limit (Infinity) to the cap", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchScan(Number.POSITIVE_INFINITY)).toBe(MAX_SEARCH_SCAN);
+    });
+
+    it("passes through a limit within the cap", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchScan(10)).toBe(10);
+    });
+
+    it("throws rather than silently truncating a limit past the cap", () => {
+        expect.assertions(1);
+
+        expect(() => resolveSearchScan(MAX_SEARCH_SCAN + 1)).toThrow(LunoraError);
+    });
+});
+
+describe(planSearchPage, () => {
+    it("accepts a page that reaches exactly the cap", () => {
+        expect.assertions(1);
+
+        expect(planSearchPage({ cursor: null, numItems: MAX_SEARCH_SCAN })).toStrictEqual({
+            numItems: MAX_SEARCH_SCAN,
+            offset: 0,
+        });
+    });
+
+    it("rejects a page that reaches one row past the cap", () => {
+        expect.assertions(1);
+
+        expect(() => planSearchPage({ cursor: null, numItems: MAX_SEARCH_SCAN + 1 })).toThrow(LunoraError);
+    });
+
+    it("rejects bounded (endCursor) pagination", () => {
+        expect.assertions(1);
+
+        expect(() => planSearchPage({ endCursor: "anything", numItems: 10 })).toThrow(LunoraError);
+    });
+
+    it("rejects an unparseable cursor", () => {
+        expect.assertions(1);
+
+        expect(() => planSearchPage({ cursor: "garbage", numItems: 10 })).toThrow(LunoraError);
+    });
+
+    it("resumes from a previously encoded offset", () => {
+        expect.assertions(1);
+
+        expect(planSearchPage({ cursor: encodeSearchCursor(500), numItems: 10 })).toStrictEqual({ numItems: 10, offset: 500 });
+    });
+});
+
+describe(searchPageScan, () => {
+    it("never scans past the cap even when offset + numItems + 1 would exceed it", () => {
+        expect.assertions(1);
+
+        expect(searchPageScan({ numItems: 10, offset: MAX_SEARCH_SCAN - 5 })).toBe(MAX_SEARCH_SCAN);
+    });
+
+    it("otherwise scans one row past the requested page, to detect hasMore", () => {
+        expect.assertions(1);
+
+        expect(searchPageScan({ numItems: 10, offset: 0 })).toBe(11);
+    });
+});
+
+describe(assertSearchWithinCap, () => {
+    it("passes silently at exactly the cap", () => {
+        expect.assertions(1);
+
+        expect(() => {
+            assertSearchWithinCap(Array.from({ length: MAX_SEARCH_SCAN }));
+        }).not.toThrow();
+    });
+
+    it("throws one row past the cap, rather than truncating", () => {
+        expect.assertions(1);
+
+        expect(() => {
+            assertSearchWithinCap(Array.from({ length: MAX_SEARCH_SCAN + 1 }));
+        }).toThrow(LunoraError);
+    });
+});
+
+describe(searchTermRange, () => {
+    it("returns an exact (non-prefix) range for a non-final term", () => {
+        expect.assertions(1);
+
+        expect(searchTermRange("cat", false)).toStrictEqual({ exact: true, lower: "cat", upper: "cat" });
+    });
+
+    it("returns a half-open range for the prefix-matching final term", () => {
+        expect.assertions(1);
+
+        expect(searchTermRange("cat", true)).toStrictEqual({ exact: false, lower: "cat", upper: "cau" });
+    });
+
+    it("increments the last *code point*, not the last UTF-16 code unit, for an astral-plane final token", () => {
+        expect.assertions(1);
+
+        // U+1F600 (😀, code point 128512) is a surrogate pair in UTF-16. A
+        // range bound that incremented the trailing code unit in isolation
+        // could produce an invalid lone surrogate; the codepoint-aware bound
+        // instead lands on U+1F601 (😁, 128513), the very next code point,
+        // keeping the range a valid string on both ends.
+        const emojiCodePoint = 128_512;
+        const token = `emoji${String.fromCodePoint(emojiCodePoint)}`;
+
+        expect(searchTermRange(token, true)).toStrictEqual({
+            exact: false,
+            lower: token,
+            upper: `emoji${String.fromCodePoint(emojiCodePoint + 1)}`,
+        });
+    });
+});
+
+describe(scoreDocument, () => {
+    const analyzer = createSearchAnalyzer(undefined);
+
+    it("sums occurrences across every AND'ed term when all are present", () => {
+        expect.assertions(1);
+
+        // "quick" is required exact and appears twice; "fo" is the final term
+        // and prefix-matches "fox" once.
+        const text = "quick fox jumps over the quick dog";
+
+        expect(scoreDocument(text, ["quick", "fo"], analyzer)).toBe(3);
+    });
+
+    it("prefix-matches only the final term, not earlier ones", () => {
+        expect.assertions(2);
+
+        const text = "quick fox";
+
+        // "qu" as a non-final term must match exactly, so it finds nothing.
+        expect(scoreDocument(text, ["qu", "fox"], analyzer)).toBe(0);
+        // The same "qu" as the final term prefix-matches "quick" (1) on top of
+        // the exact match on "fox" (1).
+        expect(scoreDocument(text, ["fox", "qu"], analyzer)).toBe(2);
+    });
+
+    it("returns 0 (AND semantics) when any required term is absent", () => {
+        expect.assertions(1);
+
+        const text = "quick brown fox";
+
+        expect(scoreDocument(text, ["quick", "zzz"], analyzer)).toBe(0);
+    });
+
+    it("returns 0 for text that analyzes to no tokens", () => {
+        expect.assertions(1);
+
+        expect(scoreDocument("   ", ["anything"], analyzer)).toBe(0);
+    });
+});
+
+describe(buildFtsMatch, () => {
+    it("ands quoted terms together, with prefix matching only on the final term", () => {
+        expect.assertions(1);
+
+        expect(buildFtsMatch(["quick", "fo"])).toBe('"quick" AND "fo"*');
+    });
+
+    it("still applies the trailing prefix star to a single term", () => {
+        expect.assertions(1);
+
+        expect(buildFtsMatch(["quick"])).toBe('"quick"*');
+    });
+});
+
+describe(createSearchBuilder, () => {
+    const makeStage = (): SearchStageLike => {
+        return {
+            definition: { field: "text", filterFields: ["status"] },
+            field: "text",
+            filters: [],
+            hasQuery: false,
+            indexName: "by_text",
+            query: "",
+        };
+    };
+
+    it("stages a .search() call against the indexed field", () => {
+        expect.assertions(1);
+
+        const stage = makeStage();
+
+        createSearchBuilder(stage, "messages", createSearchAnalyzer(undefined)).search("text", "hello world");
+
+        expect(stage).toMatchObject({ field: "text", hasQuery: true, query: "hello world" });
+    });
+
+    it("rejects .search() against a field the index doesn't cover", () => {
+        expect.assertions(1);
+
+        const stage = makeStage();
+        const builder = createSearchBuilder(stage, "messages", createSearchAnalyzer(undefined));
+
+        expect(() => builder.search("other", "hello")).toThrow(LunoraError);
+    });
+
+    it("rejects .search() past the term cap", () => {
+        expect.assertions(1);
+
+        const stage = makeStage();
+        const builder = createSearchBuilder(stage, "messages", createSearchAnalyzer(undefined));
+        const tooManyTerms = Array.from({ length: MAX_SEARCH_TERMS + 1 }, (_unused, index) => `term${String(index)}`).join(" ");
+
+        expect(() => builder.search("text", tooManyTerms)).toThrow(LunoraError);
+    });
+
+    it("stages a .eq() filter against a declared filter field", () => {
+        expect.assertions(1);
+
+        const stage = makeStage();
+
+        createSearchBuilder(stage, "messages", createSearchAnalyzer(undefined)).eq("status", "open");
+
+        expect(stage.filters).toStrictEqual([{ field: "status", value: "open" }]);
+    });
+
+    it("rejects .eq() against a field that isn't a declared filter field", () => {
+        expect.assertions(1);
+
+        const stage = makeStage();
+        const builder = createSearchBuilder(stage, "messages", createSearchAnalyzer(undefined));
+
+        expect(() => builder.eq("unknown", "value")).toThrow(LunoraError);
+    });
+
+    it("rejects .eq() past the filter cap", () => {
+        expect.assertions(1);
+
+        const stage: SearchStageLike = {
+            definition: { field: "text", filterFields: ["a", "b", "c", "d", "e", "f", "g", "h", "i"] },
+            field: "text",
+            filters: [],
+            hasQuery: false,
+            indexName: "by_text",
+            query: "",
+        };
+        const builder = createSearchBuilder(stage, "messages", createSearchAnalyzer(undefined));
+
+        for (const field of ["a", "b", "c", "d", "e", "f", "g", "h"]) {
+            builder.eq(field, 1);
+        }
+
+        expect(() => builder.eq("i", 1)).toThrow(LunoraError);
+    });
+});

--- a/packages/search-core/__tests__/text.test.ts
+++ b/packages/search-core/__tests__/text.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import { createSearchAnalyzer } from "../src/analyzer";
+import {
+    analyzedSearchText,
+    countSearchTokens,
+    FTS_COUNT_COLUMN,
+    FTS_ID_COLUMN,
+    FTS_TEXT_COLUMN,
+    FTS_TOKEN_COLUMN,
+    ftsTableName,
+    MAX_INDEXED_TOKENS,
+    resolveSearchField,
+    searchTextUnchanged,
+    splitSearchTokens,
+    stringifySearchText,
+} from "../src/text";
+
+/**
+ * The indexing side of `.searchIndex()`: what gets written into a companion
+ * table, and whether a write can skip re-indexing entirely. Frozen into stored
+ * indexes, so these pin the current, load-bearing behaviour.
+ */
+
+describe(ftsTableName, () => {
+    it("namespaces the companion table under the reserved __fts_ infix", () => {
+        expect.assertions(1);
+
+        expect(ftsTableName("messages", "by_body")).toBe("messages__fts_by_body");
+    });
+});
+
+describe("companion column names", () => {
+    it("stay stable, since they are load-bearing schema identifiers", () => {
+        expect.assertions(4);
+
+        expect(FTS_TEXT_COLUMN).toBe("__text__");
+        expect(FTS_ID_COLUMN).toBe("__id__");
+        expect(FTS_TOKEN_COLUMN).toBe("__token__");
+        expect(FTS_COUNT_COLUMN).toBe("__n__");
+    });
+});
+
+describe(resolveSearchField, () => {
+    it("reads a top-level field directly", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchField({ title: "hello" }, "title")).toBe("hello");
+    });
+
+    it("resolves a dot-separated nested path", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchField({ properties: { name: "Ada" } }, "properties.name")).toBe("Ada");
+    });
+
+    it("returns undefined for a missing segment", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchField({ properties: {} }, "properties.name")).toBeUndefined();
+    });
+
+    it("returns undefined when a path segment is not an object", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchField({ properties: "not an object" }, "properties.name")).toBeUndefined();
+    });
+
+    it("returns undefined when a path segment is an array", () => {
+        expect.assertions(1);
+
+        expect(resolveSearchField({ properties: ["a", "b"] }, "properties.name")).toBeUndefined();
+    });
+});
+
+describe(stringifySearchText, () => {
+    it("passes a string value through unchanged", () => {
+        expect.assertions(1);
+
+        expect(stringifySearchText("hello")).toBe("hello");
+    });
+
+    it("coerces null and undefined to the empty string", () => {
+        expect.assertions(2);
+
+        expect(stringifySearchText(null)).toBe("");
+        expect(stringifySearchText(undefined)).toBe("");
+    });
+
+    it("stringifies numbers, bigints and booleans with String()", () => {
+        expect.assertions(3);
+
+        expect(stringifySearchText(42)).toBe("42");
+        expect(stringifySearchText(10n)).toBe("10");
+        expect(stringifySearchText(true)).toBe("true");
+    });
+
+    it("serializes objects and arrays as JSON instead of yielding [object Object]", () => {
+        expect.assertions(2);
+
+        expect(stringifySearchText({ a: 1 })).toBe('{"a":1}');
+        expect(stringifySearchText([1, 2, 3])).toBe("[1,2,3]");
+    });
+});
+
+describe(searchTextUnchanged, () => {
+    const index = { field: "title" };
+
+    it("is true when the indexed field's value is identical across the write", () => {
+        expect.assertions(1);
+
+        expect(searchTextUnchanged({ title: "same" }, { title: "same" }, index)).toBe(true);
+    });
+
+    it("is false when the indexed field's value differs", () => {
+        expect.assertions(1);
+
+        expect(searchTextUnchanged({ title: "old" }, { title: "new" }, index)).toBe(false);
+    });
+
+    it("is false on an insert (no previous document)", () => {
+        expect.assertions(1);
+
+        expect(searchTextUnchanged(undefined, { title: "new" }, index)).toBe(false);
+    });
+
+    it("is false on a delete (no next document)", () => {
+        expect.assertions(1);
+
+        expect(searchTextUnchanged({ title: "old" }, undefined, index)).toBe(false);
+    });
+
+    it("is false when the indexed field itself is a re-created but deep-equal object, the safe direction to be wrong in", () => {
+        expect.assertions(1);
+
+        // The indexed field resolves to the object itself (not a leaf
+        // primitive), so a fresh-but-equal object compares unequal under ===
+        // and the write is treated as changed rather than skipped.
+        const objectFieldIndex = { field: "properties" };
+
+        expect(searchTextUnchanged({ properties: { name: "Ada" } }, { properties: { name: "Ada" } }, objectFieldIndex)).toBe(false);
+    });
+});
+
+describe(splitSearchTokens, () => {
+    it("delegates to the analyzer's document-side tokenizer, keeping repeats", () => {
+        expect.assertions(1);
+
+        expect(splitSearchTokens("cat cat dog", createSearchAnalyzer(undefined))).toStrictEqual(["cat", "cat", "dog"]);
+    });
+});
+
+describe(analyzedSearchText, () => {
+    it("joins the analyzed tokens with a single space", () => {
+        expect.assertions(1);
+
+        expect(analyzedSearchText({ title: "The Quick Brown Fox" }, { field: "title", language: "en" })).toBe("quick brown fox");
+    });
+
+    it("caps the stored text at MAX_INDEXED_TOKENS tokens", () => {
+        expect.assertions(1);
+
+        const words = Array.from({ length: MAX_INDEXED_TOKENS + 10 }, (_unused, index) => `word${String(index)}`);
+
+        expect(analyzedSearchText({ body: words.join(" ") }, { field: "body" }).split(" ")).toHaveLength(MAX_INDEXED_TOKENS);
+    });
+
+    it("resolves a nested field path before analyzing", () => {
+        expect.assertions(1);
+
+        expect(analyzedSearchText({ properties: { name: "Café" } }, { field: "properties.name" })).toBe("cafe");
+    });
+
+    it("indexes an empty string for a document that doesn't carry the field", () => {
+        expect.assertions(1);
+
+        expect(analyzedSearchText({}, { field: "title" })).toBe("");
+    });
+});
+
+describe(countSearchTokens, () => {
+    it("tallies occurrences per distinct token", () => {
+        expect.assertions(1);
+
+        const analyzer = createSearchAnalyzer(undefined);
+
+        expect(countSearchTokens("cat cat dog", analyzer)).toStrictEqual(
+            new Map([
+                ["cat", 2],
+                ["dog", 1],
+            ]),
+        );
+    });
+
+    it("returns an empty map for text with nothing to index", () => {
+        expect.assertions(1);
+
+        expect(countSearchTokens("", createSearchAnalyzer(undefined))).toStrictEqual(new Map());
+    });
+});

--- a/packages/shard-engine/__tests__/aggregate-tally.test.ts
+++ b/packages/shard-engine/__tests__/aggregate-tally.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import type { AggregateTally } from "../src/aggregate-tally";
+import { aggregateTableName, coerceAggregateNumber, encodeAggregateKey, foldAggregateTally, readAggregateValue } from "../src/aggregate-tally";
+import type { AggregateIndexDefinitionLike } from "../src/schema-types";
+
+/**
+ * Shared aggregate-companion primitives maintained byte-for-byte identically
+ * by the DO and D1 ctx-db dialects. Pure functions, so these pin the
+ * dialect-agnostic behaviour both backends must reproduce.
+ */
+
+describe(aggregateTableName, () => {
+    it("namespaces the companion table under the reserved __agg_ infix", () => {
+        expect.assertions(1);
+
+        expect(aggregateTableName("orders", "by_status")).toBe("orders__agg_by_status");
+    });
+});
+
+describe(coerceAggregateNumber, () => {
+    it("passes through a finite number", () => {
+        expect.assertions(1);
+
+        expect(coerceAggregateNumber(42)).toBe(42);
+    });
+
+    it("treats NaN and Infinity as non-numeric", () => {
+        expect.assertions(2);
+
+        expect(coerceAggregateNumber(Number.NaN)).toBeUndefined();
+        expect(coerceAggregateNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+    });
+
+    it("treats a numeric string, null, undefined and objects as non-numeric", () => {
+        expect.assertions(4);
+
+        expect(coerceAggregateNumber("42")).toBeUndefined();
+        expect(coerceAggregateNumber(null)).toBeUndefined();
+        expect(coerceAggregateNumber(undefined)).toBeUndefined();
+        expect(coerceAggregateNumber({})).toBeUndefined();
+    });
+});
+
+describe(encodeAggregateKey, () => {
+    it("keys the whole-table aggregate (empty by) on the empty string", () => {
+        expect.assertions(1);
+
+        expect(encodeAggregateKey([], { status: "open" })).toBe("");
+    });
+
+    it("is stable across field order in the by-tuple", () => {
+        expect.assertions(1);
+
+        expect(encodeAggregateKey(["b", "a"], { a: 1, b: 2 })).toBe(encodeAggregateKey(["a", "b"], { a: 1, b: 2 }));
+    });
+
+    it("never misses a lookup for the same logical group, regardless of source key order", () => {
+        expect.assertions(1);
+
+        const insertedAsAB = encodeAggregateKey(["a", "b"], { a: 1, b: 2 });
+        const insertedAsBA = encodeAggregateKey(["a", "b"], { b: 2, a: 1 });
+
+        expect(insertedAsAB).toBe(insertedAsBA);
+    });
+
+    it("encodes a missing by-field as null rather than dropping it", () => {
+        expect.assertions(1);
+
+        expect(encodeAggregateKey(["a", "missing"], { a: 1 })).toBe(JSON.stringify({ a: 1, missing: null }));
+    });
+});
+
+describe(readAggregateValue, () => {
+    it("reads count as 0 for an absent group, never null", () => {
+        expect.assertions(2);
+
+        expect(readAggregateValue("count", undefined)).toBe(0);
+        expect(readAggregateValue("count", { count: 0, value: 0 })).toBe(0);
+    });
+
+    it("reads sum/min/max as null for an absent or empty group", () => {
+        expect.assertions(6);
+
+        for (const op of ["sum", "min", "max"]) {
+            expect(readAggregateValue(op, undefined)).toBeNull();
+            expect(readAggregateValue(op, { count: 0, value: null })).toBeNull();
+        }
+    });
+
+    it("reads sum/min/max verbatim from a non-empty group", () => {
+        expect.assertions(3);
+
+        expect(readAggregateValue("sum", { count: 3, value: 42 })).toBe(42);
+        expect(readAggregateValue("min", { count: 3, value: 1 })).toBe(1);
+        expect(readAggregateValue("max", { count: 3, value: 9 })).toBe(9);
+    });
+
+    it("divides sum by count for avg", () => {
+        expect.assertions(1);
+
+        expect(readAggregateValue("avg", { count: 4, value: 10 })).toBe(2.5);
+    });
+
+    it("reads avg as null when the divisor (count) is 0", () => {
+        expect.assertions(1);
+
+        expect(readAggregateValue("avg", { count: 0, value: null })).toBeNull();
+    });
+});
+
+describe(foldAggregateTally, () => {
+    const countIndex: AggregateIndexDefinitionLike = { name: "by_status", on: "orders", op: "count" };
+    const sumIndex: AggregateIndexDefinitionLike = { field: "total", name: "by_status_sum", on: "orders", op: "sum" };
+    const avgIndex: AggregateIndexDefinitionLike = { field: "total", name: "by_status_avg", on: "orders", op: "avg" };
+    const minIndex: AggregateIndexDefinitionLike = { field: "total", name: "by_status_min", on: "orders", op: "min" };
+    const maxIndex: AggregateIndexDefinitionLike = { field: "total", name: "by_status_max", on: "orders", op: "max" };
+
+    it("count: tallies every row regardless of field values", () => {
+        expect.assertions(1);
+
+        const tallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(tallies, "open", countIndex, {});
+        foldAggregateTally(tallies, "open", countIndex, {});
+        foldAggregateTally(tallies, "open", countIndex, {});
+
+        expect(tallies.get("open")).toStrictEqual({ count: 3, value: 3 });
+    });
+
+    it("sum: accumulates only numeric field values, and skips non-numeric ones", () => {
+        expect.assertions(1);
+
+        const tallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(tallies, "open", sumIndex, { total: 10 });
+        foldAggregateTally(tallies, "open", sumIndex, { total: 5 });
+        foldAggregateTally(tallies, "open", sumIndex, { total: "not a number" });
+
+        // Non-numeric row neither shifts the running sum nor counts toward the divisor.
+        expect(tallies.get("open")).toStrictEqual({ count: 2, value: 15 });
+    });
+
+    it("avg: shares the same accumulator shape as sum (count is avg's divisor)", () => {
+        expect.assertions(1);
+
+        const tallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(tallies, "open", avgIndex, { total: 10 });
+        foldAggregateTally(tallies, "open", avgIndex, { total: 20 });
+
+        expect(tallies.get("open")).toStrictEqual({ count: 2, value: 30 });
+    });
+
+    it("min/max: every row counts toward the group, but only numeric ones move the extreme", () => {
+        expect.assertions(2);
+
+        const minTallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(minTallies, "open", minIndex, { total: 5 });
+        foldAggregateTally(minTallies, "open", minIndex, { total: 1 });
+        // A non-numeric row still counts (so the group reads non-empty) but doesn't move the extreme.
+        foldAggregateTally(minTallies, "open", minIndex, { total: "n/a" });
+
+        expect(minTallies.get("open")).toStrictEqual({ count: 3, value: 1 });
+
+        const maxTallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(maxTallies, "open", maxIndex, { total: 5 });
+        foldAggregateTally(maxTallies, "open", maxIndex, { total: 9 });
+
+        expect(maxTallies.get("open")).toStrictEqual({ count: 2, value: 9 });
+    });
+
+    it("min/max: a group with only non-numeric rows counts as non-empty with a null extreme", () => {
+        expect.assertions(1);
+
+        const tallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(tallies, "open", minIndex, { total: "n/a" });
+
+        expect(tallies.get("open")).toStrictEqual({ count: 1, value: null });
+    });
+
+    it("folds into separate groups keyed by the caller-supplied encoded key", () => {
+        expect.assertions(1);
+
+        const tallies = new Map<string, AggregateTally>();
+
+        foldAggregateTally(tallies, "open", countIndex, {});
+        foldAggregateTally(tallies, "closed", countIndex, {});
+        foldAggregateTally(tallies, "closed", countIndex, {});
+
+        expect([...tallies.entries()]).toStrictEqual([
+            ["open", { count: 1, value: 1 }],
+            ["closed", { count: 2, value: 2 }],
+        ]);
+    });
+});

--- a/packages/shard-engine/__tests__/audit-log.test.ts
+++ b/packages/shard-engine/__tests__/audit-log.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { appendAuditEntry, AUDIT_LOG_TABLE, ensureAuditTable, readAuditLog } from "../src/audit-log";
+import type { SqlExec } from "../src/ctx-db";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Per-shard durable audit log — the reserved `__lunora_audit__` table backing
+ * the studio Audit tab. Runs against a real SQLite build (see
+ * `_helpers/node-sqlite.ts`) so AUTOINCREMENT ordering, retention deletes and
+ * the stored-JSON round-trip all behave the way they will inside a Durable
+ * Object.
+ */
+describe("audit-log", () => {
+    let harness: ReturnType<typeof createSqliteExec>;
+    let sql: SqlExec;
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+        sql = harness.sql;
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    describe(ensureAuditTable, () => {
+        it("is idempotent — callable defensively from both the read and write paths", () => {
+            expect.assertions(1);
+
+            ensureAuditTable(sql);
+            ensureAuditTable(sql);
+            ensureAuditTable(sql);
+
+            expect(readAuditLog(sql)).toStrictEqual([]);
+        });
+    });
+
+    describe(readAuditLog, () => {
+        it("returns an empty list on a never-audited shard rather than throwing", () => {
+            expect.assertions(1);
+
+            expect(readAuditLog(sql)).toStrictEqual([]);
+        });
+    });
+
+    describe(appendAuditEntry, () => {
+        it("creates the table on first use, so callers needn't call ensureAuditTable themselves", () => {
+            expect.assertions(1);
+
+            appendAuditEntry(sql, { op: "writeRow", ts: 1 });
+
+            const rows = harness.raw(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, AUDIT_LOG_TABLE);
+
+            expect(rows).toHaveLength(1);
+        });
+
+        it("records op/table/id/detail and assigns a monotonic seq", () => {
+            expect.assertions(1);
+
+            appendAuditEntry(sql, { detail: { count: 3, user: "alice" }, id: "row-1", op: "writeRow", table: "orders", ts: 1000 });
+
+            expect(readAuditLog(sql)).toStrictEqual([{ detail: { count: 3, user: "alice" }, id: "row-1", op: "writeRow", seq: 1, table: "orders", ts: 1000 }]);
+        });
+
+        it("omits table/id/detail from the decoded entry when none was recorded", () => {
+            expect.assertions(1);
+
+            appendAuditEntry(sql, { op: "runMigration", ts: 500 });
+
+            expect(readAuditLog(sql)).toStrictEqual([{ op: "runMigration", seq: 1, ts: 500 }]);
+        });
+
+        it("orders entries newest-first by seq", () => {
+            expect.assertions(1);
+
+            appendAuditEntry(sql, { op: "first", ts: 1 });
+            appendAuditEntry(sql, { op: "second", ts: 2 });
+            appendAuditEntry(sql, { op: "third", ts: 3 });
+
+            expect(readAuditLog(sql).map((entry) => entry.op)).toStrictEqual(["third", "second", "first"]);
+        });
+
+        it("trims the log back to AUDIT_LOG_RETENTION rows after each append", () => {
+            expect.assertions(2);
+
+            // A small retention would be nicer to assert against directly, but
+            // AUDIT_LOG_RETENTION is a module constant (1000) — insert one past it
+            // and confirm the oldest entry was dropped rather than accumulating.
+            const overRetention = 1002;
+
+            for (let index = 0; index < overRetention; index += 1) {
+                appendAuditEntry(sql, { op: `op-${String(index)}`, ts: index });
+            }
+
+            const entries = readAuditLog(sql, { limit: 10_000 });
+
+            expect(entries).toHaveLength(1000);
+            // The oldest surviving entry is the (overRetention - 1000)th write, not op-0.
+            expect(entries.at(-1)?.op).toBe(`op-${String(overRetention - 1000)}`);
+        });
+
+        it("filters to entries after sinceSeq", () => {
+            expect.assertions(1);
+
+            appendAuditEntry(sql, { op: "first", ts: 1 });
+            appendAuditEntry(sql, { op: "second", ts: 2 });
+            appendAuditEntry(sql, { op: "third", ts: 3 });
+
+            const sinceFirst = readAuditLog(sql, { sinceSeq: 1 });
+
+            expect(sinceFirst.map((entry) => entry.op)).toStrictEqual(["third", "second"]);
+        });
+
+        it("clamps limit into [1, 10000]", () => {
+            expect.assertions(2);
+
+            for (let index = 0; index < 5; index += 1) {
+                appendAuditEntry(sql, { op: `op-${String(index)}`, ts: index });
+            }
+
+            expect(readAuditLog(sql, { limit: 0 })).toHaveLength(1);
+            expect(readAuditLog(sql, { limit: 999_999 })).toHaveLength(5);
+        });
+
+        it("throws a raw JSON.parse error on a malformed stored detail column, rather than degrading gracefully", () => {
+            expect.assertions(1);
+
+            ensureAuditTable(sql);
+
+            // Simulate a corrupted/hand-edited detail column that isn't valid
+            // JSON — readAuditLog's JSON.parse over `row.detail` has no
+            // surrounding try/catch, so this is expected to throw rather than
+            // skip the row or fall back to an empty object.
+            harness.raw(`INSERT INTO "${AUDIT_LOG_TABLE}" (ts, op, "table", id, detail) VALUES (?, ?, ?, ?, ?)`, 1, "writeRow", null, null, "{not valid json");
+
+            expect(() => readAuditLog(sql)).toThrow(SyntaxError);
+        });
+    });
+});

--- a/packages/shard-engine/__tests__/queue-catcher.test.ts
+++ b/packages/shard-engine/__tests__/queue-catcher.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { SqlExec } from "../src/ctx-db";
+import type { RecordQueueMessageInput } from "../src/queue-catcher";
+import {
+    clearQueueMessages,
+    ensureQueueTable,
+    isLossyBody,
+    MAX_BODY_CHARS,
+    QUEUE_RETENTION,
+    QUEUE_TABLE,
+    readQueueMessageById,
+    readQueueMessages,
+    recordQueueMessages,
+} from "../src/queue-catcher";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * The dev queue catcher — the reserved `__lunora_queue_messages` table backing
+ * the studio Queues panel, the only way to see what a push consumer actually
+ * processed (Cloudflare Queues exposes no peek API). Runs against a real
+ * SQLite build so retention deletes, ordering and the JSON body round-trip all
+ * behave the way they will inside a Durable Object.
+ */
+describe("queue-catcher", () => {
+    let harness: ReturnType<typeof createSqliteExec>;
+    let sql: SqlExec;
+
+    const baseInput: RecordQueueMessageInput = {
+        attempts: 1,
+        body: { hello: "world" },
+        messageId: "msg-1",
+        outcome: "ack",
+        queue: "emails",
+        timestamp: 1000,
+    };
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+        sql = harness.sql;
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    describe(ensureQueueTable, () => {
+        it("is idempotent", () => {
+            expect.assertions(1);
+
+            ensureQueueTable(sql);
+            ensureQueueTable(sql);
+
+            expect(readQueueMessages(sql).entries).toStrictEqual([]);
+        });
+    });
+
+    describe(readQueueMessages, () => {
+        it("returns an empty list on an app whose consumers have never run", () => {
+            expect.assertions(1);
+
+            expect(readQueueMessages(sql).entries).toStrictEqual([]);
+        });
+    });
+
+    describe(recordQueueMessages, () => {
+        it("creates the table on first use", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [baseInput], 5000);
+
+            const rows = harness.raw(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`, QUEUE_TABLE);
+
+            expect(rows).toHaveLength(1);
+        });
+
+        it("round-trips a message body, decoding it back to the same value", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [baseInput], 5000);
+
+            const { entries } = readQueueMessages(sql);
+
+            expect(entries[0]?.body).toStrictEqual({ hello: "world" });
+        });
+
+        it("returns the number of messages recorded", () => {
+            expect.assertions(1);
+
+            const result = recordQueueMessages(sql, [baseInput, { ...baseInput, messageId: "msg-2" }], 5000);
+
+            expect(result).toStrictEqual({ recorded: 2 });
+        });
+
+        it("records attempts, outcome, deadLettered and error verbatim", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [{ ...baseInput, attempts: 3, deadLettered: true, error: "boom", exportName: "sendWelcome", outcome: "error" }], 5000);
+
+            const { entries } = readQueueMessages(sql);
+
+            expect(entries[0]).toMatchObject({ attempts: 3, deadLettered: true, error: "boom", exportName: "sendWelcome", outcome: "error" });
+        });
+
+        it("leaves exportName/error undefined (not empty string) when absent", () => {
+            expect.assertions(2);
+
+            recordQueueMessages(sql, [baseInput], 5000);
+
+            const { entries } = readQueueMessages(sql);
+
+            expect(entries[0]?.exportName).toBeUndefined();
+            expect(entries[0]?.error).toBeUndefined();
+        });
+
+        it("orders newest first by capturedAt", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [{ ...baseInput, messageId: "first" }], 1000);
+            recordQueueMessages(sql, [{ ...baseInput, messageId: "second" }], 2000);
+
+            const { entries } = readQueueMessages(sql);
+
+            expect(entries.map((entry) => entry.messageId)).toStrictEqual(["second", "first"]);
+        });
+
+        it("trims the log back to QUEUE_RETENTION rows after each write", () => {
+            expect.assertions(1);
+
+            for (let index = 0; index < QUEUE_RETENTION + 5; index += 1) {
+                recordQueueMessages(sql, [{ ...baseInput, messageId: `msg-${String(index)}` }], index);
+            }
+
+            const { entries } = readQueueMessages(sql, { limit: QUEUE_RETENTION });
+
+            expect(entries).toHaveLength(QUEUE_RETENTION);
+        });
+
+        it("filters by queue name", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [{ ...baseInput, messageId: "a", queue: "emails" }], 1000);
+            recordQueueMessages(sql, [{ ...baseInput, messageId: "b", queue: "webhooks" }], 2000);
+
+            const { entries } = readQueueMessages(sql, { queue: "webhooks" });
+
+            expect(entries.map((entry) => entry.messageId)).toStrictEqual(["b"]);
+        });
+
+        it("caps an oversized body with a visible truncation marker", () => {
+            expect.assertions(2);
+
+            const oversized = "x".repeat(MAX_BODY_CHARS + 100);
+
+            recordQueueMessages(sql, [{ ...baseInput, body: oversized }], 5000);
+
+            const { entries } = readQueueMessages(sql);
+            const body = entries[0]?.body;
+
+            expect(typeof body).toBe("string");
+            expect(isLossyBody(body)).toBe(true);
+        });
+
+        it("stores a diagnostic marker for a body that can't be JSON-encoded", () => {
+            expect.assertions(2);
+
+            // A function value stringifies to `undefined`, which is what
+            // `encodeBody` treats as "unserializable" (its .length access throws).
+            recordQueueMessages(sql, [{ ...baseInput, body: () => {} }], 5000);
+
+            const { entries } = readQueueMessages(sql);
+
+            expect(entries[0]?.body).toBe("[unserializable message body]");
+            expect(isLossyBody(entries[0]?.body)).toBe(true);
+        });
+
+        it("stores an undefined body as null", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [{ ...baseInput, body: undefined }], 5000);
+
+            const { entries } = readQueueMessages(sql);
+
+            expect(entries[0]?.body).toBeNull();
+        });
+    });
+
+    describe(readQueueMessageById, () => {
+        it("returns undefined for an id that was never captured", () => {
+            expect.assertions(1);
+
+            expect(readQueueMessageById(sql, "nope")).toBeUndefined();
+        });
+
+        it("reads a single captured row by its synthetic id", () => {
+            expect.assertions(1);
+
+            recordQueueMessages(sql, [baseInput], 5000);
+
+            const { entries } = readQueueMessages(sql);
+            const id = entries[0]?.id;
+
+            expect(readQueueMessageById(sql, id ?? "")).toStrictEqual(entries[0]);
+        });
+    });
+
+    describe(clearQueueMessages, () => {
+        it("empties the log", () => {
+            expect.assertions(2);
+
+            recordQueueMessages(sql, [baseInput], 5000);
+
+            expect(readQueueMessages(sql).entries).toHaveLength(1);
+
+            clearQueueMessages(sql);
+
+            expect(readQueueMessages(sql).entries).toHaveLength(0);
+        });
+
+        it("is safe to call on a never-audited shard", () => {
+            expect.assertions(1);
+
+            expect(clearQueueMessages(sql)).toStrictEqual({ cleared: true });
+        });
+    });
+
+    describe(isLossyBody, () => {
+        it("is false for an ordinary decoded object body", () => {
+            expect.assertions(1);
+
+            expect(isLossyBody({ hello: "world" })).toBe(false);
+        });
+
+        it("is false for an ordinary string body that happens not to be the marker", () => {
+            expect.assertions(1);
+
+            expect(isLossyBody("just a plain string")).toBe(false);
+        });
+    });
+});

--- a/packages/shard-engine/__tests__/shard-runner.test.ts
+++ b/packages/shard-engine/__tests__/shard-runner.test.ts
@@ -1,0 +1,230 @@
+import type { ShardHost } from "@lunora/platform";
+import type { ReferenceHost } from "@lunora/platform/conformance";
+import { createReferenceHost } from "@lunora/platform/conformance";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ShardRunner } from "../src/shard-runner";
+
+/**
+ * `ShardRunner` — the host-neutral orchestrator every provider wrapper
+ * (`ShardDO` on Cloudflare) mounts on top of. It is the seam the platform
+ * extraction rests on, so these pin what a host wrapper can rely on: socket
+ * identity resolution, the single-writer + transaction composition, and the
+ * `handlers` delegation for the request/alarm paths that haven't moved yet.
+ *
+ * Built on `@lunora/platform`'s reference host (also used by
+ * `engine-conformance.test.ts`) rather than a bespoke double — a real
+ * `ShardHost`/`SocketHost` implementation, not a hand-rolled stand-in that
+ * could silently diverge from the contract `ShardRunner` is written against.
+ */
+describe(ShardRunner, () => {
+    let host: ReferenceHost;
+
+    beforeEach(() => {
+        host = createReferenceHost();
+    });
+
+    afterEach(() => {
+        host.cleanup?.();
+    });
+
+    describe("construction", () => {
+        it("exposes the shard host's shardKey, undefined when the host doesn't name its shards", () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            expect(runner.shardKey).toBeUndefined();
+        });
+
+        it("exposes a host that does name its shard", () => {
+            expect.assertions(1);
+
+            const namedShard: ShardHost = { ...host.shard, shardKey: "room-42" };
+            const runner = new ShardRunner(namedShard, host.socket);
+
+            expect(runner.shardKey).toBe("room-42");
+        });
+
+        it("defaults options to {} when none are supplied", () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            expect(runner.options).toStrictEqual({});
+        });
+    });
+
+    describe("socketFor", () => {
+        it("resolves a raw socket the runtime handed back to the handle issued at accept()", () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+            const raw = {};
+            const handle = host.socket.accept(raw);
+
+            expect(runner.socketFor(raw)).toBe(handle);
+        });
+
+        it("falls back to the raw object's own identity for a socket the host never accepted", () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+            const neverAccepted = { send: () => {} };
+
+            expect(runner.socketFor(neverAccepted)).toBe(neverAccepted);
+        });
+    });
+
+    describe("sockets", () => {
+        it("lists every live socket when called without a tag", () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            host.socket.accept({}, undefined, ["room:a"]);
+            host.socket.accept({}, undefined, ["room:b"]);
+
+            expect(runner.sockets()).toHaveLength(2);
+        });
+
+        it("narrows to exactly the sockets carrying the given tag", () => {
+            expect.assertions(2);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            const handleA = host.socket.accept({}, undefined, ["room:a"]);
+            host.socket.accept({}, undefined, ["room:b"]);
+
+            const tagged = runner.sockets("room:a");
+
+            expect(tagged).toHaveLength(1);
+            expect(tagged[0]).toBe(handleA);
+        });
+    });
+
+    describe("background", () => {
+        it("delegates to the host's waitUntil and returns true when the host supports it", () => {
+            expect.assertions(2);
+
+            const seen: Promise<unknown>[] = [];
+            const shard: ShardHost = {
+                ...host.shard,
+                waitUntil: (work) => {
+                    seen.push(work);
+                },
+            };
+            const runner = new ShardRunner(shard, host.socket);
+            const work = Promise.resolve("done");
+
+            const took = runner.background(work);
+
+            expect(took).toBe(true);
+            expect(seen).toStrictEqual([work]);
+        });
+
+        it("returns false without throwing when the host omits waitUntil", () => {
+            expect.assertions(1);
+
+            const shard: ShardHost = { ...host.shard, waitUntil: undefined };
+            const runner = new ShardRunner(shard, host.socket);
+
+            expect(runner.background(Promise.resolve())).toBe(false);
+        });
+    });
+
+    describe("runInTransaction", () => {
+        it("returns the work closure's result", async () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            await expect(runner.runInTransaction(async () => "ok")).resolves.toBe("ok");
+        });
+
+        it("propagates a thrown error rather than swallowing it", async () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            await expect(
+                runner.runInTransaction(async () => {
+                    throw new Error("boom");
+                }),
+            ).rejects.toThrow("boom");
+        });
+
+        it("serializes concurrent calls through the single-writer gate — never two at once", async () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+            let concurrent = 0;
+            let maxConcurrent = 0;
+
+            const work = async (): Promise<void> => {
+                concurrent += 1;
+                maxConcurrent = Math.max(maxConcurrent, concurrent);
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 5);
+                });
+                concurrent -= 1;
+            };
+
+            await Promise.all([runner.runInTransaction(work), runner.runInTransaction(work), runner.runInTransaction(work)]);
+
+            expect(maxConcurrent).toBe(1);
+        });
+    });
+
+    describe("handleFetch", () => {
+        it("returns 501 Not Implemented when the host mounts the runner without a handler", async () => {
+            expect.assertions(2);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+            const response = await runner.handleFetch(new Request("https://example.test"));
+
+            expect(response.status).toBe(501);
+            await expect(response.text()).resolves.toBe("Not implemented");
+        });
+
+        it("delegates to handlers.handleFetch when supplied", async () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket, {
+                handlers: {
+                    handleFetch: async () => new Response("handled", { status: 200 }),
+                },
+            });
+            const response = await runner.handleFetch(new Request("https://example.test"));
+
+            await expect(response.text()).resolves.toBe("handled");
+        });
+    });
+
+    describe("handleAlarm", () => {
+        it("no-ops when the host mounts the runner without a handler", async () => {
+            expect.assertions(1);
+
+            const runner = new ShardRunner(host.shard, host.socket);
+
+            await expect(runner.handleAlarm()).resolves.toBeUndefined();
+        });
+
+        it("delegates to handlers.handleAlarm when supplied", async () => {
+            expect.assertions(1);
+
+            let called = false;
+            const runner = new ShardRunner(host.shard, host.socket, {
+                handlers: {
+                    handleAlarm: async () => {
+                        called = true;
+                    },
+                },
+            });
+
+            await runner.handleAlarm();
+
+            expect(called).toBe(true);
+        });
+    });
+});

--- a/packages/studio/__tests__/features/queues/queues-panel.test.tsx
+++ b/packages/studio/__tests__/features/queues/queues-panel.test.tsx
@@ -1,0 +1,192 @@
+import { LunoraProvider } from "@lunora/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import QueuesPanel from "../../../src/features/queues/queues-panel";
+import type { QueueMessageRow, QueueMetadata, QueuesResult, ReplayQueueMessageResult } from "../../../src/lib/admin";
+import { ADMIN_FUNCTIONS } from "../../../src/lib/admin";
+import type { MockClientHooks } from "../../mock-client";
+import { createMockClient } from "../../mock-client";
+
+const renderPanel = (mock: MockClientHooks): ReactElement => (
+    <LunoraProvider client={mock.asClient}>
+        <QueuesPanel />
+    </LunoraProvider>
+);
+
+const oneQueue: QueueMetadata = { binding: "EMAIL_QUEUE", exportName: "sendWelcome", mode: "push", name: "emails" };
+
+const message = (overrides: Partial<QueueMessageRow> = {}): QueueMessageRow => {
+    return {
+        attempts: 1,
+        body: { hello: "world" },
+        capturedAt: 1_700_000_000_000,
+        deadLettered: false,
+        exportName: "sendWelcome",
+        id: "msg-1",
+        messageId: "cf-1",
+        outcome: "ack",
+        queue: "emails",
+        timestamp: 1_700_000_000_000,
+        ...overrides,
+    };
+};
+
+describe("queuesPanel", () => {
+    it("loads the declared queues on the default tab", async () => {
+        expect.assertions(1);
+
+        const mock = createMockClient({
+            query: (reference): unknown => {
+                if (reference === ADMIN_FUNCTIONS.listQueues) {
+                    return { queues: [oneQueue] } satisfies QueuesResult;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getQueueMessages) {
+                    return { entries: [] };
+                }
+
+                throw new Error(`unexpected ${reference}`);
+            },
+        });
+
+        render(renderPanel(mock));
+
+        await screen.findByTestId("queues-row-sendWelcome");
+
+        expect(screen.getByTestId("queues-row-sendWelcome").textContent).toContain("emails");
+    });
+
+    it("replays a message: sends the id, and refetches the log", async () => {
+        expect.hasAssertions();
+
+        let replayedId: string | undefined;
+        let messagesReadCount = 0;
+
+        const mock = createMockClient({
+            query: (reference, args): unknown => {
+                if (reference === ADMIN_FUNCTIONS.listQueues) {
+                    return { queues: [oneQueue] } satisfies QueuesResult;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getQueueMessages) {
+                    messagesReadCount += 1;
+
+                    return { entries: [message()] };
+                }
+
+                if (reference === ADMIN_FUNCTIONS.replayQueueMessage) {
+                    replayedId = (args as { id: string }).id;
+
+                    return { sent: 1, target: "emails" } satisfies ReplayQueueMessageResult;
+                }
+
+                throw new Error(`unexpected ${reference}`);
+            },
+        });
+
+        render(renderPanel(mock));
+
+        fireEvent.click(screen.getByTestId("queues-tab-messages"));
+
+        await screen.findByTestId("queues-message-msg-1");
+
+        const readsBeforeReplay = messagesReadCount;
+
+        fireEvent.click(screen.getByTestId("queues-replay-msg-1"));
+
+        await waitFor(() => {
+            expect(messagesReadCount).toBeGreaterThan(readsBeforeReplay);
+        });
+
+        expect(replayedId).toBe("msg-1");
+        expect(screen.queryByTestId("queues-error")).toBeNull();
+    });
+
+    it("surfaces a rejected replay in the panel's error surface", async () => {
+        expect.assertions(1);
+
+        const mock = createMockClient({
+            query: (reference): unknown => {
+                if (reference === ADMIN_FUNCTIONS.listQueues) {
+                    return { queues: [oneQueue] } satisfies QueuesResult;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getQueueMessages) {
+                    return { entries: [message()] };
+                }
+
+                if (reference === ADMIN_FUNCTIONS.replayQueueMessage) {
+                    throw new Error("QUEUE_REPLAY_FAILED");
+                }
+
+                throw new Error(`unexpected ${reference}`);
+            },
+        });
+
+        render(renderPanel(mock));
+
+        fireEvent.click(screen.getByTestId("queues-tab-messages"));
+
+        await screen.findByTestId("queues-message-msg-1");
+
+        fireEvent.click(screen.getByTestId("queues-replay-msg-1"));
+
+        await screen.findByTestId("queues-error");
+
+        expect(screen.getByTestId("queues-error").textContent).toContain("QUEUE_REPLAY_FAILED");
+    });
+
+    // Every other destructive action in the studio (storage delete, migrations,
+    // export/import, PITR restore, …) is gated behind the shared `ConfirmButton`
+    // component before it fires. `clearQueueMessages` is not: the "Clear log"
+    // button in queues-panel.tsx wires straight to `onClear` with no confirm
+    // step, so a single click irreversibly wipes the dev consumed-message log.
+    // This test pins that CURRENT behaviour rather than the gated behaviour the
+    // rest of the studio's destructive actions have — it is a real gap, not a
+    // desired contract, and is flagged as a finding rather than "fixed" here.
+    it("clears the log on a single click, with no confirmation gate (flagged: unlike every sibling destructive action)", async () => {
+        expect.hasAssertions();
+
+        let cleared = false;
+
+        const mock = createMockClient({
+            query: (reference): unknown => {
+                if (reference === ADMIN_FUNCTIONS.listQueues) {
+                    return { queues: [oneQueue] } satisfies QueuesResult;
+                }
+
+                if (reference === ADMIN_FUNCTIONS.getQueueMessages) {
+                    return { entries: cleared ? [] : [message()] };
+                }
+
+                if (reference === ADMIN_FUNCTIONS.clearQueueMessages) {
+                    cleared = true;
+
+                    return { cleared: true };
+                }
+
+                throw new Error(`unexpected ${reference}`);
+            },
+        });
+
+        render(renderPanel(mock));
+
+        fireEvent.click(screen.getByTestId("queues-tab-messages"));
+
+        await screen.findByTestId("queues-message-msg-1");
+
+        // No intermediate confirm affordance exists to assert against — the
+        // click below is the entire interaction.
+        fireEvent.click(screen.getByTestId("queues-clear"));
+
+        await waitFor(() => {
+            expect(cleared).toBe(true);
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByTestId("queues-message-msg-1")).toBeNull();
+        });
+    });
+});

--- a/packages/studio/__tests__/hooks/use-admin-query.test.tsx
+++ b/packages/studio/__tests__/hooks/use-admin-query.test.tsx
@@ -1,0 +1,241 @@
+import { LunoraProvider } from "@lunora/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren, ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useAdminQuery } from "../../src/hooks/use-admin-query";
+import type { MockClientHooks } from "../mock-client";
+import { createMockClient } from "../mock-client";
+
+/**
+ * `useAdminQuery` is every studio panel's data path: the one-shot admin-RPC
+ * read, the live WS bridge layered on top when `live: true`, and the
+ * `liveError` suppression that keeps a stale rejection from lingering once the
+ * live window isn't active. None of that had a direct test — every panel test
+ * exercises it only incidentally through whichever panel happens to render.
+ */
+const wrapper =
+    (mock: MockClientHooks) =>
+    ({ children }: PropsWithChildren): ReactElement => <LunoraProvider client={mock.asClient}>{children}</LunoraProvider>;
+
+describe("useAdminQuery", () => {
+    it("performs a one-shot fetch and resolves data", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { ok: true };
+            },
+        });
+        const { result } = renderHook(() => useAdminQuery<{ ok: boolean }>("listThings", {}), { wrapper: wrapper(mock) });
+
+        expect(result.current.isLoading).toBe(true);
+        expect(result.current.data).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current.data).toStrictEqual({ ok: true });
+        });
+
+        expect(result.current.isLoading).toBe(false);
+        expect(mock.query).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fetch or subscribe while enabled is false", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { ok: true };
+            },
+        });
+        const { result } = renderHook(() => useAdminQuery<{ ok: boolean }>("listThings", {}, { enabled: false, live: true }), {
+            wrapper: wrapper(mock),
+        });
+
+        // Give any accidental async fetch a tick to have fired.
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mock.query).not.toHaveBeenCalled();
+        expect(mock.subscribe).not.toHaveBeenCalled();
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it("re-derives the same cache key for an equal-but-new args object, without tearing down the live subscription", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { ok: true };
+            },
+        });
+        const { rerender } = renderHook(({ args }: { args: Record<string, unknown> }) => useAdminQuery("listThings", args, { live: true }), {
+            initialProps: { args: { table: "orders" } },
+            wrapper: wrapper(mock),
+        });
+
+        await waitFor(() => {
+            expect(mock.subscribe).toHaveBeenCalledTimes(1);
+        });
+
+        // A fresh object, same shape/values — the effect keys on JSON.stringify,
+        // so this must NOT close and reopen the subscription.
+        rerender({ args: { table: "orders" } });
+        rerender({ args: { table: "orders" } });
+
+        expect(mock.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes and reopens the live subscription when the key actually changes", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { ok: true };
+            },
+        });
+        const { rerender } = renderHook(({ table }: { table: string }) => useAdminQuery("listThings", { table }, { live: true }), {
+            initialProps: { table: "orders" },
+            wrapper: wrapper(mock),
+        });
+
+        await waitFor(() => {
+            expect(mock.subscribe).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ table: "invoices" });
+
+        await waitFor(() => {
+            expect(mock.subscribe).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it("counts one unsubscribe per resubscribe as the key changes across re-renders", async () => {
+        expect.hasAssertions();
+
+        const unsubscribed: number[] = [];
+        const mock = createMockClient({
+            query: () => {
+                return { ok: true };
+            },
+        });
+        let nextId = 0;
+
+        // Wrap `subscribe` to observe the returned unsubscribe function being called.
+        mock.subscribe.mockImplementation(() => {
+            const id = nextId;
+
+            nextId += 1;
+
+            return () => {
+                unsubscribed.push(id);
+            };
+        });
+
+        const { rerender, unmount } = renderHook(({ table }: { table: string }) => useAdminQuery("listThings", { table }, { live: true }), {
+            initialProps: { table: "orders" },
+            wrapper: wrapper(mock),
+        });
+
+        await waitFor(() => {
+            expect(mock.subscribe).toHaveBeenCalledTimes(1);
+        });
+
+        rerender({ table: "invoices" });
+
+        await waitFor(() => {
+            expect(mock.subscribe).toHaveBeenCalledTimes(2);
+        });
+
+        expect(unsubscribed).toStrictEqual([0]);
+
+        unmount();
+
+        expect(unsubscribed).toStrictEqual([0, 1]);
+    });
+
+    it("pushes a live value straight into the cached data", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { count: 1 };
+            },
+        });
+        const { result } = renderHook(() => useAdminQuery<{ count: number }>("counter", {}, { live: true }), { wrapper: wrapper(mock) });
+
+        await waitFor(() => {
+            expect(result.current.data).toStrictEqual({ count: 1 });
+        });
+
+        act(() => {
+            mock.emit("counter", { count: 2 });
+        });
+
+        await waitFor(() => {
+            expect(result.current.data).toStrictEqual({ count: 2 });
+        });
+    });
+
+    it("surfaces a subscription rejection as liveError, while keeping the one-shot data visible", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { count: 1 };
+            },
+        });
+        const { result } = renderHook(() => useAdminQuery<{ count: number }>("counter", {}, { live: true }), { wrapper: wrapper(mock) });
+
+        await waitFor(() => {
+            expect(result.current.data).toStrictEqual({ count: 1 });
+        });
+
+        act(() => {
+            mock.emitError("counter", "subscription rejected");
+        });
+
+        await waitFor(() => {
+            expect(result.current.liveError).toBe("subscription rejected");
+        });
+
+        expect(result.current.data).toStrictEqual({ count: 1 });
+    });
+
+    it("suppresses a stale liveError once enabled flips to false, without unmounting", async () => {
+        expect.hasAssertions();
+
+        const mock = createMockClient({
+            query: () => {
+                return { count: 1 };
+            },
+        });
+        const { rerender, result } = renderHook(
+            ({ enabled }: { enabled: boolean }) => useAdminQuery<{ count: number }>("counter", {}, { enabled, live: true }),
+            {
+                initialProps: { enabled: true },
+                wrapper: wrapper(mock),
+            },
+        );
+
+        await waitFor(() => {
+            expect(result.current.data).toStrictEqual({ count: 1 });
+        });
+
+        act(() => {
+            mock.emitError("counter", "subscription rejected");
+        });
+
+        await waitFor(() => {
+            expect(result.current.liveError).toBe("subscription rejected");
+        });
+
+        rerender({ enabled: false });
+
+        await waitFor(() => {
+            expect(result.current.liveError).toBeUndefined();
+        });
+    });
+});

--- a/packages/svelte/__tests__/auth.test.ts
+++ b/packages/svelte/__tests__/auth.test.ts
@@ -2,7 +2,7 @@ import type { LunoraClient, Unsubscribe, User } from "@lunora/client";
 import { get } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
-import { auth } from "../src/auth";
+import { auth, authGate } from "../src/auth";
 
 const createAuthFakeClient = () => {
     let token: string | null = null;
@@ -107,5 +107,80 @@ describe("auth store (Svelte)", () => {
         expect(get(user)).toBeNull();
 
         stop();
+    });
+});
+
+describe("authGate store (Svelte)", () => {
+    it("is neither loading nor authenticated before a token is set (signed out)", () => {
+        const fake = createAuthFakeClient();
+        const { isAuthenticated, isLoading } = authGate(fake.client);
+
+        const stopA = isAuthenticated.subscribe(() => {});
+        const stopL = isLoading.subscribe(() => {});
+
+        expect(get(isAuthenticated)).toBe(false);
+        expect(get(isLoading)).toBe(false);
+
+        stopA();
+        stopL();
+    });
+
+    it("is loading once a token is set but the user hasn't resolved yet", () => {
+        const fake = createAuthFakeClient();
+        const { isAuthenticated, isLoading } = authGate(fake.client);
+
+        const stopA = isAuthenticated.subscribe(() => {});
+        const stopL = isLoading.subscribe(() => {});
+
+        fake.setAuthToken("jwt-abc");
+
+        expect(get(isLoading)).toBe(true);
+        expect(get(isAuthenticated)).toBe(false);
+
+        stopA();
+        stopL();
+    });
+
+    it("is authenticated once the token is set and the user has resolved", async () => {
+        const fake = createAuthFakeClient();
+        fake.setCurrentUser({ id: "u_1" });
+
+        const { isAuthenticated, isLoading } = authGate(fake.client);
+
+        const stopA = isAuthenticated.subscribe(() => {});
+        const stopL = isLoading.subscribe(() => {});
+
+        fake.setAuthToken("jwt-abc");
+        await flushAsync();
+
+        expect(get(isAuthenticated)).toBe(true);
+        expect(get(isLoading)).toBe(false);
+
+        stopA();
+        stopL();
+    });
+
+    it("returns to signed out on sign-out", async () => {
+        const fake = createAuthFakeClient();
+        fake.setCurrentUser({ id: "u_1" });
+
+        const { isAuthenticated, isLoading } = authGate(fake.client);
+
+        const stopA = isAuthenticated.subscribe(() => {});
+        const stopL = isLoading.subscribe(() => {});
+
+        fake.setAuthToken("jwt-abc");
+        await flushAsync();
+
+        expect(get(isAuthenticated)).toBe(true);
+
+        fake.setAuthToken(null);
+        await flushAsync();
+
+        expect(get(isAuthenticated)).toBe(false);
+        expect(get(isLoading)).toBe(false);
+
+        stopA();
+        stopL();
     });
 });

--- a/packages/svelte/src/auth.ts
+++ b/packages/svelte/src/auth.ts
@@ -1,7 +1,7 @@
 import type { User } from "@lunora/client";
 import { getIdentityStore } from "@lunora/client/auth";
 import type { Readable } from "svelte/store";
-import { readable } from "svelte/store";
+import { derived, readable } from "svelte/store";
 
 import { getLunoraClient } from "./context";
 
@@ -51,5 +51,40 @@ const auth = (explicitClient?: ReturnType<typeof getLunoraClient>): AuthStore =>
     return { setToken, token, user };
 };
 
-export type { AuthStore };
-export { auth };
+/** Derived auth-gate stores for template gating (`{#if $isAuthenticated}`), built on {@link auth}. */
+interface AuthGateStore {
+    /** Readable store, `true` once a token is set and the user has resolved. */
+    isAuthenticated: Readable<boolean>;
+
+    /** Readable store, `true` while a token is set but the user hasn't resolved yet. */
+    isLoading: Readable<boolean>;
+}
+
+/**
+ * Derived auth-gate stores built on {@link auth}. Svelte has no JSX-style
+ * `Authenticated` slot component the way React/Vue/Solid do (this package is
+ * plain `.ts` over stores — no `.svelte` component compiler required), so this
+ * exposes the same three-state logic as two boolean stores instead: a token
+ * with no resolved user yet is `isLoading`; a token with a resolved user is
+ * `isAuthenticated`; no token is neither (the signed-out state a template
+ * checks for with a plain `{:else}`).
+ *
+ * ```ts
+ * import { authGate } from "@lunora/svelte";
+ * const { isAuthenticated, isLoading } = authGate();
+ * // markup: {#if $isAuthenticated} signed in {:else if $isLoading} loading… {:else} signed out {/if}
+ * ```
+ *
+ * Pass an explicit client to bypass the ambient context (useful in tests).
+ */
+const authGate = (explicitClient?: ReturnType<typeof getLunoraClient>): AuthGateStore => {
+    const { token, user } = auth(explicitClient);
+
+    const isLoading = derived([token, user], ([$token, $user]) => $token !== null && $user === null);
+    const isAuthenticated = derived([token, user], ([$token, $user]) => $token !== null && $user !== null);
+
+    return { isAuthenticated, isLoading };
+};
+
+export type { AuthGateStore, AuthStore };
+export { auth, authGate };

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -6,8 +6,8 @@ export type { AgentStateApi, AgentStateHandle, AgentStateOptions } from "./agent
 export { agentState } from "./agent-state";
 export type { AgentToolEvent, AgentToolEventsApi, AgentToolEventsHandle, AgentToolEventsOptions } from "./agent-tool-events";
 export { agentToolEvents } from "./agent-tool-events";
-export type { AuthStore } from "./auth";
-export { auth } from "./auth";
+export type { AuthGateStore, AuthStore } from "./auth";
+export { auth, authGate } from "./auth";
 export type { ConnectionStatusStore } from "./connection-status";
 export { connectionStatus } from "./connection-status";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1932,6 +1932,9 @@ importers:
       '@lunora/ratelimit':
         specifier: workspace:*
         version: link:../ratelimit
+      '@visulima/storage-client':
+        specifier: catalog:storage
+        version: 1.0.0(@tanstack/react-query@5.101.4(react@19.2.8))(@tanstack/solid-query@5.101.3(solid-js@1.9.14))(@tanstack/svelte-query@6.1.37(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(@tanstack/vue-query@5.101.3(vue@3.5.40(typescript@6.0.3)))(react@19.2.8)(solid-js@1.9.14)(svelte@5.56.7(@typescript-eslint/types@8.65.0))(vue@3.5.40(typescript@6.0.3))
     devDependencies:
       '@angular/core':
         specifier: ^22.0.8


### PR DESCRIPTION
> **Stacked on #217** (base `advisor/217-client-lifecycle`) — section D's characterization builds on 217's watchdog context. GitHub retargets this to `alpha` when #217 merges. Review after #217.

Five workstreams. Mostly additive tests + thin adapter wrappers; the one risky refactor was correctly **not** attempted (see D).

## A — search-core cursor algebra + scorer
`query.test.ts` + `text.test.ts` (60 tests), table-driven: cap constants, `encode`/`parseSearchCursor` round-trip (incl. `"search:"`→offset 0), terminal-page at `numItems===0`, `resolveSearchScan(Infinity)` clamp, `planSearchPage` at exactly `MAX_SEARCH_SCAN`, `searchTermRange` on an astral-plane token, `scoreDocument` AND+prefix. The shared search core was previously covered only transitively through three engines.

## B — four zero-coverage shard-engine modules
Named suites (64 tests) for `shard-runner.ts` (the host-neutral portability seam, over the `@lunora/platform/conformance` reference host), `audit-log.ts` (incl. the unguarded-`JSON.parse` throw on a malformed stored `detail`), `queue-catcher.ts`, `aggregate-tally.ts`.

## C — the admin-query primitive + queues panel
`use-admin-query.test.tsx` (8: one-shot fetch, `enabled:false` suppression, key re-derivation on equal-but-new args, subscribe/unsubscribe counts, live push→cache, `onError`→`liveError`) and `queues-panel.test.tsx` (4: declared-queues load, replay round-trip, rejected-write error surface).

**Finding (flagged, not fixed — tests-only scope):** `clearQueueMessages`'s Clear-log button has **no `ConfirmButton` gate**, unlike every other destructive studio action (storage delete, migrations, export/import, PITR restore). The test pins the actual single-click behavior and comments the gap. Worth a follow-up fix.

## D — CLIENT-05 socket lifecycle: characterized, extraction deferred (escape hatch)
The plan's STOP-D fired: the shard `openSocket`/`ensureSocket`/`handleDisconnect` state threads through dozens of call sites in the 5667-line client, and `subscribeScheduledJobs`'s closure has no branch point to construct a genuine two-socket race against — extracting a shared `openManagedSocket` **blind** was too risky. Per the plan, shipped **3 characterization tests** instead (pinning `subscribeScheduledJobs`'s current lack of connect-timeout, heartbeat/watchdog, and bare-`error` handling) and left the extraction — where 217's watchdog should eventually live, unduplicated — as a follow-up. **Zero `client/src` changes**; only the `MockSocket` harness gained a `triggerError()`.

## E — adapter surface gaps
`@lunora/angular/upload` (new signal-based subpath over the client's TUS/chunked-REST core) + `authGate()` on both `@lunora/angular` and `@lunora/svelte` (derived `isAuthenticated`/`isLoading`, matching Vue's semantics). These satisfy #268's adapter-parity gate shape.

## Verification
search-core 60, shard-engine 64 (package 903), studio 12 (package 972), client 129 (+1 pre-existing expected-fail, unrelated), angular 15, svelte 8 — all pass. `lint:types` clean; `lint:eslint`/prettier clean on touched files; **package.json sort** green (new angular subpath); `build:packages` 53/53.

## Follow-ups surfaced
1. The `clearQueueMessages` missing-confirm-gate (C).
2. The shared `openManagedSocket` extraction + folding 217's watchdog into it (D).

Plan: `plans/231-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)