### PR TITLE
fix(studio): confirm before clearing a queue's messages

### DIFF
--- a/packages/studio/__tests__/features/queues/queues-panel.test.tsx
+++ b/packages/studio/__tests__/features/queues/queues-panel.test.tsx
@@ -140,13 +140,11 @@ describe("queuesPanel", () => {
 
     // Every other destructive action in the studio (storage delete, migrations,
     // export/import, PITR restore, …) is gated behind the shared `ConfirmButton`
-    // component before it fires. `clearQueueMessages` is not: the "Clear log"
-    // button in queues-panel.tsx wires straight to `onClear` with no confirm
-    // step, so a single click irreversibly wipes the dev consumed-message log.
-    // This test pins that CURRENT behaviour rather than the gated behaviour the
-    // rest of the studio's destructive actions have — it is a real gap, not a
-    // desired contract, and is flagged as a finding rather than "fixed" here.
-    it("clears the log on a single click, with no confirmation gate (flagged: unlike every sibling destructive action)", async () => {
+    // component before it fires. `clearQueueMessages` matches that: the "Clear
+    // log" button in queues-panel.tsx is a `ConfirmButton`, so the first click
+    // only reveals the confirm/cancel prompt and `onClear` (which invokes
+    // `clearQueueMessages`) fires only from the `queues-clear-confirm` click.
+    it("does not clear on the first click; only the confirm click invokes clearQueueMessages", async () => {
         expect.hasAssertions();
 
         let cleared = false;
@@ -177,9 +175,14 @@ describe("queuesPanel", () => {
 
         await screen.findByTestId("queues-message-msg-1");
 
-        // No intermediate confirm affordance exists to assert against — the
-        // click below is the entire interaction.
+        // First click only reveals the confirm/cancel prompt — the log must
+        // still be intact and clearQueueMessages must not have fired.
         fireEvent.click(screen.getByTestId("queues-clear"));
+
+        expect(cleared).toBe(false);
+        expect(screen.getByTestId("queues-message-msg-1")).toBeDefined();
+
+        fireEvent.click(screen.getByTestId("queues-clear-confirm"));
 
         await waitFor(() => {
             expect(cleared).toBe(true);

--- a/packages/studio/src/features/queues/queues-panel.tsx
+++ b/packages/studio/src/features/queues/queues-panel.tsx
@@ -2,6 +2,7 @@ import { useLunora } from "@lunora/react";
 import type { ChangeEvent, MouseEvent, ReactElement } from "react";
 import { useState } from "react";
 
+import { ConfirmButton } from "../../components/confirm-button";
 import { ErrorAlert } from "../../components/error-alert";
 import { Alert } from "../../components/ui/alert";
 import { Badge } from "../../components/ui/badge";
@@ -215,17 +216,16 @@ const QueuesMessagesTab = ({
                 <p className="text-sm text-muted-foreground">
                     {t("Cloudflare Queues have no peek API, so this is what push consumers actually processed — not pending depth.")}
                 </p>
-                <Button
-                    className="ml-auto"
-                    data-testid="queues-clear"
-                    disabled={messages.length === 0}
-                    onClick={onClear}
-                    size="sm"
-                    type="button"
-                    variant="outline"
-                >
-                    {t("Clear log")}
-                </Button>
+                <div className="ml-auto">
+                    <ConfirmButton
+                        confirmLabel={t("Clear {count} messages?", { count: messages.length })}
+                        disabled={messages.length === 0}
+                        onConfirm={onClear}
+                        testId="queues-clear"
+                    >
+                        {t("Clear log")}
+                    </ConfirmButton>
+                </div>
                 {messages.length > 0 && (
                     <Badge data-testid="queues-count" variant="secondary">
                         {t("{count} messages", { count: messages.length })}

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -1080,6 +1080,7 @@ const MESSAGE_IDS = [
     "Body must be valid JSON.",
     "Captured",
     "Clear log",
+    "Clear {count} messages?",
     "Cloudflare Queues have no peek API, so this is what push consumers actually processed — not pending depth.",
     "Consumed messages appear here once a push consumer processes a batch in dev. Send one from the Send tab to see it captured.",
     "Declare a queue with defineQueue in lunora/queues.ts to enqueue a test message.",


### PR DESCRIPTION
> **Stacked on #279** (base `advisor/231-coverage-socket`) — it updates the queues-panel test #279 added. #279 is itself stacked on #217, so this retargets down the chain to `alpha` as each base merges.

## What

The queues "Clear log" button irreversibly purges a queue's messages from a **plain `onClick`** with no confirmation — the lone destructive action in the studio not gated behind `ConfirmButton` (storage delete, migrations, export/import, PITR restore, apply-index all are). A single misclick dropped the queue with no undo. Now gated.

## Change

- `queues-panel.tsx`: swapped the plain button for `ConfirmButton` (`confirmLabel={t("Clear {count} messages?", { count })}` + `onConfirm={onClear}`), mirroring `export-import.tsx`'s inline-toolbar usage + `pitr-panel.tsx`'s prop shape. Kept the `ml-auto` right-push via a wrapper div (ConfirmButton takes no `className`) — same pattern as `function-stats.tsx`; no layout change.
- `en.ts`: added the confirm-copy key next to "Clear log".
- `queues-panel.test.tsx`: flipped the #279 test from "single click clears" to the confirm flow — the first click does **not** clear (message row still present), only the confirm click invokes `clearQueueMessages`. Removed the stale gap comment.

## Verification
`@lunora/studio` 972/972 pass (queues-panel 4/4); `lint:types` + `lint:eslint` + prettier clean. Confirmed the destructive ref fires **only** on the confirm click, never the initial click.

Follow-up surfaced by #279 (plan 231-C), now closed. Plan: `plans/252-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)