### PR TITLE
fix(observability): escape the NUL delimiter in the metric-history cache key

### DIFF
--- a/packages/observability/src/metric-history.ts
+++ b/packages/observability/src/metric-history.ts
@@ -218,7 +218,7 @@ const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?:
     // distinct-series cap scan and the retention trim both run only when a
     // *genuinely new* bucket appears (≈ once per series per minute).
     const cache = knownBucketsFor(sql);
-    const cacheKey = `${key} ${bucket.toString()}`;
+    const cacheKey = `${key}\u0000${bucket.toString()}`;
 
     const bucketExists =
         cache.has(cacheKey) ||


### PR DESCRIPTION
## Summary

- `packages/observability/src/metric-history.ts` embedded a raw U+0000 control byte directly in the source, as the delimiter between `key` and `bucket` in a cache-key template literal. Writing the delimiter as a literal control byte (instead of the `` escape sequence) corrupts tooling: plain `grep` treats the whole file as binary and silently returns no matches (only `grep -a` finds anything), and some editors/diff viewers choke on it too.
- Fix: replace the literal byte with the `` escape sequence. The runtime string is byte-identical — it still contains exactly one U+0000 delimiter character — so this only changes the source *representation*, not the value. Cache keys and all existing behavior are unchanged.
- Found by a code-quality sweep whose `grep`-based scan flagged the file as binary.

## Test plan

- [x] `python3 -c "print(open('packages/observability/src/metric-history.ts','rb').read().count(b'\x00'))"` → `0` (no raw NUL bytes remain)
- [x] `grep -n 'u0000' packages/observability/src/metric-history.ts` now finds the line with plain `grep` (no `-a` needed), confirming the file is no longer treated as binary
- [x] `pnpm --filter "@lunora/observability" run test` → 15 test files / 195 tests passed, same as before the fix
- [x] `pnpm --filter "@lunora/observability" run lint:types` → clean
- [x] `npx eslint src/metric-history.ts` (in `packages/observability`) → clean, no complaints
- [x] `pnpm run build:packages` → succeeds
