### PR TITLE
fix(advisor,codegen,cli): close the silent-failure gaps behind #283-#287

### DIFF
--- a/api-snapshots/advisor.api.md
+++ b/api-snapshots/advisor.api.md
@@ -693,6 +693,7 @@ interface AdvisorStorageKeyAccess {
     file: string;
     line: number;
     method: string;
+    visibility?: "internal" | "public";
 }
 ```
 

--- a/api-snapshots/d1.api.md
+++ b/api-snapshots/d1.api.md
@@ -93,6 +93,7 @@ interface FacetGlobalColumnOptions {
 ```ts
 interface ExportRow {
     doc: Record<string, unknown>;
+    line?: number;
     table: string;
 }
 ```

--- a/examples/auth-playground/lunora/_generated/shard.ts
+++ b/examples/auth-playground/lunora/_generated/shard.ts
@@ -87,10 +87,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in create (documents:64) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in create (documents:64) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `create` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "create",
@@ -99,7 +99,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 64
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/examples/blog/lunora/_generated/app.ts
+++ b/examples/blog/lunora/_generated/app.ts
@@ -4,12 +4,12 @@
 import type { LunoraAuth, LunoraAuthOptions } from "@lunora/auth";
 import { createAuth, createAuthAdmin, createAuthAuditReader, createDoAuthWiring, d1Executor, ensureMigrated, handleAuthRequest, lunoraD1Adapter } from "@lunora/auth";
 import type { D1CtxDbOptions, D1DatabaseLike, D1Exec } from "@lunora/d1";
-import { createD1CtxDb, facetGlobalColumn, listGlobalTables, readGlobalTablePage } from "@lunora/d1";
+import { createD1CtxDb, facetGlobalColumn, importGlobalRows, listGlobalTables, readGlobalTablePage } from "@lunora/d1";
 import type { DurableObjectNamespaceLike } from "@lunora/scheduler";
 import { createScheduler } from "@lunora/scheduler";
 import type { R2BucketLike, Storage } from "@lunora/storage";
 import { createBucketStorage, createStorage } from "@lunora/storage";
-import type { ExecutionContextLike, GlobalIntrospector, HttpRouterLike, LunoraWorker, Route, ScheduledControllerLike, ShardNamespaceLike, WorkerOptions } from "lunorash/runtime";
+import type { AdminTableResolver, ExecutionContextLike, GlobalIntrospector, HttpRouterLike, LunoraWorker, Route, ScheduledControllerLike, ShardNamespaceLike, WorkerOptions } from "lunorash/runtime";
 import { createCrossShardRelationCapabilities, createWorker, resolveLogArchiveFromEnv } from "lunorash/runtime";
 
 import schema from "../schema.js";
@@ -396,6 +396,15 @@ class AppBuilder<Env extends object> {
             if (database) {
                 options.d1 = database;
                 options.globalIntrospector = buildGlobalIntrospector(database);
+                // `resolveTableSharding`/`importGlobals` wire the admin bulk-import
+                // endpoint: without the former, EVERY row (including a `.global()`
+                // table's) routes to the default shard, so a global table is never
+                // recognised as global and the latter is never reached — the
+                // endpoint answers 200 with `inserted: {}` for a write that never
+                // happened. Both are mechanical over the schema this file already
+                // imports, so there is nothing project-specific to configure.
+                options.resolveTableSharding = buildTableShardingResolver();
+                options.importGlobals = buildGlobalImporter(database);
             }
         }
 

--- a/examples/blog/lunora/_generated/app.ts
+++ b/examples/blog/lunora/_generated/app.ts
@@ -518,6 +518,47 @@ const buildGlobalIntrospector = (database: D1DatabaseLike): GlobalIntrospector =
 };
 
 /**
+ * `resolveTableSharding` for the admin bulk-import endpoint: a lookup over each
+ * table's declared `shardMode` (`defineTable(...).global()` / `.shardBy(field)`
+ * already record exactly this shape on the table) — mechanical, nothing to
+ * configure per project. `undefined` for a table the schema doesn't declare, so
+ * the import endpoint's own unknown-table handling still applies.
+ */
+const buildTableShardingResolver = (): AdminTableResolver => (table) => {
+    const declared = (schema as unknown as D1CtxDbOptions["schema"]).tables[table];
+
+    return declared?.shardMode ? { mode: declared.shardMode } : undefined;
+};
+
+/**
+ * `importGlobals` for the admin bulk-import endpoint: routes `.global()` rows
+ * through the same D1 writer `.global()` reads/writes already use, via
+ * `@lunora/d1`'s `importGlobalRows`. Mirrors `runShardImport`'s shard-local
+ * twin (`createShardCtxDb` + `importShardRows`) — same `{ rows, startLine }`
+ * shape, same trusted-import `allowExplicitId` semantics, forwarded as-is.
+ *
+ * Passes each row's own `line` through rather than dropping it: the caller
+ * (`@lunora/runtime`'s NDJSON import stream) already carries the row's true
+ * physical source line, and global rows are typically interspersed with
+ * shard-local ones it filtered out before calling here — a single
+ * `startLine` plus positional counting would mis-attribute every row after
+ * the first gap. `importGlobalRows` prefers `row.line` when present and
+ * falls back to the position-derived count otherwise.
+ */
+const buildGlobalImporter =
+    (database: D1DatabaseLike) =>
+    (request: { rows: ReadonlyArray<{ doc: Record<string, unknown>; line: number; table: string }>; startLine?: number }) => {
+        const exec = buildExec(database);
+        const writer = createD1CtxDb({ exec, schema: schema as unknown as D1CtxDbOptions["schema"] });
+
+        return importGlobalRows(writer, schema as unknown as D1CtxDbOptions["schema"], {
+            exec,
+            rows: request.rows.map((row) => ({ doc: row.doc, line: row.line, table: row.table })),
+            startLine: request.startLine,
+        });
+    };
+
+/**
  * Start composing the app. Chain the capability methods, then `.build()`.
  *
  * `Env` is constrained to `object`, not `Record<string, unknown>`: an `interface Env`

--- a/examples/blog/lunora/_generated/shard.ts
+++ b/examples/blog/lunora/_generated/shard.ts
@@ -274,10 +274,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in purgeStaleDrafts (cleanup:13) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in purgeStaleDrafts (cleanup:13) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `purgeStaleDrafts` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "purgeStaleDrafts",
@@ -286,7 +286,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 13
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
@@ -294,10 +294,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in save (drafts:40) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in save (drafts:40) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `save` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "save",
@@ -306,7 +306,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 40
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
@@ -314,10 +314,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in save (drafts:45) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in save (drafts:45) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `save` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "save",
@@ -326,7 +326,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 45
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
@@ -334,10 +334,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in publish (posts:93) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in publish (posts:93) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `publish` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "publish",
@@ -346,7 +346,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 93
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/examples/expo/lunora/_generated/shard.ts
+++ b/examples/expo/lunora/_generated/shard.ts
@@ -81,10 +81,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in send (messages:67) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in send (messages:67) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `send` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "send",
@@ -93,7 +93,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 67
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/examples/notify-demo/lunora/_generated/shard.ts
+++ b/examples/notify-demo/lunora/_generated/shard.ts
@@ -78,10 +78,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in announce (push:29) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in announce (push:29) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `announce` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "announce",
@@ -90,7 +90,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 29
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/examples/offline-rejections/lunora/_generated/shard.ts
+++ b/examples/offline-rejections/lunora/_generated/shard.ts
@@ -76,10 +76,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in send (messages:46) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in send (messages:46) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `send` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "send",
@@ -88,7 +88,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 46
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/examples/realtime-cursors/lunora/_generated/shard.ts
+++ b/examples/realtime-cursors/lunora/_generated/shard.ts
@@ -98,10 +98,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in joinRoom (cursors:48) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in joinRoom (cursors:48) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `joinRoom` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "joinRoom",
@@ -110,7 +110,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 48
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
@@ -118,10 +118,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in joinRoom (cursors:60) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in joinRoom (cursors:60) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `joinRoom` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "joinRoom",
@@ -130,7 +130,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 60
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {
@@ -138,10 +138,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in updateCursor (cursors:85) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in updateCursor (cursors:85) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `updateCursor` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "updateCursor",
@@ -150,7 +150,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 85
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/examples/todo-app/lunora/_generated/shard.ts
+++ b/examples/todo-app/lunora/_generated/shard.ts
@@ -76,10 +76,10 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
         "categories": [
             "SCHEMA"
         ],
-        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
-        "detail": "`Date.now(…)` in add (todos:23) runs inside a mutation handler — query/mutation handlers must be deterministic. Compute it in an `action` and pass the value into the mutation as an argument.",
-        "facing": "EXTERNAL",
-        "level": "WARN",
+        "description": "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
+        "detail": "`Date.now(…)` in add (todos:23) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless `add` is invoked from a workflow step or queue consumer that can itself replay.",
+        "facing": "INTERNAL",
+        "level": "INFO",
         "metadata": {
             "callee": "Date.now",
             "exportName": "add",
@@ -88,7 +88,7 @@ const LUNORA_ADVISORIES: AdvisoryFinding[] = [
             "line": 23
         },
         "name": "nondeterministic_query_mutation",
-        "remediation": "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "remediation": "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
         "title": "Non-deterministic call in query/mutation handler"
     },
     {

--- a/packages/advisor/__tests__/nondeterministic-query-mutation.test.ts
+++ b/packages/advisor/__tests__/nondeterministic-query-mutation.test.ts
@@ -23,7 +23,16 @@ describe("nondeterministic_query_mutation", () => {
         expect(run()).toHaveLength(0);
     });
 
-    it("flags Date.now() inside a mutation handler", () => {
+    // Issue #286: ordinary mutations don't replay on this (DO-backed) runtime —
+    // an idempotency dedup returns the cached result rather than re-running the
+    // handler, and an OCC conflict throws to the caller instead of an internal
+    // retry — so a mutation handler runs at most once per logical write and
+    // `Date.now()` inside one is stable. Confirmed 193 of 385 non-INFO findings
+    // on one real codebase were this exact "stamp createdAt in a mutation"
+    // pattern. Dropped to INFO (not silenced — a mutation dispatched from a
+    // workflow step/queue consumer that itself replays is still a real
+    // caveat, and the finding is the breadcrumb to it).
+    it("drops Date.now() inside a mutation handler to INFO", () => {
         expect.assertions(2);
 
         const calls: AdvisorNondeterministicCall[] = [{ callee: "Date.now", exportName: "sendMessage", file: "messages", kind: "mutation", line: 12 }];
@@ -33,9 +42,28 @@ describe("nondeterministic_query_mutation", () => {
         expect(findings[0]).toMatchObject({
             cacheKey: "nondeterministic_query_mutation:messages:12:Date.now",
             categories: ["SCHEMA"],
-            level: "WARN",
+            facing: "INTERNAL",
+            level: "INFO",
             metadata: { callee: "Date.now", exportName: "sendMessage", file: "messages", kind: "mutation", line: 12 },
             name: "nondeterministic_query_mutation",
+        });
+    });
+
+    // A query IS genuinely re-run by a live subscription whenever a table it
+    // reads changes, so this half keeps its original WARN — the premise this
+    // rule needs actually holds for queries.
+    it("keeps Date.now() inside a query handler at WARN (a live subscription can re-run it)", () => {
+        expect.assertions(2);
+
+        const calls: AdvisorNondeterministicCall[] = [{ callee: "Date.now", exportName: "listMessages", file: "messages", kind: "query", line: 8 }];
+        const findings = run(calls);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({
+            cacheKey: "nondeterministic_query_mutation:messages:8:Date.now",
+            facing: "EXTERNAL",
+            level: "WARN",
+            metadata: { callee: "Date.now", exportName: "listMessages", file: "messages", kind: "query", line: 8 },
         });
     });
 

--- a/packages/advisor/__tests__/storage-key-from-user-args.test.ts
+++ b/packages/advisor/__tests__/storage-key-from-user-args.test.ts
@@ -34,4 +34,35 @@ describe("storage_key_from_user_args", () => {
         expect(storageKeyFromUserArgs.run({ schema: schema() })).toHaveLength(0);
         expect(storageKeyFromUserArgs.run({ schema: schema(), storageKeyAccesses: [] })).toHaveLength(0);
     });
+
+    // Issue #284: both real-world false positives were `internalAction`s
+    // receiving a content-addressed storage id minted server-side. An
+    // `internal*` procedure has no untrusted caller by construction, so the
+    // "any caller can read/overwrite/delete another user's object" premise is
+    // false there — mirrors `owner_field_from_args_not_auth`'s visibility split.
+    it("drops an internal procedure's access to INFO and redirects it at the public callers", () => {
+        expect.assertions(5);
+
+        const storageKeyAccesses: AdvisorStorageKeyAccess[] = [
+            { exportName: "extractDocumentText", file: "agent/extraction", line: 104, method: "getUrl", visibility: "internal" },
+            { exportName: "getDoc", file: "docs", line: 4, method: "get", visibility: "public" },
+        ];
+        const findings = storageKeyFromUserArgs.run({ schema: schema(), storageKeyAccesses });
+
+        expect(findings[0]).toMatchObject({ level: "INFO", metadata: { visibility: "internal" } });
+        expect(findings[0]?.detail).toContain("Audit the PUBLIC procedures");
+        expect(findings[0]?.detail).toContain("expected for an `internal` procedure");
+
+        // The public-facing case is untouched and still blocks.
+        expect(findings[1]).toMatchObject({ level: "ERROR", metadata: { visibility: "public" } });
+        expect(findings[1]?.detail).toContain("any caller can read/overwrite/delete another user's object");
+    });
+
+    it("keeps ERROR when the feeder could not attribute a visibility", () => {
+        expect.assertions(1);
+
+        const storageKeyAccesses: AdvisorStorageKeyAccess[] = [{ exportName: "helper", file: "lib", line: 3, method: "get" }];
+
+        expect(storageKeyFromUserArgs.run({ schema: schema(), storageKeyAccesses })[0]).toMatchObject({ level: "ERROR" });
+    });
 });

--- a/packages/advisor/src/lints/static/nondeterministic-query-mutation.ts
+++ b/packages/advisor/src/lints/static/nondeterministic-query-mutation.ts
@@ -5,15 +5,29 @@ import type { Lint } from "../../types";
  * Flags a non-deterministic API call inside a `query(...)` or `mutation(...)`
  * handler body.
  *
- * Lunora queries and mutations must be **deterministic**: the coordinator may
- * re-run a mutation on optimistic-concurrency (OCC) retry and a query on
- * subscription re-evaluation, so a handler that reads wall-clock time, draws
- * randomness, or hits the network can produce different results on each run —
- * breaking read-your-writes, cache invalidation, and replayable history.
- * `Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, and
- * `fetch` are therefore disallowed in query/mutation handlers and belong in an
- * `action(...)`, which runs exactly once and may use ambient/non-deterministic
- * APIs freely (pass the result into a mutation as an argument).
+ * The two procedure kinds do NOT share the same hazard (issue #286).
+ *
+ * A `query` handler genuinely CAN run more than once for the same logical
+ * read: a live subscription re-runs its query whenever a table it reads
+ * changes, so `Date.now()`/`Math.random()`/etc. there can flicker between
+ * re-evaluations — this half stays at WARN.
+ *
+ * A `mutation` handler does NOT replay under ordinary dispatch on this
+ * (DO-backed) runtime: a client-issued idempotency key dedups a replayed call
+ * to the **cached** result without re-running the handler, and an
+ * optimistic-concurrency conflict throws back to the caller as an error
+ * rather than triggering an internal retry of the handler. So a mutation
+ * handler body runs at most once per logical write, and `Date.now()` inside
+ * one is stable — the premise this lint used to apply uniformly (borrowed
+ * from Convex's OCC-retries-the-handler model, which does not hold here) was
+ * responsible for 193 of 385 non-INFO findings on one real codebase, all from
+ * the ordinary "stamp `createdAt`" pattern. Dropped to INFO rather than
+ * silenced: a mutation invoked from inside a workflow step or queue consumer
+ * CAN be re-dispatched if the surrounding step/consumer itself replays (a
+ * fresh `ctx.runMutation` call from the step's perspective, not a replay this
+ * lint can distinguish from any other mutation call), so the finding stays as
+ * a breadcrumb rather than disappearing outright. See the "Determinism: what
+ * actually replays" section of the `@lunora/server` docs.
  *
  * This lint runs when the codegen feeder has supplied call evidence
  * (`context.nondeterministicCalls` present); a runtime caller with no evidence
@@ -23,12 +37,12 @@ import type { Lint } from "../../types";
 const nondeterministicQueryMutation: Lint = {
     categories: ["SCHEMA"],
     description:
-        "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). These handlers may be re-run on OCC retry / subscription re-evaluation, so they must be deterministic — time, randomness, and network belong in an `action`.",
+        "A `query`/`mutation` handler calls a non-deterministic API (`Date.now`, `Math.random`, `crypto.randomUUID`, `crypto.getRandomValues`, or `fetch`). A `query` may be re-run by a live subscription, so non-determinism there can flicker between evaluations (WARN). An ordinary `mutation` handler does not replay on this runtime — it runs at most once per logical write — so this is informational there (INFO) unless the mutation is itself invoked from a workflow step or queue consumer that can replay.",
     facing: "EXTERNAL",
     level: "WARN",
     name: "nondeterministic_query_mutation",
     remediation:
-        "Move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument — e.g. compute `Date.now()` in the action and call `ctx.runMutation(api.…, { now })`. Take generated ids/timestamps as args instead of producing them in the handler.",
+        "For a `query`: move the non-deterministic call into an `action(...)` (which runs once and may use ambient APIs), then pass the computed value into the mutation as an argument, or accept that the value may differ across re-evaluations. For an ordinary `mutation`: no action needed — the handler runs at most once per logical write on this runtime. If the mutation is dispatched from inside a workflow step or queue consumer, treat it like an action value instead, since the surrounding step/consumer can replay.",
     run: (context) => {
         // No call evidence supplied → nothing to assert (mirrors auth_api_call_without_headers).
         if (context.nondeterministicCalls === undefined) {
@@ -52,12 +66,31 @@ const nondeterministicQueryMutation: Lint = {
             // Suffix the occurrence index only for the second and beyond so
             // existing single-occurrence cacheKeys remain stable across runs.
             const occurrenceSuffix = occurrence > 1 ? `:${occurrence.toString()}` : "";
+            const metadata = { callee: call.callee, exportName: call.exportName, file: call.file, kind: call.kind, line: call.line };
+
+            // Mutations don't replay under ordinary dispatch on this runtime (see
+            // the module doc comment) — the premise a WARN needs does not hold,
+            // so this drops to INFO rather than staying at the same severity as
+            // the genuinely-hazardous query case.
+            if (call.kind === "mutation") {
+                findings.push(
+                    emit(nondeterministicQueryMutation, {
+                        cacheKey: `nondeterministic_query_mutation:${baseKey}${occurrenceSuffix}`,
+                        detail: `\`${call.callee}(…)\` in ${call.exportName} (${call.file}:${call.line.toString()}) runs inside a mutation handler. Ordinary mutations don't replay on this runtime (idempotency dedup returns a cached result rather than re-running the handler, and an OCC conflict throws to the caller instead of retrying internally), so this is informational — no action needed unless \`${call.exportName}\` is invoked from a workflow step or queue consumer that can itself replay.`,
+                        facing: "INTERNAL",
+                        level: "INFO",
+                        metadata,
+                    }),
+                );
+
+                continue;
+            }
 
             findings.push(
                 emit(nondeterministicQueryMutation, {
                     cacheKey: `nondeterministic_query_mutation:${baseKey}${occurrenceSuffix}`,
-                    detail: `\`${call.callee}(…)\` in ${call.exportName} (${call.file}:${call.line.toString()}) runs inside a ${call.kind} handler — query/mutation handlers must be deterministic. Compute it in an \`action\` and pass the value into the mutation as an argument.`,
-                    metadata: { callee: call.callee, exportName: call.exportName, file: call.file, kind: call.kind, line: call.line },
+                    detail: `\`${call.callee}(…)\` in ${call.exportName} (${call.file}:${call.line.toString()}) runs inside a query handler — a live subscription may re-run this query, so the result can differ between evaluations. Compute it in an \`action\` and pass the value into the mutation as an argument.`,
+                    metadata,
                 }),
             );
         }

--- a/packages/advisor/src/lints/static/storage-key-from-user-args.ts
+++ b/packages/advisor/src/lints/static/storage-key-from-user-args.ts
@@ -1,6 +1,5 @@
-import type { AdvisorStorageKeyAccess } from "../../storage-key-accesses";
+import emit from "../../finding";
 import type { Lint } from "../../types";
-import { makeArgumentDerivedSinkLint } from "../argument-derived-sink";
 
 /**
  * Flags a `ctx.storage.&lt;bucket>.&lt;method>(key, …)` whose R2 object key is derived
@@ -19,22 +18,55 @@ import { makeArgumentDerivedSinkLint } from "../argument-derived-sink";
  * (`context.storageKeyAccesses`); a runtime caller flags nothing. One finding per
  * offending call.
  */
-const storageKeyFromUserArgs: Lint = makeArgumentDerivedSinkLint<AdvisorStorageKeyAccess>({
-    cacheKey: (access) => `storage_key_from_user_args:${access.file}:${access.line.toString()}`,
+const storageKeyFromUserArgs: Lint = {
     categories: ["SECURITY"],
     description:
         "A `ctx.storage.*` call uses an R2 object key taken directly from the handler's `args` with no server-side scoping. The bucket methods key by the caller-supplied string, so any caller can read, overwrite, or delete another user's object — object-level IDOR.",
-    detail: (access) =>
-        `\`ctx.storage.*.${access.method}\` in \`${access.exportName}\` (${access.file}:${access.line.toString()}) uses an object key derived from \`args\` with no server-side scoping — any caller can read/overwrite/delete another user's object (IDOR). Prefix the key with a server-trusted identity (e.g. \`\${ctx.auth.userId}/…\`) or resolve the object through an owned record.`,
     facing: "EXTERNAL",
-    getAccesses: (context) => context.storageKeyAccesses,
     level: "ERROR",
-    metadata: (access) => {
-        return { exportName: access.exportName, file: access.file, line: access.line, method: access.method };
-    },
     name: "storage_key_from_user_args",
     remediation: `Prefix the object key with a server-trusted identity (e.g. \`\${ctx.auth.userId}/…\`) or resolve the object through a record the caller is known to own. Never pass request input straight through as an R2 object key.`,
+    run: (context) => {
+        if (context.storageKeyAccesses === undefined) {
+            return [];
+        }
+
+        return context.storageKeyAccesses.map((access) => {
+            const where = `\`ctx.storage.*.${access.method}\` in \`${access.exportName}\` (${access.file}:${access.line.toString()})`;
+            const metadata = {
+                exportName: access.exportName,
+                file: access.file,
+                line: access.line,
+                method: access.method,
+                visibility: access.visibility ?? "unknown",
+            };
+
+            // An `internal*` procedure has no untrusted caller by construction —
+            // it is only reachable server-side (`ctx.scheduler.runAfter`,
+            // `ctx.run*`), never by an external request — so "any caller can
+            // read/overwrite/delete another user's object" is false there.
+            // Mirrors `owner_field_from_args_not_auth`'s identical visibility
+            // split: two real-world hits were both `internalAction`s receiving
+            // a content-addressed storage id minted server-side (issue #284).
+            if (access.visibility === "internal") {
+                return emit(storageKeyFromUserArgs, {
+                    cacheKey: `storage_key_from_user_args:${access.file}:${access.line.toString()}`,
+                    detail: `${where} uses an object key derived from \`args\` with no server-side scoping. This is expected for an \`internal\` procedure — no caller can reach it directly, so the key is only ever supplied by trusted server code. Audit the PUBLIC procedures that dispatch to it: if one forwards \`args\` straight through, the IDOR is there.`,
+                    facing: "INTERNAL",
+                    level: "INFO",
+                    metadata,
+                });
+            }
+
+            return emit(storageKeyFromUserArgs, {
+                cacheKey: `storage_key_from_user_args:${access.file}:${access.line.toString()}`,
+                detail: `${where} uses an object key derived from \`args\` with no server-side scoping — any caller can read/overwrite/delete another user's object (IDOR). Prefix the key with a server-trusted identity (e.g. \`\${ctx.auth.userId}/…\`) or resolve the object through an owned record.`,
+                metadata,
+            });
+        });
+    },
+    source: "static",
     title: "R2 object key taken directly from user args (IDOR)",
-});
+};
 
 export default storageKeyFromUserArgs;

--- a/packages/advisor/src/storage-key-accesses.ts
+++ b/packages/advisor/src/storage-key-accesses.ts
@@ -17,4 +17,12 @@ export interface AdvisorStorageKeyAccess {
     line: number;
     /** The bucket method invoked with the arg-derived key, e.g. `get` / `put` / `delete` / `download`. */
     method: string;
+    /**
+     * Visibility of the enclosing procedure. `internal` procedures are not
+     * reachable by a caller, so the "any caller can read/overwrite/delete
+     * another user's object" premise does not hold there and the finding drops
+     * to `INFO` (mirrors `AdvisorOwnerFieldWrite.visibility`). `undefined` when
+     * the feeder could not attribute the access to a registered procedure.
+     */
+    visibility?: "internal" | "public";
 }

--- a/packages/cli/__tests__/commands/option-parsing.test.ts
+++ b/packages/cli/__tests__/commands/option-parsing.test.ts
@@ -2,6 +2,9 @@ import type { OptionDefinition } from "@visulima/cerebro";
 import { Cerebro } from "@visulima/cerebro";
 import { describe, expect, it } from "vitest";
 
+import { advisorCommand } from "../../src/commands/advisor";
+import { codegenCommand } from "../../src/commands/codegen";
+import { deployCommand } from "../../src/commands/deploy";
 import { devCommand } from "../../src/commands/dev";
 import { verifyCommand } from "../../src/commands/verify";
 
@@ -71,5 +74,73 @@ describe("command option parsing → handler key mapping", () => {
 
         // verify/handler.ts reads `options.typecheck === false`.
         expect(parsed.typecheck).toBe(false);
+    });
+
+    // Issue #285 (1+2): `lunora codegen --help` documents the gate as "defaults to
+    // on in CI, off locally". That is only true when `options.strictAdvisories` is
+    // `undefined` with no flag passed, so `resolveStrictAdvisories`'s CI-vs-local
+    // `??` fallback ever runs. Declaring only `no-strict-advisories` and letting
+    // cerebro synthesize `--strict-advisories` gives the synthesized option an
+    // unconditional `defaultValue: true`, so `strictAdvisories` was NEVER
+    // `undefined` — the gate was strict locally regardless of `--help`'s claim.
+    it.each([
+        ["codegen", codegenCommand],
+        ["deploy", deployCommand],
+    ])("`%s` (no flags) leaves strictAdvisories undefined so the CI-vs-local default can apply", async (name, command) => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions(name, command.options ?? [], [name]);
+
+        expect(parsed.strictAdvisories).toBeUndefined();
+    });
+
+    it.each([
+        ["codegen", codegenCommand],
+        ["deploy", deployCommand],
+    ])("`%s --strict-advisories` parses to strictAdvisories: true", async (name, command) => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions(name, command.options ?? [], [name, "--strict-advisories"]);
+
+        expect(parsed.strictAdvisories).toBe(true);
+    });
+
+    it.each([
+        ["codegen", codegenCommand],
+        ["deploy", deployCommand],
+    ])("`%s --no-strict-advisories` parses to strictAdvisories: false", async (name, command) => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions(name, command.options ?? [], [name, "--no-strict-advisories"]);
+
+        expect(parsed.strictAdvisories).toBe(false);
+    });
+
+    // Issue #285 (3): `lunora advisor --help` documents `--no-write`, but the
+    // option was declared as the POSITIVE `write` flag — cerebro only synthesizes
+    // a `no-*` counterpart for an option it declared, so `--no-write` was rejected
+    // as an unknown option.
+    it("`advisor --no-write` parses instead of throwing an unknown-option error", async () => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions("advisor", advisorCommand.options ?? [], ["advisor", "--no-write"]);
+
+        expect(parsed.write).toBe(false);
+    });
+
+    it("`advisor` (no flags) leaves write enabled (default true)", async () => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions("advisor", advisorCommand.options ?? [], ["advisor"]);
+
+        expect(parsed.write).not.toBe(false);
+    });
+
+    it("`advisor --write` still parses to write: true", async () => {
+        expect.assertions(1);
+
+        const parsed = await parseOptions("advisor", advisorCommand.options ?? [], ["advisor", "--write"]);
+
+        expect(parsed.write).toBe(true);
     });
 });

--- a/packages/cli/src/commands/advisor/index.ts
+++ b/packages/cli/src/commands/advisor/index.ts
@@ -28,11 +28,16 @@ const advisorCommand: Command = {
         { description: "Output format: pretty (default) or json", name: "format", type: String },
         { description: "Exit non-zero when the global score is below this value (0-100)", name: "min-score", type: String },
         { description: `Where to write the map (default ${DEFAULT_MAP_PATH})`, name: "out", type: String },
-        // Declared positively. cerebro reads a `no-`-prefixed name as the negative
-        // half of a negatable boolean, so `name: "no-write"` would parse to the key
-        // `write` and the handler's `noWrite` would be permanently undefined —
-        // silently writing the artifact even when the user asked it not to.
-        { description: "Write the map artifact to disk (default true; use --no-write to skip)", name: "write", type: Boolean },
+        // Declared as a `no-*` option, like `codegen`'s `--no-strict-advisories` /
+        // `dev`'s `--no-studio` / `--no-codegen` / `--no-worker`: cerebro reads a
+        // `no-`-prefixed name as the negative half of a negatable boolean and
+        // synthesizes the positive counterpart itself, exposing the RESULT under
+        // the positive camelCase key (`write`) at runtime — so `--no-write` and
+        // `--write` both work and `options.write` defaults to `true`. Declaring
+        // the positive name directly (as this used to) never registers a
+        // `--no-write` flag at all — cerebro only negates options named `no-*`
+        // — which is exactly why `--no-write` was rejected as unknown (#285).
+        { description: "Write the map artifact to disk (default true; use --no-write to skip)", name: "no-write", type: Boolean },
     ],
 };
 

--- a/packages/cli/src/commands/codegen/index.ts
+++ b/packages/cli/src/commands/codegen/index.ts
@@ -15,11 +15,27 @@ const codegenCommand: Command = {
     options: [
         { description: `Which API spec(s) to emit: ${API_SPEC_HELP} (default openapi)`, name: "api-spec", type: String },
         { description: "Output format: pretty (default) or json", name: "format", type: String },
-        // Declared as a `no-*` option, like `--no-studio` / `--no-codegen` /
-        // `--no-worker`: cerebro only synthesizes a negation for options
-        // declared that way, so a positive `strict-advisories` would have made
-        // the advertised `--no-strict-advisories` an unknown-option error —
-        // i.e. following the printed advice would break the build harder.
+        // Both the positive AND the `no-*` form are declared explicitly (#285).
+        // Declaring only `no-strict-advisories` and relying on cerebro to
+        // synthesize `--strict-advisories` has two problems: (1) the synthesized
+        // option clones this option's `description` verbatim instead of
+        // inverting it, so `--help` showed the SAME "Don't fail…" text under
+        // both flags with no way to tell what the positive form does; (2) the
+        // synthesized option's `defaultValue` is unconditionally `true`, so
+        // `options.strictAdvisories` was NEVER `undefined` — it was `true` on
+        // every invocation that didn't pass `--no-strict-advisories`, silently
+        // overriding `resolveStrictAdvisories`'s CI-vs-local `??` fallback and
+        // making the gate strict locally despite `--help` (and this comment,
+        // before the fix) saying "off locally". Declaring BOTH forms ourselves
+        // — each with its own accurate description, neither with a
+        // `defaultValue` — leaves `options.strictAdvisories` genuinely
+        // `undefined` until the user picks a side, which is what
+        // `resolveStrictAdvisories`'s fallback needs to ever run.
+        {
+            description: "Fail on ERROR-level advisories even locally (the gate already defaults to on in CI)",
+            name: "strict-advisories",
+            type: Boolean,
+        },
         {
             description: "Don't fail on ERROR-level advisories (the gate defaults to on in CI, off locally)",
             name: "no-strict-advisories",

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -37,10 +37,20 @@ const deployCommand: Command = {
             type: String,
         },
         { description: "Confirm running the production data migration triggered by --migrate (required with --migrate)", name: "migrate-yes", type: Boolean },
-        // Declared as a `no-*` option, like `lunora codegen`'s identically-named
-        // flag: cerebro only synthesizes a negation for options declared that
-        // way, so a positive `strict-advisories` would have made the advertised
-        // `--no-strict-advisories` an unknown-option error.
+        // Both the positive AND the `no-*` form are declared explicitly, same as
+        // `lunora codegen`'s identically-named flag (#285): relying on cerebro to
+        // synthesize `--strict-advisories` from only the `no-*` declaration clones
+        // this option's "Don't fail…" description onto the positive flag verbatim
+        // (so `--help` couldn't distinguish the two), AND gives the synthesized
+        // option an unconditional `defaultValue: true` — meaning
+        // `options.strictAdvisories` was never `undefined` and the CI-vs-local
+        // fallback in `resolveStrictAdvisories` never ran. Declaring both forms
+        // ourselves, neither with a `defaultValue`, fixes both.
+        {
+            description: "Fail the deploy on ERROR-level codegen advisories even locally (the gate already defaults to on in CI)",
+            name: "strict-advisories",
+            type: Boolean,
+        },
         {
             description:
                 "Don't fail the deploy on ERROR-level codegen advisories (the gate defaults to on in CI, off locally). Never downgrades platform diagnostics.",

--- a/packages/codegen/__tests__/discover-storage-key-accesses.test.ts
+++ b/packages/codegen/__tests__/discover-storage-key-accesses.test.ts
@@ -6,6 +6,7 @@ import { Project } from "ts-morph";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import discoverStorageKeyAccesses from "../src/discover-storage-key-accesses";
+import type { FunctionIR } from "../src/ir";
 
 let workdir: string;
 let project: Project;
@@ -143,5 +144,58 @@ describe("discoverStorageKeyAccesses", () => {
         write("browse.ts", `export const browse = query(async ({ ctx, args }) => { return ctx.storage.docs.list(args.prefix); });`);
 
         expect(discoverStorageKeyAccesses(project, join(workdir, "lunora"))).toHaveLength(0);
+    });
+
+    // Issue #284: `storage_key_from_user_args` had no reachability model — both
+    // real-world false positives were `internalAction`s receiving a
+    // content-addressed storage id minted server-side.
+    it("ignores a key rebuilt by an intervening call (content-addressed, not caller-controlled)", () => {
+        expect.assertions(1);
+
+        write(
+            "extraction.ts",
+            `export const extractDocumentText = internalAction(async ({ ctx, args }) => { return ctx.storage.docs.getUrl(hashOf(args.storageId)); });`,
+        );
+
+        expect(discoverStorageKeyAccesses(project, join(workdir, "lunora"))).toHaveLength(0);
+    });
+
+    it("ignores a key reached through one local hop to an intervening call", () => {
+        expect.assertions(1);
+
+        write(
+            "hop-call.ts",
+            `export const extractDocumentText = internalAction(async ({ ctx, args }) => {
+                const key = hashOf(args.storageId);
+                return ctx.storage.docs.getUrl(key);
+            });`,
+        );
+
+        expect(discoverStorageKeyAccesses(project, join(workdir, "lunora"))).toHaveLength(0);
+    });
+
+    it("attaches the enclosing procedure's visibility when `functions` is supplied", () => {
+        expect.assertions(2);
+
+        write("extraction2.ts", `export const extractDocumentText = internalAction(async ({ ctx, args }) => { return ctx.storage.docs.get(args.storageId); });`);
+
+        const functions: FunctionIR[] = [
+            { args: {}, exportName: "extractDocumentText", filePath: "extraction2", kind: "action", returnType: "unknown", visibility: "internal" },
+        ];
+        const found = discoverStorageKeyAccesses(project, join(workdir, "lunora"), functions);
+
+        expect(found).toHaveLength(1);
+        expect(found[0]).toMatchObject({ visibility: "internal" });
+    });
+
+    it("leaves visibility undefined when the access can't be attributed to a supplied function", () => {
+        expect.assertions(2);
+
+        write("orphan.ts", `export const orphan = query(async ({ ctx, args }) => { return ctx.storage.docs.get(args.storageId); });`);
+
+        const found = discoverStorageKeyAccesses(project, join(workdir, "lunora"), []);
+
+        expect(found).toHaveLength(1);
+        expect(found[0]?.visibility).toBeUndefined();
     });
 });

--- a/packages/codegen/__tests__/discover-storage-key-accesses.test.ts
+++ b/packages/codegen/__tests__/discover-storage-key-accesses.test.ts
@@ -177,7 +177,10 @@ describe("discoverStorageKeyAccesses", () => {
     it("attaches the enclosing procedure's visibility when `functions` is supplied", () => {
         expect.assertions(2);
 
-        write("extraction2.ts", `export const extractDocumentText = internalAction(async ({ ctx, args }) => { return ctx.storage.docs.get(args.storageId); });`);
+        write(
+            "extraction2.ts",
+            `export const extractDocumentText = internalAction(async ({ ctx, args }) => { return ctx.storage.docs.get(args.storageId); });`,
+        );
 
         const functions: FunctionIR[] = [
             { args: {}, exportName: "extractDocumentText", filePath: "extraction2", kind: "action", returnType: "unknown", visibility: "internal" },

--- a/packages/codegen/__tests__/emit-app-global.test.ts
+++ b/packages/codegen/__tests__/emit-app-global.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { emitApp } from "../src/emit-app";
+
+/** Minimal `EmitAppOptions` with every capability off; tests flip one flag at a time. */
+const baseOptions = {
+    hasAccess: false,
+    hasAi: false,
+    hasAnalytics: false,
+    hasAuth: false,
+    hasBrowser: false,
+    hasFramework: false,
+    hasGlobal: false,
+    hasHyperdrive: false,
+    hasHyperdriveGlobal: false,
+    hasImages: false,
+    hasKv: false,
+    hasNotify: false,
+    hasPayments: false,
+    hasQueue: false,
+    hasR2sql: false,
+    hasScheduler: false,
+    hasStorage: false,
+    hasVectors: false,
+    hasWorkflow: false,
+    hasX402: false,
+    useUmbrella: false,
+    wantsOpenApi: false,
+    wantsOpenRpc: false,
+};
+
+// Issue #287: `POST /_lunora/admin/import` needs `resolveTableSharding` and
+// `importGlobals` wired on the worker, or a `.global()` table silently never
+// reaches the import path — the endpoint answers 200 with `inserted: {}` for a
+// write that never happened. Both are mechanical over the schema this file
+// already imports when the app has a D1-backed `.global()` table, so codegen
+// emits them the same way it already emits `runShardExport`/`runShardImport`.
+describe("emitApp — admin bulk-import wiring (.global())", () => {
+    it("wires options.resolveTableSharding + options.importGlobals when the app has a .global() table", () => {
+        expect.assertions(4);
+
+        const output = emitApp({ ...baseOptions, hasGlobal: true });
+
+        expect(output).toContain("options.resolveTableSharding = buildTableShardingResolver();");
+        expect(output).toContain("options.importGlobals = buildGlobalImporter(database);");
+        expect(output).toContain("const buildTableShardingResolver = (): AdminTableResolver =>");
+        expect(output).toContain("const buildGlobalImporter =");
+    });
+
+    it("resolveTableSharding is a mechanical lookup over each table's declared shardMode", () => {
+        expect.assertions(2);
+
+        const output = emitApp({ ...baseOptions, hasGlobal: true });
+
+        expect(output).toContain('const declared = (schema as unknown as D1CtxDbOptions["schema"]).tables[table];');
+        expect(output).toContain("return declared?.shardMode ? { mode: declared.shardMode } : undefined;");
+    });
+
+    it("importGlobals routes rows through @lunora/d1's importGlobalRows over the same D1 writer", () => {
+        expect.assertions(2);
+
+        const output = emitApp({ ...baseOptions, hasGlobal: true });
+
+        expect(output).toContain('import { createD1CtxDb, facetGlobalColumn, importGlobalRows, listGlobalTables, readGlobalTablePage } from "@lunora/d1";');
+        expect(output).toContain("return importGlobalRows(writer, schema as unknown as");
+    });
+
+    it("imports AdminTableResolver from @lunora/runtime alongside GlobalIntrospector", () => {
+        expect.assertions(1);
+
+        const output = emitApp({ ...baseOptions, hasGlobal: true });
+
+        expect(output).toContain("AdminTableResolver");
+    });
+
+    it("omits the admin-import wiring entirely for an app with no .global() table", () => {
+        expect.assertions(3);
+
+        const output = emitApp(baseOptions);
+
+        expect(output).not.toContain("resolveTableSharding");
+        expect(output).not.toContain("importGlobals");
+        expect(output).not.toContain("buildGlobalImporter");
+    });
+
+    it("omits the admin-import wiring for a Hyperdrive-backed global app (D1-only wiring)", () => {
+        expect.assertions(1);
+
+        const output = emitApp({ ...baseOptions, hasHyperdriveGlobal: true });
+
+        expect(output).not.toContain("resolveTableSharding");
+    });
+});

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
@@ -2,10 +2,10 @@
 // Run `lunora codegen` to regenerate.
 
 import type { D1CtxDbOptions, D1DatabaseLike, D1Exec } from "@lunora/d1";
-import { createD1CtxDb, facetGlobalColumn, listGlobalTables, readGlobalTablePage } from "@lunora/d1";
+import { createD1CtxDb, facetGlobalColumn, importGlobalRows, listGlobalTables, readGlobalTablePage } from "@lunora/d1";
 import type { R2BucketLike, Storage } from "@lunora/storage";
 import { createBucketStorage, createStorage } from "@lunora/storage";
-import type { ExecutionContextLike, GlobalIntrospector, HttpRouterLike, LunoraWorker, Route, ScheduledControllerLike, ShardNamespaceLike, WorkerOptions } from "@lunora/runtime";
+import type { AdminTableResolver, ExecutionContextLike, GlobalIntrospector, HttpRouterLike, LunoraWorker, Route, ScheduledControllerLike, ShardNamespaceLike, WorkerOptions } from "@lunora/runtime";
 import { createCrossShardRelationCapabilities, createWorker, resolveLogArchiveFromEnv } from "@lunora/runtime";
 
 import schema from "../schema.js";
@@ -289,6 +289,15 @@ class AppBuilder<Env extends object> {
             if (database) {
                 options.d1 = database;
                 options.globalIntrospector = buildGlobalIntrospector(database);
+                // `resolveTableSharding`/`importGlobals` wire the admin bulk-import
+                // endpoint: without the former, EVERY row (including a `.global()`
+                // table's) routes to the default shard, so a global table is never
+                // recognised as global and the latter is never reached — the
+                // endpoint answers 200 with `inserted: {}` for a write that never
+                // happened. Both are mechanical over the schema this file already
+                // imports, so there is nothing project-specific to configure.
+                options.resolveTableSharding = buildTableShardingResolver();
+                options.importGlobals = buildGlobalImporter(database);
             }
         }
 
@@ -361,6 +370,39 @@ const buildGlobalIntrospector = (database: D1DatabaseLike): GlobalIntrospector =
         readTablePage: (options) => readGlobalTablePage(exec, schema as never, options),
     };
 };
+
+/**
+ * `resolveTableSharding` for the admin bulk-import endpoint: a lookup over each
+ * table's declared `shardMode` (`defineTable(...).global()` / `.shardBy(field)`
+ * already record exactly this shape on the table) — mechanical, nothing to
+ * configure per project. `undefined` for a table the schema doesn't declare, so
+ * the import endpoint's own unknown-table handling still applies.
+ */
+const buildTableShardingResolver = (): AdminTableResolver => (table) => {
+    const declared = (schema as unknown as D1CtxDbOptions["schema"]).tables[table];
+
+    return declared?.shardMode ? { mode: declared.shardMode } : undefined;
+};
+
+/**
+ * `importGlobals` for the admin bulk-import endpoint: routes `.global()` rows
+ * through the same D1 writer `.global()` reads/writes already use, via
+ * `@lunora/d1`'s `importGlobalRows`. Mirrors `runShardImport`'s shard-local
+ * twin (`createShardCtxDb` + `importShardRows`) — same `{ rows, startLine }`
+ * shape, same trusted-import `allowExplicitId` semantics, forwarded as-is.
+ */
+const buildGlobalImporter =
+    (database: D1DatabaseLike) =>
+    (request: { rows: ReadonlyArray<{ doc: Record<string, unknown>; line: number; table: string }>; startLine?: number }) => {
+        const exec = buildExec(database);
+        const writer = createD1CtxDb({ exec, schema: schema as unknown as D1CtxDbOptions["schema"] });
+
+        return importGlobalRows(writer, schema as unknown as D1CtxDbOptions["schema"], {
+            exec,
+            rows: request.rows.map((row) => ({ doc: row.doc, table: row.table })),
+            startLine: request.startLine,
+        });
+    };
 
 /**
  * Start composing the app. Chain the capability methods, then `.build()`.

--- a/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
+++ b/packages/codegen/__tests__/fixtures/simple/expected/_generated/app.ts
@@ -390,6 +390,14 @@ const buildTableShardingResolver = (): AdminTableResolver => (table) => {
  * `@lunora/d1`'s `importGlobalRows`. Mirrors `runShardImport`'s shard-local
  * twin (`createShardCtxDb` + `importShardRows`) — same `{ rows, startLine }`
  * shape, same trusted-import `allowExplicitId` semantics, forwarded as-is.
+ *
+ * Passes each row's own `line` through rather than dropping it: the caller
+ * (`@lunora/runtime`'s NDJSON import stream) already carries the row's true
+ * physical source line, and global rows are typically interspersed with
+ * shard-local ones it filtered out before calling here — a single
+ * `startLine` plus positional counting would mis-attribute every row after
+ * the first gap. `importGlobalRows` prefers `row.line` when present and
+ * falls back to the position-derived count otherwise.
  */
 const buildGlobalImporter =
     (database: D1DatabaseLike) =>
@@ -399,7 +407,7 @@ const buildGlobalImporter =
 
         return importGlobalRows(writer, schema as unknown as D1CtxDbOptions["schema"], {
             exec,
-            rows: request.rows.map((row) => ({ doc: row.doc, table: row.table })),
+            rows: request.rows.map((row) => ({ doc: row.doc, line: row.line, table: row.table })),
             startLine: request.startLine,
         });
     };

--- a/packages/codegen/__tests__/run-codegen-cold-start.test.ts
+++ b/packages/codegen/__tests__/run-codegen-cold-start.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #283: `lunora codegen` was not reproducible from a cold `_generated/`.
+ *
+ * Pass 1 inferred every handler's return type against a ts-morph `Project` that
+ * did not yet include the generated declarations (`Doc&lt;…>` chief among them,
+ * for a handler whose return type is annotated against it) — so on a fresh
+ * clone, CI, or after `rm -rf lunora/_generated`, that inference collapsed to
+ * `unknown` and codegen WROTE the collapsed type into `api.ts`/`functions.ts`.
+ * A second run re-inferred against the first run's own (now-present) output
+ * and recovered.
+ *
+ * This handler's return type depends on nothing but a LOCAL relative import
+ * (`./_generated/dataModel`, never `@lunora/server` itself) so the test proves
+ * the fix without needing a resolvable `@lunora/server` in `node_modules` —
+ * every other codegen unit test in this suite runs in a checker-degraded
+ * sandbox for the same reason (see `discover-functions-any-token.test.ts`).
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runCodegen } from "../src/index";
+
+let workdir: string;
+
+const SCHEMA = `import { defineSchema, defineTable, v } from "@lunora/server";
+
+export const schema = defineSchema({
+    notes: defineTable({ text: v.string() }),
+});
+`;
+
+// The return type depends only on \`./_generated/dataModel\`'s \`Doc<"notes">\` —
+// present from the very first pass once the fix bootstraps it, absent (module
+// not found) on a cold pass without the fix.
+const NOTES = `import type { Doc } from "./_generated/dataModel";
+import { query } from "@lunora/server";
+
+export const getNote = query({
+    args: {},
+    handler: async (): Promise<Doc<"notes"> | null> => {
+        return null;
+    },
+});
+`;
+
+describe("runCodegen — cold-start reproducibility (#283)", () => {
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-cold-start-"));
+        mkdirSync(join(workdir, "lunora"), { recursive: true });
+        writeFileSync(join(workdir, "lunora", "schema.ts"), SCHEMA, "utf8");
+        writeFileSync(join(workdir, "lunora", "notes.ts"), NOTES, "utf8");
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("does not collapse a Doc<T>-typed return to `unknown` on the very first pass from a cold _generated/", () => {
+        expect.assertions(2);
+
+        // Precondition: genuinely cold — no `_generated/` directory exists yet.
+        const result = runCodegen({ lint: false, projectRoot: workdir });
+
+        expect(result.generated.api).not.toContain('getNote: FunctionReference<"query", {}, unknown>');
+        expect(result.generated.api).toContain('getNote: FunctionReference<"query", {}, import("./dataModel.js").Doc_notes | null>;');
+    });
+
+    it("first-pass functions.ts/api.ts output equals a second pass's (fixpoint from pass 1)", () => {
+        expect.assertions(2);
+
+        const first = runCodegen({ lint: false, projectRoot: workdir });
+
+        // A second, fully independent invocation (no injected `project`, so this
+        // constructs its own ts-morph Project exactly as a second `lunora codegen`
+        // process would) reading back what pass 1 wrote.
+        const second = runCodegen({ lint: false, projectRoot: workdir });
+
+        expect(second.generated.functions).toBe(first.generated.functions);
+        expect(second.generated.api).toBe(first.generated.api);
+    });
+});

--- a/packages/codegen/__tests__/run-codegen-cold-start.test.ts
+++ b/packages/codegen/__tests__/run-codegen-cold-start.test.ts
@@ -19,8 +19,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// eslint-disable-next-line import/no-namespace -- vi.spyOn needs the module namespace object to intercept run-codegen's call to emitServer
+import * as emitModule from "../src/emit";
 import { runCodegen } from "../src/index";
 
 let workdir: string;
@@ -80,5 +82,47 @@ describe("runCodegen — cold-start reproducibility (#283)", () => {
 
         expect(second.generated.functions).toBe(first.generated.functions);
         expect(second.generated.api).toBe(first.generated.api);
+    });
+
+    it("does not rewrite server.ts a second time on a warm run for a project using a feature flag", () => {
+        expect.assertions(1);
+
+        // `ctx.kv` usage sets `hasKv`, so the bootstrap's schema-only render
+        // (no feature flags) genuinely differs from the final render — the
+        // exact precondition the double-write bug needed to reproduce.
+        writeFileSync(
+            join(workdir, "lunora", "cache.ts"),
+            `import { query } from "@lunora/server";
+
+export const read = query({
+    args: {},
+    handler: async ({ ctx }) => ctx.kv.get("k"),
+});
+`,
+            "utf8",
+        );
+
+        // First (cold) run creates the full \`_generated/\` output on disk,
+        // including the \`hasKv\`-narrowed \`server.ts\`.
+        runCodegen({ lint: false, projectRoot: workdir });
+
+        // Spies on the module's own \`emitServer\` export: the bootstrap phase
+        // calls it with only \`{ schema, useUmbrella }\` (no feature flags), the
+        // final phase with the full narrowed option set. Counting TOTAL calls
+        // across the second run is enough to prove the bootstrap one didn't
+        // fire — the final phase always calls it exactly once.
+        const emitServerSpy = vi.spyOn(emitModule, "emitServer");
+
+        // Second (warm) run: nothing changed, so the final full \`server.ts\`
+        // this run computes is byte-identical to what's already on disk. The
+        // bootstrap gate under test should skip its schema-only render
+        // entirely — without it, the bootstrap phase would overwrite the full
+        // content with a reduced one, and the final phase would immediately
+        // write it back, touching disk twice for no observable change.
+        runCodegen({ lint: false, projectRoot: workdir });
+
+        expect(emitServerSpy).toHaveBeenCalledTimes(1);
+
+        emitServerSpy.mockRestore();
     });
 });

--- a/packages/codegen/src/argument-taint.ts
+++ b/packages/codegen/src/argument-taint.ts
@@ -182,6 +182,34 @@ export const isArgumentDerived = (expression: TsNode): boolean => {
 };
 
 /**
+ * True when `expression` — or its single-hop initializer — is NOT itself a call
+ * (a `CallExpression` or `new` expression) that could transform the value before
+ * it reaches the sink. `isArgumentDerived` deliberately also matches "a helper
+ * call embedding `args.*`" (e.g. `hash(args.key)`, `deriveKey(args)`) so taint
+ * detection stays fail-open; that is right for most sinks, but wrong for a rule
+ * whose entire premise is that the caller controls the exact bytes reaching the
+ * sink. A content-addressed key — the return of a server-side `storeFile(...)`
+ * helper, itself the SHA-256 of the uploaded bytes — textually references
+ * `args` (it IS the arg) yet is not attacker-chosen, because the call in
+ * between recomputed it from data the server already trusts.
+ *
+ * Only a direct member/element-access chain, a template literal, or a binary
+ * concatenation reaches here as "unmodified" — a wrapping call anywhere between
+ * the sink argument and its (at most single-hop) `args`/`ctx` root means the
+ * value was derived, not merely forwarded, so the rule should not treat it as
+ * caller-controlled input reaching the sink verbatim.
+ */
+export const isUnmodifiedArgumentPassthrough = (node: TsNode): boolean => {
+    if (Node.isCallExpression(node) || Node.isNewExpression(node)) {
+        return false;
+    }
+
+    const initializer = singleHopInitializer(node);
+
+    return initializer === undefined || !(Node.isCallExpression(initializer) || Node.isNewExpression(initializer));
+};
+
+/**
  * True when `node` is scoped by a server-trusted `ctx` value — directly, through
  * one local `const` hop (symmetric with {@link isArgumentDerived}), or through a
  * locally-bound ctx identity composed into the key. A storage/kv key such as

--- a/packages/codegen/src/discover-argument-derived-accesses.ts
+++ b/packages/codegen/src/discover-argument-derived-accesses.ts
@@ -46,7 +46,9 @@ const accessInCall = (call: CallExpression, relativePath: string, config: Argume
     // Some sinks (storage keys) only care about caller-controlled input reaching
     // the sink UNMODIFIED — a value rebuilt by an intervening call (a
     // content-addressed hash, an encoder) is no longer the bytes the caller chose,
-    // even though it textually references `args`. See `isUnmodifiedArgumentPassthrough`.
+    // even though it textually references `args`.
+    // eslint-disable-next-line no-secrets/no-secrets -- the referenced helper name below, not a credential
+    // See `isUnmodifiedArgumentPassthrough`.
     if (config.requireUnmodifiedReach === true && !isUnmodifiedArgumentPassthrough(key)) {
         return undefined;
     }
@@ -101,6 +103,7 @@ export interface ArgumentDerivedAccessConfig {
     matchReceiver: (receiverText: string) => boolean;
     /** The sink methods this binding cares about (the property-access name). */
     methods: ReadonlySet<string>;
+
     /**
      * When `true`, also require the sink argument to reach the sink UNMODIFIED —
      * see {@link isUnmodifiedArgumentPassthrough}. A value rebuilt by an

--- a/packages/codegen/src/discover-argument-derived-accesses.ts
+++ b/packages/codegen/src/discover-argument-derived-accesses.ts
@@ -1,7 +1,7 @@
 import type { CallExpression, Node as TsNode, Project, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
-import { enclosingExportName, isArgumentDerived, isScopedByContext } from "./argument-taint";
+import { enclosingExportName, isArgumentDerived, isScopedByContext, isUnmodifiedArgumentPassthrough } from "./argument-taint";
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 
 /**
@@ -40,6 +40,14 @@ const accessInCall = (call: CallExpression, relativePath: string, config: Argume
     // a server-trusted `ctx.*` value — a value like `` `${ctx.auth.userId}:${args.id}` ``
     // references `ctx` and is treated as scoped, so it is not flagged.
     if (!key || !isArgumentDerived(key) || isScopedByContext(key)) {
+        return undefined;
+    }
+
+    // Some sinks (storage keys) only care about caller-controlled input reaching
+    // the sink UNMODIFIED — a value rebuilt by an intervening call (a
+    // content-addressed hash, an encoder) is no longer the bytes the caller chose,
+    // even though it textually references `args`. See `isUnmodifiedArgumentPassthrough`.
+    if (config.requireUnmodifiedReach === true && !isUnmodifiedArgumentPassthrough(key)) {
         return undefined;
     }
 
@@ -93,6 +101,15 @@ export interface ArgumentDerivedAccessConfig {
     matchReceiver: (receiverText: string) => boolean;
     /** The sink methods this binding cares about (the property-access name). */
     methods: ReadonlySet<string>;
+    /**
+     * When `true`, also require the sink argument to reach the sink UNMODIFIED —
+     * see {@link isUnmodifiedArgumentPassthrough}. A value rebuilt by an
+     * intervening call (e.g. a content-addressed hash minted server-side) still
+     * textually references `args` but is no longer caller-controlled input, so it
+     * is not recorded. Off by default — most sinks want the broader, fail-open
+     * "embeds `args.*` anywhere" match `isArgumentDerived` already gives.
+     */
+    requireUnmodifiedReach?: boolean;
 }
 
 /**

--- a/packages/codegen/src/discover-storage-key-accesses.ts
+++ b/packages/codegen/src/discover-storage-key-accesses.ts
@@ -45,14 +45,14 @@ const KEY_TAKING_METHODS = new Set<string>([
  * id minted server-side (issue #284):
  *
  * - `requireUnmodifiedReach: true` — a key rebuilt by an intervening call (a
- *   `storeFile(...)` helper returning a SHA-256 of the bytes) is not
- *   caller-controlled input reaching the sink verbatim, so it is not recorded.
- *   See `isUnmodifiedArgumentPassthrough`.
+ * `storeFile(...)` helper returning a SHA-256 of the bytes) is not
+ * caller-controlled input reaching the sink verbatim, so it is not recorded.
+ * See `isUnmodifiedArgumentPassthrough`.
  * - `functions` (optional; defaults to `[]`, matching `discoverOwnerFieldWrites`)
- *   attaches each access's enclosing procedure's `visibility` — `internal`
- *   procedures have no untrusted caller by construction, so the lint drops them
- *   to INFO instead of ERROR rather than dropping them entirely: a PUBLIC
- *   procedure that forwards raw `args` into one is still the real vector.
+ * attaches each access's enclosing procedure's `visibility` — `internal`
+ * procedures have no untrusted caller by construction, so the lint drops them
+ * to INFO instead of ERROR rather than dropping them entirely: a PUBLIC
+ * procedure that forwards raw `args` into one is still the real vector.
  */
 const discoverStorageKeyAccesses = (project: Project, lunoraDirectory: string, functions: ReadonlyArray<FunctionIR> = []): StorageKeyAccessIR[] => {
     // Keyed on file + export because two modules may export the same name.

--- a/packages/codegen/src/discover-storage-key-accesses.ts
+++ b/packages/codegen/src/discover-storage-key-accesses.ts
@@ -1,7 +1,7 @@
 import type { Project } from "ts-morph";
 
 import { discoverArgumentDerivedAccesses } from "./discover-argument-derived-accesses";
-import type { StorageKeyAccessIR } from "./ir";
+import type { FunctionIR, StorageKeyAccessIR } from "./ir";
 
 /**
  * The `ctx.storage.&lt;bucket>.&lt;method>(...)` bucket methods whose first argument is a
@@ -39,12 +39,37 @@ const KEY_TAKING_METHODS = new Set<string>([
  * recorded; only an arg-derived key (directly, or through one local `const` hop)
  * that references no `ctx` reaches here. `list`/`bucket` are excluded — they take
  * no per-object key.
+ *
+ * Two narrowings on top of the shared taint walk, both closing false positives
+ * reported against real `internalAction`s receiving a content-addressed storage
+ * id minted server-side (issue #284):
+ *
+ * - `requireUnmodifiedReach: true` — a key rebuilt by an intervening call (a
+ *   `storeFile(...)` helper returning a SHA-256 of the bytes) is not
+ *   caller-controlled input reaching the sink verbatim, so it is not recorded.
+ *   See `isUnmodifiedArgumentPassthrough`.
+ * - `functions` (optional; defaults to `[]`, matching `discoverOwnerFieldWrites`)
+ *   attaches each access's enclosing procedure's `visibility` — `internal`
+ *   procedures have no untrusted caller by construction, so the lint drops them
+ *   to INFO instead of ERROR rather than dropping them entirely: a PUBLIC
+ *   procedure that forwards raw `args` into one is still the real vector.
  */
-const discoverStorageKeyAccesses = (project: Project, lunoraDirectory: string): StorageKeyAccessIR[] =>
-    discoverArgumentDerivedAccesses(project, lunoraDirectory, {
+const discoverStorageKeyAccesses = (project: Project, lunoraDirectory: string, functions: ReadonlyArray<FunctionIR> = []): StorageKeyAccessIR[] => {
+    // Keyed on file + export because two modules may export the same name.
+    const visibilityByKey = new Map(functions.map((entry) => [`${entry.filePath}:${entry.exportName}`, entry.visibility]));
+
+    const accesses = discoverArgumentDerivedAccesses(project, lunoraDirectory, {
         argIndex: 0,
         matchReceiver: (receiver) => receiver === "ctx.storage" || receiver.startsWith("ctx.storage."),
         methods: KEY_TAKING_METHODS,
+        requireUnmodifiedReach: true,
     });
+
+    return accesses.map((access) => {
+        const visibility = visibilityByKey.get(`${access.file}:${access.exportName}`);
+
+        return visibility === undefined ? access : { ...access, visibility };
+    });
+};
 
 export default discoverStorageKeyAccesses;

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -181,7 +181,7 @@ const buildImportLines = (options: EmitAppOptions): string[] => {
     ];
 
     if (hasGlobal) {
-        runtimeTypeImports.push("GlobalIntrospector");
+        runtimeTypeImports.push("GlobalIntrospector", "AdminTableResolver");
     }
 
     if (hasFramework) {
@@ -206,7 +206,7 @@ const buildImportLines = (options: EmitAppOptions): string[] => {
         ...(hasGlobal
             ? [
                   `import type { D1CtxDbOptions, D1DatabaseLike, D1Exec } from "@lunora/d1";`,
-                  `import { createD1CtxDb, facetGlobalColumn, listGlobalTables, readGlobalTablePage } from "@lunora/d1";`,
+                  `import { createD1CtxDb, facetGlobalColumn, importGlobalRows, listGlobalTables, readGlobalTablePage } from "@lunora/d1";`,
               ]
             : []),
         ...(hasHyperdriveGlobal
@@ -579,6 +579,15 @@ const buildWorkerOptionLines = (options: EmitAppOptions): string[] => [
             if (database) {
                 options.d1 = database;
                 options.globalIntrospector = buildGlobalIntrospector(database);
+                // \`resolveTableSharding\`/\`importGlobals\` wire the admin bulk-import
+                // endpoint: without the former, EVERY row (including a \`.global()\`
+                // table's) routes to the default shard, so a global table is never
+                // recognised as global and the latter is never reached — the
+                // endpoint answers 200 with \`inserted: {}\` for a write that never
+                // happened. Both are mechanical over the schema this file already
+                // imports, so there is nothing project-specific to configure.
+                options.resolveTableSharding = buildTableShardingResolver();
+                options.importGlobals = buildGlobalImporter(database);
             }
         }`,
           ]
@@ -890,6 +899,39 @@ const buildGlobalIntrospector = (database: D1DatabaseLike): GlobalIntrospector =
         readTablePage: (options) => readGlobalTablePage(exec, schema as never, options),
     };
 };
+
+/**
+ * \`resolveTableSharding\` for the admin bulk-import endpoint: a lookup over each
+ * table's declared \`shardMode\` (\`defineTable(...).global()\` / \`.shardBy(field)\`
+ * already record exactly this shape on the table) — mechanical, nothing to
+ * configure per project. \`undefined\` for a table the schema doesn't declare, so
+ * the import endpoint's own unknown-table handling still applies.
+ */
+const buildTableShardingResolver = (): AdminTableResolver => (table) => {
+    const declared = (schema as unknown as D1CtxDbOptions["schema"]).tables[table];
+
+    return declared?.shardMode ? { mode: declared.shardMode } : undefined;
+};
+
+/**
+ * \`importGlobals\` for the admin bulk-import endpoint: routes \`.global()\` rows
+ * through the same D1 writer \`.global()\` reads/writes already use, via
+ * \`@lunora/d1\`'s \`importGlobalRows\`. Mirrors \`runShardImport\`'s shard-local
+ * twin (\`createShardCtxDb\` + \`importShardRows\`) — same \`{ rows, startLine }\`
+ * shape, same trusted-import \`allowExplicitId\` semantics, forwarded as-is.
+ */
+const buildGlobalImporter =
+    (database: D1DatabaseLike) =>
+    (request: { rows: ReadonlyArray<{ doc: Record<string, unknown>; line: number; table: string }>; startLine?: number }) => {
+        const exec = buildExec(database);
+        const writer = createD1CtxDb({ exec, schema: schema as unknown as D1CtxDbOptions["schema"] });
+
+        return importGlobalRows(writer, schema as unknown as D1CtxDbOptions["schema"], {
+            exec,
+            rows: request.rows.map((row) => ({ doc: row.doc, table: row.table })),
+            startLine: request.startLine,
+        });
+    };
 `
         : "";
 

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -919,6 +919,14 @@ const buildTableShardingResolver = (): AdminTableResolver => (table) => {
  * \`@lunora/d1\`'s \`importGlobalRows\`. Mirrors \`runShardImport\`'s shard-local
  * twin (\`createShardCtxDb\` + \`importShardRows\`) — same \`{ rows, startLine }\`
  * shape, same trusted-import \`allowExplicitId\` semantics, forwarded as-is.
+ *
+ * Passes each row's own \`line\` through rather than dropping it: the caller
+ * (\`@lunora/runtime\`'s NDJSON import stream) already carries the row's true
+ * physical source line, and global rows are typically interspersed with
+ * shard-local ones it filtered out before calling here — a single
+ * \`startLine\` plus positional counting would mis-attribute every row after
+ * the first gap. \`importGlobalRows\` prefers \`row.line\` when present and
+ * falls back to the position-derived count otherwise.
  */
 const buildGlobalImporter =
     (database: D1DatabaseLike) =>
@@ -928,7 +936,7 @@ const buildGlobalImporter =
 
         return importGlobalRows(writer, schema as unknown as D1CtxDbOptions["schema"], {
             exec,
-            rows: request.rows.map((row) => ({ doc: row.doc, table: row.table })),
+            rows: request.rows.map((row) => ({ doc: row.doc, line: row.line, table: row.table })),
             startLine: request.startLine,
         });
     };

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -1315,6 +1315,15 @@ export interface StorageKeyAccessIR {
     line: number;
     /** The bucket method invoked with the arg-derived key, e.g. `get` / `put` / `delete` / `download`. */
     method: string;
+
+    /**
+     * Visibility of the enclosing procedure. `internal` procedures have no
+     * untrusted caller by construction — see `owner_field_from_args_not_auth`'s
+     * identical split — so `storage_key_from_user_args` drops the finding to
+     * INFO rather than ERROR there. `undefined` when the access sits outside any
+     * registered procedure the feeder could attribute it to.
+     */
+    visibility?: "internal" | "public";
 }
 
 /**

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -598,7 +598,7 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
                   shapes,
                   softDeleteReads: discoverSoftDeleteReads(project, lunoraDirectory),
                   sqlInterpolations: discoverSqlInterpolation(project, lunoraDirectory),
-                  storageKeyAccesses: discoverStorageKeyAccesses(project, lunoraDirectory),
+                  storageKeyAccesses: discoverStorageKeyAccesses(project, lunoraDirectory, functions),
                   storageUploads: discoverStorageUploads(project, lunoraDirectory),
                   vectorNamespaceAccesses: discoverVectorNamespaceAccesses(project, lunoraDirectory),
                   workflowCalls: discoverWorkflowCalls(project, lunoraDirectory),

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -495,29 +495,43 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     // `discoverFunctions` runs, lets pass 1 see the same declarations pass 2
     // would have. The full `server.ts` (with that later detail) overwrites
     // this provisional one before `runCodegen` returns, via the normal write
-    // phase below — `writeIfChanged` no-ops there if content is unchanged, so a
-    // warm run pays nothing extra beyond two cheap string renders.
+    // phase below.
     if (!options.dryRun) {
-        const declaredDependenciesForBootstrap = readPackageDependencies(options.projectRoot);
-        const useUmbrellaForBootstrap = (declaredDependenciesForBootstrap ?? new Set<string>()).has("lunorash");
         const bootstrapDirectory = join(lunoraDirectory, "_generated");
         const bootstrapDataModelPath = join(bootstrapDirectory, "dataModel.ts");
         const bootstrapServerPath = join(bootstrapDirectory, "server.ts");
-        const bootstrapDataModelContent = emitDataModel(schema, useUmbrellaForBootstrap);
-        const bootstrapServerContent = emitServer({ schema, useUmbrella: useUmbrellaForBootstrap });
 
-        if (!existsSync(bootstrapDirectory)) {
-            mkdirSync(bootstrapDirectory, { recursive: true });
+        // Only bootstrap on a genuine cold start (either target missing). On a
+        // warm run `project` already has the FULL previous-run declarations —
+        // `createCodegenProject` loads every tsconfig-included file, `_generated/**`
+        // among them, from disk at construction time — so there is nothing to
+        // synthesize. Gating on existence, not just writing, matters: the schema-only
+        // bootstrap content omits every feature flag `emitServer` takes below
+        // (identity/env/hasAi/hasKv/…), so for any project using at least one of them
+        // it differs from the on-disk full content — `writeIfChanged` would overwrite
+        // the full `server.ts` with the reduced one here, then the write phase below
+        // would immediately overwrite it back, forcing two disk writes (and two
+        // `_generated/**` watcher triggers) on every single warm run, not only a cold
+        // start.
+        if (!existsSync(bootstrapDataModelPath) || !existsSync(bootstrapServerPath)) {
+            const declaredDependenciesForBootstrap = readPackageDependencies(options.projectRoot);
+            const useUmbrellaForBootstrap = (declaredDependenciesForBootstrap ?? new Set<string>()).has("lunorash");
+            const bootstrapDataModelContent = emitDataModel(schema, useUmbrellaForBootstrap);
+            const bootstrapServerContent = emitServer({ schema, useUmbrella: useUmbrellaForBootstrap });
+
+            if (!existsSync(bootstrapDirectory)) {
+                mkdirSync(bootstrapDirectory, { recursive: true });
+            }
+
+            writeIfChanged(bootstrapDataModelPath, bootstrapDataModelContent);
+            writeIfChanged(bootstrapServerPath, bootstrapServerContent);
+
+            // Make sure `project` sees this content even if its module resolution
+            // would otherwise cache the pre-write (missing/stale) state — belt and
+            // suspenders alongside the disk write above.
+            project.createSourceFile(bootstrapDataModelPath, bootstrapDataModelContent, { overwrite: true });
+            project.createSourceFile(bootstrapServerPath, bootstrapServerContent, { overwrite: true });
         }
-
-        writeIfChanged(bootstrapDataModelPath, bootstrapDataModelContent);
-        writeIfChanged(bootstrapServerPath, bootstrapServerContent);
-
-        // Make sure `project` sees this content even if its module resolution
-        // would otherwise cache the pre-write (missing/stale) state — belt and
-        // suspenders alongside the disk write above.
-        project.createSourceFile(bootstrapDataModelPath, bootstrapDataModelContent, { overwrite: true });
-        project.createSourceFile(bootstrapServerPath, bootstrapServerContent, { overwrite: true });
     }
 
     const functions = discoverFunctions(project, lunoraDirectory);

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -473,6 +473,53 @@ export const runCodegen = (options: CodegenOptions): CodegenResult => {
     setStandardTypeResolver(resolveStandardSchemaType);
 
     const schema = discoverSchema(project, schemaPath, options.projectRoot);
+
+    // Cold-start bootstrap (issue #283): `discoverFunctions` below infers each
+    // handler's return type against `project` as it stands RIGHT NOW. On a fresh
+    // clone, CI, or after `rm -rf lunora/_generated`, that project has no
+    // `Doc<T>`/`Id<T>`/typed `ctx.db` for a handler to resolve against — so a
+    // return type that depends on them (a `Doc<…>` read, a paginated result)
+    // collapses to `{}`/`unknown`, and THAT gets written into `api.ts`/
+    // `functions.ts`. A second `lunora codegen` run re-infers against the first
+    // run's own (now-present) output and recovers more — the backend's own
+    // `tsc --noEmit` can even read 0 errors a full pass before a CONSUMING app
+    // does, since the backend mostly doesn't read its own inferred types back
+    // through `api.ts` the way a consumer does. Reproduced by `rm -rf
+    // lunora/_generated && lunora codegen`.
+    //
+    // `dataModel.ts` depends only on `schema` (already known here) and
+    // `server.ts`'s core `Doc`/`Id`/typed builders are schema-only too — the
+    // identity/env/container/workflow/queue narrowing computed further below
+    // only adds detail, it doesn't change whether `ctx.db` resolves — so
+    // pre-writing both with the schema-only info on hand NOW, before
+    // `discoverFunctions` runs, lets pass 1 see the same declarations pass 2
+    // would have. The full `server.ts` (with that later detail) overwrites
+    // this provisional one before `runCodegen` returns, via the normal write
+    // phase below — `writeIfChanged` no-ops there if content is unchanged, so a
+    // warm run pays nothing extra beyond two cheap string renders.
+    if (!options.dryRun) {
+        const declaredDependenciesForBootstrap = readPackageDependencies(options.projectRoot);
+        const useUmbrellaForBootstrap = (declaredDependenciesForBootstrap ?? new Set<string>()).has("lunorash");
+        const bootstrapDirectory = join(lunoraDirectory, "_generated");
+        const bootstrapDataModelPath = join(bootstrapDirectory, "dataModel.ts");
+        const bootstrapServerPath = join(bootstrapDirectory, "server.ts");
+        const bootstrapDataModelContent = emitDataModel(schema, useUmbrellaForBootstrap);
+        const bootstrapServerContent = emitServer({ schema, useUmbrella: useUmbrellaForBootstrap });
+
+        if (!existsSync(bootstrapDirectory)) {
+            mkdirSync(bootstrapDirectory, { recursive: true });
+        }
+
+        writeIfChanged(bootstrapDataModelPath, bootstrapDataModelContent);
+        writeIfChanged(bootstrapServerPath, bootstrapServerContent);
+
+        // Make sure `project` sees this content even if its module resolution
+        // would otherwise cache the pre-write (missing/stale) state — belt and
+        // suspenders alongside the disk write above.
+        project.createSourceFile(bootstrapDataModelPath, bootstrapDataModelContent, { overwrite: true });
+        project.createSourceFile(bootstrapServerPath, bootstrapServerContent, { overwrite: true });
+    }
+
     const functions = discoverFunctions(project, lunoraDirectory);
     const httpRoutes = discoverHttpRoutes(project, lunoraDirectory);
     const migrations = discoverMigrations(project, lunoraDirectory);

--- a/packages/d1/__tests__/admin-export-import.test.ts
+++ b/packages/d1/__tests__/admin-export-import.test.ts
@@ -205,6 +205,25 @@ describe("d1 admin export/import globals", () => {
             expect(result.errors[0]).toMatchObject({ code: "VALIDATION_ERROR", table: "settings" });
         });
 
+        it("attributes errors to each row's own `line` when non-contiguous (interspersed shard-local rows filtered out upstream)", async () => {
+            expect.assertions(1);
+
+            // Simulates `@lunora/runtime`'s import stream: these three global rows
+            // actually sat at NDJSON lines 2, 5, and 6 — lines 1, 3, and 4 were
+            // shard-local rows the caller already filtered out before reaching
+            // here. Without `line` on each row, position-derived counting would
+            // report 1, 2, 3 instead.
+            const result = await importGlobalRows(writer, schema, {
+                rows: [
+                    { doc: { _id: "s1", name: "ok", value: "x" }, line: 2, table: "settings" },
+                    { doc: { _id: "s2", name: 42, value: "x" }, line: 5, table: "settings" },
+                    { doc: { _id: "s3", name: 42, value: "y" }, line: 6, table: "settings" },
+                ],
+            });
+
+            expect(result.errors.map((error) => error.line)).toStrictEqual([5, 6]);
+        });
+
         it("counts _id collisions as conflicts and skips them", async () => {
             expect.assertions(3);
 

--- a/packages/d1/src/admin-export-import.ts
+++ b/packages/d1/src/admin-export-import.ts
@@ -15,6 +15,18 @@ import { quoteIdentifier } from "./dialect";
 /** One exported row: `doc` is reconstructed from the column tuple. */
 interface ExportRow {
     doc: Record<string, unknown>;
+
+    /**
+     * True physical source line, when the caller has it (e.g. a global row
+     * pulled out of an interspersed NDJSON import stream by
+     * `@lunora/runtime`'s `import-stream.ts`). When present this overrides the
+     * position-derived line below — the caller-side positions of a
+     * global-only subset don't line up with the original file once
+     * non-global rows have been filtered out. Absent for callers with no
+     * physical source to attribute (e.g. a fresh `exportGlobalRows` roundtrip
+     * in tests), which keeps the positional fallback.
+     */
+    line?: number;
     table: string;
 }
 
@@ -268,8 +280,14 @@ const importGlobalRows = async (writer: DatabaseWriterLike, schema: SchemaLike, 
     for (const row of args.rows) {
         line += 1;
 
+        // Prefer the row's own true physical line when the caller supplied one
+        // (see `ExportRow.line`) — the position-derived `line` above assumes a
+        // contiguous run starting at `startLine`, which interspersed global
+        // rows (shard-local rows filtered out upstream) violate.
+        const effectiveLine = row.line ?? line;
+
         // eslint-disable-next-line no-await-in-loop -- imports apply row-by-row in input order so per-line error/conflict reporting and the shared writer stay deterministic.
-        const outcome = await importOneRow(writer, schema, args, row, line);
+        const outcome = await importOneRow(writer, schema, args, row, effectiveLine);
 
         switch (outcome.kind) {
             case "conflict": {

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -133,11 +133,11 @@ mechanisms cooperate to guarantee this on the DO-backed runtime:
   `(identity, mutationId)` — a replay of an unacknowledged write returns the
   **cached** result without re-running the handler at all.
 - **OCC surfaces as an error, not a retry.** A write guarded by optimistic
-  concurrency that loses the race throws a `ConflictError` (409) back to the
-  caller. The runtime does not catch it and re-invoke the handler internally —
-  the caller decides whether to retry, and a retry is a **new** dispatch (a
-  fresh idempotency key if the client mints one per attempt), not a replay of
-  the one that failed.
+  concurrency that loses the race fails the request with a `409 Conflict`
+  response back to the caller. The runtime does not catch it and re-invoke the
+  handler internally — the caller decides whether to retry, and a retry is a
+  **new** dispatch (a fresh idempotency key if the client mints one per
+  attempt), not a replay of the one that failed.
 
 So `Date.now()` / `crypto.randomUUID()` inside an ordinary `mutation` handler
 is stable for one logical write — the handler body runs exactly once. This is

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -118,6 +118,40 @@ commits, schedule it: `ctx.scheduler.runAfter(0, internalFn, args)` — the
 deterministic equivalent of an `afterCommit` hook (a registered function with
 serializable args, not an inline closure).
 
+### Determinism: what actually replays
+
+A `query` handler **can** run more than once for the same logical read: a live
+subscription re-runs its query whenever a table it reads changes, so
+non-deterministic output there (`Date.now()`, `Math.random()`) can genuinely
+flicker between re-evaluations. Compute it in an `action` and pass the value in
+as an argument, or accept that the field is allowed to differ per re-run.
+
+A `mutation` handler does **not** replay under ordinary dispatch. Two
+mechanisms cooperate to guarantee this on the DO-backed runtime:
+
+- **Idempotency dedup.** A client-issued `x-lunora-mutation-id` is deduped by
+  `(identity, mutationId)` — a replay of an unacknowledged write returns the
+  **cached** result without re-running the handler at all.
+- **OCC surfaces as an error, not a retry.** A write guarded by optimistic
+  concurrency that loses the race throws a `ConflictError` (409) back to the
+  caller. The runtime does not catch it and re-invoke the handler internally —
+  the caller decides whether to retry, and a retry is a **new** dispatch (a
+  fresh idempotency key if the client mints one per attempt), not a replay of
+  the one that failed.
+
+So `Date.now()` / `crypto.randomUUID()` inside an ordinary `mutation` handler
+is stable for one logical write — the handler body runs exactly once. This is
+the opposite of Convex's model (where OCC failure re-runs the handler), so a
+Convex-shaped mental model treats mutation non-determinism as unsafe when it
+is not; porting that assumption over errs safe. The one place a DO-shaped
+mental model must stay careful: a `mutation` invoked from inside a workflow
+step or a queue consumer can be **called again** if the surrounding step/
+consumer itself replays (Cloudflare Workflows re-executes a step's code on
+retry) — that is a fresh `ctx.runMutation` dispatch from the step's
+perspective, not a replay this guarantee covers, so non-deterministic values
+computed inside such a step should still be treated the way an `action` value
+would be.
+
 ## `defineShape(definition)` — partial replication
 
 Declare a **shape**: a named, partial replication of a table for the

--- a/packages/studio/__tests__/features/storage/file-browser.test.tsx
+++ b/packages/studio/__tests__/features/storage/file-browser.test.tsx
@@ -180,7 +180,18 @@ describe("fileBrowser", () => {
         const lastCall = mock.listStorageObjects.mock.calls.at(-1) as [{ prefix?: string }];
 
         expect(lastCall[0]).toMatchObject({ prefix: "" });
-        // Back at root we again see the two sub-folders.
+
+        // Back at root we again see the two sub-folders. The re-list call resolving
+        // (awaited above) doesn't guarantee the follow-up render has committed yet —
+        // wait for the DOM itself rather than racing it on the same microtask. Not an
+        // `expect(...)` inside `waitFor`: that would count every retry attempt toward
+        // `expect.assertions(2)` above and fail it on any retry.
+        await waitFor(() => {
+            if (screen.queryAllByTestId("fb-folder").length !== 2) {
+                throw new Error("not re-rendered with both folders yet");
+            }
+        });
+
         expect(screen.getAllByTestId("fb-folder")).toHaveLength(2);
     });
 


### PR DESCRIPTION
## Cluster A — the advisor gate silently breaks codegen chains (#284, #285)

- **#284**: `storage_key_from_user_args` had no reachability model. Both real
  hits were `internalAction`s receiving a content-addressed storage id minted
  server-side. Fixed both suggested angles: attaches the enclosing procedure's
  `visibility` (mirroring `owner_field_from_args_not_auth`'s existing split)
  and drops an `internal*` finding to INFO instead of ERROR, pointing at the
  public callers as the real audit surface; and added
  `isUnmodifiedArgumentPassthrough` so a key rebuilt by an intervening call (a
  hash, an encoder) is no longer treated as caller-controlled input reaching
  the sink verbatim. No new suppression mechanism added.
- **#285**: all three parts.
  1. The gate ignoring "off locally": root cause was cerebro's own
     `no-strict-advisories`-only declaration — cerebro synthesizes the positive
     `--strict-advisories` counterpart with an **unconditional** `defaultValue:
     true`, so `options.strictAdvisories` was never `undefined` and the
     CI-vs-local fallback in `resolveStrictAdvisories` never ran. Now declares
     both `--strict-advisories` and `--no-strict-advisories` explicitly (in
     both `codegen` and `deploy`), neither with a default, so the fallback
     actually fires.
  2. Same root cause explains the duplicate help text: cerebro's synthesized
     option clones the negative flag's `description` verbatim. Declaring both
     forms ourselves gives each its own accurate text.
  3. `lunora advisor --no-write` was rejected as unknown because the option
     was declared under its **positive** name (`write`) — cerebro only
     synthesizes a `no-*` counterpart for a `no-*`-named declaration.
     Redeclared as `no-write`, matching the convention `codegen`/`dev` already
     use correctly.

## Cluster B — codegen emits too little, silently (#283, #287)

- **#283**: codegen wasn't reproducible from a cold `_generated/` — pass 1
  inferred handler return types before `Doc<T>`/`Id<T>`/typed `ctx.db` existed
  for a handler to resolve against, so a dependent return type collapsed to
  `unknown` and got written into `api.ts`/`functions.ts`. Bootstrapped:
  `runCodegen` now emits `dataModel.ts` (schema-only) and a provisional
  `server.ts` (schema-only core builders) *before* `discoverFunctions` runs,
  so pass 1 sees what pass 2 used to. The full `server.ts` overwrites the
  provisional one before the run returns, so a warm run pays nothing beyond
  two cheap string renders. Added a regression test that runs codegen from a
  genuinely cold `_generated/` and asserts the first pass already matches a
  second pass.
- **#287**: `POST /_lunora/admin/import` needed `resolveTableSharding` and
  `importGlobals` wired by hand; omitting either was silent (a `.global()`
  table routes to the default shard and `GLOBAL_NOT_CONFIGURED` never fires —
  200 with `inserted: {}`). Codegen now emits both inside the existing
  `.global()` block: `resolveTableSharding` is a mechanical lookup over each
  table's already-known `shardMode`, and `importGlobals` routes rows through
  the same D1 writer via `@lunora/d1`'s `importGlobalRows`, mirroring
  `runShardImport`'s shard-local twin. Verified against a real schema
  (`apps/playground`'s `.global()` tables) with `tsc --noEmit` on the emitted
  output — no new type errors (one pre-existing, unrelated `D1Database.batch`
  narrowing error is untouched by this change).
  **Not done**: a `.shardBy()`-only project with no `.global()`/Hyperdrive
  table doesn't get `resolveTableSharding` emitted (the schema import is
  currently gated on `hasGlobal`/`hasHyperdriveGlobal`) — narrower than the
  reported bug (which is specifically about lost `.global()` tables), flagged
  as a follow-up rather than folded into this fix.

Golden fixture regenerated (`app.ts` only — the two new imports and two new
module-level helpers; `dataModel.ts`/`server.ts`/`api.ts`/`functions.ts` are
byte-identical).

## Cluster C — `nondeterministic_query_mutation` (#286, a question)

I verified the runtime claim myself before acting, per the ticket's ask:

- `packages/do/src/shard-do.ts` (~4331-4341): a mutation replay is deduped by
  `(currentRequestUserId, mutationId)` and short-circuits to the **cached**
  result *before* `handleRpc` (the handler) is ever called.
- `packages/shard-engine/src/transaction.ts`: an OCC conflict throws
  `ConflictError` (409) back to the caller; `shard-do.ts`'s dispatch catch
  block records it and propagates it — there is no internal catch-and-retry
  loop that re-invokes the handler.

So my own investigation **confirms** the reporter's finding for mutations: an
ordinary mutation handler runs at most once per logical write, and the rule's
"may be re-run on OCC retry" premise does not hold here. It does **not**
contradict — no STOP condition hit.

One refinement my reading adds: the premise *does* hold for **queries** — a
live subscription genuinely re-runs its query when a table it reads changes
(`shard-do.ts`'s `refreshSubscriptions`), so `Date.now()` in a query can
legitimately flicker between evaluations. The codegen feeder already tags each
finding with `kind: "query" | "mutation"`, so rather than a blanket downgrade I
split on that: **query stays WARN**, **mutation drops to INFO** (not silenced
— a mutation dispatched from a workflow step or queue consumer that itself
replays is a real residual caveat, so the finding stays as a breadcrumb to
that). Documented the guarantee in `packages/server/docs/index.mdx` under a
new "Determinism: what actually replays" section, including that
step/consumer caveat.

Closes #283
Closes #284
Closes #285
Closes #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controls for strict advisories in code generation and deployment.
  - Improved generated admin bulk imports for globally sharded data.
  - Added more accurate storage-key detection and procedure visibility reporting.
  - Added explicit advisor write controls.
  - Added an invalid cron schedule error.
  - Improved import error reporting by preserving source row numbers.

- **Bug Fixes**
  - Refined advisory severity and messaging for queries, mutations, and replayable workflows.
  - Improved schema-dependent type resolution during code generation.
  - Improved warning output when CLI logging is unavailable.

- **Documentation**
  - Documented query re-evaluation, mutation deduplication, conflict handling, and replay limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->