### PR TITLE
docs: reconcile agents.md with the workspace and guard it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,30 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Repository Overview
 
-Lunora is a pnpm monorepo for the Lunora framework — a type-safe, real-time backend on Cloudflare Workers + Durable Objects with a Vite-first DX. Packages live under `packages/<name>/`. Apps (examples, docs site, studio) live under `apps/<name>/`.
+Lunora is a pnpm monorepo for the Lunora framework — a type-safe, real-time backend on Cloudflare Workers + Durable Objects with a Vite-first DX.
 
-**Package manager**: pnpm v11.5.3 (enforced via `packageManager`). **Monorepo orchestration**: @visulima/vis. **Node**: ^22.15.0 || >=24.11.0.
+**Package manager**: pnpm v11.15.0 (enforced via `packageManager`; `engines.pnpm` is `>=10.32.1`). **Monorepo orchestration**: @visulima/vis. **Node**: ^22.15.0 || >=24.11.0.
+
+### Repo layout
+
+pnpm workspaces are `apps/*`, `packages/*`, `examples/*`, `tests/*`. The rest of the top level is not a workspace:
+
+| Path             | What it is                                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/*`     | The published `@lunora/*` packages (+ the `lunorash` umbrella). See [Packages](#packages).                                      |
+| `apps/*`         | `docs` (site), `studio` (admin UI), `playground` (dev app), `cloud` (hosted control plane).                                     |
+| `examples/*`     | Runnable example apps (`todo-app`, `blog`, `expo`, `payment-demo`, …).                                                          |
+| `templates/*`    | Whole-project starters fetched by `lunora init` (`next`, `nuxt`, `expo`, `standalone`, …).                                      |
+| `registry/*`     | Copy-in registry items installed with `lunora registry add` (`auth`, `auth-ui-*`, `ai`, …).                                     |
+| `tests/*`        | Cross-cutting suites: `e2e` (`@lunora/e2e`, Playwright) and `vis-templates`.                                                    |
+| `scripts/*`      | Repo checks + release helpers (`check-*.js` run from `postinstall`, `api-snapshot.js`).                                         |
+| `api-snapshots/` | Committed public-API snapshots, one `<pkg>.api.md` per package — gated by `pnpm run api:check`.                                 |
+| `shared/`        | Bundler-inlined helpers, **not** a package. See [Top-level `shared/`](#top-level-shared--bundler-inlined-source-not-a-package). |
+| `protocol/`      | Wire-protocol spec + shared fixtures.                                                                                           |
+| `plans/`         | Implementation plans handed to agents; `plans/README.md` is the index.                                                          |
+| `sdks/`          | Non-JS client SDKs (`python`).                                                                                                  |
+| `patches/`       | pnpm patches applied to third-party deps.                                                                                       |
+| `marketing/`     | Brand + design tokens.                                                                                                          |
 
 ## Build & Test Commands
 
@@ -32,6 +53,13 @@ pnpm run lint:types               # TypeScript type check
 pnpm run lint:affected:eslint     # Only changed
 pnpm run lint:affected:types      # Only changed
 pnpm run lint:package-json        # package.json key order (add :fix to autofix)
+pnpm run lint:registry:sync       # registry/auth-ui-* in sync with packages/auth-ui
+
+# Gates that lint/test do not cover (see the CI gates note below)
+pnpm run api:check                # public API vs api-snapshots/*.api.md (api:update to accept)
+pnpm run dist:check               # built dist/ is production-clean
+pnpm run test:templates           # templates/* still build
+pnpm run e2e                      # Playwright suite in tests/e2e
 ```
 
 > **`package.json` key-order gotcha.** Key order is enforced by its own CI job ("Lint (package.json sort)") and by **nothing else** — ESLint, Prettier, `lint:types`, `api:check`, and `dist:check` are all blind to it. So a hand-added block in the wrong position (classically `peerDependencies` placed above `devDependencies` instead of below) goes green locally and red in CI. Canonical order is whatever `vis sort-package-json` emits; run `pnpm run lint:package-json` (= `vis sort-package-json --check`) after editing any manifest.
@@ -39,6 +67,10 @@ pnpm run lint:package-json        # package.json key order (add :fix to autofix)
 > Note `vis sort-package-json --help` currently crashes ([visulima#741](https://github.com/visulima/visulima/issues/741)) whenever a command's help text contains a literal `{`, so its flags aren't discoverable that way. `--check`, `--sort-scripts`, `--indent`, `--ignore <glob>`, `--sort-order`, `--unsorted <section>`, and `--line-ending` all exist.
 
 > **Stale-`dist` gotcha.** `dist/` is gitignored and built on demand. A raw `pnpm --filter … run test` / `lint:types` does **not** rebuild workspace dependencies, so if an upstream `@lunora/*` package's source changed you may hit stale-`dist` errors (`X is not a function`, "missing export"). Build first — `pnpm run build:packages` once, or `pnpm --filter "@lunora/<pkg>..." run build` (the trailing `...` includes dependencies) — or use `pnpm run test:affected` / `pnpm run lint:affected:types`, which build dependencies for you.
+
+> **CI gates beyond lint/test.** Green `lint:*` + `test` locally is not enough — `api:check` and `dist:check` have their own CI jobs and fail on changes the linters cannot see. `api:check` compares each package's public surface against its committed `api-snapshots/<pkg>.api.md`; an intentional surface change needs `pnpm run api:update` **after a fresh build** (it reads `dist/`, so a stale build writes a wrong snapshot). `lint:package-json` (key order) and `lint:registry:sync` are likewise CI-only.
+
+> **Don't use `pnpm -r run test`.** Running every package's vitest in parallel across the whole repo fails a different, arbitrary set each run (resource contention, not real failures). Use `pnpm run test` (vis orchestrates it), `pnpm run test:affected`, or a single `pnpm --filter "@lunora/<pkg>" run test`.
 
 ## Commit Convention
 
@@ -56,6 +88,8 @@ Types: `feat`, `fix`, `perf`, `docs`, `dx`, `refactor`, `test`, `workflow`, `bui
 - **main**: Stable releases
 - **next/beta**: Pre-release channels
 - Feature branches: `feat/name`, `fix/issue-number`
+
+> **Never text-merge `pnpm-lock.yaml`.** After merging or rebasing onto the base branch, discard any conflicted lockfile and regenerate it (`pnpm install --lockfile-only`) — a hand-resolved lockfile installs a tree nobody has. CI builds `refs/pull/N/merge`, not your branch head, so a lockfile that only works on the head fails there and nowhere else.
 
 ## Architecture Overview
 
@@ -75,12 +109,12 @@ The CLI binary is `lunora`. The npm scope is `@lunora/*`. The "main" server pack
 
 There is an unscoped **umbrella** package `lunorash` (directory `packages/lunora/`; npm name is `lunorash` because `lunora` is taken on npm, but the directory and CLI bin stay `lunora`). It re-exports the base packages (`@lunora/server` + subpaths, `@lunora/values`, `@lunora/runtime`, `@lunora/do`, `@lunora/client`) via subpaths (`lunorash/server`, …) and ships the `lunora` CLI bin. Codegen emits `lunorash/*` imports in `_generated/*` when a project declares a `lunorash` dependency (else `@lunora/*`) — opt-in and backward-compatible. Add-ons/adapters/Vite plugin stay separate installs.
 
-**Platform family (plan 114).** Multi-platform support ships as exactly **two** packages:
+**Platform family (plan 114).** Multi-platform support is split into **contracts**, a host-neutral **engine**, and **one host package per target**:
 
 - `@lunora/platform` — **contracts** (types + capability matrix, zero deps): `ShardHost`, `SocketHost`, `ShardDirectory`, `ShardKvStore`, `SchedulerHost`, the canonical binding `*Like` projections, `PlatformCapabilities`. The behavioural TCK lives at the `@lunora/platform/conformance` subpath (`/conformance/suite` is the workerd-safe pure suite; the barrel adds the `node:sqlite` reference host) — the TCK versions in lockstep with the contracts it asserts, and a subpath keeps the root import types-only.
-- `@lunora/shard-engine` — the host-neutral reactive engine (extracted from `@lunora/do`).
-
+- `@lunora/shard-engine` — the host-neutral reactive engine (extracted from `@lunora/do`): per-shard state, OCC, CDC, reactive subscriptions, the poke protocol. Mountable on any host.
 - `@lunora/platform-cloudflare` — the Cloudflare **host**: the contracts implemented over Durable Object primitives, plus the composition roots (`createShardPlatform` / `createWorkerPlatform`). `@lunora/do` depends on it and stays the Durable Object class itself; app code never imports it directly.
+- `@lunora/platform-node` — the Node **host**, still an experimental spike (plan 234): no `lunora dev` wiring, no deploy driver, capabilities mostly `unsupported`/`emulated`. Do not treat it as a shipping target.
 - `@lunora/observability` — host-neutral telemetry (logs, metrics, traces, issues), also extracted from `@lunora/do`.
 
 Each host is its own `@lunora/platform-<target>` package — never a subpath of the contracts package, since each carries its own provider deps. `@lunora/platform` stays zero-dependency.
@@ -89,58 +123,63 @@ Each host is its own `@lunora/platform-<target>` package — never a subpath of 
 
 Concise roles below — read the package's `src/` and `docs/` for detail. Flags: **Internal** = supporting layer, depend on the CLI/Vite/runtime that uses it; **not published** = build-time only; **Experimental** = outside the 1.0 stability promise.
 
-| Package                     | Role                                                                                                                                                                                           |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lunorash`                  | **Unscoped umbrella** (dir `packages/lunora/`, npm `lunorash`, bin `lunora`). Re-exports the base packages via subpaths; codegen emits `lunorash/*` when depended on.                          |
-| `@lunora/server`            | Main API: `defineSchema`, `defineTable`, `query`, `mutation`, `action`; ships `ctx.secrets` (Cloudflare Secrets Store).                                                                        |
-| `@lunora/values`            | `v.*` validators, return-type inference.                                                                                                                                                       |
-| `@lunora/errors`            | **Zero-dep** error layer: `LunoraError`, `ERROR_CATALOG`, guards, `invariant`/`unreachable`, `toErrorBody`. Terminal renderer lives in `@lunora/cli`.                                          |
-| `@lunora/runtime`           | Worker entry: RPC router, shard resolver, query coordinator.                                                                                                                                   |
-| `@lunora/do`                | `ShardDO` (SQLite, OCC, hibernated WS subscriptions) and `SessionDO`.                                                                                                                          |
-| `@lunora/d1`                | D1 adapter for `.global()` tables; wraps the Sessions API for read-your-writes.                                                                                                                |
-| `@lunora/codegen`           | Emits `_generated/{api,server,dataModel}.ts` from `schema.ts`.                                                                                                                                 |
-| `@lunora/client`            | Browser SDK: WebSocket, optimistic updates, offline queue.                                                                                                                                     |
-| `@lunora/react`             | `useQuery` / `useMutation` / `useSubscription` / `useAuth`.                                                                                                                                    |
-| `@lunora/react-native`      | React Native / Expo: re-exports `@lunora/react`, adds `createLunoraClient` + `@lunora/react-native/auth` better-auth Expo bridge.                                                              |
-| `@lunora/vue`               | Vue adapter: live composables, optimistic mutations, reactive loaders.                                                                                                                         |
-| `@lunora/solid`             | SolidJS adapter: live queries, optimistic mutations, reactive loaders.                                                                                                                         |
-| `@lunora/svelte`            | Svelte adapter: live stores, optimistic mutations, reactive loaders.                                                                                                                           |
-| `@lunora/angular`           | Angular signal-based adapter: `provideLunora` / `injectLunoraClient` / `liveQuery` / `mutate` / `connectionStatus`.                                                                            |
-| `@lunora/astro`             | Astro integration: single-worker composition + reactive-loader server helpers.                                                                                                                 |
-| `@lunora/nuxt`              | Nuxt module: mounts Lunora inside Nitro; `@lunora/nuxt/server` reactive-loader helpers.                                                                                                        |
-| `@lunora/db`                | TanStack DB binding: `defineCollections` → live indexed collections + durable offline outbox.                                                                                                  |
-| `@lunora/replica`           | Local-first replica runtime: `EventSource`, `LocalMirror` (pluggable SQLite), `EventsSync`; SQLite adapters as subpath exports.                                                                |
-| `@lunora/vite`              | Vite plugin over `@cloudflare/vite-plugin`: codegen, wrangler validator, error overlay.                                                                                                        |
-| `@lunora/cli`               | CLI subcommands: `init`, `dev`, `deploy`, `codegen`, `run`, `reset`, `migrate`.                                                                                                                |
-| `@lunora/auth`              | Auth on **better-auth**, D1-backed; email/password + OAuth, session policies; curated plugins via `@lunora/auth/plugins`.                                                                      |
-| `@lunora/cloudflare-access` | Cloudflare Access (Zero Trust) identity → `ctx.auth` / RLS via a `resolveIdentity` adapter.                                                                                                    |
-| `@lunora/mail`              | Resend adapter, TSX templates, queue-backed sends.                                                                                                                                             |
-| `@lunora/observability`     | Host-neutral telemetry storage + read models: request logs, traces, metrics, issue grouping, security audit. Backs the Studio's observability pages; extracted from `@lunora/do`.              |
-| `@lunora/notify`            | Multi-channel notifications: `ctx.notify`/`ctx.push` over `@visulima/notification`; Web Push + FCM, subscription stores + queue fan-out; `/web` browser subpath.                               |
-| `@lunora/storage`           | R2 typed buckets, signed URLs.                                                                                                                                                                 |
-| `@lunora/scheduler`         | `runAfter` / `runAt` + Cron Triggers via `SchedulerDO`.                                                                                                                                        |
-| `@lunora/container`         | Cloudflare Containers: `defineContainer` → container DO classes + typed `ctx.containers`; `@lunora/container/do` + `/bridge` subpaths.                                                         |
-| `@lunora/agent`             | Durable AI agents (add-on): `defineAgent` compiles a replay-safe tool-loop onto Cloudflare Workflows — tools (MCP/function/agent/sandbox), memory, HITL approvals, token streaming, telemetry. |
-| `@lunora/ai`                | Workers AI on Vercel AI SDK v7 → `ctx.ai`; `@lunora/ai/rag` ships `defineRag` (chunk→embed→Vectorize + retrieve).                                                                              |
-| `@lunora/flags`             | OpenFeature feature flags: `defineFlags` → `ctx.flags`; `useFlag`/`useFlags` client hooks; read-only Studio page.                                                                              |
-| `@lunora/advisor`           | Schema & query lints (splinter-style) feeding the Studio Advisors pages (~81 static rules + runtime lints).                                                                                    |
-| `@lunora/config`            | **Internal.** Shared CLI+Vite config/scaffolding: `wrangler.jsonc` validator, `.dev.vars` grammar/scaffolder, prompt helper.                                                                   |
-| `@lunora/search-core`       | **Internal, not published** (bundled into server/do/sql-store). The shared full-text search core: analyzer, tokenizer, scorer, caps, cursor algebra, backfill policy.                          |
-| `@lunora/sql-store`         | **Internal.** Dialect-parameterized SQL store core for `.global()` backends (D1, PlanetScale).                                                                                                 |
-| `@lunora/studio`            | Local admin UI for schema, data, logs, and advisors. Embedded by the CLI/Vite.                                                                                                                 |
-| `@lunora/mcp`               | MCP server exposing a Lunora deployment to AI agents; can front durable `@lunora/agent` runs (config-gated, fail-closed).                                                                      |
-| `@lunora/ratelimit`         | Rate limiting: token-bucket / fixed-window / sliding-window, deny list, sharding, pluggable stores, procedure middleware.                                                                      |
-| `@lunora/testing`           | Testing toolkit: `lunoraTest` in-memory harness, `agentHarness` double, `evaluate` scorers, mail-catcher helpers.                                                                              |
-| `@lunora/seed`              | Deterministic seeding from `defineSchema` (FK-ordered fake data); `@lunora/seed/testing` + `lunora seed` CLI.                                                                                  |
-| `@lunora/bindings`          | Cloudflare binding helpers, per-binding subpaths: `/kv`, `/images`, `/analytics`, `/pipelines`, `/vectors`, `/r2sql` → `ctx.*` facades.                                                        |
-| `@lunora/browser`           | Cloudflare Browser Rendering: `ctx.browser` (action-only) — navigate, screenshot/PDF, scrape.                                                                                                  |
-| `@lunora/hyperdrive`        | BYO Postgres/MySQL via Cloudflare Hyperdrive: driver-agnostic `ctx.sql` (action-only); node-postgres / postgres.js / mysql2 adapters.                                                          |
-| `@lunora/payment`           | Provider-agnostic payments: Stripe-first + Polar adapters, webhook sync, subscription state machine, entitlements, money helpers.                                                              |
-| `@lunora/x402`              | **Experimental.** Agentic payments (x402): charge agents per request (`/charge`) and pay x402-gated resources (`/pay`).                                                                        |
-| `@lunora/workflow`          | Durable workflows over Cloudflare Workflows: `defineWorkflow` + generated `WorkflowEntrypoint` classes, `ctx.workflows`.                                                                       |
-| `@lunora/queue`             | Cloudflare Queues: `defineQueue` → typed `ctx.queues.<name>` producers + a generated `queue()` consumer (or `mode: "pull"`).                                                                   |
-| `@lunora/dispatch`          | **Internal, not published** (bundled into queue/workflow). Shared dispatch runner calling a Lunora function from a server-initiated context.                                                   |
-| `@lunora/fingerprint`       | **Zero-dep** deterministic error-grouping (`fingerprintError` → stable 16-char hash); feeds the `getIssues` RPC + Studio Issues panel.                                                         |
+| Package                       | Role                                                                                                                                                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lunorash`                    | **Unscoped umbrella** (dir `packages/lunora/`, npm `lunorash`, bin `lunora`). Re-exports the base packages via subpaths; codegen emits `lunorash/*` when depended on.                                                     |
+| `@lunora/server`              | Main API: `defineSchema`, `defineTable`, `query`, `mutation`, `action`; ships `ctx.secrets` (Cloudflare Secrets Store).                                                                                                   |
+| `@lunora/values`              | `v.*` validators, return-type inference.                                                                                                                                                                                  |
+| `@lunora/errors`              | **Zero-dep** error layer: `LunoraError`, `ERROR_CATALOG`, guards, `invariant`/`unreachable`, `toErrorBody`. Terminal renderer lives in `@lunora/cli`.                                                                     |
+| `@lunora/runtime`             | Worker entry: RPC router, shard resolver, query coordinator.                                                                                                                                                              |
+| `@lunora/do`                  | `ShardDO` (SQLite, OCC, hibernated WS subscriptions) and `SessionDO`.                                                                                                                                                     |
+| `@lunora/d1`                  | D1 adapter for `.global()` tables; wraps the Sessions API for read-your-writes.                                                                                                                                           |
+| `@lunora/codegen`             | Emits `_generated/{api,server,dataModel}.ts` from `schema.ts`.                                                                                                                                                            |
+| `@lunora/client`              | Browser SDK: WebSocket, optimistic updates, offline queue.                                                                                                                                                                |
+| `@lunora/react`               | `useQuery` / `useMutation` / `useSubscription` / `useAuth`.                                                                                                                                                               |
+| `@lunora/react-native`        | React Native / Expo: re-exports `@lunora/react`, adds `createLunoraClient` + `@lunora/react-native/auth` better-auth Expo bridge.                                                                                         |
+| `@lunora/vue`                 | Vue adapter: live composables, optimistic mutations, reactive loaders.                                                                                                                                                    |
+| `@lunora/solid`               | SolidJS adapter: live queries, optimistic mutations, reactive loaders.                                                                                                                                                    |
+| `@lunora/svelte`              | Svelte adapter: live stores, optimistic mutations, reactive loaders.                                                                                                                                                      |
+| `@lunora/angular`             | Angular signal-based adapter: `provideLunora` / `injectLunoraClient` / `liveQuery` / `mutate` / `connectionStatus`.                                                                                                       |
+| `@lunora/astro`               | Astro integration: single-worker composition + reactive-loader server helpers.                                                                                                                                            |
+| `@lunora/nuxt`                | Nuxt module: mounts Lunora inside Nitro; `@lunora/nuxt/server` reactive-loader helpers.                                                                                                                                   |
+| `@lunora/db`                  | TanStack DB binding: `defineCollections` → live indexed collections + durable offline outbox.                                                                                                                             |
+| `@lunora/replica`             | Local-first replica runtime: `EventSource`, `LocalMirror` (pluggable SQLite), `EventsSync`; SQLite adapters as subpath exports.                                                                                           |
+| `@lunora/vite`                | Vite plugin over `@cloudflare/vite-plugin`: codegen, wrangler validator, error overlay.                                                                                                                                   |
+| `@lunora/cli`                 | The `lunora` binary. ~30 subcommands (`packages/cli/src/commands/`) — `init`, `dev`, `deploy`, `codegen`, `migrate`, `run`, `reset`, `seed`, `doctor`, `insights`, `advisor`, `registry`, `logs`, `env`, `eval`, `mcp`, … |
+| `@lunora/auth`                | Auth on **better-auth**, D1-backed; email/password + OAuth, session policies; curated plugins via `@lunora/auth/plugins`.                                                                                                 |
+| `@lunora/auth-ui`             | **Internal, not published.** Source of truth for the copy-in, user-owned auth screens; synced into `registry/auth-ui-<framework>/` (gate: `pnpm run lint:registry:sync`) and copied into consumer projects.               |
+| `@lunora/cloudflare-access`   | Cloudflare Access (Zero Trust) identity → `ctx.auth` / RLS via a `resolveIdentity` adapter.                                                                                                                               |
+| `@lunora/mail`                | Resend adapter, TSX templates, queue-backed sends.                                                                                                                                                                        |
+| `@lunora/platform`            | **Zero-dep contracts** for the platform family: `ShardHost`/`SocketHost`/`ShardDirectory`/`ShardKvStore`/`SchedulerHost`, binding `*Like` projections, `PlatformCapabilities`; TCK at `/conformance`.                     |
+| `@lunora/shard-engine`        | Host-neutral reactive engine: per-shard state, OCC, CDC, reactive subscriptions, poke protocol. Mounts on any `@lunora/platform` host.                                                                                    |
+| `@lunora/platform-cloudflare` | Cloudflare **host**: the contracts over Durable Object primitives + `createShardPlatform` / `createWorkerPlatform`. Consumed by `@lunora/do`, never by app code.                                                          |
+| `@lunora/platform-node`       | **Experimental.** Node **host** spike (plan 234) over better-sqlite3 + an in-process socket registry; dev/test target only — no dev wiring, no deploy driver.                                                             |
+| `@lunora/observability`       | Host-neutral telemetry storage + read models: request logs, traces, metrics, issue grouping, security audit. Backs the Studio's observability pages; extracted from `@lunora/do`.                                         |
+| `@lunora/notify`              | Multi-channel notifications: `ctx.notify`/`ctx.push` over `@visulima/notification`; Web Push + FCM, subscription stores + queue fan-out; `/web` browser subpath.                                                          |
+| `@lunora/storage`             | R2 typed buckets, signed URLs.                                                                                                                                                                                            |
+| `@lunora/scheduler`           | `runAfter` / `runAt` + Cron Triggers via `SchedulerDO`.                                                                                                                                                                   |
+| `@lunora/container`           | Cloudflare Containers: `defineContainer` → container DO classes + typed `ctx.containers`; `@lunora/container/do` + `/bridge` subpaths.                                                                                    |
+| `@lunora/agent`               | Durable AI agents (add-on): `defineAgent` compiles a replay-safe tool-loop onto Cloudflare Workflows — tools (MCP/function/agent/sandbox), memory, HITL approvals, token streaming, telemetry.                            |
+| `@lunora/ai`                  | Workers AI on Vercel AI SDK v7 → `ctx.ai`; `@lunora/ai/rag` ships `defineRag` (chunk→embed→Vectorize + retrieve).                                                                                                         |
+| `@lunora/flags`               | OpenFeature feature flags: `defineFlags` → `ctx.flags`; `useFlag`/`useFlags` client hooks; read-only Studio page.                                                                                                         |
+| `@lunora/advisor`             | Schema & query lints (splinter-style) feeding the Studio Advisors pages. Live rule set = `STATIC_LINTS` + `RUNTIME_LINTS` in `packages/advisor/src/index.ts` (~95 static at last count).                                  |
+| `@lunora/config`              | **Internal.** Shared CLI+Vite config/scaffolding: `wrangler.jsonc` validator, `.dev.vars` grammar/scaffolder, prompt helper.                                                                                              |
+| `@lunora/search-core`         | **Internal, not published** (bundled into server/do/sql-store). The shared full-text search core: analyzer, tokenizer, scorer, caps, cursor algebra, backfill policy.                                                     |
+| `@lunora/sql-store`           | **Internal.** Dialect-parameterized SQL store core for `.global()` backends (D1, PlanetScale).                                                                                                                            |
+| `@lunora/studio`              | Local admin UI for schema, data, logs, and advisors. Embedded by the CLI/Vite.                                                                                                                                            |
+| `@lunora/mcp`                 | MCP server exposing a Lunora deployment to AI agents; can front durable `@lunora/agent` runs (config-gated, fail-closed).                                                                                                 |
+| `@lunora/ratelimit`           | Rate limiting: token-bucket / fixed-window / sliding-window, deny list, sharding, pluggable stores, procedure middleware.                                                                                                 |
+| `@lunora/testing`             | Testing toolkit: `lunoraTest` in-memory harness, `agentHarness` double, `evaluate` scorers, mail-catcher helpers.                                                                                                         |
+| `@lunora/seed`                | Deterministic seeding from `defineSchema` (FK-ordered fake data); `@lunora/seed/testing` + `lunora seed` CLI.                                                                                                             |
+| `@lunora/bindings`            | Cloudflare binding helpers, per-binding subpaths: `/kv`, `/images`, `/analytics`, `/pipelines`, `/vectors`, `/r2sql` → `ctx.*` facades.                                                                                   |
+| `@lunora/browser`             | Cloudflare Browser Rendering: `ctx.browser` (action-only) — navigate, screenshot/PDF, scrape.                                                                                                                             |
+| `@lunora/hyperdrive`          | BYO Postgres/MySQL via Cloudflare Hyperdrive: driver-agnostic `ctx.sql` (action-only); node-postgres / postgres.js / mysql2 adapters.                                                                                     |
+| `@lunora/payment`             | Provider-agnostic payments: Stripe-first + Polar adapters, webhook sync, subscription state machine, entitlements, money helpers.                                                                                         |
+| `@lunora/x402`                | **Experimental.** Agentic payments (x402): charge agents per request (`/charge`) and pay x402-gated resources (`/pay`).                                                                                                   |
+| `@lunora/workflow`            | Durable workflows over Cloudflare Workflows: `defineWorkflow` + generated `WorkflowEntrypoint` classes, `ctx.workflows`.                                                                                                  |
+| `@lunora/queue`               | Cloudflare Queues: `defineQueue` → typed `ctx.queues.<name>` producers + a generated `queue()` consumer (or `mode: "pull"`).                                                                                              |
+| `@lunora/dispatch`            | **Internal, not published** (bundled into queue/workflow). Shared dispatch runner calling a Lunora function from a server-initiated context.                                                                              |
+| `@lunora/fingerprint`         | **Zero-dep** deterministic error-grouping (`fingerprintError` → stable 16-char hash); feeds the `getIssues` RPC + Studio Issues panel.                                                                                    |
 
 ### Layout
 
@@ -157,6 +196,14 @@ Every package follows the same shape:
 ## Conventions & Best Practices
 
 **Research the codebase before editing. Never change code you haven't read.**
+
+- **Do not preserve backward compatibility — on pre-release branches only.** On `alpha` (and `next` / `beta`), packages are pre-1.0 (`1.0.0-alpha.*`): change the API, delete the old path, and update all call sites in the same change — no deprecated aliases, no `legacy*` shims, no dual code paths kept alive "just in case". Say so in the commit body so semantic-release records the break. **On `main` the opposite holds** — `main` carries stable releases, so keep the existing API working, deprecate before removing, and land the removal on a pre-release branch. Check the branch before you decide (`git branch --show-current`); when a change targets both, write it the `main` way.
+- **Choose the simplest implementation that fully meets the current requirements.** Build for what is asked, not for a hypothetical future caller.
+- **Avoid premature abstraction.** Prefer simple concrete solutions until a real pattern emerges. No config knobs, extension points, or abstraction layers with a single implementation until a second one actually exists.
+- **Prefer established, well-maintained libraries over custom implementations.** Reach for a dependency before hand-rolling; add the version to the right catalog in `pnpm-workspace.yaml` (see [Dependency Catalog](#dependency-catalog)). The exceptions are the zero-dep packages (`@lunora/errors`, `@lunora/fingerprint`, `@lunora/platform`) and `shared/`, which must stay dependency-free, plus anything that would not survive the Workers runtime.
+- **Prefer composition over centralization.** Small focused modules with explicit interfaces, not one central system everything routes through.
+- **Keep responsibilities clear.** Keep modules focused; don't mix transport, orchestration, domain/workflow state, persistence, and infrastructure in the same unit.
+- **Never skip verification.** Do not bypass required checks, tests, or quality gates — no `--no-verify`, no skipped/`.skip`ped tests, no silenced type errors or lint rules to get something green.
 
 ### Module imports — no `.js` extensions
 
@@ -217,6 +264,8 @@ Git hooks are **vis-native** (no husky). Committed scripts live in `.vis/hooks/`
 
 If hooks aren't firing, run `pnpm exec vis hook install` (or `vis hook validate` to diagnose).
 
+**Order matters when fixing by hand: Prettier first, then ESLint.** `prettier --write` followed by `eslint --fix`. The reverse order lets Prettier reformat lines ESLint just fixed and reintroduce the violations.
+
 ### Release
 
 Independent per-package versioning via `multi-semantic-release`. Publishable packages ship a `.releaserc.json` extending `@anolilab/semantic-release-preset/pnpm`. Conventional Commits drive bumps; the `semantic-release.yml` workflow publishes on push to `alpha` / `main` / `next` / `beta`. Do not author `release` commits manually.
@@ -238,6 +287,7 @@ vis generate lunora-queue --name=emailQueue                # producer + queue() 
 vis generate lunora-step --name=chargeOrder                # reusable defineStep, run via ctx.runStep
 vis generate lunora-agent --name=support                   # defineAgent, appends to lunora/agents.ts (@lunora/agent)
 vis generate lunora-flags                                  # → lunora/flags.ts singleton (@lunora/flags); refuses if it exists
+vis generate lunora-auth-do                                # → lunora/auth-do.ts singleton (DO-backed auth mode); refuses if it exists
 vis generate lunora-collections                            # → lunora/collections.ts (@lunora/db)
 vis generate lunora-package --name=foo --description='…'   # → packages/foo/
 vis generate --list                                         # list all generators

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -11,9 +11,12 @@ The Lunora documentation & marketing site (`@lunora/docs`) — built with **TanS
 ## Commands
 
 ```bash
-pnpm dev      # Dev server (runs generate-packages + copy-docs first)
-pnpm build    # Production build (runs generate-packages + copy-docs + fetch-stats + vite build)
-pnpm serve    # Preview production build
+pnpm dev               # Dev server (runs generate-packages + copy-docs first)
+pnpm build             # generate-packages + copy-docs + check-doc-imports + fetch-stats + vite build
+pnpm serve             # Preview production build
+pnpm start             # Serve the built output (.output/server/index.mjs)
+pnpm lint:doc-imports  # Verify code samples in docs import real, exported symbols
+pnpm lint:types        # fumadocs-mdx codegen, then tsc --noEmit
 ```
 
 ## Architecture
@@ -43,7 +46,8 @@ Scripts run before Vite build (in order):
 
 1. **`scripts/generate-packages.js`** — discovers flat workspace packages via `project.json` `category:*` tags + `package.json`, merges with `src/data/packages-metadata.json`, outputs `src/data/packages.ts`.
 2. **`scripts/copy-package-docs.js`** — copies every `packages/<name>/docs/` into `src/content/docs/packages/<name>/`, sanitises MDX for Fumadocs, and builds a categorised `packages/meta.json` (categories come from `CATEGORY_CONFIG`).
-3. **`scripts/fetch-stats.js`** — fetches npm + GitHub stats (derived from `packages.ts`, repo `anolilab/lunora`) into `src/data/stats.json`. Network-bound; skipped by `dev`.
+3. **`scripts/check-doc-imports.mjs`** — fails the build when a code sample imports a symbol no package actually exports. Run it alone with `pnpm lint:doc-imports`; it does not run in `dev`.
+4. **`scripts/fetch-stats.js`** — fetches npm + GitHub stats (derived from `packages.ts`, repo `anolilab/lunora`) into `src/data/stats.json`. Network-bound; skipped by `dev`.
 
 ### Adding a Package to the Website
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "lint:types": "vis run lint:types && pnpm run lint:types:registry",
         "lint:types:registry": "pnpm run build:packages && tsc -p registry/tsconfig.json",
         "multi-semantic-release": "multi-semantic-release",
-        "postinstall": "node scripts/generate-package-og-images.js && node scripts/generate-labeler-config.js --skip-ci && node scripts/check-cerebro-peer-lockstep.js && node scripts/check-sibling-peer-ranges.js && node scripts/check-skill-mirrors.js && node scripts/check-registry-catalog-ranges.js",
+        "postinstall": "node scripts/generate-package-og-images.js && node scripts/generate-labeler-config.js --skip-ci && node scripts/check-cerebro-peer-lockstep.js && node scripts/check-sibling-peer-ranges.js && node scripts/check-skill-mirrors.js && node scripts/check-registry-catalog-ranges.js && node scripts/check-agents-md-packages.js",
         "prepare": "vis hook install",
         "test": "vis run test --query \"project!=lunora-e2e&&project!=lunora-playground\"",
         "test:affected": "vis affected test --fail-fast --query \"project!=lunora-e2e&&project!=lunora-playground\"",

--- a/scripts/check-agents-md-packages.js
+++ b/scripts/check-agents-md-packages.js
@@ -1,0 +1,82 @@
+/**
+ * Guards against `AGENTS.md` losing track of a package.
+ *
+ * `AGENTS.md` (which `CLAUDE.md` symlinks to) is what every coding agent reads
+ * to decide which package owns a change. Its `### Packages` table is
+ * hand-maintained, so a new or extracted package only appears there if whoever
+ * added it remembered — and five in a row did not: `@lunora/auth-ui`,
+ * `@lunora/platform`, `@lunora/platform-cloudflare`, `@lunora/platform-node`,
+ * and `@lunora/shard-engine` all shipped without a row. An agent asked to touch
+ * auth UI found no `auth-ui` package, and either edited `@lunora/auth` or
+ * invented a location. Wrong-package edits and duplicated code are the failure
+ * mode, and nothing else in the repo catches it.
+ *
+ * The check is deliberately loose: it asserts only that each `packages/*`
+ * manifest name appears *somewhere* in the file. A prose mention counts. That
+ * keeps it from being brittle about table formatting (Prettier reflows the
+ * column widths on every edit) while still failing on the case that actually
+ * hurts — a package the file has never heard of.
+ *
+ * Scope is `packages/` only. `apps/`, `examples/`, `templates/`, and `tests/`
+ * are described by the repo-layout table rather than enumerated, so requiring a
+ * per-directory mention there would fail on the file's own design.
+ *
+ * Run on every `pnpm install` via the root `postinstall` script.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, "..");
+const packagesDir = join(rootDir, "packages");
+const agentsMdPath = join(rootDir, "AGENTS.md");
+
+let agentsMd;
+
+try {
+    agentsMd = readFileSync(agentsMdPath, "utf8");
+} catch {
+    console.error("❌ AGENTS.md is missing or unreadable at the repo root.");
+    console.error("   It is the entry point for every coding agent — restore it before continuing.");
+
+    process.exit(1);
+}
+
+const missing = [];
+
+for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+        continue;
+    }
+
+    let manifest;
+
+    try {
+        manifest = JSON.parse(readFileSync(join(packagesDir, entry.name, "package.json"), "utf8"));
+    } catch {
+        continue;
+    }
+
+    if (typeof manifest.name !== "string" || agentsMd.includes(manifest.name)) {
+        continue;
+    }
+
+    missing.push({ directory: entry.name, name: manifest.name });
+}
+
+if (missing.length > 0) {
+    console.error(`❌ ${missing.length} package(s) exist on disk but are never mentioned in AGENTS.md:`);
+
+    for (const { directory, name } of missing) {
+        console.error(`   ${name} (packages/${directory})`);
+    }
+
+    console.error("   Add a row to the `### Packages` table describing what the package owns.");
+    console.error("   Agents use that table to pick which package a change belongs in.");
+
+    process.exit(1);
+}
+
+console.log("✅ Every packages/* manifest name appears in AGENTS.md.");


### PR DESCRIPTION
`AGENTS.md` is what every coding agent reads to decide which package owns a change (`CLAUDE.md` symlinks to it). It had drifted from the workspace, and nothing checked it.

## The drift

- **The package table listed 50 of 55 packages.** `@lunora/auth-ui` and `@lunora/platform-node` appeared *nowhere* in the file; `@lunora/platform`, `@lunora/platform-cloudflare`, and `@lunora/shard-engine` only in prose. An agent asked to touch auth UI finds no owning package and either edits `@lunora/auth` or invents a location.
- **The platform-family paragraph said the family "ships as exactly two packages"** and was immediately followed by four bullets, with a fifth member on disk.
- **`@lunora/advisor` claimed "~81 static rules"**; `STATIC_LINTS` has 95.
- **`@lunora/cli` listed 7 subcommands**; there are ~30.
- **pnpm was recorded as v11.5.3**; `packageManager` says 11.15.0.
- **Twelve top-level directories went undescribed** — `templates/`, `registry/`, `tests/`, `api-snapshots/`, `protocol/`, `sdks/`, and the rest.

## Also recorded

Four things that were costing rework and lived nowhere:

- **CI gates beyond lint/test** — `api:check`, `dist:check`, and `lint:registry:sync` have their own jobs and fail on changes linters cannot see. `api:update` reads `dist/`, so running it on a stale build writes a wrong snapshot.
- **`pnpm -r run test` fails an arbitrary set each run** (contention, not real failures).
- **Never text-merge `pnpm-lock.yaml`** — CI builds `refs/pull/N/merge`, so a hand-resolved lockfile fails there and nowhere else.
- **Prettier before ESLint** when fixing by hand; the reverse re-breaks what ESLint fixed.

`apps/docs/AGENTS.md` was missing `check-doc-imports.mjs` from its documented build order (it gates the build).

## The guard

Five packages in a row skipped the table, so the process does not self-correct. `scripts/check-agents-md-packages.js` runs on `postinstall` — alongside the existing `check-*.js` chain — and fails if any `packages/*` manifest name is absent from the file. It is loose on purpose: a prose mention counts, so Prettier reflowing the table columns cannot break it.

**Fail-before / pass-after**, with the five rows stripped:

```
❌ 5 package(s) exist on disk but are never mentioned in AGENTS.md:
   @lunora/auth-ui (packages/auth-ui)
   @lunora/platform (packages/platform)
   @lunora/platform-cloudflare (packages/platform-cloudflare)
   @lunora/platform-node (packages/platform-node)
   @lunora/shard-engine (packages/shard-engine)
exit=1
```
```
✅ Every packages/* manifest name appears in AGENTS.md.
exit=0
```

## Verification

- `pnpm exec prettier --check` clean on all four files
- `pnpm run lint:package-json` — all 69 manifests sorted (root `package.json` was edited; this gate is CI-only)
- `CLAUDE.md -> AGENTS.md` symlink intact
- `scripts/` is not covered by an ESLint config, so Prettier is the only formatter gate on the new script

Implements plans/287-agents-md-drift.md (W1–W4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer command and build pipeline documentation.
  * Added guidance for validating imported symbols in documentation code samples.

* **Chores**
  * Added an installation-time check to verify all package names are documented.
  * The check now reports missing package documentation and fails when coverage is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->