### PR TITLE
fix(auth-ui): resync the registry mirror with its source

### DIFF
--- a/registry/auth-ui-angular/angular/auth-cards.ts
+++ b/registry/auth-ui-angular/angular/auth-cards.ts
@@ -348,7 +348,7 @@ class ResetPasswordCardComponent implements OnInit {
     selector: "lunora-reset-password-otp-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.resetPassword" [description]="t.resetPasswordOtpDescription">
+        <!-- secret-scanner:allow -- i18n key, not a credential --><lunora-auth-card [title]="t.resetPassword" [description]="t.resetPasswordOtpDescription">
             <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
                 <lunora-auth-banner [error]="state().formError" [success]="state().successMessage" />
                 <lunora-auth-field


### PR DESCRIPTION
## What

Propagates the `secret-scanner:allow` marker from `packages/auth-ui/src/angular/auth-cards.ts` into its mirror at `registry/auth-ui-angular/angular/auth-cards.ts`. One file, one line.

## Why

`alpha` is currently red on **`Lint (auth-ui registry sync)`**.

`packages/auth-ui` is the source of truth for the copy-in auth screens and is mirrored into `registry/auth-ui-<framework>/`, with `pnpm run lint:registry:sync` gating that they match. PR #291 edited the source to silence a false-positive secret-scanner hit but did not move the mirror, so the two blobs diverged when it merged:

- `packages/auth-ui/src/angular/auth-cards.ts` → has the marker
- `registry/auth-ui-angular/angular/auth-cards.ts` → does not

This is a follow-up to that omission, not a new change in behaviour. The marker itself suppresses a `kingfisher.generic.5` low-confidence hit on the Angular binding `[description]="t.resetPasswordOtpDescription"` — an i18n translation key, not a credential.

## How

Generated by the sync script rather than hand-edited:

```
node scripts/sync-auth-ui-registry.mjs
→ Synced auth-ui registry (1 file(s) changed).
```

Only that one file was rewritten.

## Verification

```
node scripts/sync-auth-ui-registry.mjs --check   → auth-ui registry is up to date.
pnpm run lint:registry:sync                      → auth-ui registry is up to date.
pnpm exec vis secrets                            → No secrets detected.
pnpm exec prettier --check <the file>            → All matched files use Prettier code style!
pnpm --filter "@lunora/auth-ui" run lint:types   → 412 FILES 0 ERRORS 0 WARNINGS
```

Run after `pnpm run build:packages`, per the stale-`dist` trap in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EELf27TTEX6ohpmP2vPrMa