### PR TITLE
fix(server,shard-engine): gate lookupById and rankPageRows in the writer wrappers

### DIFF
--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -263,6 +263,22 @@ const enableRankPageRows = (database: FakeDatabase, rows: (Record<string, unknow
 };
 
 /**
+ * Mirrors `@lunora/shard-engine`'s `guardWriter` contract for `rankPageRows`
+ * ONLY: the key is present on the returned writer if and only if `raw`
+ * carries it — never unconditionally, and never as a stub that would
+ * TypeError on a writer that omits it (the exact shape plan 254 restores;
+ * see `rls-guard.test.ts`'s "optional analytical methods omitted..." suite for
+ * the direct regression test against the real `guardWriter`). We don't import
+ * `@lunora/shard-engine` here — wrong dependency direction, mirrors
+ * `rls-secure-by-default.test.ts`'s own inline guard for the same reason.
+ */
+const withRlsGuardShape = (writer: FakeDatabase["writer"]): FakeDatabase["writer"] => {
+    const { rankPageRows, ...rest } = writer;
+
+    return rankPageRows ? { ...rest, rankPageRows } : rest;
+};
+
+/**
  * Install a chainable `query()` reader on the fake writer — the legacy
  * iterator-style reader that masking's `wrapReader` wraps. Mirrors `@lunora/do`'s
  * reader surface (`withIndex` / `order` / `filter` / terminal `collect` etc.) so
@@ -1239,6 +1255,23 @@ describe("mask — value oracle via rank reads fails closed (plan 209)", () => {
         // rankBefore D1-twin-omission test above.
         await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toBe("undefined");
     });
+
+    it("does not surface rankPageRows() when mask() is composed OVER a guard-shaped writer that omits it (plan 254)", async () => {
+        expect.assertions(1);
+
+        // The realistic production shape: under `.rls("required")`, the `ctx.db`
+        // that flows into `mask()` is ALREADY the output of `@lunora/shard-engine`'s
+        // `guardWriter`, not a bare fake. This is the exact composition the
+        // original bug broke — `guardWriter` used to install `rankPageRows`
+        // unconditionally, so it was always present (and would TypeError on
+        // call) even when the raw writer never had it.
+        const database = createFakeDatabase([{ _id: "u1", ssn: "123-45-6789", table: "users" }]);
+        const guarded = withRlsGuardShape(database.writer);
+
+        const handler = lunora.query.use(maskForTest({ users: { ssn: "redact" } })).query(({ ctx }) => typeof (ctx as unknown as TestContext).db.rankPageRows);
+
+        await expect(handler.handler({ auth: { roles: [], userId: "u1" }, db: guarded }, {})).resolves.toBe("undefined");
+    });
 });
 
 describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 250)", () => {
@@ -1790,8 +1823,8 @@ describe("mask — guarded-read coverage (every MaskDatabase read method)", () =
         const coveredNames = READ_METHODS_WITH_WHERE.map((entry) => entry.name).toSorted((a, b) => a.localeCompare(b));
 
         expect(coveredNames).toStrictEqual(
-            ["aggregate", "count", "findFirst", "findFirstOrThrow", "findMany", "groupBy", "rank", "rankBefore", "rankPage", "rankPageRows"].toSorted(
-                (a, b) => a.localeCompare(b),
+            ["aggregate", "count", "findFirst", "findFirstOrThrow", "findMany", "groupBy", "rank", "rankBefore", "rankPage", "rankPageRows"].toSorted((a, b) =>
+                a.localeCompare(b),
             ),
         );
     });

--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -108,6 +108,16 @@ interface FakeDatabase {
             indexName: string,
             options?: unknown,
         ) => Promise<{ continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] }>;
+        /** Optional — mirrors `@lunora/shard-engine`'s cross-shard companion to `rankPage`. Enabled per-test via `enableRankPageRows`. */
+        rankPageRows?: (
+            tableName: string,
+            indexName: string,
+            options?: unknown,
+        ) => Promise<{
+            directions: ReadonlyArray<"asc" | "desc">;
+            hasMore: boolean;
+            rows: ReadonlyArray<{ doc: Record<string, unknown>; key: { partitionKey: string; rowId: string; sortValues: ReadonlyArray<unknown> } }>;
+        }>;
         replace: (id: string, document: Record<string, unknown>) => Promise<void>;
     };
 }
@@ -234,6 +244,24 @@ const enableRankBefore = (database: FakeDatabase, rows: (Record<string, unknown>
     };
 };
 
+/** Enable the optional `rankPageRows` seam — the cross-shard companion to `rankPage` (mirrors `@lunora/shard-engine`'s writer). */
+const enableRankPageRows = (database: FakeDatabase, rows: (Record<string, unknown> & { _id: string; table: string })[]): void => {
+    // eslint-disable-next-line no-param-reassign -- the helper installs the seam on the caller's fake writer
+    database.writer.rankPageRows = async (tableName, _indexName, options) => {
+        database.calls.push({ args: options, method: "rankPageRows", tableOrId: tableName });
+
+        return {
+            directions: ["asc"],
+            hasMore: false,
+            rows: rows
+                .filter((row) => row.table === tableName)
+                .map((row, index) => {
+                    return { doc: row, key: { partitionKey: "", rowId: row._id, sortValues: [index] } };
+                }),
+        };
+    };
+};
+
 /**
  * Install a chainable `query()` reader on the fake writer — the legacy
  * iterator-style reader that masking's `wrapReader` wraps. Mirrors `@lunora/do`'s
@@ -298,19 +326,6 @@ const enableQueryReader = (
                 };
 
                 search(builder);
-
-                return makeReader(list);
-            },
-            // Same shape as `withIndex`: run the builder against a chainable
-            // no-op (mirrors `@lunora/do`'s geo reader), so the reader still
-            // works end-to-end for a geo read the declaration guard lets through.
-            withGeoIndex: (_indexName, build) => {
-                const builder: FakeGeoBuilder = {
-                    near: () => builder,
-                    within: () => builder,
-                };
-
-                build(builder);
 
                 return makeReader(list);
             },
@@ -1161,6 +1176,69 @@ describe("mask — value oracle via rank reads fails closed (plan 209)", () => {
         // handling — must not synthesize one either.
         await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toBe("undefined");
     });
+
+    it("rankPageRows() with a where on a masked column throws MASK_UNSUPPORTED (plan 254)", async () => {
+        expect.assertions(2);
+
+        const rows = [{ _id: "u1", ssn: "123-45-6789", table: "users" }];
+        const database = createFakeDatabase(rows);
+
+        enableRankPageRows(database, rows);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPageRows?.("users", "by_ssn", { where: { ssn: { eq: "123-45-6789" } } }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+        expect(database.calls.some((call) => call.method === "rankPageRows")).toBe(false);
+    });
+
+    it("rankPageRows() with a baseWhere on a masked column throws MASK_UNSUPPORTED (plan 254)", async () => {
+        expect.assertions(1);
+
+        const rows = [{ _id: "u1", ssn: "123-45-6789", table: "users" }];
+        const database = createFakeDatabase(rows);
+
+        enableRankPageRows(database, rows);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPageRows?.("users", "by_ssn", { baseWhere: { ssn: { eq: "123-45-6789" } } }));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("rankPageRows() with a where on a NON-masked column of a masked table still works and masks every doc (plan 254)", async () => {
+        expect.assertions(3);
+
+        const rows = [{ _id: "u1", ssn: "123-45-6789", status: "active", table: "users" }];
+        const database = createFakeDatabase(rows);
+
+        enableRankPageRows(database, rows);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { ssn: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPageRows?.("users", "by_status", { where: { status: { eq: "active" } } }));
+
+        const result = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(database.calls.some((call) => call.method === "rankPageRows")).toBe(true);
+        expect(result?.rows[0]?.doc["ssn"]).toBeNull();
+        expect(result?.rows[0]?.doc["status"]).toBe("active");
+    });
+
+    it("does not surface rankPageRows() at all when the underlying writer omits it (D1 twin) (plan 254)", async () => {
+        expect.assertions(1);
+
+        const database = createFakeDatabase([{ _id: "u1", ssn: "123-45-6789", table: "users" }]);
+
+        const handler = lunora.query.use(maskForTest({ users: { ssn: "redact" } })).query(({ ctx }) => typeof (ctx as unknown as TestContext).db.rankPageRows);
+
+        // No `enableRankPageRows` call: the fake writer never carries the
+        // method, so the wrapper must not synthesize one either — mirrors the
+        // rankBefore D1-twin-omission test above.
+        await expect(handler.handler(makeContext(database, "u1"), {})).resolves.toBe("undefined");
+    });
 });
 
 describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 250)", () => {
@@ -1488,6 +1566,45 @@ describe("mask — get() table resolution", () => {
         expect(result?.["_id"]).toBe("e1");
         expect(result?.["email"]).toBe("raw@x.com");
     });
+
+    it("lookupById() itself (not just get()) masks the row it resolves (plan 254)", async () => {
+        expect.assertions(2);
+
+        // The `...base` spread would otherwise expose `base.lookupById`
+        // directly, unmasked — `get()` above delegates to a `locate` helper
+        // that already masks its result, but a caller reaching the
+        // `lookupById` seam directly must see the same masked column.
+        const rows = [{ _id: "u1", email: "a@x.com", table: "users" }];
+        const database = createFakeDatabase(rows);
+
+        enableGetWithTable(database, rows);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.lookupById?.("u1"));
+
+        const result = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(result?.row["email"]).toBeNull();
+        expect(result?.tableName).toBe("users");
+    });
+
+    it("lookupById() on a row outside every masked table returns it unmasked (plan 254)", async () => {
+        expect.assertions(1);
+
+        const rows = [{ _id: "e1", email: "raw@x.com", table: "events" }];
+        const database = createFakeDatabase(rows);
+
+        enableGetWithTable(database, rows);
+
+        const handler = lunora.query
+            .use(maskForTest({ users: { email: "redact" } }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.lookupById?.("e1"));
+
+        const result = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(result?.row["email"]).toBe("raw@x.com");
+    });
 });
 
 describe("mask — opt-in scope & stored data", () => {
@@ -1644,6 +1761,9 @@ describe("mask — guarded-read coverage (every MaskDatabase read method)", () =
         // in `Promise.resolve` so a fake writer missing the seam unifies with the
         // other entries' `Promise<unknown>` instead of `Promise<unknown> | undefined`.
         { invoke: (db) => Promise.resolve(db.rankBefore?.("users", "by_ssn", { rowId: "u1", where: maskedWhere })), name: "rankBefore" },
+        // `rankPageRows` (plan 254) is likewise optional on `MaskDatabase` — the
+        // cross-shard companion to `rankPage`, gated the same way.
+        { invoke: (db) => Promise.resolve(db.rankPageRows?.("users", "by_ssn", { where: maskedWhere })), name: "rankPageRows" },
     ];
 
     it.each(READ_METHODS_WITH_WHERE)("$name(...) with a where on a masked column throws MASK_UNSUPPORTED", async ({ invoke }) => {
@@ -1653,6 +1773,7 @@ describe("mask — guarded-read coverage (every MaskDatabase read method)", () =
         const database = createFakeDatabase(rows);
 
         enableRankBefore(database, rows);
+        enableRankPageRows(database, rows);
 
         const handler = lunora.query.use(maskForTest({ users: { ssn: "redact" } })).query(async ({ ctx }) => invoke((ctx as unknown as TestContext).db));
 
@@ -1666,10 +1787,12 @@ describe("mask — guarded-read coverage (every MaskDatabase read method)", () =
         // new filterable read method, this name list must grow with it — this
         // assertion is the tripwire a reviewer (or this test file's own drift)
         // would otherwise miss silently.
-        const coveredNames = READ_METHODS_WITH_WHERE.map((entry) => entry.name).toSorted();
+        const coveredNames = READ_METHODS_WITH_WHERE.map((entry) => entry.name).toSorted((a, b) => a.localeCompare(b));
 
         expect(coveredNames).toStrictEqual(
-            ["aggregate", "count", "findFirst", "findFirstOrThrow", "findMany", "groupBy", "rank", "rankBefore", "rankPage"].toSorted(),
+            ["aggregate", "count", "findFirst", "findFirstOrThrow", "findMany", "groupBy", "rank", "rankBefore", "rankPage", "rankPageRows"].toSorted(
+                (a, b) => a.localeCompare(b),
+            ),
         );
     });
 });

--- a/packages/server/__tests__/rls.test.ts
+++ b/packages/server/__tests__/rls.test.ts
@@ -72,6 +72,16 @@ interface FakeDatabase {
             indexName: string,
             options?: unknown,
         ) => Promise<{ continueCursor: null | string; isDone: boolean; page: Record<string, unknown>[] }>;
+        /** Optional — mirrors `@lunora/shard-engine`'s cross-shard companion to `rankPage`. Enabled per-test via `enableRankPageRows`. */
+        rankPageRows?: (
+            tableName: string,
+            indexName: string,
+            options?: unknown,
+        ) => Promise<{
+            directions: ReadonlyArray<"asc" | "desc">;
+            hasMore: boolean;
+            rows: ReadonlyArray<{ doc: Record<string, unknown>; key: { partitionKey: string; rowId: string; sortValues: ReadonlyArray<unknown> } }>;
+        }>;
         replace: (id: string, document: Record<string, unknown>) => Promise<void>;
         restore: (id: string, expectedTable?: string) => Promise<void>;
     };
@@ -226,6 +236,24 @@ const enableGetWithTable = (database: FakeDatabase, rows: (Record<string, unknow
         const row = byId.get(id);
 
         return row ? { row, tableName: row.table } : null;
+    };
+};
+
+/** Enable the optional `rankPageRows` seam — the cross-shard companion to `rankPage` (mirrors `@lunora/shard-engine`'s writer). */
+const enableRankPageRows = (database: FakeDatabase, rows: (Record<string, unknown> & { _id: string; table: string })[]): void => {
+    // eslint-disable-next-line no-param-reassign -- the helper's purpose is to install the seam on the caller's fake writer
+    database.writer.rankPageRows = async (tableName, _indexName, options) => {
+        database.calls.push({ args: options, method: "rankPageRows", tableOrId: tableName });
+
+        return {
+            directions: ["asc"],
+            hasMore: false,
+            rows: rows
+                .filter((row) => row.table === tableName)
+                .map((row, index) => {
+                    return { doc: row, key: { partitionKey: "", rowId: row._id, sortValues: [index] } };
+                }),
+        };
     };
 };
 
@@ -544,6 +572,121 @@ describe("rls — read path", () => {
         const unscopedProbes = fake.calls.filter((call) => call.method === "findFirst" && !(call.args as { baseWhere?: unknown } | undefined)?.baseWhere);
 
         expect(unscopedProbes).toHaveLength(0);
+    });
+
+    it("lookupById() resolves null (not the row) when the read policy denies it (plan 254)", async () => {
+        expect.assertions(1);
+
+        // Same shape as "get() does NOT leak a row that the read policy
+        // denied" above, but calling the `lookupById` seam directly — the
+        // `...base` spread in `rls/middleware.ts` would otherwise expose
+        // `base.lookupById` (the RLS-guarded, but not policy-filtered, seam)
+        // unfiltered by the read policy, leaking another user's row.
+        const policy = definePolicy<TestContext>({
+            on: "read",
+            table: "documents",
+            when: ({ auth }) => {
+                return { ownerId: auth.userId };
+            },
+        });
+
+        const rows = [{ _id: "d1", ownerId: "u2", table: "documents" }];
+        const fake = createFakeDatabase(rows);
+
+        enableGetWithTable(fake, rows);
+
+        // Honest fake: a baseWhere-scoped findFirst filters by the predicate,
+        // mirroring what `@lunora/do`'s `findFirst` does at runtime (the
+        // default fake ignores `baseWhere` entirely).
+        const wrappedFindFirst = fake.writer.findFirst;
+
+        fake.writer.findFirst = async (tableName, args) => {
+            const candidate = await wrappedFindFirst(tableName, args);
+            const baseWhere = (args as { baseWhere?: { ownerId?: unknown } } | undefined)?.baseWhere;
+
+            if (!candidate || !baseWhere || !("ownerId" in baseWhere)) {
+                return candidate;
+            }
+
+            return candidate["ownerId"] === baseWhere.ownerId ? candidate : null;
+        };
+
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([policy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.lookupById?.("d1"));
+
+        await expect(handler.handler(makeContext(fake, "u1"), {})).resolves.toBeNull();
+    });
+
+    it("lookupById() returns { row, tableName } when the read policy grants access (plan 254)", async () => {
+        expect.assertions(1);
+
+        const policy = definePolicy<TestContext>({
+            on: "read",
+            table: "documents",
+            when: ({ auth }) => {
+                return { ownerId: auth.userId };
+            },
+        });
+
+        const rows = [{ _id: "d1", ownerId: "u1", table: "documents" }];
+        const fake = createFakeDatabase(rows);
+
+        enableGetWithTable(fake, rows);
+
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([policy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.lookupById?.("d1"));
+
+        await expect(handler.handler(makeContext(fake, "u1"), {})).resolves.toMatchObject({ row: { _id: "d1" }, tableName: "documents" });
+    });
+
+    it("lookupById() on an id outside every policy-gated table passes through unrestricted (plan 254)", async () => {
+        expect.assertions(1);
+
+        const policy = definePolicy<TestContext>({
+            on: "read",
+            table: "documents",
+            when: () => {
+                return { ownerId: "anyone" };
+            },
+        });
+
+        const rows = [{ _id: "a1", event: "login", table: "audit" }];
+        const fake = createFakeDatabase(rows);
+
+        enableGetWithTable(fake, rows);
+
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([policy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.lookupById?.("a1"));
+
+        await expect(handler.handler(makeContext(fake, "u1"), {})).resolves.toMatchObject({ row: { _id: "a1" }, tableName: "audit" });
+    });
+
+    it("lookupById() on an unresolvable (e.g. global) id returns null rather than throwing (plan 254)", async () => {
+        expect.assertions(1);
+
+        // Mirrors `@lunora/shard-engine`'s own contract: a global row's table
+        // isn't resolvable by the shard-local seam, so it returns `null` and
+        // the caller keeps its probe fallback — the gate must not turn this
+        // into a thrown error.
+        const policy = definePolicy<TestContext>({
+            on: "read",
+            table: "documents",
+            when: () => true,
+        });
+
+        const rows: (Record<string, unknown> & { _id: string; table: string })[] = [];
+        const fake = createFakeDatabase(rows);
+
+        enableGetWithTable(fake, rows);
+
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([policy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.lookupById?.("unresolvable-id"));
+
+        await expect(handler.handler(makeContext(fake, "u1"), {})).resolves.toBeNull();
     });
 
     it("count() on a non-policy table does NOT mark restrictsCounts", async () => {
@@ -1377,6 +1520,41 @@ describe("rls — analytical reads (baseWhere on the full facade)", () => {
 
         await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "COUNT_RLS_UNSUPPORTED" });
         expect(database.calls.some((entry) => entry.method === "rankPage")).toBe(false);
+    });
+
+    it("fails rankPageRows() closed with COUNT_RLS_UNSUPPORTED under a read policy (plan 254)", async () => {
+        expect.assertions(2);
+
+        const rows = [{ _id: "d1", ownerId: "u1", table: "documents" }];
+        const database = createFakeDatabase(rows);
+
+        enableRankPageRows(database, rows);
+
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([ownerPolicy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPageRows?.("documents", "byScore"));
+
+        await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "COUNT_RLS_UNSUPPORTED" });
+        // The underlying writer is never reached — the guard throws first.
+        expect(database.calls.some((entry) => entry.method === "rankPageRows")).toBe(false);
+    });
+
+    it("leaves rankPageRows() UNRESTRICTED on a table with no read policy (plan 254)", async () => {
+        expect.assertions(2);
+
+        const rows = [{ _id: "e1", table: "events" }];
+        const database = createFakeDatabase(rows);
+
+        enableRankPageRows(database, rows);
+
+        const handler = lunora.query
+            .use(rlsForTest<TestContext>([ownerPolicy]))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPageRows?.("events", "byTime"));
+
+        const result = await handler.handler(makeContext(database, "u1"), {});
+
+        expect(result?.rows).toHaveLength(1);
+        expect(database.calls.some((entry) => entry.method === "rankPageRows")).toBe(true);
     });
 
     it("leaves analytical reads UNRESTRICTED on a table with no read policy", async () => {

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -95,6 +95,26 @@ interface QueryPage {
     page: Record<string, unknown>[];
 }
 
+/** Structural mirror of `@lunora/shard-engine`'s `RankPageRowKey`. */
+interface RankPageRowKeyLike {
+    partitionKey: string;
+    rowId: string;
+    sortValues: ReadonlyArray<unknown>;
+}
+
+/** Structural mirror of `@lunora/shard-engine`'s `RankPageRow`. */
+interface RankPageRowLike {
+    doc: Record<string, unknown>;
+    key: RankPageRowKeyLike;
+}
+
+/** Structural mirror of `@lunora/shard-engine`'s `ShardRankPageResult` — the `rankPageRows` return shape. */
+interface ShardRankPageResultLike {
+    directions: ReadonlyArray<"asc" | "desc">;
+    hasMore: boolean;
+    rows: ReadonlyArray<RankPageRowLike>;
+}
+
 interface QueryArgs {
     baseWhere?: unknown;
     cursor?: null | string;
@@ -182,6 +202,9 @@ interface MaskDatabase {
     rank: (tableName: string, indexName: string, options: unknown) => Promise<null | { position: number; total: number }>;
     rankBefore?: (tableName: string, indexName: string, options: unknown) => Promise<{ before: number; total: number }>;
     rankPage: (tableName: string, indexName: string, options?: unknown) => Promise<QueryPage>;
+
+    /** Cross-shard companion to `rankPage`, gated the same way `rankPage` is masked below. */
+    rankPageRows?: (tableName: string, indexName: string, options?: unknown) => Promise<ShardRankPageResultLike>;
     replace: (id: string, document: Record<string, unknown>, expectedTable?: string) => Promise<void>;
 }
 
@@ -386,6 +409,11 @@ const wrapDatabase = <Context>(
     // override below can call it without re-narrowing `base.rankBefore` inside
     // the nested closure.
     const baseRankBefore = base.rankBefore;
+
+    // `rankPageRows` (plan 254) is likewise optional — the D1 twin omits it too
+    // (only the shard-local writer implements the cross-shard rank companion) —
+    // so it's captured and conditionally overridden the same way as `rankBefore`.
+    const baseRankPageRows = base.rankPageRows;
 
     /**
      * SECURITY (position oracle on the index DECLARATION path): `assertIndexFieldsAllowed`
@@ -823,6 +851,25 @@ const wrapDatabase = <Context>(
             return maskRow(row, columns, context);
         },
 
+        // Delegates to `base.lookupById` directly (not the `locate` helper
+        // above, which folds an unmasked table's name away to `undefined` —
+        // `lookupById`'s contract must keep returning the row's REAL owning
+        // table regardless of masking). Masks the row when that table carries
+        // masked columns; the `...base` spread would otherwise expose
+        // `base.lookupById` with its column values in the clear.
+        async lookupById(id, expectedTable) {
+            const located = await base.lookupById?.(id, expectedTable);
+
+            if (!located) {
+                // eslint-disable-next-line unicorn/no-null -- mirrors the seam's own `null`-for-absent contract
+                return null;
+            }
+
+            const columns = perTable.get(located.tableName);
+
+            return { row: columns ? maskRow(located.row, columns, context) : located.row, tableName: located.tableName };
+        },
+
         groupBy(tableName, options) {
             assertReductionAllowed(tableName, [...options.by, options.agg?.field], "groupBy");
             assertWhereAllowed(tableName, options.where, "groupBy");
@@ -864,6 +911,32 @@ const wrapDatabase = <Context>(
                       assertIndexDeclarationAllowed(tableName, indexName, "rankBefore");
 
                       return baseRankBefore(tableName, indexName, options);
+                  },
+              }
+            : {}),
+
+        // `rankPageRows` (plan 254) is likewise optional (the D1 twin omits it) —
+        // only override it when `base` actually carries one, mirroring the
+        // `rankBefore` conditional above.
+        ...(baseRankPageRows
+            ? {
+                  async rankPageRows(tableName: string, indexName: string, options: unknown) {
+                      assertRankWhereAllowed(tableName, options, "rankPageRows");
+                      assertIndexDeclarationAllowed(tableName, indexName, "rankPageRows");
+
+                      const result = await baseRankPageRows(tableName, indexName, options);
+                      const columns = perTable.get(tableName);
+
+                      if (!columns) {
+                          return result;
+                      }
+
+                      return {
+                          ...result,
+                          rows: result.rows.map((row) => {
+                              return { ...row, doc: maskRow(row.doc, columns, context) };
+                          }),
+                      };
                   },
               }
             : {}),

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -85,6 +85,8 @@ import type { Middleware } from "../builder/types";
 import { LunoraError } from "../error";
 import type { FacadeEntry } from "../facade";
 import { bindOrm, bindTableFacade } from "../facade";
+import { optionalWriterOverride } from "../optional-writer-override";
+import type { ShardRankPageResultLike } from "../rank-page-rows-shape";
 import type { IndexFieldsByTable } from "../schema";
 import { tagMaskMiddleware } from "./policy-tag";
 import type { MaskColumns, MaskContext, MaskOptions, MaskPolicies, Permission, Role } from "./types";
@@ -93,26 +95,6 @@ interface QueryPage {
     continueCursor: null | string;
     isDone: boolean;
     page: Record<string, unknown>[];
-}
-
-/** Structural mirror of `@lunora/shard-engine`'s `RankPageRowKey`. */
-interface RankPageRowKeyLike {
-    partitionKey: string;
-    rowId: string;
-    sortValues: ReadonlyArray<unknown>;
-}
-
-/** Structural mirror of `@lunora/shard-engine`'s `RankPageRow`. */
-interface RankPageRowLike {
-    doc: Record<string, unknown>;
-    key: RankPageRowKeyLike;
-}
-
-/** Structural mirror of `@lunora/shard-engine`'s `ShardRankPageResult` — the `rankPageRows` return shape. */
-interface ShardRankPageResultLike {
-    directions: ReadonlyArray<"asc" | "desc">;
-    hasMore: boolean;
-    rows: ReadonlyArray<RankPageRowLike>;
 }
 
 interface QueryArgs {
@@ -202,7 +184,6 @@ interface MaskDatabase {
     rank: (tableName: string, indexName: string, options: unknown) => Promise<null | { position: number; total: number }>;
     rankBefore?: (tableName: string, indexName: string, options: unknown) => Promise<{ before: number; total: number }>;
     rankPage: (tableName: string, indexName: string, options?: unknown) => Promise<QueryPage>;
-
     /** Cross-shard companion to `rankPage`, gated the same way `rankPage` is masked below. */
     rankPageRows?: (tableName: string, indexName: string, options?: unknown) => Promise<ShardRankPageResultLike>;
     replace: (id: string, document: Record<string, unknown>, expectedTable?: string) => Promise<void>;
@@ -404,15 +385,10 @@ const wrapDatabase = <Context>(
     context: MaskContext<Context>,
     indexFields: IndexFieldsByTable | undefined,
 ): MaskDatabase => {
-    // `rankBefore` is the one optional method (the D1 twin omits it) — captured
-    // here (mirrors `../rls/middleware`'s `baseRankBefore`) so the conditional
-    // override below can call it without re-narrowing `base.rankBefore` inside
-    // the nested closure.
+    // `rankBefore`/`rankPageRows` are both optional (the D1 twin omits both) —
+    // captured here so `optionalWriterOverride` below can call each without
+    // re-narrowing `base.<method>` inside the nested closure.
     const baseRankBefore = base.rankBefore;
-
-    // `rankPageRows` (plan 254) is likewise optional — the D1 twin omits it too
-    // (only the shard-local writer implements the cross-shard rank companion) —
-    // so it's captured and conditionally overridden the same way as `rankBefore`.
     const baseRankPageRows = base.rankPageRows;
 
     /**
@@ -851,12 +827,8 @@ const wrapDatabase = <Context>(
             return maskRow(row, columns, context);
         },
 
-        // Delegates to `base.lookupById` directly (not the `locate` helper
-        // above, which folds an unmasked table's name away to `undefined` —
-        // `lookupById`'s contract must keep returning the row's REAL owning
-        // table regardless of masking). Masks the row when that table carries
-        // masked columns; the `...base` spread would otherwise expose
-        // `base.lookupById` with its column values in the clear.
+        // Delegates to `base.lookupById` directly, not `locate` above (which
+        // folds the table name away) — the `...base` spread would otherwise expose it unmasked.
         async lookupById(id, expectedTable) {
             const located = await base.lookupById?.(id, expectedTable);
 
@@ -901,45 +873,29 @@ const wrapDatabase = <Context>(
             return columns ? maskPage(page, columns, context) : page;
         },
 
-        // `rankBefore` is the one optional method (the D1 twin omits it) — only
-        // override it when `base` actually carries one, mirroring the `...base`
-        // spread's own pass-through for a writer that doesn't.
-        ...(baseRankBefore
-            ? {
-                  rankBefore(tableName: string, indexName: string, options: unknown) {
-                      assertRankWhereAllowed(tableName, options, "rankBefore");
-                      assertIndexDeclarationAllowed(tableName, indexName, "rankBefore");
+        // `rankBefore`/`rankPageRows` are the two optional methods (the D1 twin omits both) — see `optionalWriterOverride`.
+        ...optionalWriterOverride("rankBefore", baseRankBefore, (rankBefore) => (tableName: string, indexName: string, options: unknown) => {
+            assertRankWhereAllowed(tableName, options, "rankBefore");
+            assertIndexDeclarationAllowed(tableName, indexName, "rankBefore");
 
-                      return baseRankBefore(tableName, indexName, options);
-                  },
-              }
-            : {}),
+            return rankBefore(tableName, indexName, options);
+        }),
+        ...optionalWriterOverride("rankPageRows", baseRankPageRows, (rankPageRows) => async (tableName: string, indexName: string, options: unknown) => {
+            assertRankWhereAllowed(tableName, options, "rankPageRows");
+            assertIndexDeclarationAllowed(tableName, indexName, "rankPageRows");
 
-        // `rankPageRows` (plan 254) is likewise optional (the D1 twin omits it) —
-        // only override it when `base` actually carries one, mirroring the
-        // `rankBefore` conditional above.
-        ...(baseRankPageRows
-            ? {
-                  async rankPageRows(tableName: string, indexName: string, options: unknown) {
-                      assertRankWhereAllowed(tableName, options, "rankPageRows");
-                      assertIndexDeclarationAllowed(tableName, indexName, "rankPageRows");
+            const result = await rankPageRows(tableName, indexName, options);
+            const columns = perTable.get(tableName);
 
-                      const result = await baseRankPageRows(tableName, indexName, options);
-                      const columns = perTable.get(tableName);
-
-                      if (!columns) {
-                          return result;
-                      }
-
-                      return {
-                          ...result,
-                          rows: result.rows.map((row) => {
-                              return { ...row, doc: maskRow(row.doc, columns, context) };
-                          }),
-                      };
-                  },
-              }
-            : {}),
+            return columns
+                ? {
+                      ...result,
+                      rows: result.rows.map((row) => {
+                          return { ...row, doc: maskRow(row.doc, columns, context) };
+                      }),
+                  }
+                : result;
+        }),
     };
 
     // SECURITY: the generated runtime glues a per-table facade

--- a/packages/server/src/optional-writer-override.ts
+++ b/packages/server/src/optional-writer-override.ts
@@ -1,0 +1,21 @@
+/**
+ * Spread-friendly single-key override for an OPTIONAL writer method.
+ * `rankBefore` and `rankPageRows` are both optional on the real writer type —
+ * only the shard-local `@lunora/shard-engine` writer implements them, the
+ * D1/sql-store twin omits both — so `../rls/middleware` and `../mask/middleware`
+ * each need to add their override to the wrapped writer ONLY when the
+ * underlying `base` actually carries the method, exactly mirroring the
+ * `...base` spread's own pass-through for a writer that doesn't. Every one of
+ * those four call sites (two methods × two middlewares) used to hand-write the
+ * same `...(base ? { [key]: … } : {})` shape; this collapses it to one call so
+ * the four can't drift out of sync with each other.
+ * @param key the property name to install on the returned object
+ * @param base the underlying method, or `undefined` when the writer omits it
+ * @param build builds the override from the underlying method; only invoked when `base` is defined
+ * @returns `{ [key]: build(base) }` when `base` is defined, otherwise `{}` (so the spread adds nothing)
+ */
+const optionalWriterOverride = <F>(key: string, base: F | undefined, build: (base: F) => unknown): Record<string, unknown> =>
+    base ? { [key]: build(base) } : {};
+
+// eslint-disable-next-line import/prefer-default-export -- named export keeps the re-export chain through the module uniform (same rationale as `estimate-bytes.ts`/`serialize-sql.ts`).
+export { optionalWriterOverride };

--- a/packages/server/src/rank-page-rows-shape.ts
+++ b/packages/server/src/rank-page-rows-shape.ts
@@ -1,0 +1,38 @@
+/**
+ * Structural mirrors of `@lunora/shard-engine`'s rank-page-row shapes
+ * (`RankPageRowKey` / `RankPageRow` / `ShardRankPageResult`) — the return type
+ * of the writer's `rankPageRows` seam, the cross-shard companion to
+ * `rankPage`.
+ *
+ * Shared by `../rls/middleware` and `../mask/middleware`: both wrap
+ * `rankPageRows` structurally (no `@lunora/shard-engine` import, mirroring how
+ * every other method on their `DatabaseWriterLike`/`MaskDatabase` projections
+ * is hand-mirrored rather than imported) and both need the exact same result
+ * shape to type their overrides. A single copy here means the two wrappers
+ * can't drift out of lockstep with each other — see AGENTS.md's platform
+ * parity note on `ShardSqlExec` and the canonical binding `*Like` projections
+ * shipping wrong for exactly this reason (two hand-maintained mirrors of one
+ * upstream type).
+ */
+
+/** Structural mirror of `@lunora/shard-engine`'s `RankPageRowKey`. */
+interface RankPageRowKeyLike {
+    partitionKey: string;
+    rowId: string;
+    sortValues: ReadonlyArray<unknown>;
+}
+
+/** Structural mirror of `@lunora/shard-engine`'s `RankPageRow`. */
+interface RankPageRowLike {
+    doc: Record<string, unknown>;
+    key: RankPageRowKeyLike;
+}
+
+/** Structural mirror of `@lunora/shard-engine`'s `ShardRankPageResult` — the `rankPageRows` return shape. */
+interface ShardRankPageResultLike {
+    directions: ReadonlyArray<"asc" | "desc">;
+    hasMore: boolean;
+    rows: ReadonlyArray<RankPageRowLike>;
+}
+
+export type { RankPageRowKeyLike, RankPageRowLike, ShardRankPageResultLike };

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -46,6 +46,8 @@ import type { Middleware } from "../builder/types";
 import { LunoraError } from "../error";
 import type { FacadeEntry } from "../facade";
 import { bindOrm, bindTableFacade } from "../facade";
+import { optionalWriterOverride } from "../optional-writer-override";
+import type { ShardRankPageResultLike } from "../rank-page-rows-shape";
 import { tagRlsMiddleware } from "./policy-tag";
 import { deny } from "./predicates";
 import type { Permission, Policy, PolicyContext, RlsOptions, Role, WhereInput } from "./types";
@@ -130,26 +132,6 @@ interface QueryPage {
     continueCursor: null | string;
     isDone: boolean;
     page: Record<string, unknown>[];
-}
-
-/** Structural mirror of `@lunora/shard-engine`'s `RankPageRowKey`. */
-interface RankPageRowKeyLike {
-    partitionKey: string;
-    rowId: string;
-    sortValues: ReadonlyArray<unknown>;
-}
-
-/** Structural mirror of `@lunora/shard-engine`'s `RankPageRow`. */
-interface RankPageRowLike {
-    doc: Record<string, unknown>;
-    key: RankPageRowKeyLike;
-}
-
-/** Structural mirror of `@lunora/shard-engine`'s `ShardRankPageResult` — the `rankPageRows` return shape. */
-interface ShardRankPageResultLike {
-    directions: ReadonlyArray<"asc" | "desc">;
-    hasMore: boolean;
-    rows: ReadonlyArray<RankPageRowLike>;
 }
 
 interface TableReaderLike {
@@ -1065,15 +1047,10 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
         return baseWhere;
     };
 
-    // `rankBefore` is the only analytical method that may be absent (the D1
-    // twin omits it); capture it so the truthy check narrows into the wrapper
-    // without a non-null assertion.
+    // `rankBefore`/`rankPageRows` are the two analytical methods that may be
+    // absent (the D1/sql-store twin omits both) — captured here so
+    // `optionalWriterOverride` below can narrow each without a non-null assertion.
     const baseRankBefore = base.rankBefore;
-
-    // `rankPageRows` (plan 254) is likewise optional — the D1/sql-store twin
-    // omits it too (only the shard-local engine implements the cross-shard
-    // rank companion) — captured the same way so the conditional override
-    // below narrows without a non-null assertion.
     const baseRankPageRows = base.rankPageRows;
 
     const wrapped: RlsDatabase = {
@@ -1536,42 +1513,29 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
             );
         },
 
-        // `rankBefore` is the one optional method (the D1 twin omits it).
-        ...(baseRankBefore
-            ? {
-                  rankBefore: (tableName: string, indexName: string, options: RankBeforeArgs) => {
-                      requireUnrestrictedReadBase(tableName, "rankBefore");
+        // `rankBefore`/`rankPageRows` are the two optional methods (the D1/sql-store
+        // twin omits both) — see `optionalWriterOverride`. `rankPageRows` fails
+        // closed for the same reason `rankPage` does: its rows carry partition
+        // rank keys that cannot be reduced under a row policy.
+        ...optionalWriterOverride("rankBefore", baseRankBefore, (rankBefore) => (tableName: string, indexName: string, options: RankBeforeArgs) => {
+            requireUnrestrictedReadBase(tableName, "rankBefore");
 
-                      // Route to the policy/non-policy writer; both carry
-                      // `rankBefore` when `base` does (the guard spreads `raw`).
-                      const target = route(tableName);
+            // Route to the policy/non-policy writer; both carry `rankBefore` when `base` does (the guard spreads `raw`).
+            const target = route(tableName);
 
-                      return (target.rankBefore ?? baseRankBefore)(tableName, indexName, options);
-                  },
-              }
-            : {}),
+            return (target.rankBefore ?? rankBefore)(tableName, indexName, options);
+        }),
+        ...optionalWriterOverride("rankPageRows", baseRankPageRows, (rankPageRows) => (tableName: string, indexName: string, options?: RankPageArgs) => {
+            const baseWhere = requireUnrestrictedReadBase(tableName, "rankPageRows");
 
-        // `rankPageRows` (plan 254) is likewise optional (the D1/sql-store twin
-        // omits it) — only synthesized when `base` actually carries one,
-        // mirroring the `rankBefore` conditional above. Same reasoning as
-        // `rankPage`: the returned rows carry partition rank keys that cannot
-        // be reduced under a row policy, so it fails closed the same way.
-        ...(baseRankPageRows
-            ? {
-                  rankPageRows: (tableName: string, indexName: string, options?: RankPageArgs) => {
-                      const baseWhere = requireUnrestrictedReadBase(tableName, "rankPageRows");
+            // Route to the policy/non-policy writer; both carry `rankPageRows` when `base` does (the guard spreads `raw`).
+            const target = route(tableName);
 
-                      // Route to the policy/non-policy writer; both carry
-                      // `rankPageRows` when `base` does (the guard spreads `raw`).
-                      const target = route(tableName);
-
-                      return (target.rankPageRows ?? baseRankPageRows)(tableName, indexName, {
-                          ...options,
-                          baseWhere: mergeBaseWhere(options?.baseWhere, baseWhere),
-                      });
-                  },
-              }
-            : {}),
+            return (target.rankPageRows ?? rankPageRows)(tableName, indexName, {
+                ...options,
+                baseWhere: mergeBaseWhere(options?.baseWhere, baseWhere),
+            });
+        }),
     };
 
     // SECURITY: the generated runtime glues a per-table facade

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -132,6 +132,26 @@ interface QueryPage {
     page: Record<string, unknown>[];
 }
 
+/** Structural mirror of `@lunora/shard-engine`'s `RankPageRowKey`. */
+interface RankPageRowKeyLike {
+    partitionKey: string;
+    rowId: string;
+    sortValues: ReadonlyArray<unknown>;
+}
+
+/** Structural mirror of `@lunora/shard-engine`'s `RankPageRow`. */
+interface RankPageRowLike {
+    doc: Record<string, unknown>;
+    key: RankPageRowKeyLike;
+}
+
+/** Structural mirror of `@lunora/shard-engine`'s `ShardRankPageResult` — the `rankPageRows` return shape. */
+interface ShardRankPageResultLike {
+    directions: ReadonlyArray<"asc" | "desc">;
+    hasMore: boolean;
+    rows: ReadonlyArray<RankPageRowLike>;
+}
+
 interface TableReaderLike {
     collect: () => Promise<Record<string, unknown>[]>;
     filter: (predicate: (document: Record<string, unknown>) => boolean) => TableReaderLike;
@@ -224,6 +244,14 @@ interface DatabaseWriterLike {
      * Required for the same reason as `aggregate`.
      */
     rankPage: (tableName: string, indexName: string, options?: RankPageArgs) => Promise<QueryPage>;
+
+    /**
+     * Cross-shard companion to `rankPage`: same ranked slice, but each row
+     * keeps its rank-key tuple for the query coordinator's k-way merge. Same
+     * count-of-partition RLS hazard as `rankPage` — failed closed under a read
+     * policy for the identical reason (see `rankPage` above).
+     */
+    rankPageRows?: (tableName: string, indexName: string, options?: RankPageArgs) => Promise<ShardRankPageResultLike>;
     replace: (id: string, document: Record<string, unknown>, expectedTable?: string) => Promise<void>;
     restore?: (id: string, expectedTable?: string) => Promise<void>;
 
@@ -1042,6 +1070,12 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
     // without a non-null assertion.
     const baseRankBefore = base.rankBefore;
 
+    // `rankPageRows` (plan 254) is likewise optional — the D1/sql-store twin
+    // omits it too (only the shard-local engine implements the cross-shard
+    // rank companion) — captured the same way so the conditional override
+    // below narrows without a non-null assertion.
+    const baseRankPageRows = base.rankPageRows;
+
     const wrapped: RlsDatabase = {
         ...base,
         async count(tableName, whereOrArgs) {
@@ -1219,6 +1253,47 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
 
             // eslint-disable-next-line unicorn/no-null -- null is the deliberate "denied" verdict surfaced by get(), mirroring @lunora/do
             return allowed?.["_id"] === id ? allowed : null;
+        },
+
+        // Same locate + readBase shape as `get` above, but returns the seam's
+        // `{ row, tableName }` pair rather than a bare row — this is the fast
+        // path `locateRow` itself probes via `raw.lookupById`, so the wrapped
+        // writer must apply the identical policy check before handing a row
+        // back, not just pass the raw seam through (the `...base` spread would
+        // otherwise expose `base.lookupById` unfiltered by any read policy).
+        async lookupById(id, expectedTable) {
+            const located = await locateRow(id, expectedTable);
+
+            if (!located.row) {
+                // eslint-disable-next-line unicorn/no-null -- mirrors get()'s absent-row null
+                return null;
+            }
+
+            // Row exists but isn't in any policy-gated table, or the owning
+            // table has no active read policy: defer to the GUARDED
+            // `base.lookupById` (secure-by-default for a protected table,
+            // pass-through for `.public()`), exactly like `get` defers to
+            // `base.get` in the same two cases.
+            if (located.tableName === undefined || !readBase(located.tableName).restricts) {
+                // eslint-disable-next-line unicorn/no-null -- mirrors the seam's own `null`-for-absent contract
+                return (await base.lookupById?.(id, expectedTable)) ?? null;
+            }
+
+            const { baseWhere } = readBase(located.tableName);
+
+            // Read policy grants unconditionally (`true` predicate, no baseWhere).
+            if (!baseWhere) {
+                return { row: located.row, tableName: located.tableName };
+            }
+
+            // Policy check: re-fetch WITH baseWhere on the owning table, through
+            // the UNGUARDED `raw` writer (a policy table — the guard would deny
+            // it). `null` here is the policy verdict ("denied"), not a fall
+            // through to the unguarded row.
+            const allowed = await raw.findFirst(located.tableName, { baseWhere, limit: 1, where: { _id: id } });
+
+            // eslint-disable-next-line unicorn/no-null -- null is the deliberate "denied" verdict, mirroring get()
+            return allowed?.["_id"] === id ? { row: allowed, tableName: located.tableName } : null;
         },
 
         async insert(tableName, document) {
@@ -1472,6 +1547,28 @@ const wrapDatabase = <Context>(base: RlsDatabase, raw: RlsDatabase, perTable: Ma
                       const target = route(tableName);
 
                       return (target.rankBefore ?? baseRankBefore)(tableName, indexName, options);
+                  },
+              }
+            : {}),
+
+        // `rankPageRows` (plan 254) is likewise optional (the D1/sql-store twin
+        // omits it) — only synthesized when `base` actually carries one,
+        // mirroring the `rankBefore` conditional above. Same reasoning as
+        // `rankPage`: the returned rows carry partition rank keys that cannot
+        // be reduced under a row policy, so it fails closed the same way.
+        ...(baseRankPageRows
+            ? {
+                  rankPageRows: (tableName: string, indexName: string, options?: RankPageArgs) => {
+                      const baseWhere = requireUnrestrictedReadBase(tableName, "rankPageRows");
+
+                      // Route to the policy/non-policy writer; both carry
+                      // `rankPageRows` when `base` does (the guard spreads `raw`).
+                      const target = route(tableName);
+
+                      return (target.rankPageRows ?? baseRankPageRows)(tableName, indexName, {
+                          ...options,
+                          baseWhere: mergeBaseWhere(options?.baseWhere, baseWhere),
+                      });
                   },
               }
             : {}),

--- a/packages/shard-engine/__tests__/rls-guard.test.ts
+++ b/packages/shard-engine/__tests__/rls-guard.test.ts
@@ -23,11 +23,15 @@ const createFakeWriter = () => {
         get: vi.fn<(id: string) => Promise<string>>((id: string) => Promise.resolve(`get:${id}`)),
         groupBy: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`groupBy:${tableName}`)),
         insert: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`insert:${tableName}`)),
+        lookupById: vi.fn<(id: string) => Promise<null | { row: Record<string, unknown>; tableName: string }>>((id: string) =>
+            Promise.resolve({ row: { _id: id }, tableName: "sentinel" }),
+        ),
         patch: vi.fn<(id: string) => Promise<string>>((id: string) => Promise.resolve(`patch:${id}`)),
         query: vi.fn<(tableName: string) => string>((tableName: string) => `query:${tableName}`),
         rank: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`rank:${tableName}`)),
         rankBefore: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`rankBefore:${tableName}`)),
         rankPage: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`rankPage:${tableName}`)),
+        rankPageRows: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`rankPageRows:${tableName}`)),
         replace: vi.fn<(id: string) => Promise<string>>((id: string) => Promise.resolve(`replace:${id}`)),
     };
 };
@@ -84,6 +88,7 @@ describe("guardWriter — table-named methods under .rls('required')", () => {
         "rank",
         "rankBefore",
         "rankPage",
+        "rankPageRows",
     ] as const;
 
     it.each(tableMethods)("denies %s against the protected table", (method) => {
@@ -124,6 +129,7 @@ describe("guardWriter — id-based methods with a pinned table (by-id facade)", 
     const idMethods: ReadonlyArray<{ call: (m: Record<string, (...a: unknown[]) => unknown>, table: string) => unknown; name: string }> = [
         { call: (m, table) => m["delete"]!("any-id", table), name: "delete" },
         { call: (m, table) => m["get"]!("any-id", table), name: "get" },
+        { call: (m, table) => m["lookupById"]!("any-id", table), name: "lookupById" },
         { call: (m, table) => m["patch"]!("any-id", {}, table), name: "patch" },
         { call: (m, table) => m["replace"]!("any-id", {}, table), name: "replace" },
     ];
@@ -181,6 +187,54 @@ describe("guardWriter — generic id-based access resolves the owning table", ()
         await guarded.patch("orphan_id", { x: 1 });
 
         expect(raw.patch).toHaveBeenCalledTimes(1);
+    });
+
+    it("denies lookupById(id) for a bare id that resolves to a protected table (plan 254)", async () => {
+        expect.assertions(2);
+
+        const raw = createFakeWriter();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as { lookupById: (id: string) => Promise<unknown> };
+
+        await expect(guarded.lookupById("post_42")).rejects.toThrow(RlsRequiredError);
+        expect(raw.lookupById).not.toHaveBeenCalled();
+    });
+
+    it("allows lookupById(id) for a bare id that resolves to a .public() table (plan 254)", async () => {
+        expect.assertions(1);
+
+        const raw = createFakeWriter();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as { lookupById: (id: string) => Promise<unknown> };
+
+        await guarded.lookupById("stat_7");
+
+        expect(raw.lookupById).toHaveBeenCalledWith("stat_7", undefined);
+    });
+
+    it("passes an unresolvable bare id through lookupById without throwing (nothing to leak) (plan 254)", async () => {
+        expect.assertions(2);
+
+        const raw = createFakeWriter();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as { lookupById: (id: string) => Promise<unknown> };
+
+        await expect(guarded.lookupById("orphan_id")).resolves.not.toBeNull();
+
+        expect(raw.lookupById).toHaveBeenCalledTimes(1);
+    });
+
+    it("lookupById(id) resolves null (does not throw) when the underlying writer has no match, mirroring the seam's own contract (plan 254)", async () => {
+        expect.assertions(1);
+
+        const raw = createFakeWriter();
+
+        // Override the fake's default sentinel-object return to mirror the
+        // real seam's "absent row" contract (`ctx-db.ts`'s `lookupById`
+        // returns `null`, never throws, when the id/table can't be resolved —
+        // e.g. a `.global()` row this shard-local seam can't see).
+        raw.lookupById.mockResolvedValueOnce(null);
+
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as { lookupById: (id: string) => Promise<unknown> };
+
+        await expect(guarded.lookupById("orphan_id")).resolves.toBeNull();
     });
 });
 

--- a/packages/shard-engine/__tests__/rls-guard.test.ts
+++ b/packages/shard-engine/__tests__/rls-guard.test.ts
@@ -123,6 +123,36 @@ describe("guardWriter — table-named methods under .rls('required')", () => {
     });
 });
 
+describe("guardWriter — optional analytical methods omitted on the underlying writer (D1/sql-store twin) (plan 254)", () => {
+    // `rankBefore` and `rankPageRows` are both optional on the real writer type
+    // (only the shard-local engine implements them; the D1/sql-store backend
+    // omits both) — the `...raw` spread must not leave an unguarded copy
+    // behind, and the guard must not synthesize a call that reaches into a
+    // method the raw writer never had (a TypeError, not a denial).
+    const optionalMethods = ["rankBefore", "rankPageRows"] as const;
+
+    it.each(optionalMethods)("does not synthesize %s when the raw writer omits it, and does not throw", (method) => {
+        expect.assertions(2);
+
+        const full = createFakeWriter();
+        // Omit `method` up front (rather than deleting it after the fact) so
+        // the fake writer never has the key at all, matching the D1/sql-store
+        // twin's actual shape rather than a shard-local writer with a key
+        // deleted off it.
+        const raw = Object.fromEntries(Object.entries(full).filter(([key]) => key !== method)) as Partial<FakeWriter>;
+
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as Record<string, unknown>;
+
+        expect(guarded[method]).toBeUndefined();
+        // Calling through the `...raw` spread's own copy (if any leaked) would
+        // either throw RlsRequiredError (still gated, acceptable) or a
+        // TypeError (the regression this test guards against) — assert the
+        // property itself is gone rather than calling it, since `undefined`
+        // is the only correct shape for "this writer doesn't support it".
+        expect(method in guarded).toBe(false);
+    });
+});
+
 describe("guardWriter — id-based methods with a pinned table (by-id facade)", () => {
     // `delete`/`get` pin the table at arg[1]; `patch`/`replace` carry a
     // body at arg[1] and pin at arg[2]. Each entry calls with the correct shape.

--- a/packages/shard-engine/src/rls-guard.ts
+++ b/packages/shard-engine/src/rls-guard.ts
@@ -86,6 +86,7 @@ interface GuardableWriter {
         documents: ReadonlyArray<Record<string, unknown>>,
         options?: { allowExplicitId?: boolean; limit?: number },
     ) => unknown;
+    lookupById?: (id: string, expectedTable?: string) => Promise<null | { row: Record<string, unknown>; tableName: string }>;
     patch: (id: string, patch: unknown, expectedTable?: string) => unknown;
     patchMany: (patches: ReadonlyArray<{ id: string; patch: Record<string, unknown> }>, options?: { limit?: number }, expectedTable?: string) => unknown;
     patchWhere?: (tableName: string, args: { patch: Record<string, unknown>; where: Record<string, unknown> }, options?: { limit?: number }) => unknown;
@@ -93,6 +94,7 @@ interface GuardableWriter {
     rank: (tableName: string, indexName: string, options: unknown) => unknown;
     rankBefore?: (tableName: string, indexName: string, options: unknown) => unknown;
     rankPage: (tableName: string, indexName: string, options?: unknown) => unknown;
+    rankPageRows: (tableName: string, indexName: string, options?: unknown) => unknown;
     replace: (id: string, document: unknown, expectedTable?: string, options?: { allowExplicitId?: boolean }) => unknown;
     restore?: (id: string, expectedTable?: string) => unknown;
     wipeShard?: (options?: { chunkSize?: number; exclude?: ReadonlyArray<string>; tables?: ReadonlyArray<string> }) => unknown;
@@ -314,6 +316,14 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
 
             return base.insertManyUnsafe(tableName, documents, options);
         },
+        lookupById: async (id: string, expectedTable?: string) => {
+            // The spread would otherwise expose the raw lookup, letting a bare id
+            // read any row in any table past the table-level secure-by-default check.
+            await guardById(id, expectedTable);
+
+            // eslint-disable-next-line unicorn/no-null -- mirrors the seam's own `null`-for-absent contract
+            return base.lookupById?.(id, expectedTable) ?? null;
+        },
         patch: async (id: string, patch: unknown, expectedTable?: string) => {
             await guardById(id, expectedTable);
 
@@ -351,6 +361,11 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
             guardTable(tableName);
 
             return base.rankPage(tableName, indexName, options);
+        },
+        rankPageRows: (tableName: string, indexName: string, options?: unknown) => {
+            guardTable(tableName);
+
+            return base.rankPageRows(tableName, indexName, options);
         },
         replace: async (id: string, document: unknown, expectedTable?: string, options?: { allowExplicitId?: boolean }) => {
             await guardById(id, expectedTable);

--- a/packages/shard-engine/src/rls-guard.ts
+++ b/packages/shard-engine/src/rls-guard.ts
@@ -94,7 +94,7 @@ interface GuardableWriter {
     rank: (tableName: string, indexName: string, options: unknown) => unknown;
     rankBefore?: (tableName: string, indexName: string, options: unknown) => unknown;
     rankPage: (tableName: string, indexName: string, options?: unknown) => unknown;
-    rankPageRows: (tableName: string, indexName: string, options?: unknown) => unknown;
+    rankPageRows?: (tableName: string, indexName: string, options?: unknown) => unknown;
     replace: (id: string, document: unknown, expectedTable?: string, options?: { allowExplicitId?: boolean }) => unknown;
     restore?: (id: string, expectedTable?: string) => unknown;
     wipeShard?: (options?: { chunkSize?: number; exclude?: ReadonlyArray<string>; tables?: ReadonlyArray<string> }) => unknown;
@@ -229,6 +229,7 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
     };
 
     const baseRankBefore = base.rankBefore;
+    const baseRankPageRows = base.rankPageRows;
 
     const guarded: Record<PropertyKey, unknown> = {
         ...(raw as Record<string, unknown>),
@@ -362,11 +363,6 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
 
             return base.rankPage(tableName, indexName, options);
         },
-        rankPageRows: (tableName: string, indexName: string, options?: unknown) => {
-            guardTable(tableName);
-
-            return base.rankPageRows(tableName, indexName, options);
-        },
         replace: async (id: string, document: unknown, expectedTable?: string, options?: { allowExplicitId?: boolean }) => {
             await guardById(id, expectedTable);
 
@@ -387,6 +383,14 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
             guardTable(tableName);
 
             return baseRankBefore(tableName, indexName, options);
+        };
+    }
+
+    if (baseRankPageRows) {
+        guarded["rankPageRows"] = (tableName: string, indexName: string, options?: unknown) => {
+            guardTable(tableName);
+
+            return baseRankPageRows(tableName, indexName, options);
         };
     }
 


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(server,shard-engine): gate lookupById and rankPageRows in the writer wrappers
- fix(shard-engine): don't call an absent rankPageRows unguarded in guardWriter
- refactor(server): dedupe rank-page-row mirror types and optional-override spread

## Files this branch still changes relative to alpha

```
packages/server/__tests__/mask.test.ts
packages/server/__tests__/rls.test.ts
packages/server/src/mask/middleware.ts
packages/server/src/optional-writer-override.ts
packages/server/src/rank-page-rows-shape.ts
packages/server/src/rls/middleware.ts
packages/shard-engine/__tests__/rls-guard.test.ts
packages/shard-engine/src/rls-guard.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ranked, paginated row results while preserving access controls across data partitions.
  * Added permission-aware masking for ranked results and direct record lookups.
* **Bug Fixes**
  * Direct lookups now consistently enforce ownership and read policies.
  * Restricted analytical queries fail safely when the required permissions are unavailable.
  * Improved protection for tables without applicable policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->