### PR TITLE
fix(bindings,codegen): scope ctx.vectors reads by the DO shard namespace

### DIFF
--- a/packages/bindings/__tests__/vectors/ctx.test.ts
+++ b/packages/bindings/__tests__/vectors/ctx.test.ts
@@ -95,6 +95,179 @@ describe("createContextVectors", () => {
     });
 });
 
+describe("createContextVectors — namespace default (tenant isolation, plan 255)", () => {
+    it("the 1-arg form forwards `undefined` (no behaviour change)", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex();
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora);
+
+        await context.query("docs", { vector: [0.1] });
+
+        expect(index.query).toHaveBeenCalledWith([0.1], expect.objectContaining({ namespace: undefined }));
+    });
+
+    it("query defaults to the constructor namespace when the input has none", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex();
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+
+        await context.query("docs", { vector: [0.1] });
+
+        expect(index.query).toHaveBeenCalledWith([0.1], expect.objectContaining({ namespace: "tenant-a" }));
+    });
+
+    it("an explicit input.namespace wins over the constructor default", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex();
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+
+        await context.query("docs", { namespace: "tenant-b", vector: [0.1] });
+
+        expect(index.query).toHaveBeenCalledWith([0.1], expect.objectContaining({ namespace: "tenant-b" }));
+    });
+
+    it("upsert/upsertNow default to the constructor namespace when the input has none", async () => {
+        expect.assertions(2);
+
+        const index = fakeIndex();
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+        const embed = async (value: string): Promise<ReadonlyArray<number>> => [value.length];
+
+        await context.upsert("docs", { embed, id: "a", input: "hello" });
+        await context.upsertNow("docs", { embed, id: "b", input: "yo" });
+
+        expect(index.upsert).toHaveBeenNthCalledWith(1, [{ id: "a", metadata: undefined, namespace: "tenant-a", values: [5] }]);
+        expect(index.upsert).toHaveBeenNthCalledWith(2, [{ id: "b", metadata: undefined, namespace: "tenant-a", values: [2] }]);
+    });
+
+    it("upsert honors an explicit input.namespace over the constructor default", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex();
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+        const embed = async (value: string): Promise<ReadonlyArray<number>> => [value.length];
+
+        await context.upsert("docs", { embed, id: "a", input: "hello", namespace: "tenant-b" });
+
+        expect(index.upsert).toHaveBeenCalledWith([{ id: "a", metadata: undefined, namespace: "tenant-b", values: [5] }]);
+    });
+
+    it("getByIds under a default namespace returns only the matching records (fails pre-fix: returns all)", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex({
+            getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+                ids.map((id) => {
+                    return { id, namespace: id === "a" ? "tenant-a" : "tenant-b", values: [1, 2] };
+                }),
+            ),
+        });
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+
+        const records = await context.getByIds("docs", ["a", "b"]);
+
+        expect(records).toEqual([{ id: "a", metadata: undefined, namespace: "tenant-a", values: [1, 2] }]);
+    });
+
+    it("getByIds fails closed on a record with no namespace at all", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex({
+            getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+                ids.map((id) => {
+                    return { id, values: [1, 2] };
+                }),
+            ),
+        });
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+
+        const records = await context.getByIds("docs", ["a"]);
+
+        expect(records).toEqual([]);
+    });
+
+    it("getByIds with no default namespace passes every record through unfiltered", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex({
+            getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+                ids.map((id) => {
+                    return { id, namespace: id === "a" ? "tenant-a" : "tenant-b", values: [1, 2] };
+                }),
+            ),
+        });
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora);
+
+        const records = await context.getByIds("docs", ["a", "b"]);
+
+        expect(records).toEqual([
+            { id: "a", metadata: undefined, namespace: "tenant-a", values: [1, 2] },
+            { id: "b", metadata: undefined, namespace: "tenant-b", values: [1, 2] },
+        ]);
+    });
+
+    it("deleteByIds under a default namespace only deletes the matching subset (fails pre-fix: deletes all)", async () => {
+        expect.assertions(2);
+
+        const index = fakeIndex({
+            getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+                ids.map((id) => {
+                    return { id, namespace: id === "a" ? "tenant-a" : "tenant-b", values: [1, 2] };
+                }),
+            ),
+        });
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+
+        await context.deleteByIds("docs", ["a", "b"]);
+
+        expect(index.getByIds).toHaveBeenCalledWith(["a", "b"]);
+        expect(index.deleteByIds).toHaveBeenCalledWith(["a"]);
+    });
+
+    it("deleteByIds under a default namespace is a no-op (skips the underlying delete) when nothing matches", async () => {
+        expect.assertions(1);
+
+        const index = fakeIndex({
+            getByIds: vi.fn<VectorizeIndexLike["getByIds"]>(async (ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> =>
+                ids.map((id) => {
+                    return { id, namespace: "tenant-b", values: [1, 2] };
+                }),
+            ),
+        });
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora, { namespace: "tenant-a" });
+
+        await context.deleteByIds("docs", ["a"]);
+
+        expect(index.deleteByIds).not.toHaveBeenCalled();
+    });
+
+    it("deleteByIds with no default namespace passes every id through unfiltered (no getByIds pre-read)", async () => {
+        expect.assertions(2);
+
+        const index = fakeIndex();
+        const lunora = createVectors({ indexes: { docs: index } });
+        const context = createContextVectors(lunora);
+
+        await context.deleteByIds("docs", ["a", "b"]);
+
+        expect(index.getByIds).not.toHaveBeenCalled();
+        expect(index.deleteByIds).toHaveBeenCalledWith(["a", "b"]);
+    });
+});
+
 const fakeVectorSearch = (): VectorSearchLike & { deletes: [string, ReadonlyArray<string>][]; upserts: [string, unknown][] } => {
     const upserts: [string, unknown][] = [];
     const deletes: [string, ReadonlyArray<string>][] = [];

--- a/packages/bindings/docs/index.mdx
+++ b/packages/bindings/docs/index.mdx
@@ -115,6 +115,14 @@ export const search = action({
 
 `query(index, { input })` embeds `input` with the index's configured embedder, then runs the search; pass a precomputed `vector` instead of `input` to skip embedding. `upsert` / `upsertMany` write vectors back. The index name is narrowed to the ones your schema declares, so a typo is a compile error.
 
+### Tenant isolation on `.shardBy()` tables
+
+Vectorize indexes are **account-global** — every shard DO shares the same index, so a query with no `namespace` matches every tenant's vectors. When a `.shardBy()`'d table declares a vector index, codegen scopes both sides automatically: the auto-sync write hook and `ctx.vectors` itself default `namespace` to the owning DO's shard key, so `ctx.vectors.query`/`getByIds`/`deleteByIds`/`upsert`/`upsertNow` only ever see this tenant's vectors unless you pass an explicit `namespace` yourself (which always wins over the default).
+
+Vectorize's id-based operations (`getByIds`, `deleteByIds`) take no `namespace` option at all, so that isolation is enforced client-side rather than by a remote filter: `getByIds` drops any returned record whose `namespace` doesn't match (a record with no `namespace` is treated as a mismatch, never as "belongs to everyone"), and `deleteByIds` resolves the ids first and only deletes the ones that belong to the caller's namespace.
+
+A vectorized table with **no** `.shardBy()` (or the single default DO) keeps today's namespace-less behavior — there is no per-tenant key to scope by.
+
 ### Filtering on metadata
 
 `.vectorize(field, { metadata: ["authorId"] })` mirrors those columns into each vector's metadata so `query(index, { filter })` can narrow by them:

--- a/packages/bindings/src/vectors/context.ts
+++ b/packages/bindings/src/vectors/context.ts
@@ -1,6 +1,6 @@
 import { resolveDocumentPath } from "../../../../shared/document-path";
 import { concurrentMap, UPSERT_EMBED_CONCURRENCY } from "./concurrent";
-import type { LunoraVectors } from "./types";
+import type { LunoraVectors, VectorizeVector } from "./types";
 
 /**
  * `(input: string) => vector`. Matches `@lunora/server`'s `VectorEmbedder` so
@@ -22,6 +22,7 @@ interface VectorMatchesLike {
 interface VectorRecordLike {
     id: string;
     metadata?: Record<string, unknown>;
+    namespace?: string;
     values: ReadonlyArray<number>;
 }
 
@@ -63,32 +64,91 @@ interface VectorSearchLike {
     upsertNow: (indexName: string, input: VectorUpsertInputLike) => Promise<void>;
 }
 
+/** Options for {@link createContextVectors}. */
+interface CreateContextVectorsOptions {
+    /**
+     * The DO's own shard/tenant key, applied as the default `namespace` for
+     * every read/write that doesn't pass one explicitly. Vectorize indexes are
+     * account-global, so without this a sharded app's `ctx.vectors.query` (and
+     * `getByIds`/`deleteByIds`, which Vectorize can't filter by namespace
+     * remotely at all) matches or returns every tenant's vectors. `undefined`
+     * (the default, and always the case for a root-mode/unsharded DO) keeps
+     * today's namespace-less behaviour — byte-identical codegen for schemas
+     * with no `.shardBy()`'d vector table.
+     */
+    namespace?: string;
+}
+
 /**
  * Bridge `LunoraVectors` (returns Vectorize mutation receipts) to the server's
  * `VectorSearch` contract (void mutations, server match/record shapes). Both
  * `upsert` and `upsertNow` write inline — this design has no post-commit queue,
  * so "now" and "deferred" collapse to the same synchronous call.
+ *
+ * Tenant isolation (read side) — IMPORTANT: `options.namespace`, when passed,
+ * defaults every operation's `namespace` to the caller's shard/tenant key
+ * whenever the operation itself doesn't specify one explicitly (an explicit
+ * `input.namespace` always wins). `query`/`upsert`/`upsertNow` forward the
+ * default straight to Vectorize, which filters remotely. `getByIds` and
+ * `deleteByIds` can't — Vectorize's id-based operations take no `namespace`
+ * option at all — so isolation there is enforced client-side: `getByIds`
+ * drops any returned record whose `namespace` doesn't match (fail closed: a
+ * record with no `namespace` field is treated as a mismatch, never treated as
+ * "belongs to everyone"), and `deleteByIds` resolves ids via `getByIds` first
+ * and only deletes the subset that belongs to the caller's namespace.
  */
-const createContextVectors = (lunora: LunoraVectors): VectorSearchLike => {
+const createContextVectors = (lunora: LunoraVectors, options?: CreateContextVectorsOptions): VectorSearchLike => {
+    const defaultNamespace = options?.namespace;
+
     const upsert = async (indexName: string, input: VectorUpsertInputLike): Promise<void> => {
         await lunora.upsert(indexName, {
             embed: input.embed,
             id: input.id,
             input: input.input,
             metadata: input.metadata,
-            namespace: input.namespace,
+            namespace: input.namespace ?? defaultNamespace,
         });
+    };
+
+    // Shared by `getByIds` and `deleteByIds`: fetch the raw records and keep
+    // only the ones whose `namespace` matches the active default. Vectorize's
+    // id-based operations carry no remote namespace filter, so this is the
+    // only enforcement point for the id path. Fail closed on a record with no
+    // `namespace` at all — absent is not "belongs to everyone".
+    const getMatchingRecords = async (indexName: string, ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorizeVector>> => {
+        const records = await lunora.getByIds(indexName, ids);
+
+        if (defaultNamespace === undefined) {
+            return records;
+        }
+
+        return records.filter((record) => record.namespace === defaultNamespace);
     };
 
     return {
         deleteByIds: async (indexName: string, ids: ReadonlyArray<string>): Promise<void> => {
-            await lunora.deleteByIds(indexName, ids);
+            if (defaultNamespace === undefined) {
+                await lunora.deleteByIds(indexName, ids);
+
+                return;
+            }
+
+            const matching = await getMatchingRecords(indexName, ids);
+
+            if (matching.length === 0) {
+                return;
+            }
+
+            await lunora.deleteByIds(
+                indexName,
+                matching.map((record) => record.id),
+            );
         },
         getByIds: async (indexName: string, ids: ReadonlyArray<string>): Promise<ReadonlyArray<VectorRecordLike>> => {
-            const records = await lunora.getByIds(indexName, ids);
+            const records = await getMatchingRecords(indexName, ids);
 
             return records.map((record) => {
-                return { id: record.id, metadata: record.metadata, values: record.values };
+                return { id: record.id, metadata: record.metadata, namespace: record.namespace, values: record.values };
             });
         },
         query: async (indexName: string, input: VectorQueryInputLike): Promise<VectorMatchesLike> => {
@@ -96,7 +156,7 @@ const createContextVectors = (lunora: LunoraVectors): VectorSearchLike => {
                 embed: input.embed,
                 filter: input.filter,
                 input: input.input,
-                namespace: input.namespace,
+                namespace: input.namespace ?? defaultNamespace,
                 // Default to "indexed" rather than "all": returning every
                 // metadata field by default leaks whatever was stored on the
                 // vector (potentially cross-tenant if namespaces aren't wired).
@@ -174,6 +234,14 @@ const sharedNamespaceWarned = new Set<string>();
  * index carries no metadata, so the warning fires on ANY namespace-less sync,
  * not only when metadata is present. Side-effect-only: never touches the upsert
  * payload. At most one warning per index name per process.
+ *
+ * Note (plan 255): for a `.shardBy()`'d vectorized table, codegen wires the
+ * matching read-side default automatically — the `createContextVectors`
+ * instance handed to `ctx.vectors` gets the same shard key as `namespace`,
+ * so this warning firing (write side unscoped) implies the read side is
+ * unscoped too. It only fires when the app itself constructs an unscoped
+ * sync hook (no `.shardBy()`'d table, or a hand-rolled `createVectorSyncHook`
+ * call outside codegen).
  */
 const warnSharedNamespace = (indexName: string): void => {
     if (sharedNamespaceWarned.has(indexName)) {
@@ -222,6 +290,19 @@ const pickMetadata = (row: Record<string, unknown>, fields: ReadonlyArray<string
  * owns this hook. Any namespace-less sync emits a one-time-per-index dev warning
  * (regardless of whether metadata is present); a genuinely single-tenant app
  * suppresses it with `allowSharedNamespace: true`.
+ *
+ * Since plan 255, codegen satisfies the query-side requirement automatically
+ * for a `.shardBy()`'d vectorized table: the `vectors` instance passed in
+ * `options` here is the SAME `createContextVectors(...)` instance exposed as
+ * `ctx.vectors`, constructed with the identical shard-key `namespace` default —
+ * so `ctx.vectors.query`/`getByIds`/`deleteByIds` are scoped without any app
+ * code changes. One consequence of sharing that instance: this hook's own
+ * internal `deleteByIds` calls (on row delete, on a cleared inline field, and
+ * on compensation after a failed upsert) now also go through the
+ * namespace-verifying path described on {@link createContextVectors} — an
+ * extra `getByIds` subrequest per delete-shaped write, not a behavior change
+ * (the row being deleted was written under this same shard's namespace, so
+ * the verification passes).
  *
  * Consistency — IMPORTANT: this hook runs inline within the mutation but talks
  * to Vectorize, which is external and non-transactional. The per-index calls
@@ -344,6 +425,7 @@ const createVectorSyncHook = (options: { allowSharedNamespace?: boolean; namespa
 };
 
 export type {
+    CreateContextVectorsOptions,
     SchemaLike,
     TableDefinitionLike,
     TableVectorIndexLike,

--- a/packages/codegen/__tests__/discover-mask-metadata.test.ts
+++ b/packages/codegen/__tests__/discover-mask-metadata.test.ts
@@ -157,4 +157,74 @@ describe("discoverMaskHasNonLiteralPolicy", () => {
 
         expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(false);
     });
+
+    // Plan 257: `dfa7e16ee` closed the `mask(sharedPolicies)` fail-open above,
+    // but a spread-bearing OR computed-keyed object literal argument still IS
+    // an object literal — `extractMaskColumns` skips the member it can't name
+    // and contributes zero pairs for it, silently reopening the same
+    // fail-open through a trivial rewrite of the policies object. These four
+    // cases pin the closed hole; the fifth pins the no-false-positive
+    // boundary.
+
+    it("is true when a mask() policies object literal spreads a variable at the table level", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    const sharedPolicies = { users: { email: "redact" } };
+
+    export const list = c.query.use(mask({ ...sharedPolicies })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true when a mask() policies object literal has a computed table key", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    const tableName = "users";
+
+    export const list = c.query.use(mask({ [tableName]: { email: "redact" } })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true when a mask() policies object literal spreads a variable at the column level (nested under a literal table key)", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    const piiColumns = { email: "redact" as const };
+
+    export const list = c.query.use(mask({ users: { ...piiColumns } })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is false for a mask() policies object literal using a quoted string key (not a computed key)", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    export const list = c.query.use(mask({ "users": { "email": "redact" } })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(false);
+    });
 });

--- a/packages/codegen/__tests__/discover-mask-metadata.test.ts
+++ b/packages/codegen/__tests__/discover-mask-metadata.test.ts
@@ -227,4 +227,142 @@ describe("discoverMaskHasNonLiteralPolicy", () => {
 
         expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(false);
     });
+
+    it("is false for a nested custom-strategy object at the column value (NOT a fail-open — a spread there is inside the strategy value, not a table/column key)", () => {
+        expect.assertions(1);
+
+        // Regression: `objectLiteralHasUnnameableMember` originally recursed
+        // unboundedly into every nested object literal, so a THIRD level here
+        // (the strategy value itself, e.g. `{ kind: "custom", ...opts }`) was
+        // wrongly treated the same as an unnameable table/column key. Every
+        // table and column key in this call is a fully literal, fully
+        // enumerable string — `strategyOf` labels the "ssn" column "custom"
+        // without ever needing to look inside its value — so this must stay
+        // `false`, matching `extractMaskColumns`'s exact two-level walk.
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    const opts = { note: "sensitive" };
+
+    export const list = c.query.use(mask({ users: { ssn: { kind: "custom", ...opts } } })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(false);
+    });
+
+    it("is true for a set-accessor table member (a member kind memberName rejects, just like a spread)", () => {
+        expect.assertions(1);
+
+        // `memberName` only accepts PropertyAssignment/ShorthandPropertyAssignment/
+        // MethodDeclaration/GetAccessorDeclaration — a SetAccessorDeclaration table
+        // entry is silently skipped by `extractMaskColumns` (same as a spread), so
+        // it must count as unnameable here too.
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    export const list = c.query.use(mask({ set users(_value: unknown) {} })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true for a set-accessor column member (nested under a literal table key)", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    export const list = c.query.use(mask({ users: { set email(_value: unknown) {}, name: "hash" } })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    // A table entry can be an unenumerable non-object-literal value (or an
+    // unenumerable KEY shape) while the top-level `mask(...)` argument is
+    // still a plain object literal — `extractMaskColumns`'s table loop skips
+    // any such entry (`continue`), contributing zero columns for it, same as
+    // a spread/computed table key. Each of these must be `true`.
+
+    it("is true when a table's value is an identifier reference, not an inline object literal", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    const piiColumns = { email: "redact" as const };
+
+    export const list = c.query.use(mask({ users: piiColumns })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true when a table's value is an object literal wrapped in `as const`", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    export const list = c.query.use(mask({ users: { email: "redact" } as const })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true when a table's value is an object literal wrapped in `satisfies`", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    export const list = c.query.use(mask({ users: { email: "redact" } satisfies Record<string, Strategy> })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true when a table's value is a call expression", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    declare function buildPolicy(): Record<string, Strategy>;
+
+    export const list = c.query.use(mask({ users: buildPolicy() })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
+
+    it("is true when a table entry is a shorthand property (referencing a variable, not a plain key: value pair)", () => {
+        expect.assertions(1);
+
+        writeFileSync(
+            join(workdir, "lunora", "users.ts"),
+            `${PREAMBLE}
+    const users = { email: "redact" as const };
+
+    export const list = c.query.use(mask({ users })).query(() => null);
+`,
+            "utf8",
+        );
+
+        expect(discoverMaskHasNonLiteralPolicy(project, join(workdir, "lunora"))).toBe(true);
+    });
 });

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2752,7 +2752,7 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
         });
 
         it("emits the bare (namespace-less) createVectorSyncHook call for an unsharded (root) vectorized table", () => {
-            expect.assertions(4);
+            expect.assertions(5);
 
             const schema: SchemaIR = {
                 tables: [
@@ -2776,13 +2776,15 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             // shard key to scope by — so the emit must stay byte-identical to
             // today: no `namespace`, no `ROOT_SHARD_NAME` import, no shard-key read.
             expect(output).toContain("onWrite = createVectorSyncHook({ schema: schema as unknown as VectorSchemaLike, vectors });");
+            // The read side (`ctx.vectors`) must stay just as bare as the write side.
+            expect(output).toContain("vectors = createContextVectors(lunora);");
             expect(output).not.toContain("namespace:");
             expect(output).not.toContain("ROOT_SHARD_NAME");
             expect(output).not.toContain("currentShardKey");
         });
 
         it("scopes the createVectorSyncHook auto-sync by the DO's shard key when the vectorized table is .shardBy()'d", () => {
-            expect.assertions(5);
+            expect.assertions(6);
 
             const schema: SchemaIR = {
                 tables: [
@@ -2813,12 +2815,16 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             expect(output).toContain(
                 "onWrite = createVectorSyncHook({ namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, schema: schema as unknown as VectorSchemaLike, vectors });",
             );
+            // The read side gets the same sentinel-mapped namespace default —
+            // the cross-tenant leak this plan closes was on `ctx.vectors`, not
+            // just the auto-sync write hook above.
+            expect(output).toContain("vectors = createContextVectors(lunora, { namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey });");
             expect(output).toContain("vectors,");
             expect(output).toContain("onWrite,");
         });
 
         it("scopes the createVectorSyncHook auto-sync by the DO's shard key when the vectorized table is indexed via a standalone defineVectorIndex (Shape B), not inline .vectorize()", () => {
-            expect.assertions(5);
+            expect.assertions(6);
 
             const schema: SchemaIR = {
                 tables: [
@@ -2851,6 +2857,7 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             expect(output).toContain(
                 "onWrite = createVectorSyncHook({ namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, schema: schema as unknown as VectorSchemaLike, vectors });",
             );
+            expect(output).toContain("vectors = createContextVectors(lunora, { namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey });");
             expect(output).toContain("vectors,");
             expect(output).toContain("onWrite,");
         });

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -255,6 +255,53 @@ export default defineSchema({
             expect(() => runCodegen({ projectRoot: workdir })).toThrow(/mask\(\.\.\.\)` policy whose argument isn't a plain object literal/u);
         });
 
+        it("rejects a shape when a mask() policies object literal spreads a variable (fail closed on spread/computed mask keys, plan 257)", () => {
+            expect.assertions(1);
+
+            // `mask({ ...sharedPolicies })`'s argument IS an object literal, so the
+            // pre-plan-257 non-literal-policy guard (which only rejected a
+            // non-object-literal argument) let this through — `extractMaskColumns`
+            // still contributes ZERO pairs for the spread member, so a shape over
+            // "users" would have shipped raw. Pre-fix this build SUCCEEDS; post-fix
+            // it must throw MASK_UNSUPPORTED.
+            writeFileSync(
+                join(workdir, "lunora", "userMask.ts"),
+                `
+                import { mask, query } from "@lunora/server";
+                const sharedPolicies = { users: { email: "redact" } };
+                export const listUsers = query.use(mask({ ...sharedPolicies })).query(async ({ ctx }) => ctx.db.findMany("users"));
+            `,
+            );
+            writeFileSync(
+                join(workdir, "lunora", "shapes.ts"),
+                `
+                import { defineShape } from "@lunora/server";
+                export const allUsers = defineShape({ table: "users", where: () => ({}) });
+            `,
+            );
+
+            expect(() => runCodegen({ projectRoot: workdir })).toThrow(/isn't a plain object literal.*spread.*computed key/su);
+        });
+
+        it("does not throw for a mask() policies object literal that spreads a variable when the project declares no shapes (scoping preserved)", () => {
+            expect.assertions(1);
+
+            // Same spread-bearing mask as above, but no `defineShape` anywhere —
+            // `assertNoMaskedShapeTable` only fires when `shapes.length > 0`, so a
+            // shape-free project stays buildable (degraded studio/advisor metadata,
+            // no leak path since nothing replicates raw rows).
+            writeFileSync(
+                join(workdir, "lunora", "userMask.ts"),
+                `
+                import { mask, query } from "@lunora/server";
+                const sharedPolicies = { users: { email: "redact" } };
+                export const listUsers = query.use(mask({ ...sharedPolicies })).query(async ({ ctx }) => ctx.db.findMany("users"));
+            `,
+            );
+
+            expect(() => runCodegen({ projectRoot: workdir })).not.toThrow();
+        });
+
         it("is silent and output-unchanged when LUNORA_CODEGEN_TIMING is unset", () => {
             expect.assertions(3);
 

--- a/packages/codegen/src/discover-mask-procedures.ts
+++ b/packages/codegen/src/discover-mask-procedures.ts
@@ -1,4 +1,4 @@
-import type { CallExpression, Node as TsNode, Project, SourceFile } from "ts-morph";
+import type { CallExpression, Node as TsNode, ObjectLiteralExpression, Project, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
 import { classifyProcedureCall, listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
@@ -490,14 +490,68 @@ const discoverMaskStrategies = (project: Project, lunoraDirectory: string): Mask
 };
 
 /**
+ * True when `member` has a name {@link memberName} would resolve, but the name
+ * is COMPUTED (`[expr]: …`) rather than a plain identifier/string/numeric
+ * literal — e.g. `mask({ [tableName]: { email: "redact" } })`. Whether
+ * ts-morph's `getName()` renders the bracketed source text or throws for such
+ * a member, neither is a table/column name codegen can trust enumerating
+ * against, so this is checked independently of {@link memberName} rather than
+ * relying on it returning `undefined`. Covers every member kind `memberName`
+ * accepts except `ShorthandPropertyAssignment`, which can't have a computed
+ * name by grammar.
+ */
+const hasComputedName = (member: TsNode): boolean => {
+    if (Node.isPropertyAssignment(member) || Node.isMethodDeclaration(member) || Node.isGetAccessorDeclaration(member)) {
+        return Node.isComputedPropertyName(member.getNameNode());
+    }
+
+    return false;
+};
+
+/**
+ * True when `object` — a `mask(...)` policies literal, or one of its
+ * table-level initializers — has a member {@link extractMaskColumns} can't
+ * enumerate: a `SpreadAssignment` (`...shared`) or a computed property name
+ * (`[expr]: …`), at EITHER the table level or, recursively, the column level
+ * (`mask({ users: { ...piiColumns } })` hides columns of a perfectly literal,
+ * named table). Mirrors the two-level table→column walk
+ * {@link extractMaskColumns}/{@link extractMaskColumnMetadata} perform, so
+ * "this object has a member the extractors would skip" and "this object has
+ * an unnameable member" agree by construction.
+ */
+const objectLiteralHasUnnameableMember = (object: ObjectLiteralExpression): boolean => {
+    for (const property of object.getProperties()) {
+        if (Node.isSpreadAssignment(property) || hasComputedName(property)) {
+            return true;
+        }
+
+        if (Node.isPropertyAssignment(property)) {
+            const initializer = property.getInitializer();
+
+            if (initializer && Node.isObjectLiteralExpression(initializer) && objectLiteralHasUnnameableMember(initializer)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+};
+
+/**
  * True when the project declares at least one `mask(...)` call whose policies
  * argument IS PRESENT but isn't a plain object literal — e.g. a hoisted
- * `mask(sharedPolicies)`. {@link extractMaskColumns}/{@link extractMaskColumnMetadata}
- * both return `[]` for that call (a variable reference can't be statically
- * enumerated), so every masked-column consumer derived from
- * {@link discoverMaskMetadata} is blind to whichever table(s) it actually
- * masks. `assertNoMaskedShapeTable` (in `run-codegen.ts`) uses this to fail
- * closed rather than clear a `defineShape` it can't actually prove safe.
+ * `mask(sharedPolicies)` — OR is an object literal that contains a spread or
+ * computed key (see {@link objectLiteralHasUnnameableMember}) at either the
+ * table or the column level — e.g. `mask({ ...sharedPolicies })`,
+ * `mask({ [tableName]: { email: "redact" } })`, or
+ * `mask({ users: { ...piiColumns } })`. {@link extractMaskColumns}/
+ * {@link extractMaskColumnMetadata} silently contribute `[]` (or an
+ * incomplete column list) for all of these — a variable reference, a spread,
+ * or a computed key can't be statically enumerated — so every masked-column
+ * consumer derived from {@link discoverMaskMetadata} is blind to whichever
+ * table(s)/column(s) the call actually masks. `assertNoMaskedShapeTable` (in
+ * `run-codegen.ts`) uses this to fail closed rather than clear a `defineShape`
+ * it can't actually prove safe.
  *
  * Deliberately kept OUT of {@link MaskMetadataIR} — that IR is JSON-embedded
  * verbatim into the generated `LUNORA_MASK_METADATA` literal and type-checked
@@ -514,7 +568,7 @@ const discoverMaskHasNonLiteralPolicy = (project: Project, lunoraDirectory: stri
             for (const maskCall of maskCallsInChain(receiver)) {
                 const argument = maskCall.getArguments()[0];
 
-                if (argument !== undefined && !Node.isObjectLiteralExpression(argument)) {
+                if (argument !== undefined && (!Node.isObjectLiteralExpression(argument) || objectLiteralHasUnnameableMember(argument))) {
                     return true;
                 }
             }

--- a/packages/codegen/src/discover-mask-procedures.ts
+++ b/packages/codegen/src/discover-mask-procedures.ts
@@ -509,28 +509,81 @@ const hasComputedName = (member: TsNode): boolean => {
 };
 
 /**
- * True when `object` — a `mask(...)` policies literal, or one of its
- * table-level initializers — has a member {@link extractMaskColumns} can't
- * enumerate: a `SpreadAssignment` (`...shared`) or a computed property name
- * (`[expr]: …`), at EITHER the table level or, recursively, the column level
- * (`mask({ users: { ...piiColumns } })` hides columns of a perfectly literal,
- * named table). Mirrors the two-level table→column walk
- * {@link extractMaskColumns}/{@link extractMaskColumnMetadata} perform, so
- * "this object has a member the extractors would skip" and "this object has
- * an unnameable member" agree by construction.
+ * True when `member` is something {@link memberName} can't turn into a usable
+ * table/column name — mirrors `memberName`'s accepted-kinds list BY
+ * CONSTRUCTION rather than enumerating specific unsupported kinds by name:
+ * anything that isn't one of the four kinds `memberName` accepts
+ * (`PropertyAssignment`, `ShorthandPropertyAssignment`, `MethodDeclaration`,
+ * `GetAccessorDeclaration`) is unnameable — this covers `SpreadAssignment`,
+ * `SetAccessorDeclaration`, and any other object-literal member kind
+ * ts-morph exposes now or later, matching exactly what the extractors'
+ * `memberName(...) === undefined` skip already treats as unenumerable. Among
+ * the four accepted kinds, a COMPUTED name is unnameable too even though
+ * `memberName` resolves some text for it (see {@link hasComputedName}).
  */
-const objectLiteralHasUnnameableMember = (object: ObjectLiteralExpression): boolean => {
+const isUnnameableMember = (member: TsNode): boolean => {
+    if (
+        Node.isPropertyAssignment(member) ||
+        Node.isShorthandPropertyAssignment(member) ||
+        Node.isMethodDeclaration(member) ||
+        Node.isGetAccessorDeclaration(member)
+    ) {
+        return hasComputedName(member);
+    }
+
+    return true;
+};
+
+/**
+ * True when `object` — a `mask(...)` policies literal — has a member
+ * {@link extractMaskColumns} can't enumerate, checked at the table level and,
+ * for each table entry that IS enumerable, ONE further level at the column
+ * level. This is exactly the two-level table→column walk
+ * {@link extractMaskColumns}/{@link extractMaskColumnMetadata} perform — NOT
+ * unbounded recursion, and NOT the same test at both levels.
+ *
+ * Table level applies {@link isUnnameableMember} plus a stricter shape check:
+ * the extractor's table loop requires the entry to be a plain property
+ * assignment (a shorthand, method, or get-accessor table entry — e.g.
+ * `{ users }` referencing a variable — is skipped there even though
+ * {@link memberName} can name it) whose value is a bare object literal; an
+ * identifier reference (`{ users: piiColumns }`), an `as const`/`satisfies`
+ * wrapper, or a call expression all fail that shape check and are treated as
+ * unnameable, matching the extractor's fall-through-and-skip.
+ *
+ * Column level (recursed one level in, `atColumnLevel: true`) applies only
+ * {@link isUnnameableMember} — a column's value is a STRATEGY, not required
+ * to be an object literal. {@link strategyOf} labels any non-string-literal
+ * strategy `"custom"` without needing to enumerate inside it, so column
+ * values are never shape-checked or recursed into further. A legitimately
+ * nested object at that depth — e.g.
+ * `mask({ users: { ssn: { kind: "custom", ...opts } } })`, a fully literal
+ * and fully enumerable table/column pair — is therefore NOT a fail-open the
+ * extractors miss, and flagging it would be a false positive (recursing past
+ * the column level was an earlier bug here).
+ */
+const objectLiteralHasUnnameableMember = (object: ObjectLiteralExpression, atColumnLevel = false): boolean => {
     for (const property of object.getProperties()) {
-        if (Node.isSpreadAssignment(property) || hasComputedName(property)) {
+        if (isUnnameableMember(property)) {
             return true;
         }
 
-        if (Node.isPropertyAssignment(property)) {
-            const initializer = property.getInitializer();
+        if (atColumnLevel) {
+            continue;
+        }
 
-            if (initializer && Node.isObjectLiteralExpression(initializer) && objectLiteralHasUnnameableMember(initializer)) {
-                return true;
-            }
+        if (!Node.isPropertyAssignment(property)) {
+            return true;
+        }
+
+        const initializer = property.getInitializer();
+
+        if (!initializer || !Node.isObjectLiteralExpression(initializer)) {
+            return true;
+        }
+
+        if (objectLiteralHasUnnameableMember(initializer, true)) {
+            return true;
         }
     }
 

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -4451,6 +4451,15 @@ const vectorsStub: VectorSearchLike = {
 `
         : "";
     const vectorNamespaceOption = hasShardedVectors ? "namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey, " : "";
+    // Read-side counterpart to `vectorNamespaceOption`: the same sentinel-mapped
+    // shard key, but threaded into `createContextVectors` so `ctx.vectors`
+    // (query/getByIds/deleteByIds/upsert/upsertNow) defaults to this DO's own
+    // namespace too — otherwise `ctx.vectors.query` searches every tenant's
+    // vectors (namespace-less Vectorize queries match the whole index) even
+    // though the auto-sync write hook above is already scoped. Gated on
+    // `hasShardedVectors` so an unsharded (or no-vectors) schema keeps emitting
+    // the bare `createContextVectors(lunora)` call, byte-identical.
+    const vectorsContextNamespaceOption = hasShardedVectors ? ", { namespace: vectorShardKey === ROOT_SHARD_NAME ? undefined : vectorShardKey }" : "";
     const vectorsBuild = hasVectors
         ? `
             let vectors: VectorSearchLike;
@@ -4459,7 +4468,7 @@ const vectorsStub: VectorSearchLike = {
             if (config.vectors) {
                 const lunora = createVectors({ indexes: config.vectors(env) });
 ${vectorNamespaceField}
-                vectors = createContextVectors(lunora);
+                vectors = createContextVectors(lunora${vectorsContextNamespaceOption});
                 onWrite = createVectorSyncHook({ ${vectorNamespaceOption}schema: schema as unknown as VectorSchemaLike, vectors });
             } else {
                 vectors = vectorsStub;

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -310,7 +310,7 @@ const assertNoMaskedShapeTable = (shapes: ReadonlyArray<ShapeIR>, maskMetadata: 
 
         throw new LunoraError(
             "MASK_UNSUPPORTED",
-            `This project declares a \`mask(...)\` policy whose argument isn't a plain object literal (e.g. \`mask(sharedPolicies)\` referencing a hoisted variable), so codegen can't enumerate which columns it masks. Because the project also declares replication shape(s) (${shapeList}), codegen can't verify none of them replicate a table that policy masks — inline the mask(...) policies object literal so codegen can verify it, or remove the affected shape(s).`,
+            `This project declares a \`mask(...)\` policy whose argument isn't a plain object literal (e.g. \`mask(sharedPolicies)\` referencing a hoisted variable), or contains a spread (\`...shared\`) or computed key (\`[name]:\`) codegen can't enumerate, so codegen can't tell which columns it masks. Because the project also declares replication shape(s) (${shapeList}), codegen can't verify none of them replicate a table that policy masks — inline every table and column as literal keys so codegen can verify it, or remove the affected shape(s).`,
             { status: 422 },
         );
     }

--- a/packages/platform/src/capabilities.ts
+++ b/packages/platform/src/capabilities.ts
@@ -97,7 +97,10 @@ export const CLOUDFLARE_CAPABILITIES: PlatformCapabilities = {
         scheduler: { level: "emulated", note: "SchedulerDO (Lunora, on DO alarms) + declarative Cron Triggers; no runtime cron registration" },
         objectStorage: { level: "native", note: "R2" },
         keyValueStore: { level: "native", note: "Workers KV" },
-        vectorStore: { level: "native", note: "Vectorize" },
+        vectorStore: {
+            level: "native",
+            note: "Vectorize; query/upsert namespace scoping is native (remote filter), but getByIds/deleteByIds id-path tenant isolation is facade-enforced (client-side verification) since Vectorize's id operations take no namespace option",
+        },
         ai: { level: "native", note: "Workers AI" },
         browser: { level: "native", note: "Browser Rendering" },
         containers: { level: "native", note: "Cloudflare Containers" },


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(bindings,codegen): scope ctx.vectors reads by the DO shard namespace
- fix(codegen): fail closed on spread and computed keys in mask() policies
- fix(codegen): bound mask-policy recursion to two levels, close table-value gap

## Files this branch still changes relative to alpha

```
packages/bindings/__tests__/vectors/ctx.test.ts
packages/bindings/docs/index.mdx
packages/bindings/src/vectors/context.ts
packages/codegen/__tests__/discover-mask-metadata.test.ts
packages/codegen/__tests__/run-codegen.test.ts
packages/codegen/src/discover-mask-procedures.ts
packages/codegen/src/emit.ts
packages/codegen/src/run-codegen.ts
packages/platform/src/capabilities.ts
```
