### PR TITLE
fix(server): key the mask index-declaration guard per index kind

### DIFF
--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -673,7 +673,11 @@ interface IndexDefinition {
 ### `IndexFieldsByTable` (type)
 
 ```ts
-type IndexFieldsByTable = Readonly<Record<string, Readonly<Record<string, ReadonlyArray<string>>>>>;
+type IndexFieldsByTable = Readonly<Record<string, {
+    readonly geo?: Readonly<Record<string, ReadonlyArray<string>>>;
+    readonly index?: Readonly<Record<string, ReadonlyArray<string>>>;
+    readonly rank?: Readonly<Record<string, ReadonlyArray<string>>>;
+}>>;
 ```
 
 ### `IndexRangeBuilder` (interface)

--- a/packages/server/__tests__/mask.test.ts
+++ b/packages/server/__tests__/mask.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { MaskOptions, MaskPolicies, Middleware } from "../src/index";
-import { definePermission, defineRole, initLunora, LunoraError, mask } from "../src/index";
+import { definePermission, defineRole, defineSchema, defineTable, indexFieldsFromSchema, initLunora, LunoraError, mask, v } from "../src/index";
 
 /**
  * The procedure builder types `ctx.db` nominally; the mask middleware's
@@ -1173,7 +1173,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         enableQueryReader(database, seed);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn: ["ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { index: { by_ssn: ["ssn"] } } } }))
             // No range callback: this is the bare scan the range-recorder can't
             // see — it still returns every row ORDERED by the masked `ssn`
             // column, which is the position oracle `assertIndexDeclarationAllowed`
@@ -1192,7 +1192,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         enableQueryReader(database, seed);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { by_createdAt: ["createdAt"] } } }))
+            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { index: { by_createdAt: ["createdAt"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("users").withIndex("by_createdAt").collect());
 
         const rows = await handler.handler(makeContext(database, "u1"), {});
@@ -1210,7 +1210,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         enableQueryReader(database, seed);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_time: ["createdAt", "ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { index: { by_ssn_time: ["createdAt", "ssn"] } } } }))
             // The callback only ever names `createdAt` — `assertIndexFieldsAllowed`'s
             // recorder would let this through on its own — but `by_ssn_time`
             // DECLARES `ssn` too, so the row order still leaks the hidden value.
@@ -1235,7 +1235,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         enableQueryReader(database, seed);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { by_ssn: ["ssn"] } } }))
+            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { index: { by_ssn: ["ssn"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("users").withIndex("by_unknown").collect());
 
         const rows = await handler.handler(makeContext(database, "u1"), {});
@@ -1267,7 +1267,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { by_ssn_rank: ["ssn"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "by_ssn_rank", { row: "u1" }));
 
         await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
@@ -1279,7 +1279,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_score_per_ssn: ["score", "ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { by_score_per_ssn: ["score", "ssn"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "by_score_per_ssn", { row: "u1" }));
 
         await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
@@ -1291,7 +1291,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { leaderboard: ["score"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { leaderboard: ["score"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rank("users", "leaderboard", { row: "u1" }));
 
         const result = await handler.handler(makeContext(database, "u1"), {});
@@ -1306,7 +1306,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { by_ssn_rank: ["ssn"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPage("users", "by_ssn_rank", {}));
 
         await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
@@ -1319,7 +1319,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { leaderboard: ["score"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { leaderboard: ["score"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankPage("users", "leaderboard", {}));
 
         const result = (await handler.handler(makeContext(database, "u1"), {})) as Page;
@@ -1337,7 +1337,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         enableRankBefore(database, rows);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { by_ssn_rank: ["ssn"] } } } }))
             .query(async ({ ctx }) => (ctx as unknown as TestContext).db.rankBefore?.("users", "by_ssn_rank", { rowId: "u1" }));
 
         await expect(handler.handler(makeContext(database, "u1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
@@ -1349,7 +1349,7 @@ describe("mask — bare-index-scan / rank declaration oracle fails closed (plan 
         const database = createFakeDatabase([{ _id: "u1", score: 10, ssn: "123-45-6789", table: "users" }]);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { by_ssn_rank: ["ssn"] } } }))
+            .use(maskForTest({ users: { ssn: "redact" } }, { indexFields: { users: { rank: { by_ssn_rank: ["ssn"] } } } }))
             .query(({ ctx }) => typeof (ctx as unknown as TestContext).db.rankBefore);
 
         // No `enableRankBefore` call: the fake writer never carries the method.
@@ -1381,7 +1381,7 @@ describe("mask — withGeoIndex position oracle fails closed (plan 250 follow-up
         enableQueryReader(database, seed);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { homeLocation: "redact" } }, { indexFields: { users: { by_location: ["homeLocation"] } } }))
+            .use(maskForTest({ users: { homeLocation: "redact" } }, { indexFields: { users: { geo: { by_location: ["homeLocation"] } } } }))
             // A caller sweeping `point`/`radiusMeters` here gets rows sorted by
             // distance from an arbitrary point of their own choosing — the same
             // shape of ordinal leak as the bare-`withIndex` oracle, but over a
@@ -1407,7 +1407,7 @@ describe("mask — withGeoIndex position oracle fails closed (plan 250 follow-up
         enableQueryReader(database, seed);
 
         const handler = lunora.query
-            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { by_location: ["homeLocation"] } } }))
+            .use(maskForTest({ users: { email: "redact" } }, { indexFields: { users: { geo: { by_location: ["homeLocation"] } } } }))
             .query(async ({ ctx }) =>
                 (ctx as unknown as TestContext).db
                     .query("users")
@@ -1442,6 +1442,78 @@ describe("mask — withGeoIndex position oracle fails closed (plan 250 follow-up
         const rows = await handler.handler(makeContext(database, "u1"), {});
 
         expect(rows).toHaveLength(1);
+    });
+});
+
+describe("mask — index name reused across kinds is looked up in its own namespace (plan 258)", () => {
+    // `places` declares a REGULAR index and a GEO index sharing the name
+    // "byLoc" — legal and unambiguous at the engine level (three separate
+    // namespaces: `tableDefinition.indexes` / `.geoIndexes` / `.rankIndexes`),
+    // but a flat `indexFieldsFromSchema` map used to let the later-built geo
+    // entry overwrite the regular one, so the guard checked the WRONG index's
+    // declared fields for a `withIndex("byLoc")` read.
+    const placesSchema = defineSchema({
+        places: defineTable({ coords: v.geoPoint(), homeAddress: v.string() }).index("byLoc", ["homeAddress"]).geoIndex("byLoc", { field: "coords" }),
+    });
+
+    it("bare withIndex(name) throws when the REGULAR index's own declared fields (not the colliding geo entry's) include a masked column", async () => {
+        expect.assertions(1);
+
+        const seed = [{ _id: "p1", coords: { lat: 1, lng: 2 }, homeAddress: "1 Main St", table: "places" }];
+        const database = createFakeDatabase(seed);
+
+        enableQueryReader(database, seed);
+
+        const handler = lunora.query
+            .use(maskForTest({ places: { homeAddress: "redact" } }, { indexFields: indexFieldsFromSchema(placesSchema) }))
+            // Pre-fix (flat map): the geo entry `["coords"]` was written to the
+            // map AFTER the regular entry and overwrote it, so the guard checked
+            // `["coords"]` against the masked `homeAddress` column, found no
+            // intersection, and let the bare scan through — reopening the
+            // ordinal oracle plans 247/250 closed. Post-fix: the guard looks up
+            // `places.index.byLoc` (not `places.geo.byLoc`) and correctly finds
+            // `homeAddress` masked.
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("places").withIndex("byLoc").collect());
+
+        await expect(handler.handler(makeContext(database, "p1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
+    });
+
+    it("mirror: withIndex(name) over the unmasked REGULAR index succeeds, while withGeoIndex over the same colliding name still throws for the masked geo field", async () => {
+        expect.assertions(2);
+
+        const seed = [{ _id: "p1", coords: { lat: 1, lng: 2 }, homeAddress: "1 Main St", table: "places" }];
+
+        // `withIndex` succeeds: `homeAddress` (the regular index's declared
+        // field) is not masked. Pre-fix (flat map), this used to THROW instead —
+        // the false-denial mirror bug — because the colliding geo entry's
+        // masked `coords` field shadowed the regular index's own (unmasked)
+        // declared fields.
+        const indexDatabase = createFakeDatabase(seed);
+
+        enableQueryReader(indexDatabase, seed);
+
+        const indexHandler = lunora.query
+            .use(maskForTest({ places: { coords: "redact" } }, { indexFields: indexFieldsFromSchema(placesSchema) }))
+            .query(async ({ ctx }) => (ctx as unknown as TestContext).db.query("places").withIndex("byLoc").collect());
+
+        await expect(indexHandler.handler(makeContext(indexDatabase, "p1"), {})).resolves.toHaveLength(1);
+
+        // `withGeoIndex` over the SAME name still throws: `coords` (the geo
+        // index's own declared field) is masked.
+        const geoDatabase = createFakeDatabase(seed);
+
+        enableQueryReader(geoDatabase, seed);
+
+        const geoHandler = lunora.query
+            .use(maskForTest({ places: { coords: "redact" } }, { indexFields: indexFieldsFromSchema(placesSchema) }))
+            .query(async ({ ctx }) =>
+                (ctx as unknown as TestContext).db
+                    .query("places")
+                    .withGeoIndex("byLoc", (q) => q.near({ lat: 1, lng: 2 }, 1000))
+                    .collect(),
+            );
+
+        await expect(geoHandler.handler(makeContext(geoDatabase, "p1"), {})).rejects.toMatchObject({ code: "MASK_UNSUPPORTED", name: "LunoraError" });
     });
 });
 

--- a/packages/server/__tests__/plugin.test.ts
+++ b/packages/server/__tests__/plugin.test.ts
@@ -307,6 +307,33 @@ describe("defineSchema(...).extend(...)", () => {
 
         expect(() => intermediate.extend(second)).toThrow(/extend\("dupes"\): table "dupes_same" already exists/);
     });
+
+    // Plan 258 §5 S3: `defineSchema` only validates the tables it was called
+    // with — an extension's tables never passed through it, so without
+    // re-running `validateIndexFields` on the merged set, a bad
+    // extension-contributed index was never checked at all (it only failed
+    // later, at migration time, as an opaque SQLite error).
+    it("re-validates the merged schema, throwing for an extension-contributed index naming a column absent from its table's shape", () => {
+        expect.assertions(1);
+
+        const broken = defineSchemaExtension("broken", {
+            tables: { widgets: defineTable({ title: v.string() }).index("by_owner", ["ownerId" as never]) },
+        });
+
+        expect(() => defineSchema({ todos: defineTable({ title: v.string() }) }).extend(broken)).toThrow(
+            /table "broken_widgets" index "by_owner" names column "ownerId" which is not in the table's shape/,
+        );
+    });
+
+    it("still accepts a well-formed extension index (no false positive from the re-validation)", () => {
+        expect.assertions(1);
+
+        const ok = defineSchemaExtension("ok", {
+            tables: { widgets: defineTable({ ownerId: v.string(), title: v.string() }).index("by_owner", ["ownerId"]) },
+        });
+
+        expect(() => defineSchema({ todos: defineTable({ title: v.string() }) }).extend(ok)).not.toThrow();
+    });
 });
 
 describe("defineComponent", () => {
@@ -412,6 +439,23 @@ describe("installPlugins", () => {
         expect(Object.keys(schema.tables).toSorted((a, b) => a.localeCompare(b))).toEqual(["audit_events", "ratelimit_buckets", "todos"]);
         // Same collision policy as `.extend(...)`: a duplicate prefixed table throws.
         expect(() => installPlugins(schema, [ratelimit])).toThrow(/table "ratelimit_buckets" already exists/);
+    });
+
+    // Plan 258 §5 S3: `installPlugins` shares `mergeSchemaExtension` with
+    // `.extend(...)`, so it gets the same re-validation for free — a plugin's
+    // bad index is caught here too, not just on the `.extend(...)` chain.
+    it("re-validates a plugin's contributed index too, throwing for a column absent from the plugin table's shape", () => {
+        expect.assertions(1);
+
+        const broken = definePlugin("broken", {
+            extension: defineSchemaExtension("broken", {
+                tables: { widgets: defineTable({ title: v.string() }).index("by_owner", ["ownerId" as never]) },
+            }),
+        });
+
+        expect(() => installPlugins(defineSchema({ todos: defineTable({ title: v.string() }) }), [broken])).toThrow(
+            /table "broken_widgets" index "by_owner" names column "ownerId" which is not in the table's shape/,
+        );
     });
 });
 

--- a/packages/server/__tests__/schema-index-validation.test.ts
+++ b/packages/server/__tests__/schema-index-validation.test.ts
@@ -70,3 +70,96 @@ describe("defineSchema validates .index() fields", () => {
         ).not.toThrow();
     });
 });
+
+/**
+ * Plan 258 §4/§5 S3 — rank/geo declarations feed the exact same
+ * `indexFieldsFromSchema` map the mask guard trusts, so a typo'd `sortBy`/
+ * `partitionBy`/`field` column must be caught here rather than surfacing as a
+ * silent gap in that guard (or a late SQLite error). Duplicate-name detection
+ * is per KIND — a name reused ACROSS kinds (regular vs. rank vs. geo) is
+ * legal (the engine resolves each in its own namespace), but a duplicate
+ * WITHIN one kind is rejected exactly like a duplicate regular index name.
+ */
+describe("defineSchema validates .rankIndex() and .geoIndex() fields", () => {
+    it("throws for a rankIndex sortBy field absent from the table's shape", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                posts: defineTable({ title: v.string() }).rankIndex("by_score", { sortBy: [{ field: "score" as never }] }),
+            }),
+        ).toThrow(/table "posts" index "by_score" names column "score" which is not in the table's shape/);
+    });
+
+    it("throws for a rankIndex partitionBy field absent from the table's shape", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                posts: defineTable({ score: v.number(), title: v.string() }).rankIndex("by_score", {
+                    partitionBy: ["author" as never],
+                    sortBy: [{ field: "score" }],
+                }),
+            }),
+        ).toThrow(/table "posts" index "by_score" names column "author" which is not in the table's shape/);
+    });
+
+    it("throws for a geoIndex field absent from the table's shape", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                places: defineTable({ title: v.string() }).geoIndex("by_loc", { field: "coords" as never }),
+            }),
+        ).toThrow(/table "places" index "by_loc" names column "coords" which is not in the table's shape/);
+    });
+
+    it("accepts rankIndex/geoIndex fields that ARE in the table's shape", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                places: defineTable({ coords: v.geoPoint(), score: v.number() })
+                    .rankIndex("by_score", { sortBy: [{ field: "score" }] })
+                    .geoIndex("by_loc", { field: "coords" }),
+            }),
+        ).not.toThrow();
+    });
+
+    it("throws for a duplicate rank index name within a table", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                posts: defineTable({ score: v.number(), views: v.number() })
+                    .rankIndex("by_score", { sortBy: [{ field: "score" }] })
+                    .rankIndex("by_score", { sortBy: [{ field: "views" }] }),
+            }),
+        ).toThrow(/table "posts" declares rank index "by_score" more than once/);
+    });
+
+    it("throws for a duplicate geo index name within a table", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                places: defineTable({ coordsA: v.geoPoint(), coordsB: v.geoPoint() })
+                    .geoIndex("by_loc", { field: "coordsA" })
+                    .geoIndex("by_loc", { field: "coordsB" }),
+            }),
+        ).toThrow(/table "places" declares geo index "by_loc" more than once/);
+    });
+
+    it("does NOT reject the SAME name reused across kinds — regular, rank, and geo namespaces are independent", () => {
+        expect.assertions(1);
+
+        expect(() =>
+            defineSchema({
+                places: defineTable({ coords: v.geoPoint(), homeAddress: v.string(), score: v.number() })
+                    .index("byLoc", ["homeAddress"])
+                    .rankIndex("byLoc", { sortBy: [{ field: "score" }] })
+                    .geoIndex("byLoc", { field: "coords" }),
+            }),
+        ).not.toThrow();
+    });
+});

--- a/packages/server/__tests__/schema.test.ts
+++ b/packages/server/__tests__/schema.test.ts
@@ -338,8 +338,8 @@ describe("indexFieldsFromSchema (plan 250 — mask() bare-index-scan / rank orac
 
         expect(indexFieldsFromSchema(schema)).toStrictEqual({
             users: {
-                by_score: ["score", "ssn"],
-                by_ssn: ["ssn"],
+                index: { by_ssn: ["ssn"] },
+                rank: { by_score: ["score", "ssn"] },
             },
         });
     });
@@ -359,7 +359,7 @@ describe("indexFieldsFromSchema (plan 250 — mask() bare-index-scan / rank orac
             messages: defineTable({ createdAt: v.number() }).rankIndex("byTime", { sortBy: [{ field: "createdAt" }] }),
         });
 
-        expect(indexFieldsFromSchema(schema)).toStrictEqual({ messages: { byTime: ["createdAt"] } });
+        expect(indexFieldsFromSchema(schema)).toStrictEqual({ messages: { rank: { byTime: ["createdAt"] } } });
     });
 
     it("maps a geo index's declared `field` (closes the withGeoIndex position oracle)", () => {
@@ -371,7 +371,7 @@ describe("indexFieldsFromSchema (plan 250 — mask() bare-index-scan / rank orac
 
         expect(indexFieldsFromSchema(schema)).toStrictEqual({
             users: {
-                by_location: ["homeLocation"],
+                geo: { by_location: ["homeLocation"] },
             },
         });
     });

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -400,22 +400,32 @@ const wrapDatabase = <Context>(
      * trilaterates a masked `v.geoPoint()` column to geohash precision.
      *
      * Unlike `assertIndexFieldsAllowed`, this guards the index's DECLARED fields —
-     * it needs `indexFields`, the per-table index→fields map an app supplies via
-     * `mask(policies, { indexFields: indexFieldsFromSchema(schema) })`
-     * ({@link MaskOptions.indexFields}). Fails OPEN (returns without throwing) for
-     * the un-hardenable cases: `indexFields` wasn't supplied, or the table/index
+     * it needs `indexFields`, the per-table, per-KIND index→fields map an app
+     * supplies via `mask(policies, { indexFields: indexFieldsFromSchema(schema) })`
+     * ({@link MaskOptions.indexFields}). The caller passes its own `kind` — one of
+     * `"index" | "geo" | "rank"`, the same vocabulary `@lunora/shard-engine`'s
+     * `IndexUseHook` already uses — because the engine resolves `withIndex` /
+     * `withGeoIndex` / rank reads in THREE SEPARATE namespaces
+     * (`tableDefinition.indexes` / `.geoIndexes` / `.rankIndexes`), so the same
+     * index NAME can legally denote a different index per kind. Looking up only
+     * `[tableName][indexName]` on a flat map would let one kind's fields shadow
+     * another's for a colliding name — checking the wrong index's fields instead
+     * of the documented fail-open — which is exactly the bug this kind parameter
+     * closes (plan 258). Fails OPEN (returns without throwing) for the
+     * un-hardenable cases: `indexFields` wasn't supplied, or the table/kind/index
      * name isn't declared in it (an unknown index name errors downstream anyway,
      * so there is nothing left to protect by throwing here too). Only a KNOWN
-     * index whose declared fields intersect the masked column set throws.
+     * index (of the CALLER'S kind) whose declared fields intersect the masked
+     * column set throws.
      */
-    const assertIndexDeclarationAllowed = (tableName: string, indexName: string, method: string): void => {
+    const assertIndexDeclarationAllowed = (tableName: string, indexName: string, method: string, kind: "geo" | "index" | "rank"): void => {
         const columns = perTable.get(tableName);
 
         if (!columns) {
             return;
         }
 
-        const declaredFields = indexFields?.[tableName]?.[indexName];
+        const declaredFields = indexFields?.[tableName]?.[kind]?.[indexName];
 
         if (!declaredFields) {
             return;
@@ -529,7 +539,7 @@ const wrapDatabase = <Context>(
                 // Declared-fields guard FIRST: it closes the BARE scan (no `range`),
                 // which the callback-recorder just below can't see — see the guard
                 // function's own docblock, above `wrapDatabase`.
-                assertIndexDeclarationAllowed(tableName, indexName, "withIndex");
+                assertIndexDeclarationAllowed(tableName, indexName, "withIndex", "index");
                 assertIndexFieldsAllowed(range, columns, tableName, "withIndex");
 
                 return wrapReader(reader.withIndex(indexName, range), columns, tableName);
@@ -549,7 +559,7 @@ const wrapDatabase = <Context>(
             // keyed off the geo index's declared field (see
             // `indexFieldsFromSchema`).
             withGeoIndex: (indexName, build) => {
-                assertIndexDeclarationAllowed(tableName, indexName, "withGeoIndex");
+                assertIndexDeclarationAllowed(tableName, indexName, "withGeoIndex", "geo");
 
                 return wrapReader(reader.withGeoIndex(indexName, build), columns, tableName);
             },
@@ -839,14 +849,14 @@ const wrapDatabase = <Context>(
 
         async rank(tableName, indexName, options) {
             assertRankWhereAllowed(tableName, options, "rank");
-            assertIndexDeclarationAllowed(tableName, indexName, "rank");
+            assertIndexDeclarationAllowed(tableName, indexName, "rank", "rank");
 
             return base.rank(tableName, indexName, options);
         },
 
         async rankPage(tableName, indexName, options) {
             assertRankWhereAllowed(tableName, options, "rankPage");
-            assertIndexDeclarationAllowed(tableName, indexName, "rankPage");
+            assertIndexDeclarationAllowed(tableName, indexName, "rankPage", "rank");
 
             const page = await base.rankPage(tableName, indexName, options);
             const columns = perTable.get(tableName);
@@ -861,7 +871,7 @@ const wrapDatabase = <Context>(
             ? {
                   rankBefore(tableName: string, indexName: string, options: unknown) {
                       assertRankWhereAllowed(tableName, options, "rankBefore");
-                      assertIndexDeclarationAllowed(tableName, indexName, "rankBefore");
+                      assertIndexDeclarationAllowed(tableName, indexName, "rankBefore", "rank");
 
                       return baseRankBefore(tableName, indexName, options);
                   },

--- a/packages/server/src/mask/types.ts
+++ b/packages/server/src/mask/types.ts
@@ -97,16 +97,21 @@ export interface MaskOptions<Context = unknown> {
     readonly bypass?: (context: MaskContext<Context>) => boolean;
 
     /**
-     * Per-table index→declared-fields map (regular index `fields`; rank index
-     * `sortBy` ∪ `partitionBy`; geo index `field`). Supplied to close the
-     * bare-index-scan / rank / geo position oracle: a `withIndex(name)` with no
-     * range callback, a `rank`/`rankPage`/`rankBefore` read, or a
-     * `withGeoIndex` read, over an index whose DECLARED fields intersect a
-     * masked column, is rejected. OPTIONAL and additive — omit it and
-     * behaviour is unchanged (the oracle stays open, exactly as before this
-     * option existed). Build it with `indexFieldsFromSchema` (exported from
-     * `@lunora/server`): `mask(policies, { indexFields:
-     * indexFieldsFromSchema(schema) })`.
+     * Per-table, per-KIND index→declared-fields map (regular index `fields`
+     * under `index`; rank index `sortBy` ∪ `partitionBy` under `rank`; geo
+     * index `field` under `geo`). Supplied to close the bare-index-scan /
+     * rank / geo position oracle: a `withIndex(name)` with no range callback,
+     * a `rank`/`rankPage`/`rankBefore` read, or a `withGeoIndex` read, over an
+     * index whose DECLARED fields (for that read's own kind) intersect a
+     * masked column, is rejected. Kept per kind — rather than one flat
+     * name→fields map — because the engine resolves `withIndex` /
+     * `withGeoIndex` / rank reads in three separate namespaces, so the same
+     * index name can legally denote a different index per kind; a flat map
+     * would let one kind's fields shadow another's for a colliding name.
+     * OPTIONAL and additive — omit it and behaviour is unchanged (the oracle
+     * stays open, exactly as before this option existed). Build it with
+     * `indexFieldsFromSchema` (exported from `@lunora/server`):
+     * `mask(policies, { indexFields: indexFieldsFromSchema(schema) })`.
      */
     readonly indexFields?: IndexFieldsByTable;
     readonly roles?: ReadonlyArray<Role>;

--- a/packages/server/src/plugin.ts
+++ b/packages/server/src/plugin.ts
@@ -62,6 +62,7 @@ import { LunoraError } from "@lunora/errors";
 
 import runMiddlewareChain from "./builder/run-middleware";
 import type { Middleware, MiddlewareNext } from "./builder/types";
+import { validateIndexFields } from "./schema";
 import type {
     AggregateIndexDefinition,
     FunctionKind,
@@ -390,6 +391,16 @@ export type PrefixedTables<X extends Record<string, TableDefinition>, Key extend
  * collisions are impossible. The only remaining hard error is two extensions
  * sharing the same `key` and producing the same prefixed table (or vector
  * index) name — silent shadow would let one plugin hijack another's data.
+ *
+ * Re-runs {@link validateIndexFields} against the merged table set before
+ * returning: `defineSchema` only validates the tables it was called with, so
+ * without this an extension-contributed index with a typo'd/out-of-shape
+ * field (or a duplicate name within one kind) would never be checked at all.
+ * Re-validating the whole merged set (base + prefixed extension tables) is
+ * cheap and idempotent for the base tables, which already passed this same
+ * check when the base schema was built. Both callers of this function —
+ * `withExtend.extend()` (`./schema`) and `installPlugins` (below) — get the
+ * re-validation for free from this single call site (plan 258 §4/§9 Q3).
  */
 export const mergeSchemaExtension = <T extends Record<string, TableDefinition>, X extends Record<string, TableDefinition>, Key extends string = string>(
     base: Schema<T>,
@@ -431,6 +442,8 @@ export const mergeSchemaExtension = <T extends Record<string, TableDefinition>, 
             mergedVectorIndexes[prefixed] = { ...index, table: rewriteReference(index.table, key, bareNames) };
         }
     }
+
+    validateIndexFields(merged);
 
     return {
         // Preserve secure-by-default RLS across `.extend(...)` — a plugin's

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -892,15 +892,70 @@ const SYSTEM_INDEX_FIELDS = ["_creationTime", "_id"] as const;
 const SYSTEM_INDEX_FIELDS_SET = new Set<string>(SYSTEM_INDEX_FIELDS);
 
 /**
- * Cross-check every `.index(name, fields)` declaration against the table's
- * ASSEMBLED shape (run late — after `.softDelete()` has injected its marker
- * column onto `shape`, so a soft-delete field indexed by name isn't a false
- * positive). `.index()` is the one table-builder method whose `fields` were
- * historically typed `ReadonlyArray&lt;string>` with no cross-check against
- * `table.shape` — a typo'd column type-checked, passed `defineSchema`, and
- * only failed at migration time as a SQLite "no such column" error. This also
- * rejects a duplicate index name within a table, which SQLite would otherwise
- * silently let collide.
+ * Cross-check a single field name against the table's ASSEMBLED shape (plus
+ * the implicit system columns), throwing the standard message shape used for
+ * every index kind. Shared by `.index()`, `.rankIndex()` (`sortBy` /
+ * `partitionBy`), and `.geoIndex()` (`field`) — all publish these exact
+ * strings to `indexFieldsFromSchema`'s map as authoritative "declared fields"
+ * for the mask guard, so all three need the same shape check.
+ */
+const assertFieldInShape = (tableName: string, indexName: string, field: string, table: TableDefinition): void => {
+    if (SYSTEM_INDEX_FIELDS_SET.has(field) || field in table.shape) {
+        return;
+    }
+
+    throw new LunoraError(
+        "INTERNAL",
+        `defineSchema: table "${tableName}" index "${indexName}" names column "${field}" which is not in the table's shape`,
+    );
+};
+
+/**
+ * Validate one index KIND's entries on a table: reject a name reused WITHIN
+ * this kind (`seenNames` is local to this call, so it never sees another
+ * kind's names — the same name across kinds is a separate, legal namespace),
+ * then shape-check each entry's fields via `checkFields`. Factored out so
+ * {@link validateIndexFields} stays a flat dispatch (one call per kind)
+ * instead of three near-identical inline loops.
+ */
+const validateIndexKind = <Entry extends { name: string }>(
+    tableName: string,
+    kindLabel: string,
+    entries: ReadonlyArray<Entry>,
+    checkFields: (entry: Entry) => void,
+): void => {
+    const seenNames = new Set<string>();
+
+    for (const entry of entries) {
+        if (seenNames.has(entry.name)) {
+            throw new LunoraError("INTERNAL", `defineSchema: table "${tableName}" declares ${kindLabel} "${entry.name}" more than once`);
+        }
+
+        seenNames.add(entry.name);
+        checkFields(entry);
+    }
+};
+
+/**
+ * Cross-check every `.index(name, fields)` / `.rankIndex(name, ...)` /
+ * `.geoIndex(name, ...)` declaration against the table's ASSEMBLED shape (run
+ * late — after `.softDelete()` has injected its marker column onto `shape`,
+ * so a soft-delete field indexed by name isn't a false positive). `.index()`
+ * is the one table-builder method whose `fields` were historically typed
+ * `ReadonlyArray` of plain strings with no cross-check against `table.shape`
+ * — a typo'd column type-checked, passed `defineSchema`, and only failed at
+ * migration time as a SQLite "no such column" error. Rank (`sortBy[].field` /
+ * `partitionBy[]`) and geo (`field`) declarations get the same shape check,
+ * because `indexFieldsFromSchema` hands exactly those strings to the mask
+ * guard as authoritative declared fields — an unchecked typo there would be a
+ * silent gap in the guard, not just a late SQLite error.
+ *
+ * Duplicate-name detection is per KIND, not global — see
+ * {@link validateIndexKind}'s docblock. The SAME name reused ACROSS kinds is
+ * legal: the engine resolves `withIndex`/`withGeoIndex`/rank reads in three
+ * separate namespaces (see `@lunora/shard-engine`'s `ctx-db.ts`), and
+ * `indexFieldsFromSchema`'s per-kind map (below) is exactly what lets the
+ * mask guard tell those namespaces apart instead of one shadowing another.
  *
  * `searchIndex`'s `filterFields` is deliberately excluded — its dot-separated
  * paths reach into nested JSON, so there is no flat column list to check it
@@ -908,43 +963,63 @@ const SYSTEM_INDEX_FIELDS_SET = new Set<string>(SYSTEM_INDEX_FIELDS);
  */
 const validateIndexFields = (tables: Record<string, TableDefinition>): void => {
     for (const [tableName, table] of Object.entries(tables)) {
-        const seenNames = new Set<string>();
-
-        for (const index of table.indexes) {
-            if (seenNames.has(index.name)) {
-                throw new LunoraError("INTERNAL", `defineSchema: table "${tableName}" declares index "${index.name}" more than once`);
-            }
-
-            seenNames.add(index.name);
-
+        validateIndexKind(tableName, "index", table.indexes, (index) => {
             for (const field of index.fields) {
-                if (SYSTEM_INDEX_FIELDS_SET.has(field) || field in table.shape) {
-                    continue;
-                }
-
-                throw new LunoraError(
-                    "INTERNAL",
-                    `defineSchema: table "${tableName}" index "${index.name}" names column "${field}" which is not in the table's shape`,
-                );
+                assertFieldInShape(tableName, index.name, field, table);
             }
-        }
+        });
+
+        validateIndexKind(tableName, "rank index", table.rankIndexes, (rankIndex) => {
+            for (const sortKey of rankIndex.sortBy) {
+                assertFieldInShape(tableName, rankIndex.name, sortKey.field, table);
+            }
+
+            for (const field of rankIndex.partitionBy ?? []) {
+                assertFieldInShape(tableName, rankIndex.name, field, table);
+            }
+        });
+
+        validateIndexKind(tableName, "geo index", table.geoIndexes, (geoIndex) => {
+            assertFieldInShape(tableName, geoIndex.name, geoIndex.field, table);
+        });
     }
 };
 
 /**
- * Per-table index→declared-fields map: for each table, each declared index
- * NAME maps to the column names it declares. Distilled by
+ * Per-table, per-KIND index→declared-fields map: for each table, each index
+ * KIND (`index` | `rank` | `geo`) that has at least one declared index maps
+ * to a name→fields record for that kind only. Distilled by
  * {@link indexFieldsFromSchema}; this is the shape `mask()`'s
  * `MaskOptions.indexFields` expects (see `./mask/types`), so a table not
- * present here (no declared indexes) is simply absent from the map rather than
- * mapped to `{}`.
+ * present here (no declared indexes of any kind) is simply absent from the
+ * map rather than mapped to `{}`, and a kind with no declared indexes on a
+ * table that HAS other kinds is simply absent from that table's entry.
+ *
+ * Kept per kind (rather than one flat name→fields record) because the engine
+ * resolves `withIndex`/`withGeoIndex`/rank reads in THREE separate
+ * namespaces (`tableDefinition.indexes` / `.geoIndexes` / `.rankIndexes` —
+ * see `@lunora/shard-engine`'s `ctx-db.ts`), so the same name can legally and
+ * unambiguously denote a different index per kind. A flat map would let one
+ * kind's fields silently shadow another's for a colliding name, producing a
+ * wrong-namespace answer from the mask guard (checking the wrong index's
+ * fields) instead of the documented fail-open (missing lookup) — see plan 258.
  */
-type IndexFieldsByTable = Readonly<Record<string, Readonly<Record<string, ReadonlyArray<string>>>>>;
+type IndexFieldsByTable = Readonly<
+    Record<
+        string,
+        {
+            readonly geo?: Readonly<Record<string, ReadonlyArray<string>>>;
+            readonly index?: Readonly<Record<string, ReadonlyArray<string>>>;
+            readonly rank?: Readonly<Record<string, ReadonlyArray<string>>>;
+        }
+    >
+>;
 
 /**
  * Distill a schema's declared index fields into an {@link IndexFieldsByTable}
- * map — regular index `fields`; rank index `sortBy[].field` ∪ `partitionBy`;
- * geo index `field` (its single geospatial column). Built to close the
+ * map, keyed per table and then per KIND — regular index `fields` under
+ * `index`; rank index `sortBy[].field` ∪ `partitionBy` under `rank`; geo index
+ * `field` (its single geospatial column) under `geo`. Built to close the
  * `mask()` bare-index-scan / rank / geo position oracle: pass the result as
  * `mask(policies, { indexFields: indexFieldsFromSchema(schema) })` so the
  * middleware can reject a bare `withIndex`/`rank`/`withGeoIndex` read over an
@@ -956,6 +1031,11 @@ type IndexFieldsByTable = Readonly<Record<string, Readonly<Record<string, Readon
  * nothing to observe, so the guard needs the index's *declaration* instead
  * (see `./mask/middleware`).
  *
+ * Kinds are kept separate — never merged into one flat name→fields map — so a
+ * name reused across kinds (legal at the engine level; each entry point
+ * resolves its own namespace) can't have one kind's fields silently shadow
+ * another's. The guard looks up its own kind explicitly instead.
+ *
  * Deliberately does NOT emit `vectorIndexes` or `aggregateIndexes`: vector
  * search isn't reachable through `TableReaderLike` (the masked reader), and
  * aggregate reads are already guarded column-by-column by
@@ -966,32 +1046,72 @@ type IndexFieldsByTable = Readonly<Record<string, Readonly<Record<string, Readon
  * `ExtendableSchema`, or a plugin-merged schema), so it works whether called
  * before or after `.extend(...)`.
  */
+
+/**
+ * Fold one index kind's entries into a name→fields record, or `undefined`
+ * when the table declares none of this kind (so the caller can omit the key
+ * entirely rather than publish an empty `{}`). Factored out so
+ * {@link indexFieldsFromSchema} stays a flat per-kind dispatch instead of
+ * three near-identical inline loops.
+ */
+const buildKindFieldMap = <Entry>(
+    entries: ReadonlyArray<Entry>,
+    nameOf: (entry: Entry) => string,
+    fieldsOf: (entry: Entry) => ReadonlyArray<string>,
+): Record<string, ReadonlyArray<string>> | undefined => {
+    if (entries.length === 0) {
+        return undefined;
+    }
+
+    const byName: Record<string, ReadonlyArray<string>> = {};
+
+    for (const entry of entries) {
+        byName[nameOf(entry)] = fieldsOf(entry);
+    }
+
+    return byName;
+};
+
+/** `rankIndex.sortBy[].field` ∪ `partitionBy` as a deduplicated array — the declared-fields set for one rank index. */
+const rankIndexFields = (rankIndex: RankIndexDefinition): ReadonlyArray<string> => {
+    const fields = new Set<string>(rankIndex.sortBy.map((key) => key.field));
+
+    for (const field of rankIndex.partitionBy ?? []) {
+        fields.add(field);
+    }
+
+    return [...fields];
+};
+
 const indexFieldsFromSchema = (schema: Schema): IndexFieldsByTable => {
-    const result: Record<string, Record<string, ReadonlyArray<string>>> = {};
+    const result: Record<
+        string,
+        {
+            geo?: Record<string, ReadonlyArray<string>>;
+            index?: Record<string, ReadonlyArray<string>>;
+            rank?: Record<string, ReadonlyArray<string>>;
+        }
+    > = {};
 
     for (const [tableName, table] of Object.entries(schema.tables)) {
-        const perIndex: Record<string, ReadonlyArray<string>> = {};
+        const geo = buildKindFieldMap(
+            table.geoIndexes,
+            (geoIndex) => geoIndex.name,
+            (geoIndex) => [geoIndex.field],
+        );
+        const index = buildKindFieldMap(
+            table.indexes,
+            (regularIndex) => regularIndex.name,
+            (regularIndex) => regularIndex.fields,
+        );
+        const rank = buildKindFieldMap(table.rankIndexes, (rankIndex) => rankIndex.name, rankIndexFields);
 
-        for (const index of table.indexes) {
-            perIndex[index.name] = index.fields;
-        }
-
-        for (const rankIndex of table.rankIndexes) {
-            const fields = new Set<string>(rankIndex.sortBy.map((key) => key.field));
-
-            for (const field of rankIndex.partitionBy ?? []) {
-                fields.add(field);
-            }
-
-            perIndex[rankIndex.name] = [...fields];
-        }
-
-        for (const geoIndex of table.geoIndexes) {
-            perIndex[geoIndex.name] = [geoIndex.field];
-        }
-
-        if (Object.keys(perIndex).length > 0) {
-            result[tableName] = perIndex;
+        if (geo || index || rank) {
+            result[tableName] = {
+                ...(geo ? { geo } : {}),
+                ...(index ? { index } : {}),
+                ...(rank ? { rank } : {}),
+            };
         }
     }
 
@@ -1012,7 +1132,13 @@ const defineSchema = <T extends Record<string, TableDefinition>>(
     return withExtend({ tables, vectorIndexes });
 };
 
-export { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex, indexFieldsFromSchema };
+// `validateIndexFields` is exported package-internally (not re-exported from
+// `./index`, so it stays outside the public API surface) so `./plugin`'s
+// `mergeSchemaExtension` can re-run it against the merged table set — the
+// seam that closes the "extension-contributed bad index never validated" gap
+// (plan 258 §1). Both `mergeSchemaExtension` callers (`withExtend.extend()`
+// here and `installPlugins` in `./plugin`) get the re-validation for free.
+export { defineAggregateIndex, defineRankIndex, defineSchema, defineTable, defineVectorIndex, indexFieldsFromSchema, validateIndexFields };
 
 export type {
     AggregateIndexOptions,


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(server): key the mask index-declaration guard per index kind

## Files this branch still changes relative to alpha

```
api-snapshots/server.api.md
packages/server/__tests__/mask.test.ts
packages/server/__tests__/plugin.test.ts
packages/server/__tests__/schema-index-validation.test.ts
packages/server/__tests__/schema.test.ts
packages/server/src/mask/middleware.ts
packages/server/src/mask/types.ts
packages/server/src/plugin.ts
packages/server/src/schema.ts
```
