### PR TITLE
fix(agent): drop expired-credential voice sockets with TOKEN_EXPIRED/4001

### DIFF
--- a/packages/agent/__tests__/voice-do.test.ts
+++ b/packages/agent/__tests__/voice-do.test.ts
@@ -79,8 +79,10 @@ const env: Record<string, unknown> = {
     },
 };
 
-/** Subclass overriding the AI seams so a turn completes without a real Workers AI binding, and counts how many utterances actually reached transcription. */
+/** Subclass overriding the AI seams so a turn completes without a real Workers AI binding, and counts how many utterances/synthesis calls actually reached the seam (i.e. how many times a turn — including a greeting — actually spoke). */
 class TestVoiceDO extends VoiceSessionDO {
+    public synthesizeCalls = 0;
+
     public transcribedPcmLengths: number[] = [];
 
     protected override async transcribe(pcm: Uint8Array): Promise<string> {
@@ -89,8 +91,9 @@ class TestVoiceDO extends VoiceSessionDO {
         return "test utterance";
     }
 
-    // eslint-disable-next-line class-methods-use-this -- structural override matching the base class's instance-method signature; this test double needs no instance state
     protected override async synthesize(_text: string): Promise<VoiceAudioSource> {
+        this.synthesizeCalls += 1;
+
         return new Uint8Array([1]);
     }
 }
@@ -182,6 +185,155 @@ describe("voice session credential expiry", () => {
 
             expect(attachment?.["expiresAt"]).toBe(exp);
             expect(attachment?.["userId"]).toBe("user-1");
+        });
+    });
+
+    describe("checked at upgrade (before ready/greeting)", () => {
+        it("drops an already-expired credential at upgrade, before ready and before the greeting ever runs", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            // A greeting is configured, so — pre-fix — `fetch()` would
+            // unconditionally schedule `speakGreeting` via `waitUntil` after
+            // sending `ready`, running a full LLM+TTS turn under an already-lapsed
+            // credential.
+            const greetingAgent = defineAgent({
+                instructions: "Be brief.",
+                model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+                voice: { greeting: "Hello! How can I help you today?" },
+            });
+
+            const waited: Promise<unknown>[] = [];
+            const state = {
+                acceptWebSocket: () => {
+                    /* no-op: the fake socket needs no host-side registration */
+                },
+                getWebSockets: () => [],
+                waitUntil: (promise: Promise<unknown>) => {
+                    waited.push(promise);
+                },
+            };
+
+            const instance = new TestVoiceDO(state, env, greetingAgent, "support");
+
+            const sent: unknown[] = [];
+            let closed: { code?: number; reason?: string } | undefined;
+            const server = {
+                close: (code?: number, reason?: string) => {
+                    closed = { code, reason };
+                },
+                send: (data: unknown) => {
+                    sent.push(data);
+                },
+                serializeAttachment: () => {
+                    throw new Error("must not stamp an attachment for a credential already expired at upgrade");
+                },
+            };
+
+            const globalWithPair = globalThis as { WebSocketPair?: unknown };
+            const original = globalWithPair.WebSocketPair;
+
+            globalWithPair.WebSocketPair = function WebSocketPair() {
+                return { 0: {}, 1: server } as unknown;
+            };
+
+            try {
+                instance.fetch(
+                    new Request("https://do.internal/?threadKey=t1", {
+                        headers: new Headers({ Upgrade: "websocket", "x-lunora-identity-exp": String(now - 1) }),
+                    }),
+                );
+            } catch (error) {
+                if (!(error instanceof RangeError)) {
+                    throw error;
+                }
+            } finally {
+                globalWithPair.WebSocketPair = original;
+            }
+
+            // Only the TOKEN_EXPIRED frame was sent — never `ready`, never a greeting frame.
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toStrictEqual({
+                code: "TOKEN_EXPIRED",
+                error: { code: "TOKEN_EXPIRED", message: "authentication token expired" },
+                type: "error",
+            });
+            expect(closed).toStrictEqual({ code: 4001, reason: "token_expired" });
+
+            // The greeting was never scheduled at all (no `waitUntil` call), so no
+            // LLM/TTS turn ran and no thread write was ever attempted.
+            expect(waited).toHaveLength(0);
+            expect(instance.synthesizeCalls).toBe(0);
+            expect(instance.transcribedPcmLengths).toStrictEqual([]);
+        });
+
+        it("still sends ready and schedules the greeting for a non-expired credential (no regression)", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const greetingAgent = defineAgent({
+                instructions: "Be brief.",
+                model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+                voice: { greeting: "Hello! How can I help you today?" },
+            });
+
+            const waited: Promise<unknown>[] = [];
+            const state = {
+                acceptWebSocket: () => {
+                    /* no-op: the fake socket needs no host-side registration */
+                },
+                getWebSockets: () => [],
+                waitUntil: (promise: Promise<unknown>) => {
+                    waited.push(promise);
+                },
+            };
+
+            const instance = new TestVoiceDO(state, env, greetingAgent, "support");
+
+            const sent: unknown[] = [];
+            const server = {
+                close: () => {
+                    /* not expected to be called */
+                },
+                send: (data: unknown) => {
+                    sent.push(data);
+                },
+                serializeAttachment: () => {
+                    /* stamped — irrelevant to this assertion */
+                },
+            };
+
+            const globalWithPair = globalThis as { WebSocketPair?: unknown };
+            const original = globalWithPair.WebSocketPair;
+
+            globalWithPair.WebSocketPair = function WebSocketPair() {
+                return { 0: {}, 1: server } as unknown;
+            };
+
+            try {
+                instance.fetch(
+                    new Request("https://do.internal/?threadKey=t1", {
+                        headers: new Headers({ Upgrade: "websocket", "x-lunora-identity-exp": String(now + 60_000) }),
+                    }),
+                );
+            } catch (error) {
+                if (!(error instanceof RangeError)) {
+                    throw error;
+                }
+            } finally {
+                globalWithPair.WebSocketPair = original;
+            }
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toMatchObject({ type: "ready" });
+            expect(waited).toHaveLength(1);
+
+            // Let the scheduled greeting settle before asserting on it — it dispatches
+            // through the real `run` seam, which has no bindings in this test env and
+            // is expected to fail; only that it was ATTEMPTED matters here.
+            await Promise.allSettled(waited);
         });
     });
 

--- a/packages/agent/__tests__/voice-do.test.ts
+++ b/packages/agent/__tests__/voice-do.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { encodeIdentityHeader } from "../../../shared/identity-header";
+import { defineAgent } from "../src/define-agent";
+import VoiceSessionDO from "../src/voice-do";
+import type { VoiceAudioSource } from "../src/voice-turn";
+
+/** Structural double of `DurableObjectState` — accepts the socket, never actually hibernates. */
+const fakeState = (): { acceptWebSocket: (ws: unknown) => void; getWebSockets: () => never[] } => {
+    return {
+        acceptWebSocket: () => {
+            /* no-op: the fake socket needs no host-side registration */
+        },
+        getWebSockets: () => [],
+    };
+};
+
+/**
+ * A hibernation-attachment-carrying fake socket. `serializeAttachment` /
+ * `deserializeAttachment` read and write the SAME closure variable, so the DO's
+ * own re-serialize-on-finally (`runTurn`'s `{ ...attachment, turn: turn + 1 }`)
+ * round-trips exactly as it does against a real hibernatable WebSocket.
+ */
+const createFakeSocket = (
+    initial: Record<string, unknown>,
+    options: { throwOnClose?: boolean; throwOnSend?: boolean } = {},
+): {
+    getAttachment: () => Record<string, unknown>;
+    getClosed: () => { code?: number; reason?: string } | undefined;
+    sent: unknown[];
+    setAttachment: (value: Record<string, unknown>) => void;
+    ws: WebSocket;
+} => {
+    let attachment = initial;
+    const sent: unknown[] = [];
+    let closed: { code?: number; reason?: string } | undefined;
+
+    const ws = {
+        close: (code?: number, reason?: string) => {
+            if (options.throwOnClose) {
+                throw new Error("socket already gone");
+            }
+
+            closed = { code, reason };
+        },
+        deserializeAttachment: () => attachment,
+        send: (data: unknown) => {
+            if (options.throwOnSend) {
+                throw new Error("socket already gone");
+            }
+
+            sent.push(data);
+        },
+        serializeAttachment: (value: unknown) => {
+            attachment = value as Record<string, unknown>;
+        },
+    };
+
+    return {
+        getAttachment: () => attachment,
+        getClosed: () => closed,
+        sent,
+        setAttachment: (value: Record<string, unknown>) => {
+            attachment = value;
+        },
+        ws: ws as unknown as WebSocket,
+    };
+};
+
+/** A voice-enabled agent with no greeting (so `fetch()` never schedules `speakGreeting`). */
+const agent = defineAgent({ instructions: "Be brief.", model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", voice: {} });
+// `createAi` requires an `AI` binding at construction time — the fake is never
+// actually called because `TestVoiceDO` overrides `transcribe`/`synthesize`.
+const env: Record<string, unknown> = {
+    AI: {
+        run: async () => {
+            throw new Error("unexpected real AI call — TestVoiceDO should have overridden the seam that reached this");
+        },
+    },
+};
+
+/** Subclass overriding the AI seams so a turn completes without a real Workers AI binding, and counts how many utterances actually reached transcription. */
+class TestVoiceDO extends VoiceSessionDO {
+    public transcribedPcmLengths: number[] = [];
+
+    protected override async transcribe(pcm: Uint8Array): Promise<string> {
+        this.transcribedPcmLengths.push(pcm.byteLength);
+
+        return "test utterance";
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- structural override matching the base class's instance-method signature; this test double needs no instance state
+    protected override async synthesize(_text: string): Promise<VoiceAudioSource> {
+        return new Uint8Array([1]);
+    }
+}
+
+/** Upgrade `instance` and capture the stamped hibernation attachment (mirrors `shard-do.admin-subscription.test.ts`'s pattern for the same Node/workerd gap). */
+const upgradeAndCaptureAttachment = async (
+    instance: VoiceSessionDO,
+    url: string,
+    headers?: Record<string, string>,
+): Promise<Record<string, unknown> | undefined> => {
+    let captured: Record<string, unknown> | undefined;
+    const server = {
+        send: () => {
+            /* the "ready" frame — irrelevant to attachment capture */
+        },
+        serializeAttachment: (value: unknown) => {
+            captured = value as Record<string, unknown>;
+        },
+    };
+
+    const globalWithPair = globalThis as { WebSocketPair?: unknown };
+    const original = globalWithPair.WebSocketPair;
+
+    globalWithPair.WebSocketPair = function WebSocketPair() {
+        return { 0: {}, 1: server } as unknown;
+    };
+
+    try {
+        // The attachment is stamped before `new Response(null, { status: 101 })`,
+        // which Node's Response rejects (101 is out of its allowed range) — that
+        // throw is expected here, `captured` is already set by then. `fetch()` is
+        // synchronous (not `Promise`-returning), so this throw is synchronous too.
+        instance.fetch(new Request(url, { headers: new Headers({ Upgrade: "websocket", ...headers }) }));
+    } catch (error) {
+        if (!(error instanceof RangeError)) {
+            throw error;
+        }
+    } finally {
+        globalWithPair.WebSocketPair = original;
+    }
+
+    return captured;
+};
+
+describe("voice session credential expiry", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("captured at upgrade", () => {
+        it("stamps expiresAt from a valid x-lunora-identity-exp header", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const exp = Date.now() + 60_000;
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1", { "x-lunora-identity-exp": String(exp) });
+
+            expect(attachment?.["expiresAt"]).toBe(exp);
+        });
+
+        it("stamps no expiresAt when the header is absent", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1");
+
+            expect(attachment).not.toHaveProperty("expiresAt");
+        });
+
+        it.each(["abc", "0", "-5", ""])("stamps no expiresAt for a malformed header (%s)", async (raw) => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1", { "x-lunora-identity-exp": raw });
+
+            expect(attachment).not.toHaveProperty("expiresAt");
+        });
+
+        it("still carries identity/userId alongside expiresAt", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const exp = Date.now() + 60_000;
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1", {
+                "x-lunora-identity": encodeIdentityHeader({ claims: { sub: "user-1" } }),
+                "x-lunora-identity-exp": String(exp),
+                "x-lunora-userid": "user-1",
+            });
+
+            expect(attachment?.["expiresAt"]).toBe(exp);
+            expect(attachment?.["userId"]).toBe("user-1");
+        });
+    });
+
+    describe("enforced at webSocketMessage", () => {
+        it("drops an expired socket on a control frame with TOKEN_EXPIRED/4001, never running the turn", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, sent, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toStrictEqual({
+                code: "TOKEN_EXPIRED",
+                error: { code: "TOKEN_EXPIRED", message: "authentication token expired" },
+                type: "error",
+            });
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+            expect(instance.transcribedPcmLengths).toStrictEqual([]);
+        });
+
+        it("drops an expired socket on a text turn frame the same way", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, sent, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ text: "hello", type: "text" }));
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toMatchObject({ code: "TOKEN_EXPIRED" });
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+        });
+
+        it("gates binary audio frames the same way — no audio is buffered while expired", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, sent, setAttachment, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, new ArrayBuffer(4));
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toMatchObject({ code: "TOKEN_EXPIRED" });
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+
+            // Flip the credential to unexpired and commit — transcribe sees an
+            // EMPTY utterance, proving the binary frame above was never buffered.
+            setAttachment({ connectionId: "c1", expiresAt: now + 60_000, threadKey: "t1", turn: 0 });
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(instance.transcribedPcmLengths).toStrictEqual([0]);
+        });
+
+        it("treats expiresAt === Date.now() as expired (boundary, matching ShardDO's >=)", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+            expect(instance.transcribedPcmLengths).toStrictEqual([]);
+        });
+
+        it("lets frames flow unchanged when no expiresAt is stamped (additive, no regression)", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, ws } = createFakeSocket({ connectionId: "c1", threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(getClosed()).toBeUndefined();
+            expect(instance.transcribedPcmLengths).toStrictEqual([0]);
+        });
+
+        it("lets frames flow when expiresAt is in the future", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now + 60_000, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(getClosed()).toBeUndefined();
+            expect(instance.transcribedPcmLengths).toStrictEqual([0]);
+        });
+
+        it("never throws even when the expired socket's send/close both throw", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 }, { throwOnClose: true, throwOnSend: true });
+
+            await expect(instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }))).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/agent/src/voice-do.ts
+++ b/packages/agent/src/voice-do.ts
@@ -151,6 +151,21 @@ class VoiceSessionDO {
         const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
         const expiresAt = decodeIdentityExpiryHeader(request.headers.get("x-lunora-identity-exp"));
 
+        // A credential that was ALREADY expired before the upgrade completed
+        // (the runtime forwards `x-lunora-identity-exp` but does not itself
+        // reject a lapsed one — enforcing `exp` is this DO's job) must never
+        // reach `ready`/a greeting: `webSocketMessage`'s check only gates
+        // frames the CLIENT sends, but `speakGreeting` below runs unconditionally
+        // from this handler, so without this check an already-expired socket
+        // still buys one full LLM+TTS greeting turn — billed, and written to
+        // the caller's thread — before any inbound frame could trip it.
+        if (isIdentityExpired(expiresAt)) {
+            dropExpiredCredentialSocket(server);
+
+            // eslint-disable-next-line unicorn/no-null -- Web Response body for a 101 upgrade is `BodyInit | null`; null is the standard "no body" value
+            return new Response(null, { status: 101, webSocket: client } as unknown as ResponseInit);
+        }
+
         (server as unknown as HibernatableWebSocket).serializeAttachment?.({
             connectionId,
             threadKey,

--- a/packages/agent/src/voice-do.ts
+++ b/packages/agent/src/voice-do.ts
@@ -4,7 +4,7 @@ import { createAi } from "@lunora/ai";
 import { createDispatchRunner } from "@lunora/dispatch";
 
 import { toBase64 } from "../../../shared/base64";
-import { decodeUserIdHeader } from "../../../shared/identity-header";
+import { decodeIdentityExpiryHeader, decodeUserIdHeader, dropExpiredCredentialSocket, isIdentityExpired } from "../../../shared/identity-header";
 import { createStreamGenerate } from "./generate";
 import { DEFAULT_AGENT_FUNCTION_PATHS, toFunctionReference } from "./paths";
 import type { AgentDefinition, AgentFunctionPaths, AgentRunFunction, AgentStreamGenerate } from "./types";
@@ -149,10 +149,7 @@ class VoiceSessionDO {
         const connectionId = crypto.randomUUID();
         const identity = parseIdentity(request.headers.get("x-lunora-identity"));
         const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
-        // Optional credential expiry (epoch ms) forwarded by the runtime. A
-        // malformed value is ignored (the socket simply never auto-expires).
-        const expiresAtRaw = Number(request.headers.get("x-lunora-identity-exp"));
-        const expiresAt = Number.isFinite(expiresAtRaw) && expiresAtRaw > 0 ? expiresAtRaw : undefined;
+        const expiresAt = decodeIdentityExpiryHeader(request.headers.get("x-lunora-identity-exp"));
 
         (server as unknown as HibernatableWebSocket).serializeAttachment?.({
             connectionId,
@@ -453,28 +450,25 @@ class VoiceSessionDO {
         this.bufferedBytes.delete(attachment.connectionId);
     }
 
-    /** Whether `attachment` carries a credential whose expiry (stamped at upgrade) is now past. */
+    /**
+     * Whether `attachment` carries a credential whose expiry (stamped at
+     * upgrade) is now past. Delegates to the shared boundary check
+     * `@lunora/do`'s `ShardDO` uses for the same decision, so the two DOs can
+     * never disagree about it.
+     */
     // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with dropExpiredSocket; operates only on the passed attachment
     private isSocketExpired(attachment: VoiceSocketAttachment): boolean {
-        return typeof attachment.expiresAt === "number" && Date.now() >= attachment.expiresAt;
+        return isIdentityExpired(attachment.expiresAt);
     }
 
     /**
-     * Send the `TOKEN_EXPIRED` error frame and close the socket with code 4001 so
-     * the client distinguishes an expired-credential drop from an ordinary one
-     * and refreshes before reconnecting. Best-effort: a throw (socket already
-     * gone) is swallowed — this must never escape the hibernation handlers.
+     * Drop an expired-credential socket via the shared `TOKEN_EXPIRED`/`4001`
+     * helper `@lunora/do`'s `ShardDO` also calls, so both DOs send the
+     * client-facing wire shape from one place.
      */
     // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with isSocketExpired; operates only on the passed socket
     private dropExpiredSocket(ws: WebSocket): void {
-        try {
-            (ws as unknown as HibernatableWebSocket).send(
-                JSON.stringify({ code: "TOKEN_EXPIRED", error: { code: "TOKEN_EXPIRED", message: "authentication token expired" }, type: "error" }),
-            );
-            (ws as unknown as HibernatableWebSocket).close?.(4001, "token_expired");
-        } catch {
-            /* socket already gone */
-        }
+        dropExpiredCredentialSocket(ws);
     }
 
     /** Send a JSON control frame, swallowing a closed-socket error (never throw from a handler). */

--- a/packages/agent/src/voice-do.ts
+++ b/packages/agent/src/voice-do.ts
@@ -37,6 +37,16 @@ const MAX_DRAIN_WAIT_MS = 5000;
  */
 interface VoiceSocketAttachment {
     connectionId: string;
+
+    /**
+     * Token-expiry (epoch ms) of the credential resolved at upgrade, when the
+     * runtime forwarded one (`x-lunora-identity-exp`). The DO drops the socket
+     * with a `TOKEN_EXPIRED` error + close code `4001` the next time it
+     * receives a frame at or after this instant, so the client reconnects and
+     * re-resolves a fresh identity. Absent for sockets whose identity declares
+     * no expiry.
+     */
+    expiresAt?: number;
     identity?: Record<string, unknown>;
     threadKey: string;
     turn: number;
@@ -52,6 +62,7 @@ interface VoiceSessionState {
 
 /** The hibernation-attachment methods the runtime adds to every accepted socket. */
 interface HibernatableWebSocket {
+    close?: (code?: number, reason?: string) => void;
     deserializeAttachment?: () => unknown;
     send: (data: ArrayBuffer | ArrayBufferView | string) => void;
     serializeAttachment?: (value: unknown) => void;
@@ -138,11 +149,16 @@ class VoiceSessionDO {
         const connectionId = crypto.randomUUID();
         const identity = parseIdentity(request.headers.get("x-lunora-identity"));
         const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
+        // Optional credential expiry (epoch ms) forwarded by the runtime. A
+        // malformed value is ignored (the socket simply never auto-expires).
+        const expiresAtRaw = Number(request.headers.get("x-lunora-identity-exp"));
+        const expiresAt = Number.isFinite(expiresAtRaw) && expiresAtRaw > 0 ? expiresAtRaw : undefined;
 
         (server as unknown as HibernatableWebSocket).serializeAttachment?.({
             connectionId,
             threadKey,
             turn: 0,
+            ...(expiresAt === undefined ? {} : { expiresAt }),
             ...(identity === undefined ? {} : { identity }),
             ...(userId === undefined ? {} : { userId }),
         } satisfies VoiceSocketAttachment);
@@ -164,6 +180,12 @@ class VoiceSessionDO {
         const attachment = (ws as unknown as HibernatableWebSocket).deserializeAttachment?.() as VoiceSocketAttachment | undefined;
 
         if (!attachment) {
+            return;
+        }
+
+        if (this.isSocketExpired(attachment)) {
+            this.dropExpiredSocket(ws);
+
             return;
         }
 
@@ -429,6 +451,30 @@ class VoiceSessionDO {
         this.controllers.delete(attachment.connectionId);
         this.audioBuffers.delete(attachment.connectionId);
         this.bufferedBytes.delete(attachment.connectionId);
+    }
+
+    /** Whether `attachment` carries a credential whose expiry (stamped at upgrade) is now past. */
+    // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with dropExpiredSocket; operates only on the passed attachment
+    private isSocketExpired(attachment: VoiceSocketAttachment): boolean {
+        return typeof attachment.expiresAt === "number" && Date.now() >= attachment.expiresAt;
+    }
+
+    /**
+     * Send the `TOKEN_EXPIRED` error frame and close the socket with code 4001 so
+     * the client distinguishes an expired-credential drop from an ordinary one
+     * and refreshes before reconnecting. Best-effort: a throw (socket already
+     * gone) is swallowed — this must never escape the hibernation handlers.
+     */
+    // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with isSocketExpired; operates only on the passed socket
+    private dropExpiredSocket(ws: WebSocket): void {
+        try {
+            (ws as unknown as HibernatableWebSocket).send(
+                JSON.stringify({ code: "TOKEN_EXPIRED", error: { code: "TOKEN_EXPIRED", message: "authentication token expired" }, type: "error" }),
+            );
+            (ws as unknown as HibernatableWebSocket).close?.(4001, "token_expired");
+        } catch {
+            /* socket already gone */
+        }
     }
 
     /** Send a JSON control frame, swallowing a closed-socket error (never throw from a handler). */

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -207,7 +207,7 @@ import type { BatchEntry } from "../../../shared/batch-wire";
 import { MAX_BATCH_ENTRIES } from "../../../shared/batch-wire";
 import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
-import { decodeUserIdHeader } from "../../../shared/identity-header";
+import { decodeIdentityExpiryHeader, decodeUserIdHeader, dropExpiredCredentialSocket, isIdentityExpired } from "../../../shared/identity-header";
 import { jsonResponse } from "../../../shared/json-response";
 import type { LogSinkContext } from "../../../shared/log-event";
 import type { LogFields } from "../../../shared/log-fields";
@@ -8889,10 +8889,7 @@ abstract class ShardDO {
         // request of its own.
         const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
         const identity = parseIdentityHeader(request.headers.get("x-lunora-identity"));
-        // Optional credential expiry (epoch ms) forwarded by the runtime. A
-        // malformed value is ignored (the socket simply never auto-expires).
-        const expiresAtRaw = Number(request.headers.get("x-lunora-identity-exp"));
-        const expiresAt = Number.isFinite(expiresAtRaw) && expiresAtRaw > 0 ? expiresAtRaw : undefined;
+        const expiresAt = decodeIdentityExpiryHeader(request.headers.get("x-lunora-identity-exp"));
 
         // Stamp admin authorization onto the socket at upgrade so later
         // `__lunora_admin__:*` subscribe envelopes (which carry no credential of
@@ -8935,27 +8932,24 @@ abstract class ShardDO {
         }
     }
 
-    /** Whether `ws` carries a credential whose expiry (stamped at upgrade) is now past. */
+    /**
+     * Whether `ws` carries a credential whose expiry (stamped at upgrade) is
+     * now past. Delegates to the shared boundary check `@lunora/agent`'s
+     * voice DO uses for the same decision, so the two DOs can never disagree
+     * about it.
+     */
     private isSocketExpired(ws: ShardSocketLike): boolean {
-        const { expiresAt } = this.readAttachment(ws);
-
-        return typeof expiresAt === "number" && Date.now() >= expiresAt;
+        return isIdentityExpired(this.readAttachment(ws).expiresAt);
     }
 
     /**
-     * Send the `TOKEN_EXPIRED` error frame and close the socket with code 4001 so
-     * the client distinguishes an expired-credential drop from an ordinary one
-     * and refreshes before reconnecting. Best-effort: a throw (socket already
-     * gone) is swallowed — this must never escape the hibernation handlers.
+     * Drop an expired-credential socket via the shared `TOKEN_EXPIRED`/`4001`
+     * helper `@lunora/agent`'s voice DO also calls, so both DOs send the
+     * client-facing wire shape from one place.
      */
     // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with isSocketExpired; operates only on the passed socket
     private dropExpiredSocket(ws: ShardSocketLike): void {
-        try {
-            ws.send(JSON.stringify({ code: "TOKEN_EXPIRED", error: { code: "TOKEN_EXPIRED", message: "authentication token expired" }, type: "error" }));
-            ws.close?.(4001, "token_expired");
-        } catch {
-            /* socket already gone */
-        }
+        dropExpiredCredentialSocket(ws);
     }
 
     /**

--- a/shared/identity-header.ts
+++ b/shared/identity-header.ts
@@ -142,4 +142,64 @@ const decodeUserIdHeader = (raw: null | string | undefined): string | undefined 
     }
 };
 
-export { decodeIdentityHeader, decodeUserIdHeader, encodeIdentityHeader, encodeUserIdHeader, isByteStringSafe };
+/**
+ * Structural view of a socket that can receive an expired-credential drop —
+ * satisfied by both a hibernatable `WebSocket` (cast structurally, as
+ * `@lunora/agent`'s voice DO does) and `@lunora/do`'s `ShardSocketLike`
+ * (which carries the same two members plus more). `send` takes a string
+ * because the drop only ever sends a JSON error frame, never binary.
+ */
+interface ExpirableSocket {
+    close?: (code?: number, reason?: string) => void;
+    send: (data: string) => void;
+}
+
+/**
+ * Parse the `x-lunora-identity-exp` header (epoch ms) the runtime forwards on
+ * a WebSocket upgrade alongside `x-lunora-identity`/`x-lunora-userid`. A
+ * malformed value — absent, non-numeric, zero, or negative — is ignored (the
+ * socket simply never auto-expires); `Number(null)` is `0`, so an absent
+ * header takes the same "ignored" path as a garbled one without a separate
+ * null check.
+ */
+const decodeIdentityExpiryHeader = (raw: null | string): number | undefined => {
+    const parsed = Number(raw);
+
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+/**
+ * Whether an `expiresAt` (epoch ms, from {@link decodeIdentityExpiryHeader})
+ * is now past. `undefined` — no expiry was stamped on the socket — is never
+ * expired, so a socket whose identity declared no expiry keeps flowing.
+ */
+const isIdentityExpired = (expiresAt: number | undefined): boolean => typeof expiresAt === "number" && Date.now() >= expiresAt;
+
+/**
+ * Send the `TOKEN_EXPIRED` error frame and close the socket with code 4001 so
+ * the client distinguishes an expired-credential drop from an ordinary one
+ * and refreshes before reconnecting, instead of treating it as a generic
+ * error or a silent disconnect. Best-effort: a throw (the socket is already
+ * gone) is swallowed — this must never escape a hibernation message handler,
+ * where a thrown handler is fatal to the socket.
+ */
+const dropExpiredCredentialSocket = (ws: ExpirableSocket): void => {
+    try {
+        ws.send(JSON.stringify({ code: "TOKEN_EXPIRED", error: { code: "TOKEN_EXPIRED", message: "authentication token expired" }, type: "error" }));
+        ws.close?.(4001, "token_expired");
+    } catch {
+        /* socket already gone */
+    }
+};
+
+export {
+    decodeIdentityExpiryHeader,
+    decodeIdentityHeader,
+    decodeUserIdHeader,
+    dropExpiredCredentialSocket,
+    encodeIdentityHeader,
+    encodeUserIdHeader,
+    isByteStringSafe,
+    isIdentityExpired,
+};
+export type { ExpirableSocket };


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(agent): drop expired-credential voice sockets with TOKEN_EXPIRED/4001
- refactor(agent,do): extract the expired-credential-socket check into shared
- fix(agent): reject an already-expired credential at voice upgrade

## Files this branch still changes relative to alpha

```
packages/agent/__tests__/voice-do.test.ts
packages/agent/src/voice-do.ts
packages/do/src/shard-do.ts
shared/identity-header.ts
```
