### PR TITLE
fix(workflow,runtime,agent,do): reject the reserved branch marker at every workflow create entrypoint

### DIFF
--- a/packages/agent/__tests__/channels.test.ts
+++ b/packages/agent/__tests__/channels.test.ts
@@ -7,6 +7,7 @@ const encoder = new TextEncoder();
 
 const NO_BINDING_PATTERN = /no Workflow binding/u;
 const TRANSIENT_FAILURE_PATTERN = /temporarily unavailable/u;
+const BRANCH_MARKER_PATTERN = /reserved workflow branch-marker key/u;
 
 const bytesToHex = (bytes: Uint8Array): string => [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 
@@ -389,5 +390,31 @@ describe(dispatchAgentChannel, () => {
 
         // Verified + claimed, but AGENT_MISSING is absent from env.
         await expect(handler(await slackRequest(secret, '{"event":{}}'), { SLACK_SECRET: secret })).rejects.toThrow(NO_BINDING_PATTERN);
+    });
+
+    it("rejects (throws, does not ack) a claimed run whose mapper injects the reserved branch-marker key", async () => {
+        const { binding, created } = fakeBinding();
+        const agent = {
+            onInbound: {
+                channel: "slack" as const,
+                map: () => {
+                    return {
+                        input: "x",
+                        threadKey: "t",
+                        __lunoraBranch: { eventType: "lunora:branch:x", index: 0, parentBinding: "WORKFLOW_X", parentId: "p" },
+                    };
+                },
+                secret: "SLACK_SECRET",
+            },
+        };
+        const handler = dispatchAgentChannel([{ agent, binding: "AGENT_SUPPORT" }]);
+
+        // Verified + claimed, but the mapper's run carries a forged marker — must
+        // throw (surfacing as non-2xx so the provider redelivers), never be acked
+        // as handled, and never reach `create()`.
+        await expect(handler(await slackRequest(secret, '{"event":{}}'), { AGENT_SUPPORT: binding, SLACK_SECRET: secret })).rejects.toThrow(
+            BRANCH_MARKER_PATTERN,
+        );
+        expect(created).toStrictEqual([]);
     });
 });

--- a/packages/agent/__tests__/create-agent-context.test.ts
+++ b/packages/agent/__tests__/create-agent-context.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import createAgentContext from "../src/create-agent-context";
-import type { AgentFunctionReference } from "../src/types";
+import type { AgentFunctionReference, AgentRunInput } from "../src/types";
 
 const MISSING_BINDING_PATTERN = /AGENT_SUPPORT/u;
+const BRANCH_MARKER_PATTERN = /reserved workflow branch-marker key/u;
 
 const fakeBinding = (): {
     binding: {
@@ -72,6 +73,22 @@ describe(createAgentContext, () => {
         const agents = createAgentContext({}, [{ binding: "AGENT_SUPPORT", exportName: "support" }]);
 
         await expect(agents["support"]!.run({ input: "hi", threadKey: "t-1" })).rejects.toThrow(MISSING_BINDING_PATTERN);
+    });
+
+    it("rejects run() input carrying the reserved branch-marker key, and never calls create()", async () => {
+        const { binding, createCalls } = fakeBinding();
+        const agents = createAgentContext({ AGENT_SUPPORT: binding }, [{ binding: "AGENT_SUPPORT", exportName: "support" }]);
+
+        // Reachable from the public `agents:agentRun` mutation when `publicRun:
+        // true` — a forged marker must be rejected before it ever reaches create().
+        const forgedInput = {
+            __lunoraBranch: { eventType: "lunora:branch:x", index: 0, parentBinding: "WORKFLOW_X", parentId: "p" },
+            input: "hi",
+            threadKey: "t-1",
+        } as unknown as AgentRunInput;
+
+        await expect(agents["support"]!.run(forgedInput)).rejects.toThrow(BRANCH_MARKER_PATTERN);
+        expect(createCalls).toHaveLength(0);
     });
 
     it("cancels a run: terminates the instance and marks its thread cancelled", async () => {

--- a/packages/agent/__tests__/inbound.test.ts
+++ b/packages/agent/__tests__/inbound.test.ts
@@ -138,4 +138,25 @@ describe(dispatchAgentEmail, () => {
 
         expect(rejects).toHaveLength(1);
     });
+
+    it("bounces the message (setReject) and never calls create() when the mapper's run carries the reserved branch-marker key", async () => {
+        expect.assertions(2);
+
+        const support = fakeBinding();
+        // A fully untrusted inbound email could fold attacker JSON into the run —
+        // simulate a mapper that (mistakenly or maliciously) forwards a forged marker.
+        const onEmail: AgentEmailMapper = () => ({
+                __lunoraBranch: { eventType: "lunora:branch:x", index: 0, parentBinding: "WORKFLOW_X", parentId: "p" },
+                input: "x",
+                threadKey: "t",
+            } as unknown as ReturnType<AgentEmailMapper>);
+
+        const handler = dispatchAgentEmail([{ agent: { onEmail }, binding: "AGENT_SUPPORT" }]);
+        const { message, rejects } = fakeMessage();
+
+        await handler(message, { AGENT_SUPPORT: support.binding }, {});
+
+        expect(support.calls).toHaveLength(0);
+        expect(rejects).toHaveLength(1);
+    });
 });

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -20,7 +20,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
-import { hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import type { AgentChannelRun, AgentDefinition, AgentInboundChannelKind, AgentWorkflowBindingLike, InboundChannelEvent } from "./types";
 
 /** Max age (seconds) of a signed request before it is rejected as a replay. */
@@ -278,7 +278,7 @@ const startChannelRun = async (
     // `create()`. Thrown (not acked): a forged marker must not be reported as
     // handled, or the provider would never redeliver it once the bug is fixed.
     if (hasBranchMarker(run)) {
-        throw new LunoraError("BAD_REQUEST", "@lunora/agent: inbound channel run params may not contain the reserved workflow branch-marker key");
+        throw new LunoraError("BAD_REQUEST", `@lunora/agent: inbound channel run params ${BRANCH_MARKER_REJECTION}`);
     }
 
     // Sanitize the id alone (the `channel-` prefix is already instance-id-safe);

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -20,6 +20,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
+import { hasBranchMarker } from "../../../shared/branch-marker";
 import type { AgentChannelRun, AgentDefinition, AgentInboundChannelKind, AgentWorkflowBindingLike, InboundChannelEvent } from "./types";
 
 /** Max age (seconds) of a signed request before it is rejected as a replay. */
@@ -272,6 +273,14 @@ const startChannelRun = async (
     channel: AgentInboundChannelKind,
     id: string | undefined,
 ): Promise<Response> => {
+    // `run` derives from an inbound channel webhook mapper — reject the reserved
+    // workflow branch-marker key at this trust boundary before it ever reaches
+    // `create()`. Thrown (not acked): a forged marker must not be reported as
+    // handled, or the provider would never redeliver it once the bug is fixed.
+    if (hasBranchMarker(run)) {
+        throw new LunoraError("BAD_REQUEST", "@lunora/agent: inbound channel run params may not contain the reserved workflow branch-marker key");
+    }
+
     // Sanitize the id alone (the `channel-` prefix is already instance-id-safe);
     // an id absent or reduced to empty by sanitization gives no dedup key.
     const sanitizedId = id === undefined ? "" : id.replaceAll(UNSAFE_INSTANCE_ID, "");

--- a/packages/agent/src/create-agent-context.ts
+++ b/packages/agent/src/create-agent-context.ts
@@ -2,6 +2,7 @@
 import { createDispatchRunner } from "@lunora/dispatch";
 import { LunoraError } from "@lunora/errors";
 
+import { hasBranchMarker } from "../../../shared/branch-marker";
 import { DEFAULT_AGENT_FUNCTION_PATHS, toFunctionReference } from "./paths";
 import type { AgentBindingSpec, AgentHandle, AgentRunFunction, AgentRunInput, AgentWorkflowBindingLike } from "./types";
 
@@ -63,6 +64,14 @@ const createAgentContext = (env: Record<string, unknown>, specs: ReadonlyArray<A
             // server-side `run(...)` below is unaffected.
             publicRun: spec.publicRun === true,
             run: async (input: AgentRunInput, options?: { id?: string }) => {
+                // `input` is reachable from the public `agents:agentRun` mutation
+                // when `publicRun: true` — reject the reserved workflow
+                // branch-marker key at this trust boundary before it ever reaches
+                // `create()`.
+                if (hasBranchMarker(input)) {
+                    throw new LunoraError("BAD_REQUEST", "@lunora/agent: run input may not contain the reserved workflow branch-marker key");
+                }
+
                 const instance = await resolve().create({ ...(options?.id === undefined ? {} : { id: options.id }), params: input });
 
                 return { id: instance.id };

--- a/packages/agent/src/create-agent-context.ts
+++ b/packages/agent/src/create-agent-context.ts
@@ -2,7 +2,7 @@
 import { createDispatchRunner } from "@lunora/dispatch";
 import { LunoraError } from "@lunora/errors";
 
-import { hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import { DEFAULT_AGENT_FUNCTION_PATHS, toFunctionReference } from "./paths";
 import type { AgentBindingSpec, AgentHandle, AgentRunFunction, AgentRunInput, AgentWorkflowBindingLike } from "./types";
 
@@ -69,7 +69,7 @@ const createAgentContext = (env: Record<string, unknown>, specs: ReadonlyArray<A
                 // branch-marker key at this trust boundary before it ever reaches
                 // `create()`.
                 if (hasBranchMarker(input)) {
-                    throw new LunoraError("BAD_REQUEST", "@lunora/agent: run input may not contain the reserved workflow branch-marker key");
+                    throw new LunoraError("BAD_REQUEST", `@lunora/agent: run input ${BRANCH_MARKER_REJECTION}`);
                 }
 
                 const instance = await resolve().create({ ...(options?.id === undefined ? {} : { id: options.id }), params: input });

--- a/packages/agent/src/inbound.ts
+++ b/packages/agent/src/inbound.ts
@@ -31,7 +31,7 @@ import { LunoraError } from "@lunora/errors";
 import type { ForwardableEmailMessageLike } from "@lunora/mail/inbound";
 import { createInboundEmailHandler, parseInboundEmail } from "@lunora/mail/inbound";
 
-import { hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import type { AgentDefinition, AgentWorkflowBindingLike } from "./types";
 
 /**
@@ -101,7 +101,7 @@ const dispatchAgentEmail = (targets: ReadonlyArray<AgentEmailTarget>): InboundAg
                 // branch-marker key at this trust boundary before it ever reaches
                 // `create()`.
                 if (hasBranchMarker(run)) {
-                    throw new LunoraError("BAD_REQUEST", "@lunora/agent: inbound run params may not contain the reserved workflow branch-marker key");
+                    throw new LunoraError("BAD_REQUEST", `@lunora/agent: inbound run params ${BRANCH_MARKER_REJECTION}`);
                 }
 
                 // `AgentEmailRun` is the run-input shape (input/owner/threadKey/title).

--- a/packages/agent/src/inbound.ts
+++ b/packages/agent/src/inbound.ts
@@ -31,6 +31,7 @@ import { LunoraError } from "@lunora/errors";
 import type { ForwardableEmailMessageLike } from "@lunora/mail/inbound";
 import { createInboundEmailHandler, parseInboundEmail } from "@lunora/mail/inbound";
 
+import { hasBranchMarker } from "../../../shared/branch-marker";
 import type { AgentDefinition, AgentWorkflowBindingLike } from "./types";
 
 /**
@@ -93,6 +94,14 @@ const dispatchAgentEmail = (targets: ReadonlyArray<AgentEmailTarget>): InboundAg
                         "INTERNAL",
                         `@lunora/agent: no Workflow binding "${target.binding}" on env for an inbound agent — run codegen/dev so wrangler.jsonc declares it`,
                     );
+                }
+
+                // `run` is built by an app-authored `onEmail` mapper from a fully
+                // untrusted inbound email — reject the reserved workflow
+                // branch-marker key at this trust boundary before it ever reaches
+                // `create()`.
+                if (hasBranchMarker(run)) {
+                    throw new LunoraError("BAD_REQUEST", "@lunora/agent: inbound run params may not contain the reserved workflow branch-marker key");
                 }
 
                 // `AgentEmailRun` is the run-input shape (input/owner/threadKey/title).

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -31,6 +31,7 @@ import {
 } from "@lunora/shard-engine";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { BRANCH_MARKER_REJECTION } from "../../../shared/branch-marker";
 import type {
     RunShardApplyCdcArgs,
     RunShardApplyCdcResult,
@@ -1172,7 +1173,7 @@ describe("shardDO admin introspection", () => {
     });
 
     it("rejects (400) createWorkflowInstance params carrying the reserved branch-marker key, and never calls create()", async () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
         const created: { id?: string; params?: unknown }[] = [];
 
@@ -1201,6 +1202,11 @@ describe("shardDO admin introspection", () => {
 
         expect(response.status).toBe(400);
         expect(created).toHaveLength(0);
+
+        // Shared across all five create-surface rejections (plan 262 review) —
+        // the admin-rpc message must carry the same reason text as
+        // workflow/runtime/agent, not just the same status code.
+        await expect(response.json()).resolves.toMatchObject({ error: { message: expect.stringContaining(BRANCH_MARKER_REJECTION) } });
     });
 
     it("reports a workflow instance's status, output, and error", async () => {

--- a/packages/do/__tests__/shard-do.admin.test.ts
+++ b/packages/do/__tests__/shard-do.admin.test.ts
@@ -1171,6 +1171,38 @@ describe("shardDO admin introspection", () => {
         expect(created).toStrictEqual([{ id: undefined, params: { orderId: "o1" } }]);
     });
 
+    it("rejects (400) createWorkflowInstance params carrying the reserved branch-marker key, and never calls create()", async () => {
+        expect.assertions(2);
+
+        const created: { id?: string; params?: unknown }[] = [];
+
+        const binding = {
+            create: (options: { id?: string; params?: unknown }) => {
+                created.push(options);
+
+                return Promise.resolve({ id: options.id ?? "wf-generated", status: () => Promise.resolve({ status: "queued" }) });
+            },
+            get: () => Promise.reject(new Error("get must not run for create")),
+        };
+
+        // Admin-token-gated, but rejected for uniformity with every other create
+        // surface — a forged marker must never reach `create()`.
+        const shard = new DeclaredWorkflowShard(state, { LUNORA_ADMIN_TOKEN: ADMIN_TOKEN, WORKFLOW_ORDER_PIPELINE: binding });
+        const response = await shard.fetch(
+            adminRequest(
+                ADMIN_FUNCTIONS.createWorkflowInstance,
+                {
+                    exportName: "orderPipeline",
+                    params: { __lunoraBranch: { eventType: "lunora:branch:x", index: 0, parentBinding: "WORKFLOW_X", parentId: "p" }, orderId: "o1" },
+                },
+                ADMIN_TOKEN,
+            ),
+        );
+
+        expect(response.status).toBe(400);
+        expect(created).toHaveLength(0);
+    });
+
     it("reports a workflow instance's status, output, and error", async () => {
         expect.assertions(1);
 

--- a/packages/do/src/admin-rpc-args.ts
+++ b/packages/do/src/admin-rpc-args.ts
@@ -31,6 +31,7 @@ import type {
 } from "@lunora/shard-engine";
 import { ADMIN_FUNCTION_PREFIX, tableFromDepKey } from "@lunora/shard-engine";
 
+import { hasBranchMarker } from "../../../shared/branch-marker";
 import { decodeIdentityHeader } from "../../../shared/identity-header";
 
 /** Recovers the process exit code embedded in a container `stop` message as `(exit &lt;n>)`. */
@@ -350,6 +351,14 @@ const parseCreateWorkflowInstanceArgs = (args: Record<string, unknown>): CreateW
     }
 
     const id = typeof args["id"] === "string" && args["id"] !== "" ? args["id"] : undefined;
+
+    // Admin-token-gated, but reject the reserved workflow branch-marker key for
+    // uniformity with every other create surface — a forged marker could
+    // otherwise reach a child's `event.payload` and spoof events into an
+    // arbitrary workflow instance.
+    if (hasBranchMarker(args["params"])) {
+        throw new LunoraError("BAD_REQUEST", "createWorkflowInstance: params may not contain the reserved workflow branch-marker key");
+    }
 
     return { exportName, id, params: args["params"] };
 };

--- a/packages/do/src/admin-rpc-args.ts
+++ b/packages/do/src/admin-rpc-args.ts
@@ -31,7 +31,7 @@ import type {
 } from "@lunora/shard-engine";
 import { ADMIN_FUNCTION_PREFIX, tableFromDepKey } from "@lunora/shard-engine";
 
-import { hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import { decodeIdentityHeader } from "../../../shared/identity-header";
 
 /** Recovers the process exit code embedded in a container `stop` message as `(exit &lt;n>)`. */
@@ -357,7 +357,7 @@ const parseCreateWorkflowInstanceArgs = (args: Record<string, unknown>): CreateW
     // otherwise reach a child's `event.payload` and spoof events into an
     // arbitrary workflow instance.
     if (hasBranchMarker(args["params"])) {
-        throw new LunoraError("BAD_REQUEST", "createWorkflowInstance: params may not contain the reserved workflow branch-marker key");
+        throw new LunoraError("BAD_REQUEST", `createWorkflowInstance: params ${BRANCH_MARKER_REJECTION}`);
     }
 
     return { exportName, id, params: args["params"] };

--- a/packages/runtime/__tests__/scheduled-workpool.test.ts
+++ b/packages/runtime/__tests__/scheduled-workpool.test.ts
@@ -147,4 +147,59 @@ describe("createWorker — scheduled workflow/agent dispatch", () => {
 
         expect(response.status).toBe(500);
     });
+
+    it("rejects (400) scheduled workflow args carrying the reserved branch-marker key, and never calls create()", async () => {
+        expect.assertions(2);
+
+        const created: { params?: Record<string, unknown> }[] = [];
+        const env = {
+            AGENT_SUPPORT: {
+                create: async (options: { params?: Record<string, unknown> }) => {
+                    created.push(options);
+
+                    return { id: "wf-1" };
+                },
+            },
+        };
+        const sched = schedulerSpy();
+        const worker = createWorker({ adminToken: ADMIN, schedulerDO: sched.namespace, shardDO: okShard() });
+
+        // A forged marker in the scheduled args (e.g. forwarded from a public
+        // mutation's `ctx.scheduler.runAfter(workflowRef, args)`) must be rejected
+        // at this trust boundary, the same as every other workflow create surface.
+        const response = await dispatchWithEnv(
+            worker,
+            {
+                args: { __lunoraBranch: { eventType: "lunora:branch:x", index: 0, parentBinding: "WORKFLOW_X", parentId: "p" }, prompt: "digest" },
+                id: "job-5",
+                workflow: "AGENT_SUPPORT",
+            },
+            env,
+        );
+
+        expect(response.status).toBe(400);
+        expect(created).toHaveLength(0);
+    });
+
+    it("starts an ordinary scheduled workflow unaffected by the branch-marker guard", async () => {
+        expect.assertions(2);
+
+        const created: { params?: Record<string, unknown> }[] = [];
+        const env = {
+            AGENT_SUPPORT: {
+                create: async (options: { params?: Record<string, unknown> }) => {
+                    created.push(options);
+
+                    return { id: "wf-1" };
+                },
+            },
+        };
+        const sched = schedulerSpy();
+        const worker = createWorker({ adminToken: ADMIN, schedulerDO: sched.namespace, shardDO: okShard() });
+
+        const response = await dispatchWithEnv(worker, { args: { prompt: "digest" }, id: "job-6", workflow: "AGENT_SUPPORT" }, env);
+
+        expect(response.status).toBe(200);
+        expect(created).toStrictEqual([{ params: { prompt: "digest" } }]);
+    });
 });

--- a/packages/runtime/__tests__/scheduled-workpool.test.ts
+++ b/packages/runtime/__tests__/scheduled-workpool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { BRANCH_MARKER_REJECTION } from "../../../shared/branch-marker";
 import type { ExecutionContextLike } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
@@ -149,7 +150,7 @@ describe("createWorker — scheduled workflow/agent dispatch", () => {
     });
 
     it("rejects (400) scheduled workflow args carrying the reserved branch-marker key, and never calls create()", async () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
         const created: { params?: Record<string, unknown> }[] = [];
         const env = {
@@ -179,6 +180,13 @@ describe("createWorker — scheduled workflow/agent dispatch", () => {
 
         expect(response.status).toBe(400);
         expect(created).toHaveLength(0);
+
+        // Shared across all five create-surface rejections (plan 262 review) —
+        // the runtime's message must carry the same reason text as
+        // workflow/agent/do, not just the same status code.
+        const body: { error: { message: string } } = await response.json();
+
+        expect(body.error.message).toContain(BRANCH_MARKER_REJECTION);
     });
 
     it("starts an ordinary scheduled workflow unaffected by the branch-marker guard", async () => {

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -2,7 +2,7 @@ import { isLunoraError, toErrorBody } from "@lunora/errors";
 
 import { asBucketStorage } from "../../../shared/as-bucket-storage";
 import type { BatchEntry } from "../../../shared/batch-wire";
-import { hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { ExecutionContextLike } from "../../../shared/execution-context";
@@ -2394,7 +2394,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // every other create surface, or a forged marker could reach a child's
         // `event.payload` and spoof events into an arbitrary workflow instance.
         if (hasBranchMarker(args)) {
-            throw new LunoraError(`${label} params may not contain the reserved workflow branch-marker key`, {
+            throw new LunoraError(`${label} params ${BRANCH_MARKER_REJECTION}`, {
                 code: "BAD_REQUEST",
                 status: 400,
             });

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -2,6 +2,7 @@ import { isLunoraError, toErrorBody } from "@lunora/errors";
 
 import { asBucketStorage } from "../../../shared/as-bucket-storage";
 import type { BatchEntry } from "../../../shared/batch-wire";
+import { hasBranchMarker } from "../../../shared/branch-marker";
 import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { ExecutionContextLike } from "../../../shared/execution-context";
@@ -2384,6 +2385,18 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             throw new LunoraError(`${label} targets workflow binding "${binding}", which is not bound on env`, {
                 code: "CRON_JOB_FAILED",
                 status: 500,
+            });
+        }
+
+        // `args` may carry app-forwarded, user-derived input (e.g. a public
+        // mutation's `ctx.scheduler.runAfter(workflowRef, args)`) — reject the
+        // reserved workflow branch-marker key at this trust boundary the same as
+        // every other create surface, or a forged marker could reach a child's
+        // `event.payload` and spoof events into an arbitrary workflow instance.
+        if (hasBranchMarker(args)) {
+            throw new LunoraError(`${label} params may not contain the reserved workflow branch-marker key`, {
+                code: "BAD_REQUEST",
+                status: 400,
             });
         }
 

--- a/packages/workflow/__tests__/create-workflows.test.ts
+++ b/packages/workflow/__tests__/create-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { BRANCH_MARKER_KEY, BRANCH_MARKER_REJECTION } from "../../../shared/branch-marker";
 import createWorkflows from "../src/create-workflows";
-import { BRANCH_MARKER_KEY } from "../src/fan-out";
 import type { WorkflowBindingLike, WorkflowCreateOptions, WorkflowInstanceLike } from "../src/types";
 
 const fakeInstance = (id: string): WorkflowInstanceLike => {
@@ -70,7 +70,7 @@ describe("createWorkflows", () => {
     });
 
     it("rejects create() params carrying the reserved branch marker without touching the binding", async () => {
-        expect.assertions(3);
+        expect.assertions(4);
 
         const binding = fakeBinding();
         const workflows = createWorkflows({ bindings: { orderPipeline: binding } });
@@ -83,11 +83,15 @@ describe("createWorkflows", () => {
 
         expect((error as Error).name).toBe("LunoraError");
         expect((error as { code?: string }).code).toBe("BAD_REQUEST");
+        // Shared across all five create-surface rejections (plan 262 review) —
+        // @lunora/workflow's own message must carry the same reason text as
+        // runtime/agent/do, not just the same error code.
+        expect((error as Error).message).toContain(BRANCH_MARKER_REJECTION);
         expect(binding.create).not.toHaveBeenCalled();
     });
 
     it("rejects createBatch() when any entry carries the reserved branch marker without touching the binding", async () => {
-        expect.assertions(3);
+        expect.assertions(4);
 
         const binding = fakeBinding();
         const workflows = createWorkflows({ bindings: { orderPipeline: binding } });
@@ -100,6 +104,7 @@ describe("createWorkflows", () => {
 
         expect((error as Error).name).toBe("LunoraError");
         expect((error as { code?: string }).code).toBe("BAD_REQUEST");
+        expect((error as Error).message).toContain(BRANCH_MARKER_REJECTION);
         expect(binding.createBatch).not.toHaveBeenCalled();
     });
 });

--- a/packages/workflow/__tests__/fan-out.test.ts
+++ b/packages/workflow/__tests__/fan-out.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { hasBranchMarker } from "../../../shared/branch-marker";
 import type { BranchOutcome, FanOutDeps } from "../src/fan-out";
 import {
     branch,
@@ -388,6 +389,17 @@ describe("branch marker helpers", () => {
 
         expect(stripBranchMarker({ [BRANCH_MARKER_KEY]: { index: 0 }, keep: true })).toEqual({ keep: true });
         expect(stripBranchMarker("scalar")).toBe("scalar");
+    });
+
+    it("hasBranchMarker (shared/branch-marker.ts): detects a top-level key, ignores a nested one and non-objects", () => {
+        expect.assertions(5);
+
+        expect(hasBranchMarker({ [BRANCH_MARKER_KEY]: {}, other: 1 })).toBe(true);
+        // A nested marker is inert — only the top-level own-property is checked.
+        expect(hasBranchMarker({ nested: { [BRANCH_MARKER_KEY]: {} } })).toBe(false);
+        expect(hasBranchMarker({ other: 1 })).toBe(false);
+        expect(hasBranchMarker("scalar")).toBe(false);
+        expect(hasBranchMarker(undefined)).toBe(false);
     });
 });
 

--- a/packages/workflow/__tests__/fan-out.test.ts
+++ b/packages/workflow/__tests__/fan-out.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_KEY, BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import type { BranchOutcome, FanOutDeps } from "../src/fan-out";
 import {
     branch,
-    BRANCH_MARKER_KEY,
     createParallel,
     createSpawn,
     errorOutcome,
@@ -339,7 +338,7 @@ describe("createSpawn", () => {
     });
 
     it("rejects a caller-supplied reserved branch marker without touching the step API", async () => {
-        expect.assertions(4);
+        expect.assertions(5);
 
         const step = makeStep();
         const { create, deps } = makeDeps(step);
@@ -350,6 +349,8 @@ describe("createSpawn", () => {
 
         expect((error as Error).name).toBe("LunoraError");
         expect((error as { code?: string }).code).toBe("BAD_REQUEST");
+        // Shared across all five create-surface rejections (plan 262 review).
+        expect((error as Error).message).toContain(BRANCH_MARKER_REJECTION);
         expect(step.do).not.toHaveBeenCalled();
         expect(create).not.toHaveBeenCalled();
     });

--- a/packages/workflow/__tests__/workerd/workflow-smoke.workerd.test.ts
+++ b/packages/workflow/__tests__/workerd/workflow-smoke.workerd.test.ts
@@ -19,8 +19,8 @@
 import { env, introspectWorkflowInstance } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 
+import { BRANCH_MARKER_KEY } from "../../../../shared/branch-marker";
 import createWorkflows from "../../src/create-workflows";
-import { BRANCH_MARKER_KEY } from "../../src/fan-out";
 import type { WorkflowBindingLike } from "../../src/types";
 import type { SmokeParams } from "./test-worker";
 
@@ -78,7 +78,9 @@ describe("@lunora/workflow (workerd)", () => {
 
         const handle = workflows.get("smokeWorkflow");
 
-        await expect(handle.create({ params: { [BRANCH_MARKER_KEY]: { forged: true } } })).rejects.toThrow(/may not contain the reserved key/);
+        await expect(handle.create({ params: { [BRANCH_MARKER_KEY]: { forged: true } } })).rejects.toThrow(
+            /may not contain the reserved workflow branch-marker key/,
+        );
     });
 
     it("throws a directed error for an undeclared workflow name", () => {

--- a/packages/workflow/src/create-workflows.ts
+++ b/packages/workflow/src/create-workflows.ts
@@ -5,7 +5,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
-import { BRANCH_MARKER_KEY } from "./fan-out";
+import { BRANCH_MARKER_KEY, hasBranchMarker } from "../../../shared/branch-marker";
 import type { LunoraWorkflowsOptions, WorkflowBindingLike, WorkflowCreateOptions, WorkflowHandle, WorkflowInstanceLike, Workflows } from "./types";
 
 /**
@@ -18,9 +18,7 @@ import type { LunoraWorkflowsOptions, WorkflowBindingLike, WorkflowCreateOptions
  * free of the reserved key while leaving `createParallel`'s own injection intact.
  */
 const rejectReservedParams = (options?: WorkflowCreateOptions): void => {
-    const { params } = options ?? {};
-
-    if (params !== undefined && Object.hasOwn(params, BRANCH_MARKER_KEY)) {
+    if (hasBranchMarker(options?.params)) {
         throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params may not contain the reserved key "${BRANCH_MARKER_KEY}"`);
     }
 };

--- a/packages/workflow/src/create-workflows.ts
+++ b/packages/workflow/src/create-workflows.ts
@@ -5,7 +5,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
-import { BRANCH_MARKER_KEY, hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import type { LunoraWorkflowsOptions, WorkflowBindingLike, WorkflowCreateOptions, WorkflowHandle, WorkflowInstanceLike, Workflows } from "./types";
 
 /**
@@ -19,7 +19,7 @@ import type { LunoraWorkflowsOptions, WorkflowBindingLike, WorkflowCreateOptions
  */
 const rejectReservedParams = (options?: WorkflowCreateOptions): void => {
     if (hasBranchMarker(options?.params)) {
-        throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params may not contain the reserved key "${BRANCH_MARKER_KEY}"`);
+        throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params ${BRANCH_MARKER_REJECTION}`);
     }
 };
 

--- a/packages/workflow/src/fan-out.ts
+++ b/packages/workflow/src/fan-out.ts
@@ -24,7 +24,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
-import { BRANCH_MARKER_KEY, hasBranchMarker } from "../../../shared/branch-marker";
+import { BRANCH_MARKER_KEY, BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import { NonRetryableError } from "./errors";
 import type {
     BranchCompensationParams,
@@ -313,7 +313,7 @@ const createSpawn =
         // Reject a caller-supplied reserved branch marker at the trust boundary —
         // only `createParallel`'s internal injection may set `__lunoraBranch`.
         if (hasBranchMarker(params)) {
-            throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params may not contain the reserved key "${BRANCH_MARKER_KEY}"`);
+            throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params ${BRANCH_MARKER_REJECTION}`);
         }
 
         const childId = deps.nextChildId(options?.id);
@@ -442,5 +442,3 @@ export {
     signalBranchParentSafe,
     stripBranchMarker,
 };
-
-export {BRANCH_MARKER_KEY} from "../../../shared/branch-marker";

--- a/packages/workflow/src/fan-out.ts
+++ b/packages/workflow/src/fan-out.ts
@@ -24,6 +24,7 @@
  */
 import { LunoraError } from "@lunora/errors";
 
+import { BRANCH_MARKER_KEY, hasBranchMarker } from "../../../shared/branch-marker";
 import { NonRetryableError } from "./errors";
 import type {
     BranchCompensationParams,
@@ -37,9 +38,6 @@ import type {
 
 /** Hard cap on branches per `ctx.parallel` call — auto-scale, never silently spawn unbounded DOs. */
 const MAX_BRANCHES = 100;
-
-/** The params key the parent injects so a child knows to signal completion back. Stripped before the user handler sees `ctx.params`. */
-const BRANCH_MARKER_KEY = "__lunoraBranch";
 
 /** Durable-step name prefix for a branch/spawn create. */
 const SPAWN_STEP_PREFIX = "lunora:spawn:";
@@ -314,7 +312,7 @@ const createSpawn =
     async (workflow: string, params?: Record<string, unknown>, options?: { id?: string }): Promise<WorkflowInstanceLike> => {
         // Reject a caller-supplied reserved branch marker at the trust boundary —
         // only `createParallel`'s internal injection may set `__lunoraBranch`.
-        if (params !== undefined && Object.hasOwn(params, BRANCH_MARKER_KEY)) {
+        if (hasBranchMarker(params)) {
             throw new LunoraError("BAD_REQUEST", `@lunora/workflow: params may not contain the reserved key "${BRANCH_MARKER_KEY}"`);
         }
 
@@ -434,7 +432,6 @@ const signalBranchParentSafe = async (
 export type { BranchMarker, BranchOutcome, FanOutDeps, WorkflowBindingResolver };
 export {
     branch,
-    BRANCH_MARKER_KEY,
     createParallel,
     createSpawn,
     errorOutcome,
@@ -445,3 +442,5 @@ export {
     signalBranchParentSafe,
     stripBranchMarker,
 };
+
+export {BRANCH_MARKER_KEY} from "../../../shared/branch-marker";

--- a/packages/workflow/tsconfig.json
+++ b/packages/workflow/tsconfig.json
@@ -1,8 +1,12 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages, and unlike
+        // this package's own prior config): `lint:types` is `tsc --noEmit` and the
+        // real build is packem (driven by package.json exports), so neither is
+        // load-bearing here. A set `rootDir` would raise TS6059 for the inlined
+        // `../../../shared/branch-marker` import (a file outside this package,
+        // bundled in at build time). See shared/branch-marker.ts.
         "moduleResolution": "bundler",
         "types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-pool-workers/types", "node"]
     },

--- a/shared/branch-marker.ts
+++ b/shared/branch-marker.ts
@@ -25,3 +25,16 @@ export const BRANCH_MARKER_KEY = "__lunoraBranch";
 
 /** True when caller-supplied workflow params carry the reserved branch-marker key. */
 export const hasBranchMarker = (params: unknown): boolean => typeof params === "object" && params !== null && Object.hasOwn(params, BRANCH_MARKER_KEY);
+
+/**
+ * The shared rejection-reason fragment every create surface must state when it
+ * refuses a caller-supplied branch marker — kept in one place so the five call
+ * sites (`@lunora/workflow`'s `create`/`createBatch`/`createSpawn`,
+ * `@lunora/runtime`'s scheduler/cron dispatch, `@lunora/agent`'s inbound
+ * email/channel/run handles, and `@lunora/do`'s admin-rpc) state the same
+ * contract instead of independently-drifting prose. Each site composes it with
+ * its own subject and package-prefix convention, e.g.
+ * `` `@lunora/workflow: params ${BRANCH_MARKER_REJECTION}` `` or
+ * `` `${label} params ${BRANCH_MARKER_REJECTION}` ``.
+ */
+export const BRANCH_MARKER_REJECTION: string = `may not contain the reserved workflow branch-marker key ("${BRANCH_MARKER_KEY}")`;

--- a/shared/branch-marker.ts
+++ b/shared/branch-marker.ts
@@ -1,0 +1,27 @@
+/**
+ * The reserved workflow-branch join-callback marker key, shared without a
+ * runtime dependency edge.
+ *
+ * `@lunora/workflow`'s `ctx.parallel` injects `__lunoraBranch` into a spawned
+ * child's params so the child can signal completion back to its parent
+ * instance/binding/event (see `packages/workflow/src/fan-out.ts`). Every public
+ * create surface that accepts caller-supplied params — in `@lunora/workflow`
+ * itself, and in `@lunora/runtime`, `@lunora/agent`, and `@lunora/do`, which all
+ * call a `Workflow` binding's `create()` with app- or user-derived params —
+ * must reject a caller-supplied marker at that trust boundary, or a forged one
+ * can reach a child's `event.payload` and spoof events into an arbitrary
+ * workflow instance.
+ *
+ * It is deliberately **not** a package: `@lunora/runtime` keeps `@lunora/workflow`
+ * as a type-only devDependency (see `packages/runtime/src/create-worker.ts`),
+ * and `@lunora/do` has no dependency on `@lunora/workflow` at all. Each consumer
+ * imports this file by relative path and the bundler inlines it — no runtime
+ * dependency edge is created, and the literal/check exists in exactly one
+ * source location.
+ */
+
+/** The reserved join-callback key `ctx.parallel` injects into a child's params. */
+export const BRANCH_MARKER_KEY = "__lunoraBranch";
+
+/** True when caller-supplied workflow params carry the reserved branch-marker key. */
+export const hasBranchMarker = (params: unknown): boolean => typeof params === "object" && params !== null && Object.hasOwn(params, BRANCH_MARKER_KEY);


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(workflow,runtime,agent,do): reject the reserved branch marker at every workflow create entrypoint
- fix(workflow,runtime,agent,do): unify the branch-marker rejection message and drop a malformed re-export

## Files this branch still changes relative to alpha

```
packages/agent/__tests__/channels.test.ts
packages/agent/__tests__/create-agent-context.test.ts
packages/agent/__tests__/inbound.test.ts
packages/agent/src/channels.ts
packages/agent/src/create-agent-context.ts
packages/agent/src/inbound.ts
packages/do/__tests__/shard-do.admin.test.ts
packages/do/src/admin-rpc-args.ts
packages/runtime/__tests__/scheduled-workpool.test.ts
packages/runtime/src/create-worker.ts
packages/workflow/__tests__/create-workflows.test.ts
packages/workflow/__tests__/fan-out.test.ts
packages/workflow/__tests__/workerd/workflow-smoke.workerd.test.ts
packages/workflow/src/create-workflows.ts
packages/workflow/src/fan-out.ts
packages/workflow/tsconfig.json
shared/branch-marker.ts
```
