### PR TITLE
fix(shard-engine): encode bigint/bytes doc columns so they round-trip on the DO row store

### DIFF
--- a/packages/shard-engine/__tests__/ctx-db.bigint-bytes.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.bigint-bytes.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
+import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import { encodeDocJson } from "../src/do-sql";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * `v.bigint()` / `v.bytes()` round-trip through the DO row store (plan 265).
+ *
+ * Before this fix the store's document blob serialized with a raw
+ * `JSON.stringify` and read back with a bare `JSON.parse`:
+ *
+ * - `JSON.stringify(1n)` **throws** (`TypeError: Do not know how to serialize
+ * a BigInt`) — a `v.bigint()` column made `ctx.db.insert` fail outright.
+ * - `JSON.stringify(new ArrayBuffer(n))` silently yields `{}` — a `v.bytes()`
+ * column's write "succeeds" while the payload is permanently lost.
+ *
+ * `encodeDocJson` / `decodeDocJson` (`../src/do-sql.ts`) now route the blob
+ * through the shared wire codec (`shared/wire-codec.ts`) so both round-trip.
+ * A document with neither leaf still encodes byte-identically to plain
+ * `JSON.stringify` (asserted below) — the property the OCC compare-and-swap
+ * and every `json_extract(__doc__, …)` read depend on for existing rows.
+ */
+const schema: SchemaLike = {
+    tables: {
+        accounts: {
+            indexes: [],
+            shape: {
+                amount: { kind: "bigint" },
+                blob: { kind: "bytes" },
+                deletedAt: { kind: "number" },
+                name: { kind: "string" },
+            },
+            softDeleteMode: { field: "deletedAt" },
+        },
+    },
+};
+
+let harness: ReturnType<typeof createSqliteExec>;
+
+const setup = (): DatabaseWriterLike => {
+    runShardMigrations(harness.sql, schema);
+
+    return createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+};
+
+describe("ctx-db bigint/bytes doc-blob round-trip", () => {
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    describe("v.bigint()", () => {
+        it("insert/get round-trips a bigint column (pre-fix: insert throws)", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+
+            await writer.insert("accounts", { _id: "a1", amount: 10n, name: "acme" }, { allowExplicitId: true });
+
+            const row = await writer.get("a1");
+
+            expect(row?.["amount"]).toBe(10n);
+        });
+
+        it("findMany round-trips a bigint column", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+
+            await writer.insert("accounts", { _id: "a1", amount: 10n, name: "acme" }, { allowExplicitId: true });
+
+            const { page } = await writer.findMany("accounts", {});
+
+            expect(page[0]?.["amount"]).toBe(10n);
+        });
+
+        it("patch preserves a previously-stored bigint column", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+
+            await writer.insert("accounts", { _id: "a1", amount: 10n, name: "acme" }, { allowExplicitId: true });
+            await writer.patch("a1", { name: "acme2" });
+
+            const row = await writer.get("a1");
+
+            expect(row?.["amount"]).toBe(10n);
+        });
+
+        it("patch can itself write a bigint column", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+
+            await writer.insert("accounts", { _id: "a1", name: "acme" }, { allowExplicitId: true });
+            await writer.patch("a1", { amount: 99n });
+
+            const row = await writer.get("a1");
+
+            expect(row?.["amount"]).toBe(99n);
+        });
+    });
+
+    describe("v.bytes()", () => {
+        it("insert/get round-trips a bytes column with identical bytes (pre-fix: reads back {})", async () => {
+            expect.assertions(2);
+
+            const writer = setup();
+            const bytes = new Uint8Array([1, 2, 3, 255]).buffer;
+
+            await writer.insert("accounts", { _id: "a1", blob: bytes, name: "acme" }, { allowExplicitId: true });
+
+            const row = await writer.get("a1");
+
+            expect(row?.["blob"]).toBeInstanceOf(ArrayBuffer);
+            expect(new Uint8Array(row?.["blob"] as ArrayBuffer)).toStrictEqual(new Uint8Array([1, 2, 3, 255]));
+        });
+
+        it("patch preserves a previously-stored bytes column", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+            const bytes = new Uint8Array([9, 8, 7]).buffer;
+
+            await writer.insert("accounts", { _id: "a1", blob: bytes, name: "acme" }, { allowExplicitId: true });
+            await writer.patch("a1", { name: "acme2" });
+
+            const row = await writer.get("a1");
+
+            expect(new Uint8Array(row?.["blob"] as ArrayBuffer)).toStrictEqual(new Uint8Array([9, 8, 7]));
+        });
+
+        it("replace round-trips a bytes column in the new document", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+            const bytes = new Uint8Array([1, 1, 2, 3, 5]).buffer;
+
+            await writer.insert("accounts", { _id: "a1", blob: new Uint8Array([0]).buffer, name: "acme" }, { allowExplicitId: true });
+            await writer.replace("a1", { blob: bytes, name: "acme2" });
+
+            const row = await writer.get("a1");
+
+            expect(new Uint8Array(row?.["blob"] as ArrayBuffer)).toStrictEqual(new Uint8Array([1, 1, 2, 3, 5]));
+        });
+
+        it("soft delete's re-stamped doc preserves the bytes column", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+            const bytes = new Uint8Array([42, 42]).buffer;
+
+            await writer.insert("accounts", { _id: "a1", blob: bytes, name: "acme" }, { allowExplicitId: true });
+            await writer.delete("a1", "accounts");
+
+            const row = await writer.get("a1", "accounts");
+
+            expect(new Uint8Array(row?.["blob"] as ArrayBuffer)).toStrictEqual(new Uint8Array([42, 42]));
+        });
+    });
+
+    describe("backward compatibility", () => {
+        it("a doc with no bigint/bytes/Date leaves encodes byte-identically to plain JSON.stringify", () => {
+            expect.assertions(1);
+
+            const plainDoc = { _creationTime: 1, _id: "a1", name: "acme", nested: { flag: true, list: [1, 2, 3], missing: null } };
+
+            expect(encodeDocJson(plainDoc)).toBe(JSON.stringify(plainDoc));
+        });
+
+        it("a row stored as plain JSON before this codec shipped still reads through ctx.db.get", async () => {
+            expect.assertions(1);
+
+            const writer = setup();
+            const legacyDoc = { _creationTime: 1_700_000_000_000, _id: "legacy-1", name: "legacy" };
+
+            // Bypass the writer entirely — insert the row exactly as it would have
+            // been written pre-fix (bare `JSON.stringify`, no wire-codec tags).
+            harness.raw("INSERT INTO accounts (id, _creationTime, __doc__) VALUES (?, ?, ?)", "legacy-1", 1_700_000_000_000, JSON.stringify(legacyDoc));
+
+            const row = await writer.get("legacy-1", "accounts");
+
+            expect(row).toMatchObject({ _id: "legacy-1", name: "legacy" });
+        });
+    });
+});

--- a/packages/shard-engine/__tests__/ctx-db.cdc.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.cdc.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import type { CdcChange, DatabaseWriterLike } from "../src/ctx-db";
+import type { CdcChange, DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
 import { applyCdcChanges, createShardCtxDb as createShardContextDatabase, readCdcChanges, runShardMigrations, trimCdcChanges } from "../src/ctx-db";
 import messagesSchema from "./_helpers/messages-schema";
 import createSqliteExec from "./_helpers/node-sqlite";
@@ -208,5 +208,47 @@ describe("applyCdcChanges (replay-PITR engine)", () => {
 
         await expect(writer.get("m_1")).resolves.toMatchObject({ text: "v2" });
         await expect(writer.get("m_2")).resolves.toBeNull();
+    });
+});
+
+describe("cdc round-trip of a v.bigint() column (plan 265)", () => {
+    // A dedicated schema — `messagesSchema` declares no bigint/bytes column,
+    // and this regression is specifically about `recordCdc` (ctx-db-cdc.ts)
+    // no longer throwing one line after a successful insert of such a row.
+    const bigintSchema: SchemaLike = {
+        tables: {
+            accounts: {
+                indexes: [],
+                shape: { amount: { kind: "bigint" }, name: { kind: "string" } },
+            },
+        },
+    };
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("readCdcChanges yields a doc whose bigint survives (pre-fix: recordCdc throws)", async () => {
+        expect.assertions(1);
+
+        runShardMigrations(harness.sql, bigintSchema, { cdc: true });
+
+        const writer = createShardContextDatabase({
+            broadcast: () => undefined,
+            cdc: true,
+            clock: () => 1_700_000_000_000,
+            schema: bigintSchema,
+            sql: harness.sql,
+        });
+
+        await writer.insert("accounts", { _id: "a1", amount: 10n, name: "acme" }, { allowExplicitId: true });
+
+        const { changes } = readCdcChanges(harness.sql);
+
+        expect(changes[0]?.doc?.["amount"]).toBe(10n);
     });
 });

--- a/packages/shard-engine/src/ctx-db-cdc.ts
+++ b/packages/shard-engine/src/ctx-db-cdc.ts
@@ -16,6 +16,7 @@ import { sql as dsql } from "drizzle-orm";
 
 import type { DatabaseWriterLike, SqlExec } from "./ctx-db";
 import { runDrizzle } from "./do-exec";
+import { decodeDocJson, encodeDocJson } from "./do-sql";
 import { ConflictError } from "./transaction";
 
 /** Reserved append-only changelog table backing CDC streaming export and replay-PITR. */
@@ -60,7 +61,7 @@ const migrateCdcLog = (sql: SqlExec): void => {
  */
 const appendCdcChange = (sql: SqlExec, ts: number, table: string, id: string, op: CdcChange["op"], doc: Record<string, unknown> | undefined): void => {
     // eslint-disable-next-line unicorn/no-null -- SQL NULL is the correct post-image for a delete; the `id` column identifies the removed row.
-    const docValue = doc === undefined ? null : JSON.stringify(doc);
+    const docValue = doc === undefined ? null : encodeDocJson(doc);
 
     runDrizzle(
         sql,
@@ -103,7 +104,7 @@ const readCdcChanges = (
     const changes = rows.map((row): CdcChange => {
         const base = { id: row.id, op: row.op as CdcChange["op"], seq: row.seq, table: row.table, ts: row.ts };
 
-        return row.doc === null ? base : { ...base, doc: JSON.parse(row.doc) as Record<string, unknown> };
+        return row.doc === null ? base : { ...base, doc: decodeDocJson(row.doc) };
     });
 
     return { changes, cursor: changes.at(-1)?.seq ?? sinceSeq };

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -67,6 +67,7 @@ import {
     AGG_KEY,
     AGG_VALUE,
     DOC_COLUMN,
+    encodeDocJson,
     geoTableName,
     isFtsAvailable,
     jsonPathSql,
@@ -2333,7 +2334,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
         // can compare-and-swap on it — a concurrent write that changed the
         // row flips the blob and the guarded UPDATE/DELETE matches zero rows.
         const rawDocument = firstRow[DOC_COLUMN];
-        const documentJson = typeof rawDocument === "string" ? rawDocument : JSON.stringify(rawDocument ?? {});
+        const documentJson = typeof rawDocument === "string" ? rawDocument : encodeDocJson((rawDocument ?? {}) as Record<string, unknown>);
 
         return { docJson: documentJson, row, tableName };
     };
@@ -2621,7 +2622,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 runGuardedWrite(
                     sql,
                     tableName,
-                    dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${JSON.stringify(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
+                    dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${encodeDocJson(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
                 );
 
                 // Search stays maintained (the marker filter hides it on read), but
@@ -3249,7 +3250,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             runWrite(
                 sql,
                 tableName,
-                dsql`INSERT INTO ${dsql.identifier(tableName)} (id, _creationTime, ${dsql.identifier(DOC_COLUMN)}) VALUES (${id}, ${creationTime}, ${JSON.stringify(documentWithMeta)})`,
+                dsql`INSERT INTO ${dsql.identifier(tableName)} (id, _creationTime, ${dsql.identifier(DOC_COLUMN)}) VALUES (${id}, ${creationTime}, ${encodeDocJson(documentWithMeta)})`,
             );
 
             syncCompanionsForInsert(tableName, id, documentWithMeta);
@@ -3342,7 +3343,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // ONE multi-row INSERT — the throughput win over `insertMany`'s N
             // single-row statements (and the skipped per-row JS pipeline).
             const valuesSql = dsql.join(
-                rows.map((row) => dsql`(${row.id}, ${row.creationTime}, ${JSON.stringify(row.document)})`),
+                rows.map((row) => dsql`(${row.id}, ${row.creationTime}, ${encodeDocJson(row.document)})`),
                 dsql`, `,
             );
 
@@ -3460,7 +3461,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             runGuardedWrite(
                 sql,
                 tableName,
-                dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${JSON.stringify(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
+                dsql`UPDATE ${dsql.identifier(tableName)} SET ${dsql.identifier(DOC_COLUMN)} = ${encodeDocJson(merged)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
             );
 
             syncSearch(tableName, id, merged, existing);
@@ -3887,7 +3888,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             runGuardedWrite(
                 sql,
                 tableName,
-                dsql`UPDATE ${dsql.identifier(tableName)} SET _creationTime = ${creationTime}, ${dsql.identifier(DOC_COLUMN)} = ${JSON.stringify(replaced)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
+                dsql`UPDATE ${dsql.identifier(tableName)} SET _creationTime = ${creationTime}, ${dsql.identifier(DOC_COLUMN)} = ${encodeDocJson(replaced)} WHERE id = ${id} AND ${dsql.identifier(DOC_COLUMN)} = ${existingJson}`,
             );
 
             syncSearch(tableName, id, replaced, previous);

--- a/packages/shard-engine/src/do-sql.ts
+++ b/packages/shard-engine/src/do-sql.ts
@@ -16,11 +16,35 @@
 import type { Name, SQL } from "drizzle-orm";
 import { sql as dsql } from "drizzle-orm";
 
+import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { ColumnMetaLike, SqlExec, TableDefinitionLike } from "./ctx-db";
 import { runDrizzle } from "./do-exec";
 
 /** The stored JSON document column every DO table carries alongside `id` / `_creationTime`. */
 const DOC_COLUMN = "__doc__";
+
+/**
+ * Encode a document into the `__doc__` blob's on-disk string form. Wraps
+ * `encodeWire` (the repo's tagged JSON-safe value codec, `shared/wire-codec.ts`)
+ * so `v.bigint()` (a real `bigint` — `JSON.stringify` throws on it) and
+ * `v.bytes()` (an `ArrayBuffer` — `JSON.stringify` silently corrupts it to
+ * `{}`) round-trip through storage. A document with no bigint/bytes/Date/Map/
+ * Set leaves encodes byte-identically to plain `JSON.stringify` (the wire
+ * codec's documented fidelity guarantee) — load-bearing for the OCC
+ * compare-and-swap and every `json_extract(__doc__, …)` read, which must see
+ * the same stored string for a doc this change doesn't touch.
+ */
+// eslint-disable-next-line unicorn/prevent-abbreviations -- "DocJson" mirrors the established `DOC_COLUMN`/`__doc__` naming this module already uses throughout.
+const encodeDocJson = (document: Record<string, unknown>): string => JSON.stringify(encodeWire(document));
+
+/**
+ * Inverse of {@link encodeDocJson}. Accepts both new tagged blobs and
+ * pre-existing plain-JSON blobs unchanged — `decodeWire` is a no-op on a tree
+ * with no `$lunora.wire$` sentinel, so rows written before this codec shipped
+ * keep parsing exactly as they did under bare `JSON.parse`.
+ */
+// eslint-disable-next-line unicorn/prevent-abbreviations -- see encodeDocJson above.
+const decodeDocJson = (raw: string): Record<string, unknown> => decodeWire(JSON.parse(raw)) as Record<string, unknown>;
 
 /** The geohash-companion table name for `.geoIndex(name)` on `table` (mirrors `ftsTableName`'s `__fts_` convention). */
 const geoTableName = (table: string, indexName: string): string => `${table}__geo_${indexName}`;
@@ -119,7 +143,7 @@ const rowToDocument = (row: Record<string, unknown> | undefined): Record<string,
     let parsed: Record<string, unknown>;
 
     if (typeof raw === "string") {
-        parsed = JSON.parse(raw) as Record<string, unknown>;
+        parsed = decodeDocJson(raw);
     } else if (raw && typeof raw === "object") {
         parsed = raw as Record<string, unknown>;
     } else {
@@ -206,7 +230,9 @@ export {
     AGG_VALUE,
     aggUpsertSql,
     createIndexSql,
+    decodeDocJson,
     DOC_COLUMN,
+    encodeDocJson,
     geoTableName,
     isFtsAvailable,
     jsonPath,

--- a/packages/sql-store/__tests__/value-codec.test.ts
+++ b/packages/sql-store/__tests__/value-codec.test.ts
@@ -74,6 +74,59 @@ describe("sqliteDecode — round-trips with sqliteEncode by kind", () => {
         expect(sqliteDecode("2026-06-20", "date")).toBe("2026-06-20");
         expect(sqliteDecode(7, "number")).toBe(7);
     });
+
+    describe("bytes (plan 265)", () => {
+        // `v.bytes()` validates `value instanceof ArrayBuffer` — a BLOB read back
+        // as any other view (node:sqlite `Uint8Array`, pg/mysql2 `Buffer`) fails
+        // re-validation without this branch. Pre-fix: `sqliteDecode` had no
+        // `"bytes"` case, so the switch's `default` returned the view unconverted.
+        it("passes a genuine ArrayBuffer through unchanged", () => {
+            expect.assertions(1);
+
+            const { buffer } = new Uint8Array([1, 2, 3, 4]);
+
+            expect(sqliteDecode(buffer, "bytes")).toBe(buffer);
+        });
+
+        it("converts a Uint8Array view to an ArrayBuffer with the same bytes", () => {
+            expect.assertions(2);
+
+            const view = new Uint8Array([9, 8, 7, 6]);
+            const decoded = sqliteDecode(view, "bytes");
+
+            expect(decoded).toBeInstanceOf(ArrayBuffer);
+            expect(new Uint8Array(decoded as ArrayBuffer)).toStrictEqual(new Uint8Array([9, 8, 7, 6]));
+        });
+
+        it("slices to the view's own window — a Buffer-pool view does not leak neighboring bytes", () => {
+            expect.assertions(3);
+
+            // A single larger backing pool, with a 4-byte view starting at offset 8 —
+            // mirrors how Node's Buffer allocator shares one backing ArrayBuffer
+            // across several small Buffers.
+            const pool = new ArrayBuffer(16);
+            const poolBytes = new Uint8Array(pool);
+
+            poolBytes.set([255, 255, 255, 255, 255, 255, 255, 255, 11, 22, 33, 44, 255, 255, 255, 255]);
+
+            const view = new Uint8Array(pool, 8, 4);
+            const decoded = sqliteDecode(view, "bytes");
+
+            // Pre-fix (no "bytes" case): `decoded` is the original view object
+            // itself, not a genuine ArrayBuffer — this is the assertion that
+            // actually distinguishes pre-fix from post-fix; byteLength/contents
+            // alone happen to already match since the view was already windowed.
+            expect(decoded).toBeInstanceOf(ArrayBuffer);
+            expect((decoded as ArrayBuffer).byteLength).toBe(4);
+            expect(new Uint8Array(decoded as ArrayBuffer)).toStrictEqual(new Uint8Array([11, 22, 33, 44]));
+        });
+
+        it("null stays null", () => {
+            expect.assertions(1);
+
+            expect(sqliteDecode(null, "bytes")).toBeNull();
+        });
+    });
 });
 
 describe("decodeBigint / tryJsonParse edge cases", () => {
@@ -110,5 +163,11 @@ describe("effectiveColumnKind", () => {
         expect.assertions(1);
 
         expect(effectiveColumnKind(validator("optional", validator("optional", validator("object"))))).toBe("object");
+    });
+
+    it('unwraps v.optional(v.bytes()) to "bytes" (plan 265)', () => {
+        expect.assertions(1);
+
+        expect(effectiveColumnKind(validator("optional", validator("bytes")))).toBe("bytes");
     });
 });

--- a/packages/sql-store/src/value-codec.ts
+++ b/packages/sql-store/src/value-codec.ts
@@ -86,6 +86,11 @@ export const effectiveColumnKind = (validator: ValidatorLike): string | undefine
  *
  * - `boolean`: 1/0 → true/false (SQLite has no boolean type).
  * - `bigint`: decimal string → `BigInt`.
+ * - `bytes`: normalizes any driver return shape to a genuine `ArrayBuffer` — a
+ *   view (`Uint8Array`/`Buffer`/…) is sliced to its own byte window, a plain
+ *   `ArrayBuffer` passes through. Required because `v.bytes()` validates
+ *   `value instanceof ArrayBuffer` and different backends return different BLOB
+ *   shapes (workerd D1 `ArrayBuffer`, node:sqlite `Uint8Array`, pg/mysql2 `Buffer`).
  * - `object`/`array`/`record`: JSON string → parsed value.
  * - `union`/`any`: parsed back only when the stored string is a JSON non-scalar
  *   (a scalar union member round-trips through SQLite's native column type).
@@ -117,6 +122,19 @@ export const sqliteDecode = (raw: unknown, kind: string | undefined): unknown =>
         }
         case "boolean": {
             return raw === 0 || raw === 1 ? raw === 1 : raw;
+        }
+        case "bytes": {
+            if (raw instanceof ArrayBuffer) {
+                return raw;
+            }
+
+            if (ArrayBuffer.isView(raw)) {
+                // Slice on the view's window — a Buffer is a view over a shared pool,
+                // and `.buffer` without slicing would leak unrelated pool bytes.
+                return raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength);
+            }
+
+            return raw;
         }
         default: {
             return raw;


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(shard-engine): encode bigint/bytes doc columns so they round-trip on the DO row store
- fix(sql-store): decode BLOB columns back to ArrayBuffer for v.bytes()

## Files this branch still changes relative to alpha

```
packages/shard-engine/__tests__/ctx-db.bigint-bytes.test.ts
packages/shard-engine/__tests__/ctx-db.cdc.test.ts
packages/shard-engine/src/ctx-db-cdc.ts
packages/shard-engine/src/ctx-db.ts
packages/shard-engine/src/do-sql.ts
packages/sql-store/__tests__/value-codec.test.ts
packages/sql-store/src/value-codec.ts
```
