### PR TITLE
fix(sql-store): allow filter() on the bare global reader so RLS can stage a search

### DIFF
--- a/packages/sql-store/__tests__/ctx-db-search.test.ts
+++ b/packages/sql-store/__tests__/ctx-db-search.test.ts
@@ -4,6 +4,7 @@ import type { SchemaLike, SearchIndexDefinitionLike, TableDefinitionLike, Valida
 import { sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { createSqlCtxDb } from "../src/ctx-db";
 import { backfillSqlSearchIndexes, createSearchSync, runSqlSearch, runSqlSearchMigrations } from "../src/ctx-db-search";
 import type { SqlDialect } from "../src/dialect";
 import { companionFor } from "../src/search-layout";
@@ -351,6 +352,115 @@ describe("global search provisioning", () => {
             );
 
             expect(rows.map((document) => document["_id"])).toStrictEqual(["b"]);
+        });
+    });
+
+    // Plan 269: RLS installs a `.filter()` predicate at `query()` time, BEFORE
+    // the caller can chain `.withSearchIndex(...)` — so the predicate must be
+    // chainable on the bare (stage-less) reader and still apply once a search
+    // stage is chosen. These exercise the full `createSqlCtxDb` reader (not the
+    // lower-level `runSqlSearch` helper above) since the bug lives in the
+    // reader's `filter` member, not in the search execution itself.
+    describe("query() reader — filter() before withSearchIndex() (plan 269)", () => {
+        const makeWriter = () => createSqlCtxDb({ clock: () => 1, dialect, exec, schema: searchSchema });
+
+        it("carries a pre-stage filter into a staged search (the RLS repro)", async () => {
+            expect.assertions(1);
+
+            createNotesTable();
+
+            const writer = makeWriter();
+
+            await writer.insert("notes", { body: "hello world", channel: "general" });
+            await writer.insert("notes", { body: "hello world", channel: "other" });
+
+            const rows = await writer
+                .query("notes")
+                .filter((document) => document["channel"] === "general")
+                .withSearchIndex("by_body", (q) => q.search("body", "hello"))
+                .collect();
+
+            expect(rows.map((row) => row["channel"])).toStrictEqual(["general"]);
+        });
+
+        it("honours the pre-stage predicate on every terminal", async () => {
+            expect.assertions(3);
+
+            createNotesTable();
+
+            const writer = makeWriter();
+
+            await writer.insert("notes", { body: "hello world", channel: "general" });
+            await writer.insert("notes", { body: "hello world", channel: "other" });
+
+            const chain = () =>
+                writer
+                    .query("notes")
+                    .filter((document) => document["channel"] === "general")
+                    .withSearchIndex("by_body", (q) => q.search("body", "hello"));
+
+            const taken = await chain().take(10);
+
+            expect(taken.map((row) => row["channel"])).toStrictEqual(["general"]);
+
+            const first = await chain().first();
+
+            expect(first?.["channel"]).toBe("general");
+
+            const paged = await chain().paginate({ numItems: 10 });
+
+            expect(paged.page.map((row) => row["channel"])).toStrictEqual(["general"]);
+        });
+
+        it("applies filters staged both before and after withSearchIndex()", async () => {
+            expect.assertions(1);
+
+            createNotesTable();
+
+            const writer = makeWriter();
+
+            await writer.insert("notes", { body: "hello world", channel: "general" });
+            await writer.insert("notes", { body: "hello world", channel: "other" });
+            await writer.insert("notes", { body: "hello moon", channel: "general" });
+
+            const rows = await writer
+                .query("notes")
+                .filter((document) => document["channel"] === "general")
+                .withSearchIndex("by_body", (q) => q.search("body", "hello"))
+                .filter((document) => (document["body"] as string).includes("world"))
+                .collect();
+
+            expect(rows.map((row) => row["body"])).toStrictEqual(["hello world"]);
+        });
+
+        it("still throws LEGACY_READER_ERROR on a stage-less chain (no regression)", async () => {
+            expect.assertions(3);
+
+            createNotesTable();
+
+            const writer = makeWriter();
+
+            await writer.insert("notes", { body: "hello world", channel: "general" });
+
+            // A `.filter()` with no `.withSearchIndex()` staged is still not a
+            // real reader — only the throw moves from `.filter()` (eagerly) to
+            // the terminal.
+            await expect(
+                writer
+                    .query("notes")
+                    .filter(() => true)
+                    .collect(),
+            ).rejects.toThrow(/legacy query\(\)\/withIndex\(\) reader is not available/u);
+
+            // `.withIndex()` keeps throwing immediately — untouched by this fix.
+            expect(() => writer.query("notes").withIndex("by_body")).toThrow(/legacy query\(\)\/withIndex\(\) reader is not available/u);
+
+            // The async iterator on a stage-less chain rejects too — advance it
+            // once directly rather than looping, since the throw happens before
+            // any value would ever be yielded.
+            await expect(writer.query("notes").filter(() => true)[Symbol.asyncIterator]().next()).rejects.toThrow(
+                /legacy query\(\)\/withIndex\(\) reader is not available/u,
+            );
         });
     });
 });

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -2842,10 +2842,13 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
                         );
                     },
                     filter(predicate) {
-                        if (!stage) {
-                            throw new LunoraError("INTERNAL", LEGACY_READER_ERROR);
-                        }
-
+                        // Chainable on the bare reader (like `order()` below): RLS
+                        // installs a predicate at query() time, BEFORE the caller
+                        // can stage `.withSearchIndex()`. `searchFilters` is
+                        // scoped to the whole query() call, so a pre-stage
+                        // predicate carries into the search stage; a non-search
+                        // chain still surfaces LEGACY_READER_ERROR at its
+                        // terminal.
                         searchFilters.push(predicate);
 
                         return reader;


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(sql-store): allow filter() on the bare global reader so RLS can stage a search

## Files this branch still changes relative to alpha

```
packages/sql-store/__tests__/ctx-db-search.test.ts
packages/sql-store/src/ctx-db.ts
```
