### PR TITLE
fix(search-core): derive the prefix upper bound from the last code point, not code unit

### DIFF
--- a/packages/search-core/__tests__/query.test.ts
+++ b/packages/search-core/__tests__/query.test.ts
@@ -235,6 +235,72 @@ describe(searchTermRange, () => {
             upper: `emoji${String.fromCodePoint(emojiCodePoint + 1)}`,
         });
     });
+
+    // Plan 272: `codePointAt(token.length - 1)` is a code-*unit* index, so for a
+    // token ending in a surrogate pair it reads the lone low surrogate rather
+    // than the character. The 😀 case above happens to produce the right
+    // answer anyway (the low surrogate's increment stays inside the surrogate
+    // block, so the pair re-forms by luck) — these cases pin the ones where
+    // that luck runs out.
+
+    it("increments the true last code point for U+10437 (𐐷, DESERET SMALL LETTER YEE) — a case where the code-unit bug happens to still land right", () => {
+        expect.assertions(2);
+
+        const codePoint = 0x1_04_37;
+        const token = String.fromCodePoint(codePoint);
+        const result = searchTermRange(token, true);
+
+        expect(result).toStrictEqual({ exact: false, lower: token, upper: String.fromCodePoint(codePoint + 1) });
+        // No lone surrogate anywhere in the bound — spreading a string iterates by
+        // code point, so a well-formed trailing astral character spreads to
+        // exactly one element (a lone surrogate would instead spread to one
+        // element per unpaired UTF-16 unit only by coincidence of length, so this
+        // is a coarse but sufficient smoke check alongside the exact-value assertion above).
+        // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional: code-point iteration is the property under test
+        expect([...result.upper]).toHaveLength(1);
+    });
+
+    it('increments the true last code point when the astral character is not the whole token ("a𐐷")', () => {
+        expect.assertions(1);
+
+        const codePoint = 0x1_04_37;
+        const token = `a${String.fromCodePoint(codePoint)}`;
+
+        expect(searchTermRange(token, true)).toStrictEqual({ exact: false, lower: token, upper: `a${String.fromCodePoint(codePoint + 1)}` });
+    });
+
+    it("increments the true last code point for a token ending at the UTF-16 low-surrogate boundary (U+103FF → U+10400)", () => {
+        expect.assertions(2);
+
+        // U+103FF's UTF-16 low surrogate is 0xDFFF — the top of the low-surrogate
+        // range. The CODE-UNIT bug reads that raw code unit via
+        // `codePointAt(token.length - 1)` and increments it in isolation,
+        // escaping the surrogate block entirely (0xE000, a real BMP character)
+        // and stranding the high surrogate — producing an invalid lone
+        // high-surrogate bound (`\uD800` followed by ``). Reading the
+        // true *code point* instead (0x103FF) increments correctly to its
+        // real successor, U+10400 — an ordinary astral code point, not a
+        // surrogate-range value, so this is a normal widen, not a refusal.
+        const codePoint = 0x1_03_FF;
+        const token = String.fromCodePoint(codePoint);
+        const result = searchTermRange(token, true);
+
+        expect(result).toStrictEqual({ exact: false, lower: token, upper: String.fromCodePoint(codePoint + 1) });
+        // No lone surrogate in the bound: spreading a well-formed string yields
+        // one element per code point, so a single trailing astral character
+        // spreads to exactly one element.
+        // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional: code-point iteration is the property under test
+        expect([...result.upper]).toHaveLength(1);
+    });
+
+    it("refuses to widen (falls back to exact match) for a token ending at the Hangul block boundary (U+D7FF), whose successor is the surrogate block", () => {
+        expect.assertions(1);
+
+        const codePoint = 0xD7_FF;
+        const token = `x${String.fromCodePoint(codePoint)}`;
+
+        expect(searchTermRange(token, true)).toStrictEqual({ exact: true, lower: token, upper: token });
+    });
 });
 
 describe(scoreDocument, () => {

--- a/packages/search-core/src/query.ts
+++ b/packages/search-core/src/query.ts
@@ -157,17 +157,35 @@ export const scoreDocument = (text: string, tokens: ReadonlyArray<string>, analy
  * Shared because both engines have to derive the *same* bound or their result
  * sets differ on the one term the user is still typing. The increment assumes
  * the last code point is not the maximum, which holds for the `[\p{L}\p{N}]+`
- * tokens the analyzer produces.
+ * tokens the analyzer produces — except at the two boundaries where a
+ * successor code point would not be a valid scalar value (see below), which
+ * degrade to an exact match instead.
  */
 export const searchTermRange = (token: string, isPrefix: boolean): { exact: boolean; lower: string; upper: string } => {
     if (!isPrefix) {
         return { exact: true, lower: token, upper: token };
     }
 
-    const lastCodePoint = token.codePointAt(token.length - 1) ?? 0;
-    const head = token.slice(0, Math.max(0, token.length - String.fromCodePoint(lastCodePoint).length));
+    // Spread iterates by code point (not UTF-16 code unit), so the last
+    // element is the whole trailing character even when it's a surrogate
+    // pair — exactly what a code-point-correct increment needs.
+    // eslint-disable-next-line @typescript-eslint/no-misused-spread -- intentional: code-point iteration is the fix, not the bug (see the docblock above)
+    const lastCharacter = [...token].at(-1) ?? "";
+    const lastCodePoint = lastCharacter.codePointAt(0) ?? 0;
+    const nextCodePoint = lastCodePoint + 1;
 
-    return { exact: false, lower: token, upper: head + String.fromCodePoint(lastCodePoint + 1) };
+    // The successor of U+D7FF is the surrogate block and the successor of
+    // U+10FFFF does not exist — a bound built from either is not a valid
+    // scalar-value string (a UTF-8 binding mangles it to U+FFFD). Degrade the
+    // term to an exact match instead: never wrong, merely narrower, and only
+    // reachable for tokens ending exactly at those two boundaries.
+    if ((nextCodePoint >= 0xD8_00 && nextCodePoint <= 0xDF_FF) || nextCodePoint > 0x10_FF_FF) {
+        return { exact: true, lower: token, upper: token };
+    }
+
+    const head = token.slice(0, token.length - lastCharacter.length);
+
+    return { exact: false, lower: token, upper: head + String.fromCodePoint(nextCodePoint) };
 };
 
 /**

--- a/packages/shard-engine/__tests__/ctx-db.search.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.search.test.ts
@@ -135,6 +135,27 @@ describe.each(ENGINES)("ctx-db search — $label", (engine) => {
             expect(results.map((document) => document["title"]).toSorted((a, b) => String(a).localeCompare(String(b)))).toStrictEqual(["a", "b"]);
         });
 
+        it("prefix-matches a final token ending in an astral (surrogate-pair) character (plan 272)", async () => {
+            expect.assertions(1);
+
+            const writer = setupWriter();
+
+            // U+10437 (𐐷, DESERET SMALL LETTER YEE) is a surrogate pair in
+            // UTF-16 — the exact shape `searchTermRange` must derive a
+            // code-point-correct upper bound for, not a code-unit one.
+            const astral = String.fromCodePoint(0x1_04_37);
+
+            await writer.insert("docs", { body: `${astral}ord some other text`, channel: "x", title: "a" });
+            await writer.insert("docs", { body: "unrelated document", channel: "x", title: "b" });
+
+            const results = await writer
+                .query("docs")
+                .withSearchIndex("by_body", (q) => q.search("body", astral))
+                .collect();
+
+            expect(results.map((document) => document["title"])).toStrictEqual(["a"]);
+        });
+
         it("narrows by an .eq() filter field", async () => {
             expect.assertions(1);
 

--- a/packages/sql-store/__tests__/ctx-db-search.test.ts
+++ b/packages/sql-store/__tests__/ctx-db-search.test.ts
@@ -352,5 +352,31 @@ describe("global search provisioning", () => {
 
             expect(rows.map((document) => document["_id"])).toStrictEqual(["b"]);
         });
+
+        it("prefix-matches a final token ending in an astral (surrogate-pair) character (plan 272)", async () => {
+            expect.assertions(1);
+
+            // U+10437 (𐐷, DESERET SMALL LETTER YEE) is a surrogate pair in
+            // UTF-16 — the exact shape `searchTermRange` must derive a
+            // code-point-correct upper bound for, not a code-unit one.
+            const astral = String.fromCodePoint(0x1_04_37);
+
+            createNotesTable();
+            insertNote("a", `${astral}ord some other text`);
+            insertNote("b", "unrelated document");
+
+            await runSqlSearchMigrations(exec, searchSchema, dialect);
+
+            const rows = await runSqlSearch(
+                exec,
+                dialect,
+                notesDefinition,
+                "notes",
+                { definition: BY_BODY, field: "body", filters: [], hasQuery: true, indexName: "by_body", query: astral },
+                10,
+            );
+
+            expect(rows.map((document) => document["_id"])).toStrictEqual(["a"]);
+        });
     });
 });


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(search-core): derive the prefix upper bound from the last code point, not code unit

## Files this branch still changes relative to alpha

```
packages/search-core/__tests__/query.test.ts
packages/search-core/src/query.ts
packages/shard-engine/__tests__/ctx-db.search.test.ts
packages/sql-store/__tests__/ctx-db-search.test.ts
```
