### PR TITLE
fix(observability): correct the metric-cap rationale to the post-guard threat model

### DIFF
--- a/api-snapshots/observability.api.md
+++ b/api-snapshots/observability.api.md
@@ -162,6 +162,7 @@ interface DatabaseTally {
 ```ts
 interface DatabaseTelemetryDeps {
     anchor: TraceAnchor;
+    captureRaw?: boolean;
     functionPath: string;
     mode: DatabaseInstrumentation;
     record: (span: SpanEvent) => void;
@@ -505,6 +506,7 @@ interface MetricHistoryPoint {
 
 ```ts
 interface MetricHistoryResult {
+    capped: boolean;
     series: MetricHistorySeries[];
 }
 ```
@@ -909,6 +911,7 @@ interface TracedFetchDeps {
 ```ts
 interface TracerDeps {
     anchor: TraceAnchor;
+    captureRaw?: boolean;
     functionPath: string;
     fuseHostSpans?: boolean;
     record: (span: SpanEvent) => void;
@@ -950,7 +953,7 @@ const createMetrics: (deps: MetricsDeps) => ContextMetrics;
 const createSpanCollector: (ids: {
     spanId: string;
     traceId: string;
-}) => SpanCollector;
+}, captureRaw?: boolean) => SpanCollector;
 ```
 
 ### `createTracedFetch` (const)
@@ -970,6 +973,7 @@ const createTracer: (deps: TracerDeps) => ContextTracer;
 ```ts
 const dispatchRootSpan: (input: {
     anchor: TraceAnchor;
+    captureRaw?: boolean;
     collected?: SpanCollection;
     durationMs: number;
     failure: {
@@ -1105,6 +1109,7 @@ const readFunctionMetrics: (sql: SqlExec) => FunctionCallStat[];
 
 ```ts
 const readFunctionMetricsTotals: (sql: SqlExec) => {
+    capped: boolean;
     errors: number;
     requests: number;
 };
@@ -1114,6 +1119,7 @@ const readFunctionMetricsTotals: (sql: SqlExec) => {
 
 ```ts
 const readMetricHistory: (sql: SqlExec, options?: {
+    maxSeries?: number;
     sinceMs?: number;
 }) => MetricHistoryResult;
 ```

--- a/packages/do/__tests__/function-metrics.test.ts
+++ b/packages/do/__tests__/function-metrics.test.ts
@@ -203,7 +203,7 @@ describe("function-metrics module", () => {
             expect(buckets[0]).toEqual({ bucketMs: base, calls: 2, errors: 1, path: "f:a" });
             expect(buckets[1]).toEqual({ bucketMs: base + FUNCTION_METRICS_BUCKET_MS, calls: 1, errors: 0, path: "f:a" });
 
-            expect(readFunctionMetricsTotals(database.sql)).toEqual({ errors: 1, requests: 3 });
+            expect(readFunctionMetricsTotals(database.sql)).toEqual({ capped: false, errors: 1, requests: 3 });
         } finally {
             database.close();
         }
@@ -339,33 +339,30 @@ describe("function-metrics module", () => {
             expect(readFunctionMetricBuckets(database.sql)).toEqual({ buckets: [], truncated: false });
             expect(readFunctionMetricScans(database.sql).size).toBe(0);
             expect(readFunctionMetricIndexHits(database.sql)).toEqual([]);
-            expect(readFunctionMetricsTotals(database.sql)).toEqual({ errors: 0, requests: 0 });
+            expect(readFunctionMetricsTotals(database.sql)).toEqual({ capped: false, errors: 0, requests: 0 });
         } finally {
             database.close();
         }
     });
 
-    it("evicts the coldest path so an unregistered-path flood can't grow the table unbounded", () => {
+    it("caps distinct paths so an unregistered-path flood can't grow the table unbounded", () => {
         expect.assertions(2);
 
         const database = createSqliteExec();
 
         try {
-            // Fill the accumulator to its distinct-path cap, oldest first —
-            // distinct timestamps make eviction order deterministic: `fn:0` ends
-            // up with the smallest `last_called_at`.
+            // Fill the accumulator to its distinct-path cap.
             for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-                recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: `fn:${String(index)}`, ts: index });
+                recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: `fn:${String(index)}`, ts: 1000 });
             }
 
-            // A brand-new path past the cap evicts the coldest tracked path
-            // (`fn:0`) to admit itself; an already-tracked path keeps
-            // accumulating past the cap.
-            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:flood-1", ts: FUNCTION_METRICS_MAX_PATHS });
-            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:1", ts: FUNCTION_METRICS_MAX_PATHS + 1 });
+            // A brand-new path past the cap is refused; an already-tracked path
+            // keeps accumulating.
+            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:flood-1", ts: 2000 });
+            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:0", ts: 2000 });
 
             const total = database.raw(`SELECT COUNT(*) AS c FROM "${FUNCTION_METRICS_TABLE}"`)[0] as { c: number };
-            const tracked = database.raw(`SELECT calls AS c FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'fn:1'`)[0] as { c: number };
+            const tracked = database.raw(`SELECT calls AS c FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'fn:0'`)[0] as { c: number };
 
             expect(total.c).toBe(FUNCTION_METRICS_MAX_PATHS);
             expect(tracked.c).toBe(2);

--- a/packages/do/__tests__/function-metrics.test.ts
+++ b/packages/do/__tests__/function-metrics.test.ts
@@ -345,24 +345,27 @@ describe("function-metrics module", () => {
         }
     });
 
-    it("caps distinct paths so an unregistered-path flood can't grow the table unbounded", () => {
+    it("evicts the coldest path so an unregistered-path flood can't grow the table unbounded", () => {
         expect.assertions(2);
 
         const database = createSqliteExec();
 
         try {
-            // Fill the accumulator to its distinct-path cap.
+            // Fill the accumulator to its distinct-path cap, oldest first —
+            // distinct timestamps make eviction order deterministic: `fn:0` ends
+            // up with the smallest `last_called_at`.
             for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-                recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: `fn:${String(index)}`, ts: 1000 });
+                recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: `fn:${String(index)}`, ts: index });
             }
 
-            // A brand-new path past the cap is dropped; an already-tracked path
-            // keeps accumulating.
-            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:flood-1", ts: 2000 });
-            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:0", ts: 2000 });
+            // A brand-new path past the cap evicts the coldest tracked path
+            // (`fn:0`) to admit itself; an already-tracked path keeps
+            // accumulating past the cap.
+            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:flood-1", ts: FUNCTION_METRICS_MAX_PATHS });
+            recordFunctionMetric(database.sql, { durationMs: 1, errored: false, path: "fn:1", ts: FUNCTION_METRICS_MAX_PATHS + 1 });
 
             const total = database.raw(`SELECT COUNT(*) AS c FROM "${FUNCTION_METRICS_TABLE}"`)[0] as { c: number };
-            const tracked = database.raw(`SELECT calls AS c FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'fn:0'`)[0] as { c: number };
+            const tracked = database.raw(`SELECT calls AS c FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'fn:1'`)[0] as { c: number };
 
             expect(total.c).toBe(FUNCTION_METRICS_MAX_PATHS);
             expect(tracked.c).toBe(2);

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -3671,6 +3671,10 @@ abstract class ShardDO {
 
         return createTracer({
             anchor: resolvedAnchor,
+            // Raw span error messages/stacktraces in dev only — production
+            // defaults to the same redacted posture as the request log and
+            // function-metrics sinks (see `context-telemetry.ts`'s `captureRaw`).
+            captureRaw: isDevEnvironment(this.env),
             fuseHostSpans: sink?.fuseCloudflareTraces === true,
             functionPath,
             record: (span) => {
@@ -3719,6 +3723,9 @@ abstract class ShardDO {
 
         return instrumentDatabase(database, {
             anchor,
+            // Raw constraint-error messages in dev only — matches `makeTracer`'s
+            // `captureRaw` posture.
+            captureRaw: isDevEnvironment(this.env),
             functionPath,
             mode,
             record: (recorded) => {
@@ -3803,7 +3810,9 @@ abstract class ShardDO {
             const key = dispatchSpanKey(anchor);
             const entry = this.dispatchSpans.get(key) ?? { sink };
 
-            entry.collector ??= createSpanCollector({ spanId: anchor.rootSpanId, traceId: anchor.traceId });
+            // Raw `recordException` stacktraces/messages in dev only — matches
+            // `makeTracer`'s `captureRaw` posture for the wide event's collector.
+            entry.collector ??= createSpanCollector({ spanId: anchor.rootSpanId, traceId: anchor.traceId }, isDevEnvironment(this.env));
             this.dispatchSpans.set(key, entry);
 
             return entry.collector;
@@ -4739,6 +4748,9 @@ abstract class ShardDO {
             this.spans.push(
                 dispatchRootSpan({
                     anchor,
+                    // Raw failure messages in dev only — matches `makeTracer`'s
+                    // `captureRaw` posture for this synthetic root span.
+                    captureRaw: isDevEnvironment(this.env),
                     // The wide event, if the handler attached one through `ctx.span`.
                     ...(collected === undefined ? {} : { collected }),
                     durationMs,

--- a/packages/observability/__tests__/context-telemetry.test.ts
+++ b/packages/observability/__tests__/context-telemetry.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import type { SpanEvent } from "../../../shared/span-event";
+import type { TracerDeps } from "../src/context-telemetry";
+import { createSpanCollector, createTracer, dispatchRootSpan } from "../src/context-telemetry";
+
+/**
+ * Span redaction (finding b/b′ of plan 276): the span pipeline is the one
+ * sink with third-party fan-out (`otlpSink`/`webhookSink`), so its error
+ * messages and exception stacktraces must default to the same redacted
+ * posture the request log and function-metrics sinks already have —
+ * `captureRaw` (dev-only, mirroring `isDevEnvironment`) is the one escape
+ * hatch, exactly as `request-log.ts` already established.
+ */
+
+const anchor = { rootSpanId: "root0000root0000", traceId: "trace00000000000000000000000000" };
+
+/** Build a tracer over a captured `record`, with deps merged in. */
+const setup = (overrides: Partial<TracerDeps> = {}) => {
+    const recorded: SpanEvent[] = [];
+
+    const trace = createTracer({
+        anchor,
+        functionPath: "messages:list",
+        record: (span) => {
+            recorded.push(span);
+        },
+        shardKey: "room-1",
+        userId: () => "user-42",
+        ...overrides,
+    });
+
+    return { recorded, trace };
+};
+
+describe("createTracer error-message redaction", () => {
+    it("redacts a span body's thrown message by default", async () => {
+        expect.assertions(2);
+
+        const { recorded, trace } = setup();
+
+        await expect(
+            trace("span", () => {
+                throw new Error("User 12345 not found");
+            }),
+        ).rejects.toThrow("User 12345 not found");
+
+        // Redacted like the request log's `errorMessage` by default —
+        // `@visulima/redact`'s `standardRules` masks a bare 5-digit run as `<DL>`.
+        expect(recorded[0]?.error?.message).toBe("User <DL> not found");
+    });
+
+    it("keeps the raw message when captureRaw is true (the dev escape hatch)", async () => {
+        expect.assertions(2);
+
+        const { recorded, trace } = setup({ captureRaw: true });
+
+        await expect(
+            trace("span", () => {
+                throw new Error("User 12345 not found");
+            }),
+        ).rejects.toThrow("User 12345 not found");
+
+        expect(recorded[0]?.error?.message).toBe("User 12345 not found");
+    });
+
+    it("re-throws the original error untouched regardless of redaction", async () => {
+        expect.assertions(1);
+
+        const boom = new Error("User 12345 not found");
+        const { trace } = setup();
+
+        await expect(
+            trace("span", () => {
+                throw boom;
+            }),
+        ).rejects.toBe(boom);
+    });
+});
+
+describe("createSpanCollector recordException redaction and stacktrace gating", () => {
+    it("redacts exception.message and omits exception.stacktrace by default", () => {
+        expect.assertions(2);
+
+        const { collected, handle } = createSpanCollector({ spanId: "span0000span0000", traceId: anchor.traceId });
+
+        const error = new Error("User 12345 not found");
+
+        handle.recordException(error);
+
+        const event = collected.events[0];
+
+        expect(event?.attributes?.["exception.message"]).toBe("User <DL> not found");
+        expect(event?.attributes?.["exception.stacktrace"]).toBeUndefined();
+    });
+
+    it("keeps the raw message and attaches exception.stacktrace when captureRaw is true", () => {
+        expect.assertions(2);
+
+        const { collected, handle } = createSpanCollector({ spanId: "span0000span0000", traceId: anchor.traceId }, true);
+
+        const error = new Error("User 12345 not found");
+
+        handle.recordException(error);
+
+        const event = collected.events[0];
+
+        expect(event?.attributes?.["exception.message"]).toBe("User 12345 not found");
+        expect(typeof event?.attributes?.["exception.stacktrace"]).toBe("string");
+    });
+});
+
+describe("dispatchRootSpan error-message redaction", () => {
+    it("redacts the thrown failure's message by default", () => {
+        expect.assertions(1);
+
+        const span = dispatchRootSpan({
+            anchor,
+            durationMs: 12,
+            failure: { thrown: new Error("User 12345 not found") },
+            functionPath: "messages:list",
+            shardKey: "room-1",
+            startTs: 1000,
+            userId: "user-42",
+        });
+
+        expect(span.error?.message).toBe("User <DL> not found");
+    });
+
+    it("keeps the raw message when captureRaw is true", () => {
+        expect.assertions(1);
+
+        const span = dispatchRootSpan({
+            anchor,
+            captureRaw: true,
+            durationMs: 12,
+            failure: { thrown: new Error("User 12345 not found") },
+            functionPath: "messages:list",
+            shardKey: "room-1",
+            startTs: 1000,
+            userId: "user-42",
+        });
+
+        expect(span.error?.message).toBe("User 12345 not found");
+    });
+
+    it("carries no error field on a successful dispatch", () => {
+        expect.assertions(1);
+
+        const span = dispatchRootSpan({
+            anchor,
+            durationMs: 12,
+            failure: undefined,
+            functionPath: "messages:list",
+            shardKey: "room-1",
+            startTs: 1000,
+            userId: "user-42",
+        });
+
+        expect(span.error).toBeUndefined();
+    });
+});

--- a/packages/observability/__tests__/database-telemetry.test.ts
+++ b/packages/observability/__tests__/database-telemetry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SpanEvent } from "../../../shared/span-event";
 import type { DatabaseTally } from "../src/database-telemetry";
-import { createDatabaseTally, formatTally, instrumentDatabase } from "../src/database-telemetry";
+import { createDatabaseTally, describeFailure, formatTally, instrumentDatabase } from "../src/database-telemetry";
 
 /**
  * Automatic `ctx.db` instrumentation.
@@ -14,9 +14,10 @@ import { createDatabaseTally, formatTally, instrumentDatabase } from "../src/dat
  * a cheap-but-present proxy.
  */
 
-const deps = (mode: "off" | "spans" | "summary", tally: DatabaseTally, record: (span: SpanEvent) => void) => {
+const deps = (mode: "off" | "spans" | "summary", tally: DatabaseTally, record: (span: SpanEvent) => void, captureRaw?: boolean) => {
     return {
         anchor: { rootSpanId: "b7ad6b7169203331", traceId: "0af7651916cd43dd8448eb211c80319c" },
+        ...(captureRaw === undefined ? {} : { captureRaw }),
         functionPath: "orders:checkout",
         mode,
         record,
@@ -178,5 +179,119 @@ describe("instrumentDatabase", () => {
         // Repeated property access must not mint a new closure each time —
         // callers legitimately destructure or compare these.
         expect(instrumented.findMany).toBe(instrumented.findMany);
+    });
+});
+
+describe("client-span error-message redaction (captureRaw)", () => {
+    it("redacts a constraint error's message by default, matching the request-log posture", async () => {
+        expect.assertions(2);
+
+        const database = fakeDatabase();
+
+        database.insert.mockRejectedValueOnce(new Error("User 12345 not found"));
+
+        const tally = createDatabaseTally();
+        const spans: SpanEvent[] = [];
+        const instrumented = instrumentDatabase(
+            database,
+            deps("spans", tally, (recorded) => {
+                spans.push(recorded);
+            }),
+        );
+
+        await expect(instrumented.insert("orders", {})).rejects.toThrow("User 12345 not found");
+
+        // Redacted like `@visulima/redact`'s `standardRules` masks a bare
+        // 5-digit run as `<DL>` — same treatment the request log gives
+        // `errorMessage` by default.
+        expect(spans[0]?.error?.message).toBe("User <DL> not found");
+    });
+
+    it("keeps the raw message when captureRaw is true (the dev escape hatch)", async () => {
+        expect.assertions(2);
+
+        const database = fakeDatabase();
+
+        database.insert.mockRejectedValueOnce(new Error("User 12345 not found"));
+
+        const tally = createDatabaseTally();
+        const spans: SpanEvent[] = [];
+        const instrumented = instrumentDatabase(
+            database,
+            deps(
+                "spans",
+                tally,
+                (recorded) => {
+                    spans.push(recorded);
+                },
+                true,
+            ),
+        );
+
+        await expect(instrumented.insert("orders", {})).rejects.toThrow("User 12345 not found");
+
+        expect(spans[0]?.error?.message).toBe("User 12345 not found");
+    });
+});
+
+describe("describeFailure fallback (a non-Error, non-string failure)", () => {
+    // `JSON.stringify` is typed `=> string` but returns `undefined` for a
+    // function/symbol/undefined value. `SpanEvent["error"].message` is declared
+    // `string`, so `describeFailure` must still render one of these as a string —
+    // never the literal `undefined` value — exactly like `request-log.ts`'s
+    // `renderLogMessage` fallback.
+    it.each([
+        { label: "a function", value: () => "nope" },
+        { label: "a symbol", value: Symbol("x") },
+        { label: "undefined", value: undefined },
+    ])("renders $label as a string, not undefined", ({ value }) => {
+        expect.assertions(1);
+
+        expect(typeof describeFailure(value)).toBe("string");
+    });
+
+    it('renders undefined as the literal string "undefined"', () => {
+        expect.assertions(1);
+
+        expect(describeFailure(undefined)).toBe("undefined");
+    });
+
+    it("renders a symbol via String()", () => {
+        expect.assertions(1);
+
+        expect(describeFailure(Symbol("x"))).toBe("Symbol(x)");
+    });
+
+    it("still returns the raw Error.message for an Error input", () => {
+        expect.assertions(1);
+
+        expect(describeFailure(new Error("boom"))).toBe("boom");
+    });
+
+    it("still returns a plain string unchanged", () => {
+        expect.assertions(1);
+
+        expect(describeFailure("already a string")).toBe("already a string");
+    });
+
+    it("propagates the rendered message onto the recorded CLIENT span via instrumentDatabase", async () => {
+        expect.assertions(2);
+
+        const database = fakeDatabase();
+
+        database.insert.mockRejectedValueOnce(() => "nope");
+
+        const tally = createDatabaseTally();
+        const spans: SpanEvent[] = [];
+        const instrumented = instrumentDatabase(
+            database,
+            deps("spans", tally, (recorded) => {
+                spans.push(recorded);
+            }),
+        );
+
+        await expect(instrumented.insert("orders", {})).rejects.toBeTypeOf("function");
+
+        expect(typeof spans[0]?.error?.message).toBe("string");
     });
 });

--- a/packages/observability/__tests__/database-telemetry.test.ts
+++ b/packages/observability/__tests__/database-telemetry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SpanEvent } from "../../../shared/span-event";
 import type { DatabaseTally } from "../src/database-telemetry";
-import { createDatabaseTally, describeFailure, formatTally, instrumentDatabase } from "../src/database-telemetry";
+import { createDatabaseTally, formatTally, instrumentDatabase } from "../src/database-telemetry";
 
 /**
  * Automatic `ctx.db` instrumentation.
@@ -234,52 +234,29 @@ describe("client-span error-message redaction (captureRaw)", () => {
     });
 });
 
-describe("describeFailure fallback (a non-Error, non-string failure)", () => {
-    // `JSON.stringify` is typed `=> string` but returns `undefined` for a
-    // function/symbol/undefined value. `SpanEvent["error"].message` is declared
-    // `string`, so `describeFailure` must still render one of these as a string —
+describe("describeFailure fallback (a non-Error, non-string failure), exercised through instrumentDatabase", () => {
+    // `describeFailure` is a private module helper (not exported) — reached
+    // here through `instrumentDatabase`'s public surface, the only production
+    // consumer. `JSON.stringify` is typed `=> string` but returns `undefined`
+    // for a function/symbol/undefined value; `SpanEvent["error"].message` is
+    // declared `string`, so the rendered message must still be a string —
     // never the literal `undefined` value — exactly like `request-log.ts`'s
     // `renderLogMessage` fallback.
+    //
+    // A bare `throw undefined` isn't exercised here: `buildDatabaseSpan`
+    // treats `failure === undefined` as "no failure" (the same sentinel
+    // `createTracer`'s `let error: SpanEvent["error"]` uses), so a literal
+    // `undefined` rejection never reaches `describeFailure` through this
+    // path — a separate, pre-existing limitation this plan doesn't touch.
     it.each([
         { label: "a function", value: () => "nope" },
         { label: "a symbol", value: Symbol("x") },
-        { label: "undefined", value: undefined },
-    ])("renders $label as a string, not undefined", ({ value }) => {
-        expect.assertions(1);
-
-        expect(typeof describeFailure(value)).toBe("string");
-    });
-
-    it('renders undefined as the literal string "undefined"', () => {
-        expect.assertions(1);
-
-        expect(describeFailure(undefined)).toBe("undefined");
-    });
-
-    it("renders a symbol via String()", () => {
-        expect.assertions(1);
-
-        expect(describeFailure(Symbol("x"))).toBe("Symbol(x)");
-    });
-
-    it("still returns the raw Error.message for an Error input", () => {
-        expect.assertions(1);
-
-        expect(describeFailure(new Error("boom"))).toBe("boom");
-    });
-
-    it("still returns a plain string unchanged", () => {
-        expect.assertions(1);
-
-        expect(describeFailure("already a string")).toBe("already a string");
-    });
-
-    it("propagates the rendered message onto the recorded CLIENT span via instrumentDatabase", async () => {
+    ])("renders $label's message as a string, not undefined", async ({ value }) => {
         expect.assertions(2);
 
         const database = fakeDatabase();
 
-        database.insert.mockRejectedValueOnce(() => "nope");
+        database.insert.mockRejectedValueOnce(value);
 
         const tally = createDatabaseTally();
         const spans: SpanEvent[] = [];
@@ -290,8 +267,29 @@ describe("describeFailure fallback (a non-Error, non-string failure)", () => {
             }),
         );
 
-        await expect(instrumented.insert("orders", {})).rejects.toBeTypeOf("function");
+        await expect(instrumented.insert("orders", {})).rejects.toBe(value);
 
         expect(typeof spans[0]?.error?.message).toBe("string");
+    });
+
+    it("still uses the raw Error.message for an Error rejection", async () => {
+        expect.assertions(2);
+
+        const database = fakeDatabase();
+
+        database.insert.mockRejectedValueOnce(new Error("boom"));
+
+        const tally = createDatabaseTally();
+        const spans: SpanEvent[] = [];
+        const instrumented = instrumentDatabase(
+            database,
+            deps("spans", tally, (recorded) => {
+                spans.push(recorded);
+            }),
+        );
+
+        await expect(instrumented.insert("orders", {})).rejects.toThrow("boom");
+
+        expect(spans[0]?.error?.message).toBe("boom");
     });
 });

--- a/packages/observability/__tests__/function-metrics.test.ts
+++ b/packages/observability/__tests__/function-metrics.test.ts
@@ -7,6 +7,7 @@ import {
     FUNCTION_METRICS_BUCKETS_TABLE,
     FUNCTION_METRICS_MAX_PATHS,
     FUNCTION_METRICS_READ_LIMIT,
+    FUNCTION_METRICS_SCANS_TABLE,
     FUNCTION_METRICS_TABLE,
     mergeScanAttribution,
     readFunctionMetricBuckets,
@@ -285,32 +286,73 @@ describe("recordFunctionMetric", () => {
         expect(readFunctionMetricIndexHits(sql)).toStrictEqual([]);
     });
 
-    it("drops a brand-new path once the accumulator is at its cap", () => {
-        expect.assertions(4);
+    it("evicts the coldest path (smallest last_called_at) to admit a genuinely new one at the cap", () => {
+        expect.assertions(5);
 
         const harness = createSqliteExec();
         const { sql } = harness;
 
         ensureFunctionMetricsTables(sql);
 
-        // The cap exists because `path` is attacker-reachable: a FUNCTION_NOT_FOUND
-        // dispatch still records under the caller-supplied name. Seeding straight
-        // to the limit keeps this a test of the guard, not of 5000 upserts.
+        // Seed the accumulator to the cap with distinct `last_called_at` values
+        // so eviction order is deterministic: `seed:0` is the coldest.
         for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path) VALUES (?)`, `seed:${String(index)}`);
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path, last_called_at) VALUES (?, ?)`, `seed:${String(index)}`, index);
         }
 
-        recordFunctionMetric(sql, dispatch({ path: "attacker:random" }));
+        harness.raw(`INSERT INTO "${FUNCTION_METRICS_SCANS_TABLE}" (path, table_name, scans) VALUES ('seed:0', 'posts', 3)`);
+        harness.raw(`INSERT INTO "${FUNCTION_METRICS_BUCKETS_TABLE}" (path, bucket_ms, calls, errors) VALUES ('seed:0', 60000, 1, 0)`);
+
+        recordFunctionMetric(sql, dispatch({ path: "new:fn", ts: FUNCTION_METRICS_MAX_PATHS }));
+
+        const [count] = harness.raw(`SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`);
+
+        // The table stays at the cap: the new path was admitted, exactly one
+        // (the coldest) was evicted to make room.
+        expect(count?.["n"]).toBe(FUNCTION_METRICS_MAX_PATHS);
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'new:fn'`)).toHaveLength(1);
+        // The coldest seed (`last_called_at = 0`) is gone — pre-fix, `new:fn`
+        // would be refused and every seed row (including this one) would survive.
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'seed:0'`)).toStrictEqual([]);
+        // The satellites matter as much as the accumulator: an eviction that only
+        // cleared the accumulator row would leave the bucket/scan tables growing
+        // without bound for a path no longer tracked.
+        expect(readFunctionMetricBuckets(sql, "seed:0")).toStrictEqual({ buckets: [], truncated: false });
+        expect(readFunctionMetricScans(sql).get("seed:0")).toBeUndefined();
+    });
+
+    it("drops an evicted path from the known-paths cache so it re-verifies rather than bypassing the cap", () => {
+        expect.assertions(3);
+
+        const harness = createSqliteExec();
+        const { sql } = harness;
+
+        ensureFunctionMetricsTables(sql);
+
+        // Record `cold:fn` through `recordFunctionMetric` (not a raw seed) so it
+        // is marked "known" in THIS handle's in-memory cache, exactly like a
+        // real repeatedly-called function would be.
+        recordFunctionMetric(sql, dispatch({ path: "cold:fn", ts: 0 }));
+
+        for (let index = 1; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path, last_called_at) VALUES (?, ?)`, `seed:${String(index)}`, index);
+        }
+
+        // `cold:fn` has the smallest `last_called_at` (0), so it is the one
+        // evicted here.
+        recordFunctionMetric(sql, dispatch({ path: "new:fn", ts: FUNCTION_METRICS_MAX_PATHS }));
+
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'cold:fn'`)).toStrictEqual([]);
+
+        // If eviction left `cold:fn` in the known-paths cache, this call would
+        // skip the cap check entirely (`known.has` short-circuits `admitPath`)
+        // and the table would grow to MAX_PATHS + 1 instead of evicting again.
+        recordFunctionMetric(sql, dispatch({ path: "cold:fn", ts: FUNCTION_METRICS_MAX_PATHS + 1 }));
 
         const [count] = harness.raw(`SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`);
 
         expect(count?.["n"]).toBe(FUNCTION_METRICS_MAX_PATHS);
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'attacker:random'`)).toStrictEqual([]);
-        // The satellites matter as much as the accumulator: a guard that only
-        // protected the accumulator would leave the bucket, scan and index tables
-        // growing without bound, which is the whole reason the cap exists.
-        expect(readFunctionMetricBuckets(sql, "attacker:random")).toStrictEqual({ buckets: [], truncated: false });
-        expect(readFunctionMetricScans(sql).get("attacker:random")).toBeUndefined();
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'cold:fn'`)).toHaveLength(1);
     });
 
     it("keeps accumulating an already-tracked path past the cap", () => {
@@ -543,14 +585,14 @@ describe("per-handle memoization (OBS-02)", () => {
     });
 
     it("re-verifies the distinct-path cap against durable state on a fresh post-hibernation handle", () => {
-        expect.assertions(1);
+        expect.assertions(2);
 
         const harness = createSqliteExec();
 
         ensureFunctionMetricsTables(harness.sql);
 
         for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path) VALUES (?)`, `seed:${String(index)}`);
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path, last_called_at) VALUES (?, ?)`, `seed:${String(index)}`, index);
         }
 
         // A fresh handle has no local cache of what's tracked — it must fall
@@ -558,9 +600,15 @@ describe("per-handle memoization (OBS-02)", () => {
         // means the cap hasn't been reached.
         const fresh = freshHandleOver(harness);
 
-        recordFunctionMetric(fresh, dispatch({ path: "attacker:random" }));
+        recordFunctionMetric(fresh, dispatch({ path: "new:fn", ts: FUNCTION_METRICS_MAX_PATHS }));
 
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'attacker:random'`)).toStrictEqual([]);
+        // Admitted by evicting the coldest seed, not refused outright, and the
+        // table stays bounded at the cap.
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'new:fn'`)).toHaveLength(1);
+
+        const [count] = harness.raw(`SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`);
+
+        expect(count?.["n"]).toBe(FUNCTION_METRICS_MAX_PATHS);
     });
 });
 

--- a/packages/observability/__tests__/function-metrics.test.ts
+++ b/packages/observability/__tests__/function-metrics.test.ts
@@ -7,7 +7,6 @@ import {
     FUNCTION_METRICS_BUCKETS_TABLE,
     FUNCTION_METRICS_MAX_PATHS,
     FUNCTION_METRICS_READ_LIMIT,
-    FUNCTION_METRICS_SCANS_TABLE,
     FUNCTION_METRICS_TABLE,
     mergeScanAttribution,
     readFunctionMetricBuckets,
@@ -286,73 +285,31 @@ describe("recordFunctionMetric", () => {
         expect(readFunctionMetricIndexHits(sql)).toStrictEqual([]);
     });
 
-    it("evicts the coldest path (smallest last_called_at) to admit a genuinely new one at the cap", () => {
-        expect.assertions(5);
+    it("refuses a brand-new path once the accumulator is at its cap, protecting incumbents", () => {
+        expect.assertions(4);
 
         const harness = createSqliteExec();
         const { sql } = harness;
 
         ensureFunctionMetricsTables(sql);
 
-        // Seed the accumulator to the cap with distinct `last_called_at` values
-        // so eviction order is deterministic: `seed:0` is the coldest.
+        // Seeding straight to the limit keeps this a test of the guard, not of
+        // 5000 upserts.
         for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path, last_called_at) VALUES (?, ?)`, `seed:${String(index)}`, index);
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path) VALUES (?)`, `seed:${String(index)}`);
         }
 
-        harness.raw(`INSERT INTO "${FUNCTION_METRICS_SCANS_TABLE}" (path, table_name, scans) VALUES ('seed:0', 'posts', 3)`);
-        harness.raw(`INSERT INTO "${FUNCTION_METRICS_BUCKETS_TABLE}" (path, bucket_ms, calls, errors) VALUES ('seed:0', 60000, 1, 0)`);
-
-        recordFunctionMetric(sql, dispatch({ path: "new:fn", ts: FUNCTION_METRICS_MAX_PATHS }));
-
-        const [count] = harness.raw(`SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`);
-
-        // The table stays at the cap: the new path was admitted, exactly one
-        // (the coldest) was evicted to make room.
-        expect(count?.["n"]).toBe(FUNCTION_METRICS_MAX_PATHS);
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'new:fn'`)).toHaveLength(1);
-        // The coldest seed (`last_called_at = 0`) is gone — pre-fix, `new:fn`
-        // would be refused and every seed row (including this one) would survive.
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'seed:0'`)).toStrictEqual([]);
-        // The satellites matter as much as the accumulator: an eviction that only
-        // cleared the accumulator row would leave the bucket/scan tables growing
-        // without bound for a path no longer tracked.
-        expect(readFunctionMetricBuckets(sql, "seed:0")).toStrictEqual({ buckets: [], truncated: false });
-        expect(readFunctionMetricScans(sql).get("seed:0")).toBeUndefined();
-    });
-
-    it("drops an evicted path from the known-paths cache so it re-verifies rather than bypassing the cap", () => {
-        expect.assertions(3);
-
-        const harness = createSqliteExec();
-        const { sql } = harness;
-
-        ensureFunctionMetricsTables(sql);
-
-        // Record `cold:fn` through `recordFunctionMetric` (not a raw seed) so it
-        // is marked "known" in THIS handle's in-memory cache, exactly like a
-        // real repeatedly-called function would be.
-        recordFunctionMetric(sql, dispatch({ path: "cold:fn", ts: 0 }));
-
-        for (let index = 1; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path, last_called_at) VALUES (?, ?)`, `seed:${String(index)}`, index);
-        }
-
-        // `cold:fn` has the smallest `last_called_at` (0), so it is the one
-        // evicted here.
-        recordFunctionMetric(sql, dispatch({ path: "new:fn", ts: FUNCTION_METRICS_MAX_PATHS }));
-
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'cold:fn'`)).toStrictEqual([]);
-
-        // If eviction left `cold:fn` in the known-paths cache, this call would
-        // skip the cap check entirely (`known.has` short-circuits `admitPath`)
-        // and the table would grow to MAX_PATHS + 1 instead of evicting again.
-        recordFunctionMetric(sql, dispatch({ path: "cold:fn", ts: FUNCTION_METRICS_MAX_PATHS + 1 }));
+        recordFunctionMetric(sql, dispatch({ path: "flood:random" }));
 
         const [count] = harness.raw(`SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`);
 
         expect(count?.["n"]).toBe(FUNCTION_METRICS_MAX_PATHS);
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'cold:fn'`)).toHaveLength(1);
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'flood:random'`)).toStrictEqual([]);
+        // The satellites matter as much as the accumulator: a guard that only
+        // protected the accumulator would leave the bucket, scan and index tables
+        // growing without bound, which is the whole reason the cap exists.
+        expect(readFunctionMetricBuckets(sql, "flood:random")).toStrictEqual({ buckets: [], truncated: false });
+        expect(readFunctionMetricScans(sql).get("flood:random")).toBeUndefined();
     });
 
     it("keeps accumulating an already-tracked path past the cap", () => {
@@ -585,14 +542,14 @@ describe("per-handle memoization (OBS-02)", () => {
     });
 
     it("re-verifies the distinct-path cap against durable state on a fresh post-hibernation handle", () => {
-        expect.assertions(2);
+        expect.assertions(1);
 
         const harness = createSqliteExec();
 
         ensureFunctionMetricsTables(harness.sql);
 
         for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
-            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path, last_called_at) VALUES (?, ?)`, `seed:${String(index)}`, index);
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path) VALUES (?)`, `seed:${String(index)}`);
         }
 
         // A fresh handle has no local cache of what's tracked — it must fall
@@ -600,15 +557,9 @@ describe("per-handle memoization (OBS-02)", () => {
         // means the cap hasn't been reached.
         const fresh = freshHandleOver(harness);
 
-        recordFunctionMetric(fresh, dispatch({ path: "new:fn", ts: FUNCTION_METRICS_MAX_PATHS }));
+        recordFunctionMetric(fresh, dispatch({ path: "attacker:random" }));
 
-        // Admitted by evicting the coldest seed, not refused outright, and the
-        // table stays bounded at the cap.
-        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'new:fn'`)).toHaveLength(1);
-
-        const [count] = harness.raw(`SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`);
-
-        expect(count?.["n"]).toBe(FUNCTION_METRICS_MAX_PATHS);
+        expect(harness.raw(`SELECT path FROM "${FUNCTION_METRICS_TABLE}" WHERE path = 'attacker:random'`)).toStrictEqual([]);
     });
 });
 
@@ -625,7 +576,7 @@ describe("reads on a never-called shard", () => {
         expect(readFunctionMetricBuckets(sql)).toStrictEqual({ buckets: [], truncated: false });
         expect(readFunctionMetricScans(sql).size).toBe(0);
         expect(readFunctionMetricIndexHits(sql)).toStrictEqual([]);
-        expect(readFunctionMetricsTotals(sql)).toStrictEqual({ errors: 0, requests: 0 });
+        expect(readFunctionMetricsTotals(sql)).toStrictEqual({ capped: false, errors: 0, requests: 0 });
     });
 });
 
@@ -683,7 +634,22 @@ describe("readFunctionMetricsTotals", () => {
         recordFunctionMetric(sql, dispatch({ errored: true, path: "b:fn" }));
         recordFunctionMetric(sql, dispatch({ path: "b:fn" }));
 
-        expect(readFunctionMetricsTotals(sql)).toStrictEqual({ errors: 1, requests: 3 });
+        expect(readFunctionMetricsTotals(sql)).toStrictEqual({ capped: false, errors: 1, requests: 3 });
+    });
+
+    it("reports capped once the distinct-path cap is reached — the write-side signal a refused path leaves behind", () => {
+        expect.assertions(1);
+
+        const harness = createSqliteExec();
+        const { sql } = harness;
+
+        ensureFunctionMetricsTables(sql);
+
+        for (let index = 0; index < FUNCTION_METRICS_MAX_PATHS; index += 1) {
+            harness.raw(`INSERT INTO "${FUNCTION_METRICS_TABLE}" (path) VALUES (?)`, `seed:${String(index)}`);
+        }
+
+        expect(readFunctionMetricsTotals(sql).capped).toBe(true);
     });
 });
 

--- a/packages/observability/__tests__/metric-history.test.ts
+++ b/packages/observability/__tests__/metric-history.test.ts
@@ -187,16 +187,14 @@ describe("metricHistory", () => {
         });
     });
 
-    describe("distinct-series cap eviction", () => {
-        it("evicts the least-recently-updated series to admit a genuinely new one at the cap", () => {
-            expect.assertions(3);
+    describe("distinct-series cap", () => {
+        it("refuses a brand-new series once the cap is reached, protecting incumbents", () => {
+            expect.assertions(2);
 
             const sql = makeSql();
             const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
             const maxSeries = 5;
 
-            // Fill the cap, oldest first — series `s0` ends up with the smallest
-            // `MAX(last_ts)` since it is never touched again.
             for (let index = 0; index < maxSeries; index += 1) {
                 recordMetricHistory(sql, event({ kind: "counter", name: `s${String(index)}`, ts: base + index * 1000, value: 1 }), undefined, { maxSeries });
             }
@@ -207,11 +205,10 @@ describe("metricHistory", () => {
             const { series } = readMetricHistory(sql);
             const names = series.map((s) => s.name);
 
-            // The new series was admitted — pre-fix this is absent.
-            expect(names).toContain("new-series");
-            // The coldest series (`s0`, the oldest `last_ts`) was evicted to make room.
-            expect(names).not.toContain("s0");
-            // Every other pre-existing series survived — only the coldest was evicted.
+            // Refused, not evicted: every incumbent series survives and the
+            // new one is absent — a flood of one-off series must not be able
+            // to trade away the app's own tracked series.
+            expect(names).not.toContain("new-series");
             expect(names).toHaveLength(maxSeries);
         });
 

--- a/packages/observability/__tests__/metric-history.test.ts
+++ b/packages/observability/__tests__/metric-history.test.ts
@@ -17,6 +17,8 @@ const event = (over: Partial<MetricEvent> & Pick<MetricEvent, "kind" | "name" | 
 const MINUTE = 60_000;
 
 describe("metricHistory", () => {
+    // Per-test SQLite handle, torn down below — shared by both nested describe
+    // blocks so the harness setup isn't duplicated.
     let harness: ReturnType<typeof createSqliteExec> | undefined;
 
     const makeSql = (): SqlExec => {
@@ -30,156 +32,227 @@ describe("metricHistory", () => {
         harness = undefined;
     });
 
-    it("folds measurements in the same minute into one bucket", () => {
-        expect.assertions(5);
+    describe("recording and reading", () => {
+        it("folds measurements in the same minute into one bucket", () => {
+            expect.assertions(5);
 
-        const sql = makeSql();
-        const base = 1_749_300_000_000;
+            const sql = makeSql();
+            const base = 1_749_300_000_000;
 
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 1000, value: 2 }));
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 2000, value: 3 }));
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 1000, value: 2 }));
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 2000, value: 3 }));
 
-        const { series } = readMetricHistory(sql);
-        const [point] = series[0]?.points ?? [];
+            const { series } = readMetricHistory(sql);
+            const [point] = series[0]?.points ?? [];
 
-        expect(series).toHaveLength(1);
-        expect(series[0]?.points).toHaveLength(1);
-        expect(point?.count).toBe(2);
-        expect(point?.sum).toBe(5);
-        expect(point?.max).toBe(3);
+            expect(series).toHaveLength(1);
+            expect(series[0]?.points).toHaveLength(1);
+            expect(point?.count).toBe(2);
+            expect(point?.sum).toBe(5);
+            expect(point?.max).toBe(3);
+        });
+
+        it("folds many repeats of one series correctly (the known-bucket cache path)", () => {
+            expect.assertions(3);
+
+            const sql = makeSql();
+            const base = 1_749_300_000_000;
+
+            // The first call primes the known-bucket set; every later call is a cache
+            // hit that skips the existence read and goes straight to the upsert. The
+            // fold must still be exact — the cache stores membership, never values.
+            for (let index = 0; index < 50; index += 1) {
+                recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + index, value: 1 }));
+            }
+
+            const { series } = readMetricHistory(sql);
+            const [point] = series[0]?.points ?? [];
+
+            expect(series[0]?.points).toHaveLength(1);
+            expect(point?.count).toBe(50);
+            expect(point?.sum).toBe(50);
+        });
+
+        it("does not resurrect a bucket the retention trim removed (late out-of-window sample)", () => {
+            expect.assertions(2);
+
+            const sql = makeSql();
+            const base = 1_749_300_000_000;
+            // METRIC_HISTORY_BUCKET_RETENTION — buckets older than this many minutes
+            // behind the newest are trimmed.
+            const retention = 1440;
+
+            // One bucket, then a bucket far enough ahead that the first falls outside
+            // the retention window and is trimmed the moment the second arrives.
+            recordMetricHistory(sql, event({ kind: "counter", name: "m", ts: base, value: 1 }));
+            recordMetricHistory(sql, event({ kind: "counter", name: "m", ts: base + (retention + 1) * MINUTE, value: 1 }));
+
+            // Re-record the OLD (now-trimmed) bucket. The known-bucket cache must NOT
+            // have marked it as durable — this write must re-check and re-trim it,
+            // leaving only the in-window bucket rather than an expired row.
+            recordMetricHistory(sql, event({ kind: "counter", name: "m", ts: base, value: 1 }));
+
+            const points = readMetricHistory(sql).series[0]?.points ?? [];
+
+            expect(points).toHaveLength(1);
+            expect(points[0]?.bucketMs).toBe(base + (retention + 1) * MINUTE);
+        });
+
+        it("splits measurements across minute boundaries into separate buckets", () => {
+            expect.assertions(3);
+
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+
+            recordMetricHistory(sql, event({ kind: "histogram", name: "checkout.ms", ts: base + 1000, value: 100 }));
+            recordMetricHistory(sql, event({ kind: "histogram", name: "checkout.ms", ts: base + MINUTE + 1000, value: 200 }));
+
+            const { series } = readMetricHistory(sql);
+            const points = series[0]?.points ?? [];
+
+            expect(points).toHaveLength(2);
+            // Ascending time order.
+            expect(points[0]?.bucketMs).toBeLessThan(points[1]?.bucketMs ?? 0);
+            expect(points[1]?.last).toBe(200);
+        });
+
+        it("keeps series distinct by name, kind, and dimensions", () => {
+            expect.assertions(2);
+
+            const sql = makeSql();
+
+            recordMetricHistory(sql, event({ kind: "counter", name: "http.requests", value: 1 }));
+            recordMetricHistory(sql, event({ attributes: { route: "/a" }, kind: "counter", name: "http.requests", value: 1 }));
+            recordMetricHistory(sql, event({ kind: "gauge", name: "http.requests", value: 1 }));
+            // Dimension key order must not create a distinct series.
+            recordMetricHistory(sql, event({ attributes: { region: "eu", route: "/a" }, kind: "counter", name: "http.requests", value: 1 }));
+            recordMetricHistory(sql, event({ attributes: { route: "/a", region: "eu" }, kind: "counter", name: "http.requests", value: 1 }));
+
+            const { series } = readMetricHistory(sql);
+
+            expect(series).toHaveLength(4);
+
+            const eu = series.find((s) => s.attributes?.region === "eu" && s.attributes.route === "/a");
+
+            expect(eu?.points[0]?.count).toBe(2);
+        });
+
+        it("stores an exemplar traceId per bucket, latest sample winning", () => {
+            expect.assertions(2);
+
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 1000, value: 1 }), "trace-a");
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 2000, value: 1 }), "trace-b");
+
+            const point = readMetricHistory(sql).series[0]?.points[0];
+
+            expect(point?.exemplarTraceId).toBe("trace-b");
+
+            // A later sample without a trace leaves the exemplar intact.
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 3000, value: 1 }));
+
+            expect(readMetricHistory(sql).series[0]?.points[0]?.exemplarTraceId).toBe("trace-b");
+        });
+
+        it("trims buckets older than the retention window", () => {
+            expect.assertions(2);
+
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+
+            // One ancient bucket, then one 2000 minutes later (past the 1440 retention).
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base, value: 1 }));
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 2000 * MINUTE, value: 1 }));
+
+            const points = readMetricHistory(sql).series[0]?.points ?? [];
+
+            expect(points).toHaveLength(1);
+            expect(points[0]?.bucketMs).toBe(base + 2000 * MINUTE);
+        });
+
+        it("windows the read to buckets at or after sinceMs", () => {
+            expect.assertions(1);
+
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base, value: 1 }));
+            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 5 * MINUTE, value: 1 }));
+
+            const { series } = readMetricHistory(sql, { sinceMs: base + 3 * MINUTE });
+
+            expect(series[0]?.points).toHaveLength(1);
+        });
     });
 
-    it("folds many repeats of one series correctly (the known-bucket cache path)", () => {
-        expect.assertions(3);
+    describe("distinct-series cap eviction", () => {
+        it("evicts the least-recently-updated series to admit a genuinely new one at the cap", () => {
+            expect.assertions(3);
 
-        const sql = makeSql();
-        const base = 1_749_300_000_000;
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+            const maxSeries = 5;
 
-        // The first call primes the known-bucket set; every later call is a cache
-        // hit that skips the existence read and goes straight to the upsert. The
-        // fold must still be exact — the cache stores membership, never values.
-        for (let index = 0; index < 50; index += 1) {
-            recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + index, value: 1 }));
-        }
+            // Fill the cap, oldest first — series `s0` ends up with the smallest
+            // `MAX(last_ts)` since it is never touched again.
+            for (let index = 0; index < maxSeries; index += 1) {
+                recordMetricHistory(sql, event({ kind: "counter", name: `s${String(index)}`, ts: base + index * 1000, value: 1 }), undefined, { maxSeries });
+            }
 
-        const { series } = readMetricHistory(sql);
-        const [point] = series[0]?.points ?? [];
+            // A genuinely new series arrives at capacity.
+            recordMetricHistory(sql, event({ kind: "counter", name: "new-series", ts: base + maxSeries * 1000, value: 1 }), undefined, { maxSeries });
 
-        expect(series[0]?.points).toHaveLength(1);
-        expect(point?.count).toBe(50);
-        expect(point?.sum).toBe(50);
-    });
+            const { series } = readMetricHistory(sql);
+            const names = series.map((s) => s.name);
 
-    it("does not resurrect a bucket the retention trim removed (late out-of-window sample)", () => {
-        expect.assertions(2);
+            // The new series was admitted — pre-fix this is absent.
+            expect(names).toContain("new-series");
+            // The coldest series (`s0`, the oldest `last_ts`) was evicted to make room.
+            expect(names).not.toContain("s0");
+            // Every other pre-existing series survived — only the coldest was evicted.
+            expect(names).toHaveLength(maxSeries);
+        });
 
-        const sql = makeSql();
-        const base = 1_749_300_000_000;
-        // METRIC_HISTORY_BUCKET_RETENTION — buckets older than this many minutes
-        // behind the newest are trimmed.
-        const retention = 1440;
+        it("keeps accumulating an already-tracked series past the cap", () => {
+            expect.assertions(1);
 
-        // One bucket, then a bucket far enough ahead that the first falls outside
-        // the retention window and is trimmed the moment the second arrives.
-        recordMetricHistory(sql, event({ kind: "counter", name: "m", ts: base, value: 1 }));
-        recordMetricHistory(sql, event({ kind: "counter", name: "m", ts: base + (retention + 1) * MINUTE, value: 1 }));
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+            const maxSeries = 5;
 
-        // Re-record the OLD (now-trimmed) bucket. The known-bucket cache must NOT
-        // have marked it as durable — this write must re-check and re-trim it,
-        // leaving only the in-window bucket rather than an expired row.
-        recordMetricHistory(sql, event({ kind: "counter", name: "m", ts: base, value: 1 }));
+            for (let index = 0; index < maxSeries; index += 1) {
+                recordMetricHistory(sql, event({ kind: "counter", name: `s${String(index)}`, ts: base + index * 1000, value: 1 }), undefined, { maxSeries });
+            }
 
-        const points = readMetricHistory(sql).series[0]?.points ?? [];
+            // A second measurement for an already-tracked series must never be
+            // refused, however full the table is.
+            recordMetricHistory(sql, event({ kind: "counter", name: "s3", ts: base + 9000, value: 1 }), undefined, { maxSeries });
 
-        expect(points).toHaveLength(1);
-        expect(points[0]?.bucketMs).toBe(base + (retention + 1) * MINUTE);
-    });
+            const { series } = readMetricHistory(sql);
 
-    it("splits measurements across minute boundaries into separate buckets", () => {
-        expect.assertions(3);
+            expect(series.find((s) => s.name === "s3")?.points[0]?.count).toBe(2);
+        });
 
-        const sql = makeSql();
-        const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+        it("reports capped on readMetricHistory once the series count reaches the cap", () => {
+            expect.assertions(2);
 
-        recordMetricHistory(sql, event({ kind: "histogram", name: "checkout.ms", ts: base + 1000, value: 100 }));
-        recordMetricHistory(sql, event({ kind: "histogram", name: "checkout.ms", ts: base + MINUTE + 1000, value: 200 }));
+            const sql = makeSql();
+            const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
+            const maxSeries = 5;
 
-        const { series } = readMetricHistory(sql);
-        const points = series[0]?.points ?? [];
+            for (let index = 0; index < maxSeries - 1; index += 1) {
+                recordMetricHistory(sql, event({ kind: "counter", name: `s${String(index)}`, ts: base + index * 1000, value: 1 }), undefined, { maxSeries });
+            }
 
-        expect(points).toHaveLength(2);
-        // Ascending time order.
-        expect(points[0]?.bucketMs).toBeLessThan(points[1]?.bucketMs ?? 0);
-        expect(points[1]?.last).toBe(200);
-    });
+            expect(readMetricHistory(sql, { maxSeries }).capped).toBe(false);
 
-    it("keeps series distinct by name, kind, and dimensions", () => {
-        expect.assertions(2);
+            recordMetricHistory(sql, event({ kind: "counter", name: `s${String(maxSeries - 1)}`, ts: base + maxSeries * 1000, value: 1 }), undefined, {
+                maxSeries,
+            });
 
-        const sql = makeSql();
-
-        recordMetricHistory(sql, event({ kind: "counter", name: "http.requests", value: 1 }));
-        recordMetricHistory(sql, event({ attributes: { route: "/a" }, kind: "counter", name: "http.requests", value: 1 }));
-        recordMetricHistory(sql, event({ kind: "gauge", name: "http.requests", value: 1 }));
-        // Dimension key order must not create a distinct series.
-        recordMetricHistory(sql, event({ attributes: { region: "eu", route: "/a" }, kind: "counter", name: "http.requests", value: 1 }));
-        recordMetricHistory(sql, event({ attributes: { route: "/a", region: "eu" }, kind: "counter", name: "http.requests", value: 1 }));
-
-        const { series } = readMetricHistory(sql);
-
-        expect(series).toHaveLength(4);
-
-        const eu = series.find((s) => s.attributes?.region === "eu" && s.attributes.route === "/a");
-
-        expect(eu?.points[0]?.count).toBe(2);
-    });
-
-    it("stores an exemplar traceId per bucket, latest sample winning", () => {
-        expect.assertions(2);
-
-        const sql = makeSql();
-        const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
-
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 1000, value: 1 }), "trace-a");
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 2000, value: 1 }), "trace-b");
-
-        const point = readMetricHistory(sql).series[0]?.points[0];
-
-        expect(point?.exemplarTraceId).toBe("trace-b");
-
-        // A later sample without a trace leaves the exemplar intact.
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 3000, value: 1 }));
-
-        expect(readMetricHistory(sql).series[0]?.points[0]?.exemplarTraceId).toBe("trace-b");
-    });
-
-    it("trims buckets older than the retention window", () => {
-        expect.assertions(2);
-
-        const sql = makeSql();
-        const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
-
-        // One ancient bucket, then one 2000 minutes later (past the 1440 retention).
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base, value: 1 }));
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 2000 * MINUTE, value: 1 }));
-
-        const points = readMetricHistory(sql).series[0]?.points ?? [];
-
-        expect(points).toHaveLength(1);
-        expect(points[0]?.bucketMs).toBe(base + 2000 * MINUTE);
-    });
-
-    it("windows the read to buckets at or after sinceMs", () => {
-        expect.assertions(1);
-
-        const sql = makeSql();
-        const base = Math.floor(1_749_300_000_000 / MINUTE) * MINUTE;
-
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base, value: 1 }));
-        recordMetricHistory(sql, event({ kind: "counter", name: "orders.placed", ts: base + 5 * MINUTE, value: 1 }));
-
-        const { series } = readMetricHistory(sql, { sinceMs: base + 3 * MINUTE });
-
-        expect(series[0]?.points).toHaveLength(1);
+            expect(readMetricHistory(sql, { maxSeries }).capped).toBe(true);
+        });
     });
 });

--- a/packages/observability/__tests__/query-metrics.test.ts
+++ b/packages/observability/__tests__/query-metrics.test.ts
@@ -2,8 +2,6 @@ import type { SqlExec } from "@lunora/shard-engine";
 import { describe, expect, it, vi } from "vitest";
 
 import {
-    ensureQueryMetricsTable,
-    hashStatement,
     normalizeSql,
     pruneQueryBuckets,
     QUERY_BUCKET_RETENTION,
@@ -76,45 +74,6 @@ describe("normalizeSql", () => {
         expect.assertions(1);
 
         expect(normalizeSql(`SELECT "user_id" FROM t`)).toBe(`SELECT "user_id" FROM t`);
-    });
-});
-
-describe("ensureQueryMetricsTable", () => {
-    it("backfills last_seen_at on a table that predates the eviction feature", () => {
-        expect.assertions(3);
-
-        const harness = createSqliteExec();
-        const { sql } = harness;
-
-        try {
-            // A shard created before the distinct-statement eviction landed has
-            // the original column set — build that shape by hand rather than
-            // assume the guarded `ALTER TABLE` is safe against it.
-            harness.raw(`CREATE TABLE "${QUERY_METRICS_TABLE}" (
-                normalized_sql TEXT PRIMARY KEY,
-                exec_count     INTEGER NOT NULL DEFAULT 0,
-                total_duration_ms REAL NOT NULL DEFAULT 0,
-                rows_read      INTEGER NOT NULL DEFAULT 0,
-                rows_written   INTEGER NOT NULL DEFAULT 0
-            )`);
-
-            expect(() => {
-                ensureQueryMetricsTable(sql);
-            }).not.toThrow();
-
-            const columns = harness.raw(`PRAGMA table_info("${QUERY_METRICS_TABLE}")`).map((row) => row["name"]);
-
-            expect(columns).toContain("last_seen_at");
-
-            // A write against the back-filled table must not throw either —
-            // the column is nullable, so the upsert's explicit `last_seen_at`
-            // value is what populates it going forward.
-            expect(() => {
-                recordQueryMetric(sql, "SELECT * FROM posts WHERE id = 1", 5, 1, 0);
-            }).not.toThrow();
-        } finally {
-            harness.close();
-        }
     });
 });
 
@@ -232,55 +191,31 @@ describe("recordQueryMetric + readQueryMetrics", () => {
         }
     });
 
-    it("evicts the least-recently-seen statement to admit a genuinely new one at the cap", () => {
-        expect.assertions(3);
+    it("refuses a brand-new statement once the cap is reached, protecting incumbents", () => {
+        expect.assertions(2);
 
         const { sql, close } = createSqliteExec();
 
         try {
-            // Fill the table to the cap, oldest first — distinct explicit `now`
-            // values make eviction order deterministic: `col0`'s statement ends
-            // up with the smallest `last_seen_at`.
+            // Fill the table to the cap.
             for (let i = 0; i < QUERY_METRICS_MAX_STATEMENTS; i += 1) {
                 // Use distinct column names to generate distinct normalized SQL (identifier numbers are kept).
-                recordQueryMetric(sql, `SELECT col${String(i)} FROM t`, 1, 0, 0, i);
+                recordQueryMetric(sql, `SELECT col${String(i)} FROM t`, 1, 0, 0);
             }
 
-            // A genuinely new statement arrives at capacity.
-            recordQueryMetric(sql, "SELECT extra_col FROM t", 999, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
+            // Attempt to add one more new statement.
+            recordQueryMetric(sql, "SELECT extra_col FROM t", 999, 0, 0);
 
             const rows = readQueryMetrics(sql);
 
-            // Admitted, not dropped — the table stays bounded at the cap.
+            // Refused, not evicted: the table stays at the cap and every
+            // incumbent statement survives — a flood of one-off shapes must
+            // not be able to trade away the app's own tracked statements.
             expect(rows).toHaveLength(QUERY_METRICS_MAX_STATEMENTS);
-            expect(rows.some((r) => r.normalizedSql.includes("extra_col"))).toBe(true);
-            // The coldest statement (`col0`, the smallest `last_seen_at`) was
-            // evicted to make room.
-            expect(rows.some((r) => r.normalizedSql.includes("SELECT col0 "))).toBe(false);
-        } finally {
-            close();
-        }
-    }, 15_000);
 
-    it("evicts the evicted statement's bucket rows too", () => {
-        expect.assertions(1);
+            const found = rows.some((r) => r.normalizedSql.includes("extra_col"));
 
-        const { sql, close } = createSqliteExec();
-
-        try {
-            for (let i = 0; i < QUERY_METRICS_MAX_STATEMENTS; i += 1) {
-                recordQueryMetric(sql, `SELECT col${String(i)} FROM t`, 1, 0, 0, i);
-            }
-
-            const evictedHash = hashStatement(normalizeSql("SELECT col0 FROM t"));
-
-            recordQueryMetric(sql, "SELECT extra_col FROM t", 999, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
-
-            // The bucket table (keyed by `sql_hash`) must not keep growing for a
-            // statement no longer tracked in the lifetime table.
-            const insights = readQueryInsights(sql, 60 * 60_000, QUERY_METRICS_MAX_STATEMENTS);
-
-            expect(insights.entries.some((entry) => entry.normalizedSql === evictedHash)).toBe(false);
+            expect(found).toBe(false);
         } finally {
             close();
         }
@@ -365,12 +300,12 @@ describe("per-handle memoization (OBS-02)", () => {
     });
 
     it("re-verifies the distinct-statement cap against durable state on a fresh post-hibernation handle", () => {
-        expect.assertions(2);
+        expect.assertions(1);
 
         const harness = createSqliteExec();
 
         for (let index = 0; index < QUERY_METRICS_MAX_STATEMENTS; index += 1) {
-            recordQueryMetric(harness.sql, `SELECT col${String(index)} FROM t`, 1, 0, 0, index);
+            recordQueryMetric(harness.sql, `SELECT col${String(index)} FROM t`, 1, 0, 0);
         }
 
         // A fresh handle has no local cache of what's tracked — it must fall
@@ -378,14 +313,11 @@ describe("per-handle memoization (OBS-02)", () => {
         // means the cap hasn't been reached.
         const fresh = freshHandleOver(harness);
 
-        recordQueryMetric(fresh, "SELECT extra_col FROM t", 999, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
+        recordQueryMetric(fresh, "SELECT extra_col FROM t", 999, 0, 0);
 
         const rows = readQueryMetrics(fresh);
 
-        // Admitted by evicting the coldest tracked statement, not refused
-        // outright, and the table stays bounded at the cap.
-        expect(rows.some((row) => row.normalizedSql.includes("extra_col"))).toBe(true);
-        expect(rows).toHaveLength(QUERY_METRICS_MAX_STATEMENTS);
+        expect(rows.some((row) => row.normalizedSql.includes("extra_col"))).toBe(false);
     }, 15_000);
 
     it("reports capped on readQueryInsights once the tracked-statement count reaches the cap", () => {

--- a/packages/observability/__tests__/query-metrics.test.ts
+++ b/packages/observability/__tests__/query-metrics.test.ts
@@ -2,6 +2,8 @@ import type { SqlExec } from "@lunora/shard-engine";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+    ensureQueryMetricsTable,
+    hashStatement,
     normalizeSql,
     pruneQueryBuckets,
     QUERY_BUCKET_RETENTION,
@@ -74,6 +76,45 @@ describe("normalizeSql", () => {
         expect.assertions(1);
 
         expect(normalizeSql(`SELECT "user_id" FROM t`)).toBe(`SELECT "user_id" FROM t`);
+    });
+});
+
+describe("ensureQueryMetricsTable", () => {
+    it("backfills last_seen_at on a table that predates the eviction feature", () => {
+        expect.assertions(3);
+
+        const harness = createSqliteExec();
+        const { sql } = harness;
+
+        try {
+            // A shard created before the distinct-statement eviction landed has
+            // the original column set — build that shape by hand rather than
+            // assume the guarded `ALTER TABLE` is safe against it.
+            harness.raw(`CREATE TABLE "${QUERY_METRICS_TABLE}" (
+                normalized_sql TEXT PRIMARY KEY,
+                exec_count     INTEGER NOT NULL DEFAULT 0,
+                total_duration_ms REAL NOT NULL DEFAULT 0,
+                rows_read      INTEGER NOT NULL DEFAULT 0,
+                rows_written   INTEGER NOT NULL DEFAULT 0
+            )`);
+
+            expect(() => {
+                ensureQueryMetricsTable(sql);
+            }).not.toThrow();
+
+            const columns = harness.raw(`PRAGMA table_info("${QUERY_METRICS_TABLE}")`).map((row) => row["name"]);
+
+            expect(columns).toContain("last_seen_at");
+
+            // A write against the back-filled table must not throw either —
+            // the column is nullable, so the upsert's explicit `last_seen_at`
+            // value is what populates it going forward.
+            expect(() => {
+                recordQueryMetric(sql, "SELECT * FROM posts WHERE id = 1", 5, 1, 0);
+            }).not.toThrow();
+        } finally {
+            harness.close();
+        }
     });
 });
 
@@ -191,29 +232,55 @@ describe("recordQueryMetric + readQueryMetrics", () => {
         }
     });
 
-    it("skips new entries once the cap is reached", () => {
-        expect.assertions(2);
+    it("evicts the least-recently-seen statement to admit a genuinely new one at the cap", () => {
+        expect.assertions(3);
 
         const { sql, close } = createSqliteExec();
 
         try {
-            // Fill the table to the cap.
+            // Fill the table to the cap, oldest first — distinct explicit `now`
+            // values make eviction order deterministic: `col0`'s statement ends
+            // up with the smallest `last_seen_at`.
             for (let i = 0; i < QUERY_METRICS_MAX_STATEMENTS; i += 1) {
                 // Use distinct column names to generate distinct normalized SQL (identifier numbers are kept).
-                recordQueryMetric(sql, `SELECT col${String(i)} FROM t`, 1, 0, 0);
+                recordQueryMetric(sql, `SELECT col${String(i)} FROM t`, 1, 0, 0, i);
             }
 
-            // Attempt to add one more new statement.
-            recordQueryMetric(sql, "SELECT extra_col FROM t", 999, 0, 0);
+            // A genuinely new statement arrives at capacity.
+            recordQueryMetric(sql, "SELECT extra_col FROM t", 999, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
 
             const rows = readQueryMetrics(sql);
 
+            // Admitted, not dropped — the table stays bounded at the cap.
             expect(rows).toHaveLength(QUERY_METRICS_MAX_STATEMENTS);
+            expect(rows.some((r) => r.normalizedSql.includes("extra_col"))).toBe(true);
+            // The coldest statement (`col0`, the smallest `last_seen_at`) was
+            // evicted to make room.
+            expect(rows.some((r) => r.normalizedSql.includes("SELECT col0 "))).toBe(false);
+        } finally {
+            close();
+        }
+    }, 15_000);
 
-            // The extra statement must NOT appear (it was dropped).
-            const found = rows.some((r) => r.normalizedSql.includes("extra_col"));
+    it("evicts the evicted statement's bucket rows too", () => {
+        expect.assertions(1);
 
-            expect(found).toBe(false);
+        const { sql, close } = createSqliteExec();
+
+        try {
+            for (let i = 0; i < QUERY_METRICS_MAX_STATEMENTS; i += 1) {
+                recordQueryMetric(sql, `SELECT col${String(i)} FROM t`, 1, 0, 0, i);
+            }
+
+            const evictedHash = hashStatement(normalizeSql("SELECT col0 FROM t"));
+
+            recordQueryMetric(sql, "SELECT extra_col FROM t", 999, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
+
+            // The bucket table (keyed by `sql_hash`) must not keep growing for a
+            // statement no longer tracked in the lifetime table.
+            const insights = readQueryInsights(sql, 60 * 60_000, QUERY_METRICS_MAX_STATEMENTS);
+
+            expect(insights.entries.some((entry) => entry.normalizedSql === evictedHash)).toBe(false);
         } finally {
             close();
         }
@@ -298,12 +365,12 @@ describe("per-handle memoization (OBS-02)", () => {
     });
 
     it("re-verifies the distinct-statement cap against durable state on a fresh post-hibernation handle", () => {
-        expect.assertions(1);
+        expect.assertions(2);
 
         const harness = createSqliteExec();
 
         for (let index = 0; index < QUERY_METRICS_MAX_STATEMENTS; index += 1) {
-            recordQueryMetric(harness.sql, `SELECT col${String(index)} FROM t`, 1, 0, 0);
+            recordQueryMetric(harness.sql, `SELECT col${String(index)} FROM t`, 1, 0, 0, index);
         }
 
         // A fresh handle has no local cache of what's tracked — it must fall
@@ -311,11 +378,30 @@ describe("per-handle memoization (OBS-02)", () => {
         // means the cap hasn't been reached.
         const fresh = freshHandleOver(harness);
 
-        recordQueryMetric(fresh, "SELECT extra_col FROM t", 999, 0, 0);
+        recordQueryMetric(fresh, "SELECT extra_col FROM t", 999, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
 
         const rows = readQueryMetrics(fresh);
 
-        expect(rows.some((row) => row.normalizedSql.includes("extra_col"))).toBe(false);
+        // Admitted by evicting the coldest tracked statement, not refused
+        // outright, and the table stays bounded at the cap.
+        expect(rows.some((row) => row.normalizedSql.includes("extra_col"))).toBe(true);
+        expect(rows).toHaveLength(QUERY_METRICS_MAX_STATEMENTS);
+    }, 15_000);
+
+    it("reports capped on readQueryInsights once the tracked-statement count reaches the cap", () => {
+        expect.assertions(2);
+
+        const { sql } = createSqliteExec();
+
+        for (let index = 0; index < QUERY_METRICS_MAX_STATEMENTS - 1; index += 1) {
+            recordQueryMetric(sql, `SELECT col${String(index)} FROM t`, 1, 0, 0, index);
+        }
+
+        expect(readQueryInsights(sql, 60_000, QUERY_METRICS_MAX_STATEMENTS).capped).toBe(false);
+
+        recordQueryMetric(sql, `SELECT col${String(QUERY_METRICS_MAX_STATEMENTS - 1)} FROM t`, 1, 0, 0, QUERY_METRICS_MAX_STATEMENTS);
+
+        expect(readQueryInsights(sql, 60_000, QUERY_METRICS_MAX_STATEMENTS).capped).toBe(true);
     }, 15_000);
 });
 

--- a/packages/observability/src/context-telemetry.ts
+++ b/packages/observability/src/context-telemetry.ts
@@ -20,6 +20,7 @@ import { normalizeLogFields } from "../../../shared/log-fields";
 import type { MetricEvent, MetricKind } from "../../../shared/metric-event";
 import { buildTraceparent, LUNORA_ATTR, otlpRandomHex } from "../../../shared/otlp";
 import type { SpanEvent, SpanEventPoint, SpanHandle, SpanLink, SpanOptions } from "../../../shared/span-event";
+import { redactArgs } from "./request-log";
 import { toErrorType } from "./trace-context";
 
 /**
@@ -196,6 +197,16 @@ export interface TracerDeps {
     /** The trace this ctx's spans belong to. */
     anchor: TraceAnchor;
 
+    /**
+     * Whether to record a span body's error message (and a `recordException`
+     * stacktrace) verbatim rather than redacted. Mirrors the request log's
+     * `captureRaw`: `true` in dev (`isDevEnvironment`), `false` in production —
+     * the span pipeline is the one sink third-party collectors (Datadog/Axiom
+     * via `otlpSink`) receive, so it must not ship raw PII/internals by default
+     * the way the request log and function-metrics sinks already don't.
+     */
+    captureRaw?: boolean;
+
     /** Function path the spans are attributed to. */
     functionPath: string;
 
@@ -317,8 +328,14 @@ export interface SpanCollector {
  * attributes become the canonical one-event-per-request summary. Sharing the
  * implementation is what makes those two feel like the same API instead of two
  * that happen to resemble each other.
+ *
+ * `captureRaw` (default `false`) gates `recordException`'s `exception.message`/
+ * `exception.stacktrace` the same way {@link createTracer} gates a span's own
+ * error message — a stack is file paths and internals by definition, the exact
+ * class `isInternalCode` redaction exists for, so it rides the same dev-only
+ * escape hatch rather than shipping to a third-party collector by default.
  */
-export const createSpanCollector = (ids: { spanId: string; traceId: string }): SpanCollector => {
+export const createSpanCollector = (ids: { spanId: string; traceId: string }, captureRaw = false): SpanCollector => {
     const collected: SpanCollection = { attributes: {}, events: [], links: [] };
 
     const handle: SpanHandle = {
@@ -360,11 +377,15 @@ export const createSpanCollector = (ids: { spanId: string; traceId: string }): S
         },
         recordException: (error) => {
             // The OTel-conventional `exception` event. `exception.stacktrace` is
-            // included when present because a HANDLED exception has no other
-            // record — nothing re-throws it for a top-level handler to log.
+            // included when present AND `captureRaw` — a HANDLED exception has no
+            // other record (nothing re-throws it for a top-level handler to log),
+            // but a stack is exactly the kind of internal detail the production
+            // redaction posture exists to keep off third-party sinks.
+            const rawMessage = error instanceof Error ? error.message : String(error);
+
             handle.addEvent("exception", {
-                "exception.message": error instanceof Error ? error.message : String(error),
-                ...(error instanceof Error && typeof error.stack === "string" ? { "exception.stacktrace": error.stack } : {}),
+                "exception.message": redactArgs(rawMessage, captureRaw) as string,
+                ...(captureRaw && error instanceof Error && typeof error.stack === "string" ? { "exception.stacktrace": error.stack } : {}),
                 "exception.type": toErrorType(error),
             });
         },
@@ -436,7 +457,7 @@ export const createSpanCollector = (ids: { spanId: string; traceId: string }): S
  * waterfall is unaffected.
  */
 export const createTracer = (deps: TracerDeps): ContextTracer => {
-    const { anchor, fuseHostSpans, functionPath, record, resolveHostTracing, shardKey, userId } = deps;
+    const { anchor, captureRaw = false, fuseHostSpans, functionPath, record, resolveHostTracing, shardKey, userId } = deps;
 
     const tracerFor =
         (parentSpanId: string): ContextTracer =>
@@ -454,7 +475,7 @@ export const createTracer = (deps: TracerDeps): ContextTracer => {
             // `SpanHandle`. Attributes merge over `normalized` at record time
             // (post-hoc wins on a key clash); each write is normalized through the
             // same field coercer as the start attributes, so the bag stays JSON-safe.
-            const { collected, handle: spanHandle } = createSpanCollector({ spanId, traceId: anchor.traceId });
+            const { collected, handle: spanHandle } = createSpanCollector({ spanId, traceId: anchor.traceId }, captureRaw);
 
             // The recorded span (our `SpanBuffer`/`otlpSink`) is produced here
             // IDENTICALLY whether or not the CF bridge is active. An optional
@@ -473,8 +494,16 @@ export const createTracer = (deps: TracerDeps): ContextTracer => {
                     // Record the failure, then re-throw untouched: `ctx.trace` is
                     // instrumentation, never flow control.
                     ok = false;
+
+                    const rawMessage = error_ instanceof Error ? error_.message : String(error_);
+
                     error = {
-                        message: error_ instanceof Error ? error_.message : String(error_),
+                        // Redacted like the request log's error message by default
+                        // (`captureRaw` is the same dev-only escape hatch) — this
+                        // is the span pipeline, the one sink with third-party
+                        // fan-out (`otlpSink`/`webhookSink`), so it must not ship
+                        // a raw validation/constraint message in the clear.
+                        message: redactArgs(rawMessage, captureRaw) as string,
                         // Prefer a LunoraError's stable `code` over the class name
                         // so spans group by the same taxonomy the RPC spans use.
                         type: toErrorType(error_),
@@ -746,6 +775,15 @@ export const dispatchRootSpan = (input: {
     anchor: TraceAnchor;
 
     /**
+     * Whether to record the failure message verbatim rather than redacted —
+     * the same dev-only escape hatch as {@link TracerDeps.captureRaw}. This
+     * synthetic root span carries the SAME error message the request log and
+     * function-metrics sinks already redact by default, so it must not be the
+     * one durable copy that ships it raw to a third-party collector.
+     */
+    captureRaw?: boolean;
+
+    /**
      * What the handler attached to the dispatch through `ctx.span` — the **wide
      * event**. These are the attributes that would otherwise have been scattered
      * across a dozen `ctx.log` lines; carrying them on the one span that already
@@ -760,7 +798,7 @@ export const dispatchRootSpan = (input: {
     startTs: number;
     userId: string | undefined;
 }): SpanEvent => {
-    const { anchor, collected, durationMs, failure, functionPath, shardKey, startTs, userId } = input;
+    const { anchor, captureRaw = false, collected, durationMs, failure, functionPath, shardKey, startTs, userId } = input;
     const attributes = collected?.attributes ?? {};
 
     return {
@@ -772,7 +810,7 @@ export const dispatchRootSpan = (input: {
             ? {}
             : {
                   error: {
-                      message: failure.thrown instanceof Error ? failure.thrown.message : String(failure.thrown),
+                      message: redactArgs(failure.thrown instanceof Error ? failure.thrown.message : String(failure.thrown), captureRaw) as string,
                       type: toErrorType(failure.thrown),
                   },
               }),

--- a/packages/observability/src/database-telemetry.ts
+++ b/packages/observability/src/database-telemetry.ts
@@ -350,4 +350,4 @@ const formatTally = (tally: DatabaseTally): LogFields => {
 };
 
 export type { DatabaseInstrumentation, DatabaseTally, DatabaseTelemetryDeps };
-export { createDatabaseTally, describeFailure, formatTally, instrumentDatabase };
+export { createDatabaseTally, formatTally, instrumentDatabase };

--- a/packages/observability/src/database-telemetry.ts
+++ b/packages/observability/src/database-telemetry.ts
@@ -22,6 +22,7 @@ import type { LogFields } from "../../../shared/log-fields";
 import { otlpRandomHex } from "../../../shared/otlp";
 import type { SpanEvent } from "../../../shared/span-event";
 import type { TraceAnchor } from "./context-telemetry";
+import { redactArgs } from "./request-log";
 import { toErrorType } from "./trace-context";
 
 /**
@@ -110,7 +111,16 @@ const describeFailure = (failure: unknown): string => {
         return failure.message;
     }
 
-    return typeof failure === "string" ? failure : JSON.stringify(failure);
+    if (typeof failure === "string") {
+        return failure;
+    }
+
+    // `JSON.stringify` is typed `=> string` but returns `undefined` for a
+    // function/symbol/undefined value — fall back to `String`, mirroring
+    // `request-log.ts`'s `renderLogMessage`.
+    const json = JSON.stringify(failure) as string | undefined;
+
+    return json ?? String(failure);
 };
 
 /**
@@ -136,7 +146,7 @@ const buildDatabaseSpan = (input: {
             "db.system.name": "sqlite",
         },
         durationMs,
-        ...(failure === undefined ? {} : { error: { message: describeFailure(failure), type: toErrorType(failure) } }),
+        ...(failure === undefined ? {} : { error: { message: redactArgs(describeFailure(failure), deps.captureRaw) as string, type: toErrorType(failure) } }),
         functionPath: deps.functionPath,
         // CLIENT: from the handler's point of view this is a call OUT to a
         // datastore, which is what lets a collector render it as a dependency
@@ -180,6 +190,16 @@ type DatabaseInstrumentation = "off" | "spans" | "summary";
 interface DatabaseTelemetryDeps {
     /** The trace produced spans belong to (`"spans"` mode only). */
     anchor: TraceAnchor;
+
+    /**
+     * Whether to record a failed call's error message verbatim rather than
+     * redacted (`"spans"` mode only) — the same dev-only escape hatch as
+     * `TracerDeps.captureRaw`. A constraint-error message quotes the
+     * conflicting row, so this CLIENT span gets the same default-redacted
+     * posture as the request log and function-metrics sinks.
+     */
+    captureRaw?: boolean;
+
     /** Function path spans and attributes are attributed to. */
     functionPath: string;
     /** Detail level; see {@link DatabaseInstrumentation}. */
@@ -330,4 +350,4 @@ const formatTally = (tally: DatabaseTally): LogFields => {
 };
 
 export type { DatabaseInstrumentation, DatabaseTally, DatabaseTelemetryDeps };
-export { createDatabaseTally, formatTally, instrumentDatabase };
+export { createDatabaseTally, describeFailure, formatTally, instrumentDatabase };

--- a/packages/observability/src/function-metrics.ts
+++ b/packages/observability/src/function-metrics.ts
@@ -83,18 +83,22 @@ const FUNCTION_METRICS_BUCKET_RETENTION = 1440;
  * Maximum distinct function `path`s tracked in the accumulator table. Mirrors
  * `query-metrics.ts`'s `QUERY_METRICS_MAX_STATEMENTS` cap (and exists for the
  * same reason): the real bound is the app's own registered-function set plus
- * deploy churn (a rename/removal leaves its old path's row in place until the
- * cap evicts it) — a few thousand registered functions is already far beyond
- * any real app. `shard-do.ts`'s dispatch handler explicitly does NOT record
- * per-function metrics for an unregistered/`FUNCTION_NOT_FOUND` dispatch (see
- * the guard next to its `FUNCTION_NOT_FOUND` check), so a caller cannot mint
- * arbitrary `path`s here the way a raw caller-supplied SQL shape can in
- * `query-metrics.ts`. Without a cap, deploy churn across the app's lifetime
- * would still grow `__lunora_metrics` (and its bucket/scan satellites) without
- * bound, eventually filling the shard's SQLite store shared with the app's
- * real data. At the cap, the accumulator row with the oldest `last_called_at`
- * is evicted (along with its bucket/scan satellite rows) to admit a
- * genuinely new path; already-tracked paths keep accumulating past the cap.
+ * deploy churn (a rename/removal leaves its old path's row in place, still
+ * counted against the cap, until an operator's own retention/cleanup
+ * process — there is none built in today) — a few thousand registered
+ * functions is already far beyond any real app. `shard-do.ts`'s dispatch
+ * handler explicitly does NOT record per-function metrics for an
+ * unregistered/`FUNCTION_NOT_FOUND` dispatch (see the guard next to its
+ * `FUNCTION_NOT_FOUND` check), so a caller cannot mint arbitrary `path`s here
+ * the way a raw caller-supplied SQL shape can in `query-metrics.ts`. Without a
+ * cap, deploy churn across the app's lifetime would still grow
+ * `__lunora_metrics` (and its bucket/scan satellites) without bound,
+ * eventually filling the shard's SQLite store shared with the app's real
+ * data. At the cap, a brand-new path is refused — protecting the incumbent
+ * leaderboard from a flood of one-off paths is the point, so admission is
+ * refused rather than evicting an existing path to make room; already-tracked
+ * paths keep accumulating past the cap. `readFunctionMetricsTotals`'s
+ * `capped` is the read-side signal for this.
  */
 const FUNCTION_METRICS_MAX_PATHS = 5000;
 
@@ -369,23 +373,12 @@ const admitPath = (sql: SqlExec, path: string): boolean => {
 
     const pathCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`).one();
 
+    // At capacity: refuse the new path rather than evict an existing one —
+    // protecting the incumbent leaderboard from a flood of one-off paths is
+    // the reason this cap exists, so admission is refused, not traded away.
+    // `readFunctionMetricsTotals`'s `capped` is the read-side signal for this.
     if (pathCountRow.n >= FUNCTION_METRICS_MAX_PATHS) {
-        // At capacity: evict the coldest path (smallest `last_called_at`) to
-        // admit this genuinely new one, mirroring `metric-history.ts`'s
-        // series-cap eviction and `MetricBuffer.push`'s in-memory LRU policy.
-        // Without this, a deploy that renames/removes functions would
-        // permanently fill the accumulator with dead paths and refuse every
-        // path introduced afterward — including the app's own new functions.
-        const evictRow = runSql<{ path: string }>(sql, `SELECT path FROM "${FUNCTION_METRICS_TABLE}" ORDER BY last_called_at ASC LIMIT 1`).toArray()[0];
-
-        if (evictRow === undefined) {
-            return false;
-        }
-
-        runSql(sql, `DELETE FROM "${FUNCTION_METRICS_TABLE}" WHERE path = ?`, evictRow.path);
-        runSql(sql, `DELETE FROM "${FUNCTION_METRICS_BUCKETS_TABLE}" WHERE path = ?`, evictRow.path);
-        runSql(sql, `DELETE FROM "${FUNCTION_METRICS_SCANS_TABLE}" WHERE path = ?`, evictRow.path);
-        known.delete(evictRow.path);
+        return false;
     }
 
     known.add(path);
@@ -697,11 +690,15 @@ const readFunctionMetricBuckets = (sql: SqlExec, path?: string): FunctionMetricB
 
 /**
  * Aggregate the persisted accumulators into the lifetime totals the metrics
- * health snapshot reports: total calls (`requests`), total `errors`, and the
- * earliest `last_called_at` seen — a best-effort "since" marker for durable
- * data. Returns zeroes on a never-called shard.
+ * health snapshot reports: total calls (`requests`), total `errors`. Returns
+ * zeroes on a never-called shard.
+ *
+ * `capped` is true when the distinct-path cap ({@link FUNCTION_METRICS_MAX_PATHS})
+ * has been reached — the write-side signal that a brand-new function path is
+ * currently being refused (see `admitPath`), mirroring `readQueryInsights`'s
+ * `capped` for query-metrics and `readMetricHistory`'s for metric-history.
  */
-const readFunctionMetricsTotals = (sql: SqlExec): { errors: number; requests: number } => {
+const readFunctionMetricsTotals = (sql: SqlExec): { capped: boolean; errors: number; requests: number } => {
     ensureFunctionMetricsTables(sql);
 
     const row = runSql<{ errors: null | number; requests: null | number }>(
@@ -709,7 +706,9 @@ const readFunctionMetricsTotals = (sql: SqlExec): { errors: number; requests: nu
         `SELECT SUM(calls) AS requests, SUM(errors) AS errors FROM "${FUNCTION_METRICS_TABLE}"`,
     ).one();
 
-    return { errors: row.errors ?? 0, requests: row.requests ?? 0 };
+    const pathCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`).one();
+
+    return { capped: pathCountRow.n >= FUNCTION_METRICS_MAX_PATHS, errors: row.errors ?? 0, requests: row.requests ?? 0 };
 };
 
 export {

--- a/packages/observability/src/function-metrics.ts
+++ b/packages/observability/src/function-metrics.ts
@@ -370,7 +370,22 @@ const admitPath = (sql: SqlExec, path: string): boolean => {
     const pathCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${FUNCTION_METRICS_TABLE}"`).one();
 
     if (pathCountRow.n >= FUNCTION_METRICS_MAX_PATHS) {
-        return false;
+        // At capacity: evict the coldest path (smallest `last_called_at`) to
+        // admit this genuinely new one, mirroring `metric-history.ts`'s
+        // series-cap eviction and `MetricBuffer.push`'s in-memory LRU policy.
+        // Without this, a deploy that renames/removes functions would
+        // permanently fill the accumulator with dead paths and refuse every
+        // path introduced afterward — including the app's own new functions.
+        const evictRow = runSql<{ path: string }>(sql, `SELECT path FROM "${FUNCTION_METRICS_TABLE}" ORDER BY last_called_at ASC LIMIT 1`).toArray()[0];
+
+        if (evictRow === undefined) {
+            return false;
+        }
+
+        runSql(sql, `DELETE FROM "${FUNCTION_METRICS_TABLE}" WHERE path = ?`, evictRow.path);
+        runSql(sql, `DELETE FROM "${FUNCTION_METRICS_BUCKETS_TABLE}" WHERE path = ?`, evictRow.path);
+        runSql(sql, `DELETE FROM "${FUNCTION_METRICS_SCANS_TABLE}" WHERE path = ?`, evictRow.path);
+        known.delete(evictRow.path);
     }
 
     known.add(path);

--- a/packages/observability/src/function-metrics.ts
+++ b/packages/observability/src/function-metrics.ts
@@ -82,13 +82,19 @@ const FUNCTION_METRICS_BUCKET_RETENTION = 1440;
 /**
  * Maximum distinct function `path`s tracked in the accumulator table. Mirrors
  * `query-metrics.ts`'s `QUERY_METRICS_MAX_STATEMENTS` cap (and exists for the
- * same reason): the `path` is attacker-reachable — an unregistered/`FUNCTION_NOT_FOUND`
- * dispatch still records a row keyed by the caller-supplied `functionPath` — so
- * without a cap a flood of distinct random paths would grow `__lunora_metrics`
- * (and its bucket/scan satellites) without bound, eventually filling the shard's
- * SQLite store shared with the app's real data. A few thousand registered
- * functions is already far beyond any real app, so a new path past this cap is
- * dropped while already-tracked paths keep accumulating.
+ * same reason): the real bound is the app's own registered-function set plus
+ * deploy churn (a rename/removal leaves its old path's row in place until the
+ * cap evicts it) — a few thousand registered functions is already far beyond
+ * any real app. `shard-do.ts`'s dispatch handler explicitly does NOT record
+ * per-function metrics for an unregistered/`FUNCTION_NOT_FOUND` dispatch (see
+ * the guard next to its `FUNCTION_NOT_FOUND` check), so a caller cannot mint
+ * arbitrary `path`s here the way a raw caller-supplied SQL shape can in
+ * `query-metrics.ts`. Without a cap, deploy churn across the app's lifetime
+ * would still grow `__lunora_metrics` (and its bucket/scan satellites) without
+ * bound, eventually filling the shard's SQLite store shared with the app's
+ * real data. At the cap, the accumulator row with the oldest `last_called_at`
+ * is evicted (along with its bucket/scan satellite rows) to admit a
+ * genuinely new path; already-tracked paths keep accumulating past the cap.
  */
 const FUNCTION_METRICS_MAX_PATHS = 5000;
 

--- a/packages/observability/src/metric-history.ts
+++ b/packages/observability/src/metric-history.ts
@@ -9,10 +9,10 @@
  * external collector.
  *
  * Modelled directly on `function-metrics.ts`'s `__lunora_metrics_buckets` (same
- * bucket width, same bounded-retention trim, same distinct-key cap with the same
- * least-recently-updated eviction at capacity). One row per `(series, bucket)`,
- * written with a single PK-keyed `INSERT … ON CONFLICT … DO UPDATE` upsert plus a
- * bounded `DELETE`.
+ * bucket width, same bounded-retention trim, same distinct-key cap that
+ * protects already-tracked identities by refusing a brand-new one once full).
+ * One row per `(series, bucket)`, written with a single PK-keyed
+ * `INSERT … ON CONFLICT … DO UPDATE` upsert plus a bounded `DELETE`.
  *
  * Each bucket also carries an **exemplar**: a sample `traceId` of a measurement
  * folded into it, so the studio can jump from a point on the chart to a trace
@@ -43,8 +43,11 @@ const METRIC_HISTORY_BUCKET_RETENTION = 1440;
  * series per id — so without a cap a high-cardinality dimension would grow the
  * table without bound and eventually crowd the app's own data out of the shard's
  * SQLite. Mirrors `function-metrics.ts`'s `FUNCTION_METRICS_MAX_PATHS`: at the
- * cap, the series with the oldest `MAX(last_ts)` is evicted to admit a
- * genuinely new one; already-tracked series keep accumulating past the cap.
+ * cap, a brand-new series is refused (see `readMetricHistory`'s `capped` flag,
+ * the write-side signal this used to lack) while already-tracked series keep
+ * accumulating past the cap — protecting the incumbent leaderboard from a
+ * flood of one-off series is the point of the cap, so admission is refused
+ * rather than evicting an existing series to make room for the flood.
  */
 const METRIC_HISTORY_MAX_SERIES = 1000;
 
@@ -83,11 +86,14 @@ interface MetricHistorySeries {
 /** {@link readMetricHistory} result: every tracked series with its buckets. */
 interface MetricHistoryResult {
     /**
-     * True when the distinct-series cap has been reached, so the caller can say
-     * "showing N of a capped set" rather than implying totality — mirrors
-     * `readQueryInsights`'s `capped`. Series past the cap are still charted; only
-     * a genuinely new one arriving at capacity evicts the coldest existing series
-     * (see `recordMetricHistory`).
+     * True when the distinct-series cap has been reached — a **write-side**
+     * signal ("this shard can no longer admit a brand-new series", see
+     * `admitNewSeries`), not a read-side truncation flag. It is computed over
+     * the whole table regardless of `options.sinceMs`/the row-count read
+     * limit, so it can be `true` even when every series `readMetricHistory`
+     * actually returned fits comfortably: the caller should read it as "a
+     * flood of new series would currently be refused", the same thing
+     * `readQueryInsights`'s `capped` already signals for query-metrics.
      */
     capped: boolean;
     series: MetricHistorySeries[];
@@ -194,50 +200,20 @@ interface MetricHistoryOptions {
 }
 
 /**
- * Admit a brand-new `key` against the distinct-series cap, evicting the
- * least-recently-updated series (smallest `MAX(last_ts)`) when at capacity —
- * the durable mirror of `MetricBuffer.push`'s in-memory LRU policy. Mirrors
+ * Admit a brand-new `key` against the distinct-series cap. Mirrors
  * `function-metrics.ts`'s `admitPath` and `query-metrics.ts`'s
- * `admitStatement`. Only called for a series `recordMetricHistory` has
- * confirmed is not yet tracked (an already-tracked series always keeps
- * accumulating past the cap, so it never reaches this check).
- *
- * Split out of {@link recordMetricHistory} to keep that function's cognitive
- * complexity in bounds — this is the one branch-heavy part of it.
+ * `admitStatement`: `false` at capacity, so a flood of one-off series can't
+ * displace the app's real leaderboard — protecting already-tracked
+ * incumbents is the reason the cap exists, so admission is refused rather
+ * than evicting one of them to make room. Only called for a series
+ * `recordMetricHistory` has confirmed is not yet tracked (an already-tracked
+ * series always keeps accumulating past the cap, so it never reaches this
+ * check).
  */
-const admitNewSeries = (sql: SqlExec, cache: Set<string>, maxSeries: number): void => {
+const admitNewSeries = (sql: SqlExec, maxSeries: number): boolean => {
     const seriesCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(DISTINCT series_key) AS n FROM "${METRIC_HISTORY_TABLE}"`).one();
 
-    if (seriesCountRow.n < maxSeries) {
-        return;
-    }
-
-    // At capacity: evict the least-recently-updated series to admit this
-    // genuinely new one. A brand-new series arriving right after a deploy (or
-    // the incident being charted) must not go permanently unrecorded — only
-    // the coldest existing series pays for it.
-    const evictRow = runSql<{ series_key: string }>(
-        sql,
-        `SELECT series_key FROM "${METRIC_HISTORY_TABLE}" GROUP BY series_key ORDER BY MAX(last_ts) ASC LIMIT 1`,
-    ).toArray()[0];
-
-    if (evictRow === undefined) {
-        return;
-    }
-
-    runSql(sql, `DELETE FROM "${METRIC_HISTORY_TABLE}" WHERE series_key = ?`, evictRow.series_key);
-
-    // Drop the evicted series' entries from the known-bucket cache so a later
-    // write for it re-checks durable state rather than skipping straight to an
-    // upsert that would resurrect rows this eviction just deleted. Cache keys
-    // are `${seriesKey}\u0000${bucketMs}` (see `cacheKey` in `recordMetricHistory`).
-    const evictedPrefix = `${evictRow.series_key}\u0000`;
-
-    for (const cachedKey of cache) {
-        if (cachedKey.startsWith(evictedPrefix)) {
-            cache.delete(cachedKey);
-        }
-    }
+    return seriesCountRow.n < maxSeries;
 };
 
 /**
@@ -290,8 +266,11 @@ const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?:
         // into a new minute skips it, and an in-minute update never reaches here.
         const seriesTracked = runSql<{ c: number }>(sql, `SELECT 1 AS c FROM "${METRIC_HISTORY_TABLE}" WHERE series_key = ? LIMIT 1`, key).toArray().length > 0;
 
-        if (!seriesTracked) {
-            admitNewSeries(sql, cache, maxSeries);
+        if (!seriesTracked && !admitNewSeries(sql, maxSeries)) {
+            // At capacity: refuse the write rather than evict an existing
+            // series — see `admitNewSeries` for why. `readMetricHistory`'s
+            // `capped` flag is the read-side signal for this.
+            return;
         }
     }
 

--- a/packages/observability/src/metric-history.ts
+++ b/packages/observability/src/metric-history.ts
@@ -82,6 +82,14 @@ interface MetricHistorySeries {
 
 /** {@link readMetricHistory} result: every tracked series with its buckets. */
 interface MetricHistoryResult {
+    /**
+     * True when the distinct-series cap has been reached, so the caller can say
+     * "showing N of a capped set" rather than implying totality — mirrors
+     * `readQueryInsights`'s `capped`. Series past the cap are still charted; only
+     * a genuinely new one arriving at capacity evicts the coldest existing series
+     * (see `recordMetricHistory`).
+     */
+    capped: boolean;
     series: MetricHistorySeries[];
 }
 
@@ -179,11 +187,58 @@ const knownBucketsFor = (sql: SqlExec): Set<string> => {
  * omitted field keeps the historical behaviour.
  */
 interface MetricHistoryOptions {
-    /** Distinct series tracked before a brand-new one is dropped (default {@link METRIC_HISTORY_MAX_SERIES}). */
+    /** Distinct series tracked before the least-recently-updated one is evicted to admit a new one (default {@link METRIC_HISTORY_MAX_SERIES}). */
     maxSeries?: number;
     /** Minute-buckets kept per series before older rows are trimmed (default {@link METRIC_HISTORY_BUCKET_RETENTION}). */
     retentionBuckets?: number;
 }
+
+/**
+ * Admit a brand-new `key` against the distinct-series cap, evicting the
+ * least-recently-updated series (smallest `MAX(last_ts)`) when at capacity —
+ * the durable mirror of `MetricBuffer.push`'s in-memory LRU policy. Mirrors
+ * `function-metrics.ts`'s `admitPath` and `query-metrics.ts`'s
+ * `admitStatement`. Only called for a series `recordMetricHistory` has
+ * confirmed is not yet tracked (an already-tracked series always keeps
+ * accumulating past the cap, so it never reaches this check).
+ *
+ * Split out of {@link recordMetricHistory} to keep that function's cognitive
+ * complexity in bounds — this is the one branch-heavy part of it.
+ */
+const admitNewSeries = (sql: SqlExec, cache: Set<string>, maxSeries: number): void => {
+    const seriesCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(DISTINCT series_key) AS n FROM "${METRIC_HISTORY_TABLE}"`).one();
+
+    if (seriesCountRow.n < maxSeries) {
+        return;
+    }
+
+    // At capacity: evict the least-recently-updated series to admit this
+    // genuinely new one. A brand-new series arriving right after a deploy (or
+    // the incident being charted) must not go permanently unrecorded — only
+    // the coldest existing series pays for it.
+    const evictRow = runSql<{ series_key: string }>(
+        sql,
+        `SELECT series_key FROM "${METRIC_HISTORY_TABLE}" GROUP BY series_key ORDER BY MAX(last_ts) ASC LIMIT 1`,
+    ).toArray()[0];
+
+    if (evictRow === undefined) {
+        return;
+    }
+
+    runSql(sql, `DELETE FROM "${METRIC_HISTORY_TABLE}" WHERE series_key = ?`, evictRow.series_key);
+
+    // Drop the evicted series' entries from the known-bucket cache so a later
+    // write for it re-checks durable state rather than skipping straight to an
+    // upsert that would resurrect rows this eviction just deleted. Cache keys
+    // are `${seriesKey}\u0000${bucketMs}` (see `cacheKey` in `recordMetricHistory`).
+    const evictedPrefix = `${evictRow.series_key}\u0000`;
+
+    for (const cachedKey of cache) {
+        if (cachedKey.startsWith(evictedPrefix)) {
+            cache.delete(cachedKey);
+        }
+    }
+};
 
 /**
  * Fold one measurement into its `(series, minute)` bucket. Runs per
@@ -236,11 +291,7 @@ const recordMetricHistory = (sql: SqlExec, event: MetricEvent, exemplarTraceId?:
         const seriesTracked = runSql<{ c: number }>(sql, `SELECT 1 AS c FROM "${METRIC_HISTORY_TABLE}" WHERE series_key = ? LIMIT 1`, key).toArray().length > 0;
 
         if (!seriesTracked) {
-            const seriesCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(DISTINCT series_key) AS n FROM "${METRIC_HISTORY_TABLE}"`).one();
-
-            if (seriesCountRow.n >= maxSeries) {
-                return;
-            }
+            admitNewSeries(sql, cache, maxSeries);
         }
     }
 
@@ -337,10 +388,14 @@ const parseAttributes = (raw: string): LogFields | undefined => {
  * trend line reads oldest→newest.
  *
  * `options.sinceMs`, when set, returns only buckets at or after this epoch-ms —
- * the studio's time-window selector.
+ * the studio's time-window selector. `options.maxSeries`, mirroring the write
+ * side's tunable, is only used to compute `capped` — it does not affect which
+ * rows are read.
  */
-const readMetricHistory = (sql: SqlExec, options: { sinceMs?: number } = {}): MetricHistoryResult => {
+const readMetricHistory = (sql: SqlExec, options: { maxSeries?: number; sinceMs?: number } = {}): MetricHistoryResult => {
     ensureMetricHistoryTable(sql);
+
+    const maxSeries = options.maxSeries ?? METRIC_HISTORY_MAX_SERIES;
 
     const rows =
         options.sinceMs === undefined
@@ -387,7 +442,9 @@ const readMetricHistory = (sql: SqlExec, options: { sinceMs?: number } = {}): Me
         series.points.sort((a, b) => a.bucketMs - b.bucketMs);
     }
 
-    return { series: [...bySeries.values()] };
+    const seriesCountRow = runSql<{ n: number }>(sql, `SELECT COUNT(DISTINCT series_key) AS n FROM "${METRIC_HISTORY_TABLE}"`).one();
+
+    return { capped: seriesCountRow.n >= maxSeries, series: [...bySeries.values()] };
 };
 
 export { readMetricHistory, recordMetricHistory };

--- a/packages/observability/src/metric-history.ts
+++ b/packages/observability/src/metric-history.ts
@@ -9,9 +9,10 @@
  * external collector.
  *
  * Modelled directly on `function-metrics.ts`'s `__lunora_metrics_buckets` (same
- * bucket width, same bounded-retention trim, same distinct-key cap for
- * attacker-reachable keys). One row per `(series, bucket)`, written with a single
- * PK-keyed `INSERT … ON CONFLICT … DO UPDATE` upsert plus a bounded `DELETE`.
+ * bucket width, same bounded-retention trim, same distinct-key cap with the same
+ * least-recently-updated eviction at capacity). One row per `(series, bucket)`,
+ * written with a single PK-keyed `INSERT … ON CONFLICT … DO UPDATE` upsert plus a
+ * bounded `DELETE`.
  *
  * Each bucket also carries an **exemplar**: a sample `traceId` of a measurement
  * folded into it, so the studio can jump from a point on the chart to a trace
@@ -42,7 +43,8 @@ const METRIC_HISTORY_BUCKET_RETENTION = 1440;
  * series per id — so without a cap a high-cardinality dimension would grow the
  * table without bound and eventually crowd the app's own data out of the shard's
  * SQLite. Mirrors `function-metrics.ts`'s `FUNCTION_METRICS_MAX_PATHS`: at the
- * cap a brand-new series is dropped while already-tracked ones keep accumulating.
+ * cap, the series with the oldest `MAX(last_ts)` is evicted to admit a
+ * genuinely new one; already-tracked series keep accumulating past the cap.
  */
 const METRIC_HISTORY_MAX_SERIES = 1000;
 

--- a/packages/observability/src/query-metrics.ts
+++ b/packages/observability/src/query-metrics.ts
@@ -15,7 +15,8 @@
  * iterated via `.toArray()` / `.one()`). `rows_written` is always 0 in this
  * module; callers that know a DML statement affected rows can pass the count
  * explicitly. The tracked set is capped at {@link QUERY_METRICS_MAX_STATEMENTS}
- * entries — new statements beyond the cap are silently dropped.
+ * entries — at the cap, the least-recently-seen statement is evicted (see
+ * `admitStatement`) to admit a genuinely new one, rather than dropping it.
  */
 
 import type { SqlCursor, SqlExec } from "@lunora/shard-engine";
@@ -69,10 +70,11 @@ const LATENCY_BUCKET_EDGES = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 5000] as
 const QUERY_METRICS_MAX_SQL_LEN = 512;
 
 /**
- * Maximum distinct normalised statements tracked.  Entries beyond this cap
- * are silently dropped to prevent unbounded table growth when ad-hoc SQL
- * (e.g. DDL migrations, dynamic query builders) generates many distinct
- * statement shapes.
+ * Maximum distinct normalised statements tracked, to prevent unbounded table
+ * growth when ad-hoc SQL (e.g. DDL migrations, dynamic query builders)
+ * generates many distinct statement shapes. At the cap, the statement with the
+ * oldest `last_seen_at` is evicted (see `admitStatement`) to admit a genuinely
+ * new one; already-tracked statements keep accumulating past the cap.
  */
 const QUERY_METRICS_MAX_STATEMENTS = 500;
 
@@ -141,6 +143,18 @@ const ensuredMetricsHandles = new WeakSet<SqlExec>();
  * Create the reserved query-metrics table. Idempotent — safe to call on every
  * hot path; SQLite's `CREATE TABLE IF NOT EXISTS` is a no-op when the table
  * already exists. Only runs once per handle (see {@link ensuredMetricsHandles}).
+ *
+ * `last_seen_at` is added via a guarded `ALTER TABLE` rather than baked only
+ * into the `CREATE`, mirroring `function-metrics.ts`'s `scans`/`conflicts`
+ * back-fill, so a shard whose `__lunora_metrics_queries` predates the
+ * distinct-statement eviction (see {@link admitStatement}) gains the column on
+ * the next call without a migration. SQLite has no `ADD COLUMN IF NOT EXISTS`,
+ * so the duplicate-column error from a re-run (or the freshly-created schema
+ * above) is swallowed. Left nullable — for a row already covered by the CREATE
+ * above it is always set by `recordQueryMetric`'s upsert, and a legacy
+ * pre-migration row reads `NULL`, which `admitStatement`'s
+ * `ORDER BY last_seen_at ASC` sorts first (oldest) so it is evicted before any
+ * row with a real timestamp.
  */
 const ensureQueryMetricsTable = (sql: SqlExec): void => {
     if (ensuredMetricsHandles.has(sql)) {
@@ -154,9 +168,16 @@ const ensureQueryMetricsTable = (sql: SqlExec): void => {
             exec_count     INTEGER NOT NULL DEFAULT 0,
             total_duration_ms REAL NOT NULL DEFAULT 0,
             rows_read      INTEGER NOT NULL DEFAULT 0,
-            rows_written   INTEGER NOT NULL DEFAULT 0
+            rows_written   INTEGER NOT NULL DEFAULT 0,
+            last_seen_at   REAL
         )`,
     );
+
+    try {
+        runSql(sql, `ALTER TABLE "${QUERY_METRICS_TABLE}" ADD COLUMN last_seen_at REAL`);
+    } catch {
+        // Column already exists — no-op.
+    }
 
     ensuredMetricsHandles.add(sql);
 };
@@ -264,7 +285,15 @@ const pruneQueryBuckets = (sql: SqlExec, now: number): void => {
  * a failure here must never break the lifetime counters, which are the older
  * and more load-bearing of the two.
  */
-const recordQueryBucket = (sql: SqlExec, normalized: string, durationMs: number, rowsRead: number, rowsWritten: number, now: number, execCount: number = 1): void => {
+const recordQueryBucket = (
+    sql: SqlExec,
+    normalized: string,
+    durationMs: number,
+    rowsRead: number,
+    rowsWritten: number,
+    now: number,
+    execCount: number = 1,
+): void => {
     try {
         ensureQueryBucketsTable(sql);
 
@@ -473,6 +502,13 @@ const knownStatementsFor = (sql: SqlExec): Set<string> => {
  * first-sight one pays one indexed PK lookup to tell "already tracked" from
  * "genuinely new", and only a genuinely new statement reaches the actual
  * `COUNT(*)` gate — the rare case once the leaderboard has warmed up.
+ *
+ * At the cap, the statement with the oldest `last_seen_at` is evicted (its
+ * bucket rows too) to admit this genuinely new one, mirroring
+ * `metric-history.ts`'s series-cap eviction and `function-metrics.ts`'s
+ * path-cap eviction. `NULLS FIRST` evicts a legacy pre-migration row (which has
+ * no `last_seen_at`) before any row with a real timestamp — SQLite already
+ * orders `NULL` first in `ASC`, but the clause is kept explicit for clarity.
  */
 const admitStatement = (sql: SqlExec, normalized: string): boolean => {
     const known = knownStatementsFor(sql);
@@ -481,7 +517,8 @@ const admitStatement = (sql: SqlExec, normalized: string): boolean => {
         return true;
     }
 
-    const alreadyTracked = runSql<{ c: number }>(sql, `SELECT 1 AS c FROM "${QUERY_METRICS_TABLE}" WHERE normalized_sql = ? LIMIT 1`, normalized).toArray().length > 0;
+    const alreadyTracked =
+        runSql<{ c: number }>(sql, `SELECT 1 AS c FROM "${QUERY_METRICS_TABLE}" WHERE normalized_sql = ? LIMIT 1`, normalized).toArray().length > 0;
 
     if (alreadyTracked) {
         known.add(normalized);
@@ -492,7 +529,18 @@ const admitStatement = (sql: SqlExec, normalized: string): boolean => {
     const countRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${QUERY_METRICS_TABLE}"`).one();
 
     if (countRow.n >= QUERY_METRICS_MAX_STATEMENTS) {
-        return false;
+        const evictRow = runSql<{ normalized_sql: string }>(
+            sql,
+            `SELECT normalized_sql FROM "${QUERY_METRICS_TABLE}" ORDER BY last_seen_at ASC NULLS FIRST LIMIT 1`,
+        ).toArray()[0];
+
+        if (evictRow === undefined) {
+            return false;
+        }
+
+        runSql(sql, `DELETE FROM "${QUERY_METRICS_TABLE}" WHERE normalized_sql = ?`, evictRow.normalized_sql);
+        runSql(sql, `DELETE FROM "${QUERY_BUCKETS_TABLE}" WHERE sql_hash = ?`, hashStatement(evictRow.normalized_sql));
+        known.delete(evictRow.normalized_sql);
     }
 
     known.add(normalized);
@@ -539,15 +587,16 @@ const recordQueryMetric = (
     }
 
     // eslint-disable-next-line no-secrets/no-secrets -- SQL keyword "CONFLICT" triggers the entropy scanner; this is plain DDL, not a secret
-    const upsertSql = `INSERT INTO "${QUERY_METRICS_TABLE}" (normalized_sql, exec_count, total_duration_ms, rows_read, rows_written)
-         VALUES (?, ?, ?, ?, ?)
+    const upsertSql = `INSERT INTO "${QUERY_METRICS_TABLE}" (normalized_sql, exec_count, total_duration_ms, rows_read, rows_written, last_seen_at)
+         VALUES (?, ?, ?, ?, ?, ?)
          ON CONFLICT(normalized_sql) DO UPDATE SET
              exec_count = exec_count + excluded.exec_count,
              total_duration_ms = total_duration_ms + excluded.total_duration_ms,
              rows_read = rows_read + excluded.rows_read,
-             rows_written = rows_written + excluded.rows_written`;
+             rows_written = rows_written + excluded.rows_written,
+             last_seen_at = excluded.last_seen_at`;
 
-    runSql(sql, upsertSql, normalized, execCount, durationMs, rowsRead, rowsWritten);
+    runSql(sql, upsertSql, normalized, execCount, durationMs, rowsRead, rowsWritten, now);
     recordQueryBucket(sql, normalized, durationMs, rowsRead, rowsWritten, now, execCount);
 };
 

--- a/packages/observability/src/query-metrics.ts
+++ b/packages/observability/src/query-metrics.ts
@@ -15,8 +15,9 @@
  * iterated via `.toArray()` / `.one()`). `rows_written` is always 0 in this
  * module; callers that know a DML statement affected rows can pass the count
  * explicitly. The tracked set is capped at {@link QUERY_METRICS_MAX_STATEMENTS}
- * entries — at the cap, the least-recently-seen statement is evicted (see
- * `admitStatement`) to admit a genuinely new one, rather than dropping it.
+ * entries — new statements beyond the cap are refused (see `admitStatement`),
+ * protecting the already-tracked leaderboard from a flood of one-off shapes;
+ * `readQueryInsights`'s `capped` is the read-side signal for this.
  */
 
 import type { SqlCursor, SqlExec } from "@lunora/shard-engine";
@@ -70,11 +71,11 @@ const LATENCY_BUCKET_EDGES = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 5000] as
 const QUERY_METRICS_MAX_SQL_LEN = 512;
 
 /**
- * Maximum distinct normalised statements tracked, to prevent unbounded table
+ * Maximum distinct normalised statements tracked. Entries beyond this cap
+ * are refused (not evicted — see `admitStatement`) to prevent unbounded table
  * growth when ad-hoc SQL (e.g. DDL migrations, dynamic query builders)
- * generates many distinct statement shapes. At the cap, the statement with the
- * oldest `last_seen_at` is evicted (see `admitStatement`) to admit a genuinely
- * new one; already-tracked statements keep accumulating past the cap.
+ * generates many distinct statement shapes; already-tracked statements keep
+ * accumulating past the cap.
  */
 const QUERY_METRICS_MAX_STATEMENTS = 500;
 
@@ -143,18 +144,6 @@ const ensuredMetricsHandles = new WeakSet<SqlExec>();
  * Create the reserved query-metrics table. Idempotent — safe to call on every
  * hot path; SQLite's `CREATE TABLE IF NOT EXISTS` is a no-op when the table
  * already exists. Only runs once per handle (see {@link ensuredMetricsHandles}).
- *
- * `last_seen_at` is added via a guarded `ALTER TABLE` rather than baked only
- * into the `CREATE`, mirroring `function-metrics.ts`'s `scans`/`conflicts`
- * back-fill, so a shard whose `__lunora_metrics_queries` predates the
- * distinct-statement eviction (see {@link admitStatement}) gains the column on
- * the next call without a migration. SQLite has no `ADD COLUMN IF NOT EXISTS`,
- * so the duplicate-column error from a re-run (or the freshly-created schema
- * above) is swallowed. Left nullable — for a row already covered by the CREATE
- * above it is always set by `recordQueryMetric`'s upsert, and a legacy
- * pre-migration row reads `NULL`, which `admitStatement`'s
- * `ORDER BY last_seen_at ASC` sorts first (oldest) so it is evicted before any
- * row with a real timestamp.
  */
 const ensureQueryMetricsTable = (sql: SqlExec): void => {
     if (ensuredMetricsHandles.has(sql)) {
@@ -168,16 +157,9 @@ const ensureQueryMetricsTable = (sql: SqlExec): void => {
             exec_count     INTEGER NOT NULL DEFAULT 0,
             total_duration_ms REAL NOT NULL DEFAULT 0,
             rows_read      INTEGER NOT NULL DEFAULT 0,
-            rows_written   INTEGER NOT NULL DEFAULT 0,
-            last_seen_at   REAL
+            rows_written   INTEGER NOT NULL DEFAULT 0
         )`,
     );
-
-    try {
-        runSql(sql, `ALTER TABLE "${QUERY_METRICS_TABLE}" ADD COLUMN last_seen_at REAL`);
-    } catch {
-        // Column already exists — no-op.
-    }
 
     ensuredMetricsHandles.add(sql);
 };
@@ -503,12 +485,12 @@ const knownStatementsFor = (sql: SqlExec): Set<string> => {
  * "genuinely new", and only a genuinely new statement reaches the actual
  * `COUNT(*)` gate — the rare case once the leaderboard has warmed up.
  *
- * At the cap, the statement with the oldest `last_seen_at` is evicted (its
- * bucket rows too) to admit this genuinely new one, mirroring
- * `metric-history.ts`'s series-cap eviction and `function-metrics.ts`'s
- * path-cap eviction. `NULLS FIRST` evicts a legacy pre-migration row (which has
- * no `last_seen_at`) before any row with a real timestamp — SQLite already
- * orders `NULL` first in `ASC`, but the clause is kept explicit for clarity.
+ * At the cap, a brand-new statement is refused rather than evicting an
+ * existing one — protecting the incumbent leaderboard from a flood of
+ * one-off statement shapes (ad-hoc SQL, a dynamic query builder) is the
+ * reason this cap exists, so a flood must not be able to trade away the
+ * app's own tracked statements. `readQueryInsights`'s `capped` is the
+ * read-side signal for this.
  */
 const admitStatement = (sql: SqlExec, normalized: string): boolean => {
     const known = knownStatementsFor(sql);
@@ -529,18 +511,7 @@ const admitStatement = (sql: SqlExec, normalized: string): boolean => {
     const countRow = runSql<{ n: number }>(sql, `SELECT COUNT(*) AS n FROM "${QUERY_METRICS_TABLE}"`).one();
 
     if (countRow.n >= QUERY_METRICS_MAX_STATEMENTS) {
-        const evictRow = runSql<{ normalized_sql: string }>(
-            sql,
-            `SELECT normalized_sql FROM "${QUERY_METRICS_TABLE}" ORDER BY last_seen_at ASC NULLS FIRST LIMIT 1`,
-        ).toArray()[0];
-
-        if (evictRow === undefined) {
-            return false;
-        }
-
-        runSql(sql, `DELETE FROM "${QUERY_METRICS_TABLE}" WHERE normalized_sql = ?`, evictRow.normalized_sql);
-        runSql(sql, `DELETE FROM "${QUERY_BUCKETS_TABLE}" WHERE sql_hash = ?`, hashStatement(evictRow.normalized_sql));
-        known.delete(evictRow.normalized_sql);
+        return false;
     }
 
     known.add(normalized);
@@ -587,16 +558,15 @@ const recordQueryMetric = (
     }
 
     // eslint-disable-next-line no-secrets/no-secrets -- SQL keyword "CONFLICT" triggers the entropy scanner; this is plain DDL, not a secret
-    const upsertSql = `INSERT INTO "${QUERY_METRICS_TABLE}" (normalized_sql, exec_count, total_duration_ms, rows_read, rows_written, last_seen_at)
-         VALUES (?, ?, ?, ?, ?, ?)
+    const upsertSql = `INSERT INTO "${QUERY_METRICS_TABLE}" (normalized_sql, exec_count, total_duration_ms, rows_read, rows_written)
+         VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(normalized_sql) DO UPDATE SET
              exec_count = exec_count + excluded.exec_count,
              total_duration_ms = total_duration_ms + excluded.total_duration_ms,
              rows_read = rows_read + excluded.rows_read,
-             rows_written = rows_written + excluded.rows_written,
-             last_seen_at = excluded.last_seen_at`;
+             rows_written = rows_written + excluded.rows_written`;
 
-    runSql(sql, upsertSql, normalized, execCount, durationMs, rowsRead, rowsWritten, now);
+    runSql(sql, upsertSql, normalized, execCount, durationMs, rowsRead, rowsWritten);
     recordQueryBucket(sql, normalized, durationMs, rowsRead, rowsWritten, now, execCount);
 };
 


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(observability): correct the metric-cap rationale to the post-guard threat model
- fix(observability): evict the least-recently-updated series/path/statement at the durable metric caps
- fix(observability): stringify non-JSON-able failures and redact database-span error messages
- fix(observability): redact span error messages and gate stacktraces like the request log
- fix(observability): drop-on-full instead of evict at the durable metric caps
- fix(observability): stop exporting describeFailure solely for test access
- chore(observability): update API snapshot for this branch's surface changes

## Files this branch still changes relative to alpha

```
api-snapshots/observability.api.md
packages/do/__tests__/function-metrics.test.ts
packages/do/src/shard-do.ts
packages/observability/__tests__/context-telemetry.test.ts
packages/observability/__tests__/database-telemetry.test.ts
packages/observability/__tests__/function-metrics.test.ts
packages/observability/__tests__/metric-history.test.ts
packages/observability/__tests__/query-metrics.test.ts
packages/observability/src/context-telemetry.ts
packages/observability/src/database-telemetry.ts
packages/observability/src/function-metrics.ts
packages/observability/src/metric-history.ts
packages/observability/src/query-metrics.ts
```
