### PR TITLE
fix(agent): drop expired-credential voice sockets with TOKEN_EXPIRED/4001

### DIFF
--- a/packages/agent/__tests__/agent-loop.test.ts
+++ b/packages/agent/__tests__/agent-loop.test.ts
@@ -1365,6 +1365,152 @@ describe(runAgentLoop, () => {
         expect(runtime.threads.get("thread-1")?.status).toBe("idle");
     });
 
+    it("memoizes a function needsApproval gate in its own durable step — it resolves once, not once per replay", async () => {
+        let gateCalls = 0;
+
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: () => {
+                        gateCalls += 1;
+
+                        return false;
+                    },
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", { amount: 100 }, "charging…"), finalTurn("done")]);
+
+        const first = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(first).toStrictEqual({ stopped: "final", text: "done", turns: 2 });
+        expect(gateCalls).toBe(1);
+
+        // Replay: SAME journal + runtime (same instance) — every durable step,
+        // including the gate, is served from its memo. Nothing re-executes.
+        const replay = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(replay).toStrictEqual({ stopped: "final", text: "done", turns: 2 });
+        expect(gateCalls).toBe(1);
+        expect(journal.invoked.filter((name) => name === "tool:approval-gate:call_1")).toHaveLength(1);
+    });
+
+    it("does not hang on a replayed false→true gate flip — the memoized decision wins, no approval wait entered", async () => {
+        let flip = false;
+
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: () => flip,
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", { amount: 100 }, "charging…"), finalTurn("done")]);
+
+        const first = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(first).toStrictEqual({ stopped: "final", text: "done", turns: 2 });
+        expect(runtime.threads.get("thread-1")?.status).toBe("idle");
+
+        // The world changes after the original pass — a naive re-evaluation on
+        // replay would now gate `true` and park the run on a wait no client will
+        // ever resolve. The memoized `false` must win instead.
+        flip = true;
+
+        const replay = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(replay).toStrictEqual({ stopped: "final", text: "done", turns: 2 });
+        expect(journal.waitedNames).toStrictEqual([]);
+        expect([...runtime.messages.values()].some((message) => message.status === "awaiting_approval")).toBe(false);
+    });
+
+    it("hands the function gate a read-only context with no setState", async () => {
+        let sawSetState: boolean | undefined;
+
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: (_input, context) => {
+                        sawSetState = "setState" in context;
+
+                        return false;
+                    },
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", { amount: 100 }, "charging…"), finalTurn("done")]);
+
+        await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run }));
+
+        expect(sawSetState).toBe(false);
+    });
+
+    it("keys the gate's durable step per call id — two calls in one turn each memoize independently", async () => {
+        const gateCallCounts: Record<string, number> = {};
+
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: (input: { amount: number }) => `charged ${String(input.amount)}`,
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: (_input, context) => {
+                        gateCallCounts[context.toolCallId] = (gateCallCounts[context.toolCallId] ?? 0) + 1;
+
+                        return false;
+                    },
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+        const generate = scriptedGenerate([
+            {
+                text: "charging both…",
+                toolCalls: [
+                    { id: "call_1", input: { amount: 10 }, name: "charge" },
+                    { id: "call_2", input: { amount: 20 }, name: "charge" },
+                ],
+            },
+            finalTurn("done"),
+        ]);
+
+        const first = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(first).toStrictEqual({ stopped: "final", text: "done", turns: 2 });
+        expect(gateCallCounts).toStrictEqual({ call_1: 1, call_2: 1 });
+        expect(journal.invoked).toContain("tool:approval-gate:call_1");
+        expect(journal.invoked).toContain("tool:approval-gate:call_2");
+
+        // Replay: both calls' gate decisions are memoized independently.
+        const replay = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(replay).toStrictEqual({ stopped: "final", text: "done", turns: 2 });
+        expect(gateCallCounts).toStrictEqual({ call_1: 1, call_2: 1 });
+    });
+
     it("streams token deltas in order and persists the concatenated final text", async () => {
         const agent = defineAgent({ model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast" });
         const runtime = memoryRuntime();

--- a/packages/agent/__tests__/voice-do.test.ts
+++ b/packages/agent/__tests__/voice-do.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { encodeIdentityHeader } from "../../../shared/identity-header";
+import { defineAgent } from "../src/define-agent";
+import VoiceSessionDO from "../src/voice-do";
+import type { VoiceAudioSource } from "../src/voice-turn";
+
+/** Structural double of `DurableObjectState` — accepts the socket, never actually hibernates. */
+const fakeState = (): { acceptWebSocket: (ws: unknown) => void; getWebSockets: () => never[] } => {
+    return {
+        acceptWebSocket: () => {
+            /* no-op: the fake socket needs no host-side registration */
+        },
+        getWebSockets: () => [],
+    };
+};
+
+/**
+ * A hibernation-attachment-carrying fake socket. `serializeAttachment` /
+ * `deserializeAttachment` read and write the SAME closure variable, so the DO's
+ * own re-serialize-on-finally (`runTurn`'s `{ ...attachment, turn: turn + 1 }`)
+ * round-trips exactly as it does against a real hibernatable WebSocket.
+ */
+const createFakeSocket = (
+    initial: Record<string, unknown>,
+    options: { throwOnClose?: boolean; throwOnSend?: boolean } = {},
+): {
+    getAttachment: () => Record<string, unknown>;
+    getClosed: () => { code?: number; reason?: string } | undefined;
+    sent: unknown[];
+    setAttachment: (value: Record<string, unknown>) => void;
+    ws: WebSocket;
+} => {
+    let attachment = initial;
+    const sent: unknown[] = [];
+    let closed: { code?: number; reason?: string } | undefined;
+
+    const ws = {
+        close: (code?: number, reason?: string) => {
+            if (options.throwOnClose) {
+                throw new Error("socket already gone");
+            }
+
+            closed = { code, reason };
+        },
+        deserializeAttachment: () => attachment,
+        send: (data: unknown) => {
+            if (options.throwOnSend) {
+                throw new Error("socket already gone");
+            }
+
+            sent.push(data);
+        },
+        serializeAttachment: (value: unknown) => {
+            attachment = value as Record<string, unknown>;
+        },
+    };
+
+    return {
+        getAttachment: () => attachment,
+        getClosed: () => closed,
+        sent,
+        setAttachment: (value: Record<string, unknown>) => {
+            attachment = value;
+        },
+        ws: ws as unknown as WebSocket,
+    };
+};
+
+/** A voice-enabled agent with no greeting (so `fetch()` never schedules `speakGreeting`). */
+const agent = defineAgent({ instructions: "Be brief.", model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast", voice: {} });
+// `createAi` requires an `AI` binding at construction time — the fake is never
+// actually called because `TestVoiceDO` overrides `transcribe`/`synthesize`.
+const env: Record<string, unknown> = {
+    AI: {
+        run: async () => {
+            throw new Error("unexpected real AI call — TestVoiceDO should have overridden the seam that reached this");
+        },
+    },
+};
+
+/** Subclass overriding the AI seams so a turn completes without a real Workers AI binding, and counts how many utterances actually reached transcription. */
+class TestVoiceDO extends VoiceSessionDO {
+    public transcribedPcmLengths: number[] = [];
+
+    protected override async transcribe(pcm: Uint8Array): Promise<string> {
+        this.transcribedPcmLengths.push(pcm.byteLength);
+
+        return "test utterance";
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- structural override matching the base class's instance-method signature; this test double needs no instance state
+    protected override async synthesize(_text: string): Promise<VoiceAudioSource> {
+        return new Uint8Array([1]);
+    }
+}
+
+/** Upgrade `instance` and capture the stamped hibernation attachment (mirrors `shard-do.admin-subscription.test.ts`'s pattern for the same Node/workerd gap). */
+const upgradeAndCaptureAttachment = async (
+    instance: VoiceSessionDO,
+    url: string,
+    headers?: Record<string, string>,
+): Promise<Record<string, unknown> | undefined> => {
+    let captured: Record<string, unknown> | undefined;
+    const server = {
+        send: () => {
+            /* the "ready" frame — irrelevant to attachment capture */
+        },
+        serializeAttachment: (value: unknown) => {
+            captured = value as Record<string, unknown>;
+        },
+    };
+
+    const globalWithPair = globalThis as { WebSocketPair?: unknown };
+    const original = globalWithPair.WebSocketPair;
+
+    globalWithPair.WebSocketPair = function WebSocketPair() {
+        return { 0: {}, 1: server } as unknown;
+    };
+
+    try {
+        // The attachment is stamped before `new Response(null, { status: 101 })`,
+        // which Node's Response rejects (101 is out of its allowed range) — that
+        // throw is expected here, `captured` is already set by then. `fetch()` is
+        // synchronous (not `Promise`-returning), so this throw is synchronous too.
+        instance.fetch(new Request(url, { headers: new Headers({ Upgrade: "websocket", ...headers }) }));
+    } catch (error) {
+        if (!(error instanceof RangeError)) {
+            throw error;
+        }
+    } finally {
+        globalWithPair.WebSocketPair = original;
+    }
+
+    return captured;
+};
+
+describe("voice session credential expiry", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("captured at upgrade", () => {
+        it("stamps expiresAt from a valid x-lunora-identity-exp header", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const exp = Date.now() + 60_000;
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1", { "x-lunora-identity-exp": String(exp) });
+
+            expect(attachment?.["expiresAt"]).toBe(exp);
+        });
+
+        it("stamps no expiresAt when the header is absent", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1");
+
+            expect(attachment).not.toHaveProperty("expiresAt");
+        });
+
+        it.each(["abc", "0", "-5", ""])("stamps no expiresAt for a malformed header (%s)", async (raw) => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1", { "x-lunora-identity-exp": raw });
+
+            expect(attachment).not.toHaveProperty("expiresAt");
+        });
+
+        it("still carries identity/userId alongside expiresAt", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const exp = Date.now() + 60_000;
+
+            const attachment = await upgradeAndCaptureAttachment(instance, "https://do.internal/?threadKey=t1", {
+                "x-lunora-identity": encodeIdentityHeader({ claims: { sub: "user-1" } }),
+                "x-lunora-identity-exp": String(exp),
+                "x-lunora-userid": "user-1",
+            });
+
+            expect(attachment?.["expiresAt"]).toBe(exp);
+            expect(attachment?.["userId"]).toBe("user-1");
+        });
+    });
+
+    describe("enforced at webSocketMessage", () => {
+        it("drops an expired socket on a control frame with TOKEN_EXPIRED/4001, never running the turn", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, sent, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toStrictEqual({
+                code: "TOKEN_EXPIRED",
+                error: { code: "TOKEN_EXPIRED", message: "authentication token expired" },
+                type: "error",
+            });
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+            expect(instance.transcribedPcmLengths).toStrictEqual([]);
+        });
+
+        it("drops an expired socket on a text turn frame the same way", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, sent, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ text: "hello", type: "text" }));
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toMatchObject({ code: "TOKEN_EXPIRED" });
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+        });
+
+        it("gates binary audio frames the same way — no audio is buffered while expired", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, sent, setAttachment, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, new ArrayBuffer(4));
+
+            expect(sent).toHaveLength(1);
+            expect(JSON.parse(sent[0] as string)).toMatchObject({ code: "TOKEN_EXPIRED" });
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+
+            // Flip the credential to unexpired and commit — transcribe sees an
+            // EMPTY utterance, proving the binary frame above was never buffered.
+            setAttachment({ connectionId: "c1", expiresAt: now + 60_000, threadKey: "t1", turn: 0 });
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(instance.transcribedPcmLengths).toStrictEqual([0]);
+        });
+
+        it("treats expiresAt === Date.now() as expired (boundary, matching ShardDO's >=)", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(getClosed()).toStrictEqual({ code: 4001, reason: "token_expired" });
+            expect(instance.transcribedPcmLengths).toStrictEqual([]);
+        });
+
+        it("lets frames flow unchanged when no expiresAt is stamped (additive, no regression)", async () => {
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, ws } = createFakeSocket({ connectionId: "c1", threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(getClosed()).toBeUndefined();
+            expect(instance.transcribedPcmLengths).toStrictEqual([0]);
+        });
+
+        it("lets frames flow when expiresAt is in the future", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { getClosed, ws } = createFakeSocket({ connectionId: "c1", expiresAt: now + 60_000, threadKey: "t1", turn: 0 });
+
+            await instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }));
+
+            expect(getClosed()).toBeUndefined();
+            expect(instance.transcribedPcmLengths).toStrictEqual([0]);
+        });
+
+        it("never throws even when the expired socket's send/close both throw", async () => {
+            const now = Date.now();
+
+            vi.setSystemTime(now);
+
+            const instance = new TestVoiceDO(fakeState(), env, agent, "support");
+            const { ws } = createFakeSocket({ connectionId: "c1", expiresAt: now - 1, threadKey: "t1", turn: 0 }, { throwOnClose: true, throwOnSend: true });
+
+            await expect(instance.webSocketMessage(ws, JSON.stringify({ type: "commit" }))).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -6,6 +6,7 @@ import { buildModelMessages } from "./model-messages";
 import { agentBindingName } from "./naming";
 import { toFunctionReference } from "./paths";
 import type {
+    AgentApprovalContext,
     AgentCompact,
     AgentConfig,
     AgentDefinition,
@@ -27,7 +28,6 @@ import type {
     AgentStreamGenerate,
     AgentTokenSink,
     AgentToolCall,
-    AgentToolContext,
     AgentUsage,
     AgentWorkflowBindingLike,
     AnyAgentTool,
@@ -187,10 +187,21 @@ const addUsage = (base: AgentUsage | undefined, next: AgentUsage | undefined): A
 };
 
 /**
- * Resolve a tool's `needsApproval` gate against the (replay-stable) model input.
- * A boolean gates statically; a function gates per input.
+ * Resolve a tool's `needsApproval` gate against the (replay-stable) model
+ * input. The `true`/`false`/`undefined` forms are compile-time constants —
+ * replay re-derives them identically for free, so they stay outside any
+ * durable step. The FUNCTION form can read `getState`/`run` and so can be
+ * non-deterministic or (if misused) side-effecting; it is memoized in its own
+ * durable step (`gateStepName`, distinct from the tool's own step — see
+ * `runToolCall`) so it now resolves exactly ONCE per call, not once per replay.
  */
-const resolveNeedsApproval = async (tool: AnyAgentTool, input: unknown, context: AgentToolContext): Promise<boolean> => {
+const resolveNeedsApproval = async (
+    tool: AnyAgentTool,
+    input: unknown,
+    step: AgentStepLike,
+    gateStepName: string,
+    context: AgentApprovalContext,
+): Promise<boolean> => {
     const { needsApproval } = tool;
 
     if (needsApproval === undefined || needsApproval === false) {
@@ -201,7 +212,7 @@ const resolveNeedsApproval = async (tool: AnyAgentTool, input: unknown, context:
         return true;
     }
 
-    return needsApproval(input, context);
+    return step.do(gateStepName, async () => needsApproval(input, context));
 };
 
 /**
@@ -264,13 +275,24 @@ const runToolCall = async (turnContext: TurnContext, call: AgentToolCall): Promi
     };
 
     const toolContext = { env, getState, idempotencyKey: stepName, reportProgress, run, setState, threadKey, toolCallId: call.id };
+    // The gate's view: everything `toolContext` has EXCEPT `setState` — a gate
+    // that mutates state is a side effect inside a decision predicate, which is
+    // exactly the misuse durability here is fixing, not relocating.
+    const gateContext: AgentApprovalContext = { env, getState, idempotencyKey: stepName, reportProgress, run, threadKey, toolCallId: call.id };
+    // Distinct from `stepName` (`tool:${call.name}:${call.id}`) so
+    // `@lunora/workflow`'s BY-NAME step memoization can never confuse the gate's
+    // durable result with the tool's own (see the advisor's duplicate-step-name
+    // lint for this collision class). Keyed on `call.id` alone (the
+    // replay-stable identity `stepName` and `approval:${call.id}` already
+    // trust), so it stays collision-free per call.
+    const gateStepName = `tool:approval-gate:${call.id}`;
 
     // Human-in-the-loop: a gated tool pauses the run until a client approves or
     // rejects it. A rejection skips the tool and records why, so the next LLM
     // turn can recover instead of stalling.
     let status: "approved" | undefined;
 
-    if (await resolveNeedsApproval(tool, call.input, toolContext)) {
+    if (await resolveNeedsApproval(tool, call.input, step, gateStepName, gateContext)) {
         const { decision, note } = await awaitApproval(turnContext, call);
 
         if (decision === "reject") {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -21,6 +21,7 @@ export type { BrowserToolInput, BrowserToolOptions, ContainerToolInput, Containe
 export { browserTool, containerTool, fsTool } from "./sandbox";
 export { defineSkill, isSkillDefinition } from "./skill";
 export type {
+    AgentApprovalContext,
     AgentAsToolOptions,
     AgentBindingSpec,
     AgentConfig,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -111,6 +111,18 @@ export interface AgentToolContext {
 }
 
 /**
+ * The READ-ONLY view of {@link AgentToolContext} handed to a `needsApproval`
+ * gate function — every field except `setState`. A gate that mutates thread
+ * state is a side effect inside a decision predicate, which this type makes a
+ * compile-time error rather than a documented-but-unenforced rule: `getState`
+ * and `run` stay available (reads are legitimate gate inputs, and the
+ * function form is resolved inside its own durable step, so they are
+ * replay-safe there too).
+ * @experimental
+ */
+export type AgentApprovalContext = Omit<AgentToolContext, "setState">;
+
+/**
  * An agent tool. Unlike a raw AI SDK tool, `execute` is NOT handed to the
  * model call — the loop runs it itself inside a named durable step so a
  * completed call never re-runs on replay, and passes the
@@ -135,13 +147,19 @@ export interface AgentToolDefinition<Input = unknown, Output = unknown> {
      * On approve the tool runs exactly as normal; on reject it is skipped and a
      * tool result explaining the rejection is persisted so the next turn recovers.
      * A boolean gates statically; a function gates per input. Default: `false`
-     * (unchanged behavior). Evaluated from replay-stable input OUTSIDE the
-     * durable step (it re-runs on every replay), so it must be a PURE predicate:
-     * deterministic (no `Date.now()`/`Math.random()`) and free of side effects —
-     * never call {@link AgentToolContext.setState}/`getState` or a mutating `run`
-     * here; state writes belong only in `execute`, inside the memoized step.
+     * (unchanged behavior).
+     *
+     * The boolean/`undefined` forms are compile-time constants re-derived
+     * identically on every replay — no durable step. The FUNCTION form runs
+     * inside its OWN durable step (`tool:approval-gate:&lt;toolCallId>`, distinct
+     * from the tool's own step), so it now runs exactly once per call, not once
+     * per replay. It must still be otherwise pure: deterministic given its
+     * inputs (no `Date.now()`/`Math.random()`) and free of side effects — the
+     * context it receives is {@link AgentApprovalContext}, which has no
+     * `setState`; state writes belong only in `execute`, inside the tool's own
+     * memoized step.
      */
-    needsApproval?: ((input: Input, context: AgentToolContext) => boolean | Promise<boolean>) | boolean;
+    needsApproval?: ((input: Input, context: AgentApprovalContext) => boolean | Promise<boolean>) | boolean;
 }
 
 /**

--- a/packages/agent/src/voice-do.ts
+++ b/packages/agent/src/voice-do.ts
@@ -37,6 +37,16 @@ const MAX_DRAIN_WAIT_MS = 5000;
  */
 interface VoiceSocketAttachment {
     connectionId: string;
+
+    /**
+     * Token-expiry (epoch ms) of the credential resolved at upgrade, when the
+     * runtime forwarded one (`x-lunora-identity-exp`). The DO drops the socket
+     * with a `TOKEN_EXPIRED` error + close code `4001` the next time it
+     * receives a frame at or after this instant, so the client reconnects and
+     * re-resolves a fresh identity. Absent for sockets whose identity declares
+     * no expiry.
+     */
+    expiresAt?: number;
     identity?: Record<string, unknown>;
     threadKey: string;
     turn: number;
@@ -52,6 +62,7 @@ interface VoiceSessionState {
 
 /** The hibernation-attachment methods the runtime adds to every accepted socket. */
 interface HibernatableWebSocket {
+    close?: (code?: number, reason?: string) => void;
     deserializeAttachment?: () => unknown;
     send: (data: ArrayBuffer | ArrayBufferView | string) => void;
     serializeAttachment?: (value: unknown) => void;
@@ -138,11 +149,16 @@ class VoiceSessionDO {
         const connectionId = crypto.randomUUID();
         const identity = parseIdentity(request.headers.get("x-lunora-identity"));
         const userId = decodeUserIdHeader(request.headers.get("x-lunora-userid"));
+        // Optional credential expiry (epoch ms) forwarded by the runtime. A
+        // malformed value is ignored (the socket simply never auto-expires).
+        const expiresAtRaw = Number(request.headers.get("x-lunora-identity-exp"));
+        const expiresAt = Number.isFinite(expiresAtRaw) && expiresAtRaw > 0 ? expiresAtRaw : undefined;
 
         (server as unknown as HibernatableWebSocket).serializeAttachment?.({
             connectionId,
             threadKey,
             turn: 0,
+            ...(expiresAt === undefined ? {} : { expiresAt }),
             ...(identity === undefined ? {} : { identity }),
             ...(userId === undefined ? {} : { userId }),
         } satisfies VoiceSocketAttachment);
@@ -164,6 +180,12 @@ class VoiceSessionDO {
         const attachment = (ws as unknown as HibernatableWebSocket).deserializeAttachment?.() as VoiceSocketAttachment | undefined;
 
         if (!attachment) {
+            return;
+        }
+
+        if (this.isSocketExpired(attachment)) {
+            this.dropExpiredSocket(ws);
+
             return;
         }
 
@@ -429,6 +451,30 @@ class VoiceSessionDO {
         this.controllers.delete(attachment.connectionId);
         this.audioBuffers.delete(attachment.connectionId);
         this.bufferedBytes.delete(attachment.connectionId);
+    }
+
+    /** Whether `attachment` carries a credential whose expiry (stamped at upgrade) is now past. */
+    // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with dropExpiredSocket; operates only on the passed attachment
+    private isSocketExpired(attachment: VoiceSocketAttachment): boolean {
+        return typeof attachment.expiresAt === "number" && Date.now() >= attachment.expiresAt;
+    }
+
+    /**
+     * Send the `TOKEN_EXPIRED` error frame and close the socket with code 4001 so
+     * the client distinguishes an expired-credential drop from an ordinary one
+     * and refreshes before reconnecting. Best-effort: a throw (socket already
+     * gone) is swallowed — this must never escape the hibernation handlers.
+     */
+    // eslint-disable-next-line class-methods-use-this -- cohesive socket helper grouped with isSocketExpired; operates only on the passed socket
+    private dropExpiredSocket(ws: WebSocket): void {
+        try {
+            (ws as unknown as HibernatableWebSocket).send(
+                JSON.stringify({ code: "TOKEN_EXPIRED", error: { code: "TOKEN_EXPIRED", message: "authentication token expired" }, type: "error" }),
+            );
+            (ws as unknown as HibernatableWebSocket).close?.(4001, "token_expired");
+        } catch {
+            /* socket already gone */
+        }
     }
 
     /** Send a JSON control frame, swallowing a closed-socket error (never throw from a handler). */


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(agent): drop expired-credential voice sockets with TOKEN_EXPIRED/4001
- fix(agent): memoize the dynamic tool-approval gate in its own durable step

## Files this branch still changes relative to alpha

```
packages/agent/__tests__/agent-loop.test.ts
packages/agent/__tests__/voice-do.test.ts
packages/agent/src/agent-loop.ts
packages/agent/src/index.ts
packages/agent/src/types.ts
packages/agent/src/voice-do.ts
```
