### PR TITLE
fix(auth): record sign-in completion endpoints, fix a response-clobbering hook bug, and validate audit-read options

### DIFF
--- a/packages/auth/__tests__/audit-hooks.behaviour.test.ts
+++ b/packages/auth/__tests__/audit-hooks.behaviour.test.ts
@@ -1,0 +1,465 @@
+import { createHmac } from "node:crypto";
+
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { createAuthMiddleware } from "better-auth/api";
+import { magicLink } from "better-auth/plugins/magic-link";
+import { twoFactor } from "better-auth/plugins/two-factor";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createAuth } from "../src/create-auth";
+
+/**
+ * Plan 280 S0 — pins the better-auth `1.7.0-rc.2` after-hook contract that
+ * `audit-hooks.ts`'s classifier rewrite depends on, against a REAL better-auth
+ * instance (in-memory adapter, no mocks). This suite is a gate: if any pinned
+ * assumption below turns out false, the classifier design in the plan changes
+ * (or the plan's S1 item stops), per the plan's own §8 STOP condition.
+ *
+ * Each captured entry mirrors exactly what `audit-hooks.ts`'s `AuditHookContext`
+ * reads off the real context — `path`, `context.returned`, `context.newSession`,
+ * `context.session`, and (the thing under test) `body` — so the pins are a
+ * direct readout of the shape the classifier will see, not a paraphrase of it.
+ */
+
+const SECRET = "x".repeat(32);
+const STRONG_PASSWORD = "correct horse battery staple";
+const EMAIL = "ada@example.com";
+
+interface Captured {
+    body: unknown;
+    newSession: unknown;
+    path: string | undefined;
+    returned: unknown;
+    session: unknown;
+}
+
+let captured: Captured[];
+
+/** Whether `value` is a plain object carrying own key `key` — avoids an inline ternary inside `expect(...)`. */
+const hasKey = (value: unknown, key: string): boolean => typeof value === "object" && value !== null && key in value;
+
+/** Sorted top-level key names of a parsed JSON body — a `response.json()` result is `unknown` here, narrowed once in one place. */
+const sortedKeysOf = (value: unknown): string[] =>
+    typeof value === "object" && value !== null ? Object.keys(value).toSorted((a, b) => a.localeCompare(b)) : [];
+
+/**
+ * Captures instead of recording, so each pin reads real context. Returns
+ * `undefined`, NOT `{}` — see the "hooks.after return value" describe block
+ * below: returning a bare `{}` (which is what the shipped `authAuditHook`
+ * does today) is a confirmed, severe bug that replaces EVERY hooked
+ * endpoint's response body with `{}`. Using the correct (`undefined`) return
+ * here keeps the rest of this suite's pins measuring real endpoint behaviour
+ * instead of the bug's fallout.
+ */
+const capturingAfterHook = (): ReturnType<typeof createAuthMiddleware> =>
+    createAuthMiddleware(async (ctx) => {
+        captured.push({
+            body: (ctx as { body?: unknown }).body,
+            newSession: ctx.context?.newSession,
+            path: ctx.path,
+            returned: ctx.context?.returned,
+            session: ctx.context?.session,
+        });
+
+        return undefined;
+    });
+
+const seedMemoryDatabase = (): Record<string, unknown[]> => {
+    return { account: [], rateLimit: [], session: [], twoFactor: [], user: [], verification: [] };
+};
+
+// eslint-disable-next-line no-secrets/no-secrets -- the standard base32 alphabet (RFC 4648 §6), not a credential
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/** RFC 6238 TOTP, reimplemented independently of better-auth's own `createOTP` (which the code under test also uses) so the pin isn't circular. SHA-1/6-digit/30s — better-auth's defaults. */
+const base32Decode = (encoded: string): Buffer => {
+    // eslint-disable-next-line sonarjs/slow-regex -- bounded trailing-padding strip on a short (a few dozen char), fully-controlled test fixture string, not attacker input
+    const clean = encoded.toUpperCase().replaceAll(/=+$/gu, "");
+    let bits = "";
+
+    for (const char of clean) {
+        const index = BASE32_ALPHABET.indexOf(char);
+
+        if (index === -1) {
+            continue;
+        }
+
+        bits += index.toString(2).padStart(5, "0");
+    }
+
+    const bytes: number[] = [];
+
+    for (let index = 0; index + 8 <= bits.length; index += 8) {
+        bytes.push(Number.parseInt(bits.slice(index, index + 8), 2));
+    }
+
+    return Buffer.from(bytes);
+};
+
+/* eslint-disable no-bitwise -- RFC 6238 HOTP dynamic truncation is defined in terms of bitwise ops; there is no non-bitwise equivalent */
+const totpCode = (rawSecretBase32: string): string => {
+    const key = base32Decode(rawSecretBase32);
+    const counter = Math.floor(Date.now() / 30_000);
+    const counterBuffer = Buffer.alloc(8);
+
+    counterBuffer.writeBigUInt64BE(BigInt(counter));
+
+    const hmac = createHmac("sha1", key).update(counterBuffer).digest();
+    const offset = (hmac.at(-1) ?? 0) & 0x0f;
+    const binary = (((hmac[offset] ?? 0) & 0x7f) << 24) | (((hmac[offset + 1] ?? 0) & 0xff) << 16) | (((hmac[offset + 2] ?? 0) & 0xff) << 8) | ((hmac[offset + 3] ?? 0) & 0xff);
+    const otp = binary % (10 ** 6);
+
+    return otp.toString().padStart(6, "0");
+};
+/* eslint-enable no-bitwise */
+
+describe("better-auth 1.7.0-rc.2 after-hook contract (plan 280 S0 gate)", () => {
+    let database: Record<string, unknown[]>;
+
+    beforeEach(() => {
+        database = seedMemoryDatabase();
+        captured = [];
+    });
+
+    /**
+     * UNPLANNED, SEVERE FINDING surfaced by this gate (not one of the three
+     * assumptions the plan named, but load-bearing for the whole feature):
+     * `authAuditHook`'s handler ends with `return {};` — its own docblock
+     * justifies this as "must return an object: returning `undefined` would
+     * throw". That justification is FALSE for `1.7.0-rc.2`, and the `{}` it
+     * returns instead is not inert: `runAfterHooks` (better-auth's
+     * `dispatch.mjs`) treats ANY non-undefined value the handler resolves to
+     * as the endpoint's new response and overwrites `context.context.returned`
+     * with it. A bare `{}` therefore REPLACES every hooked endpoint's real
+     * response body with `{}` on the wire — sign-up, sign-in, everything.
+     * `undefined` does not throw and leaves the response untouched (proven
+     * below on both sides). This is a live production bug in the shipped hook,
+     * independent of the classification rewrite; the fix (S1) is a one-line
+     * change to `audit-hooks.ts`'s trailing `return {};`.
+     */
+    describe("hooks.after return value: `{}` clobbers the response, `undefined` does not", () => {
+        const bodyOf = async (afterHandler: ReturnType<typeof createAuthMiddleware>): Promise<string> => {
+            const database2: Record<string, unknown[]> = seedMemoryDatabase();
+            const auth = createAuth({
+                database: memoryAdapter(database2),
+                emailAndPassword: { enabled: true },
+                hooks: { after: afterHandler },
+                secret: SECRET,
+            });
+
+            const response = await auth.handler(
+                new Request("http://localhost/api/auth/sign-up/email", {
+                    body: JSON.stringify({ email: EMAIL, name: "Ada", password: STRONG_PASSWORD }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+
+            return response.text();
+        };
+
+        it("returning `{}` (the shipped `authAuditHook` pattern) replaces the real sign-up response with `{}`", async () => {
+            expect.assertions(1);
+
+            const body = await bodyOf(
+                createAuthMiddleware(async () => {
+                    return {};
+                }),
+            );
+
+            expect(body).toBe("{}");
+        });
+
+        it("returning `undefined` does NOT throw, and leaves the real sign-up response intact", async () => {
+            expect.assertions(2);
+
+            const body = await bodyOf(
+                createAuthMiddleware(async () => undefined),
+            );
+
+            expect(body).not.toBe("{}");
+            expect(JSON.parse(body)).toHaveProperty("user");
+        });
+
+        it("no hooks.after at all produces the identical body an `undefined`-returning hook produces (proves `undefined` is a true no-op, not a different-but-also-intact shape)", async () => {
+            expect.assertions(1);
+
+            const database2: Record<string, unknown[]> = seedMemoryDatabase();
+            const auth = createAuth({ database: memoryAdapter(database2), emailAndPassword: { enabled: true }, secret: SECRET });
+
+            const response = await auth.handler(
+                new Request("http://localhost/api/auth/sign-up/email", {
+                    body: JSON.stringify({ email: EMAIL, name: "Ada", password: STRONG_PASSWORD }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+            const noHookBody = await response.json();
+
+            const withUndefinedHookBody = JSON.parse(
+                await bodyOf(
+                    createAuthMiddleware(async () => undefined),
+                ),
+            );
+
+            // Random per-call fields (`token`, `user.id`, timestamps) will differ —
+            // the no-op claim is about SHAPE, not byte-identity: same top-level
+            // keys, same nested `user` keys, neither reduced to `{}`.
+            expect(sortedKeysOf(withUndefinedHookBody)).toStrictEqual(sortedKeysOf(noHookBody));
+        });
+    });
+
+    describe("credential sign-in", () => {
+        const buildAuth = () =>
+            createAuth({
+                database: memoryAdapter(database),
+                emailAndPassword: { enabled: true },
+                hooks: { after: capturingAfterHook() },
+                secret: SECRET,
+            });
+
+        it("fires hooks.after on a SUCCESSFUL /sign-in/email, with ctx.body carrying the request body and ctx.context.returned the plain success payload (not an Error, no `.status`)", async () => {
+            expect.assertions(6);
+
+            const auth = buildAuth();
+
+            await auth.api.signUpEmail({ body: { email: EMAIL, name: "Ada", password: STRONG_PASSWORD } });
+            captured = [];
+
+            const response = await auth.handler(
+                new Request("http://localhost/api/auth/sign-in/email", {
+                    body: JSON.stringify({ email: EMAIL, password: STRONG_PASSWORD }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+
+            expect(response.status).toBe(200);
+
+            const entry = captured.find((row) => row.path === "/sign-in/email");
+
+            expect(entry).toBeDefined();
+            expect((entry?.body as { email?: string } | undefined)?.email).toBe(EMAIL);
+            expect(entry?.returned).not.toBeInstanceOf(Error);
+            expect(hasKey(entry?.returned, "status")).toBe(false);
+            // A real session was created and is visible to our hook at the point it runs.
+            expect((entry?.newSession as { user?: { email?: string } } | undefined)?.user?.email).toBe(EMAIL);
+        });
+
+        it("fires hooks.after on a REJECTED /sign-in/email (wrong password), with ctx.context.returned an Error-shaped APIError and ctx.body still carrying the attempted email", async () => {
+            expect.assertions(4);
+
+            const auth = buildAuth();
+
+            await auth.api.signUpEmail({ body: { email: EMAIL, name: "Ada", password: STRONG_PASSWORD } });
+            captured = [];
+
+            const response = await auth.handler(
+                new Request("http://localhost/api/auth/sign-in/email", {
+                    body: JSON.stringify({ email: EMAIL, password: "totally-wrong" }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+
+            expect(response.status).toBe(401);
+
+            const entry = captured.find((row) => row.path === "/sign-in/email");
+
+            expect(entry).toBeDefined();
+            expect(entry?.returned).toBeInstanceOf(Error);
+            expect((entry?.body as { email?: string } | undefined)?.email).toBe(EMAIL);
+        });
+
+        it("does NOT see the two-factor plugin's {twoFactorRedirect:true} rewrite: the app's own hooks.after runs BEFORE plugin after-hooks, so for a 2FA-enabled account our hook still observes the pre-interception successful session response", async () => {
+            expect.assertions(6);
+
+            // `any` — `createAuth`'s return type isn't generic over `plugins`, so
+            // plugin-contributed endpoints (`enableTwoFactor`) aren't visible on
+            // `auth.api` without it (same precedent as `admin.behaviour.test.ts`).
+            const auth: any = createAuth({
+                database: memoryAdapter(database),
+                emailAndPassword: { enabled: true },
+                hooks: { after: capturingAfterHook() },
+                plugins: [twoFactor()],
+                secret: SECRET,
+            });
+
+            const signUp = await auth.api.signUpEmail({ body: { email: EMAIL, name: "Ada", password: STRONG_PASSWORD }, returnHeaders: true });
+            const cookie = signUp.headers.get("set-cookie") ?? "";
+
+            // Enable TOTP 2FA (skip verification so the very next sign-in is challenged).
+            await auth.api.enableTwoFactor({
+                body: { password: STRONG_PASSWORD },
+                headers: new Headers({ cookie: cookie.split(";")[0] ?? "" }),
+            });
+
+            // Mark it verified directly in the memory store — `enableTwoFactor` alone
+            // leaves `verified: false` until a TOTP is confirmed, and the sign-in-time
+            // 2FA hook only triggers for `user.twoFactorEnabled`, which the "enable"
+            // call itself does not flip until verified. This is the least invasive way
+            // to reach "2FA is enabled and would challenge the next sign-in" without a
+            // second, unrelated round-trip through /two-factor/verify-totp.
+            // Fixture setup, not an assertion: both rows are guaranteed present by the
+            // enrollment calls just above — `?.` degrades to a no-op only if that
+            // assumption ever breaks, which a later assertion in this test would catch.
+            const twoFactorRow = database["twoFactor"]?.[0] as Record<string, unknown> | undefined;
+
+            // eslint-disable-next-line vitest/no-conditional-in-test -- fixture setup, not an assertion (see comment above)
+            if (twoFactorRow) {
+                twoFactorRow["verified"] = true;
+            }
+
+            const userRow = database["user"]?.[0] as Record<string, unknown> | undefined;
+
+            // eslint-disable-next-line vitest/no-conditional-in-test -- fixture setup, not an assertion (see comment above)
+            if (userRow) {
+                userRow["twoFactorEnabled"] = true;
+            }
+
+            captured = [];
+
+            const response = await auth.handler(
+                new Request("http://localhost/api/auth/sign-in/email", {
+                    body: JSON.stringify({ email: EMAIL, password: STRONG_PASSWORD }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+
+            // The HTTP RESPONSE the client sees IS the 2FA challenge — proves 2FA is
+            // really active on this account and the plugin's rewrite really happened.
+            await expect(response.json()).resolves.toMatchObject({ twoFactorRedirect: true });
+
+            const entry = captured.find((row) => row.path === "/sign-in/email");
+
+            expect(entry).toBeDefined();
+            // But OUR hook — which ran before the plugin's own after-hook rewrote the
+            // response — saw the ORIGINAL successful sign-in: a populated `newSession`
+            // and a `returned` with no `twoFactorRedirect` field at all.
+            expect((entry?.newSession as { user?: { email?: string } } | undefined)?.user?.email).toBe(EMAIL);
+            expect(entry?.returned).not.toBeInstanceOf(Error);
+            expect(hasKey(entry?.returned, "twoFactorRedirect")).toBe(false);
+            expect((entry?.body as { email?: string } | undefined)?.email).toBe(EMAIL);
+        });
+    });
+
+    describe("magic-link", () => {
+        it("fires hooks.after for BOTH /sign-in/magic-link (dispatch) and /magic-link/verify (completion), the latter with a populated ctx.context.newSession", async () => {
+            expect.assertions(5);
+
+            let sentToken: string | undefined;
+
+            const auth = createAuth({
+                database: memoryAdapter(database),
+                hooks: { after: capturingAfterHook() },
+                plugins: [
+                    magicLink({
+                        sendMagicLink: ({ token }) => {
+                            sentToken = token;
+                        },
+                    }),
+                ],
+                secret: SECRET,
+            });
+
+            const dispatchResponse = await auth.handler(
+                new Request("http://localhost/api/auth/sign-in/magic-link", {
+                    body: JSON.stringify({ email: EMAIL, name: "Ada" }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+
+            expect(dispatchResponse.status).toBe(200);
+            expect(captured.some((row) => row.path === "/sign-in/magic-link")).toBe(true);
+            expect(sentToken).toBeDefined();
+
+            captured = [];
+
+            // Omitting `callbackURL` takes magic-link/verify's JSON-response branch
+            // instead of the redirect-throw branch (see the plugin's own source) —
+            // the simpler case to pin first for "does the after-hook fire at all".
+            const verifyResponse = await auth.handler(
+                new Request(`http://localhost/api/auth/magic-link/verify?token=${String(sentToken)}`, { method: "GET" }),
+            );
+
+            expect(verifyResponse.status).toBe(200);
+
+            const entry = captured.find((row) => row.path === "/magic-link/verify");
+
+            expect((entry?.newSession as { user?: { email?: string } } | undefined)?.user?.email).toBe(EMAIL);
+        });
+    });
+
+    describe("two-factor TOTP verification", () => {
+        it("fires hooks.after for /two-factor/verify-totp on a sign-in challenge, populating ctx.context.newSession once the code is accepted", async () => {
+            expect.assertions(4);
+
+            // `any` — see the sibling test above for why.
+            const auth: any = createAuth({
+                database: memoryAdapter(database),
+                emailAndPassword: { enabled: true },
+                hooks: { after: capturingAfterHook() },
+                plugins: [twoFactor()],
+                secret: SECRET,
+            });
+
+            const signUp = await auth.api.signUpEmail({ body: { email: EMAIL, name: "Ada", password: STRONG_PASSWORD }, returnHeaders: true });
+            const signUpCookie = (signUp.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+            const enableResponse = await auth.handler(
+                new Request("http://localhost/api/auth/two-factor/enable", {
+                    body: JSON.stringify({ password: STRONG_PASSWORD }),
+                    headers: { "content-type": "application/json", cookie: signUpCookie },
+                    method: "POST",
+                }),
+            );
+            const enableResultText = await enableResponse.text();
+            const enableResult = JSON.parse(enableResultText) as { backupCodes?: string[]; method?: string; totpURI?: string };
+            const totpUri = enableResult.totpURI ?? "";
+            const secretParam = new URL(totpUri.replace("otpauth://", "https://")).searchParams.get("secret") ?? "";
+
+            // Confirm enrollment with a real TOTP code — flips `verified: true` and
+            // `user.twoFactorEnabled: true` for real, via the actual endpoint (no
+            // hand-editing the store, unlike the sign-in-observability test above).
+            await auth.api.verifyTOTP({ body: { code: totpCode(secretParam) }, headers: new Headers({ cookie: signUpCookie }) });
+
+            captured = [];
+
+            const challengeResponse = await auth.handler(
+                new Request("http://localhost/api/auth/sign-in/email", {
+                    body: JSON.stringify({ email: EMAIL, password: STRONG_PASSWORD }),
+                    headers: { "content-type": "application/json" },
+                    method: "POST",
+                }),
+            );
+
+            await expect(challengeResponse.json()).resolves.toMatchObject({ twoFactorRedirect: true });
+
+            // The challenge response sets MULTIPLE cookies (it deletes the credential
+            // session cookie AND sets the two-factor challenge cookie) — `.get()`
+            // on a multi-valued header is unreliable, so pick the `two_factor` one
+            // out of `getSetCookie()`'s array explicitly.
+            const twoFactorSetCookie = challengeResponse.headers.getSetCookie().find((entry: string) => entry.includes("two_factor")) ?? "";
+            const twoFactorCookie = twoFactorSetCookie.split(";")[0] ?? "";
+
+            captured = [];
+
+            const verifyResponse = await auth.handler(
+                new Request("http://localhost/api/auth/two-factor/verify-totp", {
+                    body: JSON.stringify({ code: totpCode(secretParam) }),
+                    headers: { "content-type": "application/json", cookie: twoFactorCookie },
+                    method: "POST",
+                }),
+            );
+
+            expect(verifyResponse.status).toBe(200);
+
+            const entry = captured.find((row) => row.path === "/two-factor/verify-totp");
+
+            expect(entry).toBeDefined();
+            expect((entry?.newSession as { user?: { email?: string } } | undefined)?.user?.email).toBe(EMAIL);
+        });
+    });
+});

--- a/packages/auth/__tests__/audit.test.ts
+++ b/packages/auth/__tests__/audit.test.ts
@@ -2,7 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { appendAuthAuditEntry, readAuthAuditLog } from "../src/audit";
+import { appendAuthAuditEntry, ensureAuthAuditTable, readAuthAuditLog } from "../src/audit";
 import { buildAuditEntry } from "../src/audit-hooks";
 import type { SqlExecutor } from "../src/sql-store";
 
@@ -63,6 +63,24 @@ describe("auth audit trail", () => {
             expect.assertions(1);
 
             await expect(readAuthAuditLog(executor)).resolves.toStrictEqual([]);
+        });
+
+        /**
+         * Plan 280 §5 S3: `Math.max(1, Math.min(NaN, MAX_READ_LIMIT))` is `NaN` —
+         * previously reached the SQL `LIMIT ?` bind unchecked. The library-level
+         * fix falls back to `DEFAULT_READ_LIMIT` for any non-finite `limit`, so
+         * every caller of `readAuthAuditLog` is protected, not just the DO's
+         * `#readAudit` boundary (which now also 400s before ever calling this).
+         */
+        it("falls back to the default limit when `limit` is NaN, instead of binding NaN as the SQL LIMIT", async () => {
+            expect.assertions(1);
+
+            for (let index = 0; index < 5; index += 1) {
+                // eslint-disable-next-line no-await-in-loop -- sequential appends model the real per-request write order
+                await appendAuthAuditEntry(executor, { event: "sign-in", outcome: "success", ts: index });
+            }
+
+            await expect(readAuthAuditLog(executor, { limit: Number.NaN })).resolves.toHaveLength(5);
         });
     });
 
@@ -137,6 +155,49 @@ describe("auth audit trail", () => {
             expect(persisted.event).toBe("sign-in");
             expect((persisted.detail as Record<string, unknown>)["secret"]).not.toBe("abc123");
         });
+
+        /**
+         * Plan 280 §4's verified correction: `targetEmail` MUST be a top-level
+         * column, not a `detail` key — `AUDIT_REDACT_RULES` scrubs email-shaped
+         * VALUES inside `detail` regardless of key name (a deep value-pattern
+         * rule, not just a key-name rule), so the same address survives as
+         * `targetEmail` while it is erased inside `detail`.
+         */
+        it("`targetEmail` survives redaction (top-level) while the SAME address inside `detail` is scrubbed", async () => {
+            expect.assertions(2);
+
+            await appendAuthAuditEntry(executor, {
+                detail: { email: "victim@example.com" },
+                event: "sign-in",
+                outcome: "failure",
+                targetEmail: "victim@example.com",
+                ts: 1,
+            });
+
+            const [row] = await readAuthAuditLog(executor);
+
+            expect(row?.targetEmail).toBe("victim@example.com");
+            expect(row?.detail?.["email"]).not.toBe("victim@example.com");
+        });
+
+        it("old-shape rows (written before `target_email` existed) read back with no `targetEmail` field", async () => {
+            expect.assertions(1);
+
+            // Simulate a pre-migration row: create the (now-migrated) table first,
+            // then insert directly with the OLD column list, bypassing
+            // `appendAuthAuditEntry` (which always supplies `target_email` now
+            // that the column exists) — `target_email` lands NULL, same as any
+            // row written before this change shipped.
+            await ensureAuthAuditTable(executor);
+            await executor.run(
+                `INSERT INTO "__lunora_auth_audit__" (ts, event, outcome, actor_id, actor_email, ip, user_agent, detail) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                [1, "sign-in", "success", "u1", null, null, null, null],
+            );
+
+            const [row] = await readAuthAuditLog(executor);
+
+            expect(row).not.toHaveProperty("targetEmail");
+        });
     });
 
     describe("buildAuditEntry — classification & extraction", () => {
@@ -148,6 +209,105 @@ describe("auth audit trail", () => {
             expect(buildAuditEntry({ path: "/api/auth/change-password" })?.event).toBe("password-change");
             expect(buildAuditEntry({ path: "/api/auth/two-factor/enable" })?.event).toBe("mfa-enable");
             expect(buildAuditEntry({ path: "/api/auth/two-factor/disable" })?.event).toBe("mfa-disable");
+        });
+
+        /**
+         * Plan 280 §1/§4: `/sign-in/social` and `/sign-in/magic-link` only DISPATCH
+         * (mint a redirect URL / send an email) — pre-fix they were misclassified as
+         * a completed `sign-in`. The endpoints that actually complete a challenged
+         * or third-party sign-in (`/callback/:id`, `/magic-link/verify`, every
+         * `/two-factor/verify-*`) were not recorded at all before this change.
+         */
+        it("classifies dispatch-only sign-in endpoints as `sign-in-initiated`, not `sign-in`", () => {
+            expect.assertions(2);
+
+            expect(buildAuditEntry({ path: "/api/auth/sign-in/social" })?.event).toBe("sign-in-initiated");
+            expect(buildAuditEntry({ path: "/api/auth/sign-in/magic-link" })?.event).toBe("sign-in-initiated");
+        });
+
+        it("classifies every sign-in COMPLETION endpoint as `sign-in` (previously unrecorded)", () => {
+            expect.assertions(5);
+
+            expect(buildAuditEntry({ path: "/api/auth/callback/github" })?.event).toBe("sign-in");
+            expect(buildAuditEntry({ path: "/api/auth/magic-link/verify" })?.event).toBe("sign-in");
+            expect(buildAuditEntry({ path: "/api/auth/two-factor/verify-totp" })?.event).toBe("sign-in");
+            expect(buildAuditEntry({ path: "/api/auth/two-factor/verify-otp" })?.event).toBe("sign-in");
+            expect(buildAuditEntry({ path: "/api/auth/two-factor/verify-backup-code" })?.event).toBe("sign-in");
+        });
+
+        it("still classifies every credential/username/phone sign-in as plain `sign-in` (no regression)", () => {
+            expect.assertions(3);
+
+            expect(buildAuditEntry({ path: "/api/auth/sign-in/email" })?.event).toBe("sign-in");
+            expect(buildAuditEntry({ path: "/api/auth/sign-in/username" })?.event).toBe("sign-in");
+            expect(buildAuditEntry({ path: "/api/auth/sign-in/phone-number" })?.event).toBe("sign-in");
+        });
+
+        it("no-regression: sign-up / sign-out / MFA-toggle / revoke / link / unlink classify exactly as before", () => {
+            expect.assertions(7);
+
+            expect(buildAuditEntry({ path: "/api/auth/sign-up/email" })?.event).toBe("sign-up");
+            expect(buildAuditEntry({ path: "/api/auth/sign-out" })?.event).toBe("sign-out");
+            expect(buildAuditEntry({ path: "/api/auth/two-factor/enable" })?.event).toBe("mfa-enable");
+            expect(buildAuditEntry({ path: "/api/auth/two-factor/disable" })?.event).toBe("mfa-disable");
+            expect(buildAuditEntry({ path: "/api/auth/revoke-session" })?.event).toBe("session-revoke");
+            expect(buildAuditEntry({ path: "/api/auth/link-social" })?.event).toBe("account-link");
+            expect(buildAuditEntry({ path: "/api/auth/unlink-account" })?.event).toBe("account-unlink");
+        });
+
+        /**
+         * Plan 280 §4/§9 Q2: the identifier extraction is shared across the
+         * sign-in family, so `sign-in-initiated` (a magic-link dispatch) carries
+         * `targetEmail` too — the address the link was sent to.
+         */
+        it("carries `targetEmail` from the request body for BOTH sign-in and sign-in-initiated events", () => {
+            expect.assertions(2);
+
+            const initiated = buildAuditEntry({ body: { email: "ada@example.com" }, path: "/api/auth/sign-in/magic-link" });
+            const completed = buildAuditEntry({ body: { email: "ada@example.com" }, path: "/api/auth/sign-in/email" });
+
+            expect(initiated?.targetEmail).toBe("ada@example.com");
+            expect(completed?.targetEmail).toBe("ada@example.com");
+        });
+
+        it("falls back to `body.username` when `email` is absent", () => {
+            expect.assertions(1);
+
+            expect(buildAuditEntry({ body: { username: "ada" }, path: "/api/auth/sign-in/username" })?.targetEmail).toBe("ada");
+        });
+
+        it("does NOT carry `targetEmail` for a non-sign-in event, even if the body happens to have an `email` field", () => {
+            expect.assertions(1);
+
+            expect(buildAuditEntry({ body: { email: "ada@example.com" }, path: "/api/auth/change-password" })?.targetEmail).toBeUndefined();
+        });
+
+        it("length-caps `targetEmail` at 320 chars (RFC 5321) against a hostile body", () => {
+            expect.assertions(1);
+
+            const hostile = `${"a".repeat(400)}@example.com`;
+            const entry = buildAuditEntry({ body: { email: hostile }, path: "/api/auth/sign-in/email" });
+
+            expect(entry?.targetEmail).toHaveLength(320);
+        });
+
+        /**
+         * A FAILED credential sign-in records no `actorEmail` (no authenticated
+         * user), so without `targetEmail` a credential-stuffing sweep against one
+         * address is invisible in the trail — this is the finding the plan opened
+         * with.
+         */
+        it("a FAILED /sign-in/email still carries the attempted `targetEmail`", () => {
+            expect.assertions(2);
+
+            const entry = buildAuditEntry({
+                body: { email: "victim@example.com" },
+                context: { returned: new Error("invalid credentials") },
+                path: "/api/auth/sign-in/email",
+            });
+
+            expect(entry?.outcome).toBe("failure");
+            expect(entry?.targetEmail).toBe("victim@example.com");
         });
 
         it("skips non-security endpoints (returns undefined)", () => {

--- a/packages/auth/__tests__/auth-do.behaviour.test.ts
+++ b/packages/auth/__tests__/auth-do.behaviour.test.ts
@@ -182,6 +182,62 @@ describe("lunoraAuthDO", () => {
         await expect(response.json()).resolves.toStrictEqual({ entries: [] });
     });
 
+    /**
+     * Plan 280 §5 S3: a trusted caller sending a malformed body previously threw
+     * an unhandled exception out of `#readAudit` (an opaque 500) instead of the
+     * 400 a caller error deserves.
+     */
+    it("400s a trusted caller's malformed (non-JSON) body instead of throwing a 500", async () => {
+        expect.assertions(2);
+
+        const { authDo } = createDo();
+        const response = await authDo.fetch(
+            new Request(`https://example.test${READ_AUDIT_PATH}`, {
+                body: "not-json",
+                headers: { "content-type": "application/json", [INTERNAL_SECRET_HEADER]: INTERNAL_SECRET },
+                method: "POST",
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({ error: expect.any(String) });
+    });
+
+    /**
+     * Plan 280 §5 S3: a non-numeric `limit` previously reached `readAuthAuditLog`
+     * unchecked, where `Math.min`/`Math.max` propagate `NaN` and it is bound as
+     * the SQL `LIMIT` parameter.
+     */
+    it("400s a non-numeric `limit` instead of letting NaN reach the SQL LIMIT clause", async () => {
+        expect.assertions(1);
+
+        const { authDo } = createDo();
+        const response = await authDo.fetch(
+            new Request(`https://example.test${READ_AUDIT_PATH}`, {
+                body: JSON.stringify({ limit: "1e2junk" }),
+                headers: { "content-type": "application/json", [INTERNAL_SECRET_HEADER]: INTERNAL_SECRET },
+                method: "POST",
+            }),
+        );
+
+        expect(response.status).toBe(400);
+    });
+
+    it("400s an unknown audit-read option instead of silently ignoring it", async () => {
+        expect.assertions(1);
+
+        const { authDo } = createDo();
+        const response = await authDo.fetch(
+            new Request(`https://example.test${READ_AUDIT_PATH}`, {
+                body: JSON.stringify({ limit: 5, unexpectedField: "anything" }),
+                headers: { "content-type": "application/json", [INTERNAL_SECRET_HEADER]: INTERNAL_SECRET },
+                method: "POST",
+            }),
+        );
+
+        expect(response.status).toBe(400);
+    });
+
     it("refuses the audit log without the secret", async () => {
         expect.assertions(1);
 

--- a/packages/auth/src/audit-hooks.ts
+++ b/packages/auth/src/audit-hooks.ts
@@ -33,8 +33,16 @@ interface AuthAuditHookConfig extends AppendAuthAuditOptions {
     onRecord?: (entry: AppendAuthAuditEntry) => Promise<void> | void;
 }
 
-/** Structural view of the fields we read off better-auth's after-hook context — kept loose to avoid coupling to internal types. */
+/**
+ * Structural view of the fields we read off better-auth's after-hook context —
+ * kept loose to avoid coupling to internal types.
+ *
+ * `body` is the parsed request body better-auth's middleware context exposes
+ * as `ctx.body` — pinned present and populated (e.g. `.email`) in the after-hook
+ * by `__tests__/audit-hooks.behaviour.test.ts` (plan 280 S0).
+ */
 interface AuditHookContext {
+    body?: Record<string, unknown>;
     context?: {
         newSession?: { session?: { userId?: string }; user?: { email?: string; id?: string } } | null;
         returned?: unknown;
@@ -49,6 +57,27 @@ interface AuditHookContext {
  * Map a better-auth endpoint path to the security event it represents, or
  * `undefined` for endpoints not worth auditing (session reads, config, …). Match
  * is by suffix so a caller `basePath` prefix (`/api/auth`) never affects it.
+ *
+ * Sign-in is split by what the endpoint actually DOES (plan 280 §4):
+ *
+ * - `/sign-in/social`, `/sign-in/magic-link` only DISPATCH — the first mints a
+ * provider redirect URL, the second sends an email. Nobody is authenticated
+ * yet, so these are `sign-in-initiated`, not `sign-in`.
+ * - `/callback/:id` (social + generic-oauth), `/magic-link/verify`, and every
+ * `/two-factor/verify-*` (`verify-totp` / `verify-otp` / `verify-backup-code`
+ * — all three complete a challenged sign-in the same way) are where a
+ * session actually gets issued, so they join credential sign-ins
+ * (`/sign-in/email`, `/sign-in/username`, `/sign-in/phone-number`, …) as
+ * plain `sign-in`. They were NOT recorded at all before this change.
+ *
+ * `/oauth2/callback/*` is deliberately NOT matched here: it does not exist as
+ * an endpoint in the pinned `1.7.0-rc.2` (checked against the installed
+ * `better-auth` and `@better-auth/*` dist — generic-oauth reuses the core
+ * `/callback/:id` endpoint, it does not register its own path). `@better-auth/sso`
+ * does expose its own `/sso/callback/:providerId`, but `@lunora/auth`'s
+ * `plugins.ts` does not currently re-export `sso` — recorded as a gap for a
+ * follow-up (plan 280 §9 Q1), not matched here since it is unreachable through
+ * this package today.
  */
 const eventForPath = (path: string): AuthAuditEvent | undefined => {
     const normalized = path.toLowerCase();
@@ -58,7 +87,11 @@ const eventForPath = (path: string): AuthAuditEvent | undefined => {
         return "sign-up";
     }
 
-    if (normalized.includes("/sign-in/")) {
+    if (ends("/sign-in/social") || ends("/sign-in/magic-link")) {
+        return "sign-in-initiated";
+    }
+
+    if (normalized.includes("/sign-in/") || normalized.includes("/callback/") || ends("/magic-link/verify") || normalized.includes("/two-factor/verify-")) {
         return "sign-in";
     }
 
@@ -154,9 +187,52 @@ const resolveOutcome = (context: AuditHookContext): AuthAuditOutcome => {
 };
 
 /**
+ * RFC 5321's address-length ceiling — caps how much attacker-controlled request
+ * body text can land in the forensic `targetEmail` column (§8 risk: a hostile
+ * body's `email`/`username` is bound as a plain SQL parameter, never
+ * interpreted, but is still worth bounding).
+ */
+const MAX_TARGET_EMAIL_LENGTH = 320;
+
+/**
+ * The attempted identifier for a sign-in-family event (`sign-in` or
+ * `sign-in-initiated`) — `ctx.body.email`, falling back to `ctx.body.username`
+ * (credential sign-in also accepts a username in some configurations). `undefined`
+ * for every other event, and for a non-string/empty value. Deliberately a
+ * TOP-LEVEL entry field (see {@link AppendAuthAuditEntry.targetEmail}), never a
+ * `detail` key: `AUDIT_REDACT_RULES` (`./audit.ts`) scrubs email-shaped values
+ * inside `detail` regardless of key name, which would erase exactly this datum.
+ */
+const resolveTargetEmail = (context: AuditHookContext, event: AuthAuditEvent): string | undefined => {
+    if (event !== "sign-in" && event !== "sign-in-initiated") {
+        return undefined;
+    }
+
+    const candidate = context.body?.["email"] ?? context.body?.["username"];
+
+    if (typeof candidate !== "string" || candidate.length === 0) {
+        return undefined;
+    }
+
+    return candidate.length > MAX_TARGET_EMAIL_LENGTH ? candidate.slice(0, MAX_TARGET_EMAIL_LENGTH) : candidate;
+};
+
+/**
  * Build the entry a given after-hook context should record, or `undefined` when
  * the path is not an audited security event. Exported for direct unit testing of
  * the classification/extraction without spinning up better-auth.
+ *
+ * Does NOT attempt to distinguish a 2FA-challenged credential sign-in from a
+ * fully successful one (a `sign-in-challenged` event, as an earlier design for
+ * this change proposed) — pinned in `__tests__/audit-hooks.behaviour.test.ts`
+ * (plan 280 S0): better-auth runs the APP's own `hooks.after` BEFORE the
+ * `twoFactor` plugin's own after-hook that rewrites the response to
+ * `{ twoFactorRedirect: true }` and nulls `ctx.context.newSession`. By the time
+ * THIS hook runs, `context.returned`/`context.newSession` still reflect the
+ * pre-interception, fully-successful sign-in — there is nothing here to detect
+ * the challenge from. Distinguishing it would need a different seam (e.g. a
+ * plugin-ordered-after-`twoFactor` hook, or reading `twoFactor`'s own
+ * database state) and is left to a follow-up.
  */
 const buildAuditEntry = (context: AuditHookContext, now: number = Date.now()): AppendAuthAuditEntry | undefined => {
     const event = context.path === undefined ? undefined : eventForPath(context.path);
@@ -167,6 +243,7 @@ const buildAuditEntry = (context: AuditHookContext, now: number = Date.now()): A
 
     const ip = resolveIp(context);
     const userAgent = header(context, "user-agent");
+    const targetEmail = resolveTargetEmail(context, event);
 
     return {
         ...resolveActor(context),
@@ -174,6 +251,7 @@ const buildAuditEntry = (context: AuditHookContext, now: number = Date.now()): A
         outcome: resolveOutcome(context),
         ts: now,
         ...(ip === undefined ? {} : { ip }),
+        ...(targetEmail === undefined ? {} : { targetEmail }),
         ...(userAgent === undefined ? {} : { userAgent }),
         detail: { path: context.path },
     };
@@ -190,6 +268,33 @@ const buildAuditEntry = (context: AuditHookContext, now: number = Date.now()): A
  *     hooks: { after: authAuditHook({ executor: d1Executor(env.DB), retention: 100_000 }) },
  * });
  * ```
+ *
+ * ## Behaviour change (plan 280) — `onRecord`/SIEM consumers keyed on `event` strings, read this
+ *
+ * | Endpoint                                          | Before              | After                 |
+ * | -------------------------------------------------- | ------------------- | --------------------- |
+ * | `/sign-in/email` (and other credential sign-ins)  | `sign-in`           | `sign-in` (unchanged) |
+ * | `/sign-in/social`                                  | `sign-in`           | `sign-in-initiated`   |
+ * | `/sign-in/magic-link`                              | `sign-in`           | `sign-in-initiated`   |
+ * | `/callback/:id` (social + generic-oauth)          | _(not recorded)_    | `sign-in`             |
+ * | `/magic-link/verify`                               | _(not recorded)_    | `sign-in`             |
+ * | `/two-factor/verify-totp` / `-otp` / `-backup-code`| _(not recorded)_    | `sign-in`             |
+ *
+ * A caller matching on `event === "sign-in"` now sees FEWER events for
+ * `/sign-in/social` and `/sign-in/magic-link` (they never actually authenticated
+ * anyone) and MORE events for the four previously-unrecorded completion
+ * endpoints — the net effect is a more truthful count, not a strictly larger or
+ * smaller one. `sign-in-initiated` is a new event name (open `AuthAuditEvent`
+ * union, so no wire/type break, but SIEM rules enumerating event names should
+ * add it). A failed sign-in now also carries `targetEmail` (the attempted
+ * address/username) when the request body supplied one — see
+ * {@link AppendAuthAuditEntry.targetEmail} — so credential-stuffing attempts can
+ * be grouped by target even though they never produce an `actorEmail`.
+ *
+ * NOT changed: `/sign-in/email` under an active 2FA challenge still records
+ * plain `sign-in` / `success` (not a distinct `sign-in-challenged` event) — see
+ * {@link buildAuditEntry}'s docblock for why that distinction turned out not to
+ * be buildable from this hook.
  */
 const authAuditHook = (config: AuthAuditHookConfig): ReturnType<typeof createAuthMiddleware> =>
     createAuthMiddleware(async (context) => {
@@ -212,9 +317,18 @@ const authAuditHook = (config: AuthAuditHookConfig): ReturnType<typeof createAut
             console.error("@lunora/auth: audit hook failed to record event", error);
         }
 
-        // Must return an object: better-auth's after-hook runner reads `.headers`
-        // / `.response` off the result, so returning `undefined` would throw.
-        return {};
+        // CRITICAL: return `undefined`, NEVER a bare object. better-auth's after-hook
+        // runner (`dispatch.mjs`'s `runAfterHooks`) treats ANY non-undefined value a
+        // hook resolves to as the endpoint's NEW response and overwrites
+        // `context.context.returned` with it — so a hook that ends `return {};` (this
+        // function's shape until this fix) silently REPLACES every hooked endpoint's
+        // real response body with `{}` on the wire: sign-up, sign-in, everything.
+        // `undefined` does not throw (the opposite of what the old comment here
+        // claimed) and is the true no-op — pinned empirically in
+        // `__tests__/audit-hooks.behaviour.test.ts`'s "hooks.after return value"
+        // suite (plan 280 S0), which reproduces the `{}` clobber and proves
+        // `undefined` leaves the response byte-for-byte equivalent to no hook at all.
+        return undefined;
     });
 
 /**

--- a/packages/auth/src/audit.ts
+++ b/packages/auth/src/audit.ts
@@ -43,6 +43,11 @@ type AuthAuditEvent =
     | "password-reset"
     | "session-revoke"
     | "sign-in"
+    // A sign-in-family endpoint that only DISPATCHES (mints a provider
+    // redirect URL, or sends a magic-link email) — nobody is authenticated
+    // yet. Split out from `sign-in` (plan 280) so a caller can't mistake it
+    // for a completed authentication.
+    | "sign-in-initiated"
     | "sign-out"
     | "sign-up"
     | "token-refresh"
@@ -67,6 +72,19 @@ interface AuthAuditEntry {
     outcome: AuthAuditOutcome;
     /** Monotonic per-database cursor — strictly increasing, never reused. */
     seq: number;
+
+    /**
+     * The identifier (email or username) a sign-in-family request ATTEMPTED,
+     * read from the request body. Present for both successful and failed
+     * attempts — unlike `actorEmail` (which requires an authenticated
+     * session), this is what lets a FAILED credential-stuffing attempt be
+     * grouped by target. Same redaction exemption as `actorEmail`: a
+     * top-level column, not a `detail` key, because `AUDIT_REDACT_RULES`
+     * scrubs email-shaped values inside `detail` regardless of key name —
+     * putting it there would erase exactly this datum. Length-capped to 320
+     * chars (RFC 5321) since it carries attacker-controlled request-body text.
+     */
+    targetEmail?: string;
     /** Wall-clock millis when the event was recorded. */
     ts: number;
     /** Client User-Agent, when present on the request. */
@@ -81,6 +99,8 @@ interface AppendAuthAuditEntry {
     event: string;
     ip?: string;
     outcome: AuthAuditOutcome;
+    /** See {@link AuthAuditEntry.targetEmail}. */
+    targetEmail?: string;
     ts: number;
     userAgent?: string;
 }
@@ -142,6 +162,16 @@ const text = (value: unknown): string | undefined => {
  * Create the `__lunora_auth_audit__` table. `seq` is an `AUTOINCREMENT` primary
  * key giving the database a monotonic cursor the Security page pages through.
  * Idempotent, so read and write paths can call it defensively.
+ *
+ * `target_email` is added via a guarded `ALTER TABLE` rather than baked only
+ * into the `CREATE`, mirroring `@lunora/observability`'s
+ * `ensureRequestLogTable`/`ensureFunctionMetricsTables` — `CREATE TABLE IF NOT
+ * EXISTS` only helps a table that doesn't exist yet, so a database whose audit
+ * table predates this column needs the `ALTER` to gain it. SQLite has no `ADD
+ * COLUMN IF NOT EXISTS`; the duplicate-column error from a re-run (or from the
+ * column already existing on the freshly-created schema above) is swallowed —
+ * anything else re-throws, so a genuinely broken executor is not silently
+ * papered over.
  */
 const ensureAuthAuditTable = async (executor: SqlExecutor): Promise<void> => {
     await executor.run(
@@ -152,12 +182,23 @@ const ensureAuthAuditTable = async (executor: SqlExecutor): Promise<void> => {
             outcome TEXT NOT NULL,
             actor_id TEXT,
             actor_email TEXT,
+            target_email TEXT,
             ip TEXT,
             user_agent TEXT,
             detail TEXT
         )`,
         [],
     );
+
+    try {
+        await executor.run(`ALTER TABLE "${AUTH_AUDIT_TABLE}" ADD COLUMN target_email TEXT`, []);
+    } catch (error) {
+        const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+
+        if (!message.includes("duplicate column")) {
+            throw error;
+        }
+    }
 };
 
 /**
@@ -180,13 +221,14 @@ const appendAuthAuditEntry = async (
     }
 
     await executor.run(
-        `INSERT INTO "${AUTH_AUDIT_TABLE}" (ts, event, outcome, actor_id, actor_email, ip, user_agent, detail) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO "${AUTH_AUDIT_TABLE}" (ts, event, outcome, actor_id, actor_email, target_email, ip, user_agent, detail) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
             entry.ts,
             entry.event,
             entry.outcome,
             entry.actorId ?? SQL_NULL,
             entry.actorEmail ?? SQL_NULL,
+            entry.targetEmail ?? SQL_NULL,
             entry.ip ?? SQL_NULL,
             entry.userAgent ?? SQL_NULL,
             detail === undefined ? SQL_NULL : JSON.stringify(detail),
@@ -208,11 +250,19 @@ const appendAuthAuditEntry = async (
  * paged past `sinceSeq`, up to `limit` (clamped to [1, 10000]). Parses each row's
  * `detail` JSON back into an object. Creates the table first so reads on a
  * never-audited database return `[]` instead of throwing.
+ *
+ * `limit` is NaN-safe: a non-finite/non-number value (e.g. a caller passing
+ * `Number.NaN`, or an upstream boundary that failed to reject one) falls back
+ * to {@link DEFAULT_READ_LIMIT} rather than reaching `Math.min`/`Math.max`,
+ * which both propagate `NaN` and would otherwise bind it as the SQL `LIMIT`
+ * parameter. This is the library-level fix; `#readAudit` (`./auth-do`) also
+ * rejects a non-numeric `limit` at the boundary with a 400 — this clamp is the
+ * safety net for every OTHER caller of this function too.
  */
 const readAuthAuditLog = async (executor: SqlExecutor, options: ReadAuthAuditOptions = {}): Promise<AuthAuditEntry[]> => {
     await ensureAuthAuditTable(executor);
 
-    const limit = Math.max(1, Math.min(options.limit ?? DEFAULT_READ_LIMIT, MAX_READ_LIMIT));
+    const limit = Number.isFinite(options.limit) ? Math.max(1, Math.min(options.limit as number, MAX_READ_LIMIT)) : DEFAULT_READ_LIMIT;
     const clauses: string[] = ["seq > ?"];
     const parameters: unknown[] = [options.sinceSeq ?? 0];
 
@@ -229,7 +279,7 @@ const readAuthAuditLog = async (executor: SqlExecutor, options: ReadAuthAuditOpt
     parameters.push(limit);
 
     const rows = await executor.all(
-        `SELECT seq, ts, event, outcome, actor_id, actor_email, ip, user_agent, detail FROM "${AUTH_AUDIT_TABLE}" WHERE ${clauses.join(" AND ")} ORDER BY seq DESC LIMIT ?`,
+        `SELECT seq, ts, event, outcome, actor_id, actor_email, target_email, ip, user_agent, detail FROM "${AUTH_AUDIT_TABLE}" WHERE ${clauses.join(" AND ")} ORDER BY seq DESC LIMIT ?`,
         parameters,
     );
 
@@ -243,6 +293,7 @@ const readAuthAuditLog = async (executor: SqlExecutor, options: ReadAuthAuditOpt
 
         const actorId = text(row["actor_id"]);
         const actorEmail = text(row["actor_email"]);
+        const targetEmail = text(row["target_email"]);
         const ip = text(row["ip"]);
         const userAgent = text(row["user_agent"]);
         const detail = text(row["detail"]);
@@ -253,6 +304,10 @@ const readAuthAuditLog = async (executor: SqlExecutor, options: ReadAuthAuditOpt
 
         if (actorEmail !== undefined) {
             base.actorEmail = actorEmail;
+        }
+
+        if (targetEmail !== undefined) {
+            base.targetEmail = targetEmail;
         }
 
         if (ip !== undefined) {

--- a/packages/auth/src/auth-do.ts
+++ b/packages/auth/src/auth-do.ts
@@ -29,7 +29,7 @@
  */
 import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { lunoraDoAdapter } from "./adapter";
-import type { AuthAuditEntry } from "./audit";
+import type { AuthAuditEntry, ReadAuthAuditOptions } from "./audit";
 import { createAuthAuditReader, ensureAuthAuditTable } from "./audit";
 import type { LunoraAuth, LunoraAuthOptions } from "./create-auth";
 import { createAuth, resolveAuthOptions } from "./create-auth";
@@ -59,6 +59,46 @@ const READ_AUDIT_PATH = "/__lunora/auth/audit";
 
 /** Header carrying the shared secret that authenticates the calling worker. */
 const INTERNAL_SECRET_HEADER = "x-lunora-auth-do-secret";
+
+/**
+ * Narrow an already-JSON-parsed request body into {@link ReadAuthAuditOptions},
+ * or an error message for the first field that fails validation. Guards the
+ * one boundary `readAuthAuditLog` itself does not (it trusts its caller):
+ * before this, a non-numeric `limit` reached `Math.min`/`Math.max` as `NaN`
+ * and was bound as the SQL `LIMIT` parameter, and a malformed body threw an
+ * unhandled exception out of `#readAudit` (a 500) instead of a 400. Only the
+ * four fields `readAuthAuditLog` reads are accepted; anything else — an
+ * unknown key or an ill-typed value — is rejected rather than silently
+ * ignored, since a caller sending garbage deserves a 400, not a request that
+ * quietly did something other than what was asked.
+ */
+const parseReadAuditOptions = (parsed: unknown): { error: string } | { options: ReadAuthAuditOptions } => {
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { error: "body must be a JSON object" };
+    }
+
+    const options: ReadAuthAuditOptions = {};
+
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (key === "limit" || key === "sinceSeq") {
+            if (typeof value !== "number" || !Number.isFinite(value)) {
+                return { error: `"${key}" must be a finite number` };
+            }
+
+            options[key] = value;
+        } else if (key === "actorId" || key === "event") {
+            if (typeof value !== "string") {
+                return { error: `"${key}" must be a string` };
+            }
+
+            options[key] = value;
+        } else {
+            return { error: `unknown audit read option "${key}"` };
+        }
+    }
+
+    return { options };
+};
 
 /**
  * Options for the auth DO, beyond the better-auth options themselves.
@@ -186,10 +226,33 @@ class LunoraAuthDO {
      * `AuthAuditEntry` is entirely JSON-safe (`ts` and `seq` are numbers, there are no
      * `Date` values), so proxying it over HTTP is lossless rather than a lossy
      * serialisation the studio would have to compensate for.
+     *
+     * The body is parsed and validated defensively (plan 280 §5 S3): a
+     * malformed body (not JSON at all) previously threw an unhandled exception
+     * out of this method — a 500 — instead of the 400 a caller error deserves;
+     * an ill-typed field (e.g. `limit` as a string) previously reached
+     * `readAuthAuditLog` unchecked and could bind `NaN` as the SQL `LIMIT`.
+     * Both are now rejected here, before the reader ever runs.
      */
     async #readAudit(request: Request): Promise<Response> {
         if (!this.#isTrustedCaller(request)) {
             return Response.json({ error: "unauthorized" }, { status: 401 });
+        }
+
+        let parsedBody: unknown;
+
+        try {
+            parsedBody = await request.json();
+        } catch {
+            return Response.json({ error: "invalid body" }, { status: 400 });
+        }
+
+        // An empty body parses to `undefined`/`null` — treat that as "no options",
+        // matching the reader's own default, rather than rejecting it.
+        const parsed = parseReadAuditOptions(parsedBody ?? {});
+
+        if ("error" in parsed) {
+            return Response.json({ error: parsed.error }, { status: 400 });
         }
 
         const executor = doExecutor(this.#storage);
@@ -199,8 +262,7 @@ class LunoraAuthDO {
         // the request path for apps that never read the log.
         await ensureAuthAuditTable(executor);
 
-        const options = await request.json();
-        const entries = await createAuthAuditReader(executor).read(options ?? {});
+        const entries = await createAuthAuditReader(executor).read(parsed.options);
 
         return Response.json({ entries } satisfies { entries: AuthAuditEntry[] });
     }


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(auth): record sign-in completion endpoints, fix a response-clobbering hook bug, and validate audit-read options

## Files this branch still changes relative to alpha

```
packages/auth/__tests__/audit-hooks.behaviour.test.ts
packages/auth/__tests__/audit.test.ts
packages/auth/__tests__/auth-do.behaviour.test.ts
packages/auth/src/audit-hooks.ts
packages/auth/src/audit.ts
packages/auth/src/auth-do.ts
```
