### PR TITLE
fix(nuxt): verify worker.ts actually re-exports ShardDO before staying silent

### DIFF
--- a/packages/nuxt/__tests__/module-worker-guard.test.ts
+++ b/packages/nuxt/__tests__/module-worker-guard.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { checkWorkerEntry } from "../src/module";
+
+/**
+ * `checkWorkerEntry` — the guard behind the module's `worker.ts` warning
+ * (plan 281). Extracted from `setup()` and tested directly here, mirroring
+ * `@lunora/astro`'s `astro:config:done` hook tests: `defineNuxtModule`'s
+ * `setup` needs full Nuxt Kit scaffolding to invoke (unlike Astro's
+ * plain-object integration hooks), so this plain function is the testable
+ * seam instead.
+ */
+describe("checkWorkerEntry", () => {
+    let directory: string;
+
+    afterEach(() => {
+        rmSync(directory, { force: true, recursive: true });
+    });
+
+    it("warns when worker.ts does not exist (fails on baseline: the old guard never checked content, but a MISSING file already warned there too — this case alone doesn't distinguish old from new)", () => {
+        expect.assertions(2);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toMatch(/missing worker\.ts at the project root/u);
+    });
+
+    it("warns when worker.ts exists but only re-exports the Nitro handler (no ShardDO) — FAILS ON BASELINE (the old presence-only guard stayed silent)", () => {
+        expect.assertions(2);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        writeFileSync(join(directory, "worker.ts"), 'export { default } from "./.output/server/index.mjs";\n');
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toMatch(/does not appear to export `ShardDO`/u);
+    });
+
+    it("is silent when worker.ts has the documented two-line snippet (no false positive on a correct file)", () => {
+        expect.assertions(1);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        writeFileSync(
+            join(directory, "worker.ts"),
+            'export { default } from "./.output/server/index.mjs";\nexport { ShardDO } from "./lunora/server";\n',
+        );
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("is silent for an `export * from \"./lunora/server\"` re-export (covers ShardDO without naming it)", () => {
+        expect.assertions(1);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        writeFileSync(join(directory, "worker.ts"), 'export { default } from "./.output/server/index.mjs";\nexport * from "./lunora/server";\n');
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("is silent for a local re-export form (`export { ShardDO }`, no specifier)", () => {
+        expect.assertions(1);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        writeFileSync(
+            join(directory, "worker.ts"),
+            'import { ShardDO } from "./lunora/server";\nexport { default } from "./.output/server/index.mjs";\nexport { ShardDO };\n',
+        );
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("warns (does not throw) when worker.ts exists but cannot be read — FAILS ON BASELINE (the old guard treated a directory named worker.ts as \"present\" and stayed silent)", () => {
+        expect.assertions(3);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        // `existsSync` passing doesn't mean `readFileSync` will succeed — a
+        // directory at that path raises EISDIR.
+        mkdirSync(join(directory, "worker.ts"));
+
+        const warn = vi.fn<(message: string) => void>();
+
+        expect(() => {
+            checkWorkerEntry(directory, warn);
+        }).not.toThrow();
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toMatch(/could not read worker\.ts/u);
+    });
+
+    it("known false positive (documented on looksLikeShardDoExport): a `ShardDO` mention inside a comment, anywhere in a file that also has a real `export`, silences the warning", () => {
+        expect.assertions(1);
+
+        directory = mkdtempSync(join(tmpdir(), "lunora-nuxt-"));
+        // The guard checks "has an export keyword" and "mentions ShardDO"
+        // independently, anywhere in the file — it does not verify ShardDO
+        // sits inside an actual export statement. A comment mentioning ShardDO,
+        // in a file that separately exports something else entirely, is
+        // indistinguishable from a real `export { ShardDO }`. This is the
+        // documented imprecision, not a regression; a real TS parse would not
+        // have this gap, which is exactly the tradeoff the pattern's docblock
+        // calls out (a build-time warning hook doesn't warrant one).
+        writeFileSync(join(directory, "worker.ts"), "// TODO: remember to export ShardDO from here\nexport { default } from \"./.output/server/index.mjs\";\n");
+
+        const warn = vi.fn<(message: string) => void>();
+
+        checkWorkerEntry(directory, warn);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -30,7 +30,7 @@
  */
 
 /* eslint-disable import/exports-last -- the public ModuleOptions type is declared next to the module definition it configures rather than grouped at the file end */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { addServerHandler, createResolver, defineNuxtModule, useLogger } from "@nuxt/kit";
@@ -100,6 +100,94 @@ const lunoraTsSourceResolver = (rootDirectory: string): TsSourceResolverPlugin =
             order: "pre",
         },
     };
+};
+
+/** Wrapper snippet shown in every `worker.ts` warning — kept as one constant so the three messages below stay byte-identical. */
+const WORKER_TS_SNIPPET = 'export { default } from "./.output/server/index.mjs"; export { ShardDO } from "./lunora/server";';
+
+/** Whether the source has an `export` keyword anywhere at all. */
+const EXPORT_KEYWORD_PATTERN = /\bexport\b/u;
+
+/** Whether the source mentions the `ShardDO` identifier anywhere at all. */
+const SHARD_DO_IDENTIFIER_PATTERN = /\bShardDO\b/u;
+
+/** `export * from` a specifier containing "lunora" — re-exports everything (including `ShardDO`) from a barrel without naming it, the common case being `export * from "./lunora/server"`. */
+const LUNORA_STAR_EXPORT_PATTERN = /\bexport\s*\*\s*from\s*["'][^"']*lunora[^"']*["']/u;
+
+/**
+ * Whether `source` looks like it exports `ShardDO` — the file has an `export`
+ * keyword AND either mentions the `ShardDO` identifier somewhere (covers
+ * `export { ShardDO } from "./lunora/server"`, a local `export { ShardDO }`,
+ * `export { X as ShardDO }` — a binding named `ShardDO` is what wrangler
+ * resolves the Durable Object class by, whether it's the bare name or the
+ * right side of `as`) or re-exports a lunora barrel wholesale via
+ * {@link LUNORA_STAR_EXPORT_PATTERN}.
+ *
+ * Deliberately two independent, simple keyword/identifier checks rather than
+ * one combined regex trying to prove `ShardDO` sits INSIDE a specific `export`
+ * statement — not a real TS parse (mirrors `@lunora/astro`'s
+ * `WITH_LUNORA_CALL_PATTERN`: a documented regex is judged proportionate to a
+ * build-time warning hook; ts-morph would be heavier than this hook
+ * warrants). Known imprecisions: false-POSITIVE on `export { ShardDO as
+ * Other }` (renames `ShardDO` away, so the binding wrangler needs is actually
+ * named `Other` — not caught), on a `ShardDO` mention inside a comment
+ * anywhere alongside an unrelated `export`, or in principle on `export`ing
+ * something else entirely while `ShardDO` is merely imported (not exported)
+ * elsewhere in the file. All are accepted trade-offs for a two-line worker
+ * entry file, where the realistic failure mode is "forgot the line
+ * entirely", not an adversarial one.
+ */
+const looksLikeShardDoExport = (source: string): boolean => {
+    if (!EXPORT_KEYWORD_PATTERN.test(source)) {
+        return false;
+    }
+
+    return SHARD_DO_IDENTIFIER_PATTERN.test(source) || LUNORA_STAR_EXPORT_PATTERN.test(source);
+};
+
+/**
+ * Check that `worker.ts` at the project root actually re-exports `ShardDO` —
+ * not just that the file exists. Extracted from `setup()` so it is testable
+ * without booting Nuxt (`defineNuxtModule`'s `setup` needs full Nuxt Kit
+ * scaffolding to invoke; this plain function does not).
+ *
+ * All three outcomes — missing file, unreadable file, present-but-no-`ShardDO`-
+ * export — WARN and return; none of them throws. Matches the module's existing
+ * stance ("we can't write the user's file, so warn... rather than fail an
+ * otherwise-valid build") and the `@lunora/astro` precedent this mirrors.
+ */
+export const checkWorkerEntry = (rootDirectory: string, warn: (message: string) => void): void => {
+    const workerPath = join(rootDirectory, "worker.ts");
+
+    if (!existsSync(workerPath)) {
+        warn(
+            `missing worker.ts at the project root — add a wrapper that re-exports Nitro's handler and \`ShardDO\` (\`${WORKER_TS_SNIPPET}\`) and point wrangler's \`main\` at it, so the SHARD Durable Object is exported from the deployed worker.`,
+        );
+
+        return;
+    }
+
+    let source: string;
+
+    try {
+        source = readFileSync(workerPath, "utf8");
+    } catch (error) {
+        // `existsSync` passing doesn't guarantee a readable regular file (it
+        // could be a directory, permission-denied, a broken symlink loop, …) —
+        // this hook warns rather than fails the build, so a read failure must
+        // degrade to a warning too, not an uncaught throw out of `setup()`.
+        const reason = error instanceof Error ? error.message : String(error);
+
+        warn(`could not read worker.ts at the project root (${reason}) — skipping the \`ShardDO\` export check.`);
+
+        return;
+    }
+
+    if (!looksLikeShardDoExport(source)) {
+        warn(
+            `worker.ts at the project root does not appear to export \`ShardDO\` — add \`export { ShardDO } from "./lunora/server";\` (e.g. \`${WORKER_TS_SNIPPET}\`) and point wrangler's \`main\` at it, so the SHARD Durable Object is exported from the deployed worker.`,
+        );
+    }
 };
 
 /** Options for the `@lunora/nuxt` module (configurable under the `lunora` key in `nuxt.config`). */
@@ -172,12 +260,10 @@ const lunoraNuxtModule: LunoraNuxtModule = defineNuxtModule<ModuleOptions>({
         // `cloudflare_module` output exports only the SSR handler, so the project
         // needs a root `worker.ts` wrapper (pointed at by `wrangler.jsonc`'s
         // `main`) that re-exports `ShardDO` too. We can't write the user's file,
-        // so warn when it's missing rather than fail an otherwise-valid build.
-        if (!existsSync(join(nuxt.options.rootDir, "worker.ts"))) {
-            useLogger("@lunora/nuxt").warn(
-                'missing worker.ts at the project root — add a wrapper that re-exports Nitro\'s handler and `ShardDO` (`export { default } from "./.output/server/index.mjs"; export { ShardDO } from "./lunora/server";`) and point wrangler\'s `main` at it, so the SHARD Durable Object is exported from the deployed worker.',
-            );
-        }
+        // so warn — for a missing file, an unreadable one, or one that exists
+        // but doesn't actually export `ShardDO` — rather than fail an
+        // otherwise-valid build. See `checkWorkerEntry` for the three checks.
+        checkWorkerEntry(nuxt.options.rootDir, (message) => { useLogger("@lunora/nuxt").warn(message); });
     },
 });
 


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(nuxt): verify worker.ts actually re-exports ShardDO before staying silent

## Files this branch still changes relative to alpha

```
packages/nuxt/__tests__/module-worker-guard.test.ts
packages/nuxt/src/module.ts
```
