### PR TITLE
fix(studio): re-seed the data browser when a same-table view arrives via the URL

### DIFF
--- a/packages/studio/__tests__/features/data/data-browser.test.tsx
+++ b/packages/studio/__tests__/features/data/data-browser.test.tsx
@@ -6,7 +6,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { DataBrowserProps } from "../../../src/features/data/data-browser";
 import { DataBrowser } from "../../../src/features/data/data-browser";
+import { useMirroredRef } from "../../../src/hooks/use-mirrored-ref";
 import { ADMIN_FUNCTIONS } from "../../../src/lib/admin";
+import { dataViewToSearch, searchToDataView } from "../../../src/lib/data-view-params";
+import type { DataView } from "../../../src/lib/saved-queries";
 import type { MockClientHooks } from "../../mock-client";
 import { createMockClient } from "../../mock-client";
 
@@ -1722,5 +1725,309 @@ describe("dataBrowser — bulk delete cap exhaustion (STUDIO-02)", () => {
         });
 
         expect(screen.queryByTestId("db-write-error")).toBeNull();
+    });
+});
+
+interface SameTableRow {
+    __id__: string;
+    category: string;
+    text: string;
+}
+
+/**
+ * Two shard fixtures for the SAME table name (`messages`), so a test can drive
+ * a saved-query apply that changes shard/search/filters while the URL's `table`
+ * param never changes — the same-table dead spot STUDIO-274 fixes (a
+ * `tableParam`-only reset gate can't see this apply, since `tableParam` alone
+ * hasn't moved).
+ */
+const SAME_TABLE_FIXTURES: Record<string, SameTableRow[]> = {
+    "": [
+        { __id__: "r1", category: "default", text: "hello" },
+        { __id__: "r2", category: "default", text: "world" },
+    ],
+    b: [
+        { __id__: "b1", category: "beta", text: "b-row-one" },
+        { __id__: "b2", category: "beta", text: "b-row-two" },
+    ],
+};
+
+const createSameTableClient = (): MockClientHooks =>
+    createMockClient({
+        query: (reference, args, options): unknown => {
+            const shard = (options as { shardKey?: string } | undefined)?.shardKey ?? "";
+            const fixture = SAME_TABLE_FIXTURES[shard];
+
+            if (fixture === undefined) {
+                throw new Error(`unknown shard: ${shard}`);
+            }
+
+            if (reference === ADMIN_FUNCTIONS.listTables) {
+                return [{ name: "messages", rowCount: fixture.length }];
+            }
+
+            if (reference !== ADMIN_FUNCTIONS.readTablePage) {
+                // describeTables / facetColumn / etc — not exercised by these tests.
+                return { columns: [], rows: [], total: 0 };
+            }
+
+            const {
+                filters = [],
+                limit = 50,
+                offset = 0,
+                search = "",
+                table,
+            } = args as {
+                filters?: { column: string; operator: string; value?: unknown }[];
+                limit?: number;
+                offset?: number;
+                search?: string;
+                table: string;
+            };
+
+            if (table !== "messages") {
+                throw new Error(`unknown table: ${table}`);
+            }
+
+            const needle = search.trim().toLowerCase();
+            let matched = needle === "" ? fixture : fixture.filter((row) => row.text.toLowerCase().includes(needle));
+
+            for (const clause of filters) {
+                if (clause.operator === "eq") {
+                    matched = matched.filter((row) => row[clause.column as keyof SameTableRow] === clause.value);
+                }
+            }
+
+            return { columns: ["__id__", "category", "text"], rows: matched.slice(offset, offset + limit), total: matched.length };
+        },
+    });
+
+/** The saved query STUDIO-274 exercises: same table, new shard/search/filter. */
+const SAME_TABLE_SAVED_QUERY: DataView = {
+    filters: [{ column: "category", operator: "eq", value: "beta" }],
+    orderBy: undefined,
+    search: "b-row",
+    shard: "b",
+    table: "messages",
+    tier: "shard",
+};
+
+/** The `onViewChange` payload shape — the mirrored view's shard/search/filters/sort. */
+type MirroredView = Pick<DataView, "filters" | "orderBy" | "search" | "shard">;
+
+/**
+ * A faithful miniature of `table-editor.tsx`'s URL wiring: the view lives in a
+ * plain in-memory "URL" object, `onViewChange` mirrors the loaded view back
+ * into it (skipping the write when the URL already reflects it — the same
+ * `unchanged` short-circuit `table-editor.tsx` uses), and applying a saved
+ * query pushes a fresh URL object carrying table + shard + search + filters in
+ * ONE update, exactly like `onApplyQuery`. Modeling this precisely (rather than
+ * a `ControlledDataBrowser`-style ad hoc host) is what lets these tests exercise
+ * the actual regression: a same-table apply that changes shard/search/filters
+ * without ever changing `tableParam`.
+ */
+const MiniTableEditor = ({ onViewChangeCall, pageSize }: { onViewChangeCall?: (view: MirroredView) => void; pageSize?: number }): ReactElement => {
+    const [urlSearch, setUrlSearch] = useState<Record<string, unknown>>({ table: "messages" });
+    const urlRef = useMirroredRef(urlSearch);
+    const view = searchToDataView(urlSearch);
+
+    const onSelectTable = (table: string, options?: { search?: string }): void => {
+        setUrlSearch({ search: options?.search, table });
+    };
+
+    const onViewChange = (next: MirroredView): void => {
+        onViewChangeCall?.(next);
+
+        const patch = dataViewToSearch(next);
+        const { current } = urlRef;
+
+        const unchanged =
+            (current["filters"] ?? undefined) === patch.filters &&
+            (current["order"] ?? undefined) === patch.order &&
+            (current["search"] ?? undefined) === patch.search &&
+            (current["shard"] ?? undefined) === patch.shard;
+
+        if (unchanged) {
+            return;
+        }
+
+        setUrlSearch((previous) => {
+            return { ...previous, filters: patch.filters, order: patch.order, search: patch.search, shard: patch.shard };
+        });
+    };
+
+    const applySavedQuery = (): void => {
+        const patch = dataViewToSearch(SAME_TABLE_SAVED_QUERY);
+
+        setUrlSearch({ filters: patch.filters, order: patch.order, schema: patch.schema, search: patch.search, shard: patch.shard, table: patch.table });
+    };
+
+    return (
+        <>
+            <button data-testid="apply-saved-query" onClick={applySavedQuery} type="button">
+                apply saved query
+            </button>
+            <DataBrowser
+                editable
+                initialFilters={view.filters}
+                initialOrderBy={view.orderBy}
+                initialSearch={view.search}
+                initialShardKey={view.shard}
+                onSelectTable={onSelectTable}
+                onViewChange={onViewChange}
+                pageSize={pageSize}
+                tableParam={view.table}
+            />
+        </>
+    );
+};
+
+describe("dataBrowser — same-table saved-query apply (STUDIO-274)", () => {
+    it("re-seeds shard, search, and filters when a saved query names the ALREADY-OPEN table", async () => {
+        expect.assertions(2);
+
+        const mock = createSameTableClient();
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <MiniTableEditor pageSize={10} />
+            </LunoraProvider>,
+        );
+
+        // Mount opens "messages" on the root shard.
+        await screen.findByText("hello");
+
+        fireEvent.click(screen.getByTestId("apply-saved-query"));
+
+        // The saved query names shard "b", search "b-row", and an `eq` filter on
+        // `category` — all while `table` stays "messages" throughout. Asserted
+        // via the cell testids (not `findByText`) because the active search
+        // highlights the "b-row" match, splitting the cell's text across
+        // `<mark>` spans — `findByText` can't match text split across elements.
+        await waitFor(
+            () => {
+                if (
+                    screen.queryByTestId("db-cell-b1-text")?.textContent !== "b-row-one" ||
+                    screen.queryByTestId("db-cell-b2-text")?.textContent !== "b-row-two"
+                ) {
+                    throw new Error("rows not re-seeded to shard b yet");
+                }
+            },
+            { timeout: 3000 },
+        );
+
+        expect(screen.getByTestId<HTMLInputElement>("db-shard-input").value).toBe("b");
+
+        const reads = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage);
+        const lastRead = reads.at(-1) as [unknown, { table: string }, { shardKey?: string } | undefined];
+
+        // The read that produced the rows above already targeted shard "b" — not
+        // the root shard the browser opened with.
+        expect(lastRead[2]?.shardKey).toBe("b");
+    });
+
+    it("mirrors the newly-applied view back to the host, never with the stale pre-apply shard/search", async () => {
+        expect.assertions(2);
+
+        const mock = createSameTableClient();
+        const onViewChangeCall = vi.fn<(view: MirroredView) => void>();
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <MiniTableEditor onViewChangeCall={onViewChangeCall} pageSize={10} />
+            </LunoraProvider>,
+        );
+
+        await screen.findByText("hello");
+
+        // Discard the mount-time mirror call(s) — only what happens AFTER the
+        // apply matters here.
+        onViewChangeCall.mockClear();
+
+        fireEvent.click(screen.getByTestId("apply-saved-query"));
+
+        // See the sibling test above for why this is a testid check, not
+        // `findByText("b-row-one")` — the active search highlights the match.
+        await waitFor(
+            () => {
+                if (screen.queryByTestId("db-cell-b1-text")?.textContent !== "b-row-one") {
+                    throw new Error("rows not re-seeded to shard b yet");
+                }
+            },
+            { timeout: 3000 },
+        );
+
+        // Give the mirror a chance to fire (or, on the pre-fix code, to not).
+        await waitFor(
+            () => {
+                if (onViewChangeCall.mock.calls.length === 0) {
+                    throw new Error("view was never mirrored back after the apply");
+                }
+            },
+            { timeout: 3000 },
+        );
+
+        // Every post-apply mirror call reflects the NEW view — none regresses to
+        // the pre-apply shard ("") or search (undefined), which is the reported
+        // "operator watches the just-applied link revert" symptom.
+        const revertedToStale = onViewChangeCall.mock.calls.some(([call]) => call.shard !== "b" || call.search !== "b-row");
+
+        expect(revertedToStale).toBe(false);
+
+        // And it did settle on the new view at least once (not just avoid the
+        // stale one) — otherwise "never reverts" would be vacuously true.
+        const mirroredNewView = onViewChangeCall.mock.calls.some(([call]) => call.shard === "b" && call.search === "b-row");
+
+        expect(mirroredNewView).toBe(true);
+    });
+
+    it("never re-seeds on a keystroke, even once the URL mirror echoes it back (contract — holds before AND after the fix)", async () => {
+        expect.assertions(2);
+
+        const mock = createSameTableClient();
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <MiniTableEditor pageSize={10} />
+            </LunoraProvider>,
+        );
+
+        await screen.findByText("hello");
+
+        // Type a search that only matches one of the root shard's rows — the
+        // debounced round trip (state → debounce → onViewChange → URL →
+        // `initialSearch`) must be a fixed point: it can echo `initialSearch`
+        // back without ever resetting what's on screen.
+        fireEvent.change(screen.getByTestId("db-filter"), { target: { value: "hel" } });
+
+        await waitFor(() => {
+            const reads = mock.query.mock.calls.filter(
+                (call) =>
+                    (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage && (call[1] as { search?: string }).search === "hel",
+            );
+
+            if (reads.length === 0) {
+                throw new Error("debounced search not applied yet");
+            }
+        });
+
+        // The typed value is still exactly what was typed — never reset by a
+        // re-seed reacting to the mirror's own echo of `initialSearch`.
+        expect(screen.getByTestId<HTMLInputElement>("db-filter").value).toBe("hel");
+
+        const settledCount = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage).length;
+
+        // Wait well past every debounce window; a re-seed loop would keep
+        // issuing reads (its own reset re-triggers the mirror, which re-seeds
+        // again, …). No loop → the read count stays put.
+        await act(async () => {
+            await new Promise((resolve) => {
+                setTimeout(resolve, 500);
+            });
+        });
+
+        const laterCount = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage).length;
+
+        expect(laterCount).toBe(settledCount);
     });
 });

--- a/packages/studio/__tests__/features/data/data-browser.test.tsx
+++ b/packages/studio/__tests__/features/data/data-browser.test.tsx
@@ -2030,4 +2030,100 @@ describe("dataBrowser — same-table saved-query apply (STUDIO-274)", () => {
 
         expect(laterCount).toBe(settledCount);
     });
+
+    it("keeps mirroring — and never reverts a SECOND change — after the URL has already echoed back the first one", async () => {
+        expect.assertions(3);
+
+        const mock = createSameTableClient();
+        const onViewChangeCall = vi.fn<(view: Pick<DataView, "filters" | "orderBy" | "search" | "shard">) => void>();
+
+        render(
+            <LunoraProvider client={mock.asClient}>
+                <MiniTableEditor onViewChangeCall={onViewChangeCall} pageSize={10} />
+            </LunoraProvider>,
+        );
+
+        await screen.findByText("hello");
+
+        // Stage an inline cell edit BEFORE touching the search box — a spurious
+        // re-seed (this test's whole point) wipes it via `stagedEdits.clear()`.
+        fireEvent.doubleClick(screen.getByTestId("db-cell-r1-text"));
+
+        const cellInput = await screen.findByTestId<HTMLInputElement>("db-cell-input-r1-text");
+
+        fireEvent.change(cellInput, { target: { value: "edited" } });
+        fireEvent.keyDown(cellInput, { key: "Enter" });
+        await screen.findByTestId("db-staged");
+
+        // First change: type "hel" and let it debounce-settle, mirror, and echo
+        // back through `initialSearch` — the exact round trip the same-table
+        // gate exists to survive.
+        fireEvent.change(screen.getByTestId("db-filter"), { target: { value: "hel" } });
+
+        await waitFor(
+            () => {
+                const reads = mock.query.mock.calls.filter(
+                    (call) =>
+                        (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage &&
+                        (call[1] as { search?: string }).search === "hel",
+                );
+
+                if (reads.length === 0) {
+                    throw new Error("first change not applied yet");
+                }
+            },
+            { timeout: 3000 },
+        );
+
+        // Give the mirror's echo (onViewChange → host state → back down as
+        // `initialSearch`) a moment to actually round-trip before the second edit.
+        await waitFor(
+            () => {
+                if (!onViewChangeCall.mock.calls.some(([view]) => view.search === "hel")) {
+                    throw new Error("first change was never mirrored to the host");
+                }
+            },
+            { timeout: 3000 },
+        );
+
+        onViewChangeCall.mockClear();
+
+        // Second change: type "hell" — a further, distinct edit made AFTER the
+        // first one's echo has already landed as this render's `initialSearch`.
+        fireEvent.change(screen.getByTestId("db-filter"), { target: { value: "hell" } });
+
+        await waitFor(
+            () => {
+                const reads = mock.query.mock.calls.filter(
+                    (call) =>
+                        (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.readTablePage &&
+                        (call[1] as { search?: string }).search === "hell",
+                );
+
+                if (reads.length === 0) {
+                    throw new Error("second change never took effect — the mirror died after the first echo");
+                }
+            },
+            { timeout: 3000 },
+        );
+
+        // (a) the host's view reflects the SECOND change — the mirror is still
+        // alive, not permanently blocked by a `seededViewKey` that fell behind
+        // `incomingViewKey` after the first echo.
+        expect(onViewChangeCall.mock.calls.some(([view]) => view.search === "hell")).toBe(true);
+
+        // `keepPreviousData` is off, so the page (and everything inside it,
+        // including the filter bar) can briefly disappear between the read
+        // landing above and the new page committing — `findByTestId` waits for
+        // that to settle rather than racing it.
+        const filterInput = await screen.findByTestId<HTMLInputElement>("db-filter");
+
+        // The search box itself must still show what was typed — a spurious
+        // re-seed snaps it back to the stale `initialSearch` ("hel").
+        expect(filterInput.value).toBe("hell");
+
+        // (b) the staged inline edit survives. A spurious re-seed wipes it via
+        // `stagedEdits.clear()` / `setEditingCell(null)`.
+        expect(screen.getByTestId("db-staged").textContent).toContain("edited");
+    });
 });

--- a/packages/studio/__tests__/features/data/generate-rows-dialog.test.tsx
+++ b/packages/studio/__tests__/features/data/generate-rows-dialog.test.tsx
@@ -4,6 +4,7 @@ import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GenerateRowsDialog } from "../../../src/features/data/generate-rows-dialog";
+import type { InsertBatchOutcome } from "../../../src/features/data/hooks/use-generate-rows";
 import { useGenerateRows } from "../../../src/features/data/hooks/use-generate-rows";
 import type { ColumnMeta } from "../../../src/lib/admin";
 import { ADMIN_FUNCTIONS } from "../../../src/lib/admin";
@@ -50,7 +51,10 @@ const stubSeedFetch = (rows: ReadonlyArray<Record<string, unknown>> = [{ title: 
 
 // ── Render helpers ───────────────────────────────────────────────────────────
 
-const makeInsertRows = (returnValue?: string) => vi.fn<(_rows: ReadonlyArray<Record<string, unknown>>) => Promise<string | undefined>>(async () => returnValue);
+const makeInsertRows = (error?: string) =>
+    vi.fn<(_rows: ReadonlyArray<Record<string, unknown>>) => Promise<InsertBatchOutcome>>(async (rows) => {
+        return { conflicts: 0, error, inserted: error === undefined ? rows.length : 0 };
+    });
 
 const renderDialog = ({ columns = SIMPLE_COLUMNS, fkPools = {}, onClose = vi.fn<() => void>(), onInsertRows = makeInsertRows(), table = "posts" } = {}) =>
     render(<GenerateRowsDialog columns={columns} fkPools={fkPools} onClose={onClose} onInsertRows={onInsertRows} table={table} />);
@@ -146,6 +150,29 @@ describe("generateRowsDialog", () => {
         });
     });
 
+    it("reports the REAL inserted count when every row conflicted, not the requested count (STUDIO-292 M5)", async () => {
+        expect.hasAssertions();
+
+        // Every generated row's planned `_id` collided with an existing row —
+        // `onInsertRows` (the hook's `insertBatch`) treats this as `error ===
+        // undefined` (still success), but NOTHING was actually written.
+        const onInsertRows = vi.fn<(_rows: ReadonlyArray<Record<string, unknown>>) => Promise<InsertBatchOutcome>>(async (rows) => {
+            return { conflicts: rows.length, error: undefined, inserted: 0 };
+        });
+
+        renderDialog({ onInsertRows });
+
+        fireEvent.click(screen.getByTestId("gen-rows-generate"));
+
+        const success = await screen.findByTestId("gen-rows-success");
+
+        // Must never read as if the row landed — that's the exact "reports
+        // success when nothing was written" bug.
+        expect(success.textContent).not.toContain("Inserted 1 rows successfully");
+        expect(success.textContent).toContain("Inserted 0 of 1 rows");
+        expect(success.textContent).toContain("1 skipped as id conflicts");
+    });
+
     it("shows error message when onInsertRows returns an error string", async () => {
         expect.hasAssertions();
 
@@ -203,11 +230,11 @@ describe("generateRowsDialog", () => {
 
         // Use a slow insert to observe the disabled state.
         let settle!: () => void;
-        const onInsertRows = vi.fn<(_rows: ReadonlyArray<Record<string, unknown>>) => Promise<string | undefined>>(
-            () =>
-                new Promise<undefined>((resolve) => {
+        const onInsertRows = vi.fn<(_rows: ReadonlyArray<Record<string, unknown>>) => Promise<InsertBatchOutcome>>(
+            (rows) =>
+                new Promise<InsertBatchOutcome>((resolve) => {
                     settle = () => {
-                        resolve(undefined);
+                        resolve({ conflicts: 0, error: undefined, inserted: rows.length });
                     };
                 }),
         );
@@ -282,13 +309,13 @@ describe("useGenerateRows — insertBatch routes through the bulk importShard RP
         const rows = Array.from({ length: 200 }, (_, index) => {
             return { _id: `id-${index.toString()}`, title: `row ${index.toString()}` };
         });
-        let outcome: string | undefined;
+        let outcome: InsertBatchOutcome | undefined;
 
         await act(async () => {
             outcome = await result.current.insertBatch(rows, vi.fn());
         });
 
-        expect(outcome).toBeUndefined();
+        expect(outcome?.error).toBeUndefined();
 
         const importCalls = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.importShard);
         const writeRowCalls = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.writeRow);
@@ -316,21 +343,25 @@ describe("useGenerateRows — insertBatch routes through the bulk importShard RP
 
         await openAndSettle(result, "posts");
 
-        let outcome: string | undefined;
+        let outcome: InsertBatchOutcome | undefined;
 
         await act(async () => {
             outcome = await result.current.insertBatch([{ title: "a" }, { title: "b" }, { title: "c" }], vi.fn());
         });
 
-        expect(outcome).toContain("row 3 (posts): bad title");
+        expect(outcome?.error).toContain("row 3 (posts): bad title");
     });
 
-    it("treats conflicts alone (no errors) as success", async () => {
-        expect.assertions(1);
+    it("treats conflicts alone (no errors) as success, but reports the REAL inserted/conflicts counts — not the requested row count (STUDIO-292 M5)", async () => {
+        expect.assertions(3);
 
+        // Every row's planned `_id` collides with an existing one (a re-click
+        // with an unchanged seed) — nothing actually lands, but `errors` is
+        // empty, so this must still resolve as "success" per the Export/Import
+        // panel's semantics.
         const mock = createGenerateRowsClient((reference) => {
             if (reference === ADMIN_FUNCTIONS.importShard) {
-                return { conflicts: 2, errors: [], inserted: { posts: 0 } };
+                return { conflicts: 2, errors: [], inserted: {} };
             }
 
             return undefined;
@@ -340,13 +371,49 @@ describe("useGenerateRows — insertBatch routes through the bulk importShard RP
 
         await openAndSettle(result, "posts");
 
-        let outcome: string | undefined;
+        let outcome: InsertBatchOutcome | undefined;
 
         await act(async () => {
             outcome = await result.current.insertBatch([{ title: "a" }, { title: "b" }], vi.fn());
         });
 
-        expect(outcome).toBeUndefined();
+        expect(outcome?.error).toBeUndefined();
+
+        // The whole point: a conflict-only batch must report ZERO inserted, not
+        // the two requested rows — "success" and "everything landed" are NOT
+        // the same claim.
+        expect(outcome?.inserted).toBe(0);
+        expect(outcome?.conflicts).toBe(2);
+    });
+
+    it("reports the real inserted count alongside conflicts when a batch partially collides", async () => {
+        expect.assertions(2);
+
+        const mock = createGenerateRowsClient((reference) => {
+            if (reference === ADMIN_FUNCTIONS.importShard) {
+                return { conflicts: 3, errors: [], inserted: { posts: 197 } };
+            }
+
+            return undefined;
+        });
+
+        const { result } = renderHook(() => useGenerateRows(vi.fn()), { wrapper: wrapWithClient(mock) });
+
+        await openAndSettle(result, "posts");
+
+        let outcome: InsertBatchOutcome | undefined;
+
+        await act(async () => {
+            outcome = await result.current.insertBatch(
+                Array.from({ length: 200 }, () => {
+                    return { title: "row" };
+                }),
+                vi.fn(),
+            );
+        });
+
+        expect(outcome?.inserted).toBe(197);
+        expect(outcome?.conflicts).toBe(3);
     });
 
     it("still returns the error message when the transport throws (today's catch path)", async () => {
@@ -364,12 +431,12 @@ describe("useGenerateRows — insertBatch routes through the bulk importShard RP
 
         await openAndSettle(result, "posts");
 
-        let outcome: string | undefined;
+        let outcome: InsertBatchOutcome | undefined;
 
         await act(async () => {
             outcome = await result.current.insertBatch([{ title: "a" }], vi.fn());
         });
 
-        expect(outcome).toBe("network down");
+        expect(outcome?.error).toBe("network down");
     });
 });

--- a/packages/studio/__tests__/features/data/generate-rows-dialog.test.tsx
+++ b/packages/studio/__tests__/features/data/generate-rows-dialog.test.tsx
@@ -1,8 +1,14 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { LunoraProvider } from "@lunora/react";
+import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GenerateRowsDialog } from "../../../src/features/data/generate-rows-dialog";
+import { useGenerateRows } from "../../../src/features/data/hooks/use-generate-rows";
 import type { ColumnMeta } from "../../../src/lib/admin";
+import { ADMIN_FUNCTIONS } from "../../../src/lib/admin";
+import type { MockClientHooks } from "../../mock-client";
+import { createMockClient } from "../../mock-client";
 
 // ── Fixture column definitions ───────────────────────────────────────────────
 
@@ -218,5 +224,152 @@ describe("generateRowsDialog", () => {
 
         // Settle to avoid dangling promise.
         settle();
+    });
+});
+
+// ── `useGenerateRows`'s `insertBatch` — the bulk `importShard` route (STUDIO-292) ──
+// Unlike the dialog tests above (which stub `onInsertRows` as a prop and never
+// reach the hook), these mount the REAL hook against a mock `LunoraClient` so
+// the actual `client.query` traffic `insertBatch` issues is observable.
+
+const DESCRIBE_TABLE_COLUMNS: ColumnMeta[] = [
+    { name: "_id", optional: false, pk: true, type: "id" },
+    { name: "title", optional: false, type: "string" },
+];
+
+/** A mock client that serves `describeTable` (so `openDialog` can complete) and delegates everything else to `queryImpl`. */
+const createGenerateRowsClient = (queryImpl: (reference: string, args: unknown, options: unknown) => unknown): MockClientHooks =>
+    createMockClient({
+        query: (reference, args, options): unknown => {
+            if (reference === ADMIN_FUNCTIONS.describeTable) {
+                return { columns: DESCRIBE_TABLE_COLUMNS };
+            }
+
+            return queryImpl(reference, args, options);
+        },
+    });
+
+const wrapWithClient =
+    (mock: MockClientHooks) =>
+    ({ children }: { children: ReactNode }): ReactElement => <LunoraProvider client={mock.asClient}>{children}</LunoraProvider>;
+
+/** Open the dialog against `table` and wait for `openDialogAsync`'s `describeTable` round trip to settle. */
+const openAndSettle = async (result: { current: ReturnType<typeof useGenerateRows> }, table: string): Promise<void> => {
+    await act(async () => {
+        result.current.openDialog(table, "");
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+};
+
+describe("useGenerateRows — insertBatch routes through the bulk importShard RPC (STUDIO-292)", () => {
+    it("issues exactly ONE importShard call carrying all 200 rows, not 200 writeRow calls", async () => {
+        expect.assertions(3);
+
+        const mock = createGenerateRowsClient((reference) => {
+            if (reference === ADMIN_FUNCTIONS.importShard) {
+                return { conflicts: 0, errors: [], inserted: { posts: 200 } };
+            }
+
+            return undefined;
+        });
+
+        const { result } = renderHook(() => useGenerateRows(vi.fn()), { wrapper: wrapWithClient(mock) });
+
+        await openAndSettle(result, "posts");
+
+        const rows = Array.from({ length: 200 }, (_, index) => {
+            return { _id: `id-${index.toString()}`, title: `row ${index.toString()}` };
+        });
+        let outcome: string | undefined;
+
+        await act(async () => {
+            outcome = await result.current.insertBatch(rows, vi.fn());
+        });
+
+        expect(outcome).toBeUndefined();
+
+        const importCalls = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.importShard);
+        const writeRowCalls = mock.query.mock.calls.filter((call) => (call[0] as { __lunoraRef: string }).__lunoraRef === ADMIN_FUNCTIONS.writeRow);
+
+        expect(importCalls).toHaveLength(1);
+        expect(writeRowCalls).toHaveLength(0);
+    });
+
+    it("surfaces a string naming the failing row's line and table when errors is non-empty", async () => {
+        expect.assertions(1);
+
+        const mock = createGenerateRowsClient((reference) => {
+            if (reference === ADMIN_FUNCTIONS.importShard) {
+                return {
+                    conflicts: 0,
+                    errors: [{ code: "VALIDATION_ERROR", line: 3, message: "bad title", table: "posts" }],
+                    inserted: { posts: 2 },
+                };
+            }
+
+            return undefined;
+        });
+
+        const { result } = renderHook(() => useGenerateRows(vi.fn()), { wrapper: wrapWithClient(mock) });
+
+        await openAndSettle(result, "posts");
+
+        let outcome: string | undefined;
+
+        await act(async () => {
+            outcome = await result.current.insertBatch([{ title: "a" }, { title: "b" }, { title: "c" }], vi.fn());
+        });
+
+        expect(outcome).toContain("row 3 (posts): bad title");
+    });
+
+    it("treats conflicts alone (no errors) as success", async () => {
+        expect.assertions(1);
+
+        const mock = createGenerateRowsClient((reference) => {
+            if (reference === ADMIN_FUNCTIONS.importShard) {
+                return { conflicts: 2, errors: [], inserted: { posts: 0 } };
+            }
+
+            return undefined;
+        });
+
+        const { result } = renderHook(() => useGenerateRows(vi.fn()), { wrapper: wrapWithClient(mock) });
+
+        await openAndSettle(result, "posts");
+
+        let outcome: string | undefined;
+
+        await act(async () => {
+            outcome = await result.current.insertBatch([{ title: "a" }, { title: "b" }], vi.fn());
+        });
+
+        expect(outcome).toBeUndefined();
+    });
+
+    it("still returns the error message when the transport throws (today's catch path)", async () => {
+        expect.assertions(1);
+
+        const mock = createGenerateRowsClient((reference) => {
+            if (reference === ADMIN_FUNCTIONS.importShard) {
+                throw new Error("network down");
+            }
+
+            return undefined;
+        });
+
+        const { result } = renderHook(() => useGenerateRows(vi.fn()), { wrapper: wrapWithClient(mock) });
+
+        await openAndSettle(result, "posts");
+
+        let outcome: string | undefined;
+
+        await act(async () => {
+            outcome = await result.current.insertBatch([{ title: "a" }], vi.fn());
+        });
+
+        expect(outcome).toBe("network down");
     });
 });

--- a/packages/studio/__tests__/features/data/use-facets.test.tsx
+++ b/packages/studio/__tests__/features/data/use-facets.test.tsx
@@ -65,4 +65,39 @@ describe("useFacets", () => {
 
         expect(result.current.facets["status"]?.result).toStrictEqual(facetResult("new"));
     });
+
+    it("clearFacets has no synchronous ref mutation — facetsRef.current only updates once the commit lands", async () => {
+        expect.assertions(2);
+
+        const fetcher = vi.fn<FacetFetcher>(async () => facetResult("a"));
+
+        const { result } = renderHook(() => useFacets());
+
+        await act(async () => {
+            result.current.toggleFacet("status", fetcher);
+            await Promise.resolve();
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        const refBeforeClear = result.current.facetsRef.current;
+
+        expect(refBeforeClear).not.toStrictEqual({});
+
+        // Call OUTSIDE `act` deliberately, so the ref can be inspected between the
+        // `setFacets({})` call and the commit — the render-phase write this
+        // replaces (`facetsRef.current = {}`) mutated the ref synchronously, right
+        // here, before React ever committed anything; this assertion fails against
+        // that code. `useMirroredRef`'s effect only publishes `{}` once the commit
+        // (and its effects) actually run, which the subsequent `act` below flushes.
+        result.current.clearFacets();
+
+        expect(result.current.facetsRef.current).toBe(refBeforeClear);
+
+        // Flush the commit + `useMirroredRef`'s effect so the hook settles cleanly
+        // before the test ends (avoids an act() warning bleeding into later tests).
+        await act(async () => {
+            await Promise.resolve();
+        });
+    });
 });

--- a/packages/studio/src/features/data/data-browser.tsx
+++ b/packages/studio/src/features/data/data-browser.tsx
@@ -18,6 +18,7 @@ import { CellDetailDialog } from "./grid-features";
 import { useBackRelations } from "./hooks/use-back-relations";
 import { useDataBrowser } from "./hooks/use-data-browser";
 import { useDataViewPreferences } from "./hooks/use-data-view-preferences";
+import type { InsertBatchOutcome } from "./hooks/use-generate-rows";
 import { useGenerateRows } from "./hooks/use-generate-rows";
 import { useRowInspection } from "./hooks/use-row-inspection";
 import { RowDetailDrawer } from "./row-detail";
@@ -336,7 +337,7 @@ export const DataBrowser = ({
         }
     };
 
-    const onInsertGeneratedRows = (rows: ReadonlyArray<Record<string, unknown>>): Promise<string | undefined> => insertBatch(rows, closeGenerateDialog);
+    const onInsertGeneratedRows = (rows: ReadonlyArray<Record<string, unknown>>): Promise<InsertBatchOutcome> => insertBatch(rows, closeGenerateDialog);
 
     // Follow a `v.id` ref cell. Targets in another storage tier (a `.global()` D1
     // table) can't be read from this shard, so route those to the global tier via

--- a/packages/studio/src/features/data/generate-rows-dialog.tsx
+++ b/packages/studio/src/features/data/generate-rows-dialog.tsx
@@ -6,6 +6,7 @@ import { useT } from "../../i18n/i18n-context";
 import type { ColumnMeta } from "../../lib/admin";
 import { fireAndForget } from "../../lib/internal";
 import { collectSkippedFkColumns, MAX_GENERATE_ROWS, requestSeedRows } from "../../lib/seed-data";
+import type { InsertBatchOutcome } from "./hooks/use-generate-rows";
 
 /** Shared control-button class for dialog actions. */
 const BTN =
@@ -26,10 +27,12 @@ interface GenerateRowsDialogProps {
 
     /**
      * Called with the generated row documents. The caller (data browser) routes
-     * them through the schema-aware `writeRow` insert path one by one. Returns
-     * `undefined` on success or an error message string on failure.
+     * them through the bulk `importShard` admin RPC in one call. The returned
+     * {@link InsertBatchOutcome} carries the REAL inserted/conflict counts —
+     * `error === undefined` does not mean every requested row landed (a
+     * conflict-only batch also has no `error`).
      */
-    readonly onInsertRows: (rows: ReadonlyArray<Record<string, unknown>>) => Promise<string | undefined>;
+    readonly onInsertRows: (rows: ReadonlyArray<Record<string, unknown>>) => Promise<InsertBatchOutcome>;
     /** The name of the table being seeded — for display only. */
     readonly table: string;
 }
@@ -51,6 +54,8 @@ const GenerateRowsDialog = ({ columns, fkPools, onClose, onInsertRows, table }: 
     const [inserting, setInserting] = useState<boolean>(false);
     const [error, setError] = useState<string | undefined>(undefined);
     const [inserted, setInserted] = useState<number | undefined>(undefined);
+    /** Rows skipped as id conflicts on the last successful (`error === undefined`) insert — surfaced alongside `inserted` so "0 inserted, 200 conflicts" never reads as "200 inserted". */
+    const [conflicts, setConflicts] = useState<number>(0);
 
     const onCountChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         const next = Number(event.target.value);
@@ -63,6 +68,7 @@ const GenerateRowsDialog = ({ columns, fkPools, onClose, onInsertRows, table }: 
     const handleGenerate = async (): Promise<void> => {
         setError(undefined);
         setInserted(undefined);
+        setConflicts(0);
         setInserting(true);
 
         // react-doctor-disable-next-line react-hooks-js/todo -- React Compiler cannot lower `try` without `catch`; the `finally` must still clear the busy flag on the throw path, and adding a catch just to satisfy the compiler would swallow the error
@@ -85,20 +91,25 @@ const GenerateRowsDialog = ({ columns, fkPools, onClose, onInsertRows, table }: 
                 return;
             }
 
-            const result = await onInsertRows(rows);
+            const outcome = await onInsertRows(rows);
 
-            if (result !== undefined) {
-                setError(result);
+            if (outcome.error !== undefined) {
+                setError(outcome.error);
 
                 return;
             }
 
-            setInserted(rows.length);
+            // `outcome.inserted` is the count that ACTUALLY landed — never
+            // `rows.length` (the requested count), which a conflict-only batch
+            // (every planned `_id` already existed) would overstate as if
+            // nothing had been skipped.
+            setInserted(outcome.inserted);
+            setConflicts(outcome.conflicts);
 
             const skippedFkColumns = collectSkippedFkColumns(columns, fkPools);
 
             if (skippedFkColumns.length > 0) {
-                setError(t("Inserted {count} rows. Skipped FK columns: {cols}", { cols: skippedFkColumns.join(", "), count: rows.length.toString() }));
+                setError(t("Inserted {count} rows. Skipped FK columns: {cols}", { cols: skippedFkColumns.join(", "), count: outcome.inserted.toString() }));
             }
         } finally {
             setInserting(false);
@@ -183,7 +194,13 @@ const GenerateRowsDialog = ({ columns, fkPools, onClose, onInsertRows, table }: 
 
             {inserted !== undefined && error === undefined && (
                 <p className="text-xs text-success" data-testid="gen-rows-success">
-                    {t("Inserted {count} rows successfully.", { count: inserted.toString() })}
+                    {conflicts > 0
+                        ? t("Inserted {inserted} of {total} rows — {conflicts} skipped as id conflicts.", {
+                              conflicts: conflicts.toString(),
+                              inserted: inserted.toString(),
+                              total: (inserted + conflicts).toString(),
+                          })
+                        : t("Inserted {count} rows successfully.", { count: inserted.toString() })}
                 </p>
             )}
 

--- a/packages/studio/src/features/data/hooks/use-data-browser.tsx
+++ b/packages/studio/src/features/data/hooks/use-data-browser.tsx
@@ -1,6 +1,6 @@
 import { useLunora } from "@lunora/react";
 import type { OnChangeFn, SortingState } from "@tanstack/react-table";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useAdminQuery } from "../../../hooks/use-admin-query";
 import useDebounced from "../../../hooks/use-debounced";
@@ -62,6 +62,37 @@ const toEditableFilters = (clauses: ReadonlyArray<FilterClause>): EditableFilter
 
 /** Translate a single-sort `orderBy` into the TanStack sorting state the grid renders. */
 const fromOrderBy = (orderBy: DataView["orderBy"]): SortingState => (orderBy === undefined ? [] : [{ desc: orderBy.direction === "desc", id: orderBy.column }]);
+
+/**
+ * A {@link FilterClause} reduced to a fixed-shape tuple. `JSON.stringify` of an
+ * object literal preserves THAT object's own key insertion order, which two
+ * structurally-equal clauses need not share (e.g. one parsed from a URL's JSON
+ * blob) — serializing a tuple instead means two equal clauses always produce
+ * the same string, regardless of where they came from.
+ */
+const filterClauseTuple = (clause: FilterClause): [string, string, unknown] => [clause.column, clause.operator, clause.value];
+
+/**
+ * Serialize the fields a data-browser view is keyed on (shard / search /
+ * filters / sort) into one comparable string. Used both for "what view is
+ * incoming right now" (from props) and "what view is this component currently
+ * emitting to the host" (from local state) so the render-time re-seed check
+ * below can tell an actual apply from the URL mirror's own echo. Built from
+ * fixed-shape tuples/arrays throughout (never a bare object), so two views
+ * that are equal in value always serialize identically.
+ */
+const serializeView = (
+    shard: string | undefined,
+    search: string | undefined,
+    filters: ReadonlyArray<FilterClause> | undefined,
+    orderBy: DataView["orderBy"],
+): string =>
+    JSON.stringify([
+        shard ?? "",
+        search ?? "",
+        (filters ?? []).map((clause) => filterClauseTuple(clause)),
+        orderBy === undefined ? null : [orderBy.column, orderBy.direction],
+    ]);
 
 /**
  * Hard ceiling on the number of bounded server `deleteRows`/`clearTable` calls
@@ -370,16 +401,67 @@ const useDataBrowser = ({
     const [editingCell, setEditingCell] = useState<null | { column: string; rowId: string }>(null);
     const [committing, setCommitting] = useState<boolean>(false);
 
-    // Tracks the table the local view has been (re-)seeded for. Seeded with the
-    // mount `tableParam` so the first render is a no-op (the `useState`
-    // initializers above already hydrated from the URL).
+    // Tracks the (table, view) identity the local view state has been (re-)seeded
+    // for. Seeded with the mount `tableParam`/incoming view so the first render is
+    // a no-op (the `useState` initializers above already hydrated from the URL).
+    // `seededViewKey` is a serialized snapshot of the fields a re-seed consumes
+    // (shard/search/filters/order — see `serializeView`), so a same-table apply (a
+    // saved query, or browser back/forward, that changes the view WITHOUT
+    // changing the table) is visible even though `tableParam` alone isn't.
     const [seededTableParameter, setSeededTableParameter] = useState<string | undefined>(tableParam);
+    const [seededViewKey, setSeededViewKey] = useState<string>(() => serializeView(initialShardKey, initialSearch, initialFilters, initialOrderBy));
+
+    // Bumped on every re-seed (table switch OR same-table view apply) to re-key
+    // both debounces below, so a re-seed's shard/search snap immediately instead
+    // of trailing the OLD value for up to 300–400ms (see `filterInput`/
+    // `shardInput` below).
+    const [seedEpoch, setSeedEpoch] = useState<number>(0);
+
+    // The view this component last EMITTED (or would emit) to the host — the
+    // exact payload the mirror effect far below sends. Read here, at the TOP of
+    // the function, to tell an incoming view apart from the mirror's own echo of
+    // it; updated by a plain effect (not `useMirroredRef`) because the value
+    // isn't computable until this render's `search`/`debouncedShard` exist,
+    // further down — see that effect for why.
+    const emittedViewKeyRef = useRef<string>(serializeView(initialShardKey, initialSearch, initialFilters, initialOrderBy));
+
     const isTableSwitch = tableParam !== seededTableParameter;
 
-    // Re-seed the per-table local view state whenever the open table changes — an
-    // in-app switch, an FK-nav, a deep link, or browser back/forward. The new
-    // values come from the new URL (empty on a plain switch, the id on an FK-nav,
-    // the saved view on a deep link), so the table and its view never disagree.
+    // The incoming view this render's props describe — compared against BOTH
+    // `seededViewKey` (what the reset block below last locked in) and
+    // `emittedViewKeyRef.current` (what this component last mirrored to the
+    // host). Needing BOTH to differ is what makes the URL round trip a fixed
+    // point, without a second seeding mechanism:
+    //
+    //  - `seededViewKey` breaks the loop WITHIN one re-seed: React's "adjust
+    //    state while rendering" pattern discards this render and retries
+    //    synchronously once a setter below runs; on that retry `seededViewKey`
+    //    already equals the incoming key (it's plain state, so the update is
+    //    visible on the retry), so the condition goes false immediately.
+    //    Without it, `emittedViewKeyRef` — only updated by a COMMITTED render's
+    //    effect, which the retry hasn't reached yet — would still read stale,
+    //    and the retry would re-trigger itself forever.
+    //  - `emittedViewKeyRef` breaks the loop ACROSS renders: the user's own
+    //    typing debounces into `search`/`debouncedShard`, the mirror effect
+    //    below sends that to the host, and the host echoes it straight back as
+    //    this same render's `initialSearch`/`initialShardKey`. By the time that
+    //    echo arrives, the mirror's effect has already updated
+    //    `emittedViewKeyRef` to match it, so the echo reads as "already
+    //    current" rather than as a fresh apply.
+    //
+    // Gated on `!isTableSwitch` because a real table switch already
+    // unconditionally re-seeds below; this only covers the same-table case a
+    // switch doesn't reach.
+    const incomingViewKey = serializeView(initialShardKey, initialSearch, initialFilters, initialOrderBy);
+    const isSameTableViewApply = !isTableSwitch && incomingViewKey !== seededViewKey && incomingViewKey !== emittedViewKeyRef.current;
+    const isReseed = isTableSwitch || isSameTableViewApply;
+
+    // Re-seed the per-table local view state whenever the open table changes OR
+    // (same table) a saved-query apply / browser back-forward hands this render a
+    // genuinely new view — an in-app switch, an FK-nav, a deep link, a same-table
+    // apply, or browser back/forward. The new values come from the new URL (empty
+    // on a plain switch, the id on an FK-nav, the saved view on a deep link or
+    // apply), so the table + view and the local state never disagree.
     //
     // Done RENDER-TIME (the "adjusting state when a prop changes" pattern), not in
     // an effect: an effect — even a synchronous one, even one that skips the old
@@ -396,24 +478,27 @@ const useDataBrowser = ({
     // reconcile/"select the URL's table" step — opening the URL's table is
     // implicit. Reads `initialFilters`/`initialOrderBy`/`initialSearch`/
     // `initialShardKey` DIRECTLY (this render's props), not through a mirrored
-    // ref: unlike the effect this replaces, this block is gated by a plain
-    // condition re-evaluated every render (`tableParam !== seededTableParameter`)
-    // rather than an effect dependency array, so it can only ever fire on a real
-    // `tableParam` change. The URL-mirror round trip from the user's OWN typing
-    // (which changes `initialSearch` etc. without changing `tableParam`) can't
-    // retrigger it, so there is no staleness hazard here to route around with a
-    // ref the way the mirror effect below still has to.
-    if (isTableSwitch) {
+    // ref: this block is gated by a plain condition re-evaluated every render
+    // (`isReseed`, above) rather than an effect dependency array, so it can only
+    // ever fire when the table actually changed or the incoming view actually
+    // differs from both what was seeded AND what was just emitted. The URL-mirror
+    // round trip from the user's OWN typing (which changes `initialSearch` etc.
+    // without changing `tableParam`) is exactly the case `emittedViewKeyRef`
+    // exists to recognize as "no-op" rather than "apply" — see the comment on
+    // `isSameTableViewApply` above.
+    if (isReseed) {
         setSeededTableParameter(tableParam);
+        setSeededViewKey(incomingViewKey);
+        setSeedEpoch((epoch) => epoch + 1);
         setSorting(fromOrderBy(initialOrderBy));
         setFilter(initialSearch ?? "");
 
         const nextFilters = toEditableFilters(initialFilters ?? []);
 
         setFilters(nextFilters);
-        // Re-seed the shard from the new URL too, so a switch that also changes
-        // shard (a saved query / cross-shard deep link) points reads AND writes
-        // at the URL's shard instead of leaving the previous table's shard live.
+        // Re-seed the shard from the new URL too, so a switch/apply that also
+        // changes shard (a saved query / cross-shard deep link) points reads AND
+        // writes at the URL's shard instead of leaving the previous shard live.
         setShardKey(initialShardKey ?? "");
         clearFacets();
         stagedEdits.clear();
@@ -422,13 +507,14 @@ const useDataBrowser = ({
     }
 
     // The raw input each debounced mirror below reflects for THIS render: on a
-    // table switch, the new table's URL values directly — the `filter`/`shardKey`
-    // STATE above only catches up once React retries this render, and feeding
-    // `useDebounced` the stale state on THIS pass would bake the stale value into
-    // its own internal (persistent) `debounced` state via its `resetKey` snap (see
-    // `useDebounced`'s doc comment). Otherwise, the live state as usual.
-    const filterInput = isTableSwitch ? (initialSearch ?? "") : filter;
-    const shardInput = isTableSwitch ? (initialShardKey ?? "") : shardKey;
+    // re-seed (table switch OR same-table view apply), the new view's URL values
+    // directly — the `filter`/`shardKey` STATE above only catches up once React
+    // retries this render, and feeding `useDebounced` the stale state on THIS
+    // pass would bake the stale value into its own internal (persistent)
+    // `debounced` state via its `resetKey` snap (see `useDebounced`'s doc
+    // comment). Otherwise, the live state as usual.
+    const filterInput = isReseed ? (initialSearch ?? "") : filter;
+    const shardInput = isReseed ? (initialShardKey ?? "") : shardKey;
 
     // Search box value, debounced into a server-side `search` (filters across the
     // WHOLE table, not just the loaded page), which re-fetches from offset 0.
@@ -440,12 +526,25 @@ const useDataBrowser = ({
     // rows are on screen during the debounce window. The live `shardKey` is only the
     // input value + the share-link descriptor.
     //
-    // Both key their `resetKey` on `tableParam`: a table switch snaps them straight
-    // to the new table's values (via `filterInput`/`shardInput` above) with NO
-    // trailing debounce window, instead of continuing to serve the previous
-    // table's search predicate / shard for up to 300–400ms after the switch.
-    const search = useDebounced(filterInput.trim(), 300, tableParam);
-    const debouncedShard = useDebounced(shardInput.trim(), 400, tableParam);
+    // Both key their `resetKey` on `tableParam` + `seedEpoch`: a re-seed (table
+    // switch OR same-table apply) snaps them straight to the new view's values
+    // (via `filterInput`/`shardInput` above) with NO trailing debounce window,
+    // instead of continuing to serve the previous view's search predicate / shard
+    // for up to 300–400ms after the switch/apply.
+    const debounceResetKey = `${tableParam ?? ""}:${seedEpoch.toString()}`;
+    const search = useDebounced(filterInput.trim(), 300, debounceResetKey);
+    const debouncedShard = useDebounced(shardInput.trim(), 400, debounceResetKey);
+
+    // Mirror the emitted view — the exact payload the mirror effect far below
+    // sends to the host — into `emittedViewKeyRef` on every commit, so the
+    // render-time re-seed check above can compare against it next render. No dep
+    // array: track every commit, the same way `useMirroredRef` does (this can't
+    // just BE a `useMirroredRef` call up there, since its value depends on
+    // `search`/`debouncedShard`/`filters`/`sorting`, none of which exist yet at
+    // that point in the function).
+    useEffect(() => {
+        emittedViewKeyRef.current = serializeView(debouncedShard, search, toFilterClauses(filters), toOrderBy(sorting));
+    });
 
     // ── Reads via TanStack Query: a one-shot fetch plus a live WS push into the
     // cache (the same model as every other studio panel). The table list follows
@@ -598,14 +697,16 @@ const useDataBrowser = ({
     // search are debounced, so it tracks the displayed view; the table itself is
     // mirrored separately by `onSelectTable`.
     useEffect(() => {
-        // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler -- the URL is a projection of the active view (a value, not a discrete event); mirroring it when the view changes is the correct pattern.
-        if (selectedTable === null || onViewChangeRef.current === undefined || seededTableParameter !== tableParam) {
-            // The render-time reset above keeps `seededTableParameter` in lockstep with
-            // `tableParam` on every COMMITTED render, so this branch is a defensive
-            // invariant rather than a live gate now (there's no longer a committed
-            // render where a switch has landed but the reset hasn't) — kept so a
-            // future change to the reset can't silently reintroduce the stale-URL-
-            // write hazard the two-effect version had to route around.
+        /* eslint-disable react-you-might-not-need-an-effect/no-event-handler -- the URL is a projection of the active view (a value, not a discrete event); mirroring it when the view changes is the correct pattern. */
+        if (selectedTable === null || onViewChangeRef.current === undefined || seededTableParameter !== tableParam || seededViewKey !== incomingViewKey) {
+            /* eslint-enable react-you-might-not-need-an-effect/no-event-handler */
+            // The render-time reset above keeps `seededTableParameter`/`seededViewKey`
+            // in lockstep with `tableParam`/the incoming view on every COMMITTED
+            // render, so this branch is a defensive invariant rather than a live gate
+            // now (there's no longer a committed render where a re-seed has landed but
+            // the reset hasn't) — kept so a future change to the reset can't silently
+            // reintroduce the stale-URL-write hazard the two-effect version had to
+            // route around.
             return;
         }
 
@@ -618,7 +719,7 @@ const useDataBrowser = ({
         // Fire on the displayed view; `onViewChange` is read via `onViewChangeRef` (see above).
         // react-doctor-disable-next-line react-doctor/exhaustive-deps -- the ref is a `useMirroredRef` handle — stable by construction; depending on `onViewChange` itself is what caused the navigate loop this pattern exists to avoid
         // eslint-disable-next-line react-hooks/exhaustive-deps -- same reason: the ref handle is stable, and depending on `onViewChange` is exactly the loop this avoids
-    }, [selectedTable, tableParam, seededTableParameter, filters, sorting, search, debouncedShard]);
+    }, [selectedTable, tableParam, seededTableParameter, seededViewKey, incomingViewKey, filters, sorting, search, debouncedShard]);
 
     const goToPage = (nextOffset: number): void => {
         if (selectedTable === null) {

--- a/packages/studio/src/features/data/hooks/use-data-browser.tsx
+++ b/packages/studio/src/features/data/hooks/use-data-browser.tsx
@@ -401,13 +401,24 @@ const useDataBrowser = ({
     const [editingCell, setEditingCell] = useState<null | { column: string; rowId: string }>(null);
     const [committing, setCommitting] = useState<boolean>(false);
 
-    // Tracks the (table, view) identity the local view state has been (re-)seeded
-    // for. Seeded with the mount `tableParam`/incoming view so the first render is
-    // a no-op (the `useState` initializers above already hydrated from the URL).
+    // Tracks the (table, view) identity the local view state has last been
+    // caught up to — either by a full re-seed, OR by simply catching up to the
+    // URL mirror's own echo (see the `else if` below the reset block). Seeded
+    // with the mount `tableParam`/incoming view so the first render is a no-op
+    // (the `useState` initializers above already hydrated from the URL).
     // `seededViewKey` is a serialized snapshot of the fields a re-seed consumes
-    // (shard/search/filters/order — see `serializeView`), so a same-table apply (a
-    // saved query, or browser back/forward, that changes the view WITHOUT
+    // (shard/search/filters/order — see `serializeView`), so a same-table apply
+    // (a saved query, or browser back/forward, that changes the view WITHOUT
     // changing the table) is visible even though `tableParam` alone isn't.
+    //
+    // MUST advance on every committed render whose incoming view is accounted
+    // for — a re-seed OR an echo — never JUST a re-seed. It is also read by the
+    // mirror effect's guard below, and if it only ever advanced inside the
+    // reset block, the FIRST echo would permanently desync it from
+    // `incomingViewKey` (the echo isn't a re-seed, so the reset block never
+    // runs) — the guard would then block the mirror forever after that point,
+    // and the next unrelated render would misread whatever the user had typed
+    // SINCE as a fresh external apply, wrongly re-seeding and reverting it.
     const [seededTableParameter, setSeededTableParameter] = useState<string | undefined>(tableParam);
     const [seededViewKey, setSeededViewKey] = useState<string>(() => serializeView(initialShardKey, initialSearch, initialFilters, initialOrderBy));
 
@@ -504,6 +515,28 @@ const useDataBrowser = ({
         stagedEdits.clear();
         setEditingCell(null);
         setOffset(0);
+    } else if (incomingViewKey !== seededViewKey) {
+        // Not a re-seed (`isReseed` is false here, and `isReseed` is
+        // `isTableSwitch || isSameTableViewApply` — so BOTH are false too: this
+        // only reaches here when `incomingViewKey === emittedViewKeyRef.current`),
+        // but `incomingViewKey` still differs from `seededViewKey` — the URL
+        // mirror's own echo of what THIS component last emitted, arriving back
+        // as this render's `initialSearch`/`initialShardKey`/etc.
+        //
+        // `seededViewKey` MUST still advance here, even though nothing else
+        // does: it is also read by the mirror effect's guard below
+        // (`seededViewKey !== incomingViewKey`), which exists to skip a stale
+        // mirror write while a re-seed is in flight. Leaving `seededViewKey`
+        // frozen at its last RESEED value (rather than catching it up to every
+        // harmless echo too) would permanently desync it from `incomingViewKey`
+        // after the FIRST echo — the mirror guard would then block every future
+        // commit, and the next render whose `emittedViewKeyRef` has moved on
+        // further (from a SECOND, later keystroke) would misread the still-stale
+        // `incomingViewKey` as a fresh external apply and wrongly re-seed,
+        // reverting the second change and wiping staged edits/offset/facets with
+        // it. Advancing it here — without touching any other state — keeps the
+        // invariant the mirror guard depends on actually true.
+        setSeededViewKey(incomingViewKey);
     }
 
     // The raw input each debounced mirror below reflects for THIS render: on a

--- a/packages/studio/src/features/data/hooks/use-facets.tsx
+++ b/packages/studio/src/features/data/hooks/use-facets.tsx
@@ -110,7 +110,6 @@ export const useFacets = (): UseFacets => {
 
     const clearFacets = (): void => {
         setFacets({});
-        facetsRef.current = {};
     };
 
     return { clearFacets, facets, facetsRef, refetchFacets, toggleFacet };

--- a/packages/studio/src/features/data/hooks/use-generate-rows.ts
+++ b/packages/studio/src/features/data/hooks/use-generate-rows.ts
@@ -37,6 +37,23 @@ const extractId = (row: Record<string, unknown>): string => {
  * Export/Import panel uses. All state is local to this hook; the data browser
  * refresh is the caller's responsibility after a successful insert.
  */
+
+/**
+ * Outcome of one `insertBatch` call. A bare `string | undefined` (the original
+ * `writeRow`-loop contract) can't distinguish "every row inserted" from "every
+ * row skipped as an id conflict" — both have no `error` — so the caller needs
+ * the real `inserted`/`conflicts` counts to report honestly instead of assuming
+ * the requested row count is what actually landed.
+ */
+interface InsertBatchOutcome {
+    /** Rows skipped because their `_id` already existed on the shard (e.g. a re-click with the same seed regenerating the same planned ids). */
+    conflicts: number;
+    /** Set when the batch had at least one row-level error, naming the first failing row. `undefined` when there were none — a conflict-only result still counts as success. */
+    error: string | undefined;
+    /** Rows actually inserted (never assume this equals the requested count — conflicts and errors both reduce it). */
+    inserted: number;
+}
+
 interface UseGenerateRowsModel {
     /** Close the dialog and reset state. */
     closeDialog: () => void;
@@ -49,11 +66,11 @@ interface UseGenerateRowsModel {
 
     /**
      * Insert a batch of pre-generated row documents in ONE `importShard` call.
-     * Returns `undefined` on full success (no row-level errors — conflicts alone
-     * still count as success, see `composeImportError`) or an error string
-     * naming the first failing row on failure.
+     * The returned {@link InsertBatchOutcome} carries the REAL inserted/conflict
+     * counts — never assume every requested row landed just because `error` is
+     * `undefined` (see `composeInsertOutcome`).
      */
-    insertBatch: (rows: ReadonlyArray<Record<string, unknown>>, onDone: () => void) => Promise<string | undefined>;
+    insertBatch: (rows: ReadonlyArray<Record<string, unknown>>, onDone: () => void) => Promise<InsertBatchOutcome>;
     /** True while fetching column meta / FK pools or inserting rows. */
     loading: boolean;
     /** Whether the dialog is currently open. */
@@ -67,28 +84,32 @@ interface UseGenerateRowsModel {
 }
 
 /**
- * Compose an `importShard` result into the dialog's single error string. Only a
- * non-empty `errors` array is a failure — a conflict-only result (every row's
+ * Compose an `importShard` result into an {@link InsertBatchOutcome}. Only a
+ * non-empty `errors` array sets `error` — a conflict-only result (every row's
  * `_id` collided with an existing one, e.g. a re-click with the same seed)
- * counts as success, matching the Export/Import panel's semantics. The first
- * error names its row (by 1-based `line`, which `importShard` treats as the
- * row's position in `rows` since generated rows have no file lines) and table;
- * a trailing count covers the rest so a big batch doesn't dump every failure.
+ * counts as success, matching the Export/Import panel's semantics, but
+ * `inserted`/`conflicts` are always the real counts so the caller can tell
+ * "200 inserted" apart from "0 inserted, 200 conflicts" instead of assuming
+ * the requested row count is what landed. The error string names the first
+ * failing row (by 1-based `line`, which `importShard` treats as the row's
+ * position in `rows` since generated rows have no file lines) and table; a
+ * trailing count covers the rest so a big batch doesn't dump every failure.
  */
-const composeImportError = (result: ImportShardResult): string | undefined => {
+const composeInsertOutcome = (result: ImportShardResult): InsertBatchOutcome => {
+    const insertedTotal = Object.values(result.inserted).reduce((sum, count) => sum + count, 0);
     const [firstError] = result.errors;
 
     if (firstError === undefined) {
-        return undefined;
+        return { conflicts: result.conflicts, error: undefined, inserted: insertedTotal };
     }
 
-    const insertedTotal = Object.values(result.inserted).reduce((sum, count) => sum + count, 0);
     const remaining = result.errors.length - 1;
     const attempted = insertedTotal + result.conflicts + result.errors.length;
     const errorWord = remaining === 1 ? "error" : "errors";
     const suffix = remaining > 0 ? ` (+${remaining.toString()} more ${errorWord})` : "";
+    const error = `Inserted ${insertedTotal.toString()} of ${attempted.toString()} rows — row ${firstError.line.toString()} (${firstError.table}): ${firstError.message}${suffix}`;
 
-    return `Inserted ${insertedTotal.toString()} of ${attempted.toString()} rows — row ${firstError.line.toString()} (${firstError.table}): ${firstError.message}${suffix}`;
+    return { conflicts: result.conflicts, error, inserted: insertedTotal };
 };
 
 /**
@@ -180,9 +201,9 @@ const useGenerateRows = (onRefresh: () => void): UseGenerateRowsModel => {
         setError(undefined);
     };
 
-    const insertBatch = async (rows: ReadonlyArray<Record<string, unknown>>, onDone: () => void): Promise<string | undefined> => {
+    const insertBatch = async (rows: ReadonlyArray<Record<string, unknown>>, onDone: () => void): Promise<InsertBatchOutcome> => {
         if (table === undefined || shardKey === undefined) {
-            return "No table selected.";
+            return { conflicts: 0, error: "No table selected.", inserted: 0 };
         }
 
         try {
@@ -196,18 +217,18 @@ const useGenerateRows = (onRefresh: () => void): UseGenerateRowsModel => {
                 callOptions(shardKey),
             )) as ImportShardResult;
 
-            const batchError = composeImportError(result);
+            const outcome = composeInsertOutcome(result);
 
-            if (batchError !== undefined) {
-                return batchError;
+            if (outcome.error !== undefined) {
+                return outcome;
             }
 
             onDone();
             onRefresh();
 
-            return undefined;
+            return outcome;
         } catch (error_) {
-            return (error_ as Error).message;
+            return { conflicts: 0, error: (error_ as Error).message, inserted: 0 };
         }
     };
 
@@ -215,4 +236,4 @@ const useGenerateRows = (onRefresh: () => void): UseGenerateRowsModel => {
 };
 
 export { useGenerateRows };
-export type { UseGenerateRowsModel };
+export type { InsertBatchOutcome, UseGenerateRowsModel };

--- a/packages/studio/src/features/data/hooks/use-generate-rows.ts
+++ b/packages/studio/src/features/data/hooks/use-generate-rows.ts
@@ -1,14 +1,14 @@
 import { useLunora } from "@lunora/react";
 import { useState } from "react";
 
-import type { ColumnMeta, TableColumnsResult, TablePage, WriteRowResult } from "../../../lib/admin";
+import type { ColumnMeta, ImportShardResult, TableColumnsResult, TablePage } from "../../../lib/admin";
 import { ADMIN_FUNCTIONS } from "../../../lib/admin";
 import { adminRef, callOptions, fireAndForget } from "../../../lib/internal";
 import { MAX_FK_SAMPLE } from "../../../lib/seed-data";
 
 const DESCRIBE_TABLE = adminRef(ADMIN_FUNCTIONS.describeTable);
 const READ_TABLE_PAGE = adminRef(ADMIN_FUNCTIONS.readTablePage);
-const WRITE_ROW = adminRef(ADMIN_FUNCTIONS.writeRow);
+const IMPORT_SHARD = adminRef(ADMIN_FUNCTIONS.importShard);
 
 /**
  * Extract a string row-id from a raw row object, trying common id column names.
@@ -33,8 +33,8 @@ const extractId = (row: Record<string, unknown>): string => {
  *
  * The hook fetches column metadata from `describeTable` and FK pools from
  * `readTablePage` lazily (when the dialog opens), then routes generated rows
- * through the schema-aware `writeRow` insert path — the same path the
- * add-row form uses. All state is local to this hook; the data browser
+ * through the bulk `importShard` admin RPC — the same batch path the
+ * Export/Import panel uses. All state is local to this hook; the data browser
  * refresh is the caller's responsibility after a successful insert.
  */
 interface UseGenerateRowsModel {
@@ -48,9 +48,10 @@ interface UseGenerateRowsModel {
     fkPools: Readonly<Record<string, ReadonlyArray<string>>>;
 
     /**
-     * Insert a batch of pre-generated row documents. Routes each through
-     * `writeRow insert`. Returns `undefined` on full success or an error string on
-     * the first failure.
+     * Insert a batch of pre-generated row documents in ONE `importShard` call.
+     * Returns `undefined` on full success (no row-level errors — conflicts alone
+     * still count as success, see `composeImportError`) or an error string
+     * naming the first failing row on failure.
      */
     insertBatch: (rows: ReadonlyArray<Record<string, unknown>>, onDone: () => void) => Promise<string | undefined>;
     /** True while fetching column meta / FK pools or inserting rows. */
@@ -66,10 +67,35 @@ interface UseGenerateRowsModel {
 }
 
 /**
+ * Compose an `importShard` result into the dialog's single error string. Only a
+ * non-empty `errors` array is a failure — a conflict-only result (every row's
+ * `_id` collided with an existing one, e.g. a re-click with the same seed)
+ * counts as success, matching the Export/Import panel's semantics. The first
+ * error names its row (by 1-based `line`, which `importShard` treats as the
+ * row's position in `rows` since generated rows have no file lines) and table;
+ * a trailing count covers the rest so a big batch doesn't dump every failure.
+ */
+const composeImportError = (result: ImportShardResult): string | undefined => {
+    const [firstError] = result.errors;
+
+    if (firstError === undefined) {
+        return undefined;
+    }
+
+    const insertedTotal = Object.values(result.inserted).reduce((sum, count) => sum + count, 0);
+    const remaining = result.errors.length - 1;
+    const attempted = insertedTotal + result.conflicts + result.errors.length;
+    const errorWord = remaining === 1 ? "error" : "errors";
+    const suffix = remaining > 0 ? ` (+${remaining.toString()} more ${errorWord})` : "";
+
+    return `Inserted ${insertedTotal.toString()} of ${attempted.toString()} rows — row ${firstError.line.toString()} (${firstError.table}): ${firstError.message}${suffix}`;
+};
+
+/**
  * Manages the full lifecycle of the "Generate & insert dummy rows" dialog:
  * - Fetches column metadata from `describeTable` when the dialog opens.
  * - Fetches FK pools (sampled row ids) from `readTablePage` for each FK column.
- * - Routes generated rows through the schema-aware `writeRow` insert path.
+ * - Routes generated rows through the bulk `importShard` admin RPC in one call, instead of one `writeRow` round trip per row.
  *
  * Used exclusively by `DataBrowser` — not a shared hook.
  */
@@ -160,9 +186,20 @@ const useGenerateRows = (onRefresh: () => void): UseGenerateRowsModel => {
         }
 
         try {
-            for (const rowDocument of rows) {
-                // eslint-disable-next-line no-await-in-loop -- sequential inserts through schema-aware writer; failure pins the offending row
-                (await client.query(WRITE_ROW, { doc: rowDocument, op: "insert", table }, callOptions(shardKey))) as WriteRowResult;
+            const result = (await client.query(
+                IMPORT_SHARD,
+                {
+                    rows: rows.map((document_) => {
+                        return { doc: document_, table };
+                    }),
+                },
+                callOptions(shardKey),
+            )) as ImportShardResult;
+
+            const batchError = composeImportError(result);
+
+            if (batchError !== undefined) {
+                return batchError;
             }
 
             onDone();

--- a/packages/studio/src/locales/en.ts
+++ b/packages/studio/src/locales/en.ts
@@ -738,6 +738,7 @@ const MESSAGE_IDS = [
     "No rows generated — all columns were skipped.",
     "Inserted {count} rows. Skipped FK columns: {cols}",
     "Inserted {count} rows successfully.",
+    "Inserted {inserted} of {total} rows — {conflicts} skipped as id conflicts.",
     "Generate & insert",
     "Inserting…",
     // Time Travel (PITR) panel.


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(studio): re-seed the data browser when a same-table view arrives via the URL
- fix(studio): drop the render-phase facets ref write in clearFacets
- fix(studio): keep the URL mirror alive past the first echoed change
- perf(studio): insert generated rows through the bulk importShard RPC
- fix(studio): stop reporting a false success when a batch inserts nothing

## Files this branch still changes relative to alpha

```
packages/studio/__tests__/features/data/data-browser.test.tsx
packages/studio/__tests__/features/data/generate-rows-dialog.test.tsx
packages/studio/__tests__/features/data/use-facets.test.tsx
packages/studio/src/features/data/data-browser.tsx
packages/studio/src/features/data/generate-rows-dialog.tsx
packages/studio/src/features/data/hooks/use-data-browser.tsx
packages/studio/src/features/data/hooks/use-facets.tsx
packages/studio/src/features/data/hooks/use-generate-rows.ts
packages/studio/src/locales/en.ts
```
