### PR TITLE
fix(codegen): reject non-identifier table names with a pinpointed diagnostic

### DIFF
--- a/packages/codegen/__tests__/discover-schema.test.ts
+++ b/packages/codegen/__tests__/discover-schema.test.ts
@@ -577,6 +577,65 @@ describe("discoverSchema", () => {
         expect(() => discoverSchema(project, schemaPath)).toThrow(/table name "query" is reserved/u);
     });
 
+    it("throws a diagnostic when a table name is not a valid JS identifier", () => {
+        expect.assertions(3);
+
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            export const schema = defineSchema({
+                "user-profiles": defineTable({ text: v.string() }),
+            });
+        `);
+
+        expect(() => discoverSchema(project, schemaPath)).toThrow(CodegenDiagnosticError);
+        expect(() => discoverSchema(project, schemaPath)).toThrow(/user-profiles/u);
+        expect(() => discoverSchema(project, schemaPath)).toThrow(/identifier/u);
+    });
+
+    it("throws with a file:line:column suffix for a non-identifier table name", () => {
+        expect.assertions(1);
+
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            export const schema = defineSchema({
+                "user-profiles": defineTable({ text: v.string() }),
+            });
+        `);
+
+        expect(() => discoverSchema(project, schemaPath)).toThrow(/schema\.ts:\d+:\d+\)/u);
+    });
+
+    it("rejects a quoted string-literal table name that collides with a `ctx.db` member (reserved name)", () => {
+        expect.assertions(2);
+
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            export const schema = defineSchema({
+                "delete": defineTable({ text: v.string() }),
+            });
+        `);
+
+        expect(() => discoverSchema(project, schemaPath)).toThrow(CodegenDiagnosticError);
+        expect(() => discoverSchema(project, schemaPath)).toThrow(/table name "delete" is reserved/u);
+    });
+
+    it("accepts a valid camelCase table name without throwing", () => {
+        expect.assertions(1);
+
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            export const schema = defineSchema({
+                userProfiles: defineTable({ text: v.string() }),
+            });
+        `);
+
+        expect(() => discoverSchema(project, schemaPath)).not.toThrow();
+    });
+
     it("captures an inline .vectorize() index hoisted into schema.vectorIndexes (Shape A)", () => {
         expect.assertions(2);
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { UMBRELLA_BASE_PACKAGES } from "../src/emit";
 import {
     createCodegenProject,
     emitApi,
@@ -2290,6 +2291,87 @@ export const ping = query({ args: { id: v.string() }, handler: async (_context, 
             const output = emitApi({ functions: [makeFunction({ returnType: "{ ok: boolean }" })] });
 
             expect(output).not.toContain("./dataModel.js");
+        });
+
+        it("leaves a checker-rendered @lunora/flags qualifier untouched for a non-umbrella project", () => {
+            expect.assertions(1);
+
+            const output = emitApi({ functions: [makeFunction({ returnType: 'import("@lunora/flags").LunoraFlags' })] });
+
+            expect(output).toContain('import("@lunora/flags").LunoraFlags');
+        });
+
+        it("rewrites a checker-rendered qualifier for each of the five newly-covered umbrella packages (errors, flags, observability, platform, ratelimit)", () => {
+            expect.assertions(10);
+
+            for (const pkg of ["errors", "flags", "observability", "platform", "ratelimit"]) {
+                const output = emitApi({ functions: [makeFunction({ returnType: `import("@lunora/${pkg}").Placeholder` })], useUmbrella: true });
+
+                expect(output).toContain(`import("lunorash/${pkg}").Placeholder`);
+                expect(output).not.toContain(`import("@lunora/${pkg}")`);
+            }
+        });
+
+        it("forwards a mirrored deep subpath (flags/web) but leaves an unmirrored one (flags/providers/env) unrewritten under the umbrella", () => {
+            expect.assertions(2);
+
+            const mirrored = emitApi({ functions: [makeFunction({ returnType: 'import("@lunora/flags/web").WebProvider' })], useUmbrella: true });
+            const unmirrored = emitApi({
+                functions: [makeFunction({ exportName: "list2", returnType: 'import("@lunora/flags/providers/env").EnvProvider' })],
+                useUmbrella: true,
+            });
+
+            expect(mirrored).toContain('import("lunorash/flags/web").WebProvider');
+            // Not mirrored by the umbrella (`./flags/env`, not `./flags/providers/env`) — left as-is rather than rewritten into a dead specifier.
+            expect(unmirrored).toContain('import("@lunora/flags/providers/env").EnvProvider');
+        });
+
+        it("leaves a platform conformance subpath unrewritten (the umbrella exports only bare `./platform`) but still rewrites the bare import", () => {
+            expect.assertions(2);
+
+            const subpath = emitApi({ functions: [makeFunction({ returnType: 'import("@lunora/platform/conformance").Suite' })], useUmbrella: true });
+            const bare = emitApi({ functions: [makeFunction({ exportName: "list2", returnType: 'import("@lunora/platform").ShardHost' })], useUmbrella: true });
+
+            expect(subpath).toContain('import("@lunora/platform/conformance").Suite');
+            expect(bare).toContain('import("lunorash/platform").ShardHost');
+        });
+    });
+
+    describe("umbrella_base_packages parity (anti-drift lock for the umbrella qualifier rewrite)", () => {
+        // Read the umbrella's manifest directly rather than importing it, so this
+        // test exercises the same "static list vs. source of truth" comparison a
+        // reviewer would do by hand — and fails loudly (ENOENT) if the umbrella
+        // package ever moves, per plan 295 §8's accepted risk.
+        const umbrellaPackageJsonPath = join(here, "..", "..", "lunora", "package.json");
+        const umbrellaExports = JSON.parse(readFileSync(umbrellaPackageJsonPath, "utf8")) as { exports: Record<string, unknown> };
+
+        /** First path segment of a subpath export key, e.g. `"./server/types"` -> `"server"`. */
+        const topLevelExportNames: ReadonlyArray<string> = [
+            ...new Set(
+                Object.keys(umbrellaExports.exports)
+                    .filter((key) => key !== "." && key !== "./package.json")
+                    .map((key) => key.replace(/^\.\//u, "").split("/")[0] ?? ""),
+            ),
+        ];
+
+        it("every UMBRELLA_BASE_PACKAGES entry has a matching top-level export in packages/lunora/package.json", () => {
+            // One assertion per entry in the (10-entry) constant.
+            expect.assertions(10);
+
+            for (const pkg of UMBRELLA_BASE_PACKAGES) {
+                expect(topLevelExportNames).toContain(pkg);
+            }
+        });
+
+        it("every top-level export in packages/lunora/package.json (other than `.`/`./package.json`) is covered by UMBRELLA_BASE_PACKAGES", () => {
+            // One assertion per distinct top-level export segment — currently the
+            // same 10 as UMBRELLA_BASE_PACKAGES; a divergence changes this count
+            // and fails loudly rather than silently under- or over-asserting.
+            expect.assertions(10);
+
+            for (const name of topLevelExportNames) {
+                expect(UMBRELLA_BASE_PACKAGES as ReadonlyArray<string>).toContain(name);
+            }
         });
     });
 

--- a/packages/codegen/src/discover-schema.ts
+++ b/packages/codegen/src/discover-schema.ts
@@ -32,15 +32,43 @@ const ON_DELETE_ACTIONS = new Set(["cascade", "restrict", "set null"]);
 const RESERVED_TABLE_NAMES = new Set(["delete", "get", "insert", "normalizeId", "patch", "query", "replace", "system"]);
 
 /**
+ * Table names are interpolated raw into generated type names (`Doc_${name}`)
+ * and unquoted property keys — they must be JS identifiers. Must stay in
+ * sync with `IDENTIFIER_RE` in `emit.ts` (the emit-side E1 gate is
+ * defense-in-depth behind this check).
+ */
+const TABLE_NAME_IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/u;
+
+/**
+ * `property.getName()` returns the string-literal's text WITH its surrounding
+ * quotes for a quoted key (e.g. `"delete"` yields `'"delete"'`, not `delete`),
+ * verified empirically against ts-morph — so both the reserved-name and
+ * identifier checks below must strip them first, or a quoted `"delete"` key
+ * would slip past `RESERVED_TABLE_NAMES.has` and a quoted `"user-profiles"`
+ * key would slip past the identifier test.
+ */
+const stripQuotes = (name: string): string => name.replaceAll(/^["']|["']$/gu, "");
+
+/**
  * Throw a pinpointed diagnostic when a discovered table key collides with a
- * `ctx.db` member. The `node` is the table's name node (or the table builder
- * expression) so the error points at the offending declaration.
+ * `ctx.db` member, or is not a valid JS identifier. The `node` is the table's
+ * name node (or the table builder expression) so the error points at the
+ * offending declaration.
  */
 const assertTableNameAllowed = (name: string, node: Node): void => {
-    if (RESERVED_TABLE_NAMES.has(name)) {
+    const unquoted = stripQuotes(name);
+
+    if (RESERVED_TABLE_NAMES.has(unquoted)) {
         throw diagnosticAt(
             node,
-            `table name "${name}" is reserved — it collides with a \`ctx.db\` member (one of ${[...RESERVED_TABLE_NAMES].map((reserved) => `"${reserved}"`).join(", ")}). Rename the table.`,
+            `table name "${unquoted}" is reserved — it collides with a \`ctx.db\` member (one of ${[...RESERVED_TABLE_NAMES].map((reserved) => `"${reserved}"`).join(", ")}). Rename the table.`,
+        );
+    }
+
+    if (!TABLE_NAME_IDENTIFIER_RE.test(unquoted)) {
+        throw diagnosticAt(
+            node,
+            `table name ${JSON.stringify(unquoted)} is not a valid JS identifier — table names are used in generated type names (Doc_<name>) and must match [A-Za-z_$][A-Za-z0-9_$]*. Rename the table.`,
         );
     }
 };

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -98,7 +98,12 @@ const baseSpecifiers = (useUmbrella = false): BaseSpecifiers =>
  * Matches the JS identifier subset we accept verbatim in emitted source.
  * Used to gate raw interpolation of table names, field names, etc. into
  * generated TS — anything outside the allowlist throws (E1) so we never
- * embed unescaped source from a `schema.ts`.
+ * embed unescaped source from a `schema.ts`. Table names are additionally
+ * gated earlier, at discovery, by `TABLE_NAME_IDENTIFIER_RE` in
+ * `discover-schema.ts` — that is the user-facing boundary (a pinpointed
+ * `file:line:column` diagnostic on the schema); this E1 throw is
+ * defense-in-depth behind it and should never fire for table names in
+ * practice. Must stay in sync with the discovery-side copy.
  */
 const IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/u;
 

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -679,27 +679,75 @@ const relocateUserRelativeImports = (returnType: string, filePath: string): stri
     });
 
 /**
+ * Every base package the `lunorash` umbrella re-exports (its top-level,
+ * non-`.`/non-`./package.json` export segments — see
+ * `packages/lunora/package.json`). Drives both {@link UMBRELLA_QUALIFIER_RE}
+ * below and the codegen test asserting this list stays in sync with the
+ * umbrella's manifest (`run-codegen.test.ts`) — the anti-drift lock that
+ * catches the next omission before it ships, the way `flags` was omitted
+ * here once already.
+ */
+const UMBRELLA_BASE_PACKAGES = ["client", "do", "errors", "flags", "observability", "platform", "ratelimit", "runtime", "server", "values"] as const;
+
+/**
  * An `import("@lunora/&lt;base>")` qualifier the type checker rendered into a
  * function's args/return type — e.g. a mutator whose `server` impl returns
  * `ctx.db.insert(...)`'s `Id&lt;"messages">` from a file that never imports `Id`, so
  * ts-morph fully qualifies it as `import("@lunora/values").Id&lt;"messages">`.
  *
- * Only the BASE packages the `lunorash` umbrella re-exports are listed. An
- * umbrella-only app has no `@lunora/values` in its `package.json`, so the
- * verbatim qualifier is a TS2307 in the generated file; rewriting it to
- * `import("lunorash/values")` resolves through the dependency it actually
- * declares. Add-ons (`@lunora/agent`, `@lunora/notify`, …) are installed
- * separately either way and are deliberately left alone.
+ * Only the BASE packages the `lunorash` umbrella re-exports are listed
+ * (derived from {@link UMBRELLA_BASE_PACKAGES}, not hand-maintained — this
+ * regex used to list only five of the ten and silently missed `errors`,
+ * `flags`, `observability`, `platform`, `ratelimit`). An umbrella-only app
+ * has no `@lunora/values` in its `package.json`, so the verbatim qualifier is
+ * a TS2307 in the generated file; rewriting it to `import("lunorash/values")`
+ * resolves through the dependency it actually declares. Add-ons
+ * (`@lunora/agent`, `@lunora/notify`, …) are installed separately either way
+ * and are deliberately left alone.
  */
-const UMBRELLA_QUALIFIER_RE = /import\("@lunora\/(?<pkg>client|do|runtime|server|values)(?<subpath>\/[^"]*)?"\)/gu;
+const UMBRELLA_QUALIFIER_RE = new RegExp(String.raw`import\("@lunora/(?<pkg>${UMBRELLA_BASE_PACKAGES.join("|")})(?<subpath>/[^"]*)?"\)`, "gu");
+
+/**
+ * Deep-subpath forwarding is only safe for a package whose umbrella subpaths
+ * mirror its own subpath exports 1:1 (the umbrella re-exports `&lt;pkg>/&lt;sub>`
+ * for every `&lt;sub>` the package itself exports) — true for every one of the
+ * five ORIGINAL base packages (`client`'s `/query|/auth|/pagination|/ssr|/upload`,
+ * `server`'s `/types|/drizzle|/data-model|/rls/testing|/otel`; `do`, `runtime`,
+ * `values` have no subpaths at all). Two of the five newly-covered packages
+ * break that assumption, checked against `packages/lunora/package.json`
+ * versus each package's own manifest:
+ *
+ * - `flags`: the package exports `/providers/env`, `/providers/flagship`, `/providers/memory`, `/web`; the umbrella flattens/renames three of them to `/env`, `/flagship`, `/memory` and mirrors only `/web` verbatim. Forwarding `/providers/env` verbatim would rewrite into `lunorash/flags/providers/env`, which the umbrella does not export.
+ * - `platform`: the package exports `/conformance` and `/conformance/suite`; the umbrella re-exports only bare `./platform`, no subpaths at all.
+ *
+ * For these two, only a subpath present in the allowlist (or no subpath) is
+ * rewritten; anything else is left untouched rather than rewritten into a
+ * `lunorash/*` specifier that would not resolve. Packages absent from this
+ * map either have no subpaths (`errors`, `observability`, `ratelimit`) or
+ * mirror every subpath 1:1 (`client`, `do`, `runtime`, `server`, `values`) —
+ * forwarding is unconditionally safe for them.
+ */
+const UMBRELLA_MIRRORED_SUBPATHS: Partial<Record<string, ReadonlySet<string>>> = {
+    flags: new Set(["/web"]),
+    platform: new Set(),
+};
 
 /** Rewrite base-package type qualifiers in a rendered generated file to the project's import form. */
 const relocateBaseQualifiers = (rendered: string, useUmbrella: boolean): string =>
     useUmbrella
-        ? rendered.replaceAll(
-              UMBRELLA_QUALIFIER_RE,
-              (_match, packageName: string, subpath: string | undefined) => `import("lunorash/${packageName}${subpath ?? ""}")`,
-          )
+        ? rendered.replaceAll(UMBRELLA_QUALIFIER_RE, (match: string, packageName: string, subpath: string | undefined) => {
+              const mirroredSubpaths = UMBRELLA_MIRRORED_SUBPATHS[packageName];
+
+              // A subpath outside the mirrored set (only reachable for `flags`/
+              // `platform` today) has no matching umbrella export — leave the
+              // qualifier as-is rather than rewrite it into a specifier that
+              // would not resolve.
+              if (subpath && mirroredSubpaths && !mirroredSubpaths.has(subpath)) {
+                  return match;
+              }
+
+              return `import("lunorash/${packageName}${subpath ?? ""}")`;
+          })
         : rendered;
 
 /**
@@ -5927,4 +5975,5 @@ export {
     emitWorkflows,
     emitWranglerCronTriggers,
     GENERATED_HEADER,
+    UMBRELLA_BASE_PACKAGES,
 };


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(codegen): reject non-identifier table names with a pinpointed diagnostic
- fix(codegen): derive the umbrella qualifier rewrite from one shared package list

## Files this branch still changes relative to alpha

```
packages/codegen/__tests__/discover-schema.test.ts
packages/codegen/__tests__/run-codegen.test.ts
packages/codegen/src/discover-schema.ts
packages/codegen/src/emit.ts
```
