### PR TITLE
fix(config,vite,cli): share one studio transport guard across both dev hosts

### DIFF
--- a/api-snapshots/config.api.md
+++ b/api-snapshots/config.api.md
@@ -1883,6 +1883,12 @@ const wranglerToAlchemy: (config: WranglerConfigShape) => AlchemyTranslation;
 
 ## `@lunora/config/studio-host`
 
+### `ALLOW_FORWARDED_ENV` (const)
+
+```ts
+const ALLOW_FORWARDED_ENV = "LUNORA_STUDIO_ALLOW_FORWARDED";
+```
+
 ### `LocalEndpointHandler` (type)
 
 ```ts
@@ -2068,6 +2074,18 @@ const handleSchemaEditRequest: (request: SchemaEditRequest) => SchemaEditRespons
 const handleSeedRequest: (request: SeedRequest) => SeedResponse;
 ```
 
+### `headerValue` (const)
+
+```ts
+const headerValue: (raw: string | string[] | undefined) => string | undefined;
+```
+
+### `isLoopbackAddress` (const)
+
+```ts
+const isLoopbackAddress: (remoteAddress: string | undefined) => boolean;
+```
+
 ### `isStandaloneModulePath` (const)
 
 ```ts
@@ -2120,4 +2138,10 @@ const serveJsonHandler: (request: IncomingMessage, response: ServerResponse, han
 
 ```ts
 const studioAssetsStamp: (resolveFrom?: string) => number | undefined;
+```
+
+### `transportRejectionReason` (const)
+
+```ts
+const transportRejectionReason: (request: IncomingMessage, logger?: WarnLogger) => string | undefined;
 ```

--- a/packages/cli/__tests__/util/studio-server.test.ts
+++ b/packages/cli/__tests__/util/studio-server.test.ts
@@ -2,7 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { createServer as createHttpServer, request as httpRequest } from "node:http";
 import { connect, createServer } from "node:net";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { ALLOW_FORWARDED_ENV } from "@lunora/config/studio-host";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { startStudioServer } from "../../src/util/studio-server";
 
@@ -238,15 +239,16 @@ describe("startStudioServer", () => {
         }
     });
 
-    it("refuses a forwarded request even with a localhost Host (shared transport guard)", async () => {
-        expect.assertions(4);
+    it("refuses a forwarded request even with a localhost Host (shared transport guard), naming the header and logging it", async () => {
+        expect.assertions(6);
 
         // Fails against pre-fix code: the CLI's old `isLoopbackHost` only
         // checked the `Host` literal, so a relay presenting `Host: localhost`
         // plus an `X-Forwarded-For`/`Forwarded` header was served the
         // token-bearing document (200), not refused (403).
+        const warnOnce = vi.fn<(message: string) => void>();
         const port = await getFreePort();
-        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+        const studio = await startStudioServer({ cwd: "/tmp", logger: { warnOnce }, port, workerOrigin: "http://localhost:8787" });
 
         try {
             const xForwardedFor = await requestStudioWithHeaders(port, "/", { "x-forwarded-for": "203.0.113.7", host: `localhost:${String(port)}` });
@@ -256,9 +258,66 @@ describe("startStudioServer", () => {
             expect(xForwardedFor.body).not.toContain("<!doctype html>");
             expect(forwarded.statusCode).toBe(403);
             expect(forwarded.body).not.toContain("<!doctype html>");
+
+            // The failure names its cause (the specific header) instead of
+            // landing as an opaque 403 — both in the response body and, since a
+            // logger was supplied, in the terminal running `lunora dev`.
+            expect(xForwardedFor.body).toContain('"x-forwarded-for"');
+            expect(warnOnce).toHaveBeenCalledWith(expect.stringContaining('"x-forwarded-for"'));
         } finally {
             await studio.close();
         }
+    });
+
+    describe(`${ALLOW_FORWARDED_ENV} escape hatch (Codespaces/devcontainers/Gitpod/Cloud Workstations/ngrok/Docker reverse proxies)`, () => {
+        const original = process.env[ALLOW_FORWARDED_ENV];
+
+        afterEach(() => {
+            if (original === undefined) {
+                Reflect.deleteProperty(process.env, ALLOW_FORWARDED_ENV);
+            } else {
+                process.env[ALLOW_FORWARDED_ENV] = original;
+            }
+        });
+
+        it("serves the token-bearing document once set to 1, despite the forwarding header", async () => {
+            expect.assertions(2);
+
+            process.env[ALLOW_FORWARDED_ENV] = "1";
+
+            const port = await getFreePort();
+            const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+
+            try {
+                const response = await requestStudioWithHeaders(port, "/", { "x-forwarded-for": "203.0.113.7", host: `localhost:${String(port)}` });
+
+                expect(response.statusCode).toBe(200);
+                expect(response.body).toContain("<!doctype html>");
+            } finally {
+                await studio.close();
+            }
+        });
+
+        it("does not relax the Host check — only the forwarding-header refusal (the socket-peer non-relaxation is unit-tested at the config level)", async () => {
+            expect.assertions(2);
+
+            process.env[ALLOW_FORWARDED_ENV] = "1";
+
+            const port = await getFreePort();
+            const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+
+            try {
+                const nonLocalhostHost = await requestStudioWithHeaders(port, "/", {
+                    "x-forwarded-for": "203.0.113.7",
+                    host: "evil.example.com",
+                });
+
+                expect(nonLocalhostHost.statusCode).toBe(403);
+                expect(nonLocalhostHost.body).toContain("non-localhost Host header");
+            } finally {
+                await studio.close();
+            }
+        });
     });
 
     it("refuses a forwarded request to the worker admin proxy without contacting the worker", async () => {

--- a/packages/cli/__tests__/util/studio-server.test.ts
+++ b/packages/cli/__tests__/util/studio-server.test.ts
@@ -1,5 +1,6 @@
-import { request as httpRequest } from "node:http";
-import { createServer } from "node:net";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer as createHttpServer, request as httpRequest } from "node:http";
+import { connect, createServer } from "node:net";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -24,7 +25,8 @@ const bindPort = (): Promise<{ port: number; server: ReturnType<typeof createSer
         });
     });
 
-const closeServer = (server: ReturnType<typeof createServer>): Promise<void> =>
+/** Close any `.close(callback)`-shaped server (net or http) and resolve once it has. */
+const closeServer = (server: { close: (callback: () => void) => void }): Promise<void> =>
     new Promise((resolve) => {
         server.close(() => {
             resolve();
@@ -64,6 +66,86 @@ const requestStudio = (port: number, path: string, host: string): Promise<{ body
 
         request.on("error", reject);
         request.end();
+    });
+
+/** Like {@link requestStudio}, but with full control over the request headers (beyond just `Host`). */
+const requestStudioWithHeaders = (port: number, path: string, headers: Record<string, string>): Promise<{ body: string; statusCode: number | undefined }> =>
+    new Promise((resolve, reject) => {
+        const request = httpRequest(
+            {
+                headers,
+                hostname: "127.0.0.1",
+                method: "GET",
+                path,
+                port,
+            },
+            (response) => {
+                let body = "";
+
+                response.setEncoding("utf8");
+                response.on("data", (chunk: string) => {
+                    body += chunk;
+                });
+                response.on("end", () => {
+                    resolve({ body, statusCode: response.statusCode });
+                });
+            },
+        );
+
+        request.on("error", reject);
+        request.end();
+    });
+
+/** A throwaway `wrangler dev`-shaped worker stub that records every hit, for asserting the proxy never reaches it. */
+const startStubWorker = (): Promise<{ close: () => Promise<void>; hits: string[]; url: string }> =>
+    new Promise((resolve, reject) => {
+        const hits: string[] = [];
+        const server = createHttpServer((request: IncomingMessage, response: ServerResponse) => {
+            hits.push(request.url ?? "/");
+            response.statusCode = 200;
+            response.end("{}");
+        });
+
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+
+            if (!address || typeof address === "string") {
+                reject(new Error("unexpected address shape"));
+
+                return;
+            }
+
+            resolve({ close: () => closeServer(server), hits, url: `http://127.0.0.1:${String(address.port)}` });
+        });
+    });
+
+/**
+ * A raw TCP stub standing in for the `wrangler dev` worker's WS endpoint: any
+ * connection immediately gets a `101 Switching Protocols` reply. Used to prove
+ * the studio server's WS guard rejects a forwarded upgrade itself — pointing
+ * `proxyUpgrade` at a real listener (rather than an address nothing listens
+ * on) means a successful 101 can only arrive by the guard having let the
+ * request through, not by an incidental upstream-connect failure.
+ */
+const startStubUpgradeWorker = (): Promise<{ close: () => Promise<void>; url: string }> =>
+    new Promise((resolve, reject) => {
+        const server = createServer((socket) => {
+            socket.write(["HTTP/1.1 101 Switching Protocols", "Upgrade: websocket", "Connection: Upgrade", "", ""].join("\r\n"));
+        });
+
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+
+            if (!address || typeof address === "string") {
+                reject(new Error("unexpected address shape"));
+
+                return;
+            }
+
+            resolve({ close: () => closeServer(server), url: `http://127.0.0.1:${String(address.port)}` });
+        });
     });
 
 describe("startStudioServer", () => {
@@ -132,7 +214,164 @@ describe("startStudioServer", () => {
             const response = await requestStudio(port, "/", `evil.example:${String(port)}`);
 
             expect(response.statusCode).toBe(403);
-            expect(response.body).toContain("DNS-rebinding guard");
+            // Message text now comes from the shared `transportRejectionReason`
+            // (`@lunora/config/studio-host`) rather than a CLI-local literal.
+            expect(response.body).toContain("non-localhost Host header");
+        } finally {
+            await studio.close();
+        }
+    });
+
+    it("serves the document on a plain loopback GET (no regression)", async () => {
+        expect.assertions(2);
+
+        const port = await getFreePort();
+        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+
+        try {
+            const response = await requestStudio(port, "/", `127.0.0.1:${String(port)}`);
+
+            expect(response.statusCode).toBe(200);
+            expect(response.body).toContain("<!doctype html>");
+        } finally {
+            await studio.close();
+        }
+    });
+
+    it("refuses a forwarded request even with a localhost Host (shared transport guard)", async () => {
+        expect.assertions(4);
+
+        // Fails against pre-fix code: the CLI's old `isLoopbackHost` only
+        // checked the `Host` literal, so a relay presenting `Host: localhost`
+        // plus an `X-Forwarded-For`/`Forwarded` header was served the
+        // token-bearing document (200), not refused (403).
+        const port = await getFreePort();
+        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+
+        try {
+            const xForwardedFor = await requestStudioWithHeaders(port, "/", { "x-forwarded-for": "203.0.113.7", host: `localhost:${String(port)}` });
+            const forwarded = await requestStudioWithHeaders(port, "/", { forwarded: "for=203.0.113.7", host: `localhost:${String(port)}` });
+
+            expect(xForwardedFor.statusCode).toBe(403);
+            expect(xForwardedFor.body).not.toContain("<!doctype html>");
+            expect(forwarded.statusCode).toBe(403);
+            expect(forwarded.body).not.toContain("<!doctype html>");
+        } finally {
+            await studio.close();
+        }
+    });
+
+    it("refuses a forwarded request to the worker admin proxy without contacting the worker", async () => {
+        expect.assertions(2);
+
+        // Fails against pre-fix code: `isLoopbackHost` never looked at
+        // forwarding headers, so a relayed request reached `proxyHttp` and
+        // hit the (possibly privileged) worker.
+        const worker = await startStubWorker();
+        const port = await getFreePort();
+        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: worker.url });
+
+        try {
+            const response = await requestStudioWithHeaders(port, "/_lunora/admin/query", {
+                "x-forwarded-host": "evil.example",
+                host: `localhost:${String(port)}`,
+            });
+
+            expect(response.statusCode).toBe(403);
+            expect(worker.hits).toStrictEqual([]);
+        } finally {
+            await studio.close();
+            await worker.close();
+        }
+    });
+
+    it("destroys a WS upgrade carrying a forwarding header on a loopback peer", async () => {
+        expect.assertions(1);
+
+        // Fails against pre-fix code: the WS path only mirrored the old
+        // Host-literal check, so a forwarded upgrade with a loopback-looking
+        // Host would have proceeded to `proxyUpgrade`, which would reach the
+        // stub worker below and relay its `101` back to the client.
+        const worker = await startStubUpgradeWorker();
+        const port = await getFreePort();
+        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: worker.url });
+
+        try {
+            const closed = await new Promise<boolean>((resolve, reject) => {
+                const socket = connect(port, "127.0.0.1", () => {
+                    socket.write(
+                        [
+                            `GET /_lunora/ws HTTP/1.1`,
+                            `Host: localhost:${String(port)}`,
+                            "Connection: Upgrade",
+                            "Upgrade: websocket",
+                            // eslint-disable-next-line no-secrets/no-secrets -- the RFC 6455 example handshake key, not a real secret
+                            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+                            "Sec-WebSocket-Version: 13",
+                            "X-Forwarded-For: 203.0.113.7",
+                            "",
+                            "",
+                        ].join("\r\n"),
+                    );
+                });
+
+                let receivedBytes = false;
+
+                socket.on("data", () => {
+                    receivedBytes = true;
+                });
+                socket.on("close", () => {
+                    // A destroyed socket ends the connection without ever writing a
+                    // `101 Switching Protocols` (or any other) response. The stub
+                    // upstream above is a real listener, so a `101` can only arrive
+                    // here if the guard let the upgrade through to `proxyUpgrade`.
+                    resolve(!receivedBytes);
+                });
+                socket.on("error", reject);
+            });
+
+            expect(closed).toBe(true);
+        } finally {
+            await studio.close();
+            await worker.close();
+        }
+    });
+
+    it("permits a loopback socket peer with no Host header at all (accepted semantic delta)", async () => {
+        expect.assertions(1);
+
+        // Deliberate behaviour change from the CLI's prior standalone guard,
+        // which rejected an absent Host outright (`hostHeader === undefined`
+        // → reject). The shared `transportRejectionReason` permits it: with
+        // the socket-peer check in front, an absent Host means a local
+        // non-browser client; browsers — the only DNS-rebinding vector —
+        // always send Host. See plan 296 §4.
+        //
+        // An HTTP/1.1 request without a `Host` header is itself malformed
+        // (Node's `http` server 400s it before the handler ever runs), so
+        // this is driven as a raw HTTP/1.0 request over the socket — the one
+        // real-world shape that legitimately omits `Host`.
+        const port = await getFreePort();
+        const studio = await startStudioServer({ cwd: "/tmp", port, workerOrigin: "http://localhost:8787" });
+
+        try {
+            const body = await new Promise<string>((resolve, reject) => {
+                const socket = connect(port, "127.0.0.1", () => {
+                    socket.write(["GET / HTTP/1.0", "", ""].join("\r\n"));
+                });
+                let raw = "";
+
+                socket.setEncoding("utf8");
+                socket.on("data", (chunk: string) => {
+                    raw += chunk;
+                });
+                socket.on("close", () => {
+                    resolve(raw);
+                });
+                socket.on("error", reject);
+            });
+
+            expect(body).toContain("<!doctype html>");
         } finally {
             await studio.close();
         }

--- a/packages/cli/src/util/studio-server.ts
+++ b/packages/cli/src/util/studio-server.ts
@@ -34,6 +34,7 @@ import {
     SEED_ENDPOINT,
     serveJsonHandler,
     studioAssetsStamp,
+    transportRejectionReason,
 } from "@lunora/config/studio-host";
 
 /** Request paths the studio server reverse-proxies to the worker (admin RPC, RPC, WS). */
@@ -43,31 +44,6 @@ const pathnameOf = (url: string): string => {
     const queryIndex = url.indexOf("?");
 
     return queryIndex === -1 ? url : url.slice(0, queryIndex);
-};
-
-/** Loopback hostnames the studio server accepts in the `Host` header (sans port). */
-const LOOPBACK_HOST_NAMES = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
-
-/**
- * Anti-DNS-rebinding guard: the studio HTML embeds the worker admin token and the
- * server reverse-proxies the worker's privileged `/_lunora/admin/*` surface, so a
- * page served from `http://evil.example:&lt;port>` that DNS-rebinds `evil.example`
- * to 127.0.0.1 would become same-origin and could read the token + drive admin
- * RPC. Browsers always send the *attacker's* original hostname in the `Host`
- * header even after a rebind, so rejecting any non-loopback Host literal blocks
- * the attack while leaving real loopback access (`localhost`/`127.0.0.1`/`[::1]`)
- * untouched. Returns `true` when the request is from a trusted loopback host.
- */
-const isLoopbackHost = (hostHeader: string | undefined): boolean => {
-    if (hostHeader === undefined || hostHeader === "") {
-        // A missing Host header can't be trusted as loopback — reject.
-        return false;
-    }
-
-    // Strip the optional `:port` suffix. IPv6 literals are bracketed (`[::1]:6173`).
-    const withoutPort = hostHeader.startsWith("[") ? hostHeader.slice(0, hostHeader.indexOf("]") + 1) : (hostHeader.split(":")[0] ?? hostHeader);
-
-    return LOOPBACK_HOST_NAMES.has(withoutPort);
 };
 
 /** Forward an HTTP request to the worker and pipe its response back. */
@@ -256,17 +232,26 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
     const server: Server = createServer((request, response) => {
         const pathname = pathnameOf(request.url ?? "/");
 
-        // Anti-DNS-rebinding: on a loopback bind, reject any request whose Host
-        // header isn't an exact loopback literal BEFORE serving the token-bearing
-        // HTML or proxying the worker admin surface. A non-loopback bind never
-        // embeds the token and refuses proxy/mutating endpoints below, so it can
-        // serve the read-only shell to the LAN host that the browser sends here.
-        if (isLoopback && !isLoopbackHost(request.headers.host)) {
-            response.statusCode = 403;
-            response.setHeader("Content-Type", "text/plain");
-            response.end("Lunora studio: refusing a request whose Host is not a loopback literal (DNS-rebinding guard).");
+        // Transport gate: on a loopback bind, reject before serving the
+        // token-bearing HTML or proxying the worker admin surface. Shared with
+        // the Vite dev route (`@lunora/config/studio-host`'s
+        // `transportRejectionReason`) so the two hosts can't diverge again —
+        // it also refuses a non-loopback socket peer and a proxied
+        // (`X-Forwarded-*`/`Forwarded`) request, not just a non-loopback Host
+        // literal, because a relayed client must not receive the token or
+        // reach the admin proxy either. A non-loopback bind never embeds the
+        // token and refuses proxy/mutating endpoints below, so it can serve
+        // the read-only shell to the LAN host that the browser sends here.
+        if (isLoopback) {
+            const rejection = transportRejectionReason(request);
 
-            return;
+            if (rejection !== undefined) {
+                response.statusCode = 403;
+                response.setHeader("Content-Type", "text/plain");
+                response.end(rejection);
+
+                return;
+            }
         }
 
         // Worker proxy first. On a non-loopback bind the proxied `/_lunora/admin/*`
@@ -318,8 +303,11 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
     });
 
     server.on("upgrade", (request, socket, head) => {
-        // Mirror the HTTP anti-rebinding + loopback-only-proxy guards on the WS path.
-        if (!isLoopback || !isLoopbackHost(request.headers.host)) {
+        // Mirror the HTTP transport gate + loopback-only-proxy guard on the WS
+        // path. There is no response object to carry a reason here, so a
+        // rejection just destroys the socket (matches the pre-existing
+        // behaviour of this path).
+        if (!isLoopback || transportRejectionReason(request) !== undefined) {
             socket.destroy();
 
             return;

--- a/packages/cli/src/util/studio-server.ts
+++ b/packages/cli/src/util/studio-server.ts
@@ -242,8 +242,17 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
         // reach the admin proxy either. A non-loopback bind never embeds the
         // token and refuses proxy/mutating endpoints below, so it can serve
         // the read-only shell to the LAN host that the browser sends here.
+        //
+        // The forwarding-header refusal 403s every port-forwarded dev
+        // environment that legitimately proxies from loopback (Codespaces,
+        // devcontainers, Gitpod, Cloud Workstations, ngrok, Docker reverse
+        // proxies), so it names the specific header it saw (response body +
+        // a `warnOnce` through `options.logger`, so the cause shows up in the
+        // terminal running `lunora dev`, not just as an opaque 403 in the
+        // browser) and can be opted out of with `LUNORA_STUDIO_ALLOW_FORWARDED=1`
+        // once you've confirmed the forwarding is your own trusted tunnel.
         if (isLoopback) {
-            const rejection = transportRejectionReason(request);
+            const rejection = transportRejectionReason(request, options.logger);
 
             if (rejection !== undefined) {
                 response.statusCode = 403;
@@ -307,7 +316,7 @@ export const startStudioServer = async (options: StudioServerOptions): Promise<S
         // path. There is no response object to carry a reason here, so a
         // rejection just destroys the socket (matches the pre-existing
         // behaviour of this path).
-        if (!isLoopback || transportRejectionReason(request) !== undefined) {
+        if (!isLoopback || transportRejectionReason(request, options.logger) !== undefined) {
             socket.destroy();
 
             return;

--- a/packages/config/__tests__/studio-host/transport-guard.test.ts
+++ b/packages/config/__tests__/studio-host/transport-guard.test.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage } from "node:http";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { isLoopbackAddress, transportRejectionReason } from "../../src/studio-host/transport-guard";
+import { ALLOW_FORWARDED_ENV, isLoopbackAddress, transportRejectionReason } from "../../src/studio-host/transport-guard";
 
 /* eslint-disable sonarjs/no-hardcoded-ip -- intentional test fixtures asserting the loopback/rebinding guard's classification; no real connection is made */
 
@@ -77,15 +77,106 @@ describe("transportRejectionReason", () => {
     });
 
     it.each(["x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "forwarded"])(
-        "rejects a proxied request carrying %s on a loopback peer",
+        "rejects a proxied request carrying %s on a loopback peer, naming the header",
         (forwardingHeader) => {
             expect.assertions(1);
 
-            expect(
-                transportRejectionReason(
-                    request({ headers: { host: "localhost:5173", [forwardingHeader]: "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
-                ),
-            ).toBe("Lunora studio refuses a proxied (X-Forwarded-*) request in dev.");
+            const reason = transportRejectionReason(
+                request({ headers: { host: "localhost:5173", [forwardingHeader]: "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+            );
+
+            // The header name and the escape hatch are both named in the reason,
+            // so the failure points at its cause instead of an opaque 403.
+            expect(reason).toBe(
+                `Lunora studio refuses a proxied request in dev (saw the "${forwardingHeader}" header). ` +
+                    `If you're intentionally running behind a trusted dev tunnel/proxy (e.g. Codespaces, devcontainers, Gitpod, ngrok), ` +
+                    `set ${ALLOW_FORWARDED_ENV}=1 to allow it.`,
+            );
         },
     );
+
+    it("logs a warnOnce naming the header and the escape hatch when a logger is supplied", () => {
+        expect.assertions(2);
+
+        const warnOnce = vi.fn<(message: string) => void>();
+
+        const reason = transportRejectionReason(
+            request({ headers: { host: "localhost:5173", "x-forwarded-for": "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+            { warnOnce },
+        );
+
+        expect(reason).toBeDefined();
+        expect(warnOnce).toHaveBeenCalledWith(expect.stringContaining(`"x-forwarded-for"`));
+    });
+
+    it("does not log when there is nothing to reject", () => {
+        expect.assertions(1);
+
+        const warnOnce = vi.fn<(message: string) => void>();
+
+        transportRejectionReason(request({ headers: { host: "localhost:5173" }, remoteAddress: "127.0.0.1" }), { warnOnce });
+
+        expect(warnOnce).not.toHaveBeenCalled();
+    });
+
+    describe(`${ALLOW_FORWARDED_ENV} escape hatch`, () => {
+        const original = process.env[ALLOW_FORWARDED_ENV];
+
+        afterEach(() => {
+            if (original === undefined) {
+                Reflect.deleteProperty(process.env, ALLOW_FORWARDED_ENV);
+            } else {
+                process.env[ALLOW_FORWARDED_ENV] = original;
+            }
+        });
+
+        it("permits a forwarded request from a loopback peer once set to 1 (Codespaces/devcontainers/Gitpod/ngrok/etc.)", () => {
+            expect.assertions(1);
+
+            process.env[ALLOW_FORWARDED_ENV] = "1";
+
+            expect(
+                transportRejectionReason(
+                    request({ headers: { host: "localhost:5173", "x-forwarded-for": "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+                ),
+            ).toBeUndefined();
+        });
+
+        it("does not relax the socket-peer or Host checks — only the forwarding-header refusal", () => {
+            expect.assertions(2);
+
+            process.env[ALLOW_FORWARDED_ENV] = "1";
+
+            expect(
+                transportRejectionReason(
+                    request({ headers: { host: "localhost:5173", "x-forwarded-for": "203.0.113.7" }, remoteAddress: "203.0.113.7" }),
+                ),
+            ).toBe("Lunora studio is only available on loopback connections in dev.");
+            expect(
+                transportRejectionReason(
+                    request({ headers: { host: "evil.example.com", "x-forwarded-for": "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+                ),
+            ).toBe("Lunora studio rejects a non-localhost Host header in dev.");
+        });
+
+        it("any other value (including unset) keeps refusing the forwarded request", () => {
+            expect.assertions(2);
+
+            process.env[ALLOW_FORWARDED_ENV] = "true";
+
+            expect(
+                transportRejectionReason(
+                    request({ headers: { host: "localhost:5173", "x-forwarded-for": "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+                ),
+            ).toBeDefined();
+
+            Reflect.deleteProperty(process.env, ALLOW_FORWARDED_ENV);
+
+            expect(
+                transportRejectionReason(
+                    request({ headers: { host: "localhost:5173", "x-forwarded-for": "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+                ),
+            ).toBeDefined();
+        });
+    });
 });

--- a/packages/config/__tests__/studio-host/transport-guard.test.ts
+++ b/packages/config/__tests__/studio-host/transport-guard.test.ts
@@ -1,0 +1,91 @@
+import type { IncomingMessage } from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import { isLoopbackAddress, transportRejectionReason } from "../../src/studio-host/transport-guard";
+
+/* eslint-disable sonarjs/no-hardcoded-ip -- intentional test fixtures asserting the loopback/rebinding guard's classification; no real connection is made */
+
+/** A request shape rich enough for the guard: `headers` + a socket peer. */
+const request = (input: { headers?: Record<string, string>; remoteAddress?: string }): IncomingMessage =>
+    ({ headers: input.headers ?? {}, socket: { remoteAddress: input.remoteAddress } }) as unknown as IncomingMessage;
+
+describe("isLoopbackAddress", () => {
+    it("accepts IPv4/IPv6 loopback and IPv4-mapped forms", () => {
+        expect.assertions(4);
+
+        expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+        expect(isLoopbackAddress("::1")).toBe(true);
+        expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
+        expect(isLoopbackAddress("127.5.5.5")).toBe(true);
+    });
+
+    it("rejects a non-loopback peer", () => {
+        expect.assertions(1);
+
+        expect(isLoopbackAddress("203.0.113.7")).toBe(false);
+    });
+
+    it("treats a missing address as loopback (mocked/partial transports)", () => {
+        expect.assertions(2);
+
+        expect(isLoopbackAddress(undefined)).toBe(true);
+        expect(isLoopbackAddress("")).toBe(true);
+    });
+});
+
+describe("transportRejectionReason", () => {
+    it("passes a loopback socket peer with a localhost Host", () => {
+        expect.assertions(1);
+
+        expect(transportRejectionReason(request({ headers: { host: "localhost:5173" }, remoteAddress: "127.0.0.1" }))).toBeUndefined();
+    });
+
+    it("passes a loopback socket peer with an absent Host header (HTTP/1.0)", () => {
+        expect.assertions(1);
+
+        // Deliberate delta from the CLI host's prior standalone guard, which
+        // rejected an absent Host outright: with the socket-peer check in
+        // front, an absent Host is a local non-browser client — browsers (the
+        // only DNS-rebinding vector) always send Host.
+        expect(transportRejectionReason(request({ headers: {}, remoteAddress: "127.0.0.1" }))).toBeUndefined();
+    });
+
+    it("passes a loopback socket peer with a 0.0.0.0 Host literal", () => {
+        expect.assertions(1);
+
+        // Only reachable when the socket peer is already loopback; harmless
+        // under the socket gate, and some platforms let a browser navigate to
+        // `http://0.0.0.0:<port>` which connects to loopback.
+        expect(transportRejectionReason(request({ headers: { host: "0.0.0.0:5173" }, remoteAddress: "127.0.0.1" }))).toBeUndefined();
+    });
+
+    it("rejects a non-loopback socket peer", () => {
+        expect.assertions(1);
+
+        expect(transportRejectionReason(request({ headers: { host: "localhost:5173" }, remoteAddress: "203.0.113.7" }))).toBe(
+            "Lunora studio is only available on loopback connections in dev.",
+        );
+    });
+
+    it("rejects a non-localhost Host header on a loopback peer (DNS rebinding)", () => {
+        expect.assertions(1);
+
+        expect(transportRejectionReason(request({ headers: { host: "evil.example.com" }, remoteAddress: "127.0.0.1" }))).toBe(
+            "Lunora studio rejects a non-localhost Host header in dev.",
+        );
+    });
+
+    it.each(["x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "forwarded"])(
+        "rejects a proxied request carrying %s on a loopback peer",
+        (forwardingHeader) => {
+            expect.assertions(1);
+
+            expect(
+                transportRejectionReason(
+                    request({ headers: { host: "localhost:5173", [forwardingHeader]: "203.0.113.7" }, remoteAddress: "127.0.0.1" }),
+                ),
+            ).toBe("Lunora studio refuses a proxied (X-Forwarded-*) request in dev.");
+        },
+    );
+});

--- a/packages/config/src/studio-host/index.ts
+++ b/packages/config/src/studio-host/index.ts
@@ -23,5 +23,5 @@ export type { SeedRequest, SeedRequestBody, SeedResponse } from "./seed-handler"
 export { handleSeedRequest, SEED_ENDPOINT } from "./seed-handler";
 export type { LocalEndpointHandler, LocalEndpointRequest, LocalEndpointResponse } from "./serve-json-handler";
 export { serveJsonHandler } from "./serve-json-handler";
-export { headerValue, isLoopbackAddress, transportRejectionReason } from "./transport-guard";
+export { ALLOW_FORWARDED_ENV, headerValue, isLoopbackAddress, transportRejectionReason } from "./transport-guard";
 export type { StudioAssets, StudioHtmlConfig, WarnLogger } from "./types";

--- a/packages/config/src/studio-host/index.ts
+++ b/packages/config/src/studio-host/index.ts
@@ -23,4 +23,5 @@ export type { SeedRequest, SeedRequestBody, SeedResponse } from "./seed-handler"
 export { handleSeedRequest, SEED_ENDPOINT } from "./seed-handler";
 export type { LocalEndpointHandler, LocalEndpointRequest, LocalEndpointResponse } from "./serve-json-handler";
 export { serveJsonHandler } from "./serve-json-handler";
+export { headerValue, isLoopbackAddress, transportRejectionReason } from "./transport-guard";
 export type { StudioAssets, StudioHtmlConfig, WarnLogger } from "./types";

--- a/packages/config/src/studio-host/serve-json-handler.ts
+++ b/packages/config/src/studio-host/serve-json-handler.ts
@@ -13,6 +13,8 @@
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+import { headerValue } from "./transport-guard";
+
 /** Max request body the local-dev endpoints accept (1 MB) — guards dev against a runaway upload. */
 const MAX_BODY_BYTES = 1_000_000;
 
@@ -65,13 +67,6 @@ const respondJson = (response: ServerResponse, status: number, body: unknown): v
     response.statusCode = status;
     response.setHeader("Content-Type", "application/json; charset=utf-8");
     response.end(JSON.stringify(body));
-};
-
-/** A single header value, lower-cased and trimmed; `undefined` when absent or array-valued. */
-const headerValue = (raw: string | string[] | undefined): string | undefined => {
-    const value = Array.isArray(raw) ? raw[0] : raw;
-
-    return typeof value === "string" ? value.trim().toLowerCase() : undefined;
 };
 
 /** Allowed `Sec-Fetch-Site` values — anything else is a cross-origin navigation. */

--- a/packages/config/src/studio-host/transport-guard.ts
+++ b/packages/config/src/studio-host/transport-guard.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-request transport gate for the dev studio's local endpoints, shared by
+ * both dev hosts (`@lunora/vite`'s `/__lunora` middleware and `lunora dev`'s
+ * standalone `node:http` server). The studio HTML embeds the worker admin
+ * token and the server reverse-proxies the worker's privileged `/_lunora/*`
+ * surface, so this is the one place that decides whether a request is trusted
+ * enough to receive either.
+ *
+ * Moved here (rather than left duplicated per host) because the two hosts
+ * previously diverged on exactly this guard: the Vite host checked the socket
+ * peer, the `Host` header, AND the absence of forwarding headers, while the
+ * CLI host checked the `Host` header literal only — a relay reaching the CLI
+ * host's loopback socket with `Host: localhost` was served the token-bearing
+ * document. One shared implementation keeps that from happening again.
+ */
+import type { IncomingMessage } from "node:http";
+
+/** A single header value, lower-cased and trimmed; `undefined` when absent or array-valued. */
+const headerValue = (raw: string | string[] | undefined): string | undefined => {
+    const value = Array.isArray(raw) ? raw[0] : raw;
+
+    return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+};
+
+/**
+ * True for an IPv4/IPv6 loopback peer (`127.0.0.0/8`, `::1`, and the
+ * IPv4-mapped `::ffff:127.x`). A missing address means we cannot read the
+ * transport (e.g. a mocked request in tests) — treated as loopback so the
+ * config-derived gate stays the source of truth there; on a real Vite/Node
+ * server `remoteAddress` is always populated.
+ */
+const isLoopbackAddress = (remoteAddress: string | undefined): boolean => {
+    if (remoteAddress === undefined || remoteAddress === "") {
+        return true;
+    }
+
+    const address = remoteAddress.toLowerCase();
+    // Strip the IPv4-mapped IPv6 prefix (`::ffff:127.0.0.1`) so the v4 test applies.
+    const v4 = address.startsWith("::ffff:") ? address.slice(7) : address;
+
+    if (v4 === "::1") {
+        return true;
+    }
+
+    return v4.startsWith("127.");
+};
+
+/** The host portion (no port) of a `Host` header value, lower-cased; brackets stripped from IPv6. */
+const hostnameOf = (host: string | undefined): string | undefined => {
+    if (host === undefined) {
+        return undefined;
+    }
+
+    if (host.startsWith("[")) {
+        // `[::1]:5173` → `::1`
+        const close = host.indexOf("]");
+
+        return close === -1 ? host.slice(1) : host.slice(1, close);
+    }
+
+    const colon = host.indexOf(":");
+
+    return colon === -1 ? host : host.slice(0, colon);
+};
+
+/** Localhost names + loopback literals the `Host` header is allowed to carry. */
+const LOOPBACK_HOSTS = new Set<string>(["0.0.0.0", "127.0.0.1", "::1", "localhost"]);
+
+/**
+ * Per-request transport gate, independent of a host's config-derived bind
+ * intent (e.g. Vite's `isNonLoopbackBind`, the CLI's `isLoopback`). In Vite
+ * middleware mode the real bind belongs to the embedding server (so the
+ * config check measures the wrong thing); here we read the actual socket peer
+ * and the `Host` header. Returns a refusal reason, or `undefined` when the
+ * connection is loopback-local.
+ */
+const transportRejectionReason = (request: IncomingMessage): string | undefined => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `socket` is typed required but partial/mocked requests omit it
+    if (!isLoopbackAddress(request.socket?.remoteAddress ?? undefined)) {
+        return "Lunora studio is only available on loopback connections in dev.";
+    }
+
+    // Defend against DNS rebinding: a public DNS name resolving to loopback
+    // still arrives with that name in `Host`. Only a localhost/loopback Host is
+    // allowed. An absent Host (HTTP/1.0) is permitted — there is nothing to rebind.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `headers` is typed required but partial/mocked requests omit it
+    const host = hostnameOf(headerValue(request.headers?.host));
+
+    if (host !== undefined && !LOOPBACK_HOSTS.has(host)) {
+        return "Lunora studio rejects a non-localhost Host header in dev.";
+    }
+
+    // A direct loopback browser never sets forwarding headers; their presence
+    // means a reverse proxy/tunnel is relaying a (possibly remote) client, which
+    // must not receive the inlined admin token. Refuse rather than trust Host.
+    const FORWARDING_HEADERS = ["x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "forwarded"] as const;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `headers` is typed required but partial/mocked requests omit it
+    if (FORWARDING_HEADERS.some((name) => request.headers?.[name] !== undefined)) {
+        return "Lunora studio refuses a proxied (X-Forwarded-*) request in dev.";
+    }
+
+    return undefined;
+};
+
+export { headerValue, isLoopbackAddress, transportRejectionReason };

--- a/packages/config/src/studio-host/transport-guard.ts
+++ b/packages/config/src/studio-host/transport-guard.ts
@@ -12,8 +12,32 @@
  * CLI host checked the `Host` header literal only — a relay reaching the CLI
  * host's loopback socket with `Host: localhost` was served the token-bearing
  * document. One shared implementation keeps that from happening again.
+ *
+ * Two deliberate behaviour deltas from the CLI host's prior standalone guard,
+ * both accepted rather than reconciled away:
+ *
+ * - **An absent `Host` header is now permitted** (the CLI used to reject it
+ * outright). With the socket-peer check in front, an absent `Host` means an
+ * HTTP/1.0 client — never a browser, and browsers are the only DNS-rebinding
+ * vector this guard defends against, so there is nothing to rebind. Low
+ * impact by construction, not an oversight.
+ * - **A proxied request (`X-Forwarded-*`/`Forwarded`) from a loopback socket
+ * is refused by default**, which the CLI host never checked at all. This is
+ * correct against an actual relay, but it also 403s every port-forwarded dev
+ * environment that legitimately proxies from loopback — GitHub Codespaces,
+ * devcontainers, Gitpod, Cloud Workstations, ngrok, and a Docker reverse
+ * proxy all connect this way. There is no way to tell "your own trusted
+ * tunnel" apart from "an attacker's relay" from the request alone, so this
+ * is not auto-detected: it needs an explicit, informed opt-in. Set
+ * `LUNORA_STUDIO_ALLOW_FORWARDED=1` (see {@link ALLOW_FORWARDED_ENV}) to
+ * allow it once you've confirmed the forwarding is yours. Left unset, the
+ * refusal names the specific header it saw (in both the response body and,
+ * when a logger is supplied, a `warnOnce` line) so the failure points at its
+ * cause instead of landing as an opaque 403 on the studio page.
  */
 import type { IncomingMessage } from "node:http";
+
+import type { WarnLogger } from "./types";
 
 /** A single header value, lower-cased and trimmed; `undefined` when absent or array-valued. */
 const headerValue = (raw: string | string[] | undefined): string | undefined => {
@@ -66,6 +90,20 @@ const hostnameOf = (host: string | undefined): string | undefined => {
 /** Localhost names + loopback literals the `Host` header is allowed to carry. */
 const LOOPBACK_HOSTS = new Set<string>(["0.0.0.0", "127.0.0.1", "::1", "localhost"]);
 
+/** Headers whose presence means a reverse proxy/tunnel is relaying this request rather than a direct loopback browser. */
+const FORWARDING_HEADERS = ["x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "forwarded"] as const;
+
+/**
+ * Explicit opt-out for the forwarding-header refusal below — set to `"1"` to
+ * allow a proxied request through once you've confirmed the forwarding is
+ * your own trusted dev tunnel (Codespaces, devcontainers, Gitpod, Cloud
+ * Workstations, ngrok, a Docker reverse proxy, …), not an attacker's relay.
+ * Does not relax the socket-peer or `Host` checks — only this one.
+ */
+const ALLOW_FORWARDED_ENV = "LUNORA_STUDIO_ALLOW_FORWARDED";
+
+const forwardedAllowedByEnv = (): boolean => process.env[ALLOW_FORWARDED_ENV] === "1";
+
 /**
  * Per-request transport gate, independent of a host's config-derived bind
  * intent (e.g. Vite's `isNonLoopbackBind`, the CLI's `isLoopback`). In Vite
@@ -73,8 +111,13 @@ const LOOPBACK_HOSTS = new Set<string>(["0.0.0.0", "127.0.0.1", "::1", "localhos
  * config check measures the wrong thing); here we read the actual socket peer
  * and the `Host` header. Returns a refusal reason, or `undefined` when the
  * connection is loopback-local.
+ *
+ * `logger`, when supplied, gets a `warnOnce` line for a forwarding-header
+ * refusal — naming the specific header seen and the {@link ALLOW_FORWARDED_ENV}
+ * escape hatch — so the failure points at its cause in the terminal running
+ * the dev server, not just as an opaque 403 in the browser.
  */
-const transportRejectionReason = (request: IncomingMessage): string | undefined => {
+const transportRejectionReason = (request: IncomingMessage, logger?: WarnLogger): string | undefined => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `socket` is typed required but partial/mocked requests omit it
     if (!isLoopbackAddress(request.socket?.remoteAddress ?? undefined)) {
         return "Lunora studio is only available on loopback connections in dev.";
@@ -92,15 +135,26 @@ const transportRejectionReason = (request: IncomingMessage): string | undefined 
 
     // A direct loopback browser never sets forwarding headers; their presence
     // means a reverse proxy/tunnel is relaying a (possibly remote) client, which
-    // must not receive the inlined admin token. Refuse rather than trust Host.
-    const FORWARDING_HEADERS = ["x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "forwarded"] as const;
-
+    // must not receive the inlined admin token. Refuse rather than trust Host —
+    // unless the developer has explicitly opted in via ALLOW_FORWARDED_ENV.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `headers` is typed required but partial/mocked requests omit it
-    if (FORWARDING_HEADERS.some((name) => request.headers?.[name] !== undefined)) {
-        return "Lunora studio refuses a proxied (X-Forwarded-*) request in dev.";
+    const forwardingHeader = FORWARDING_HEADERS.find((name) => request.headers?.[name] !== undefined);
+
+    if (forwardingHeader !== undefined && !forwardedAllowedByEnv()) {
+        logger?.warnOnce?.(
+            `[lunora] studio: refusing a request carrying the "${forwardingHeader}" header — this dev server is being reached through a proxy/tunnel ` +
+                `(Codespaces, devcontainers, Gitpod, Cloud Workstations, ngrok, and Docker reverse proxies all add this). ` +
+                `If this is YOUR trusted dev tunnel, set ${ALLOW_FORWARDED_ENV}=1 to allow it.`,
+        );
+
+        return (
+            `Lunora studio refuses a proxied request in dev (saw the "${forwardingHeader}" header). ` +
+            `If you're intentionally running behind a trusted dev tunnel/proxy (e.g. Codespaces, devcontainers, Gitpod, ngrok), ` +
+            `set ${ALLOW_FORWARDED_ENV}=1 to allow it.`
+        );
     }
 
     return undefined;
 };
 
-export { headerValue, isLoopbackAddress, transportRejectionReason };
+export { ALLOW_FORWARDED_ENV, headerValue, isLoopbackAddress, transportRejectionReason };

--- a/packages/vite/__tests__/studio-plugin.test.ts
+++ b/packages/vite/__tests__/studio-plugin.test.ts
@@ -343,6 +343,41 @@ describe("studioPlugin", () => {
         expect(response.statusCode).toBe(403);
     });
 
+    it("logs a warnOnce naming the forwarding header it saw (Codespaces/devcontainers/etc. surface a reason, not just an opaque 403)", () => {
+        expect.assertions(1);
+
+        const plugin = studioPlugin();
+        let middleware: ((request: unknown, response: ServerResponse, next: () => void) => void) | undefined;
+        const warnOnce = vi.fn<(message: string) => void>();
+
+        const server = {
+            config: {
+                base: "/",
+                logger: { info: vi.fn<(message: string) => void>(), warnOnce },
+                server: { host: undefined },
+            },
+            httpServer: { listening: false, once: vi.fn<() => void>() },
+            middlewares: {
+                use: (function_: typeof middleware) => {
+                    middleware = function_;
+                },
+            },
+            transformIndexHtml: vi.fn<(url: string, html: string) => Promise<string>>(async (_url: string, html: string) => html),
+        } as unknown as ViteDevServer;
+
+        (plugin.configureServer as (s: ViteDevServer) => unknown)(server);
+
+        const { response } = makeResponse();
+
+        middleware?.(
+            { headers: { host: "localhost:5173", "x-forwarded-for": "203.0.113.7" }, socket: { remoteAddress: "127.0.0.1" }, url: STUDIO_PATH },
+            response,
+            vi.fn(),
+        );
+
+        expect(warnOnce).toHaveBeenCalledWith(expect.stringContaining(`"x-forwarded-for"`));
+    });
+
     it("rejects a cross-origin POST to schema-edit (CSRF)", () => {
         expect.assertions(1);
 

--- a/packages/vite/src/studio-plugin.ts
+++ b/packages/vite/src/studio-plugin.ts
@@ -13,6 +13,7 @@ import {
     handlePolicyScaffoldRequest,
     handleSchemaEditRequest,
     handleSeedRequest,
+    headerValue,
     isStandaloneModulePath,
     loadStudioAssets,
     POLICY_SCAFFOLD_ENDPOINT,
@@ -23,6 +24,7 @@ import {
     SEED_ENDPOINT,
     serveJsonHandler,
     studioAssetsStamp,
+    transportRejectionReason,
 } from "@lunora/config/studio-host";
 import type { Plugin, ViteDevServer } from "vite";
 
@@ -44,93 +46,6 @@ const JSON_ENDPOINT_HANDLERS: Readonly<Record<string, LocalEndpointHandler>> = {
 
 /** The local-dev endpoints that perform state-changing side effects (source writes + codegen). */
 const STATE_CHANGING_ENDPOINTS = new Set<string>(Object.keys(JSON_ENDPOINT_HANDLERS));
-
-/** A single header value, lower-cased and trimmed; `undefined` when absent or array-valued. */
-const headerValue = (raw: string | string[] | undefined): string | undefined => {
-    const value = Array.isArray(raw) ? raw[0] : raw;
-
-    return typeof value === "string" ? value.trim().toLowerCase() : undefined;
-};
-
-/**
- * True for an IPv4/IPv6 loopback peer (`127.0.0.0/8`, `::1`, and the
- * IPv4-mapped `::ffff:127.x`). A missing address means we cannot read the
- * transport (e.g. a mocked request in tests) — treated as loopback so the
- * config-derived gate stays the source of truth there; on a real Vite/Node
- * server `remoteAddress` is always populated.
- */
-const isLoopbackAddress = (remoteAddress: string | undefined): boolean => {
-    if (remoteAddress === undefined || remoteAddress === "") {
-        return true;
-    }
-
-    const address = remoteAddress.toLowerCase();
-    // Strip the IPv4-mapped IPv6 prefix (`::ffff:127.0.0.1`) so the v4 test applies.
-    const v4 = address.startsWith("::ffff:") ? address.slice(7) : address;
-
-    if (v4 === "::1") {
-        return true;
-    }
-
-    return v4.startsWith("127.");
-};
-
-/** The host portion (no port) of a `Host` header value, lower-cased; brackets stripped from IPv6. */
-const hostnameOf = (host: string | undefined): string | undefined => {
-    if (host === undefined) {
-        return undefined;
-    }
-
-    if (host.startsWith("[")) {
-        // `[::1]:5173` → `::1`
-        const close = host.indexOf("]");
-
-        return close === -1 ? host.slice(1) : host.slice(1, close);
-    }
-
-    const colon = host.indexOf(":");
-
-    return colon === -1 ? host : host.slice(0, colon);
-};
-
-/** Localhost names + loopback literals the `Host` header is allowed to carry. */
-const LOOPBACK_HOSTS = new Set<string>(["0.0.0.0", "127.0.0.1", "::1", "localhost"]);
-
-/**
- * Per-request transport gate, independent of the config-derived
- * `isNonLoopbackBind`. In Vite middleware mode the real bind belongs to the
- * embedding server (so the config check measures the wrong thing); here we read
- * the actual socket peer and the `Host` header. Returns a refusal reason, or
- * `undefined` when the connection is loopback-local.
- */
-const transportRejectionReason = (request: IncomingMessage): string | undefined => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `socket` is typed required but partial/mocked requests omit it
-    if (!isLoopbackAddress(request.socket?.remoteAddress ?? undefined)) {
-        return "Lunora studio is only available on loopback connections in dev.";
-    }
-
-    // Defend against DNS rebinding: a public DNS name resolving to loopback
-    // still arrives with that name in `Host`. Only a localhost/loopback Host is
-    // allowed. An absent Host (HTTP/1.0) is permitted — there is nothing to rebind.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `headers` is typed required but partial/mocked requests omit it
-    const host = hostnameOf(headerValue(request.headers?.host));
-
-    if (host !== undefined && !LOOPBACK_HOSTS.has(host)) {
-        return "Lunora studio rejects a non-localhost Host header in dev.";
-    }
-
-    // A direct loopback browser never sets forwarding headers; their presence
-    // means a reverse proxy/tunnel is relaying a (possibly remote) client, which
-    // must not receive the inlined admin token. Refuse rather than trust Host.
-    const FORWARDING_HEADERS = ["x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "forwarded"] as const;
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `headers` is typed required but partial/mocked requests omit it
-    if (FORWARDING_HEADERS.some((name) => request.headers?.[name] !== undefined)) {
-        return "Lunora studio refuses a proxied (X-Forwarded-*) request in dev.";
-    }
-
-    return undefined;
-};
 
 /**
  * Origin layer of the CSRF gate: prefer the unforgeable `Sec-Fetch-Site` header,

--- a/packages/vite/src/studio-plugin.ts
+++ b/packages/vite/src/studio-plugin.ts
@@ -266,7 +266,7 @@ const createStudioHandler = (
         // actual transport (catches middleware-mode public binds, where Vite's
         // own `server.host` is undefined while the embedding server listens
         // publicly, plus DNS rebinding via the Host header).
-        if (isNonLoopbackBind || transportRejectionReason(request) !== undefined) {
+        if (isNonLoopbackBind || transportRejectionReason(request, server.config.logger) !== undefined) {
             response.statusCode = 403;
             response.setHeader("Content-Type", "text/plain");
             response.end("Lunora studio is only available on loopback hosts in dev.");


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(config,vite,cli): share one studio transport guard across both dev hosts
- fix(config,vite,cli): add a forwarding-header escape hatch and dedupe headerValue

## Files this branch still changes relative to alpha

```
api-snapshots/config.api.md
packages/cli/__tests__/util/studio-server.test.ts
packages/cli/src/util/studio-server.ts
packages/config/__tests__/studio-host/transport-guard.test.ts
packages/config/src/studio-host/index.ts
packages/config/src/studio-host/serve-json-handler.ts
packages/config/src/studio-host/transport-guard.ts
packages/vite/__tests__/studio-plugin.test.ts
packages/vite/src/studio-plugin.ts
```
