### PR TITLE
perf(mcp): share one bounded client cache across local tools and resources

### DIFF
--- a/packages/mcp/__tests__/local.test.ts
+++ b/packages/mcp/__tests__/local.test.ts
@@ -1,6 +1,7 @@
 import type { FunctionDescriptor } from "@lunora/client";
+import { LunoraClient } from "@lunora/client";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { ListResourcesRequestSchema, ReadResourceRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { CallToolRequestSchema, ListResourcesRequestSchema, ReadResourceRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it, vi } from "vitest";
 
 import type { LocalDeployment } from "../src/local";
@@ -252,5 +253,56 @@ describe("deployment spec resources", () => {
         await handlerFor(server, ReadResourceRequestSchema.shape.method.value)({ params: { uri: OPENRPC_RESOURCE_URI } });
 
         expect(sawAuthorization).toBe(true);
+    });
+});
+
+describe("shared client cache", () => {
+    it("shares one client across the tool and resource surfaces for the same deployment", async () => {
+        expect.assertions(1);
+
+        // A fresh `LunoraClient` per surface (the pre-fix duplication —
+        // `lazyDeploymentTools` and `deploymentSpecResources` each built their
+        // own `createClientCache`) would set the auth token twice: once for
+        // the tool-side client, once for the resource-side client. Sharing one
+        // cache across both means the token is set exactly once, on first
+        // construction.
+        const { asFetch } = stubFetch();
+        const setAuthTokenSpy = vi.spyOn(LunoraClient.prototype, "setAuthToken");
+
+        const server = createLocalMcpServer({ deployment: { token: "shared-token", url: "https://worker.example" }, fetch: asFetch });
+
+        await handlerFor(server, CallToolRequestSchema.shape.method.value)({ params: { arguments: {}, name: "lunora_list_functions" } });
+        await handlerFor(server, ReadResourceRequestSchema.shape.method.value)({ params: { uri: OPENRPC_RESOURCE_URI } });
+
+        expect(setAuthTokenSpy).toHaveBeenCalledTimes(1);
+
+        setAuthTokenSpy.mockRestore();
+    });
+
+    it("keeps working after the client cache evicts the oldest entry past its bound", async () => {
+        expect.assertions(1);
+
+        // No assertion on map internals — the FIFO bound (`shared/evict-oldest.ts`,
+        // capacity 8) just means the first deployment's client gets silently
+        // replaced once 9 distinct deployments have been seen. Re-requesting it
+        // must still work (a fresh client minted transparently), not error.
+        const { asFetch } = stubFetch();
+        const deployments = Array.from({ length: 9 }, (_, index): LocalDeployment => {return { url: `https://worker-${String(index)}.example` }});
+        let current = 0;
+
+        const tools = localTools({ deployment: () => deployments[current], docs: false, fetch: asFetch });
+        const listFunctions = tools.find((tool) => tool.definition.name === "lunora_list_functions");
+
+        for (; current < deployments.length; current += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential rotation through distinct deployments, mirroring a dev-server restart sequence
+            await listFunctions?.handle({});
+        }
+
+        // Re-request the first (now-evicted) deployment.
+        current = 0;
+
+        const result = await listFunctions?.handle({});
+
+        expect(result?.isError).not.toBe(true);
     });
 });

--- a/packages/mcp/src/local.ts
+++ b/packages/mcp/src/local.ts
@@ -21,6 +21,10 @@ import { LunoraClient } from "@lunora/client";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
+// `shared/` is bundler-inlined (not a package): relative import, no `.js`
+// extension, and this package's tsconfig drops `outDir`/`rootDir` for it (see
+// packages/mcp/tsconfig.json).
+import { evictOldestEntry } from "../../../shared/evict-oldest";
 import type { McpResourceProvider, McpResourceSummary, McpTool } from "./compose";
 import { createToolServer } from "./compose";
 import { createRemoteDocsIndex } from "./docs/remote-index";
@@ -84,11 +88,29 @@ const NO_DEPLOYMENT_MESSAGE =
     "no Lunora dev server is running for this project — start one with `lunora dev`, then call this tool again (call lunora_dev_status to check).";
 
 /**
- * Reuse one `LunoraClient` per `url|token` pair.
+ * Small — the realistic population is one dev server plus a handful of stale
+ * restarts, not a long tail of distinct deployments.
+ */
+const MAX_CLIENT_CACHE = 8;
+
+/**
+ * Reuse one `LunoraClient` per `url|token` pair, shared by both the tool and
+ * resource surfaces (one instance built by {@link createLocalMcpServer} and
+ * injected into both), so a tool call and a resource read against the same
+ * deployment share one client instead of minting their own.
  *
  * Not just an allocation win: `tools.ts` memoizes the deployment's function
- * registry in a `WeakMap` keyed by client, so minting a fresh client per call
- * would re-fetch that registry on every single tool call.
+ * registry in a `WeakMap` keyed by client, so minting a fresh client per
+ * surface would re-fetch that registry on every single tool call.
+ *
+ * Bounded FIFO (`evictOldestEntry`, `shared/evict-oldest.ts`): this server is
+ * long-lived by design (an editor spawns it once and keeps it alive across
+ * every `lunora dev` restart afterwards — see the resolver rationale above),
+ * and every restart can rotate the dev server's port/token, so an unbounded
+ * map would accrete one dead client per restart for the process's life.
+ * Evicting a client whose request is still in flight is safe — eviction only
+ * drops the map's reference; the in-flight call keeps its own reference to
+ * the client alive.
  */
 const createClientCache = (fetchImplementation: typeof fetch | undefined): ((deployment: LocalDeployment) => LunoraClient) => {
     const cache = new Map<string, LunoraClient>();
@@ -109,6 +131,7 @@ const createClientCache = (fetchImplementation: typeof fetch | undefined): ((dep
             client.setAuthToken(deployment.token);
         }
 
+        evictOldestEntry(cache, MAX_CLIENT_CACHE);
         cache.set(key, client);
 
         return client;
@@ -124,9 +147,12 @@ const createClientCache = (fetchImplementation: typeof fetch | undefined): ((dep
  * session. Calling one while nothing is running returns an actionable error
  * instead.
  */
-const lazyDeploymentTools = (source: LocalDeploymentSource, allowWrites: boolean, fetchImplementation: typeof fetch | undefined): ReadonlyArray<McpTool> => {
+const lazyDeploymentTools = (
+    source: LocalDeploymentSource,
+    allowWrites: boolean,
+    clientFor: (deployment: LocalDeployment) => LunoraClient,
+): ReadonlyArray<McpTool> => {
     const resolve = typeof source === "function" ? source : (): LocalDeployment => source;
-    const clientFor = createClientCache(fetchImplementation);
 
     return toolDefinitions(allowWrites).map((definition) => {
         return {
@@ -198,9 +224,8 @@ const SPEC_RESOURCE_ENTRIES: ReadonlyArray<SpecResourceEntry> = [
  * endpoint but no spec configured still resolves 200 with an empty document,
  * so it stays listed — only a hard failure omits it.
  */
-const deploymentSpecResources = (source: LocalDeploymentSource, fetchImplementation: typeof fetch | undefined): McpResourceProvider => {
+const deploymentSpecResources = (source: LocalDeploymentSource, clientFor: (deployment: LocalDeployment) => LunoraClient): McpResourceProvider => {
     const resolve = typeof source === "function" ? source : (): LocalDeployment => source;
-    const clientFor = createClientCache(fetchImplementation);
 
     /** The live document for `entry`, or `undefined` when the deployment can't serve it. */
     const fetchEntry = async (entry: SpecResourceEntry): Promise<Record<string, unknown> | undefined> => {
@@ -273,8 +298,16 @@ const combineResourceProviders = (providers: ReadonlyArray<McpResourceProvider>)
  * surface that always works), then the caller's extras, then the deployment
  * tools. Order also decides precedence — `createToolServer` keeps the first
  * registration of a duplicated name.
+ *
+ * `clientFor` is the shared client cache built once by
+ * {@link createLocalMcpServer} and threaded into both the tool and resource
+ * surfaces. Exported (and called directly by tests) without going through
+ * `createLocalMcpServer`, so a caller that omits it gets a private,
+ * call-scoped cache — same shape as before this surface was shared, just
+ * without the cross-surface sharing that only matters once a resource
+ * surface exists alongside it.
  */
-const localTools = (options: LocalMcpServerOptions): ReadonlyArray<McpTool> => {
+const localTools = (options: LocalMcpServerOptions, clientFor?: (deployment: LocalDeployment) => LunoraClient): ReadonlyArray<McpTool> => {
     const tools: McpTool[] = [];
 
     if (options.docs !== false) {
@@ -291,7 +324,7 @@ const localTools = (options: LocalMcpServerOptions): ReadonlyArray<McpTool> => {
     tools.push(...(options.extraTools ?? []));
 
     if (options.deployment !== undefined) {
-        tools.push(...lazyDeploymentTools(options.deployment, options.allowWrites ?? false, options.fetch));
+        tools.push(...lazyDeploymentTools(options.deployment, options.allowWrites ?? false, clientFor ?? createClientCache(options.fetch)));
     }
 
     return tools;
@@ -315,16 +348,20 @@ const createLocalMcpServer = (options: LocalMcpServerOptions = {}): Server => {
         resourceProviders.push(docsResources(index));
     }
 
+    // One client cache for the whole server, shared by the tool and resource
+    // surfaces below — see `createClientCache`'s docstring for why.
+    const clientFor = createClientCache(options.fetch);
+
     // Only offer the spec resources when a deployment is configured at all —
     // mirrors the docs-index check above (the whole surface is opt-in, not a
     // live probe at server-build time).
     if (options.deployment !== undefined) {
-        resourceProviders.push(deploymentSpecResources(options.deployment, options.fetch));
+        resourceProviders.push(deploymentSpecResources(options.deployment, clientFor));
     }
 
     return createToolServer(
         { name: LOCAL_SERVER_NAME, version: options.version ?? "0.0.0" },
-        localTools(options),
+        localTools(options, clientFor),
         resourceProviders.length === 0 ? undefined : combineResourceProviders(resourceProviders),
     );
 };

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,8 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
+        // Intentionally no `outDir`/`rootDir`: `lint:types` is `tsc --noEmit` and the
+        // real build is packem (driven by package.json exports), so neither is
+        // load-bearing here. A set `rootDir` would raise TS6059 for the inlined
+        // `../../../shared/evict-oldest` import (a file outside this package, bundled
+        // in at build time). See shared/evict-oldest.ts.
         "moduleResolution": "bundler",
         "types": ["node"]
     },


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- perf(mcp): share one bounded client cache across local tools and resources

## Files this branch still changes relative to alpha

```
packages/mcp/__tests__/local.test.ts
packages/mcp/src/local.ts
packages/mcp/tsconfig.json
```
