### PR TITLE
fix(platform-cloudflare): reject over-budget accept tags with an actionable error

### DIFF
--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -476,6 +476,10 @@ const ERROR_CATALOG: {
         readonly status: 404;
         readonly title: "Unknown admin operation";
     };
+    readonly SOCKET_TAG_BUDGET_EXCEEDED: {
+        readonly status: 400;
+        readonly title: "Socket tag budget exceeded";
+    };
     readonly RELAY_CANNOT_SEED: {
         readonly status: 500;
         readonly title: "Relay cannot seed";

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -284,6 +284,15 @@ export const ERROR_CATALOG = {
     UNKNOWN_ADMIN_OP: { status: 404, title: "Unknown admin operation" },
 
     /**
+     * `@lunora/platform-cloudflare`'s `SocketHost.accept` guard — a caller
+     * supplied more accept-time tags (or a longer tag) than Cloudflare's
+     * `acceptWebSocket` budget allows once the host's own identity tag is
+     * reserved. Caller-actionable and safe (names counts, not internals) —
+     * not `internal`.
+     */
+    SOCKET_TAG_BUDGET_EXCEEDED: { status: 400, title: "Socket tag budget exceeded" },
+
+    /**
      * `@lunora/shard-engine`'s relay hub (cross-shard shape relay coordination).
      * Mirrors `SHARD_ERROR`/`SHARD_UNAVAILABLE` above: operational status for an
      * app's own relay topology, not a secret — not `internal`.

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.tag-budget.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.tag-budget.test.ts
@@ -1,0 +1,127 @@
+import { LunoraError } from "@lunora/errors";
+import { describe, expect, it } from "vitest";
+
+import { createSocketHost } from "../src/cloudflare-host";
+
+/**
+ * The Cloudflare socket host reserves one `acceptWebSocket` tag slot for its
+ * own identity tag (`lunora-socket:&lt;uuid>`, see `cloudflare-host.ts`'s
+ * `ID_TAG_PREFIX`), so Cloudflare's documented cap of 10 tags / 256 characters
+ * per tag (developers.cloudflare.com/durable-objects/api/state/) becomes a
+ * caller-visible budget of 9 usable tags. These tests pin that the adapter
+ * enforces the budget itself — with an actionable `LunoraError` naming the
+ * counts — rather than letting the provider throw about a combined list that
+ * blames a tag the caller never supplied.
+ */
+
+/** A hibernatable-socket double: the surface the host adapter touches. */
+class FakeSocket {
+    private attachment: unknown;
+
+    // eslint-disable-next-line class-methods-use-this -- socket double: the adapter only needs the method to exist
+    public close(): void {}
+
+    public deserializeAttachment(): unknown {
+        return this.attachment;
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- socket double: the adapter only needs the method to exist
+    public send(): void {}
+
+    public serializeAttachment(value: unknown): void {
+        this.attachment = value;
+    }
+}
+
+/** A `DurableObjectState` double that records every `acceptWebSocket` call so a rejected accept can be asserted never to have reached it. */
+const stateRecordingAccepts = () => {
+    const calls: string[][] = [];
+
+    return {
+        acceptWebSocket(_socket: FakeSocket, socketTags?: string[]) {
+            calls.push(socketTags ?? []);
+        },
+        calls,
+        getTags: () => [] as string[],
+        getWebSockets: () => [] as FakeSocket[],
+    };
+};
+
+describe("createSocketHost accept-time tag budget", () => {
+    it("accepts 9 caller tags — acceptWebSocket receives 10 with the id tag first", () => {
+        expect.assertions(3);
+
+        const state = stateRecordingAccepts();
+        const host = createSocketHost(state as never);
+        const nineTags = Array.from({ length: 9 }, (_unused, index) => `tag-${String(index)}`);
+
+        host.accept(new FakeSocket(), undefined, nineTags);
+
+        expect(state.calls).toHaveLength(1);
+        expect(state.calls[0]).toHaveLength(10);
+        expect(state.calls[0]?.[0]?.startsWith("lunora-socket:")).toBe(true);
+    });
+
+    it("rejects 10 caller tags with SOCKET_TAG_BUDGET_EXCEEDED — acceptWebSocket is never called", () => {
+        expect.assertions(4);
+
+        const state = stateRecordingAccepts();
+        const host = createSocketHost(state as never);
+        const tenTags = Array.from({ length: 10 }, (_unused, index) => `tag-${String(index)}`);
+
+        let thrown: unknown;
+
+        try {
+            host.accept(new FakeSocket(), undefined, tenTags);
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(LunoraError);
+        expect((thrown as LunoraError).code).toBe("SOCKET_TAG_BUDGET_EXCEEDED");
+        expect((thrown as LunoraError).message).toContain("10");
+        expect(state.calls).toHaveLength(0);
+    });
+
+    it("rejects a single over-length tag with SOCKET_TAG_BUDGET_EXCEEDED — acceptWebSocket is never called", () => {
+        expect.assertions(3);
+
+        const state = stateRecordingAccepts();
+        const host = createSocketHost(state as never);
+        const tooLong = "x".repeat(257);
+
+        let thrown: unknown;
+
+        try {
+            host.accept(new FakeSocket(), undefined, [tooLong]);
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(LunoraError);
+        expect((thrown as LunoraError).code).toBe("SOCKET_TAG_BUDGET_EXCEEDED");
+        expect(state.calls).toHaveLength(0);
+    });
+
+    it("accepts a 256-character tag (the boundary) without throwing", () => {
+        expect.assertions(1);
+
+        const state = stateRecordingAccepts();
+        const host = createSocketHost(state as never);
+        const exactly256 = "x".repeat(256);
+
+        expect(() => host.accept(new FakeSocket(), undefined, [exactly256])).not.toThrow();
+    });
+
+    it("leaves a zero-tag accept unchanged", () => {
+        expect.assertions(2);
+
+        const state = stateRecordingAccepts();
+        const host = createSocketHost(state as never);
+
+        host.accept(new FakeSocket());
+
+        expect(state.calls).toHaveLength(1);
+        expect(state.calls[0]).toHaveLength(1);
+    });
+});

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -57,6 +57,7 @@
         "fallow:health": "fallow health --score"
     },
     "dependencies": {
+        "@lunora/errors": "1.0.0-alpha.11",
         "@lunora/platform": "1.0.0-alpha.2"
     },
     "devDependencies": {

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -15,6 +15,7 @@
  */
 
 import type { DurableObjectNamespace, DurableObjectState, DurableObjectStub, WebSocket } from "@cloudflare/workers-types";
+import { LunoraError } from "@lunora/errors";
 import type {
     ShardAlarms,
     ShardDirectory,
@@ -293,6 +294,57 @@ const readSocketId = (state: DurableObjectState, ws: WebSocket): string => {
 };
 
 /**
+ * Cloudflare's `acceptWebSocket` tag budget: at most 10 tags per socket, each
+ * at most 256 characters, for the socket's whole lifetime (tags are frozen at
+ * accept — there is no per-call vs. per-lifetime distinction because there is
+ * only ever one accept call per socket). Verified against
+ * https://developers.cloudflare.com/durable-objects/api/state/ (2026-08-01);
+ * update these two constants and the comment's date if that page's numbers
+ * ever change.
+ */
+const MAX_ACCEPT_TAGS = 10;
+const MAX_TAG_LENGTH = 256;
+
+/**
+ * `accept` always prepends one identity tag ({@link ID_TAG_PREFIX}) before
+ * calling `state.acceptWebSocket`, which is what turns Cloudflare's
+ * {@link MAX_ACCEPT_TAGS}-tag provider cap into a caller-visible budget one
+ * smaller — the reservation the guard below enforces.
+ */
+const RESERVED_ID_TAG_COUNT = 1;
+
+/**
+ * Reject an over-budget `tags` argument before it ever reaches
+ * `state.acceptWebSocket` — the provider throws about the combined list
+ * (including the host's own reserved id tag), which blames the caller for a
+ * count or tag it never supplied. The adapter knows whose fault it is and
+ * says so.
+ */
+const assertWithinTagBudget = (tags: ReadonlyArray<string> | undefined): void => {
+    if (!tags || tags.length === 0) {
+        return;
+    }
+
+    const usableBudget = MAX_ACCEPT_TAGS - RESERVED_ID_TAG_COUNT;
+
+    if (tags.length > usableBudget) {
+        throw new LunoraError(
+            "SOCKET_TAG_BUDGET_EXCEEDED",
+            `${String(tags.length)} tags supplied; Cloudflare allows ${String(MAX_ACCEPT_TAGS)} per socket and 1 is reserved for the host's identity tag — pass at most ${String(usableBudget)}.`,
+        );
+    }
+
+    const overLength = tags.find((tag) => tag.length > MAX_TAG_LENGTH);
+
+    if (overLength !== undefined) {
+        throw new LunoraError(
+            "SOCKET_TAG_BUDGET_EXCEEDED",
+            `Tag ${JSON.stringify(overLength)} is ${String(overLength.length)} characters; Cloudflare allows at most ${String(MAX_TAG_LENGTH)} characters per tag.`,
+        );
+    }
+};
+
+/**
  * Build the socket host for a DO.
  *
  * Note what is deliberately absent: `setTag` / `removeTag`. Cloudflare freezes
@@ -343,6 +395,8 @@ const createSocketHost = (state: DurableObjectState): SocketHost => {
 
     return {
         accept: (socket, attachment, tags) => {
+            assertWithinTagBudget(tags);
+
             const ws = socket as WebSocket;
             const id = crypto.randomUUID();
 

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -311,6 +311,30 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
                 host.cleanup?.();
             });
 
+            // This is a regression fence, not a bug reproduction: nine tags plus
+            // one host-reserved identity tag lands exactly at Cloudflare's
+            // documented 10-tag `acceptWebSocket` cap
+            // (developers.cloudflare.com/durable-objects/api/state/), so it
+            // passes today on every host and starts failing the moment the
+            // Cloudflare adapter (or any future host with its own cap) grows a
+            // second reserved slot without updating the portable budget this
+            // asserts. See `packages/platform/src/socket-host.ts`'s
+            // "Reserved-slot budget" note.
+            it("accepts the portable budget of nine caller tags", async () => {
+                expect.assertions(9);
+
+                const host = await createHost();
+                const tags = Array.from({ length: 9 }, (_unused, index) => `tag-${String(index)}`);
+                const socket = host.socket.accept(rawSocket(host), {}, tags);
+                const idOf = (s: SocketHandle): string => host.socket.idFor(s);
+
+                for (const tag of tags) {
+                    expect(host.socket.getSockets(tag).map(idOf)).toStrictEqual([idOf(socket)]);
+                }
+
+                host.cleanup?.();
+            });
+
             // Enumeration yields handles while the runtime's message/close
             // callbacks yield raw sockets. A host that cannot bridge the two
             // forces every caller back onto the provider socket type, which is

--- a/packages/platform/src/socket-host.ts
+++ b/packages/platform/src/socket-host.ts
@@ -28,6 +28,17 @@
  * — optional. Presence declares that the host can retag a live socket. Hosts
  * that cannot (Cloudflare) omit both methods, and callers that need to
  * retag must instead close and re-accept the socket with new tags.
+ *
+ * **Reserved-slot budget.** A host may reserve some of its accept-time tag
+ * slots for its own bookkeeping — Cloudflare's adapter prepends one identity
+ * tag (so `idFor` survives hibernation) before every `acceptWebSocket` call.
+ * Cloudflare's own cap is 10 tags per socket, 256 characters each
+ * (developers.cloudflare.com/durable-objects/api/state/), so with one slot
+ * reserved a portable caller should assume **at most 9 usable tags, each
+ * bounded to at most 256 characters** — a budget-exceeding `accept` call
+ * fails loudly on the host that enforces it (see
+ * {@link SocketHost.accept}) rather than passing silently on hosts with no
+ * cap and only failing, opaquely, on Cloudflare.
  */
 
 /**
@@ -88,6 +99,14 @@ export interface SocketHost {
      * survive recycling too and must be honoured by
      * {@link SocketHost.getSockets}. Returns a handle the engine can
      * send/close through.
+     *
+     * Portable callers should assume a budget of **at most 9 usable tags, each
+     * at most 256 characters** — some hosts (Cloudflare) reserve one tag slot
+     * of their own 10-tag cap for bookkeeping; see this file's module-header
+     * "Reserved-slot budget" note. A host that enforces a cap rejects an
+     * over-budget call rather than accepting it and silently dropping or
+     * truncating tags, which would break {@link SocketHost.getSockets}'s
+     * exactness requirement.
      */
     accept: (socket: unknown, attachment?: unknown, tags?: ReadonlyArray<string>) => SocketHandle;
 


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(platform-cloudflare): reject over-budget accept tags with an actionable error
- docs(platform): state the reserved socket-tag budget on SocketHost.accept

## Files this branch still changes relative to alpha

```
api-snapshots/errors.api.md
packages/errors/src/catalog.ts
packages/platform-cloudflare/__tests__/cloudflare-host.tag-budget.test.ts
packages/platform-cloudflare/package.json
packages/platform-cloudflare/src/cloudflare-host.ts
packages/platform/src/conformance/suite.ts
packages/platform/src/socket-host.ts
```
