### PR TITLE
feat(platform-node): close the host durability gaps

### DIFF
--- a/packages/platform-node/__tests__/engine-conformance.test.ts
+++ b/packages/platform-node/__tests__/engine-conformance.test.ts
@@ -18,8 +18,8 @@ describe("@lunora/shard-engine/conformance (node host)", () => {
     defineEngineContractSuite(
         "platform-node",
         () => {
-            const { host } = createNodeShardHost();
-            const { readFrames, socket } = createNodeSocketHost();
+            const { database, host } = createNodeShardHost();
+            const { readFrames, socket } = createNodeSocketHost(database);
 
             return { host, readFrames, sockets: socket };
         },

--- a/packages/platform-node/__tests__/global-store.test.ts
+++ b/packages/platform-node/__tests__/global-store.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { SchemaLike, ValidatorLike } from "@lunora/shard-engine";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createNodeGlobalStore } from "../src/node-global-store";
+
+/**
+ * End-to-end coverage for the `.global()` backend on the Node target.
+ *
+ * `@lunora/sql-store` already proves the dialect-blind store core against a
+ * hand-rolled SQLite dialect, and `@lunora/d1` proves the D1 binding. What is
+ * unproven until here is that *this package's* assembly — the reference
+ * `sqliteDialect` bound to a `better-sqlite3` exec, in its own database file —
+ * actually provisions tables and round-trips documents. `globalTables` moves
+ * from `unsupported` to a real rating on the strength of this file, so it
+ * asserts behaviour rather than wiring.
+ */
+
+const col = (kind: string, extra: Record<string, unknown> = {}): ValidatorLike => {
+    return { _meta: { column: { notNull: true, ...extra } }, kind };
+};
+
+const schema: SchemaLike = {
+    tables: {
+        notes: {
+            indexes: [],
+            shape: {
+                archived: col("boolean"),
+                body: col("string"),
+                priority: col("number"),
+                slug: col("string", { unique: true }),
+            },
+            shardMode: { kind: "global" },
+        },
+    },
+} as never;
+
+describe("createNodeGlobalStore", () => {
+    let workdir: string;
+
+    beforeEach(() => {
+        workdir = mkdtempSync(join(tmpdir(), "lunora-platform-node-global-"));
+    });
+
+    afterEach(() => {
+        rmSync(workdir, { force: true, recursive: true });
+    });
+
+    it("provisions the schema's global tables and round-trips a document", async () => {
+        expect.assertions(3);
+
+        const store = createNodeGlobalStore();
+
+        try {
+            await store.migrate(schema);
+
+            const writer = store.writer({ schema });
+            const id = await writer.insert("notes", { archived: false, body: "hello", priority: 3, slug: "a" });
+
+            expect(typeof id).toBe("string");
+
+            const document = await writer.get(id);
+
+            // Booleans and numbers come back in their JS forms, not as the
+            // INTEGER/REAL SQLite stored them as — the value codec is wired.
+            expect(document).toMatchObject({ archived: false, body: "hello", priority: 3, slug: "a" });
+            expect(document?._id).toBe(id);
+        } finally {
+            store.dispose();
+        }
+    });
+
+    it("is idempotent: migrating twice over the same file does not throw or lose rows", async () => {
+        expect.assertions(1);
+
+        const path = join(workdir, "global.sqlite3");
+        const first = createNodeGlobalStore({ path });
+
+        await first.migrate(schema);
+
+        const id = await first.writer({ schema }).insert("notes", { archived: false, body: "kept", priority: 1, slug: "keep" });
+
+        first.dispose();
+
+        // A dev server re-runs migrations on every boot, so the second pass has
+        // to be a no-op over an existing file rather than a failure or a reset.
+        const second = createNodeGlobalStore({ path });
+
+        try {
+            await second.migrate(schema);
+
+            const document = await second.writer({ schema }).get(id);
+
+            expect(document).toMatchObject({ body: "kept", slug: "keep" });
+        } finally {
+            second.dispose();
+        }
+    });
+});

--- a/packages/platform-node/__tests__/lifecycle.test.ts
+++ b/packages/platform-node/__tests__/lifecycle.test.ts
@@ -2,12 +2,14 @@ import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { SocketHandle } from "@lunora/platform";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createNodePlatform } from "../src/node-platform";
 import { createNodeSchedulerHost } from "../src/node-scheduler-host";
 import { createNodeShardHost } from "../src/node-shard-host";
+import { createNodeSocketHost } from "../src/node-socket-host";
 
 /**
  * Covers the lifecycle-owner cluster: nothing previously closed the
@@ -118,7 +120,8 @@ describe("lifecycle disposers", () => {
             vi.useFakeTimers();
 
             try {
-                const { dispose, scheduler } = createNodeSchedulerHost();
+                const database = new Database(":memory:");
+                const { dispose, scheduler } = createNodeSchedulerHost(database);
 
                 await scheduler.schedule("some/fn", {}, { delayMs: 5000 });
                 await scheduler.schedule("some/other-fn", {}, { delayMs: 10_000 });
@@ -128,9 +131,118 @@ describe("lifecycle disposers", () => {
                 dispose();
 
                 expect(vi.getTimerCount()).toBe(0);
+
+                database.close();
             } finally {
                 vi.useRealTimers();
             }
+        });
+
+        it("re-arms a job persisted by an earlier host over the same database", async () => {
+            expect.assertions(2);
+
+            const path = join(workdir, "scheduler-rearm.sqlite3");
+            const database = new Database(path);
+
+            try {
+                const first = createNodeSchedulerHost(database);
+
+                await first.scheduler.schedule("some/fn", { user: "ada" }, { delayMs: 60_000 });
+                // Shutdown clears the timer but leaves the row — the whole point
+                // of the durable table.
+                first.dispose();
+
+                // A second host over the same connection stands in for a process
+                // restart: it must find the row and arm a timer for it, or the
+                // job is a log entry nobody will ever act on.
+                const second = createNodeSchedulerHost(database);
+                // `list` is optional on the contract (a fire-and-forget host
+                // omits it); this host always supplies it, which is the thing
+                // being asserted.
+                const pending = (await second.scheduler.list?.()) ?? [];
+
+                expect(pending.map((job) => job.functionPath)).toStrictEqual(["some/fn"]);
+                expect(pending[0]?.attempts).toBe(0);
+
+                second.dispose();
+            } finally {
+                database.close();
+            }
+        });
+    });
+
+    /**
+     * The parity legs. `simulateRecycle()` and the TCK prove state survives a
+     * host *forgetting* its runtime half; these prove it survives the process
+     * that held it going away, which is what `ShardAlarms` ("survive host
+     * recycling") and `SocketHost` guarantee 2 ("survive recycling and be
+     * readable on wake") actually promise. A second host constructed over the
+     * same database file is this package's stand-in for a restart.
+     */
+    describe("survives a process restart", () => {
+        it("re-arms and delivers an alarm the previous host persisted", async () => {
+            expect.assertions(2);
+
+            const path = join(workdir, "alarm-rearm.sqlite3");
+            const first = createNodeShardHost({ path });
+
+            // Already elapsed: the case a restart is most likely to hit, and the
+            // one a host that only re-armed *future* alarms would silently drop.
+            await first.host.alarms.set(Date.now() - 1000);
+            first.dispose();
+
+            let delivered = 0;
+            const second = createNodeShardHost({
+                onAlarm: () => {
+                    delivered += 1;
+                },
+                path,
+            });
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, 20);
+            });
+
+            expect(delivered).toBe(1);
+
+            // And the row is consumed, so a third host does not re-deliver it.
+            // Bound to a variable rather than asserted inline: `ShardAlarms.get`
+            // is `Promise<number | null> | number | null` by contract, and this
+            // host answers synchronously — so `.resolves` (which eslint's
+            // autofix reaches for) would reject a legitimate return.
+            const pendingAfterDelivery = await second.host.alarms.get();
+
+            expect(pendingAfterDelivery).toBeNull();
+
+            second.dispose();
+        });
+
+        it("restores a socket's attachment and tags written by the previous host", () => {
+            expect.assertions(3);
+
+            const path = join(workdir, "socket-restore.sqlite3");
+            const first = createNodeShardHost({ path });
+            const firstSockets = createNodeSocketHost(first.database);
+
+            const handle = firstSockets.socket.accept({}, { roles: ["admin"], roomId: "room-1" }, ["room-a"]);
+            const id = firstSockets.socket.idFor(handle);
+
+            first.dispose();
+
+            const second = createNodeShardHost({ path });
+            const secondSockets = createNodeSocketHost(second.database);
+
+            // `undefined` as the fallback: if the attachment comes back, it came
+            // out of SQLite and not from an argument the test kept alive.
+            const restored = secondSockets.restoreSocket(id, undefined);
+
+            expect(restored.deserializeAttachment()).toStrictEqual({ roles: ["admin"], roomId: "room-1" });
+            expect(secondSockets.socket.idFor(restored)).toBe(id);
+            // Tags too — a restored socket that lost them silently drops out of
+            // every tagged fan-out it was subscribed to.
+            expect(secondSockets.socket.getSockets("room-a").map((entry: SocketHandle) => secondSockets.socket.idFor(entry))).toStrictEqual([id]);
+
+            second.dispose();
         });
     });
 

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -60,8 +60,11 @@
         "fallow:health": "fallow health --score"
     },
     "dependencies": {
+        "@lunora/d1": "1.0.0-alpha.56",
         "@lunora/platform": "1.0.0-alpha.1",
-        "better-sqlite3": "^12.11.1"
+        "@lunora/sql-store": "1.0.0-alpha.58",
+        "better-sqlite3": "^12.11.1",
+        "cron-parser": "5.6.2"
     },
     "devDependencies": {
         "@codspeed/vitest-plugin": "catalog:test",

--- a/packages/platform-node/src/conformance/index.ts
+++ b/packages/platform-node/src/conformance/index.ts
@@ -27,8 +27,8 @@ export const createNodeConformanceHost = (): ConformanceHost => {
     const { database, dispose: disposeShard, host: shard } = createNodeShardHost();
     const kv = createNodeShardKvStore(database);
     const directory = createNodeShardDirectory();
-    const { readFrames, restoreSocket, simulateRecycle, socket } = createNodeSocketHost();
-    const { dispose: disposeScheduler, scheduler, simulateDeadLetter } = createNodeSchedulerHost();
+    const { readFrames, restoreSocket, simulateRecycle, socket } = createNodeSocketHost(database);
+    const { dispose: disposeScheduler, scheduler, simulateDeadLetter } = createNodeSchedulerHost(database);
 
     return {
         awaitAlarmFired: async (target) => {

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -4,19 +4,33 @@
  * `SchedulerHost`) over `better-sqlite3` and an in-process socket/directory/
  * scheduler registry.
  *
- * **Spike (plan 234).** Promoted from `@lunora/platform`'s `node:sqlite`
- * reference host (`src/conformance/reference-host.ts`) and hardened toward
- * real persistence semantics — see each adapter module's docstring for what
- * changed and why, and `plans/234-node-host-findings.md` for every contract
- * gap this construction surfaced. Not wired into `lunora dev`; no deploy
- * driver; several capabilities are honestly rated `emulated`/`unsupported` in
- * `NODE_CAPABILITIES` (`@lunora/platform`).
+ * Promoted from `@lunora/platform`'s `node:sqlite` reference host
+ * (`src/conformance/reference-host.ts`) under plan 234, then hardened until the
+ * durability half of each contract actually holds: alarms and scheduler jobs
+ * are persisted **and re-armed on construction**, socket attachments and tags
+ * live in SQLite rather than a `Map`, and `.global()` tables run the real
+ * `@lunora/sql-store` core (`./node-global-store`). Each of those is pinned by
+ * a restart test — a second host over the same database file — not only by the
+ * TCK's simulated recycle.
+ *
+ * Three suites run against this package: `@lunora/platform/conformance`'s host
+ * TCK, `@lunora/shard-engine/conformance`'s engine suite, and its own
+ * lifecycle/global-store tests.
+ *
+ * **Still missing**, and rated accordingly in `NODE_CAPABILITIES`
+ * (`@lunora/platform`): cross-shard fan-out (no query coordinator), a deploy
+ * driver — so `lunora dev --target node` does not exist yet — and every
+ * Cloudflare product binding (R2, Queues, Workflows, Vectorize, Workers AI,
+ * Browser Rendering, Containers, Analytics Engine, Pipelines, Secrets Store,
+ * Hyperdrive). See `plans/234-node-host-findings.md`.
  */
 
+export type { NodeGlobalContextDatabaseOptions, NodeGlobalStore, NodeGlobalStoreOptions } from "./node-global-store";
+export { createNodeGlobalStore, createNodeSqlExec } from "./node-global-store";
 export { createNodeShardKvStore } from "./node-kv-store";
 export type { NodePlatform, NodePlatformOptions } from "./node-platform";
 export { createNodePlatform } from "./node-platform";
-export type { NodeSchedulerHost } from "./node-scheduler-host";
+export type { NodeSchedulerHost, NodeSchedulerHostOptions } from "./node-scheduler-host";
 export { createNodeSchedulerHost } from "./node-scheduler-host";
 export { createNodeShardDirectory } from "./node-shard-directory";
 export type { NodeShardHostOptions } from "./node-shard-host";

--- a/packages/platform-node/src/node-global-store.ts
+++ b/packages/platform-node/src/node-global-store.ts
@@ -1,0 +1,152 @@
+/**
+ * Node binding of the shared `@lunora/sql-store` core — the `.global()` table
+ * backend for this target.
+ *
+ * `.global()` tables are the one part of the engine that does not live in a
+ * shard: they are a single replicated SQL store every shard reads. On
+ * Cloudflare that store is D1 (`@lunora/d1`); on PlanetScale it is Postgres or
+ * MySQL through Hyperdrive (`@lunora/hyperdrive/global`). Both are the same
+ * dialect-parameterized core (`createSqlCtxDb`) with a different
+ * `SqlDialect` and a different exec bolted on.
+ *
+ * This module is the third such binding, and the cheapest: the engine that
+ * already backs a Node shard *is* SQLite, so the dialect is the same one D1
+ * injects, and the exec is the `ShardAsyncSqlExec` `createNodeShardHost`
+ * already exposes. The store lives in its own database file rather than a
+ * shard's, because a global table shared by every shard must not be inside any
+ * one of them.
+ *
+ * # Why this imports from `@lunora/d1`
+ *
+ * `sqliteDialect` is the reference dialect the store core was written against,
+ * and it happens to live in `@lunora/d1` — the package's own docstring says it
+ * is "kept as a separate module ... so the Postgres/MySQL dialects in
+ * `@lunora/hyperdrive/global` have a concrete template to mirror". Nothing
+ * about it is Cloudflare-bound (`@lunora/d1`'s dependencies are `@lunora/errors`,
+ * `@lunora/platform`, `@lunora/shard-engine`, `@lunora/sql-store` and
+ * `drizzle-orm` — the `@cloudflare/workers-types` reference is type-only and
+ * erased), so importing it here is a naming awkwardness rather than a layering
+ * violation: a Node host depends on a package called `d1`.
+ *
+ * The tidy fix is to move `sqliteDialect` down into `@lunora/sql-store`, beside
+ * the `SqlDialect` contract it implements. That was not done here because it
+ * also requires moving `sqlAffinityForKind` out of `@lunora/d1`'s `dialect.ts`,
+ * which the CLI migration emitter imports — a three-package refactor with
+ * nothing to do with this target. Filed in `plans/234-node-host-findings.md`.
+ */
+
+import { sqliteDialect } from "@lunora/d1";
+import type { SchemaLike } from "@lunora/shard-engine";
+import type { SqlCtxDbOptions, SqlCtxExec } from "@lunora/sql-store";
+import {
+    backfillSqlSearchIndexes,
+    createSqlCtxDb,
+    runSqlAggregateMigrations,
+    runSqlCdcMigration,
+    runSqlGlobalTableMigrations,
+    runSqlRankMigrations,
+    runSqlSearchMigrations,
+} from "@lunora/sql-store";
+import Database from "better-sqlite3";
+
+/**
+ * The Node store options — the shared store options minus the two this binding
+ * owns. `dialect` is fixed (SQLite) and `exec` is the store's own connection;
+ * letting a caller pass either would let them point the writer at a different
+ * engine or a different database than the one `migrate` just provisioned.
+ */
+export type NodeGlobalContextDatabaseOptions = Omit<SqlCtxDbOptions, "dialect" | "exec">;
+
+/**
+ * Wrap a `better-sqlite3` connection as the async exec the store core consumes.
+ *
+ * `batch` is deliberately **not** implemented. The contract lets an exec that
+ * omits it fall back to a sequential `run()` loop, and that fallback is already
+ * optimal here: `batch` exists to collapse network round trips (D1 does it
+ * atomically in one request; the Hyperdrive adapters dispatch concurrently over
+ * a pool), and an embedded database has no round trip to collapse. Declaring it
+ * would buy nothing and would opt this exec into the "MAY reorder or
+ * parallelize" licence for no reason.
+ */
+export const createNodeSqlExec = (database: Database.Database): SqlCtxExec => {
+    return {
+        // eslint-disable-next-line @typescript-eslint/require-await -- the exec seam is async so a networked engine can await; better-sqlite3 is synchronous
+        all: async (statement, parameters) => database.prepare(statement).all(...(parameters as unknown[])) as Record<string, unknown>[],
+        // eslint-disable-next-line @typescript-eslint/require-await -- see `all`
+        run: async (statement, parameters) => {
+            const result = database.prepare(statement).run(...(parameters as unknown[]));
+
+            return { rowsAffected: result.changes };
+        },
+    };
+};
+
+/** Options for {@link createNodeGlobalStore}. */
+export interface NodeGlobalStoreOptions {
+    /**
+     * SQLite file backing the `.global()` tables. Defaults to `:memory:`.
+     *
+     * Deliberately a *separate* database from any shard's: a global table is
+     * shared by every shard, so keeping it inside one shard's file would make
+     * that shard's lifecycle (and its single-writer gate) the global store's
+     * too.
+     */
+    path?: string;
+}
+
+/** A `.global()` store for the Node target, plus the handles to run it down. */
+export interface NodeGlobalStore {
+    /** The underlying connection, for callers that need to run migrations or inspect it. */
+    database: Database.Database;
+    /** Close the connection. Safe to call more than once. */
+    dispose: () => void;
+    /** The async exec the store core (and the migration helpers) consume. */
+    exec: SqlCtxExec;
+
+    /**
+     * Create the schema's `.global()` tables and every companion table
+     * (aggregate, rank, search) they need, then backfill the search indexes.
+     * Idempotent — every statement is `CREATE TABLE IF NOT EXISTS`-shaped — so
+     * it is safe to run on each boot, which is what a dev server does.
+     */
+    migrate: (schema: SchemaLike, options?: { cdc?: boolean }) => Promise<void>;
+    /** Build a `.global()` writer bound to this store. */
+    writer: (options: NodeGlobalContextDatabaseOptions) => ReturnType<typeof createSqlCtxDb>;
+}
+
+/**
+ * Stand up the `.global()` backend for a Node target.
+ *
+ * The returned `writer` is the same `createSqlCtxDb` every other backend
+ * returns, so the engine above it cannot tell which target it is running on —
+ * which is the whole point of the dialect seam.
+ */
+export const createNodeGlobalStore = (options: NodeGlobalStoreOptions = {}): NodeGlobalStore => {
+    const database = new Database(options.path ?? ":memory:");
+
+    database.pragma("journal_mode = WAL");
+
+    const exec = createNodeSqlExec(database);
+
+    return {
+        database,
+        dispose: () => {
+            if (database.open) {
+                database.close();
+            }
+        },
+        exec,
+        migrate: async (schema, migrateOptions = {}) => {
+            await runSqlGlobalTableMigrations(exec, schema, sqliteDialect);
+            await runSqlAggregateMigrations(exec, schema, sqliteDialect);
+            await runSqlRankMigrations(exec, schema, sqliteDialect);
+            await runSqlSearchMigrations(exec, schema, sqliteDialect);
+            await backfillSqlSearchIndexes(exec, schema, sqliteDialect);
+
+            if (migrateOptions.cdc === true) {
+                await runSqlCdcMigration(exec, sqliteDialect);
+            }
+        },
+        writer: (writerOptions) => createSqlCtxDb({ ...writerOptions, dialect: sqliteDialect, exec }),
+    };
+};

--- a/packages/platform-node/src/node-platform.ts
+++ b/packages/platform-node/src/node-platform.ts
@@ -17,6 +17,7 @@ import type { PlatformCapabilities, SchedulerHost, ShardDirectory, ShardHost, Sh
 import { NODE_CAPABILITIES } from "@lunora/platform";
 
 import { createNodeShardKvStore } from "./node-kv-store";
+import type { NodeSchedulerHostOptions } from "./node-scheduler-host";
 import { createNodeSchedulerHost } from "./node-scheduler-host";
 import { createNodeShardDirectory } from "./node-shard-directory";
 import type { NodeShardHostOptions } from "./node-shard-host";
@@ -43,31 +44,51 @@ export interface NodePlatform {
     close: () => void;
     /** In-process shard directory (see `createNodeShardDirectory`'s docstring for what it cannot do). */
     directory: ShardDirectory;
+
+    /**
+     * Wait for every promise handed to `shard.waitUntil` to settle.
+     *
+     * Separate from `close()` because the two answer different questions:
+     * `close()` releases handles and stays synchronous (it backs
+     * `Symbol.dispose`), while draining is inherently awaitable. A graceful
+     * shutdown is `await platform.drain()` then `platform.close()`.
+     */
+    drain: () => Promise<void>;
+
     /** Durable key-value storage backed by the same `better-sqlite3` database as `shard`. */
     kv: ShardKvStore;
-    /** In-process delayed jobs — NOT durable across a process restart; see `createNodeSchedulerHost`. */
+    /** Delayed jobs and crons, persisted to the same database and re-armed on construction. */
     scheduler: SchedulerHost;
-    /** Single-writer execution, local SQL, transactions, alarms. */
+    /** Single-writer execution, local SQL, transactions, durable alarms. */
     shard: ShardHost;
-    /** In-process socket registry with mutable tags. */
+    /** Socket registry with mutable tags and SQLite-persisted attachments. */
     sockets: SocketHost;
 }
 
-/** Options for {@link createNodePlatform}. */
-export type NodePlatformOptions = NodeShardHostOptions;
+/**
+ * Options for {@link createNodePlatform} — the shard host's (`path`,
+ * `shardKey`, `onAlarm`) plus the scheduler's (`onDispatch`). Both delivery
+ * hooks are optional and both are what make the durable halves useful: a
+ * re-armed alarm or job with nowhere to land is bookkeeping.
+ */
+export type NodePlatformOptions = NodeSchedulerHostOptions & NodeShardHostOptions;
 
 /** Compose every contract this package provides over one `better-sqlite3` database. */
 export const createNodePlatform = (options: NodePlatformOptions = {}): NodePlatform => {
-    const { database, dispose: disposeShard, host: shard } = createNodeShardHost(options);
+    const { database, dispose: disposeShard, drain, host: shard } = createNodeShardHost(options);
     const kv = createNodeShardKvStore(database);
     const directory = createNodeShardDirectory();
-    const { socket: sockets } = createNodeSocketHost();
-    const { dispose: disposeScheduler, scheduler } = createNodeSchedulerHost();
+    const { socket: sockets } = createNodeSocketHost(database);
+    const { dispose: disposeScheduler, scheduler } = createNodeSchedulerHost(database, options);
 
     const close = (): void => {
-        disposeShard();
+        // Scheduler timers first: `disposeShard` closes the connection, and a
+        // job timer that fired in between would find it closed. Both are
+        // guarded, but ordering makes the guard the backstop rather than the
+        // mechanism.
         disposeScheduler();
+        disposeShard();
     };
 
-    return { capabilities: NODE_CAPABILITIES, close, directory, kv, scheduler, shard, sockets, [Symbol.dispose]: close };
+    return { capabilities: NODE_CAPABILITIES, close, directory, drain, kv, scheduler, shard, sockets, [Symbol.dispose]: close };
 };

--- a/packages/platform-node/src/node-scheduler-host.ts
+++ b/packages/platform-node/src/node-scheduler-host.ts
@@ -1,62 +1,200 @@
 /**
- * Node adapter: an in-process job table satisfying the provider-neutral
+ * Node adapter: a SQLite-backed job table satisfying the provider-neutral
  * `@lunora/platform` `SchedulerHost` contract.
  *
- * **This is the one contract this package cannot honestly hold as "hardened
- * toward a real implementation."** `SchedulerHost`'s docstring promises
- * "durable persistence — scheduled jobs survive host recycling." On
- * Cloudflare, `SchedulerDO` backs this with alarms on Durable Object storage:
- * the platform re-delivers an alarm to a freshly-woken DO even after the
- * process that scheduled it is long gone. A plain Node process has no
- * equivalent — nothing re-arms a `setTimeout` after `node` restarts, and there
- * is no host-level daemon to hand that job to. Persisting the job row to
- * SQLite without something to re-arm it on process start would be *worse* than
- * this in-memory implementation: it would report a job as "pending" forever
- * after a restart that will in fact never fire. This is filed as a finding,
- * not silently worked around — see `plans/234-node-host-findings.md`.
+ * `SchedulerHost`'s docstring promises three things: at-least-once delivery,
+ * durable persistence across host recycling, and time-based dispatch. On
+ * Cloudflare all three come from `SchedulerDO` — Durable Object storage holds
+ * the job rows and workerd re-delivers the alarm that drains them, even after
+ * the process that scheduled a job is long gone.
  *
- * `cron` is omitted, matching Cloudflare (whose crons are declared in
- * `wrangler.jsonc`, not registered at runtime) — but for the opposite reason:
- * Cloudflare could not add dynamic registration even if it wanted to, while a
- * Node host technically could (a real cron parser + `setInterval`), and this
- * spike deliberately does not build one. Wiring a dev-time cron runner is a
- * `lunora dev` concern, out of this plan's scope.
+ * A Node process has no runtime to hand that job to, so this host owns the
+ * whole loop itself: rows live in `_lunora_scheduler_jobs` on the same
+ * `better-sqlite3` connection as the rest of the shard, and **construction
+ * re-arms every pending row**. That last part is what turns persistence into
+ * durability. An earlier revision of this file persisted nothing and said so,
+ * on the grounds that "persisting the job row without something to re-arm it
+ * would be worse than this in-memory implementation" — correct as far as it
+ * went, and the missing half was simply the re-arm.
+ *
+ * A job whose `scheduled_for` elapsed while nothing was running fires on the
+ * next construction rather than being dropped: late, but delivered, which is
+ * what at-least-once owes a caller.
+ *
+ * `cron` **is** implemented here, and this is the first host in the repo to
+ * populate it. Its optionality on the contract is Cloudflare-shaped — crons
+ * live in `wrangler.jsonc` and are reconciled at build time, so there is no
+ * runtime call that could add one — and `SchedulerHost.cron`'s docstring is
+ * explicit that presence is a host's declaration that dynamic cron works. On
+ * Node it does: expressions are parsed by `cron-parser` (the same dependency
+ * `@lunora/scheduler` validates with, so one grammar stays authoritative across
+ * the repo) and re-armed from the durable table on construction exactly like
+ * one-shot jobs.
  */
 
-import type { ScheduledJobStatus, ScheduleOptions, SchedulerHost } from "@lunora/platform";
+import { deserialize, serialize } from "node:v8";
 
-interface NodeJob {
-    args: Record<string, unknown>;
+import type { ScheduledJob, ScheduledJobStatus, ScheduleOptions, SchedulerHost } from "@lunora/platform";
+import type Database from "better-sqlite3";
+import { CronExpressionParser } from "cron-parser";
+
+/**
+ * Retry policy applied when a caller supplies none. `ScheduleOptions.retry`
+ * documents each field as falling back to "the host's defaults"; these are this
+ * host's, and they are deliberately modest — a Node host is usually a dev
+ * server or a single-node deployment, where a job retrying for ten minutes is
+ * noise rather than resilience.
+ */
+const DEFAULT_RETRY = {
+    backoffMultiplier: 2,
+    initialDelayMs: 1000,
+    maxAttempts: 5,
+    maxDelayMs: 60_000,
+} as const;
+
+/** Row shape of `_lunora_scheduler_jobs`. */
+interface JobRow {
+    args: Buffer;
     attempts: number;
-    functionPath: string;
-    options: ScheduleOptions;
-    scheduledFor: number;
-    timer: ReturnType<typeof setTimeout> | undefined;
+    function_path: string;
+    id: string;
+    retry: Buffer | null;
+    scheduled_for: number;
+    state: "dead" | "pending";
+}
+
+/** Row shape of `_lunora_scheduler_crons`. */
+interface CronRow {
+    args: Buffer;
+    expression: string;
+    function_path: string;
+    key: string;
+}
+
+/** Options for {@link createNodeSchedulerHost}. */
+interface NodeSchedulerHostOptions {
+    /**
+     * Called when a job or cron tick comes due — this host's stand-in for the
+     * Worker fetch `SchedulerDO` makes when its alarm drains the queue.
+     *
+     * A handler that **throws** marks the delivery failed, which is what drives
+     * the retry/dead-letter machinery: the job's `attempts` increments and it is
+     * either re-armed with backoff or parked. A handler that resolves marks the
+     * job delivered and removes it.
+     *
+     * Omitting it makes every delivery trivially succeed. That is the right
+     * default for the conformance suite — which asserts scheduling, cancellation
+     * and dead-letter bookkeeping rather than dispatch — but it means a caller
+     * who forgets to pass one gets a scheduler that drops work silently, so
+     * supply one in anything real.
+     */
+    onDispatch?: (functionPath: string, args: Record<string, unknown>) => Promise<void> | void;
 }
 
 /**
- * Test-only hook the TCK's dead-letter legs need: force a pending job straight
- * to "exhausted its retry budget" without waiting out a real retry schedule.
+ * The scheduler half of a Node platform instance, plus the test-only hook the
+ * TCK's dead-letter legs need.
  */
-export interface NodeSchedulerHost {
+interface NodeSchedulerHost {
     /**
-     * Clear every `setTimeout` this host has armed (every job still in
-     * `pending`). Dead-lettered jobs never carry a live timer — their `timer`
-     * is always `undefined` by the time they land in `dead` — so this only
-     * needs to walk `pending`. Call it on teardown: an armed job timer is a
-     * handle that keeps the event loop (and, transitively, the process) alive
-     * until it fires, so leaving it uncleared on shutdown is what produces the
-     * "worker process failed to exit gracefully" delay.
+     * Clear every armed `setTimeout` (one-shot jobs and cron ticks alike).
+     *
+     * Rows are left in place on purpose: `dispose()` is shutdown, not deletion,
+     * and the next construction over the same database re-arms exactly what was
+     * still pending. An armed timer is also a handle that keeps the event loop —
+     * and transitively the process — alive until it fires, which is what
+     * produces the "worker process failed to exit gracefully" delay if it is
+     * left uncleared.
      */
     dispose: () => void;
     scheduler: SchedulerHost;
+
+    /**
+     * Drive a pending job straight to its dead-letter state without waiting out
+     * a real retry budget. Exactly the hook `ConformanceHost.simulateDeadLetter`
+     * describes: the observable invariants of dead-lettering are contract-level,
+     * while how many failures it takes to get there is host policy.
+     */
     simulateDeadLetter: (id: string) => Promise<boolean>;
 }
 
-/** Build the in-process scheduler. */
-export const createNodeSchedulerHost = (): NodeSchedulerHost => {
-    const pending = new Map<string, NodeJob>();
-    const dead = new Map<string, NodeJob>();
+/**
+ * Delay before attempt number `attempts` (1-based), capped at `maxDelayMs`.
+ * Exponential on the multiplier, the shape `ScheduleOptions.retry` describes.
+ */
+const backoffFor = (attempts: number, retry: ScheduleOptions["retry"]): number => {
+    const initial = retry?.initialDelayMs ?? DEFAULT_RETRY.initialDelayMs;
+    const multiplier = retry?.backoffMultiplier ?? DEFAULT_RETRY.backoffMultiplier;
+    const max = retry?.maxDelayMs ?? DEFAULT_RETRY.maxDelayMs;
+
+    return Math.min(max, initial * multiplier ** Math.max(0, attempts - 1));
+};
+
+/** Build a durable, SQLite-backed scheduler over `database`. */
+const createNodeSchedulerHost = (database: Database.Database, options: NodeSchedulerHostOptions = {}): NodeSchedulerHost => {
+    database.exec(
+        `CREATE TABLE IF NOT EXISTS _lunora_scheduler_jobs (
+            id TEXT PRIMARY KEY,
+            function_path TEXT NOT NULL,
+            args BLOB NOT NULL,
+            scheduled_for INTEGER NOT NULL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            retry BLOB,
+            state TEXT NOT NULL DEFAULT 'pending'
+        )`,
+    );
+    database.exec(
+        `CREATE TABLE IF NOT EXISTS _lunora_scheduler_crons (
+            key TEXT PRIMARY KEY,
+            expression TEXT NOT NULL,
+            function_path TEXT NOT NULL,
+            args BLOB NOT NULL
+        )`,
+    );
+
+    const insertJob = database.prepare<[string, string, Buffer, number, Buffer | null]>(
+        "INSERT INTO _lunora_scheduler_jobs (id, function_path, args, scheduled_for, retry) VALUES (?, ?, ?, ?, ?)",
+    );
+    const selectJob = database.prepare<[string], JobRow>("SELECT * FROM _lunora_scheduler_jobs WHERE id = ?");
+    const selectByState = database.prepare<[string], JobRow>("SELECT * FROM _lunora_scheduler_jobs WHERE state = ? ORDER BY scheduled_for");
+    const deleteJob = database.prepare<[string]>("DELETE FROM _lunora_scheduler_jobs WHERE id = ?");
+    const deletePendingJob = database.prepare<[string]>("DELETE FROM _lunora_scheduler_jobs WHERE id = ? AND state = 'pending'");
+    const updateAttempt = database.prepare<[number, number, string]>("UPDATE _lunora_scheduler_jobs SET attempts = ?, scheduled_for = ? WHERE id = ?");
+    const parkJob = database.prepare<[number, string]>("UPDATE _lunora_scheduler_jobs SET state = 'dead', attempts = ? WHERE id = ?");
+    const requeueJob = database.prepare<[number, string]>(
+        "UPDATE _lunora_scheduler_jobs SET state = 'pending', attempts = 0, scheduled_for = ? WHERE id = ? AND state = 'dead'",
+    );
+    const upsertCron = database.prepare<[string, string, string, Buffer]>(
+        `INSERT INTO _lunora_scheduler_crons (key, expression, function_path, args) VALUES (?, ?, ?, ?)
+         ON CONFLICT (key) DO UPDATE SET expression = excluded.expression, args = excluded.args`,
+    );
+    const selectCrons = database.prepare<[], CronRow>("SELECT * FROM _lunora_scheduler_crons");
+
+    /**
+     * Read the connection's open/closed state *now*.
+     *
+     * Called through a function rather than as `database.open` directly because
+     * TypeScript narrows the property after an early `if (!database.open)
+     * return`, and then treats every later check in the same function as
+     * redundant — which is exactly wrong here, since an `await` sits in
+     * between and the caller may have closed the connection during it. The
+     * indirection keeps each check a real runtime read.
+     */
+    const isOpen = (): boolean => database.open;
+
+    /**
+     * Decode a job's stored retry policy. `null` is SQLite's own NULL arriving
+     * through better-sqlite3's nullable-column mapping, not a value this
+     * package's API ever produces.
+     */
+
+    const decodeRetry = (value: Buffer | null): ScheduleOptions["retry"] => (value === null ? undefined : (deserialize(value) as ScheduleOptions["retry"]));
+
+    /** Armed one-shot job timers, keyed by job id. */
+    const jobTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    /** Armed cron tick timers, keyed by cron key. */
+    const cronTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
     let counter = 0;
 
     const nextId = (): string => {
@@ -65,96 +203,267 @@ export const createNodeSchedulerHost = (): NodeSchedulerHost => {
         return `node-job-${String(counter)}`;
     };
 
-    const toStatus = (id: string, job: NodeJob): ScheduledJobStatus => {
+    const toStatus = (row: JobRow): ScheduledJobStatus => {
         return {
-            attempts: job.attempts,
-            functionPath: job.functionPath,
-            id,
-            scheduledFor: job.scheduledFor,
+            attempts: row.attempts,
+            functionPath: row.function_path,
+            id: row.id,
+            scheduledFor: row.scheduled_for,
         };
     };
 
-    const scheduler: SchedulerHost = {
-        // eslint-disable-next-line @typescript-eslint/require-await -- the contract's cancel is async so a real host can await I/O; this one is synchronous state
-        cancel: async (id) => {
-            const job = pending.get(id);
+    const clearJobTimer = (id: string): void => {
+        const timer = jobTimers.get(id);
 
-            if (job === undefined) {
-                return false;
+        if (timer !== undefined) {
+            clearTimeout(timer);
+            jobTimers.delete(id);
+        }
+    };
+
+    const armJob = (id: string, scheduledFor: number): void => {
+        clearJobTimer(id);
+
+        const timer = setTimeout(
+            () => {
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define -- `armJob` and `deliver` are mutually recursive by nature (a retry re-arms, an arm delivers), so one of the two references has to precede its definition
+                deliver(id).catch(() => {
+                    // `deliver` settles its own failures into the retry /
+                    // dead-letter machinery; this only keeps the promise from
+                    // floating.
+                });
+            },
+            Math.max(0, scheduledFor - Date.now()),
+        );
+
+        jobTimers.set(id, timer);
+    };
+
+    /**
+     * Deliver one job, then settle its row: removed on success, re-armed with
+     * backoff while attempts remain, parked in `dead` once they are exhausted.
+     *
+     * Every database touch is guarded on `database.open`, because a timer can
+     * outlive a `close()` the caller made in between (shutdown, test cleanup)
+     * and a statement against a closed better-sqlite3 connection throws
+     * synchronously inside the timer callback, where no caller's try/catch can
+     * reach it.
+     */
+    const deliver = async (id: string): Promise<void> => {
+        jobTimers.delete(id);
+
+        if (!isOpen()) {
+            return;
+        }
+
+        const row = selectJob.get(id);
+
+        if (row?.state !== "pending") {
+            return;
+        }
+
+        const attempts = row.attempts + 1;
+        const retry = decodeRetry(row.retry);
+
+        try {
+            await options.onDispatch?.(row.function_path, deserialize(row.args) as Record<string, unknown>);
+
+            if (isOpen()) {
+                deleteJob.run(id);
+            }
+        } catch {
+            // Delivery failed. The catch is bare because *why* it failed is the
+            // handler's business; all this loop decides is whether any budget is
+            // left.
+            if (!isOpen()) {
+                return;
             }
 
-            clearTimeout(job.timer);
-            pending.delete(id);
+            const maxAttempts = retry?.maxAttempts ?? DEFAULT_RETRY.maxAttempts;
 
-            return true;
+            if (attempts >= maxAttempts) {
+                parkJob.run(attempts, id);
+
+                return;
+            }
+
+            const nextAt = Date.now() + backoffFor(attempts, retry);
+
+            updateAttempt.run(attempts, nextAt, id);
+            armJob(id, nextAt);
+        }
+    };
+
+    /**
+     * Arm the next tick for a cron row, and keep arming after each one.
+     *
+     * Unlike a one-shot job a cron has no row to delete on success and no retry
+     * budget to exhaust — a tick that throws is dropped and the next tick is
+     * armed regardless, which is how a recurring schedule has to behave: a
+     * failed 09:00 run must not cancel 10:00.
+     */
+    const armCron = (row: CronRow): void => {
+        const existing = cronTimers.get(row.key);
+
+        if (existing !== undefined) {
+            clearTimeout(existing);
+        }
+
+        let nextAt: number;
+
+        try {
+            nextAt = CronExpressionParser.parse(row.expression).next().getTime();
+        } catch {
+            // An unparseable expression is a permanent condition, not a transient
+            // one — re-arming would spin. `cron()` validates before it ever
+            // writes a row, so reaching here means the row predates this process
+            // (a database written by an older build).
+            return;
+        }
+
+        const timer = setTimeout(
+            () => {
+                cronTimers.delete(row.key);
+
+                (async (): Promise<void> => {
+                    try {
+                        await options.onDispatch?.(row.function_path, deserialize(row.args) as Record<string, unknown>);
+                    } catch {
+                        // See the docstring: a dropped tick must not stop the schedule.
+                    }
+
+                    if (isOpen()) {
+                        armCron(row);
+                    }
+                })().catch(() => {
+                    // Unreachable — the body catches its own dispatch failure —
+                    // but an unhandled rejection here would take the process down.
+                });
+            },
+            Math.max(0, nextAt - Date.now()),
+        );
+
+        cronTimers.set(row.key, timer);
+    };
+
+    const scheduler: SchedulerHost = {
+        // eslint-disable-next-line @typescript-eslint/require-await -- the contract's cancel is async so a real host can await I/O; better-sqlite3 is synchronous
+        cancel: async (id) => {
+            clearJobTimer(id);
+
+            // Scoped to `state = 'pending'` so cancelling a *parked* job reports
+            // `false`. A dead-lettered job is no longer on its way — answering
+            // `true` would tell a caller it stopped a delivery that had already
+            // permanently failed.
+            return deletePendingJob.run(id).changes > 0;
         },
+
+        // eslint-disable-next-line @typescript-eslint/require-await -- see `cancel`
+        cron: async (expression, functionPath, args) => {
+            // Parse before writing: an invalid expression must fail the caller's
+            // await rather than land a row that can never be armed.
+            CronExpressionParser.parse(expression);
+
+            const row: CronRow = {
+                args: serialize(args ?? {}),
+                expression,
+                function_path: functionPath,
+                key: `${expression} ${functionPath}`,
+            };
+
+            upsertCron.run(row.key, row.expression, row.function_path, row.args);
+            armCron(row);
+        },
+
         deadLetter: {
             // eslint-disable-next-line @typescript-eslint/require-await -- see `cancel`
-            list: async () => [...dead].map(([id, job]) => toStatus(id, job)),
+            list: async () => selectByState.all("dead").map((row) => toStatus(row)),
             // eslint-disable-next-line @typescript-eslint/require-await -- see `cancel`
             requeue: async (id) => {
-                const job = dead.get(id);
+                // "Due immediately" rather than the original `scheduled_for`,
+                // which is by definition in the past by the time an operator
+                // requeues it: recovering a parked job means trying it now, and
+                // re-arming an elapsed timestamp is the same thing said less
+                // clearly.
+                const dueAt = Date.now();
 
-                if (job === undefined) {
+                if (requeueJob.run(dueAt, id).changes === 0) {
                     return false;
                 }
 
-                dead.delete(id);
-                // A fresh attempt budget is the point of a requeue — see the
-                // `SchedulerHost.deadLetter` docstring. Note the job is NOT
-                // re-armed with a live `setTimeout` here: it re-enters `pending`
-                // with its original `scheduledFor`, which is almost certainly in
-                // the past by the time an operator requeues it. That mirrors "due
-                // immediately" rather than firing an already-elapsed timer.
-                pending.set(id, { ...job, attempts: 0, timer: undefined });
+                armJob(id, dueAt);
 
                 return true;
             },
         },
+
         // eslint-disable-next-line @typescript-eslint/require-await -- see `cancel`
-        list: async () => [...pending].map(([id, job]) => toStatus(id, job)),
+        list: async () => selectByState.all("pending").map((row) => toStatus(row)),
+
         // eslint-disable-next-line @typescript-eslint/require-await -- see `cancel`
-        schedule: async (functionPath, args, options) => {
+        schedule: async (functionPath, args, scheduleOptions) => {
             const id = nextId();
             let scheduledFor: number;
 
-            if (options?.at === undefined) {
-                scheduledFor = Date.now() + (options?.delayMs ?? 0);
+            if (scheduleOptions?.at === undefined) {
+                scheduledFor = Date.now() + (scheduleOptions?.delayMs ?? 0);
             } else {
-                scheduledFor = typeof options.at === "number" ? options.at : options.at.getTime();
+                scheduledFor = typeof scheduleOptions.at === "number" ? scheduleOptions.at : scheduleOptions.at.getTime();
             }
 
-            const delay = Math.max(0, scheduledFor - Date.now());
-            const timer = setTimeout(() => {
-                pending.delete(id);
-            }, delay);
+            // eslint-disable-next-line unicorn/no-null -- writing SQL NULL into the nullable `retry` BLOB column; better-sqlite3 has no other spelling for it
+            insertJob.run(id, functionPath, serialize(args), scheduledFor, scheduleOptions?.retry === undefined ? null : serialize(scheduleOptions.retry));
+            armJob(id, scheduledFor);
 
-            pending.set(id, { args, attempts: 0, functionPath, options: options ?? {}, scheduledFor, timer });
+            const job: ScheduledJob = { id, scheduledFor };
 
-            return { id, scheduledFor };
+            return job;
         },
     };
 
+    // Re-arm everything the last process left behind. This is the loop that
+    // makes the durability claim true rather than aspirational — without it the
+    // rows above are a log of work nobody will ever do.
+    for (const row of selectByState.all("pending")) {
+        armJob(row.id, row.scheduled_for);
+    }
+
+    for (const row of selectCrons.all()) {
+        armCron(row);
+    }
+
     return {
         dispose: () => {
-            for (const job of pending.values()) {
-                clearTimeout(job.timer);
+            for (const timer of jobTimers.values()) {
+                clearTimeout(timer);
             }
+
+            for (const timer of cronTimers.values()) {
+                clearTimeout(timer);
+            }
+
+            jobTimers.clear();
+            cronTimers.clear();
         },
         scheduler,
         // eslint-disable-next-line @typescript-eslint/require-await -- see `cancel`
         simulateDeadLetter: async (id) => {
-            const job = pending.get(id);
+            const row = selectJob.get(id);
 
-            if (job === undefined) {
+            if (row?.state !== "pending") {
                 return false;
             }
 
-            clearTimeout(job.timer);
-            pending.delete(id);
-            dead.set(id, { ...job, attempts: (job.options.retry?.maxAttempts ?? 5) + 1, timer: undefined });
+            clearJobTimer(id);
+
+            const retry = decodeRetry(row.retry);
+
+            parkJob.run((retry?.maxAttempts ?? DEFAULT_RETRY.maxAttempts) + 1, id);
 
             return true;
         },
     };
 };
+
+export type { NodeSchedulerHost, NodeSchedulerHostOptions };
+export { createNodeSchedulerHost };

--- a/packages/platform-node/src/node-shard-host.ts
+++ b/packages/platform-node/src/node-shard-host.ts
@@ -102,19 +102,28 @@ const createAsyncSql = (database: Database.Database): ShardAsyncSqlExec => {
 };
 
 /**
- * Build the `ShardAlarms` surface over an in-process `setTimeout`.
+ * Build the `ShardAlarms` surface: a timestamp persisted to SQLite, an
+ * in-process `setTimeout` that delivers it, and — the part that makes the two
+ * add up to the contract — a re-arm on construction.
  *
- * This is the finding the spike's write-up leads with: an alarm that only
- * fires within the lifetime of the current Node process is not what
- * `ShardAlarms`'s docstring promises — "survive host recycling". SQLite could
- * persist the timestamp trivially — the gap is that nothing re-arms the timer
- * on process start, and a Node host has no host-level scheduler to do that for
- * it the way Cloudflare's runtime re-delivers alarms after an evicted DO
- * wakes. Persisting the timestamp without re-arming would be worse than not
- * persisting it: a caller reading `get()` after a restart would see a
- * "pending" alarm that will never fire.
+ * `ShardAlarms`'s docstring promises alarms "survive host recycling and fire at
+ * the requested timestamp". Cloudflare gets both halves from the runtime: DO
+ * storage holds the timestamp and workerd re-delivers `alarm()` to a freshly
+ * woken object. A Node process has no runtime to lean on, so this host owns
+ * both halves itself — the row in `_lunora_alarm` is the durable half, and
+ * reading it back when a host is constructed over the same database file is the
+ * delivery half. An alarm whose timestamp already elapsed while the process was
+ * down fires immediately on the next construction rather than being dropped,
+ * which is the at-least-once behavior a caller that scheduled it is owed.
+ *
+ * Delivery goes to `onAlarm`, because `ShardAlarms` deliberately has no
+ * callback of its own — on Cloudflare the runtime invokes the DO's `alarm()`
+ * method, so the contract models scheduling and leaves delivery to the host.
+ * A caller that supplies no `onAlarm` still gets the durable timestamp and the
+ * `get()`-clears-on-fire transition; it simply has nowhere for the wakeup to
+ * land.
  */
-const createAlarms = (database: Database.Database): { alarms: ShardAlarms; dispose: () => void } => {
+const createAlarms = (database: Database.Database, onAlarm?: () => Promise<void> | void): { alarms: ShardAlarms; dispose: () => void } => {
     let alarmAt: number | undefined;
     let alarmTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -137,6 +146,52 @@ const createAlarms = (database: Database.Database): { alarms: ShardAlarms; dispo
         }
     };
 
+    /**
+     * Arm the in-process timer for `ms`. Shared by `set` and by the
+     * construction-time re-arm below, so a restored alarm fires through exactly
+     * the same path as a freshly scheduled one.
+     */
+    const arm = (ms: number): void => {
+        clearAlarmTimeout();
+
+        const delay = Math.max(0, ms - Date.now());
+
+        alarmTimeout = setTimeout(() => {
+            alarmAt = undefined;
+            alarmTimeout = undefined;
+
+            // A caller may close the database before this timer fires — e.g.
+            // it set a future alarm, then tore the platform down (process
+            // shutdown, test cleanup). `persist` runs a prepared statement
+            // against `database`; on a closed better-sqlite3 connection that
+            // throws synchronously *inside* the `setTimeout` callback, which
+            // is an uncaught exception Node has no way to route back to a
+            // caller's try/catch — it crashes the process. Guard on the
+            // connection's own open/closed state rather than trying to track
+            // "did dispose() already run" separately, since `close()` is the
+            // one fact that actually determines whether `.run()` is safe.
+            if (!database.open) {
+                return;
+            }
+
+            // Clear the durable row BEFORE delivering. An `onAlarm` that throws
+            // (or that itself schedules the next alarm, which is the normal
+            // pattern) must not race a stale row: the timestamp this timer just
+            // consumed is spent either way, and leaving it behind would re-fire
+            // it on the next construction over this database.
+            persist(undefined);
+
+            (async (): Promise<void> => {
+                await onAlarm?.();
+            })().catch(() => {
+                // Delivery is the caller's business. A throwing handler must
+                // not become an unhandled rejection that takes the process
+                // down — Cloudflare likewise isolates an `alarm()` that
+                // throws to that invocation.
+            });
+        }, delay);
+    };
+
     const alarms: ShardAlarms = {
         delete: () => {
             alarmAt = undefined;
@@ -153,35 +208,38 @@ const createAlarms = (database: Database.Database): { alarms: ShardAlarms; dispo
 
             alarmAt = ms;
             persist(ms);
-            clearAlarmTimeout();
-
-            const delay = Math.max(0, ms - Date.now());
-
-            alarmTimeout = setTimeout(() => {
-                alarmAt = undefined;
-
-                // A caller may close the database before this timer fires — e.g.
-                // it set a future alarm, then tore the platform down (process
-                // shutdown, test cleanup). `persist` runs a prepared statement
-                // against `database`; on a closed better-sqlite3 connection that
-                // throws synchronously *inside* the `setTimeout` callback, which
-                // is an uncaught exception Node has no way to route back to a
-                // caller's try/catch — it crashes the process. Guard on the
-                // connection's own open/closed state rather than trying to track
-                // "did dispose() already run" separately, since `close()` is the
-                // one fact that actually determines whether `.run()` is safe.
-                if (database.open) {
-                    persist(undefined);
-                }
-            }, delay);
+            arm(ms);
         },
     };
+
+    // Re-arm whatever the last process left behind. `Math.max(0, …)` inside
+    // `arm` means an alarm whose time passed while nothing was running fires on
+    // the next tick rather than never — late, but delivered.
+    const restored = database.prepare<[], { scheduled_for: number }>("SELECT scheduled_for FROM _lunora_alarm WHERE id = 0").get();
+
+    if (restored !== undefined) {
+        alarmAt = restored.scheduled_for;
+        arm(restored.scheduled_for);
+    }
 
     return { alarms, dispose: clearAlarmTimeout };
 };
 
 /** Options for {@link createNodeShardHost}. */
 interface NodeShardHostOptions {
+    /**
+     * Called when a durable alarm comes due — this host's stand-in for the
+     * `alarm()` method workerd invokes on a Durable Object. Fires for alarms
+     * set during this process's lifetime AND for one restored from
+     * `_lunora_alarm` when the host is constructed over an existing database,
+     * including an alarm whose time elapsed while nothing was running.
+     *
+     * A handler that throws is isolated to its own delivery; it never reaches
+     * the caller that set the alarm, because by then that call has long
+     * returned.
+     */
+    onAlarm?: () => Promise<void> | void;
+
     /**
      * SQLite database file. Defaults to `:memory:` (matching the reference
      * host) — pass a real path to exercise cross-process persistence, the one
@@ -221,14 +279,29 @@ interface NodeShardHostOptions {
  * rather than closing `database` directly, so the alarm timer and the
  * connection are always retired together.
  */
-const createNodeShardHost = (options: NodeShardHostOptions = {}): { database: Database.Database; dispose: () => void; host: ShardHost } => {
+const createNodeShardHost = (
+    options: NodeShardHostOptions = {},
+): { database: Database.Database; dispose: () => void; drain: () => Promise<void>; host: ShardHost } => {
     const database = new Database(options.path ?? ":memory:");
 
     database.pragma("journal_mode = WAL");
 
     const sql = createSql(database);
     const asyncSql = createAsyncSql(database);
-    const { alarms, dispose: disposeAlarms } = createAlarms(database);
+    const { alarms, dispose: disposeAlarms } = createAlarms(database, options.onAlarm);
+
+    /**
+     * Background work handed to `waitUntil`, held until it settles.
+     *
+     * Retaining the promise is the whole job: a Node process has no
+     * request/response boundary to extend past, so the only thing the contract's
+     * `waitUntil` can meaningfully do here is make sure the work is not
+     * dropped*. A bare no-op left a rejected background promise with no
+     * handler attached, which Node surfaces as an unhandled rejection and — on
+     * the default `--unhandled-rejections=throw` — kills the process. The set
+     * also gives `drain()` something to await on shutdown.
+     */
+    const background = new Set<Promise<unknown>>();
 
     let tail: Promise<unknown> = Promise.resolve();
 
@@ -265,12 +338,36 @@ const createNodeShardHost = (options: NodeShardHostOptions = {}): { database: Da
         shardKey: options.shardKey,
         sql,
         transaction,
-        waitUntil: () => {
-            // A Node process has no separate request/background lifetime split —
-            // there is no response to return before background work finishes —
-            // so, like the reference host, this is a documented no-op rather than
-            // a fire-and-forget that could outlive the process silently.
+        waitUntil: (promise) => {
+            const tracked = promise
+                .catch(() => {
+                    // Swallowed on purpose — see `background`. Background work
+                    // that fails has no caller left to tell.
+                })
+                .finally(() => {
+                    background.delete(tracked);
+                });
+
+            background.add(tracked);
         },
+    };
+
+    /**
+     * Wait for every promise handed to `waitUntil` to settle.
+     *
+     * Kept separate from `dispose()` because the two answer different
+     * questions: `dispose()` releases handles and must stay synchronous (it
+     * backs `Symbol.dispose`), while draining is inherently awaitable. A
+     * graceful shutdown does `await drain()` then `dispose()`; a test that only
+     * needs the file handle back calls `dispose()` alone. Re-entrant by
+     * construction: each pass awaits the set as it stood, and background work
+     * that spawns more background work is picked up by the next loop.
+     */
+    const drain = async (): Promise<void> => {
+        while (background.size > 0) {
+            // eslint-disable-next-line no-await-in-loop -- sequential is the point: each pass drains the set as it stood, and background work that spawned more background work is picked up by the next iteration. Hoisting the await out would settle only the first generation.
+            await Promise.all(background);
+        }
     };
 
     const dispose = (): void => {
@@ -281,7 +378,7 @@ const createNodeShardHost = (options: NodeShardHostOptions = {}): { database: Da
         }
     };
 
-    return { database, dispose, host };
+    return { database, dispose, drain, host };
 };
 
 export type { NodeShardHostOptions };

--- a/packages/platform-node/src/node-socket-host.ts
+++ b/packages/platform-node/src/node-socket-host.ts
@@ -1,23 +1,42 @@
 /**
- * Node adapter: an in-process socket registry satisfying the provider-neutral
- * `@lunora/platform` `SocketHost` contract.
+ * Node adapter: a socket registry satisfying the provider-neutral
+ * `@lunora/platform` `SocketHost` contract, with attachments and tags persisted
+ * to SQLite.
  *
- * Cloudflare's `SocketHost` is backed by the DO WebSocket hibernation API —
- * sockets survive eviction because the *runtime* owns them. A plain Node
- * process has no hibernation primitive to borrow: every socket this host
- * tracks lives only as long as the process does, and "recycle" only ever
- * means "the caller told us to forget the runtime half and rehydrate it" —
- * there is no involuntary eviction to model. That is a real asymmetry, not a
- * simplification made for the spike: see `plans/234-node-host-findings.md`.
+ * Cloudflare's `SocketHost` is backed by the DO WebSocket hibernation API — the
+ * runtime* owns the sockets, so an attachment and its accept-time tags survive
+ * eviction for free. A Node process has no hibernation primitive to borrow, so
+ * this host splits the two halves explicitly:
  *
- * Unlike Cloudflare — whose tags freeze at `acceptWebSocket` — a Node
- * in-process registry has no reason a live socket's tags can't change, so
- * `setTag`/`removeTag` are implemented here. That is the mutable-tag tier
- * `SocketHost` documents as optional, and this host is the first one in the
- * repo to actually declare it.
+ * - **Runtime state** (the live transport object, its outbound frames, its
+ * in-memory tag set) lives in a `Map` and dies with the process. There is no
+ * way around that: a TCP socket cannot outlive the process holding it.
+ * - **Durable state** (attachment + tags, keyed by socket id) lives in
+ * `_lunora_sockets` on the same `better-sqlite3` connection as the rest of the
+ * shard, so it survives both a `simulateRecycle()` and a genuine process
+ * restart.
+ *
+ * That second half is what the contract actually asks for. `SocketHost`'s
+ * guarantee 2 is "arbitrary JSON state serialized with the socket must survive
+ * recycling and be readable on wake" — a guarantee about the *state*, not about
+ * the connection. A client that reconnects after a restart and presents its
+ * socket id gets its subscription state back, which is the behavior the engine
+ * reassociates on.
+ *
+ * Ids are `crypto.randomUUID()` rather than a counter. A counter restarts at 1
+ * on every process start and would collide with ids already in the table —
+ * silently handing a reconnecting client someone else's attachment.
+ *
+ * Unlike Cloudflare — whose tags freeze at `acceptWebSocket` — a Node registry
+ * has no reason a live socket's tags can't change, so `setTag`/`removeTag` are
+ * implemented. That is the mutable-tag tier `SocketHost` documents as optional,
+ * and this host is the first in the repo to declare it.
  */
 
+import { deserialize, serialize } from "node:v8";
+
 import type { SocketHandle, SocketHost } from "@lunora/platform";
+import type Database from "better-sqlite3";
 
 /** Internal record for one accepted (or restored) socket. */
 interface NodeSocket {
@@ -30,6 +49,12 @@ interface NodeSocket {
     raw: unknown;
     received: (string | ArrayBuffer)[];
     tags: Set<string>;
+}
+
+/** Row shape of `_lunora_sockets`. */
+interface SocketRow {
+    attachment: Buffer | null;
+    tags: string;
 }
 
 const toArrayBuffer = (data: string | ArrayBufferLike | Blob | ArrayBufferView): ArrayBuffer => {
@@ -59,7 +84,14 @@ const toArrayBuffer = (data: string | ArrayBufferLike | Blob | ArrayBufferView):
 export interface NodeSocketHost {
     /** Read back the frames sent to a socket, oldest first, text frames only. */
     readFrames: (handle: SocketHandle) => string[];
-    /** Re-create a runtime socket from durable state (post-"recycle"). */
+
+    /**
+     * Re-create a runtime socket from durable state.
+     *
+     * `attachment` is a fallback only: this host restores what it persisted,
+     * because that is what a real wake looks like. The argument covers an id
+     * this host never durably tracked (a synthetic id a test constructs).
+     */
     restoreSocket: (id: string, attachment: unknown) => SocketHandle;
     /** Drop the runtime socket map while keeping durable attachments/tags. */
     simulateRecycle: () => void;
@@ -67,12 +99,40 @@ export interface NodeSocketHost {
     socket: SocketHost;
 }
 
-/** Build the in-process socket registry. */
-export const createNodeSocketHost = (): NodeSocketHost => {
+/** Build the socket registry, persisting attachments and tags to `database`. */
+export const createNodeSocketHost = (database: Database.Database): NodeSocketHost => {
+    database.exec("CREATE TABLE IF NOT EXISTS _lunora_sockets (id TEXT PRIMARY KEY, attachment BLOB, tags TEXT NOT NULL DEFAULT '[]')");
+
+    const upsertRow = database.prepare<[string, Buffer | null, string]>(
+        `INSERT INTO _lunora_sockets (id, attachment, tags) VALUES (?, ?, ?)
+         ON CONFLICT (id) DO UPDATE SET attachment = excluded.attachment, tags = excluded.tags`,
+    );
+    const updateAttachment = database.prepare<[Buffer | null, string]>("UPDATE _lunora_sockets SET attachment = ? WHERE id = ?");
+    const updateTags = database.prepare<[string, string]>("UPDATE _lunora_sockets SET tags = ? WHERE id = ?");
+    const selectRow = database.prepare<[string], SocketRow>("SELECT attachment, tags FROM _lunora_sockets WHERE id = ?");
+    const deleteRow = database.prepare<[string]>("DELETE FROM _lunora_sockets WHERE id = ?");
+
     const runtimeSockets = new Map<string, NodeSocket>();
-    const durableAttachments = new Map<string, unknown>();
-    const durableTags = new Map<string, Set<string>>();
     const handleIds = new WeakMap<SocketHandle, string>();
+
+    /**
+     * Every durable write is guarded on `database.open`. A socket handle can
+     * outlive the connection — a caller that closes the platform still holds
+     * handles, and `send`/`serializeAttachment` on one must not throw from a
+     * closed connection.
+     */
+    const persistAttachment = (id: string, value: unknown): void => {
+        if (database.open) {
+            // eslint-disable-next-line unicorn/no-null -- writing SQL NULL into a nullable BLOB column; better-sqlite3 has no other spelling for it
+            updateAttachment.run(value === undefined ? null : serialize(value), id);
+        }
+    };
+
+    const persistTags = (id: string, tags: Set<string>): void => {
+        if (database.open) {
+            updateTags.run(JSON.stringify([...tags]), id);
+        }
+    };
 
     const createHandle = (socketState: NodeSocket): SocketHandle => {
         // Alias so the mutation is on a local binding, not the parameter
@@ -83,6 +143,16 @@ export const createNodeSocketHost = (): NodeSocketHost => {
             bufferedAmount: state.bufferedAmount,
             close: (_code, _reason) => {
                 state.closed = true;
+                runtimeSockets.delete(state.id);
+
+                // A closed socket is never restored, so its durable row is
+                // garbage the moment it closes. Cloudflare drops the socket from
+                // `getWebSockets()` on the close event; leaving the row (and the
+                // map entry) behind would both leak and fan updates out at a dead
+                // subscriber.
+                if (database.open) {
+                    deleteRow.run(state.id);
+                }
             },
             deserializeAttachment: () => state.attachment,
             send: (data) => {
@@ -90,7 +160,7 @@ export const createNodeSocketHost = (): NodeSocketHost => {
             },
             serializeAttachment: (value) => {
                 state.attachment = value;
-                durableAttachments.set(state.id, value);
+                persistAttachment(state.id, value);
             },
         };
 
@@ -100,16 +170,10 @@ export const createNodeSocketHost = (): NodeSocketHost => {
         return handle;
     };
 
-    let counter = 0;
-    const nextId = (): string => {
-        counter += 1;
-
-        return `node-socket-${String(counter)}`;
-    };
-
     const socket: SocketHost = {
         accept: (raw, attachment, tags) => {
-            const id = nextId();
+            const id = crypto.randomUUID();
+            const tagSet = new Set(tags);
             const state: NodeSocket = {
                 attachment,
                 bufferedAmount: 0,
@@ -118,14 +182,14 @@ export const createNodeSocketHost = (): NodeSocketHost => {
                 id,
                 raw,
                 received: [],
-                tags: new Set(tags),
+                tags: tagSet,
             };
 
             runtimeSockets.set(id, state);
-            durableTags.set(id, new Set(tags));
 
-            if (attachment !== undefined) {
-                durableAttachments.set(id, attachment);
+            if (database.open) {
+                // eslint-disable-next-line unicorn/no-null -- see `persistAttachment`: SQL NULL for an absent attachment
+                upsertRow.run(id, attachment === undefined ? null : serialize(attachment), JSON.stringify([...tagSet]));
             }
 
             return createHandle(state);
@@ -166,7 +230,7 @@ export const createNodeSocketHost = (): NodeSocketHost => {
                 state.tags.delete(tag);
             }
 
-            durableTags.set(id, new Set(state.tags));
+            persistTags(id, state.tags);
         },
         setTag: (handle, tag) => {
             const id = handleIds.get(handle);
@@ -177,27 +241,25 @@ export const createNodeSocketHost = (): NodeSocketHost => {
             }
 
             state.tags.add(tag);
-            durableTags.set(id, new Set(state.tags));
+            persistTags(id, state.tags);
         },
     };
 
     return {
         readFrames: (handle) => (runtimeSockets.get(handleIds.get(handle) ?? "")?.received ?? []).filter((frame): frame is string => typeof frame === "string"),
         restoreSocket: (id, attachment) => {
+            const row = database.open ? selectRow.get(id) : undefined;
+
+            const persisted = row?.attachment === null ? undefined : row?.attachment;
             const state: NodeSocket = {
-                // Prefer this host's OWN durable record over the caller-supplied
-                // `attachment` — a real host restores from what it persisted, not
-                // from a copy the caller happens to still be holding. Falling back
-                // to the argument only covers an id this host never durably
-                // tracked (a synthetic id a test constructs directly).
-                attachment: durableAttachments.has(id) ? durableAttachments.get(id) : attachment,
+                attachment: persisted === undefined ? attachment : deserialize(persisted),
                 bufferedAmount: 0,
                 closed: false,
                 handle: undefined as unknown as SocketHandle,
                 id,
                 raw: undefined,
                 received: [],
-                tags: new Set(durableTags.get(id)),
+                tags: new Set(row === undefined ? [] : (JSON.parse(row.tags) as string[])),
             };
 
             runtimeSockets.set(id, state);

--- a/packages/platform/src/capabilities.ts
+++ b/packages/platform/src/capabilities.ts
@@ -113,51 +113,58 @@ export const CLOUDFLARE_CAPABILITIES: PlatformCapabilities = {
  * The Node capability matrix — `@lunora/platform-node`'s honest self-rating
  * (plan 234).
  *
- * `@lunora/platform-node` is a spike: a `ShardHost`/`SocketHost`/
- * `ShardDirectory`/`ShardKvStore`/`SchedulerHost` implementation over
- * `better-sqlite3` and an in-process registry, built to run the conformance
- * TCK against a second host and discover what the contracts under-specify.
- * It is a single Node process with no distributed placement, no host-level
- * scheduler to re-arm timers after a restart, and no bindings at all for the
- * Cloudflare-specific products (R2, Vectorize, Workers AI, Queues,
- * Workflows, Containers, Browser Rendering, Analytics Engine, Secrets Store,
- * Hyperdrive) most `ctx.*` surfaces are built on. Every one of those is
- * rated `"unsupported"` here rather than left undeclared — see
- * `gateAgainstMatrix` in `@lunora/codegen`, whose fail-closed gate (plan
- * 229) treats an undeclared feature as unsupported anyway, but under a
- * different diagnostic name than an honest, explicit rating.
+ * `@lunora/platform-node` implements every contract in this package
+ * (`ShardHost`, `SocketHost`, `ShardDirectory`, `ShardKvStore`,
+ * `SchedulerHost`) over `better-sqlite3` and an in-process registry, plus the
+ * `.global()` table backend via `@lunora/sql-store`. It began as a spike to run
+ * the conformance TCK against a second host; the durability gaps that spike
+ * surfaced — alarms and scheduler jobs that were persisted but never re-armed,
+ * socket attachments that lived only in memory — are closed, and each is now
+ * pinned by a restart test rather than only by a simulated recycle.
  *
- * Two features are rated `"emulated"` rather than `"native"` even though
- * this package fully implements their contract, because "native" would
- * overstate what a bare Node process provides on its own: `keyValueStore` is
- * a SQL table wearing a KV-shaped API, not a dedicated KV product, and
- * `websocketHibernation` never actually evicts a socket to save memory — it
- * only proves the attachment/tag durability half of the contract, not real
- * hibernation. Both ratings, and the `"unsupported"` ones for `scheduler`
- * durability and `globalTables`, are argued in detail in
- * `plans/234-node-host-findings.md`.
+ * What remains genuinely absent is everything a single Node process cannot
+ * distribute: placement across nodes, failover, the cross-shard query
+ * coordinator, and any binding at all for the Cloudflare-specific products
+ * (R2, Vectorize, Workers AI, Queues, Workflows, Containers, Browser Rendering,
+ * Analytics Engine, Secrets Store, Hyperdrive) most `ctx.*` surfaces are built
+ * on. Every one of those is rated `"unsupported"` here rather than left
+ * undeclared — see `gateAgainstMatrix` in `@lunora/codegen`, whose fail-closed
+ * gate (plan 229) treats an undeclared feature as unsupported anyway, but under
+ * a different diagnostic name than an honest, explicit rating.
+ *
+ * Almost nothing here is rated `"native"`, and that is the matrix's own
+ * definition doing its job rather than a hedge: `native` means the platform
+ * itself provides the feature, and a bare Node process provides essentially
+ * none of them — Lunora builds alarms out of `setTimeout` plus a durable row,
+ * a KV store out of a SQL table, and `.global()` tables out of a second SQLite
+ * file. `localSql` is the exception, because SQLite genuinely is the platform
+ * primitive there. The ratings say who does the work; the notes say how well.
+ * Both are argued in detail in `plans/234-node-host-findings.md`.
  */
 export const NODE_CAPABILITIES: PlatformCapabilities = {
     id: "node",
     name: "Node",
     features: {
         shardedState: { level: "emulated", note: "One better-sqlite3 database per shard key, one process — no distributed placement or failover" },
-        globalTables: { level: "unsupported", note: "No replicated SQL store (D1-equivalent) implemented" },
+        globalTables: {
+            level: "emulated",
+            note: "The @lunora/sql-store core on its own SQLite file via the reference sqliteDialect — full store semantics, but one node with no replication",
+        },
         websocketHibernation: {
             level: "emulated",
-            note: "In-process socket registry; attachments/tags survive a simulated recycle, not a process restart, and nothing is ever actually evicted from memory",
+            note: "Socket registry with attachments/tags persisted to SQLite, so subscription state survives a process restart; nothing is ever actually evicted from memory, so this is durability without hibernation's memory saving",
         },
         localSql: { level: "native", note: "better-sqlite3 (synchronous, embedded)" },
         shardAlarms: {
             level: "emulated",
-            note: "In-process setTimeout; the timestamp can be persisted to SQLite but nothing re-arms it on process restart",
+            note: "setTimeout over a durable row; re-armed on construction, so an alarm survives a restart and one whose time elapsed while the process was down fires late rather than never",
         },
         crossShardFanout: { level: "unsupported", note: "No query coordinator / relay tier implemented" },
         queues: { level: "unsupported", note: "No Cloudflare Queues equivalent implemented" },
         workflows: { level: "unsupported", note: "No Cloudflare Workflows equivalent implemented" },
         scheduler: {
             level: "emulated",
-            note: "In-process setTimeout only; not durable across a process restart, and no dynamic cron registration is implemented",
+            note: "SQLite job table re-armed on construction, with retry backoff and a dead-letter queue; the only host that implements runtime cron registration (SchedulerHost.cron), which Cloudflare cannot offer",
         },
         objectStorage: { level: "unsupported", note: "No R2/S3-equivalent binding implemented" },
         keyValueStore: { level: "emulated", note: "better-sqlite3 table behind the ShardKvStore API — not a dedicated KV product" },

--- a/plans/234-node-host-findings.md
+++ b/plans/234-node-host-findings.md
@@ -390,3 +390,75 @@ all-`native`-or-`emulated` Cloudflare matrix, which never took the
   none ([Finding 9](#finding-9-zero-new-engine-coupling-gaps-229-generalizes)), so there is nothing to file there. The two host-bugs found in
   the _reference host_ ([#5](#finding-5-host-bug-the-reference-hosts-durableattachments-map-is-dead-code), [#6](#finding-6-host-bug-class-the-reference-hosts-readwrite-heuristic-is-weaker-than-necessary)) and the `ShardDirectory.jurisdiction` architecture gap
   ([#2](#finding-2-contract-under-specification-shard-directoryjurisdiction-has-zero-real-callers)) are real but sized for their own follow-up plans, not this one.
+
+---
+
+# Update — durability hardening (commit `ae75f844`)
+
+The spike's ratings above are superseded for four features. Everything the
+spike _discovered_ stands; what changed is that three of the gaps it recorded
+as inherent turned out to be missing code rather than missing platform.
+
+## What closed, and why the original reasoning was wrong
+
+[Finding 3](#finding-3-contract-under-specification-durable-does-not-say-durable-against-what) argued that persisting an alarm timestamp without a
+host-level daemon to re-deliver it would be _worse_ than not persisting —
+because a caller reading `get()` after a restart would see a pending alarm that
+never fires. That is true of persistence alone, and it quietly assumed the
+re-arm had to come from outside the process. It doesn't: the next construction
+of a host over the same database file is itself the wake, and reading the row
+back there is the whole fix. The same argument had been copied into the
+scheduler, which is why that contract was implemented entirely in memory.
+
+| Feature                | Was                                                     | Now      | What changed                                                                                                 |
+| ---------------------- | ------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `shardAlarms`          | emulated, "nothing re-arms it on restart"               | emulated | Re-armed on construction; an elapsed alarm fires late rather than never; delivery via a new `onAlarm` option |
+| `scheduler`            | emulated, "not durable, no dynamic cron"                | emulated | SQLite job table re-armed on construction, retry backoff, dead-letter, and runtime `cron`                    |
+| `websocketHibernation` | emulated, "survives a simulated recycle, not a restart" | emulated | Attachments and tags in `_lunora_sockets`; survives a real restart                                           |
+| `globalTables`         | unsupported                                             | emulated | The `@lunora/sql-store` core on its own SQLite file via the reference `sqliteDialect`                        |
+
+The levels mostly did not move, and that is the matrix's definition working as
+intended: `native` means the _platform_ provides the feature, and Node provides
+none of these. The notes carry the real information, and three of them had
+become false.
+
+`crossShardFanout` and the deploy driver remain as recorded.
+
+## Finding 10 (layering): the reference SQLite dialect lives in `@lunora/d1`
+
+`sqliteDialect` is the reference `SqlDialect` the store core was written
+against, and every SQLite-backed target needs it — but it lives in
+`packages/d1/src/sqlite-dialect.ts`, so `@lunora/platform-node` now depends on
+a package called `d1` to get it. Nothing about it is Cloudflare-bound
+(`@lunora/d1`'s dependencies are `errors`, `platform`, `shard-engine`,
+`sql-store`, `drizzle-orm`; the `@cloudflare/workers-types` reference is
+type-only), so this is a naming smell rather than a layering violation — but it
+is the second consumer, and `@lunora/sql-store`'s own tests already keep a
+third, hand-rolled copy specifically to avoid depending on a downstream
+package.
+
+**Proposed fix**: move `sqliteDialect` into `@lunora/sql-store` beside the
+`SqlDialect` contract, re-exporting from `@lunora/d1` for its existing callers.
+Not done here because it also requires moving `sqlAffinityForKind` out of
+`@lunora/d1`'s `dialect.ts`, which the CLI migration emitter imports — a
+three-package refactor unrelated to this target.
+
+## Finding 11 (host-bug-class): TypeScript narrows `database.open` across an `await`
+
+The scheduler's delivery path guards every statement on `database.open`,
+because a timer can outlive a `close()` and a statement on a closed
+better-sqlite3 connection throws synchronously inside the timer callback, where
+no caller's `try`/`catch` can reach it.
+
+After an early `if (!database.open) { return; }`, TypeScript narrows the
+property to `true` for the rest of the function — and then
+`@typescript-eslint/no-unnecessary-condition` reports every later check as
+redundant. It is exactly wrong: an `await` sits in between, and the caller may
+have closed the connection during it. Taking the lint at face value would have
+deleted the guards that make the timer safe.
+
+The fix is a one-line `const isOpen = (): boolean => database.open;` so each
+check stays a real runtime read. Worth knowing generally: any `readonly boolean`
+liveness flag re-checked after an `await` will attract the same false positive,
+and `@lunora/platform-cloudflare` has the same shape in `execSql`'s call-time
+probing.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2810,7 +2810,7 @@ importers:
         version: link:../platform
       '@lunora/platform-cloudflare':
         specifier: 1.0.0-alpha.1
-        version: link:../platform-cloudflare
+        version: 1.0.0-alpha.1
       '@lunora/shard-engine':
         specifier: workspace:*
         version: link:../shard-engine
@@ -3389,12 +3389,21 @@ importers:
 
   packages/platform-node:
     dependencies:
+      '@lunora/d1':
+        specifier: workspace:*
+        version: link:../d1
       '@lunora/platform':
         specifier: workspace:*
         version: link:../platform
+      '@lunora/sql-store':
+        specifier: workspace:*
+        version: link:../sql-store
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
+      cron-parser:
+        specifier: 5.6.2
+        version: 5.6.2
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: catalog:test
@@ -7522,6 +7531,10 @@ packages:
   '@lingui/message-utils@6.6.0':
     resolution: {integrity: sha512-XkEcuMjIUjq7KZfTe83jP6UWQvKskpae/Ve7E8M8HEJ3TujHIPLzKn/quEmot6pKRtGwYxQzktGRfs2sPcZaqg==}
     engines: {node: '>=22.19.0'}
+
+  '@lunora/platform-cloudflare@1.0.0-alpha.1':
+    resolution: {integrity: sha512-6awpLQm1Q2tCnPn0ESNoM4czxYvxFtKjBwU3XhIl5HzdIWlUbbxRJ2rZI0m+EBfEYxhkSbCzyd2vua17wtPV7w==}
+    engines: {node: ^22.15.0 || >=24.11.0}
 
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
     resolution: {integrity: sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==}
@@ -16066,10 +16079,12 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cron-parser@5.6.2:
     resolution: {integrity: sha512-yJ/G1LVir6CnlkLI40CsampPLKl1SprGGlUagWtGJxewytRVYezv5xVyzzbT+Pvzx+VIRvZVF7/a0eEMTxdnTA==}
     engines: {node: '>=18'}
+    deprecated: 'Published tarball was built from a stale dist/ and is missing the fixes from #414 and #415 — its contents are effectively v5.6.1. Upgrade to v5.7.0.'
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
@@ -27389,6 +27404,10 @@ snapshots:
       '@messageformat/date-skeleton': 1.1.0
       '@messageformat/parser': 5.1.1
       js-sha256: 0.10.1
+
+  '@lunora/platform-cloudflare@1.0.0-alpha.1':
+    dependencies:
+      '@lunora/platform': link:packages/platform
 
   '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
     optional: true


### PR DESCRIPTION
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- feat(platform-node): close the host durability gaps
- docs(platform-node): record the durability-hardening findings

## Files this branch still changes relative to alpha

```
packages/platform-node/__tests__/engine-conformance.test.ts
packages/platform-node/__tests__/global-store.test.ts
packages/platform-node/__tests__/lifecycle.test.ts
packages/platform-node/package.json
packages/platform-node/src/conformance/index.ts
packages/platform-node/src/index.ts
packages/platform-node/src/node-global-store.ts
packages/platform-node/src/node-platform.ts
packages/platform-node/src/node-scheduler-host.ts
packages/platform-node/src/node-shard-host.ts
packages/platform-node/src/node-socket-host.ts
packages/platform/src/capabilities.ts
plans/234-node-host-findings.md
pnpm-lock.yaml
```
