### PR TITLE
fix(client): promote a follower after the leader yields leadership

### DIFF
--- a/api-snapshots/client.api.md
+++ b/api-snapshots/client.api.md
@@ -1349,12 +1349,14 @@ class TabCoordinator {
     start(): void;
     stop(): void;
     isLeader(): boolean;
+    promoteImmediately(): void;
     get leaderTabId(): string | undefined;
     get id(): string;
     get isRunning(): boolean;
-    broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string): void;
+    broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string, identity?: string | null): void;
     broadcastSubscriptionError(key: string, error: SubscriptionError): void;
-    broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number): void;
+    broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string, identity?: string | null): void;
+    broadcastConnectionStatus(status: ConnectionStatus, identity?: string | null): void;
 }
 ```
 

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -3904,7 +3904,7 @@ const selectShapeRows: (sql: SqlExec, table: string, effectiveWhere: WhereInput 
 ### `sendDeltaFrames` (const)
 
 ```ts
-const sendDeltaFrames: (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string) => boolean;
+const sendDeltaFrames: (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string, lastMutationId?: number) => boolean;
 ```
 
 ### `serializeSqlValue` (const)

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -8,10 +8,11 @@ import type { FunctionReference } from "../src/types";
 /** Wire shape mirrored from `cross-tab.ts`'s internal message union, for raw test-side sends. */
 type RawMessage = { tabId: string; ts: number; type: "claim-leadership" | "heartbeat" };
 
-/** Wire shape of a leader's `subscription-data` / `subscription-settled` broadcast, for raw test-side sends simulating a leader tab. */
+/** Wire shape of a leader's `subscription-data` / `subscription-settled` / `connection-status` broadcast, for raw test-side sends simulating a leader tab. */
 type RawLeaderMessage =
     | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
-    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" };
+    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
+    | { status: "connected" | "connecting" | "idle" | "offline"; tabId: string; type: "connection-status" };
 
 const fnRef = (ref: string): FunctionReference => {
     return { __lunoraRef: ref };
@@ -533,6 +534,140 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
         } finally {
             rogue.close();
             client.close();
+        }
+    });
+});
+
+describe("lunoraClient — follower connection-status mirror + offline-queue gate (plan 266 S2)", () => {
+    it("a follower queues an offline mutation instead of rejecting it, gated by the mirrored leader status", async () => {
+        expect.assertions(3);
+
+        // A rejecting fetch stands in for "the network is actually down" — the
+        // fix's whole point is that the follower queues BEFORE ever reaching
+        // this call, not that the call itself somehow succeeds.
+        const fetchMock = vi.fn<typeof fetch>(async () => {
+            throw new TypeError("Failed to fetch");
+        });
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            // The leader reports connected once (establishing the follower's
+            // sticky `leaderWasEverConnected`), then offline.
+            rogue.postMessage({ status: "connected", tabId: "leader-tab", type: "connection-status" } satisfies RawLeaderMessage);
+            await delay(30);
+            rogue.postMessage({ status: "offline", tabId: "leader-tab", type: "connection-status" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(client.connectionStatus()).toBe("offline");
+
+            let rejected = false;
+
+            client.mutation(fnRef("posts:create"), { title: "a" }).catch(() => {
+                rejected = true;
+            });
+
+            // Queued, not sent — `fetchMock` (which would reject) is never
+            // called. (Fails pre-fix: a follower's `conn` is always
+            // `undefined`, so `wasEverConnected` is always `false` and the
+            // write falls through to the rejecting `fetchMock`.)
+            expect(client.pendingCount()).toBe(1);
+
+            await delay(30);
+
+            expect(rejected).toBe(false);
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("a follower's connectionStatus mirrors the leader's aggregate status instead of staying idle forever", async () => {
+        expect.assertions(4);
+
+        const client = new LunoraClient({ crossTabSync: true, fetch: vi.fn<typeof fetch>(async () => jsonResponse({ result: {} })), url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+        const statuses: string[] = [];
+
+        client.onConnectionStatus((status) => statuses.push(status));
+
+        try {
+            expect(client.connectionStatus()).toBe("idle");
+
+            rogue.postMessage({ status: "connected", tabId: "leader-tab", type: "connection-status" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            // Fails pre-fix: `computeStatus()` reads the follower's own (always
+            // empty) `connections` map and reports `"idle"` forever.
+            expect(client.connectionStatus()).toBe("connected");
+
+            rogue.postMessage({ status: "offline", tabId: "leader-tab", type: "connection-status" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(client.connectionStatus()).toBe("offline");
+            expect(statuses).toStrictEqual(["idle", "connected", "offline"]);
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("demotion tears down a connection's timers via the shared teardown sequence (no leak)", async () => {
+        expect.assertions(4);
+
+        vi.useFakeTimers();
+
+        const client = new LunoraClient({ crossTabSync: true, fetch: vi.fn<typeof fetch>(async () => jsonResponse({ result: {} })), url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            // Solo self-promotion: no competing claim, so this client becomes
+            // leader after the coordinator's default leader-timeout window.
+            await vi.advanceTimersByTimeAsync(3100);
+
+            // White-box: inject a `ShardConnection`-shaped record directly into
+            // the connections map with its own armed timers and a `socket`
+            // whose `close()` has no side effects of its own — isolates this
+            // test from the real socket-close -> `handleDisconnect` path
+            // (which already stops the heartbeat independently of demotion),
+            // so it targets exactly what `onStopBeingLeader`/`teardownConnection`
+            // do. `ShardConnection`'s fields aren't part of the public API,
+            // but `private` isn't runtime-enforced.
+            const heartbeatTimer = setInterval(() => undefined, 1000);
+            const connectTimer = setTimeout(() => undefined, 1000);
+            const socketClose = vi.fn<() => void>();
+
+            const internals = client as unknown as {
+                connections: Map<
+                    string,
+                    { connectTimer?: unknown; heartbeatTimer?: unknown; reconnectTimer?: unknown; socket?: { close: () => void }; wsState?: string }
+                >;
+            };
+
+            internals.connections.set("", { connectTimer, heartbeatTimer, reconnectTimer: undefined, socket: { close: socketClose }, wsState: "open" });
+
+            const conn = internals.connections.get("");
+
+            expect(conn?.heartbeatTimer).toBeDefined();
+
+            // A smaller-tabId heartbeat forces this client's coordinator to
+            // step down — the same demotion CLIENT-02 covers for a bare
+            // `TabCoordinator`, now exercised through the full `LunoraClient`.
+            rogue.postMessage({ tabId: SMALLER_ID, ts: Date.now(), type: "heartbeat" });
+
+            await vi.advanceTimersByTimeAsync(20);
+
+            // Before the fix, `onStopBeingLeader` only called
+            // `conn.socket?.close()` — the connect timer and heartbeat
+            // interval survived the map deletion (a leak). `teardownConnection`
+            // clears both, and still closes the socket.
+            expect(conn?.heartbeatTimer).toBeUndefined();
+            expect(conn?.connectTimer).toBeUndefined();
+            expect(socketClose).toHaveBeenCalledTimes(1);
+        } finally {
+            rogue.close();
+            client.close();
+            vi.useRealTimers();
         }
     });
 });

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -10,9 +10,18 @@ type RawMessage = { tabId: string; ts: number; type: "claim-leadership" | "heart
 
 /** Wire shape of a leader's `subscription-data` / `subscription-settled` / `connection-status` broadcast, for raw test-side sends simulating a leader tab. */
 type RawLeaderMessage =
-    | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
-    | { clientId?: string; cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
-    | { status: "connected" | "connecting" | "idle" | "offline"; tabId: string; type: "connection-status" };
+    | { cursor?: number; data: unknown; epoch?: string; identity?: string | null; key: string; tabId: string; type: "subscription-data" }
+    | {
+          clientId?: string;
+          cursor?: number;
+          epoch?: string;
+          identity?: string | null;
+          key: string;
+          lastMutationId?: number;
+          tabId: string;
+          type: "subscription-settled";
+      }
+    | { identity?: string | null; status: "connected" | "connecting" | "idle" | "offline"; tabId: string; type: "connection-status" };
 
 const fnRef = (ref: string): FunctionReference => {
     return { __lunoraRef: ref };
@@ -979,6 +988,90 @@ describe("lunoraClient — cross-tab channel scoped to deployment + identity (pl
 
             probeOnAnon.close();
             probeOnSignedIn.close();
+        } finally {
+            client.close();
+        }
+    });
+});
+
+describe("lunoraClient — identity stamp on data-bearing frames (plan 263 S2)", () => {
+    it("drops a data frame whose identity stamp mismatches this follower's own fingerprint, even on its own channel", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: {} }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: TEST_URL });
+
+        client.setAuthToken("token-me", "user-me");
+
+        try {
+            const received: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, (value) => received.push(value));
+
+            const rogue = new BroadcastChannel(clientChannel(client));
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            // A stamp from a DIFFERENT identity than this follower's own — the
+            // race the belt-and-braces stamp exists for: a `setAuthToken` in
+            // this tab already moved it to a new (this) channel while a stale
+            // frame from the OLD identity's leader was already queued.
+            rogue.postMessage(
+                { data: "not-mine", identity: "subj:someone-else", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage,
+            );
+            await delay(30);
+
+            expect(received).toStrictEqual([]);
+
+            // An absent stamp (mixed-version / old leader) is still accepted
+            // — today's behavior, unchanged.
+            rogue.postMessage({ data: "old-leader-row", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(received).toStrictEqual(["old-leader-row"]);
+
+            rogue.close();
+        } finally {
+            client.close();
+        }
+    });
+
+    it("drops a settled frame and a connection-status frame with a mismatched identity stamp too", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: {} }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: TEST_URL });
+
+        client.setAuthToken("token-me", "user-me");
+
+        try {
+            const checkpoints: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, () => undefined, { onCheckpoint: (watermark) => checkpoints.push(watermark) });
+
+            const rogue = new BroadcastChannel(clientChannel(client));
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            rogue.postMessage({
+                cursor: 10,
+                identity: "subj:someone-else",
+                key,
+                lastMutationId: 5,
+                tabId: "leader-tab",
+                type: "subscription-settled",
+            } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(checkpoints).toStrictEqual([]);
+
+            rogue.postMessage({ identity: "subj:someone-else", status: "connected", tabId: "leader-tab", type: "connection-status" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            // The mismatched connection-status frame must not have been
+            // mirrored either — the client stays "idle" (its default), not
+            // "connected" as the dropped frame claimed.
+            expect(client.connectionStatus()).toBe("idle");
+
+            rogue.close();
         } finally {
             client.close();
         }

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -20,6 +20,57 @@ const fnRef = (ref: string): FunctionReference => {
 
 const jsonResponse = (body: unknown): Response => Response.json(body, { headers: { "content-type": "application/json" }, status: 200 });
 
+// --- Minimal mock WebSocket (for tests needing a leader that actually opens
+// a connection — e.g. proving deployment isolation by counting how many
+// sockets got constructed, not just a status string 266's follower-mirror
+// fix already keeps off `"idle"`). Records each constructed instance's url
+// into the shared `constructed` array passed in, so a caller can tell
+// "exactly one leader opened a socket" from "every tab opened its own". ---
+
+const createMockWebSocket = (constructed: string[]): typeof WebSocket => {
+    class WS {
+        public readonly url: string;
+
+        public readyState = 0;
+
+        public onopen: ((event?: unknown) => void) | null = null;
+
+        public onmessage: ((event: { data: unknown }) => void) | null = null;
+
+        public onclose: ((event?: unknown) => void) | null = null;
+
+        public onerror: ((event?: unknown) => void) | null = null;
+
+        public constructor(url: string) {
+            this.url = url;
+            constructed.push(url);
+        }
+
+        // eslint-disable-next-line class-methods-use-this -- test double: no listener bookkeeping needed for these tests
+        public addEventListener(): void {}
+
+        // eslint-disable-next-line class-methods-use-this -- test double: never actually sends
+        public send(): void {}
+
+        public close(): void {
+            this.readyState = 3;
+            this.onclose?.();
+        }
+    }
+
+    return WS as unknown as typeof WebSocket;
+};
+
+// Every `crossTabSync` client below in the CLIENT-01/plan-266 tests is
+// constructed with this SAME url — the channel is now scoped to
+// `deployment + identity` (plan 263 S1), so a raw same-origin
+// `BroadcastChannel` probe must derive the exact channel the client itself
+// is listening on instead of the old bare `"lunora-bridge"` name.
+const TEST_URL = "https://app.example";
+
+/** The identity-scoped channel a `crossTabSync` client (constructed with `url: TEST_URL`) is actually listening on — see `LunoraClient.createTabCoordinator`. */
+const clientChannel = (client: LunoraClient): string => `lunora-bridge::${TEST_URL}::${client.currentIdentity() ?? "anon"}`;
+
 // Real `TabCoordinator` ids always start with `"tab_"` (see `cross-tab.ts`). These
 // fabricated ids are chosen to sort deterministically on either side of that
 // prefix regardless of the module-level `nextTabId` counter's current value or
@@ -396,7 +447,7 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const received: unknown[] = [];
@@ -433,7 +484,7 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const received: unknown[] = [];
@@ -472,7 +523,7 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const received: unknown[] = [];
@@ -512,7 +563,7 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const checkpoints: unknown[] = [];
@@ -556,7 +607,7 @@ describe("lunoraClient — follower connection-status mirror + offline-queue gat
             throw new TypeError("Failed to fetch");
         });
         const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             // The leader reports connected once (establishing the follower's
@@ -593,7 +644,7 @@ describe("lunoraClient — follower connection-status mirror + offline-queue gat
         expect.assertions(4);
 
         const client = new LunoraClient({ crossTabSync: true, fetch: vi.fn<typeof fetch>(async () => jsonResponse({ result: {} })), url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
         const statuses: string[] = [];
 
         client.onConnectionStatus((status) => statuses.push(status));
@@ -625,7 +676,7 @@ describe("lunoraClient — follower connection-status mirror + offline-queue gat
         vi.useFakeTimers();
 
         const client = new LunoraClient({ crossTabSync: true, fetch: vi.fn<typeof fetch>(async () => jsonResponse({ result: {} })), url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             // Solo self-promotion: no competing claim, so this client becomes
@@ -685,7 +736,7 @@ describe("lunoraClient — cross-tab settled watermark scoped to the owning clie
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ clientId: "client-X", crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const checkpoints: unknown[] = [];
@@ -723,7 +774,7 @@ describe("lunoraClient — cross-tab settled watermark scoped to the owning clie
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ clientId: "client-X", crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const checkpoints: unknown[] = [];
@@ -768,7 +819,7 @@ describe("lunoraClient — cross-tab settled watermark scoped to the owning clie
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
         const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
-        const rogue = new BroadcastChannel("lunora-bridge");
+        const rogue = new BroadcastChannel(clientChannel(client));
 
         try {
             const checkpoints: unknown[] = [];
@@ -784,6 +835,151 @@ describe("lunoraClient — cross-tab settled watermark scoped to the owning clie
             expect(checkpoints).toStrictEqual([{ checkpoint: 10, mutationId: undefined }]);
         } finally {
             rogue.close();
+            client.close();
+        }
+    });
+});
+
+describe("lunoraClient — cross-tab channel scoped to deployment + identity (plan 263 S1)", () => {
+    it("two same-origin clients with different identities land on different channels — no cross-identity leak", async () => {
+        expect.assertions(3);
+
+        const url = "https://app.example";
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: {} }));
+
+        const clientA = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url });
+
+        clientA.setAuthToken("token-A");
+
+        const clientB = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url });
+
+        clientB.setAuthToken("token-B");
+
+        try {
+            const channelA = `lunora-bridge::${url}::${clientA.currentIdentity() ?? "anon"}`;
+            const channelB = `lunora-bridge::${url}::${clientB.currentIdentity() ?? "anon"}`;
+
+            expect(channelA).not.toBe(channelB);
+
+            const receivedB: unknown[] = [];
+
+            clientB.subscribe(fnRef("q:list"), {}, (value) => receivedB.push(value));
+
+            const key = SubscriptionRegistry.key("q:list", {});
+            const probeOnA = new BroadcastChannel(channelA);
+
+            // A frame posted on A's (different) channel must never reach B —
+            // B isn't listening there.
+            probeOnA.postMessage({ data: "leaked-from-A", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(receivedB).toStrictEqual([]);
+
+            // Sanity: the SAME shape of frame posted on B's OWN (identity-scoped)
+            // channel DOES reach it — proving B is genuinely listening there,
+            // not just silently dropping everything.
+            const probeOnB = new BroadcastChannel(channelB);
+
+            probeOnB.postMessage({ data: "own-channel-row", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(receivedB).toStrictEqual(["own-channel-row"]);
+
+            probeOnA.close();
+            probeOnB.close();
+        } finally {
+            clientA.close();
+            clientB.close();
+        }
+    });
+
+    it("two clients on different deployments (urls) land on different channels — each still self-promotes its own leader", async () => {
+        expect.assertions(2);
+
+        vi.useFakeTimers();
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: {} }));
+        const constructed: string[] = [];
+
+        const clientA = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app-a.example", WebSocket: createMockWebSocket(constructed) });
+        const clientB = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app-b.example", WebSocket: createMockWebSocket(constructed) });
+
+        try {
+            expect(`lunora-bridge::https://app-a.example::${clientA.currentIdentity() ?? "anon"}`).not.toBe(
+                `lunora-bridge::https://app-b.example::${clientB.currentIdentity() ?? "anon"}`,
+            );
+
+            clientA.subscribe(fnRef("q:list"), {}, () => undefined);
+            clientB.subscribe(fnRef("q:list"), {}, () => undefined);
+
+            // Solo self-promotion on each client's OWN (deployment-scoped)
+            // channel — no cross-app leader adoption/election fight.
+            await vi.advanceTimersByTimeAsync(3100);
+
+            // BOTH became leader independently and each opened its own
+            // socket — not just one of them winning a shared election (a
+            // shared "lunora-bridge" channel would elect exactly one leader,
+            // and only a leader ever calls `ensureSocket`, so only one socket
+            // would ever be constructed regardless of plan 266's follower
+            // status-mirror, which alone would keep the loser's
+            // `connectionStatus()` off `"idle"` and mask this exact bug).
+            expect(constructed).toHaveLength(2);
+        } finally {
+            clientA.close();
+            clientB.close();
+            vi.useRealTimers();
+        }
+    });
+
+    it("restarts the coordinator on an identity change, moving to the re-derived channel", async () => {
+        expect.assertions(4);
+
+        const url = "https://app.example";
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: {} }));
+
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url });
+
+        try {
+            const anonChannel = `lunora-bridge::${url}::${client.currentIdentity() ?? "anon"}`;
+
+            const received: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, (value) => received.push(value));
+
+            const key = SubscriptionRegistry.key("q:list", {});
+            const probeOnAnon = new BroadcastChannel(anonChannel);
+
+            probeOnAnon.postMessage({ data: "anon-row", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(received).toStrictEqual(["anon-row"]);
+
+            // A genuine credential change — the coordinator must restart onto
+            // the re-derived (signed-in) channel.
+            client.setAuthToken("token-X", "user-1");
+            await delay(30);
+
+            const signedInChannel = `lunora-bridge::${url}::${client.currentIdentity() ?? "anon"}`;
+
+            expect(signedInChannel).not.toBe(anonChannel);
+
+            // The OLD (anon) channel is dead — nothing is listening there anymore.
+            probeOnAnon.postMessage({ data: "stale-anon-row", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(received).toStrictEqual(["anon-row"]);
+
+            // The NEW channel is live.
+            const probeOnSignedIn = new BroadcastChannel(signedInChannel);
+
+            probeOnSignedIn.postMessage({ data: "signed-in-row", key, tabId: "leader-tab", type: "subscription-data" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(received).toStrictEqual(["anon-row", "signed-in-row"]);
+
+            probeOnAnon.close();
+            probeOnSignedIn.close();
+        } finally {
             client.close();
         }
     });

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -168,6 +168,145 @@ describe("tabCoordinator — leader demotion / health (CLIENT-02)", () => {
     });
 });
 
+describe("tabCoordinator — promotion after yield-leadership (plan 266 S1)", () => {
+    it("a follower promotes once the leader stops and yields", async () => {
+        expect.assertions(3);
+
+        const channelName = `test-cross-tab-${crypto.randomUUID()}`;
+        const eventsA: string[] = [];
+        const eventsB: string[] = [];
+
+        const coordinatorA = new TabCoordinator({
+            channelName,
+            heartbeatInterval: HEARTBEAT_INTERVAL_MS,
+            leaderTimeout: LEADER_TIMEOUT_MS,
+            onBecomeLeader: () => eventsA.push("become-leader"),
+        });
+        const coordinatorB = new TabCoordinator({
+            channelName,
+            heartbeatInterval: HEARTBEAT_INTERVAL_MS,
+            leaderTimeout: LEADER_TIMEOUT_MS,
+            onBecomeLeader: () => eventsB.push("become-leader"),
+        });
+
+        try {
+            coordinatorA.start();
+            coordinatorB.start();
+
+            // Let the pair converge on a single leader (the smaller tabId, per
+            // the existing claim tie-break).
+            await delay(LEADER_TIMEOUT_MS + 60);
+
+            const aIsLeader = coordinatorA.isLeader();
+
+            // Exactly one of the pair is leader.
+            expect(coordinatorB.isLeader()).toBe(!aIsLeader);
+
+            const leader = aIsLeader ? coordinatorA : coordinatorB;
+            const follower = aIsLeader ? coordinatorB : coordinatorA;
+            const followerEvents = aIsLeader ? eventsB : eventsA;
+
+            // The leader tab closes (sign-out, SPA teardown, HMR dispose) —
+            // `stop()` broadcasts `yield-leadership`. Before the fix nothing
+            // ever promoted a new leader after this, so every remaining tab's
+            // live queries would freeze forever.
+            leader.stop();
+
+            await delay(LEADER_TIMEOUT_MS + 60);
+
+            expect(follower.isLeader()).toBe(true);
+            expect(followerEvents).toContain("become-leader");
+        } finally {
+            coordinatorA.stop();
+            coordinatorB.stop();
+        }
+    });
+
+    it("exactly one of several followers promotes after the leader yields — no split-brain", async () => {
+        expect.assertions(2);
+
+        const channelName = `test-cross-tab-${crypto.randomUUID()}`;
+        const coordinators = [0, 1, 2].map(
+            () => new TabCoordinator({ channelName, heartbeatInterval: HEARTBEAT_INTERVAL_MS, leaderTimeout: LEADER_TIMEOUT_MS }),
+        );
+
+        try {
+            for (const coordinator of coordinators) {
+                coordinator.start();
+            }
+
+            // Three-tab election converges via the same claim tie-break +
+            // heartbeat-override mechanism CLIENT-02 already covers for two
+            // tabs (see `resolveLeaderVsLeaderTieBreak`'s doc comment).
+            await delay(LEADER_TIMEOUT_MS + 100);
+
+            const leader = coordinators.find((coordinator) => coordinator.isLeader());
+
+            expect(leader).toBeDefined();
+
+            const followers = coordinators.filter((coordinator) => coordinator !== leader);
+
+            leader?.stop();
+
+            await delay(LEADER_TIMEOUT_MS + 100);
+
+            const nowLeaders = followers.filter((coordinator) => coordinator.isLeader());
+
+            expect(nowLeaders).toHaveLength(1);
+        } finally {
+            for (const coordinator of coordinators) {
+                coordinator.stop();
+            }
+        }
+    });
+
+    it("a stopped coordinator does not act on a yield-leadership frame (the running guard)", async () => {
+        expect.assertions(1);
+
+        const channelName = `test-cross-tab-${crypto.randomUUID()}`;
+        const events: string[] = [];
+
+        const coordinator = new TabCoordinator({
+            channelName,
+            heartbeatInterval: HEARTBEAT_INTERVAL_MS,
+            leaderTimeout: LEADER_TIMEOUT_MS,
+            onBecomeLeader: () => events.push("become-leader"),
+        });
+
+        try {
+            coordinator.start();
+
+            // Establish a known leader (some other tab) via a raw heartbeat so
+            // `knownLeader` is set to something this coordinator will later be
+            // told is yielding.
+            const rogue = new BroadcastChannel(channelName);
+
+            rogue.postMessage({ tabId: LARGER_ID, ts: Date.now(), type: "heartbeat" } satisfies RawMessage);
+            await delay(20);
+            rogue.close();
+
+            coordinator.stop();
+
+            // White-box: invoke the private message handler directly to
+            // simulate a `yield-leadership` frame observed after `stop()` (a
+            // real `BroadcastChannel` can't reliably force this ordering, but
+            // the `running` guard in the handler exists for exactly this
+            // race — an in-flight frame delivered just as the tab tears down
+            // must not spin up a new claim window on a coordinator that's
+            // already gone).
+            const internals = coordinator as unknown as { handleMessage: (message: { tabId: string; type: "yield-leadership" }) => void };
+
+            internals.handleMessage({ tabId: LARGER_ID, type: "yield-leadership" });
+
+            await delay(LEADER_TIMEOUT_MS + 40);
+
+            expect(events).not.toContain("become-leader");
+        } finally {
+            coordinator.stop();
+        }
+    });
+});
+
 describe("tabCoordinator — subscription-data/subscription-settled wire frames (CLIENT-01)", () => {
     it("broadcastSubscriptionData/broadcastSubscriptionSettled carry cursor/epoch on the wire when supplied, and omit them when not", async () => {
         expect.assertions(4);

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -11,7 +11,7 @@ type RawMessage = { tabId: string; ts: number; type: "claim-leadership" | "heart
 /** Wire shape of a leader's `subscription-data` / `subscription-settled` / `connection-status` broadcast, for raw test-side sends simulating a leader tab. */
 type RawLeaderMessage =
     | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
-    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
+    | { clientId?: string; cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
     | { status: "connected" | "connecting" | "idle" | "offline"; tabId: string; type: "connection-status" };
 
 const fnRef = (ref: string): FunctionReference => {
@@ -501,7 +501,13 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
         }
     });
 
-    it("a follower's onCheckpoint fires with the leader-broadcast lastMutationId on a subscription-settled frame", async () => {
+    it("a follower's onCheckpoint fires with the leader-broadcast lastMutationId on a subscription-settled frame FROM ITS OWN clientId", async () => {
+        // Changed by plan 266 S3: the settled frame's `lastMutationId` is the
+        // leader's own per-client watermark, so it only applies when the
+        // frame's `clientId` matches this follower's — this test now stamps
+        // a matching `clientId` (`client.clientIdentifier()`) to keep
+        // exercising the "confirmed write reaches a follower" path; the
+        // mismatched/absent-clientId cases are covered separately below.
         expect.assertions(1);
 
         const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
@@ -520,6 +526,7 @@ describe("lunoraClient — cross-tab follower drops confirmed optimistic layers 
             // forwarding `lastMutationId`, a follower's `@lunora/db` `onCheckpoint`
             // gate would never see this confirmed write and would hang.
             rogue.postMessage({
+                clientId: client.clientIdentifier(),
                 cursor: 10,
                 epoch: "epoch-1",
                 key,
@@ -668,6 +675,116 @@ describe("lunoraClient — follower connection-status mirror + offline-queue gat
             rogue.close();
             client.close();
             vi.useRealTimers();
+        }
+    });
+});
+
+describe("lunoraClient — cross-tab settled watermark scoped to the owning clientId (plan 266 S3)", () => {
+    it("a mismatched clientId skips the mutationId half — only the checkpoint half fires", async () => {
+        expect.assertions(1);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ clientId: "client-X", crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const checkpoints: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, () => undefined, { onCheckpoint: (watermark) => checkpoints.push(watermark) });
+
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            // The leader's watermark is scoped to ITS OWN clientId — a
+            // different follower clientId must not resolve this follower's
+            // own pending `awaitMutationId(<=6)` gate.
+            rogue.postMessage({
+                clientId: "client-Y",
+                cursor: 10,
+                epoch: "epoch-1",
+                key,
+                lastMutationId: 6,
+                tabId: "leader-tab",
+                type: "subscription-settled",
+            } satisfies RawLeaderMessage);
+
+            await delay(30);
+
+            // The checkpoint (cursor) half still fires unconditionally — only
+            // `mutationId` stays at its prior (never-advanced) value.
+            expect(checkpoints).toStrictEqual([{ checkpoint: 10, mutationId: undefined }]);
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("a matching clientId applies the mutationId half, monotonically (never regresses)", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ clientId: "client-X", crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const checkpoints: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, () => undefined, { onCheckpoint: (watermark) => checkpoints.push(watermark) });
+
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            rogue.postMessage({
+                clientId: "client-X",
+                cursor: 10,
+                key,
+                lastMutationId: 6,
+                tabId: "leader-tab",
+                type: "subscription-settled",
+            } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(checkpoints.at(-1)).toStrictEqual({ checkpoint: 10, mutationId: 6 });
+
+            // A later, LOWER watermark from the same (matching) clientId must
+            // never move `lastMutationId` backwards.
+            rogue.postMessage({
+                clientId: "client-X",
+                cursor: 11,
+                key,
+                lastMutationId: 4,
+                tabId: "leader-tab",
+                type: "subscription-settled",
+            } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(checkpoints.at(-1)).toStrictEqual({ checkpoint: 11, mutationId: 6 });
+        } finally {
+            rogue.close();
+            client.close();
+        }
+    });
+
+    it("an absent clientId (mixed-version leader) skips the mutationId half but still delivers the checkpoint", async () => {
+        expect.assertions(1);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ commitCursor: 10, result: { ok: true } }));
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: "https://app.example" });
+        const rogue = new BroadcastChannel("lunora-bridge");
+
+        try {
+            const checkpoints: unknown[] = [];
+
+            client.subscribe(fnRef("q:list"), {}, () => undefined, { onCheckpoint: (watermark) => checkpoints.push(watermark) });
+
+            const key = SubscriptionRegistry.key("q:list", {});
+
+            // No `clientId` field at all — an old (pre-S3) leader.
+            rogue.postMessage({ cursor: 10, key, lastMutationId: 6, tabId: "leader-tab", type: "subscription-settled" } satisfies RawLeaderMessage);
+            await delay(30);
+
+            expect(checkpoints).toStrictEqual([{ checkpoint: 10, mutationId: undefined }]);
+        } finally {
+            rogue.close();
+            client.close();
         }
     });
 });

--- a/packages/client/__tests__/cross-tab.test.ts
+++ b/packages/client/__tests__/cross-tab.test.ts
@@ -1077,3 +1077,44 @@ describe("lunoraClient — identity stamp on data-bearing frames (plan 263 S2)",
         }
     });
 });
+
+describe("lunoraClient — identity-change coordinator restart promotes immediately (thermos H3)", () => {
+    it("a tab that was leader before an identity change reconnects immediately, not after the full leaderTimeout", async () => {
+        expect.assertions(2);
+
+        vi.useFakeTimers();
+
+        const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ result: {} }));
+        const constructed: string[] = [];
+
+        const client = new LunoraClient({ crossTabSync: true, fetch: fetchMock, url: TEST_URL, WebSocket: createMockWebSocket(constructed) });
+
+        try {
+            client.subscribe(fnRef("q:list"), {}, () => undefined);
+
+            // Solo self-promotion on the ANON channel (default 3s leaderTimeout).
+            await vi.advanceTimersByTimeAsync(3100);
+
+            expect(constructed).toHaveLength(1);
+
+            // A genuine identity change while this tab IS the leader — the
+            // coordinator restarts on a new (re-derived) channel. Without
+            // `promoteImmediately`, this tab wouldn't reconnect until ANOTHER
+            // full leaderTimeout elapsed on the new channel, freezing every
+            // live query for the same 3s window this exact pattern
+            // (`setAuthToken(token)` on every JWT refresh, no stable
+            // `subject`) hits on every single refresh.
+            client.setAuthToken("token-1", "user-1");
+
+            // No further virtual time advance beyond flushing the current
+            // microtask queue — a real leaderTimeout-gated restart would
+            // still show only the ORIGINAL socket here.
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(constructed).toHaveLength(2);
+        } finally {
+            client.close();
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -1189,6 +1189,7 @@ describe("lunoraClient", () => {
             expect(firstSub(second)?.query?.functionPath).toBe("messages:list");
             expect(data).toHaveLength(0);
 
+            client.close();
             vi.useRealTimers();
         });
 
@@ -1224,6 +1225,7 @@ describe("lunoraClient", () => {
             expect(second.url).toContain("token=adm1n");
             expect(firstSub(second).query.functionPath).toBe("__lunora_admin__:getMetrics");
 
+            client.close();
             vi.useRealTimers();
         });
 
@@ -1262,6 +1264,8 @@ describe("lunoraClient", () => {
 
             expect(env.type).toBe("subscribe");
             expect(env.query.args).toEqual({ x: 1 });
+
+            client.close();
         });
 
         it("duplicate subscribe calls share a single server-side subscription", () => {
@@ -1450,6 +1454,8 @@ describe("lunoraClient", () => {
 
             expect(value).toEqual({ id: "1" });
             expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            client.close();
         });
     });
 
@@ -2988,7 +2994,12 @@ describe("lunoraClient", () => {
 
             expect(seen).toEqual(["idle", "connecting", "connected", "offline"]);
 
+            // This test's own `triggerClose()` armed a REAL 10ms reconnect
+            // timer (no fake timers here) — without closing, it fires during
+            // whatever test happens to be running ~10ms later and leaks a
+            // stray, un-tokened socket into that test's `sockets` array.
             unsubscribe();
+            client.close();
         });
 
         it("stops notifying after unsubscribe", () => {
@@ -3071,6 +3082,7 @@ describe("lunoraClient", () => {
             expect(seen).toHaveLength(1);
 
             unsubscribe();
+            client.close();
         });
 
         it("reconnects after the socket drops", () => {
@@ -3101,6 +3113,7 @@ describe("lunoraClient", () => {
             expect(second.url).toContain("/_lunora/admin/scheduled/ws");
 
             unsubscribe();
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3159,6 +3172,7 @@ describe("lunoraClient", () => {
             expect(second?.url).toContain("token=eph-2");
 
             unsubscribe();
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3205,6 +3219,7 @@ describe("lunoraClient", () => {
             expect(second.url).toContain("/_lunora/admin/scheduled/ws");
 
             unsubscribe();
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3243,6 +3258,7 @@ describe("lunoraClient", () => {
             expect(second).not.toBe(first);
 
             unsubscribe();
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3287,6 +3303,7 @@ describe("lunoraClient", () => {
             expect(latestSocket()).toBe(socket);
 
             unsubscribe();
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3321,6 +3338,7 @@ describe("lunoraClient", () => {
             expect(second).not.toBe(first);
 
             unsubscribe();
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3377,6 +3395,7 @@ describe("lunoraClient", () => {
 
             expect(fresh.readyState).toBe(3);
 
+            client.close();
             vi.useRealTimers();
         });
     });
@@ -3413,6 +3432,16 @@ describe("lunoraClient", () => {
 
             expect(tokened?.url).toContain("token=eph-token");
             expect(provider).toHaveBeenCalledTimes(1);
+
+            // Without this, the connect-timeout fail-fast timer (a REAL
+            // setTimeout — this test never engages fake timers) stays armed
+            // on the un-opened socket and can fire well into a LATER test's
+            // run, re-arming the reconnect loop and pushing a stray socket
+            // into whatever test happens to be executing when it lands (the
+            // exact class of cross-test flake the `sockets.find(...)`
+            // workarounds throughout this describe block are defending
+            // against — closing the client removes the root cause instead).
+            client.close();
         });
 
         it("re-invokes the provider on the reconnect after a token-expired (4001) drop", async () => {
@@ -3458,6 +3487,15 @@ describe("lunoraClient", () => {
             expect(second).not.toBe(first);
             expect(second?.url).toContain("token=eph-2");
 
+            // Close WHILE fake timers are still installed, so `close()`'s
+            // `clearTimeout`/`clearInterval` calls actually cancel the
+            // fake-scheduled reconnect/connect-timeout/heartbeat timers this
+            // client armed. Without this, the client is abandoned with those
+            // timers still pending; switching to real timers doesn't fire
+            // them, but it also doesn't guarantee they're gone — leaving
+            // that to chance is exactly what made this test (and its
+            // siblings below) intermittently flaky under load.
+            client.close();
             vi.useRealTimers();
         });
 
@@ -3495,6 +3533,10 @@ describe("lunoraClient", () => {
 
             expect(latestSocket().url).toContain("token=eph-recovered");
 
+            // See the sibling test above — close before switching timer
+            // modes so the fake-scheduled timers this client armed are
+            // actually cancelled, not just abandoned.
+            client.close();
             vi.useRealTimers();
         });
     });

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -584,6 +584,49 @@ describe("lunoraClient", () => {
             client.close();
         });
 
+        it("forwards a data frame's lastMutationId to onCheckpoint, monotonically, alongside the data callback (plan 266 S4)", () => {
+            expect.assertions(3);
+
+            const client = new LunoraClient({
+                clientId: "client-A",
+                fetch: vi.fn<typeof fetch>(),
+                url: "https://app.example",
+                WebSocket: createMockWebSocket(),
+            });
+
+            const received: unknown[] = [];
+            const checkpoints: { checkpoint?: number; mutationId?: number }[] = [];
+
+            client.subscribe(fnRef("messages:list"), {}, (d) => received.push(d), {
+                onCheckpoint: (watermark) => checkpoints.push(watermark),
+            });
+
+            const socket = latestSocket();
+
+            socket.open();
+
+            const sub = firstSub(socket);
+
+            socket.receive({ id: sub.id, type: "ack" });
+            // The server now stamps the client's per-mutator watermark on a plain
+            // `data` frame too (not just `settled`) — the frame the client can
+            // trust as reflecting what THESE rows actually confirm.
+            socket.receive({ cursor: 10, data: [{ _id: "m1" }], epoch: "e1", id: sub.id, lastMutationId: 5, type: "data" });
+
+            // The value changed, so the data callback fires...
+            expect(received).toEqual([[{ _id: "m1" }]]);
+            // ...and the frame's own watermark ALSO reaches onCheckpoint, same
+            // tail as a `settled` frame.
+            expect(checkpoints).toEqual([{ checkpoint: 10, mutationId: 5 }]);
+
+            // A later frame with a LOWER watermark must never move it backwards.
+            socket.receive({ cursor: 11, data: [{ _id: "m2" }], epoch: "e1", id: sub.id, lastMutationId: 3, type: "data" });
+
+            expect(checkpoints.at(-1)).toStrictEqual({ checkpoint: 11, mutationId: 5 });
+
+            client.close();
+        });
+
         it("ignores a settled frame for an unknown subscription id", () => {
             expect.assertions(1);
 

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -291,6 +291,30 @@ class TabCoordinator {
         return this.leader;
     }
 
+    /**
+     * Force this (freshly `start()`-ed) tab to become leader immediately,
+     * skipping the normal claim-then-`leaderTimeout` dance. Safe to call
+     * right after `start()` when the caller already knows this tab was the
+     * SOLE leader of the group it's replacing (e.g. `LunoraClient`'s
+     * identity-change coordinator restart — waiting out the full
+     * `leaderTimeout` there would freeze every live query for no reason,
+     * since this tab is overwhelmingly likely to be alone on the freshly
+     * derived channel). A sibling tab going through the normal `start()`
+     * dance for the SAME transition observes this tab's `becomeLeader`
+     * heartbeat and defers before its own claim-timeout fires; if another
+     * tab ALSO force-promotes at the same moment (e.g. two tabs both
+     * transitioning to the same new identity), the existing
+     * `resolveLeaderVsLeaderTieBreak` resolves the rare double-promotion
+     * the same way it resolves any other split-brain.
+     */
+    public promoteImmediately(): void {
+        if (!this.running) {
+            return;
+        }
+
+        this.becomeLeader();
+    }
+
     /** The tab id of the current leader, or `undefined` if unknown / no leader. */
     public get leaderTabId(): string | undefined {
         return this.knownLeader;

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -106,6 +106,13 @@ class TabCoordinator {
     /** `true` once `start()` has been called. */
     private running: boolean = false;
 
+    /**
+     * `true` while a `claimAndPromote()` claim window is open. Guards the yield
+     * handler and `checkLeaderHealth`'s belt-and-braces else-branch so the two
+     * promotion paths can't both arm a `becomeLeader` timeout for the same gap.
+     */
+    private promotionPending: boolean = false;
+
     /** Timestamp of the most recent leader heartbeat. */
     private lastHeartbeat: number = 0;
 
@@ -360,9 +367,17 @@ class TabCoordinator {
             }
 
             case "yield-leadership": {
-                // The leader is stepping down. If it's the one we know, clear.
+                // The leader is stepping down. If it's the one we know, clear
+                // and immediately attempt to claim leadership ourselves —
+                // waiting for the next health-check tick (up to
+                // `leaderTimeout`) before even starting the claim window would
+                // double the freeze every remaining tab experiences.
                 if (this.knownLeader === message.tabId) {
                     this.knownLeader = undefined;
+
+                    if (this.running && !this.leader) {
+                        this.claimAndPromote();
+                    }
                 }
 
                 break;
@@ -480,23 +495,50 @@ class TabCoordinator {
             return;
         }
 
-        // If we have a known leader but haven't heard from them...
-        if (this.knownLeader !== undefined) {
-            const elapsed = Date.now() - this.lastHeartbeat;
+        // No known leader at all — belt-and-braces recovery for any path
+        // (besides `yield-leadership`, which already claims immediately) that
+        // strands `knownLeader`. `claimAndPromote` no-ops while a claim
+        // window is already open, so this can't stack a second `becomeLeader`
+        // timeout on top of one already in flight.
+        if (this.knownLeader === undefined) {
+            this.claimAndPromote();
 
-            if (elapsed > this.leaderTimeout) {
-                // Leader is gone — attempt to claim.
-                this.knownLeader = undefined;
-                this.broadcast({ type: "claim-leadership", tabId: this.tabId, ts: Date.now() });
-
-                // Become leader if no one responds within a short window.
-                setTimeout(() => {
-                    if (this.running && this.knownLeader === undefined) {
-                        this.becomeLeader();
-                    }
-                }, this.leaderTimeout);
-            }
+            return;
         }
+
+        // We have a known leader but haven't heard from them...
+        const elapsed = Date.now() - this.lastHeartbeat;
+
+        if (elapsed > this.leaderTimeout) {
+            // Leader is gone — attempt to claim.
+            this.knownLeader = undefined;
+            this.claimAndPromote();
+        }
+    }
+
+    /**
+     * Broadcast a leadership claim and arm a `becomeLeader` fallback: if no
+     * other tab has asserted itself as leader by the time the window elapses,
+     * self-promote. Shared by `checkLeaderHealth`'s stale-leader path and the
+     * `yield-leadership` handler so both promotion triggers use one claim
+     * window instead of each arming its own timeout.
+     */
+    private claimAndPromote(): void {
+        if (this.promotionPending) {
+            return;
+        }
+
+        this.promotionPending = true;
+        this.broadcast({ type: "claim-leadership", tabId: this.tabId, ts: Date.now() });
+
+        // Become leader if no one responds within a short window.
+        setTimeout(() => {
+            this.promotionPending = false;
+
+            if (this.running && this.knownLeader === undefined) {
+                this.becomeLeader();
+            }
+        }, this.leaderTimeout);
     }
 }
 

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -10,6 +10,7 @@
  * React Native, Node.js).
  */
 
+import type { ConnectionStatus } from "./lunora-client";
 import type { SubscriptionError } from "./subscription";
 
 // ---------------------------------------------------------------------------
@@ -37,6 +38,16 @@ interface TabCoordinatorOptions {
      * Called when this tab becomes the leader (should open WS connections).
      */
     onBecomeLeader?: () => void;
+
+    /**
+     * Called when the leader broadcasts its aggregate `ConnectionStatus`
+     * (see `LunoraClient.emitConnectionStatus`) — a follower owns no socket
+     * of its own, so this is its only truthful signal for a status indicator
+     * or the offline-queue gate. Sent on every leader-side status change and
+     * once more right after a new leader takes over, so a follower already
+     * mid-mirroring isn't stuck on a stale value from the PREVIOUS leader.
+     */
+    onConnectionStatus?: (status: ConnectionStatus) => void;
 
     /**
      * Called when this tab loses leadership (should close WS connections).
@@ -77,7 +88,8 @@ type WsFollowerMessage =
 type WsLeaderMessage =
     | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
     | { error: SubscriptionError; key: string; tabId: string; type: "subscription-error" }
-    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" };
+    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
+    | { status: ConnectionStatus; tabId: string; type: "connection-status" };
 
 type TabCoordinatorMessage = WsFollowerMessage | WsLeaderMessage;
 
@@ -122,6 +134,7 @@ class TabCoordinator {
     /** Callbacks set via constructor options. */
     private readonly onBecomeLeader: (() => void) | undefined;
     private readonly onStopBeingLeader: (() => void) | undefined;
+    private readonly onConnectionStatus: ((status: ConnectionStatus) => void) | undefined;
     private readonly onSubscriptionData: ((key: string, data: unknown, cursor?: number, epoch?: string) => void) | undefined;
     private readonly onSubscriptionError: ((key: string, error: SubscriptionError) => void) | undefined;
     private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string, lastMutationId?: number) => void) | undefined;
@@ -138,6 +151,7 @@ class TabCoordinator {
         this.leaderTimeout = options.leaderTimeout ?? DEFAULT_LEADER_TIMEOUT_MS;
         this.onBecomeLeader = options.onBecomeLeader;
         this.onStopBeingLeader = options.onStopBeingLeader;
+        this.onConnectionStatus = options.onConnectionStatus;
         this.onSubscriptionData = options.onSubscriptionData;
         this.onSubscriptionError = options.onSubscriptionError;
         this.onSubscriptionSettled = options.onSubscriptionSettled;
@@ -313,6 +327,20 @@ class TabCoordinator {
         });
     }
 
+    /**
+     * Broadcast this tab's aggregate `ConnectionStatus` to follower tabs, so
+     * they can mirror a truthful status without a socket of their own (see
+     * `LunoraClient.computeStatus`/`emitConnectionStatus`). Only the leader
+     * should call this.
+     */
+    public broadcastConnectionStatus(status: ConnectionStatus): void {
+        if (!this.leader) {
+            return;
+        }
+
+        this.broadcast({ type: "connection-status", tabId: this.tabId, status });
+    }
+
     // -----------------------------------------------------------------------
     // Internal
     // -----------------------------------------------------------------------
@@ -326,6 +354,16 @@ class TabCoordinator {
         switch (message.type) {
             case "claim-leadership": {
                 this.handleClaimLeadership(message);
+
+                break;
+            }
+
+            case "connection-status": {
+                if (this.leader || message.tabId === this.tabId) {
+                    break;
+                }
+
+                this.onConnectionStatus?.(message.status);
 
                 break;
             }

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -46,8 +46,17 @@ interface TabCoordinatorOptions {
      * or the offline-queue gate. Sent on every leader-side status change and
      * once more right after a new leader takes over, so a follower already
      * mid-mirroring isn't stuck on a stale value from the PREVIOUS leader.
+     *
+     * `identity` is the leader's own `identityFingerprint()` (`null` = signed
+     * out) — the channel-name scoping (see `LunoraClient.createTabCoordinator`)
+     * is the primary defence against a stale frame from a since-changed
+     * identity, but `setAuthToken` in one tab can move it to a new channel
+     * while this frame is already queued in another tab's message task queue.
+     * A follower drops the frame when `identity` is present and doesn't match
+     * its own; an **absent** `identity` (mixed-version leader) is accepted —
+     * today's behavior, and the channel split already separates version groups.
      */
-    onConnectionStatus?: (status: ConnectionStatus) => void;
+    onConnectionStatus?: (status: ConnectionStatus, identity?: string | null) => void;
 
     /**
      * Called when this tab loses leadership (should close WS connections).
@@ -61,8 +70,12 @@ interface TabCoordinatorOptions {
      * value; both are absent on a mixed-version leader that hasn't shipped the
      * cursor yet (the follower falls back to its historical behavior — see
      * `lunora-client.ts`'s `onSubscriptionData` wiring).
+     *
+     * `identity` is the leader's `identityFingerprint()` (see
+     * `onConnectionStatus`'s docblock for the full rationale and the
+     * absent-field mixed-version rule — identical here).
      */
-    onSubscriptionData?: (key: string, data: unknown, cursor?: number, epoch?: string) => void;
+    onSubscriptionData?: (key: string, data: unknown, cursor?: number, epoch?: string, identity?: string | null) => void;
 
     /**
      * Called when the leader broadcasts a subscription error.
@@ -88,18 +101,30 @@ interface TabCoordinatorOptions {
      * bounded fallback. The checkpoint (cursor) half of this callback fires
      * unconditionally regardless of `clientId` — only the `mutationId` half
      * is scoped.
+     *
+     * `identity` is the leader's `identityFingerprint()` — see
+     * `onConnectionStatus`'s docblock for the drop rule (identical here).
      */
-    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string) => void;
+    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string, identity?: string | null) => void;
 }
 
 type WsFollowerMessage =
     { tabId: string; ts: number; type: "heartbeat" } | { tabId: string; ts: number; type: "claim-leadership" } | { tabId: string; type: "yield-leadership" };
 
 type WsLeaderMessage =
-    | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
+    | { cursor?: number; data: unknown; epoch?: string; identity?: string | null; key: string; tabId: string; type: "subscription-data" }
     | { error: SubscriptionError; key: string; tabId: string; type: "subscription-error" }
-    | { clientId?: string; cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
-    | { status: ConnectionStatus; tabId: string; type: "connection-status" };
+    | {
+          clientId?: string;
+          cursor?: number;
+          epoch?: string;
+          identity?: string | null;
+          key: string;
+          lastMutationId?: number;
+          tabId: string;
+          type: "subscription-settled";
+      }
+    | { identity?: string | null; status: ConnectionStatus; tabId: string; type: "connection-status" };
 
 type TabCoordinatorMessage = WsFollowerMessage | WsLeaderMessage;
 
@@ -144,10 +169,12 @@ class TabCoordinator {
     /** Callbacks set via constructor options. */
     private readonly onBecomeLeader: (() => void) | undefined;
     private readonly onStopBeingLeader: (() => void) | undefined;
-    private readonly onConnectionStatus: ((status: ConnectionStatus) => void) | undefined;
-    private readonly onSubscriptionData: ((key: string, data: unknown, cursor?: number, epoch?: string) => void) | undefined;
+    private readonly onConnectionStatus: ((status: ConnectionStatus, identity?: string | null) => void) | undefined;
+    private readonly onSubscriptionData: ((key: string, data: unknown, cursor?: number, epoch?: string, identity?: string | null) => void) | undefined;
     private readonly onSubscriptionError: ((key: string, error: SubscriptionError) => void) | undefined;
-    private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string) => void) | undefined;
+    private readonly onSubscriptionSettled:
+        | ((key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string, identity?: string | null) => void)
+        | undefined;
 
     public constructor(options: TabCoordinatorOptions = {}) {
         // A random UUID suffix makes `tabId` globally unique across tabs/realms,
@@ -288,9 +315,14 @@ class TabCoordinator {
      * call this. `cursor`/`epoch` are omitted from the wire frame when
      * `undefined` (e.g. a CDC-off shard) — a follower on ANY version treats a
      * missing `cursor` as "no confirmed-layer drop this frame", so omitting it
-     * here is equivalent to sending it as `undefined`.
+     * here is equivalent to sending it as `undefined`. `identity` is this
+     * (leader) tab's own `identityFingerprint()` (`null` = signed out) —
+     * stamped so a follower can drop a frame from a since-changed identity
+     * (see the `onSubscriptionData` docblock); spread-included whenever
+     * supplied, since a fixed leader always knows its own identity (never
+     * omits it) and `null` must round-trip distinctly from "field absent".
      */
-    public broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string): void {
+    public broadcastSubscriptionData(key: string, data: unknown, cursor?: number, epoch?: string, identity?: string | null): void {
         if (!this.leader) {
             return;
         }
@@ -302,6 +334,7 @@ class TabCoordinator {
             data,
             ...(cursor === undefined ? {} : { cursor }),
             ...(epoch === undefined ? {} : { epoch }),
+            ...(identity === undefined ? {} : { identity }),
         });
     }
 
@@ -323,9 +356,18 @@ class TabCoordinator {
      * `LunoraClient.handleSettledMessage`). `clientId` is this (leader) tab's
      * own client id, stamped so a follower can tell whether the echoed
      * `lastMutationId` watermark is genuinely its own (see the
-     * `onSubscriptionSettled` docblock). Only the leader should call this.
+     * `onSubscriptionSettled` docblock). `identity` is this tab's own
+     * `identityFingerprint()` — see `broadcastSubscriptionData`'s docblock for
+     * the same round-tripping rule. Only the leader should call this.
      */
-    public broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string): void {
+    public broadcastSubscriptionSettled(
+        key: string,
+        cursor?: number,
+        epoch?: string,
+        lastMutationId?: number,
+        clientId?: string,
+        identity?: string | null,
+    ): void {
         if (!this.leader) {
             return;
         }
@@ -338,21 +380,24 @@ class TabCoordinator {
             ...(epoch === undefined ? {} : { epoch }),
             ...(lastMutationId === undefined ? {} : { lastMutationId }),
             ...(clientId === undefined ? {} : { clientId }),
+            ...(identity === undefined ? {} : { identity }),
         });
     }
 
     /**
      * Broadcast this tab's aggregate `ConnectionStatus` to follower tabs, so
      * they can mirror a truthful status without a socket of their own (see
-     * `LunoraClient.computeStatus`/`emitConnectionStatus`). Only the leader
-     * should call this.
+     * `LunoraClient.computeStatus`/`emitConnectionStatus`). `identity` is this
+     * tab's own `identityFingerprint()` — see `broadcastSubscriptionData`'s
+     * docblock for the same round-tripping rule. Only the leader should call
+     * this.
      */
-    public broadcastConnectionStatus(status: ConnectionStatus): void {
+    public broadcastConnectionStatus(status: ConnectionStatus, identity?: string | null): void {
         if (!this.leader) {
             return;
         }
 
-        this.broadcast({ type: "connection-status", tabId: this.tabId, status });
+        this.broadcast({ type: "connection-status", tabId: this.tabId, status, ...(identity === undefined ? {} : { identity }) });
     }
 
     // -----------------------------------------------------------------------
@@ -377,7 +422,7 @@ class TabCoordinator {
                     break;
                 }
 
-                this.onConnectionStatus?.(message.status);
+                this.onConnectionStatus?.(message.status, message.identity);
 
                 break;
             }
@@ -393,7 +438,7 @@ class TabCoordinator {
                     break; // ignore our own broadcasts
                 }
 
-                this.onSubscriptionData?.(message.key, message.data, message.cursor, message.epoch);
+                this.onSubscriptionData?.(message.key, message.data, message.cursor, message.epoch, message.identity);
 
                 break;
             }
@@ -413,7 +458,7 @@ class TabCoordinator {
                     break;
                 }
 
-                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch, message.lastMutationId, message.clientId);
+                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch, message.lastMutationId, message.clientId, message.identity);
 
                 break;
             }

--- a/packages/client/src/cross-tab.ts
+++ b/packages/client/src/cross-tab.ts
@@ -75,11 +75,21 @@ interface TabCoordinatorOptions {
      * too — otherwise a `setQuery`/per-call optimistic overlay that a
      * byte-identical write just confirmed stays masked on follower tabs until
      * the next VISIBLE data frame arrives, even though the leader already
-     * dropped it. `lastMutationId` rides along the same way so a follower's
-     * `@lunora/db` `onCheckpoint` gate advances too, instead of waiting on a
-     * confirmed write the leader already acknowledged.
+     * dropped it.
+     *
+     * `lastMutationId` is the LEADER's own per-client `__client_watermark` —
+     * scoped server-side to the socket's announced `clientId` — so it only
+     * means anything to a follower whose `clientId` matches the leader's
+     * (`clientId` rides along for exactly that comparison; see
+     * `LunoraClient`'s wiring). An **absent** `clientId` (a mixed-version
+     * leader that hasn't shipped this field yet) also skips the
+     * `mutationId` half — safe, because the follower's own gates still
+     * resolve via its own RPC-ack watermark path and the `CheckpointRegistry`
+     * bounded fallback. The checkpoint (cursor) half of this callback fires
+     * unconditionally regardless of `clientId` — only the `mutationId` half
+     * is scoped.
      */
-    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string, lastMutationId?: number) => void;
+    onSubscriptionSettled?: (key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string) => void;
 }
 
 type WsFollowerMessage =
@@ -88,7 +98,7 @@ type WsFollowerMessage =
 type WsLeaderMessage =
     | { cursor?: number; data: unknown; epoch?: string; key: string; tabId: string; type: "subscription-data" }
     | { error: SubscriptionError; key: string; tabId: string; type: "subscription-error" }
-    | { cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
+    | { clientId?: string; cursor?: number; epoch?: string; key: string; lastMutationId?: number; tabId: string; type: "subscription-settled" }
     | { status: ConnectionStatus; tabId: string; type: "connection-status" };
 
 type TabCoordinatorMessage = WsFollowerMessage | WsLeaderMessage;
@@ -137,7 +147,7 @@ class TabCoordinator {
     private readonly onConnectionStatus: ((status: ConnectionStatus) => void) | undefined;
     private readonly onSubscriptionData: ((key: string, data: unknown, cursor?: number, epoch?: string) => void) | undefined;
     private readonly onSubscriptionError: ((key: string, error: SubscriptionError) => void) | undefined;
-    private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string, lastMutationId?: number) => void) | undefined;
+    private readonly onSubscriptionSettled: ((key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string) => void) | undefined;
 
     public constructor(options: TabCoordinatorOptions = {}) {
         // A random UUID suffix makes `tabId` globally unique across tabs/realms,
@@ -310,9 +320,12 @@ class TabCoordinator {
     /**
      * Broadcast a `settled` frame's checkpoint advance to all follower tabs
      * (no value change, but the resume cursor/epoch moved — see
-     * `LunoraClient.handleSettledMessage`). Only the leader should call this.
+     * `LunoraClient.handleSettledMessage`). `clientId` is this (leader) tab's
+     * own client id, stamped so a follower can tell whether the echoed
+     * `lastMutationId` watermark is genuinely its own (see the
+     * `onSubscriptionSettled` docblock). Only the leader should call this.
      */
-    public broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number): void {
+    public broadcastSubscriptionSettled(key: string, cursor?: number, epoch?: string, lastMutationId?: number, clientId?: string): void {
         if (!this.leader) {
             return;
         }
@@ -324,6 +337,7 @@ class TabCoordinator {
             ...(cursor === undefined ? {} : { cursor }),
             ...(epoch === undefined ? {} : { epoch }),
             ...(lastMutationId === undefined ? {} : { lastMutationId }),
+            ...(clientId === undefined ? {} : { clientId }),
         });
     }
 
@@ -399,7 +413,7 @@ class TabCoordinator {
                     break;
                 }
 
-                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch, message.lastMutationId);
+                this.onSubscriptionSettled?.(message.key, message.cursor, message.epoch, message.lastMutationId, message.clientId);
 
                 break;
             }

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -5235,6 +5235,23 @@ class LunoraClient {
             state.serverEpoch = message.epoch;
         }
 
+        // Consume the per-client custom-mutator watermark this frame carries
+        // (mirrors the `settled` tail in `handleSettledMessage`), so a
+        // `@lunora/db` checkpoint gate sees the watermark THIS frame's rows
+        // actually reflect, instead of relying solely on the provisional
+        // RPC-ack signal (`confirmedMutationWatermark`) which can race ahead
+        // of what has actually synced. `Math.max` guards monotonicity. Fired
+        // BEFORE `notifySubscription` below (which drives `@lunora/db`'s
+        // `onRows`) so a fresher, frame-scoped watermark is already recorded
+        // by the time any RPC-ack-based fallback would otherwise run.
+        if (message.lastMutationId !== undefined) {
+            state.lastMutationId = Math.max(state.lastMutationId ?? 0, message.lastMutationId);
+
+            for (const onCheckpoint of state.checkpointCallbacks) {
+                onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
+            }
+        }
+
         // Persist the authoritative server value (never the optimistic overlay)
         // to the durable read cache (debounced).
         this.persistQueryValue(state);
@@ -5247,7 +5264,10 @@ class LunoraClient {
 
         // When cross-tab sync is active and we're the WS leader, broadcast
         // the new value to follower tabs so they stay in sync without their
-        // own WS connections.
+        // own WS connections. Deliberately does NOT carry `lastMutationId` —
+        // a follower gets the watermark only via the `settled` broadcast,
+        // which is clientId-scoped (plan 266 S3); relaying a `data` frame's
+        // watermark here would reintroduce the same cross-client leak S3 fixed.
         if (this.tabCoordinator?.isLeader()) {
             const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -973,150 +973,7 @@ class LunoraClient {
         // Cross-tab coordinator: when `crossTabSync` is set, tabs coordinate
         // via BroadcastChannel so only one tab (the leader) opens WS sockets.
         if (options.crossTabSync) {
-            this.tabCoordinator = new TabCoordinator({
-                onBecomeLeader: () => {
-                    // Re-open sockets for every active subscription now that
-                    // we own the WS connections.
-                    for (const state of this.subscriptions.all()) {
-                        this.ensureSocket(state.shardKey);
-                        this.sendSubscribeIfOpen(state);
-                    }
-
-                    // Broadcast our aggregate status once immediately, so a
-                    // follower that was mirroring the PREVIOUS leader isn't
-                    // stuck displaying a stale value until this tab's own
-                    // status happens to change (which may be a while, e.g. no
-                    // active subscription ever opens a socket).
-                    this.tabCoordinator?.broadcastConnectionStatus(this.computeStatus());
-                },
-                onStopBeingLeader: () => {
-                    // Close all WS connections now that another tab leads —
-                    // reuse the same timer-teardown sequence `close()` uses so
-                    // a demoted leader can't leak a `reconnectTimer` /
-                    // `heartbeatTimer` the way an inline `conn.socket?.close()`
-                    // (which skips both) used to.
-                    for (const [key, conn] of this.connections) {
-                        this.teardownConnection(conn);
-                        this.connections.delete(key);
-                    }
-
-                    // We're now a follower of whoever won leadership — clear
-                    // any stale mirror from the previous leader until the new
-                    // one's first `connection-status` broadcast arrives.
-                    this.leaderStatus = undefined;
-                    this.leaderWasEverConnected = false;
-                },
-                onConnectionStatus: (status) => {
-                    // A follower has no `ShardConnection` of its own — this is
-                    // its only truthful status signal. Mirror it and re-run
-                    // the same notify path a real status change takes so this
-                    // tab's own `onConnectionStatus`/`connectionStatus()`
-                    // consumers see it.
-                    const transitionedToConnected = status === "connected" && this.leaderStatus !== "connected";
-
-                    this.leaderStatus = status;
-
-                    if (status === "connected") {
-                        this.leaderWasEverConnected = true;
-                    }
-
-                    this.emitConnectionStatus();
-
-                    // Flush this tab's own queued offline writes now that the
-                    // (leader's) connection is back — they replay over HTTP
-                    // RPC, which needs no socket of this follower's own.
-                    if (transitionedToConnected) {
-                        this.flushAllOfflineQueues();
-                    }
-                },
-                onSubscriptionData: (key, data, cursor, epoch) => {
-                    // A follower tab received the authoritative server value from
-                    // the leader. Update serverBase and re-fold any local optimistic
-                    // layers so the displayed value reflects both the new base and
-                    // the follower's own pending writes.
-                    const state = this.subscriptions.get(key);
-
-                    if (!state) {
-                        return;
-                    }
-
-                    state.serverBase = data;
-
-                    // `cursor` rides the broadcast only from a CLIENT-01-aware
-                    // leader tab. When present, advance this follower's own resume
-                    // cursor/epoch and run the SAME confirmed-layer drop + notify
-                    // tail `handleDataMessage` uses on the leader — so a follower's
-                    // optimistic overlay (per-call or `setQuery`) is released the
-                    // moment the confirming frame arrives instead of staying masked
-                    // forever (CLIENT-01). A mixed-version deploy where the leader
-                    // hasn't shipped the cursor yet falls through to the historical
-                    // fold-and-notify-without-drop behavior below — backward
-                    // compatible with a cursor-less wire frame.
-                    if (cursor !== undefined) {
-                        state.serverCursor = cursor;
-
-                        if (epoch !== undefined) {
-                            state.serverEpoch = epoch;
-                        }
-
-                        dropConfirmedLayers(state, cursor);
-                        notifySubscription(state, state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers));
-
-                        return;
-                    }
-
-                    const folded = state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers);
-
-                    notifySubscription(state, folded);
-                },
-                onSubscriptionError: (key, error) => {
-                    const state = this.subscriptions.get(key);
-
-                    if (state) {
-                        fanSubscriptionError(state.errorCallbacks, error);
-                    }
-                },
-                onSubscriptionSettled: (key, cursor, epoch, lastMutationId, clientId) => {
-                    // The leader's `settled` checkpoint advanced with no value
-                    // change — reuse the exact same tail the leader itself runs
-                    // (ack + advance cursor/epoch + drop confirmed layers +
-                    // notify) so a follower's `setQuery`/per-call overlay a
-                    // byte-identical write just confirmed gets released here too.
-                    const state = this.subscriptions.get(key);
-
-                    if (state) {
-                        this.ackAndAdvanceCursor(state, cursor, epoch);
-
-                        // The echoed `lastMutationId` is the LEADER's own
-                        // per-client watermark — scoped server-side to ITS
-                        // announced `clientId` — so it only belongs to this
-                        // follower when the two clientIds match (clientIds CAN
-                        // legitimately be shared across tabs, e.g. a `@lunora/db`
-                        // app persisting one stable id alongside its outbox; see
-                        // `this.clientId`'s docblock). An absent `clientId`
-                        // (mixed-version leader) also skips this half — the
-                        // follower's own RPC-ack watermark path and the
-                        // `CheckpointRegistry` bounded fallback still resolve it.
-                        // `Math.max` guards monotonicity: this must never move
-                        // `state.lastMutationId` backwards.
-                        if (lastMutationId !== undefined && clientId === this.clientId) {
-                            state.lastMutationId = Math.max(state.lastMutationId ?? 0, lastMutationId);
-                        }
-
-                        // Fan out to every registered checkpoint subscriber, same
-                        // as the leader's own `handleSettledMessage` tail — a
-                        // `@lunora/db` `onCheckpoint` gate on a follower tab must
-                        // advance too, or it hangs on a confirmed write the leader
-                        // already acknowledged. The checkpoint (cursor) half
-                        // always fires; `state.lastMutationId` is whatever it was
-                        // above — unchanged (a no-op re-resolve) when the frame
-                        // didn't own this follower's watermark.
-                        for (const onCheckpoint of state.checkpointCallbacks) {
-                            onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
-                        }
-                    }
-                },
-            });
+            this.tabCoordinator = this.createTabCoordinator();
             this.tabCoordinator.start();
         } else {
             this.tabCoordinator = undefined;
@@ -1233,6 +1090,17 @@ class LunoraClient {
                 // just got more stable (a subject resolved). Migrate queued writes
                 // to the new fingerprint instead of dropping them.
                 this.restampQueuedIdentity(previousIdentity, newIdentity);
+            }
+
+            // The cross-tab channel name embeds the identity fingerprint (see
+            // `createTabCoordinator`) — restart on the re-derived channel so
+            // this tab doesn't keep leading/following the PREVIOUS identity's
+            // group. After the queue handling above, so drained/restamped
+            // writes settle before the new group's leader election begins.
+            if (this.tabCoordinator) {
+                this.tabCoordinator.stop();
+                this.tabCoordinator = this.createTabCoordinator();
+                this.tabCoordinator.start();
             }
         }
 
@@ -3674,6 +3542,176 @@ class LunoraClient {
 
         conn.wsState = "closed";
         /* eslint-enable no-param-reassign */
+    }
+
+    /**
+     * Build (but do not start) this client's `TabCoordinator`. Extracted out of
+     * the constructor so `setAuthToken` can rebuild it on an identity change —
+     * the default channel name embeds the identity fingerprint (see below), so
+     * a new identity needs a new coordinator on a new channel. The callback
+     * bodies are the drift-sensitive region (a hand-merged identity guard on
+     * the shard message listener sits ahead of an extracted `lastFrameAt`
+     * stamp elsewhere in this file) — moved verbatim, not reflowed.
+     */
+    private createTabCoordinator(): TabCoordinator {
+        // Scope the channel to this deployment + identity so two same-origin
+        // tabs signed in as different users (or two different Lunora apps on
+        // one origin) never share a leader or a query result — see the durable
+        // read-cache identity gate this mirrors (`identityFingerprint()`'s
+        // docblock, and the `entry.identity === this.identityFingerprint()`
+        // check at the cache-peek/hydration-seed sites). `anon` is a stable,
+        // non-secret label for "no identity yet" (signed-out or not-yet-resolved) —
+        // distinct from the fingerprint's own `null` sentinel, which can't appear
+        // in a channel-name string. The fingerprint itself is already a
+        // non-reversible stamp (see its docblock), so this introduces no new
+        // exposure class; `this.url` is not a secret to same-origin script either.
+        const channelName = `lunora-bridge::${this.url}::${this.identityFingerprint() ?? "anon"}`;
+
+        return new TabCoordinator({
+            channelName,
+            onBecomeLeader: () => {
+                // Re-open sockets for every active subscription now that
+                // we own the WS connections.
+                for (const state of this.subscriptions.all()) {
+                    this.ensureSocket(state.shardKey);
+                    this.sendSubscribeIfOpen(state);
+                }
+
+                // Broadcast our aggregate status once immediately, so a
+                // follower that was mirroring the PREVIOUS leader isn't
+                // stuck displaying a stale value until this tab's own
+                // status happens to change (which may be a while, e.g. no
+                // active subscription ever opens a socket).
+                this.tabCoordinator?.broadcastConnectionStatus(this.computeStatus());
+            },
+            onStopBeingLeader: () => {
+                // Close all WS connections now that another tab leads —
+                // reuse the same timer-teardown sequence `close()` uses so
+                // a demoted leader can't leak a `reconnectTimer` /
+                // `heartbeatTimer` the way an inline `conn.socket?.close()`
+                // (which skips both) used to.
+                for (const [key, conn] of this.connections) {
+                    this.teardownConnection(conn);
+                    this.connections.delete(key);
+                }
+
+                // We're now a follower of whoever won leadership — clear
+                // any stale mirror from the previous leader until the new
+                // one's first `connection-status` broadcast arrives.
+                this.leaderStatus = undefined;
+                this.leaderWasEverConnected = false;
+            },
+            onConnectionStatus: (status) => {
+                // A follower has no `ShardConnection` of its own — this is
+                // its only truthful status signal. Mirror it and re-run
+                // the same notify path a real status change takes so this
+                // tab's own `onConnectionStatus`/`connectionStatus()`
+                // consumers see it.
+                const transitionedToConnected = status === "connected" && this.leaderStatus !== "connected";
+
+                this.leaderStatus = status;
+
+                if (status === "connected") {
+                    this.leaderWasEverConnected = true;
+                }
+
+                this.emitConnectionStatus();
+
+                // Flush this tab's own queued offline writes now that the
+                // (leader's) connection is back — they replay over HTTP
+                // RPC, which needs no socket of this follower's own.
+                if (transitionedToConnected) {
+                    this.flushAllOfflineQueues();
+                }
+            },
+            onSubscriptionData: (key, data, cursor, epoch) => {
+                // A follower tab received the authoritative server value from
+                // the leader. Update serverBase and re-fold any local optimistic
+                // layers so the displayed value reflects both the new base and
+                // the follower's own pending writes.
+                const state = this.subscriptions.get(key);
+
+                if (!state) {
+                    return;
+                }
+
+                state.serverBase = data;
+
+                // `cursor` rides the broadcast only from a CLIENT-01-aware
+                // leader tab. When present, advance this follower's own resume
+                // cursor/epoch and run the SAME confirmed-layer drop + notify
+                // tail `handleDataMessage` uses on the leader — so a follower's
+                // optimistic overlay (per-call or `setQuery`) is released the
+                // moment the confirming frame arrives instead of staying masked
+                // forever (CLIENT-01). A mixed-version deploy where the leader
+                // hasn't shipped the cursor yet falls through to the historical
+                // fold-and-notify-without-drop behavior below — backward
+                // compatible with a cursor-less wire frame.
+                if (cursor !== undefined) {
+                    state.serverCursor = cursor;
+
+                    if (epoch !== undefined) {
+                        state.serverEpoch = epoch;
+                    }
+
+                    dropConfirmedLayers(state, cursor);
+                    notifySubscription(state, state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers));
+
+                    return;
+                }
+
+                const folded = state.optimisticLayers.length === 0 ? data : foldOptimistic(data, state.optimisticLayers);
+
+                notifySubscription(state, folded);
+            },
+            onSubscriptionError: (key, error) => {
+                const state = this.subscriptions.get(key);
+
+                if (state) {
+                    fanSubscriptionError(state.errorCallbacks, error);
+                }
+            },
+            onSubscriptionSettled: (key, cursor, epoch, lastMutationId, clientId) => {
+                // The leader's `settled` checkpoint advanced with no value
+                // change — reuse the exact same tail the leader itself runs
+                // (ack + advance cursor/epoch + drop confirmed layers +
+                // notify) so a follower's `setQuery`/per-call overlay a
+                // byte-identical write just confirmed gets released here too.
+                const state = this.subscriptions.get(key);
+
+                if (state) {
+                    this.ackAndAdvanceCursor(state, cursor, epoch);
+
+                    // The echoed `lastMutationId` is the LEADER's own
+                    // per-client watermark — scoped server-side to ITS
+                    // announced `clientId` — so it only belongs to this
+                    // follower when the two clientIds match (clientIds CAN
+                    // legitimately be shared across tabs, e.g. a `@lunora/db`
+                    // app persisting one stable id alongside its outbox; see
+                    // `this.clientId`'s docblock). An absent `clientId`
+                    // (mixed-version leader) also skips this half — the
+                    // follower's own RPC-ack watermark path and the
+                    // `CheckpointRegistry` bounded fallback still resolve it.
+                    // `Math.max` guards monotonicity: this must never move
+                    // `state.lastMutationId` backwards.
+                    if (lastMutationId !== undefined && clientId === this.clientId) {
+                        state.lastMutationId = Math.max(state.lastMutationId ?? 0, lastMutationId);
+                    }
+
+                    // Fan out to every registered checkpoint subscriber, same
+                    // as the leader's own `handleSettledMessage` tail — a
+                    // `@lunora/db` `onCheckpoint` gate on a follower tab must
+                    // advance too, or it hangs on a confirmed write the leader
+                    // already acknowledged. The checkpoint (cursor) half
+                    // always fires; `state.lastMutationId` is whatever it was
+                    // above — unchanged (a no-op re-resolve) when the frame
+                    // didn't own this follower's watermark.
+                    for (const onCheckpoint of state.checkpointCallbacks) {
+                        onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
+                    }
+                }
+            },
+        });
     }
 
     // --- Internals ----------------------------------------------------------

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -814,6 +814,26 @@ class LunoraClient {
      */
     private tabCoordinator: TabCoordinator | undefined;
 
+    /**
+     * The leader's last-broadcast aggregate {@link ConnectionStatus}, mirrored
+     * on a follower tab — which owns no `ShardConnection` of its own to
+     * compute a status from (see `computeStatus`). `undefined` until the
+     * leader's first broadcast (falls back to `"idle"`), and reset back to
+     * `undefined` whenever this tab stops being a follower of the CURRENT
+     * leader (becomes leader itself, or the leader changes), so a stale
+     * mirror from a previous leader never survives a leadership change.
+     */
+    private leaderStatus: ConnectionStatus | undefined;
+
+    /**
+     * Sticky "has the mirrored leader status ever reported `connected`" flag —
+     * the follower's counterpart to {@link ShardConnection.wasEverConnected},
+     * since a follower has no `ShardConnection` of its own. Feeds the
+     * offline-queue gate (see `mutation`) exactly like the real per-shard flag
+     * does on the leader/single-tab path.
+     */
+    private leaderWasEverConnected = false;
+
     /** One {@link ShardConnection} per shard key (keyed by `shardKey ?? ""`). */
     private readonly connections = new Map<string, ShardConnection>();
 
@@ -865,6 +885,18 @@ class LunoraClient {
      * See `identityFingerprint` for the fingerprint shape.
      */
     private readonly queuedIdentities = new Map<string, string | null>();
+
+    /**
+     * Distinct shard keys with a mutation currently sitting in `offlineQueue`
+     * — fresh writes queued this session (`enqueueOfflineMutation`) or writes
+     * restored from durable storage (`hydratePersistedQueue`). A follower tab
+     * has no per-shard `ShardConnection` to iterate when its mirrored leader
+     * status turns `"connected"` (see the `onConnectionStatus` coordinator
+     * option), so this is what that flush walks instead. Entries are never
+     * removed — flushing an already-empty shard is a cheap no-op, and the set
+     * is bounded by the app's own distinct shard-key cardinality.
+     */
+    private readonly queuedOfflineShardKeys = new Set<string | undefined>();
 
     private closed = false;
 
@@ -949,12 +981,52 @@ class LunoraClient {
                         this.ensureSocket(state.shardKey);
                         this.sendSubscribeIfOpen(state);
                     }
+
+                    // Broadcast our aggregate status once immediately, so a
+                    // follower that was mirroring the PREVIOUS leader isn't
+                    // stuck displaying a stale value until this tab's own
+                    // status happens to change (which may be a while, e.g. no
+                    // active subscription ever opens a socket).
+                    this.tabCoordinator?.broadcastConnectionStatus(this.computeStatus());
                 },
                 onStopBeingLeader: () => {
-                    // Close all WS connections now that another tab leads.
+                    // Close all WS connections now that another tab leads —
+                    // reuse the same timer-teardown sequence `close()` uses so
+                    // a demoted leader can't leak a `reconnectTimer` /
+                    // `heartbeatTimer` the way an inline `conn.socket?.close()`
+                    // (which skips both) used to.
                     for (const [key, conn] of this.connections) {
-                        conn.socket?.close();
+                        this.teardownConnection(conn);
                         this.connections.delete(key);
+                    }
+
+                    // We're now a follower of whoever won leadership — clear
+                    // any stale mirror from the previous leader until the new
+                    // one's first `connection-status` broadcast arrives.
+                    this.leaderStatus = undefined;
+                    this.leaderWasEverConnected = false;
+                },
+                onConnectionStatus: (status) => {
+                    // A follower has no `ShardConnection` of its own — this is
+                    // its only truthful status signal. Mirror it and re-run
+                    // the same notify path a real status change takes so this
+                    // tab's own `onConnectionStatus`/`connectionStatus()`
+                    // consumers see it.
+                    const transitionedToConnected = status === "connected" && this.leaderStatus !== "connected";
+
+                    this.leaderStatus = status;
+
+                    if (status === "connected") {
+                        this.leaderWasEverConnected = true;
+                    }
+
+                    this.emitConnectionStatus();
+
+                    // Flush this tab's own queued offline writes now that the
+                    // (leader's) connection is back — they replay over HTTP
+                    // RPC, which needs no socket of this follower's own.
+                    if (transitionedToConnected) {
+                        this.flushAllOfflineQueues();
                     }
                 },
                 onSubscriptionData: (key, data, cursor, epoch) => {
@@ -1967,11 +2039,10 @@ class LunoraClient {
         // queue when we're mid-reconnect (wsState === "connecting") provided
         // we've been connected before — otherwise the mutation would race
         // the resubscribe. State is scoped to the mutation's own shard so a
-        // dropped shard only queues writes destined for it.
-        const conn = this.getConnection(options.shardKey);
-        const wsState: WSState = conn?.wsState ?? "idle";
-        const hasSocket = conn?.socket !== undefined;
-        const wasEverConnected = conn?.wasEverConnected ?? false;
+        // dropped shard only queues writes destined for it. A follower tab
+        // has no `ShardConnection` of its own — `connectionGateState` derives
+        // the same triple from the mirrored leader status instead.
+        const { hasSocket, wasEverConnected, wsState } = this.connectionGateState(options.shardKey);
         const { queueBeforeFirstConnect } = this.offlineQueue;
         const connectedGate = wasEverConnected || queueBeforeFirstConnect;
         const shouldQueueOffline = this.WebSocketImpl !== undefined && connectedGate;
@@ -3515,29 +3586,7 @@ class LunoraClient {
         this.streams.clear();
 
         for (const conn of this.connections.values()) {
-            if (conn.reconnectTimer !== undefined) {
-                clearTimeout(conn.reconnectTimer);
-                conn.reconnectTimer = undefined;
-            }
-
-            if (conn.connectTimer !== undefined) {
-                clearTimeout(conn.connectTimer);
-                conn.connectTimer = undefined;
-            }
-
-            this.stopHeartbeat(conn);
-
-            if (conn.socket) {
-                try {
-                    conn.socket.close();
-                } catch {
-                    /* ignore */
-                }
-
-                conn.socket = undefined;
-            }
-
-            conn.wsState = "closed";
+            this.teardownConnection(conn);
         }
 
         this.offlineQueue.clear();
@@ -3574,6 +3623,42 @@ class LunoraClient {
         // Stop cross-tab coordination and release the BroadcastChannel.
         this.tabCoordinator?.stop();
         this.tabCoordinator = undefined;
+    }
+
+    /**
+     * Tear down one {@link ShardConnection}'s live state: clear its reconnect/
+     * connect timers, stop its heartbeat, and close its socket (if any).
+     * Shared by `close()` (terminal) and the cross-tab `onStopBeingLeader`
+     * handler (demoted, but still alive) so a demoted leader can't leak a
+     * pending `reconnectTimer` or an open socket's `heartbeatTimer` the way
+     * an inline `conn.socket?.close()` — which skips both — used to.
+     */
+    private teardownConnection(conn: ShardConnection): void {
+        /* eslint-disable no-param-reassign -- mutate the shared, long-lived ShardConnection record so every timer/socket field observes the same teardown (matches `handleDisconnect`'s established pattern in this file) */
+        if (conn.reconnectTimer !== undefined) {
+            clearTimeout(conn.reconnectTimer);
+            conn.reconnectTimer = undefined;
+        }
+
+        if (conn.connectTimer !== undefined) {
+            clearTimeout(conn.connectTimer);
+            conn.connectTimer = undefined;
+        }
+
+        this.stopHeartbeat(conn);
+
+        if (conn.socket) {
+            try {
+                conn.socket.close();
+            } catch {
+                /* ignore */
+            }
+
+            conn.socket = undefined;
+        }
+
+        conn.wsState = "closed";
+        /* eslint-enable no-param-reassign */
     }
 
     // --- Internals ----------------------------------------------------------
@@ -3672,6 +3757,10 @@ class LunoraClient {
             };
 
             this.offlineQueue.enqueue<ReturnOf<F>>(entry);
+            // Track the shard so a follower tab (no `ShardConnection` of its
+            // own to iterate) knows to flush it once the mirrored leader
+            // status turns `"connected"` — see `flushAllOfflineQueues`.
+            this.queuedOfflineShardKeys.add(shardKey);
 
             // `enqueue` assigns `entry.id` when absent; stamp the captured
             // identity against it for the flush-time check.
@@ -3691,6 +3780,11 @@ class LunoraClient {
             const shardKeys = await this.offlineQueue.hydrate();
 
             for (const shardKey of shardKeys) {
+                // Track the shard even on a follower tab, where `ensureSocket`
+                // is a no-op — `flushAllOfflineQueues` is what actually
+                // replays a follower's restored writes, once the mirrored
+                // leader status turns `"connected"`.
+                this.queuedOfflineShardKeys.add(shardKey);
                 this.ensureSocket(shardKey);
             }
         } catch {
@@ -3853,6 +3947,15 @@ class LunoraClient {
 
     /** Derive the aggregate status from the per-shard socket states. */
     private computeStatus(): ConnectionStatus {
+        // A follower owns no `ShardConnection` of its own (that's the whole
+        // point of cross-tab sync — see `ensureSocket`) — mirror whatever the
+        // leader last broadcast instead of reading the (always-empty)
+        // `connections` map, which would otherwise report `"idle"` forever
+        // regardless of the leader's real socket state.
+        if (this.tabCoordinator && !this.tabCoordinator.isLeader()) {
+            return this.leaderStatus ?? "idle";
+        }
+
         const conns = [...this.connections.values()];
 
         if (conns.length === 0) {
@@ -3883,6 +3986,14 @@ class LunoraClient {
         this.lastStatus = next;
 
         this.statusListeners.emit(next);
+
+        // Mirror our own aggregate status to follower tabs, which have no
+        // socket of their own to compute it from (see `computeStatus`). A
+        // no-op on a follower or single-tab client — `broadcastConnectionStatus`
+        // itself gates on `isLeader()`.
+        if (this.tabCoordinator?.isLeader()) {
+            this.tabCoordinator.broadcastConnectionStatus(next);
+        }
     }
 
     /**
@@ -3987,6 +4098,36 @@ class LunoraClient {
 
     private getConnection(shardKey: string | undefined): ShardConnection | undefined {
         return this.connections.get(connectionKey(shardKey));
+    }
+
+    /**
+     * The `(wsState, hasSocket, wasEverConnected)` triple `mutation()`'s
+     * offline-queue gate reads. On the leader/single-tab path this is exactly
+     * the real `ShardConnection`'s state (byte-identical to the pre-cross-tab
+     * behavior). A follower has no `ShardConnection` of its own (see
+     * `ensureSocket`), so it derives the same triple from the mirrored
+     * `leaderStatus`/`leaderWasEverConnected` instead: `"connected"` maps to
+     * `"open"` (queue-eligible once `wasEverConnected`), `"connecting"` stays
+     * `"connecting"` (the mid-reconnect queue branch), anything else is
+     * `"idle"`. `hasSocket` is always `false` for a follower — it never has
+     * one.
+     */
+    private connectionGateState(shardKey: string | undefined): { hasSocket: boolean; wasEverConnected: boolean; wsState: WSState } {
+        if (this.tabCoordinator && !this.tabCoordinator.isLeader()) {
+            let wsState: WSState = "idle";
+
+            if (this.leaderStatus === "connected") {
+                wsState = "open";
+            } else if (this.leaderStatus === "connecting") {
+                wsState = "connecting";
+            }
+
+            return { hasSocket: false, wasEverConnected: this.leaderWasEverConnected, wsState };
+        }
+
+        const conn = this.getConnection(shardKey);
+
+        return { hasSocket: conn?.socket !== undefined, wasEverConnected: conn?.wasEverConnected ?? false, wsState: conn?.wsState ?? "idle" };
     }
 
     private getOrCreateConnection(shardKey: string | undefined): ShardConnection {
@@ -5444,6 +5585,23 @@ class LunoraClient {
         this.pendingCacheWrites.clear();
         this.hydratedQueryCache.clear();
         this.queryCache?.clear().catch(() => undefined);
+    }
+
+    /**
+     * Flush every shard with a mutation currently queued in `offlineQueue`
+     * (see `queuedOfflineShardKeys`). Used on a FOLLOWER tab when the
+     * mirrored leader status transitions to `"connected"` — a follower has no
+     * per-shard `ShardConnection` reconnect event to hang the usual
+     * single-shard `flushOfflineQueue(shardKey)` call off of (see the
+     * `handleConnect` call site), so this walks every shard that might have
+     * something queued instead. Flushing an already-empty shard is a cheap
+     * no-op (`flushOfflineQueue` returns immediately once `drain` yields
+     * nothing), so over-inclusion here is harmless.
+     */
+    private flushAllOfflineQueues(): void {
+        for (const shardKey of this.queuedOfflineShardKeys) {
+            this.flushOfflineQueue(shardKey).catch(() => undefined);
+        }
     }
 
     private async flushOfflineQueue(shardKey: string | undefined): Promise<void> {

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -1076,7 +1076,7 @@ class LunoraClient {
                         fanSubscriptionError(state.errorCallbacks, error);
                     }
                 },
-                onSubscriptionSettled: (key, cursor, epoch, lastMutationId) => {
+                onSubscriptionSettled: (key, cursor, epoch, lastMutationId, clientId) => {
                     // The leader's `settled` checkpoint advanced with no value
                     // change — reuse the exact same tail the leader itself runs
                     // (ack + advance cursor/epoch + drop confirmed layers +
@@ -1087,15 +1087,30 @@ class LunoraClient {
                     if (state) {
                         this.ackAndAdvanceCursor(state, cursor, epoch);
 
-                        if (lastMutationId !== undefined) {
-                            state.lastMutationId = lastMutationId;
+                        // The echoed `lastMutationId` is the LEADER's own
+                        // per-client watermark — scoped server-side to ITS
+                        // announced `clientId` — so it only belongs to this
+                        // follower when the two clientIds match (clientIds CAN
+                        // legitimately be shared across tabs, e.g. a `@lunora/db`
+                        // app persisting one stable id alongside its outbox; see
+                        // `this.clientId`'s docblock). An absent `clientId`
+                        // (mixed-version leader) also skips this half — the
+                        // follower's own RPC-ack watermark path and the
+                        // `CheckpointRegistry` bounded fallback still resolve it.
+                        // `Math.max` guards monotonicity: this must never move
+                        // `state.lastMutationId` backwards.
+                        if (lastMutationId !== undefined && clientId === this.clientId) {
+                            state.lastMutationId = Math.max(state.lastMutationId ?? 0, lastMutationId);
                         }
 
                         // Fan out to every registered checkpoint subscriber, same
                         // as the leader's own `handleSettledMessage` tail — a
                         // `@lunora/db` `onCheckpoint` gate on a follower tab must
                         // advance too, or it hangs on a confirmed write the leader
-                        // already acknowledged.
+                        // already acknowledged. The checkpoint (cursor) half
+                        // always fires; `state.lastMutationId` is whatever it was
+                        // above — unchanged (a no-op re-resolve) when the frame
+                        // didn't own this follower's watermark.
                         for (const onCheckpoint of state.checkpointCallbacks) {
                             onCheckpoint({ checkpoint: state.serverCursor, mutationId: state.lastMutationId });
                         }
@@ -5296,7 +5311,7 @@ class LunoraClient {
         if (this.tabCoordinator?.isLeader()) {
             const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
 
-            this.tabCoordinator.broadcastSubscriptionSettled(key, state.serverCursor, state.serverEpoch, state.lastMutationId);
+            this.tabCoordinator.broadcastSubscriptionSettled(key, state.serverCursor, state.serverEpoch, state.lastMutationId, this.clientId);
         }
     }
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -3582,7 +3582,7 @@ class LunoraClient {
                 // stuck displaying a stale value until this tab's own
                 // status happens to change (which may be a while, e.g. no
                 // active subscription ever opens a socket).
-                this.tabCoordinator?.broadcastConnectionStatus(this.computeStatus());
+                this.tabCoordinator?.broadcastConnectionStatus(this.computeStatus(), this.identityFingerprint());
             },
             onStopBeingLeader: () => {
                 // Close all WS connections now that another tab leads —
@@ -3601,7 +3601,18 @@ class LunoraClient {
                 this.leaderStatus = undefined;
                 this.leaderWasEverConnected = false;
             },
-            onConnectionStatus: (status) => {
+            onConnectionStatus: (status, identity) => {
+                // Belt-and-braces: the channel-name scoping is the primary
+                // defence (a different identity is normally on a different
+                // channel entirely), but a `setAuthToken` in this tab can move
+                // it to a new channel while a stale frame from the OLD leader
+                // is already queued in the message task queue. Drop it when a
+                // stamp is present and doesn't match; an absent stamp
+                // (mixed-version leader) is accepted, same as today.
+                if (identity !== undefined && identity !== this.identityFingerprint()) {
+                    return;
+                }
+
                 // A follower has no `ShardConnection` of its own — this is
                 // its only truthful status signal. Mirror it and re-run
                 // the same notify path a real status change takes so this
@@ -3624,7 +3635,13 @@ class LunoraClient {
                     this.flushAllOfflineQueues();
                 }
             },
-            onSubscriptionData: (key, data, cursor, epoch) => {
+            onSubscriptionData: (key, data, cursor, epoch, identity) => {
+                // Belt-and-braces identity check — see `onConnectionStatus`'s
+                // comment for the full rationale (identical here).
+                if (identity !== undefined && identity !== this.identityFingerprint()) {
+                    return;
+                }
+
                 // A follower tab received the authoritative server value from
                 // the leader. Update serverBase and re-fold any local optimistic
                 // layers so the displayed value reflects both the new base and
@@ -3671,7 +3688,13 @@ class LunoraClient {
                     fanSubscriptionError(state.errorCallbacks, error);
                 }
             },
-            onSubscriptionSettled: (key, cursor, epoch, lastMutationId, clientId) => {
+            onSubscriptionSettled: (key, cursor, epoch, lastMutationId, clientId, identity) => {
+                // Belt-and-braces identity check — see `onConnectionStatus`'s
+                // comment for the full rationale (identical here).
+                if (identity !== undefined && identity !== this.identityFingerprint()) {
+                    return;
+                }
+
                 // The leader's `settled` checkpoint advanced with no value
                 // change — reuse the exact same tail the leader itself runs
                 // (ack + advance cursor/epoch + drop confirmed layers +
@@ -4045,7 +4068,7 @@ class LunoraClient {
         // no-op on a follower or single-tab client — `broadcastConnectionStatus`
         // itself gates on `isLeader()`.
         if (this.tabCoordinator?.isLeader()) {
-            this.tabCoordinator.broadcastConnectionStatus(next);
+            this.tabCoordinator.broadcastConnectionStatus(next, this.identityFingerprint());
         }
     }
 
@@ -5309,7 +5332,7 @@ class LunoraClient {
         if (this.tabCoordinator?.isLeader()) {
             const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
 
-            this.tabCoordinator.broadcastSubscriptionData(key, payload, state.serverCursor, state.serverEpoch);
+            this.tabCoordinator.broadcastSubscriptionData(key, payload, state.serverCursor, state.serverEpoch, this.identityFingerprint());
         }
     }
 
@@ -5369,7 +5392,14 @@ class LunoraClient {
         if (this.tabCoordinator?.isLeader()) {
             const key = SubscriptionRegistry.key(state.fn.__lunoraRef, state.args, state.shardKey);
 
-            this.tabCoordinator.broadcastSubscriptionSettled(key, state.serverCursor, state.serverEpoch, state.lastMutationId, this.clientId);
+            this.tabCoordinator.broadcastSubscriptionSettled(
+                key,
+                state.serverCursor,
+                state.serverEpoch,
+                state.lastMutationId,
+                this.clientId,
+                this.identityFingerprint(),
+            );
         }
     }
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -1097,10 +1097,28 @@ class LunoraClient {
             // this tab doesn't keep leading/following the PREVIOUS identity's
             // group. After the queue handling above, so drained/restamped
             // writes settle before the new group's leader election begins.
+            // BroadcastChannel names are immutable, so a stop-old+construct-new
+            // is the only way to move channels — but that means the fresh
+            // coordinator would otherwise sit through the full
+            // claim-then-`leaderTimeout` dance (3s default) before any tab
+            // opens a socket again, freezing every live query for that long
+            // on EVERY identity change (including a routine JWT refresh for
+            // an app that doesn't pass a stable `subject` — the documented
+            // reason to pass one). If this tab was already the leader, it's
+            // overwhelmingly likely to remain the sole tab on the new
+            // channel too, so promote it immediately instead of waiting —
+            // `promoteImmediately`'s docblock covers the (self-healing) rare
+            // case where another tab does the same at once.
             if (this.tabCoordinator) {
+                const wasLeader = this.tabCoordinator.isLeader();
+
                 this.tabCoordinator.stop();
                 this.tabCoordinator = this.createTabCoordinator();
                 this.tabCoordinator.start();
+
+                if (wasLeader) {
+                    this.tabCoordinator.promoteImmediately();
+                }
             }
         }
 

--- a/packages/db/__tests__/collection-options.test.ts
+++ b/packages/db/__tests__/collection-options.test.ts
@@ -422,6 +422,69 @@ describe("lunoraCollectionOptions (list source)", () => {
 });
 
 /**
+ * Plan 266 S4 — the `list` path's `onRows` compensator resolves the checkpoint
+ * gate off `client.confirmedMutationWatermark`, a PROVISIONAL signal advanced
+ * by the RPC ack the moment a write is accepted, independent of whether that
+ * write's rows have actually synced via a `data` frame yet. Two writes to the
+ * same list, HTTP-ack-races-WS-broadcast: write A (mutationId 5) and write B
+ * (mutationId 6) are BOTH acked before A's `data` frame (reflecting only A's
+ * row) arrives — the compensator reads the watermark (6) rather than what
+ * THIS frame actually represents, dropping B's still-unsynced overlay early.
+ *
+ * The fix threads a frame-carried watermark (fed by `onCheckpoint`, which a
+ * fixed client now fires from a `data` frame's own `lastMutationId` BEFORE
+ * `onRows`, not just from `settled` frames) and prefers it over the
+ * compensator once any such watermark has been observed.
+ */
+describe("lunoraCollectionOptions (list source) — data-frame watermark race (plan 266 S4)", () => {
+    it("a data frame reflecting only A's write must not resolve B's still-unsynced overlay merely because B's RPC ack raced ahead", async () => {
+        expect.assertions(1);
+
+        const { client } = makeClient();
+        const watermark = (client as unknown as { confirmedMutationWatermark: ReturnType<typeof vi.fn> }).confirmedMutationWatermark;
+
+        // Both A (5) and B (6) have already been acked over HTTP by the time
+        // the WS frame below arrives — the provisional signal is at 6.
+        watermark.mockReturnValue(6);
+
+        const options = lunoraCollectionOptions({ client, list: ref("messages:list") });
+        const collection = createCollection(options.config);
+
+        collection.subscribeChanges(() => {});
+        await flush();
+
+        const subscribeMock = (client as unknown as { subscribe: ReturnType<typeof vi.fn> }).subscribe;
+        const onRows = subscribeMock.mock.calls[0]?.[2] as (data: unknown) => void;
+        const { onCheckpoint } = (subscribeMock.mock.calls[0]?.[3] ?? {}) as {
+            onCheckpoint?: (watermark: { checkpoint?: number; mutationId?: number }) => void;
+        };
+
+        const order: string[] = [];
+        const pendingA = options.checkpoints.awaitMutationId(5).then(() => order.push("A"));
+        const pendingB = options.checkpoints.awaitMutationId(6).then(() => order.push("B"));
+
+        // A fixed client fires `onCheckpoint` with the FRAME's own watermark
+        // (5 — this frame reflects only A's commit) before `onRows` — see
+        // `handleDataMessage`'s ordering.
+        onCheckpoint?.({ checkpoint: 12, mutationId: 5 });
+        onRows([{ _creationTime: 0, _id: "a", text: "A" }]);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // A's overlay legitimately drops (A's row IS in this frame). B's must
+        // NOT — its own rows haven't synced, only its ack has. Against
+        // baseline (pre-fix) `onRows` unconditionally resolves off the
+        // provisional watermark (6), dropping B's overlay too — this is the
+        // repro failure.
+        expect(order).toStrictEqual(["A"]);
+
+        void pendingA;
+        void pendingB;
+    });
+});
+
+/**
  * The scope/sync lifecycle for a `scopeBy` collection: a sync restart (after gc
  * cleanup) must re-open the last scope, and a `scope(...)` issued before sync
  * first starts must still deliver the source's initial snapshot.

--- a/packages/db/__tests__/collection-options.test.ts
+++ b/packages/db/__tests__/collection-options.test.ts
@@ -482,6 +482,101 @@ describe("lunoraCollectionOptions (list source) — data-frame watermark race (p
         void pendingA;
         void pendingB;
     });
+
+    it("a genuinely-zero frame watermark does not permanently disable the RPC-ack fallback (thermos H1)", async () => {
+        expect.assertions(1);
+
+        // Every socket announces a clientId unconditionally, and a fresh
+        // `__client_watermark` row reads back 0 (not "no row") — so the
+        // VERY FIRST frame this session legitimately carries `mutationId: 0`.
+        // A sticky `frameWatermark ?? fallback` design reads that `0` as
+        // "already have an authoritative answer" forever after, since `0` is
+        // not nullish — disabling the compensator for every later write.
+        const { client } = makeClient();
+        const watermark = (client as unknown as { confirmedMutationWatermark: ReturnType<typeof vi.fn> }).confirmedMutationWatermark;
+
+        const options = lunoraCollectionOptions({ client, list: ref("messages:list") });
+        const collection = createCollection(options.config);
+
+        collection.subscribeChanges(() => {});
+        await flush();
+
+        const subscribeMock = (client as unknown as { subscribe: ReturnType<typeof vi.fn> }).subscribe;
+        const onRows = subscribeMock.mock.calls[0]?.[2] as (data: unknown) => void;
+        const { onCheckpoint } = (subscribeMock.mock.calls[0]?.[3] ?? {}) as {
+            onCheckpoint?: (watermark: { checkpoint?: number; mutationId?: number }) => void;
+        };
+
+        // The first (seed) frame: nothing confirmed yet for this client.
+        onCheckpoint?.({ checkpoint: 1, mutationId: 0 });
+        onRows([{ _creationTime: 0, _id: "m1", text: "seed" }]);
+
+        // A LATER frame carrying no watermark of its own (e.g. an unstamped
+        // delta from an un-upgraded server) must fall back to the client's
+        // provisional RPC-ack watermark — not resolve against a stale `0`
+        // forever. `confirmedMutationWatermark` now reports 5 (a real write
+        // was acked since the seed frame).
+        watermark.mockReturnValue(5);
+
+        const order: string[] = [];
+        const pending = options.checkpoints.awaitMutationId(5).then(() => order.push("resolved"));
+
+        onRows([{ _creationTime: 0, _id: "m1", text: "seed" }, { _creationTime: 0, _id: "m2", text: "new" }]);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(order).toStrictEqual(["resolved"]);
+
+        void pending;
+    });
+
+    it("a follower's onRows falls back to the RPC-ack watermark instead of a stale leader-era value (thermos H2)", async () => {
+        expect.assertions(1);
+
+        // A demoted leader's own writes now go over HTTP RPC; the cross-tab
+        // `subscription-data` broadcast that drives a follower's `onRows`
+        // deliberately never carries `lastMutationId` (plan 266 S3's
+        // clientId-scoping lives on the SETTLED path only). A sticky
+        // watermark left over from before demotion would resolve every
+        // later `onRows` against that stale value instead of ever falling
+        // back — hanging every follower-issued write for the full
+        // CHECKPOINT_FALLBACK_MS.
+        const { client } = makeClient();
+        const watermark = (client as unknown as { confirmedMutationWatermark: ReturnType<typeof vi.fn> }).confirmedMutationWatermark;
+
+        const options = lunoraCollectionOptions({ client, list: ref("messages:list") });
+        const collection = createCollection(options.config);
+
+        collection.subscribeChanges(() => {});
+        await flush();
+
+        const subscribeMock = (client as unknown as { subscribe: ReturnType<typeof vi.fn> }).subscribe;
+        const onRows = subscribeMock.mock.calls[0]?.[2] as (data: unknown) => void;
+        const { onCheckpoint } = (subscribeMock.mock.calls[0]?.[3] ?? {}) as {
+            onCheckpoint?: (watermark: { checkpoint?: number; mutationId?: number }) => void;
+        };
+
+        // While still leader: a real frame-carried watermark arrives and
+        // resolves normally.
+        onCheckpoint?.({ checkpoint: 1, mutationId: 3 });
+        onRows([{ _creationTime: 0, _id: "m1", text: "leader-era" }]);
+
+        // Demotion: no more onCheckpoint calls ever arrive for this
+        // subscription. A follower-issued write's watermark (7) must still
+        // resolve via the compensator, not the stale leader-era "3".
+        watermark.mockReturnValue(7);
+
+        const order: string[] = [];
+        const pending = options.checkpoints.awaitMutationId(7).then(() => order.push("resolved"));
+
+        onRows([{ _creationTime: 0, _id: "m1", text: "leader-era" }, { _creationTime: 0, _id: "m2", text: "follower-write" }]);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(order).toStrictEqual(["resolved"]);
+
+        void pending;
+    });
 });
 
 /**

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -521,6 +521,17 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
     // starts (while `emit` is undefined) is applied once sync begins.
     let scopedArgs: Record<string, unknown> | undefined;
 
+    // The highest per-frame watermark ever observed via `onCheckpoint` for the
+    // `list` path (fed by `settled` frames, and — once the server ships it —
+    // a `data` frame's own `lastMutationId`; see `handleDataMessage`). Once
+    // any such watermark has been seen, `onRows`'s compensator below stops
+    // trusting the provisional RPC-ack signal (which can race ahead of what a
+    // given frame's rows actually represent — plan 266 finding d) and defers
+    // to this instead. Survives a resubscribe (gc-cleanup restart, reconnect)
+    // — the watermark it tracks is a property of the shard's mutation
+    // sequence, not of any one subscription instance.
+    let frameWatermark: number | undefined;
+
     // Open the underlying sync source — a full-table `list` query subscription or
     // a replication-`shape` poke subscription — with one uniform callback shape.
     // `onReady` is invoked on the first rowset so the collection leaves `loading`.
@@ -531,16 +542,20 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
             emit?.(toMap(data as TRow[], getKey));
             onReady?.();
 
-            // The shape path resolves the registry from the poke `checkpoint`,
-            // and the list path resolves it from the `onCheckpoint` watermark a
-            // `settled` frame forwards (both wired below). A `list` *data* frame
-            // carries no per-frame watermark, so advance from the client's
-            // server-confirmed custom-mutator watermark (the push-ack stream) as
-            // synced rows land — a `bindMutators` optimistic overlay then drops
-            // exactly when the server rows arrive instead of `awaitMutationId`
+            // The shape path resolves the registry from the poke `checkpoint`
+            // (wired below). The list path prefers `frameWatermark` — the
+            // AUTHORITATIVE watermark a prior `onCheckpoint` call (a `settled`
+            // frame, or now a `data` frame's own `lastMutationId`; onCheckpoint
+            // fires before onRows for the frame that carries both) recorded as
+            // reflecting what THIS subscription's rows actually are. Only when
+            // no such watermark has ever arrived (an un-upgraded server, or the
+            // very first frame this session) does it fall back to the client's
+            // provisional server-confirmed custom-mutator watermark (the
+            // push-ack stream) — a `bindMutators` optimistic overlay then drops
+            // once its threshold is reached instead of `awaitMutationId`
             // hanging forever after the write is accepted.
             if (options.shape === undefined) {
-                checkpoints.resolve({ mutationId: options.client.confirmedMutationWatermark(options.shardKey) });
+                checkpoints.resolve({ mutationId: frameWatermark ?? options.client.confirmedMutationWatermark(options.shardKey) });
             }
         };
         const onError = (error: SubscriptionError): void => onErrorHandler?.(error);
@@ -548,8 +563,13 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
         // Advance the registry as the source syncs, so a mutator runtime can drop
         // optimistic overlays once the server's rows (or a `settled` no-change
         // acknowledgement) have landed. Both paths forward the same watermark
-        // shape, so the handler is identical.
+        // shape, so the handler is identical. Also records the high-watermark
+        // `onRows`'s list-path compensator above defers to.
         const onCheckpoint = (watermark: { checkpoint?: number; mutationId?: number }): void => {
+            if (watermark.mutationId !== undefined) {
+                frameWatermark = Math.max(frameWatermark ?? 0, watermark.mutationId);
+            }
+
             checkpoints.resolve(watermark);
         };
 

--- a/packages/db/src/collection-options.ts
+++ b/packages/db/src/collection-options.ts
@@ -521,16 +521,35 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
     // starts (while `emit` is undefined) is applied once sync begins.
     let scopedArgs: Record<string, unknown> | undefined;
 
-    // The highest per-frame watermark ever observed via `onCheckpoint` for the
-    // `list` path (fed by `settled` frames, and — once the server ships it —
-    // a `data` frame's own `lastMutationId`; see `handleDataMessage`). Once
-    // any such watermark has been seen, `onRows`'s compensator below stops
-    // trusting the provisional RPC-ack signal (which can race ahead of what a
-    // given frame's rows actually represent — plan 266 finding d) and defers
-    // to this instead. Survives a resubscribe (gc-cleanup restart, reconnect)
-    // — the watermark it tracks is a property of the shard's mutation
-    // sequence, not of any one subscription instance.
-    let frameWatermark: number | undefined;
+    // The watermark from the MOST RECENT `onCheckpoint` call, for the `list`
+    // path — consumed (read, then cleared) by the very next `onRows` call,
+    // never accumulated or left sticky. Two failure modes a sticky/`Math.max`
+    // design hits, both closed by "consume once, per frame":
+    //
+    //  1. A frame-carried watermark of exactly `0` (every socket announces a
+    //     `clientId` unconditionally, and a fresh `__client_watermark` row
+    //     reads back `0`, not "no row" — see `readClientWatermark`/
+    //     `socketClientWatermark`) is a legitimately DEFINED number. `0 ?? X`
+    //     never evaluates `X` — a sticky `frameWatermark` pinned at `0` by the
+    //     very first frame would disable the compensator fallback FOREVER,
+    //     for every later write, because `0` reads as "already have an
+    //     authoritative answer" instead of "nothing confirmed yet".
+    //  2. A demoted leader's follower-mirror `onRows` (fed by the leader's
+    //     `subscription-data` cross-tab broadcast, which deliberately omits
+    //     `lastMutationId` — plan 266 S3's clientId-scoping) would otherwise
+    //     keep resolving against a STALE value left over from before
+    //     demotion, silently wrong, instead of falling back to this
+    //     follower's own `confirmedMutationWatermark` for its own
+    //     HTTP-RPC-issued writes.
+    //
+    // Both are fixed by scoping the watermark to the ONE `onRows` call it was
+    // reported for: `onCheckpoint` sets it, the matching `onRows` reads
+    // (falling back only when nothing arrived for THIS frame) and clears it,
+    // so a frame with no watermark of its own (an unstamped delta from an
+    // un-upgraded server, or a follower's data broadcast) always sees
+    // `undefined` and defers to the compensator — never a leftover value from
+    // an unrelated earlier frame.
+    let pendingFrameWatermark: number | undefined;
 
     // Open the underlying sync source — a full-table `list` query subscription or
     // a replication-`shape` poke subscription — with one uniform callback shape.
@@ -543,19 +562,23 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
             onReady?.();
 
             // The shape path resolves the registry from the poke `checkpoint`
-            // (wired below). The list path prefers `frameWatermark` — the
-            // AUTHORITATIVE watermark a prior `onCheckpoint` call (a `settled`
-            // frame, or now a `data` frame's own `lastMutationId`; onCheckpoint
-            // fires before onRows for the frame that carries both) recorded as
-            // reflecting what THIS subscription's rows actually are. Only when
-            // no such watermark has ever arrived (an un-upgraded server, or the
-            // very first frame this session) does it fall back to the client's
-            // provisional server-confirmed custom-mutator watermark (the
-            // push-ack stream) — a `bindMutators` optimistic overlay then drops
-            // once its threshold is reached instead of `awaitMutationId`
-            // hanging forever after the write is accepted.
+            // (wired below). The list path prefers `pendingFrameWatermark` —
+            // set by the `onCheckpoint` call THIS SAME frame fired
+            // immediately beforehand (a `settled` frame, or a `data`/`delta`
+            // frame's own `lastMutationId`; `onCheckpoint` always fires
+            // before `onRows` for a frame that carries both — see
+            // `handleDataMessage`) — reflecting what THIS frame's rows
+            // actually are. Only when nothing arrived for THIS frame (an
+            // un-upgraded server's unstamped frame, or a follower's
+            // cross-tab data broadcast, which never carries one) does it
+            // fall back to the client's provisional server-confirmed
+            // custom-mutator watermark (the push-ack stream) — a
+            // `bindMutators` optimistic overlay then drops once its
+            // threshold is reached instead of `awaitMutationId` hanging
+            // forever after the write is accepted.
             if (options.shape === undefined) {
-                checkpoints.resolve({ mutationId: frameWatermark ?? options.client.confirmedMutationWatermark(options.shardKey) });
+                checkpoints.resolve({ mutationId: pendingFrameWatermark ?? options.client.confirmedMutationWatermark(options.shardKey) });
+                pendingFrameWatermark = undefined;
             }
         };
         const onError = (error: SubscriptionError): void => onErrorHandler?.(error);
@@ -563,11 +586,11 @@ export const lunoraCollectionOptions = <TRow extends Row>(options: LunoraCollect
         // Advance the registry as the source syncs, so a mutator runtime can drop
         // optimistic overlays once the server's rows (or a `settled` no-change
         // acknowledgement) have landed. Both paths forward the same watermark
-        // shape, so the handler is identical. Also records the high-watermark
-        // `onRows`'s list-path compensator above defers to.
+        // shape, so the handler is identical. Also records the watermark
+        // `onRows`'s list-path compensator above consumes.
         const onCheckpoint = (watermark: { checkpoint?: number; mutationId?: number }): void => {
             if (watermark.mutationId !== undefined) {
-                frameWatermark = Math.max(frameWatermark ?? 0, watermark.mutationId);
+                pendingFrameWatermark = watermark.mutationId;
             }
 
             checkpoints.resolve(watermark);

--- a/packages/do/__tests__/subscription-data-watermark.test.ts
+++ b/packages/do/__tests__/subscription-data-watermark.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Plan 266 S4 — a plain `{type:"data"}` subscription frame now carries the
+ * SAME per-client `lastMutationId` stamp the sibling `{type:"settled"}` frame
+ * already carried (see `pushSubscriptionData` in `shard-do.ts`), closing the
+ * gap where the client had no per-frame watermark to trust and instead
+ * compensated with a provisional, frame-independent signal.
+ *
+ * Unlike `subscription-refresh.integration.test.ts`'s fake `sql.exec()` (which
+ * always returns empty rows, so `socketClientWatermark` reads `0` for every
+ * clientId), this suite drives the REAL `node:sqlite` harness so the announced
+ * client's `__client_watermark` genuinely advances via the custom-mutator
+ * dispatch path — the only way to observe a non-zero stamped value.
+ */
+import type { SocketAttachment, SubscriptionEnvelope } from "@lunora/shard-engine";
+import { runShardMigrations } from "@lunora/shard-engine";
+import { describe, expect, it } from "vitest";
+
+import type { ShardDOState, SubscriptionOutcome } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import messagesSchema from "./_helpers/messages-schema";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+// ---------------------------------------------------------------------------
+// Fake WebSocket — mirrors the shape in subscription-refresh.integration.test.ts.
+// ---------------------------------------------------------------------------
+interface FakeWebSocket {
+    attachment: SocketAttachment | undefined;
+    close: (code?: number, reason?: string) => void;
+    closed: boolean;
+    deserializeAttachment: () => unknown;
+    send: (data: string) => void;
+    sent: string[];
+    serializeAttachment: (value: unknown) => void;
+}
+
+const createFakeWebSocket = (): FakeWebSocket => {
+    return {
+        attachment: undefined,
+        close() {
+            this.closed = true;
+        },
+        closed: false,
+        deserializeAttachment() {
+            return this.attachment;
+        },
+        send(data: string) {
+            this.sent.push(data);
+        },
+        sent: [],
+        serializeAttachment(value: unknown) {
+            this.attachment = value as SocketAttachment | undefined;
+        },
+    };
+};
+
+const makeState = (database: ReturnType<typeof createSqliteExec>): ShardDOState & { sockets: FakeWebSocket[] } => {
+    const sockets: FakeWebSocket[] = [];
+
+    return {
+        acceptWebSocket(ws) {
+            sockets.push(ws as unknown as FakeWebSocket);
+        },
+        getWebSockets() {
+            return sockets as unknown as WebSocket[];
+        },
+        sockets,
+        storage: { sql: database.sql as unknown as ShardDOState["storage"]["sql"] },
+    };
+};
+
+/**
+ * A shard whose `messages:list` subscription returns a NEW result (a fresh
+ * row) on every call — so a refresh always takes the plain `data` frame path,
+ * never the `settled` (byte-identical) suppression path — and whose
+ * `handleRpc` runs a real custom-mutator commit for `messages:sendMutator`
+ * (advancing `__client_watermark` via `commitMutationBookkeeping`, exactly
+ * like `CountingMutatorShard` in `shard-do.client-watermark.test.ts`) while
+ * also recording `messages` as changed so the write triggers the
+ * subscription-refresh pipeline.
+ */
+class DataWatermarkShard extends ShardDO {
+    private nextRow = 0;
+
+    public override handleRpc(functionPath: string): Promise<unknown> {
+        return this.runInTransaction(() => {
+            this.recordChangedTable("messages");
+
+            const result = { ok: true, path: functionPath };
+
+            this.commitMutationBookkeeping(result);
+
+            return result;
+        });
+    }
+
+    public registerSocket(ws: FakeWebSocket, attachment?: SocketAttachment): void {
+        this.state.acceptWebSocket(ws as unknown as WebSocket);
+        ws.serializeAttachment(attachment ?? { subs: {} });
+    }
+
+    public driveMessage(ws: FakeWebSocket, envelope: SubscriptionEnvelope): Promise<void> {
+        return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
+    }
+
+    /** Push a custom-mutator write (advances `__client_watermark` for `clientId`) and touches "messages". */
+    public pushMutator(clientId: string, seq: number): Promise<Response> {
+        return this.fetch(
+            new Request("https://shard.internal/rpc", {
+                body: JSON.stringify({ args: {}, functionPath: "messages:sendMutator" }),
+                headers: { "content-type": "application/json", "x-lunora-client-id": clientId, "x-lunora-client-seq": String(seq) },
+                method: "POST",
+            }),
+        );
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
+    protected override isCustomMutator(functionPath: string): boolean {
+        return functionPath === "messages:sendMutator";
+    }
+
+    protected override executeSubscription(_functionPath: string, _args: Record<string, unknown>): Promise<SubscriptionOutcome | null> {
+        this.nextRow += 1;
+
+        const outcome: SubscriptionOutcome = {
+            result: [{ _id: `m${String(this.nextRow)}`, text: `row ${String(this.nextRow)}` }],
+            tables: new Set(["messages"]),
+        };
+
+        return Promise.resolve(outcome);
+    }
+}
+
+/** `{type:"data"}` frames for a given subId, with their (optional) `lastMutationId`. */
+const dataFrames = (ws: FakeWebSocket, subId: string): { data?: unknown; lastMutationId?: number }[] =>
+    ws.sent
+        .map((line) => JSON.parse(line) as { data?: unknown; id: string; lastMutationId?: number; type: string })
+        .filter((frame) => frame.type === "data" && frame.id === subId)
+        .map((frame) => {
+            return { data: frame.data, lastMutationId: frame.lastMutationId };
+        });
+
+/** The raw (unmapped) last `{type:"data"}` frame for a subId — used to check field ABSENCE, not just `undefined`. */
+const lastRawDataFrame = (ws: FakeWebSocket, subId: string): Record<string, unknown> | undefined =>
+    ws.sent.map((line) => JSON.parse(line) as Record<string, unknown>).findLast((frame) => frame.type === "data" && frame.id === subId);
+
+const subscribeSocket = (shard: DataWatermarkShard, ws: FakeWebSocket, subId: string, functionPath: string): Promise<void> =>
+    shard.driveMessage(ws, { id: subId, query: { args: {}, functionPath }, type: "subscribe" });
+
+describe("shardDO: plain data frame carries the per-client lastMutationId (plan 266 S4)", () => {
+    it("stamps lastMutationId on a data frame for a clientId socket with an advanced watermark; omits it for a socket with no clientId", async () => {
+        expect.assertions(4);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+            const shard = new DataWatermarkShard(makeState(database), {});
+
+            // Socket A announces a clientId (a custom-mutator @lunora/db client).
+            const wsA = createFakeWebSocket();
+
+            shard.registerSocket(wsA, { clientId: "client-A", subs: {}, userId: "" });
+
+            // Socket B is a plain useQuery client — no clientId.
+            const wsB = createFakeWebSocket();
+
+            shard.registerSocket(wsB);
+
+            await subscribeSocket(shard, wsA, "sub-A", "messages:list");
+            await subscribeSocket(shard, wsB, "sub-B", "messages:list");
+
+            // The seed frame already carries client-A's watermark (0 — the
+            // resting default `readClientWatermark` returns for a clientId
+            // with no row yet, since it announced a clientId).
+            expect(dataFrames(wsA, "sub-A")[0]?.lastMutationId).toBe(0);
+
+            // Client A's mutator write advances ITS watermark to 1 and touches
+            // "messages", refreshing both subscriptions with a NEW row (never
+            // byte-identical, so this always takes the plain `data` path).
+            await shard.pushMutator("client-A", 1);
+
+            const framesA = dataFrames(wsA, "sub-A");
+            const framesB = dataFrames(wsB, "sub-B");
+
+            // The refreshed frame on socket A (clientId "client-A") carries the
+            // now-advanced watermark.
+            expect(framesA.at(-1)?.lastMutationId).toBe(1);
+
+            // The refreshed frame on socket B (no clientId) carries no field at
+            // all — not `undefined`-valued, ABSENT (wire-compat: an old client
+            // checking `"lastMutationId" in frame` must see it missing).
+            const rawFrameB = lastRawDataFrame(wsB, "sub-B");
+
+            expect(rawFrameB && "lastMutationId" in rawFrameB).toBe(false);
+            // The refresh still delivered a (new, non-suppressed) row.
+            expect(framesB.at(-1)?.data).not.toStrictEqual(framesB[0]?.data);
+        } finally {
+            database.close();
+        }
+    });
+});

--- a/packages/do/__tests__/subscription-data-watermark.test.ts
+++ b/packages/do/__tests__/subscription-data-watermark.test.ts
@@ -102,17 +102,6 @@ class DataWatermarkShard extends ShardDO {
         return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
     }
 
-    /** Push a custom-mutator write (advances `__client_watermark` for `clientId`) and touches "messages". */
-    public pushMutator(clientId: string, seq: number): Promise<Response> {
-        return this.fetch(
-            new Request("https://shard.internal/rpc", {
-                body: JSON.stringify({ args: {}, functionPath: "messages:sendMutator" }),
-                headers: { "content-type": "application/json", "x-lunora-client-id": clientId, "x-lunora-client-seq": String(seq) },
-                method: "POST",
-            }),
-        );
-    }
-
     // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
     protected override isCustomMutator(functionPath: string): boolean {
         return functionPath === "messages:sendMutator";
@@ -130,6 +119,21 @@ class DataWatermarkShard extends ShardDO {
     }
 }
 
+/** A shard exposing `driveMessage` (both fixtures below implement this). */
+interface DriveableShard {
+    driveMessage: (ws: FakeWebSocket, envelope: SubscriptionEnvelope) => Promise<void>;
+}
+
+/** Push a custom-mutator write (advances `__client_watermark` for `clientId`) and touches "messages" — shared by both shard fixtures below. */
+const pushMutatorWrite = (shard: ShardDO, clientId: string, seq: number): Promise<Response> =>
+    shard.fetch(
+        new Request("https://shard.internal/rpc", {
+            body: JSON.stringify({ args: {}, functionPath: "messages:sendMutator" }),
+            headers: { "content-type": "application/json", "x-lunora-client-id": clientId, "x-lunora-client-seq": String(seq) },
+            method: "POST",
+        }),
+    );
+
 /** `{type:"data"}` frames for a given subId, with their (optional) `lastMutationId`. */
 const dataFrames = (ws: FakeWebSocket, subId: string): { data?: unknown; lastMutationId?: number }[] =>
     ws.sent
@@ -143,7 +147,7 @@ const dataFrames = (ws: FakeWebSocket, subId: string): { data?: unknown; lastMut
 const lastRawDataFrame = (ws: FakeWebSocket, subId: string): Record<string, unknown> | undefined =>
     ws.sent.map((line) => JSON.parse(line) as Record<string, unknown>).findLast((frame) => frame.type === "data" && frame.id === subId);
 
-const subscribeSocket = (shard: DataWatermarkShard, ws: FakeWebSocket, subId: string, functionPath: string): Promise<void> =>
+const subscribeSocket = (shard: DriveableShard, ws: FakeWebSocket, subId: string, functionPath: string): Promise<void> =>
     shard.driveMessage(ws, { id: subId, query: { args: {}, functionPath }, type: "subscribe" });
 
 describe("shardDO: plain data frame carries the per-client lastMutationId (plan 266 S4)", () => {
@@ -178,7 +182,7 @@ describe("shardDO: plain data frame carries the per-client lastMutationId (plan 
             // Client A's mutator write advances ITS watermark to 1 and touches
             // "messages", refreshing both subscriptions with a NEW row (never
             // byte-identical, so this always takes the plain `data` path).
-            await shard.pushMutator("client-A", 1);
+            await pushMutatorWrite(shard, "client-A", 1);
 
             const framesA = dataFrames(wsA, "sub-A");
             const framesB = dataFrames(wsB, "sub-B");
@@ -195,6 +199,108 @@ describe("shardDO: plain data frame carries the per-client lastMutationId (plan 
             expect(rawFrameB && "lastMutationId" in rawFrameB).toBe(false);
             // The refresh still delivered a (new, non-suppressed) row.
             expect(framesB.at(-1)?.data).not.toStrictEqual(framesB[0]?.data);
+        } finally {
+            database.close();
+        }
+    });
+});
+
+/**
+ * Thermos H1 — the snapshot-only stamp above left the DELTA path (the
+ * `{type:"delta"}` frames `sendDeltaFrames` emits) unstamped, and a
+ * `@lunora/db` list collection is exactly the id-keyed, order-preserving
+ * shape `subscriptionListDeltas` accepts — so after the first snapshot,
+ * EVERY subsequent write for it goes out as deltas. Growing the row set by
+ * one ID each write (keeping every prior row as a survivor) is what makes
+ * `subscriptionListDeltas` accept the change instead of falling back to a
+ * full snapshot (see its "near-total change" guard).
+ */
+class GrowingListShard extends ShardDO {
+    private readonly rows: { _id: string; text: string }[] = [];
+
+    private nextRow = 0;
+
+    public override handleRpc(functionPath: string): Promise<unknown> {
+        return this.runInTransaction(() => {
+            this.nextRow += 1;
+            this.rows.push({ _id: `m${String(this.nextRow)}`, text: `row ${String(this.nextRow)}` });
+            this.recordChangedTable("messages");
+
+            const result = { ok: true, path: functionPath };
+
+            this.commitMutationBookkeeping(result);
+
+            return result;
+        });
+    }
+
+    public registerSocket(ws: FakeWebSocket, attachment?: SocketAttachment): void {
+        this.state.acceptWebSocket(ws as unknown as WebSocket);
+        ws.serializeAttachment(attachment ?? { subs: {} });
+    }
+
+    public driveMessage(ws: FakeWebSocket, envelope: SubscriptionEnvelope): Promise<void> {
+        return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
+    }
+
+    // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
+    protected override isCustomMutator(functionPath: string): boolean {
+        return functionPath === "messages:sendMutator";
+    }
+
+    protected override executeSubscription(_functionPath: string, _args: Record<string, unknown>): Promise<SubscriptionOutcome | null> {
+        // A fresh array each call — `subscriptionListDeltas` diffs by VALUE,
+        // not by reference, but a fresh array also matches how a real query
+        // re-run would produce a fresh result object.
+        return Promise.resolve({ result: [...this.rows], tables: new Set(["messages"]) });
+    }
+}
+
+/** `{type:"delta"}` frames for a given subId, with their (optional) `lastMutationId`. */
+const deltaFrames = (ws: FakeWebSocket, subId: string): { delta?: unknown; lastMutationId?: number }[] =>
+    ws.sent
+        .map((line) => JSON.parse(line) as { delta?: unknown; id: string; lastMutationId?: number; type: string })
+        .filter((frame) => frame.type === "delta" && frame.id === subId)
+        .map((frame) => {
+            return { delta: frame.delta, lastMutationId: frame.lastMutationId };
+        });
+
+describe("shardDO: delta frames also carry the per-client lastMutationId (thermos H1)", () => {
+    it("stamps lastMutationId on delta frames, not just the first snapshot", async () => {
+        expect.assertions(3);
+
+        const database = createSqliteExec();
+
+        try {
+            runShardMigrations(database.sql, messagesSchema, { cdc: true });
+
+            const shard = new GrowingListShard(makeState(database), {});
+            const ws = createFakeWebSocket();
+
+            shard.registerSocket(ws, { clientId: "client-A", subs: {}, userId: "" });
+
+            // Seed row + subscribe: the FIRST frame is always a snapshot
+            // (nothing to diff against yet).
+            await pushMutatorWrite(shard, "client-A", 1);
+            await subscribeSocket(shard, ws, "sub-A", "messages:list");
+
+            expect(dataFrames(ws, "sub-A")).toHaveLength(1);
+
+            // A second write GROWS the list (keeps row 1, adds row 2) — an
+            // id-keyed, order-preserving change `subscriptionListDeltas`
+            // accepts, so this refresh goes out as a `{type:"delta"}` frame,
+            // not another snapshot.
+            await pushMutatorWrite(shard, "client-A", 2);
+
+            const deltas = deltaFrames(ws, "sub-A");
+
+            expect(deltas.length).toBeGreaterThan(0);
+            // The delta frame carries client-A's NOW-advanced watermark (2) —
+            // before this fix, only the snapshot branch ever stamped
+            // `lastMutationId`, so a `@lunora/db` list collection (which is
+            // in delta mode for every write after the first) would never see
+            // a per-frame watermark again after its initial subscribe.
+            expect(deltas.at(-1)?.lastMutationId).toBe(2);
         } finally {
             database.close();
         }

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -7576,6 +7576,13 @@ abstract class ShardDO {
 
             const attachment = this.readAttachment(ws);
 
+            // Read once per socket per flush, not once per affected
+            // subscription below — the value depends only on this socket's
+            // announced `clientId`/`userId`, identical for every subscription
+            // on it, so re-reading it per subscription was a redundant
+            // `SELECT … FROM __client_watermark` per subscription per flush.
+            const clientWatermark = this.socketClientWatermark(ws);
+
             for (const [subId, query] of Object.entries(attachment.subs)) {
                 const { functionPath } = query;
 
@@ -7633,7 +7640,7 @@ abstract class ShardDO {
                     // eslint-disable-next-line no-await-in-loop -- intentional per-socket backpressure: drain before pushing the next subscription's frame
                     await awaitWsDrain(ws);
 
-                    this.pushSubscriptionData(ws, subId, outcome, frameCursor, frameEpoch);
+                    this.pushSubscriptionData(ws, subId, outcome, frameCursor, frameEpoch, clientWatermark);
                 } catch (error) {
                     // A throwing subscription must not abort the refresh of its
                     // siblings, nor fail the mutation that triggered it. The memo
@@ -7711,7 +7718,7 @@ abstract class ShardDO {
             return;
         }
 
-        this.pushSubscriptionData(ws, subId, outcome, resume?.cursor ?? this.currentCdcCursor(), epoch);
+        this.pushSubscriptionData(ws, subId, outcome, resume?.cursor ?? this.currentCdcCursor(), epoch, this.socketClientWatermark(ws));
     }
 
     /**
@@ -8612,8 +8619,23 @@ abstract class ShardDO {
      * persist its resume position and replay it as `sinceSeq` on reconnect
      * (Pillar 1b). Omitted on shards without CDC, keeping the wire byte-identical
      * to the pre-cursor format.
+     *
+     * `clientWatermark` is this socket's `socketClientWatermark(ws)` — read
+     * ONCE by the caller and passed in, not recomputed here. A single
+     * write-flush can call this method many times for the same socket (once
+     * per affected subscription — see `refreshOne`), and the watermark
+     * depends only on `ws`, never on `subId`/`outcome`, so recomputing it per
+     * subscription was a redundant `SELECT … FROM __client_watermark` per
+     * subscription per socket per flush.
      */
-    private pushSubscriptionData(ws: ShardSocketLike, subId: string, outcome: SubscriptionOutcome, cursor?: number, epoch?: string): void {
+    private pushSubscriptionData(
+        ws: ShardSocketLike,
+        subId: string,
+        outcome: SubscriptionOutcome,
+        cursor: number | undefined,
+        epoch: string | undefined,
+        clientWatermark: number | undefined,
+    ): void {
         let memos = this.subMemos.get(ws);
 
         if (!memos) {
@@ -8647,8 +8669,7 @@ abstract class ShardDO {
             // So emit a lightweight `settled` frame (carrying the cursor/epoch)
             // unconditionally, with `lastMutationId` only when this socket has a
             // watermark. An old client ignores the unknown frame.
-            const settledWatermark = this.socketClientWatermark(ws);
-            const watermarkField = settledWatermark === undefined ? "" : `,"lastMutationId":${String(settledWatermark)}`;
+            const watermarkField = clientWatermark === undefined ? "" : `,"lastMutationId":${String(clientWatermark)}`;
 
             trySendFrame(ws, `{"type":"settled","id":${JSON.stringify(subId)}${watermarkField}${cursorSuffix}}`);
 
@@ -8672,10 +8693,14 @@ abstract class ShardDO {
         // instead of a provisional RPC-ack signal that can race ahead of it
         // (plan 266 finding d: write A's data frame arriving after write B's
         // ack has already landed, but before B's own rows synced, must not
-        // resolve B's overlay early). Out of scope here: the delta path below
-        // rides the same suppressed-value machinery and is a follow-up.
-        const dataWatermark = this.socketClientWatermark(ws);
-        const lastMutationIdField = dataWatermark === undefined ? "" : `,"lastMutationId":${String(dataWatermark)}`;
+        // resolve B's overlay early). The delta branch below stamps the SAME
+        // watermark on every delta frame it sends (not a follow-up: a
+        // `@lunora/db` list collection is exactly the id-keyed shape the
+        // delta path targets, so after the first snapshot EVERY subsequent
+        // write for it goes out as deltas — leaving them unstamped would
+        // starve the checkpoint gate of a frame-carried watermark for the
+        // common case, not a rare one).
+        const lastMutationIdField = clientWatermark === undefined ? "" : `,"lastMutationId":${String(clientWatermark)}`;
 
         // At-least-once delivery: advance the diff BASELINE (`lastJson`) only once
         // the frame(s) for this value actually leave the socket. `ws.send` throws
@@ -8690,7 +8715,7 @@ abstract class ShardDO {
         const delivered =
             deltas === undefined
                 ? trySendFrame(ws, `{"type":"data","id":${JSON.stringify(subId)},"data":${json}${lastMutationIdField}${cursorSuffix}}`)
-                : sendDeltaFrames(ws, subId, deltaFrames, cursorSuffix);
+                : sendDeltaFrames(ws, subId, deltaFrames, cursorSuffix, clientWatermark);
 
         memos.set(subId, { lastJson: delivered ? json : (existing?.lastJson ?? UNDELIVERED_BASELINE), ranges: outcome.ranges, tables: outcome.tables });
     }

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -8666,6 +8666,17 @@ abstract class ShardDO {
                 ? undefined
                 : subscriptionListDeltas(existing.lastJson, outcome.result, outcome.tables.values().next().value ?? "", deltaFrames);
 
+        // Stamp this socket's per-mutator watermark on the plain `data` frame
+        // the same way the `settled` branch above does, so the client's
+        // checkpoint gate can trust what THIS frame's rows actually reflect
+        // instead of a provisional RPC-ack signal that can race ahead of it
+        // (plan 266 finding d: write A's data frame arriving after write B's
+        // ack has already landed, but before B's own rows synced, must not
+        // resolve B's overlay early). Out of scope here: the delta path below
+        // rides the same suppressed-value machinery and is a follow-up.
+        const dataWatermark = this.socketClientWatermark(ws);
+        const lastMutationIdField = dataWatermark === undefined ? "" : `,"lastMutationId":${String(dataWatermark)}`;
+
         // At-least-once delivery: advance the diff BASELINE (`lastJson`) only once
         // the frame(s) for this value actually leave the socket. `ws.send` throws
         // when the socket has closed or its outbound buffer is gone. Advancing the
@@ -8678,7 +8689,7 @@ abstract class ShardDO {
         // tracking stays accurate even when delivery failed.
         const delivered =
             deltas === undefined
-                ? trySendFrame(ws, `{"type":"data","id":${JSON.stringify(subId)},"data":${json}${cursorSuffix}}`)
+                ? trySendFrame(ws, `{"type":"data","id":${JSON.stringify(subId)},"data":${json}${lastMutationIdField}${cursorSuffix}}`)
                 : sendDeltaFrames(ws, subId, deltaFrames, cursorSuffix);
 
         memos.set(subId, { lastJson: delivered ? json : (existing?.lastJson ?? UNDELIVERED_BASELINE), ranges: outcome.ranges, tables: outcome.tables });

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -271,13 +271,25 @@ const trySendFrame = (ws: FrameSink, frame: string): boolean => {
  * last fully-delivered value so the next flush re-diffs the whole change. Keyed
  * list deltas are idempotent on replay, so re-sending an already-applied row is
  * harmless.
+ *
+ * `lastMutationId` (when supplied) is stamped on EVERY delta frame in this
+ * batch, not just the last — a client's checkpoint gate reads whichever frame
+ * it happens to observe, and re-stamping the same value on each is a no-op
+ * for a client that already saw an earlier one (idempotent, monotonic
+ * `Math.max` on the read side). Without this, a `@lunora/db` list collection
+ * — the exact id-keyed shape this delta path exists for — never sees a
+ * per-frame watermark past its first snapshot, permanently starving the
+ * checkpoint gate of the frame-carried signal `pushSubscriptionData`'s
+ * snapshot branch provides (plan 266 finding d's fix was incomplete without
+ * this — the delta path is this feature's common case, not a rare fallback).
  */
-const sendDeltaFrames = (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string): boolean => {
+const sendDeltaFrames = (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string, lastMutationId?: number): boolean => {
     const idJson = JSON.stringify(subId);
+    const watermarkSuffix = lastMutationId === undefined ? "" : `,"lastMutationId":${String(lastMutationId)}`;
     let delivered = true;
 
     for (const deltaBody of deltaFrames) {
-        if (!trySendFrame(ws, `{"type":"delta","id":${idJson},"delta":${deltaBody}${cursorSuffix}}`)) {
+        if (!trySendFrame(ws, `{"type":"delta","id":${idJson},"delta":${deltaBody}${watermarkSuffix}${cursorSuffix}}`)) {
             delivered = false;
         }
     }


### PR DESCRIPTION
Work from an agent worktree, pushed under a descriptive name (local branch was `worktree-agent-a296f70ca717ffc10`).
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(client): promote a follower after the leader yields leadership
- fix(client): mirror leader connection status so follower tabs queue offline writes
- fix(client): scope the cross-tab settled watermark to the owning clientId
- fix(client,do,db): carry lastMutationId on list data frames and consume it
- fix(client): scope the cross-tab channel to deployment and identity
- fix(client): stamp and verify leader identity on cross-tab data frames
- test(client): close every fake/real-timer LunoraClient in socket-lifecycle tests
- fix(db): stop a zero mutation watermark from disabling the RPC-ack fallback
- fix(client): promote a leader tab's fresh coordinator immediately
- chore(api-snapshots): sync client and shard-engine snapshots
