### PR TITLE
fix(cli): refuse to push placeholder values to a deploy target

### DIFF
--- a/packages/cli/__tests__/commands/env.test.ts
+++ b/packages/cli/__tests__/commands/env.test.ts
@@ -287,6 +287,38 @@ describe("lunora env", () => {
             expect(recorded.warnings.join("\n")).toContain("A");
         });
 
+        it("push refuses to upload a placeholder value, naming the offending key and nothing gets spawned", async () => {
+            expect.assertions(4);
+
+            const { logger, recorded } = recordingLogger();
+
+            writeFileSync(join(workdir, ".dev.vars"), 'REAL_KEY="a-real-value"\nAUTH_SECRET="replace-me"\n', "utf8");
+
+            const { calls, spawner } = createRecordingSpawner();
+
+            const result = await runEnvCommand({ cwd: workdir, logger, spawner, subcommand: "push", yes: true });
+
+            expect(result.code).toBe(1);
+            expect(calls).toHaveLength(0);
+            expect(recorded.errors.join("\n")).toContain("AUTH_SECRET");
+            expect(recorded.errors.join("\n")).toContain("env doctor");
+        });
+
+        it("push proceeds when every value is real (no placeholder regression)", async () => {
+            expect.assertions(2);
+
+            const { logger } = recordingLogger();
+
+            writeFileSync(join(workdir, ".dev.vars"), 'REAL_KEY="a-real-value"\nOTHER_KEY="also-real"\n', "utf8");
+
+            const { calls, spawner } = createRecordingSpawner();
+
+            const result = await runEnvCommand({ cwd: workdir, logger, spawner, subcommand: "push", yes: true });
+
+            expect(result.code).toBe(0);
+            expect(calls).toHaveLength(2);
+        });
+
         it("push without --yes is refused", async () => {
             expect.assertions(3);
 

--- a/packages/cli/src/commands/env/handler.ts
+++ b/packages/cli/src/commands/env/handler.ts
@@ -329,6 +329,17 @@ const runEnvPush = async (context: EnvContext): Promise<EnvCommandResult> => {
         return { code: 0, descriptors: [] };
     }
 
+    const placeholders = [...map.values()].filter((entry) => isPlaceholderValue(entry.value)).map((entry) => entry.key);
+
+    if (placeholders.length > 0) {
+        logger.error(
+            `env push: refusing to upload placeholder value(s) for ${placeholders.join(", ")} — ` +
+                `run \`lunora env doctor\` to review, and \`lunora env generate --set\` (or \`lunora env set <KEY> <VALUE>\`) to fill them, then re-run.`,
+        );
+
+        return { code: 1, descriptors: [] };
+    }
+
     const spawner = options.spawner ?? defaultSpawner;
     const cwd = options.cwd ?? process.cwd();
     const manager = detectPackageManager(cwd);


### PR DESCRIPTION
Work from an agent worktree, pushed under a descriptive name (local branch was `worktree-agent-a3889b49019f7f7a5`).
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(cli): refuse to push placeholder values to a deploy target
