### PR TITLE
refactor(vue,svelte): share the isBrowser guard

### DIFF
--- a/packages/angular/__tests__/paginated-query.test.ts
+++ b/packages/angular/__tests__/paginated-query.test.ts
@@ -123,6 +123,55 @@ describe(paginatedQuery, () => {
     });
 });
 
+// Plan 285 — converge on `stableWireKey` for page keys instead of raw
+// `JSON.stringify`.
+//
+// Open Question 1 (answered by reading `usePaginatedCore`): `narrowedArgs`
+// (the base args `buildPageArgs` spreads under `paginationOpts`) is a `const`
+// captured once per `paginatedQuery`/`infiniteQuery` call and never rebuilt —
+// so within a SINGLE engine instance, `buildPageKey`'s output is deterministic
+// and property order never drifts across the calls this file makes (the args
+// come from one fixed object every time). The plan's headline "duplicate
+// subscriptions" / "result-carry miss" consequences are about TWO SEPARATE
+// component instances whose args are structurally equal but built with
+// different property order — that collapses (or doesn't) at the underlying
+// `client.subscribe` / `SubscriptionRegistry` dedup layer, which already uses
+// `stableWireKey` (per plan 285 §1) and is external to this adapter's own
+// bookkeeping; this package's fake `LunoraClient` doesn't model that dedup, so
+// there is no reachable pre/post-fix difference to assert for the
+// permutation/result-carry scenarios via this file's harness (Test plan items
+// 1–2's own downgrade allowance). The wire-typed-arg test below is the
+// reachable, demonstrably pre/post-fix-differentiating case.
+describe("paginatedQuery — stableWireKey page keys (plan 285)", () => {
+    const bigintArgFn = { __lunoraRef: "messages:list" } as FunctionReference<"query", { since: bigint }>;
+    const permutableArgFn = { __lunoraRef: "messages:list" } as FunctionReference<"query", { a: number; b: number }>;
+
+    it("accepts a bigint in the query args without throwing (wire-typed arg)", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        // Pre-fix, `buildPageKey` used raw `JSON.stringify`, which throws
+        // `TypeError: Do not know how to serialize a BigInt` the instant a
+        // page's args carry a `bigint` — this call would never complete.
+        // Post-fix, `stableWireKey` tokenizes it deterministically instead.
+        expect(() => {
+            paginatedQuery(bigintArgFn, { since: 10n }, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+        }).not.toThrow();
+
+        expect(fake.subscriptions).toHaveLength(1);
+    });
+
+    it("subscribes normally when caller args are not in canonical key order", () => {
+        const fake = createFakeClient();
+        const destroy = createFakeDestroyRef();
+
+        const { status } = paginatedQuery(permutableArgFn, { a: 2, b: 1 }, { client: fake.asClient, destroyRef: destroy.asDestroyRef, initialNumItems: NUM_ITEMS });
+
+        expect(fake.subscriptions).toHaveLength(1);
+        expect(status()).toBe("LoadingFirstPage");
+    });
+});
+
 /**
  * A `LunoraClient` stand-in whose `subscribe` replays a preseeded cached value
  * to the new subscriber SYNCHRONOUSLY — the callback fires before `subscribe`

--- a/packages/angular/__tests__/upload.test.ts
+++ b/packages/angular/__tests__/upload.test.ts
@@ -162,6 +162,11 @@ describe(upload, () => {
 
         const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
 
+        // `pause()` is a no-op unless an upload is in flight — drive the
+        // adapter's start callback first so `status() === "uploading"` before
+        // pausing (see the `pause()`/`resume()` in-flight guard added below).
+        fakeAdapter.onStart?.();
+
         handle.pause();
 
         expect(fakeAdapter.pause).toHaveBeenCalledTimes(1);
@@ -185,5 +190,103 @@ describe(upload, () => {
         destroy.destroy();
 
         expect(fakeAdapter.abort).toHaveBeenCalledTimes(1);
+    });
+
+    it("retry after error clears the previous attempt's terminal signals", () => {
+        expect.assertions(5);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+        const file1 = new File(["one"], "one.txt");
+        const file2 = new File(["two"], "two.txt");
+
+        handle.start(file1).catch(() => undefined);
+        fakeAdapter.onStart?.();
+        fakeAdapter.onProgress?.(50, 5000);
+        fakeAdapter.onError?.(new Error("network drop"));
+
+        expect(handle.status()).toBe("error");
+        expect(handle.error()?.message).toBe("network drop");
+
+        // A fresh `start()` is a new attempt — it must clear the stale error,
+        // result, and progress from the failed attempt immediately, not wait
+        // for the adapter's own `onStart` tick.
+        handle.start(file2).catch(() => undefined);
+
+        expect(handle.error()).toBeUndefined();
+        expect(handle.result()).toBeUndefined();
+        expect(handle.progress()).toBe(0);
+    });
+
+    it("success after retry carries no stale error", () => {
+        expect.assertions(3);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+        const file1 = new File(["one"], "one.txt");
+        const file2 = new File(["two"], "two.txt");
+
+        handle.start(file1).catch(() => undefined);
+        fakeAdapter.onError?.(new Error("network drop"));
+
+        handle.start(file2).catch(() => undefined);
+        fakeAdapter.onFinish?.({ key: "uploads/two" });
+
+        expect(handle.status()).toBe("success");
+        expect(handle.result()).toStrictEqual({ key: "uploads/two" });
+        expect(handle.error()).toBeUndefined();
+    });
+
+    it("restart after success clears the previous result and progress", () => {
+        expect.assertions(2);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+        const file1 = new File(["one"], "one.txt");
+        const file2 = new File(["two"], "two.txt");
+
+        handle.start(file1).catch(() => undefined);
+        fakeAdapter.onProgress?.(100, 10_000);
+        fakeAdapter.onFinish?.({ key: "uploads/one" });
+
+        handle.start(file2).catch(() => undefined);
+
+        expect(handle.result()).toBeUndefined();
+        expect(handle.progress()).toBe(0);
+    });
+
+    it("pause()/resume() are no-ops outside an in-flight upload", () => {
+        expect.assertions(6);
+
+        fakeAdapter = createFakeAdapter();
+        const destroy = createFakeDestroyRef();
+
+        const handle = upload({ destroyRef: destroy.asDestroyRef, endpoint: "https://test.local/upload" });
+
+        // Fresh handle: idle. Neither action has anything to act on.
+        handle.pause();
+
+        expect(fakeAdapter.pause).not.toHaveBeenCalled();
+        expect(handle.status()).toBe("idle");
+        expect(handle.isPaused()).toBe(false);
+
+        handle.resume();
+
+        expect(fakeAdapter.resume).not.toHaveBeenCalled();
+
+        // Terminal (success) state: pause() must not stamp "paused" over it.
+        handle.start(new File(["one"], "one.txt")).catch(() => undefined);
+        fakeAdapter.onFinish?.({ key: "uploads/one" });
+
+        handle.pause();
+
+        expect(fakeAdapter.pause).not.toHaveBeenCalled();
+        expect(handle.status()).toBe("success");
     });
 });

--- a/packages/angular/src/paginated-query.ts
+++ b/packages/angular/src/paginated-query.ts
@@ -4,6 +4,7 @@ import type { FunctionReference, LunoraClient, Unsubscribe } from "@lunora/clien
 import type { Page, PaginationResult, PaginationStatus } from "@lunora/client/pagination";
 import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "@lunora/client/pagination";
 
+import { stableWireKey } from "../../../shared/wire-key";
 import { resolveLunoraClient } from "./client";
 import { shouldOpenSubscription } from "./platform";
 
@@ -21,7 +22,12 @@ type ReturnTypeOf<F extends FunctionReference> = F extends FunctionReference<"qu
 
 // ── Page key helpers ────────────────────────────────────────────────────────
 
-const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): string => `${functionPath}::${JSON.stringify(pageArgs)}`;
+// Key pages with the repo's canonical `stableWireKey` (keys sorted at every
+// depth, wire-typed args tokenized) rather than raw `JSON.stringify`, so two
+// structurally-equal arg records built with a different key order collapse to
+// one key instead of opening a duplicate subscription — matching the client's
+// own `SubscriptionRegistry.key`.
+const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): string => `${functionPath}::${stableWireKey(pageArgs)}`;
 
 const buildPageArgs = (page: Page, baseArgs: Record<string, unknown>): Record<string, unknown> => {
     return {

--- a/packages/angular/src/upload.ts
+++ b/packages/angular/src/upload.ts
@@ -63,7 +63,7 @@ export interface UploadApi {
     /** Whether the upload is currently paused. */
     isPaused: Signal<boolean>;
 
-    /** Pause the in-flight upload (TUS / chunked-REST only support this mid-upload). */
+    /** Pause the in-flight upload (TUS / chunked-REST only support this mid-upload). A no-op unless `status() === "uploading"`. */
     pause: () => void;
 
     /** Upload progress, as the adapter reports it (0–100). */
@@ -72,7 +72,7 @@ export interface UploadApi {
     /** The resolved upload result, or `undefined` before it finishes. */
     result: Signal<UploadResult | undefined>;
 
-    /** Resume a paused upload. */
+    /** Resume a paused upload. A no-op unless `status() === "paused"`. */
     resume: () => void;
 
     /** Start (or restart) the upload for `file`. Also resolves/rejects with the same result the `result`/`error` signals settle to. */
@@ -137,15 +137,38 @@ export const upload = (options: UploadOptions): UploadApi => {
         status.set("error");
     });
 
-    const start = (file: File): Promise<UploadResult> => adapter.upload(file);
+    const start = (file: File): Promise<UploadResult> => {
+        // A (re)start is a fresh attempt: clear the previous attempt's terminal
+        // signals so a retry can't render a stale error/result/progress alongside
+        // the new upload's status (see UploadApi.start — "Start (or restart)").
+        error.set(undefined);
+        result.set(undefined);
+        progress.set(0);
+        isPaused.set(false);
+        status.set("uploading");
+
+        return adapter.upload(file);
+    };
 
     const pause = (): void => {
+        // A no-op unless an upload is actually in flight — calling `pause()`
+        // from `"idle"`/`"success"`/`"error"` must not stamp `"paused"` over a
+        // terminal state that has nothing to pause.
+        if (status() !== "uploading") {
+            return;
+        }
+
         adapter.pause();
         isPaused.set(true);
         status.set("paused");
     };
 
     const resume = (): void => {
+        // A no-op unless the upload is actually paused — mirrors `pause()`'s guard.
+        if (status() !== "paused") {
+            return;
+        }
+
         // `adapter.resume()` is async (it may re-probe the upload offset before
         // resuming); route failure into the same `error`/`status` signals a
         // failed `start()` would, rather than an unhandled rejection.

--- a/packages/svelte/__tests__/agent.test.ts
+++ b/packages/svelte/__tests__/agent.test.ts
@@ -1,6 +1,6 @@
 import type { FunctionReference, LunoraClient } from "@lunora/client";
 import { get } from "svelte/store";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentApi } from "../src/agent";
 import { agent } from "../src/agent";
@@ -59,7 +59,22 @@ const createFakeClient = () => {
     };
 };
 
+// Solid (`createEffect`/`onMount`) and Angular (`shouldOpenSubscription`/
+// `PLATFORM_ID`) are SSR-safe by construction — do not port this guard there
+// (plan 282 §1/§8).
 describe(agent, () => {
+    beforeEach(() => {
+        // `agent` gates its thread subscription on a browser `window`
+        // (SVELTE-01); the vitest env is `node` (no `window`), so define one
+        // for these client-path tests. The SSR test below removes it to
+        // exercise the guard, mirroring `presence.test.ts`.
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("subscribes to the thread channel and flows live status through", () => {
         const fake = createFakeClient();
         const handle = agent(fake.client, {
@@ -147,5 +162,34 @@ describe(agent, () => {
         expect(fake.mutationSpy).not.toHaveBeenCalled();
 
         handle.teardown();
+    });
+
+    it("does not open the thread subscription during SSR (no window) (SVELTE-01)", () => {
+        const fake = createFakeClient();
+
+        // Simulate the server render: no browser `window` (this package pairs
+        // with `@lunora/nuxt`'s server rendering, where a component's init runs
+        // inside `renderToString` with no `window`). Opening a live WS
+        // subscription there fires during `renderToString` with no
+        // corresponding `onDestroy` to close it — every server render would
+        // leak a subscription.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const handle = agent(fake.client, {
+            api: buildApi(),
+            cancel: makeRef(CANCEL_REF) as FunctionReference<"mutation">,
+            run: makeRef(RUN_REF) as FunctionReference<"mutation">,
+            threadKey: "t1",
+        });
+
+        expect(fake.subscribeCalls).toHaveLength(0);
+        expect(get(handle.status)).toBeUndefined();
+        expect(get(handle.thread)).toBeUndefined();
+
+        // Teardown itself must not throw with nothing live to unsubscribe.
+        expect(() => {
+            handle.teardown();
+        }).not.toThrow();
+        expect(fake.unsubscribeSpy).not.toHaveBeenCalled();
     });
 });

--- a/packages/svelte/__tests__/paginated-query.test.ts
+++ b/packages/svelte/__tests__/paginated-query.test.ts
@@ -524,3 +524,57 @@ describe("infiniteQuery (Svelte)", () => {
         stopPages();
     });
 });
+
+// Plan 285 — converge on `stableWireKey` for page keys instead of raw
+// `JSON.stringify`.
+//
+// Open Question 1 (answered by reading `createPaginatedEngine`):
+// `currentBaseArgs` is a `const` captured once per engine and never rebuilt —
+// so within a SINGLE engine instance, `buildPageKey`'s output is deterministic
+// and property order never drifts across the calls this file makes. The
+// plan's headline "duplicate subscriptions" / "result-carry miss"
+// consequences are about TWO SEPARATE component instances whose args are
+// structurally equal but built with different property order — that
+// collapses (or doesn't) at the underlying `client.subscribe` /
+// `SubscriptionRegistry` dedup layer, which already uses `stableWireKey` (per
+// plan 285 §1) and is external to this adapter's own bookkeeping; this file's
+// hand-rolled fake `subscribe` doesn't model that dedup, so there is no
+// reachable pre/post-fix difference to assert for the permutation/
+// result-carry scenarios via this file's harness (Test plan items 1–2's own
+// downgrade allowance). The wire-typed-arg test below is the reachable,
+// demonstrably pre/post-fix-differentiating case.
+describe("paginatedQuery — stableWireKey page keys (plan 285)", () => {
+    it("accepts a bigint in the query args without throwing (wire-typed arg)", () => {
+        const fake = createFakePaginatedClient();
+
+        // Pre-fix, `buildPageKey` used raw `JSON.stringify`, which throws
+        // `TypeError: Do not know how to serialize a BigInt` the instant the
+        // lazy readable's first subscriber opens the page subscription and
+        // computes the key. Post-fix, `stableWireKey` tokenizes it
+        // deterministically instead.
+        const { results } = paginatedQuery(fake.client, fn, { since: 10n }, { initialNumItems: NUM_ITEMS });
+
+        expect(() => {
+            const stop = results.subscribe(() => {});
+
+            stop();
+        }).not.toThrow();
+
+        expect(fake.subscribeCalls).toHaveLength(1);
+    });
+
+    it("subscribes normally when caller args are not in canonical key order", () => {
+        const fake = createFakePaginatedClient();
+
+        const { results, status } = paginatedQuery(fake.client, fn, { b: 1, a: 2 }, { initialNumItems: NUM_ITEMS });
+
+        const stopStatus = status.subscribe(() => {});
+        const stopResults = results.subscribe(() => {});
+
+        expect(fake.subscribeCalls).toHaveLength(1);
+        expect(get(status)).toBe("LoadingFirstPage");
+
+        stopStatus();
+        stopResults();
+    });
+});

--- a/packages/svelte/__tests__/rate-limit.test.ts
+++ b/packages/svelte/__tests__/rate-limit.test.ts
@@ -72,4 +72,41 @@ describe("rateLimit (Svelte)", () => {
 
         handle.teardown();
     });
+
+    // NOTE (plan 282, SSR guard for `startIntervalIfThrottled()`'s creation-time
+    // call): the plan's audit assumed a handle could start "already throttled"
+    // at creation and modeled a dedicated SSR test on that premise. It cannot:
+    // `evaluate()` throws ("requested count N exceeds the limiter capacity C")
+    // whenever the read-only status check's implicit `count: 1` would exceed
+    // the config's own capacity, and a fresh (unconsumed) bucket is *always*
+    // fully available for any non-throwing config — every algorithm variant
+    // documents this ("a fresh key starts full"). So a freshly constructed
+    // handle can never be `disabled` before its first `consume()`, in the
+    // browser or during SSR; the guarded creation-time call is unreachable
+    // today. The guard is kept anyway (harmless, and matches the "no eager
+    // side effects during SSR" convention used by every other primitive in
+    // this family) but there is no reachable pre/post-fix behavioural
+    // difference to assert here — recorded for the plan's Open Questions
+    // rather than asserted as a test.
+    it("consume() still arms the auto-tick interval during SSR once it drains the bucket (unguarded by design)", () => {
+        vi.useFakeTimers();
+
+        // No browser `window` (this file's default vitest env has none). Per
+        // the design decision (plan 282 §4): `consume()`'s own call to
+        // `startIntervalIfThrottled()` stays unguarded — a caller invoking
+        // `consume()` is actively using the handle, so the auto-recover ticker
+        // is still expected to arm even server-side.
+        const clock = { now: 0 };
+        const handle = rateLimit({ kind: "token bucket", period: 1000, rate: 2 }, { now: () => clock.now });
+
+        expect(vi.getTimerCount()).toBe(0);
+
+        handle.consume();
+        handle.consume();
+
+        expect(get(handle.disabled)).toBe(true);
+        expect(vi.getTimerCount()).toBe(1);
+
+        handle.teardown();
+    });
 });

--- a/packages/svelte/src/agent-chat.ts
+++ b/packages/svelte/src/agent-chat.ts
@@ -3,6 +3,7 @@ import { maxSeq, reconcileOptimistic } from "@lunora/client";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
+import { isBrowser } from "../../../shared/is-browser";
 import type { AgentThreadRecord, AgentThreadStatus } from "./agent";
 import { isClient, NO_MUTATION_REF } from "./agent";
 import { getLunoraClient } from "./context";
@@ -257,7 +258,6 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
     // mirrors the `presence.ts` guard). Skip them server-side; `messages`/
     // `status`/`streamingText` stay at their inert initial values until the
     // component hydrates and `teardown` becomes a no-op.
-    const isBrowser = (globalThis as { window?: unknown }).window !== undefined;
 
     // The token stream is optional: with no reference we pass the sentinel + "skip"
     // so `stream` never opens a stream (and `streamingText` stays empty). Subscribed
@@ -266,7 +266,7 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
     // `chunks` store opens the underlying stream on its first subscriber, so calling
     // it unconditionally here would open (and leak) a live stream during SSR too.
     const streamArguments = streamReference === undefined ? "skip" : { key: threadKey };
-    const unsubscribeStream = isBrowser
+    const unsubscribeStream = isBrowser()
         ? stream(client, streamReference ?? NO_STREAM_REF, streamArguments).chunks.subscribe((value) => {
               liveEvents = value;
               recomputeStreamingText();
@@ -274,14 +274,14 @@ const createAgentChatHandle = (client: LunoraClient, options: AgentChatOptions):
         : (): void => undefined;
 
     const historyArgs = limit === undefined ? { key: threadKey } : { key: threadKey, limit };
-    const unsubscribeHistory = isBrowser
+    const unsubscribeHistory = isBrowser()
         ? client.subscribe(api.agents.agentMessages, historyArgs, (value) => {
               durable = value as unknown as ReadonlyArray<AgentChatMessage>;
               recompute();
               recomputeStreamingText();
           })
         : (): void => undefined;
-    const unsubscribeThread = isBrowser
+    const unsubscribeThread = isBrowser()
         ? client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
               latestThread = value as AgentThreadRecord | undefined;
               statusStore.set(latestThread?.status);

--- a/packages/svelte/src/agent.ts
+++ b/packages/svelte/src/agent.ts
@@ -2,6 +2,7 @@ import type { FunctionReference, LunoraClient } from "@lunora/client";
 import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
+import { isBrowser } from "../../../shared/is-browser";
 import { getLunoraClient } from "./context";
 import { mutation } from "./mutation";
 
@@ -115,11 +116,19 @@ const createAgentHandle = (client: LunoraClient, options: AgentOptions): AgentHa
     const threadStore = writable<AgentThreadRecord | undefined>();
     const statusStore = writable<AgentThreadStatus | undefined>();
 
-    const unsubscribe = client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
-        latestThread = value as AgentThreadRecord | undefined;
-        threadStore.set(latestThread);
-        statusStore.set(latestThread?.status);
-    });
+    // Client-only: a component's init can run server-side (this package pairs
+    // with `@lunora/nuxt`'s server rendering) with no `window`, and opening a
+    // live WS subscription there would fire during `renderToString` with no
+    // corresponding `onDestroy` to close it (SVELTE-01, mirrors the
+    // `presence.ts`/`agent-chat.ts` guard). Skip it server-side; `thread`/
+    // `status` stay at their inert initial values until the component hydrates.
+    const unsubscribe = isBrowser()
+        ? client.subscribe(api.agents.agentThread, { key: threadKey }, (value) => {
+              latestThread = value as AgentThreadRecord | undefined;
+              threadStore.set(latestThread);
+              statusStore.set(latestThread?.status);
+          })
+        : (): void => undefined;
 
     const run = async (input: string, arguments_?: Record<string, unknown>): Promise<void> => {
         await runMutation.mutate({ input, threadKey, ...runArgs, ...arguments_ });

--- a/packages/svelte/src/paginated-query.ts
+++ b/packages/svelte/src/paginated-query.ts
@@ -4,6 +4,7 @@ import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "
 import type { Readable } from "svelte/store";
 import { derived, get, readable, writable } from "svelte/store";
 
+import { stableWireKey } from "../../../shared/wire-key";
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
 
@@ -56,7 +57,12 @@ const buildPageArgs = (page: Page, baseArgs: Record<string, unknown>): Record<st
     };
 };
 
-const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): string => `${functionPath}::${JSON.stringify(pageArgs)}`;
+// Key pages with the repo's canonical `stableWireKey` (keys sorted at every
+// depth, wire-typed args tokenized) rather than raw `JSON.stringify`, so two
+// structurally-equal arg records built with a different key order collapse to
+// one key instead of opening a duplicate subscription — matching the client's
+// own `SubscriptionRegistry.key`.
+const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): string => `${functionPath}::${stableWireKey(pageArgs)}`;
 
 /**
  * Internal pagination engine. Manages page boundaries, subscriptions, results,

--- a/packages/svelte/src/presence.ts
+++ b/packages/svelte/src/presence.ts
@@ -3,6 +3,7 @@ import { onDestroy } from "svelte";
 import type { Readable } from "svelte/store";
 import { readable } from "svelte/store";
 
+import { isBrowser } from "../../../shared/is-browser";
 import { randomSessionId } from "../../../shared/random-session-id";
 import { getLunoraClient } from "./context";
 
@@ -105,9 +106,7 @@ const createPresenceHandle = <H extends HeartbeatReference, L extends ListPresen
     // handle (SVELTE-01). Skip the whole client wiring server-side, mirroring
     // `@lunora/vue`'s `use-presence.ts` guard; the returned store stays inert
     // until the component hydrates.
-    const isBrowser = (globalThis as { window?: unknown }).window !== undefined;
-
-    if (isBrowser) {
+    if (isBrowser()) {
         sendHeartbeat();
         intervalHandle = setInterval(sendHeartbeat, intervalMs);
 
@@ -128,7 +127,7 @@ const createPresenceHandle = <H extends HeartbeatReference, L extends ListPresen
     // during `renderToString` WOULD trigger it — so guard it too rather than
     // open a live WS subscription server-side.
     const present = readable<ReturnOf<L> | undefined>(undefined, (set) => {
-        if (!isBrowser) {
+        if (!isBrowser()) {
             return undefined;
         }
 

--- a/packages/svelte/src/rate-limit.ts
+++ b/packages/svelte/src/rate-limit.ts
@@ -3,6 +3,8 @@ import { evaluate } from "@lunora/ratelimit";
 import type { Readable } from "svelte/store";
 import { derived, writable } from "svelte/store";
 
+import { isBrowser } from "../../../shared/is-browser";
+
 export interface RateLimitOptions {
     /** Clock injection for tests. Defaults to `Date.now`. */
     now?: () => number;
@@ -88,8 +90,16 @@ export const rateLimit = (config: RateLimitConfig, options: RateLimitOptions = {
         }, tickMs);
     };
 
-    // Kick off the ticker if we start already throttled.
-    startIntervalIfThrottled();
+    // Kick off the ticker if we start already throttled — but only in the
+    // browser: a component's init can run server-side (this package pairs
+    // with `@lunora/nuxt`'s server rendering) with no `window`, and arming a
+    // bare `setInterval` there would strand a live timer for the life of the
+    // process (no `onDestroy` ever fires to call `teardown`). `consume()`'s
+    // own call below stays unguarded — an explicit caller invoking `consume()`
+    // is actively using the handle, and `reset()`/`teardown` remain reachable.
+    if (isBrowser()) {
+        startIntervalIfThrottled();
+    }
 
     const consume = (count = 1): RateLimitStatus => {
         const result = evaluate(config, value, { consume: true, count, now: now(), reserve: false });

--- a/packages/vue/__tests__/hydrate-preloaded.test.ts
+++ b/packages/vue/__tests__/hydrate-preloaded.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference, Preloaded } from "@lunora/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, nextTick, ref } from "vue";
 
 import { hydratePreloaded } from "../src/hydrate-preloaded";
@@ -19,6 +19,19 @@ const makePreloaded = <T>(value: T, overrides: Partial<Preloaded<T>> = {}): Prel
 };
 
 describe(hydratePreloaded, () => {
+    // `hydratePreloaded` is built on `subscribeToQuery`, which gates its live
+    // subscription on a browser `window` (SSR guard); the vitest env is
+    // `node` (no `window`), so define one for these client-path tests. The
+    // dedicated SSR test in the `subscribeToQuery` describe below removes it
+    // to exercise the guard, mirroring `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("seeds the ref synchronously from preloaded.value on first read — no loading flash", () => {
         const fake = createFakeClient();
         const preloaded = makePreloaded(["hello", "world"]);
@@ -86,7 +99,16 @@ describe(hydratePreloaded, () => {
 });
 
 describe(subscribeToQuery, () => {
+    // `subscribeToQuery` gates its live subscription on a browser `window`
+    // (SSR guard); the vitest env is `node` (no `window`), so define one for
+    // these client-path tests. The dedicated SSR test below removes it to
+    // exercise the guard, mirroring `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
     afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
         vi.restoreAllMocks();
     });
 
@@ -117,9 +139,39 @@ describe(subscribeToQuery, () => {
 
         expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(1);
     });
+
+    it("does not subscribe during SSR (no window), but the seed still seeds the ref", () => {
+        const fake = createFakeClient();
+
+        // Simulate the server render: no browser `window`.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const scope = effectScope();
+        const data = scope.run(() => subscribeToQuery(fake.client, listMessages, { channelId: "c1" }, { seed: ["hello", "world"] }));
+
+        // No live subscription opened server-side …
+        expect(fake.subscribeCalls).toHaveLength(0);
+        // … but the seed still gives SSR HTML its value (the `hydratePreloaded`
+        // contract this primitive backs).
+        expect(data?.value).toStrictEqual(["hello", "world"]);
+
+        scope.stop();
+    });
 });
 
 describe(useQuery, () => {
+    // `useQuery` gates its subscription on a browser `window` (SSR guard);
+    // the vitest env is `node` (no `window`), so define one for these
+    // client-path tests. The dedicated SSR test below removes it to exercise
+    // the guard, mirroring `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("opens a subscription that is undefined until the first push, then updates", () => {
         const fake = createFakeClient();
         const scope = effectScope();
@@ -244,6 +296,27 @@ describe(useQuery, () => {
         await nextTick();
 
         expect(fake.unsubscribeSpy).toHaveBeenCalledTimes(1);
+        expect(data?.value).toBeUndefined();
+
+        scope.stop();
+    });
+
+    it("does not subscribe during SSR (no window)", () => {
+        const fake = createFakeClient();
+
+        // Simulate the server render: no browser `window`.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const scope = effectScope();
+        let data: ReturnType<typeof useQuery> | undefined;
+
+        scope.run(() => {
+            fake.provide(() => {
+                data = useQuery(listMessages, { channelId: "c1" });
+            });
+        });
+
+        expect(fake.subscribeCalls).toHaveLength(0);
         expect(data?.value).toBeUndefined();
 
         scope.stop();

--- a/packages/vue/__tests__/use-agent-chat.test.ts
+++ b/packages/vue/__tests__/use-agent-chat.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference } from "@lunora/client";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { effectScope } from "vue";
 
 import type { AgentLiveEvent, UseAgentChatApi, UseAgentChatResult } from "../src/use-agent-chat";
@@ -33,6 +33,19 @@ const buildApi = (): UseAgentChatApi =>
     }) as unknown as UseAgentChatApi;
 
 describe(useAgentChat, () => {
+    // `useAgentChat` is built on `useSubscription`, which gates its
+    // subscriptions on a browser `window` (SSR guard); the vitest env is
+    // `node` (no `window`), so define one for these client-path tests. The
+    // dedicated SSR test below removes it to exercise the guard, mirroring
+    // `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("surfaces durable history and live status over the agents:* subscriptions", () => {
         expect.hasAssertions();
 

--- a/packages/vue/__tests__/use-agent-state.test.ts
+++ b/packages/vue/__tests__/use-agent-state.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference } from "@lunora/client";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { effectScope } from "vue";
 
 import type { UseAgentStateApi, UseAgentStateResult } from "../src/use-agent-state";
@@ -25,6 +25,19 @@ const buildApi = (): UseAgentStateApi =>
     }) as unknown as UseAgentStateApi;
 
 describe(useAgentState, () => {
+    // `useAgentState` is built on `useSubscription`, which gates its
+    // subscription on a browser `window` (SSR guard); the vitest env is
+    // `node` (no `window`), so define one for these client-path tests. The
+    // dedicated SSR test below removes it to exercise the guard, mirroring
+    // `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("subscribes to agents:agentState and is undefined before the first frame", () => {
         expect.hasAssertions();
 

--- a/packages/vue/__tests__/use-agent-tool-events.test.ts
+++ b/packages/vue/__tests__/use-agent-tool-events.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference } from "@lunora/client";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { effectScope } from "vue";
 
 import type { AgentLiveEvent } from "../src/use-agent-chat";
@@ -30,6 +30,19 @@ const buildApi = (): UseAgentToolEventsApi =>
     }) as unknown as UseAgentToolEventsApi;
 
 describe(useAgentToolEvents, () => {
+    // `useAgentToolEvents` is built on `useSubscription`, which gates its
+    // subscription on a browser `window` (SSR guard); the vitest env is
+    // `node` (no `window`), so define one for these client-path tests. The
+    // dedicated SSR test below removes it to exercise the guard, mirroring
+    // `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("derives the durable tool lifecycle (call, result, awaiting-approval) from agentMessages", () => {
         expect.hasAssertions();
 

--- a/packages/vue/__tests__/use-agent.test.ts
+++ b/packages/vue/__tests__/use-agent.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference } from "@lunora/client";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { effectScope, nextTick } from "vue";
 
 import type { UseAgentApi, UseAgentResult } from "../src/use-agent";
@@ -22,6 +22,19 @@ const buildApi = (): UseAgentApi =>
     }) as unknown as UseAgentApi;
 
 describe(useAgent, () => {
+    // `useAgent` is built on `useSubscription`, which gates its subscription on
+    // a browser `window` (SSR guard); the vitest env is `node` (no `window`),
+    // so define one for these client-path tests. The dedicated SSR test below
+    // removes it to exercise the guard, mirroring `@lunora/vue`'s
+    // `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("subscribes to the thread channel and flows live status through", () => {
         expect.hasAssertions();
 

--- a/packages/vue/__tests__/use-paginated-query.test.ts
+++ b/packages/vue/__tests__/use-paginated-query.test.ts
@@ -1,5 +1,5 @@
 import type { PaginationResult } from "@lunora/client/pagination";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope, nextTick, ref } from "vue";
 
 import { useInfiniteQuery, usePaginatedQuery } from "../src/use-paginated-query";
@@ -26,6 +26,19 @@ const firstPageItems = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }, { id
 const secondPageItems = [{ id: "f" }, { id: "g" }, { id: "h" }, { id: "i" }, { id: "j" }];
 
 describe("usePaginatedQuery (Vue)", () => {
+    // `usePaginatedQuery` is built on the paginated core, which gates opening
+    // page subscriptions on a browser `window` (SSR guard); the vitest env is
+    // `node` (no `window`), so define one for these client-path tests. The
+    // dedicated SSR test below removes it to exercise the guard, mirroring
+    // `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("first page loads and results flatten", async () => {
         const fake = createFakeClient();
 
@@ -206,9 +219,37 @@ describe("usePaginatedQuery (Vue)", () => {
 
         scope.stop();
     });
+
+    it("does not open page subscriptions during SSR (no window)", async () => {
+        const fake = createFakeClient();
+
+        // Simulate the server render: no browser `window`.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const scope = effectScope();
+        const result = scope.run(() => fake.provide(() => usePaginatedQuery(fn, {}, { initialNumItems: NUM_ITEMS })))!;
+
+        await flushAsync();
+
+        expect(fake.subscribeCalls).toHaveLength(0);
+        expect(result.status.value).toBe("LoadingFirstPage");
+        expect(result.results.value).toStrictEqual([]);
+
+        scope.stop();
+    });
 });
 
 describe("useInfiniteQuery (Vue)", () => {
+    // `useInfiniteQuery` shares the same paginated core as `usePaginatedQuery`
+    // (see that describe block above for the SSR-guard rationale).
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("first page loads as first page array", async () => {
         const fake = createFakeClient();
 

--- a/packages/vue/__tests__/use-subscription.test.ts
+++ b/packages/vue/__tests__/use-subscription.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference } from "@lunora/client";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { effectScope } from "vue";
 
 import { useSubscription } from "../src/use-subscription";
@@ -8,7 +8,22 @@ import { createFakeClient } from "./fake-client";
 const msgRef = { __lunoraRef: "messages:subscribe" } as unknown as FunctionReference;
 const args = { channelId: "c1" } as unknown;
 
+// Solid (`createEffect`/`onMount`) and Angular (`shouldOpenSubscription`/
+// `PLATFORM_ID`) are SSR-safe by construction — do not port this guard there
+// (plan 282 §1/§8).
 describe(useSubscription, () => {
+    // `useSubscription` gates its live subscription on a browser `window`
+    // (SSR guard); the vitest env is `node` (no `window`), so define one for
+    // these client-path tests. The dedicated SSR test below removes it to
+    // exercise the guard, mirroring `@lunora/vue`'s `use-presence.test.ts`.
+    beforeEach(() => {
+        Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    });
+
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, "window");
+    });
+
     it("is undefined until the first server push", () => {
         const fake = createFakeClient();
 
@@ -87,6 +102,22 @@ describe(useSubscription, () => {
         expect(error.value).toBeInstanceOf(Error);
         expect(error.value?.message).toBe("boom");
         expect((error.value as { code?: string }).code).toBeUndefined();
+
+        scope.stop();
+    });
+
+    it("does not subscribe during SSR (no window)", () => {
+        const fake = createFakeClient();
+
+        // Simulate the server render: no browser `window`.
+        Reflect.deleteProperty(globalThis, "window");
+
+        const scope = effectScope();
+        const { data, error } = scope.run(() => fake.provide(() => useSubscription(msgRef, args)))!;
+
+        expect(fake.subscribeCalls).toHaveLength(0);
+        expect(data.value).toBeUndefined();
+        expect(error.value).toBeUndefined();
 
         scope.stop();
     });

--- a/packages/vue/src/use-paginated-core.ts
+++ b/packages/vue/src/use-paginated-core.ts
@@ -4,6 +4,7 @@ import { applyLoadMore, derivePaginationStatus, initialPages, rebalance } from "
 import type { MaybeRefOrGetter, ShallowRef } from "vue";
 import { onScopeDispose, shallowRef, toValue, watch } from "vue";
 
+import { isBrowser } from "../../../shared/is-browser";
 import { stableWireKey } from "../../../shared/wire-key";
 import { useLunora } from "./lunora-provider";
 
@@ -220,6 +221,15 @@ const usePaginatedCore = <T>(
     watch(
         () => stableWireKey(toValue(args)),
         () => {
+            // Client-only: an `immediate: true` watcher fires once during
+            // `renderToString` with no unmount to run `onScopeDispose(teardownAll)`
+            // (see `use-presence.ts`'s guard rationale) — skip opening page
+            // subscriptions server-side and leave `pages`/`pageResults` at their
+            // inert initial values.
+            if (!isBrowser()) {
+                return;
+            }
+
             const current = toValue(args);
 
             teardownAll();

--- a/packages/vue/src/use-presence.ts
+++ b/packages/vue/src/use-presence.ts
@@ -2,6 +2,7 @@ import type { ArgsOf, FunctionReference, ReturnOf } from "@lunora/client";
 import type { ShallowRef } from "vue";
 import { getCurrentScope, onScopeDispose, shallowRef } from "vue";
 
+import { isBrowser } from "../../../shared/is-browser";
 import { randomSessionId } from "../../../shared/random-session-id";
 import { useLunora } from "./lunora-provider";
 
@@ -92,7 +93,7 @@ const usePresence = <H extends HeartbeatReference, L extends ListPresentReferenc
     // and the render scope never stops — so `onScopeDispose` never fires and each
     // request would leak a live `setInterval` handle. Skip the whole client wiring
     // server-side; the returned refs stay inert until the component hydrates.
-    if ((globalThis as { window?: unknown }).window !== undefined) {
+    if (isBrowser()) {
         // Heartbeat: immediately on mount, on interval, and on tab re-focus.
         sendHeartbeat();
         const intervalHandle = setInterval(sendHeartbeat, intervalMs);

--- a/packages/vue/src/use-query.ts
+++ b/packages/vue/src/use-query.ts
@@ -3,6 +3,7 @@ import { createQuerySubscription } from "@lunora/client/query";
 import type { MaybeRefOrGetter, Ref } from "vue";
 import { getCurrentScope, onScopeDispose, shallowRef, toValue, watch } from "vue";
 
+import { isBrowser } from "../../../shared/is-browser";
 import { useLunora } from "./lunora-provider";
 import type { UseQueryOptions } from "./types";
 
@@ -34,22 +35,27 @@ export const subscribeToQuery = <F extends FunctionReference, T = ReturnOf<F>>(
     // mutated in place, so deep reactivity would only add overhead.
     const data = shallowRef<T | undefined>(options.seed) as Ref<T | undefined>;
 
-    const unsubscribe: Unsubscribe = client.subscribe(
-        function_,
-        args,
-        (value) => {
-            data.value = value as T;
-        },
-        { shardKey: options.shardKey },
-    );
-
-    if (getCurrentScope()) {
-        onScopeDispose(unsubscribe);
-    } else if (process.env.NODE_ENV !== "production") {
-        console.warn(
-            "[@lunora/vue] subscribeToQuery called with no active effect scope — its subscription will not be cleaned up automatically. " +
-                "Call it inside setup()/an effect scope, or call the returned teardown yourself.",
+    // Client-only: called during SSR this would open a live subscription that
+    // never tears down (see `use-presence.ts`'s guard rationale). The seed
+    // above already gives SSR HTML its value; skip the subscription server-side.
+    if (isBrowser()) {
+        const unsubscribe: Unsubscribe = client.subscribe(
+            function_,
+            args,
+            (value) => {
+                data.value = value as T;
+            },
+            { shardKey: options.shardKey },
         );
+
+        if (getCurrentScope()) {
+            onScopeDispose(unsubscribe);
+        } else if (process.env.NODE_ENV !== "production") {
+            console.warn(
+                "[@lunora/vue] subscribeToQuery called with no active effect scope — its subscription will not be cleaned up automatically. " +
+                    "Call it inside setup()/an effect scope, or call the returned teardown yourself.",
+            );
+        }
     }
 
     return data;
@@ -88,6 +94,14 @@ export const useQuery = <F extends FunctionReference>(
     watch(
         () => toValue(args),
         (current, _previous, onCleanup) => {
+            // Client-only: an `immediate: true` watcher fires once during
+            // `renderToString` with no unmount to run `onCleanup` (see
+            // `use-presence.ts`'s guard rationale) — skip the subscription
+            // server-side and leave `data` at its inert initial value.
+            if (!isBrowser()) {
+                return;
+            }
+
             const unsubscribe = createQuerySubscription(
                 client,
                 function_,

--- a/packages/vue/src/use-subscription.ts
+++ b/packages/vue/src/use-subscription.ts
@@ -4,6 +4,7 @@ import { LunoraError } from "@lunora/errors";
 import type { MaybeRefOrGetter, Ref } from "vue";
 import { onScopeDispose, ref, toValue, watch } from "vue";
 
+import { isBrowser } from "../../../shared/is-browser";
 import { useLunora } from "./lunora-provider";
 import type { UseQueryOptions } from "./types";
 
@@ -37,6 +38,14 @@ const useSubscription = <F extends FunctionReference>(
             if (currentArgs === "skip") {
                 data.value = undefined;
                 error.value = undefined;
+                return;
+            }
+
+            // Client-only: an `immediate: true` watcher fires once during
+            // `renderToString` with no unmount to run `onCleanup` (see
+            // `use-presence.ts`'s guard rationale) — skip the subscription
+            // server-side and leave `data`/`error` at their inert initial values.
+            if (!isBrowser()) {
                 return;
             }
 

--- a/shared/is-browser.ts
+++ b/shared/is-browser.ts
@@ -1,0 +1,27 @@
+/**
+ * Canonical browser-vs-SSR detector shared by the framework adapters that ship
+ * a server-render path (`@lunora/vue`, `@lunora/svelte`) and pair with an SSR
+ * host (`@lunora/nuxt`). A component's setup/init can run inside
+ * `renderToString` with no `window`: opening a live subscription or a
+ * `setInterval` there leaks for the lifetime of the process, because the
+ * render scope never stops and no unmount hook ever fires to close it.
+ *
+ * There must be exactly ONE definition rather than byte-similar inline copies
+ * that can drift: two of the four call sites this replaces had the guard and
+ * two didn't — that divergence is precisely the SSR-leak bug this file exists
+ * to prevent, mirroring `shared/random-session-id.ts` and
+ * `shared/constant-time-equal.ts`.
+ *
+ * Deliberately a **function**, not a module-level constant: it must be
+ * evaluated per call so a test (or a runtime like happy-dom booting late)
+ * that defines/deletes `window` after import still observes the correct
+ * behaviour on every subsequent call.
+ *
+ * Like the repo's other `shared/` helpers, this is deliberately **not** a
+ * package: consumers import it by relative path and the bundler
+ * (packem/rollup) inlines it — no runtime dependency edge. Keep it genuinely
+ * zero-dependency (relative/built-in imports only) or inlining breaks.
+ * Consumers must drop `outDir`/`rootDir` from their `tsconfig.json` (a set
+ * `rootDir` raises TS6059 for this out-of-package file under `tsc --noEmit`).
+ */
+export const isBrowser = (): boolean => (globalThis as { window?: unknown }).window !== undefined;


### PR DESCRIPTION
Work from an agent worktree, pushed under a descriptive name (local branch was `worktree-agent-a5593d536c42bc6b6`).
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- refactor(vue,svelte): share the isBrowser guard
- fix(vue,svelte): guard eager subscriptions and timers against SSR
- fix(angular,svelte): key pagination pages with stableWireKey
- fix(angular): reset upload signals on restart and guard pause/resume
