### PR TITLE
fix(auth-ui): guard AuthView route lookup against prototype segments

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -240,12 +240,6 @@
             - "name": "Lint (prettier)"
               "run": "pnpm run lint:prettier"
 
-            # The auth-ui-* registry items are generated from @lunora/auth-ui's
-            # source by scripts/sync-auth-ui-registry.mjs; fail if they've drifted
-            # (someone edited src without re-running the sync).
-            - "name": "Lint (auth-ui registry sync)"
-              "run": "pnpm run lint:registry:sync"
-
     "package-json-sort":
         "name": "Lint (package.json sort)"
         "if": "needs.files-changed.outputs.package_json_lintable == 'true'"
@@ -304,6 +298,42 @@
             - "name": "Scan for secrets"
               "run": "pnpm exec vis secrets"
 
+    # The auth-ui-* registry items are generated from @lunora/auth-ui's source by
+    # scripts/sync-auth-ui-registry.mjs. This used to be the last step of the
+    # `prettier` job, which meant it was skipped whenever a PR's diff had no
+    # frontend-lintable file, and masked whenever an earlier step in that job
+    # failed — drift landed on `alpha` despite the check nominally existing.
+    # No `if` path-filter, same as `secrets` above: the script only needs
+    # `node` + the repo's `prettier` dependency (no package builds), so an
+    # unconditional run costs well under a minute and closes the skip class
+    # outright.
+    "registry-sync":
+        "name": "Lint (auth-ui registry sync)"
+        "needs": "files-changed"
+        "runs-on": "ubuntu-latest"
+        "timeout-minutes": 10
+        "steps":
+            - "name": "Harden Runner"
+              "uses": "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411" # v2.19.4
+              "with":
+                  "egress-policy": "audit"
+
+            - "name": "Git checkout"
+              "uses": "anolilab/workflows/step/checkout-with-retry@6c16895f4c3b5273b373656988505d1a8264e78b" # main
+
+            - "name": "Setup resources and environment"
+              "uses": "anolilab/workflows/step/node@acba5fb15ac98ad23dec1ad233e40e1bb79c1dae" # v19.0.4
+              "with":
+                  "node-version": "22.15"
+                  "cache-prefix": "lint"
+                  "skip-playwright": "true"
+                  "enable-nx-cache": "false"
+                  "run-npm-audit": "false"
+                  "run-signatures-audit": "false"
+
+            - "name": "Lint (auth-ui registry sync)"
+              "run": "pnpm run lint:registry:sync"
+
     "yaml-lint":
         "name": "Lint (yaml)"
         "if": "needs.files-changed.outputs.yaml_lintable == 'true'"
@@ -329,7 +359,7 @@
     # Single required check for the Lint workflow.
     "lint-required-check":
         "name": "Check Lint Run"
-        "needs": ["files-changed", "eslint", "types", "fallow", "api-surface", "prettier", "package-json-sort", "secrets", "yaml-lint"]
+        "needs": ["files-changed", "eslint", "types", "fallow", "api-surface", "prettier", "package-json-sort", "secrets", "registry-sync", "yaml-lint"]
         "if": "always()"
         "runs-on": "ubuntu-latest"
         "timeout-minutes": 5

--- a/packages/auth-ui/__tests__/core/discovery.test.ts
+++ b/packages/auth-ui/__tests__/core/discovery.test.ts
@@ -138,6 +138,18 @@ describe("discovered config fields", () => {
         expect(context.organization.teams).toBe(true);
         expect(context.organization.roles).toBe(true);
     });
+
+    it("closes the sign-up gate when the server discloses disableSignUp", () => {
+        expect.assertions(1);
+
+        expect(contextFor(stub(), payload({ signUp: false })).signUp).toBe(false);
+    });
+
+    it("defaults the sign-up gate open when discovery never answered", () => {
+        expect.assertions(1);
+
+        expect(contextFor(stub()).signUp).toBe(true);
+    });
 });
 
 describe("discoverAuthConfig", () => {

--- a/packages/auth-ui/__tests__/core/invitations.test.ts
+++ b/packages/auth-ui/__tests__/core/invitations.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthClient, AuthResponse, ControllerContext } from "../../src/core";
+import { createAcceptInvitationController, resolveContext } from "../../src/core";
+
+const ok = <T>(data: T): Promise<AuthResponse<T>> => Promise.resolve({ data, error: null });
+
+/**
+ * A signed-out session with a loaded invitation, ready to accept — the state
+ * the bounce (`decide` inside `createAcceptInvitationController`) reads from.
+ */
+const makeContext = (
+    redirectsSignIn: string,
+): { context: ControllerContext; nav: { navigate: ReturnType<typeof vi.fn>; replace: ReturnType<typeof vi.fn> } } => {
+    const nav = { navigate: vi.fn(), replace: vi.fn() };
+    const authClient = {
+        getSession: vi.fn(() => ok(null)),
+        organization: {
+            acceptInvitation: vi.fn(() => ok({})),
+            getInvitation: vi.fn(() => ok({ email: "invitee@example.com", id: "inv-1", organizationName: "Acme" })),
+        },
+    } as unknown as AuthClient;
+
+    const context = resolveContext({ authClient, nav, redirects: { signIn: redirectsSignIn } });
+
+    return { context, nav };
+};
+
+/**
+ * The invitation sign-in bounce used to append `?redirectTo=…` blindly, which
+ * mangles a `redirects.signIn` that already carries a query (`/auth?tab=sign-in`
+ * → `/auth?tab=sign-in?redirectTo=…`) — the invitee signs in and the invitation
+ * is lost (plan 278).
+ */
+describe("createAcceptInvitationController — sign-in bounce", () => {
+    afterEach(() => {
+        globalThis.history.pushState({}, "", "/");
+    });
+
+    it("merges redirectTo and email into a signIn path that already carries a query, without a second ?", async () => {
+        expect.assertions(3);
+
+        const { context, nav } = makeContext("/auth?tab=sign-in");
+
+        globalThis.history.pushState({}, "", "/accept-invitation?invitationId=inv-1");
+
+        const controller = createAcceptInvitationController(context, { invitationId: "inv-1" });
+
+        await vi.waitFor(() => {
+            if (controller.getState().loading) {
+                throw new Error("still loading");
+            }
+        });
+
+        await controller.actions.accept();
+
+        expect(nav.replace).toHaveBeenCalledTimes(1);
+
+        const [calledUrl] = nav.replace.mock.calls[0] as [string];
+
+        expect(calledUrl.match(/\?/g)?.length).toBe(1);
+
+        const parsed = new URL(calledUrl, "http://example.test");
+
+        expect(Object.fromEntries(parsed.searchParams)).toStrictEqual({
+            email: "invitee@example.com",
+            redirectTo: "/accept-invitation?invitationId=inv-1",
+            tab: "sign-in",
+        });
+    });
+
+    it("still produces the pre-existing URL shape when redirects.signIn carries no query", async () => {
+        expect.assertions(2);
+
+        const { context, nav } = makeContext("/sign-in");
+
+        globalThis.history.pushState({}, "", "/accept-invitation?invitationId=inv-1");
+
+        const controller = createAcceptInvitationController(context, { invitationId: "inv-1" });
+
+        await vi.waitFor(() => {
+            if (controller.getState().loading) {
+                throw new Error("still loading");
+            }
+        });
+
+        await controller.actions.accept();
+
+        const [calledUrl] = nav.replace.mock.calls[0] as [string];
+
+        expect(calledUrl.startsWith("/sign-in?")).toBe(true);
+
+        const parsed = new URL(calledUrl, "http://example.test");
+
+        expect(Object.fromEntries(parsed.searchParams)).toStrictEqual({
+            email: "invitee@example.com",
+            redirectTo: "/accept-invitation?invitationId=inv-1",
+        });
+    });
+});

--- a/packages/auth-ui/__tests__/core/organization-logo.test.ts
+++ b/packages/auth-ui/__tests__/core/organization-logo.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuthClient, AuthResponse, ControllerContext } from "../../src/core";
+import { resolveContext } from "../../src/core";
+import { createOrganizationLogoController } from "../../src/core/organization-logo";
+
+const ok = <T>(data: T): Promise<AuthResponse<T>> => Promise.resolve({ data, error: null });
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** A `File` whose `type` is deliberately empty, the way some pickers hand one back. */
+const fileWithBytes = (bytes: number[], name = "upload"): File => new File([new Uint8Array(bytes)], name, { type: "" });
+
+const makeContext = (upload: (file: File) => Promise<string>): ControllerContext => {
+    const authClient = {
+        getSession: vi.fn(),
+        organization: { update: vi.fn(() => ok({ status: true })) },
+    } as unknown as AuthClient;
+
+    return resolveContext({ authClient, avatar: { upload }, nav: { navigate: vi.fn(), replace: vi.fn() } });
+};
+
+/**
+ * `createOrganizationLogoController` carried the exact predicate that
+ * `avatar.ts` was explicitly fixed for: a `File` with an empty `type` skipped
+ * the accept-list check entirely (plan 260).
+ */
+describe("createOrganizationLogoController — empty-MIME sniff", () => {
+    it("rejects a file with an empty type and non-image bytes, without uploading", async () => {
+        expect.assertions(2);
+
+        const upload = vi.fn(async () => "https://cdn.test/logo.png");
+        const controller = createOrganizationLogoController(makeContext(upload));
+
+        await controller.actions.upload(fileWithBytes([0x00, 0x01, 0x02, 0x03], "not-an-image"));
+
+        expect(controller.getState().status).toBe("error");
+        expect(upload).not.toHaveBeenCalled();
+    });
+
+    it("accepts a real PNG whose type is empty, via magic-byte sniff", async () => {
+        expect.assertions(2);
+
+        const upload = vi.fn(async () => "https://cdn.test/logo.png");
+        const controller = createOrganizationLogoController(makeContext(upload));
+
+        await controller.actions.upload(fileWithBytes(PNG_MAGIC, "photo"));
+
+        expect(upload).toHaveBeenCalledTimes(1);
+        expect(controller.getState().status).toBe("success");
+    });
+
+    it("still rejects a declared type outside the accept list, empty type or not", async () => {
+        expect.assertions(1);
+
+        const upload = vi.fn(async () => "https://cdn.test/logo.png");
+        const controller = createOrganizationLogoController(makeContext(upload));
+
+        await controller.actions.upload(new File([new Uint8Array(PNG_MAGIC)], "logo.svg", { type: "image/svg+xml" }));
+
+        expect(controller.getState().status).toBe("error");
+    });
+});

--- a/packages/auth-ui/__tests__/core/redirect-to.test.ts
+++ b/packages/auth-ui/__tests__/core/redirect-to.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { mergeQuery, withRedirectTo } from "../../src/core/redirect-to";
+
+/**
+ * `mergeQuery` is the parse-and-merge extracted out of `withRedirectTo` so the
+ * invitation bounce (`invitations.ts`) can share it instead of re-appending a
+ * blind `?redirectTo=…`, which mangled any `redirects.signIn` that already
+ * carried a query (plan 278).
+ */
+describe("mergeQuery", () => {
+    it("adds a query to a path with none", () => {
+        expect.assertions(1);
+
+        expect(mergeQuery("/sign-in", { redirectTo: "/app" })).toBe("/sign-in?redirectTo=%2Fapp");
+    });
+
+    it("merges into a path that already carries a query, without a second ?", () => {
+        expect.assertions(2);
+
+        const merged = mergeQuery("/auth?tab=sign-in", { redirectTo: "/app" });
+
+        expect(merged.match(/\?/g)?.length).toBe(1);
+        expect(new URL(merged, "https://x").searchParams.get("tab")).toBe("sign-in");
+    });
+
+    it("overwrites an existing key rather than duplicating it — the new value wins", () => {
+        expect.assertions(2);
+
+        const merged = mergeQuery("/two-factor?redirectTo=/stale", { redirectTo: "/fresh" });
+        const params = new URL(merged, "https://x").searchParams;
+
+        expect(params.getAll("redirectTo")).toStrictEqual(["/fresh"]);
+        expect(params.get("redirectTo")).toBe("/fresh");
+    });
+
+    it("merges several parameters at once", () => {
+        expect.assertions(1);
+
+        const merged = mergeQuery("/auth?tab=sign-in", { email: "a@b.co", redirectTo: "/app" });
+        const params = new URL(merged, "https://x").searchParams;
+
+        expect(Object.fromEntries(params)).toStrictEqual({ email: "a@b.co", redirectTo: "/app", tab: "sign-in" });
+    });
+});
+
+describe("withRedirectTo (refactored onto mergeQuery — behaviour unchanged)", () => {
+    afterEach(() => {
+        globalThis.history.pushState({}, "", "/");
+    });
+
+    it("passes the path through untouched when there is no redirectTo on the current URL", () => {
+        expect.assertions(1);
+
+        expect(withRedirectTo("/two-factor")).toBe("/two-factor");
+    });
+
+    it("carries redirectTo onto the intermediate step's URL", () => {
+        expect.assertions(1);
+
+        globalThis.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+
+        // eslint-disable-next-line no-secrets/no-secrets -- a URL path, not a credential.
+        expect(withRedirectTo("/two-factor")).toBe("/two-factor?redirectTo=%2Finvite%2Fxyz"); // secret-scanner:allow -- a URL path, not a credential.
+    });
+
+    it("the configured redirectTo does not win over the invitation target it exists to carry", () => {
+        expect.assertions(1);
+
+        globalThis.history.pushState({}, "", "/sign-in?redirectTo=%2Finvite%2Fxyz");
+
+        // eslint-disable-next-line no-secrets/no-secrets -- a URL path, not a credential.
+        expect(withRedirectTo("/two-factor?redirectTo=%2Fconfigured")).toBe("/two-factor?redirectTo=%2Finvite%2Fxyz"); // secret-scanner:allow -- a URL path, not a credential.
+    });
+});

--- a/packages/auth-ui/__tests__/core/sign-up-gate-parity.test.ts
+++ b/packages/auth-ui/__tests__/core/sign-up-gate-parity.test.ts
@@ -1,0 +1,81 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The server can close self-serve sign-up
+ * (`emailAndPassword.disableSignUp`), the client resolves it onto
+ * `ControllerContext.signUp`, and every port is meant to read it in three
+ * places: the sign-up card, the sign-up route, and the sign-in footer link
+ * (plan 278). `credentials` — the field right beside it in `config.ts` — got
+ * this wiring in all five ports; `signUp` didn't, silently, until this plan.
+ *
+ * This test is the drift-stopper `credentials` never had: it fails if any
+ * port's source tree stops containing a genuine context read of `signUp`.
+ * Each port's regex is written to match only a *context* read (`context.signUp`,
+ * `context.value.signUp`, `this.context().signUp`, …) — never `t.signUp`
+ * (localization), `viewPaths.signUp` (the URL segment), or `signUpHref` (a
+ * plain link prop), any of which would satisfy a naive `\bsignUp\b` scan
+ * without the app ever gating anything on the resolved flag.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const AUTH_UI_SRC = join(HERE, "..", "..", "src");
+
+const TS_FILE_RE = /\.(?:svelte|tsx?|vue)$/;
+
+/** Every source file under `dir`, recursively. */
+const filesUnder = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            return filesUnder(full);
+        }
+
+        return TS_FILE_RE.test(entry.name) ? [full] : [];
+    });
+
+/**
+ * Per-port pattern for a genuine *context read* of the resolved `signUp` flag.
+ * Deliberately narrow — a prefix that only a real context access produces —
+ * rather than a bare `\bsignUp\b`, which `viewPaths.signUp` and `t.signUp`
+ * would also satisfy.
+ */
+const PORT_PATTERNS: Record<string, RegExp> = {
+    angular: /this\.context\(\)\.signUp\b/,
+    react: /context\.signUp\b/,
+    solid: /context\.signUp\b/,
+    svelte: /context\.signUp\b/,
+    vue: /context\.(?:value\.)?signUp\b/,
+};
+
+const hasContextRead = (port: string): boolean => {
+    const pattern = PORT_PATTERNS[port];
+
+    if (pattern === undefined) {
+        return false;
+    }
+
+    return filesUnder(join(AUTH_UI_SRC, port)).some((file) => pattern.test(readFileSync(file, "utf8")));
+};
+
+describe("signUp × port parity", () => {
+    it.each(Object.keys(PORT_PATTERNS))("%s reads context.signUp somewhere in its source tree", (port) => {
+        expect.assertions(1);
+
+        expect(hasContextRead(port), `no file under src/${port} contains a context read of signUp matching ${String(PORT_PATTERNS[port])}`).toBe(true);
+    });
+
+    it("the pattern list does not vacuously match localization, viewPaths, or href references", () => {
+        expect.assertions(Object.keys(PORT_PATTERNS).length * 3);
+
+        for (const pattern of Object.values(PORT_PATTERNS)) {
+            expect(pattern.test("t.signUp")).toBe(false);
+            expect(pattern.test("viewPaths.signUp")).toBe(false);
+            expect(pattern.test("signUpHref")).toBe(false);
+        }
+    });
+});

--- a/packages/auth-ui/__tests__/react/auth-view.test.tsx
+++ b/packages/auth-ui/__tests__/react/auth-view.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuthClient, AuthResponse } from "../../src/core";
+import { AuthUIProvider, AuthView } from "../../src/react";
+
+const ok = <T,>(data: T = null as T): Promise<AuthResponse<T>> => Promise.resolve({ data, error: null });
+
+const renderView = (view?: string): void => {
+    const nav = { navigate: vi.fn(), replace: vi.fn() };
+    const client = {
+        emailOtp: { sendVerificationOtp: vi.fn(() => ok()) },
+        forgetPassword: vi.fn(() => ok()),
+        resetPassword: vi.fn(() => ok()),
+        signIn: {
+            email: vi.fn(() => ok({ user: { email: "a@b.co" } })),
+            emailOtp: vi.fn(() => ok()),
+            magicLink: vi.fn(() => ok()),
+            social: vi.fn(() => ok()),
+        },
+        signUp: { email: vi.fn(() => ok()) },
+        twoFactor: { disable: vi.fn(), enable: vi.fn(), verifyOtp: vi.fn(), verifyTotp: vi.fn() },
+    } as unknown as AuthClient;
+
+    const tree: ReactElement = (
+        <AuthUIProvider authClient={client} discover={false} nav={nav} redirects={{ afterSignIn: "/app" }}>
+            <AuthView view={view} />
+        </AuthUIProvider>
+    );
+
+    render(tree);
+};
+
+/**
+ * `AuthView` dispatches the URL segment through a plain object literal, which
+ * inherits `Object.prototype`. These segments name inherited members and must
+ * still fall back to the sign-in card rather than invoking the inherited
+ * member as a route renderer (plan 260).
+ */
+describe(AuthView, () => {
+    it('falls back to sign-in for "valueOf" (pre-fix: throws a TypeError)', () => {
+        expect.assertions(1);
+
+        renderView("valueOf");
+
+        expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+    });
+
+    it('falls back to sign-in for "constructor" (pre-fix: "Objects are not valid as a React child")', () => {
+        expect.assertions(1);
+
+        renderView("constructor");
+
+        expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+    });
+
+    it('falls back to sign-in for "toString", and never renders "[object Undefined]" (pre-fix: it is the whole page)', () => {
+        expect.assertions(2);
+
+        renderView("toString");
+
+        expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+        expect(screen.queryByText("[object Undefined]")).toBeNull();
+    });
+
+    it("still renders the sign-up card for a configured segment", () => {
+        expect.assertions(1);
+
+        renderView("sign-up");
+
+        expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Create account");
+    });
+
+    it("falls back to sign-in for an unrecognized segment", () => {
+        expect.assertions(1);
+
+        renderView("definitely-not-a-view");
+
+        expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+    });
+
+    it("falls back to sign-in when no segment is given", () => {
+        expect.assertions(1);
+
+        renderView();
+
+        expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+    });
+});

--- a/packages/auth-ui/__tests__/react/discovery-rebuild.test.tsx
+++ b/packages/auth-ui/__tests__/react/discovery-rebuild.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resetAuthConfigDiscovery } from "../../src/core";
+import { AuthUIProvider, SignInCard } from "../../src/react";
+import { bareClient, fakeNav } from "../fake-client";
+
+/**
+ * Plan 278 (c) — measured, not fixed.
+ *
+ * `provider.tsx`'s `core` memo keys on `discoveryKey`, so the arrival of the
+ * server's `/ui-config` answer rebuilds every controller memoized on it from
+ * `initialState()` — including whatever the user already typed. The mechanism
+ * is certain (see `provider.tsx`'s `discoveryKey` comment); this test pins the
+ * measured* window instead of "fixing" it, per plan 278 §5 S3.
+ *
+ * Why "accept" rather than fix A (stable accessor) or fix B (re-seed): the
+ * request is a same-origin GET fired on provider mount (`provider.tsx:131`),
+ * so on a healthy deployment it resolves in the tens-of-milliseconds range —
+ * well before a human reads a label, moves focus, and types. The realistic
+ * risk window is therefore narrow for manual typing. It is *not* narrow for a
+ * password manager's autofill, which can land within the same tick as mount —
+ * that case can still lose a race with the network. Both fix directions carry
+ * their own cost: fix A threads an accessor through `ControllerContext`'s
+ * public field shape (a ripple through every controller and all five ports —
+ * flagged as a plan 278 §8 STOP condition on its own); fix B needs a generic
+ * `seed`/`hydrate` seam on `Controller` that would have to make sense for
+ * every domain controller's state shape, not just form fields (a resource
+ * controller's in-flight loading state, an upload controller's `File` handle,
+ * …). Neither is a change to make inside this plan without a wider design
+ * pass, so (c) is accepted here: this test documents the trade-off rather
+ * than asserting a bug, and the same note lives beside `discoveryKey` in
+ * `provider.tsx`. A follow-up plan is the right place to revisit fix A/B if
+ * the autofill case turns out to matter in practice.
+ */
+describe("discovery rebuild vs in-flight form state (documented trade-off, not a regression)", () => {
+    afterEach(() => {
+        resetAuthConfigDiscovery();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("clears a field typed before a late-arriving discovery answer settles", async () => {
+        let resolveFetch: ((value: unknown) => void) | undefined;
+
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(
+                () =>
+                    new Promise((resolve) => {
+                        resolveFetch = resolve;
+                    }),
+            ),
+        );
+
+        const { client } = bareClient();
+
+        const tree: ReactElement = (
+            <AuthUIProvider authClient={client} nav={fakeNav()} redirects={{ afterSignIn: "/app" }}>
+                <SignInCard />
+            </AuthUIProvider>
+        );
+
+        render(tree);
+
+        // Typed while discovery is still in flight — the realistic case for a
+        // fast human or an autofilling password manager.
+        fireEvent.change(screen.getByLabelText("Email"), { target: { value: "ada@example.com" } });
+
+        expect(screen.getByLabelText<HTMLInputElement>("Email").value).toBe("ada@example.com");
+
+        // The answer lands late. `resolveFetch` is guaranteed set: `fetch` is
+        // called synchronously from the effect-less `useMemo` on mount.
+        resolveFetch?.({
+            json: async () => {
+                return { emailAndPassword: true, plugins: [], signUp: true, socialProviders: [] };
+            },
+            ok: true,
+        });
+
+        await waitFor(() => {
+            // The rebuilt controller starts from `initialState()` again — this
+            // is the accepted trade-off, not the desired outcome. If this ever
+            // starts failing because the field survived, that is fix A/B
+            // having landed elsewhere; update this test's framing rather than
+            // treating the new (better) behaviour as a regression.
+            expect(screen.getByLabelText<HTMLInputElement>("Email").value).toBe("");
+        });
+    });
+});

--- a/packages/auth-ui/__tests__/react/sign-up-gate.test.tsx
+++ b/packages/auth-ui/__tests__/react/sign-up-gate.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resetAuthConfigDiscovery } from "../../src/core";
+import { AuthUIProvider, AuthView, SignInCard, SignUpCard } from "../../src/react";
+import { bareClient, fakeNav } from "../fake-client";
+
+/** Stub `GET {basePath}/ui-config` reporting `signUp: false` — the server closed self-serve sign-up. */
+const stubSignUpClosed = (): void => {
+    vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+            return {
+                json: async () => {
+                    return {
+                        emailAndPassword: true,
+                        organization: { allowUserToCreate: true, enabled: false, roles: false, teams: false },
+                        plugins: [],
+                        signUp: false,
+                        socialProviders: [],
+                    };
+                },
+                ok: true,
+            };
+        }),
+    );
+};
+
+afterEach(() => {
+    resetAuthConfigDiscovery();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+const renderInProvider = (children: ReactElement): void => {
+    const { client } = bareClient();
+
+    render(
+        <AuthUIProvider authClient={client} nav={fakeNav()} redirects={{ afterSignIn: "/app" }}>
+            {children}
+        </AuthUIProvider>,
+    );
+};
+
+/**
+ * With self-serve sign-up closed on the server (`emailAndPassword.disableSignUp`),
+ * `SignUpCard` still rendered a full form, `AuthView` still routed `/auth/sign-up`
+ * to it, and `SignInCard`'s footer still advertised the link — `signUp` was
+ * resolved onto `ControllerContext` but nothing read it (plan 278).
+ */
+describe("signUp gate", () => {
+    it("signUpCard renders no form when signUp is closed", async () => {
+        stubSignUpClosed();
+        renderInProvider(<SignUpCard />);
+
+        await waitFor(() => {
+            // SignUpCard renders nothing when gated, so no heading of any kind
+            // is left on the page — the card's usual title is "Create account".
+            expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+        });
+    });
+
+    it('authView view="sign-up" falls back to the sign-in card when signUp is closed', async () => {
+        stubSignUpClosed();
+        renderInProvider(<AuthView view="sign-up" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+        });
+    });
+
+    it("signInCard hides the sign-up footer link when signUp is closed", async () => {
+        stubSignUpClosed();
+        renderInProvider(<SignInCard />);
+
+        await waitFor(() => {
+            expect(screen.queryByText("Don't have an account?", { exact: false })).toBeNull();
+        });
+    });
+});

--- a/packages/auth-ui/__tests__/react/user-account-cards.test.tsx
+++ b/packages/auth-ui/__tests__/react/user-account-cards.test.tsx
@@ -145,8 +145,6 @@ describe("avatarCard", () => {
     });
 
     it("uploads a picked file and stores the returned URL", async () => {
-        expect.assertions(2);
-
         const upload = vi.fn(() => Promise.resolve("https://cdn.example.com/a.png"));
         const client = stubClient();
 
@@ -156,11 +154,16 @@ describe("avatarCard", () => {
 
         fireEvent.change(screen.getByLabelText("Upload photo"), { target: { files: [file] } });
 
+        // Both assertions live inside the one `waitFor`: the accept-list check
+        // is async now (it shares `isAcceptedImage` with the organization-logo
+        // controller), so `upload` and the follow-up `updateUser` land a
+        // microtask apart from the `fireEvent.change` that triggered them —
+        // asserting `updateUser` outside `waitFor` raced its own retry count
+        // against `expect.assertions`, which this avoids entirely.
         await waitFor(() => {
             expect(upload).toHaveBeenCalledWith(file);
+            expect(client.updateUser).toHaveBeenCalledWith({ image: "https://cdn.example.com/a.png" });
         });
-
-        expect(client.updateUser).toHaveBeenCalledWith({ image: "https://cdn.example.com/a.png" });
     });
 
     it("rejects an oversized file before spending the upload", async () => {

--- a/packages/auth-ui/src/angular/auth-cards.ts
+++ b/packages/auth-ui/src/angular/auth-cards.ts
@@ -72,7 +72,7 @@ class AnonymousButtonComponent {
     selector: "lunora-sign-in-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.signIn" [footer]="true">
+        <lunora-auth-card [title]="t.signIn" [footer]="signUp()">
             <lunora-auth-social-buttons [providers]="social()" [lastUsed]="lastUsed()" (select)="signInSocial($event)" />
             @if (anonymous()) {
                 <lunora-anonymous-button />
@@ -110,7 +110,9 @@ class AnonymousButtonComponent {
                     <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signIn }}</lunora-auth-submit-button>
                 </form>
             }
-            <lunora-auth-link lunoraAuthCardFooter [href]="signUpHref()">{{ t.noAccount }}</lunora-auth-link>
+            @if (signUp()) {
+                <lunora-auth-link lunoraAuthCardFooter [href]="signUpHref()">{{ t.noAccount }}</lunora-auth-link>
+            }
         </lunora-auth-card>
     `,
 })
@@ -136,6 +138,7 @@ class SignInCardComponent {
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
     protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
+    protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
 
     protected signInSocial(provider: string): void {
@@ -158,49 +161,58 @@ class SignInCardComponent {
     selector: "lunora-sign-up-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.signUp" [footer]="true">
-            <!--
-              Social buttons belong on sign-up too — OAuth is a sign-up path, not
-              just a sign-in one, and omitting them here sends new users through
-              a password form they never needed.
-            -->
-            <lunora-auth-social-buttons [providers]="social()" (select)="signInSocial($event)" />
-            @if (social().length > 0) {
-                <lunora-auth-divider />
-            }
-            <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
-                <lunora-auth-banner [error]="state().formError" />
-                <lunora-auth-field
-                    [field]="state().fields.name"
-                    [label]="t.nameLabel"
-                    name="name"
-                    autoComplete="name"
-                    (changed)="actions.setField('name', $event)"
-                    (blurred)="actions.blur('name')"
-                />
-                <lunora-auth-field
-                    [field]="state().fields.email"
-                    [label]="t.emailLabel"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    (changed)="actions.setField('email', $event)"
-                    (blurred)="actions.blur('email')"
-                />
-                <lunora-auth-field
-                    [field]="state().fields.password"
-                    [label]="t.passwordLabel"
-                    name="password"
-                    type="password"
-                    autoComplete="new-password"
-                    (changed)="actions.setField('password', $event)"
-                    (blurred)="actions.blur('password')"
-                />
-                <lunora-auth-password-strength [value]="state().fields.password.value" />
-                <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signUp }}</lunora-auth-submit-button>
-            </form>
-            <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.haveAccount }}</lunora-auth-link>
-        </lunora-auth-card>
+        <!--
+          The server can close self-serve sign-up
+          (emailAndPassword.disableSignUp). Mirrors the plugin-gated cards:
+          mounted directly, this card renders nothing rather than a form that
+          will fail on submit; AuthView's route falls back to the sign-in
+          card instead of landing on a blank page.
+        -->
+        @if (enabled()) {
+            <lunora-auth-card [title]="t.signUp" [footer]="true">
+                <!--
+                  Social buttons belong on sign-up too — OAuth is a sign-up path, not
+                  just a sign-in one, and omitting them here sends new users through
+                  a password form they never needed.
+                -->
+                <lunora-auth-social-buttons [providers]="social()" (select)="signInSocial($event)" />
+                @if (social().length > 0) {
+                    <lunora-auth-divider />
+                }
+                <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
+                    <lunora-auth-banner [error]="state().formError" />
+                    <lunora-auth-field
+                        [field]="state().fields.name"
+                        [label]="t.nameLabel"
+                        name="name"
+                        autoComplete="name"
+                        (changed)="actions.setField('name', $event)"
+                        (blurred)="actions.blur('name')"
+                    />
+                    <lunora-auth-field
+                        [field]="state().fields.email"
+                        [label]="t.emailLabel"
+                        name="email"
+                        type="email"
+                        autoComplete="email"
+                        (changed)="actions.setField('email', $event)"
+                        (blurred)="actions.blur('email')"
+                    />
+                    <lunora-auth-field
+                        [field]="state().fields.password"
+                        [label]="t.passwordLabel"
+                        name="password"
+                        type="password"
+                        autoComplete="new-password"
+                        (changed)="actions.setField('password', $event)"
+                        (blurred)="actions.blur('password')"
+                    />
+                    <lunora-auth-password-strength [value]="state().fields.password.value" />
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signUp }}</lunora-auth-submit-button>
+                </form>
+                <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.haveAccount }}</lunora-auth-link>
+            </lunora-auth-card>
+        }
     `,
 })
 class SignUpCardComponent {
@@ -212,6 +224,8 @@ class SignUpCardComponent {
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
 
+    /** Derived, so a discovery answer that closes self-serve sign-up takes effect. */
+    protected readonly enabled = computed(() => this.context().signUp);
     /** Derived, so the provider list follows server discovery. */
     protected readonly social = computed(() => this.context().social);
 

--- a/packages/auth-ui/src/angular/auth-view.ts
+++ b/packages/auth-ui/src/angular/auth-view.ts
@@ -182,7 +182,11 @@ class PhoneSignInCardComponent {
                 }
             }
             @case (viewPaths().signUp) {
-                <lunora-sign-up-card />
+                @if (signUp()) {
+                    <lunora-sign-up-card />
+                } @else {
+                    <lunora-sign-in-card />
+                }
             }
             @case (viewPaths().twoFactor) {
                 @if (plugins().twoFactor) {
@@ -209,6 +213,8 @@ class AuthViewComponent {
     /** Derived, so a discovery answer that turns a plugin off redirects to sign-in. */
     protected readonly plugins: Signal<Required<PluginFlags>> = computed(() => this.context().plugins);
     protected readonly forgotPasswordMethod: Signal<"link" | "otp"> = computed(() => this.context().forgotPasswordMethod);
+    /** Derived, so a discovery answer that closes self-serve sign-up redirects to sign-in. */
+    protected readonly signUp: Signal<boolean> = computed(() => this.context().signUp);
     protected readonly viewPaths: Signal<Required<ViewPaths>> = computed(() => this.context().viewPaths);
 }
 

--- a/packages/auth-ui/src/core/avatar.ts
+++ b/packages/auth-ui/src/core/avatar.ts
@@ -84,6 +84,15 @@ const sniffImageType = async (file: File): Promise<boolean> => {
     return MAGIC_SIGNATURES.some((signature) => signature.every((run) => runMatches(run)));
 };
 
+/**
+ * Whether a picked file passes the client-side image check: accept-list when
+ * the browser reports a type, magic-byte sniff when it doesn't. Shared by the
+ * avatar and organization-logo controllers so the empty-`type` handling can't
+ * drift between the two copies again — see {@link sniffImageType}'s docblock
+ * for why an empty `type` isn't a green light.
+ */
+const isAcceptedImage = async (file: File): Promise<boolean> => (file.type === "" ? sniffImageType(file) : ACCEPTED_TYPES.has(file.type));
+
 const createAvatarUploadController = (context: ControllerContext, options: { initialImage?: string } = {}): AvatarUploadController => {
     const store = createStore<AvatarUploadState>({ imageUrl: options.initialImage, status: "idle" });
 
@@ -132,7 +141,7 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
                 // doesn't know, which happens for real image files often enough
                 // (some file managers' drag-and-drop, camera-roll exports) that
                 // sniffing the bytes beats either trusting or rejecting blindly.
-                if (file.type === "" ? !(await sniffImageType(file)) : !ACCEPTED_TYPES.has(file.type)) {
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;
@@ -159,4 +168,4 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
 };
 
 export type { AvatarUploadActions, AvatarUploadController, AvatarUploadState };
-export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController };
+export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController, isAcceptedImage };

--- a/packages/auth-ui/src/core/invitations.ts
+++ b/packages/auth-ui/src/core/invitations.ts
@@ -15,6 +15,7 @@ import type { ControllerContext } from "./config";
 import type { ResourceState } from "./create-resource-controller";
 import { createResourceController } from "./create-resource-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { mergeQuery } from "./redirect-to";
 import { createStore } from "./store";
 import type { AuthInvitationDetail, Controller, FlowStatus } from "./types";
 
@@ -94,13 +95,17 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
                  * somewhere else entirely.
                  */
                 const invited = store.get().invitation?.email;
-                const target = new URLSearchParams({ redirectTo: currentPath() });
+                const parameters: Record<string, string> = { redirectTo: currentPath() };
 
                 if (invited !== undefined && invited !== "") {
-                    target.set("email", invited);
+                    parameters.email = invited;
                 }
 
-                context.nav.replace(`${context.redirects.signIn}?${target.toString()}`);
+                // Merged rather than appended: an app whose `redirects.signIn`
+                // already carries a query (e.g. `/auth?tab=sign-in`, common when
+                // hosting every screen on one `AuthView` route) would otherwise
+                // get a mangled second `?` and lose the invitation on sign-in.
+                context.nav.replace(mergeQuery(context.redirects.signIn, parameters));
 
                 return;
             }

--- a/packages/auth-ui/src/core/organization-logo.ts
+++ b/packages/auth-ui/src/core/organization-logo.ts
@@ -11,7 +11,7 @@
  * `updateUser` — and folding both into one would mean a controller that takes a
  * discriminator and branches on it in three places.
  */
-import { ACCEPTED_TYPES } from "./avatar";
+import { isAcceptedImage } from "./avatar";
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
 import { createStore } from "./store";
@@ -85,7 +85,11 @@ const createOrganizationLogoController = (context: ControllerContext, options: L
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;

--- a/packages/auth-ui/src/core/redirect-to.ts
+++ b/packages/auth-ui/src/core/redirect-to.ts
@@ -72,6 +72,26 @@ const readRedirectTo = (parameter = "redirectTo"): string | undefined => {
 const resolveAfterSignIn = (fallback: string): string => readRedirectTo() ?? fallback;
 
 /**
+ * Merge `parameters` into `path`'s existing query.
+ *
+ * Parsed rather than appended: blindly appending a second `?` mangles the URL
+ * (its own parameters become part of the *first* query's last value), and
+ * `URLSearchParams.set` overwrites rather than duplicating a key that already
+ * exists — so a caller-supplied value always wins over whatever `path` already
+ * carried, never silently loses to a second occurrence.
+ */
+const mergeQuery = (path: string, parameters: Readonly<Record<string, string>>): string => {
+    const [base, existing = ""] = path.split("?");
+    const merged = new URLSearchParams(existing);
+
+    for (const [key, value] of Object.entries(parameters)) {
+        merged.set(key, value);
+    }
+
+    return `${base ?? path}?${merged.toString()}`;
+};
+
+/**
  * Carry `redirectTo` onto an intermediate step's URL.
  *
  * Sign-in can hand off to a second factor before it finishes, and that hop is a
@@ -88,17 +108,12 @@ const withRedirectTo = (path: string): string => {
     }
 
     /*
-     * Parsed rather than appended: an app whose `redirects.twoFactor` already
+     * Merged rather than appended: an app whose `redirects.twoFactor` already
      * carries a `redirectTo` would otherwise end up with two, and
      * `URLSearchParams.get` returns the first — so the configured value would
      * win over the invitation target this function exists to carry.
      */
-    const [base, existing = ""] = path.split("?");
-    const parameters = new URLSearchParams(existing);
-
-    parameters.set("redirectTo", target);
-
-    return `${base ?? path}?${parameters.toString()}`;
+    return mergeQuery(path, { redirectTo: target });
 };
 
-export { isSafeRedirect, readRedirectTo, resolveAfterSignIn, withRedirectTo };
+export { isSafeRedirect, mergeQuery, readRedirectTo, resolveAfterSignIn, withRedirectTo };

--- a/packages/auth-ui/src/react/auth-cards.tsx
+++ b/packages/auth-ui/src/react/auth-cards.tsx
@@ -61,7 +61,7 @@ const SignInCard = ({ forgotPasswordHref = "/forgot-password", signUpHref = "/si
     const lastUsed = readLastLoginMethod();
 
     return (
-        <AuthCard footer={<AuthLink href={signUpHref}>{t.noAccount}</AuthLink>} title={t.signIn}>
+        <AuthCard footer={context.signUp ? <AuthLink href={signUpHref}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
                 lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
                 onSelect={(provider) => {
@@ -123,10 +123,18 @@ interface SignUpCardProps {
     signInHref?: string;
 }
 
-const SignUpCard = ({ signInHref = "/sign-in" }: SignUpCardProps = {}): ReactElement => {
+const SignUpCard = ({ signInHref = "/sign-in" }: SignUpCardProps = {}): ReactElement | null => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = useController(createSignUpController);
+
+    // The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+    // Mirrors the plugin-gated cards below: mounted directly, this card renders
+    // nothing rather than a form that will fail on submit; `AuthView`'s route
+    // falls back to the sign-in card instead of landing on a blank page.
+    if (!context.signUp) {
+        return null;
+    }
 
     return (
         <AuthCard footer={<AuthLink href={signInHref}>{t.haveAccount}</AuthLink>} title={t.signUp}>

--- a/packages/auth-ui/src/react/auth-view.tsx
+++ b/packages/auth-ui/src/react/auth-view.tsx
@@ -123,7 +123,7 @@ interface AuthViewProps {
 }
 
 const AuthView = ({ view }: AuthViewProps = {}): ReactElement => {
-    const { forgotPasswordMethod, plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = useAuthUI();
 
     /*
      * A lookup keyed by the resolved segment, not a `switch` over
@@ -144,14 +144,18 @@ const AuthView = ({ view }: AuthViewProps = {}): ReactElement => {
         [viewPaths.forgotPassword]: () => <ForgotPasswordCard />,
         [viewPaths.magicLink]: () => (plugins.magicLink ? <MagicLinkCard /> : <SignInCard />),
         [viewPaths.resetPassword]: () => (forgotPasswordMethod === "otp" ? <ResetPasswordOtpCard /> : <ResetPasswordCard />),
-        [viewPaths.signUp]: () => <SignUpCard />,
+        [viewPaths.signUp]: () => (signUp ? <SignUpCard /> : <SignInCard />),
         [viewPaths.twoFactor]: () => (plugins.twoFactor ? <TwoFactorCard /> : <SignInCard />),
         [viewPaths.verifyEmail]: () => <VerifyEmailCard />,
     };
 
     // An unrecognized segment falls back to sign-in rather than rendering
-    // nothing, because a typo'd auth URL should still let someone in.
-    const render = view === undefined ? undefined : routes[view];
+    // nothing, because a typo'd auth URL should still let someone in. The
+    // own-key check matters because `view` is URL input: a plain object
+    // literal inherits `Object.prototype`, so a segment like "valueOf" or
+    // "constructor" would otherwise resolve to an inherited member instead of
+    // falling through.
+    const render = view !== undefined && Object.hasOwn(routes, view) ? routes[view] : undefined;
 
     return render === undefined ? <SignInCard /> : render();
 };

--- a/packages/auth-ui/src/react/provider.tsx
+++ b/packages/auth-ui/src/react/provider.tsx
@@ -149,6 +149,20 @@ const AuthUIProvider = ({
     // The discovered payload is a fresh object per fetch but settles exactly
     // once, so keying on its content keeps the memo from churning on re-renders
     // while still rebuilding the context when the answer lands.
+    //
+    // Known, accepted trade-off (plan 278 §5 S3): a rebuilt `core` rebuilds
+    // every controller memoized on it (see `use-controller.ts`), which loses
+    // whatever the user already typed into an in-flight form if discovery
+    // settles after they started. `/ui-config` is a same-origin GET fired on
+    // mount, so on a healthy deployment this window is narrow — well under
+    // typical human typing latency — but a password manager's autofill can
+    // still race it, since autofill can land within the same tick as mount.
+    // Fixing it needs either a stable accessor threaded through
+    // `ControllerContext`'s public shape (a ripple through every controller
+    // and all five ports) or a generic seed/hydrate seam on `Controller` that
+    // would have to make sense for every domain controller's state, not just
+    // form fields — both bigger than this plan's scope. See
+    // `__tests__/react/discovery-rebuild.test.tsx` for the measured repro.
     const discoveryKey = JSON.stringify(discovery.config ?? null);
 
     const core = useMemo<ControllerContext>(

--- a/packages/auth-ui/src/solid/auth-cards.tsx
+++ b/packages/auth-ui/src/solid/auth-cards.tsx
@@ -58,7 +58,7 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
     const lastUsed = readLastLoginMethod();
 
     return (
-        <AuthCard footer={<AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink>} title={t.signIn}>
+        <AuthCard footer={context.signUp ? <AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
                 lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
                 onSelect={(provider) => {
@@ -122,6 +122,14 @@ const SignUpCard = (props: SignUpCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = createController(createSignUpController);
+
+    // The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+    // Mirrors the plugin-gated cards above: mounted directly, this card renders
+    // nothing rather than a form that will fail on submit; `AuthView`'s route
+    // falls back to the sign-in card instead of landing on a blank page.
+    if (!context.signUp) {
+        return null;
+    }
 
     return (
         <AuthCard footer={<AuthLink href={props.signInHref ?? "/sign-in"}>{t.haveAccount}</AuthLink>} title={t.signUp}>

--- a/packages/auth-ui/src/solid/auth-view.tsx
+++ b/packages/auth-ui/src/solid/auth-view.tsx
@@ -123,7 +123,7 @@ interface AuthViewProps {
 }
 
 const AuthView = (props: AuthViewProps = {}): JSX.Element => {
-    const { forgotPasswordMethod, plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = useAuthUI();
 
     /*
      * Plugin-gated views are checked here rather than left to the card's own
@@ -164,7 +164,9 @@ const AuthView = (props: AuthViewProps = {}): JSX.Element => {
                 </Show>
             </Match>
             <Match when={props.view === viewPaths.signUp}>
-                <SignUpCard />
+                <Show fallback={<SignInCard />} when={signUp}>
+                    <SignUpCard />
+                </Show>
             </Match>
             <Match when={props.view === viewPaths.twoFactor}>
                 <Show fallback={<SignInCard />} when={plugins.twoFactor}>

--- a/packages/auth-ui/src/svelte/AuthView.svelte
+++ b/packages/auth-ui/src/svelte/AuthView.svelte
@@ -28,7 +28,7 @@
         view?: string;
     } = $props();
 
-    const { forgotPasswordMethod, plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = useAuthUI();
 </script>
 
 <!--
@@ -53,7 +53,7 @@
     {:else}
         <ResetPasswordCard />
     {/if}
-{:else if view === viewPaths.signUp}
+{:else if view === viewPaths.signUp && signUp}
     <SignUpCard />
 {:else if view === viewPaths.twoFactor && plugins.twoFactor}
     <TwoFactorCard />

--- a/packages/auth-ui/src/svelte/SignInCard.svelte
+++ b/packages/auth-ui/src/svelte/SignInCard.svelte
@@ -90,6 +90,8 @@
         </form>
     {/if}
     {#snippet footer()}
-        <AuthLink href={signUpHref}>{t.noAccount}</AuthLink>
+        {#if context.signUp}
+            <AuthLink href={signUpHref}>{t.noAccount}</AuthLink>
+        {/if}
     {/snippet}
 </AuthCard>

--- a/packages/auth-ui/src/svelte/SignUpCard.svelte
+++ b/packages/auth-ui/src/svelte/SignUpCard.svelte
@@ -20,72 +20,80 @@
     const { actions, state: form } = controllerStore(createSignUpController);
 </script>
 
-<AuthCard title={t.signUp}>
-    <!--
+<!--
+    The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+    Mirrors the plugin-gated cards: mounted directly, this card renders
+    nothing rather than a form that will fail on submit; `AuthView`'s route
+    falls back to the sign-in card instead of landing on a blank page.
+-->
+{#if context.signUp}
+    <AuthCard title={t.signUp}>
+        <!--
         Social buttons belong on sign-up too — OAuth is a sign-up path, not just a
         sign-in one, and omitting them here sends new users through a password form
         they never needed. This was the gap against better-auth-ui's <AuthView>.
     -->
-    <SocialButtons
-        onSelect={(provider) => {
-            void signInWithSocial(context, provider);
-        }}
-        providers={social}
-    />
-    {#if social.length > 0}
-        <AuthDivider />
-    {/if}
-    <form
-        class="lunora-auth-form"
-        novalidate
-        onsubmit={(event) => {
-            event.preventDefault();
-            void actions.submit();
-        }}
-    >
-        <FormBanner error={$form.formError} />
-        <Field
-            autoComplete="name"
-            field={$form.fields.name}
-            label={t.nameLabel}
-            name="name"
-            onBlur={() => {
-                actions.blur("name");
+        <SocialButtons
+            onSelect={(provider) => {
+                void signInWithSocial(context, provider);
             }}
-            onChange={(value) => {
-                actions.setField("name", value);
-            }}
+            providers={social}
         />
-        <Field
-            autoComplete="email"
-            field={$form.fields.email}
-            label={t.emailLabel}
-            name="email"
-            onBlur={() => {
-                actions.blur("email");
+        {#if social.length > 0}
+            <AuthDivider />
+        {/if}
+        <form
+            class="lunora-auth-form"
+            novalidate
+            onsubmit={(event) => {
+                event.preventDefault();
+                void actions.submit();
             }}
-            onChange={(value) => {
-                actions.setField("email", value);
-            }}
-            type="email"
-        />
-        <Field
-            autoComplete="new-password"
-            field={$form.fields.password}
-            label={t.passwordLabel}
-            name="password"
-            onBlur={() => {
-                actions.blur("password");
-            }}
-            onChange={(value) => {
-                actions.setField("password", value);
-            }}
-            type="password"
-        />
-        <PasswordStrength value={$form.fields.password.value} />
-        <SubmitButton pending={$form.status === "submitting"}>{t.signUp}</SubmitButton>
-    </form>
-    {#snippet footer()}
-        <AuthLink href={signInHref}>{t.haveAccount}</AuthLink>
-    {/snippet}
-</AuthCard>
+        >
+            <FormBanner error={$form.formError} />
+            <Field
+                autoComplete="name"
+                field={$form.fields.name}
+                label={t.nameLabel}
+                name="name"
+                onBlur={() => {
+                    actions.blur("name");
+                }}
+                onChange={(value) => {
+                    actions.setField("name", value);
+                }}
+            />
+            <Field
+                autoComplete="email"
+                field={$form.fields.email}
+                label={t.emailLabel}
+                name="email"
+                onBlur={() => {
+                    actions.blur("email");
+                }}
+                onChange={(value) => {
+                    actions.setField("email", value);
+                }}
+                type="email"
+            />
+            <Field
+                autoComplete="new-password"
+                field={$form.fields.password}
+                label={t.passwordLabel}
+                name="password"
+                onBlur={() => {
+                    actions.blur("password");
+                }}
+                onChange={(value) => {
+                    actions.setField("password", value);
+                }}
+                type="password"
+            />
+            <PasswordStrength value={$form.fields.password.value} />
+            <SubmitButton pending={$form.status === "submitting"}>{t.signUp}</SubmitButton>
+        </form>
+        {#snippet footer()}
+            <AuthLink href={signInHref}>{t.haveAccount}</AuthLink>
+        {/snippet}
+    </AuthCard>
+{/if}

--- a/packages/auth-ui/src/vue/AuthView.vue
+++ b/packages/auth-ui/src/vue/AuthView.vue
@@ -39,7 +39,7 @@ const context = useAuthUIContextRef();
  * gate for when they are mounted directly.
  */
 const card = computed<Component>(() => {
-    const { forgotPasswordMethod, plugins, viewPaths } = context.value;
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = context.value;
 
     switch (props.view) {
         case viewPaths.acceptInvitation: {
@@ -67,7 +67,7 @@ const card = computed<Component>(() => {
         }
 
         case viewPaths.signUp: {
-            return SignUpCard;
+            return signUp ? SignUpCard : SignInCard;
         }
 
         case viewPaths.twoFactor: {

--- a/packages/auth-ui/src/vue/SignInCard.vue
+++ b/packages/auth-ui/src/vue/SignInCard.vue
@@ -74,7 +74,7 @@ const onSocial = (provider: string): void => {
             <AuthLink :href="forgotPasswordHref">{{ t.forgotPasswordLink }}</AuthLink>
             <SubmitButton :pending="state.status === 'submitting'">{{ t.signIn }}</SubmitButton>
         </form>
-        <template #footer>
+        <template v-if="context.signUp" #footer>
             <AuthLink :href="signUpHref">{{ t.noAccount }}</AuthLink>
         </template>
     </AuthCard>

--- a/packages/auth-ui/src/vue/SignUpCard.vue
+++ b/packages/auth-ui/src/vue/SignUpCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
 import AuthCard from "./AuthCard.vue";
@@ -27,13 +29,18 @@ const context = useAuthUIContextRef();
 const t = context.value.localization;
 const { actions, state } = useController(createSignUpController);
 
+// The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+// Computed, not read at setup: `setup()` never re-runs, so a gate resolved
+// here would stay frozen on the pre-discovery answer.
+const signUp = computed(() => context.value.signUp);
+
 const onSocial = (provider: string): void => {
     void signInWithSocial(context.value, provider);
 };
 </script>
 
 <template>
-    <AuthCard :title="t.signUp">
+    <AuthCard v-if="signUp" :title="t.signUp">
         <!--
             Social buttons belong on sign-up too — OAuth is a sign-up path, not
             just a sign-in one, and omitting them here sends new users through a

--- a/registry/auth-ui-angular/angular/auth-cards.ts
+++ b/registry/auth-ui-angular/angular/auth-cards.ts
@@ -5,9 +5,12 @@
  * standalone component binding a core controller to the shared view primitives.
  */
 import type { OnInit, Signal } from "@angular/core";
-import { ChangeDetectionStrategy, Component, computed, inject, Injector, input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject, Injector, input, signal } from "@angular/core";
 
 import { signInAnonymously } from "../core/anonymous";
+import type { BackupCodeSignInField } from "../core/backup-codes";
+import { createBackupCodeSignInController } from "../core/backup-codes";
+import { queryParameter } from "../core/browser-location";
 import type { EmailOtpActions, EmailOtpState } from "../core/email-otp";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
@@ -17,6 +20,8 @@ import { readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import type { ResetPasswordField } from "../core/reset-password";
 import { createResetPasswordController } from "../core/reset-password";
+import type { ResetPasswordOtpField } from "../core/reset-password-otp";
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import { createSignInController } from "../core/sign-in";
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
@@ -67,7 +72,7 @@ class AnonymousButtonComponent {
     selector: "lunora-sign-in-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.signIn" [footer]="true">
+        <lunora-auth-card [title]="t.signIn" [footer]="signUp()">
             <lunora-auth-social-buttons [providers]="social()" [lastUsed]="lastUsed()" (select)="signInSocial($event)" />
             @if (anonymous()) {
                 <lunora-anonymous-button />
@@ -105,7 +110,9 @@ class AnonymousButtonComponent {
                     <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signIn }}</lunora-auth-submit-button>
                 </form>
             }
-            <lunora-auth-link lunoraAuthCardFooter [href]="signUpHref()">{{ t.noAccount }}</lunora-auth-link>
+            @if (signUp()) {
+                <lunora-auth-link lunoraAuthCardFooter [href]="signUpHref()">{{ t.noAccount }}</lunora-auth-link>
+            }
         </lunora-auth-card>
     `,
 })
@@ -131,6 +138,7 @@ class SignInCardComponent {
     protected readonly anonymous = computed(() => this.context().plugins.anonymous);
     protected readonly credentials = computed(() => this.context().credentials);
     protected readonly lastUsed = computed(() => (this.context().plugins.lastLoginMethod ? this.lastLoginMethod : undefined));
+    protected readonly signUp = computed(() => this.context().signUp);
     protected readonly social = computed(() => this.context().social);
 
     protected signInSocial(provider: string): void {
@@ -153,49 +161,58 @@ class SignInCardComponent {
     selector: "lunora-sign-up-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.signUp" [footer]="true">
-            <!--
-              Social buttons belong on sign-up too — OAuth is a sign-up path, not
-              just a sign-in one, and omitting them here sends new users through
-              a password form they never needed.
-            -->
-            <lunora-auth-social-buttons [providers]="social()" (select)="signInSocial($event)" />
-            @if (social().length > 0) {
-                <lunora-auth-divider />
-            }
-            <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
-                <lunora-auth-banner [error]="state().formError" />
-                <lunora-auth-field
-                    [field]="state().fields.name"
-                    [label]="t.nameLabel"
-                    name="name"
-                    autoComplete="name"
-                    (changed)="actions.setField('name', $event)"
-                    (blurred)="actions.blur('name')"
-                />
-                <lunora-auth-field
-                    [field]="state().fields.email"
-                    [label]="t.emailLabel"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    (changed)="actions.setField('email', $event)"
-                    (blurred)="actions.blur('email')"
-                />
-                <lunora-auth-field
-                    [field]="state().fields.password"
-                    [label]="t.passwordLabel"
-                    name="password"
-                    type="password"
-                    autoComplete="new-password"
-                    (changed)="actions.setField('password', $event)"
-                    (blurred)="actions.blur('password')"
-                />
-                <lunora-auth-password-strength [value]="state().fields.password.value" />
-                <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signUp }}</lunora-auth-submit-button>
-            </form>
-            <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.haveAccount }}</lunora-auth-link>
-        </lunora-auth-card>
+        <!--
+          The server can close self-serve sign-up
+          (emailAndPassword.disableSignUp). Mirrors the plugin-gated cards:
+          mounted directly, this card renders nothing rather than a form that
+          will fail on submit; AuthView's route falls back to the sign-in
+          card instead of landing on a blank page.
+        -->
+        @if (enabled()) {
+            <lunora-auth-card [title]="t.signUp" [footer]="true">
+                <!--
+                  Social buttons belong on sign-up too — OAuth is a sign-up path, not
+                  just a sign-in one, and omitting them here sends new users through
+                  a password form they never needed.
+                -->
+                <lunora-auth-social-buttons [providers]="social()" (select)="signInSocial($event)" />
+                @if (social().length > 0) {
+                    <lunora-auth-divider />
+                }
+                <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
+                    <lunora-auth-banner [error]="state().formError" />
+                    <lunora-auth-field
+                        [field]="state().fields.name"
+                        [label]="t.nameLabel"
+                        name="name"
+                        autoComplete="name"
+                        (changed)="actions.setField('name', $event)"
+                        (blurred)="actions.blur('name')"
+                    />
+                    <lunora-auth-field
+                        [field]="state().fields.email"
+                        [label]="t.emailLabel"
+                        name="email"
+                        type="email"
+                        autoComplete="email"
+                        (changed)="actions.setField('email', $event)"
+                        (blurred)="actions.blur('email')"
+                    />
+                    <lunora-auth-field
+                        [field]="state().fields.password"
+                        [label]="t.passwordLabel"
+                        name="password"
+                        type="password"
+                        autoComplete="new-password"
+                        (changed)="actions.setField('password', $event)"
+                        (blurred)="actions.blur('password')"
+                    />
+                    <lunora-auth-password-strength [value]="state().fields.password.value" />
+                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.signUp }}</lunora-auth-submit-button>
+                </form>
+                <lunora-auth-link lunoraAuthCardFooter [href]="signInHref()">{{ t.haveAccount }}</lunora-auth-link>
+            </lunora-auth-card>
+        }
     `,
 })
 class SignUpCardComponent {
@@ -207,6 +224,8 @@ class SignUpCardComponent {
     protected readonly state = this.bridge.state;
     protected readonly actions = this.bridge.actions;
 
+    /** Derived, so a discovery answer that closes self-serve sign-up takes effect. */
+    protected readonly enabled = computed(() => this.context().signUp);
     /** Derived, so the provider list follows server discovery. */
     protected readonly social = computed(() => this.context().social);
 
@@ -293,7 +312,7 @@ class ForgotPasswordCardComponent implements OnInit {
     `,
 })
 class ResetPasswordCardComponent implements OnInit {
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     readonly token = input<string>();
 
     private readonly context = injectAuthUIContext();
@@ -302,8 +321,12 @@ class ResetPasswordCardComponent implements OnInit {
     protected state!: Signal<FormState<ResetPasswordField>>;
     protected actions!: FormActions<ResetPasswordField>;
 
+    // Built in ngOnInit, not a field initializer: `token()` is unbound until
+    // Angular has set the inputs, so the controller would consume the URL's
+    // token even when the caller passed one of their own.
     ngOnInit(): void {
-        const bridge = controllerSignal((context) => createResetPasswordController(context, { token: this.token() }), {
+        const resolved = this.token() ?? queryParameter("token");
+        const bridge = controllerSignal((context) => createResetPasswordController(context, { token: resolved }), {
             context: this.context,
             injector: this.injector,
         });
@@ -311,6 +334,69 @@ class ResetPasswordCardComponent implements OnInit {
         this.state = bridge.state;
         this.actions = bridge.actions;
     }
+}
+
+/**
+ * Redeems an emailed one-time code instead of a link — for apps that set
+ * `forgotPassword: { method: "otp" }`. Unlike {@link ResetPasswordCardComponent},
+ * the email address is a field rather than something carried from the previous
+ * screen: a code can legitimately be redeemed from a fresh tab.
+ */
+@Component({
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [AuthCardComponent, AuthFieldComponent, FormBannerComponent, SubmitButtonComponent],
+    selector: "lunora-reset-password-otp-card",
+    standalone: true,
+    template: `
+        <lunora-auth-card [title]="t.resetPassword" [description]="t.resetPasswordOtpDescription">
+            <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
+                <lunora-auth-banner [error]="state().formError" [success]="state().successMessage" />
+                <lunora-auth-field
+                    [field]="state().fields.email"
+                    [label]="t.emailLabel"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    (changed)="actions.setField('email', $event)"
+                    (blurred)="actions.blur('email')"
+                />
+                <lunora-auth-field
+                    [field]="state().fields.otp"
+                    [label]="t.codeLabel"
+                    name="otp"
+                    autoComplete="one-time-code"
+                    (changed)="actions.setField('otp', $event)"
+                    (blurred)="actions.blur('otp')"
+                />
+                <lunora-auth-field
+                    [field]="state().fields.password"
+                    [label]="t.passwordLabel"
+                    name="password"
+                    type="password"
+                    autoComplete="new-password"
+                    (changed)="actions.setField('password', $event)"
+                    (blurred)="actions.blur('password')"
+                />
+                <lunora-auth-field
+                    [field]="state().fields.confirmPassword"
+                    [label]="t.confirmPasswordLabel"
+                    name="confirmPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    (changed)="actions.setField('confirmPassword', $event)"
+                    (blurred)="actions.blur('confirmPassword')"
+                />
+                <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.resetPassword }}</lunora-auth-submit-button>
+            </form>
+        </lunora-auth-card>
+    `,
+})
+class ResetPasswordOtpCardComponent {
+    private readonly context = injectAuthUIContext();
+    protected readonly t = this.context().localization;
+    private readonly bridge = controllerSignal(createResetPasswordOtpController, { context: this.context });
+    protected readonly state: Signal<FormState<ResetPasswordOtpField>> = this.bridge.state;
+    protected readonly actions: FormActions<ResetPasswordOtpField> = this.bridge.actions;
 }
 
 @Component({
@@ -407,20 +493,41 @@ class EmailOtpCardComponent {
     standalone: true,
     template: `
         @if (enabled()) {
-            <lunora-auth-card [title]="t.twoFactor">
-                <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
-                    <lunora-auth-banner [error]="state().formError" />
-                    <lunora-auth-field
-                        [field]="state().fields.code"
-                        [label]="t.codeLabel"
-                        name="code"
-                        autoComplete="one-time-code"
-                        (changed)="actions.setField('code', $event)"
-                        (blurred)="actions.blur('code')"
-                    />
-                    <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.twoFactor }}</lunora-auth-submit-button>
-                </form>
-            </lunora-auth-card>
+            @if (useBackupCode()) {
+                <lunora-auth-card [title]="t.twoFactor" [footer]="true">
+                    <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); backupActions.submit()">
+                        <lunora-auth-banner [error]="backupState().formError" />
+                        <lunora-auth-field
+                            [field]="backupState().fields.code"
+                            [label]="t.backupCodeLabel"
+                            name="code"
+                            autoComplete="one-time-code"
+                            (changed)="backupActions.setField('code', $event)"
+                            (blurred)="backupActions.blur('code')"
+                        />
+                        <lunora-auth-submit-button [pending]="backupState().status === 'submitting'">{{ t.twoFactor }}</lunora-auth-submit-button>
+                    </form>
+                    <button lunoraAuthCardFooter class="lunora-auth-link" type="button" (click)="useBackupCode.set(false)">
+                        {{ t.twoFactorUseAuthenticator }}
+                    </button>
+                </lunora-auth-card>
+            } @else {
+                <lunora-auth-card [title]="t.twoFactor" [footer]="true">
+                    <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
+                        <lunora-auth-banner [error]="state().formError" />
+                        <lunora-auth-field
+                            [field]="state().fields.code"
+                            [label]="t.codeLabel"
+                            name="code"
+                            autoComplete="one-time-code"
+                            (changed)="actions.setField('code', $event)"
+                            (blurred)="actions.blur('code')"
+                        />
+                        <lunora-auth-submit-button [pending]="state().status === 'submitting'">{{ t.twoFactor }}</lunora-auth-submit-button>
+                    </form>
+                    <button lunoraAuthCardFooter class="lunora-auth-link" type="button" (click)="useBackupCode.set(true)">{{ t.backupCodeSignIn }}</button>
+                </lunora-auth-card>
+            }
         }
     `,
 })
@@ -434,6 +541,14 @@ class TwoFactorCardComponent implements OnInit {
     protected readonly t = this.context().localization;
     protected state!: Signal<FormState<TwoFactorField>>;
     protected actions!: FormActions<TwoFactorField>;
+    protected backupState!: Signal<FormState<BackupCodeSignInField>>;
+    protected backupActions!: FormActions<BackupCodeSignInField>;
+
+    /**
+     * Both controllers stay live regardless of which form is showing — a
+     * session-mutating submit must not depend on the toggle's current position.
+     */
+    protected readonly useBackupCode = signal(false);
 
     ngOnInit(): void {
         const bridge = controllerSignal((context) => createTwoFactorVerifyController(context, { method: this.method(), trustDevice: this.trustDevice() }), {
@@ -443,6 +558,14 @@ class TwoFactorCardComponent implements OnInit {
 
         this.state = bridge.state;
         this.actions = bridge.actions;
+
+        const backupBridge = controllerSignal((context) => createBackupCodeSignInController(context, { trustDevice: this.trustDevice() }), {
+            context: this.context,
+            injector: this.injector,
+        });
+
+        this.backupState = backupBridge.state;
+        this.backupActions = backupBridge.actions;
     }
 }
 
@@ -452,6 +575,7 @@ export {
     ForgotPasswordCardComponent,
     MagicLinkCardComponent,
     ResetPasswordCardComponent,
+    ResetPasswordOtpCardComponent,
     SignInCardComponent,
     SignUpCardComponent,
     TwoFactorCardComponent,

--- a/registry/auth-ui-angular/angular/auth-view.ts
+++ b/registry/auth-ui-angular/angular/auth-view.ts
@@ -17,6 +17,7 @@ import {
     ForgotPasswordCardComponent,
     MagicLinkCardComponent,
     ResetPasswordCardComponent,
+    ResetPasswordOtpCardComponent,
     SignInCardComponent,
     SignUpCardComponent,
     TwoFactorCardComponent,
@@ -136,6 +137,7 @@ class PhoneSignInCardComponent {
         ForgotPasswordCardComponent,
         MagicLinkCardComponent,
         ResetPasswordCardComponent,
+        ResetPasswordOtpCardComponent,
         SignInCardComponent,
         SignUpCardComponent,
         TwoFactorCardComponent,
@@ -173,10 +175,18 @@ class PhoneSignInCardComponent {
                 }
             }
             @case (viewPaths().resetPassword) {
-                <lunora-reset-password-card />
+                @if (forgotPasswordMethod() === "otp") {
+                    <lunora-reset-password-otp-card />
+                } @else {
+                    <lunora-reset-password-card />
+                }
             }
             @case (viewPaths().signUp) {
-                <lunora-sign-up-card />
+                @if (signUp()) {
+                    <lunora-sign-up-card />
+                } @else {
+                    <lunora-sign-in-card />
+                }
             }
             @case (viewPaths().twoFactor) {
                 @if (plugins().twoFactor) {
@@ -202,6 +212,9 @@ class AuthViewComponent {
 
     /** Derived, so a discovery answer that turns a plugin off redirects to sign-in. */
     protected readonly plugins: Signal<Required<PluginFlags>> = computed(() => this.context().plugins);
+    protected readonly forgotPasswordMethod: Signal<"link" | "otp"> = computed(() => this.context().forgotPasswordMethod);
+    /** Derived, so a discovery answer that closes self-serve sign-up redirects to sign-in. */
+    protected readonly signUp: Signal<boolean> = computed(() => this.context().signUp);
     protected readonly viewPaths: Signal<Required<ViewPaths>> = computed(() => this.context().viewPaths);
 }
 

--- a/registry/auth-ui-angular/angular/index.ts
+++ b/registry/auth-ui-angular/angular/index.ts
@@ -34,6 +34,7 @@ export {
     ForgotPasswordCardComponent,
     MagicLinkCardComponent,
     ResetPasswordCardComponent,
+    ResetPasswordOtpCardComponent,
     SignInCardComponent,
     SignUpCardComponent,
     TwoFactorCardComponent,

--- a/registry/auth-ui-angular/angular/organization.ts
+++ b/registry/auth-ui-angular/angular/organization.ts
@@ -37,7 +37,7 @@ const nextId = (prefix: string): string => {
     standalone: true,
     template: `
         @if (enabled()) {
-            <lunora-auth-card [title]="t.organizations">
+            <lunora-auth-card [title]="t.organizations" [headingLevel]="2">
                 <lunora-auth-banner [error]="state().error" />
                 @if (state().loading) {
                     <p class="lunora-auth-card__description">…</p>
@@ -120,7 +120,7 @@ class OrganizationsCardComponent {
     standalone: true,
     template: `
         @if (enabled()) {
-            <lunora-auth-card [title]="t.members">
+            <lunora-auth-card [title]="t.members" [headingLevel]="2">
                 <lunora-auth-banner [error]="state().error" />
 
                 @if (state().loading) {
@@ -222,7 +222,7 @@ class MembersCardComponent {
     standalone: true,
     template: `
         @if (enabled()) {
-            <lunora-auth-card [title]="t.organizationSettings">
+            <lunora-auth-card [title]="t.organizationSettings" [headingLevel]="2">
                 @if (state().loading) {
                     <p class="lunora-auth-card__description">…</p>
                 } @else {

--- a/registry/auth-ui-angular/angular/primitives.ts
+++ b/registry/auth-ui-angular/angular/primitives.ts
@@ -29,7 +29,17 @@ const serializeThemeVariables = (variables: Readonly<Record<string, string>>): s
     template: `
         <section class="lunora-auth-card" [attr.style]="themeStyle">
             <header class="lunora-auth-card__header">
-                <h1 class="lunora-auth-card__title">{{ title() }}</h1>
+                @switch (headingLevel()) {
+                    @case (2) {
+                        <h2 class="lunora-auth-card__title">{{ title() }}</h2>
+                    }
+                    @case (3) {
+                        <h3 class="lunora-auth-card__title">{{ title() }}</h3>
+                    }
+                    @default {
+                        <h1 class="lunora-auth-card__title">{{ title() }}</h1>
+                    }
+                }
                 @if (description() !== undefined) {
                     <p class="lunora-auth-card__description">{{ description() }}</p>
                 }
@@ -55,6 +65,13 @@ class AuthCardComponent {
     readonly description = input<string>();
     /** Set true when projecting `[lunoraAuthCardFooter]` content. */
     readonly footer = input(false);
+
+    /**
+     * The title's heading level (default 1) — see the React `AuthCard`'s doc
+     * comment for why a settings/organization composition passes `2` rather
+     * than letting every card render an `h1`.
+     */
+    readonly headingLevel = input<1 | 2 | 3>(1);
     readonly title = input.required<string>();
 }
 

--- a/registry/auth-ui-angular/angular/settings-cards.ts
+++ b/registry/auth-ui-angular/angular/settings-cards.ts
@@ -32,7 +32,7 @@ import { injectAuthUIContext } from "./provider";
     selector: "lunora-profile-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.profile">
+        <lunora-auth-card [title]="t.profile" [headingLevel]="2">
             <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
                 <lunora-auth-banner [error]="state().formError" [success]="state().successMessage" />
                 <lunora-auth-field
@@ -75,7 +75,7 @@ class ProfileCardComponent implements OnInit {
     selector: "lunora-change-email-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.changeEmail">
+        <lunora-auth-card [title]="t.changeEmail" [headingLevel]="2">
             <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
                 <lunora-auth-banner [error]="state().formError" [success]="state().successMessage" />
                 <lunora-auth-field
@@ -106,7 +106,7 @@ class ChangeEmailCardComponent {
     selector: "lunora-change-password-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.changePassword">
+        <lunora-auth-card [title]="t.changePassword" [headingLevel]="2">
             <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
                 <lunora-auth-banner [error]="state().formError" [success]="state().successMessage" />
                 <lunora-auth-field
@@ -155,7 +155,7 @@ class ChangePasswordCardComponent {
     selector: "lunora-delete-account-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.deleteAccount" [description]="t.deleteAccountWarning">
+        <lunora-auth-card [title]="t.deleteAccount" [description]="t.deleteAccountWarning" [headingLevel]="2">
             <form class="lunora-auth-form" novalidate (submit)="$event.preventDefault(); actions.submit()">
                 <lunora-auth-banner [error]="state().formError" />
                 <lunora-auth-field
@@ -186,7 +186,7 @@ class DeleteAccountCardComponent {
     selector: "lunora-sessions-card",
     standalone: true,
     template: `
-        <lunora-auth-card [title]="t.sessions">
+        <lunora-auth-card [title]="t.sessions" [headingLevel]="2">
             <lunora-auth-banner [error]="state().error" />
             @if (state().loading) {
                 <p class="lunora-auth-card__description">…</p>
@@ -235,7 +235,7 @@ class SessionsCardComponent {
     standalone: true,
     template: `
         @if (enabled()) {
-            <lunora-auth-card [title]="t.passkeys">
+            <lunora-auth-card [title]="t.passkeys" [headingLevel]="2">
                 <lunora-auth-banner [error]="state().error" />
                 @if (state().loading) {
                     <p class="lunora-auth-card__description">…</p>

--- a/registry/auth-ui-angular/angular/two-factor-setup-card.ts
+++ b/registry/auth-ui-angular/angular/two-factor-setup-card.ts
@@ -10,7 +10,7 @@ import { ChangeDetectionStrategy, Component, computed } from "@angular/core";
 
 import { isFlowEnabled } from "../core/flow-gate";
 import type { TwoFactorSetupActions, TwoFactorSetupState } from "../core/two-factor-setup";
-import { createTwoFactorSetupController } from "../core/two-factor-setup";
+import { createTwoFactorSetupController, totpSecret } from "../core/two-factor-setup";
 import { controllerSignal } from "./controller-signal";
 import { AuthCardComponent, AuthFieldComponent, FormBannerComponent, SubmitButtonComponent } from "./primitives";
 import { injectAuthUIContext } from "./provider";
@@ -40,8 +40,15 @@ import { injectAuthUIContext } from "./provider";
             } @else if (state().step === "verify") {
                 <lunora-auth-card [title]="t.twoFactorSetup" [description]="t.twoFactorScan">
                     <lunora-auth-banner [error]="state().error" />
-                    @if (state().totpUri !== undefined) {
-                        <code class="lunora-auth-code">{{ state().totpUri }}</code>
+                    <!--
+                        The setup key, not the raw otpauth:// URI: this package
+                        ships no QR encoder, so there is nothing to scan, and
+                        most authenticators reject a pasted otpauth:// string
+                        anyway — the key is the only path that reliably works.
+                    -->
+                    @if (secret() !== undefined) {
+                        <p class="lunora-auth-note">{{ t.twoFactorSecret }}</p>
+                        <code class="lunora-auth-code">{{ secret() }}</code>
                     }
                     @if (state().backupCodes.length > 0) {
                         <p class="lunora-auth-card__description">{{ t.backupCodes }}</p>
@@ -88,6 +95,7 @@ class TwoFactorSetupCardComponent {
     private readonly bridge = controllerSignal(createTwoFactorSetupController, { context: this.context });
     protected readonly state: Signal<TwoFactorSetupState> = this.bridge.state;
     protected readonly actions: TwoFactorSetupActions = this.bridge.actions;
+    protected readonly secret = computed(() => totpSecret(this.state().totpUri));
 }
 
 export { TwoFactorSetupCardComponent };

--- a/registry/auth-ui-angular/core/admin-users.ts
+++ b/registry/auth-ui-angular/core/admin-users.ts
@@ -50,6 +50,8 @@ type AdminUsersController = Controller<AdminUsersState, AdminUsersActions>;
 
 interface AdminUsersOptions {
     autoLoad?: boolean;
+    /** Milliseconds to wait after the last keystroke before re-querying. Defaults to 300. */
+    debounceMs?: number;
     limit?: number;
 }
 
@@ -84,6 +86,16 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
         { autoLoad: options.autoLoad, initialExtra: { search: "" } },
     );
 
+    const debounceMs = options.debounceMs ?? 300;
+    let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearSearchTimer = (): void => {
+        if (searchTimer !== undefined) {
+            clearTimeout(searchTimer);
+            searchTimer = undefined;
+        }
+    };
+
     /**
      * Navigate only when the mutation actually ran and succeeded.
      *
@@ -108,14 +120,31 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
             refetch: resource.refetch,
             remove: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.removeUser({ userId }))),
             setRole: (userId: string, role: string) => resource.mutate(async () => assertOk(await context.authClient.admin.setRole({ role, userId }))),
-            setSearch: async (value: string) => {
+            setSearch: (value: string) => {
+                // The field itself updates at once (it's controlled off
+                // `state.extra.search`) — only the network `refetch` is debounced,
+                // or every keystroke would fire `admin.listUsers`.
                 resource.patch({ search: value });
-                await resource.refetch();
+                clearSearchTimer();
+
+                if (typeof setTimeout !== "function") {
+                    return resource.refetch();
+                }
+
+                return new Promise<void>((resolve) => {
+                    searchTimer = setTimeout(() => {
+                        searchTimer = undefined;
+                        resolve(resource.refetch());
+                    }, debounceMs);
+                });
             },
             stopImpersonating: () => afterSessionSwap(async () => resource.mutateOk(async () => assertOk(await context.authClient.admin.stopImpersonating()))),
             unban: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.unbanUser({ userId }))),
         },
-        destroy: resource.destroy,
+        destroy: () => {
+            clearSearchTimer();
+            resource.destroy();
+        },
         getState: resource.getState,
         subscribe: resource.subscribe,
     };

--- a/registry/auth-ui-angular/core/avatar.ts
+++ b/registry/auth-ui-angular/core/avatar.ts
@@ -39,6 +39,60 @@ type AvatarUploadController = Controller<AvatarUploadState, AvatarUploadActions>
 /** Human-readable size for the too-big message, in whole MB. */
 const megabytes = (bytes: number): string => `${String(Math.round((bytes / (1024 * 1024)) * 10) / 10)} MB`;
 
+/** One byte run a signature requires at a given offset into the file. */
+interface MagicRun {
+    bytes: ReadonlyArray<number>;
+    offset: number;
+}
+
+/**
+ * Magic-number signatures for the {@link ACCEPTED_TYPES} formats. Most formats
+ * are one contiguous run at offset 0; WebP and AVIF need two non-contiguous
+ * runs (a container header, then a fixed marker further in), so a signature is
+ * a list of runs that must ALL match — never just the first, or a signature
+ * would accept any RIFF-family file (WAV, AVI, …) as WebP.
+ */
+const MAGIC_SIGNATURES: ReadonlyArray<ReadonlyArray<MagicRun>> = [
+    [{ bytes: [0x89, 0x50, 0x4e, 0x47], offset: 0 }], // PNG
+    [{ bytes: [0xff, 0xd8, 0xff], offset: 0 }], // JPEG
+    [{ bytes: [0x47, 0x49, 0x46, 0x38], offset: 0 }], // GIF ("GIF8")
+    [
+        { bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 }, // "RIFF"…
+        { bytes: [0x57, 0x45, 0x42, 0x50], offset: 8 }, // …"WEBP" at byte 8
+    ],
+    [
+        { bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 }, // "ftyp" after the box-size prefix…
+        { bytes: [0x61, 0x76, 0x69], offset: 8 }, // …"avi" brand at byte 8 (covers both "avif" and "avis")
+    ],
+];
+
+/**
+ * Sniffs the first bytes of a file for a known image format's magic number,
+ * for the case `file.type` is empty — a drag-and-drop from some file managers,
+ * a camera-roll export, anything the OS's extension-to-MIME table has no entry
+ * for. An empty `type` used to bypass the check entirely, letting arbitrary
+ * bytes through under any file name.
+ *
+ * This is still only a client-side courtesy, exactly like the `ACCEPTED_TYPES`
+ * check it extends: the server must re-validate every upload regardless of
+ * what either check reports.
+ */
+const sniffImageType = async (file: File): Promise<boolean> => {
+    const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+    const runMatches = (run: MagicRun): boolean => run.bytes.every((byte, index) => header[run.offset + index] === byte);
+
+    return MAGIC_SIGNATURES.some((signature) => signature.every((run) => runMatches(run)));
+};
+
+/**
+ * Whether a picked file passes the client-side image check: accept-list when
+ * the browser reports a type, magic-byte sniff when it doesn't. Shared by the
+ * avatar and organization-logo controllers so the empty-`type` handling can't
+ * drift between the two copies again — see {@link sniffImageType}'s docblock
+ * for why an empty `type` isn't a green light.
+ */
+const isAcceptedImage = async (file: File): Promise<boolean> => (file.type === "" ? sniffImageType(file) : ACCEPTED_TYPES.has(file.type));
+
 const createAvatarUploadController = (context: ControllerContext, options: { initialImage?: string } = {}): AvatarUploadController => {
     const store = createStore<AvatarUploadState>({ imageUrl: options.initialImage, status: "idle" });
 
@@ -83,7 +137,11 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;
@@ -110,4 +168,4 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
 };
 
 export type { AvatarUploadActions, AvatarUploadController, AvatarUploadState };
-export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController };
+export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController, isAcceptedImage };

--- a/registry/auth-ui-angular/core/create-resource-controller.ts
+++ b/registry/auth-ui-angular/core/create-resource-controller.ts
@@ -83,20 +83,41 @@ const createResourceController = <T, TExtra extends object = Record<never, never
         status: "idle",
     });
 
+    /*
+     * Which `refetch` is current. A search box firing a query per keystroke can
+     * have a slow answer for an early prefix land after a fast answer for the
+     * full query — without a ticket, the stale prefix result would overwrite
+     * the correct one an admin is already looking at. Mirrors
+     * `createFormController.load`'s `generation`.
+     */
+    let generation = 0;
+
     const refetch = async (): Promise<void> => {
+        generation += 1;
+
+        const ticket = generation;
+
         store.update({ error: undefined, loading: true, status: "submitting" });
 
         try {
             const result = await load(context, store.get().extra);
-            // A loader that needs no extra state just returns the array.
-            const { extra: patched, items } = Array.isArray(result) ? { extra: undefined, items: result } : result;
+
+            if (ticket !== generation) {
+                return;
+            }
+
+            const { extra: patched, items } = result;
 
             store.update({ items, loading: false, status: "success" });
 
             if (patched !== undefined) {
-                store.update(patched);
+                store.update({ extra: { ...store.get().extra, ...patched } });
             }
         } catch (error) {
+            if (ticket !== generation) {
+                return;
+            }
+
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.genericError), loading: false, status: "error" });
         }

--- a/registry/auth-ui-angular/core/invitations.ts
+++ b/registry/auth-ui-angular/core/invitations.ts
@@ -15,6 +15,7 @@ import type { ControllerContext } from "./config";
 import type { ResourceState } from "./create-resource-controller";
 import { createResourceController } from "./create-resource-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { mergeQuery } from "./redirect-to";
 import { createStore } from "./store";
 import type { AuthInvitationDetail, Controller, FlowStatus } from "./types";
 
@@ -94,13 +95,17 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
                  * somewhere else entirely.
                  */
                 const invited = store.get().invitation?.email;
-                const target = new URLSearchParams({ redirectTo: currentPath() });
+                const parameters: Record<string, string> = { redirectTo: currentPath() };
 
                 if (invited !== undefined && invited !== "") {
-                    target.set("email", invited);
+                    parameters.email = invited;
                 }
 
-                context.nav.replace(`${context.redirects.signIn}?${target.toString()}`);
+                // Merged rather than appended: an app whose `redirects.signIn`
+                // already carries a query (e.g. `/auth?tab=sign-in`, common when
+                // hosting every screen on one `AuthView` route) would otherwise
+                // get a mangled second `?` and lose the invitation on sign-in.
+                context.nav.replace(mergeQuery(context.redirects.signIn, parameters));
 
                 return;
             }

--- a/registry/auth-ui-angular/core/localization.ts
+++ b/registry/auth-ui-angular/core/localization.ts
@@ -33,6 +33,7 @@ interface Localization {
     avatarUploadFailed: string;
     avatarWrongType: string;
     backToSignIn: string;
+    backupCodeLabel: string;
     backupCodes: string;
     backupCodeSignIn: string;
     backupCodesRegenerate: string;
@@ -133,6 +134,7 @@ interface Localization {
     remove: string;
     resetPassword: string;
     resetPasswordDone: string;
+    resetPasswordOtpDescription: string;
     revoke: string;
     revokeAccess: string;
     revokeOthers: string;
@@ -165,6 +167,7 @@ interface Localization {
     twoFactorScan: string;
     twoFactorSecret: string;
     twoFactorSetup: string;
+    twoFactorUseAuthenticator: string;
     /** Fallback when a session has neither a user-agent nor an IP. */
     unknownDevice: string;
     usernameAvailable: string;
@@ -206,6 +209,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     avatarUploadFailed: "Could not upload that image. Try again.",
     avatarWrongType: "Choose a PNG, JPEG, WebP, GIF, or AVIF image.",
     backToSignIn: "Back to sign in",
+    backupCodeLabel: "Backup code",
     backupCodes: "Save these backup codes somewhere safe:",
     backupCodeSignIn: "Use a backup code",
     backupCodesRegenerate: "Regenerate backup codes",
@@ -306,6 +310,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     remove: "Remove",
     resetPassword: "Set new password",
     resetPasswordDone: "Your password has been updated. You can sign in now.",
+    resetPasswordOtpDescription: "Enter the code we emailed you, then choose a new password.",
     revoke: "Revoke",
     revokeAccess: "Revoke access",
     revokeOthers: "Sign out other sessions",
@@ -335,9 +340,10 @@ const DEFAULT_LOCALIZATION: Localization = {
     twoFactorEnabled: "Two-factor authentication is on.",
     twoFactorFailed: "That code is not valid. Try again.",
     twoFactorNeedsPassword: "Set a password before turning on two-factor authentication.",
-    twoFactorScan: "Scan this with your authenticator app, then enter the 6-digit code.",
-    twoFactorSecret: "Or enter this key manually:",
+    twoFactorScan: "Add this account to your authenticator app using the setup key below, then enter the 6-digit code it generates.",
+    twoFactorSecret: "Setup key:",
     twoFactorSetup: "Two-factor authentication",
+    twoFactorUseAuthenticator: "Use your authenticator app instead",
     unknownDevice: "Unknown device",
     usernameAvailable: "That username is available.",
     usernameChecking: "Checking…",

--- a/registry/auth-ui-angular/core/magic-link.ts
+++ b/registry/auth-ui-angular/core/magic-link.ts
@@ -2,6 +2,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import type { FormController } from "./types";
 import { email as validateEmail } from "./validators";
 
@@ -16,7 +17,7 @@ const createMagicLinkController = (context: ControllerContext): FormController<M
         submit: async (values, context_) => {
             assertOk(
                 await context_.authClient.signIn.magicLink({
-                    callbackURL: context_.redirects.afterSignIn,
+                    callbackURL: resolveAfterSignIn(context_.redirects.afterSignIn),
                     email: values.email.trim(),
                 }),
             );

--- a/registry/auth-ui-angular/core/one-tap.ts
+++ b/registry/auth-ui-angular/core/one-tap.ts
@@ -13,6 +13,7 @@
  * working exactly as intended, so they only reach `onError`.
  */
 import type { ControllerContext } from "./config";
+import { resolveAfterSignIn } from "./redirect-to";
 
 /**
  * Show the One Tap prompt, if the browser and the user's Google session allow.
@@ -21,7 +22,7 @@ import type { ControllerContext } from "./config";
  */
 const promptOneTap = async (context: ControllerContext): Promise<void> => {
     try {
-        await context.authClient.oneTap({ callbackURL: context.redirects.afterSignIn });
+        await context.authClient.oneTap({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn) });
         context.onSessionChange?.();
     } catch (error) {
         context.onError?.(error);

--- a/registry/auth-ui-angular/core/organization-logo.ts
+++ b/registry/auth-ui-angular/core/organization-logo.ts
@@ -11,7 +11,7 @@
  * `updateUser` — and folding both into one would mean a controller that takes a
  * discriminator and branches on it in three places.
  */
-import { ACCEPTED_TYPES } from "./avatar";
+import { isAcceptedImage } from "./avatar";
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
 import { createStore } from "./store";
@@ -85,7 +85,11 @@ const createOrganizationLogoController = (context: ControllerContext, options: L
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;

--- a/registry/auth-ui-angular/core/redirect-to.ts
+++ b/registry/auth-ui-angular/core/redirect-to.ts
@@ -72,6 +72,26 @@ const readRedirectTo = (parameter = "redirectTo"): string | undefined => {
 const resolveAfterSignIn = (fallback: string): string => readRedirectTo() ?? fallback;
 
 /**
+ * Merge `parameters` into `path`'s existing query.
+ *
+ * Parsed rather than appended: blindly appending a second `?` mangles the URL
+ * (its own parameters become part of the *first* query's last value), and
+ * `URLSearchParams.set` overwrites rather than duplicating a key that already
+ * exists — so a caller-supplied value always wins over whatever `path` already
+ * carried, never silently loses to a second occurrence.
+ */
+const mergeQuery = (path: string, parameters: Readonly<Record<string, string>>): string => {
+    const [base, existing = ""] = path.split("?");
+    const merged = new URLSearchParams(existing);
+
+    for (const [key, value] of Object.entries(parameters)) {
+        merged.set(key, value);
+    }
+
+    return `${base ?? path}?${merged.toString()}`;
+};
+
+/**
  * Carry `redirectTo` onto an intermediate step's URL.
  *
  * Sign-in can hand off to a second factor before it finishes, and that hop is a
@@ -88,17 +108,12 @@ const withRedirectTo = (path: string): string => {
     }
 
     /*
-     * Parsed rather than appended: an app whose `redirects.twoFactor` already
+     * Merged rather than appended: an app whose `redirects.twoFactor` already
      * carries a `redirectTo` would otherwise end up with two, and
      * `URLSearchParams.get` returns the first — so the configured value would
      * win over the invitation target this function exists to carry.
      */
-    const [base, existing = ""] = path.split("?");
-    const parameters = new URLSearchParams(existing);
-
-    parameters.set("redirectTo", target);
-
-    return `${base ?? path}?${parameters.toString()}`;
+    return mergeQuery(path, { redirectTo: target });
 };
 
-export { isSafeRedirect, readRedirectTo, resolveAfterSignIn, withRedirectTo };
+export { isSafeRedirect, mergeQuery, readRedirectTo, resolveAfterSignIn, withRedirectTo };

--- a/registry/auth-ui-angular/core/social.ts
+++ b/registry/auth-ui-angular/core/social.ts
@@ -9,10 +9,11 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInWithSocial = async (context: ControllerContext, provider: string): Promise<void> => {
     try {
-        assertOk(await context.authClient.signIn.social({ callbackURL: context.redirects.afterSignIn, provider }));
+        assertOk(await context.authClient.signIn.social({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn), provider }));
     } catch (error) {
         // A failed social redirect leaves the user on the same page with no
         // explanation, so this is one of the paths that needs a toast.

--- a/registry/auth-ui-react/core/admin-users.ts
+++ b/registry/auth-ui-react/core/admin-users.ts
@@ -50,6 +50,8 @@ type AdminUsersController = Controller<AdminUsersState, AdminUsersActions>;
 
 interface AdminUsersOptions {
     autoLoad?: boolean;
+    /** Milliseconds to wait after the last keystroke before re-querying. Defaults to 300. */
+    debounceMs?: number;
     limit?: number;
 }
 
@@ -84,6 +86,16 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
         { autoLoad: options.autoLoad, initialExtra: { search: "" } },
     );
 
+    const debounceMs = options.debounceMs ?? 300;
+    let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearSearchTimer = (): void => {
+        if (searchTimer !== undefined) {
+            clearTimeout(searchTimer);
+            searchTimer = undefined;
+        }
+    };
+
     /**
      * Navigate only when the mutation actually ran and succeeded.
      *
@@ -108,14 +120,31 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
             refetch: resource.refetch,
             remove: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.removeUser({ userId }))),
             setRole: (userId: string, role: string) => resource.mutate(async () => assertOk(await context.authClient.admin.setRole({ role, userId }))),
-            setSearch: async (value: string) => {
+            setSearch: (value: string) => {
+                // The field itself updates at once (it's controlled off
+                // `state.extra.search`) — only the network `refetch` is debounced,
+                // or every keystroke would fire `admin.listUsers`.
                 resource.patch({ search: value });
-                await resource.refetch();
+                clearSearchTimer();
+
+                if (typeof setTimeout !== "function") {
+                    return resource.refetch();
+                }
+
+                return new Promise<void>((resolve) => {
+                    searchTimer = setTimeout(() => {
+                        searchTimer = undefined;
+                        resolve(resource.refetch());
+                    }, debounceMs);
+                });
             },
             stopImpersonating: () => afterSessionSwap(async () => resource.mutateOk(async () => assertOk(await context.authClient.admin.stopImpersonating()))),
             unban: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.unbanUser({ userId }))),
         },
-        destroy: resource.destroy,
+        destroy: () => {
+            clearSearchTimer();
+            resource.destroy();
+        },
         getState: resource.getState,
         subscribe: resource.subscribe,
     };

--- a/registry/auth-ui-react/core/avatar.ts
+++ b/registry/auth-ui-react/core/avatar.ts
@@ -39,6 +39,60 @@ type AvatarUploadController = Controller<AvatarUploadState, AvatarUploadActions>
 /** Human-readable size for the too-big message, in whole MB. */
 const megabytes = (bytes: number): string => `${String(Math.round((bytes / (1024 * 1024)) * 10) / 10)} MB`;
 
+/** One byte run a signature requires at a given offset into the file. */
+interface MagicRun {
+    bytes: ReadonlyArray<number>;
+    offset: number;
+}
+
+/**
+ * Magic-number signatures for the {@link ACCEPTED_TYPES} formats. Most formats
+ * are one contiguous run at offset 0; WebP and AVIF need two non-contiguous
+ * runs (a container header, then a fixed marker further in), so a signature is
+ * a list of runs that must ALL match — never just the first, or a signature
+ * would accept any RIFF-family file (WAV, AVI, …) as WebP.
+ */
+const MAGIC_SIGNATURES: ReadonlyArray<ReadonlyArray<MagicRun>> = [
+    [{ bytes: [0x89, 0x50, 0x4e, 0x47], offset: 0 }], // PNG
+    [{ bytes: [0xff, 0xd8, 0xff], offset: 0 }], // JPEG
+    [{ bytes: [0x47, 0x49, 0x46, 0x38], offset: 0 }], // GIF ("GIF8")
+    [
+        { bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 }, // "RIFF"…
+        { bytes: [0x57, 0x45, 0x42, 0x50], offset: 8 }, // …"WEBP" at byte 8
+    ],
+    [
+        { bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 }, // "ftyp" after the box-size prefix…
+        { bytes: [0x61, 0x76, 0x69], offset: 8 }, // …"avi" brand at byte 8 (covers both "avif" and "avis")
+    ],
+];
+
+/**
+ * Sniffs the first bytes of a file for a known image format's magic number,
+ * for the case `file.type` is empty — a drag-and-drop from some file managers,
+ * a camera-roll export, anything the OS's extension-to-MIME table has no entry
+ * for. An empty `type` used to bypass the check entirely, letting arbitrary
+ * bytes through under any file name.
+ *
+ * This is still only a client-side courtesy, exactly like the `ACCEPTED_TYPES`
+ * check it extends: the server must re-validate every upload regardless of
+ * what either check reports.
+ */
+const sniffImageType = async (file: File): Promise<boolean> => {
+    const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+    const runMatches = (run: MagicRun): boolean => run.bytes.every((byte, index) => header[run.offset + index] === byte);
+
+    return MAGIC_SIGNATURES.some((signature) => signature.every((run) => runMatches(run)));
+};
+
+/**
+ * Whether a picked file passes the client-side image check: accept-list when
+ * the browser reports a type, magic-byte sniff when it doesn't. Shared by the
+ * avatar and organization-logo controllers so the empty-`type` handling can't
+ * drift between the two copies again — see {@link sniffImageType}'s docblock
+ * for why an empty `type` isn't a green light.
+ */
+const isAcceptedImage = async (file: File): Promise<boolean> => (file.type === "" ? sniffImageType(file) : ACCEPTED_TYPES.has(file.type));
+
 const createAvatarUploadController = (context: ControllerContext, options: { initialImage?: string } = {}): AvatarUploadController => {
     const store = createStore<AvatarUploadState>({ imageUrl: options.initialImage, status: "idle" });
 
@@ -83,7 +137,11 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;
@@ -110,4 +168,4 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
 };
 
 export type { AvatarUploadActions, AvatarUploadController, AvatarUploadState };
-export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController };
+export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController, isAcceptedImage };

--- a/registry/auth-ui-react/core/create-resource-controller.ts
+++ b/registry/auth-ui-react/core/create-resource-controller.ts
@@ -83,20 +83,41 @@ const createResourceController = <T, TExtra extends object = Record<never, never
         status: "idle",
     });
 
+    /*
+     * Which `refetch` is current. A search box firing a query per keystroke can
+     * have a slow answer for an early prefix land after a fast answer for the
+     * full query — without a ticket, the stale prefix result would overwrite
+     * the correct one an admin is already looking at. Mirrors
+     * `createFormController.load`'s `generation`.
+     */
+    let generation = 0;
+
     const refetch = async (): Promise<void> => {
+        generation += 1;
+
+        const ticket = generation;
+
         store.update({ error: undefined, loading: true, status: "submitting" });
 
         try {
             const result = await load(context, store.get().extra);
-            // A loader that needs no extra state just returns the array.
-            const { extra: patched, items } = Array.isArray(result) ? { extra: undefined, items: result } : result;
+
+            if (ticket !== generation) {
+                return;
+            }
+
+            const { extra: patched, items } = result;
 
             store.update({ items, loading: false, status: "success" });
 
             if (patched !== undefined) {
-                store.update(patched);
+                store.update({ extra: { ...store.get().extra, ...patched } });
             }
         } catch (error) {
+            if (ticket !== generation) {
+                return;
+            }
+
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.genericError), loading: false, status: "error" });
         }

--- a/registry/auth-ui-react/core/invitations.ts
+++ b/registry/auth-ui-react/core/invitations.ts
@@ -15,6 +15,7 @@ import type { ControllerContext } from "./config";
 import type { ResourceState } from "./create-resource-controller";
 import { createResourceController } from "./create-resource-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { mergeQuery } from "./redirect-to";
 import { createStore } from "./store";
 import type { AuthInvitationDetail, Controller, FlowStatus } from "./types";
 
@@ -94,13 +95,17 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
                  * somewhere else entirely.
                  */
                 const invited = store.get().invitation?.email;
-                const target = new URLSearchParams({ redirectTo: currentPath() });
+                const parameters: Record<string, string> = { redirectTo: currentPath() };
 
                 if (invited !== undefined && invited !== "") {
-                    target.set("email", invited);
+                    parameters.email = invited;
                 }
 
-                context.nav.replace(`${context.redirects.signIn}?${target.toString()}`);
+                // Merged rather than appended: an app whose `redirects.signIn`
+                // already carries a query (e.g. `/auth?tab=sign-in`, common when
+                // hosting every screen on one `AuthView` route) would otherwise
+                // get a mangled second `?` and lose the invitation on sign-in.
+                context.nav.replace(mergeQuery(context.redirects.signIn, parameters));
 
                 return;
             }

--- a/registry/auth-ui-react/core/localization.ts
+++ b/registry/auth-ui-react/core/localization.ts
@@ -33,6 +33,7 @@ interface Localization {
     avatarUploadFailed: string;
     avatarWrongType: string;
     backToSignIn: string;
+    backupCodeLabel: string;
     backupCodes: string;
     backupCodeSignIn: string;
     backupCodesRegenerate: string;
@@ -133,6 +134,7 @@ interface Localization {
     remove: string;
     resetPassword: string;
     resetPasswordDone: string;
+    resetPasswordOtpDescription: string;
     revoke: string;
     revokeAccess: string;
     revokeOthers: string;
@@ -165,6 +167,7 @@ interface Localization {
     twoFactorScan: string;
     twoFactorSecret: string;
     twoFactorSetup: string;
+    twoFactorUseAuthenticator: string;
     /** Fallback when a session has neither a user-agent nor an IP. */
     unknownDevice: string;
     usernameAvailable: string;
@@ -206,6 +209,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     avatarUploadFailed: "Could not upload that image. Try again.",
     avatarWrongType: "Choose a PNG, JPEG, WebP, GIF, or AVIF image.",
     backToSignIn: "Back to sign in",
+    backupCodeLabel: "Backup code",
     backupCodes: "Save these backup codes somewhere safe:",
     backupCodeSignIn: "Use a backup code",
     backupCodesRegenerate: "Regenerate backup codes",
@@ -306,6 +310,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     remove: "Remove",
     resetPassword: "Set new password",
     resetPasswordDone: "Your password has been updated. You can sign in now.",
+    resetPasswordOtpDescription: "Enter the code we emailed you, then choose a new password.",
     revoke: "Revoke",
     revokeAccess: "Revoke access",
     revokeOthers: "Sign out other sessions",
@@ -335,9 +340,10 @@ const DEFAULT_LOCALIZATION: Localization = {
     twoFactorEnabled: "Two-factor authentication is on.",
     twoFactorFailed: "That code is not valid. Try again.",
     twoFactorNeedsPassword: "Set a password before turning on two-factor authentication.",
-    twoFactorScan: "Scan this with your authenticator app, then enter the 6-digit code.",
-    twoFactorSecret: "Or enter this key manually:",
+    twoFactorScan: "Add this account to your authenticator app using the setup key below, then enter the 6-digit code it generates.",
+    twoFactorSecret: "Setup key:",
     twoFactorSetup: "Two-factor authentication",
+    twoFactorUseAuthenticator: "Use your authenticator app instead",
     unknownDevice: "Unknown device",
     usernameAvailable: "That username is available.",
     usernameChecking: "Checking…",

--- a/registry/auth-ui-react/core/magic-link.ts
+++ b/registry/auth-ui-react/core/magic-link.ts
@@ -2,6 +2,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import type { FormController } from "./types";
 import { email as validateEmail } from "./validators";
 
@@ -16,7 +17,7 @@ const createMagicLinkController = (context: ControllerContext): FormController<M
         submit: async (values, context_) => {
             assertOk(
                 await context_.authClient.signIn.magicLink({
-                    callbackURL: context_.redirects.afterSignIn,
+                    callbackURL: resolveAfterSignIn(context_.redirects.afterSignIn),
                     email: values.email.trim(),
                 }),
             );

--- a/registry/auth-ui-react/core/one-tap.ts
+++ b/registry/auth-ui-react/core/one-tap.ts
@@ -13,6 +13,7 @@
  * working exactly as intended, so they only reach `onError`.
  */
 import type { ControllerContext } from "./config";
+import { resolveAfterSignIn } from "./redirect-to";
 
 /**
  * Show the One Tap prompt, if the browser and the user's Google session allow.
@@ -21,7 +22,7 @@ import type { ControllerContext } from "./config";
  */
 const promptOneTap = async (context: ControllerContext): Promise<void> => {
     try {
-        await context.authClient.oneTap({ callbackURL: context.redirects.afterSignIn });
+        await context.authClient.oneTap({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn) });
         context.onSessionChange?.();
     } catch (error) {
         context.onError?.(error);

--- a/registry/auth-ui-react/core/organization-logo.ts
+++ b/registry/auth-ui-react/core/organization-logo.ts
@@ -11,7 +11,7 @@
  * `updateUser` — and folding both into one would mean a controller that takes a
  * discriminator and branches on it in three places.
  */
-import { ACCEPTED_TYPES } from "./avatar";
+import { isAcceptedImage } from "./avatar";
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
 import { createStore } from "./store";
@@ -85,7 +85,11 @@ const createOrganizationLogoController = (context: ControllerContext, options: L
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;

--- a/registry/auth-ui-react/core/redirect-to.ts
+++ b/registry/auth-ui-react/core/redirect-to.ts
@@ -72,6 +72,26 @@ const readRedirectTo = (parameter = "redirectTo"): string | undefined => {
 const resolveAfterSignIn = (fallback: string): string => readRedirectTo() ?? fallback;
 
 /**
+ * Merge `parameters` into `path`'s existing query.
+ *
+ * Parsed rather than appended: blindly appending a second `?` mangles the URL
+ * (its own parameters become part of the *first* query's last value), and
+ * `URLSearchParams.set` overwrites rather than duplicating a key that already
+ * exists — so a caller-supplied value always wins over whatever `path` already
+ * carried, never silently loses to a second occurrence.
+ */
+const mergeQuery = (path: string, parameters: Readonly<Record<string, string>>): string => {
+    const [base, existing = ""] = path.split("?");
+    const merged = new URLSearchParams(existing);
+
+    for (const [key, value] of Object.entries(parameters)) {
+        merged.set(key, value);
+    }
+
+    return `${base ?? path}?${merged.toString()}`;
+};
+
+/**
  * Carry `redirectTo` onto an intermediate step's URL.
  *
  * Sign-in can hand off to a second factor before it finishes, and that hop is a
@@ -88,17 +108,12 @@ const withRedirectTo = (path: string): string => {
     }
 
     /*
-     * Parsed rather than appended: an app whose `redirects.twoFactor` already
+     * Merged rather than appended: an app whose `redirects.twoFactor` already
      * carries a `redirectTo` would otherwise end up with two, and
      * `URLSearchParams.get` returns the first — so the configured value would
      * win over the invitation target this function exists to carry.
      */
-    const [base, existing = ""] = path.split("?");
-    const parameters = new URLSearchParams(existing);
-
-    parameters.set("redirectTo", target);
-
-    return `${base ?? path}?${parameters.toString()}`;
+    return mergeQuery(path, { redirectTo: target });
 };
 
-export { isSafeRedirect, readRedirectTo, resolveAfterSignIn, withRedirectTo };
+export { isSafeRedirect, mergeQuery, readRedirectTo, resolveAfterSignIn, withRedirectTo };

--- a/registry/auth-ui-react/core/social.ts
+++ b/registry/auth-ui-react/core/social.ts
@@ -9,10 +9,11 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInWithSocial = async (context: ControllerContext, provider: string): Promise<void> => {
     try {
-        assertOk(await context.authClient.signIn.social({ callbackURL: context.redirects.afterSignIn, provider }));
+        assertOk(await context.authClient.signIn.social({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn), provider }));
     } catch (error) {
         // A failed social redirect leaves the user on the same page with no
         // explanation, so this is one of the paths that needs a toast.

--- a/registry/auth-ui-react/react/auth-cards.tsx
+++ b/registry/auth-ui-react/react/auth-cards.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import type { ReactElement } from "react";
+import { useState } from "react";
 
 import { signInAnonymously } from "../core/anonymous";
+import { createBackupCodeSignInController } from "../core/backup-codes";
+import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
 import { LAST_METHOD_EMAIL, LAST_METHOD_MAGIC_LINK, readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import { createSignInController } from "../core/sign-in";
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
@@ -57,7 +61,7 @@ const SignInCard = ({ forgotPasswordHref = "/forgot-password", signUpHref = "/si
     const lastUsed = readLastLoginMethod();
 
     return (
-        <AuthCard footer={<AuthLink href={signUpHref}>{t.noAccount}</AuthLink>} title={t.signIn}>
+        <AuthCard footer={context.signUp ? <AuthLink href={signUpHref}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
                 lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
                 onSelect={(provider) => {
@@ -119,10 +123,18 @@ interface SignUpCardProps {
     signInHref?: string;
 }
 
-const SignUpCard = ({ signInHref = "/sign-in" }: SignUpCardProps = {}): ReactElement => {
+const SignUpCard = ({ signInHref = "/sign-in" }: SignUpCardProps = {}): ReactElement | null => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = useController(createSignUpController);
+
+    // The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+    // Mirrors the plugin-gated cards below: mounted directly, this card renders
+    // nothing rather than a form that will fail on submit; `AuthView`'s route
+    // falls back to the sign-in card instead of landing on a blank page.
+    if (!context.signUp) {
+        return null;
+    }
 
     return (
         <AuthCard footer={<AuthLink href={signInHref}>{t.haveAccount}</AuthLink>} title={t.signUp}>
@@ -219,18 +231,90 @@ const ForgotPasswordCard = ({ resetPath, signInHref = "/sign-in" }: ForgotPasswo
 };
 
 interface ResetPasswordCardProps {
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     token?: string;
 }
 
 const ResetPasswordCard = ({ token }: ResetPasswordCardProps = {}): ReactElement => {
     const { localization: t } = useAuthUI();
-    const [state, actions] = useController((context) => createResetPasswordController(context, { token }), [token]);
+    const resolved = token ?? queryParameter("token");
+    const [state, actions] = useController((context) => createResetPasswordController(context, { token: resolved }), [resolved]);
 
     return (
         <AuthCard title={t.resetPassword}>
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.password}
+                    label={t.passwordLabel}
+                    name="password"
+                    onBlur={() => {
+                        actions.blur("password");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("password", value);
+                    }}
+                    type="password"
+                />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.confirmPassword}
+                    label={t.confirmPasswordLabel}
+                    name="confirmPassword"
+                    onBlur={() => {
+                        actions.blur("confirmPassword");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("confirmPassword", value);
+                    }}
+                    type="password"
+                />
+                <SubmitButton pending={state.status === "submitting"}>{t.resetPassword}</SubmitButton>
+            </form>
+        </AuthCard>
+    );
+};
+
+/**
+ * Redeems an emailed one-time code instead of a link — for apps that set
+ * `forgotPassword: { method: "otp" }`. Unlike {@link ResetPasswordCard}, the
+ * email address is a field rather than something carried from the previous
+ * screen: a code can legitimately be redeemed from a fresh tab.
+ */
+const ResetPasswordOtpCard = (): ReactElement => {
+    const { localization: t } = useAuthUI();
+    const [state, actions] = useController(createResetPasswordOtpController);
+
+    return (
+        <AuthCard description={t.resetPasswordOtpDescription} title={t.resetPassword}>
+            <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
+                <FormBanner error={state.formError} success={state.successMessage} />
+                <Field
+                    autoComplete="email"
+                    field={state.fields.email}
+                    label={t.emailLabel}
+                    name="email"
+                    onBlur={() => {
+                        actions.blur("email");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("email", value);
+                    }}
+                    type="email"
+                />
+                <Field
+                    autoComplete="one-time-code"
+                    field={state.fields.otp}
+                    label={t.codeLabel}
+                    name="otp"
+                    onBlur={() => {
+                        actions.blur("otp");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("otp", value);
+                    }}
+                />
                 <Field
                     autoComplete="new-password"
                     field={state.fields.password}
@@ -368,13 +452,66 @@ const TwoFactorCard = ({ method, trustDevice }: TwoFactorCardProps = {}): ReactE
     const context = useAuthUI();
     const { localization: t } = context;
     const [state, actions] = useController((context_) => createTwoFactorVerifyController(context_, { method, trustDevice }), [method, trustDevice]);
+    const [backupState, backupActions] = useController((context_) => createBackupCodeSignInController(context_, { trustDevice }), [trustDevice]);
+    // Both controllers are always live — a form's live session-mutating submit
+    // must not depend on which mode happened to be showing when it was called.
+    const [useBackupCode, setUseBackupCode] = useState(false);
 
     if (!isFlowEnabled(context, "twoFactor", "TwoFactorCard")) {
         return null;
     }
 
+    if (useBackupCode) {
+        return (
+            <AuthCard
+                footer={
+                    <button
+                        className="lunora-auth-link"
+                        onClick={() => {
+                            setUseBackupCode(false);
+                        }}
+                        type="button"
+                    >
+                        {t.twoFactorUseAuthenticator}
+                    </button>
+                }
+                title={t.twoFactor}
+            >
+                <form className="lunora-auth-form" noValidate onSubmit={onSubmit(backupActions.submit)}>
+                    <FormBanner error={backupState.formError} />
+                    <Field
+                        autoComplete="one-time-code"
+                        field={backupState.fields.code}
+                        label={t.backupCodeLabel}
+                        name="code"
+                        onBlur={() => {
+                            backupActions.blur("code");
+                        }}
+                        onChange={(value) => {
+                            backupActions.setField("code", value);
+                        }}
+                    />
+                    <SubmitButton pending={backupState.status === "submitting"}>{t.twoFactor}</SubmitButton>
+                </form>
+            </AuthCard>
+        );
+    }
+
     return (
-        <AuthCard title={t.twoFactor}>
+        <AuthCard
+            footer={
+                <button
+                    className="lunora-auth-link"
+                    onClick={() => {
+                        setUseBackupCode(true);
+                    }}
+                    type="button"
+                >
+                    {t.backupCodeSignIn}
+                </button>
+            }
+            title={t.twoFactor}
+        >
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} />
                 <Field
@@ -396,4 +533,4 @@ const TwoFactorCard = ({ method, trustDevice }: TwoFactorCardProps = {}): ReactE
 };
 
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps };
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard };
+export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard };

--- a/registry/auth-ui-react/react/auth-view.tsx
+++ b/registry/auth-ui-react/react/auth-view.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from "react";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createPhoneSignInController } from "../core/phone-number";
 import { createUsernameSignInController } from "../core/username";
-import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
 import { DeviceAuthorizationCard } from "./plugin-cards";
 import { AuthCard, Field, FormBanner, SubmitButton } from "./primitives";
 import { useAuthUI } from "./provider";
@@ -123,7 +123,7 @@ interface AuthViewProps {
 }
 
 const AuthView = ({ view }: AuthViewProps = {}): ReactElement => {
-    const { plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = useAuthUI();
 
     /*
      * A lookup keyed by the resolved segment, not a `switch` over
@@ -143,15 +143,19 @@ const AuthView = ({ view }: AuthViewProps = {}): ReactElement => {
         [viewPaths.emailOtp]: () => (plugins.emailOtp ? <EmailOtpCard /> : <SignInCard />),
         [viewPaths.forgotPassword]: () => <ForgotPasswordCard />,
         [viewPaths.magicLink]: () => (plugins.magicLink ? <MagicLinkCard /> : <SignInCard />),
-        [viewPaths.resetPassword]: () => <ResetPasswordCard />,
-        [viewPaths.signUp]: () => <SignUpCard />,
+        [viewPaths.resetPassword]: () => (forgotPasswordMethod === "otp" ? <ResetPasswordOtpCard /> : <ResetPasswordCard />),
+        [viewPaths.signUp]: () => (signUp ? <SignUpCard /> : <SignInCard />),
         [viewPaths.twoFactor]: () => (plugins.twoFactor ? <TwoFactorCard /> : <SignInCard />),
         [viewPaths.verifyEmail]: () => <VerifyEmailCard />,
     };
 
     // An unrecognized segment falls back to sign-in rather than rendering
-    // nothing, because a typo'd auth URL should still let someone in.
-    const render = view === undefined ? undefined : routes[view];
+    // nothing, because a typo'd auth URL should still let someone in. The
+    // own-key check matters because `view` is URL input: a plain object
+    // literal inherits `Object.prototype`, so a segment like "valueOf" or
+    // "constructor" would otherwise resolve to an inherited member instead of
+    // falling through.
+    const render = view !== undefined && Object.hasOwn(routes, view) ? routes[view] : undefined;
 
     return render === undefined ? <SignInCard /> : render();
 };

--- a/registry/auth-ui-react/react/extras.tsx
+++ b/registry/auth-ui-react/react/extras.tsx
@@ -19,13 +19,15 @@ import { useController } from "./use-controller";
  *
  * Errors that *do* belong to a card still render on that card's banner and never
  * reach here, so nothing is announced twice.
+ *
+ * The `aria-live` region mounts unconditionally — including with no toasts yet.
+ * A live region only announces changes made AFTER it exists in the accessibility
+ * tree; mounting it together with the first toast (as `{toasts.length === 0 ?
+ * null : …}` did) means that very first toast lands before assistive tech is
+ * watching the region, so it goes unannounced.
  */
-const ErrorToaster = (): ReactElement | null => {
+const ErrorToaster = (): ReactElement => {
     const toasts = useSyncExternalStore(subscribeToasts, getToasts, getToasts);
-
-    if (toasts.length === 0) {
-        return null;
-    }
 
     return (
         // `polite`, not `assertive`: these are failures the user can retry, not

--- a/registry/auth-ui-react/react/index.ts
+++ b/registry/auth-ui-react/react/index.ts
@@ -17,7 +17,17 @@ export * from "../core";
  */
 export { AppearanceCard, AvatarCard, LinkedAccountsCard, SetUsernameCard } from "./account-cards";
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps } from "./auth-cards";
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+export {
+    AnonymousButton,
+    EmailOtpCard,
+    ForgotPasswordCard,
+    MagicLinkCard,
+    ResetPasswordCard,
+    ResetPasswordOtpCard,
+    SignInCard,
+    SignUpCard,
+    TwoFactorCard,
+} from "./auth-cards";
 export type { AuthViewProps } from "./auth-view";
 export { AuthView, PhoneSignInCard, UsernameSignInCard } from "./auth-view";
 export type { CaptchaProps, OrganizationLogoCardProps } from "./extras";

--- a/registry/auth-ui-react/react/organization.tsx
+++ b/registry/auth-ui-react/react/organization.tsx
@@ -107,7 +107,7 @@ const OrganizationsCard = (): ReactElement | null => {
     })();
 
     return (
-        <AuthCard title={t.organizations}>
+        <AuthCard headingLevel={2} title={t.organizations}>
             <FormBanner error={state.error} />
             {list}
             {cannotCreate ? <p className="lunora-auth-note">{createBlockedReason}</p> : null}
@@ -156,7 +156,7 @@ const MembersCard = (): ReactElement | null => {
     };
 
     return (
-        <AuthCard title={t.members}>
+        <AuthCard headingLevel={2} title={t.members}>
             <FormBanner error={state.error} />
 
             {state.loading ? (
@@ -275,7 +275,7 @@ const OrganizationSettingsCard = ({ organizationId }: OrganizationSettingsCardPr
     }
 
     return (
-        <AuthCard title={t.organizationSettings}>
+        <AuthCard headingLevel={2} title={t.organizationSettings}>
             {state.loading ? (
                 <p className="lunora-auth-card__description">…</p>
             ) : (

--- a/registry/auth-ui-react/react/primitives.tsx
+++ b/registry/auth-ui-react/react/primitives.tsx
@@ -14,16 +14,26 @@ interface AuthCardProps {
     children: ReactNode;
     description?: string;
     footer?: ReactNode;
+
+    /**
+     * The title's heading level (default 1). A standalone auth screen is the
+     * page's only heading, so `h1` is right there — but a settings/organization
+     * page composes several cards under its own `h1`, and stacking six more
+     * `h1`s breaks the WCAG 1.3.1 heading outline a screen-reader user
+     * navigates by. Pass `2` (or `3`, nested deeper) from a composition.
+     */
+    headingLevel?: 1 | 2 | 3;
     title: string;
 }
 
-const AuthCard = ({ children, description, footer, title }: AuthCardProps): ReactElement => {
+const AuthCard = ({ children, description, footer, headingLevel = 1, title }: AuthCardProps): ReactElement => {
     const style = useThemeStyle();
+    const Heading = `h${String(headingLevel)}` as "h1" | "h2" | "h3";
 
     return (
         <section className="lunora-auth-card" style={style}>
             <header className="lunora-auth-card__header">
-                <h1 className="lunora-auth-card__title">{title}</h1>
+                <Heading className="lunora-auth-card__title">{title}</Heading>
                 {description === undefined ? null : <p className="lunora-auth-card__description">{description}</p>}
             </header>
             <div className="lunora-auth-card__body">{children}</div>

--- a/registry/auth-ui-react/react/provider.tsx
+++ b/registry/auth-ui-react/react/provider.tsx
@@ -149,6 +149,20 @@ const AuthUIProvider = ({
     // The discovered payload is a fresh object per fetch but settles exactly
     // once, so keying on its content keeps the memo from churning on re-renders
     // while still rebuilding the context when the answer lands.
+    //
+    // Known, accepted trade-off (plan 278 §5 S3): a rebuilt `core` rebuilds
+    // every controller memoized on it (see `use-controller.ts`), which loses
+    // whatever the user already typed into an in-flight form if discovery
+    // settles after they started. `/ui-config` is a same-origin GET fired on
+    // mount, so on a healthy deployment this window is narrow — well under
+    // typical human typing latency — but a password manager's autofill can
+    // still race it, since autofill can land within the same tick as mount.
+    // Fixing it needs either a stable accessor threaded through
+    // `ControllerContext`'s public shape (a ripple through every controller
+    // and all five ports) or a generic seed/hydrate seam on `Controller` that
+    // would have to make sense for every domain controller's state, not just
+    // form fields — both bigger than this plan's scope. See
+    // `__tests__/react/discovery-rebuild.test.tsx` for the measured repro.
     const discoveryKey = JSON.stringify(discovery.config ?? null);
 
     const core = useMemo<ControllerContext>(

--- a/registry/auth-ui-react/react/settings-cards.tsx
+++ b/registry/auth-ui-react/react/settings-cards.tsx
@@ -38,7 +38,7 @@ const ProfileCard = ({ defaultImage, defaultName }: ProfileCardProps = {}): Reac
     );
 
     return (
-        <AuthCard title={t.profile}>
+        <AuthCard headingLevel={2} title={t.profile}>
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <Field
@@ -64,7 +64,7 @@ const ChangeEmailCard = (): ReactElement => {
     const [state, actions] = useController(createChangeEmailController);
 
     return (
-        <AuthCard title={t.changeEmail}>
+        <AuthCard headingLevel={2} title={t.changeEmail}>
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <Field
@@ -91,7 +91,7 @@ const ChangePasswordCard = (): ReactElement => {
     const [state, actions] = useController(createChangePasswordController);
 
     return (
-        <AuthCard title={t.changePassword}>
+        <AuthCard headingLevel={2} title={t.changePassword}>
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <Field
@@ -144,7 +144,7 @@ const DeleteAccountCard = (): ReactElement => {
     const [state, actions] = useController(createDeleteAccountController);
 
     return (
-        <AuthCard description={t.deleteAccountWarning} title={t.deleteAccount}>
+        <AuthCard description={t.deleteAccountWarning} headingLevel={2} title={t.deleteAccount}>
             <form className="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} />
                 <Field
@@ -208,7 +208,7 @@ const SessionsCard = (): ReactElement => {
     })();
 
     return (
-        <AuthCard title={t.sessions}>
+        <AuthCard headingLevel={2} title={t.sessions}>
             <FormBanner error={state.error} />
             {body}
             <button
@@ -278,7 +278,7 @@ const PasskeysCard = (): ReactElement | null => {
     })();
 
     return (
-        <AuthCard title={t.passkeys}>
+        <AuthCard headingLevel={2} title={t.passkeys}>
             <FormBanner error={state.error} />
             {body}
             <form

--- a/registry/auth-ui-react/react/two-factor-setup-card.tsx
+++ b/registry/auth-ui-react/react/two-factor-setup-card.tsx
@@ -74,12 +74,11 @@ const TwoFactorSetupCard = (): ReactElement | null => {
         return (
             <AuthCard description={t.twoFactorScan} title={t.twoFactorSetup}>
                 <FormBanner error={state.error} />
-                {state.totpUri === undefined ? null : <code className="lunora-auth-code">{state.totpUri}</code>}
                 {/*
-                 * The key on its own, because the URI is not a substitute for
-                 * it: most authenticators reject a pasted `otpauth://…` string,
-                 * and anyone on a desktop app or without a working camera has
-                 * no other way in.
+                 * The setup key, not the raw `otpauth://…` URI: this package
+                 * ships no QR encoder, so there is nothing to scan, and most
+                 * authenticators reject a pasted `otpauth://…` string anyway —
+                 * the key is the only path that reliably works.
                  */}
                 {totpSecret(state.totpUri) === undefined ? null : (
                     <>

--- a/registry/auth-ui-solid/core/admin-users.ts
+++ b/registry/auth-ui-solid/core/admin-users.ts
@@ -50,6 +50,8 @@ type AdminUsersController = Controller<AdminUsersState, AdminUsersActions>;
 
 interface AdminUsersOptions {
     autoLoad?: boolean;
+    /** Milliseconds to wait after the last keystroke before re-querying. Defaults to 300. */
+    debounceMs?: number;
     limit?: number;
 }
 
@@ -84,6 +86,16 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
         { autoLoad: options.autoLoad, initialExtra: { search: "" } },
     );
 
+    const debounceMs = options.debounceMs ?? 300;
+    let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearSearchTimer = (): void => {
+        if (searchTimer !== undefined) {
+            clearTimeout(searchTimer);
+            searchTimer = undefined;
+        }
+    };
+
     /**
      * Navigate only when the mutation actually ran and succeeded.
      *
@@ -108,14 +120,31 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
             refetch: resource.refetch,
             remove: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.removeUser({ userId }))),
             setRole: (userId: string, role: string) => resource.mutate(async () => assertOk(await context.authClient.admin.setRole({ role, userId }))),
-            setSearch: async (value: string) => {
+            setSearch: (value: string) => {
+                // The field itself updates at once (it's controlled off
+                // `state.extra.search`) — only the network `refetch` is debounced,
+                // or every keystroke would fire `admin.listUsers`.
                 resource.patch({ search: value });
-                await resource.refetch();
+                clearSearchTimer();
+
+                if (typeof setTimeout !== "function") {
+                    return resource.refetch();
+                }
+
+                return new Promise<void>((resolve) => {
+                    searchTimer = setTimeout(() => {
+                        searchTimer = undefined;
+                        resolve(resource.refetch());
+                    }, debounceMs);
+                });
             },
             stopImpersonating: () => afterSessionSwap(async () => resource.mutateOk(async () => assertOk(await context.authClient.admin.stopImpersonating()))),
             unban: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.unbanUser({ userId }))),
         },
-        destroy: resource.destroy,
+        destroy: () => {
+            clearSearchTimer();
+            resource.destroy();
+        },
         getState: resource.getState,
         subscribe: resource.subscribe,
     };

--- a/registry/auth-ui-solid/core/avatar.ts
+++ b/registry/auth-ui-solid/core/avatar.ts
@@ -39,6 +39,60 @@ type AvatarUploadController = Controller<AvatarUploadState, AvatarUploadActions>
 /** Human-readable size for the too-big message, in whole MB. */
 const megabytes = (bytes: number): string => `${String(Math.round((bytes / (1024 * 1024)) * 10) / 10)} MB`;
 
+/** One byte run a signature requires at a given offset into the file. */
+interface MagicRun {
+    bytes: ReadonlyArray<number>;
+    offset: number;
+}
+
+/**
+ * Magic-number signatures for the {@link ACCEPTED_TYPES} formats. Most formats
+ * are one contiguous run at offset 0; WebP and AVIF need two non-contiguous
+ * runs (a container header, then a fixed marker further in), so a signature is
+ * a list of runs that must ALL match — never just the first, or a signature
+ * would accept any RIFF-family file (WAV, AVI, …) as WebP.
+ */
+const MAGIC_SIGNATURES: ReadonlyArray<ReadonlyArray<MagicRun>> = [
+    [{ bytes: [0x89, 0x50, 0x4e, 0x47], offset: 0 }], // PNG
+    [{ bytes: [0xff, 0xd8, 0xff], offset: 0 }], // JPEG
+    [{ bytes: [0x47, 0x49, 0x46, 0x38], offset: 0 }], // GIF ("GIF8")
+    [
+        { bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 }, // "RIFF"…
+        { bytes: [0x57, 0x45, 0x42, 0x50], offset: 8 }, // …"WEBP" at byte 8
+    ],
+    [
+        { bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 }, // "ftyp" after the box-size prefix…
+        { bytes: [0x61, 0x76, 0x69], offset: 8 }, // …"avi" brand at byte 8 (covers both "avif" and "avis")
+    ],
+];
+
+/**
+ * Sniffs the first bytes of a file for a known image format's magic number,
+ * for the case `file.type` is empty — a drag-and-drop from some file managers,
+ * a camera-roll export, anything the OS's extension-to-MIME table has no entry
+ * for. An empty `type` used to bypass the check entirely, letting arbitrary
+ * bytes through under any file name.
+ *
+ * This is still only a client-side courtesy, exactly like the `ACCEPTED_TYPES`
+ * check it extends: the server must re-validate every upload regardless of
+ * what either check reports.
+ */
+const sniffImageType = async (file: File): Promise<boolean> => {
+    const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+    const runMatches = (run: MagicRun): boolean => run.bytes.every((byte, index) => header[run.offset + index] === byte);
+
+    return MAGIC_SIGNATURES.some((signature) => signature.every((run) => runMatches(run)));
+};
+
+/**
+ * Whether a picked file passes the client-side image check: accept-list when
+ * the browser reports a type, magic-byte sniff when it doesn't. Shared by the
+ * avatar and organization-logo controllers so the empty-`type` handling can't
+ * drift between the two copies again — see {@link sniffImageType}'s docblock
+ * for why an empty `type` isn't a green light.
+ */
+const isAcceptedImage = async (file: File): Promise<boolean> => (file.type === "" ? sniffImageType(file) : ACCEPTED_TYPES.has(file.type));
+
 const createAvatarUploadController = (context: ControllerContext, options: { initialImage?: string } = {}): AvatarUploadController => {
     const store = createStore<AvatarUploadState>({ imageUrl: options.initialImage, status: "idle" });
 
@@ -83,7 +137,11 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;
@@ -110,4 +168,4 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
 };
 
 export type { AvatarUploadActions, AvatarUploadController, AvatarUploadState };
-export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController };
+export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController, isAcceptedImage };

--- a/registry/auth-ui-solid/core/create-resource-controller.ts
+++ b/registry/auth-ui-solid/core/create-resource-controller.ts
@@ -83,20 +83,41 @@ const createResourceController = <T, TExtra extends object = Record<never, never
         status: "idle",
     });
 
+    /*
+     * Which `refetch` is current. A search box firing a query per keystroke can
+     * have a slow answer for an early prefix land after a fast answer for the
+     * full query — without a ticket, the stale prefix result would overwrite
+     * the correct one an admin is already looking at. Mirrors
+     * `createFormController.load`'s `generation`.
+     */
+    let generation = 0;
+
     const refetch = async (): Promise<void> => {
+        generation += 1;
+
+        const ticket = generation;
+
         store.update({ error: undefined, loading: true, status: "submitting" });
 
         try {
             const result = await load(context, store.get().extra);
-            // A loader that needs no extra state just returns the array.
-            const { extra: patched, items } = Array.isArray(result) ? { extra: undefined, items: result } : result;
+
+            if (ticket !== generation) {
+                return;
+            }
+
+            const { extra: patched, items } = result;
 
             store.update({ items, loading: false, status: "success" });
 
             if (patched !== undefined) {
-                store.update(patched);
+                store.update({ extra: { ...store.get().extra, ...patched } });
             }
         } catch (error) {
+            if (ticket !== generation) {
+                return;
+            }
+
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.genericError), loading: false, status: "error" });
         }

--- a/registry/auth-ui-solid/core/invitations.ts
+++ b/registry/auth-ui-solid/core/invitations.ts
@@ -15,6 +15,7 @@ import type { ControllerContext } from "./config";
 import type { ResourceState } from "./create-resource-controller";
 import { createResourceController } from "./create-resource-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { mergeQuery } from "./redirect-to";
 import { createStore } from "./store";
 import type { AuthInvitationDetail, Controller, FlowStatus } from "./types";
 
@@ -94,13 +95,17 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
                  * somewhere else entirely.
                  */
                 const invited = store.get().invitation?.email;
-                const target = new URLSearchParams({ redirectTo: currentPath() });
+                const parameters: Record<string, string> = { redirectTo: currentPath() };
 
                 if (invited !== undefined && invited !== "") {
-                    target.set("email", invited);
+                    parameters.email = invited;
                 }
 
-                context.nav.replace(`${context.redirects.signIn}?${target.toString()}`);
+                // Merged rather than appended: an app whose `redirects.signIn`
+                // already carries a query (e.g. `/auth?tab=sign-in`, common when
+                // hosting every screen on one `AuthView` route) would otherwise
+                // get a mangled second `?` and lose the invitation on sign-in.
+                context.nav.replace(mergeQuery(context.redirects.signIn, parameters));
 
                 return;
             }

--- a/registry/auth-ui-solid/core/localization.ts
+++ b/registry/auth-ui-solid/core/localization.ts
@@ -33,6 +33,7 @@ interface Localization {
     avatarUploadFailed: string;
     avatarWrongType: string;
     backToSignIn: string;
+    backupCodeLabel: string;
     backupCodes: string;
     backupCodeSignIn: string;
     backupCodesRegenerate: string;
@@ -133,6 +134,7 @@ interface Localization {
     remove: string;
     resetPassword: string;
     resetPasswordDone: string;
+    resetPasswordOtpDescription: string;
     revoke: string;
     revokeAccess: string;
     revokeOthers: string;
@@ -165,6 +167,7 @@ interface Localization {
     twoFactorScan: string;
     twoFactorSecret: string;
     twoFactorSetup: string;
+    twoFactorUseAuthenticator: string;
     /** Fallback when a session has neither a user-agent nor an IP. */
     unknownDevice: string;
     usernameAvailable: string;
@@ -206,6 +209,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     avatarUploadFailed: "Could not upload that image. Try again.",
     avatarWrongType: "Choose a PNG, JPEG, WebP, GIF, or AVIF image.",
     backToSignIn: "Back to sign in",
+    backupCodeLabel: "Backup code",
     backupCodes: "Save these backup codes somewhere safe:",
     backupCodeSignIn: "Use a backup code",
     backupCodesRegenerate: "Regenerate backup codes",
@@ -306,6 +310,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     remove: "Remove",
     resetPassword: "Set new password",
     resetPasswordDone: "Your password has been updated. You can sign in now.",
+    resetPasswordOtpDescription: "Enter the code we emailed you, then choose a new password.",
     revoke: "Revoke",
     revokeAccess: "Revoke access",
     revokeOthers: "Sign out other sessions",
@@ -335,9 +340,10 @@ const DEFAULT_LOCALIZATION: Localization = {
     twoFactorEnabled: "Two-factor authentication is on.",
     twoFactorFailed: "That code is not valid. Try again.",
     twoFactorNeedsPassword: "Set a password before turning on two-factor authentication.",
-    twoFactorScan: "Scan this with your authenticator app, then enter the 6-digit code.",
-    twoFactorSecret: "Or enter this key manually:",
+    twoFactorScan: "Add this account to your authenticator app using the setup key below, then enter the 6-digit code it generates.",
+    twoFactorSecret: "Setup key:",
     twoFactorSetup: "Two-factor authentication",
+    twoFactorUseAuthenticator: "Use your authenticator app instead",
     unknownDevice: "Unknown device",
     usernameAvailable: "That username is available.",
     usernameChecking: "Checking…",

--- a/registry/auth-ui-solid/core/magic-link.ts
+++ b/registry/auth-ui-solid/core/magic-link.ts
@@ -2,6 +2,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import type { FormController } from "./types";
 import { email as validateEmail } from "./validators";
 
@@ -16,7 +17,7 @@ const createMagicLinkController = (context: ControllerContext): FormController<M
         submit: async (values, context_) => {
             assertOk(
                 await context_.authClient.signIn.magicLink({
-                    callbackURL: context_.redirects.afterSignIn,
+                    callbackURL: resolveAfterSignIn(context_.redirects.afterSignIn),
                     email: values.email.trim(),
                 }),
             );

--- a/registry/auth-ui-solid/core/one-tap.ts
+++ b/registry/auth-ui-solid/core/one-tap.ts
@@ -13,6 +13,7 @@
  * working exactly as intended, so they only reach `onError`.
  */
 import type { ControllerContext } from "./config";
+import { resolveAfterSignIn } from "./redirect-to";
 
 /**
  * Show the One Tap prompt, if the browser and the user's Google session allow.
@@ -21,7 +22,7 @@ import type { ControllerContext } from "./config";
  */
 const promptOneTap = async (context: ControllerContext): Promise<void> => {
     try {
-        await context.authClient.oneTap({ callbackURL: context.redirects.afterSignIn });
+        await context.authClient.oneTap({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn) });
         context.onSessionChange?.();
     } catch (error) {
         context.onError?.(error);

--- a/registry/auth-ui-solid/core/organization-logo.ts
+++ b/registry/auth-ui-solid/core/organization-logo.ts
@@ -11,7 +11,7 @@
  * `updateUser` — and folding both into one would mean a controller that takes a
  * discriminator and branches on it in three places.
  */
-import { ACCEPTED_TYPES } from "./avatar";
+import { isAcceptedImage } from "./avatar";
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
 import { createStore } from "./store";
@@ -85,7 +85,11 @@ const createOrganizationLogoController = (context: ControllerContext, options: L
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;

--- a/registry/auth-ui-solid/core/redirect-to.ts
+++ b/registry/auth-ui-solid/core/redirect-to.ts
@@ -72,6 +72,26 @@ const readRedirectTo = (parameter = "redirectTo"): string | undefined => {
 const resolveAfterSignIn = (fallback: string): string => readRedirectTo() ?? fallback;
 
 /**
+ * Merge `parameters` into `path`'s existing query.
+ *
+ * Parsed rather than appended: blindly appending a second `?` mangles the URL
+ * (its own parameters become part of the *first* query's last value), and
+ * `URLSearchParams.set` overwrites rather than duplicating a key that already
+ * exists — so a caller-supplied value always wins over whatever `path` already
+ * carried, never silently loses to a second occurrence.
+ */
+const mergeQuery = (path: string, parameters: Readonly<Record<string, string>>): string => {
+    const [base, existing = ""] = path.split("?");
+    const merged = new URLSearchParams(existing);
+
+    for (const [key, value] of Object.entries(parameters)) {
+        merged.set(key, value);
+    }
+
+    return `${base ?? path}?${merged.toString()}`;
+};
+
+/**
  * Carry `redirectTo` onto an intermediate step's URL.
  *
  * Sign-in can hand off to a second factor before it finishes, and that hop is a
@@ -88,17 +108,12 @@ const withRedirectTo = (path: string): string => {
     }
 
     /*
-     * Parsed rather than appended: an app whose `redirects.twoFactor` already
+     * Merged rather than appended: an app whose `redirects.twoFactor` already
      * carries a `redirectTo` would otherwise end up with two, and
      * `URLSearchParams.get` returns the first — so the configured value would
      * win over the invitation target this function exists to carry.
      */
-    const [base, existing = ""] = path.split("?");
-    const parameters = new URLSearchParams(existing);
-
-    parameters.set("redirectTo", target);
-
-    return `${base ?? path}?${parameters.toString()}`;
+    return mergeQuery(path, { redirectTo: target });
 };
 
-export { isSafeRedirect, readRedirectTo, resolveAfterSignIn, withRedirectTo };
+export { isSafeRedirect, mergeQuery, readRedirectTo, resolveAfterSignIn, withRedirectTo };

--- a/registry/auth-ui-solid/core/social.ts
+++ b/registry/auth-ui-solid/core/social.ts
@@ -9,10 +9,11 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInWithSocial = async (context: ControllerContext, provider: string): Promise<void> => {
     try {
-        assertOk(await context.authClient.signIn.social({ callbackURL: context.redirects.afterSignIn, provider }));
+        assertOk(await context.authClient.signIn.social({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn), provider }));
     } catch (error) {
         // A failed social redirect leaves the user on the same page with no
         // explanation, so this is one of the paths that needs a toast.

--- a/registry/auth-ui-solid/solid/auth-cards.tsx
+++ b/registry/auth-ui-solid/solid/auth-cards.tsx
@@ -1,13 +1,16 @@
 import type { JSX } from "solid-js";
-import { Show } from "solid-js";
+import { createSignal, Show } from "solid-js";
 
 import { signInAnonymously } from "../core/anonymous";
+import { createBackupCodeSignInController } from "../core/backup-codes";
+import { queryParameter } from "../core/browser-location";
 import { createEmailOtpController } from "../core/email-otp";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createForgotPasswordController } from "../core/forgot-password";
 import { readLastLoginMethod } from "../core/last-login-method";
 import { createMagicLinkController } from "../core/magic-link";
 import { createResetPasswordController } from "../core/reset-password";
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import { createSignInController } from "../core/sign-in";
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
@@ -55,7 +58,7 @@ const SignInCard = (props: SignInCardProps = {}): JSX.Element => {
     const lastUsed = readLastLoginMethod();
 
     return (
-        <AuthCard footer={<AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink>} title={t.signIn}>
+        <AuthCard footer={context.signUp ? <AuthLink href={props.signUpHref ?? "/sign-up"}>{t.noAccount}</AuthLink> : undefined} title={t.signIn}>
             <SocialButtons
                 lastUsed={context.plugins.lastLoginMethod ? lastUsed : undefined}
                 onSelect={(provider) => {
@@ -119,6 +122,14 @@ const SignUpCard = (props: SignUpCardProps = {}): JSX.Element => {
     const context = useAuthUI();
     const { localization: t, social } = context;
     const [state, actions] = createController(createSignUpController);
+
+    // The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+    // Mirrors the plugin-gated cards above: mounted directly, this card renders
+    // nothing rather than a form that will fail on submit; `AuthView`'s route
+    // falls back to the sign-in card instead of landing on a blank page.
+    if (!context.signUp) {
+        return null;
+    }
 
     return (
         <AuthCard footer={<AuthLink href={props.signInHref ?? "/sign-in"}>{t.haveAccount}</AuthLink>} title={t.signUp}>
@@ -217,18 +228,89 @@ const ForgotPasswordCard = (props: ForgotPasswordCardProps = {}): JSX.Element =>
 };
 
 interface ResetPasswordCardProps {
-    /** The reset token from the URL (`?token=...`). */
+    /** Defaults to `?token=` from the URL. */
     token?: string;
 }
 
 const ResetPasswordCard = (props: ResetPasswordCardProps = {}): JSX.Element => {
     const { localization: t } = useAuthUI();
-    const [state, actions] = createController((context) => createResetPasswordController(context, { token: props.token }));
+    const [state, actions] = createController((context) => createResetPasswordController(context, { token: props.token ?? queryParameter("token") }));
 
     return (
         <AuthCard title={t.resetPassword}>
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.password}
+                    label={t.passwordLabel}
+                    name="password"
+                    onBlur={() => {
+                        actions.blur("password");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("password", value);
+                    }}
+                    type="password"
+                />
+                <Field
+                    autoComplete="new-password"
+                    field={state.fields.confirmPassword}
+                    label={t.confirmPasswordLabel}
+                    name="confirmPassword"
+                    onBlur={() => {
+                        actions.blur("confirmPassword");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("confirmPassword", value);
+                    }}
+                    type="password"
+                />
+                <SubmitButton pending={state.status === "submitting"}>{t.resetPassword}</SubmitButton>
+            </form>
+        </AuthCard>
+    );
+};
+
+/**
+ * Redeems an emailed one-time code instead of a link — for apps that set
+ * `forgotPassword: { method: "otp" }`. Unlike {@link ResetPasswordCard}, the
+ * email address is a field rather than something carried from the previous
+ * screen: a code can legitimately be redeemed from a fresh tab.
+ */
+const ResetPasswordOtpCard = (): JSX.Element => {
+    const { localization: t } = useAuthUI();
+    const [state, actions] = createController((context) => createResetPasswordOtpController(context));
+
+    return (
+        <AuthCard description={t.resetPasswordOtpDescription} title={t.resetPassword}>
+            <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
+                <FormBanner error={state.formError} success={state.successMessage} />
+                <Field
+                    autoComplete="email"
+                    field={state.fields.email}
+                    label={t.emailLabel}
+                    name="email"
+                    onBlur={() => {
+                        actions.blur("email");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("email", value);
+                    }}
+                    type="email"
+                />
+                <Field
+                    autoComplete="one-time-code"
+                    field={state.fields.otp}
+                    label={t.codeLabel}
+                    name="otp"
+                    onBlur={() => {
+                        actions.blur("otp");
+                    }}
+                    onChange={(value) => {
+                        actions.setField("otp", value);
+                    }}
+                />
                 <Field
                     autoComplete="new-password"
                     field={state.fields.password}
@@ -364,32 +446,86 @@ const TwoFactorCard = (props: TwoFactorCardProps = {}): JSX.Element => {
     const [state, actions] = createController((context_) =>
         createTwoFactorVerifyController(context_, { method: props.method, trustDevice: props.trustDevice }),
     );
+    // Both controllers stay live regardless of which form is showing — a
+    // session-mutating submit must not depend on the toggle's current position.
+    const [backupState, backupActions] = createController((context_) => createBackupCodeSignInController(context_, { trustDevice: props.trustDevice }));
+    const [useBackupCode, setUseBackupCode] = createSignal(false);
 
     if (!isFlowEnabled(context, "twoFactor", "TwoFactorCard")) {
         return null;
     }
 
     return (
-        <AuthCard title={t.twoFactor}>
-            <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
-                <FormBanner error={state.formError} />
-                <Field
-                    autoComplete="one-time-code"
-                    field={state.fields.code}
-                    label={t.codeLabel}
-                    name="code"
-                    onBlur={() => {
-                        actions.blur("code");
-                    }}
-                    onChange={(value) => {
-                        actions.setField("code", value);
-                    }}
-                />
-                <SubmitButton pending={state.status === "submitting"}>{t.twoFactor}</SubmitButton>
-            </form>
-        </AuthCard>
+        <Show
+            fallback={
+                <AuthCard
+                    footer={
+                        <button
+                            class="lunora-auth-link"
+                            onClick={() => {
+                                setUseBackupCode(true);
+                            }}
+                            type="button"
+                        >
+                            {t.backupCodeSignIn}
+                        </button>
+                    }
+                    title={t.twoFactor}
+                >
+                    <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
+                        <FormBanner error={state.formError} />
+                        <Field
+                            autoComplete="one-time-code"
+                            field={state.fields.code}
+                            label={t.codeLabel}
+                            name="code"
+                            onBlur={() => {
+                                actions.blur("code");
+                            }}
+                            onChange={(value) => {
+                                actions.setField("code", value);
+                            }}
+                        />
+                        <SubmitButton pending={state.status === "submitting"}>{t.twoFactor}</SubmitButton>
+                    </form>
+                </AuthCard>
+            }
+            when={useBackupCode()}
+        >
+            <AuthCard
+                footer={
+                    <button
+                        class="lunora-auth-link"
+                        onClick={() => {
+                            setUseBackupCode(false);
+                        }}
+                        type="button"
+                    >
+                        {t.twoFactorUseAuthenticator}
+                    </button>
+                }
+                title={t.twoFactor}
+            >
+                <form class="lunora-auth-form" noValidate onSubmit={onSubmit(backupActions.submit)}>
+                    <FormBanner error={backupState.formError} />
+                    <Field
+                        autoComplete="one-time-code"
+                        field={backupState.fields.code}
+                        label={t.backupCodeLabel}
+                        name="code"
+                        onBlur={() => {
+                            backupActions.blur("code");
+                        }}
+                        onChange={(value) => {
+                            backupActions.setField("code", value);
+                        }}
+                    />
+                    <SubmitButton pending={backupState.status === "submitting"}>{t.twoFactor}</SubmitButton>
+                </form>
+            </AuthCard>
+        </Show>
     );
 };
 
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps };
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard };
+export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard };

--- a/registry/auth-ui-solid/solid/auth-view.tsx
+++ b/registry/auth-ui-solid/solid/auth-view.tsx
@@ -4,7 +4,7 @@ import { Match, Show, Switch } from "solid-js";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createPhoneSignInController } from "../core/phone-number";
 import { createUsernameSignInController } from "../core/username";
-import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+import { EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, ResetPasswordOtpCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
 import { DeviceAuthorizationCard } from "./plugin-cards";
 import { AuthCard, Field, FormBanner, SubmitButton } from "./primitives";
 import { useAuthUI } from "./provider";
@@ -123,7 +123,7 @@ interface AuthViewProps {
 }
 
 const AuthView = (props: AuthViewProps = {}): JSX.Element => {
-    const { plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = useAuthUI();
 
     /*
      * Plugin-gated views are checked here rather than left to the card's own
@@ -159,10 +159,14 @@ const AuthView = (props: AuthViewProps = {}): JSX.Element => {
                 </Show>
             </Match>
             <Match when={props.view === viewPaths.resetPassword}>
-                <ResetPasswordCard />
+                <Show fallback={<ResetPasswordCard />} when={forgotPasswordMethod === "otp"}>
+                    <ResetPasswordOtpCard />
+                </Show>
             </Match>
             <Match when={props.view === viewPaths.signUp}>
-                <SignUpCard />
+                <Show fallback={<SignInCard />} when={signUp}>
+                    <SignUpCard />
+                </Show>
             </Match>
             <Match when={props.view === viewPaths.twoFactor}>
                 <Show fallback={<SignInCard />} when={plugins.twoFactor}>

--- a/registry/auth-ui-solid/solid/index.ts
+++ b/registry/auth-ui-solid/solid/index.ts
@@ -17,7 +17,17 @@ export * from "../core";
  */
 export { AppearanceCard, AvatarCard, LinkedAccountsCard, SetUsernameCard } from "./account-cards";
 export type { ForgotPasswordCardProps, MagicLinkCardProps, ResetPasswordCardProps, SignInCardProps, SignUpCardProps, TwoFactorCardProps } from "./auth-cards";
-export { AnonymousButton, EmailOtpCard, ForgotPasswordCard, MagicLinkCard, ResetPasswordCard, SignInCard, SignUpCard, TwoFactorCard } from "./auth-cards";
+export {
+    AnonymousButton,
+    EmailOtpCard,
+    ForgotPasswordCard,
+    MagicLinkCard,
+    ResetPasswordCard,
+    ResetPasswordOtpCard,
+    SignInCard,
+    SignUpCard,
+    TwoFactorCard,
+} from "./auth-cards";
 export type { AuthViewProps } from "./auth-view";
 export { AuthView, PhoneSignInCard, UsernameSignInCard } from "./auth-view";
 export type { CaptchaProps, OrganizationLogoCardProps } from "./extras";

--- a/registry/auth-ui-solid/solid/organization.tsx
+++ b/registry/auth-ui-solid/solid/organization.tsx
@@ -45,7 +45,7 @@ const OrganizationsCard = (): JSX.Element => {
     };
 
     return (
-        <AuthCard title={t.organizations}>
+        <AuthCard headingLevel={2} title={t.organizations}>
             <FormBanner error={state.error} />
             <Show
                 fallback={
@@ -153,7 +153,7 @@ const MembersCard = (): JSX.Element => {
     };
 
     return (
-        <AuthCard title={t.members}>
+        <AuthCard headingLevel={2} title={t.members}>
             <FormBanner error={state.error} />
 
             <Show
@@ -275,7 +275,7 @@ const OrganizationSettingsCard = (props: OrganizationSettingsCardProps = {}): JS
     }
 
     return (
-        <AuthCard title={t.organizationSettings}>
+        <AuthCard headingLevel={2} title={t.organizationSettings}>
             <Show fallback={<p class="lunora-auth-card__description">…</p>} when={!state.loading}>
                 <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                     <FormBanner error={state.formError} success={state.successMessage} />

--- a/registry/auth-ui-solid/solid/primitives.tsx
+++ b/registry/auth-ui-solid/solid/primitives.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "solid-js";
 import { createUniqueId, For, Index, Show } from "solid-js";
+import { Dynamic } from "solid-js/web";
 
 import { providerLabel } from "../core/labels";
 import type { PasswordRequirement } from "../core/password-policy";
@@ -13,6 +14,13 @@ interface AuthCardProps {
     children: JSX.Element;
     description?: string;
     footer?: JSX.Element;
+
+    /**
+     * The title's heading level (default 1) — see the React `AuthCard`'s doc
+     * comment for why a settings/organization composition passes `2` rather
+     * than letting every card render an `h1`.
+     */
+    headingLevel?: 1 | 2 | 3;
     title: string;
 }
 
@@ -30,7 +38,9 @@ const themeStyle = (): Record<string, string> | undefined => {
 const AuthCard = (props: AuthCardProps): JSX.Element => (
     <section class="lunora-auth-card" style={themeStyle()}>
         <header class="lunora-auth-card__header">
-            <h1 class="lunora-auth-card__title">{props.title}</h1>
+            <Dynamic class="lunora-auth-card__title" component={`h${String(props.headingLevel ?? 1)}` as "h1" | "h2" | "h3"}>
+                {props.title}
+            </Dynamic>
             <Show when={props.description !== undefined}>
                 <p class="lunora-auth-card__description">{props.description}</p>
             </Show>

--- a/registry/auth-ui-solid/solid/settings-cards.tsx
+++ b/registry/auth-ui-solid/solid/settings-cards.tsx
@@ -34,7 +34,7 @@ const ProfileCard = (props: ProfileCardProps = {}): JSX.Element => {
     );
 
     return (
-        <AuthCard title={t.profile}>
+        <AuthCard headingLevel={2} title={t.profile}>
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <Field
@@ -60,7 +60,7 @@ const ChangeEmailCard = (): JSX.Element => {
     const [state, actions] = createController(createChangeEmailController);
 
     return (
-        <AuthCard title={t.changeEmail}>
+        <AuthCard headingLevel={2} title={t.changeEmail}>
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <Field
@@ -87,7 +87,7 @@ const ChangePasswordCard = (): JSX.Element => {
     const [state, actions] = createController(createChangePasswordController);
 
     return (
-        <AuthCard title={t.changePassword}>
+        <AuthCard headingLevel={2} title={t.changePassword}>
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} success={state.successMessage} />
                 <Field
@@ -140,7 +140,7 @@ const DeleteAccountCard = (): JSX.Element => {
     const [state, actions] = createController(createDeleteAccountController);
 
     return (
-        <AuthCard description={t.deleteAccountWarning} title={t.deleteAccount}>
+        <AuthCard description={t.deleteAccountWarning} headingLevel={2} title={t.deleteAccount}>
             <form class="lunora-auth-form" noValidate onSubmit={onSubmit(actions.submit)}>
                 <FormBanner error={state.formError} />
                 <Field
@@ -167,7 +167,7 @@ const SessionsCard = (): JSX.Element => {
     const [state, actions] = createController(createSessionsController);
 
     return (
-        <AuthCard title={t.sessions}>
+        <AuthCard headingLevel={2} title={t.sessions}>
             <FormBanner error={state.error} />
             <Show
                 fallback={
@@ -237,7 +237,7 @@ const PasskeysCard = (): JSX.Element => {
     }
 
     return (
-        <AuthCard title={t.passkeys}>
+        <AuthCard headingLevel={2} title={t.passkeys}>
             <FormBanner error={state.error} />
             <Show fallback={<p class="lunora-auth-card__description">…</p>} when={!state.loading}>
                 <Show fallback={<p class="lunora-auth-card__description">{t.passkeysEmpty}</p>} when={state.items.length > 0}>

--- a/registry/auth-ui-solid/solid/two-factor-setup-card.tsx
+++ b/registry/auth-ui-solid/solid/two-factor-setup-card.tsx
@@ -2,7 +2,7 @@ import type { JSX } from "solid-js";
 import { For, Show } from "solid-js";
 
 import { isFlowEnabled } from "../core/flow-gate";
-import { createTwoFactorSetupController } from "../core/two-factor-setup";
+import { createTwoFactorSetupController, totpSecret } from "../core/two-factor-setup";
 import { AuthCard, Field, FormBanner, SubmitButton } from "./primitives";
 import { useAuthUI } from "./provider";
 import { createController } from "./use-controller";
@@ -48,8 +48,16 @@ const TwoFactorSetupCard = (): JSX.Element => {
                 >
                     <AuthCard description={t.twoFactorScan} title={t.twoFactorSetup}>
                         <FormBanner error={state.error} />
-                        <Show when={state.totpUri !== undefined}>
-                            <code class="lunora-auth-code">{state.totpUri}</code>
+                        {/*
+                         * The setup key, not the raw `otpauth://…` URI: this
+                         * package ships no QR encoder, so there is nothing to
+                         * scan, and most authenticators reject a pasted
+                         * `otpauth://…` string anyway — the key is the only
+                         * path that reliably works.
+                         */}
+                        <Show when={totpSecret(state.totpUri) !== undefined}>
+                            <p class="lunora-auth-note">{t.twoFactorSecret}</p>
+                            <code class="lunora-auth-code">{totpSecret(state.totpUri)}</code>
                         </Show>
                         <Show when={state.backupCodes.length > 0}>
                             <p class="lunora-auth-card__description">{t.backupCodes}</p>

--- a/registry/auth-ui-svelte/core/admin-users.ts
+++ b/registry/auth-ui-svelte/core/admin-users.ts
@@ -50,6 +50,8 @@ type AdminUsersController = Controller<AdminUsersState, AdminUsersActions>;
 
 interface AdminUsersOptions {
     autoLoad?: boolean;
+    /** Milliseconds to wait after the last keystroke before re-querying. Defaults to 300. */
+    debounceMs?: number;
     limit?: number;
 }
 
@@ -84,6 +86,16 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
         { autoLoad: options.autoLoad, initialExtra: { search: "" } },
     );
 
+    const debounceMs = options.debounceMs ?? 300;
+    let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearSearchTimer = (): void => {
+        if (searchTimer !== undefined) {
+            clearTimeout(searchTimer);
+            searchTimer = undefined;
+        }
+    };
+
     /**
      * Navigate only when the mutation actually ran and succeeded.
      *
@@ -108,14 +120,31 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
             refetch: resource.refetch,
             remove: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.removeUser({ userId }))),
             setRole: (userId: string, role: string) => resource.mutate(async () => assertOk(await context.authClient.admin.setRole({ role, userId }))),
-            setSearch: async (value: string) => {
+            setSearch: (value: string) => {
+                // The field itself updates at once (it's controlled off
+                // `state.extra.search`) — only the network `refetch` is debounced,
+                // or every keystroke would fire `admin.listUsers`.
                 resource.patch({ search: value });
-                await resource.refetch();
+                clearSearchTimer();
+
+                if (typeof setTimeout !== "function") {
+                    return resource.refetch();
+                }
+
+                return new Promise<void>((resolve) => {
+                    searchTimer = setTimeout(() => {
+                        searchTimer = undefined;
+                        resolve(resource.refetch());
+                    }, debounceMs);
+                });
             },
             stopImpersonating: () => afterSessionSwap(async () => resource.mutateOk(async () => assertOk(await context.authClient.admin.stopImpersonating()))),
             unban: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.unbanUser({ userId }))),
         },
-        destroy: resource.destroy,
+        destroy: () => {
+            clearSearchTimer();
+            resource.destroy();
+        },
         getState: resource.getState,
         subscribe: resource.subscribe,
     };

--- a/registry/auth-ui-svelte/core/avatar.ts
+++ b/registry/auth-ui-svelte/core/avatar.ts
@@ -39,6 +39,60 @@ type AvatarUploadController = Controller<AvatarUploadState, AvatarUploadActions>
 /** Human-readable size for the too-big message, in whole MB. */
 const megabytes = (bytes: number): string => `${String(Math.round((bytes / (1024 * 1024)) * 10) / 10)} MB`;
 
+/** One byte run a signature requires at a given offset into the file. */
+interface MagicRun {
+    bytes: ReadonlyArray<number>;
+    offset: number;
+}
+
+/**
+ * Magic-number signatures for the {@link ACCEPTED_TYPES} formats. Most formats
+ * are one contiguous run at offset 0; WebP and AVIF need two non-contiguous
+ * runs (a container header, then a fixed marker further in), so a signature is
+ * a list of runs that must ALL match — never just the first, or a signature
+ * would accept any RIFF-family file (WAV, AVI, …) as WebP.
+ */
+const MAGIC_SIGNATURES: ReadonlyArray<ReadonlyArray<MagicRun>> = [
+    [{ bytes: [0x89, 0x50, 0x4e, 0x47], offset: 0 }], // PNG
+    [{ bytes: [0xff, 0xd8, 0xff], offset: 0 }], // JPEG
+    [{ bytes: [0x47, 0x49, 0x46, 0x38], offset: 0 }], // GIF ("GIF8")
+    [
+        { bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 }, // "RIFF"…
+        { bytes: [0x57, 0x45, 0x42, 0x50], offset: 8 }, // …"WEBP" at byte 8
+    ],
+    [
+        { bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 }, // "ftyp" after the box-size prefix…
+        { bytes: [0x61, 0x76, 0x69], offset: 8 }, // …"avi" brand at byte 8 (covers both "avif" and "avis")
+    ],
+];
+
+/**
+ * Sniffs the first bytes of a file for a known image format's magic number,
+ * for the case `file.type` is empty — a drag-and-drop from some file managers,
+ * a camera-roll export, anything the OS's extension-to-MIME table has no entry
+ * for. An empty `type` used to bypass the check entirely, letting arbitrary
+ * bytes through under any file name.
+ *
+ * This is still only a client-side courtesy, exactly like the `ACCEPTED_TYPES`
+ * check it extends: the server must re-validate every upload regardless of
+ * what either check reports.
+ */
+const sniffImageType = async (file: File): Promise<boolean> => {
+    const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+    const runMatches = (run: MagicRun): boolean => run.bytes.every((byte, index) => header[run.offset + index] === byte);
+
+    return MAGIC_SIGNATURES.some((signature) => signature.every((run) => runMatches(run)));
+};
+
+/**
+ * Whether a picked file passes the client-side image check: accept-list when
+ * the browser reports a type, magic-byte sniff when it doesn't. Shared by the
+ * avatar and organization-logo controllers so the empty-`type` handling can't
+ * drift between the two copies again — see {@link sniffImageType}'s docblock
+ * for why an empty `type` isn't a green light.
+ */
+const isAcceptedImage = async (file: File): Promise<boolean> => (file.type === "" ? sniffImageType(file) : ACCEPTED_TYPES.has(file.type));
+
 const createAvatarUploadController = (context: ControllerContext, options: { initialImage?: string } = {}): AvatarUploadController => {
     const store = createStore<AvatarUploadState>({ imageUrl: options.initialImage, status: "idle" });
 
@@ -83,7 +137,11 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;
@@ -110,4 +168,4 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
 };
 
 export type { AvatarUploadActions, AvatarUploadController, AvatarUploadState };
-export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController };
+export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController, isAcceptedImage };

--- a/registry/auth-ui-svelte/core/create-resource-controller.ts
+++ b/registry/auth-ui-svelte/core/create-resource-controller.ts
@@ -83,20 +83,41 @@ const createResourceController = <T, TExtra extends object = Record<never, never
         status: "idle",
     });
 
+    /*
+     * Which `refetch` is current. A search box firing a query per keystroke can
+     * have a slow answer for an early prefix land after a fast answer for the
+     * full query — without a ticket, the stale prefix result would overwrite
+     * the correct one an admin is already looking at. Mirrors
+     * `createFormController.load`'s `generation`.
+     */
+    let generation = 0;
+
     const refetch = async (): Promise<void> => {
+        generation += 1;
+
+        const ticket = generation;
+
         store.update({ error: undefined, loading: true, status: "submitting" });
 
         try {
             const result = await load(context, store.get().extra);
-            // A loader that needs no extra state just returns the array.
-            const { extra: patched, items } = Array.isArray(result) ? { extra: undefined, items: result } : result;
+
+            if (ticket !== generation) {
+                return;
+            }
+
+            const { extra: patched, items } = result;
 
             store.update({ items, loading: false, status: "success" });
 
             if (patched !== undefined) {
-                store.update(patched);
+                store.update({ extra: { ...store.get().extra, ...patched } });
             }
         } catch (error) {
+            if (ticket !== generation) {
+                return;
+            }
+
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.genericError), loading: false, status: "error" });
         }

--- a/registry/auth-ui-svelte/core/invitations.ts
+++ b/registry/auth-ui-svelte/core/invitations.ts
@@ -15,6 +15,7 @@ import type { ControllerContext } from "./config";
 import type { ResourceState } from "./create-resource-controller";
 import { createResourceController } from "./create-resource-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { mergeQuery } from "./redirect-to";
 import { createStore } from "./store";
 import type { AuthInvitationDetail, Controller, FlowStatus } from "./types";
 
@@ -94,13 +95,17 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
                  * somewhere else entirely.
                  */
                 const invited = store.get().invitation?.email;
-                const target = new URLSearchParams({ redirectTo: currentPath() });
+                const parameters: Record<string, string> = { redirectTo: currentPath() };
 
                 if (invited !== undefined && invited !== "") {
-                    target.set("email", invited);
+                    parameters.email = invited;
                 }
 
-                context.nav.replace(`${context.redirects.signIn}?${target.toString()}`);
+                // Merged rather than appended: an app whose `redirects.signIn`
+                // already carries a query (e.g. `/auth?tab=sign-in`, common when
+                // hosting every screen on one `AuthView` route) would otherwise
+                // get a mangled second `?` and lose the invitation on sign-in.
+                context.nav.replace(mergeQuery(context.redirects.signIn, parameters));
 
                 return;
             }

--- a/registry/auth-ui-svelte/core/localization.ts
+++ b/registry/auth-ui-svelte/core/localization.ts
@@ -33,6 +33,7 @@ interface Localization {
     avatarUploadFailed: string;
     avatarWrongType: string;
     backToSignIn: string;
+    backupCodeLabel: string;
     backupCodes: string;
     backupCodeSignIn: string;
     backupCodesRegenerate: string;
@@ -133,6 +134,7 @@ interface Localization {
     remove: string;
     resetPassword: string;
     resetPasswordDone: string;
+    resetPasswordOtpDescription: string;
     revoke: string;
     revokeAccess: string;
     revokeOthers: string;
@@ -165,6 +167,7 @@ interface Localization {
     twoFactorScan: string;
     twoFactorSecret: string;
     twoFactorSetup: string;
+    twoFactorUseAuthenticator: string;
     /** Fallback when a session has neither a user-agent nor an IP. */
     unknownDevice: string;
     usernameAvailable: string;
@@ -206,6 +209,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     avatarUploadFailed: "Could not upload that image. Try again.",
     avatarWrongType: "Choose a PNG, JPEG, WebP, GIF, or AVIF image.",
     backToSignIn: "Back to sign in",
+    backupCodeLabel: "Backup code",
     backupCodes: "Save these backup codes somewhere safe:",
     backupCodeSignIn: "Use a backup code",
     backupCodesRegenerate: "Regenerate backup codes",
@@ -306,6 +310,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     remove: "Remove",
     resetPassword: "Set new password",
     resetPasswordDone: "Your password has been updated. You can sign in now.",
+    resetPasswordOtpDescription: "Enter the code we emailed you, then choose a new password.",
     revoke: "Revoke",
     revokeAccess: "Revoke access",
     revokeOthers: "Sign out other sessions",
@@ -335,9 +340,10 @@ const DEFAULT_LOCALIZATION: Localization = {
     twoFactorEnabled: "Two-factor authentication is on.",
     twoFactorFailed: "That code is not valid. Try again.",
     twoFactorNeedsPassword: "Set a password before turning on two-factor authentication.",
-    twoFactorScan: "Scan this with your authenticator app, then enter the 6-digit code.",
-    twoFactorSecret: "Or enter this key manually:",
+    twoFactorScan: "Add this account to your authenticator app using the setup key below, then enter the 6-digit code it generates.",
+    twoFactorSecret: "Setup key:",
     twoFactorSetup: "Two-factor authentication",
+    twoFactorUseAuthenticator: "Use your authenticator app instead",
     unknownDevice: "Unknown device",
     usernameAvailable: "That username is available.",
     usernameChecking: "Checking…",

--- a/registry/auth-ui-svelte/core/magic-link.ts
+++ b/registry/auth-ui-svelte/core/magic-link.ts
@@ -2,6 +2,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import type { FormController } from "./types";
 import { email as validateEmail } from "./validators";
 
@@ -16,7 +17,7 @@ const createMagicLinkController = (context: ControllerContext): FormController<M
         submit: async (values, context_) => {
             assertOk(
                 await context_.authClient.signIn.magicLink({
-                    callbackURL: context_.redirects.afterSignIn,
+                    callbackURL: resolveAfterSignIn(context_.redirects.afterSignIn),
                     email: values.email.trim(),
                 }),
             );

--- a/registry/auth-ui-svelte/core/one-tap.ts
+++ b/registry/auth-ui-svelte/core/one-tap.ts
@@ -13,6 +13,7 @@
  * working exactly as intended, so they only reach `onError`.
  */
 import type { ControllerContext } from "./config";
+import { resolveAfterSignIn } from "./redirect-to";
 
 /**
  * Show the One Tap prompt, if the browser and the user's Google session allow.
@@ -21,7 +22,7 @@ import type { ControllerContext } from "./config";
  */
 const promptOneTap = async (context: ControllerContext): Promise<void> => {
     try {
-        await context.authClient.oneTap({ callbackURL: context.redirects.afterSignIn });
+        await context.authClient.oneTap({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn) });
         context.onSessionChange?.();
     } catch (error) {
         context.onError?.(error);

--- a/registry/auth-ui-svelte/core/organization-logo.ts
+++ b/registry/auth-ui-svelte/core/organization-logo.ts
@@ -11,7 +11,7 @@
  * `updateUser` — and folding both into one would mean a controller that takes a
  * discriminator and branches on it in three places.
  */
-import { ACCEPTED_TYPES } from "./avatar";
+import { isAcceptedImage } from "./avatar";
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
 import { createStore } from "./store";
@@ -85,7 +85,11 @@ const createOrganizationLogoController = (context: ControllerContext, options: L
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;

--- a/registry/auth-ui-svelte/core/redirect-to.ts
+++ b/registry/auth-ui-svelte/core/redirect-to.ts
@@ -72,6 +72,26 @@ const readRedirectTo = (parameter = "redirectTo"): string | undefined => {
 const resolveAfterSignIn = (fallback: string): string => readRedirectTo() ?? fallback;
 
 /**
+ * Merge `parameters` into `path`'s existing query.
+ *
+ * Parsed rather than appended: blindly appending a second `?` mangles the URL
+ * (its own parameters become part of the *first* query's last value), and
+ * `URLSearchParams.set` overwrites rather than duplicating a key that already
+ * exists — so a caller-supplied value always wins over whatever `path` already
+ * carried, never silently loses to a second occurrence.
+ */
+const mergeQuery = (path: string, parameters: Readonly<Record<string, string>>): string => {
+    const [base, existing = ""] = path.split("?");
+    const merged = new URLSearchParams(existing);
+
+    for (const [key, value] of Object.entries(parameters)) {
+        merged.set(key, value);
+    }
+
+    return `${base ?? path}?${merged.toString()}`;
+};
+
+/**
  * Carry `redirectTo` onto an intermediate step's URL.
  *
  * Sign-in can hand off to a second factor before it finishes, and that hop is a
@@ -88,17 +108,12 @@ const withRedirectTo = (path: string): string => {
     }
 
     /*
-     * Parsed rather than appended: an app whose `redirects.twoFactor` already
+     * Merged rather than appended: an app whose `redirects.twoFactor` already
      * carries a `redirectTo` would otherwise end up with two, and
      * `URLSearchParams.get` returns the first — so the configured value would
      * win over the invitation target this function exists to carry.
      */
-    const [base, existing = ""] = path.split("?");
-    const parameters = new URLSearchParams(existing);
-
-    parameters.set("redirectTo", target);
-
-    return `${base ?? path}?${parameters.toString()}`;
+    return mergeQuery(path, { redirectTo: target });
 };
 
-export { isSafeRedirect, readRedirectTo, resolveAfterSignIn, withRedirectTo };
+export { isSafeRedirect, mergeQuery, readRedirectTo, resolveAfterSignIn, withRedirectTo };

--- a/registry/auth-ui-svelte/core/social.ts
+++ b/registry/auth-ui-svelte/core/social.ts
@@ -9,10 +9,11 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInWithSocial = async (context: ControllerContext, provider: string): Promise<void> => {
     try {
-        assertOk(await context.authClient.signIn.social({ callbackURL: context.redirects.afterSignIn, provider }));
+        assertOk(await context.authClient.signIn.social({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn), provider }));
     } catch (error) {
         // A failed social redirect leaves the user on the same page with no
         // explanation, so this is one of the paths that needs a toast.

--- a/registry/auth-ui-svelte/registry.json
+++ b/registry/auth-ui-svelte/registry.json
@@ -107,6 +107,7 @@
         { "from": "svelte/ProfileCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/ProfileCard.svelte" },
         { "from": "svelte/ResendVerificationCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/ResendVerificationCard.svelte" },
         { "from": "svelte/ResetPasswordCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/ResetPasswordCard.svelte" },
+        { "from": "svelte/ResetPasswordOtpCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/ResetPasswordOtpCard.svelte" },
         { "from": "svelte/SessionsCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/SessionsCard.svelte" },
         { "from": "svelte/SetUsernameCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/SetUsernameCard.svelte" },
         { "from": "svelte/SignInCard.svelte", "merge": "create-or-skip", "to": "lunora/auth-ui/svelte/SignInCard.svelte" },

--- a/registry/auth-ui-svelte/svelte/AuthCard.svelte
+++ b/registry/auth-ui-svelte/svelte/AuthCard.svelte
@@ -8,13 +8,22 @@
         children,
         description,
         footer,
+        headingLevel = 1,
         title,
     }: {
         children: Snippet;
         description?: string;
         footer?: Snippet;
+        /**
+         * The title's heading level (default 1) — see the React `AuthCard`'s
+         * doc comment for why a settings/organization composition passes `2`
+         * rather than letting every card render an `h1`.
+         */
+        headingLevel?: 1 | 2 | 3;
         title: string;
     } = $props();
+
+    const HeadingTag = $derived(`h${headingLevel}` as const);
 
     // Only set when the app configured `theme` — otherwise the app's own design
     // tokens keep flowing through untouched.
@@ -31,7 +40,7 @@
 
 <section class="lunora-auth-card" style={themeStyle}>
     <header class="lunora-auth-card__header">
-        <h1 class="lunora-auth-card__title">{title}</h1>
+        <svelte:element this={HeadingTag} class="lunora-auth-card__title">{title}</svelte:element>
         {#if description !== undefined}
             <p class="lunora-auth-card__description">{description}</p>
         {/if}

--- a/registry/auth-ui-svelte/svelte/AuthView.svelte
+++ b/registry/auth-ui-svelte/svelte/AuthView.svelte
@@ -15,6 +15,7 @@
     import ForgotPasswordCard from "./ForgotPasswordCard.svelte";
     import MagicLinkCard from "./MagicLinkCard.svelte";
     import ResetPasswordCard from "./ResetPasswordCard.svelte";
+    import ResetPasswordOtpCard from "./ResetPasswordOtpCard.svelte";
     import SignInCard from "./SignInCard.svelte";
     import SignUpCard from "./SignUpCard.svelte";
     import TwoFactorCard from "./TwoFactorCard.svelte";
@@ -27,7 +28,7 @@
         view?: string;
     } = $props();
 
-    const { plugins, viewPaths } = useAuthUI();
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = useAuthUI();
 </script>
 
 <!--
@@ -47,8 +48,12 @@
 {:else if view === viewPaths.magicLink && plugins.magicLink}
     <MagicLinkCard />
 {:else if view === viewPaths.resetPassword}
-    <ResetPasswordCard />
-{:else if view === viewPaths.signUp}
+    {#if forgotPasswordMethod === "otp"}
+        <ResetPasswordOtpCard />
+    {:else}
+        <ResetPasswordCard />
+    {/if}
+{:else if view === viewPaths.signUp && signUp}
     <SignUpCard />
 {:else if view === viewPaths.twoFactor && plugins.twoFactor}
     <TwoFactorCard />

--- a/registry/auth-ui-svelte/svelte/ChangeEmailCard.svelte
+++ b/registry/auth-ui-svelte/svelte/ChangeEmailCard.svelte
@@ -11,7 +11,7 @@
     const { actions, state: form } = controllerStore(createChangeEmailController);
 </script>
 
-<AuthCard title={t.changeEmail}>
+<AuthCard headingLevel={2} title={t.changeEmail}>
     <form
         class="lunora-auth-form"
         novalidate

--- a/registry/auth-ui-svelte/svelte/ChangePasswordCard.svelte
+++ b/registry/auth-ui-svelte/svelte/ChangePasswordCard.svelte
@@ -11,7 +11,7 @@
     const { actions, state: form } = controllerStore(createChangePasswordController);
 </script>
 
-<AuthCard title={t.changePassword}>
+<AuthCard headingLevel={2} title={t.changePassword}>
     <form
         class="lunora-auth-form"
         novalidate

--- a/registry/auth-ui-svelte/svelte/DeleteAccountCard.svelte
+++ b/registry/auth-ui-svelte/svelte/DeleteAccountCard.svelte
@@ -11,7 +11,7 @@
     const { actions, state: form } = controllerStore(createDeleteAccountController);
 </script>
 
-<AuthCard description={t.deleteAccountWarning} title={t.deleteAccount}>
+<AuthCard description={t.deleteAccountWarning} headingLevel={2} title={t.deleteAccount}>
     <form
         class="lunora-auth-form"
         novalidate

--- a/registry/auth-ui-svelte/svelte/ErrorToaster.svelte
+++ b/registry/auth-ui-svelte/svelte/ErrorToaster.svelte
@@ -30,23 +30,26 @@
 <!--
     `polite`, not `assertive`: these are failures the user can retry, not
     something that should interrupt a screen reader mid-sentence.
+
+    Mounted unconditionally — including with no toasts yet. A live region only
+    announces changes made AFTER it exists in the accessibility tree; gating
+    the whole wrapper on `toasts.length > 0` meant the very first toast landed
+    before assistive tech was watching the region, so it went unannounced.
 -->
-{#if toasts.length > 0}
-    <div aria-live="polite" class="lunora-auth-toaster">
-        {#each toasts as toast (toast.id)}
-            <div class="lunora-auth-toast" role="status">
-                <span class="lunora-auth-toast__message">{toast.message}</span>
-                <button
-                    aria-label="Dismiss"
-                    class="lunora-auth-toast__dismiss"
-                    onclick={() => {
-                        dismissToast(toast.id);
-                    }}
-                    type="button"
-                >
-                    ×
-                </button>
-            </div>
-        {/each}
-    </div>
-{/if}
+<div aria-live="polite" class="lunora-auth-toaster">
+    {#each toasts as toast (toast.id)}
+        <div class="lunora-auth-toast" role="status">
+            <span class="lunora-auth-toast__message">{toast.message}</span>
+            <button
+                aria-label="Dismiss"
+                class="lunora-auth-toast__dismiss"
+                onclick={() => {
+                    dismissToast(toast.id);
+                }}
+                type="button"
+            >
+                ×
+            </button>
+        </div>
+    {/each}
+</div>

--- a/registry/auth-ui-svelte/svelte/MembersCard.svelte
+++ b/registry/auth-ui-svelte/svelte/MembersCard.svelte
@@ -34,7 +34,7 @@
 </script>
 
 {#if enabled}
-    <AuthCard title={t.members}>
+    <AuthCard headingLevel={2} title={t.members}>
         <FormBanner error={$res.error} />
 
         {#if $res.loading}

--- a/registry/auth-ui-svelte/svelte/OrganizationSettingsCard.svelte
+++ b/registry/auth-ui-svelte/svelte/OrganizationSettingsCard.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if enabled}
-    <AuthCard title={t.organizationSettings}>
+    <AuthCard headingLevel={2} title={t.organizationSettings}>
         {#if $form.loading}
             <p class="lunora-auth-card__description">…</p>
         {:else}

--- a/registry/auth-ui-svelte/svelte/OrganizationsCard.svelte
+++ b/registry/auth-ui-svelte/svelte/OrganizationsCard.svelte
@@ -35,7 +35,7 @@
 </script>
 
 {#if enabled}
-    <AuthCard title={t.organizations}>
+    <AuthCard headingLevel={2} title={t.organizations}>
         <FormBanner error={$res.error} />
         {#if $res.loading}
             <p class="lunora-auth-card__description">…</p>

--- a/registry/auth-ui-svelte/svelte/PasskeysCard.svelte
+++ b/registry/auth-ui-svelte/svelte/PasskeysCard.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if enabled}
-    <AuthCard title={t.passkeys}>
+    <AuthCard headingLevel={2} title={t.passkeys}>
         <FormBanner error={$res.error} />
         {#if $res.loading}
             <p class="lunora-auth-card__description">…</p>

--- a/registry/auth-ui-svelte/svelte/ProfileCard.svelte
+++ b/registry/auth-ui-svelte/svelte/ProfileCard.svelte
@@ -19,7 +19,7 @@
     const { actions, state: form } = controllerStore((context) => createProfileController(context, { initialImage: defaultImage, initialName: defaultName }));
 </script>
 
-<AuthCard title={t.profile}>
+<AuthCard headingLevel={2} title={t.profile}>
     <form
         class="lunora-auth-form"
         novalidate

--- a/registry/auth-ui-svelte/svelte/ResetPasswordOtpCard.svelte
+++ b/registry/auth-ui-svelte/svelte/ResetPasswordOtpCard.svelte
@@ -1,6 +1,11 @@
+<!--
+    Redeems an emailed one-time code instead of a link — for apps that set
+    `forgotPassword: { method: "otp" }`. Unlike ResetPasswordCard, the email
+    address is a field rather than something carried from the previous screen:
+    a code can legitimately be redeemed from a fresh tab.
+-->
 <script lang="ts">
-    import { queryParameter } from "../core/browser-location";
-    import { createResetPasswordController } from "../core/reset-password";
+    import { createResetPasswordOtpController } from "../core/reset-password-otp";
     import AuthCard from "./AuthCard.svelte";
     import { useAuthUI } from "./context";
     import { controllerStore } from "./controller-store";
@@ -8,14 +13,11 @@
     import FormBanner from "./FormBanner.svelte";
     import SubmitButton from "./SubmitButton.svelte";
 
-    let { token }: { /** Defaults to `?token=` from the URL. */ token?: string } = $props();
-
     const t = useAuthUI().localization;
-    // The reset token is read once at mount; navigate to a fresh route to reset.
-    const { actions, state: form } = controllerStore((context) => createResetPasswordController(context, { token: token ?? queryParameter("token") }));
+    const { actions, state: form } = controllerStore((context) => createResetPasswordOtpController(context));
 </script>
 
-<AuthCard title={t.resetPassword}>
+<AuthCard description={t.resetPasswordOtpDescription} title={t.resetPassword}>
     <form
         class="lunora-auth-form"
         novalidate
@@ -25,6 +27,31 @@
         }}
     >
         <FormBanner error={$form.formError} success={$form.successMessage} />
+        <Field
+            autoComplete="email"
+            field={$form.fields.email}
+            label={t.emailLabel}
+            name="email"
+            onBlur={() => {
+                actions.blur("email");
+            }}
+            onChange={(value) => {
+                actions.setField("email", value);
+            }}
+            type="email"
+        />
+        <Field
+            autoComplete="one-time-code"
+            field={$form.fields.otp}
+            label={t.codeLabel}
+            name="otp"
+            onBlur={() => {
+                actions.blur("otp");
+            }}
+            onChange={(value) => {
+                actions.setField("otp", value);
+            }}
+        />
         <Field
             autoComplete="new-password"
             field={$form.fields.password}

--- a/registry/auth-ui-svelte/svelte/SessionsCard.svelte
+++ b/registry/auth-ui-svelte/svelte/SessionsCard.svelte
@@ -10,7 +10,7 @@
     const { actions, state: res } = controllerStore(createSessionsController);
 </script>
 
-<AuthCard title={t.sessions}>
+<AuthCard headingLevel={2} title={t.sessions}>
     <FormBanner error={$res.error} />
     {#if $res.loading}
         <p class="lunora-auth-card__description">…</p>

--- a/registry/auth-ui-svelte/svelte/SignInCard.svelte
+++ b/registry/auth-ui-svelte/svelte/SignInCard.svelte
@@ -90,6 +90,8 @@
         </form>
     {/if}
     {#snippet footer()}
-        <AuthLink href={signUpHref}>{t.noAccount}</AuthLink>
+        {#if context.signUp}
+            <AuthLink href={signUpHref}>{t.noAccount}</AuthLink>
+        {/if}
     {/snippet}
 </AuthCard>

--- a/registry/auth-ui-svelte/svelte/SignUpCard.svelte
+++ b/registry/auth-ui-svelte/svelte/SignUpCard.svelte
@@ -20,72 +20,80 @@
     const { actions, state: form } = controllerStore(createSignUpController);
 </script>
 
-<AuthCard title={t.signUp}>
-    <!--
+<!--
+    The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+    Mirrors the plugin-gated cards: mounted directly, this card renders
+    nothing rather than a form that will fail on submit; `AuthView`'s route
+    falls back to the sign-in card instead of landing on a blank page.
+-->
+{#if context.signUp}
+    <AuthCard title={t.signUp}>
+        <!--
         Social buttons belong on sign-up too — OAuth is a sign-up path, not just a
         sign-in one, and omitting them here sends new users through a password form
         they never needed. This was the gap against better-auth-ui's <AuthView>.
     -->
-    <SocialButtons
-        onSelect={(provider) => {
-            void signInWithSocial(context, provider);
-        }}
-        providers={social}
-    />
-    {#if social.length > 0}
-        <AuthDivider />
-    {/if}
-    <form
-        class="lunora-auth-form"
-        novalidate
-        onsubmit={(event) => {
-            event.preventDefault();
-            void actions.submit();
-        }}
-    >
-        <FormBanner error={$form.formError} />
-        <Field
-            autoComplete="name"
-            field={$form.fields.name}
-            label={t.nameLabel}
-            name="name"
-            onBlur={() => {
-                actions.blur("name");
+        <SocialButtons
+            onSelect={(provider) => {
+                void signInWithSocial(context, provider);
             }}
-            onChange={(value) => {
-                actions.setField("name", value);
-            }}
+            providers={social}
         />
-        <Field
-            autoComplete="email"
-            field={$form.fields.email}
-            label={t.emailLabel}
-            name="email"
-            onBlur={() => {
-                actions.blur("email");
+        {#if social.length > 0}
+            <AuthDivider />
+        {/if}
+        <form
+            class="lunora-auth-form"
+            novalidate
+            onsubmit={(event) => {
+                event.preventDefault();
+                void actions.submit();
             }}
-            onChange={(value) => {
-                actions.setField("email", value);
-            }}
-            type="email"
-        />
-        <Field
-            autoComplete="new-password"
-            field={$form.fields.password}
-            label={t.passwordLabel}
-            name="password"
-            onBlur={() => {
-                actions.blur("password");
-            }}
-            onChange={(value) => {
-                actions.setField("password", value);
-            }}
-            type="password"
-        />
-        <PasswordStrength value={$form.fields.password.value} />
-        <SubmitButton pending={$form.status === "submitting"}>{t.signUp}</SubmitButton>
-    </form>
-    {#snippet footer()}
-        <AuthLink href={signInHref}>{t.haveAccount}</AuthLink>
-    {/snippet}
-</AuthCard>
+        >
+            <FormBanner error={$form.formError} />
+            <Field
+                autoComplete="name"
+                field={$form.fields.name}
+                label={t.nameLabel}
+                name="name"
+                onBlur={() => {
+                    actions.blur("name");
+                }}
+                onChange={(value) => {
+                    actions.setField("name", value);
+                }}
+            />
+            <Field
+                autoComplete="email"
+                field={$form.fields.email}
+                label={t.emailLabel}
+                name="email"
+                onBlur={() => {
+                    actions.blur("email");
+                }}
+                onChange={(value) => {
+                    actions.setField("email", value);
+                }}
+                type="email"
+            />
+            <Field
+                autoComplete="new-password"
+                field={$form.fields.password}
+                label={t.passwordLabel}
+                name="password"
+                onBlur={() => {
+                    actions.blur("password");
+                }}
+                onChange={(value) => {
+                    actions.setField("password", value);
+                }}
+                type="password"
+            />
+            <PasswordStrength value={$form.fields.password.value} />
+            <SubmitButton pending={$form.status === "submitting"}>{t.signUp}</SubmitButton>
+        </form>
+        {#snippet footer()}
+            <AuthLink href={signInHref}>{t.haveAccount}</AuthLink>
+        {/snippet}
+    </AuthCard>
+{/if}

--- a/registry/auth-ui-svelte/svelte/TwoFactorCard.svelte
+++ b/registry/auth-ui-svelte/svelte/TwoFactorCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { createBackupCodeSignInController } from "../core/backup-codes";
     import { isFlowEnabled } from "../core/flow-gate";
     import { createTwoFactorVerifyController } from "../core/two-factor-verify";
     import AuthCard from "./AuthCard.svelte";
@@ -21,9 +22,51 @@
     const enabled = isFlowEnabled(context, "twoFactor", "TwoFactorCard");
     // `method` / `trustDevice` are read once at mount.
     const { actions, state: form } = controllerStore((context) => createTwoFactorVerifyController(context, { method, trustDevice }));
+    // Both controllers stay live regardless of which form is showing — a
+    // session-mutating submit must not depend on the toggle's current position.
+    const { actions: backupActions, state: backupForm } = controllerStore((context) => createBackupCodeSignInController(context, { trustDevice }));
+
+    let useBackupCode = $state(false);
 </script>
 
-{#if enabled}
+{#if enabled && useBackupCode}
+    <AuthCard title={t.twoFactor}>
+        <form
+            class="lunora-auth-form"
+            novalidate
+            onsubmit={(event) => {
+                event.preventDefault();
+                void backupActions.submit();
+            }}
+        >
+            <FormBanner error={$backupForm.formError} />
+            <Field
+                autoComplete="one-time-code"
+                field={$backupForm.fields.code}
+                label={t.backupCodeLabel}
+                name="code"
+                onBlur={() => {
+                    backupActions.blur("code");
+                }}
+                onChange={(value) => {
+                    backupActions.setField("code", value);
+                }}
+            />
+            <SubmitButton pending={$backupForm.status === "submitting"}>{t.twoFactor}</SubmitButton>
+        </form>
+        {#snippet footer()}
+            <button
+                class="lunora-auth-link"
+                onclick={() => {
+                    useBackupCode = false;
+                }}
+                type="button"
+            >
+                {t.twoFactorUseAuthenticator}
+            </button>
+        {/snippet}
+    </AuthCard>
+{:else if enabled}
     <AuthCard title={t.twoFactor}>
         <form
             class="lunora-auth-form"
@@ -48,5 +91,16 @@
             />
             <SubmitButton pending={$form.status === "submitting"}>{t.twoFactor}</SubmitButton>
         </form>
+        {#snippet footer()}
+            <button
+                class="lunora-auth-link"
+                onclick={() => {
+                    useBackupCode = true;
+                }}
+                type="button"
+            >
+                {t.backupCodeSignIn}
+            </button>
+        {/snippet}
     </AuthCard>
 {/if}

--- a/registry/auth-ui-svelte/svelte/TwoFactorSetupCard.svelte
+++ b/registry/auth-ui-svelte/svelte/TwoFactorSetupCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { isFlowEnabled } from "../core/flow-gate";
-    import { createTwoFactorSetupController } from "../core/two-factor-setup";
+    import { createTwoFactorSetupController, totpSecret } from "../core/two-factor-setup";
     import AuthCard from "./AuthCard.svelte";
     import { useAuthUI } from "./context";
     import { controllerStore } from "./controller-store";
@@ -12,6 +12,7 @@
     const t = context.localization;
     const enabled = isFlowEnabled(context, "twoFactor", "TwoFactorSetupCard");
     const { actions, state: flow } = controllerStore(createTwoFactorSetupController);
+    const secret = $derived(totpSecret($flow.totpUri));
 </script>
 
 {#if enabled}
@@ -41,8 +42,15 @@
     {:else if $flow.step === "verify"}
         <AuthCard description={t.twoFactorScan} title={t.twoFactorSetup}>
             <FormBanner error={$flow.error} />
-            {#if $flow.totpUri !== undefined}
-                <code class="lunora-auth-code">{$flow.totpUri}</code>
+            <!--
+                The setup key, not the raw `otpauth://…` URI: this package
+                ships no QR encoder, so there is nothing to scan, and most
+                authenticators reject a pasted `otpauth://…` string anyway —
+                the key is the only path that reliably works.
+            -->
+            {#if secret !== undefined}
+                <p class="lunora-auth-note">{t.twoFactorSecret}</p>
+                <code class="lunora-auth-code">{secret}</code>
             {/if}
             {#if $flow.backupCodes.length > 0}
                 <p class="lunora-auth-card__description">{t.backupCodes}</p>

--- a/registry/auth-ui-svelte/svelte/index.ts
+++ b/registry/auth-ui-svelte/svelte/index.ts
@@ -75,6 +75,7 @@ export { default as PhoneSignInCard } from "./PhoneSignInCard.svelte";
 export { default as ProfileCard } from "./ProfileCard.svelte";
 export { default as ResendVerificationCard } from "./ResendVerificationCard.svelte";
 export { default as ResetPasswordCard } from "./ResetPasswordCard.svelte";
+export { default as ResetPasswordOtpCard } from "./ResetPasswordOtpCard.svelte";
 export { default as SessionsCard } from "./SessionsCard.svelte";
 export { default as SetUsernameCard } from "./SetUsernameCard.svelte";
 export { default as SignInCard } from "./SignInCard.svelte";

--- a/registry/auth-ui-vue/core/admin-users.ts
+++ b/registry/auth-ui-vue/core/admin-users.ts
@@ -50,6 +50,8 @@ type AdminUsersController = Controller<AdminUsersState, AdminUsersActions>;
 
 interface AdminUsersOptions {
     autoLoad?: boolean;
+    /** Milliseconds to wait after the last keystroke before re-querying. Defaults to 300. */
+    debounceMs?: number;
     limit?: number;
 }
 
@@ -84,6 +86,16 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
         { autoLoad: options.autoLoad, initialExtra: { search: "" } },
     );
 
+    const debounceMs = options.debounceMs ?? 300;
+    let searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearSearchTimer = (): void => {
+        if (searchTimer !== undefined) {
+            clearTimeout(searchTimer);
+            searchTimer = undefined;
+        }
+    };
+
     /**
      * Navigate only when the mutation actually ran and succeeded.
      *
@@ -108,14 +120,31 @@ const createAdminUsersController = (context: ControllerContext, options: AdminUs
             refetch: resource.refetch,
             remove: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.removeUser({ userId }))),
             setRole: (userId: string, role: string) => resource.mutate(async () => assertOk(await context.authClient.admin.setRole({ role, userId }))),
-            setSearch: async (value: string) => {
+            setSearch: (value: string) => {
+                // The field itself updates at once (it's controlled off
+                // `state.extra.search`) — only the network `refetch` is debounced,
+                // or every keystroke would fire `admin.listUsers`.
                 resource.patch({ search: value });
-                await resource.refetch();
+                clearSearchTimer();
+
+                if (typeof setTimeout !== "function") {
+                    return resource.refetch();
+                }
+
+                return new Promise<void>((resolve) => {
+                    searchTimer = setTimeout(() => {
+                        searchTimer = undefined;
+                        resolve(resource.refetch());
+                    }, debounceMs);
+                });
             },
             stopImpersonating: () => afterSessionSwap(async () => resource.mutateOk(async () => assertOk(await context.authClient.admin.stopImpersonating()))),
             unban: (userId: string) => resource.mutate(async () => assertOk(await context.authClient.admin.unbanUser({ userId }))),
         },
-        destroy: resource.destroy,
+        destroy: () => {
+            clearSearchTimer();
+            resource.destroy();
+        },
         getState: resource.getState,
         subscribe: resource.subscribe,
     };

--- a/registry/auth-ui-vue/core/avatar.ts
+++ b/registry/auth-ui-vue/core/avatar.ts
@@ -39,6 +39,60 @@ type AvatarUploadController = Controller<AvatarUploadState, AvatarUploadActions>
 /** Human-readable size for the too-big message, in whole MB. */
 const megabytes = (bytes: number): string => `${String(Math.round((bytes / (1024 * 1024)) * 10) / 10)} MB`;
 
+/** One byte run a signature requires at a given offset into the file. */
+interface MagicRun {
+    bytes: ReadonlyArray<number>;
+    offset: number;
+}
+
+/**
+ * Magic-number signatures for the {@link ACCEPTED_TYPES} formats. Most formats
+ * are one contiguous run at offset 0; WebP and AVIF need two non-contiguous
+ * runs (a container header, then a fixed marker further in), so a signature is
+ * a list of runs that must ALL match — never just the first, or a signature
+ * would accept any RIFF-family file (WAV, AVI, …) as WebP.
+ */
+const MAGIC_SIGNATURES: ReadonlyArray<ReadonlyArray<MagicRun>> = [
+    [{ bytes: [0x89, 0x50, 0x4e, 0x47], offset: 0 }], // PNG
+    [{ bytes: [0xff, 0xd8, 0xff], offset: 0 }], // JPEG
+    [{ bytes: [0x47, 0x49, 0x46, 0x38], offset: 0 }], // GIF ("GIF8")
+    [
+        { bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 }, // "RIFF"…
+        { bytes: [0x57, 0x45, 0x42, 0x50], offset: 8 }, // …"WEBP" at byte 8
+    ],
+    [
+        { bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 }, // "ftyp" after the box-size prefix…
+        { bytes: [0x61, 0x76, 0x69], offset: 8 }, // …"avi" brand at byte 8 (covers both "avif" and "avis")
+    ],
+];
+
+/**
+ * Sniffs the first bytes of a file for a known image format's magic number,
+ * for the case `file.type` is empty — a drag-and-drop from some file managers,
+ * a camera-roll export, anything the OS's extension-to-MIME table has no entry
+ * for. An empty `type` used to bypass the check entirely, letting arbitrary
+ * bytes through under any file name.
+ *
+ * This is still only a client-side courtesy, exactly like the `ACCEPTED_TYPES`
+ * check it extends: the server must re-validate every upload regardless of
+ * what either check reports.
+ */
+const sniffImageType = async (file: File): Promise<boolean> => {
+    const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+    const runMatches = (run: MagicRun): boolean => run.bytes.every((byte, index) => header[run.offset + index] === byte);
+
+    return MAGIC_SIGNATURES.some((signature) => signature.every((run) => runMatches(run)));
+};
+
+/**
+ * Whether a picked file passes the client-side image check: accept-list when
+ * the browser reports a type, magic-byte sniff when it doesn't. Shared by the
+ * avatar and organization-logo controllers so the empty-`type` handling can't
+ * drift between the two copies again — see {@link sniffImageType}'s docblock
+ * for why an empty `type` isn't a green light.
+ */
+const isAcceptedImage = async (file: File): Promise<boolean> => (file.type === "" ? sniffImageType(file) : ACCEPTED_TYPES.has(file.type));
+
 const createAvatarUploadController = (context: ControllerContext, options: { initialImage?: string } = {}): AvatarUploadController => {
     const store = createStore<AvatarUploadState>({ imageUrl: options.initialImage, status: "idle" });
 
@@ -83,7 +137,11 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;
@@ -110,4 +168,4 @@ const createAvatarUploadController = (context: ControllerContext, options: { ini
 };
 
 export type { AvatarUploadActions, AvatarUploadController, AvatarUploadState };
-export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController };
+export { ACCEPT_ATTRIBUTE, ACCEPTED_TYPES, createAvatarUploadController, isAcceptedImage };

--- a/registry/auth-ui-vue/core/create-resource-controller.ts
+++ b/registry/auth-ui-vue/core/create-resource-controller.ts
@@ -83,20 +83,41 @@ const createResourceController = <T, TExtra extends object = Record<never, never
         status: "idle",
     });
 
+    /*
+     * Which `refetch` is current. A search box firing a query per keystroke can
+     * have a slow answer for an early prefix land after a fast answer for the
+     * full query — without a ticket, the stale prefix result would overwrite
+     * the correct one an admin is already looking at. Mirrors
+     * `createFormController.load`'s `generation`.
+     */
+    let generation = 0;
+
     const refetch = async (): Promise<void> => {
+        generation += 1;
+
+        const ticket = generation;
+
         store.update({ error: undefined, loading: true, status: "submitting" });
 
         try {
             const result = await load(context, store.get().extra);
-            // A loader that needs no extra state just returns the array.
-            const { extra: patched, items } = Array.isArray(result) ? { extra: undefined, items: result } : result;
+
+            if (ticket !== generation) {
+                return;
+            }
+
+            const { extra: patched, items } = result;
 
             store.update({ items, loading: false, status: "success" });
 
             if (patched !== undefined) {
-                store.update(patched);
+                store.update({ extra: { ...store.get().extra, ...patched } });
             }
         } catch (error) {
+            if (ticket !== generation) {
+                return;
+            }
+
             context.onError?.(error);
             store.update({ error: mapAuthError(error, context.localization, context.localization.genericError), loading: false, status: "error" });
         }

--- a/registry/auth-ui-vue/core/invitations.ts
+++ b/registry/auth-ui-vue/core/invitations.ts
@@ -15,6 +15,7 @@ import type { ControllerContext } from "./config";
 import type { ResourceState } from "./create-resource-controller";
 import { createResourceController } from "./create-resource-controller";
 import { assertOk, mapAuthError } from "./map-error";
+import { mergeQuery } from "./redirect-to";
 import { createStore } from "./store";
 import type { AuthInvitationDetail, Controller, FlowStatus } from "./types";
 
@@ -94,13 +95,17 @@ const createAcceptInvitationController = (context: ControllerContext, options: A
                  * somewhere else entirely.
                  */
                 const invited = store.get().invitation?.email;
-                const target = new URLSearchParams({ redirectTo: currentPath() });
+                const parameters: Record<string, string> = { redirectTo: currentPath() };
 
                 if (invited !== undefined && invited !== "") {
-                    target.set("email", invited);
+                    parameters.email = invited;
                 }
 
-                context.nav.replace(`${context.redirects.signIn}?${target.toString()}`);
+                // Merged rather than appended: an app whose `redirects.signIn`
+                // already carries a query (e.g. `/auth?tab=sign-in`, common when
+                // hosting every screen on one `AuthView` route) would otherwise
+                // get a mangled second `?` and lose the invitation on sign-in.
+                context.nav.replace(mergeQuery(context.redirects.signIn, parameters));
 
                 return;
             }

--- a/registry/auth-ui-vue/core/localization.ts
+++ b/registry/auth-ui-vue/core/localization.ts
@@ -33,6 +33,7 @@ interface Localization {
     avatarUploadFailed: string;
     avatarWrongType: string;
     backToSignIn: string;
+    backupCodeLabel: string;
     backupCodes: string;
     backupCodeSignIn: string;
     backupCodesRegenerate: string;
@@ -133,6 +134,7 @@ interface Localization {
     remove: string;
     resetPassword: string;
     resetPasswordDone: string;
+    resetPasswordOtpDescription: string;
     revoke: string;
     revokeAccess: string;
     revokeOthers: string;
@@ -165,6 +167,7 @@ interface Localization {
     twoFactorScan: string;
     twoFactorSecret: string;
     twoFactorSetup: string;
+    twoFactorUseAuthenticator: string;
     /** Fallback when a session has neither a user-agent nor an IP. */
     unknownDevice: string;
     usernameAvailable: string;
@@ -206,6 +209,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     avatarUploadFailed: "Could not upload that image. Try again.",
     avatarWrongType: "Choose a PNG, JPEG, WebP, GIF, or AVIF image.",
     backToSignIn: "Back to sign in",
+    backupCodeLabel: "Backup code",
     backupCodes: "Save these backup codes somewhere safe:",
     backupCodeSignIn: "Use a backup code",
     backupCodesRegenerate: "Regenerate backup codes",
@@ -306,6 +310,7 @@ const DEFAULT_LOCALIZATION: Localization = {
     remove: "Remove",
     resetPassword: "Set new password",
     resetPasswordDone: "Your password has been updated. You can sign in now.",
+    resetPasswordOtpDescription: "Enter the code we emailed you, then choose a new password.",
     revoke: "Revoke",
     revokeAccess: "Revoke access",
     revokeOthers: "Sign out other sessions",
@@ -335,9 +340,10 @@ const DEFAULT_LOCALIZATION: Localization = {
     twoFactorEnabled: "Two-factor authentication is on.",
     twoFactorFailed: "That code is not valid. Try again.",
     twoFactorNeedsPassword: "Set a password before turning on two-factor authentication.",
-    twoFactorScan: "Scan this with your authenticator app, then enter the 6-digit code.",
-    twoFactorSecret: "Or enter this key manually:",
+    twoFactorScan: "Add this account to your authenticator app using the setup key below, then enter the 6-digit code it generates.",
+    twoFactorSecret: "Setup key:",
     twoFactorSetup: "Two-factor authentication",
+    twoFactorUseAuthenticator: "Use your authenticator app instead",
     unknownDevice: "Unknown device",
     usernameAvailable: "That username is available.",
     usernameChecking: "Checking…",

--- a/registry/auth-ui-vue/core/magic-link.ts
+++ b/registry/auth-ui-vue/core/magic-link.ts
@@ -2,6 +2,7 @@
 import type { ControllerContext } from "./config";
 import { createFormController } from "./create-form-controller";
 import { assertOk } from "./map-error";
+import { resolveAfterSignIn } from "./redirect-to";
 import type { FormController } from "./types";
 import { email as validateEmail } from "./validators";
 
@@ -16,7 +17,7 @@ const createMagicLinkController = (context: ControllerContext): FormController<M
         submit: async (values, context_) => {
             assertOk(
                 await context_.authClient.signIn.magicLink({
-                    callbackURL: context_.redirects.afterSignIn,
+                    callbackURL: resolveAfterSignIn(context_.redirects.afterSignIn),
                     email: values.email.trim(),
                 }),
             );

--- a/registry/auth-ui-vue/core/one-tap.ts
+++ b/registry/auth-ui-vue/core/one-tap.ts
@@ -13,6 +13,7 @@
  * working exactly as intended, so they only reach `onError`.
  */
 import type { ControllerContext } from "./config";
+import { resolveAfterSignIn } from "./redirect-to";
 
 /**
  * Show the One Tap prompt, if the browser and the user's Google session allow.
@@ -21,7 +22,7 @@ import type { ControllerContext } from "./config";
  */
 const promptOneTap = async (context: ControllerContext): Promise<void> => {
     try {
-        await context.authClient.oneTap({ callbackURL: context.redirects.afterSignIn });
+        await context.authClient.oneTap({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn) });
         context.onSessionChange?.();
     } catch (error) {
         context.onError?.(error);

--- a/registry/auth-ui-vue/core/organization-logo.ts
+++ b/registry/auth-ui-vue/core/organization-logo.ts
@@ -11,7 +11,7 @@
  * `updateUser` — and folding both into one would mean a controller that takes a
  * discriminator and branches on it in three places.
  */
-import { ACCEPTED_TYPES } from "./avatar";
+import { isAcceptedImage } from "./avatar";
 import type { ControllerContext } from "./config";
 import { assertOk, mapAuthError } from "./map-error";
 import { createStore } from "./store";
@@ -85,7 +85,11 @@ const createOrganizationLogoController = (context: ControllerContext, options: L
                     return;
                 }
 
-                if (file.type !== "" && !ACCEPTED_TYPES.has(file.type)) {
+                // An empty `type` isn't a green light — it's the browser saying it
+                // doesn't know, which happens for real image files often enough
+                // (some file managers' drag-and-drop, camera-roll exports) that
+                // sniffing the bytes beats either trusting or rejecting blindly.
+                if (!(await isAcceptedImage(file))) {
                     store.update({ error: context.localization.avatarWrongType, status: "error" });
 
                     return;

--- a/registry/auth-ui-vue/core/redirect-to.ts
+++ b/registry/auth-ui-vue/core/redirect-to.ts
@@ -72,6 +72,26 @@ const readRedirectTo = (parameter = "redirectTo"): string | undefined => {
 const resolveAfterSignIn = (fallback: string): string => readRedirectTo() ?? fallback;
 
 /**
+ * Merge `parameters` into `path`'s existing query.
+ *
+ * Parsed rather than appended: blindly appending a second `?` mangles the URL
+ * (its own parameters become part of the *first* query's last value), and
+ * `URLSearchParams.set` overwrites rather than duplicating a key that already
+ * exists — so a caller-supplied value always wins over whatever `path` already
+ * carried, never silently loses to a second occurrence.
+ */
+const mergeQuery = (path: string, parameters: Readonly<Record<string, string>>): string => {
+    const [base, existing = ""] = path.split("?");
+    const merged = new URLSearchParams(existing);
+
+    for (const [key, value] of Object.entries(parameters)) {
+        merged.set(key, value);
+    }
+
+    return `${base ?? path}?${merged.toString()}`;
+};
+
+/**
  * Carry `redirectTo` onto an intermediate step's URL.
  *
  * Sign-in can hand off to a second factor before it finishes, and that hop is a
@@ -88,17 +108,12 @@ const withRedirectTo = (path: string): string => {
     }
 
     /*
-     * Parsed rather than appended: an app whose `redirects.twoFactor` already
+     * Merged rather than appended: an app whose `redirects.twoFactor` already
      * carries a `redirectTo` would otherwise end up with two, and
      * `URLSearchParams.get` returns the first — so the configured value would
      * win over the invitation target this function exists to carry.
      */
-    const [base, existing = ""] = path.split("?");
-    const parameters = new URLSearchParams(existing);
-
-    parameters.set("redirectTo", target);
-
-    return `${base ?? path}?${parameters.toString()}`;
+    return mergeQuery(path, { redirectTo: target });
 };
 
-export { isSafeRedirect, readRedirectTo, resolveAfterSignIn, withRedirectTo };
+export { isSafeRedirect, mergeQuery, readRedirectTo, resolveAfterSignIn, withRedirectTo };

--- a/registry/auth-ui-vue/core/social.ts
+++ b/registry/auth-ui-vue/core/social.ts
@@ -9,10 +9,11 @@
 import type { ControllerContext } from "./config";
 import { assertOk } from "./map-error";
 import { notifyError } from "./notify-error";
+import { resolveAfterSignIn } from "./redirect-to";
 
 const signInWithSocial = async (context: ControllerContext, provider: string): Promise<void> => {
     try {
-        assertOk(await context.authClient.signIn.social({ callbackURL: context.redirects.afterSignIn, provider }));
+        assertOk(await context.authClient.signIn.social({ callbackURL: resolveAfterSignIn(context.redirects.afterSignIn), provider }));
     } catch (error) {
         // A failed social redirect leaves the user on the same page with no
         // explanation, so this is one of the paths that needs a toast.

--- a/registry/auth-ui-vue/registry.json
+++ b/registry/auth-ui-vue/registry.json
@@ -107,6 +107,7 @@
         { "from": "vue/ProfileCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/ProfileCard.vue" },
         { "from": "vue/ResendVerificationCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/ResendVerificationCard.vue" },
         { "from": "vue/ResetPasswordCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/ResetPasswordCard.vue" },
+        { "from": "vue/ResetPasswordOtpCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/ResetPasswordOtpCard.vue" },
         { "from": "vue/SessionsCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/SessionsCard.vue" },
         { "from": "vue/SetUsernameCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/SetUsernameCard.vue" },
         { "from": "vue/SignInCard.vue", "merge": "create-or-skip", "to": "lunora/auth-ui/vue/SignInCard.vue" },

--- a/registry/auth-ui-vue/vue/AuthCard.vue
+++ b/registry/auth-ui-vue/vue/AuthCard.vue
@@ -1,12 +1,25 @@
 <script setup lang="ts">
 // Card shell: heading, optional description, body (default slot), optional
 // footer (named `footer` slot).
+import { computed } from "vue";
+
 import { useAuthUI } from "./provider";
 
-defineProps<{
-    description?: string;
-    title: string;
-}>();
+const props = withDefaults(
+    defineProps<{
+        description?: string;
+        /**
+         * The title's heading level (default 1) — see the React `AuthCard`'s
+         * doc comment for why a settings/organization composition passes `2`
+         * rather than letting every card render an `h1`.
+         */
+        headingLevel?: 1 | 2 | 3;
+        title: string;
+    }>(),
+    { headingLevel: 1 },
+);
+
+const headingTag = computed(() => `h${props.headingLevel}` as const);
 
 // Only set when the app configured `theme` — otherwise the app's own design
 // tokens keep flowing through untouched.
@@ -17,7 +30,7 @@ const themeStyle = Object.keys(themeVariables).length === 0 ? undefined : themeV
 <template>
     <section class="lunora-auth-card" :style="themeStyle">
         <header class="lunora-auth-card__header">
-            <h1 class="lunora-auth-card__title">{{ title }}</h1>
+            <component :is="headingTag" class="lunora-auth-card__title">{{ title }}</component>
             <p v-if="description !== undefined" class="lunora-auth-card__description">{{ description }}</p>
         </header>
         <div class="lunora-auth-card__body">

--- a/registry/auth-ui-vue/vue/AuthView.vue
+++ b/registry/auth-ui-vue/vue/AuthView.vue
@@ -16,6 +16,7 @@ import ForgotPasswordCard from "./ForgotPasswordCard.vue";
 import MagicLinkCard from "./MagicLinkCard.vue";
 import { useAuthUIContextRef } from "./provider";
 import ResetPasswordCard from "./ResetPasswordCard.vue";
+import ResetPasswordOtpCard from "./ResetPasswordOtpCard.vue";
 import SignInCard from "./SignInCard.vue";
 import SignUpCard from "./SignUpCard.vue";
 import TwoFactorCard from "./TwoFactorCard.vue";
@@ -38,7 +39,7 @@ const context = useAuthUIContextRef();
  * gate for when they are mounted directly.
  */
 const card = computed<Component>(() => {
-    const { plugins, viewPaths } = context.value;
+    const { forgotPasswordMethod, plugins, signUp, viewPaths } = context.value;
 
     switch (props.view) {
         case viewPaths.acceptInvitation: {
@@ -62,11 +63,11 @@ const card = computed<Component>(() => {
         }
 
         case viewPaths.resetPassword: {
-            return ResetPasswordCard;
+            return forgotPasswordMethod === "otp" ? ResetPasswordOtpCard : ResetPasswordCard;
         }
 
         case viewPaths.signUp: {
-            return SignUpCard;
+            return signUp ? SignUpCard : SignInCard;
         }
 
         case viewPaths.twoFactor: {

--- a/registry/auth-ui-vue/vue/ChangeEmailCard.vue
+++ b/registry/auth-ui-vue/vue/ChangeEmailCard.vue
@@ -12,7 +12,7 @@ const { actions, state } = useController(createChangeEmailController);
 </script>
 
 <template>
-    <AuthCard :title="t.changeEmail">
+    <AuthCard :headingLevel="2" :title="t.changeEmail">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />
             <Field

--- a/registry/auth-ui-vue/vue/ChangePasswordCard.vue
+++ b/registry/auth-ui-vue/vue/ChangePasswordCard.vue
@@ -12,7 +12,7 @@ const { actions, state } = useController(createChangePasswordController);
 </script>
 
 <template>
-    <AuthCard :title="t.changePassword">
+    <AuthCard :headingLevel="2" :title="t.changePassword">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />
             <Field

--- a/registry/auth-ui-vue/vue/DeleteAccountCard.vue
+++ b/registry/auth-ui-vue/vue/DeleteAccountCard.vue
@@ -12,7 +12,7 @@ const { actions, state } = useController(createDeleteAccountController);
 </script>
 
 <template>
-    <AuthCard :title="t.deleteAccount" :description="t.deleteAccountWarning">
+    <AuthCard :title="t.deleteAccount" :description="t.deleteAccountWarning" :headingLevel="2">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" />
             <Field

--- a/registry/auth-ui-vue/vue/ErrorToaster.vue
+++ b/registry/auth-ui-vue/vue/ErrorToaster.vue
@@ -25,9 +25,17 @@ const onDismiss = (id: number): void => {
 </script>
 
 <template>
-    <!-- `polite`, not `assertive`: these are failures the user can retry, not
-    something that should interrupt a screen reader mid-sentence. -->
-    <div v-if="toasts.length > 0" class="lunora-auth-toaster" aria-live="polite">
+    <!--
+        `polite`, not `assertive`: these are failures the user can retry, not
+        something that should interrupt a screen reader mid-sentence.
+
+        Mounted unconditionally — including with no toasts yet. A live region
+        only announces changes made AFTER it exists in the accessibility tree;
+        gating the whole `<div>` on `toasts.length > 0` meant the very first
+        toast landed before assistive tech was watching the region, so it went
+        unannounced.
+    -->
+    <div class="lunora-auth-toaster" aria-live="polite">
         <div v-for="toast in toasts" :key="toast.id" class="lunora-auth-toast" role="status">
             <span class="lunora-auth-toast__message">{{ toast.message }}</span>
             <button class="lunora-auth-toast__dismiss" type="button" aria-label="Dismiss" @click="onDismiss(toast.id)">×</button>

--- a/registry/auth-ui-vue/vue/MembersCard.vue
+++ b/registry/auth-ui-vue/vue/MembersCard.vue
@@ -49,7 +49,7 @@ const onCancelInvitation = (id: string): void => {
 </script>
 
 <template>
-    <AuthCard v-if="enabled" :title="t.members">
+    <AuthCard v-if="enabled" :headingLevel="2" :title="t.members">
         <FormBanner :error="state.error" />
 
         <p v-if="state.loading" class="lunora-auth-card__description">…</p>

--- a/registry/auth-ui-vue/vue/OrganizationSettingsCard.vue
+++ b/registry/auth-ui-vue/vue/OrganizationSettingsCard.vue
@@ -29,7 +29,7 @@ const { actions, state } = useController((context_) =>
 </script>
 
 <template>
-    <AuthCard v-if="enabled" :title="t.organizationSettings">
+    <AuthCard v-if="enabled" :headingLevel="2" :title="t.organizationSettings">
         <p v-if="state.loading" class="lunora-auth-card__description">…</p>
         <form v-else class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />

--- a/registry/auth-ui-vue/vue/OrganizationsCard.vue
+++ b/registry/auth-ui-vue/vue/OrganizationsCard.vue
@@ -54,7 +54,7 @@ const onRemove = (id?: string): void => {
 </script>
 
 <template>
-    <AuthCard v-if="enabled" :title="t.organizations">
+    <AuthCard v-if="enabled" :headingLevel="2" :title="t.organizations">
         <FormBanner :error="state.error" />
         <p v-if="state.loading" class="lunora-auth-card__description">…</p>
         <p v-else-if="state.items.length === 0" class="lunora-auth-card__description">{{ t.noOrganizations }}</p>

--- a/registry/auth-ui-vue/vue/PasskeysCard.vue
+++ b/registry/auth-ui-vue/vue/PasskeysCard.vue
@@ -38,7 +38,7 @@ const onRemove = (id?: string): void => {
 </script>
 
 <template>
-    <AuthCard v-if="enabled" :title="t.passkeys">
+    <AuthCard v-if="enabled" :headingLevel="2" :title="t.passkeys">
         <FormBanner :error="state.error" />
         <p v-if="state.loading" class="lunora-auth-card__description">…</p>
         <p v-else-if="state.items.length === 0" class="lunora-auth-card__description">{{ t.passkeysEmpty }}</p>

--- a/registry/auth-ui-vue/vue/ProfileCard.vue
+++ b/registry/auth-ui-vue/vue/ProfileCard.vue
@@ -17,7 +17,7 @@ const { actions, state } = useController((context) => createProfileController(co
 </script>
 
 <template>
-    <AuthCard :title="t.profile">
+    <AuthCard :headingLevel="2" :title="t.profile">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />
             <Field

--- a/registry/auth-ui-vue/vue/ResetPasswordOtpCard.vue
+++ b/registry/auth-ui-vue/vue/ResetPasswordOtpCard.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { queryParameter } from "../core/browser-location";
-import { createResetPasswordController } from "../core/reset-password";
+// Redeems an emailed one-time code instead of a link — for apps that set
+// `forgotPassword: { method: "otp" }`. Unlike ResetPasswordCard, the email
+// address is a field rather than something carried from the previous screen:
+// a code can legitimately be redeemed from a fresh tab.
+import { createResetPasswordOtpController } from "../core/reset-password-otp";
 import AuthCard from "./AuthCard.vue";
 import Field from "./Field.vue";
 import FormBanner from "./FormBanner.vue";
@@ -8,22 +11,31 @@ import { useAuthUI } from "./provider";
 import SubmitButton from "./SubmitButton.vue";
 import { useController } from "./use-controller";
 
-const props = defineProps<{
-    /** Defaults to `?token=` from the URL. */
-    token?: string;
-}>();
-
 const { localization: t } = useAuthUI();
-// Captured at setup: the controller consumes the token once on creation, so a
-// token that changes afterwards means a new card, not a new state.
-const token = props.token ?? queryParameter("token");
-const { actions, state } = useController((context) => createResetPasswordController(context, { token }));
+const { actions, state } = useController((context) => createResetPasswordOtpController(context));
 </script>
 
 <template>
-    <AuthCard :title="t.resetPassword">
+    <AuthCard :description="t.resetPasswordOtpDescription" :title="t.resetPassword">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" :success="state.successMessage" />
+            <Field
+                :field="state.fields.email"
+                :label="t.emailLabel"
+                name="email"
+                type="email"
+                autoComplete="email"
+                @blur="actions.blur('email')"
+                @change="actions.setField('email', $event)"
+            />
+            <Field
+                :field="state.fields.otp"
+                :label="t.codeLabel"
+                name="otp"
+                autoComplete="one-time-code"
+                @blur="actions.blur('otp')"
+                @change="actions.setField('otp', $event)"
+            />
             <Field
                 :field="state.fields.password"
                 :label="t.passwordLabel"

--- a/registry/auth-ui-vue/vue/SessionsCard.vue
+++ b/registry/auth-ui-vue/vue/SessionsCard.vue
@@ -23,7 +23,7 @@ const onRevokeOthers = (): void => {
 </script>
 
 <template>
-    <AuthCard :title="t.sessions">
+    <AuthCard :headingLevel="2" :title="t.sessions">
         <FormBanner :error="state.error" />
         <p v-if="state.loading" class="lunora-auth-card__description">…</p>
         <p v-else-if="state.items.length === 0" class="lunora-auth-card__description">{{ t.sessionsEmpty }}</p>

--- a/registry/auth-ui-vue/vue/SignInCard.vue
+++ b/registry/auth-ui-vue/vue/SignInCard.vue
@@ -74,7 +74,7 @@ const onSocial = (provider: string): void => {
             <AuthLink :href="forgotPasswordHref">{{ t.forgotPasswordLink }}</AuthLink>
             <SubmitButton :pending="state.status === 'submitting'">{{ t.signIn }}</SubmitButton>
         </form>
-        <template #footer>
+        <template v-if="context.signUp" #footer>
             <AuthLink :href="signUpHref">{{ t.noAccount }}</AuthLink>
         </template>
     </AuthCard>

--- a/registry/auth-ui-vue/vue/SignUpCard.vue
+++ b/registry/auth-ui-vue/vue/SignUpCard.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
 import { createSignUpController } from "../core/sign-up";
 import { signInWithSocial } from "../core/social";
 import AuthCard from "./AuthCard.vue";
@@ -27,13 +29,18 @@ const context = useAuthUIContextRef();
 const t = context.value.localization;
 const { actions, state } = useController(createSignUpController);
 
+// The server can close self-serve sign-up (`emailAndPassword.disableSignUp`).
+// Computed, not read at setup: `setup()` never re-runs, so a gate resolved
+// here would stay frozen on the pre-discovery answer.
+const signUp = computed(() => context.value.signUp);
+
 const onSocial = (provider: string): void => {
     void signInWithSocial(context.value, provider);
 };
 </script>
 
 <template>
-    <AuthCard :title="t.signUp">
+    <AuthCard v-if="signUp" :title="t.signUp">
         <!--
             Social buttons belong on sign-up too — OAuth is a sign-up path, not
             just a sign-in one, and omitting them here sends new users through a

--- a/registry/auth-ui-vue/vue/TwoFactorCard.vue
+++ b/registry/auth-ui-vue/vue/TwoFactorCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
+import { createBackupCodeSignInController } from "../core/backup-codes";
 import { isFlowEnabled } from "../core/flow-gate";
 import { createTwoFactorVerifyController } from "../core/two-factor-verify";
 import AuthCard from "./AuthCard.vue";
@@ -21,10 +22,33 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "twoFactor", "TwoFactorCard"));
 const { actions, state } = useController((context_) => createTwoFactorVerifyController(context_, { method: props.method, trustDevice: props.trustDevice }));
+// Both controllers stay live regardless of which form is showing — a
+// session-mutating submit must not depend on the toggle's current position.
+const { actions: backupActions, state: backupState } = useController((context_) =>
+    createBackupCodeSignInController(context_, { trustDevice: props.trustDevice }),
+);
+const useBackupCode = ref(false);
 </script>
 
 <template>
-    <AuthCard v-if="enabled" :title="t.twoFactor">
+    <AuthCard v-if="enabled && useBackupCode" :title="t.twoFactor">
+        <form class="lunora-auth-form" novalidate @submit.prevent="backupActions.submit">
+            <FormBanner :error="backupState.formError" />
+            <Field
+                :field="backupState.fields.code"
+                :label="t.backupCodeLabel"
+                name="code"
+                autoComplete="one-time-code"
+                @blur="backupActions.blur('code')"
+                @change="backupActions.setField('code', $event)"
+            />
+            <SubmitButton :pending="backupState.status === 'submitting'">{{ t.twoFactor }}</SubmitButton>
+        </form>
+        <template #footer>
+            <button class="lunora-auth-link" type="button" @click="useBackupCode = false">{{ t.twoFactorUseAuthenticator }}</button>
+        </template>
+    </AuthCard>
+    <AuthCard v-else-if="enabled" :title="t.twoFactor">
         <form class="lunora-auth-form" novalidate @submit.prevent="actions.submit">
             <FormBanner :error="state.formError" />
             <Field
@@ -37,5 +61,8 @@ const { actions, state } = useController((context_) => createTwoFactorVerifyCont
             />
             <SubmitButton :pending="state.status === 'submitting'">{{ t.twoFactor }}</SubmitButton>
         </form>
+        <template #footer>
+            <button class="lunora-auth-link" type="button" @click="useBackupCode = true">{{ t.backupCodeSignIn }}</button>
+        </template>
     </AuthCard>
 </template>

--- a/registry/auth-ui-vue/vue/TwoFactorSetupCard.vue
+++ b/registry/auth-ui-vue/vue/TwoFactorSetupCard.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue";
 
 import { isFlowEnabled } from "../core/flow-gate";
-import { createTwoFactorSetupController } from "../core/two-factor-setup";
+import { createTwoFactorSetupController, totpSecret } from "../core/two-factor-setup";
 import AuthCard from "./AuthCard.vue";
 import Field from "./Field.vue";
 import FormBanner from "./FormBanner.vue";
@@ -16,6 +16,7 @@ const t = context.value.localization;
 // would stay frozen on the pre-discovery answer. See `provider.ts`.
 const enabled = computed(() => isFlowEnabled(context.value, "twoFactor", "TwoFactorSetupCard"));
 const { actions, state } = useController(createTwoFactorSetupController);
+const secret = computed(() => totpSecret(state.value.totpUri));
 </script>
 
 <template>
@@ -35,7 +36,16 @@ const { actions, state } = useController(createTwoFactorSetupController);
     </AuthCard>
     <AuthCard v-else-if="enabled && state.step === 'verify'" :title="t.twoFactorSetup" :description="t.twoFactorScan">
         <FormBanner :error="state.error" />
-        <code v-if="state.totpUri !== undefined" class="lunora-auth-code">{{ state.totpUri }}</code>
+        <!--
+            The setup key, not the raw `otpauth://…` URI: this package ships no
+            QR encoder, so there is nothing to scan, and most authenticators
+            reject a pasted `otpauth://…` string anyway — the key is the only
+            path that reliably works.
+        -->
+        <template v-if="secret !== undefined">
+            <p class="lunora-auth-note">{{ t.twoFactorSecret }}</p>
+            <code class="lunora-auth-code">{{ secret }}</code>
+        </template>
         <template v-if="state.backupCodes.length > 0">
             <p class="lunora-auth-card__description">{{ t.backupCodes }}</p>
             <ul class="lunora-auth-codes">

--- a/registry/auth-ui-vue/vue/index.ts
+++ b/registry/auth-ui-vue/vue/index.ts
@@ -73,6 +73,7 @@ export type { AuthUIProviderProps, AuthUIVueContext } from "./provider";
 export { AUTH_UI_INJECTION_KEY, createAuthUI, provideAuthUI, useAuthUI, useAuthUIContextRef, useAuthUILink } from "./provider";
 export { default as ResendVerificationCard } from "./ResendVerificationCard.vue";
 export { default as ResetPasswordCard } from "./ResetPasswordCard.vue";
+export { default as ResetPasswordOtpCard } from "./ResetPasswordOtpCard.vue";
 export { default as SessionsCard } from "./SessionsCard.vue";
 export { default as SetUsernameCard } from "./SetUsernameCard.vue";
 export { default as SignInCard } from "./SignInCard.vue";


### PR DESCRIPTION
Work from an agent worktree, pushed under a descriptive name (local branch was `worktree-agent-adfed38045ccd5c2b`).
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(auth-ui): guard AuthView route lookup against prototype segments
- fix(auth-ui): sniff empty-MIME org-logo uploads like the avatar path
- test(auth-ui): fix flaky assertion count in avatar upload test
- fix(auth-ui): gate sign-up card, route, and footer link on the discovered signUp flag
- fix(auth-ui): merge the invitation bounce params into redirects.signIn's existing query
- docs(auth-ui): record the discovery-rebuild vs in-flight form state trade-off
- fix(auth-ui): re-sync the auth-ui registry payloads from source
- ci: run the auth-ui registry drift check unconditionally
