### PR TITLE
fix(shard-engine): reject malformed geo inputs instead of returning empty results

### DIFF
--- a/packages/do/__bench__/lookup-by-id-probe.bench.ts
+++ b/packages/do/__bench__/lookup-by-id-probe.bench.ts
@@ -65,3 +65,55 @@ describe("lookupById probe — sequential per-table SELECT vs single UNION-ALL",
         }
     });
 });
+
+/**
+ * The RLS guard's `deleteMany`/`patchMany` pre-check (plan 291): resolving the
+ * owning table of MANY ids at once.
+ *
+ * - **per-id** — one single-id UNION-ALL probe (the bench above) PER id, the
+ * pre-fix `guardById` loop.
+ * - **batched** — one UNION-ALL probe per table, each branch scoped by
+ * `id IN (...)` over the WHOLE batch — `locateTablesByIds`'s shape.
+ *
+ * Same 8-table schema; the batch is 50 ids, all real rows (spread round-robin
+ * across the tables) so both variants do genuine work rather than short-circuit.
+ */
+const BATCH_SIZE = 50;
+const batchTableNames = tableNames;
+const batchIds = Array.from({ length: BATCH_SIZE }, (_, index) => `batch-row-${String(index)}`);
+
+for (const [index, id] of batchIds.entries()) {
+    const tableName = batchTableNames[index % batchTableNames.length]!;
+
+    harness.raw(`INSERT INTO "${tableName}" (id, _creationTime, __doc__) VALUES (?, ?, ?)`, id, 1, JSON.stringify({ v: 1 }));
+}
+
+const perIdUnionSql = `${batchTableNames.map((tableName) => `SELECT '${tableName}' AS __t__, id, _creationTime, __doc__ FROM "${tableName}" WHERE id = ?`).join(" UNION ALL ")} LIMIT 1`;
+
+const batchedInListSql = batchTableNames.map((tableName) => `SELECT '${tableName}' AS __t__, id FROM "${tableName}" WHERE id IN (${batchIds.map(() => "?").join(", ")})`).join(" UNION ALL ");
+
+describe(`RLS guard id→table probe — ${String(BATCH_SIZE)} bare ids: per-id UNION loop vs one batched IN-list UNION`, () => {
+    bench(`per-id: ${String(BATCH_SIZE)} single-id UNION-ALL probes (pre-fix guardById loop)`, () => {
+        let resolved = 0;
+
+        for (const id of batchIds) {
+            const [row] = harness.raw(perIdUnionSql, ...batchTableNames.map(() => id));
+
+            if (row) {
+                resolved += 1;
+            }
+        }
+
+        if (resolved !== BATCH_SIZE) {
+            throw new Error("bench invariant: not every batch row was located");
+        }
+    });
+
+    bench("batched: one IN-list UNION-ALL probe across all tables (locateTablesByIds)", () => {
+        const rows = harness.raw(batchedInListSql, ...batchTableNames.flatMap(() => batchIds));
+
+        if (rows.length !== BATCH_SIZE) {
+            throw new Error("bench invariant: not every batch row was located");
+        }
+    });
+});

--- a/packages/shard-engine/__tests__/ctx-db.by-id-table-scope.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.by-id-table-scope.test.ts
@@ -151,3 +151,168 @@ describe("by-id table scoping (IDOR)", () => {
         await expect(db.get(userId, "users")).resolves.toMatchObject({ email: "victim@example.com" });
     });
 });
+
+/**
+ * `locateTablesByIds` (`ctx-db.ts`), exercised through the RLS guard's
+ * `deleteMany`/`patchMany` batch pre-check — it has no public export of its
+ * own, so its resolution is observed via the guard decisions and row state it
+ * drives. Perf-plan companion to the IDOR suite above: same table-resolution
+ * machinery, now batched for `.rls("required")` schemas.
+ */
+describe("the RLS guard batch id→table probe (deleteMany/patchMany)", () => {
+    let harness: ReturnType<typeof createSqliteExec>;
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    const rlsSchema: SchemaLike = {
+        rlsMode: "required",
+        tables: {
+            posts: { indexes: [], isPublic: false, shape: { title: { kind: "string" } } },
+            stats: { indexes: [], isPublic: true, shape: { value: { kind: "number" } } },
+        },
+    };
+
+    const makeGuardedWriter = (targetSchema: SchemaLike): DatabaseWriterLike => {
+        runShardMigrations(harness.sql, targetSchema);
+
+        return createShardContextDatabase({ clock: () => 1_700_000_000_000, enforceRls: true, schema: targetSchema, sql: harness.sql });
+    };
+
+    it("denies a bare-id batch spanning tables when one id resolves to a protected table; nothing is removed", async () => {
+        expect.assertions(3);
+
+        runShardMigrations(harness.sql, rlsSchema);
+
+        // Seed through an UNGUARDED admin writer — `insert` is itself
+        // table-named and gated, so the guarded writer under test can't
+        // populate the protected table directly.
+        const admin = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema: rlsSchema, sql: harness.sql });
+        const publicId = await admin.insert("stats", { value: 1 });
+        const protectedId = await admin.insert("posts", { title: "secret" });
+
+        const db = createShardContextDatabase({ clock: () => 1_700_000_000_000, enforceRls: true, schema: rlsSchema, sql: harness.sql });
+
+        await expect(db.deleteMany!([publicId, protectedId, "totally-absent-id"])).rejects.toThrow(/\.rls\("required"\)/);
+
+        // Deny-before-delegate: neither row was actually removed.
+        await expect(admin.get(publicId, "stats")).resolves.not.toBeNull();
+        await expect(admin.get(protectedId, "posts")).resolves.not.toBeNull();
+    });
+
+    it("resolves a bare-id batch spanning multiple PUBLIC tables; the absent id is a no-op", async () => {
+        expect.assertions(3);
+
+        const publicOnlySchema: SchemaLike = {
+            rlsMode: "required",
+            tables: {
+                a: { indexes: [], isPublic: true, shape: { value: { kind: "number" } } },
+                b: { indexes: [], isPublic: true, shape: { value: { kind: "number" } } },
+                posts: { indexes: [], isPublic: false, shape: { title: { kind: "string" } } },
+            },
+        };
+
+        const db = makeGuardedWriter(publicOnlySchema);
+        const idA = await db.insert("a", { value: 1 });
+        const idB = await db.insert("b", { value: 2 });
+
+        const result = await db.deleteMany!([idA, idB, "totally-absent-id"]);
+
+        expect(result).toStrictEqual({ deleted: 3 });
+        await expect(db.get(idA, "a")).resolves.toBeNull();
+        await expect(db.get(idB, "b")).resolves.toBeNull();
+    });
+
+    it("resolves ids correctly across chunk boundaries on a wide (many-table) schema", async () => {
+        expect.assertions(1);
+
+        // 100 tables ⇒ chunkSize = floor(900 / 100) = 9: 25 ids cross 3 chunk
+        // boundaries (9 + 9 + 7), exercising the fold-into-map loop across
+        // multiple probe statements rather than the single-statement case above.
+        const tableCount = 100;
+        const idCount = 25;
+        const wideSchema: SchemaLike = {
+            rlsMode: "required",
+            tables: Object.fromEntries(
+                Array.from({ length: tableCount }, (_, index) => [`t${String(index)}`, { indexes: [], isPublic: true, shape: { value: { kind: "number" } } }]),
+            ),
+        };
+
+        const db = makeGuardedWriter(wideSchema);
+        const ids: string[] = [];
+
+        for (let index = 0; index < idCount; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential seeding, test setup only
+            ids.push(await db.insert(`t${String(index)}`, { value: index }));
+        }
+
+        const result = await db.patchMany!(
+            ids.map((id) => {
+                return { id, patch: { value: -1 } };
+            }),
+            undefined,
+        );
+
+        expect(result).toStrictEqual({ patched: idCount });
+    });
+
+    it("issues far fewer guard-probe statements than one per bare id (pre-fix: one per id)", async () => {
+        expect.assertions(2);
+
+        // All-public so the batch resolves cleanly with no denial — isolates the
+        // STATEMENT COUNT, not the guard's allow/deny decision (covered above).
+        const allPublicSchema: SchemaLike = {
+            rlsMode: "required",
+            tables: {
+                a: { indexes: [], isPublic: true, shape: { value: { kind: "number" } } },
+                b: { indexes: [], isPublic: true, shape: { value: { kind: "number" } } },
+                c: { indexes: [], isPublic: true, shape: { value: { kind: "number" } } },
+            },
+        };
+        const nonGlobalTableCount = 3;
+
+        const db = makeGuardedWriter(allPublicSchema);
+        const ids: string[] = [];
+
+        for (let index = 0; index < 50; index += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential seeding, test setup only
+            ids.push(await db.insert("a", { value: index }));
+        }
+
+        const originalExec = harness.sql.exec;
+        const queries: string[] = [];
+
+        harness.sql.exec = (query: string, ...parameters: unknown[]) => {
+            queries.push(query);
+
+            return originalExec(query, ...parameters);
+        };
+
+        const result = await db.patchMany!(
+            ids.map((id) => {
+                return { id, patch: { value: -1 } };
+            }),
+        );
+
+        harness.sql.exec = originalExec;
+
+        expect(result).toStrictEqual({ patched: 50 });
+
+        // Any table-resolution probe (guard batch OR the writer's own per-row
+        // CAS resolution) shares this `AS __t__, id` shape. Pre-fix, the guard
+        // alone issued one such statement PER id (50); post-fix it issues at
+        // most `ceil(ids / chunkSize)` — here 1, since 50 ids fit in a single
+        // chunk of 300 (`floor(900 / 3)`). The writer's own 50 (one per row,
+        // unavoidable — the OCC/CAS snapshot) are untouched and included below.
+        const probeLikeCount = queries.filter((query) => /AS __t__, id\b/u.test(query)).length;
+        const chunkSize = Math.max(1, Math.floor(900 / nonGlobalTableCount));
+        const expectedMax = Math.ceil(50 / chunkSize) + 50;
+
+        expect(probeLikeCount).toBeLessThanOrEqual(expectedMax);
+    });
+});

--- a/packages/shard-engine/__tests__/ctx-db.geo.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.geo.test.ts
@@ -356,4 +356,112 @@ describe("ctx-db geo", () => {
             expect(kept.map((entry) => entry.document["name"])).toStrictEqual(["brooklyn"]);
         });
     });
+
+    // Input validation: a malformed query is rejected up front (BAD_REQUEST)
+    // instead of silently paying for a scan that can only ever return [].
+    // The builder throws synchronously — the throw happens while `withGeoIndex`
+    // runs the `build` callback, before any query executes.
+    describe("input validation", () => {
+        it("rejects .within() with transposed lat corners", () => {
+            expect.assertions(1);
+
+            const writer = setupWriter();
+
+            expect(() =>
+                writer.query("places").withGeoIndex("by_location", (q) => q.within({ ne: { lat: 5, lng: -73 }, sw: { lat: 10, lng: -74 } })),
+            ).toThrow(/transposed/u);
+        });
+
+        it("rejects a .within() box crossing the antimeridian", async () => {
+            expect.assertions(2);
+
+            const writer = setupWriter();
+
+            // A row that would fall inside the intended (wrap-around) box, so a
+            // silent [] would be indistinguishable from "no data here".
+            await writer.insert("places", { location: { lat: 40, lng: 179 }, name: "near-dateline" });
+
+            expect(() =>
+                writer.query("places").withGeoIndex("by_location", (q) => q.within({ ne: { lat: 41, lng: -170 }, sw: { lat: 39, lng: 170 } })),
+            ).toThrow(/antimeridian/u);
+
+            // The row genuinely exists and is inside the intended box — proof
+            // the rejected shape was not simply "no data here".
+            const found = await writer
+                .query("places")
+                .withGeoIndex("by_location", (q) => q.within({ ne: { lat: 41, lng: 180 }, sw: { lat: 39, lng: 170 } }))
+                .collect();
+
+            expect(found.map((document) => document["name"])).toStrictEqual(["near-dateline"]);
+        });
+
+        it.each([
+            ["negative", -5],
+            ["NaN", Number.NaN],
+            ["zero", 0],
+            ["Infinity", Number.POSITIVE_INFINITY],
+        ])("rejects .near() with a %s radius", (_label, radiusMeters) => {
+            expect.assertions(1);
+
+            const writer = setupWriter();
+
+            expect(() => writer.query("places").withGeoIndex("by_location", (q) => q.near(TIMES_SQUARE, radiusMeters))).toThrow(
+                /radiusMeters must be a finite number > 0/u,
+            );
+        });
+
+        it("rejects a .near() point with an out-of-range or non-finite lat/lng", () => {
+            expect.assertions(3);
+
+            const writer = setupWriter();
+
+            expect(() => writer.query("places").withGeoIndex("by_location", (q) => q.near({ lat: 91, lng: 0 }, 1000))).toThrow(
+                /finite lat in \[-90, 90\]/u,
+            );
+            expect(() => writer.query("places").withGeoIndex("by_location", (q) => q.near({ lat: 0, lng: 200 }, 1000))).toThrow(
+                /finite lat in \[-90, 90\]/u,
+            );
+            expect(() => writer.query("places").withGeoIndex("by_location", (q) => q.near({ lat: Number.NaN, lng: 0 }, 1000))).toThrow(
+                /finite lat in \[-90, 90\]/u,
+            );
+        });
+
+        it("rejects a .within() box with an out-of-range corner", () => {
+            expect.assertions(2);
+
+            const writer = setupWriter();
+
+            expect(() =>
+                writer.query("places").withGeoIndex("by_location", (q) => q.within({ ne: { lat: 91, lng: -73 }, sw: { lat: 40, lng: -74 } })),
+            ).toThrow(/finite lat in \[-90, 90\]/u);
+            expect(() =>
+                writer.query("places").withGeoIndex("by_location", (q) => q.within({ ne: { lat: 41, lng: 200 }, sw: { lat: 40, lng: -74 } })),
+            ).toThrow(/finite lat in \[-90, 90\]/u);
+        });
+
+        it("does not reject well-formed inputs (no regression)", async () => {
+            expect.assertions(2);
+
+            const writer = setupWriter();
+
+            await writer.insert("places", { location: TIMES_SQUARE, name: "times-square" });
+
+            // A degenerate point box (sw === ne) over a row at exactly those
+            // coordinates still matches — inclusive edges are unaffected.
+            const pointBox = await writer
+                .query("places")
+                .withGeoIndex("by_location", (q) => q.within({ ne: TIMES_SQUARE, sw: TIMES_SQUARE }))
+                .collect();
+
+            expect(pointBox.map((document) => document["name"])).toStrictEqual(["times-square"]);
+
+            // A box touching +180 exactly is accepted (not treated as crossing).
+            const touchingAntimeridian = await writer
+                .query("places")
+                .withGeoIndex("by_location", (q) => q.within({ ne: { lat: 41, lng: 180 }, sw: { lat: 40, lng: 170 } }))
+                .collect();
+
+            expect(touchingAntimeridian).toStrictEqual([]);
+        });
+    });
 });

--- a/packages/shard-engine/__tests__/rls-guard.test.ts
+++ b/packages/shard-engine/__tests__/rls-guard.test.ts
@@ -17,6 +17,7 @@ const createFakeWriter = () => {
         aggregate: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`aggregate:${tableName}`)),
         count: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`count:${tableName}`)),
         delete: vi.fn<(id: string) => Promise<string>>((id: string) => Promise.resolve(`delete:${id}`)),
+        deleteMany: vi.fn<(ids: ReadonlyArray<string>) => Promise<string>>((ids: ReadonlyArray<string>) => Promise.resolve(`deleteMany:${ids.join(",")}`)),
         findFirst: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`findFirst:${tableName}`)),
         findFirstOrThrow: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`findFirstOrThrow:${tableName}`)),
         findMany: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`findMany:${tableName}`)),
@@ -24,6 +25,10 @@ const createFakeWriter = () => {
         groupBy: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`groupBy:${tableName}`)),
         insert: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`insert:${tableName}`)),
         patch: vi.fn<(id: string) => Promise<string>>((id: string) => Promise.resolve(`patch:${id}`)),
+        patchMany: vi.fn<(patches: ReadonlyArray<{ id: string; patch: Record<string, unknown> }>) => Promise<string>>(
+            (patches: ReadonlyArray<{ id: string; patch: Record<string, unknown> }>) =>
+                Promise.resolve(`patchMany:${patches.map((entry) => entry.id).join(",")}`),
+        ),
         query: vi.fn<(tableName: string) => string>((tableName: string) => `query:${tableName}`),
         rank: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`rank:${tableName}`)),
         rankBefore: vi.fn<(tableName: string) => Promise<string>>((tableName: string) => Promise.resolve(`rankBefore:${tableName}`)),
@@ -181,6 +186,101 @@ describe("guardWriter — generic id-based access resolves the owning table", ()
         await guarded.patch("orphan_id", { x: 1 });
 
         expect(raw.patch).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("guardWriter — batch id-based methods (deleteMany/patchMany)", () => {
+    /** Invoke `deleteMany`/`patchMany` with a uniform (ids, expectedTable) shape. */
+    const batchMethods: ReadonlyArray<{
+        call: (m: Record<string, (...a: unknown[]) => unknown>, ids: ReadonlyArray<string>, table?: string) => unknown;
+        name: string;
+    }> = [
+        { call: (m, ids, table) => m["deleteMany"]!(ids, undefined, table), name: "deleteMany" },
+        {
+            call: (m, ids, table) =>
+                m["patchMany"]!(
+                    ids.map((id) => {
+                        return { id, patch: {} };
+                    }),
+                    undefined,
+                    table,
+                ),
+            name: "patchMany",
+        },
+    ];
+
+    it.each(batchMethods)("$name denies a bare-id batch when one id resolves to a protected, policy-less table", async ({ call, name }) => {
+        expect.assertions(2);
+
+        const raw = createFakeWriter();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as Record<string, (...a: unknown[]) => unknown>;
+
+        // "stat_1" resolves to the public table (allowed); "post_2" resolves to
+        // the protected table and must deny the WHOLE batch before it reaches base.
+        await expect(call(guarded, ["stat_1", "post_2"])).rejects.toThrow(RlsRequiredError);
+        expect((raw as unknown as Record<string, FakeWriter[keyof FakeWriter]>)[name]).not.toHaveBeenCalled();
+    });
+
+    it.each(batchMethods)("$name denies with expectedTable pinned to a protected table, with NO probe at all", async ({ call, name }) => {
+        expect.assertions(3);
+
+        const raw = createFakeWriter();
+        const tablesOfIds = vi.fn<(ids: ReadonlyArray<string>, expectedTable?: string) => ReadonlyMap<string, string>>();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId, tablesOfIds) as unknown as Record<
+            string,
+            (...a: unknown[]) => unknown
+        >;
+
+        await expect(call(guarded, ["any-id-1", "any-id-2"], "posts")).rejects.toThrow(RlsRequiredError);
+        expect((raw as unknown as Record<string, FakeWriter[keyof FakeWriter]>)[name]).not.toHaveBeenCalled();
+        // Pinned-table gating never needs to resolve anything — no probe issued.
+        expect(tablesOfIds).not.toHaveBeenCalled();
+    });
+
+    it.each(batchMethods)("$name passes a batch of only unresolved ids through to base", async ({ call, name }) => {
+        expect.assertions(1);
+
+        const raw = createFakeWriter();
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfId) as unknown as Record<string, (...a: unknown[]) => unknown>;
+
+        await call(guarded, ["orphan_1", "orphan_2"]);
+
+        expect((raw as unknown as Record<string, FakeWriter[keyof FakeWriter]>)[name]).toHaveBeenCalledTimes(1);
+    });
+
+    it("consults the batch resolver exactly once with the deduped id set, and never the per-id tableOfId", async () => {
+        expect.assertions(3);
+
+        const raw = createFakeWriter();
+        const tableOfIdSpy = vi.fn<typeof tableOfId>(tableOfId);
+        const tablesOfIds = vi.fn<(ids: ReadonlyArray<string>) => ReadonlyMap<string, string>>((ids: ReadonlyArray<string>) =>
+            new Map(ids.map((id) => [id, "stats"])),
+        );
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfIdSpy, tablesOfIds) as unknown as {
+            deleteMany: (ids: ReadonlyArray<string>) => Promise<unknown>;
+        };
+
+        // A duplicated id ("stat_1" twice) — the resolver sees the DEDUPED set.
+        await guarded.deleteMany(["stat_1", "stat_2", "stat_1"]);
+
+        expect(tablesOfIds).toHaveBeenCalledTimes(1);
+        expect(tablesOfIds.mock.calls[0]?.[0]).toStrictEqual(["stat_1", "stat_2"]);
+        expect(tableOfIdSpy).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the per-id loop when no batch resolver is supplied (D1-twin fallback, pinned)", async () => {
+        expect.assertions(1);
+
+        const raw = createFakeWriter();
+        const tableOfIdSpy = vi.fn<typeof tableOfId>(tableOfId);
+        // No 4th argument: guardWriter's D1-twin call shape, unchanged.
+        const guarded = guardWriter(raw as never, requiredSchema as never, tableOfIdSpy) as unknown as {
+            deleteMany: (ids: ReadonlyArray<string>) => Promise<unknown>;
+        };
+
+        await guarded.deleteMany(["stat_1", "stat_2"]);
+
+        expect(tableOfIdSpy).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -632,6 +632,21 @@ const searchViaScan = (
     return scored.slice(0, limit).map((entry) => {return { document: entry.doc, score: entry.score }});
 };
 
+/**
+ * Assert `point` is a usable geo coordinate: finite lat in `[-90, 90]` and
+ * finite lng in `[-180, 180]`. `NaN`/out-of-range coordinates otherwise
+ * poison `encodeGeohash`/haversine silently and produce a misleading empty
+ * result instead of a clear rejection.
+ */
+const assertGeoPoint = (point: { lat: number; lng: number }, label: string, tableName: string, indexName: string): void => {
+    if (!Number.isFinite(point.lat) || point.lat < -90 || point.lat > 90 || !Number.isFinite(point.lng) || point.lng < -180 || point.lng > 180) {
+        throw new LunoraError(
+            "BAD_REQUEST",
+            `geo index "${indexName}" on table "${tableName}": ${label} must have a finite lat in [-90, 90] and lng in [-180, 180]`,
+        );
+    }
+};
+
 /** Builder for `withGeoIndex(name, q => q.near(...) | q.within(...))`; mutates the staged geo query in place. */
 const createGeoBuilder = (geo: GeoStage, tableName: string): GeoFilterBuilderLike => {
     // Alias so the mutation is on a local binding, not the parameter (no-param-reassign) —
@@ -643,6 +658,15 @@ const createGeoBuilder = (geo: GeoStage, tableName: string): GeoFilterBuilderLik
                 throw new LunoraError("INTERNAL", `geo index "${staged.indexName}" on table "${tableName}": call .near() or .within(), not both`);
             }
 
+            assertGeoPoint(point, ".near() point", tableName, staged.indexName);
+
+            if (!Number.isFinite(radiusMeters) || radiusMeters <= 0) {
+                throw new LunoraError(
+                    "BAD_REQUEST",
+                    `geo index "${staged.indexName}" on table "${tableName}": .near() radiusMeters must be a finite number > 0, got ${String(radiusMeters)}`,
+                );
+            }
+
             staged.near = { point: { lat: point.lat, lng: point.lng }, radiusMeters };
 
             return builder;
@@ -650,6 +674,23 @@ const createGeoBuilder = (geo: GeoStage, tableName: string): GeoFilterBuilderLik
         within: (box) => {
             if (staged.near) {
                 throw new LunoraError("INTERNAL", `geo index "${staged.indexName}" on table "${tableName}": call .near() or .within(), not both`);
+            }
+
+            assertGeoPoint(box.sw, ".within() sw corner", tableName, staged.indexName);
+            assertGeoPoint(box.ne, ".within() ne corner", tableName, staged.indexName);
+
+            if (box.sw.lat > box.ne.lat) {
+                throw new LunoraError(
+                    "BAD_REQUEST",
+                    `geo index "${staged.indexName}" on table "${tableName}": .within() corners are transposed (sw.lat > ne.lat)`,
+                );
+            }
+
+            if (box.sw.lng > box.ne.lng) {
+                throw new LunoraError(
+                    "BAD_REQUEST",
+                    `geo index "${staged.indexName}" on table "${tableName}": .within() box crosses the antimeridian (sw.lng > ne.lng), which is not supported — split it into two boxes at ±180 and union the results`,
+                );
             }
 
             staged.within = { ne: { lat: box.ne.lat, lng: box.ne.lng }, sw: { lat: box.sw.lat, lng: box.sw.lng } };

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -2379,6 +2379,74 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
         return { docJson: documentJson, row, tableName };
     };
 
+    /**
+     * Batched sibling of {@link locateRowById}, for the RLS guard's
+     * `deleteMany`/`patchMany` pre-check (`guardByIds` in `rls-guard.ts`):
+     * resolve the owning table of MANY ids in as few statements as possible
+     * instead of one `locateRowById` probe per id.
+     *
+     * Selects only `__t__, id` (the guard needs the table name, not the row —
+     * skipping the document column keeps the probe narrow) and has no
+     * `LIMIT 1`: unlike a single lookup, every id may hit a different table
+     * and all hits are wanted.
+     *
+     * Chunked because the multiplied-placeholder UNION widens with both
+     * dimensions: each of the `nonGlobalTables.length` branches repeats the
+     * full `id IN (...)` list, so one statement over `chunkSize` ids costs
+     * `chunkSize * nonGlobalTables.length` bound placeholders. Sized to stay
+     * under SQLite's historical 999-bind-variable floor regardless of what
+     * the DO runtime actually allows.
+     * @returns a map from id to its owning table; an id absent from the map resolved to no table this writer can see
+     */
+    const locateTablesByIds = (ids: ReadonlyArray<string>, expectedTable?: string): Map<string, string> => {
+        const uniqueIds = [...new Set(ids)];
+
+        const resolved = new Map<string, string>();
+
+        if (uniqueIds.length === 0) {
+            return resolved;
+        }
+
+        const nonGlobalTables = Object.entries(schema.tables)
+            .filter(([, definition]) => definition.shardMode?.kind !== "global")
+            .map(([tableName]) => tableName)
+            .filter((tableName) => expectedTable === undefined || tableName === expectedTable);
+
+        if (nonGlobalTables.length === 0) {
+            return resolved;
+        }
+
+        // `Math.max(1, …)` keeps a very-wide schema (900+ tables) from
+        // computing a 0-size chunk; the placeholder budget is best-effort at
+        // that point anyway.
+        const chunkSize = Math.max(1, Math.floor(900 / nonGlobalTables.length));
+
+        for (let start = 0; start < uniqueIds.length; start += chunkSize) {
+            const chunk = uniqueIds.slice(start, start + chunkSize);
+            const idList = dsql.join(
+                // eslint-disable-next-line no-restricted-syntax -- a drizzle tagged-template SQL bind parameter, not a string conversion; same false-positive `where-sql.ts` suppresses
+                chunk.map((id): SQL => dsql`${id}`),
+                dsql`, `,
+            );
+            const branches = nonGlobalTables.map(
+                (tableName) =>
+                    // Mirrors `locateRowById`'s inline-literal table discriminator.
+                    dsql`SELECT ${dsql.raw(`'${tableName.replaceAll("'", "''")}'`)} AS __t__, id FROM ${dsql.identifier(tableName)} WHERE id IN (${idList})`,
+            );
+            const probeQuery = dsql.join(branches, dsql` UNION ALL `);
+
+            for (const row of runDrizzle(sql, probeQuery)) {
+                const { id, __t__: tableName } = row;
+
+                if (typeof tableName === "string" && typeof id === "string") {
+                    resolved.set(id, tableName);
+                }
+            }
+        }
+
+        return resolved;
+    };
+
     // The cross-shard rank-page read unit (compute + hydrate)
     // lives in `./ctx-db-rank-page`; its SQL/order/cursor/hydration is
     // byte-identical to what the coordinator merge + codegen golden fixture
@@ -4011,7 +4079,14 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
     // denies protected tables to any handler that never engaged RLS. Triggers
     // keep the unguarded `writer` above (system path). `guardWriter` is a no-op
     // for non-`required` schemas, so the common case pays nothing.
-    return options.enforceRls === true ? guardWriter(writer, schema, (id, expectedTable) => locateRowById(id, expectedTable)?.tableName) : writer;
+    return options.enforceRls === true
+        ? guardWriter(
+              writer,
+              schema,
+              (id, expectedTable) => locateRowById(id, expectedTable)?.tableName,
+              (ids, expectedTable) => locateTablesByIds(ids, expectedTable),
+          )
+        : writer;
 };
 
 export { assertValidClientId, createShardCtxDb, normalizeIdStructurally, NotUniqueError };

--- a/packages/shard-engine/src/rls-guard.ts
+++ b/packages/shard-engine/src/rls-guard.ts
@@ -63,6 +63,18 @@ interface GuardableSchema {
 type TableOfId = (id: string, expectedTable?: string) => Promise<string | undefined> | string | undefined;
 
 /**
+ * Batched sibling of {@link TableOfId} for `deleteMany`/`patchMany`: resolve
+ * the owning table of MANY ids in one call instead of one {@link TableOfId}
+ * call per id. Optional — a caller (e.g. the D1/`.global()` twin) that has no
+ * batch-probe primitive simply omits it, and {@link guardWriter}'s batch
+ * methods fall back to the existing per-id loop unchanged. The returned map
+ * carries only RESOLVED ids; an id absent from it is treated exactly like a
+ * {@link TableOfId} `undefined` — unresolved, so it leaks nothing and passes
+ * through.
+ */
+type TablesOfIds = (ids: ReadonlyArray<string>, expectedTable?: string) => Promise<ReadonlyMap<string, string>> | ReadonlyMap<string, string>;
+
+/**
  * Structural surface the guard wraps — method syntax (bivariant params) so the
  * concrete `DatabaseWriterLike` of either dialect satisfies it. The guard reads
  * only the table-targeting methods; everything else is copied through verbatim.
@@ -183,7 +195,7 @@ const guardEraseMethods = (base: GuardableWriter, schema: GuardableSchema, guard
 // would reject the real writer and erase its extra members (`normalizeId`, …)
 // from the return type. Instead we keep `W` opaque — preserving the caller's
 // concrete type through the return — and reach the guardable surface via a cast.
-const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): W => {
+const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId, tablesOfIds?: TablesOfIds): W => {
     if (schema.rlsMode !== "required") {
         return raw;
     }
@@ -226,6 +238,48 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
         }
     };
 
+    /**
+     * The `deleteMany`/`patchMany` gate: same decision as {@link guardById}
+     * applied to every id in the batch, but fetching table ownership in as
+     * few round-trips as possible instead of one probe per id.
+     *
+     * - `expectedTable` pinned (the by-id facade's bound table) → one
+     * `guardTable` call, no probe at all — identical to the single-id path.
+     * - No {@link tablesOfIds} resolver supplied (the D1/`.global()` twin
+     * hasn't implemented the batch form) → fall back to the per-id loop,
+     * verbatim.
+     * - Otherwise: dedupe, resolve the owning table of every id in ONE call,
+     * then judge each id (in its original, possibly-duplicated input order)
+     * through the same {@link guardTable} — an unresolved id passes through
+     * exactly like {@link guardById}'s bare-id case.
+     */
+    const guardByIds = async (ids: ReadonlyArray<string>, expectedTable?: string): Promise<void> => {
+        if (expectedTable !== undefined) {
+            guardTable(expectedTable);
+
+            return;
+        }
+
+        if (!tablesOfIds) {
+            for (const id of ids) {
+                // eslint-disable-next-line no-await-in-loop -- no batch resolver supplied (D1-twin fallback): mirrors the pre-batch per-id loop verbatim
+                await guardById(id, expectedTable);
+            }
+
+            return;
+        }
+
+        const resolved = await tablesOfIds([...new Set(ids)], expectedTable);
+
+        for (const id of ids) {
+            const tableName = resolved.get(id);
+
+            if (tableName !== undefined) {
+                guardTable(tableName);
+            }
+        }
+    };
+
     const baseRankBefore = base.rankBefore;
 
     const guarded: Record<PropertyKey, unknown> = {
@@ -253,10 +307,7 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
             // can't be reached by bare id), then delegate the batch — which
             // enforces the payload cap downstream. `expectedTable` (the facade's
             // bound table) scopes each id, mirroring the single delete gate.
-            for (const id of ids) {
-                // eslint-disable-next-line no-await-in-loop -- per-id table resolution mirrors the single delete gate
-                await guardById(id, expectedTable);
-            }
+            await guardByIds(ids, expectedTable);
 
             return base.deleteMany(ids, options, expectedTable);
         },
@@ -321,10 +372,10 @@ const guardWriter = <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId): 
         },
         patchMany: async (patches: ReadonlyArray<{ id: string; patch: Record<string, unknown> }>, options?: { limit?: number }, expectedTable?: string) => {
             // `expectedTable` (the facade's bound table) scopes each id, mirroring the single patch gate.
-            for (const entry of patches) {
-                // eslint-disable-next-line no-await-in-loop -- per-id table resolution mirrors the single patch gate
-                await guardById(entry.id, expectedTable);
-            }
+            await guardByIds(
+                patches.map((entry) => entry.id),
+                expectedTable,
+            );
 
             return base.patchMany(patches, options, expectedTable);
         },


### PR DESCRIPTION
Work from an agent worktree, pushed under a descriptive name (local branch was `worktree-agent-aee0c271830bd31da`).
Branched before #288/#289 landed, so it needs a rebase onto current alpha before merge.

## Commits

- fix(shard-engine): reject malformed geo inputs instead of returning empty results
- perf(shard-engine): batch the rls-guard id→table probe for deleteMany/patchMany
