### PR TITLE
chore(platform-node): keep the spike host off npm until it is complete

### DIFF
--- a/packages/platform-node/.releaserc.json
+++ b/packages/platform-node/.releaserc.json
@@ -1,3 +1,0 @@
-{
-    "extends": "@anolilab/semantic-release-preset/pnpm"
-}

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@lunora/platform-node",
     "version": "0.0.0",
+    "private": true,
     "description": "Node implementation of the Lunora platform contracts: ShardHost, SocketHost, ShardDirectory, ShardKvStore, SchedulerHost over better-sqlite3 and an in-process socket registry (dev/test target)",
     "keywords": [
         "better-sqlite3",


### PR DESCRIPTION
## Why

`@lunora/platform-node` landed as a plan-234 spike but was configured to publish: `.releaserc.json` present, `publishConfig.access: public`, version `0.0.0`, **never released**. The next `multi-semantic-release` run from `alpha` would have shipped a half-finished host to npm as `1.0.0-alpha.1` — alarms that persist a timestamp nothing re-arms, a scheduler that stores jobs and never dispatches them, and no deploy driver.

## What

Marks the package `private` and drops its `.releaserc.json` — the same pair `@lunora/search-core` and `@lunora/dispatch` carry, both of which 404 on npm. `multi-semantic-release` skips private packages, so this is the whole gate.

The package stays in the workspace: it builds, its conformance and engine suites still run in CI, and `--target node` remains selectable for codegen. The only thing that changes is that npm cannot receive it yet.

## Follow-up

#328 completes the host and flips both settings back, so the package becomes publishable in the same change that makes it worth publishing.

## Verification

`lint:package-json` clean (key order — `private` sits directly after `version`). `check-agents-md-packages` and `check-sibling-peer-ranges` pass. No lockfile change: the drift that showed up while working on this is pre-existing and unrelated (see the follow-up PR's notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to mark the package as private.
  * Removed the package’s automated release configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->