### PR TITLE
feat(docs): add cookie consent + cookieless analytics

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -27,6 +27,7 @@
     },
     "dependencies": {
         "@babel/core": "catalog:web",
+        "@c15t/react": "catalog:web",
         "@fuma-comment/react": "catalog:web",
         "@fumadocs/mdx-remote": "catalog:web",
         "@icons-pack/react-simple-icons": "catalog:web",

--- a/apps/docs/src/components/sections/footer.tsx
+++ b/apps/docs/src/components/sections/footer.tsx
@@ -1,3 +1,4 @@
+import { ConsentDialogLink } from "@c15t/react";
 import DiscordLogoIcon from "@icons-pack/react-simple-icons/icons/SiDiscord.mjs";
 import GitHubLogoIcon from "@icons-pack/react-simple-icons/icons/SiGithub.mjs";
 import { Link } from "@tanstack/react-router";
@@ -10,8 +11,10 @@ import FlickeringGrid from "@/components/ui/flickering-grid";
 
 type TanstackLink = { title: string; to: string };
 type ExternalLinkType = { href: string; title: string };
+type ConsentDialogEntry = { consentDialog: true; title: string };
+type FooterEntry = ConsentDialogEntry | ExternalLinkType | TanstackLink;
 
-const columns: { links: (ExternalLinkType | TanstackLink)[]; title: string }[] = [
+const columns: { links: FooterEntry[]; title: string }[] = [
     {
         links: [
             { title: "Server", to: "/packages/server" },
@@ -35,6 +38,7 @@ const columns: { links: (ExternalLinkType | TanstackLink)[]; title: string }[] =
     {
         links: [
             { title: "Privacy", to: "/privacy" },
+            { consentDialog: true, title: "Cookie settings" },
             { title: "Code of Conduct", to: "/code-of-conduct" },
             { title: "Imprint", to: "/imprint" },
             { title: "Press & Brand", to: "/press" },
@@ -49,9 +53,13 @@ const socials: { href: string; icon: ReactNode; label: string }[] = [
     { href: "https://github.com/anolilab/lunora/discussions", icon: <MessagesSquare className="size-5" />, label: "Discussions" },
 ];
 
-const FooterLink: FC<{ link: ExternalLinkType | TanstackLink }> = ({ link }) => {
+const FooterLink: FC<{ link: FooterEntry }> = ({ link }) => {
     const className =
         "flex flex-1 items-center border-b border-white/[0.08] px-6 py-5 text-sm text-white/55 transition-colors last:border-b-0 hover:text-white";
+
+    if ("consentDialog" in link) {
+        return <ConsentDialogLink className={`${className} cursor-pointer`}>{link.title}</ConsentDialogLink>;
+    }
 
     if ("href" in link) {
         return (

--- a/apps/docs/src/lib/consent-overrides.ts
+++ b/apps/docs/src/lib/consent-overrides.ts
@@ -1,0 +1,49 @@
+import type { Overrides } from "@c15t/react";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequestHeaders } from "@tanstack/react-start/server";
+
+// Geo headers across the CDNs the site may sit behind (Netlify sends
+// "x-country"; the Cloudflare/Vercel/CloudFront names cost nothing to keep).
+// Advisory only — a visitor spoofing one suppresses their own banner, nothing
+// more, and absent headers fail safe (c15t defaults to GDPR → banner shown).
+// Never use these values for anything enforcement-related.
+const COUNTRY_HEADERS = ["x-country", "cf-ipcountry", "x-vercel-ip-country", "x-amz-cf-ipcountry", "x-country-code"] as const;
+
+const REGION_HEADERS = ["x-vercel-ip-country-region", "x-region-code"] as const;
+
+const firstHeader = (headers: Headers, names: ReadonlyArray<string>): string | undefined => {
+    for (const name of names) {
+        const value = headers.get(name);
+
+        if (value) {
+            return value;
+        }
+    }
+
+    return undefined;
+};
+
+/**
+ * Resolve c15t location overrides from the CDN geo headers.
+ *
+ * Runs server-side and is called from the root route's loader, so the result is
+ * dehydrated to the client and both sides initialize the consent store with the
+ * same jurisdiction — c15t decides from the country whether the banner must show.
+ */
+export const getConsentOverrides = createServerFn({ method: "GET" }).handler((): Overrides => {
+    const headers: Headers = getRequestHeaders();
+    const overrides: Overrides = {};
+
+    const country = firstHeader(headers, COUNTRY_HEADERS)?.toUpperCase();
+    const region = firstHeader(headers, REGION_HEADERS);
+
+    if (country) {
+        overrides.country = country;
+    }
+
+    if (region) {
+        overrides.region = region;
+    }
+
+    return overrides;
+});

--- a/apps/docs/src/lib/consent-overrides.ts
+++ b/apps/docs/src/lib/consent-overrides.ts
@@ -11,6 +11,12 @@ const COUNTRY_HEADERS = ["x-country", "cf-ipcountry", "x-vercel-ip-country", "x-
 
 const REGION_HEADERS = ["x-vercel-ip-country-region", "x-region-code"] as const;
 
+const ISO_COUNTRY = /^[A-Z]{2}$/;
+
+// CDN placeholders for "unknown" (XX) and Tor exit nodes (T1) — c15t would
+// treat them as a real non-GDPR country and suppress the banner.
+const PLACEHOLDER_COUNTRIES = new Set(["T1", "XX"]);
+
 const firstHeader = (headers: Headers, names: ReadonlyArray<string>): string | undefined => {
     for (const name of names) {
         const value = headers.get(name);
@@ -34,7 +40,8 @@ export const getConsentOverrides = createServerFn({ method: "GET" }).handler(():
     const headers: Headers = getRequestHeaders();
     const overrides: Overrides = {};
 
-    const country = firstHeader(headers, COUNTRY_HEADERS)?.toUpperCase();
+    const rawCountry = firstHeader(headers, COUNTRY_HEADERS)?.trim().toUpperCase();
+    const country = rawCountry && ISO_COUNTRY.test(rawCountry) && !PLACEHOLDER_COUNTRIES.has(rawCountry) ? rawCountry : undefined;
     const region = firstHeader(headers, REGION_HEADERS);
 
     if (country) {

--- a/apps/docs/src/providers/analytics-provider.tsx
+++ b/apps/docs/src/providers/analytics-provider.tsx
@@ -1,0 +1,62 @@
+import { useConsentManager } from "@c15t/react";
+// eslint-disable-next-line import/no-named-as-default
+import posthog from "posthog-js";
+import type { FC, PropsWithChildren } from "react";
+import { useEffect } from "react";
+
+const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_API_KEY as string | undefined;
+const POSTHOG_HOST = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ?? "https://eu.i.posthog.com";
+
+const isEnabled = Boolean(POSTHOG_KEY) && !import.meta.env.DEV;
+
+let initialized = false;
+
+/**
+ * PostHog in cookieless "on_reject" mode, synced to the c15t consent state.
+ *
+ * Pre-consent and after "Reject", PostHog stores nothing on the device — users
+ * are counted via PostHog's server-side daily-salted hash instead (requires
+ * "Cookieless server hash mode" enabled in the PostHog project settings, or
+ * those events are dropped). After "Accept", normal cookie/localStorage
+ * persistence with full session continuity. Init happens in an effect, so it
+ * only ever runs client-side.
+ */
+const AnalyticsProvider: FC<PropsWithChildren> = ({ children }) => {
+    const { consents, hasConsented } = useConsentManager();
+
+    const measurementConsent = hasConsented() ? consents.measurement : undefined;
+
+    useEffect(() => {
+        if (!isEnabled) {
+            return;
+        }
+
+        if (!initialized) {
+            initialized = true;
+
+            posthog.init(POSTHOG_KEY as string, {
+                api_host: POSTHOG_HOST,
+                cookieless_mode: "on_reject",
+                defaults: "2026-06-25",
+                // No storage before an explicit choice — pending consent behaves
+                // like "rejected" (cookieless hash counting) until c15t says otherwise.
+                opt_out_capturing_by_default: true,
+                opt_out_persistence_by_default: true,
+            });
+        }
+
+        if (measurementConsent === undefined) {
+            return;
+        }
+
+        if (measurementConsent) {
+            posthog.opt_in_capturing();
+        } else {
+            posthog.opt_out_capturing();
+        }
+    }, [measurementConsent]);
+
+    return children;
+};
+
+export default AnalyticsProvider;

--- a/apps/docs/src/providers/analytics-provider.tsx
+++ b/apps/docs/src/providers/analytics-provider.tsx
@@ -52,6 +52,12 @@ const AnalyticsProvider: FC<PropsWithChildren> = ({ children }) => {
         if (measurementConsent) {
             posthog.opt_in_capturing();
         } else {
+            // Withdrawal must also erase what the accept path persisted
+            // (distinct_id, device_id) — opt-out alone only stops capture.
+            if (posthog.has_opted_in_capturing()) {
+                posthog.reset(true);
+            }
+
             posthog.opt_out_capturing();
         }
     }, [measurementConsent]);

--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import "@/lib/posthog";
 import "unfonts.css";
 
+import { ConsentBanner, ConsentDialog, ConsentManagerProvider } from "@c15t/react";
 import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 import { RootProvider } from "fumadocs-ui/provider/tanstack";
 import type { FC, PropsWithChildren } from "react";
@@ -9,7 +10,9 @@ import { lazy, Suspense } from "react";
 import Footer from "@/components/sections/footer";
 import Navbar from "@/components/sections/navbar";
 import JsonLd from "@/components/seo/json-ld";
+import { getConsentOverrides } from "@/lib/consent-overrides";
 import { NotFound } from "@/pages/not-found";
+import AnalyticsProvider from "@/providers/analytics-provider";
 import appCss from "@/styles/app.css?url";
 
 const TanStackRouterDevtools =
@@ -23,64 +26,83 @@ const TanStackRouterDevtools =
               }),
           );
 
-const RootDocument: FC<PropsWithChildren> = ({ children }) => (
-    <html lang="en" suppressHydrationWarning>
-        <head>
-            <HeadContent />
-            <JsonLd
-                data={{
-                    "@type": "Organization",
-                    logo: "https://lunora.sh/favicon.svg",
-                    name: "Lunora",
-                    sameAs: ["https://github.com/anolilab/lunora"],
-                    url: "https://lunora.sh",
-                }}
-            />
-            <JsonLd
-                data={{
-                    "@type": "WebSite",
-                    name: "Lunora",
-                    potentialAction: {
-                        "@type": "SearchAction",
-                        "query-input": "required name=search_term_string",
-                        target: "https://lunora.sh/docs?q={search_term_string}",
-                    },
-                    url: "https://lunora.sh",
-                }}
-            />
-        </head>
-        <body>
-            <div className="bg-dark-coal relative isolate font-sans antialiased">
-                <svg aria-hidden="true" height="0" width="0">
-                    <defs>
-                        <pattern height="4" id="pattern-ivory" patternUnits="userSpaceOnUse" width="1">
-                            <rect className="fill-ivory" height="1" width="1" />
-                        </pattern>
-                        <pattern height="4" id="pattern-sky-sapphire" patternUnits="userSpaceOnUse" width="1">
-                            <rect className="fill-sky-sapphire" height="1" width="1" />
-                        </pattern>
-                        <pattern height="4" id="pattern-crimson-energy" patternUnits="userSpaceOnUse" width="1">
-                            <rect className="fill-crimson-energy" height="1" width="1" />
-                        </pattern>
-                        <pattern height="4" id="pattern-royal-amethyst" patternUnits="userSpaceOnUse" width="1">
-                            <rect className="fill-royal-amethyst" height="1" width="1" />
-                        </pattern>
-                    </defs>
-                </svg>
+const RootDocument: FC<PropsWithChildren> = ({ children }) => {
+    const overrides = Route.useLoaderData();
 
-                <RootProvider search={{ enabled: true }} theme={{ enabled: true, defaultTheme: "dark", forcedTheme: "dark" }}>
-                    <Navbar />
-                    <main className="relative">{children}</main>
-                </RootProvider>
-                <Footer />
-            </div>
-            <Suspense>
-                <TanStackRouterDevtools position="bottom-right" />
-            </Suspense>
-            <Scripts />
-        </body>
-    </html>
-);
+    return (
+        <html lang="en" suppressHydrationWarning>
+            <head>
+                <HeadContent />
+                <JsonLd
+                    data={{
+                        "@type": "Organization",
+                        logo: "https://lunora.sh/favicon.svg",
+                        name: "Lunora",
+                        sameAs: ["https://github.com/anolilab/lunora"],
+                        url: "https://lunora.sh",
+                    }}
+                />
+                <JsonLd
+                    data={{
+                        "@type": "WebSite",
+                        name: "Lunora",
+                        potentialAction: {
+                            "@type": "SearchAction",
+                            "query-input": "required name=search_term_string",
+                            target: "https://lunora.sh/docs?q={search_term_string}",
+                        },
+                        url: "https://lunora.sh",
+                    }}
+                />
+            </head>
+            <body>
+                <ConsentManagerProvider
+                    options={{
+                        colorScheme: "dark",
+                        consentCategories: ["measurement", "necessary"],
+                        legalLinks: { privacyPolicy: { href: "/privacy", target: "_self" } },
+                        mode: "offline",
+                        overrides,
+                        store: { overrides },
+                    }}
+                >
+                    <ConsentBanner hideBranding />
+                    <ConsentDialog hideBranding />
+                    <AnalyticsProvider>
+                        <div className="bg-dark-coal relative isolate font-sans antialiased">
+                            <svg aria-hidden="true" height="0" width="0">
+                                <defs>
+                                    <pattern height="4" id="pattern-ivory" patternUnits="userSpaceOnUse" width="1">
+                                        <rect className="fill-ivory" height="1" width="1" />
+                                    </pattern>
+                                    <pattern height="4" id="pattern-sky-sapphire" patternUnits="userSpaceOnUse" width="1">
+                                        <rect className="fill-sky-sapphire" height="1" width="1" />
+                                    </pattern>
+                                    <pattern height="4" id="pattern-crimson-energy" patternUnits="userSpaceOnUse" width="1">
+                                        <rect className="fill-crimson-energy" height="1" width="1" />
+                                    </pattern>
+                                    <pattern height="4" id="pattern-royal-amethyst" patternUnits="userSpaceOnUse" width="1">
+                                        <rect className="fill-royal-amethyst" height="1" width="1" />
+                                    </pattern>
+                                </defs>
+                            </svg>
+
+                            <RootProvider search={{ enabled: true }} theme={{ enabled: true, defaultTheme: "dark", forcedTheme: "dark" }}>
+                                <Navbar />
+                                <main className="relative">{children}</main>
+                            </RootProvider>
+                            <Footer />
+                        </div>
+                    </AnalyticsProvider>
+                </ConsentManagerProvider>
+                <Suspense>
+                    <TanStackRouterDevtools position="bottom-right" />
+                </Suspense>
+                <Scripts />
+            </body>
+        </html>
+    );
+};
 
 export const Route = createRootRoute({
     component: () => (
@@ -88,6 +110,7 @@ export const Route = createRootRoute({
             <Outlet />
         </RootDocument>
     ),
+    loader: () => getConsentOverrides(),
     head: () => {
         return {
             links: [

--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -63,7 +63,6 @@ const RootDocument: FC<PropsWithChildren> = ({ children }) => {
                         legalLinks: { privacyPolicy: { href: "/privacy", target: "_self" } },
                         mode: "offline",
                         overrides,
-                        store: { overrides },
                     }}
                 >
                     <ConsentBanner hideBranding />
@@ -135,4 +134,6 @@ export const Route = createRootRoute({
         };
     },
     notFoundComponent: (props) => <NotFound {...props} />,
+    // Geo headers don't change within a session — never re-fetch on navigation.
+    staleTime: Number.POSITIVE_INFINITY,
 });

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -1,12 +1,10 @@
 @import "tailwindcss";
-
-@plugin 'tailwindcss-animate';
-
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
-
 /* Prebuilt consent component styles — c15t v2 no longer injects these automatically. */
 @import "@c15t/react/styles.css";
+
+@plugin 'tailwindcss-animate';
 
 /* Canonical Lunora "Luna + Aurora" tokens — neutrals, aurora ramp, shadcn
    semantic set, fonts, radius (:root + .dark + @theme). Single source of truth;

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -5,6 +5,9 @@
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 
+/* Prebuilt consent component styles — c15t v2 no longer injects these automatically. */
+@import "@c15t/react/styles.css";
+
 /* Canonical Lunora "Luna + Aurora" tokens — neutrals, aurora ramp, shadcn
    semantic set, fonts, radius (:root + .dark + @theme). Single source of truth;
    see marketing/design-tokens/DESIGN.md. Docs-only animations, nav tokens, and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,7 @@ overrides:
   axios: '>=1.18.0'
   protobufjs: '>=7.6.5'
   body-parser: '>=2.3.0'
+  valibot: '>=1.4.2'
   '@lunora/advisor': workspace:*
   '@lunora/agent': workspace:*
   '@lunora/ai': workspace:*
@@ -23367,8 +23368,8 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  valibot@1.3.1:
-    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: 6.0.3
     peerDependenciesMeta:
@@ -25708,7 +25709,7 @@ snapshots:
 
   '@c15t/schema@2.1.0(typescript@6.0.3)':
     dependencies:
-      valibot: 1.3.1(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -45828,7 +45829,7 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  valibot@1.3.1(typescript@6.0.3):
+  valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ catalogs:
     '@babel/core':
       specifier: 8.0.1
       version: 8.0.1
+    '@c15t/react':
+      specifier: 2.1.0
+      version: 2.1.0
     '@eslint-react/eslint-plugin':
       specifier: 5.18.0
       version: 5.18.0
@@ -952,6 +955,9 @@ importers:
       '@babel/core':
         specifier: catalog:web
         version: 8.0.1
+      '@c15t/react':
+        specifier: catalog:web
+        version: 2.1.0(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8))
       '@fuma-comment/react':
         specifier: catalog:web
         version: 1.5.0(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(highlight.js@11.11.1)(lucide-react@1.26.0(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
@@ -5852,6 +5858,21 @@ packages:
     resolution: {integrity: sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==}
     cpu: [x64]
     os: [win32]
+
+  '@c15t/react@2.1.0':
+    resolution: {integrity: sha512-tlHPjLN8R/M2xXkjoVfoiFxAy/NALVfO+DtDVUO/KL+/fqV9j1ycL489lG7s1p2jAgYeurHEnNmeb8lgjvoIDg==}
+    peerDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8
+
+  '@c15t/schema@2.1.0':
+    resolution: {integrity: sha512-/Kxe4qv6E5cR6wgzxx1CTZuhMFfJQHi3GGFzcRCx4smqN8IrgsVtXv800O7Nz9RqoDu/8DFiHGpJ25aupwMsRQ==}
+
+  '@c15t/translations@2.1.0':
+    resolution: {integrity: sha512-pB6A5nMKHaAwFOUetcIkyIscMBr5iVm/lxBqzoSk3MU0KMGn4F/OTpcLZOT7k5P87RMkuuKkXN+gyf6jCuvBAw==}
+
+  '@c15t/ui@2.1.0':
+    resolution: {integrity: sha512-tl9mQnQdPbtWQQpXNFRzqrQDk4crjRUX+lIJmd7Le+uZVIuEiNbDeEIjQLj0XH0Cp3Xv3NJn0C7XF5H9CRVHKA==}
 
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
@@ -15494,6 +15515,9 @@ packages:
       magicast:
         optional: true
 
+  c15t@2.1.0:
+    resolution: {integrity: sha512-ukWy6y/yNGPrJv4bAr2DeMNkxtcsdehe++AeqzEC6ITDCVVaqCGeePIKo/3qMZzhyyCPtcKsQJKNIfqszyzpvQ==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -23343,6 +23367,14 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: 6.0.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-html-nesting@1.2.4:
     resolution: {integrity: sha512-doQi7e8EJ2OWneSG1aZpJluS6A49aZM0+EICXWKm1i6WvqTLmq0tpUcImc4KTWG50mORO0C4YDBtOCSYvElftw==}
 
@@ -24141,6 +24173,24 @@ packages:
       immer:
         optional: true
       react:
+        optional: true
+
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: 19.2.8
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
         optional: true
 
   zustand@5.0.14:
@@ -25643,6 +25693,37 @@ snapshots:
 
   '@bruits/satteri-win32-x64-msvc@0.9.5':
     optional: true
+
+  '@c15t/react@2.1.0(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8))':
+    dependencies:
+      '@c15t/ui': 2.1.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8))
+      c15t: 2.1.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8))
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - typescript
+      - use-sync-external-store
+
+  '@c15t/schema@2.1.0(typescript@6.0.3)':
+    dependencies:
+      valibot: 1.3.1(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@c15t/translations@2.1.0': {}
+
+  '@c15t/ui@2.1.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8))':
+    dependencies:
+      '@c15t/translations': 2.1.0
+      c15t: 2.1.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
 
   '@capsizecss/unpack@4.0.0':
     dependencies:
@@ -36203,6 +36284,18 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.3
 
+  c15t@2.1.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.8)):
+    dependencies:
+      '@c15t/schema': 2.1.0(typescript@6.0.3)
+      '@c15t/translations': 2.1.0
+      zustand: 5.0.12(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+
   cac@6.7.14: {}
 
   cac@7.0.0: {}
@@ -45735,6 +45828,10 @@ snapshots:
 
   uuid@11.1.1: {}
 
+  valibot@1.3.1(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+
   validate-html-nesting@1.2.4: {}
 
   validate-npm-package-license@3.0.4:
@@ -46679,6 +46776,13 @@ snapshots:
       '@types/react': 19.2.17
       immer: 11.1.8
       react: 19.2.8
+
+  zustand@5.0.12(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      immer: 11.1.8
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   zustand@5.0.14(@types/react@19.2.17)(immer@11.1.8)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -366,6 +366,7 @@ catalogs:
     "@anolilab/eslint-config": 28.0.1
     "@anolilab/prettier-config": 10.0.2
     "@babel/core": 8.0.1
+    "@c15t/react": 2.1.0
     "@eslint-react/eslint-plugin": 5.18.0
     "@eslint/css": 1.4.0
     "@fuma-comment/react": 1.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,6 +56,9 @@ overrides:
   axios: ">=1.18.0"
   protobufjs: ">=7.6.5"
   body-parser: ">=2.3.0"
+  # @c15t/schema pins valibot to exactly 1.3.1; <=1.4.1 has a moderate flatten()
+  # DoS (GHSA-5qjj-4xww-7phc), fixed in 1.4.2.
+  valibot: ">=1.4.2"
   # Internal packages → local workspace source. Lives in root overrides (NOT each
   # package's dependencies) so semantic-release-pnpm's per-package range rewrite
   # never clobbers it; published tarballs are unaffected (overrides are install-time).


### PR DESCRIPTION
## Summary

Adds a GDPR consent layer to the docs site and wires PostHog behind it in cookieless mode.

- **Consent banner + preferences dialog** (c15t v2, offline mode) rendered in the site's dark theme, with a first-layer link to `/privacy` and vendor branding hidden.
- **Jurisdiction-aware:** the root route loader reads the CDN geo headers server-side (`x-country` on Netlify, plus the Cloudflare/Vercel/CloudFront names) via a server function; the result is dehydrated to the client so both sides initialize the consent store with the same country and c15t decides whether the banner is required. Headers are advisory only — absent or spoofed headers fail safe (banner shown, GDPR assumed).
- **Withdrawal is as easy as consent:** a "Cookie settings" entry in the footer's Legal column reopens the dialog at any time.
- **Cookieless PostHog** (`cookieless_mode: "on_reject"`): before a choice and after "Reject", nothing is stored on the device — users are counted via PostHog's server-side daily-salted hash. "Accept" switches to normal persistence with full session continuity. Init is gated on `VITE_POSTHOG_API_KEY` (host defaults to the EU endpoint) and disabled in dev.

## Deployment requirements

- Set `VITE_POSTHOG_API_KEY` (and optionally `VITE_POSTHOG_HOST`) in the Netlify build environment.
- Enable **"Cookieless server hash mode"** in the PostHog project settings (Project Settings → Web analytics) — without it, cookieless events are silently dropped.

## Verification

- Type-check, ESLint, Prettier, package.json key-order gate, docs tests, and a full production `vite build` (incl. prerender) pass.
- Browser-verified: banner on first visit, Reject All persists, footer "Cookie settings" reopens the dialog, privacy link renders, no vendor branding.
- Geo bridge verified end-to-end: a request with `x-country: US` dehydrates `{country:"US"}` into the router payload that seeds the client consent store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EELf27TTEX6ohpmP2vPrMa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cookie consent banners and settings controls to the documentation site.
  * Added regional consent handling based on visitor location.
  * Added privacy-conscious analytics that respects measurement consent.
  * Added a cookie settings link to the site footer.
  * Added styling support for the consent management interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->