### PR TITLE
ci: path-gate benchmarks, codeql, zizmor, dep-review

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -50,6 +50,25 @@ e2e:
 codecov:
     - "codecov.yml"
 
+# CodSpeed benchmarks: anything that can change a bench result or the bench
+# selection. `vis affected test:bench` narrows further inside the job; this
+# gate only exists so docs/plans-only PRs skip the install+build entirely.
+benchmarks:
+    - "packages/**"
+    - "shared/**"
+    - "**/tsconfig*.json"
+    - "pnpm-lock.yaml"
+    - "pnpm-workspace.yaml"
+    - "package.json"
+    - "vis.config.ts"
+    - ".github/workflows/codspeed.yml"
+
+# The auth-ui → registry/auth-ui-* copy-sync check.
+registry_sync:
+    - "packages/auth-ui/**"
+    - "registry/**"
+    - "scripts/sync-auth-ui-registry.mjs"
+
 # The template scaffold+install+build+typecheck matrix. It packs every publishable
 # package and runs a real `pnpm install` per template, so it is far too slow for
 # every PR — but it is the ONLY gate that proves `lunora init` still installs and

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,22 @@
         "branches": ["main", "alpha", "next", "beta"]
     "pull_request":
         "branches": ["main", "alpha", "next", "beta"]
+        # Only scan PRs that touch analyzable JS/TS source (or this workflow).
+        # Docs/plans-only PRs skip; push + weekly schedule stay ungated so
+        # branch heads always carry a complete code-scanning baseline.
+        "paths":
+            - "**/*.ts"
+            - "**/*.tsx"
+            - "**/*.mts"
+            - "**/*.cts"
+            - "**/*.js"
+            - "**/*.jsx"
+            - "**/*.mjs"
+            - "**/*.cjs"
+            - "**/*.vue"
+            - "**/*.svelte"
+            - "**/*.astro"
+            - ".github/workflows/codeql.yml"
     "schedule":
         - "cron": "0 0 * * 1"
 "permissions": {}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -18,8 +18,38 @@
     "contents": "read" # to fetch code (actions/checkout)
 
 "jobs":
+    # PR-only path gate: docs/plans-only PRs skip the whole install+build+bench
+    # job. Push runs (main/alpha baselines) are never gated — CodSpeed needs a
+    # complete baseline on every branch head.
+    "files-changed":
+        "name": "Detect what files changed"
+        "if": "github.event_name == 'pull_request'"
+        "runs-on": "ubuntu-latest"
+        "timeout-minutes": 5
+        "outputs":
+            "benchmarks": "${{ steps.changes.outputs.benchmarks }}"
+        "steps":
+            - "name": "Harden Runner"
+              "uses": "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411" # v2.19.4
+              "with":
+                  "egress-policy": "audit"
+
+            - "name": "Git checkout"
+              "uses": "anolilab/workflows/step/checkout-with-retry@6c16895f4c3b5273b373656988505d1a8264e78b" # main
+
+            - "name": "Check for file changes"
+              "id": "changes"
+              "uses": "dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d" # v4.0.1
+              "with":
+                  "token": "${{ github.token }}"
+                  "filters": ".github/file-filters.yml"
+
     "benchmark":
         "name": "Benchmarks"
+        # `!cancelled()` (not the implicit success()) because files-changed is
+        # skipped on push/dispatch, which would otherwise skip this job too.
+        "if": "!cancelled() && (github.event_name != 'pull_request' || needs.files-changed.outputs.benchmarks == 'true')"
+        "needs": "files-changed"
         "runs-on": "ubuntu-latest"
         "timeout-minutes": 30
         # Scope the CodSpeed OIDC token to an environment so secrets and
@@ -74,8 +104,19 @@
             # Benchmarks import workspace packages from their built `dist/`, which
             # is gitignored. Without this the bench suites fail to resolve
             # `@lunora/*` entries ("Failed to resolve entry for package ...").
+            # On PRs only the affected packages (plus their dependsOn chain) are
+            # built — mirroring the affected bench selection below; pushes build
+            # everything for the full baseline run.
             - "name": "Build packages"
-              "run": "pnpm run build:packages"
+              "shell": "bash"
+              "env":
+                  "EVENT_NAME": "${{ github.event_name }}"
+              "run": |
+                  if [ "$EVENT_NAME" = "pull_request" ]; then
+                      pnpm run build:affected:packages
+                  else
+                      pnpm run build:packages
+                  fi
 
             # On PRs only the benches whose project (or an upstream dependency)
             # changed are run; on push to main/alpha every bench runs so CodSpeed

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,15 @@
 "on":
     "pull_request":
         "branches": ["main", "alpha", "next", "beta"]
+        # The review diffs the dependency graph — only manifests, lockfiles,
+        # vendored patches, action pins, and the python SDK can change it.
+        "paths":
+            - "**/package.json"
+            - "pnpm-lock.yaml"
+            - "pnpm-workspace.yaml"
+            - "patches/**"
+            - ".github/workflows/**"
+            - "sdks/**"
 "permissions": {}
 "jobs":
     "dependency-review":

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@
             "api_surface": "${{ steps.changes.outputs.api_surface }}"
             "frontend_lintable": "${{ steps.changes.outputs.frontend_lintable }}"
             "package_json_lintable": "${{ steps.changes.outputs.package_json_lintable }}"
+            "registry_sync": "${{ steps.changes.outputs.registry_sync }}"
             "yaml_lintable": "${{ steps.changes.outputs.yaml_lintable }}"
         "steps":
             - "name": "Harden Runner"
@@ -309,6 +310,7 @@
     # outright.
     "registry-sync":
         "name": "Lint (auth-ui registry sync)"
+        "if": "needs.files-changed.outputs.registry_sync == 'true'"
         "needs": "files-changed"
         "runs-on": "ubuntu-latest"
         "timeout-minutes": 10

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,8 +2,11 @@
 "on":
     "push":
         "branches": ["main", "alpha", "next", "beta"]
+        "paths": [".github/**"]
     "pull_request":
         "branches": ["main", "alpha", "next", "beta"]
+        # zizmor audits GitHub Actions workflows — nothing else can change its result.
+        "paths": [".github/**"]
 "permissions": {}
 "jobs":
     "zizmor":


### PR DESCRIPTION
## What

Extends the existing path-gating (test.yml / lint.yml already skip via `dorny/paths-filter` + `vis affected`) to the workflows that still ran unconditionally on every PR. A docs/plans-only PR currently pays for:

- **CodSpeed** — full checkout, `pnpm install`, and `build:packages` (~minutes) before `vis affected test:bench` discovers there is nothing to run, then an upload that can fail on comparison noise.
- **CodeQL** — a whole-repo JS/TS analysis.
- **zizmor** — a workflow audit no non-workflow change can affect.
- **dependency-review** — a dependency-graph diff no non-manifest change can affect.
- **registry-sync** (lint.yml) — the auth-ui copy-sync check.

## How

| Workflow | Gate |
| --- | --- |
| `codspeed.yml` | New PR-only `files-changed` job over a `benchmarks` filter (`packages/**`, `shared/**`, tsconfigs, lockfile, workspace yaml, vis config, the workflow itself). Pushes to main/alpha stay ungated so CodSpeed always has a complete baseline. PR runs now build with `build:affected:packages` (same pattern as test.yml) instead of building everything. |
| `codeql.yml` | `pull_request.paths` limited to analyzable source (`*.ts/tsx/mts/cts/js/jsx/mjs/cjs/vue/svelte/astro`) + the workflow. Push + weekly schedule unfiltered, so branch heads keep a full code-scanning baseline. |
| `zizmor.yml` | `paths: [".github/**"]` on both triggers. |
| `dependency-review.yml` | `paths`: `**/package.json`, lockfile, workspace yaml, `patches/**`, `.github/workflows/**` (action pins), `sdks/**`. |
| `lint.yml` | `registry-sync` gated on a new `registry_sync` filter (`packages/auth-ui/**`, `registry/**`, the sync script). |

## Notes

- The aggregate required checks (`Check Lint Run`, `Check Test Run`) already treat skipped dependents as green, so gated jobs cannot wedge a PR.
- Trigger-level `paths` use GitHub's filter syntax (no brace expansion — globs are expanded per extension); `file-filters.yml` keeps minimatch syntax for `dorny/paths-filter`.
- All six files pass yamllint with the repo's `.yamllint.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EELf27TTEX6ohpmP2vPrMa