### PR TITLE
fix: coded errors survive the shard boundary, plus two codegen losses

### DIFF
--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { discoverFunctions } from "../src/discover-functions";
 
 const NAMESPACE_COLLISION_RE = /Namespace collision/u;
-const CURSOR_DOC_ARRAY_RE = /CursorDoc\[\]/u;
 
 let workdir: string;
 
@@ -253,13 +252,16 @@ describe("discoverFunctions", () => {
             expect(result[0]?.returnType).toBe('null | { _id: Id<"cursors">; note?: string }');
         });
 
-        it("preserves return types that reference exported local types", () => {
+        it("expands an EXPORTED local type too — `_generated` never imports the handler's own module", () => {
             expect.assertions(1);
 
-            // The mirror case: when the same interface IS exported, downstream
-            // code can `import { CursorDoc } from "..."` to reach it — emit
-            // is still going to need to relocate the path, but the *name* is
-            // valid so we shouldn't drop the inferred return type.
+            // Exporting the interface makes it nameable from the handler, so the
+            // checker prints the bare name `CursorDoc[]` — and emit only rewrites
+            // qualifiers the checker itself rendered as `import("…")`. It never
+            // synthesises an import for the handler's own module, so that bare
+            // name reached `_generated/api.ts` unresolved: TS2304 in generated
+            // code while `lunora codegen` exited 0. Expand it, like the
+            // non-exported case above.
             writeFunction(
                 "cursors.ts",
                 `
@@ -279,7 +281,7 @@ describe("discoverFunctions", () => {
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
             const result = discoverFunctions(project, workdir);
 
-            expect(result[0]?.returnType).toMatch(CURSOR_DOC_ARRAY_RE);
+            expect(result[0]?.returnType).toBe("{ id: string }[]");
         });
 
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {

--- a/packages/codegen/__tests__/discover-schema.test.ts
+++ b/packages/codegen/__tests__/discover-schema.test.ts
@@ -25,6 +25,34 @@ const projectWith = (schemaSource: string): { project: Project; schemaPath: stri
 };
 
 describe("discoverSchema", () => {
+    it("keeps a shorthand column (`defineTable({ status })`) in the table shape", () => {
+        expect.assertions(2);
+
+        // A shorthand property is its own initializer. Skipping it dropped the
+        // column from the shape entirely: `Doc_tasks` came out without `status`,
+        // and an index over it only surfaced as a misleading
+        // `index_references_unknown_field` advisory. `object-shorthand` rewrites
+        // `status: status` into this form, so a lint run could cause the loss.
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            const status = v.union(v.literal("todo"), v.literal("done"));
+
+            export const schema = defineSchema({
+                tasks: defineTable({ title: v.string(), status }).index("by_status", ["status"]),
+            });
+        `);
+
+        const schema = discoverSchema(project, schemaPath);
+        const tasks = schema.tables.find((table) => table.name === "tasks");
+
+        expect(Object.keys(tasks?.shape ?? {})).toStrictEqual(["title", "status"]);
+        // The validator is behind an identifier, so its type is unresolvable
+        // here — but the column exists, which is what the index and the runtime
+        // insert both depend on.
+        expect(tasks?.shape.status?.kind).toBe("any");
+    });
+
     it("captures `.externallyManaged()` into the table IR; defaults to false", () => {
         expect.assertions(2);
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -343,9 +343,17 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 };
 
 /**
- * True when a type's own symbol resolves to a non-exported interface/type-alias
- * declared in the handler's source file — i.e. a name unreachable from
- * `_generated/api.ts`.
+ * True when a type's own symbol resolves to an interface/type-alias declared in
+ * the handler's source file — i.e. a name unreachable from `_generated/api.ts`.
+ *
+ * Exported declarations count too. The checker prints an exported local type by
+ * name (it is nameable from the handler), but codegen only ever emits an import
+ * for a qualifier the checker itself rendered as `import("…")` — it never
+ * synthesises one for the handler's own module. So `export interface Board` came
+ * out as a bare `Board` in `_generated/api.ts` with nothing importing it: TS2304
+ * in generated code, while `lunora codegen` exits 0. Structurally expanding it,
+ * exactly as a non-exported declaration already was, keeps the emitted type
+ * identical in shape and resolvable from anywhere.
  */
 const symbolDeclaredUnreachable = (type: Type, handlerFilePath: string): boolean => {
     for (const candidate of [type.getSymbol(), type.getAliasSymbol()]) {
@@ -364,7 +372,7 @@ const symbolDeclaredUnreachable = (type: Type, handlerFilePath: string): boolean
                 continue;
             }
 
-            if ((Node.isInterfaceDeclaration(declaration) || Node.isTypeAliasDeclaration(declaration)) && !declaration.isExported()) {
+            if (Node.isInterfaceDeclaration(declaration) || Node.isTypeAliasDeclaration(declaration)) {
                 return true;
             }
         }

--- a/packages/codegen/src/parse-validator.ts
+++ b/packages/codegen/src/parse-validator.ts
@@ -114,7 +114,17 @@ const parseObjectShape = (object: ObjectLiteralExpression): Record<string, Valid
     const out: Record<string, ValidatorIR> = {};
 
     for (const property of object.getProperties()) {
-        if (!Node.isPropertyAssignment(property)) {
+        // A shorthand property (`{ status }`, where `status` is a validator held
+        // in a const) is its own initializer. Treating it as "not a property
+        // assignment" dropped the field from the shape with no error anywhere —
+        // the column vanished from `Doc_*`, and an index over it only surfaced
+        // as a confusing `index_references_unknown_field` advisory. Every caller
+        // of this parser (table shapes, `.input()` args, http routes, mutators)
+        // was affected, and `object-shorthand` autofixes plain assignments into
+        // this form, so the loss could arrive from a lint run.
+        const shorthand = Node.isShorthandPropertyAssignment(property);
+
+        if (!shorthand && !Node.isPropertyAssignment(property)) {
             continue;
         }
 
@@ -126,7 +136,7 @@ const parseObjectShape = (object: ObjectLiteralExpression): Record<string, Valid
             continue;
         }
 
-        const initializer = property.getInitializer();
+        const initializer = shorthand ? property.getNameNode() : property.getInitializer();
 
         if (!initializer) {
             continue;

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
@@ -1,0 +1,175 @@
+import { LunoraError } from "@lunora/errors";
+import { describe, expect, it } from "vitest";
+
+import { createShardHost } from "../src/cloudflare-host";
+
+/**
+ * Error identity across the durable-transaction boundary.
+ *
+ * workerd rolls a failed `storage.transaction` back correctly, but the exception
+ * it propagates back out is a FLATTENED copy: a plain `Error` whose message is
+ * the original's `name: message`, carrying none of its own properties. Since
+ * `isLunoraError` is structural (`type` + `code` + `status`), every coded error a
+ * mutation handler threw failed that check on the way out and was rendered to the
+ * client as a generic 500 `INTERNAL` / "Internal error" — a `NOT_FOUND`, a
+ * `CONFLICT` on a unique index, an `UNAUTHENTICATED` guard, all identical and all
+ * logged as internal faults. Queries never enter a transaction, so they were
+ * unaffected, which is what made the behaviour look arbitrary.
+ *
+ * These tests pin the two halves that have to stay true together: the closure's
+ * throw still reaches the platform (so the rollback happens), and the caller
+ * still receives the *original* error object.
+ */
+
+/** A `storage` double that flattens a thrown error exactly the way workerd does. */
+const flatteningStorage = (): { calls: string[]; transaction: <R>(closure: () => Promise<R>) => Promise<R> } => {
+    const calls: string[] = [];
+
+    return {
+        calls,
+        transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+            try {
+                const value = await closure();
+
+                calls.push("committed");
+
+                return value;
+            } catch (error) {
+                calls.push("rolled-back");
+
+                // The lossy re-throw this fix exists to survive: workerd keeps
+                // only the stringified form. `cause` is carried for the lint
+                // rule's benefit — the point of the double is that `code` /
+                // `status` do NOT survive.
+                throw new Error(String(error), { cause: error });
+            }
+        },
+    };
+};
+
+const hostWith = (storage: unknown) => createShardHost({ storage } as never);
+
+/**
+ * A `blockConcurrencyWhile` double that mirrors workerd's behaviour: a closure
+ * that REJECTS aborts the object. The double records that abort so a regression
+ * is visible rather than merely slower.
+ */
+const gate = (): { aborted: boolean; blockConcurrencyWhile: <R>(closure: () => Promise<R>) => Promise<R> } => {
+    const record = {
+        aborted: false,
+        blockConcurrencyWhile: async <R>(closure: () => Promise<R>): Promise<R> => {
+            try {
+                return await closure();
+            } catch (error) {
+                record.aborted = true;
+
+                throw new Error(String(error), { cause: error });
+            }
+        },
+    };
+
+    return record;
+};
+
+describe("cloudflare shard host transaction", () => {
+    it("rethrows the handler's own error instance, not the platform's flattened copy", async () => {
+        expect.assertions(4);
+
+        const storage = flatteningStorage();
+        const thrown = new LunoraError("NOT_FOUND", "lobby not found");
+
+        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toBe(thrown);
+
+        // Same object, so the wire-relevant fields the error renderer keys on survive.
+        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toMatchObject({
+            code: "NOT_FOUND",
+            status: 404,
+        });
+
+        expect(storage.calls).toStrictEqual(["rolled-back", "rolled-back"]);
+        // The closure must still throw INTO the platform, or nothing rolls back.
+        expect(storage.calls).not.toContain("committed");
+    });
+
+    it("still surfaces a platform-side failure that the closure never raised", async () => {
+        expect.assertions(1);
+
+        // A commit/rollback fault belongs to the platform: there is no handler
+        // error to restore, so it must not be swallowed or replaced.
+        const storage = {
+            transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+                await closure();
+
+                throw new Error("commit failed");
+            },
+        };
+
+        await expect(hostWith(storage).transaction(() => Promise.resolve("ok"))).rejects.toThrow("commit failed");
+    });
+
+    it("passes a successful result through untouched", async () => {
+        expect.assertions(2);
+
+        const storage = flatteningStorage();
+
+        await expect(hostWith(storage).transaction(() => Promise.resolve({ moved: 1 }))).resolves.toStrictEqual({ moved: 1 });
+        expect(storage.calls).toStrictEqual(["committed"]);
+    });
+
+    it("preserves a thrown `undefined` rather than reporting the flattened error", async () => {
+        expect.assertions(1);
+
+        // The saved throw is boxed, so "the closure threw undefined" stays
+        // distinguishable from "the closure never threw". Thrown from the body
+        // rather than `Promise.reject(undefined)` so the non-Error rejection is
+        // expressed the way a handler would actually produce it.
+        const throwsUndefined = async (): Promise<never> => {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately non-Error: surviving a non-Error throw is what this asserts
+            throw undefined;
+        };
+
+        await expect(hostWith(flatteningStorage()).transaction(throwsUndefined)).rejects.toBeUndefined();
+    });
+
+    it("runs bare when the storage double has no transaction support", async () => {
+        expect.assertions(1);
+
+        await expect(hostWith({}).transaction(() => Promise.resolve("bare"))).resolves.toBe("bare");
+    });
+
+    it("does not abort the Durable Object when a handler throws", async () => {
+        expect.assertions(3);
+
+        // workerd tears the object down when a `blockConcurrencyWhile` closure
+        // rejects — taking its in-memory state and every hibernating WebSocket
+        // subscription with it. An ordinary application error must not cost the
+        // shard its object, nor every other client connected to it.
+        const state = gate();
+        const host = createShardHost({ ...state, storage: {} } as never);
+        const thrown = new LunoraError("CONFLICT", "not your turn");
+
+        await expect(host.runSerialized(() => Promise.reject(thrown))).rejects.toBe(thrown);
+
+        expect(state.aborted).toBe(false);
+        // And the gate still serializes the success path.
+        await expect(host.runSerialized(() => Promise.resolve(7))).resolves.toBe(7);
+    });
+
+    it("keeps the coded error intact through the full mutation path (gate + transaction)", async () => {
+        expect.assertions(2);
+
+        // `runInTransaction` composes both boundaries, and both flatten. This is
+        // the shape a real mutation error travels through.
+        const state = gate();
+        const storage = flatteningStorage();
+        const host = createShardHost({ ...state, storage } as never);
+        const thrown = new LunoraError("NOT_FOUND", "lobby not found");
+
+        await expect(host.runSerialized(async () => host.transaction(() => Promise.reject(thrown)))).rejects.toMatchObject({
+            code: "NOT_FOUND",
+            status: 404,
+        });
+
+        expect(storage.calls).toStrictEqual(["rolled-back"]);
+    });
+});

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -113,10 +113,42 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * Single-writer gate. `blockConcurrencyWhile` delays the next dispatch
      * until the closure settles, which is exactly the contract's
      * "no two closures run at once for this shard key".
+     *
+     * The closure settles to an outcome INSIDE the gate and is re-thrown outside
+     * it, because workerd treats a throwing `blockConcurrencyWhile` closure as
+     * unrecoverable: it ABORTS the Durable Object (the `durableObjectReset`
+     * marker on the propagated error), discarding its in-memory state and every
+     * hibernating WebSocket subscription attached to it, and hands the caller a
+     * flattened plain `Error` with none of the original's properties.
+     *
+     * That is the right default for the initialization work the API was designed
+     * for, where a failure leaves the object undefined. It is the wrong default
+     * here: this gate wraps every mutation, so an ordinary application error —
+     * a `NOT_FOUND`, a "not your turn" `CONFLICT`, a failed auth guard — was
+     * tearing down the shard for every other client connected to it, and
+     * arriving at the client as a generic 500 `INTERNAL`. The mutation's own
+     * writes are already rolled back by the transaction inside this closure, so
+     * the object's state is well defined after a failure and there is nothing to
+     * abort for.
+     *
+     * Serialization is unchanged: the gate is still held for the whole closure,
+     * which now resolves rather than rejects.
      */
     const runSerialized: ShardHost["runSerialized"] = async (function_) => {
         if (typeof state.blockConcurrencyWhile === "function") {
-            return state.blockConcurrencyWhile(function_);
+            const outcome = await state.blockConcurrencyWhile<{ error: unknown; ok: false } | { ok: true; value: unknown }>(async () => {
+                try {
+                    return { ok: true, value: await function_() };
+                } catch (error) {
+                    return { error, ok: false };
+                }
+            });
+
+            if (outcome.ok) {
+                return outcome.value as never;
+            }
+
+            throw outcome.error;
         }
 
         // Test doubles may not supply the gate. Running bare keeps them working;
@@ -131,12 +163,47 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * the platform primitive: atomic, auto-rolling-back when the closure throws.
      * Doubles whose storage lacks it fall through to a bare call; their fakes
      * carry no transactional semantics to preserve anyway.
+     *
+     * The closure's throw is re-thrown from the saved instance rather than from
+     * whatever comes back out of `storage.transaction`. workerd rolls the
+     * transaction back correctly, but the exception it propagates is a FLATTENED
+     * copy — a plain `Error` whose message is the original's `name: message` and
+     * which carries none of its own properties. `isLunoraError` is structural
+     * (`type`/`code`/`status`), so every coded error a handler threw failed that
+     * check on the way out and was rendered as a generic 500 `INTERNAL` /
+     * "Internal error": a `NOT_FOUND` mutation, a `CONFLICT` on a unique index,
+     * an `UNAUTHENTICATED` guard — all indistinguishable to the client, and all
+     * logged as internal faults. Queries were unaffected (they never enter a
+     * transaction), which is what made the failure look arbitrary.
+     *
+     * The re-throw still happens after the platform has rolled back: the closure
+     * rethrows first, so `storage.transaction` sees the failure and aborts as
+     * before. Only the *identity* of the error the caller receives is restored.
      */
     const transaction: ShardHost["transaction"] = async (function_) => {
         const transactional = storage as undefined | { transaction?: <R>(closure: () => Promise<R>) => Promise<R> };
 
         if (typeof transactional?.transaction === "function") {
-            return transactional.transaction(async () => function_());
+            // Boxed so a closure that legitimately throws `undefined` is still
+            // distinguishable from "the closure never threw".
+            let thrown: { value: unknown } | undefined;
+
+            try {
+                return await transactional.transaction(async () => {
+                    try {
+                        return await function_();
+                    } catch (error) {
+                        thrown = { value: error };
+
+                        throw error;
+                    }
+                });
+            } catch (error) {
+                // `thrown` is unset when the platform itself failed the commit
+                // (a rollback error, a storage fault) — that error is genuinely
+                // the platform's and is surfaced unchanged.
+                throw thrown ? thrown.value : error;
+            }
         }
 
         return function_();


### PR DESCRIPTION
Three defects, all found by running apps against the framework rather than by reading it. Each is silent: the code compiles, the command exits 0, and the damage shows up at runtime or not at all.

## 1. A thrown `LunoraError` never reached the client (`@lunora/platform-cloudflare`)

Every coded error a mutation handler threw arrived as a generic 500 `INTERNAL` / "Internal error". `NOT_FOUND`, `CONFLICT` on a unique index, an `UNAUTHENTICATED` guard — all identical on the wire, all logged as internal faults, none branchable by the client. Queries were unaffected (they never enter a transaction), which is what made it look arbitrary.

Two boundaries in the mutation path lose it:

- **`blockConcurrencyWhile`** — the single-writer gate. workerd treats a rejecting closure as unrecoverable and **aborts the Durable Object**, discarding its in-memory state and every hibernating WebSocket subscription attached to it. So one user's "not your turn" error tore the shard down for everyone else connected to it. That default is right for the initialization work the API was designed for; it is wrong for a gate wrapping every mutation, where the transaction inside has already rolled the writes back and the object's state is well defined.
- **`storage.transaction`** — rolls back correctly, but propagates a flattened copy: a plain `Error` carrying `name: message` and none of the original's own properties. `isLunoraError` is structural (`type`/`code`/`status`), so the copy fails the check and gets redacted.

Both now settle the closure's outcome inside the boundary and re-raise the original instance outside it. The gate is still held for the whole closure; the transaction closure still throws into the platform, so rollback is unchanged. A failure raised by the platform itself — with no handler error to restore — is surfaced untouched.

Before / after, same handler, same request:

```
games:start    {"error":{"code":"INTERNAL","message":"Internal error"}}   [500]
games:start    {"error":{"code":"NOT_FOUND","message":"lobby not found"}} [404]
```

## 2. Shorthand table columns were dropped (`@lunora/codegen`)

`defineTable({ status })` lost the column entirely — `parseObjectShape` skipped anything that was not a `PropertyAssignment`, and a shorthand property is its own initializer.

It fails quietly and late. With an index over the column you get an `index_references_unknown_field` advisory naming a column that is plainly there in the schema; without one you get no diagnostic at all, just a runtime insert writing a field the generated types deny. `object-shorthand` autofixes `status: status` into this form, so a lint run can introduce it into a schema that was correct yesterday. Table shapes, `.input()` args, http routes and mutators all read their shape through this parser.

## 3. Exported handler return types emitted unresolvable names (`@lunora/codegen`)

A handler annotated with a type exported from its own module emitted that bare name into `_generated/api.ts` — which never imports the handler's module. The generated file failed to compile (TS2304) while `lunora codegen` exited 0.

`symbolDeclaredUnreachable` assumed an exported name is importable. Nothing emits that import: the emitter only rewrites qualifiers the checker itself rendered as `import("…")`, and the checker prints an exported local type by bare name precisely *because* it is nameable from the handler. Non-exported declarations were already expanded structurally; exported ones now take the same path.

The existing test asserted the old behaviour on the stated grounds that "the name is valid" — it encoded the defect, so it is rewritten.

## Verification

- New `cloudflare-host.transaction.test.ts` (7 cases) covers error identity, the abort, rollback ordering, platform-raised failures, non-`Error` throws, and the composed gate+transaction path. Confirmed failing without the fix.
- Suites green: `platform-cloudflare` 31, `do` 519, `shard-engine` 967, `runtime` 833, `codegen` 1045.
- `api:check` green (44 snapshots) — no public surface change.
- End to end against a real app: two authenticated sessions playing a full game, with every illegal move now rejected as `BAD_REQUEST`/`CONFLICT` and carrying its HTTP status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYvgKochPxnrCCtKB1tXGf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated API types by correctly expanding locally declared interfaces and type aliases.
  * Fixed validation for shorthand object properties so these fields are included correctly.
  * Preserved application errors during concurrency-controlled operations and transactions while allowing platform-managed recovery to proceed safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->