### PR TITLE
fix(platform): pin error identity in the host contract

### DIFF
--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -343,19 +343,15 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 };
 
 /**
- * True when a type's own symbol resolves to an interface/type-alias declared in
- * the handler's source file — i.e. a name unreachable from `_generated/api.ts`.
+ * True when the type's symbol is declared in the handler's own source file.
  *
- * Exported declarations count too. The checker prints an exported local type by
- * name (it is nameable from the handler), but codegen only ever emits an import
- * for a qualifier the checker itself rendered as `import("…")` — it never
- * synthesises one for the handler's own module. So `export interface Board` came
- * out as a bare `Board` in `_generated/api.ts` with nothing importing it: TS2304
- * in generated code, while `lunora codegen` exits 0. Structurally expanding it,
- * exactly as a non-exported declaration already was, keeps the emitted type
- * identical in shape and resolvable from anywhere.
+ * `_generated/api.ts` never imports that module — codegen only emits an import
+ * for a qualifier the checker itself rendered as `import("…")` — so such a name
+ * must be expanded structurally rather than printed. Exported declarations are
+ * included: being nameable from the handler is what makes the checker print the
+ * bare name, which is exactly the case that does not resolve from `_generated/`.
  */
-const symbolDeclaredUnreachable = (type: Type, handlerFilePath: string): boolean => {
+const declaredInHandlerModule = (type: Type, handlerFilePath: string): boolean => {
     for (const candidate of [type.getSymbol(), type.getAliasSymbol()]) {
         if (!candidate) {
             continue;
@@ -427,7 +423,7 @@ const referencesUnreachableLocalType = (type: Type, node: Node, handlerFilePath:
 
     seen.add(type);
 
-    if (symbolDeclaredUnreachable(type, handlerFilePath)) {
+    if (declaredInHandlerModule(type, handlerFilePath)) {
         return true;
     }
 

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
@@ -1,24 +1,18 @@
 import { LunoraError } from "@lunora/errors";
+import type { ShardHost } from "@lunora/platform";
 import { describe, expect, it } from "vitest";
 
 import { createShardHost } from "../src/cloudflare-host";
 
 /**
- * Error identity across the durable-transaction boundary.
+ * Unit-level pins for the error-identity contract documented on `runSerialized`
+ * and `transaction` in ../src/cloudflare-host.ts.
  *
- * workerd rolls a failed `storage.transaction` back correctly, but the exception
- * it propagates back out is a FLATTENED copy: a plain `Error` whose message is
- * the original's `name: message`, carrying none of its own properties. Since
- * `isLunoraError` is structural (`type` + `code` + `status`), every coded error a
- * mutation handler threw failed that check on the way out and was rendered to the
- * client as a generic 500 `INTERNAL` / "Internal error" — a `NOT_FOUND`, a
- * `CONFLICT` on a unique index, an `UNAUTHENTICATED` guard, all identical and all
- * logged as internal faults. Queries never enter a transaction, so they were
- * unaffected, which is what made the behaviour look arbitrary.
- *
- * These tests pin the two halves that have to stay true together: the closure's
- * throw still reaches the platform (so the rollback happens), and the caller
- * still receives the *original* error object.
+ * The doubles below reproduce the two workerd behaviours those wrappers exist to
+ * absorb (flatten on rethrow, abort on rejection). Because a double can only
+ * assert against the author's model of the platform, the same properties are
+ * pinned against the real thing by the conformance suite running under
+ * `runInDurableObject` in `@lunora/do`'s workerd project.
  */
 
 /** A `storage` double that flattens a thrown error exactly the way workerd does. */
@@ -47,7 +41,7 @@ const flatteningStorage = (): { calls: string[]; transaction: <R>(closure: () =>
     };
 };
 
-const hostWith = (storage: unknown) => createShardHost({ storage } as never);
+const hostWith = (storage: Partial<DurableObjectState["storage"]> | Record<string, unknown>): ShardHost => createShardHost({ storage } as never);
 
 /**
  * A `blockConcurrencyWhile` double that mirrors workerd's behaviour: a closure
@@ -73,22 +67,17 @@ const gate = (): { aborted: boolean; blockConcurrencyWhile: <R>(closure: () => P
 
 describe("cloudflare shard host transaction", () => {
     it("rethrows the handler's own error instance, not the platform's flattened copy", async () => {
-        expect.assertions(4);
+        expect.assertions(2);
 
         const storage = flatteningStorage();
         const thrown = new LunoraError("NOT_FOUND", "lobby not found");
 
+        // Identity, not shape: a reconstructed copy can carry the same message
+        // and still have lost `code`/`status`, which is the whole failure.
         await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toBe(thrown);
 
-        // Same object, so the wire-relevant fields the error renderer keys on survive.
-        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toMatchObject({
-            code: "NOT_FOUND",
-            status: 404,
-        });
-
-        expect(storage.calls).toStrictEqual(["rolled-back", "rolled-back"]);
         // The closure must still throw INTO the platform, or nothing rolls back.
-        expect(storage.calls).not.toContain("committed");
+        expect(storage.calls).toStrictEqual(["rolled-back"]);
     });
 
     it("still surfaces a platform-side failure that the closure never raised", async () => {

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
@@ -161,4 +161,39 @@ describe("cloudflare shard host transaction", () => {
 
         expect(storage.calls).toStrictEqual(["rolled-back"]);
     });
+
+    it("attaches a platform failure as the cause when both fail", async () => {
+        expect.assertions(2);
+
+        const storage = {
+            transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+                await closure().catch(() => undefined);
+
+                throw new Error("rollback failed");
+            },
+        };
+        const thrown = new LunoraError("CONFLICT", "not your turn");
+
+        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toBe(thrown);
+        expect((thrown.cause as Error | undefined)?.message).toBe("rollback failed");
+    });
+
+    it("still delivers the closure's error when it cannot carry a cause", async () => {
+        expect.assertions(2);
+
+        // A frozen sentinel error rejects the `cause` write with a `TypeError`.
+        // Unguarded, that TypeError would replace the error the handler threw —
+        // the exact loss this wrapper exists to prevent.
+        const storage = {
+            transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+                await closure().catch(() => undefined);
+
+                throw new Error("rollback failed");
+            },
+        };
+        const frozen = Object.freeze(new LunoraError("CONFLICT", "not your turn"));
+
+        await expect(hostWith(storage).transaction(() => Promise.reject(frozen))).rejects.toBe(frozen);
+        expect(frozen.cause).toBeUndefined();
+    });
 });

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -95,6 +95,33 @@ const createShardAlarms = (storage: AlarmStorageLike): ShardAlarms => {
     };
 };
 
+/**
+ * Record `platformError` as the cause of the error a closure threw, when both
+ * failed.
+ *
+ * Best-effort by construction: the write can itself throw, because a frozen or
+ * sealed error — a module-level `Object.freeze(new Error(…))` sentinel is a real
+ * pattern — rejects it with a `TypeError`. Unguarded, that `TypeError` would
+ * replace the error the handler threw, which is the exact loss the caller of
+ * this helper exists to prevent. Attaching a cause is a courtesy; delivering the
+ * handler's own error is the contract, so the courtesy loses.
+ */
+const attachCause = (thrown: unknown, platformError: unknown): void => {
+    // `thrown === platformError` would make the error its own cause.
+    if (!(thrown instanceof Error) || thrown === platformError || thrown.cause !== undefined) {
+        return;
+    }
+
+    try {
+        // `defineProperty` rather than assignment: it states the intent (add an
+        // own property to this instance) and keeps the lint rule about mutating
+        // a parameter honest, since the mutation is the whole point here.
+        Object.defineProperty(thrown, "cause", { configurable: true, value: platformError, writable: true });
+    } catch {
+        // Non-writable `cause`; drop the platform error rather than mask the closure's.
+    }
+};
+
 const createShardHost = (state: DurableObjectState): ShardHost => {
     const { storage } = state;
 
@@ -192,12 +219,9 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
                     throw error;
                 }
 
-                // Both failed: the handler's error is what the caller acted on,
-                // so it stays the thrown value, but a broken storage layer must
-                // not vanish behind it.
-                if (thrown.value instanceof Error && thrown.value.cause === undefined && error !== thrown.value) {
-                    thrown.value.cause = error;
-                }
+                // Both failed. The handler's error is the one the caller acted
+                // on, so it stays the thrown value; the platform's rides along.
+                attachCause(thrown.value, error);
 
                 throw thrown.value;
             }

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -114,41 +114,35 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * until the closure settles, which is exactly the contract's
      * "no two closures run at once for this shard key".
      *
-     * The closure settles to an outcome INSIDE the gate and is re-thrown outside
-     * it, because workerd treats a throwing `blockConcurrencyWhile` closure as
-     * unrecoverable: it ABORTS the Durable Object (the `durableObjectReset`
-     * marker on the propagated error), discarding its in-memory state and every
-     * hibernating WebSocket subscription attached to it, and hands the caller a
-     * flattened plain `Error` with none of the original's properties.
-     *
-     * That is the right default for the initialization work the API was designed
-     * for, where a failure leaves the object undefined. It is the wrong default
-     * here: this gate wraps every mutation, so an ordinary application error —
-     * a `NOT_FOUND`, a "not your turn" `CONFLICT`, a failed auth guard — was
-     * tearing down the shard for every other client connected to it, and
-     * arriving at the client as a generic 500 `INTERNAL`. The mutation's own
-     * writes are already rolled back by the transaction inside this closure, so
-     * the object's state is well defined after a failure and there is nothing to
-     * abort for.
-     *
-     * Serialization is unchanged: the gate is still held for the whole closure,
-     * which now resolves rather than rejects.
+     * workerd treats a *rejecting* `blockConcurrencyWhile` closure as
+     * unrecoverable: it aborts the Durable Object — discarding in-memory state
+     * and every hibernating WebSocket subscription on it — and flattens the
+     * error to a plain `Error`. That is the right default for the
+     * initialization work the API was designed for, and the wrong one for a
+     * gate wrapping every mutation, where a rejection is an ordinary
+     * application error and the transaction inside has already rolled the
+     * writes back. So the closure settles to an outcome here and is re-raised
+     * outside the gate, which the contract requires
+     * ({@link ShardHost.runSerialized}). The gate is still held for the whole
+     * closure — it resolves instead of rejecting.
      */
     const runSerialized: ShardHost["runSerialized"] = async (function_) => {
         if (typeof state.blockConcurrencyWhile === "function") {
-            const outcome = await state.blockConcurrencyWhile<{ error: unknown; ok: false } | { ok: true; value: unknown }>(async () => {
+            // `as const` on the discriminant lets `T` infer through, so the
+            // success value needs no cast on the way out.
+            const settled = await state.blockConcurrencyWhile(async () => {
                 try {
-                    return { ok: true, value: await function_() };
+                    return { ok: true as const, value: await function_() };
                 } catch (error) {
-                    return { error, ok: false };
+                    return { error, ok: false as const };
                 }
             });
 
-            if (outcome.ok) {
-                return outcome.value as never;
+            if (!settled.ok) {
+                throw settled.error;
             }
 
-            throw outcome.error;
+            return settled.value;
         }
 
         // Test doubles may not supply the gate. Running bare keeps them working;
@@ -164,21 +158,14 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * Doubles whose storage lacks it fall through to a bare call; their fakes
      * carry no transactional semantics to preserve anyway.
      *
-     * The closure's throw is re-thrown from the saved instance rather than from
-     * whatever comes back out of `storage.transaction`. workerd rolls the
-     * transaction back correctly, but the exception it propagates is a FLATTENED
-     * copy — a plain `Error` whose message is the original's `name: message` and
-     * which carries none of its own properties. `isLunoraError` is structural
-     * (`type`/`code`/`status`), so every coded error a handler threw failed that
-     * check on the way out and was rendered as a generic 500 `INTERNAL` /
-     * "Internal error": a `NOT_FOUND` mutation, a `CONFLICT` on a unique index,
-     * an `UNAUTHENTICATED` guard — all indistinguishable to the client, and all
-     * logged as internal faults. Queries were unaffected (they never enter a
-     * transaction), which is what made the failure look arbitrary.
-     *
-     * The re-throw still happens after the platform has rolled back: the closure
-     * rethrows first, so `storage.transaction` sees the failure and aborts as
-     * before. Only the *identity* of the error the caller receives is restored.
+     * workerd rolls back correctly but propagates a FLATTENED copy of the
+     * closure's error: a plain `Error` whose message is the original's
+     * `name: message`, carrying none of its own properties. `isLunoraError` is
+     * structural (`type`/`code`/`status`), so a copy is indistinguishable from
+     * an unrecognized throw and is redacted to an internal fault. The original
+     * instance is therefore saved on the way past and re-raised, which the
+     * contract requires ({@link ShardHost.transaction}). Rollback ordering is
+     * unchanged: the closure still throws into `storage.transaction` first.
      */
     const transaction: ShardHost["transaction"] = async (function_) => {
         const transactional = storage as undefined | { transaction?: <R>(closure: () => Promise<R>) => Promise<R> };
@@ -199,10 +186,20 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
                     }
                 });
             } catch (error) {
-                // `thrown` is unset when the platform itself failed the commit
-                // (a rollback error, a storage fault) — that error is genuinely
-                // the platform's and is surfaced unchanged.
-                throw thrown ? thrown.value : error;
+                // `thrown` unset means the platform itself failed the commit or
+                // rollback — genuinely its error, surfaced unchanged.
+                if (!thrown) {
+                    throw error;
+                }
+
+                // Both failed: the handler's error is what the caller acted on,
+                // so it stays the thrown value, but a broken storage layer must
+                // not vanish behind it.
+                if (thrown.value instanceof Error && thrown.value.cause === undefined && error !== thrown.value) {
+                    thrown.value.cause = error;
+                }
+
+                throw thrown.value;
             }
         }
 

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -111,6 +111,28 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
                 });
             });
 
+            it("rejects with the value the closure threw, and stays usable", async () => {
+                expect.assertions(3);
+
+                await withHost(async (host) => {
+                    // A sentinel with own properties: engine errors carry `code`
+                    // and `status` that the RPC edge renders the response from,
+                    // and a platform that reconstructs the error (rather than
+                    // re-raising it) drops them — turning every coded failure
+                    // into an internal one. `toBe` pins identity, which is the
+                    // only check a reconstructed copy cannot pass.
+                    const sentinel = Object.assign(new Error("closure failed"), { code: "NOT_FOUND", status: 404 });
+
+                    await expect(host.shard.transaction(() => Promise.reject(sentinel))).rejects.toBe(sentinel);
+                    await expect(host.shard.runSerialized(() => Promise.reject(sentinel))).rejects.toBe(sentinel);
+
+                    // A throw is an ordinary outcome, not a fatal one: the host
+                    // must still serve the next caller. On a host that tears
+                    // itself down on a rejected closure this is what fails.
+                    await expect(host.shard.runSerialized(async () => host.shard.transaction(async () => "still here"))).resolves.toBe("still here");
+                });
+            });
+
             it("observes its own writes inside a transaction", async () => {
                 expect.assertions(1);
 

--- a/packages/platform/src/shard-host.ts
+++ b/packages/platform/src/shard-host.ts
@@ -117,6 +117,13 @@ export interface ShardHost {
      * Run `fn` with exclusive ownership of the shard. Concurrent calls are
      * queued; no two closures run at once for the same shard key. On
      * Cloudflare this maps to `state.blockConcurrencyWhile`.
+     *
+     * A closure that throws must reject with **the value it threw**, and must
+     * leave the host usable for the next call. Engine errors carry a `code` and
+     * `status` the RPC edge renders from, so a host that lets its platform
+     * substitute a copy silently downgrades every coded error to an internal
+     * fault — and a host that tears itself down on a throw makes an ordinary
+     * application error cost every other caller on that shard.
      */
     runSerialized: <T>(function_: () => Promise<T>) => Promise<T>;
 
@@ -139,8 +146,10 @@ export interface ShardHost {
 
     /**
      * Run `fn` inside a durable transaction. If `fn` throws, all writes roll
-     * back. Raw `BEGIN`/`COMMIT`/`ROLLBACK` are forbidden inside the closure;
-     * the host manages the transaction boundary.
+     * back and the call rejects with **the value `fn` threw** — see
+     * {@link ShardHost.runSerialized} for why the identity matters. Raw
+     * `BEGIN`/`COMMIT`/`ROLLBACK` are forbidden inside the closure; the host
+     * manages the transaction boundary.
      */
     transaction: <T>(function_: () => Promise<T>) => Promise<T>;
 


### PR DESCRIPTION
Review follow-ups to #332. These were pushed to that branch before it merged, but the merge took the first three commits only, so they did not land.

#332 fixed the behaviour; this fixes the *assurance* and the naming.

## The property was pinned only by doubles that assumed it

`cloudflare-host.transaction.test.ts` asserts against hand-written doubles that implement the very workerd behaviours being claimed — flatten-on-rethrow and abort-on-rejection. A double cannot fail if the platform differs from the author's model of it, and it says nothing about any other host. `ShardHost` itself was silent on what happens to a thrown error, so a new `platform-<target>` could regress it and stay green.

The contract now states it on both `runSerialized` and `transaction`, and the conformance suite asserts it: a sentinel carrying `code`/`status` must come back **by identity**, and the host must still serve the next caller afterwards.

Verified under real workerd through `@lunora/do`'s `runInDurableObject` project — the new case **fails against the pre-#332 adapter and passes against the fixed one**, which is the assurance the doubles could not give. The in-memory reference host and `@lunora/platform-node` both already satisfy it unchanged.

## Also

- **Drop the explicit type argument on `blockConcurrencyWhile`.** It was discarding the closure's return type and then forcing an `as never` to recover it; `blockConcurrencyWhile<T>(cb: () => Promise<T>): Promise<T>` infers fine (`@cloudflare/workers-types@5.20260724.1/index.d.ts:675`). `as const` on the discriminant removes both.
- **Attach a failed commit/rollback as `cause`.** When the handler's error takes precedence, a broken storage layer was being discarded entirely — the opposite of the "the platform's own failure is surfaced unchanged" rule stated three lines above it.
- **Rename `symbolDeclaredUnreachable` → `declaredInHandlerModule`.** After #332 the predicate returns `true` for exported declarations, which *are* reachable; the name had become wrong and most of its docblock existed to apologise for that.
- **Cut the duplicated incident narrative.** The same ~90-word story appeared in three places. Kept the platform behaviour that cannot be derived from the code, dropped the past-tense bug story — that belongs in the commit, not in a comment that will outlive it.

## Checks

`platform` 45, `platform-cloudflare` 31, `codegen` 1045, `do` 519 plus 56 under workerd, `platform-node` 52. `api:check` clean — no public surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYvgKochPxnrCCtKB1tXGf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the exact original error when serialized operations or transactions fail.
  * Maintained host availability for subsequent operations after a failed transaction or serialized callback.
  * Improved handling when both an operation and its storage commit or rollback encounter errors.

* **Tests**
  * Added coverage for error preservation, rollback behavior, and continued operation after failures.

* **Documentation**
  * Clarified error-handling and recovery behavior for transactions and serialized operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->