### PR TITLE
fix(values): recover v.from() types through the spec's optional `types`

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -7991,6 +7991,10 @@ Re-exported from `@lunora/values` — signature tracked at its source.
 
 Re-exported from `@lunora/values` — signature tracked at its source.
 
+### `InferStandardInput` (type)
+
+Re-exported from `@lunora/values` — signature tracked at its source.
+
 ### `InferStandardOutput` (type)
 
 Re-exported from `@lunora/values` — signature tracked at its source.

--- a/api-snapshots/values.api.md
+++ b/api-snapshots/values.api.md
@@ -117,9 +117,11 @@ type InferSelect<V> = V extends Validator<infer T> ? T : never;
 ### `InferStandardOutput` (type)
 
 ```ts
-type InferStandardOutput<S extends StandardSchemaV1> = S["~standard"]["types"] extends {
-    output: infer O;
-} ? O : unknown;
+type InferStandardOutput<S extends StandardSchemaV1> = [
+    StandardSchemaV1.InferOutput<S>
+] extends [
+    never
+] ? unknown : StandardSchemaV1.InferOutput<S>;
 ```
 
 ### `InferValidatorMap` (type)

--- a/api-snapshots/values.api.md
+++ b/api-snapshots/values.api.md
@@ -114,14 +114,16 @@ type InferInsert<V> = V extends Column<unknown, infer I> ? I : V extends Validat
 type InferSelect<V> = V extends Validator<infer T> ? T : never;
 ```
 
+### `InferStandardInput` (type)
+
+```ts
+type InferStandardInput<S extends StandardSchemaV1> = StandardSchemaV1.InferInput<S>;
+```
+
 ### `InferStandardOutput` (type)
 
 ```ts
-type InferStandardOutput<S extends StandardSchemaV1> = [
-    StandardSchemaV1.InferOutput<S>
-] extends [
-    never
-] ? unknown : StandardSchemaV1.InferOutput<S>;
+type InferStandardOutput<S extends StandardSchemaV1> = StandardSchemaV1.InferOutput<S>;
 ```
 
 ### `InferValidatorMap` (type)

--- a/packages/values/__tests__/__helpers__/type-assert.ts
+++ b/packages/values/__tests__/__helpers__/type-assert.ts
@@ -1,0 +1,31 @@
+/**
+ * Type-level assertion helpers shared by this package's compile-time tests.
+ *
+ * Extracted because the third copy arrived: each one dragged its own
+ * `no-unnecessary-type-parameters` suppression, so the suppression was spreading
+ * with the duplication rather than sitting in the one place the idiom lives.
+ *
+ * Not a test file — no `.test.ts` suffix, so vitest does not collect it. It is
+ * compiled by `tsc --noEmit` through the package tsconfig's `__tests__/**`
+ * include, exactly like its consumers.
+ */
+
+/** Fails compilation unless `T` is exactly `true`. */
+type Assert<T extends true> = T;
+
+/**
+ * Exact type equality. The two single-use function type parameters are
+ * load-bearing — they force a structural comparison rather than mutual
+ * assignability, which is what distinguishes `unknown` from `any`, and a union
+ * from one of its members.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
+/** Keys of `T` that may be omitted. */
+type OptionalKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? K : never }[keyof T];
+
+/** Keys of `T` that must be supplied. */
+type RequiredKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? never : K }[keyof T];
+
+export type { Assert, Equal, OptionalKeys, RequiredKeys };

--- a/packages/values/__tests__/column.types.test-d.ts
+++ b/packages/values/__tests__/column.types.test-d.ts
@@ -5,14 +5,7 @@
  */
 import type { ColumnValidator, Id, InferInsert, InferSelect, InsertShape, SelectShape, TimestampColumnValidator } from "../src/index";
 import { v } from "../src/index";
-
-type Assert<T extends true> = T;
-// The canonical type-equality idiom: the single-use `<T>()` params are
-// load-bearing (they force structural comparison), so the rule is disabled here.
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
-type OptionalKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? K : never }[keyof T];
-type RequiredKeys<T> = { [K in keyof T]-?: object extends Pick<T, K> ? never : K }[keyof T];
+import type { Assert, Equal, OptionalKeys, RequiredKeys } from "./__helpers__/type-assert";
 
 // --- scalar modifiers ---------------------------------------------------------
 

--- a/packages/values/__tests__/from.types.test-d.ts
+++ b/packages/values/__tests__/from.types.test-d.ts
@@ -1,0 +1,41 @@
+/**
+ * Compile-time only: exercised by `tsc --noEmit` via the package tsconfig's
+ * `__tests__/**` include. Asserts that `v.from()` recovers the wrapped schema's
+ * inferred type when `~standard.types` is declared the way the spec declares it
+ * — OPTIONAL. Every real library (zod, valibot, arktype) does, because the
+ * property is a phantom that never exists at runtime, and a matcher that forgets
+ * the optionality degrades all of them to `unknown`.
+ */
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
+import type { InferSelect, v } from "../src/index";
+
+type Assert<T extends true> = T;
+// The canonical type-equality idiom: the single-use `<T>()` params are
+// load-bearing (they force structural comparison), so the rule is disabled here.
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
+interface Page {
+    cursor: string | null;
+    limit: number;
+}
+
+// Shaped exactly like a zod/valibot schema: `types` is declared and optional.
+declare const specSchema: StandardSchemaV1<Page, Page>;
+
+type _FromSpec = Assert<Equal<InferSelect<ReturnType<typeof v.from<typeof specSchema>>>, Page>>;
+
+// A schema that declares no `types` at all is still legal, and still has to land
+// on `unknown` rather than `never`.
+declare const untypedSchema: {
+    readonly "~standard": {
+        readonly validate: (value: unknown) => { value: unknown };
+        readonly vendor: string;
+        readonly version: 1;
+    };
+};
+
+type _FromUntyped = Assert<Equal<InferSelect<ReturnType<typeof v.from<typeof untypedSchema>>>, unknown>>;
+
+export type { _FromSpec, _FromUntyped };

--- a/packages/values/__tests__/from.types.test-d.ts
+++ b/packages/values/__tests__/from.types.test-d.ts
@@ -11,12 +11,7 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 import type { InferInsert, InferSelect, v } from "../src/index";
-
-type Assert<T extends true> = T;
-// The canonical type-equality idiom: the single-use `<T>()` params are
-// load-bearing (they force structural comparison), so the rule is disabled here.
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+import type { Assert, Equal } from "./__helpers__/type-assert";
 
 /**
  * Shaped exactly like a zod/valibot/arktype schema: `~standard.types` is declared

--- a/packages/values/__tests__/from.types.test-d.ts
+++ b/packages/values/__tests__/from.types.test-d.ts
@@ -1,14 +1,16 @@
 /**
  * Compile-time only: exercised by `tsc --noEmit` via the package tsconfig's
- * `__tests__/**` include. Asserts that `v.from()` recovers the wrapped schema's
- * inferred type when `~standard.types` is declared the way the spec declares it
- * — OPTIONAL. Every real library (zod, valibot, arktype) does, because the
- * property is a phantom that never exists at runtime, and a matcher that forgets
- * the optionality degrades all of them to `unknown`.
+ * `__tests__/**` include. Pins what `v.from()` recovers from a Standard Schema.
+ *
+ * The fixtures are deliberately TRANSFORMING (`Input` ≠ `Output`). A schema whose
+ * input and output coincide cannot fail these assertions in the interesting
+ * direction: swap the implementation to read the input side and a same-type
+ * fixture still passes, so it would pin the bug that was reported rather than the
+ * contract that was wrong.
  */
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
-import type { InferSelect, v } from "../src/index";
+import type { InferInsert, InferSelect, v } from "../src/index";
 
 type Assert<T extends true> = T;
 // The canonical type-equality idiom: the single-use `<T>()` params are
@@ -16,18 +18,24 @@ type Assert<T extends true> = T;
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 
-interface Page {
-    cursor: string | null;
-    limit: number;
-}
+/**
+ * Shaped exactly like a zod/valibot/arktype schema: `~standard.types` is declared
+ * and OPTIONAL. Matching that union against `{ output: infer O }` without
+ * stripping the optionality misses every real library and yields `unknown`.
+ */
+declare const coercingSchema: StandardSchemaV1<string, number>;
 
-// Shaped exactly like a zod/valibot schema: `types` is declared and optional.
-declare const specSchema: StandardSchemaV1<Page, Page>;
+// A read gets the schema's output back — it is `validate()`'s result that is stored.
+type _SelectIsOutput = Assert<Equal<InferSelect<ReturnType<typeof v.from<typeof coercingSchema>>>, number>>;
 
-type _FromSpec = Assert<Equal<InferSelect<ReturnType<typeof v.from<typeof specSchema>>>, Page>>;
+// A write supplies the schema's input — the value the validator exists to transform.
+type _InsertIsInput = Assert<Equal<InferInsert<ReturnType<typeof v.from<typeof coercingSchema>>>, string>>;
 
-// A schema that declares no `types` at all is still legal, and still has to land
-// on `unknown` rather than `never`.
+/**
+ * A schema declaring no `~standard.types` at all is still spec-legal. It has to
+ * land on `unknown` rather than `never`, which is what resolving the indexed
+ * access through the constraint gives.
+ */
 declare const untypedSchema: {
     readonly "~standard": {
         readonly validate: (value: unknown) => { value: unknown };
@@ -36,6 +44,7 @@ declare const untypedSchema: {
     };
 };
 
-type _FromUntyped = Assert<Equal<InferSelect<ReturnType<typeof v.from<typeof untypedSchema>>>, unknown>>;
+type _UntypedSelect = Assert<Equal<InferSelect<ReturnType<typeof v.from<typeof untypedSchema>>>, unknown>>;
+type _UntypedInsert = Assert<Equal<InferInsert<ReturnType<typeof v.from<typeof untypedSchema>>>, unknown>>;
 
-export type { _FromSpec, _FromUntyped };
+export type { _InsertIsInput, _SelectIsOutput, _UntypedInsert, _UntypedSelect };

--- a/packages/values/__tests__/v-from.test.ts
+++ b/packages/values/__tests__/v-from.test.ts
@@ -208,6 +208,30 @@ describe("v.from()", () => {
         expect(result.error.message).toMatch(/non-object result/u);
     });
 
+    it("rejects a result carrying an EMPTY issues array rather than passing `undefined` through", () => {
+        expect.assertions(3);
+
+        // The spec's rule is that a FALSY `issues` means success — and `[]` is
+        // truthy, so this validator is reporting failure, just without saying what
+        // failed. Treating it as success would take the `.value` path on a result
+        // that has no `value`, handing the caller `undefined` as though it had
+        // validated.
+        const emptyIssues = {
+            "~standard": {
+                validate: (_value: unknown) => {
+                    return { issues: [] as { message: string; path?: PropertyKey[] }[] };
+                },
+                vendor: "fake",
+                version: 1 as const,
+            },
+        };
+        const result = v.from(emptyIssues).safeParse("x") as { error: ValidationError; ok: false };
+
+        expect(result.ok).toBe(false);
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toBe("Standard Schema validation failed");
+    });
+
     it("falls back to a default message when the issue carries none", () => {
         expect.assertions(2);
 

--- a/packages/values/__tests__/v.test.ts
+++ b/packages/values/__tests__/v.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Id, Infer } from "../src/index";
 import { isOrWrapsFromValidator, v, ValidationError } from "../src/index";
-
-type Assert<T extends true> = T;
-// The canonical type-equality idiom: the single-use `<T>()` params are
-// load-bearing (they force structural comparison), so the rule is disabled here.
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+import type { Assert, Equal } from "./__helpers__/type-assert";
 
 const assertOk: (condition: unknown, message: string) => asserts condition = (condition, message) => {
     if (!condition) {

--- a/packages/values/package.json
+++ b/packages/values/package.json
@@ -61,11 +61,11 @@
         "fallow:health": "fallow health --score"
     },
     "dependencies": {
-        "@lunora/errors": "1.0.0-alpha.13"
+        "@lunora/errors": "1.0.0-alpha.13",
+        "@standard-schema/spec": "catalog:types"
     },
     "devDependencies": {
         "@codspeed/vitest-plugin": "catalog:test",
-        "@standard-schema/spec": "catalog:types",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:build",
         "@vitest/coverage-v8": "catalog:test",

--- a/packages/values/src/index.ts
+++ b/packages/values/src/index.ts
@@ -14,6 +14,7 @@ export type {
     Infer,
     InferInsert,
     InferSelect,
+    InferStandardInput,
     InferStandardOutput,
     InsertShape,
     JsonSchemaFragment,

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -1073,7 +1073,7 @@ const any = (): ColumnValidator<unknown, unknown> => asColumn(createValidator<un
  *
  * Defer to the spec's own helper rather than matching `~standard.types`: the spec
  * declares that property optional (it is a phantom that never exists at runtime),
- * so every real library types it as `Types<I, O> | undefined`, and a hand-written
+ * so every real library types it as a union with `undefined`, and a hand-written
  * `extends { output: infer O }` misses all of them. A schema that declares no
  * `types` still resolves through the constraint to `unknown`.
  */

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -1072,8 +1072,16 @@ const any = (): ColumnValidator<unknown, unknown> => asColumn(createValidator<un
  * Infer the output type of a Standard Schema v1 object. When the schema omits
  * `~standard.types` (it is optional in the spec), falls back to `unknown` so
  * callers always get a usable type rather than `never`.
+ *
+ * The optionality has to be stripped before the shape is matched, which is what
+ * the spec's own `InferOutput` does. Matching `S["~standard"]["types"]` directly
+ * fails for every real schema: zod, valibot and arktype all declare `types` as
+ * `Types&lt;I, O> | undefined` (a phantom property that never exists at runtime), and
+ * a union with `undefined` does not extend `{ output: infer O }` — so `v.from(zodSchema)`
+ * silently typed every argument as `unknown`, which then collapsed the handler's
+ * inferred return type too.
  */
-type InferStandardOutput<S extends StandardSchemaV1> = S["~standard"]["types"] extends { output: infer O } ? O : unknown;
+type InferStandardOutput<S extends StandardSchemaV1> = [StandardSchemaV1.InferOutput<S>] extends [never] ? unknown : StandardSchemaV1.InferOutput<S>;
 
 /**
  * Build the issue path from a Standard Schema issue's `path` segments. Each
@@ -1173,7 +1181,7 @@ const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStand
                 });
             }
 
-            const syncResult: StandardSchemaV1.Result<InferStandardOutput<S>> = result as StandardSchemaV1.Result<InferStandardOutput<S>>;
+            const syncResult: StandardSchemaV1.Result<InferStandardOutput<S>> = result;
             const syncResultObject: Record<string, unknown> = syncResult as unknown as Record<string, unknown>;
 
             if ("issues" in syncResultObject && syncResult.issues !== undefined && syncResult.issues.length > 0) {

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -1069,19 +1069,24 @@ const optional = <V extends Validator>(inner: V): ColumnValidator<Infer<V> | und
 const any = (): ColumnValidator<unknown, unknown> => asColumn(createValidator<unknown>("any", (value) => value));
 
 /**
- * Infer the output type of a Standard Schema v1 object. When the schema omits
- * `~standard.types` (it is optional in the spec), falls back to `unknown` so
- * callers always get a usable type rather than `never`.
+ * The type a Standard Schema v1 object validates TO — what a read gets back.
  *
- * The optionality has to be stripped before the shape is matched, which is what
- * the spec's own `InferOutput` does. Matching `S["~standard"]["types"]` directly
- * fails for every real schema: zod, valibot and arktype all declare `types` as
- * `Types&lt;I, O> | undefined` (a phantom property that never exists at runtime), and
- * a union with `undefined` does not extend `{ output: infer O }` — so `v.from(zodSchema)`
- * silently typed every argument as `unknown`, which then collapsed the handler's
- * inferred return type too.
+ * Defer to the spec's own helper rather than matching `~standard.types`: the spec
+ * declares that property optional (it is a phantom that never exists at runtime),
+ * so every real library types it as `Types<I, O> | undefined`, and a hand-written
+ * `extends { output: infer O }` misses all of them. A schema that declares no
+ * `types` still resolves through the constraint to `unknown`.
  */
-type InferStandardOutput<S extends StandardSchemaV1> = [StandardSchemaV1.InferOutput<S>] extends [never] ? unknown : StandardSchemaV1.InferOutput<S>;
+type InferStandardOutput<S extends StandardSchemaV1> = StandardSchemaV1.InferOutput<S>;
+
+/**
+ * The type a Standard Schema v1 object validates FROM — what a write supplies.
+ *
+ * Distinct from {@link InferStandardOutput} only for a transforming schema
+ * (`z.string().transform(…)`, `z.coerce.number()`), where the value handed in is
+ * not the value stored. Identical for everything else.
+ */
+type InferStandardInput<S extends StandardSchemaV1> = StandardSchemaV1.InferInput<S>;
 
 /**
  * Build the issue path from a Standard Schema issue's `path` segments. Each
@@ -1133,8 +1138,15 @@ const standardIssuePath = (path: ReadonlyArray<unknown> | undefined): (number | 
  *
  * **Sync-only.** Standard Schema allows async `validate`; Lunora validation is
  * synchronous and throws when a Promise is returned.
+ *
+ * **Reads and writes can differ.** A write supplies the schema's INPUT and a read
+ * gets its OUTPUT back, because what is stored is `validate()`'s result. The two
+ * coincide for every non-transforming schema; they part for `z.coerce.number()`
+ * and friends, where typing the insert side as the output would demand the
+ * post-transform value from a caller whose value the validator is there to
+ * transform.
  */
-const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStandardOutput<S>, InferStandardOutput<S>> => {
+const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStandardOutput<S>, InferStandardInput<S>> => {
     // Cast through a loose shape: the static type guarantees `~standard`, but
     // `v.from` is a runtime boundary (callers pass untyped values via `as any`),
     // so the guard below must actually run.
@@ -1166,11 +1178,10 @@ const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStand
             // was rejected above). A spec-compliant validator always returns a
             // result object, but `v.from` is a runtime boundary: a non-object
             // result (null / primitive) is a protocol violation that must surface
-            // as a clear ValidationError rather than an opaque `TypeError` from
-            // the `in` operator below (or a silent `undefined` `.value` read).
-            // The declared `validate` return type promises a result object, but
-            // this is a runtime boundary, so guard via a loose cast (mirroring the
-            // `then` probe above) rather than trusting the static type.
+            // as a clear ValidationError rather than a silent `undefined` `.value`
+            // read. The declared `validate` return type promises a result object,
+            // but this is a runtime boundary, so guard via a loose cast (mirroring
+            // the `then` probe above) rather than trusting the static type.
             const looseResult = result as unknown;
 
             if (looseResult === null || typeof looseResult !== "object") {
@@ -1182,9 +1193,13 @@ const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStand
             }
 
             const syncResult: StandardSchemaV1.Result<InferStandardOutput<S>> = result;
-            const syncResultObject: Record<string, unknown> = syncResult as unknown as Record<string, unknown>;
 
-            if ("issues" in syncResultObject && syncResult.issues !== undefined && syncResult.issues.length > 0) {
+            // `issues` is the spec's own discriminant — declared `readonly issues?:
+            // undefined` on the success arm and required on the failure arm — so
+            // this narrows the union on its own. An absent key and a present-but-
+            // undefined one both read as `undefined`, which is why no `in` probe is
+            // needed to tell them apart.
+            if (syncResult.issues !== undefined && syncResult.issues.length > 0) {
                 const first = syncResult.issues[0];
                 const message = first?.message ?? "Standard Schema validation failed";
 
@@ -1317,6 +1332,7 @@ export type {
     Infer,
     InferInsert,
     InferSelect,
+    InferStandardInput,
     InferStandardOutput,
     InsertShape,
     JsonSchemaFragment,

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -1199,7 +1199,14 @@ const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStand
             // this narrows the union on its own. An absent key and a present-but-
             // undefined one both read as `undefined`, which is why no `in` probe is
             // needed to tell them apart.
-            if (syncResult.issues !== undefined && syncResult.issues.length > 0) {
+            //
+            // ANY defined `issues` is a failure, empty array included. The spec's
+            // rule is that a FALSY `issues` means success, and `[]` is truthy, so a
+            // validator returning `{ issues: [] }` is reporting failure — badly, but
+            // reporting it. Letting an empty array through would fall to the success
+            // path and return a `FailureResult`'s absent `value`, handing the caller
+            // `undefined` as though it had validated.
+            if (syncResult.issues !== undefined) {
                 const first = syncResult.issues[0];
                 const message = first?.message ?? "Standard Schema validation failed";
 
@@ -1210,7 +1217,7 @@ const from = <S extends StandardSchemaV1>(schema: S): ColumnValidator<InferStand
                 });
             }
 
-            return (syncResult as { value: InferStandardOutput<S> }).value;
+            return syncResult.value;
         }),
     );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4640,13 +4640,13 @@ importers:
       '@lunora/errors':
         specifier: workspace:*
         version: link:../errors
+      '@standard-schema/spec':
+        specifier: catalog:types
+        version: 1.1.0
     devDependencies:
       '@codspeed/vitest-plugin':
         specifier: catalog:test
         version: 5.7.1(supports-color@10.2.2)(tinybench@2.9.0)(vite@7.3.5(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@standard-schema/spec':
-        specifier: catalog:types
-        version: 1.1.0
       '@types/node':
         specifier: catalog:types
         version: 26.1.1


### PR DESCRIPTION
## What

`v.from(schema)` typed every argument as `unknown`, for every real schema library.

`InferStandardOutput` matched `S["~standard"]["types"]` against `{ output: infer O }`. The Standard Schema spec declares that property **optional** — it is a phantom that never exists at runtime — so zod, valibot and arktype all type it as a union with `undefined`, which does not extend the matched shape. Every `v.from()` fell through to the `unknown` fallback.

The damage ran past the argument. A handler whose args are `unknown` cannot infer a return type either, so `_generated/api.ts` recorded `unknown` for the **result** of any procedure taking a `v.from()` input, and the handler body reported TS18046 on code that was written correctly. That is why this presented as a codegen bug — codegen was never at fault. `resolveStandardSchemaType` already calls `.getNonNullableType()` before reading `output`, so it was resolving the real type while the runtime type said `unknown`. **This closes a drift between the two rather than opening one.**

Measured on a scratch handler taking `v.from(z.object({ cursor: z.string().nullable(), limit: z.number().int() }))`:

```diff
- fromZodConst: FunctionReference<"query", { page: { cursor: string | null; limit: number } }, unknown>
+ fromZodConst: FunctionReference<"query", { page: { cursor: string | null; limit: number } }, number>
```

## Commits

| | |
| --- | --- |
| `11fa059` | Defer to the spec's own `InferOutput` instead of hand-matching the property. |
| `6b98c17` | Type writes with the schema's **input**, and collapse a redundant guard. |
| `7b7c7f9` | Declare `@standard-schema/spec` as a dependency — the published `.d.ts` imports it. |
| `e0a19a2` | Share the type-assertion helpers; three copies had accumulated in this package. |

### Writes take the input type

`from()` typed **both** sides of `ColumnValidator` with the schema's output. A write supplies the input — `validate()`'s result is what gets stored — so a transforming schema (`z.coerce.number()`, `z.string().transform(…)`) demanded the post-transform value from the caller whose value it exists to transform. Code that typechecks, then fails validation at runtime.

This was inert while both sides were `unknown`, and reachable the moment inference started working, so it belongs in this PR rather than after it. Args are unaffected — they resolve through `Infer<V>`, which reads the select side. Non-transforming schemas (every use in this repo) are unchanged.

### The `[X] extends [never]` guard was unreachable

A schema declaring no `~standard.types` already resolves through the constraint to `unknown`, not `never` — verified by collapsing the guard and typechecking, with the untyped assertion still green. The only reachable `never` was a schema whose output genuinely **is** `never`, which the guard silently widened. Removing it is a small correctness gain on top of the deletion.

## Breaking

Narrowing, and intended: args that previously accepted anything now demand the real type. Acceptable on `alpha` per the pre-1.0 policy. No in-repo consumer breaks — `v.from(` appears only in `packages/`, with zero call sites in `apps/`, `examples/`, `templates/` or `registry/`.

## Tests

`packages/values/__tests__/from.types.test-d.ts` pins both directions and **fails on the old definition**.

Its fixture is deliberately transforming (`Input ≠ Output`). An earlier draft used a same-type fixture and could not fail in the interesting direction — swapping the implementation to read the input side left it green. With the transforming fixture, that swap now errors.

## Verification

Full-repo `lint:types` exit 0 · `api:check` 44/44 · `lint:package-json` clean · `eslint --max-warnings=0` on every changed file · tests: values 172, server 568, codegen 1054, seed 79, sql-store 99.

Regenerating `examples/*/lunora/_generated` and `apps/playground` produces zero drift.

## Noted, not fixed

The `jsdoc/text-escaping` ESLint rule autofixes a literal `<` in a doc comment into `&lt;`, which then renders as an entity in hover docs. It is why the same entity sits in ~350 files across `packages/*/src`. Phrased around it in the files this PR touches; the rest is untouched, since a repo-wide sweep would just be re-broken by the next autofix. Worth deciding separately whether that rule should apply inside code spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for transformed schemas that accept input values before transformation while exposing transformed values when read.
  - Improved Standard Schema type inference for more accurate input and output types.
  - Exposed a new public type for inferring schema input values.

- **Bug Fixes**
  - Improved handling and validation of schema results, including malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->