### PR TITLE
fix(repo): stop escaping angle brackets in doc comments

### DIFF
--- a/apps/docs/eslint.config.js
+++ b/apps/docs/eslint.config.js
@@ -369,4 +369,13 @@ export default createConfig(
             "css/no-important": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/apps/playground/eslint.config.js
+++ b/apps/playground/eslint.config.js
@@ -229,4 +229,13 @@ export default createConfig(
             "jsdoc/no-undefined-types": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/apps/studio/eslint.config.js
+++ b/apps/studio/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/advisor/eslint.config.js
+++ b/packages/advisor/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/advisor/src/admin-routes.ts
+++ b/packages/advisor/src/admin-routes.ts
@@ -1,5 +1,5 @@
 /**
- * One `httpRoute.&lt;verb&gt;("/admin/…")` REST route on an admin/privileged-looking
+ * One `httpRoute.<verb>("/admin/…")` REST route on an admin/privileged-looking
  * path, with whether its handler references an auth/admin guard — the input the
  * `admin_route_without_guard` lint consumes. Produced by the codegen feeder;
  * runtime callers don't supply it, so the lint finds nothing there.

--- a/packages/advisor/src/authapi-calls.ts
+++ b/packages/advisor/src/authapi-calls.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.authApi.&lt;method>(...)` call discovered in a function body — the input
+ * One `ctx.authApi.<method>(...)` call discovered in a function body — the input
  * the `auth_api_call_without_headers` lint consumes. Produced by the codegen
  * feeder; runtime callers don't supply it, so the lint finds nothing there.
  */

--- a/packages/advisor/src/browser-url-accesses.ts
+++ b/packages/advisor/src/browser-url-accesses.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.browser.&lt;method>(url, …)` call whose navigation URL (`arguments[0]`)
+ * One `ctx.browser.<method>(url, …)` call whose navigation URL (`arguments[0]`)
  * is derived from the handler's `args` with no server-side scoping — the input
  * the `browser_user_url_without_allowlist` lint consumes. `@lunora/browser`
  * blocks private/internal targets by default, but a request-supplied *public*

--- a/packages/advisor/src/container-key-accesses.ts
+++ b/packages/advisor/src/container-key-accesses.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.containers.&lt;exportName>.get(name, …)` call whose instance key is
+ * One `ctx.containers.<exportName>.get(name, …)` call whose instance key is
  * derived from the handler's `args` with no server-side scoping — the input
  * the `container_instance_key_from_user_input` lint consumes. A container
  * definition's `.get(name)` accessor routes to one instance per `name`, so a

--- a/packages/advisor/src/container-overrides.ts
+++ b/packages/advisor/src/container-overrides.ts
@@ -1,6 +1,6 @@
 /**
- * One runtime container-override call: a `&lt;handle>.start({ enableInternet: true, … })`
- * launch override, or a `&lt;handle>.egress.&lt;method>(...)` runtime firewall mutation
+ * One runtime container-override call: a `<handle>.start({ enableInternet: true, … })`
+ * launch override, or a `<handle>.egress.<method>(...)` runtime firewall mutation
  * (`allow` / `deny` / `setAllowed`) — the `container_start_enable_internet_override`
  * and `container_runtime_egress_relaxation` lint input. Both shapes re-open network
  * access the static `defineContainer` declaration (and its `container_public_internet`

--- a/packages/advisor/src/dedupe-cache-keys.ts
+++ b/packages/advisor/src/dedupe-cache-keys.ts
@@ -11,7 +11,7 @@ import type { Finding } from "./types";
  * within-line discriminator the second finding is silently hidden.
  *
  * This suffixes the second-and-later occurrence of any repeated key with
- * `:&lt;n>` (`:2`, `:3`, …), leaving the first occurrence unsuffixed so existing
+ * `:<n>` (`:2`, `:3`, …), leaving the first occurrence unsuffixed so existing
  * single-occurrence keys stay stable across runs. Order is preserved. Keys are
  * lint-name-prefixed, so this never merges across lints.
  */

--- a/packages/advisor/src/fail-open-guards.ts
+++ b/packages/advisor/src/fail-open-guards.ts
@@ -12,7 +12,7 @@
 export interface AdvisorFailOpenGuard {
     /** The middleware factory at the call site: `rateLimit` / `dbRateLimit` / `verifyTurnstileMiddleware`. */
     callee: string;
-    /** The exported binding name of the procedure the guard is attached to, or `"&lt;module>"` at file scope. */
+    /** The exported binding name of the procedure the guard is attached to, or `"<module>"` at file scope. */
     exportName: string;
     /** `true` only when the options literal set `failOpen: true` as a boolean literal; a non-literal or absent option is treated as fail-closed. */
     failOpen: boolean;

--- a/packages/advisor/src/flag-security-defaults.ts
+++ b/packages/advisor/src/flag-security-defaults.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.flags.boolean("key", &lt;boolean-literal>)` read — the
+ * One `ctx.flags.boolean("key", <boolean-literal>)` read — the
  * `flag_gates_security_with_unsafe_default` lint input. OpenFeature returns the
  * `defaultValue` when the provider errors, so a fail-open default on a
  * security-shaped key (an `enforce`/`rls`/`gate`/`lockdown` protection
@@ -12,7 +12,7 @@
 export interface AdvisorFlagSecurityDefault {
     /** The boolean-literal default returned on a provider outage (fail-open value). */
     defaultValue: boolean;
-    /** The exported binding name of the procedure performing the flag read, or `"&lt;module>"` at file scope. */
+    /** The exported binding name of the procedure performing the flag read, or `"<module>"` at file scope. */
     exportName: string;
     /** Source file relative to the lunora dir, no extension. */
     file: string;

--- a/packages/advisor/src/function-metrics.ts
+++ b/packages/advisor/src/function-metrics.ts
@@ -25,6 +25,6 @@ export interface AdvisorFunctionMetrics {
     errors: number;
     /** Slowest single dispatch, ms, over the same window. */
     maxDurationMs: number;
-    /** The function's registered path (`&lt;file>:&lt;exportName>`). */
+    /** The function's registered path (`<file>:<exportName>`). */
     path: string;
 }

--- a/packages/advisor/src/geo-index-usages.ts
+++ b/packages/advisor/src/geo-index-usages.ts
@@ -3,7 +3,7 @@
  * input the `geo_index_unused` lint cross-references against the declared geo
  * indexes in the lint context's schema. Produced by the codegen feeder, which
  * walks the lunora source for `ctx.db.query("t").withGeoIndex(name, …)` /
- * `ctx.db.&lt;table>.withGeoIndex(name, …)` reads and records each referenced index
+ * `ctx.db.<table>.withGeoIndex(name, …)` reads and records each referenced index
  * name. Runtime callers don't supply it, so the lint finds nothing there.
  *
  * A `.geoIndex(name, { field })` maintains a geohash companion column on every

--- a/packages/advisor/src/http-action-guards.ts
+++ b/packages/advisor/src/http-action-guards.ts
@@ -12,7 +12,7 @@
  * there.
  */
 export interface AdvisorHttpActionGuard {
-    /** The exported binding name of the handler (or `"&lt;module>"` when mounted inline / not a named binding). */
+    /** The exported binding name of the handler (or `"<module>"` when mounted inline / not a named binding). */
     exportName: string;
     /** Source file relative to the lunora dir, no extension. */
     file: string;
@@ -24,6 +24,6 @@ export interface AdvisorHttpActionGuard {
     method?: string;
     /** `true` when the handler reads `ctx.auth` (a direct member access or a `const { auth } = ctx` destructure). */
     readsAuth: boolean;
-    /** The first side effect found, as a stable label: `runMutation`, `runAction`, or `db.&lt;method>`. */
+    /** The first side effect found, as a stable label: `runMutation`, `runAction`, or `db.<method>`. */
     sideEffect: string;
 }

--- a/packages/advisor/src/http-header-writes.ts
+++ b/packages/advisor/src/http-header-writes.ts
@@ -12,7 +12,7 @@
  * to `HttpHeaderWriteIR`.
  */
 export interface AdvisorHttpHeaderWrite {
-    /** The exported binding name of the enclosing handler, or `"&lt;module>"` when mounted inline. */
+    /** The exported binding name of the enclosing handler, or `"<module>"` when mounted inline. */
     exportName: string;
     /** Source file relative to the lunora dir, no extension. */
     file: string;

--- a/packages/advisor/src/identity-claim-reads.ts
+++ b/packages/advisor/src/identity-claim-reads.ts
@@ -1,5 +1,5 @@
 /**
- * One `&lt;receiver>.identity.&lt;key>` claim read (where `&lt;receiver>` is an RLS/mask
+ * One `<receiver>.identity.<key>` claim read (where `<receiver>` is an RLS/mask
  * policy `auth`, or `ctx.auth`/`context.auth`) — the shared input for the
  * `identity_undeclared_claim_trusted` lint. `defineIdentity` validates only its
  * declared claims at the trust boundary and forwards undeclared claims
@@ -13,7 +13,7 @@
 export interface AdvisorIdentityClaimRead {
     /** `true` when `key` is a declared claim (in the `defineIdentity` contract, or the always-present `userId`). */
     declared: boolean;
-    /** The exported binding name of the enclosing declaration (`&lt;module>` at file scope). */
+    /** The exported binding name of the enclosing declaration (`<module>` at file scope). */
     exportName: string;
     /** Source file relative to the lunora dir, no extension. */
     file: string;

--- a/packages/advisor/src/kv-key-accesses.ts
+++ b/packages/advisor/src/kv-key-accesses.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.kv.&lt;method>(key, …)` call whose namespace key is derived from the
+ * One `ctx.kv.<method>(key, …)` call whose namespace key is derived from the
  * handler's `args` with no server-side scoping — the input the
  * `kv_unscoped_user_key_idor` lint consumes. Workers KV is a single flat
  * namespace, so a key taken straight from request input lets any caller read,

--- a/packages/advisor/src/lints/argument-derived-sink.ts
+++ b/packages/advisor/src/lints/argument-derived-sink.ts
@@ -3,9 +3,9 @@ import type { Category, Facing, Finding, Level, Lint, LintContext } from "../typ
 
 /**
  * Static metadata + per-occurrence templates for one "arg-derived sink" lint —
- * a lint that flags a `ctx.&lt;binding>` call whose key/URL/namespace argument is
+ * a lint that flags a `ctx.<binding>` call whose key/URL/namespace argument is
  * derived from the handler's `args` with no server-side scoping. Every such
- * lint shares one shape: read one `context.&lt;x>Accesses` evidence array (`undefined`
+ * lint shares one shape: read one `context.<x>Accesses` evidence array (`undefined`
  * means "no static evidence, flag nothing"), then emit one {@link Finding} per
  * row via {@link emit}.
  */

--- a/packages/advisor/src/lints/runtime/hot-shard.ts
+++ b/packages/advisor/src/lints/runtime/hot-shard.ts
@@ -41,7 +41,7 @@ type ShardTraffic = NonNullable<Parameters<NonNullable<Lint["run"]>>[0]["shardTr
 /**
  * Bucket shards by their `.shardBy(...)` group. `undefined` and `""` (both
  * "ungrouped / whole deployment") collapse into one bucket so they neither
- * split nor collide on the `hot_shard:&lt;group>:&lt;shardKey>` cacheKey.
+ * split nor collide on the `hot_shard:<group>:<shardKey>` cacheKey.
  */
 const groupByShardGroup = (active: ShardTraffic): Map<string, ShardTraffic> => {
     const byGroup = new Map<string, ShardTraffic>();
@@ -121,7 +121,7 @@ const hotShard: Lint = {
         // single-shard groups each look like ~33%) and lets the active-count gate
         // be met by shards from unrelated groups. `undefined` and `""` (both
         // "ungrouped / whole deployment") collapse to one bucket so they neither
-        // split nor collide on the `hot_shard:&lt;group>:&lt;shardKey>` cacheKey.
+        // split nor collide on the `hot_shard:<group>:<shardKey>` cacheKey.
         return [...groupByShardGroup(active)].flatMap(([groupKey, groupShards]) => hotShardsInGroup(hotShard, groupKey, groupShards));
     },
     source: "runtime",

--- a/packages/advisor/src/lints/static/auth-api-call-without-headers.ts
+++ b/packages/advisor/src/lints/static/auth-api-call-without-headers.ts
@@ -2,7 +2,7 @@ import emit from "../../finding";
 import type { Lint } from "../../types";
 
 /**
- * Flags a `ctx.authApi.&lt;method>(...)` call whose argument object omits `headers`.
+ * Flags a `ctx.authApi.<method>(...)` call whose argument object omits `headers`.
  *
  * `@lunora/auth`'s `withAuthPlugins` middleware attaches the full privileged
  * better-auth API to `ctx.authApi` — `banUser`, `setRole`, impersonation,

--- a/packages/advisor/src/lints/static/browser-user-url-without-allowlist.ts
+++ b/packages/advisor/src/lints/static/browser-user-url-without-allowlist.ts
@@ -3,7 +3,7 @@ import type { Lint } from "../../types";
 import { makeArgumentDerivedSinkLint } from "../argument-derived-sink";
 
 /**
- * Flags a `ctx.browser.&lt;method>(url, …)` call whose navigation URL is derived
+ * Flags a `ctx.browser.<method>(url, …)` call whose navigation URL is derived
  * from the handler's `args` with no server-side scoping — and no hardened
  * `createBrowser` allowlist to contain it.
  *

--- a/packages/advisor/src/lints/static/container-instance-key-from-user-input.ts
+++ b/packages/advisor/src/lints/static/container-instance-key-from-user-input.ts
@@ -3,7 +3,7 @@ import type { Lint } from "../../types";
 import { makeArgumentDerivedSinkLint } from "../argument-derived-sink";
 
 /**
- * Flags a `ctx.containers.&lt;exportName>.get(name, …)` call whose instance key
+ * Flags a `ctx.containers.<exportName>.get(name, …)` call whose instance key
  * is derived from the handler's `args` with no server-side scoping — a
  * cross-tenant container IDOR.
  *

--- a/packages/advisor/src/lints/static/geo-index-unused.ts
+++ b/packages/advisor/src/lints/static/geo-index-unused.ts
@@ -10,7 +10,7 @@ import type { Lint } from "../../types";
  * `withGeoIndex(name, q => q.near(…) | q.within(…))` the companion is pure dead
  * overhead — the geo analogue of a dead regular index. Cross-references every geo
  * index in the schema against the set of index names some handler references via
- * `withGeoIndex("&lt;name>")`.
+ * `withGeoIndex("<name>")`.
  *
  * Suppressed entirely when any usage passes a non-literal name
  * (`withGeoIndex(someVariable, …)`), because a dynamic reference could target any

--- a/packages/advisor/src/lints/static/identity-undeclared-claim-trusted.ts
+++ b/packages/advisor/src/lints/static/identity-undeclared-claim-trusted.ts
@@ -9,8 +9,8 @@ import type { Lint } from "../../types";
  * `defineIdentity` is the trust boundary for `ctx.auth.identity`: the worker
  * validates a resolver's returned claims against the *declared* validators, but
  * — by design — forwards any **undeclared** claims through verbatim, unchecked.
- * So a policy predicate or authorize hook that reads `auth.identity.&lt;key>` for a
- * `&lt;key>` the contract never declares is trusting a value the runtime never
+ * So a policy predicate or authorize hook that reads `auth.identity.<key>` for a
+ * `<key>` the contract never declares is trusting a value the runtime never
  * validated — a claim an attacker's token can carry with an arbitrary value.
  * Reading `userId` (always declared) or any declared claim is fine.
  *

--- a/packages/advisor/src/lints/static/masked-relation-leak-via-with.ts
+++ b/packages/advisor/src/lints/static/masked-relation-leak-via-with.ts
@@ -48,8 +48,8 @@ const relationTargetsOf = (context: LintContext): Map<string, string> => {
  * relation.
  *
  * INFO, near-zero false positives by construction: it fires only when all of
- * (1) the enclosing read is public, (2) the read declares `with: { &lt;rel> }`,
- * (3) `&lt;rel>` resolves through the schema to a real target table, and (4) that
+ * (1) the enclosing read is public, (2) the read declares `with: { <rel> }`,
+ * (3) `<rel>` resolves through the schema to a real target table, and (4) that
  * target table actually has masked columns (per the discovered mask evidence).
  * Absent any mask usage the lint is a no-op. Runs only when the codegen feeder
  * supplies `context.relationLoads`; a runtime caller flags nothing. One finding

--- a/packages/advisor/src/lints/static/privileged-dispatch-unvalidated-payload.ts
+++ b/packages/advisor/src/lints/static/privileged-dispatch-unvalidated-payload.ts
@@ -20,7 +20,7 @@ import type { Lint } from "../../types";
  * id) becomes an act-as-any-user / cross-tenant write.
  *
  * The lint is deliberately narrow to stay false-positive-free: it fires **only**
- * when the resolved target (`api.&lt;file>.&lt;export>`) is found in the
+ * when the resolved target (`api.<file>.<export>`) is found in the
  * RLS-procedure evidence with `usesRls: true`. A dispatch into a function that
  * does its own arg validation and carries no row policy (the common, correct
  * case — e.g. a welcome-message mutation with no `rls`) is not flagged. Runs

--- a/packages/advisor/src/lints/static/privileged-fanout-from-public-procedure.ts
+++ b/packages/advisor/src/lints/static/privileged-fanout-from-public-procedure.ts
@@ -6,8 +6,8 @@ import type { Lint } from "../../types";
  * Flags a public procedure whose handler fans work out to a privileged,
  * cost-bearing dispatch surface without a rate-limit guard.
  *
- * `ctx.scheduler.runAfter` / `runAt`, a `ctx.queues.&lt;name>` producer send, and
- * `ctx.workflows.&lt;name>.create` all enqueue work that runs later under the
+ * `ctx.scheduler.runAfter` / `runAt`, a `ctx.queues.<name>` producer send, and
+ * `ctx.workflows.<name>.create` all enqueue work that runs later under the
  * system identity (RLS disabled) and bills against the account. Triggered from a
  * `.public()` procedure with no rate limit, an anonymous caller can drive that
  * dispatch in a loop — a cost-amplification / denial-of-wallet vector, and a way

--- a/packages/advisor/src/lints/static/storage-key-from-user-args.ts
+++ b/packages/advisor/src/lints/static/storage-key-from-user-args.ts
@@ -2,7 +2,7 @@ import emit from "../../finding";
 import type { Lint } from "../../types";
 
 /**
- * Flags a `ctx.storage.&lt;bucket>.&lt;method>(key, …)` whose R2 object key is derived
+ * Flags a `ctx.storage.<bucket>.<method>(key, …)` whose R2 object key is derived
  * from the handler's `args` with no server-side scoping — an object-level IDOR.
  *
  * The bucket read/write/URL/delete methods (`get`, `put`, `delete`, `download`,

--- a/packages/advisor/src/lints/static/table-without-insert.ts
+++ b/packages/advisor/src/lints/static/table-without-insert.ts
@@ -7,7 +7,7 @@ import type { Lint } from "../../types";
  * Using `@lunora/codegen`'s write-side discovery (the analog of the read
  * discovery that feeds `filter_without_index`), this lint cross-references every
  * schema table against the set of tables some exported function writes via
- * `ctx.db.insert("&lt;table>", …)`. A table with no such write either is dead schema
+ * `ctx.db.insert("<table>", …)`. A table with no such write either is dead schema
  * or is populated through a path the static analysis can't see — a migration/seed,
  * cross-region replication, the `ctx.orm.insert(...)` builder, or a trusted
  * snapshot import. Hence `INFO`/`INTERNAL`: a nudge to confirm intent, not an error.

--- a/packages/advisor/src/lints/static/workflow-unused.ts
+++ b/packages/advisor/src/lints/static/workflow-unused.ts
@@ -5,7 +5,7 @@ import type { Lint } from "../../types";
  * Flags a declared workflow that nothing starts.
  *
  * Cross-references every `defineWorkflow` export against the set of workflow
- * names some function references via `ctx.workflows.get("&lt;name>")`. A workflow
+ * names some function references via `ctx.workflows.get("<name>")`. A workflow
  * with no such call is either dead code (declared, deployed as a billable
  * `WorkflowEntrypoint`, never triggered) or is started through a path the static
  * analysis can't see — the Cloudflare REST API, a `wrangler` invocation, or a

--- a/packages/advisor/src/mask-strategies.ts
+++ b/packages/advisor/src/mask-strategies.ts
@@ -11,7 +11,7 @@
 export interface AdvisorMaskStrategy {
     /** Masked column name. */
     column: string;
-    /** The exported binding name of the procedure whose `.use(mask(...))` chain declared this column, or `"&lt;module>"` when declared at file scope. */
+    /** The exported binding name of the procedure whose `.use(mask(...))` chain declared this column, or `"<module>"` when declared at file scope. */
     exportName: string;
     /** Source file relative to the lunora dir, no extension. */
     file: string;

--- a/packages/advisor/src/payment-webhooks.ts
+++ b/packages/advisor/src/payment-webhooks.ts
@@ -15,7 +15,7 @@
 export interface AdvisorPaymentWebhook {
     /** The adapter factory invoked. */
     callee: "createAutumnAdapter" | "createDodoPaymentsAdapter" | "createPolarAdapter" | "createStripeAdapter";
-    /** The exported binding name of the enclosing declaration (`&lt;module>` at file scope). */
+    /** The exported binding name of the enclosing declaration (`<module>` at file scope). */
     exportName: string;
     /** Source file relative to the lunora dir, no extension. */
     file: string;

--- a/packages/advisor/src/raw-row-returns.ts
+++ b/packages/advisor/src/raw-row-returns.ts
@@ -2,8 +2,8 @@
 
 /**
  * One `query` handler whose `return` hands back the raw rows of a table — the
- * result of a `ctx.db.&lt;table>.findMany()` / `.findFirst()` / `.get()` read, or a
- * `ctx.db.query("&lt;table>")…collect()` fluent chain — returned directly (or through
+ * result of a `ctx.db.<table>.findMany()` / `.findFirst()` / `.get()` read, or a
+ * `ctx.db.query("<table>")…collect()` fluent chain — returned directly (or through
  * one local `const` hop) with no hand-built projection. The shared input for the
  * `output_projection_missing_on_public_read` lint, which keeps only `visibility
  * === "public"` rows with no `.output(...)` / `.use(mask(...))` on the chain and

--- a/packages/advisor/src/relation-loads.ts
+++ b/packages/advisor/src/relation-loads.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.db.&lt;table>.findMany({ with: { &lt;rel> } })` relation-hydrating list read
+ * One `ctx.db.<table>.findMany({ with: { <rel> } })` relation-hydrating list read
  * — the shared input for the `masked_relation_leak_via_with` lint. Column
  * masking is applied per-procedure to the top-level rows of the table named in
  * the read; it does **not** descend into `with`-hydrated relations, so a masked

--- a/packages/advisor/src/soft-delete-reads.ts
+++ b/packages/advisor/src/soft-delete-reads.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.db.&lt;table>.findMany({ includeDeleted })` list read whose
+ * One `ctx.db.<table>.findMany({ includeDeleted })` list read whose
  * `includeDeleted` is either a hardcoded `true` or derived from the handler's
  * `args` — the shared input for the `soft_delete_include_deleted_from_args`
  * lint. `includeDeleted` resurfaces rows a `.softDelete()` table would otherwise

--- a/packages/advisor/src/storage-key-accesses.ts
+++ b/packages/advisor/src/storage-key-accesses.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.storage.&lt;bucket>.&lt;method>(key, …)` call whose R2 object key is derived
+ * One `ctx.storage.<bucket>.<method>(key, …)` call whose R2 object key is derived
  * from the handler's `args` with no server-side scoping — the input the
  * `storage_key_from_user_args` lint consumes. An object key taken straight from
  * request input lets any caller read, overwrite, or delete another user's object

--- a/packages/advisor/src/storage-uploads.ts
+++ b/packages/advisor/src/storage-uploads.ts
@@ -1,5 +1,5 @@
 /**
- * One tracked `ctx.storage.&lt;bucket>.&lt;method>(...)` upload/signing call — the
+ * One tracked `ctx.storage.<bucket>.<method>(...)` upload/signing call — the
  * shared input for the storage config-hygiene security lints
  * (`storage_upload_without_content_type_allowlist`, `storage_upload_without_max_size`,
  * `storage_generate_upload_url_no_content_type_pin`, `storage_presigned_url_for_private_content`).

--- a/packages/advisor/src/types.ts
+++ b/packages/advisor/src/types.ts
@@ -124,7 +124,7 @@ export interface Finding {
  */
 export interface LintContext {
     /**
-     * `httpRoute.&lt;verb>("/admin/…")` routes on admin/privileged-looking paths and
+     * `httpRoute.<verb>("/admin/…")` routes on admin/privileged-looking paths and
      * whether each references an auth/admin guard — the `admin_route_without_guard`
      * input. Supplied by the codegen feeder; absent for runtime callers, where the
      * lint finds nothing.
@@ -170,7 +170,7 @@ export interface LintContext {
     argValidators?: ReadonlyArray<AdvisorArgumentValidator>;
 
     /**
-     * `ctx.authApi.&lt;method>(...)` calls discovered in function bodies (the
+     * `ctx.authApi.<method>(...)` calls discovered in function bodies (the
      * `auth_api_call_without_headers` input). Supplied by the codegen feeder; absent
      * for runtime callers, where the lint finds nothing.
      */
@@ -191,7 +191,7 @@ export interface LintContext {
     authConfigs?: ReadonlyArray<AdvisorAuthConfig>;
 
     /**
-     * `ctx.browser.&lt;method>(url, …)` calls whose navigation URL is derived from the
+     * `ctx.browser.<method>(url, …)` calls whose navigation URL is derived from the
      * handler's `args` with no server-side scoping — the
      * `browser_user_url_without_allowlist` input. `@lunora/browser` blocks
      * private/internal targets by default, but a request-supplied public URL can
@@ -212,7 +212,7 @@ export interface LintContext {
     configCalls?: ReadonlyArray<AdvisorConfigCall>;
 
     /**
-     * `ctx.containers.&lt;name>.get(key, …)` calls whose instance key is derived from
+     * `ctx.containers.<name>.get(key, …)` calls whose instance key is derived from
      * the handler's `args` with no server-side scoping — the
      * `container_instance_key_from_user_input` input. Each container definition's
      * `.get(name)` accessor routes to one instance per key, so an arg-derived key lets
@@ -224,7 +224,7 @@ export interface LintContext {
 
     /**
      * Runtime container-override calls — a `.start({ enableInternet: true, … })`
-     * launch override, or a `.egress.&lt;method>(...)` runtime firewall mutation — the
+     * launch override, or a `.egress.<method>(...)` runtime firewall mutation — the
      * `container_start_enable_internet_override` and `container_runtime_egress_relaxation`
      * lint input. Supplied by the codegen feeder; absent for runtime callers, where
      * those lints find nothing.
@@ -319,7 +319,7 @@ export interface LintContext {
     hyperdriveCalls?: ReadonlyArray<AdvisorHyperdriveCall>;
 
     /**
-     * `&lt;receiver>.identity.&lt;key>` claim reads (RLS/mask policy `auth`, or
+     * `<receiver>.identity.<key>` claim reads (RLS/mask policy `auth`, or
      * `ctx.auth`/`context.auth`) — the `identity_undeclared_claim_trusted` input.
      * `defineIdentity` validates only declared claims and forwards undeclared ones
      * verbatim, so each row's `declared` flag says whether `key` is in the contract
@@ -362,7 +362,7 @@ export interface LintContext {
     inserts?: ReadonlyArray<AdvisorInsertWrite>;
 
     /**
-     * `ctx.kv.&lt;method>(key, …)` calls whose namespace key is derived from the
+     * `ctx.kv.<method>(key, …)` calls whose namespace key is derived from the
      * handler's `args` with no server-side scoping — the `kv_unscoped_user_key_idor`
      * input. Workers KV is one flat namespace, so a key taken straight from request
      * input lets any caller read/overwrite/delete another user's entry (IDOR). Only
@@ -545,7 +545,7 @@ export interface LintContext {
     /* eslint-enable no-secrets/no-secrets -- re-enable after the rawRowReturns doc block */
 
     /**
-     * `ctx.db.&lt;table>.findMany({ with: { &lt;rel> } })` relation-hydrating list reads
+     * `ctx.db.<table>.findMany({ with: { <rel> } })` relation-hydrating list reads
      * — the `masked_relation_leak_via_with` input. Column masking is applied to a
      * read's top-level rows but does not descend into `with`-hydrated relations,
      * so a masked table surfaced only through a `with` on an unprotected public
@@ -592,7 +592,7 @@ export interface LintContext {
     shardTraffic?: ReadonlyArray<AdvisorShardTraffic>;
 
     /**
-     * `ctx.db.&lt;table>.findMany({ includeDeleted })` list reads whose
+     * `ctx.db.<table>.findMany({ includeDeleted })` list reads whose
      * `includeDeleted` is a hardcoded `true` or derived from the handler's
      * `args` — the `soft_delete_include_deleted_from_args` input. On a public
      * read of a `.softDelete()` table this resurfaces soft-deleted rows to any
@@ -610,7 +610,7 @@ export interface LintContext {
     sqlInterpolations?: ReadonlyArray<AdvisorSqlInterpolation>;
 
     /**
-     * `ctx.storage.&lt;bucket>.&lt;method>(key, …)` calls whose R2 object key is derived
+     * `ctx.storage.<bucket>.<method>(key, …)` calls whose R2 object key is derived
      * from the handler's `args` with no server-side scoping — the
      * `storage_key_from_user_args` input. The bucket read/write/URL/delete methods
      * key by their first argument, so an arg-derived key is object-level IDOR
@@ -622,7 +622,7 @@ export interface LintContext {
     storageKeyAccesses?: ReadonlyArray<AdvisorStorageKeyAccess>;
 
     /**
-     * Tracked `ctx.storage.&lt;bucket>.&lt;method>(...)` upload/signing calls — the
+     * Tracked `ctx.storage.<bucket>.<method>(...)` upload/signing calls — the
      * shared input for the storage config-hygiene lints
      * (`storage_upload_without_content_type_allowlist`, `storage_upload_without_max_size`,
      * `storage_generate_upload_url_no_content_type_pin`,
@@ -666,7 +666,7 @@ export interface LintContext {
     unrestrictedWhereBranches?: ReadonlyArray<AdvisorUnrestrictedWhereBranch>;
 
     /**
-     * `ctx.vectors.&lt;method>(index, { namespace, … })` calls whose `namespace` is
+     * `ctx.vectors.<method>(index, { namespace, … })` calls whose `namespace` is
      * derived from the handler's `args` with no server-side scoping — the
      * `vectors_namespace_from_user_input` input. A Vectorize namespace partitions one
      * index into isolated sub-collections, so an arg-derived namespace lets any caller

--- a/packages/advisor/src/vector-namespace-accesses.ts
+++ b/packages/advisor/src/vector-namespace-accesses.ts
@@ -1,5 +1,5 @@
 /**
- * One `ctx.vectors.&lt;method>(indexName, input)` call whose `input.namespace` is
+ * One `ctx.vectors.<method>(indexName, input)` call whose `input.namespace` is
  * derived from the handler's `args` with no server-side scoping — the input the
  * `vectors_namespace_from_user_input` lint consumes. A Vectorize namespace
  * partitions one index into isolated sub-collections, so a namespace taken

--- a/packages/agent/__tests__/as-tool.test.ts
+++ b/packages/agent/__tests__/as-tool.test.ts
@@ -18,7 +18,7 @@ const NON_EMPTY_DESCRIPTION = /non-empty `description`/u;
 const QUOTA_EXCEEDED = /quota exceeded/u;
 
 /**
- * A mock `AGENT_&lt;NAME>` Workflow binding: `create` records the params + id, and
+ * A mock `AGENT_<NAME>` Workflow binding: `create` records the params + id, and
  * `get(id)` returns an instance whose `status()` walks a scripted sequence
  * (models a run progressing to a terminal state) and whose thread the caller
  * seeds via `finalMessages`.
@@ -47,7 +47,7 @@ const mockAgentBinding = (statuses: ReadonlyArray<string>): AgentWorkflowBinding
 };
 
 /**
- * A mock `AGENT_&lt;NAME>` Workflow binding whose `create` always rejects with the
+ * A mock `AGENT_<NAME>` Workflow binding whose `create` always rejects with the
  * given error (a duplicate-instance-id rejection, or any other failure); `get`
  * still resolves to a normal instance walking the scripted status sequence.
  */

--- a/packages/agent/eslint.config.js
+++ b/packages/agent/eslint.config.js
@@ -53,4 +53,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -219,12 +219,12 @@ const resolveNeedsApproval = async (
  * Pause the run on a human-in-the-loop tool approval: persist an
  * `"awaiting_approval"` marker (filtered out of the model prompt, but observable
  * by a client), move the thread to `"awaiting_input"`, then hibernate on the
- * deterministically named durable event `approval:&lt;toolCallId>`. A workflow
+ * deterministically named durable event `approval:<toolCallId>`. A workflow
  * replay memoizes the resolved wait, so the run resumes with the recorded
  * decision without pausing (or re-persisting) again. Named ONLY from the
  * replay-stable `call.id`.
  *
- * The wait's match `type` is scoped to THIS call (`agent-approval:&lt;call.id>`,
+ * The wait's match `type` is scoped to THIS call (`agent-approval:<call.id>`,
  * the same format `component.ts`'s `agentResolveApproval` sends) — native CF
  * Workflows matches an incoming event against a waiter by `type`, not by the
  * durable step name, so without this an approval meant for a different
@@ -548,7 +548,7 @@ const graphTraverseBounds = (graph: AgentMemoryOptions["graph"]): Record<string,
     return bounds;
 };
 
-/** Dispatch a `"semantic"` source's RAG action as a `memory:retrieve[:&lt;key>]` step and read its context. */
+/** Dispatch a `"semantic"` source's RAG action as a `memory:retrieve[:<key>]` step and read its context. */
 const dispatchSemanticMemory = async (source: AgentMemorySource, input: string, step: AgentStepLike, run: AgentRunFunction): Promise<string | undefined> => {
     // A semantic source without a `source` is rejected at `defineAgent`; guard
     // defensively for a hand-built definition that bypassed it.
@@ -565,7 +565,7 @@ const dispatchSemanticMemory = async (source: AgentMemorySource, input: string, 
 };
 
 /**
- * Dispatch a `"graph"` source's owner-scoped traversal as a `memory:traverse[:&lt;key>]`
+ * Dispatch a `"graph"` source's owner-scoped traversal as a `memory:traverse[:<key>]`
  * step and read its context. Owner-scoped by design: an anonymous run (no `owner`)
  * has no graph to read, so the source no-ops for that run.
  */
@@ -588,7 +588,7 @@ const dispatchGraphMemory = async (
 };
 
 /**
- * Dispatch an `"episodic"` source's recency recall as a `memory:recall[:&lt;key>]`
+ * Dispatch an `"episodic"` source's recency recall as a `memory:recall[:<key>]`
  * step and read its context. Owner-scoped by design: an anonymous run (no
  * `owner`) has no episode timeline, so the source no-ops for that run.
  */
@@ -615,8 +615,8 @@ const dispatchEpisodicMemory = async (
  * context. Sources run in a STABLE order — the default source (from `memory`)
  * first, then skill `knowledge` in declaration order — each inside its own
  * deterministic durable step. A `"semantic"` source keeps the historic
- * `"memory:retrieve[:&lt;key>]"` name so in-flight runs replay identically; a
- * `"graph"` source uses the `"memory:traverse[:&lt;key>]"` namespace (which can't
+ * `"memory:retrieve[:<key>]"` name so in-flight runs replay identically; a
+ * `"graph"` source uses the `"memory:traverse[:<key>]"` namespace (which can't
  * collide). Sourced from `agent.memorySources` (folded by `defineAgent`), falling
  * back to `agent.memory` alone for a directly-authored definition.
  */
@@ -704,7 +704,7 @@ const retrieveMemoryContext = async (
 /**
  * Run-end owner-scoped graph extraction. When a graph memory source is configured
  * and the run has an `owner` + a final answer, extract entities/relations from the
- * exchange in a MEMOIZED `memory:extract[:&lt;key>]` step (the model never re-runs on
+ * exchange in a MEMOIZED `memory:extract[:<key>]` step (the model never re-runs on
  * replay), then upsert them via an IDEMPOTENT dispatch keyed by the instance (the
  * `byTriple` dedup + absolute-max weight converge on replay). No-ops otherwise —
  * an anonymous run has no graph scope, and a run with no graph source or no
@@ -751,7 +751,7 @@ const extractGraphMemoryAtRunEnd = async (options: {
 /**
  * Run-end owner-scoped episode recording. When an episodic memory source is
  * configured and the run has an `owner` + a final answer, summarize the exchange
- * in a MEMOIZED `memory:episode[:&lt;key>]` step (the model never re-runs on
+ * in a MEMOIZED `memory:episode[:<key>]` step (the model never re-runs on
  * replay), then record it via an IDEMPOTENT dispatch keyed by the instance (the
  * `byOwnerMessageKey` unique index no-ops a replay). No-ops otherwise — an
  * anonymous run has no episode scope, and a run with no episodic source or no

--- a/packages/agent/src/code-tool.ts
+++ b/packages/agent/src/code-tool.ts
@@ -36,7 +36,7 @@ const capOutput = (output: unknown): unknown => {
 interface ToolScriptStep {
     /** A stable name later steps reference the output by. */
     id: string;
-    /** The tool's input; values may embed `{ "$from": "&lt;stepId>", "$path": "a.b" }` refs. */
+    /** The tool's input; values may embed `{ "$from": "<stepId>", "$path": "a.b" }` refs. */
     input?: Record<string, unknown>;
     /** The tool to call — one of the tools handed to {@link codeTool}. */
     tool: string;
@@ -100,7 +100,7 @@ const getPath = (value: unknown, path: string): unknown => {
 };
 
 /**
- * Resolve `{ "$from": "&lt;stepId>", "$path"?: "a.b" }` references in a step's input
+ * Resolve `{ "$from": "<stepId>", "$path"?: "a.b" }` references in a step's input
  * against earlier step results, recursing through nested objects and arrays. An
  * unknown `$from` throws — a forward/typo reference is a hard error, not a silent
  * `undefined`. Pure and deterministic (no I/O), so it's unit-testable alone.

--- a/packages/agent/src/component.ts
+++ b/packages/agent/src/component.ts
@@ -505,7 +505,7 @@ export const agentComponent = (): AgentComponent => {
      * ownerless one) could deliver an approve/reject to an arbitrary
      * `instanceId` — a different, unrelated run entirely.
      * - The delivered event's `type` is scoped to `toolCallId`
-     * (`agent-approval:&lt;id>`) — the SAME format `agent-loop.ts`'s
+     * (`agent-approval:<id>`) — the SAME format `agent-loop.ts`'s
      * `awaitApproval` matches on — so a decision meant for one pending tool
      * call cannot resolve a different one on the same instance.
      */
@@ -559,7 +559,7 @@ export const agentComponent = (): AgentComponent => {
     /**
      * Start a durable agent run. PUBLIC (owner-gated) — the only HTTP-reachable
      * way to begin a run, so an external client (e.g. the `@lunora/mcp` server,
-     * which fronts agents over RPC) can invoke `ctx.agents.&lt;name>.run` without
+     * which fronts agents over RPC) can invoke `ctx.agents.<name>.run` without
      * app code. Internal functions are unreachable over client RPC, so this must
      * NOT be `asInternal(...)`; the security boundary is the per-agent
      * `publicRun` opt-in and owner-scoping here (NOT the MCP-side `allowAgents`
@@ -570,7 +570,7 @@ export const agentComponent = (): AgentComponent => {
      * reachable here ONLY when its author opted in with
      * `defineAgent({ publicRun: true })`. Without the opt-in an `agentRun` caller
      * could start ANY declared agent regardless of MCP configuration; the flag
-     * restores the app-author chokepoint that `ctx.agents.&lt;name>.run`
+     * restores the app-author chokepoint that `ctx.agents.<name>.run`
      * (server-side app code) has always been — that programmatic path is
      * unaffected, it never routes through this gate.
      *

--- a/packages/agent/src/episodic-component.ts
+++ b/packages/agent/src/episodic-component.ts
@@ -146,7 +146,7 @@ const episodicComponent = (): EpisodicComponentFunctions => {
     /**
      * Episodic READ (internal query — queries are dispatchable via `run`, like
      * `agentState`). Returns the owner's most recent `limit` episodes rendered
-     * chronologically (oldest → newest) as compact `- &lt;summary>` lines, so the
+     * chronologically (oldest → newest) as compact `- <summary>` lines, so the
      * model reads a short timeline. Owner-scoped; deterministic (explicit sort);
      * `{ context: "" }` when the owner has no episodes (the loop drops it).
      */

--- a/packages/agent/src/sandbox-component.ts
+++ b/packages/agent/src/sandbox-component.ts
@@ -26,7 +26,7 @@ interface SandboxBrowserSurface {
     screenshot: (url: string, options?: { fullPage?: boolean; type?: "jpeg" | "png" }) => Promise<Uint8Array>;
 }
 
-/** Structural view of a `ctx.containers.&lt;name>` accessor + its fetch handle. */
+/** Structural view of a `ctx.containers.<name>` accessor + its fetch handle. */
 interface SandboxContainerAccessor {
     any: () => {
         fetch: (input: string, init?: { body?: string; headers?: Record<string, string>; method?: string }) => Promise<{ text: () => Promise<string> }>;

--- a/packages/agent/src/sandbox.ts
+++ b/packages/agent/src/sandbox.ts
@@ -266,7 +266,7 @@ const browserTool = (options: BrowserToolOptions = {}): AgentToolDefinition<Brow
 
 /**
  * A batteries-included agent tool that talks to a declared Cloudflare
- * Container. `name` is the `ctx.containers.&lt;name>` key (the `lunora/containers.ts`
+ * Container. `name` is the `ctx.containers.<name>` key (the `lunora/containers.ts`
  * export). One tool exposes `fetch` (HTTP request) and `exec` (run a command);
  * the model picks via `op`. The call dispatches to the auto-registered
  * `sandbox:invoke` action, which carries `ctx.containers`.

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -27,7 +27,7 @@ export interface AgentStepLike {
     /**
      * Durably hibernate until an external event of `type` arrives, then return
      * its payload. Used for human-in-the-loop approvals: a run pauses on
-     * `approval:&lt;toolCallId>` until a client resolves it. Like `do`, a resolved
+     * `approval:<toolCallId>` until a client resolves it. Like `do`, a resolved
      * wait is memoized — a replay returns the recorded decision without pausing
      * again. Signature mirrors `@lunora/workflow`'s `WorkflowStepLike`.
      */
@@ -41,7 +41,7 @@ export interface AgentStepLike {
  * `idempotencyKey`.
  *
  * The `idempotencyKey` is the deterministic durable-step name
- * (`tool:&lt;name>:&lt;toolCallId>`). A COMPLETED tool step is never re-run on a
+ * (`tool:<name>:<toolCallId>`). A COMPLETED tool step is never re-run on a
  * workflow replay (native step memoization) — but a step that FAILS mid-body
  * is retried at-least-once, so a side-effecting tool (charge a card, send a
  * mail) must dedupe on this key itself.
@@ -143,7 +143,7 @@ export interface AgentToolDefinition<Input = unknown, Output = unknown> {
      * Gate the tool behind a human approval (mirrors the AI SDK's
      * `needsApproval`). When it resolves truthy the durable run PAUSES — the
      * thread moves to `"awaiting_input"` and the workflow hibernates on
-     * `approval:&lt;toolCallId>` — until a client calls `agents:agentResolveApproval`.
+     * `approval:<toolCallId>` — until a client calls `agents:agentResolveApproval`.
      * On approve the tool runs exactly as normal; on reject it is skipped and a
      * tool result explaining the rejection is persisted so the next turn recovers.
      * A boolean gates statically; a function gates per input. Default: `false`
@@ -151,7 +151,7 @@ export interface AgentToolDefinition<Input = unknown, Output = unknown> {
      *
      * The boolean/`undefined` forms are compile-time constants re-derived
      * identically on every replay — no durable step. The FUNCTION form runs
-     * inside its OWN durable step (`tool:approval-gate:&lt;toolCallId>`, distinct
+     * inside its OWN durable step (`tool:approval-gate:<toolCallId>`, distinct
      * from the tool's own step), so it now runs exactly once per call, not once
      * per replay. It must still be otherwise pure: deterministic given its
      * inputs (no `Date.now()`/`Math.random()`) and free of side effects — the
@@ -286,7 +286,7 @@ export interface AgentMemoryOptions {
  * (`key: "default"`) from {@link AgentConfig.memory}, then one per skill that
  * carries `knowledge` (keyed by the skill's name). The key names the durable
  * step — the default source keeps the historic `"memory:retrieve"`, a skill
- * source uses `"memory:retrieve:&lt;key>"` — so replay stays deterministic.
+ * source uses `"memory:retrieve:<key>"` — so replay stays deterministic.
  * @experimental
  */
 export interface AgentMemorySource extends AgentMemoryOptions {
@@ -347,7 +347,7 @@ export interface SkillConfig {
 
     /**
      * The skill's identifier — namespaces this skill's `knowledge` memory source
-     * (the durable step `memory:retrieve:&lt;name>`). Must be identifier-shaped.
+     * (the durable step `memory:retrieve:<name>`). Must be identifier-shaped.
      */
     name: string;
 
@@ -398,7 +398,7 @@ export interface AgentStepFinishInfo {
 
 /**
  * Called after each LLM turn with that turn's text, tool calls, and usage. Runs
- * inside a named durable step (`agent:step-finish:&lt;turn>`) so it fires exactly
+ * inside a named durable step (`agent:step-finish:<turn>`) so it fires exactly
  * once per turn even across a workflow replay.
  * @experimental
  */
@@ -588,7 +588,7 @@ export interface AgentConfig {
 
     /**
      * Optional override for the deployed workflow name (`wrangler.jsonc`
-     * `workflows[].name`). Defaults to `agent-&lt;kebab-cased export name>`. Does
+     * `workflows[].name`). Defaults to `agent-<kebab-cased export name>`. Does
      * NOT change the binding name, which is always derived from the export
      * name (`support` → `AGENT_SUPPORT`).
      */
@@ -640,7 +640,7 @@ export interface AgentConfig {
      * Opt this agent into being STARTED over the public RPC boundary — i.e. via
      * the auto-registered `agents:agentRun` mutation an HTTP-only client (e.g.
      * the `@lunora/mcp` server) calls. Default `false`: an agent is startable
-     * only from server-side app code (`ctx.agents.&lt;name>.run(...)`), so declaring
+     * only from server-side app code (`ctx.agents.<name>.run(...)`), so declaring
      * an agent does NOT expose it to arbitrary RPC callers. Fail-closed — the run
      * mutation refuses an agent that has not opted in, regardless of any MCP-side
      * `allowAgents` configuration. A started thread is still owner-scoped to
@@ -764,7 +764,7 @@ export interface AgentAsToolOptions {
     maxPolls?: number;
 
     /**
-     * The child agent's export name — selects its `AGENT_&lt;NAME>` Workflow
+     * The child agent's export name — selects its `AGENT_<NAME>` Workflow
      * binding (e.g. `"researcher"` → `AGENT_RESEARCHER`). The model-facing tool
      * name is the KEY assigned in the parent's `tools` map, not this.
      */
@@ -1173,7 +1173,7 @@ export interface AgentRunHandle {
 }
 
 /**
- * The `ctx.agents.&lt;name>` producer handle.
+ * The `ctx.agents.<name>` producer handle.
  * @experimental
  */
 export interface AgentHandle {

--- a/packages/agent/src/workflow.ts
+++ b/packages/agent/src/workflow.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the generated `<Name>AgentWorkflow` class, not a credential. */
+
 import type { WorkflowDefinition } from "@lunora/workflow";
 import { defineWorkflow } from "@lunora/workflow";
 
@@ -49,15 +51,15 @@ const withAutoOtlpTelemetry = (agent: AgentDefinition, env: Record<string, unkno
 
 /**
  * Compile a `defineAgent` definition into the workflow the generated
- * `&lt;Name>AgentWorkflow` entrypoint class runs. Codegen emits, per agent:
+ * `<Name>AgentWorkflow` entrypoint class runs. Codegen emits, per agent:
  *
  * ```ts
  * import LunoraWorkflow from "@lunora/workflow/do";
  * import { compileAgentWorkflow } from "@lunora/agent";
  * import { support } from "../agents.js";
  *
- * export class SupportAgentWorkflow extends LunoraWorkflow&lt;AgentRunInput, AgentRunResult> {
- *     public constructor(ctx: ConstructorParameters&lt;typeof LunoraWorkflow>[0], env: Record&lt;string, unknown>) {
+ * export class SupportAgentWorkflow extends LunoraWorkflow<AgentRunInput, AgentRunResult> {
+ *     public constructor(ctx: ConstructorParameters<typeof LunoraWorkflow>[0], env: Record<string, unknown>) {
  *         super(ctx, env, compileAgentWorkflow(support, "support"), "support");
  *     }
  * }

--- a/packages/ai/eslint.config.js
+++ b/packages/ai/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/ai/src/rag/types.ts
+++ b/packages/ai/src/rag/types.ts
@@ -5,7 +5,7 @@ import type { EmbeddingModelInput, LunoraAi } from "../types";
 /**
  * `(text) => vector` — the embedder shape `ctx.vectors` accepts on both its
  * write (`upsert`) and read (`query`) inputs. Matches `@lunora/server`'s
- * `VectorEmbedder` and `@lunora/bindings/vectors`' `EmbedFunction&lt;string>`.
+ * `VectorEmbedder` and `@lunora/bindings/vectors`' `EmbedFunction<string>`.
  * @experimental
  */
 export type RagEmbedder = (input: string) => Promise<ReadonlyArray<number>> | ReadonlyArray<number>;
@@ -467,7 +467,7 @@ export interface RagSource {
 export interface RetrieveResult {
     /** Ranked chunks (best first). */
     chunks: ReadonlyArray<RetrievedChunk>;
-    /** Ready-to-inject prompt context: chunks joined under `[source:&lt;id>#&lt;n>]` headers. */
+    /** Ready-to-inject prompt context: chunks joined under `[source:<id>#<n>]` headers. */
     context: string;
     /** Deduped source references, in first-seen (best) order. */
     sources: ReadonlyArray<RagSource>;

--- a/packages/angular/eslint.config.js
+++ b/packages/angular/eslint.config.js
@@ -51,4 +51,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/angular/src/agent-chat.ts
+++ b/packages/angular/src/agent-chat.ts
@@ -53,7 +53,7 @@ interface AgentChatOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link AgentChatResult.cancel} is a
      * no-op.
      */
@@ -72,7 +72,7 @@ interface AgentChatOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link AgentChatOptions.sendArgs} and the per-call args.
      */
     send: FunctionReference<"mutation">;

--- a/packages/angular/src/agent-state.ts
+++ b/packages/angular/src/agent-state.ts
@@ -59,7 +59,7 @@ interface AgentStateResult<T> {
  * only on a real `setState`. The Angular counterpart to React's `useAgentState`,
  * re-expressed with signals.
  *
- * Generic over the app's state shape (`agentState&lt;SupportState>(...)`, itself a
+ * Generic over the app's state shape (`agentState<SupportState>(...)`, itself a
  * record) — the reference is typed as an optional record because codegen cannot see
  * the per-agent state type; the generic casts to `T`. The `extends` bound (not a
  * bare unbounded type parameter) is required: this `.ts` file is parsed JSX-aware by

--- a/packages/angular/src/agent.ts
+++ b/packages/angular/src/agent.ts
@@ -129,7 +129,7 @@ interface AgentOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link AgentResult.cancel} is a no-op.
      */
     cancel?: FunctionReference<"mutation">;
@@ -145,7 +145,7 @@ interface AgentOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link AgentOptions.runArgs} and the per-call args.
      */
     run: FunctionReference<"mutation">;
@@ -183,7 +183,7 @@ interface AgentResult {
  * conversation surface (durable history + streaming + approvals) use `agentChat`.
  *
  * `run` and `cancel` stay generic over the app-defined mutations that wrap
- * `ctx.agents.&lt;name>.run` / `.cancel`, so the primitive hard-codes no function
+ * `ctx.agents.<name>.run` / `.cancel`, so the primitive hard-codes no function
  * names beyond the `agents:*` surface.
  *
  * Call from an injection context (component/service field or constructor); pass an

--- a/packages/angular/src/voice-agent.ts
+++ b/packages/angular/src/voice-agent.ts
@@ -28,9 +28,9 @@ type VoiceServerFrame =
 type VoiceClientFrame = { text: string; type: "text" } | { type: "commit" } | { type: "interrupt" };
 
 /**
- * The `agents.&lt;name>Voice` reference codegen emits for a voice-enabled agent — a
+ * The `agents.<name>Voice` reference codegen emits for a voice-enabled agent — a
  * live, WS-backed session keyed by `threadKey`. A structural subset of the
- * generated member, so passing `api.agents.&lt;name>Voice` type-checks.
+ * generated member, so passing `api.agents.<name>Voice` type-checks.
  * @experimental
  */
 type VoiceReference = FunctionReference<"stream", { threadKey: string }, Record<string, unknown>>;
@@ -91,7 +91,7 @@ interface VoiceAgentOptions {
     silenceThreshold?: number;
     /** The thread to converse on — shared with the agent's text turns. Resolved when the call opens. */
     threadKey: string;
-    /** The generated `api.agents.&lt;name>Voice` reference — identifies the voice DO endpoint. */
+    /** The generated `api.agents.<name>Voice` reference — identifies the voice DO endpoint. */
     voice: VoiceReference;
 }
 
@@ -147,7 +147,7 @@ const deriveWebSocketUrl = (url: string): string => {
 
 /**
  * Derive the agent's export name from its voice reference. Codegen emits the
- * member as `agents.&lt;name>Voice` (ref `agents:&lt;name>Voice`), so strip the
+ * member as `agents.<name>Voice` (ref `agents:<name>Voice`), so strip the
  * `agents:` namespace and the `Voice` suffix.
  */
 const agentNameFromReference = (voice: VoiceReference): string => {
@@ -188,7 +188,7 @@ interface VoiceConnection {
  * WebSocket to the agent's `VoiceSessionDO`, captures mic audio as 16 kHz PCM,
  * streams the agent's synthesized speech back through the browser's audio output,
  * and mirrors the call lifecycle (`status`, `transcript`, `interimTranscript`,
- * `audioLevel`) to Angular signals. Pass the generated `api.agents.&lt;name>Voice`
+ * `audioLevel`) to Angular signals. Pass the generated `api.agents.<name>Voice`
  * reference (never a string), matching `agentChat`'s reference-passing style. The
  * Angular counterpart to React's `useVoiceAgent`, re-expressed with signals; the
  * per-call connection lives in a closure variable (the primitive runs once per

--- a/packages/astro/eslint.config.js
+++ b/packages/astro/eslint.config.js
@@ -116,4 +116,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/auth-ui/__tests__/vue/discovery.test.ts
+++ b/packages/auth-ui/__tests__/vue/discovery.test.ts
@@ -9,7 +9,7 @@
  * and a controller factory that re-reads it on rebuild. That is what these
  * assert, for the gate (`v-if`) and for the auto-load that rides along with it,
  * under both provider forms: the reactive read is what makes `createAuthUI`
- * (which has no subtree to re-create) behave identically to `&lt;AuthUIProvider>`.
+ * (which has no subtree to re-create) behave identically to `<AuthUIProvider>`.
  *
  * Lives in its own file so the module-level request cache in `core/discovery.ts`
  * cannot leak into `cards.test.ts`, which deliberately runs against a deployment

--- a/packages/auth-ui/eslint.config.js
+++ b/packages/auth-ui/eslint.config.js
@@ -252,4 +252,13 @@ export default createConfig(
             "import/no-namespace": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/auth-ui/src/angular/account-cards.ts
+++ b/packages/auth-ui/src/angular/account-cards.ts
@@ -118,7 +118,7 @@ class LinkedAccountsCardComponent {
 /**
  * Avatar upload. Rendered only when the app configured an `avatar.upload`
  * handler — without one there is nowhere to put the bytes, and
- * `&lt;lunora-profile-card>`'s URL field is the honest fallback.
+ * `<lunora-profile-card>`'s URL field is the honest fallback.
  */
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/auth-ui/src/angular/extras.ts
+++ b/packages/auth-ui/src/angular/extras.ts
@@ -156,7 +156,7 @@ class OneTapComponent {
 
 /**
  * Upload an organization's logo. Renders only when the app configured an
- * `avatar.upload` handler — without one, `&lt;lunora-organization-settings-card>`'s
+ * `avatar.upload` handler — without one, `<lunora-organization-settings-card>`'s
  * logo URL field is the fallback.
  */
 @Component({

--- a/packages/auth-ui/src/angular/index.ts
+++ b/packages/auth-ui/src/angular/index.ts
@@ -23,7 +23,7 @@ export * from "../core";
  * // a route component
  * import { SignInCardComponent } from "./lunora/auth-ui/angular";
  *
- * `@Component`({ imports: [SignInCardComponent], template: `&lt;lunora-sign-in-card />` })
+ * `@Component`({ imports: [SignInCardComponent], template: `<lunora-sign-in-card />` })
  * export class SignInPage {}
  * ```
  */

--- a/packages/auth-ui/src/angular/plugin-cards.ts
+++ b/packages/auth-ui/src/angular/plugin-cards.ts
@@ -29,7 +29,7 @@ import { UserViewComponent } from "./user-button";
 /**
  * The accounts signed in on *this device*, with switch and sign-out-just-this.
  *
- * Not `&lt;lunora-sessions-card>`, which lists this account's sessions across every
+ * Not `<lunora-sessions-card>`, which lists this account's sessions across every
  * device. The two are a keystroke apart in better-auth's API and mean opposite
  * things.
  */

--- a/packages/auth-ui/src/angular/primitives.ts
+++ b/packages/auth-ui/src/angular/primitives.ts
@@ -167,7 +167,7 @@ class FormBannerComponent {
  * server discovery on, is whatever `socialProviders` the deployment configured.
  *
  * The provider's brand mark is left to CSS: each button carries a
- * `lunora-auth-social__icon--&lt;provider>` class, so an app drops in its own icon
+ * `lunora-auth-social__icon--<provider>` class, so an app drops in its own icon
  * set with a stylesheet rule and this package ships no SVG payload for a list of
  * providers it can't know in advance.
  */
@@ -243,7 +243,7 @@ class AuthDividerComponent {
     readonly label = input("or");
 }
 
-/** Internal link using the provider's `link` hook when present, else a plain `&lt;a>`. */
+/** Internal link using the provider's `link` hook when present, else a plain `<a>`. */
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: "lunora-auth-link",

--- a/packages/auth-ui/src/angular/provider.ts
+++ b/packages/auth-ui/src/angular/provider.ts
@@ -2,7 +2,7 @@
  * Angular provider for the auth UI. `provideAuthUI(config)` returns the
  * environment providers that expose the resolved {@link ControllerContext}
  * (plus an optional client-side navigation hook for internal links) through the
- * {@link AUTH_UI_CONTEXT} injection token. Mirrors React's `&lt;AuthUIProvider>`:
+ * {@link AUTH_UI_CONTEXT} injection token. Mirrors React's `<AuthUIProvider>`:
  * one base component set serves every meta-framework — pass your router into
  * `nav`/`link` and the cards navigate through it.
  */
@@ -26,7 +26,7 @@ interface AuthUIAngularConfig extends Omit<AuthUIConfig, "nav"> {
     /**
      * Client-side navigation for internal auth links (router `navigate`, etc.).
      * When set, `AuthLinkComponent` intercepts the click and calls this
-     * instead of a full page load; when omitted the link is a plain `&lt;a href>`.
+     * instead of a full page load; when omitted the link is a plain `<a href>`.
      */
     link?: (href: string) => void;
     /** Router bridge for programmatic redirects; defaults to {@link defaultNav}. */

--- a/packages/auth-ui/src/angular/user-button.ts
+++ b/packages/auth-ui/src/angular/user-button.ts
@@ -96,7 +96,7 @@ const nextId = (prefix: string): string => {
  * The avatar menu: who is signed in, plus sign-out and whatever the app hangs
  * off it.
  *
- * It is a disclosure rather than a `&lt;menu>` because its contents are app-defined
+ * It is a disclosure rather than a `<menu>` because its contents are app-defined
  * — links, an organization switcher, a theme row — and forcing those into menu
  * item semantics would mislabel them. Escape and outside-click close it, and
  * focus returns to the trigger, which is the part hand-rolled dropdowns usually

--- a/packages/auth-ui/src/core/accounts.ts
+++ b/packages/auth-ui/src/core/accounts.ts
@@ -21,7 +21,7 @@ import type { AuthAccount, Controller } from "./types";
 /**
  * Providers that are not OAuth links and must never be offered for unlinking as
  * if they were: `credential` is the password itself, and the passkey rows are
- * managed by `&lt;PasskeysCard>`.
+ * managed by `<PasskeysCard>`.
  */
 const NON_SOCIAL_PROVIDERS = new Set(["credential", "email", "passkey"]);
 

--- a/packages/auth-ui/src/core/captcha.ts
+++ b/packages/auth-ui/src/core/captcha.ts
@@ -7,7 +7,7 @@
  * the client, and they belong in different places.
  *
  * **Rendering the widget and capturing a token** is {@link renderCaptcha}, driven
- * by each port's `&lt;Captcha>` component.
+ * by each port's `<Captcha>` component.
  *
  * **Attaching the token to auth requests** is *not* done here. Every flow would
  * have to thread fetch options through, and better-auth already has one place for
@@ -42,7 +42,7 @@ const CAPTCHA_HEADER = "x-captcha-response";
  *
  * The token must only be attached to these. `fetchOptions.onRequest` runs for
  * every* auth call, and `captchaHeaders()` consumes on read — so without this
- * filter a background `getSession` (a session refetch on focus, a `&lt;UserButton>`
+ * filter a background `getSession` (a session refetch on focus, a `<UserButton>`
  * elsewhere in the shell) spends the token on a route that ignores it, and the
  * sign-in the user then clicks arrives with no header at all.
  *
@@ -126,7 +126,7 @@ const setCaptchaToken = (token: string | undefined): void => {
     store.set({ token });
 };
 
-/** The bit of a `&lt;script>` element this module sets, named so the DOM lib isn't needed. */
+/** The bit of a `<script>` element this module sets, named so the DOM lib isn't needed. */
 interface ScriptElement {
     addEventListener: (type: string, listener: () => void) => void;
     async: boolean;

--- a/packages/auth-ui/src/core/config.ts
+++ b/packages/auth-ui/src/core/config.ts
@@ -1,7 +1,7 @@
 /**
  * The framework-agnostic configuration + resolved controller context.
  *
- * A framework provider (`&lt;AuthUIProvider>`) collects the user-facing
+ * A framework provider (`<AuthUIProvider>`) collects the user-facing
  * {@link AuthUIConfig}, then {@link resolveContext} normalizes it into a
  * {@link ControllerContext} — the fully-defaulted object every controller
  * receives. Keeping resolution here means the five framework providers share one
@@ -74,7 +74,7 @@ interface RedirectConfig {
 }
 
 /**
- * URL segments `&lt;AuthView>` maps to cards, so an app can host every auth screen
+ * URL segments `<AuthView>` maps to cards, so an app can host every auth screen
  * on one route (`/auth/:view`) instead of wiring ten of them.
  */
 interface ViewPaths {
@@ -103,7 +103,7 @@ interface AvatarConfig {
     upload?: (file: File) => Promise<string>;
 }
 
-/** The user-facing config passed to a framework `&lt;AuthUIProvider>`. */
+/** The user-facing config passed to a framework `<AuthUIProvider>`. */
 interface AuthUIConfig {
     authClient: AnyAuthClient;
     avatar?: AvatarConfig;
@@ -172,7 +172,7 @@ interface AuthUIConfig {
          * Needed because teams are detected from the server's table map and
          * have no client-side equivalent to fall back on: a deployment that
          * withholds the organization block (`uiConfig({ expose })`) would
-         * otherwise lose `&lt;TeamsCard>` from every port with no way to restore it.
+         * otherwise lose `<TeamsCard>` from every port with no way to restore it.
          */
         teams?: boolean;
     };

--- a/packages/auth-ui/src/core/create-resource-controller.ts
+++ b/packages/auth-ui/src/core/create-resource-controller.ts
@@ -19,7 +19,7 @@ import type { FlowStatus } from "./types";
  * one snapshot, one stable reference, and no flow having to re-implement the
  * engine to carry two more properties.
  *
- * A nested field rather than an intersection: `Partial&lt;A & B>` is not assignable
+ * A nested field rather than an intersection: `Partial<A & B>` is not assignable
  * from `{ busy: true }` while `B` is an unresolved generic, so an intersection
  * would need a cast at every internal update. Nesting keeps all of them honest.
  */

--- a/packages/auth-ui/src/core/default-nav.ts
+++ b/packages/auth-ui/src/core/default-nav.ts
@@ -1,6 +1,6 @@
 /**
  * The zero-config navigation fallback. When an app doesn't wire its router into
- * `&lt;AuthUIProvider nav={...}>`, the components still work by driving
+ * `<AuthUIProvider nav={...}>`, the components still work by driving
  * `globalThis.location` directly. Meta-frameworks should override this with
  * their own router for client-side transitions.
  */

--- a/packages/auth-ui/src/core/discovery.ts
+++ b/packages/auth-ui/src/core/discovery.ts
@@ -89,8 +89,8 @@ const PLUGIN_ID_TO_FLOW: Readonly<Record<string, string>> = {
  * `unavailable` until they remount. A successful answer stays cached, because
  * it cannot change.
  *
- * Module-level rather than per-provider so mounting `&lt;SignInCard>` and
- * `&lt;UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
+ * Module-level rather than per-provider so mounting `<SignInCard>` and
+ * `<UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
  * URL, so an app talking to two deployments still gets two answers.
  */
 const handles = new Map<string, DiscoveryHandle>();

--- a/packages/auth-ui/src/core/flow-gate.ts
+++ b/packages/auth-ui/src/core/flow-gate.ts
@@ -1,7 +1,7 @@
 /**
  * Which optional flows are available — and therefore which cards render.
  *
- * A card like `&lt;MagicLinkCard>` only works if the matching better-auth client
+ * A card like `<MagicLinkCard>` only works if the matching better-auth client
  * plugin is installed, so the cards need to know which are. They cannot ask the
  * client: `createAuthClient` returns a dynamic-path `Proxy`, so
  * `typeof client.organization?.list === "function"` is true for a plugin-free

--- a/packages/auth-ui/src/core/notify-error.ts
+++ b/packages/auth-ui/src/core/notify-error.ts
@@ -1,13 +1,13 @@
 /**
  * Report an error that has no card to land in.
  *
- * Most flows put their failures on a `&lt;FormBanner>`. A handful can't: social
+ * Most flows put their failures on a `<FormBanner>`. A handful can't: social
  * sign-in, account linking, sign-out and anonymous sign-in all resolve rather
  * than reject, because the ports call them from click handlers with `void` — so
  * before this, a failure was a button that did nothing at all.
  *
  * This keeps `onError` behaving exactly as it did and adds a toast beside it,
- * which `&lt;ErrorToaster>` renders if the app mounted one.
+ * which `<ErrorToaster>` renders if the app mounted one.
  */
 import type { ControllerContext } from "./config";
 import { mapAuthError } from "./map-error";

--- a/packages/auth-ui/src/core/organization-logo.ts
+++ b/packages/auth-ui/src/core/organization-logo.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 /**
  * Organization logo upload — the org-side counterpart to `avatar.ts`.
  *
  * Same shape and the same reasoning: better-auth stores `organization.logo` as a
  * string, so where the bytes live is the app's decision and comes in through
- * `avatar.upload`. Without an upload handler `&lt;OrganizationSettingsCard>`'s URL
+ * `avatar.upload`. Without an upload handler `<OrganizationSettingsCard>`'s URL
  * field is still the fallback, and this card doesn't render.
  *
  * It is a separate controller rather than a parameter on the avatar one because

--- a/packages/auth-ui/src/core/redirect-to.ts
+++ b/packages/auth-ui/src/core/redirect-to.ts
@@ -3,7 +3,7 @@
  * on purpose.
  *
  * `invitations.ts` bounces a signed-out invitee through the sign-in screen with
- * `?redirectTo=&lt;the invitation>`, and an app's own route guard usually does the
+ * `?redirectTo=<the invitation>`, and an app's own route guard usually does the
  * same. Without this the parameter is written and never read, so the user signs
  * in and lands on the generic post-login page with the invitation forgotten —
  * the bounce looks like it worked and quietly didn't.

--- a/packages/auth-ui/src/core/session.ts
+++ b/packages/auth-ui/src/core/session.ts
@@ -1,6 +1,6 @@
 /**
- * The signed-in user, for the chrome rather than a form: `&lt;UserButton>`,
- * `&lt;UserAvatar>`, `&lt;UserView>`, and any card that needs to know whether anyone
+ * The signed-in user, for the chrome rather than a form: `<UserButton>`,
+ * `<UserAvatar>`, `<UserView>`, and any card that needs to know whether anyone
  * is signed in at all.
  *
  * better-auth's framework clients each ship their own reactive `useSession`, but

--- a/packages/auth-ui/src/core/theme.ts
+++ b/packages/auth-ui/src/core/theme.ts
@@ -38,7 +38,7 @@ interface ThemeTokens {
     success: string;
 }
 
-/** Mirrors the `var(--token, &lt;fallback>)` fallbacks in `styles/auth-ui.css`. */
+/** Mirrors the `var(--token, <fallback>)` fallbacks in `styles/auth-ui.css`. */
 const DEFAULT_THEME_TOKENS: ThemeTokens = {
     background: "hsl(0 0% 100%)",
     border: "hsl(228 16% 88%)",

--- a/packages/auth-ui/src/core/toast.ts
+++ b/packages/auth-ui/src/core/toast.ts
@@ -1,14 +1,14 @@
 /**
  * Transient error messages for the flows that have nowhere to put one.
  *
- * Most flows own a card, and a card owns a `&lt;FormBanner>` — that is where their
+ * Most flows own a card, and a card owns a `<FormBanner>` — that is where their
  * errors belong, and this store deliberately does not duplicate them. What it
  * exists for is the handful of actions with **no visible surface at the moment
  * they fail**: social sign-in and account linking (a redirect that never
  * happens), sign-out, anonymous sign-in. Those call `context.onError` and then
  * resolve, so today a failure is a page that simply does nothing.
  *
- * `&lt;ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
+ * `<ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
  * with its own toast system reads the same store instead, or keeps passing
  * `onError` and ignores this entirely.
  */
@@ -25,7 +25,7 @@ interface ToastState {
 }
 
 /**
- * Module-level, like `discovery.ts`: `&lt;ErrorToaster>` is mounted once in an app
+ * Module-level, like `discovery.ts`: `<ErrorToaster>` is mounted once in an app
  * shell while the flows that push to it live anywhere in the tree, so a
  * per-provider store would need threading through every controller to reach it.
  */

--- a/packages/auth-ui/src/core/types.ts
+++ b/packages/auth-ui/src/core/types.ts
@@ -159,7 +159,7 @@ interface SessionData {
 }
 
 /**
- * What a consumer actually passes to `&lt;AuthUIProvider>`.
+ * What a consumer actually passes to `<AuthUIProvider>`.
  *
  * Deliberately almost-empty. A real better-auth client's type contains only the
  * plugins it was built with — a client without `adminClient()` has no

--- a/packages/auth-ui/src/core/username.ts
+++ b/packages/auth-ui/src/core/username.ts
@@ -2,7 +2,7 @@
  * Username sign-in, and setting a username from account settings.
  *
  * The `username` plugin doesn't replace email sign-in, it adds a second door, so
- * `&lt;SignInCard>` keeps its email field and this is a separate card rather than a
+ * `<SignInCard>` keeps its email field and this is a separate card rather than a
  * mode switch inside it. Which one an app shows is an app decision.
  */
 import type { ControllerContext } from "./config";

--- a/packages/auth-ui/src/emails/index.tsx
+++ b/packages/auth-ui/src/emails/index.tsx
@@ -7,20 +7,20 @@
  * # Why these live here and not beside the cards
  *
  * They are rendered by the **Worker**, not by the UI: `sendAuthEmail` in
- * `lunora/auth/index.ts` calls `renderEmail(&lt;VerifyEmail … />)` from
+ * `lunora/auth/index.ts` calls `renderEmail(<VerifyEmail … />)` from
  * `@lunora/mail`. That makes them framework-agnostic in the way that matters —
  * a Vue or Svelte app sends exactly the same mail — even though they are written
  * in TSX, because `@react-email/render` is what turns them into HTML + text.
  *
  * They ship as the separate `auth-emails` registry item rather than inside
- * `auth-ui-&lt;framework>`, so a project only takes on `react` +
+ * `auth-ui-<framework>`, so a project only takes on `react` +
  * `@react-email/render` when it actually wants styled mail. Without the item,
  * the base `auth` item's plain-text bodies still work.
  *
  * # Styling
  *
  * Inline styles only, and a table-free single-column layout. Every serious mail
- * client strips `&lt;style>` blocks and most ignore flexbox and grid; `@media` is
+ * client strips `<style>` blocks and most ignore flexbox and grid; `@media` is
  * unreliable. This is the subset that renders the same in Gmail, Outlook and
  * Apple Mail, so resist moving it to a stylesheet.
  */

--- a/packages/auth-ui/src/react/account-cards.tsx
+++ b/packages/auth-ui/src/react/account-cards.tsx
@@ -92,7 +92,7 @@ const LinkedAccountsCard = (): ReactElement => {
 
 /**
  * Avatar upload. Rendered only when the app configured an `avatar.upload`
- * handler — without one there is nowhere to put the bytes, and `&lt;ProfileCard>`'s
+ * handler — without one there is nowhere to put the bytes, and `<ProfileCard>`'s
  * URL field is the honest fallback.
  */
 const AvatarCard = (): ReactElement | null => {

--- a/packages/auth-ui/src/react/extras.tsx
+++ b/packages/auth-ui/src/react/extras.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 import type { ReactElement } from "react";
 import { useEffect, useRef, useSyncExternalStore } from "react";
 
@@ -111,7 +113,7 @@ const OneTap = (): null => {
 
 /**
  * Upload an organization's logo. Renders only when the app configured an
- * `avatar.upload` handler — without one, `&lt;OrganizationSettingsCard>`'s logo URL
+ * `avatar.upload` handler — without one, `<OrganizationSettingsCard>`'s logo URL
  * field is the fallback.
  */
 interface OrganizationLogoCardProps {

--- a/packages/auth-ui/src/react/plugin-cards.tsx
+++ b/packages/auth-ui/src/react/plugin-cards.tsx
@@ -26,7 +26,7 @@ const onSubmit =
 /**
  * The accounts signed in on *this device*, with switch and sign-out-just-this.
  *
- * Not `&lt;SessionsCard>`, which lists this account's sessions across every device.
+ * Not `<SessionsCard>`, which lists this account's sessions across every device.
  * The two are a keystroke apart in better-auth's API and mean opposite things.
  */
 const MultiSessionCard = (): ReactElement | null => {

--- a/packages/auth-ui/src/react/primitives.tsx
+++ b/packages/auth-ui/src/react/primitives.tsx
@@ -127,7 +127,7 @@ const FormBanner = ({ error, success }: FormBannerProps): ReactElement | null =>
     return null;
 };
 
-/** Internal link using the provider's framework `Link` when present, else `&lt;a>`. */
+/** Internal link using the provider's framework `Link` when present, else `<a>`. */
 interface AuthLinkProps {
     children: ReactNode;
     href: string;
@@ -155,7 +155,7 @@ const AuthLink = ({ children, href }: AuthLinkProps): ReactElement => {
  * A "last used" marker, shown against whichever sign-in route the user took
  * last time.
  *
- * A standalone primitive rather than something only `&lt;SocialButtons>` renders,
+ * A standalone primitive rather than something only `<SocialButtons>` renders,
  * because better-auth records `email`, `magic-link` and `passkey` as well as
  * provider ids: badging only the OAuth buttons makes the feature invisible for
  * the most common case there is.
@@ -171,7 +171,7 @@ const LastUsedBadge = (): ReactElement => {
  * server discovery on, is whatever `socialProviders` the deployment configured.
  *
  * The provider's brand mark is left to CSS: each button carries a
- * `lunora-auth-social__icon--&lt;provider>` class, so an app drops in its own icon
+ * `lunora-auth-social__icon--<provider>` class, so an app drops in its own icon
  * set with a stylesheet rule and this package ships no SVG payload for a list of
  * providers it can't know in advance.
  */

--- a/packages/auth-ui/src/react/provider.tsx
+++ b/packages/auth-ui/src/react/provider.tsx
@@ -34,7 +34,7 @@ interface AuthUIProviderProps extends Omit<AuthUIConfig, "nav"> {
 
     /**
      * Framework `Link` component for internal links (Next `Link`, react-router
-     * `Link`, …). Falls back to a plain `&lt;a>` when omitted.
+     * `Link`, …). Falls back to a plain `<a>` when omitted.
      */
     Link?: ComponentType<{ children: ReactNode; className?: string; href: string }>;
     /** Router bridge; defaults to a `location`-based fallback. */

--- a/packages/auth-ui/src/react/user-button.tsx
+++ b/packages/auth-ui/src/react/user-button.tsx
@@ -82,7 +82,7 @@ const UserView = ({ compact, user }: UserViewProps): ReactElement => (
  * The avatar menu: who is signed in, plus sign-out and whatever the app hangs
  * off it.
  *
- * It is a disclosure rather than a `&lt;menu>` because its contents are app-defined
+ * It is a disclosure rather than a `<menu>` because its contents are app-defined
  * — links, an organization switcher, a theme row — and forcing those into menu
  * item semantics would mislabel them. Escape and outside-click close it, and
  * focus returns to the trigger, which is the part hand-rolled dropdowns usually

--- a/packages/auth-ui/src/solid/account-cards.tsx
+++ b/packages/auth-ui/src/solid/account-cards.tsx
@@ -94,7 +94,7 @@ const LinkedAccountsCard = (): JSX.Element => {
 
 /**
  * Avatar upload. Rendered only when the app configured an `avatar.upload`
- * handler — without one there is nowhere to put the bytes, and `&lt;ProfileCard>`'s
+ * handler — without one there is nowhere to put the bytes, and `<ProfileCard>`'s
  * URL field is the honest fallback.
  */
 const AvatarCard = (): JSX.Element => {

--- a/packages/auth-ui/src/solid/extras.tsx
+++ b/packages/auth-ui/src/solid/extras.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 import type { JSX } from "solid-js";
 import { createEffect, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 
@@ -131,7 +133,7 @@ const OneTap = (): JSX.Element => {
 
 /**
  * Upload an organization's logo. Renders only when the app configured an
- * `avatar.upload` handler — without one, `&lt;OrganizationSettingsCard>`'s logo URL
+ * `avatar.upload` handler — without one, `<OrganizationSettingsCard>`'s logo URL
  * field is the fallback.
  */
 interface OrganizationLogoCardProps {

--- a/packages/auth-ui/src/solid/plugin-cards.tsx
+++ b/packages/auth-ui/src/solid/plugin-cards.tsx
@@ -24,7 +24,7 @@ const onSubmit =
 /**
  * The accounts signed in on *this device*, with switch and sign-out-just-this.
  *
- * Not `&lt;SessionsCard>`, which lists this account's sessions across every device.
+ * Not `<SessionsCard>`, which lists this account's sessions across every device.
  * The two are a keystroke apart in better-auth's API and mean opposite things.
  */
 const MultiSessionCard = (): JSX.Element => {

--- a/packages/auth-ui/src/solid/primitives.tsx
+++ b/packages/auth-ui/src/solid/primitives.tsx
@@ -138,7 +138,7 @@ const FormBanner = (props: FormBannerProps): JSX.Element => (
     </Show>
 );
 
-/** Internal link using the provider's framework `Link` when present, else `&lt;a>`. */
+/** Internal link using the provider's framework `Link` when present, else `<a>`. */
 interface AuthLinkProps {
     children: JSX.Element;
     href: string;
@@ -167,7 +167,7 @@ const AuthLink = (props: AuthLinkProps): JSX.Element => {
  * server discovery on, is whatever `socialProviders` the deployment configured.
  *
  * The provider's brand mark is left to CSS: each button carries a
- * `lunora-auth-social__icon--&lt;provider>` class, so an app drops in its own icon
+ * `lunora-auth-social__icon--<provider>` class, so an app drops in its own icon
  * set with a stylesheet rule and this package ships no SVG payload for a list of
  * providers it can't know in advance.
  */

--- a/packages/auth-ui/src/solid/provider.tsx
+++ b/packages/auth-ui/src/solid/provider.tsx
@@ -8,7 +8,7 @@ import { defaultNav } from "../core/default-nav";
 import type { DiscoveredConfig } from "../core/discovery";
 import { discoverAuthConfig } from "../core/discovery";
 
-/** A framework `Link` component for internal navigation (Solid Router `A`, plain `&lt;a>`, …). */
+/** A framework `Link` component for internal navigation (Solid Router `A`, plain `<a>`, …). */
 type AuthUILink = Component<{ children: JSX.Element; class?: string; href: string }>;
 
 /** The Solid context also carries an optional framework `Link` for internal navigation. */
@@ -24,7 +24,7 @@ interface AuthUIProviderProps extends Omit<AuthUIConfig, "nav"> {
 
     /**
      * Framework `Link` component for internal links (Solid Router `A`, …). Falls
-     * back to a plain `&lt;a>` when omitted.
+     * back to a plain `<a>` when omitted.
      */
     Link?: AuthUILink;
     /** Router bridge; defaults to a `location`-based fallback. */
@@ -41,7 +41,7 @@ interface AuthUIProviderProps extends Omit<AuthUIConfig, "nav"> {
  * card. Configure the provider at mount, as you would a router.
  *
  * The one exception is server discovery, which by definition answers *after*
- * mount. Its answer produces a **new** context object, and the keyed `&lt;Show>`
+ * mount. Its answer produces a **new** context object, and the keyed `<Show>`
  * below re-creates the tree on that new identity. That is load-bearing rather
  * than incidental: every card resolves its gate once in its body
  * (`const enabled = isFlowEnabled(context, …)`) and passes the answer to its

--- a/packages/auth-ui/src/solid/use-controller.ts
+++ b/packages/auth-ui/src/solid/use-controller.ts
@@ -15,7 +15,7 @@ import { useAuthUI } from "./provider";
  * Unlike the React `useController` there is no dependency array: a Solid
  * component body runs once, so any options the factory closes over are captured
  * at creation. Cards that need to react to changing props should be re-keyed by
- * the caller (`&lt;Show keyed>` / a `key` on the route) instead.
+ * the caller (`<Show keyed>` / a `key` on the route) instead.
  * @param create Builds the controller from the resolved context.
  */
 const createController = <TState extends object, TActions>(create: (context: ControllerContext) => Controller<TState, TActions>): [TState, TActions] => {

--- a/packages/auth-ui/src/solid/user-button.tsx
+++ b/packages/auth-ui/src/solid/user-button.tsx
@@ -95,7 +95,7 @@ const UserView = (props: UserViewProps): JSX.Element => (
  * The avatar menu: who is signed in, plus sign-out and whatever the app hangs
  * off it.
  *
- * It is a disclosure rather than a `&lt;menu>` because its contents are app-defined
+ * It is a disclosure rather than a `<menu>` because its contents are app-defined
  * — links, an organization switcher, a theme row — and forcing those into menu
  * item semantics would mislabel them. Escape and outside-click close it, and
  * focus returns to the trigger, which is the part hand-rolled dropdowns usually

--- a/packages/auth-ui/src/svelte/context.ts
+++ b/packages/auth-ui/src/svelte/context.ts
@@ -12,13 +12,13 @@ import { getContext, setContext } from "svelte";
 import type { ControllerContext } from "../core/config";
 
 /**
- * A framework `Link` component (SvelteKit's `&lt;a>` wrapper, a custom router link,
+ * A framework `Link` component (SvelteKit's `<a>` wrapper, a custom router link,
  * …) accepting the same props the base cards pass: `href`, an optional `class`,
- * and its `children` snippet. Falls back to a plain `&lt;a>` when omitted.
+ * and its `children` snippet. Falls back to a plain `<a>` when omitted.
  */
 type AuthUILinkComponent = Component<{ children?: Snippet; class?: string; href: string }>;
 
-/** The value published on the Svelte context tree by `&lt;AuthUIProvider>`. */
+/** The value published on the Svelte context tree by `<AuthUIProvider>`. */
 interface AuthUISvelteContext {
     core: ControllerContext;
     Link?: AuthUILinkComponent;
@@ -28,7 +28,7 @@ const AUTH_UI_CONTEXT_KEY = Symbol("lunora.auth-ui");
 
 /**
  * Publish the resolved auth-UI context on the Svelte component tree. Called once
- * by `&lt;AuthUIProvider>` during its initialisation (the `setContext` constraint),
+ * by `<AuthUIProvider>` during its initialisation (the `setContext` constraint),
  * exactly like React's provider mounts once.
  */
 const setAuthUIContext = (value: AuthUISvelteContext): AuthUISvelteContext => {
@@ -38,7 +38,7 @@ const setAuthUIContext = (value: AuthUISvelteContext): AuthUISvelteContext => {
 };
 
 /**
- * Read the resolved core controller context from the nearest `&lt;AuthUIProvider>`.
+ * Read the resolved core controller context from the nearest `<AuthUIProvider>`.
  * Throws — loud and early — when no provider is mounted, mirroring React's
  * `useAuthUI` guard. Must be called during component initialisation.
  */

--- a/packages/auth-ui/src/svelte/index.ts
+++ b/packages/auth-ui/src/svelte/index.ts
@@ -10,15 +10,15 @@ export * from "../core";
  * Usage after `lunora add auth-ui`:
  *
  * ```svelte
- * &lt;script lang="ts">
+ * <script lang="ts">
  *     import { AuthUIProvider, SignInCard } from "./lunora/auth-ui/svelte";
  *     import { authClient } from "./lunora/auth-ui/client";
  *     import "./lunora/auth-ui/styles.css";
- * &lt;/script>
+ * </script>
  *
- * &lt;AuthUIProvider {authClient}>
- *     &lt;SignInCard />
- * &lt;/AuthUIProvider>
+ * <AuthUIProvider {authClient}>
+ *     <SignInCard />
+ * </AuthUIProvider>
  * ```
  */
 

--- a/packages/auth-ui/src/vue/index.ts
+++ b/packages/auth-ui/src/vue/index.ts
@@ -20,9 +20,9 @@ export * from "../core";
  * ```
  *
  * ```vue
- * &lt;script setup lang="ts">
+ * <script setup lang="ts">
  * import { SignInCard } from "./lunora/auth-ui/vue";
- * &lt;/script>
+ * </script>
  * ```
  */
 

--- a/packages/auth-ui/src/vue/provider.ts
+++ b/packages/auth-ui/src/vue/provider.ts
@@ -52,7 +52,7 @@ interface AuthUIProviderProps {
 
     /**
      * Framework `Link` component for internal links (`NuxtLink`, `RouterLink`,
-     * …). Falls back to a plain `&lt;a>` when omitted.
+     * …). Falls back to a plain `<a>` when omitted.
      */
     Link?: Component;
     localization?: Partial<Localization>;
@@ -69,7 +69,7 @@ interface AuthUIProviderProps {
     social?: ReadonlyArray<string>;
     /** Retint the cards from config; see `core/theme.ts`. */
     theme?: AuthUIConfig["theme"];
-    /** URL segments `&lt;AuthView>` maps to cards; see `core/config.ts`. */
+    /** URL segments `<AuthView>` maps to cards; see `core/config.ts`. */
     viewPaths?: ViewPaths;
 }
 
@@ -199,7 +199,7 @@ const buildContext = (config: AuthUIProviderProps): AuthUIVueContext => {
  * `autoLoad`, the social provider list — are read *through* that ref, so they
  * re-evaluate when the server answers. Neither form needs a component boundary
  * to make that happen. Choose between them on scope: this one is app-wide,
- * `&lt;AuthUIProvider>` scopes the context to a subtree.
+ * `<AuthUIProvider>` scopes the context to a subtree.
  */
 const createAuthUI = (config: AuthUIProviderProps): { install: (app: App) => void } => {
     const context = buildContext(config);
@@ -215,7 +215,7 @@ const createAuthUI = (config: AuthUIProviderProps): { install: (app: App) => voi
  * Composition-API form: call inside a parent component's `setup()` to provide
  * the context to its subtree. The counterpart to `app.use(createAuthUI(config))`
  * when you'd rather scope the context to a subtree than the whole app. Backs the
- * `&lt;AuthUIProvider>` SFC. Must run synchronously inside `setup()`.
+ * `<AuthUIProvider>` SFC. Must run synchronously inside `setup()`.
  */
 const provideAuthUI = (config: AuthUIProviderProps): ShallowRef<ControllerContext> => {
     const context = buildContext(config);
@@ -228,7 +228,7 @@ const provideAuthUI = (config: AuthUIProviderProps): ShallowRef<ControllerContex
 /**
  * The context ref from the nearest provider — use this whenever what you read
  * has to *follow* the one identity change discovery makes: the plugin flags,
- * `credentials`, `social`, `organization`. Bound in `&lt;script setup>` the template
+ * `credentials`, `social`, `organization`. Bound in `<script setup>` the template
  * unwraps it on every read, so `v-if="context.plugins.passkey"` is reactive
  * without further ceremony; in script, wrap the read in a `computed`.
  *

--- a/packages/auth/eslint.config.js
+++ b/packages/auth/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/auth/src/middleware.ts
+++ b/packages/auth/src/middleware.ts
@@ -106,7 +106,7 @@ const guardAuthApi = <Api extends Record<string, unknown>>(api: Api): Api => {
  * authorization bypass, so a call that trips the lint also trips this guard.
  */
 export class LunoraAuthHeadersError extends LunoraError {
-    /** The `ctx.authApi.&lt;method>` that was called without `headers`. */
+    /** The `ctx.authApi.<method>` that was called without `headers`. */
     public readonly method: string;
 
     public constructor(method: string) {
@@ -135,7 +135,7 @@ export interface WithAuthPluginsOptions {
      * Whether to install the runtime header guard around `ctx.authApi`.
      *
      * **Defaults to `true` — the safe default.** When enabled, every
-     * `ctx.authApi.&lt;method>(…)` call that omits `headers` throws
+     * `ctx.authApi.<method>(…)` call that omits `headers` throws
      * {@link LunoraAuthHeadersError} instead of silently running with full
      * server-to-server privileges. For a deliberate, per-call unauthenticated
      * invocation, use the explicit `ctx.authApi.withoutHeaders()` escape hatch
@@ -189,7 +189,7 @@ export interface LunoraAuthApiContext<Auth extends LunoraAuth> {
      * statically; the guard is the runtime backstop for the cases the lint
      * can't see (dynamic method names, indirected calls). For the rare,
      * deliberate unauthenticated server-to-server call, opt out explicitly with
-     * `ctx.authApi.withoutHeaders().&lt;method>(…)`.
+     * `ctx.authApi.withoutHeaders().<method>(…)`.
      *
      * Lunora's procedure context carries only the resolved identity, not the
      * raw inbound `Headers`, so this middleware CANNOT pre-bind them for you.
@@ -281,7 +281,7 @@ export interface LunoraAuthApiContext<Auth extends LunoraAuth> {
  * Shape of the middleware {@link withAuthPlugins} returns: a callable generic
  * over the incoming ctx so chaining `.use(...)` preserves whatever ctx fields
  * the upstream middleware already installed. Lives as its own interface
- * because TypeScript doesn't allow declaring `const fn: &lt;CtxIn>() => ...` —
+ * because TypeScript doesn't allow declaring `const fn: <CtxIn>() => ...` —
  * the generic must live on a callable type alias or interface.
  */
 export type WithAuthPluginsMiddleware<Auth extends LunoraAuth> = <ContextIn>(options: {

--- a/packages/auth/src/plugins.ts
+++ b/packages/auth/src/plugins.ts
@@ -29,7 +29,7 @@
  *
  * # Lunora integration with `@lunora/server` plugins
  *
- * To surface a better-auth plugin's API under `ctx.auth.&lt;key>` in
+ * To surface a better-auth plugin's API under `ctx.auth.<key>` in
  * Lunora procedures, wrap it as a `definePlugin` middleware:
  *
  * ```ts

--- a/packages/auth/src/sql-store.ts
+++ b/packages/auth/src/sql-store.ts
@@ -40,7 +40,7 @@ const patternFragment = (column: string, value: unknown, operator: "contains" | 
     return { params: [value, value], sql: `substr(${side.column}, -length(?)) = ${side.placeholder}` };
 };
 
-/** `=`/`&lt;>` equality (or `IS [NOT] NULL`), with optional case folding. `negated` flips it to `ne`. */
+/** `=`/`<>` equality (or `IS [NOT] NULL`), with optional case folding. `negated` flips it to `ne`. */
 const equalityFragment = (column: string, value: unknown, insensitive: boolean, negated: boolean): SqlFragment => {
     if (value === null) {
         return { params: [], sql: `${column} IS ${negated ? "NOT " : ""}NULL` };

--- a/packages/bindings/__tests__/vectors/vector-reader-spike.test.ts
+++ b/packages/bindings/__tests__/vectors/vector-reader-spike.test.ts
@@ -174,7 +174,7 @@ interface DocRow {
 
 const createPolicyAwareStore = (rows: ReadonlyArray<DocRow>) => {
     return {
-        /** Mirrors `ctx.db.&lt;table>.findMany({ where: { id: { in: ids } } })` under RLS scoped to `callerTenantId`. */
+        /** Mirrors `ctx.db.<table>.findMany({ where: { id: { in: ids } } })` under RLS scoped to `callerTenantId`. */
         findMany: (ids: ReadonlyArray<string>, callerTenantId: string): DocRow[] =>
             rows.filter((row) => ids.includes(row.id) && row.tenantId === callerTenantId),
     };

--- a/packages/bindings/eslint.config.js
+++ b/packages/bindings/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/bindings/src/analytics/sql-api.ts
+++ b/packages/bindings/src/analytics/sql-api.ts
@@ -4,7 +4,7 @@
  * AE has no binding-side read path — data is queried out-of-band through
  * Cloudflare's REST SQL endpoint:
  * `POST https://api.cloudflare.com/client/v4/accounts/{accountId}/analytics_engine/sql`
- * — body: SQL text (plain text, not JSON); headers: `Authorization: Bearer &lt;token>`.
+ * — body: SQL text (plain text, not JSON); headers: `Authorization: Bearer <token>`.
  *
  * The token is an **account-scoped API token with Analytics Engine read** — a
  * secret*, never a binding and never auto-scaffolded with a real value. The

--- a/packages/bindings/src/event-store/define-event-store.ts
+++ b/packages/bindings/src/event-store/define-event-store.ts
@@ -30,9 +30,9 @@ const matchesColumnType = (value: unknown, type: EventStoreColumnType): boolean 
 };
 
 /**
- * Runtime guard behind `send()`. `EventStoreRecord&lt;Schema>` narrows the call
+ * Runtime guard behind `send()`. `EventStoreRecord<Schema>` narrows the call
  * site at compile time, but Pipelines' own binding takes untyped
- * `Record&lt;string, unknown>[]` and enforces nothing server-side — so the type
+ * `Record<string, unknown>[]` and enforces nothing server-side — so the type
  * alone is a promise a plain-JS caller, a stale build, or an `as` cast can
  * break silently. This is the actual enforcement: a record with a
  * wrong-typed field, a missing field, or a field the schema doesn't declare
@@ -57,7 +57,7 @@ const assertMatchesSchema = (schema: EventStoreSchema, record: Record<string, un
  * read path over the same Iceberg table — modeled on `defineRag`
  * (`@lunora/ai/rag`), which couples `ctx.ai` + `ctx.vectors` under one schema
  * the same way. `send()` is runtime-validated against `schema`; `query()` is
- * `r2sql.from&lt;Row>(table)` with `Row` inferred from the same `schema`, so a
+ * `r2sql.from<Row>(table)` with `Row` inferred from the same `schema`, so a
  * column can't drift between the two halves the way two hand-declared
  * column-type lists can.
  *

--- a/packages/bindings/src/event-store/types.ts
+++ b/packages/bindings/src/event-store/types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc quotes the `r2sql.from<EventStoreRecord<Schema>>(table)` call shape, not a credential. */
+
 /**
  * PROTOTYPE (plan 247, design spike) — types for `defineEventStore`, which
  * explores whether one declared schema can drive BOTH the Pipelines write
@@ -55,7 +57,7 @@ interface EventStoreConfig<Schema extends EventStoreSchema> {
      * The Pipelines binding-like `send()` is forwarded to (the same shape
      * `ctx.pipelines` wraps — see `@lunora/bindings/pipelines`'s
      * `PipelineBindingLike`). Untyped at the Cloudflare API boundary; this
-     * prototype's `EventStoreRecord&lt;Schema>` narrows the call site.
+     * prototype's `EventStoreRecord<Schema>` narrows the call site.
      */
     pipeline: PipelineBindingLike<EventStoreRecord<Schema>>;
 
@@ -88,7 +90,7 @@ interface EventStoreConfig<Schema extends EventStoreSchema> {
 interface EventStore<Schema extends EventStoreSchema> {
     /**
      * Start a typed r2sql `SELECT` over the same table + schema — literally
-     * `r2sql.from&lt;EventStoreRecord&lt;Schema>>(table)`, so it inherits every
+     * `r2sql.from<EventStoreRecord<Schema>>(table)`, so it inherits every
      * `SelectBuilder` feature (`WHERE`, joins, window functions, set
      * operations, …) for free; this prototype adds no query surface of its
      * own.
@@ -99,7 +101,7 @@ interface EventStore<Schema extends EventStoreSchema> {
      * Ingest one record through Pipelines. Runtime-validated against
      * `schema` before the record reaches the binding — Pipelines ingest is
      * otherwise fire-and-forget with zero server-side schema enforcement
-     * (see the design doc), so `EventStoreRecord&lt;Schema>` alone would only be
+     * (see the design doc), so `EventStoreRecord<Schema>` alone would only be
      * a compile-time promise a plain-JS caller (or an `as` cast) could break
      * silently.
      */

--- a/packages/bindings/src/images/create-images.ts
+++ b/packages/bindings/src/images/create-images.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `ReadableStream<Uint8Array>` return type, not a credential. */
+
 /**
  * The action-only Images client over the Cloudflare Images binding.
  *
@@ -42,7 +44,7 @@ const isR2ObjectBody = (input: ImageInput): input is R2ObjectBodyLike => {
 };
 
 /**
- * Normalize any accepted input into the `ReadableStream&lt;Uint8Array>` the binding
+ * Normalize any accepted input into the `ReadableStream<Uint8Array>` the binding
  * wants. An R2 object body (from `ctx.storage.download(key)`) is unwrapped to its
  * `.body` stream; a `Blob`/`ArrayBuffer`/`Uint8Array` is wrapped in a one-chunk
  * stream; a stream passes through.

--- a/packages/bindings/src/images/delivery-url.ts
+++ b/packages/bindings/src/images/delivery-url.ts
@@ -6,10 +6,10 @@
  *
  * Two forms are produced:
  *
- * - **Cloudflare URL-based transform** — `/cdn-cgi/image/&lt;options>/&lt;source>`,
- * where `&lt;source>` is an absolute URL or an origin-relative key. This is the
+ * - **Cloudflare URL-based transform** — `/cdn-cgi/image/<options>/<source>`,
+ * where `<source>` is an absolute URL or an origin-relative key. This is the
  * on-the-fly transform CDN endpoint.
- * - **Images delivery variant** — `&lt;baseUrl>/&lt;imageId>/&lt;variant>`, the
+ * - **Images delivery variant** — `<baseUrl>/<imageId>/<variant>`, the
  * hosted-Images delivery form (a named variant like `public`/`thumbnail`).
  */
 import { LunoraError } from "@lunora/errors";
@@ -20,7 +20,7 @@ const ABSOLUTE_URL_RE = /^[a-z][a-z\d+\-.]*:\/\//i;
 
 /**
  * Characters a transform value may not contain: `,`/`=` are the option and
- * key-value separators of the `/cdn-cgi/image/&lt;opts>/` form, and `#`/`?`/`/`
+ * key-value separators of the `/cdn-cgi/image/<opts>/` form, and `#`/`?`/`/`
  * are URL-structural (fragment / query / path-segment delimiters) that would
  * silently corrupt the delivery URL if spliced in raw.
  */
@@ -81,7 +81,7 @@ export interface ImageDeliveryUrlOptions {
 
     /**
      * Hosted-Images image id. When set, the **delivery-variant** form is built
-     * (`&lt;baseUrl>/&lt;imageId>/&lt;variant>`) and `transform`/`key` are ignored.
+     * (`<baseUrl>/<imageId>/<variant>`) and `transform`/`key` are ignored.
      */
     imageId?: string;
 
@@ -90,7 +90,7 @@ export interface ImageDeliveryUrlOptions {
      * `/cdn-cgi/image/...` transform form. Ignored when `imageId` is set.
      */
     key?: string;
-    /** Transform options for the `/cdn-cgi/image/&lt;options>/&lt;source>` form. */
+    /** Transform options for the `/cdn-cgi/image/<options>/<source>` form. */
     transform?: TransformOptions;
     /** Named delivery variant (e.g. `public`, `thumbnail`). Used with `imageId`; default `public`. */
     variant?: string;
@@ -99,8 +99,8 @@ export interface ImageDeliveryUrlOptions {
 /**
  * Build a Cloudflare Images delivery / transform URL.
  *
- * - With `imageId`: `&lt;baseUrl>/&lt;imageId>/&lt;variant>` (hosted delivery variant).
- * - With `key`: `&lt;baseUrl>/cdn-cgi/image/&lt;options>/&lt;source>` (URL-based transform).
+ * - With `imageId`: `<baseUrl>/<imageId>/<variant>` (hosted delivery variant).
+ * - With `key`: `<baseUrl>/cdn-cgi/image/<options>/<source>` (URL-based transform).
  *
  * Pure and deterministic — usable from any handler.
  */

--- a/packages/bindings/src/kv/types.ts
+++ b/packages/bindings/src/kv/types.ts
@@ -9,7 +9,7 @@ export interface LunoraKvOptions {
      * `..` or NUL in the prefix is rejected.
      */
     keyPrefix?: string;
-    /** The bound KV namespace (`env.&lt;BINDING>`). */
+    /** The bound KV namespace (`env.<BINDING>`). */
     namespace: KVNamespaceLike;
 }
 

--- a/packages/bindings/src/pipelines/types.ts
+++ b/packages/bindings/src/pipelines/types.ts
@@ -10,7 +10,7 @@
 export type PipelineRecord = Record<string, unknown>;
 
 /**
- * Minimal structural projection of workers-types' `Pipeline&lt;T>` binding. The
+ * Minimal structural projection of workers-types' `Pipeline<T>` binding. The
  * real binding's `send` takes an array of records and resolves once accepted.
  */
 export interface PipelineBindingLike<T extends PipelineRecord = PipelineRecord> {

--- a/packages/bindings/src/r2sql/client.ts
+++ b/packages/bindings/src/r2sql/client.ts
@@ -10,7 +10,7 @@
  * `createAnalyticsSqlClient` in `@lunora/bindings/analytics`.
  *
  * Surfaces: `query(sql)` / `explain(sql)` (raw escape hatches, typed rows);
- * `from&lt;Row>(table)` (the chainable {@link SelectBuilder} — window functions,
+ * `from<Row>(table)` (the chainable {@link SelectBuilder} — window functions,
  * `DISTINCT`, `QUALIFY`, set operations); and `showDatabases()` /
  * `showTables(ns)` / `describe(table)` (Iceberg schema-discovery, the same
  * surface Studio uses to render tables).

--- a/packages/bindings/src/r2sql/types.ts
+++ b/packages/bindings/src/r2sql/types.ts
@@ -61,8 +61,8 @@ export interface R2SqlColumn {
  * (`{ success, result, errors }`); we surface the `rows` (the `result` array of
  * column→value records), the inferred/echoed `columns`, and the `rowCount`.
  *
- * `Row` defaults to an open record; supply it (`from&lt;MyRow>(…)` /
- * `query&lt;MyRow>(…)`) to get typed result fields — R2 SQL tables live in Iceberg,
+ * `Row` defaults to an open record; supply it (`from<MyRow>(…)` /
+ * `query<MyRow>(…)`) to get typed result fields — R2 SQL tables live in Iceberg,
  * not `defineSchema`, so the row type is caller-declared rather than inferred.
  */
 export interface R2SqlResult<Row = Record<string, unknown>> {

--- a/packages/bindings/src/r2sql/window-expression.ts
+++ b/packages/bindings/src/r2sql/window-expression.ts
@@ -50,12 +50,12 @@ export default class WindowExpression extends Sql {
         return this.compare(">=", value);
     }
 
-    /** `expr &lt; value`. */
+    /** `expr < value`. */
     public lt(value: unknown): Sql {
         return this.compare("<", value);
     }
 
-    /** `expr &lt;= value`. */
+    /** `expr <= value`. */
     public lte(value: unknown): Sql {
         return this.compare("<=", value);
     }

--- a/packages/browser/eslint.config.js
+++ b/packages/browser/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/cli/__tests__/commands/deploy.test.ts
+++ b/packages/cli/__tests__/commands/deploy.test.ts
@@ -77,13 +77,13 @@ const VALID_WRANGLER = `{
 `;
 
 /**
- * `VALID_WRANGLER` plus a declared `env.&lt;name>` block repeating the same
+ * `VALID_WRANGLER` plus a declared `env.<name>` block repeating the same
  * (non-inheritable) bindings — real wrangler only WARNS on an undeclared
- * `--env &lt;name>` and then deploys with NO bindings at all (confirmed against
+ * `--env <name>` and then deploys with NO bindings at all (confirmed against
  * wrangler 4.114.0: `wrangler deploy --dry-run --env doesnotexist` prints
  * "No bindings found."), which is exactly the silent failure mode the deploy
  * validator's env-scoping gate exists to turn into a loud one — so any test
- * exercising a real `--env &lt;name>` deploy needs a matching declared block,
+ * exercising a real `--env <name>` deploy needs a matching declared block,
  * same as a correctly-configured project would have.
  */
 const validWranglerWithEnv = (name: string): string => `{

--- a/packages/cli/__tests__/commands/init-smoke.test.ts
+++ b/packages/cli/__tests__/commands/init-smoke.test.ts
@@ -6,7 +6,7 @@
  * and `validateWranglerProject` asserts bindings line up with the schema.
  *
  * If any step throws, the scaffold is broken — exactly the failure a fresh
- * `lunora init &amp;& lunora dev` would hit on a clean machine.
+ * `lunora init && lunora dev` would hit on a clean machine.
  *
  * The unit suite must work offline, so we use `--from` to point at the local
  * templates root rather than hitting GitHub through giget. The remote-fetch

--- a/packages/cli/__tests__/commands/registry-entrypoint.test.ts
+++ b/packages/cli/__tests__/commands/registry-entrypoint.test.ts
@@ -1,6 +1,6 @@
 /**
  * Entrypoint re-export injection for registry items — class-B/C workers get the
- * `export * from "./lunora/&lt;module&gt;.js"` line appended idempotently; class-A
+ * `export * from "./lunora/<module>.js"` line appended idempotently; class-A
  * projects get a fallback instruction instead.
  */
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -158,4 +158,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -269,7 +269,7 @@ interface BuildCliResult {
 /**
  * Build the cerebro CLI. Every command is registered as a lazy-loaded
  * {@link https://github.com/visulima/visulima cerebro} command (metadata in
- * `commands/&lt;name>/index.ts`, handler in `commands/&lt;name>/handler.ts`). cerebro
+ * `commands/<name>/index.ts`, handler in `commands/<name>/handler.ts`). cerebro
  * owns help/version/usage rendering and unknown-command handling; the injected
  * `exit` captures each command's exit code so {@link runCli} can return it
  * without terminating the process (important for in-process tests).

--- a/packages/cli/src/commands/add/features.ts
+++ b/packages/cli/src/commands/add/features.ts
@@ -1,6 +1,6 @@
 /**
  * The feature catalog shared by `lunora init`'s post-scaffold offer and the
- * `lunora add &lt;feature>` command. Each feature maps to one or more **registry
+ * `lunora add <feature>` command. Each feature maps to one or more **registry
  * items** (resolved by `runAddCommand`), so there is a single install path —
  * the registry — behind both front doors.
  */

--- a/packages/cli/src/commands/add/handler.ts
+++ b/packages/cli/src/commands/add/handler.ts
@@ -37,7 +37,7 @@ interface AddFeatureOptions {
     cwd?: string;
     /** auth: D1 database name to use without prompting. */
     db?: string;
-    /** The raw `&lt;feature>` argument: an alias (`auth` | `email` | `mail`) or a bare registry item name. */
+    /** The raw `<feature>` argument: an alias (`auth` | `email` | `mail`) or a bare registry item name. */
     feature?: string;
     /** Local registry root (offline / tests). */
     from?: string;
@@ -263,7 +263,7 @@ const syncLintIgnores = (cwd: string, logger: Logger): void => {
 };
 
 /**
- * `lunora add &lt;feature>`: validate we're in a Lunora project, resolve the
+ * `lunora add <feature>`: validate we're in a Lunora project, resolve the
  * feature to its registry item(s) (prompting for the auth provider when
  * interactive), and apply via `runAddCommand`. Returns the applied items so
  * tests/callers can assert without re-reading the filesystem.
@@ -364,7 +364,7 @@ const runAddFeature = async (options: AddFeatureOptions): Promise<AddFeatureResu
     return { code: result.code, items };
 };
 
-/** `lunora add &lt;feature>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora add <feature>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<AddOptions> = defineHandler<AddOptions>(async ({ argument, cwd, logger, options }) => {
     const formatError = validateOutputFormat("add", options.format);
 

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 /**
- * `lunora add &lt;feature>` — add a feature or registry item to an existing
+ * `lunora add <feature>` — add a feature or registry item to an existing
  * project. A thin, discoverable front door over `lunora registry add`: the
  * friendly aliases (`auth` asks which provider, `email`/`mail` → the mail item)
  * resolve to registry item(s); any other name is passed straight to the

--- a/packages/cli/src/commands/analyze/handler.ts
+++ b/packages/cli/src/commands/analyze/handler.ts
@@ -113,10 +113,10 @@ const renderText = (report: AnalyzeReport, logger: Logger): void => {
 };
 
 /**
- * Build the worker via `wrangler deploy --dry-run --outdir &lt;tmp>` and report
+ * Build the worker via `wrangler deploy --dry-run --outdir <tmp>` and report
  * total size, top modules, and the `_generated/` footprint.
  *
- * Tests inject `inspectOnly: &lt;path>` to skip the wrangler invocation and
+ * Tests inject `inspectOnly: <path>` to skip the wrangler invocation and
  * walk a pre-built directory directly.
  */
 const runAnalyzeCommand = async (options: AnalyzeCommandOptions): Promise<AnalyzeCommandResult> => {

--- a/packages/cli/src/commands/backup/handler.ts
+++ b/packages/cli/src/commands/backup/handler.ts
@@ -4,7 +4,7 @@
  *
  * `create` exports every table to a timestamped NDJSON file under a backup
  * directory and records it in a `manifest.json`; `list` prints the manifest;
- * `restore &lt;id|file>` imports a chosen snapshot back through the import
+ * `restore <id|file>` imports a chosen snapshot back through the import
  * endpoint. Schedule `create` (CI cron, or a cron-triggered action) for
  * automated backups — this is the off-platform / portable / >30-day tier.
  *
@@ -222,7 +222,7 @@ const runBackupRestore = async (options: BackupCommandOptions, directory: string
 /**
  * `lunora backup pitr` — native Durable-Object point-in-time recovery (the
  * in-place ≤30-day tier). With no flags it reads the shard's current bookmark;
- * `--at &lt;time>` previews the bookmark nearest that moment. `--restore` arms a
+ * `--at <time>` previews the bookmark nearest that moment. `--restore` arms a
  * restore (to `--bookmark`, or the one nearest `--at`) and returns an undo
  * bookmark; `--restart` applies it immediately. Hits the admin-gated
  * `/_lunora/admin/pitr` endpoint, which forwards the op to one shard.
@@ -360,7 +360,7 @@ const runBackupCommand = async (options: BackupCommandOptions): Promise<BackupCo
 /** Narrow a raw argument to a known {@link BackupSubcommand}. */
 const isBackupSubcommand = (value: unknown): value is BackupSubcommand => value === "create" || value === "list" || value === "pitr" || value === "restore";
 
-/** `lunora backup &lt;subcommand>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora backup <subcommand>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<BackupOptions> = defineHandler<BackupOptions>(({ argument, cwd, logger, options }) => {
     const sub = argument[0];
 

--- a/packages/cli/src/commands/containers/index.ts
+++ b/packages/cli/src/commands/containers/index.ts
@@ -1,7 +1,9 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc quotes the `<build|push|images|list|info|delete>` subcommand list, not a credential. */
+
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 /**
- * `lunora containers &lt;build|push|images|list|info|delete>` — thin wrappers over
+ * `lunora containers <build|push|images|list|info|delete>` — thin wrappers over
  * `wrangler containers …` so container image + instance management lives under
  * the same CLI as the rest of the deploy workflow (and CI recipes can split
  * image build/push from `lunora deploy`).

--- a/packages/cli/src/commands/data-transfer.ts
+++ b/packages/cli/src/commands/data-transfer.ts
@@ -269,7 +269,7 @@ interface ImportCommandOptions {
     prod?: boolean;
 
     /**
-     * Wrap each line as `{table:&lt;name>,doc:&lt;line>}`. Use when the source NDJSON
+     * Wrap each line as `{table:<name>,doc:<line>}`. Use when the source NDJSON
      * is bare docs from a single table — Convex's `convex import --table users`
      * shape.
      */
@@ -363,7 +363,7 @@ const resolveImportRequest = async (options: ImportCommandOptions): Promise<Impo
 const CONVEX_STORAGE_TABLE = "_storage";
 
 /**
- * The `&lt;table>/documents.jsonl` files in a `npx convex export --path &lt;dir>`
+ * The `<table>/documents.jsonl` files in a `npx convex export --path <dir>`
  * directory, sorted for deterministic output.
  *
  * Returns `undefined` when `path` is not such a directory, which is how the
@@ -506,7 +506,7 @@ const reportImportOutcome = (
 };
 
 /**
- * Stream an NDJSON file — or a `npx convex export --path &lt;dir>` directory — in
+ * Stream an NDJSON file — or a `npx convex export --path <dir>` directory — in
  * chunks, POSTing each batch to `/_lunora/admin/import`. The line buffer stays
  * bounded by `batchSize`, so a multi-GiB source imports without buffering
  * everything in memory.

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -116,14 +116,14 @@ interface DeployCommandOptions {
     /**
      * Confirm a production data migration triggered via `--migrate` (the
      * `migrate up --prod` confirmation the standalone command requires). Without
-     * it a `--migrate --migrate-url &lt;prod>` deploy refuses to run the migration.
+     * it a `--migrate --migrate-url <prod>` deploy refuses to run the migration.
      */
     migrateYes?: boolean;
 
     /**
      * Emit the bundled worker to this directory via `wrangler deploy --outdir`
      * (paired with `dryRun` by `lunora build`). Also writes esbuild metadata to
-     * `&lt;outDir>/bundle-meta.json`. When unset, no artifact is written.
+     * `<outDir>/bundle-meta.json`. When unset, no artifact is written.
      */
     outDir?: string;
 
@@ -186,7 +186,7 @@ interface DeployCommandResult {
      * The `.dev.vars`-shaped filename (never a full path, never a value) a
      * secret minted during this run was recorded into, when the missing-
      * secret gate minted one — `.dev.vars` for the default environment, or a
-     * `.dev.vars.&lt;env>` sibling for an explicit `--env`. `undefined` when
+     * `.dev.vars.<env>` sibling for an explicit `--env`. `undefined` when
      * nothing was minted this run.
      */
     mintedSecretsFile?: string;
@@ -528,7 +528,7 @@ const resolveRequiredSecretKeys = async (cwd: string): Promise<string[]> => {
 };
 
 /**
- * `wrangler secret put &lt;name>` is Cloudflare's write-only channel — the
+ * `wrangler secret put <name>` is Cloudflare's write-only channel — the
  * value never comes back. A previous version of this function minted a fresh
  * value for every key and piped it straight to `secret put`, without binding
  * it to anything the caller could see: the only trace was a key-name log
@@ -547,7 +547,7 @@ const resolveRequiredSecretKeys = async (cwd: string): Promise<string[]> => {
  * missing key, even a non-placeholder one — an earlier version of this
  * function did, on the theory that a real local value needs no fresh
  * disclosure. That reasoning doesn't hold: `isPlaceholderValue` is a marker
- * heuristic (empty / `&lt;…>` / `changeme` / `todo` / …), not a strength check,
+ * heuristic (empty / `<…>` / `changeme` / `todo` / …), not a strength check,
  * so a real-but-weak shared dev secret (`AUTH_SECRET="devsecret"`) would
  * silently become the value protecting `--env production`, and the confirm
  * prompt never named which keys were about to be promoted that way. Minting
@@ -606,7 +606,7 @@ const pushMintableSecrets = async (
 
 /**
  * Plain-identifier check before `options.env` is spliced into a filename
- * (`.dev.vars.&lt;env>`) — defense-in-depth; a `--env &lt;name>` naming no
+ * (`.dev.vars.<env>`) — defense-in-depth; a `--env <name>` naming no
  * declared `wrangler.jsonc` environment is already blocked earlier in the
  * deploy pipeline (`validateWrangler`), so this should be unreachable in
  * practice.
@@ -625,7 +625,7 @@ const SAFE_ENV_NAME = /^[\w-]+$/u;
  *
  * Which file depends on `options.env`:
  * - No explicit `--env`: the deploy targets the account's one default environment — the same one `.dev.vars`/`lunora dev`/a plain `lunora env push` already treat as authoritative — so the minted value goes into `.dev.vars` itself, same as `env set`/`env generate --set` would.
- * - An explicit `--env &lt;name>`: a DIFFERENT, named environment. Writing that secret into the bare, environment-agnostic `.dev.vars` would silently share it with local dev and with a later no-`--env` `env push` — the exact cross-environment leak an `--env`-scoped deploy is supposed to avoid. So it goes into a sibling `.dev.vars.&lt;name>` instead (already covered by this repo's `.gitignore` `.dev.vars.*` pattern). No other command reads `.dev.vars.&lt;name>` today — it exists purely as this deploy's own recoverable record of a value `wrangler secret put` can never return; open it by hand to retrieve the value.
+ * - An explicit `--env <name>`: a DIFFERENT, named environment. Writing that secret into the bare, environment-agnostic `.dev.vars` would silently share it with local dev and with a later no-`--env` `env push` — the exact cross-environment leak an `--env`-scoped deploy is supposed to avoid. So it goes into a sibling `.dev.vars.<name>` instead (already covered by this repo's `.gitignore` `.dev.vars.*` pattern). No other command reads `.dev.vars.<name>` today — it exists purely as this deploy's own recoverable record of a value `wrangler secret put` can never return; open it by hand to retrieve the value.
  *
  * Returns the (relative) filename written, or `undefined` when nothing was
  * recorded — the caller threads this through the deploy result so the

--- a/packages/cli/src/commands/deployments/handler.ts
+++ b/packages/cli/src/commands/deployments/handler.ts
@@ -32,7 +32,7 @@ interface DeploymentsCommandResult {
     error?: string;
 }
 
-/** Append `--env &lt;env>` when an environment was given. */
+/** Append `--env <env>` when an environment was given. */
 const withEnv = (args: string[], env: string | undefined): string[] => {
     if (env !== undefined) {
         args.push("--env", env);
@@ -136,7 +136,7 @@ const runDeploymentsCommand = async (options: DeploymentsCommandOptions): Promis
 const isDeploymentsSubcommand = (value: unknown): value is DeploymentsSubcommand =>
     value === "list" || value === "inspect" || value === "rollback" || value === "promote";
 
-/** `lunora deployments &lt;subcommand>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora deployments <subcommand>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<DeploymentsOptions> = defineHandler<DeploymentsOptions>(({ argument, cwd, logger, options }) => {
     const sub = argument[0];
 

--- a/packages/cli/src/commands/deployments/index.ts
+++ b/packages/cli/src/commands/deployments/index.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 /**
- * `lunora deployments &lt;subcommand>` — inspect deployment history and move
+ * `lunora deployments <subcommand>` — inspect deployment history and move
  * traffic between Worker versions, wrapping `wrangler versions` / `rollback`.
  */
 const deploymentsCommand: Command = {

--- a/packages/cli/src/commands/dev/handler.ts
+++ b/packages/cli/src/commands/dev/handler.ts
@@ -568,7 +568,7 @@ interface Teardown {
 
 /**
  * Follow the local Docker logs of every declared container and surface each
- * output line on the dev logger, tagged `[container:&lt;name>]`. Returns a disposer
+ * output line on the dev logger, tagged `[container:<name>]`. Returns a disposer
  * (or `undefined` when there are no containers, so no Docker work ever starts).
  *
  * wrangler builds + runs each declared container locally but only forwards the

--- a/packages/cli/src/commands/dev/lifecycle.ts
+++ b/packages/cli/src/commands/dev/lifecycle.ts
@@ -250,7 +250,7 @@ const readLogWindow = (path: string): string | undefined => {
     }
 };
 
-/** Read the last `count` lines of a log file (all lines when `count` &lt;= 0, bounded by {@link LOG_TAIL_MAX_BYTES}); `[]` when unreadable. */
+/** Read the last `count` lines of a log file (all lines when `count` <= 0, bounded by {@link LOG_TAIL_MAX_BYTES}); `[]` when unreadable. */
 const readLogTail = (path: string, count: number): string[] => {
     const text = readLogWindow(path);
 
@@ -866,7 +866,7 @@ const runDevLogs = (options: LogsCommandOptions): { code: number } => {
 };
 
 /**
- * Route a `lunora dev &lt;subcommand>` positional to its lifecycle command.
+ * Route a `lunora dev <subcommand>` positional to its lifecycle command.
  * Returns `undefined` when no subcommand was given (→ the caller runs the
  * start path), a `{ code: 1 }` error for an unknown one.
  */

--- a/packages/cli/src/commands/env/handler.ts
+++ b/packages/cli/src/commands/env/handler.ts
@@ -34,7 +34,7 @@ interface EnvCommandOptions {
     cwd?: string;
 
     /**
-     * Cloudflare environment name for `push`/`diff` (`wrangler … --env &lt;name>`).
+     * Cloudflare environment name for `push`/`diff` (`wrangler … --env <name>`).
      * `prod` is a boolean-only alias for `env: "production"` kept for backward
      * compatibility — when both are set, `env` wins.
      */
@@ -131,7 +131,7 @@ interface EnvContext {
 
 /**
  * The Cloudflare environment `push`/`diff` should target: the explicit
- * `--env &lt;name>` wins; `--prod` is kept as a boolean-only alias for
+ * `--env <name>` wins; `--prod` is kept as a boolean-only alias for
  * `--env production`; otherwise `undefined` (top-level config).
  */
 const resolveEnvironment = (options: EnvCommandOptions): string | undefined => options.env ?? (options.prod === true ? "production" : undefined);
@@ -566,7 +566,7 @@ const isEnvSubcommand = (value: unknown): value is EnvSubcommand =>
     value === "doctor" ||
     value === "generate";
 
-/** `lunora env &lt;subcommand>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora env <subcommand>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<EnvOptions> = defineHandler<EnvOptions>(({ argument, cwd, logger, options }) => {
     const sub = argument[0];
 

--- a/packages/cli/src/commands/import/handler.ts
+++ b/packages/cli/src/commands/import/handler.ts
@@ -5,8 +5,8 @@ import { runImportCommand } from "../data-transfer";
 import type { ImportOptions } from "./index";
 
 /**
- * `lunora import &lt;path>` handler. The positional is either an NDJSON file or a
- * `npx convex export --path &lt;dir>` directory; {@link runImportCommand} detects
+ * `lunora import <path>` handler. The positional is either an NDJSON file or a
+ * `npx convex export --path <dir>` directory; {@link runImportCommand} detects
  * which and bulk-inserts either way.
  */
 const execute: CommandHandler<ImportOptions> = defineHandler<ImportOptions>(({ argument, cwd, logger, options }) => {

--- a/packages/cli/src/commands/init/handler.ts
+++ b/packages/cli/src/commands/init/handler.ts
@@ -137,13 +137,13 @@ interface InitCommandOptions {
     name?: string;
 
     /**
-     * Local directory holding create-vite bases (one `template-&lt;id>/` subdir per
+     * Local directory holding create-vite bases (one `template-<id>/` subdir per
      * framework). When set with `vite`, the overlay copies the base from disk
      * instead of fetching `create-vite` over the network — offline mode + tests.
      */
     overlayBaseFrom?: string;
 
-    /** Probe for which package managers are installed (tests). Defaults to a real `&lt;pm> --version` check. */
+    /** Probe for which package managers are installed (tests). Defaults to a real `<pm> --version` check. */
     packageManagerProbe?: PackageManagerProbe;
 
     /**
@@ -167,7 +167,7 @@ interface InitCommandOptions {
 
     /**
      * Override the remote source giget downloads from. Default:
-     * `gh:anolilab/lunora/templates/&lt;templateType>#&lt;ref>`, where `&lt;ref>` is
+     * `gh:anolilab/lunora/templates/<templateType>#<ref>`, where `<ref>` is
      * the `ref` option when set, else derived from the CLI version (pre-release
      * channels → their branch, stable → `main`). Tests typically use `from`
      * instead to skip the network.

--- a/packages/cli/src/commands/init/overlay/adapters.ts
+++ b/packages/cli/src/commands/init/overlay/adapters.ts
@@ -32,7 +32,7 @@ interface OverlayFile {
 interface FrameworkAdapter {
     /** The `@lunora/*` client adapter to add as a dependency. */
     adapter: string;
-    /** The `create-vite` template id this overlays, e.g. `react-ts` (`npm create vite -- --template &lt;id>`). */
+    /** The `create-vite` template id this overlays, e.g. `react-ts` (`npm create vite -- --template <id>`). */
     createViteTemplate: string;
     /** Extra runtime deps beyond `lunorash` + the adapter (e.g. none for most). */
     extraDependencies?: Record<string, string>;

--- a/packages/cli/src/commands/introspect/emit.ts
+++ b/packages/cli/src/commands/introspect/emit.ts
@@ -55,7 +55,7 @@ const PATH_UNSAFE = /[^\w-]/g;
 
 /**
  * Characters `JSON.stringify` leaves raw that are still unsafe once the emitted
- * source travels: `&lt;` / `>` / `/` can close a host `&lt;/script>` if the file is
+ * source travels: `<` / `>` / `/` can close a host `</script>` if the file is
  * ever inlined into HTML (a code viewer, a docs page), and U+2028 / U+2029 are
  * line terminators that older tooling treats as breaking the literal. Their
  * escaped forms denote the identical string, so this costs nothing.

--- a/packages/cli/src/commands/introspect/model.ts
+++ b/packages/cli/src/commands/introspect/model.ts
@@ -147,7 +147,7 @@ const MYSQL_TYPES: Record<string, string> = {
 
 /**
  * Map one column onto the `v.*` expression that represents it, including array
- * nesting and nullability. A foreign key becomes `v.id("&lt;target table>")` so the
+ * nesting and nullability. A foreign key becomes `v.id("<target table>")` so the
  * generated schema states the relationship in Lunora's own vocabulary instead of
  * leaving a bare string.
  *

--- a/packages/cli/src/commands/mcp/handler.ts
+++ b/packages/cli/src/commands/mcp/handler.ts
@@ -8,7 +8,7 @@ import { runMcpServe } from "./serve";
 import { runMcpUninstall } from "./uninstall";
 
 /**
- * `lunora mcp &lt;install|serve>` handler (lazy-loaded via the command's `loader`).
+ * `lunora mcp <install|serve>` handler (lazy-loaded via the command's `loader`).
  *
  * `serve` never returns while the client holds the connection open: the stdio
  * transport keeps the process alive, so the `{ code: 0 }` below is reached only

--- a/packages/cli/src/commands/migrate/handler.ts
+++ b/packages/cli/src/commands/migrate/handler.ts
@@ -347,7 +347,7 @@ const resolveCreateTable = async (cwd: string, options: MigrateCreateCommandOpti
 };
 
 /**
- * `lunora migrate create &lt;name>` — scaffold a `defineMigration({...})` block in
+ * `lunora migrate create <name>` — scaffold a `defineMigration({...})` block in
  * `lunora/migrations.ts`, appending to the file (and creating it with the
  * import) when it already exists. Refuses to clobber an existing migration of
  * the same id or export name. The target table comes from `--table`, or from
@@ -578,7 +578,7 @@ const buildMigrateArgs = (options: MigrateDataCommandOptions): Record<string, un
 };
 
 /**
- * `lunora migrate up|down|status &lt;id>` — drive the cross-shard data-migration
+ * `lunora migrate up|down|status <id>` — drive the cross-shard data-migration
  * orchestrator. Resolves the migration's table locally, then POSTs a migration
  * admin RPC to the Worker's `/_lunora/migrate` endpoint, which fans it out to
  * every live shard of that table and rolls up the per-shard outcomes.
@@ -726,7 +726,7 @@ const runMigrateToHyperdriveCommand = async (options: MigrateToHyperdriveOptions
     }
 };
 
-/** `lunora migrate &lt;subcommand>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora migrate <subcommand>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<MigrateOptions> = defineHandler<MigrateOptions>(({ argument, cwd, logger, options }) => {
     const sub = argument[0];
 

--- a/packages/cli/src/commands/registry/command.ts
+++ b/packages/cli/src/commands/registry/command.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 /**
- * `lunora registry &lt;add|list|view|build>` — the component-registry command.
+ * `lunora registry <add|list|view|build>` — the component-registry command.
  * Metadata only; `./handler` dispatches the subcommand. (The sibling `./index`
  * barrel stays the library entry that exports the `run*` orchestrators + types.)
  */

--- a/packages/cli/src/commands/registry/reconcile.ts
+++ b/packages/cli/src/commands/registry/reconcile.ts
@@ -3,7 +3,7 @@
  * `create-or-skip` 3-way upgrade (base = last-written hash, yours = on-disk,
  * theirs = incoming). `--diff` previews; `--overwrite` force-takes theirs.
  *
- * Also handles `entrypointReexports` — injecting `export * from "./lunora/&lt;module&gt;"`
+ * Also handles `entrypointReexports` — injecting `export * from "./lunora/<module>"`
  * into the class-B/C worker entry file.
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -288,8 +288,8 @@ const findWorkerEntry = (projectRoot: string): { entryPath: string; main: string
 
 /**
  * Compute the relative import specifier from a worker entry file to
- * `lunora/&lt;module&gt;`. E.g. for `src/server/index.ts` the result is
- * `../../lunora/&lt;module&gt;`.
+ * `lunora/<module>`. E.g. for `src/server/index.ts` the result is
+ * `../../lunora/<module>`.
  */
 const computeRelativeSpecifier = (entryPath: string, projectRoot: string, moduleName: string): string => {
     const importPath = relative(dirname(entryPath), join(projectRoot, "lunora", moduleName)).replaceAll("\\", "/");
@@ -343,7 +343,7 @@ const buildReexportLines = (entrypointReexports: ReadonlyArray<EntrypointReexpor
 
 /**
  * Apply an item's declared entrypoint re-exports: inject `export * from
- * "./lunora/&lt;module&gt;"` lines into the class-B/C worker entry (the file that
+ * "./lunora/<module>"` lines into the class-B/C worker entry (the file that
  * calls `createShardDO`). For class-A (Vite plugin / no such file), log a
  * post-add instruction instead. Idempotent — skips a module whose re-export
  * already exists.

--- a/packages/cli/src/commands/registry/resolve.ts
+++ b/packages/cli/src/commands/registry/resolve.ts
@@ -19,7 +19,7 @@ const DEFAULT_SOURCE_BASE = "gh:anolilab/lunora/registry";
 /**
  * A registry item name is a single path segment / identifier. It becomes a
  * filesystem path segment (`join(--from, name)`), a remote giget subpath
- * (`&lt;base>/&lt;name>#&lt;ref>`), and — for schema-extension items — an import
+ * (`<base>/<name>#<ref>`), and — for schema-extension items — an import
  * specifier and identifier spliced into `lunora/schema.ts`. Allow only
  * letters/digits/`-`/`_`, no leading dot, so a name can never traverse out of
  * the registry root (`../../etc`), inject a path separator, or smuggle code

--- a/packages/cli/src/commands/rules/handler.ts
+++ b/packages/cli/src/commands/rules/handler.ts
@@ -114,7 +114,7 @@ const WORKSPACE_ROOT_MARKERS = ["pnpm-workspace.yaml", "pnpm-lock.yaml", "yarn.l
  *
  * Skills belong to the repo, not to whichever package you happened to `cd`
  * into: running `lunora rules install` from a subdirectory dropped them in
- * `&lt;pkg>/.agents/skills`, where the coding agent never looks. Falls back to `start` when no marker is found, so a standalone project
+ * `<pkg>/.agents/skills`, where the coding agent never looks. Falls back to `start` when no marker is found, so a standalone project
  * behaves exactly as before.
  */
 const resolveWorkspaceRoot = (start: string): string => {
@@ -219,7 +219,7 @@ const runRulesCheck = (options: RunRulesOptions): RunRulesResult => {
     return { code: options.strict === true ? 1 : 0, installed: status.present, skipped: [] };
 };
 
-/** `lunora rules &lt;install|check>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora rules <install|check>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<RulesOptions> = defineHandler<RulesOptions>(({ argument, cwd, logger, options }) => {
     const subcommand = argument[0] ?? "check";
 

--- a/packages/cli/src/commands/run/handler.ts
+++ b/packages/cli/src/commands/run/handler.ts
@@ -223,7 +223,7 @@ const runRpcCommand = async (options: RunCommandOptions): Promise<RunCommandResu
     };
 };
 
-/** `lunora run &lt;functionPath>` handler (lazy-loaded via the command's `loader`). */
+/** `lunora run <functionPath>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<RunRpcOptions> = defineHandler<RunRpcOptions>(({ argument, cwd, logger, options }) => {
     const functionPath = argument[0];
 

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 /**
- * `lunora run &lt;functionPath>` — send a single RPC to a running Lunora worker.
+ * `lunora run <functionPath>` — send a single RPC to a running Lunora worker.
  * Metadata only; the handler (lazy-loaded via `loader`) holds the logic.
  */
 const runCommand: Command = {

--- a/packages/cli/src/util/detect-package-manager.ts
+++ b/packages/cli/src/util/detect-package-manager.ts
@@ -25,7 +25,7 @@ const KNOWN_PACKAGE_MANAGERS: ReadonlySet<string> = new Set<PackageManager>(["bu
  */
 const isKnownPackageManager = (name: string): name is PackageManager => KNOWN_PACKAGE_MANAGERS.has(name);
 
-/** True when `manager` is on PATH — probed by running `&lt;manager> --version`. Injectable for tests. */
+/** True when `manager` is on PATH — probed by running `<manager> --version`. Injectable for tests. */
 type PackageManagerProbe = (manager: PackageManager) => boolean;
 
 const isManagerInstalled: PackageManagerProbe = (manager) => {
@@ -44,7 +44,7 @@ const isManagerInstalled: PackageManagerProbe = (manager) => {
  */
 const detectInstalledManagers = (probe: PackageManagerProbe = isManagerInstalled): PackageManager[] => INSTALL_PREFERENCE.filter((manager) => probe(manager));
 
-/** The argv that installs a project's dependencies with `manager` (`&lt;manager> install`). */
+/** The argv that installs a project's dependencies with `manager` (`<manager> install`). */
 const installArgsFor = (manager: PackageManager): { args: string[]; command: string } => {
     return { args: ["install"], command: manager };
 };
@@ -146,10 +146,10 @@ const execArgsFor = (manager: PackageManager, command: string, args: ReadonlyArr
  * The argv that runs a project SCRIPT with `manager` — the counterpart to
  * {@link execArgsFor}, which runs a BINARY.
  *
- * All four managers accept `&lt;manager> run &lt;script>`, so this is uniform. It is a
+ * All four managers accept `<manager> run <script>`, so this is uniform. It is a
  * separate function because reaching for `execArgsFor(manager, "run", [script])`
- * silently produces something else entirely: `pnpm exec run &lt;script>` fails with
- * `Command "run" not found`, and `npx -- run &lt;script>` resolves the registry
+ * silently produces something else entirely: `pnpm exec run <script>` fails with
+ * `Command "run" not found`, and `npx -- run <script>` resolves the registry
  * PACKAGE named `run` and executes it.
  */
 const runScriptArgsFor = (manager: PackageManager, script: string): { args: string[]; command: string } => {

--- a/packages/cli/src/util/insert-schema-extension.ts
+++ b/packages/cli/src/util/insert-schema-extension.ts
@@ -2,11 +2,11 @@
  * AST-merge helper for `lunora add` registry items that ship a schema
  * extension. Mirrors the table/cron generators in
  * `.vis/templates/_helpers/insert-*.ts` — it loads `lunora/schema.ts` into a
- * ts-morph in-memory project and chains a `.extend(&lt;key>.extension)` onto the
+ * ts-morph in-memory project and chains a `.extend(<key>.extension)` onto the
  * existing `defineSchema(...)` call, plus the matching managed import.
  *
  * Ownership / idempotency: both the import and the `.extend(...)` are wrapped in
- * `// lunora:add:&lt;key>` managed-block markers. Re-running `add` for the same
+ * `// lunora:add:<key>` managed-block markers. Re-running `add` for the same
  * item detects the marker and is a no-op, so user edits elsewhere in the file
  * survive untouched. ts-morph itself doesn't model leading-comment trivia as
  * editable nodes, so we operate on the raw text for the markers and only use
@@ -37,9 +37,9 @@ const endMarker = (key: string): string => `// lunora:add:${key}:end`;
 
 /**
  * The default module specifier a freshly-added item is imported from. The item
- * ships `lunora/&lt;key>/schema.ts` exporting `&lt;key>` (the plugin object whose
+ * ships `lunora/<key>/schema.ts` exporting `<key>` (the plugin object whose
  * `.extension` is the schema extension). Relative to `lunora/schema.ts` that is
- * `./&lt;key>/schema`.
+ * `./<key>/schema`.
  */
 const extensionImportSpecifier = (key: string): string => `./${key}/schema`;
 
@@ -82,7 +82,7 @@ const outermostChainExpression = (defineSchemaCall: CallExpression): TsNode => {
 };
 
 /**
- * Append `.extend(&lt;key>.extension)` and a managed import to an existing
+ * Append `.extend(<key>.extension)` and a managed import to an existing
  * `lunora/schema.ts`. Idempotent: a second call for the same `key` returns
  * `already-applied` and leaves the text unchanged.
  * @param source the current `lunora/schema.ts` contents

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -138,7 +138,7 @@ const configureLogHandlers = (reporters: PailReporter | PailReporter[]): void =>
 
 /**
  * Custom pail log types backing the `init` flow's step badges. Each becomes a
- * `pail.&lt;name>(message)` method; `LunoraReporter` paints them as badge boxes
+ * `pail.<name>(message)` method; `LunoraReporter` paints them as badge boxes
  * (off-TTY fallback) while the colors live in `@lunora/config`'s theme. The
  * `informational` RFC5424 level keeps them on stdout and visible at the default
  * verbosity (pail rejects the `"info"` shorthand).

--- a/packages/cli/src/util/mcp-clients.ts
+++ b/packages/cli/src/util/mcp-clients.ts
@@ -178,7 +178,7 @@ const claudeDesktopPaths = ({ home, platform }: McpPathContext): Partial<Record<
 };
 
 /**
- * Render the `[mcp_servers.&lt;name>]` table Codex reads.
+ * Render the `[mcp_servers.<name>]` table Codex reads.
  *
  * Serialized by `smol-toml` rather than by hand: TOML has real rules about
  * which keys may be bare (a dot in a server name silently becomes table

--- a/packages/cli/src/util/post-codegen-hook.ts
+++ b/packages/cli/src/util/post-codegen-hook.ts
@@ -5,7 +5,7 @@
  * to the project's own `codegen` script, which is faster and avoids depending on
  * a script existing — but it also means anything a project chained onto codegen
  * was silently skipped. A project that wraps codegen (`"codegen": "lunora
- * codegen &amp;& pnpm --filter … run patch"`) would see `prepare` revert its
+ * codegen && pnpm --filter … run patch"`) would see `prepare` revert its
  * post-step, and — the part that matters — **`lunora deploy` would ship the
  * unpatched output**, since a deploy pipeline has no reason to run the project's
  * codegen script first.

--- a/packages/cli/src/util/resolve-target.ts
+++ b/packages/cli/src/util/resolve-target.ts
@@ -16,7 +16,7 @@ import { readLinkedProject } from "@lunora/config";
 
 interface ResolveWorkerUrlInputs {
     cwd: string;
-    /** The `--env &lt;name>` the caller is targeting, when scoped. `undefined` means top-level (no `--env`). */
+    /** The `--env <name>` the caller is targeting, when scoped. `undefined` means top-level (no `--env`). */
     env?: string;
     /** Explicit `--url` flag value, when the caller passed one. */
     url?: string;

--- a/packages/cli/src/util/spawn.ts
+++ b/packages/cli/src/util/spawn.ts
@@ -6,7 +6,7 @@ import { spawn as nodeSpawn } from "node:child_process";
  * separators / redirection operators (`& | < > ^`), an env-var `%`, and a
  * literal `"` (which toggles cmd's quote state). Wrapping such a value in double
  * quotes neutralises the separators/redirection so an argument like
- * `C:\Dev&amp;Ops\dist` can't spawn `Ops\dist` as a second command.
+ * `C:\Dev&Ops\dist` can't spawn `Ops\dist` as a second command.
  */
 const NEEDS_CMD_QUOTING = /[\s"%&<>^|]/u;
 // eslint-disable-next-line sonarjs/slow-regex -- linear (no nested quantifier); input is a bounded developer-supplied CLI argument
@@ -91,7 +91,7 @@ export type Spawner = (descriptor: SpawnDescriptor) => Promise<SpawnResult>;
  * carrying a cmd metacharacter (whitespace, `& | < > ^ % "`) is double-quoted
  * here — with CommandLineToArgvW-safe escaping of embedded quotes and trailing
  * backslashes — so a `--config` temp path under a spaced user dir, or a value
- * like `C:\Dev&amp;Ops\dist`, can't be re-split or run as a second command;
+ * like `C:\Dev&Ops\dist`, can't be re-split or run as a second command;
  * everything else passes through untouched. POSIX platforms return the input
  * unchanged.
  */

--- a/packages/cli/src/util/tui-prompts.tsx
+++ b/packages/cli/src/util/tui-prompts.tsx
@@ -1116,7 +1116,7 @@ const TasksView = <T,>({ end, onSettle, start, tasks }: TasksViewProps<T>): Reac
 
 /**
  * Run a sequence of async tasks as a live checklist with the create-astro look: a
- * gradient "rocket" header that flips to `✔  &lt;end>` when done, over `□`/`▶`/`■`
+ * gradient "rocket" header that flips to `✔  <end>` when done, over `□`/`▶`/`■`
  * sub-steps. Returns each task's result. Off a TTY the tasks run bare (no render)
  * and the first failure rejects, exactly like {@link withTuiSpinner}.
  */

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -151,4 +151,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/client/src/http-stream.ts
+++ b/packages/client/src/http-stream.ts
@@ -1,8 +1,8 @@
 /**
- * HTTP-SSE stream consumer for `httpRoute.&lt;verb>(path).stream()` routes.
+ * HTTP-SSE stream consumer for `httpRoute.<verb>(path).stream()` routes.
  *
  * The server pump (`@lunora/server`'s `buildStreamHandler`) writes one
- * `data: &lt;json>\n\n` frame per yielded chunk, a final `event: complete` frame
+ * `data: <json>\n\n` frame per yielded chunk, a final `event: complete` frame
  * on iterator completion, and an `event: error` frame carrying
  * `{ code, message }` on throw. This consumer opens the route with `fetch`,
  * reads `response.body.getReader()`, parses that exact framing, and yields

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -91,7 +91,7 @@ const RPC_PATH = "/_lunora/rpc";
 const RPC_BATCH_PATH = "/_lunora/rpc-batch";
 const WS_PATH = "/_lunora/ws";
 
-/** Build the `&amp;bucket=…` query fragment for a storage admin request, or `""` when no bucket is selected. */
+/** Build the `&bucket=…` query fragment for a storage admin request, or `""` when no bucket is selected. */
 const bucketQuery = (bucket?: string): string => (bucket === undefined || bucket === "" ? "" : `&bucket=${encodeURIComponent(bucket)}`);
 
 /**
@@ -255,7 +255,7 @@ interface ClientDebugShard {
 interface ClientDebugSubscription {
     /** Whether the server has acknowledged the subscription on the current socket. */
     acked: boolean;
-    /** `namespace:fn` for a query, `shape:&lt;name>` for a replication shape. */
+    /** `namespace:fn` for a query, `shape:<name>` for a replication shape. */
     functionPath: string;
     id: string;
     kind: "query" | "shape";
@@ -311,7 +311,7 @@ interface MutationSettledEvent {
     readonly code?: string;
     /** The rejection error on `status: "rejected"`. */
     readonly error?: unknown;
-    /** The `&lt;file>:&lt;function>` reference of the mutation. */
+    /** The `<file>:<function>` reference of the mutation. */
     readonly functionPath: string;
     /** Whether a live caller was still awaiting this write's `mutation()` Promise. */
     readonly hadAwaiter: boolean;
@@ -362,7 +362,7 @@ interface MutationCallOptions<TCurrent = unknown, TValue = unknown, TArgs = unkn
 /**
  * One WebSocket per shard key. Subscriptions and the writes they observe must
  * land on the same Durable Object, so each distinct `shardKey` gets its own
- * socket connected to `?shard=&lt;key>` (the default shard uses no query param).
+ * socket connected to `?shard=<key>` (the default shard uses no query param).
  * Reconnect backoff, offline-flush state, and the pending-unsubscribe buffer
  * are all per-connection so one shard dropping doesn't disturb the others.
  */
@@ -3430,7 +3430,7 @@ class LunoraClient {
     }
 
     /**
-     * Open a typed **HTTP-SSE route stream** (`httpRoute.&lt;verb>(path).stream()`).
+     * Open a typed **HTTP-SSE route stream** (`httpRoute.<verb>(path).stream()`).
      * Distinct from {@link LunoraClient.stream}, which consumes the WS procedure
      * stream (`kind: "stream"`): this one opens the route's own URL with `fetch`
      * and parses the Server-Sent Events framing the route pump writes (`data:`
@@ -5593,7 +5593,7 @@ class LunoraClient {
     }
 
     /**
-     * Stable token-hash fingerprint of a bearer token (the `&lt;len>:&lt;fnv>:&lt;djb2>`
+     * Stable token-hash fingerprint of a bearer token (the `<len>:<fnv>:<djb2>`
      * format a token-stamped queued write carries). Extracted so the replay gate
      * can recompute the hash of the current credential and recognise a write
      * stamped under it — even after the fingerprint was relabelled to a subject.

--- a/packages/client/src/ssr/serialize-preloaded.ts
+++ b/packages/client/src/ssr/serialize-preloaded.ts
@@ -2,17 +2,17 @@ import type { Preloaded } from "../types";
 
 /**
  * Serialize a {@link Preloaded} token to a JSON string for embedding in the
- * rendered HTML (e.g. a `&lt;script>` payload the client
+ * rendered HTML (e.g. a `<script>` payload the client
  * reads on hydration). Every field of `Preloaded` is JSON-serializable by
  * construction — `preloadQuery` only captures the query args, function path,
  * optional shard key, and the resolved value — so this is a thin, explicit
  * `JSON.stringify` that documents the dehydration seam and keeps callers from
  * accidentally stringifying a non-serializable wrapper.
  *
- * The `&lt;` is escaped to `&lt;` so the payload is safe to inline inside a
- * `&lt;script>` tag without a stray `&lt;/script>` (or `&lt;!--`) prematurely closing
+ * The `<` is escaped to `<` so the payload is safe to inline inside a
+ * `<script>` tag without a stray `</script>` (or `<!--`) prematurely closing
  * it — the standard XSS-safe script-embedding precaution. This escaping is NOT
- * sufficient for an HTML *attribute* sink (which also needs the quote and `&amp;`
+ * sufficient for an HTML *attribute* sink (which also needs the quote and `&`
  * characters escaped); embed the output in a raw-text script element, not a
  * data attribute.
  */
@@ -20,7 +20,7 @@ export const serializePreloaded = <T>(preloaded: Preloaded<T>): string => JSON.s
 
 /**
  * Inverse of {@link serializePreloaded}: parse a serialized token back into a
- * {@link Preloaded} value on the client. The `&lt;` escape from serialization
+ * {@link Preloaded} value on the client. The `<` escape from serialization
  * is transparent to `JSON.parse`, so no un-escaping step is needed.
  */
 export const deserializePreloaded = <T = unknown>(serialized: string): Preloaded<T> => JSON.parse(serialized) as Preloaded<T>;

--- a/packages/client/src/ssr/server-client.ts
+++ b/packages/client/src/ssr/server-client.ts
@@ -11,7 +11,7 @@ export interface ServerClientOptions {
     fetch?: typeof fetch;
 
     /**
-     * Bearer token sent as `Authorization: Bearer &lt;token>` on every RPC. In an
+     * Bearer token sent as `Authorization: Bearer <token>` on every RPC. In an
      * SSR loader you typically read this from the request (e.g. the session
      * resolved by `getServerSession`) and pass it here so the server-side
      * load runs as the signed-in user — and so the client subscription that

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -4,7 +4,7 @@ export type FunctionKind = "action" | "mutation" | "query" | "stream";
 /**
  * Opaque reference to a registered function emitted by `@lunora/codegen`.
  *
- * At runtime it carries the `&lt;file>:&lt;function>` identifier in `__lunoraRef`.
+ * At runtime it carries the `<file>:<function>` identifier in `__lunoraRef`.
  * Generated declarations decorate this with phantom type parameters so the
  * client can infer args / return values per call site.
  */
@@ -25,8 +25,8 @@ export type ArgsOf<F> = F extends FunctionReference<infer _K, infer A, infer _R>
 export type ReturnOf<F> = F extends FunctionReference<infer _K, infer _A, infer R> ? R : never;
 
 /**
- * Typed reference to an HTTP-SSE stream route (`httpRoute.&lt;verb>(path).stream()`)
- * emitted by `@lunora/codegen` as `httpStreams.&lt;namespace>.&lt;name>`.
+ * Typed reference to an HTTP-SSE stream route (`httpRoute.<verb>(path).stream()`)
+ * emitted by `@lunora/codegen` as `httpStreams.<namespace>.<name>`.
  *
  * Distinct from {@link FunctionReference}: this is the **HTTP-SSE route stream**
  * (opened with `fetch` + `ReadableStream` against the route's own URL), not the
@@ -458,7 +458,7 @@ export interface RpcEnvelope {
 
     /**
      * Monotonic per-client mutation id (custom-mutator push path), backing the
-     * server-side per-client watermark: `id &lt;= watermark` is a replay (skipped),
+     * server-side per-client watermark: `id <= watermark` is a replay (skipped),
      * `id == watermark + 1` runs authoritatively, `id > watermark + 1` halts the
      * batch so the client resends from `watermark + 1`. Absent on plain
      * `client.mutation` calls.
@@ -924,7 +924,7 @@ export interface FunctionArgumentDescriptor {
 
 /**
  * One registered function, as returned by the worker's
- * `GET /_lunora/admin/functions` endpoint: its `&lt;file>:&lt;function>` path, which
+ * `GET /_lunora/admin/functions` endpoint: its `<file>:<function>` path, which
  * client method (`query` / `mutation` / `action`) invokes it, and its argument
  * signature. `args` is absent on responses from an older worker.
  */
@@ -937,7 +937,7 @@ export interface FunctionDescriptor {
 /**
  * One code-defined cron trigger, as returned by the worker's
  * `GET /_lunora/admin/cron-jobs` endpoint: the `cron` expression that fires it,
- * the `&lt;file>:&lt;function>` path it invokes, its human `name`, and any bound
+ * the `<file>:<function>` path it invokes, its human `name`, and any bound
  * `args` / `shardKey`. Static for the deployment (Cloudflare exposes no runtime
  * cron introspection), so the studio renders these read-only.
  */

--- a/packages/cloudflare-access/eslint.config.js
+++ b/packages/cloudflare-access/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/codegen/__tests__/discover-agents.test.ts
+++ b/packages/codegen/__tests__/discover-agents.test.ts
@@ -26,9 +26,9 @@ const newProject = (): Project => new Project({ skipAddingFilesFromTsConfig: tru
 const AGENT_COMPONENT_SOURCE_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "agent", "src", "component.ts");
 
 /**
- * Read `const &lt;constantName> = query|mutation.input({...}).query|mutation(async (...): Promise&lt;T> => ...)`'s
+ * Read `const <constantName> = query|mutation.input({...}).query|mutation(async (...): Promise<T> => ...)`'s
  * declared return-type text out of `component.ts`, unwrapped of its outer
- * `Promise&lt;…>` — mirroring codegen's own Promise-unwrap convention
+ * `Promise<…>` — mirroring codegen's own Promise-unwrap convention
  * (`unwrapHandlerReturn` in `discover-functions.ts`) so the comparison lines up
  * with what `syntheticAgentApiFunctions` hand-pins in `emit.ts`.
  */

--- a/packages/codegen/__tests__/run-codegen-cold-start.test.ts
+++ b/packages/codegen/__tests__/run-codegen-cold-start.test.ts
@@ -2,7 +2,7 @@
  * Issue #283: `lunora codegen` was not reproducible from a cold `_generated/`.
  *
  * Pass 1 inferred every handler's return type against a ts-morph `Project` that
- * did not yet include the generated declarations (`Doc&lt;…>` chief among them,
+ * did not yet include the generated declarations (`Doc<…>` chief among them,
  * for a handler whose return type is annotated against it) — so on a fresh
  * clone, CI, or after `rm -rf lunora/_generated`, that inference collapsed to
  * `unknown` and codegen WROTE the collapsed type into `api.ts`/`functions.ts`.

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -26,7 +26,7 @@ const expectedDirectory = join(fixtureRoot, "expected", "_generated");
 const SCHEMA_NOT_FOUND_RE = /schema\.ts not found/u;
 
 /**
- * Slice a single `export interface &lt;Name> ... { ... }` block out of emitted
+ * Slice a single `export interface <Name> ... { ... }` block out of emitted
  * `server.ts` so a ctx-augmentation assertion can scope to exactly one context
  * (e.g. assert a field is on `ActionCtx` but absent from `QueryCtx`).
  */

--- a/packages/codegen/eslint.config.js
+++ b/packages/codegen/eslint.config.js
@@ -154,4 +154,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/codegen/src/argument-taint.ts
+++ b/packages/codegen/src/argument-taint.ts
@@ -57,8 +57,8 @@ const textuallyReferencesContext = (node: TsNode): boolean => {
  * the request arrives as a positional parameter the user names freely
  * (`request` / `req` / `r`) rather than a fixed `args`/`ctx` binding. Mirror of
  * {@link isArgsValueReference} with a dynamic root name: excludes the trailing
- * `.&lt;requestName>` of a member access and the key of an explicit
- * `{ &lt;requestName>: … }` property; a `{ request }` shorthand IS a value reference.
+ * `.<requestName>` of a member access and the key of an explicit
+ * `{ <requestName>: … }` property; a `{ request }` shorthand IS a value reference.
  */
 const isRequestValueReference = (identifier: Identifier, requestName: string): boolean => {
     if (identifier.getText() !== requestName) {
@@ -298,7 +298,7 @@ export const isRequestInputDerived = (node: TsNode, requestName: string): boolea
 };
 
 /**
- * The export name of the nearest *exported* `const x = …` ancestor, or `"&lt;module>"`
+ * The export name of the nearest *exported* `const x = …` ancestor, or `"<module>"`
  * when the node isn't inside one (e.g. an inline-mounted handler). Walks out past
  * any local `const result = …` bindings to the exported declaration — matching
  * {@link import("./discover-ast").enclosingExportName} — so a sink nested in a

--- a/packages/codegen/src/capabilities.ts
+++ b/packages/codegen/src/capabilities.ts
@@ -51,7 +51,7 @@ interface CapabilityDescriptor {
     appMethod?: AppMethodFacet;
     /** Generated `ctx.*` helper name (the usage probe + the destructure detector); omitted when the feature has no ctx surface (`mail`). */
     contextProperty?: string;
-    /** The capability id — equal to its `FeatureUsage` key and its `ctx.&lt;key>` helper (except where `contextProperty` differs, e.g. `hyperdrive` → `ctx.sql`). */
+    /** The capability id — equal to its `FeatureUsage` key and its `ctx.<key>` helper (except where `contextProperty` differs, e.g. `hyperdrive` → `ctx.sql`). */
     key: string;
     /** The `@lunora/*` package whose import flips the usage probe. */
     moduleSpecifier: string;
@@ -242,7 +242,7 @@ type CapabilityKey = (typeof CAPABILITY_ROWS)[number]["key"];
 /**
  * The subset of {@link CapabilityKey} for capabilities that expose a fluent
  * `defineApp` builder method (an `appMethod` facet). `emit-app.ts` derives each
- * one's `has&lt;Capitalized>` option key off this union, so the derivation is
+ * one's `has<Capitalized>` option key off this union, so the derivation is
  * checked against `EmitAppOptions` at compile time (a capability whose flag is
  * missing from `EmitAppOptions` is a type error, not a silent no-op).
  */
@@ -274,7 +274,7 @@ const SERVER_CTX_FIELDS: ReadonlyMap<CapabilityKey, ServerContextFieldFacet> = n
  * The long-tail `defineApp` builder capabilities, in emit order — for
  * `emit-app.ts`, which turns each into a fluent method setting `configKey` on the
  * `createShardDO` config. Each pairs the capability's `has*` option key
- * (`has&lt;Capitalized-key>`) with its {@link AppMethodFacet}.
+ * (`has<Capitalized-key>`) with its {@link AppMethodFacet}.
  */
 const APP_METHOD_CAPABILITIES: ReadonlyArray<{ appMethod: AppMethodFacet; key: AppMethodKey }> = CAPABILITY_ROWS.flatMap((capability) =>
     "appMethod" in capability ? [{ appMethod: capability.appMethod, key: capability.key }] : [],

--- a/packages/codegen/src/diagnostics.ts
+++ b/packages/codegen/src/diagnostics.ts
@@ -27,7 +27,7 @@ export class CodegenDiagnosticError extends LunoraError {
  * location and whose `file`/`line`/`column` properties are set from the
  * ts-morph `Node`'s position in its source file.
  *
- * Message format: `@lunora/codegen: &lt;detail> (&lt;file>:&lt;line>:&lt;column>)`
+ * Message format: `@lunora/codegen: <detail> (<file>:<line>:<column>)`
  *
  * `meta` is merged onto the returned error for callers that also carry the
  * project-wide `LunoraError` envelope (`code`/`name`/`status`) — it never

--- a/packages/codegen/src/discover-admin-routes.ts
+++ b/packages/codegen/src/discover-admin-routes.ts
@@ -4,7 +4,7 @@ import { Node, SyntaxKind } from "ts-morph";
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { AdminRouteIR } from "./ir";
 
-/** The `httpRoute.&lt;verb&gt;(...)` factory verbs. */
+/** The `httpRoute.<verb>(...)` factory verbs. */
 const HTTP_VERBS = new Set(["delete", "get", "head", "options", "patch", "post", "put"]);
 
 /** The terminal steps that close a route builder chain into a mountable handler. */
@@ -36,7 +36,7 @@ const GUARD_NAMES = new Set([
     "verifyAdmin",
 ]);
 
-/** Resolve a builder chain's root `httpRoute.&lt;verb&gt;("/path")`, returning `{ method, path }` or `undefined`. */
+/** Resolve a builder chain's root `httpRoute.<verb>("/path")`, returning `{ method, path }` or `undefined`. */
 const readRootVerb = (node: TsNode): { method: string; path: string } | undefined => {
     if (!Node.isCallExpression(node)) {
         return undefined;
@@ -63,7 +63,7 @@ const readRootVerb = (node: TsNode): { method: string; path: string } | undefine
     return { method: callee.getName().toUpperCase(), path: first.getLiteralValue() };
 };
 
-/** Walk a route chain leftward from the terminal call to its `httpRoute.&lt;verb&gt;(path)` root. */
+/** Walk a route chain leftward from the terminal call to its `httpRoute.<verb>(path)` root. */
 const rootOfChain = (terminalCall: CallExpression): { method: string; path: string } | undefined => {
     const terminalCallee = terminalCall.getExpression();
 
@@ -171,7 +171,7 @@ const adminRoutesInSourceFile = (sourceFile: SourceFile, relativePath: string): 
 };
 
 /**
- * Discover `httpRoute.&lt;verb&gt;("/admin/…")` REST routes on admin/privileged-looking
+ * Discover `httpRoute.<verb>("/admin/…")` REST routes on admin/privileged-looking
  * paths and whether each references an auth/admin guard in its handler — the
  * `admin_route_without_guard` lint input. A privileged route with no visible
  * session/admin check is an authorization gap, so only the path + guard-presence

--- a/packages/codegen/src/discover-argument-derived-accesses.ts
+++ b/packages/codegen/src/discover-argument-derived-accesses.ts
@@ -5,7 +5,7 @@ import { enclosingExportName, isArgumentDerived, isScopedByContext, isUnmodified
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 
 /**
- * The sink method name when `node` is a `&lt;receiver>.&lt;method>` property access
+ * The sink method name when `node` is a `<receiver>.<method>` property access
  * satisfying `config` (name in `config.methods`, receiver text accepted by
  * `config.matchReceiver`), else `undefined`. Matched by shape — the same
  * `import`-agnostic, fail-closed convention every argument-derived-access
@@ -83,7 +83,7 @@ const accessesInSourceFile = (sourceFile: SourceFile, relativePath: string, conf
 export interface ArgumentDerivedAccessIR {
     /** Export binding name of the procedure performing the sink call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the sink call, or `0` when unknown. */
     line: number;
@@ -93,7 +93,7 @@ export interface ArgumentDerivedAccessIR {
 
 /**
  * Per-binding configuration for {@link discoverArgumentDerivedAccesses}: which
- * `&lt;receiver>.&lt;method>(...)` property-access calls count as this binding's
+ * `<receiver>.<method>(...)` property-access calls count as this binding's
  * sink, and which call argument carries the potentially-tainted value.
  */
 export interface ArgumentDerivedAccessConfig {
@@ -118,7 +118,7 @@ export interface ArgumentDerivedAccessConfig {
 /**
  * Shared AST walk behind the argument-derived property-access sink feeders
  * (`ctx.kv`, `ctx.containers.*.get`, `ctx.storage.*`, `ctx.browser`): one IR row
- * per call in `lunora/` whose callee is a `&lt;receiver>.&lt;method>` property access
+ * per call in `lunora/` whose callee is a `<receiver>.<method>` property access
  * matching `config` and whose `config.argIndex` argument is derived from the
  * handler's `args` (directly, or through one local `const` hop) with no
  * server-side scoping. A fixed literal, or a value scoped by a server-trusted

--- a/packages/codegen/src/discover-ast.ts
+++ b/packages/codegen/src/discover-ast.ts
@@ -13,7 +13,7 @@ export const TS_EXTENSION_RE: RegExp = /\.ts$/u;
  * Shared by the call-attribution discoverers (`discover-inserts`,
  * `discover-authapi-calls`, `discover-workflow-calls`). The
  * `discover-sql-interpolation` variant has divergent semantics (no export-keyword
- * check, `"&lt;module>"` fallback) and is intentionally NOT this helper.
+ * check, `"<module>"` fallback) and is intentionally NOT this helper.
  */
 export const enclosingExportName = (call: CallExpression): string => {
     for (const ancestor of call.getAncestors()) {

--- a/packages/codegen/src/discover-authapi-calls.ts
+++ b/packages/codegen/src/discover-authapi-calls.ts
@@ -8,12 +8,12 @@ import { listLunoraSourceFiles } from "./discover-functions";
 import type { AuthApiCallIR } from "./ir";
 
 /**
- * True for a `ctx.authApi.&lt;method>(...)` (or bare `authApi.&lt;method>(...)`)
+ * True for a `ctx.authApi.<method>(...)` (or bare `authApi.<method>(...)`)
  * call — the privileged better-auth API surface installed by `withAuthPlugins`.
  *
  * Accepted receiver shapes: (1) a `PropertyAccessExpression` whose receiver is
  * itself a `PropertyAccessExpression` named `authApi` — the standard
- * `ctx.authApi.&lt;method>` form; (2) a bare `authApi` identifier — the
+ * `ctx.authApi.<method>` form; (2) a bare `authApi` identifier — the
  * destructured `const { authApi } = ctx` case. We require the inner receiver
  * to be named `authApi` rather than requiring the outermost receiver to be
  * `ctx`, per the plan STOP note: under-report rather than flag unrelated code.
@@ -76,7 +76,7 @@ const hasHeadersProp = (call: CallExpression): boolean => {
 };
 
 /**
- * Discover `ctx.authApi.&lt;method>(...)` (and bare `authApi.&lt;method>(...)`) calls
+ * Discover `ctx.authApi.<method>(...)` (and bare `authApi.<method>(...)`) calls
  * under the lunora source directory and attribute each to the exported function
  * (and file) performing it. Calls outside an exported declaration are dropped.
  */

--- a/packages/codegen/src/discover-browser-url-accesses.ts
+++ b/packages/codegen/src/discover-browser-url-accesses.ts
@@ -4,7 +4,7 @@ import { discoverArgumentDerivedAccesses } from "./discover-argument-derived-acc
 import type { BrowserUrlAccessIR } from "./ir";
 
 /**
- * The `ctx.browser.&lt;method>(url, …)` navigation methods whose first argument is
+ * The `ctx.browser.<method>(url, …)` navigation methods whose first argument is
  * the URL to fetch. All four take the target URL as `arguments[0]`; the
  * page-driving `page.goto(url)` low-level method has a different receiver (a
  * page handle, not `ctx.browser`) and is not matched here.
@@ -12,7 +12,7 @@ import type { BrowserUrlAccessIR } from "./ir";
 const BROWSER_URL_METHODS = new Set(["content", "pdf", "scrape", "screenshot"]);
 
 /**
- * Discover `ctx.browser.&lt;method>(url, …)` calls in `lunora/` whose navigation
+ * Discover `ctx.browser.<method>(url, …)` calls in `lunora/` whose navigation
  * URL is derived from the handler's `args` with no server-side scoping — the
  * `browser_user_url_without_allowlist` lint input. `@lunora/browser` blocks
  * private/internal targets by default, but a request-supplied *public* URL can

--- a/packages/codegen/src/discover-config-calls.ts
+++ b/packages/codegen/src/discover-config-calls.ts
@@ -19,7 +19,7 @@ const CONSTRUCTOR_CALLEES = new Set(["RateLimiter"]);
  * Chained builder methods whose first-argument *callback* (not a bare object
  * literal) returns the config object literal a security lint inspects — the
  * generated `defineApp()...extend(fn)` escape hatch (`fn: (env, derived) =>
- * Partial&lt;WorkerOptions>`, merged straight into the `createWorker(...)` options
+ * Partial<WorkerOptions>`, merged straight into the `createWorker(...)` options
  * — see `emit-app.ts`'s `buildWorkerOptions`). Matched by name only (the same
  * import-agnostic convention as {@link FUNCTION_CALLEES}); the compound
  * signature of the method name plus a specific `trueKeys` member is precise

--- a/packages/codegen/src/discover-container-key-accesses.ts
+++ b/packages/codegen/src/discover-container-key-accesses.ts
@@ -8,7 +8,7 @@ const CONTAINER_ACCESSOR_PREFIX = "ctx.containers.";
 
 /**
  * `true` when `receiver` is a *single* container accessor
- * (`ctx.containers.&lt;exportName>`, with nothing past the export segment) — the
+ * (`ctx.containers.<exportName>`, with nothing past the export segment) — the
  * `.get(name)` receiver shape. `.any()`/`.pool()` take no key and carry a
  * different method name, so they never reach this predicate.
  */
@@ -23,7 +23,7 @@ const isContainerInstanceReceiver = (receiver: string): boolean => {
 };
 
 /**
- * Discover `ctx.containers.&lt;exportName>.get(name, …)` calls in `lunora/` whose
+ * Discover `ctx.containers.<exportName>.get(name, …)` calls in `lunora/` whose
  * instance key is derived from the handler's `args` with no server-side
  * scoping — the `container_instance_key_from_user_input` lint input. Each
  * container definition's `.get(name)` accessor routes to one instance per

--- a/packages/codegen/src/discover-container-overrides.ts
+++ b/packages/codegen/src/discover-container-overrides.ts
@@ -5,7 +5,7 @@ import { enclosingExportName } from "./argument-taint";
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { ContainerOverrideIR } from "./ir";
 
-/** Runtime egress-firewall mutators on a `&lt;handle>.egress` control surface — the `egress_relaxation` sink set. */
+/** Runtime egress-firewall mutators on a `<handle>.egress` control surface — the `egress_relaxation` sink set. */
 const EGRESS_MUTATING_METHODS = new Set(["allow", "deny", "setAllowed"]);
 
 /** True when `call`'s first argument is an object literal with an explicit `enableInternet: true` property. */
@@ -21,7 +21,7 @@ const hasEnableInternetTrue = (call: CallExpression): boolean => {
     return property !== undefined && Node.isPropertyAssignment(property) && Node.isTrueLiteral(property.getInitializerOrThrow());
 };
 
-/** The IR row for a `&lt;x>.start({ enableInternet: true, … })` launch override, or `undefined`. */
+/** The IR row for a `<x>.start({ enableInternet: true, … })` launch override, or `undefined`. */
 const enableInternetOverrideInCall = (call: CallExpression, relativePath: string): ContainerOverrideIR | undefined => {
     const callee = call.getExpression();
 
@@ -38,7 +38,7 @@ const enableInternetOverrideInCall = (call: CallExpression, relativePath: string
     };
 };
 
-/** The IR row for a `&lt;x>.egress.&lt;method>(...)` runtime firewall mutation, or `undefined`. */
+/** The IR row for a `<x>.egress.<method>(...)` runtime firewall mutation, or `undefined`. */
 const egressRelaxationInCall = (call: CallExpression, relativePath: string): ContainerOverrideIR | undefined => {
     const callee = call.getExpression();
 
@@ -83,7 +83,7 @@ const containerOverridesInSourceFile = (sourceFile: SourceFile, relativePath: st
 /**
  * Discover every runtime container-override call in `lunora/` source: a
  * `.start({ enableInternet: true, … })` launch override, or a
- * `.egress.&lt;method>(...)` runtime firewall mutation (`allow` / `deny` /
+ * `.egress.<method>(...)` runtime firewall mutation (`allow` / `deny` /
  * `setAllowed`). Matched structurally by call shape — the receiver's type is
  * never resolved, so this also works before `pnpm install` has linked
  * `@lunora/container`.

--- a/packages/codegen/src/discover-export-sinks.ts
+++ b/packages/codegen/src/discover-export-sinks.ts
@@ -7,7 +7,7 @@ import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions"
 /** The three CDC export-sink factories the runtime ships (plan 170). */
 const SINK_FACTORIES = new Set<AdvisorExportSink["factory"]>(["defineExportSink", "r2Sink", "webhookExportSink"]);
 
-/** The factory name of a `&lt;factory>({ … })` call, or `undefined` when the callee is not one of the sink factories. */
+/** The factory name of a `<factory>({ … })` call, or `undefined` when the callee is not one of the sink factories. */
 const sinkFactoryOf = (call: CallExpression): AdvisorExportSink["factory"] | undefined => {
     const callee = call.getExpression();
 

--- a/packages/codegen/src/discover-flag-security-defaults.ts
+++ b/packages/codegen/src/discover-flag-security-defaults.ts
@@ -40,7 +40,7 @@ const booleanLiteralValue = (node: TsNode | undefined): boolean | undefined => {
 };
 
 /**
- * The IR row for a `ctx.flags.boolean("key", &lt;boolean-literal>)` read, or
+ * The IR row for a `ctx.flags.boolean("key", <boolean-literal>)` read, or
  * `undefined` when the callee isn't `ctx.flags.boolean`, the key isn't a string
  * literal, or the default isn't a boolean literal (the lint's security judgment
  * needs both statically).

--- a/packages/codegen/src/discover-flags.ts
+++ b/packages/codegen/src/discover-flags.ts
@@ -10,14 +10,14 @@ import type { FlagsIR } from "./ir";
 /** The only file a feature-flag provider may be declared in — mirrors `lunora/queues.ts`. */
 const FLAGS_FILENAME = "flags.ts";
 
-/** The four typed flag reads `ctx.flags.&lt;type>(…)` / `ctx.flags.details.&lt;type>(…)` expose. */
+/** The four typed flag reads `ctx.flags.<type>(…)` / `ctx.flags.details.<type>(…)` expose. */
 const FLAG_TYPES = new Set(["boolean", "number", "object", "string"]);
 
-/** One statically-discovered flag read: the key plus the value type its `ctx.flags.&lt;type>` call implies. */
+/** One statically-discovered flag read: the key plus the value type its `ctx.flags.<type>` call implies. */
 interface FlagKey {
-    /** The flag key — the first (string-literal) argument of the `ctx.flags.&lt;type>(…)` read. */
+    /** The flag key — the first (string-literal) argument of the `ctx.flags.<type>(…)` read. */
     key: string;
-    /** The value type, derived from which `ctx.flags.&lt;type>` method read it. */
+    /** The value type, derived from which `ctx.flags.<type>` method read it. */
     type: "boolean" | "number" | "object" | "string";
 }
 
@@ -169,7 +169,7 @@ const discoverFlags = (project: Project, lunoraDirectory: string): FlagsIR | und
 const isContextIdentifier = (node: TsNode): boolean => Node.isIdentifier(node) && node.getText() === "ctx";
 
 /**
- * Decide whether `access` is a `ctx.flags.&lt;type>` or `ctx.flags.details.&lt;type>`
+ * Decide whether `access` is a `ctx.flags.<type>` or `ctx.flags.details.<type>`
  * property access and, if so, return the value type. Anchored on a literal `ctx`
  * identifier (the destructured `const { flags } = ctx` form isn't matched — like
  * the studio nav probe, a bare `flags.boolean(...)` is too ambiguous to claim).
@@ -209,7 +209,7 @@ const flagTypeFromAccess = (access: PropertyAccessExpression): FlagKey["type"] |
 
 /**
  * Statically discover every feature flag the app's `lunora/` handlers read, by
- * scanning for `ctx.flags.&lt;type>("key", …)` (and `ctx.flags.details.&lt;type>(…)`)
+ * scanning for `ctx.flags.<type>("key", …)` (and `ctx.flags.details.<type>(…)`)
  * calls whose first argument is a string literal. Powers the studio's read-only
  * Flags page (`__lunora_admin__:listFlags`) and the generated `evaluateFlags`
  * override, which evaluates each discovered key through the configured provider.
@@ -219,7 +219,7 @@ const flagTypeFromAccess = (access: PropertyAccessExpression): FlagKey["type"] |
  * won't list it). Keys are de-duplicated (first read wins on a type clash) and
  * returned sorted by key for deterministic codegen output.
  */
-/** Extract the `{ key, type }` of a single `ctx.flags.&lt;type>("key", …)` read, or `undefined` when the call isn't one. */
+/** Extract the `{ key, type }` of a single `ctx.flags.<type>("key", …)` read, or `undefined` when the call isn't one. */
 const flagKeyFromCall = (call: CallExpression): FlagKey | undefined => {
     const callee = call.getExpression();
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -582,7 +582,7 @@ const expandObjectType = (type: Type, node: Node, handlerFilePath: string, depth
 /**
  * Structurally expand a return type that references a non-exported local type,
  * so the generated `FunctionReference` carries the real shape (`PostDoc[]` →
- * `{ _id: Id&lt;"posts"&gt;; … }[]`) instead of erasing to `unknown`. Reachable names
+ * `{ _id: Id<"posts">; … }[]`) instead of erasing to `unknown`. Reachable names
  * (`Id`, `Doc`, primitives, library types) are printed verbatim; anything we
  * can't faithfully reproduce — recursion, call/index signatures, exotic types —
  * returns `undefined` so the caller keeps the `unknown` fallback. The result is
@@ -613,7 +613,7 @@ const expandUnreachableType = (type: Type, node: Node, handlerFilePath: string, 
 
 /**
  * Render a handler's resolved return type via ts-morph's type checker. Unwraps
- * the outer `Promise&lt;…>` so the emitted `FunctionReference&lt;Kind, Args, Return>`
+ * the outer `Promise<…>` so the emitted `FunctionReference<Kind, Args, Return>`
  * matches what callers see post-await. Shared by the object-literal `query(...)`
  * path and the builder terminal (`c.query(...)`) path.
  *
@@ -991,7 +991,7 @@ const chainHasStep = (receiver: Node, method: string): boolean => {
 
 /**
  * True when the builder chain rooted at `receiver` carries a
- * `.&lt;method>(&lt;wrappedCallee>(...))` step — a `.&lt;method>(...)` whose first argument
+ * `.<method>(<wrappedCallee>(...))` step — a `.<method>(...)` whose first argument
  * is a call to `wrappedCallee` (e.g. `.use(mask(...))` or `.use(rls(...))`).
  */
 const chainUsesWrappedCall = (receiver: Node, method: string, wrappedCallee: string): boolean => {
@@ -1245,12 +1245,12 @@ const functionIrFromCall = (call: CallExpression, exportName: string, relativePa
 };
 
 /**
- * Lift `export default &lt;procedure>` into a `&lt;module>.default` registration,
+ * Lift `export default <procedure>` into a `<module>.default` registration,
  * matching Convex.
  *
  * Only named exports used to be walked, so a module whose sole registration was
  * a default export did not merely lose that entry — the whole module was absent
- * from `api.ts`, and the caller's error read "Property '&lt;module>' does not
+ * from `api.ts`, and the caller's error read "Property '<module>' does not
  * exist", pointing at a file that was entirely correct.
  *
  * `export = x` is CJS and never a Lunora registration. Non-procedure defaults

--- a/packages/codegen/src/discover-geo-index-usages.ts
+++ b/packages/codegen/src/discover-geo-index-usages.ts
@@ -7,7 +7,7 @@ import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions"
 /**
  * True for a `.withGeoIndex(name, build)` call — the geo-query read entry point
  * on a table reader (`ctx.db.query("t").withGeoIndex(...)` /
- * `ctx.db.&lt;table>.withGeoIndex(...)`). `withGeoIndex` is a Lunora-only reader
+ * `ctx.db.<table>.withGeoIndex(...)`). `withGeoIndex` is a Lunora-only reader
  * method, so matching the callee name alone is unambiguous (mirrors how
  * `discover-queries` keys off the `.query`/`.withIndex` chain method names).
  */

--- a/packages/codegen/src/discover-http-action-guards.ts
+++ b/packages/codegen/src/discover-http-action-guards.ts
@@ -5,7 +5,7 @@ import { enclosingExportName } from "./argument-taint";
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { HttpActionGuardIR } from "./ir";
 
-/** The `httpRoute.&lt;verb>(...)` factory verbs — the root of a typed-REST-route builder chain. */
+/** The `httpRoute.<verb>(...)` factory verbs — the root of a typed-REST-route builder chain. */
 const HTTP_VERBS = new Set(["delete", "get", "head", "options", "patch", "post", "put"]);
 
 /** The terminal steps that close a `httpRoute` builder chain into a mountable handler. */
@@ -14,7 +14,7 @@ const TERMINAL_STEPS = new Set(["handler", "stream"]);
 /** `ctx.run*` forwarders that perform a write through the owning shard — a side effect from the HTTP edge. */
 const RUN_SIDE_EFFECTS = new Set(["runAction", "runMutation"]);
 
-/** `ctx.db.&lt;method>` mutating writes. (`insertManyUnsafe` bypasses per-row validation.) */
+/** `ctx.db.<method>` mutating writes. (`insertManyUnsafe` bypasses per-row validation.) */
 const DB_WRITE_METHODS = new Set(["delete", "insert", "insertManyUnsafe", "patch", "replace"]);
 
 /** A function whose body we can inspect — an inline arrow or function expression handler. */
@@ -32,7 +32,7 @@ const inlineHandler = (argument: TsNode | undefined): InspectableHandler | undef
  * `undefined` when it can't be resolved (so the caller skips — fail-safe under-report).
  *
  * A raw `httpAction((ctx, request) => …)` binds `ctx` as the first positional parameter; a destructured first parameter (`({ auth }) => …`) is not resolved.
- * A typed `httpRoute.&lt;verb>(…).handler(({ ctx, body }) => …)` receives one options object, so the `ctx` binding is its destructured `ctx` element (honoring an alias `{ ctx: c }`); a non-destructured options parameter is not resolved.
+ * A typed `httpRoute.<verb>(…).handler(({ ctx, body }) => …)` receives one options object, so the `ctx` binding is its destructured `ctx` element (honoring an alias `{ ctx: c }`); a non-destructured options parameter is not resolved.
  */
 const contextBinding = (handler: InspectableHandler, isHttpAction: boolean): string | undefined => {
     const parameter = handler.getParameters()[0];
@@ -67,7 +67,7 @@ const contextBinding = (handler: InspectableHandler, isHttpAction: boolean): str
 
 /**
  * The first side-effecting call in `handler` reached through the `ctx` binding —
- * a `ctx.runMutation` / `ctx.runAction` forward, or a `ctx.db.&lt;write>` mutation —
+ * a `ctx.runMutation` / `ctx.runAction` forward, or a `ctx.db.<write>` mutation —
  * as a stable label (`runMutation`, `db.insert`, …), or `undefined` when the
  * handler only reads. Descendants are walked in document order, so the earliest
  * side effect is reported deterministically.
@@ -144,7 +144,7 @@ const readsContextAuth = (handler: InspectableHandler, contextName: string): boo
     return false;
 };
 
-/** The uppercased `httpRoute.&lt;verb>` this `.handler(...)` / `.stream(...)` terminal roots at, or `undefined` when it isn't a Lunora REST route. */
+/** The uppercased `httpRoute.<verb>` this `.handler(...)` / `.stream(...)` terminal roots at, or `undefined` when it isn't a Lunora REST route. */
 const httpRouteVerbOfTerminal = (terminalCall: CallExpression): string | undefined => {
     const terminalCallee = terminalCall.getExpression();
 

--- a/packages/codegen/src/discover-http-routes.ts
+++ b/packages/codegen/src/discover-http-routes.ts
@@ -11,7 +11,7 @@ import { parseObjectShape, parseValidator } from "./parse-validator";
 const TS_EXTENSION_RE = /\.ts$/u;
 
 /**
- * The `httpRoute.&lt;verb>(...)` factory verbs. Each opens a fresh typed-route
+ * The `httpRoute.<verb>(...)` factory verbs. Each opens a fresh typed-route
  * builder; the verb is the HTTP method (uppercased) the route binds to.
  */
 const HTTP_VERBS = new Set(["delete", "get", "head", "options", "patch", "post", "put"]);
@@ -34,7 +34,7 @@ interface RouteChainState {
 }
 
 /**
- * Read the first string-literal argument of a `httpRoute.&lt;verb>(path)` call.
+ * Read the first string-literal argument of a `httpRoute.<verb>(path)` call.
  * A non-literal path (a computed expression) can't be rendered into the OpenAPI
  * document, so it returns `undefined` and the route is skipped.
  */
@@ -56,7 +56,7 @@ const readMapArgument = (call: CallExpression): Record<string, ValidatorIR> => {
 };
 
 /**
- * Resolve the receiver chain's root `httpRoute.&lt;verb>(path)` segment, returning
+ * Resolve the receiver chain's root `httpRoute.<verb>(path)` segment, returning
  * the method + path, or `undefined` when the chain doesn't bottom out in a
  * `httpRoute` verb factory (so it isn't a Lunora REST route).
  */
@@ -91,9 +91,9 @@ const readRootVerb = (node: TsNode): { method: string; path: string } | undefine
 };
 
 /**
- * Walk a `httpRoute.&lt;verb>("/p").searchParams({...}).body({...}).output(v).handler(fn)`
+ * Walk a `httpRoute.<verb>("/p").searchParams({...}).body({...}).output(v).handler(fn)`
  * chain leftward from the terminal call, merging the input maps and recording
- * `.output()`, until it reaches the `httpRoute.&lt;verb>(path)` root. Mirrors
+ * `.output()`, until it reaches the `httpRoute.<verb>(path)` root. Mirrors
  * `discover-functions`' `argsFromBuilderChain`: chains read terminal → root, so a
  * key set by a later (encountered-first) `.body()` wins over an earlier one —
  * matching the runtime's `{ ...state.body, ...validators }` spread.
@@ -160,7 +160,7 @@ const walkRouteChain = (terminalCall: CallExpression, terminalStep: string): Rou
 /**
  * Render the SSE chunk type of a `.stream(handler)` terminal — the `R` the
  * handler yields. The handler is the terminal call's only argument; its
- * `AsyncGenerator&lt;R, …>` / `AsyncIterable&lt;R>` return type is unwrapped by
+ * `AsyncGenerator<R, …>` / `AsyncIterable<R>` return type is unwrapped by
  * `unwrapHandlerReturn` (shared with function discovery), so the same
  * degraded-checker fallbacks apply. `"unknown"` when the argument isn't an
  * inline function expression (e.g. a hoisted identifier).
@@ -242,7 +242,7 @@ const discoverFileRoutes = (source: SourceFile, relativePath: string): HttpRoute
 
 /**
  * Scan all `.ts` files under `lunoraDir` (skipping `_generated/` and `schema.ts`)
- * for `export const x = httpRoute.&lt;verb>(...)…handler(...)` typed REST routes.
+ * for `export const x = httpRoute.<verb>(...)…handler(...)` typed REST routes.
  * These are the headline OpenAPI target: each becomes a real `paths` entry.
  */
 const discoverHttpRoutes = (project: Project, lunoraDirectory: string): HttpRouteIR[] => {

--- a/packages/codegen/src/discover-identity-claim-reads.ts
+++ b/packages/codegen/src/discover-identity-claim-reads.ts
@@ -77,7 +77,7 @@ const resolveDeclaredClaims = (project: Project, lunoraDirectory: string): Set<s
 /**
  * When `node` is a `.identity` property access sitting on an identity receiver
  * (`auth` / `ctx.auth` / `context.auth`), return it — the intermediate access a
- * claim read (`auth.identity.&lt;key>`) or bracket read (`auth.identity["&lt;key>"]`)
+ * claim read (`auth.identity.<key>`) or bracket read (`auth.identity["<key>"]`)
  * is built on. Otherwise `undefined`.
  */
 const identityBagAccess = (node: TsNode | undefined): TsNode | undefined => {
@@ -88,7 +88,7 @@ const identityBagAccess = (node: TsNode | undefined): TsNode | undefined => {
     return IDENTITY_RECEIVERS.has(node.getExpression().getText()) ? node : undefined;
 };
 
-/** The claim key a node reads off the identity bag — a `.identity.&lt;key>` property name, or a `.identity["&lt;key>"]` string-literal index. `undefined` when the node is neither. */
+/** The claim key a node reads off the identity bag — a `.identity.<key>` property name, or a `.identity["<key>"]` string-literal index. `undefined` when the node is neither. */
 const claimKeyRead = (node: TsNode): string | undefined => {
     if (Node.isPropertyAccessExpression(node) && identityBagAccess(node.getExpression()) !== undefined) {
         return node.getName();
@@ -103,7 +103,7 @@ const claimKeyRead = (node: TsNode): string | undefined => {
     return undefined;
 };
 
-/** Every `auth.identity.&lt;key>` / `ctx.auth.identity.&lt;key>` claim read in one source file, tagged with whether the key is in the declared allow-list. */
+/** Every `auth.identity.<key>` / `ctx.auth.identity.<key>` claim read in one source file, tagged with whether the key is in the declared allow-list. */
 const claimReadsInSourceFile = (sourceFile: SourceFile, relativePath: string, declared: Set<string>): IdentityClaimReadIR[] => {
     const found: IdentityClaimReadIR[] = [];
 
@@ -127,7 +127,7 @@ const claimReadsInSourceFile = (sourceFile: SourceFile, relativePath: string, de
 };
 
 /**
- * Discover `ctx.auth.identity.&lt;key>` / `auth.identity.&lt;key>` claim reads in
+ * Discover `ctx.auth.identity.<key>` / `auth.identity.<key>` claim reads in
  * `lunora/` — the `identity_undeclared_claim_trusted` lint input. `defineIdentity`
  * validates only its *declared* claims at the trust boundary and forwards
  * undeclared claims verbatim, so an authorization decision that reads a claim
@@ -139,7 +139,7 @@ const claimReadsInSourceFile = (sourceFile: SourceFile, relativePath: string, de
  * returns `[]`, so a project with no typed identity contract is never flagged.
  * Each read is tagged `declared` (in the contract, or the always-present
  * `userId`) so the lint flags only the undeclared reads. Deliberately narrow:
- * only the direct `&lt;receiver>.identity.&lt;key>` member/bracket chains are tracked
+ * only the direct `<receiver>.identity.<key>` member/bracket chains are tracked
  * (not a `const bag = auth.identity; bag.x` hop or a `getIdentity()` result), to
  * keep the false-positive rate low.
  */

--- a/packages/codegen/src/discover-kv-key-accesses.ts
+++ b/packages/codegen/src/discover-kv-key-accesses.ts
@@ -12,7 +12,7 @@ import type { KvKeyAccessIR } from "./ir";
 const KV_KEY_METHODS = new Set(["delete", "get", "getRaw", "getWithMetadata", "put"]);
 
 /**
- * Discover `ctx.kv.&lt;method>(key, …)` calls in `lunora/` whose key is derived from
+ * Discover `ctx.kv.<method>(key, …)` calls in `lunora/` whose key is derived from
  * the handler's `args` with no server-side scoping — the `kv_unscoped_user_key_idor`
  * lint input. Workers KV is a single flat namespace, so a key taken straight from
  * request input lets any caller read, overwrite, or delete another user's entry

--- a/packages/codegen/src/discover-mail-recipient-accesses.ts
+++ b/packages/codegen/src/discover-mail-recipient-accesses.ts
@@ -12,7 +12,7 @@ const MAIL_METHODS = new Set(["queue", "send"]);
 const RECIPIENT_FIELDS = new Set(["bcc", "cc", "to"]);
 
 /**
- * The `ctx.mail`/`ctx.email` `&lt;method>` invoked by `node`, or `undefined` when
+ * The `ctx.mail`/`ctx.email` `<method>` invoked by `node`, or `undefined` when
  * `node` is not a mailer send/queue call. Matched by shape (a property access
  * whose name is `send`/`queue` and whose receiver text is exactly `ctx.mail` or
  * `ctx.email`) — the same `import`-agnostic, fail-closed convention the other
@@ -37,7 +37,7 @@ const mailRecipientMethod = (node: TsNode): string | undefined => {
 /**
  * True when the options object literal `argument` carries a `to`/`cc`/`bcc`
  * recipient property whose value is derived from the handler's `args` with no
- * server-side scoping — inspecting both `to: &lt;expr>` assignments and `{ to }`
+ * server-side scoping — inspecting both `to: <expr>` assignments and `{ to }`
  * shorthand (which references a same-named binding, followed one `const` hop).
  * Only a direct object-literal argument is inspected; a non-literal
  * (spread/variable) options argument is skipped, fail-closed.
@@ -65,7 +65,7 @@ const hasUnscopedArgumentDerivedRecipient = (argument: TsNode): boolean => {
     });
 };
 
-/** The IR row for a `ctx.mail.&lt;method>({ to/cc/bcc, … })` call with an arg-derived, unscoped recipient, or `undefined`. */
+/** The IR row for a `ctx.mail.<method>({ to/cc/bcc, … })` call with an arg-derived, unscoped recipient, or `undefined`. */
 const mailAccessInCall = (call: CallExpression, relativePath: string): MailRecipientAccessIR | undefined => {
     const method = mailRecipientMethod(call.getExpression());
 

--- a/packages/codegen/src/discover-mask-procedures.ts
+++ b/packages/codegen/src/discover-mask-procedures.ts
@@ -138,7 +138,7 @@ const READ_METHODS = new Set(["findFirst", "findFirstOrThrow", "findMany", "get"
 /** Write-access call sites: `ctx.db.insert/patch/replace/delete` (masking never touches these — captured only for completeness). */
 const WRITE_METHODS = new Set(["delete", "insert", "patch", "replace"]);
 
-/** True when `call` is a `ctx.db.&lt;method>(...)` or bare `db.&lt;method>(...)` call against `methodSet`. */
+/** True when `call` is a `ctx.db.<method>(...)` or bare `db.<method>(...)` call against `methodSet`. */
 const isDatabaseCall = (call: CallExpression, methodSet: Set<string>): boolean => {
     const callee = call.getExpression();
 
@@ -155,7 +155,7 @@ const isDatabaseCall = (call: CallExpression, methodSet: Set<string>): boolean =
     return Node.isIdentifier(receiver) && receiver.getText() === "db";
 };
 
-/** String-literal first argument of a `ctx.db.&lt;method>("table", ...)` call, or `""` when the argument is not a string literal (dynamic table — not lintable). */
+/** String-literal first argument of a `ctx.db.<method>("table", ...)` call, or `""` when the argument is not a string literal (dynamic table — not lintable). */
 const tableArgumentOf = (call: CallExpression): string => {
     const argument = call.getArguments()[0];
 

--- a/packages/codegen/src/discover-mutators.ts
+++ b/packages/codegen/src/discover-mutators.ts
@@ -107,7 +107,7 @@ const mutatorLiteral = (call: CallExpression): ObjectLiteralExpression | undefin
 
 /**
  * The mutator's `args` validator map, parsed with the same `parseObjectShape` a
- * procedure's `args` goes through so `api.mutators.&lt;name>` and `api.&lt;file>.&lt;fn>`
+ * procedure's `args` goes through so `api.mutators.<name>` and `api.<file>.<fn>`
  * can never render a validator differently. `{}` when `args` is absent (a
  * parameterless mutator) or isn't an inline object literal.
  */
@@ -124,8 +124,8 @@ const argsFromMutator = (literal: ObjectLiteralExpression | undefined): Record<s
 };
 
 /**
- * The authoritative `server` impl's return type, `Promise&lt;…>` unwrapped — the
- * `Return` of the emitted `api.mutators.&lt;name>` reference, so `ctx.runMutation`
+ * The authoritative `server` impl's return type, `Promise<…>` unwrapped — the
+ * `Return` of the emitted `api.mutators.<name>` reference, so `ctx.runMutation`
  * on it (and a `useMutation` over it) resolves the real result instead of
  * `unknown`. `"unknown"` when `server` isn't an inline function.
  */
@@ -190,7 +190,7 @@ const mutatorsFromSource = (source: SourceFile): MutatorIR[] => {
  * Discover every custom mutator the project declares: exported
  * `defineMutator()` calls in `lunora/mutators.ts`. Returns `[]` when the file
  * doesn't exist. The export binding plus the declared `args` / `server` return
- * type are lifted — enough to emit a typed `api.mutators.&lt;name>` reference —
+ * type are lifted — enough to emit a typed `api.mutators.<name>` reference —
  * while the runtime object still carries the authoritative `server` impl +
  * `handler`, so codegen never evaluates the body. The client `client` impl is
  * split into the browser bundle separately.

--- a/packages/codegen/src/discover-normalize-id-authorization.ts
+++ b/packages/codegen/src/discover-normalize-id-authorization.ts
@@ -52,7 +52,7 @@ const OWNERSHIP_IDENTIFIER_NAMES = new Set<string>([
 /** `ctx` sub-namespaces whose read implies the handler consults the caller's identity. */
 const IDENTITY_ACCESSORS = new Set<string>(["auth", "identity", "session", "user"]);
 
-/** Equality operators — an equality check against a loaded row's property (`row.ownerId !== viewer.id`) is an ownership comparison; range operators (`&lt;`/`&gt;`) almost never are, so they are excluded to avoid suppressing on an unrelated `arr.length &gt; 0`. */
+/** Equality operators — an equality check against a loaded row's property (`row.ownerId !== viewer.id`) is an ownership comparison; range operators (`<`/`>`) almost never are, so they are excluded to avoid suppressing on an unrelated `arr.length > 0`. */
 const EQUALITY_OPERATORS = new Set<SyntaxKind>([
     SyntaxKind.EqualsEqualsEqualsToken,
     SyntaxKind.EqualsEqualsToken,
@@ -125,7 +125,7 @@ const hasNullGate = (handler: InspectableHandler, name: string): boolean =>
 
 /**
  * The id-first `ctx.db` sink method (`get`/`patch`/`delete`) the handler applies to
- * `name` as its first argument (`ctx.db.get(id)` / `ctx.db.&lt;table>.patch(id, …)`), or
+ * `name` as its first argument (`ctx.db.get(id)` / `ctx.db.<table>.patch(id, …)`), or
  * `undefined` when the normalized id never reaches such a sink.
  */
 const idSinkMethod = (handler: InspectableHandler, name: string): NormalizeIdAuthorizationIR["sinkMethod"] | undefined => {

--- a/packages/codegen/src/discover-notify.ts
+++ b/packages/codegen/src/discover-notify.ts
@@ -10,10 +10,10 @@ import { classifyProcedureCall, listLunoraSourceFiles, lunoraRelativePath } from
 /** The only file a `@lunora/notify` provider may be declared in — mirrors `lunora/flags.ts`. */
 const NOTIFY_FILENAME = "notify.ts";
 
-/** `ctx.notify.&lt;method>` sends the `notify_send_outside_action` lint records (single-channel + multi-channel senders). */
+/** `ctx.notify.<method>` sends the `notify_send_outside_action` lint records (single-channel + multi-channel senders). */
 const NOTIFY_SEND_METHODS = new Set(["chat", "inApp", "send", "webhook"]);
 
-/** `ctx.push.&lt;method>` sends the lint records — the two device-push delivery calls (register/list/unregister are store ops, not sends). */
+/** `ctx.push.<method>` sends the lint records — the two device-push delivery calls (register/list/unregister are store ops, not sends). */
 const PUSH_SEND_METHODS = new Set(["broadcast", "send"]);
 
 /**

--- a/packages/codegen/src/discover-owner-field-writes.ts
+++ b/packages/codegen/src/discover-owner-field-writes.ts
@@ -37,7 +37,7 @@ const IDENTITY_FIELDS = new Set<string>([
 const IDENTITY_WRITE_METHODS = new Set<string>(["insert", "insertManyUnsafe", "patch", "replace"]);
 
 /**
- * When `node` is a `ctx.db.&lt;method>` member access for one of the
+ * When `node` is a `ctx.db.<method>` member access for one of the
  * {@link IDENTITY_WRITE_METHODS}, return the method name; otherwise `undefined`.
  * Matched by shape (a member chain rooted at `ctx.db`), the same import-agnostic,
  * fail-closed convention the other feeders use, so a re-export or alias still resolves.

--- a/packages/codegen/src/discover-privileged-dispatches.ts
+++ b/packages/codegen/src/discover-privileged-dispatches.ts
@@ -17,7 +17,7 @@ const HANDLER_FACTORIES = new Set(["defineQueue", "defineWorkflow"]);
 /** The dispatch methods on the handler's context param that call back into a Lunora function. */
 const DISPATCH_METHODS = new Set(["run", "runAction", "runMutation", "runQuery"]);
 
-/** The `FunctionReference` root namespaces codegen emits (`api.&lt;file>.&lt;export>` / `internal.&lt;file>.&lt;export>`). */
+/** The `FunctionReference` root namespaces codegen emits (`api.<file>.<export>` / `internal.<file>.<export>`). */
 const REFERENCE_ROOTS = new Set(["api", "internal"]);
 
 type HandlerFunction = ArrowFunction | FunctionExpression;
@@ -134,9 +134,9 @@ const declaredNames = (declaration: TsNode): string[] => {
 };
 
 /**
- * The payload access-path prefixes for a queue handler — `&lt;batch>.messages`
- * (the batch param at index 1) plus `&lt;message>.body` for each `message`
- * bound by a `for (… of &lt;batch>.messages)` loop. Empty when the handler
+ * The payload access-path prefixes for a queue handler — `<batch>.messages`
+ * (the batch param at index 1) plus `<message>.body` for each `message`
+ * bound by a `for (… of <batch>.messages)` loop. Empty when the handler
  * declares no batch parameter.
  */
 const queuePayloadPrefixes = (handler: HandlerFunction): string[] => {
@@ -167,9 +167,9 @@ const queuePayloadPrefixes = (handler: HandlerFunction): string[] => {
 /**
  * Collect the payload access paths and locally-bound payload names for one
  * handler. The *payload* is the untrusted external input a privileged handler
- * receives — `&lt;context>.params` for a workflow (set by the mutation/action
+ * receives — `<context>.params` for a workflow (set by the mutation/action
  * that called `.create({ params })`, which may embed `args.*`), or a
- * `&lt;message>.body` for a queue (see {@link queuePayloadPrefixes}).
+ * `<message>.body` for a queue (see {@link queuePayloadPrefixes}).
  *
  * A `const` (or destructuring) whose initializer is already payload-derived
  * contributes its bound name(s), so `const { channelId } = context.params; …
@@ -211,8 +211,8 @@ const argumentsReferencePayload = (argsNode: TsNode, payload: { names: Set<strin
 };
 
 /**
- * Resolve a `FunctionReference` argument (`api.&lt;file>.&lt;export>` /
- * `internal.&lt;dir>.&lt;file>.&lt;export>`) to its `{ file, exportName }`, or
+ * Resolve a `FunctionReference` argument (`api.<file>.<export>` /
+ * `internal.<dir>.<file>.<export>`) to its `{ file, exportName }`, or
  * `undefined` when the target is not a static `api`/`internal` member chain
  * (a variable or computed target can't be joined to RLS evidence, so it is
  * skipped fail-closed).

--- a/packages/codegen/src/discover-procedure-middleware.ts
+++ b/packages/codegen/src/discover-procedure-middleware.ts
@@ -263,14 +263,14 @@ const isUserTableInsert = (call: CallExpression): boolean => {
 /** Method names that dispatch privileged, billable async work (fan-out surfaces). */
 const FANOUT_METHODS = new Set(["create", "runAfter", "runAt", "send", "sendBatch"]);
 
-/** `ctx.&lt;surface>` accessors those fan-out methods dispatch through. */
+/** `ctx.<surface>` accessors those fan-out methods dispatch through. */
 const FANOUT_SURFACES = new Set(["queues", "scheduler", "workflows"]);
 
 /**
  * True when `call` is a privileged fan-out dispatch — a {@link FANOUT_METHODS}
  * call whose receiver chain roots at `ctx.scheduler` / `ctx.queues` /
- * `ctx.workflows` (`ctx.scheduler.runAfter(...)`, `ctx.queues.&lt;name>.send(...)`,
- * `ctx.workflows.&lt;name>.create(...)`). Anchoring to the `ctx.&lt;surface>` root — not
+ * `ctx.workflows` (`ctx.scheduler.runAfter(...)`, `ctx.queues.<name>.send(...)`,
+ * `ctx.workflows.<name>.create(...)`). Anchoring to the `ctx.<surface>` root — not
  * just the method name — keeps generic `.create`/`.send` calls on unrelated
  * objects from matching.
  */
@@ -364,7 +364,7 @@ const MAIL_MEMBERS: ReadonlySet<string> = new Set(["email", "mail"]);
 /** `ctx.*` members that reach the outside world and can therefore fail in ways worth catching. */
 const OUTBOUND_MEMBERS: ReadonlySet<string> = new Set(["ai", "browser", "fetch", "mail", "notify", "queues", "sql", "storage", "workflows"]);
 
-/** True when any `ctx.&lt;member>` in `declaration` is one of `members`. */
+/** True when any `ctx.<member>` in `declaration` is one of `members`. */
 const referencesContextMember = (declaration: TsNode, members: ReadonlySet<string>): boolean =>
     declaration.getDescendantsOfKind(SyntaxKind.PropertyAccessExpression).some((access) => {
         if (!members.has(access.getName())) {
@@ -503,7 +503,7 @@ const isCatchGuarded = (call: CallExpression): boolean => {
 };
 
 /**
- * Resolve `access` (a `ctx.&lt;member>` property access) to the call expression it
+ * Resolve `access` (a `ctx.<member>` property access) to the call expression it
  * is directly invoked through — `ctx.fetch(...)` resolves `ctx.fetch` itself;
  * `ctx.mail.send(...)` resolves `ctx.mail` by walking the fluent chain one more
  * property-access hop. Returns `undefined` when `access` is referenced without
@@ -526,7 +526,7 @@ const outboundCallSite = (access: TsNode): CallExpression | undefined => {
 
 /**
  * Per-outbound-call-site error-handling facts: `reachesOutbound` is `true` when
- * `declaration` invokes at least one `ctx.&lt;OUTBOUND_MEMBERS>` surface;
+ * `declaration` invokes at least one `ctx.<OUTBOUND_MEMBERS>` surface;
  * `handlesErrors` is `true` only when EVERY such call site is guarded — wrapped in
  * a `try` within the same function, or the receiver of a `.catch(...)`.
  *

--- a/packages/codegen/src/discover-raw-row-returns.ts
+++ b/packages/codegen/src/discover-raw-row-returns.ts
@@ -19,7 +19,7 @@ const ROW_READ_METHODS = new Set(["findFirst", "findFirstOrThrow", "findMany", "
 
 /**
  * The table a direct `ctx.db` row read addresses, or `undefined` when `call` isn't
- * one. Facade form `ctx.db.&lt;table>.findMany(...)` puts the table in the receiver's
+ * one. Facade form `ctx.db.<table>.findMany(...)` puts the table in the receiver's
  * property name; table-arg form `ctx.db.findMany("table", ...)` puts it in the
  * string-literal argument 0. `""` when the table-arg form's first argument isn't a
  * string literal (a dynamic table — not lintable).

--- a/packages/codegen/src/discover-relation-loads.ts
+++ b/packages/codegen/src/discover-relation-loads.ts
@@ -17,7 +17,7 @@ const READ_METHODS = new Set(["findFirst", "findFirstOrThrow", "findMany"]);
  * The `(table, options)` a `ctx.db` list read addresses, or `undefined` when the
  * call isn't one. Matched by receiver **shape** (not import origin), fail-closed,
  * in both surface forms Lunora exposes. Facade form
- * `ctx.db.&lt;table>.findMany(options?)` — the form real app code writes — puts the
+ * `ctx.db.<table>.findMany(options?)` — the form real app code writes — puts the
  * table in the receiver's property name and the options object at argument 0.
  * Table-arg form `ctx.db.findMany("table", options?)` puts the table in the
  * string-literal argument 0 and the options object at argument 1. `table` is `""`
@@ -137,7 +137,7 @@ const relationLoadsInDeclaration = (declaration: TsNode, relativePath: string): 
 };
 
 /**
- * Discover `ctx.db.&lt;table>.findMany({ with: { &lt;rel> } })` relation-hydrating
+ * Discover `ctx.db.<table>.findMany({ with: { <rel> } })` relation-hydrating
  * list reads under the lunora source directory — the `masked_relation_leak_via_with`
  * lint input. Column masking is applied per-procedure to the top-level rows of
  * the table named in the read; it does **not** descend into `with`-hydrated

--- a/packages/codegen/src/discover-rls-procedures.ts
+++ b/packages/codegen/src/discover-rls-procedures.ts
@@ -144,7 +144,7 @@ const READ_METHODS = new Set(["findFirst", "findFirstOrThrow", "findMany", "get"
  */
 const WRITE_METHODS = new Set(["delete", "deleteMany", "insert", "insertMany", "patch", "patchMany", "replace"]);
 
-/** True when `call` is a `ctx.db.&lt;method>(...)` or bare `db.&lt;method>(...)` call. */
+/** True when `call` is a `ctx.db.<method>(...)` or bare `db.<method>(...)` call. */
 const isDatabaseCall = (call: CallExpression, methodSet: Set<string>): boolean => {
     const callee = call.getExpression();
 
@@ -162,7 +162,7 @@ const isDatabaseCall = (call: CallExpression, methodSet: Set<string>): boolean =
 };
 
 /**
- * String-literal first argument of a `ctx.db.&lt;method>("table", ...)` call, or
+ * String-literal first argument of a `ctx.db.<method>("table", ...)` call, or
  * `""` when the argument is not a string literal (dynamic table — not lintable).
  */
 const tableArgumentOf = (call: CallExpression): string => {

--- a/packages/codegen/src/discover-schema.ts
+++ b/packages/codegen/src/discover-schema.ts
@@ -26,7 +26,7 @@ const ON_DELETE_ACTIONS = new Set(["cascade", "restrict", "set null"]);
 /**
  * Table names that collide with members of `ctx.db` (the typed reader/writer the
  * generated `_generated/server.ts` widens with the per-table facade). A table so
- * named would shadow the corresponding `ctx.db.&lt;member>` and silently corrupt
+ * named would shadow the corresponding `ctx.db.<member>` and silently corrupt
  * the emitted type, so codegen rejects it up front with a clear diagnostic.
  */
 const RESERVED_TABLE_NAMES = new Set(["delete", "get", "insert", "normalizeId", "patch", "query", "replace", "system"]);
@@ -673,7 +673,7 @@ const FTS5_SHADOW_SUFFIXES = ["__vocab", "_config", "_content", "_data", "_docsi
  * Reject two search indexes on one table whose generated FTS5 table names
  * collide through a shadow-table suffix.
  *
- * `ftsTableName` renders `&lt;table>__fts_&lt;indexName>`, so `search_prompts` and
+ * `ftsTableName` renders `<table>__fts_<indexName>`, so `search_prompts` and
  * `search_prompts_content` on the same table produce `prompts__fts_search_prompts`
  * and `prompts__fts_search_prompts_content` — and the FIRST index already
  * reserved the second name as its own `_content` shadow. Creating the second
@@ -1260,7 +1260,7 @@ const extendCallsOf = (defineSchemaCall: CallExpression): CallExpression[] => {
 };
 
 /**
- * Walk the builder chain wrapping `defineSchemaCall` for a `.&lt;methodName>("literal")`
+ * Walk the builder chain wrapping `defineSchemaCall` for a `.<methodName>("literal")`
  * link and return its validated string-literal argument, or `undefined` when the
  * method is absent from the chain (found regardless of where it sits, e.g.
  * `defineSchema(...).rls("required").jurisdiction("us").extend(...)`). Shared by
@@ -1397,7 +1397,7 @@ const applyExtensions = (defineSchemaCall: CallExpression, tables: TableIR[], pr
 };
 
 /**
- * Load `&lt;projectRoot>/lunora/schema.ts`, find `defineSchema({...})`, and
+ * Load `<projectRoot>/lunora/schema.ts`, find `defineSchema({...})`, and
  * return a structural IR. Throws if the file or call cannot be found.
  */
 const discoverSchema = (project: Project, schemaPath: string, projectRoot?: string): SchemaIR => {

--- a/packages/codegen/src/discover-shapes.ts
+++ b/packages/codegen/src/discover-shapes.ts
@@ -112,7 +112,7 @@ const tableLiteralFrom = (call: CallExpression): string | undefined => {
 /**
  * Read the `args` validator map from a `defineShape({ args: { … } })` config, so
  * `_generated/collections.ts` can type a shape's partition selector instead of
- * widening it to `Record&lt;string, unknown>`. Returns `{}` for a parameterless shape
+ * widening it to `Record<string, unknown>`. Returns `{}` for a parameterless shape
  * (or one whose `args` isn't a plain object literal — the runtime object stays
  * authoritative either way).
  */

--- a/packages/codegen/src/discover-soft-delete-reads.ts
+++ b/packages/codegen/src/discover-soft-delete-reads.ts
@@ -18,7 +18,7 @@ const READ_METHODS = new Set(["findFirst", "findFirstOrThrow", "findMany"]);
  * The `(table, options)` a `ctx.db` list read addresses, or `undefined` when the
  * call isn't one. Matched by receiver **shape** (not import origin), fail-closed,
  * in both surface forms Lunora exposes. Facade form
- * `ctx.db.&lt;table>.findMany(options?)` — the form real app code writes — puts the
+ * `ctx.db.<table>.findMany(options?)` — the form real app code writes — puts the
  * table in the receiver's property name and the options object at argument 0.
  * Table-arg form `ctx.db.findMany("table", options?)` puts the table in the
  * string-literal argument 0 and the options object at argument 1. `table` is `""`
@@ -125,7 +125,7 @@ const softDeleteReadsInDeclaration = (declaration: TsNode, relativePath: string)
 };
 
 /**
- * Discover `ctx.db.&lt;table>.findMany({ includeDeleted })` list reads under the
+ * Discover `ctx.db.<table>.findMany({ includeDeleted })` list reads under the
  * lunora source directory whose `includeDeleted` is either a hardcoded `true` or
  * derived from the handler's `args` — the `soft_delete_include_deleted_from_args`
  * lint input. The lint joins each row's `table` against the schema's

--- a/packages/codegen/src/discover-sql-interpolation.ts
+++ b/packages/codegen/src/discover-sql-interpolation.ts
@@ -40,7 +40,7 @@ const isContextSqlTextCallee = (node: TsNode): boolean => {
  */
 const isStringBuildingText = (expression: TsNode): boolean => Node.isBinaryExpression(expression) || Node.isTemplateExpression(expression);
 
-/** The export name of the nearest exported `const x = …` ancestor, or `"&lt;module>"` when at file scope. */
+/** The export name of the nearest exported `const x = …` ancestor, or `"<module>"` when at file scope. */
 const enclosingExportName = (node: TsNode): string => {
     const declaration = node.getFirstAncestorByKind(SyntaxKind.VariableDeclaration);
 

--- a/packages/codegen/src/discover-storage-key-accesses.ts
+++ b/packages/codegen/src/discover-storage-key-accesses.ts
@@ -4,7 +4,7 @@ import { discoverArgumentDerivedAccesses } from "./discover-argument-derived-acc
 import type { FunctionIR, StorageKeyAccessIR } from "./ir";
 
 /**
- * The `ctx.storage.&lt;bucket>.&lt;method>(...)` bucket methods whose first argument is a
+ * The `ctx.storage.<bucket>.<method>(...)` bucket methods whose first argument is a
  * per-object R2 key — the IDOR sinks. Confirmed against `@lunora/storage`'s
  * `Storage` surface (the read/write/URL/multipart methods that take `key` as
  * arg[0]), plus the raw R2 verbs (`get`/`put`/`head`) a re-export may surface.
@@ -30,7 +30,7 @@ const KEY_TAKING_METHODS = new Set<string>([
 ]);
 
 /**
- * Discover `ctx.storage.&lt;bucket>.&lt;method>(key, …)` calls in `lunora/` whose object
+ * Discover `ctx.storage.<bucket>.<method>(key, …)` calls in `lunora/` whose object
  * key is derived from the handler's `args` with no server-side scoping — the
  * `storage_key_from_user_args` lint input. An R2 key taken straight from request
  * input lets any caller read, overwrite, or delete another user's object

--- a/packages/codegen/src/discover-storage-uploads.ts
+++ b/packages/codegen/src/discover-storage-uploads.ts
@@ -6,7 +6,7 @@ import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions"
 import type { StorageUploadIR } from "./ir";
 
 /**
- * `ctx.storage.&lt;bucket>.&lt;method>` calls this feeder inspects, mapped to the
+ * `ctx.storage.<bucket>.<method>` calls this feeder inspects, mapped to the
  * 0-based index of their options-object argument. Confirmed against the
  * `Storage` surface in `@lunora/storage`: `upload`/`store` take
  * `(key, body, options?: UploadOptions)`; `generateUploadUrl`/`getPresignedUrl`/
@@ -79,9 +79,9 @@ const readOptionsArgument = (argument: TsNode | undefined): StorageUploadEvidenc
 
 /**
  * The tracked method name + its options-argument index when `node` is a
- * `ctx.storage.&lt;bucket>.&lt;method>` member access, else `undefined`. Matched by
+ * `ctx.storage.<bucket>.<method>` member access, else `undefined`. Matched by
  * shape (a property access whose name is a tracked method and whose receiver
- * text is `ctx.storage` or `ctx.storage.&lt;bucket>`) — the same `import`-agnostic,
+ * text is `ctx.storage` or `ctx.storage.<bucket>`) — the same `import`-agnostic,
  * fail-closed convention the other feeders use, so a re-export or alias still
  * resolves.
  */
@@ -102,7 +102,7 @@ const storageUploadMethod = (node: TsNode): { method: string; optionsIndex: numb
     return receiver === "ctx.storage" || receiver.startsWith("ctx.storage.") ? { method, optionsIndex } : undefined;
 };
 
-/** The IR row for a tracked `ctx.storage.&lt;bucket>.&lt;method>(...)` call, or `undefined`. */
+/** The IR row for a tracked `ctx.storage.<bucket>.<method>(...)` call, or `undefined`. */
 const storageUploadInCall = (call: CallExpression, relativePath: string): StorageUploadIR | undefined => {
     const matched = storageUploadMethod(call.getExpression());
 
@@ -135,7 +135,7 @@ const storageUploadsInSourceFile = (sourceFile: SourceFile, relativePath: string
 };
 
 /**
- * Discover `ctx.storage.&lt;bucket>.&lt;method>(...)` upload/signing calls in
+ * Discover `ctx.storage.<bucket>.<method>(...)` upload/signing calls in
  * `lunora/` — the shared input for the storage config-hygiene security lints
  * (`storage_upload_without_content_type_allowlist`, `storage_upload_without_max_size`,
  * `storage_generate_upload_url_no_content_type_pin`, `storage_presigned_url_for_private_content`).

--- a/packages/codegen/src/discover-unrestricted-where-branches.ts
+++ b/packages/codegen/src/discover-unrestricted-where-branches.ts
@@ -172,7 +172,7 @@ const returnedExpressions = (predicate: PredicateFunction): TsNode[] => {
     return found;
 };
 
-/** Resolve the enclosing exported binding name for a node, or `"&lt;anonymous>"`. */
+/** Resolve the enclosing exported binding name for a node, or `"<anonymous>"`. */
 const enclosingExport = (node: TsNode): string => {
     for (const declaration of node.getAncestors()) {
         if (Node.isVariableDeclaration(declaration)) {

--- a/packages/codegen/src/discover-vector-namespace-accesses.ts
+++ b/packages/codegen/src/discover-vector-namespace-accesses.ts
@@ -18,7 +18,7 @@ import type { VectorNamespaceAccessIR } from "./ir";
 const VECTOR_NAMESPACE_METHODS = new Set(["query", "upsert", "upsertMany"]);
 
 /**
- * The `ctx.vectors.&lt;method>` namespace-taking method invoked by `node`, or
+ * The `ctx.vectors.<method>` namespace-taking method invoked by `node`, or
  * `undefined` when `node` is not a `ctx.vectors` call. Matched by shape (a
  * property access whose name is a namespace-taking method and whose receiver
  * text is exactly `ctx.vectors`) — the same `import`-agnostic, fail-closed
@@ -54,7 +54,7 @@ const namespaceInitializer = (input: TsNode): TsNode | undefined => {
     return property && Node.isPropertyAssignment(property) ? property.getInitializer() : undefined;
 };
 
-/** The IR row for a `ctx.vectors.&lt;method>(indexName, input)` call whose `input.namespace` is arg-derived and unscoped, or `undefined`. */
+/** The IR row for a `ctx.vectors.<method>(indexName, input)` call whose `input.namespace` is arg-derived and unscoped, or `undefined`. */
 const vectorNamespaceAccessInCall = (call: CallExpression, relativePath: string): VectorNamespaceAccessIR | undefined => {
     const method = vectorsNamespaceMethod(call.getExpression());
 
@@ -96,7 +96,7 @@ const vectorNamespaceAccessesInSourceFile = (sourceFile: SourceFile, relativePat
 };
 
 /**
- * Discover `ctx.vectors.&lt;method>(indexName, input)` calls in `lunora/` whose
+ * Discover `ctx.vectors.<method>(indexName, input)` calls in `lunora/` whose
  * `input.namespace` is derived from the handler's `args` with no server-side
  * scoping — the `vectors_namespace_from_user_input` lint input. A Vectorize
  * namespace partitions one index into isolated sub-collections, so a namespace

--- a/packages/codegen/src/discover-workflows.ts
+++ b/packages/codegen/src/discover-workflows.ts
@@ -136,7 +136,7 @@ const stepsFromHandler = (argument: ObjectLiteralExpression): WorkflowStepIR[] =
  * `ctx.step.*` calls statically, and a value assembled across modules or by a
  * function call cannot be read at all. Those still fail loudly — silently
  * registering a workflow whose declared `name` we could not see would make
- * `ctx.workflows.get("&lt;name>")` throw at runtime with nothing pointing here.
+ * `ctx.workflows.get("<name>")` throw at runtime with nothing pointing here.
  */
 /** Strip `as` / `satisfies` / parenthesized wrappers from an expression. */
 const unwrapTypeWrappers = (node: Node | undefined): Node | undefined => {

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -63,7 +63,7 @@ interface EmitAppOptions {
      * Voice-enabled agents (`defineAgent({ voice: … })`) → wire
      * `options.voiceAgents`, mapping each agent's export name to its `VOICE_*`
      * Durable Object namespace binding so the runtime exposes
-     * `/_lunora/voice/&lt;exportName>`. Empty/absent ⇒ no wiring, byte-identical
+     * `/_lunora/voice/<exportName>`. Empty/absent ⇒ no wiring, byte-identical
      * output for voice-free (and agent-free) projects.
      */
     voiceAgents?: ReadonlyArray<{ bindingName: string; exportName: string }>;
@@ -84,13 +84,13 @@ interface EmitAppOptions {
  * Derived from the single {@link APP_METHOD_CAPABILITIES} table (so it can't
  * drift from the usage probe / ctx-field seam) into the `[flag, methodName,
  * configKey, doc]` shape the emitters below consume — the flag is the capability
- * key's `has&lt;Capitalized>` option (`ai` → `hasAi`, `payments` → `hasPayments`).
+ * key's `has<Capitalized>` option (`ai` → `hasAi`, `payments` → `hasPayments`).
  */
 
 /**
- * The capability key's `has&lt;Capitalized>` option name (`ai` → `hasAi`, `payments`
+ * The capability key's `has<Capitalized>` option name (`ai` → `hasAi`, `payments`
  * → `hasPayments`). The internal `as` is a narrow, provably-correct cast — the
- * runtime string equals the `has${Capitalize&lt;K>}` template; string methods just
+ * runtime string equals the `has${Capitalize<K>}` template; string methods just
  * don't preserve the literal type. Correctness of the *flag* (that it names a real
  * `EmitAppOptions` key) is enforced at {@link LONG_TAIL}'s type annotation below,
  * not here — so a capability whose flag is missing from `EmitAppOptions` is a

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -268,8 +268,8 @@ const renderArgsType = (args: Record<string, ValidatorIR>): string => {
 const isOptionalOnInsert = (validator: ValidatorIR): boolean => validator.kind === "optional" || Boolean(validator.column?.hasDefault);
 
 /**
- * Render an `Insert_&lt;table>` interface: the document shape as accepted by
- * `ctx.db.&lt;table>.insert(...)`. System fields (`_id`, `_creationTime`) are
+ * Render an `Insert_<table>` interface: the document shape as accepted by
+ * `ctx.db.<table>.insert(...)`. System fields (`_id`, `_creationTime`) are
  * always optional (minted by the runtime); user fields follow
  * {@link isOptionalOnInsert}.
  */
@@ -298,7 +298,7 @@ const renderInsertInterface = (table: TableIR): string => {
  */
 const SCHEMA_MODULE_PATH = "schema";
 
-/** Emit `_generated/dataModel.ts` — `Doc&lt;"name">` + `Id&lt;"name">` for every table. */
+/** Emit `_generated/dataModel.ts` — `Doc<"name">` + `Id<"name">` for every table. */
 const emitDataModel = (schema: SchemaIR): string => {
     for (const table of schema.tables) {
         assertIdentifier(table.name, "table name");
@@ -654,10 +654,10 @@ const rebaseRelativeQualifiers = (rendered: string, filePath: string): string =>
 const UMBRELLA_BASE_PACKAGES = ["client", "do", "errors", "flags", "observability", "platform", "ratelimit", "runtime", "server", "values"] as const;
 
 /**
- * An `import("@lunora/&lt;base>")` qualifier the type checker rendered into a
+ * An `import("@lunora/<base>")` qualifier the type checker rendered into a
  * function's args/return type — e.g. a mutator whose `server` impl returns
- * `ctx.db.insert(...)`'s `Id&lt;"messages">` from a file that never imports `Id`, so
- * ts-morph fully qualifies it as `import("@lunora/values").Id&lt;"messages">`.
+ * `ctx.db.insert(...)`'s `Id<"messages">` from a file that never imports `Id`, so
+ * ts-morph fully qualifies it as `import("@lunora/values").Id<"messages">`.
  *
  * Only the BASE packages the `lunorash` umbrella re-exports are listed
  * (derived from {@link UMBRELLA_BASE_PACKAGES}, not hand-maintained — this
@@ -673,8 +673,8 @@ const UMBRELLA_QUALIFIER_RE = new RegExp(String.raw`import\("@lunora/(?<pkg>${UM
 
 /**
  * Deep-subpath forwarding is only safe for a package whose umbrella subpaths
- * mirror its own subpath exports 1:1 (the umbrella re-exports `&lt;pkg>/&lt;sub>`
- * for every `&lt;sub>` the package itself exports) — true for every one of the
+ * mirror its own subpath exports 1:1 (the umbrella re-exports `<pkg>/<sub>`
+ * for every `<sub>` the package itself exports) — true for every one of the
  * five ORIGINAL base packages (`client`'s `/query|/auth|/pagination|/ssr|/upload`,
  * `server`'s `/types|/drizzle|/data-model|/rls/testing|/otel`; `do`, `runtime`,
  * `values` have no subpaths at all). Two of the five newly-covered packages
@@ -809,10 +809,10 @@ const renderApiBody = (functions: ReadonlyArray<FunctionIR>): string => {
  * import line + the type/value) — the typed `workflows.*` and/or `agents.*`
  * reference objects, whichever the project declares.
  *
- * Each `lunora/workflows.ts` export becomes a `workflows.&lt;name>` reference
+ * Each `lunora/workflows.ts` export becomes a `workflows.<name>` reference
  * carrying its `WORKFLOW_*` binding and — via the definition's phantom
  * `__params` — its `params` type, so a `cronJobs()` registration that targets it
- * infers the args. Each `lunora/agents.ts` export becomes an `agents.&lt;name>`
+ * infers the args. Each `lunora/agents.ts` export becomes an `agents.<name>`
  * reference carrying its `AGENT_*` binding (an agent compiles onto a Cloudflare
  * Workflow, so it IS a workflow reference structurally) typed with the flat
  * `AgentRunInput`, so `crons.daily("sweep", …, agents.support, { input,
@@ -1134,7 +1134,7 @@ const syntheticAgentApiFunctions = (agents: ReadonlyArray<AgentIR>, functions: R
 
 /**
  * Synthetic `FunctionIR` entries for the project's custom mutators, so
- * `api.mutators.&lt;name>` exists as a typed reference and a client
+ * `api.mutators.<name>` exists as a typed reference and a client
  * `defineMutator({ serverRef: api.mutators.insertSibling })` binds the dispatch
  * path at COMPILE time — a rename, a typo, or a moved file becomes a type error
  * instead of a push that fails at runtime — while inferring its `args` from the
@@ -1171,7 +1171,7 @@ const syntheticMutatorApiFunctions = (mutators: ReadonlyArray<MutatorIR>, functi
 
 /**
  * Render the `httpStreams.*` typed-reference block for `_generated/api.ts` —
- * one entry per `httpRoute.&lt;verb>(path).stream()` SSE route, grouped by source
+ * one entry per `httpRoute.<verb>(path).stream()` SSE route, grouped by source
  * file the way `api.*` is. Each reference carries the verb + path at runtime
  * (what the client needs to open the endpoint) and the chunk / searchParams /
  * params types via `HttpStreamRef`'s phantom parameter, so
@@ -1361,19 +1361,19 @@ export const createSeedClient = (options?: SeedClientOptions): SeedClient<Insert
  *
  * Each shape emits **two** entry points.
  *
- * `&lt;shape>CollectionOptions(options)` is the composable form: it returns the full
+ * `<shape>CollectionOptions(options)` is the composable form: it returns the full
  * `LunoraCollectionOptions` — `config` for `createCollection`, plus `checkpoints`
  * (which `bindMutators` gates optimistic overlays on) and `scope`. This is what an app
  * with custom mutators needs, and what the old single-factory form made impossible: it
  * built the collection internally and dropped `checkpoints` on the floor, so there was
  * no way to wire mutators to the collection codegen produced.
  *
- * `&lt;shape>Collection(options)` is the convenience form for a read-only collection: it
+ * `<shape>Collection(options)` is the convenience form for a read-only collection: it
  * returns `{ checkpoints, collection, scope }` rather than a bare `Collection`, so the
  * sync controls stay reachable even from the short path.
  *
  * Both are typed: `args` comes from the shape's own validators (a parameterless
- * shape takes none), rows resolve to `Doc&lt;"table">` when the shape names its table
+ * shape takes none), rows resolve to `Doc<"table">` when the shape names its table
  * with a literal, and `shardKey` / `getKey` / `load` / `onError` / `checkpoints` are
  * all threadable — a sharded table needs `shardKey` for its watermark to land in the
  * right bucket, and a server-minted `_id` that differs from the app's natural key
@@ -1636,7 +1636,7 @@ const renderFunctionRegistry = (
  * set of functions, both grouped by namespace. The caller surfaces **every**
  * registered function — public *and* internal — because server-to-server calls
  * legitimately reach internal functions (mirroring `ctx.run*`). Each leaf is
- * `(args) => Promise&lt;Return>`; `args` is optional only when the function takes
+ * `(args) => Promise<Return>`; `args` is optional only when the function takes
  * none. The runtime leaves dispatch through `callRegistered`, which infers the
  * return type from the interface's contextual type.
  */
@@ -3050,7 +3050,7 @@ const emitAccessFragments = (hasAccessFacade: boolean): HelperFragments => {
 /**
  * The studio + reactive feature-flag fragments woven into the generated ShardDO,
  * or empty strings when the project wires no flags:
- * - `constant`: `LUNORA_FLAG_KEYS`, the statically-discovered `ctx.flags.&lt;type>` reads (key + value type) the overrides iterate.
+ * - `constant`: `LUNORA_FLAG_KEYS`, the statically-discovered `ctx.flags.<type>` reads (key + value type) the overrides iterate.
  * - `evaluateOverride`: the `evaluateFlags()` override backing `__lunora_admin__:listFlags` — evaluates every discovered key under the studio's editable targeting context and returns full `EvaluationDetails`.
  * - `subscriptionOverride`: the reactive override backing the React client's `useFlag`/`useFlags` over the reserved `__lunora_flags__:` channel — evaluates one flag under the socket's own verified identity.
  *
@@ -4032,7 +4032,7 @@ interface EmitShardOptions {
     containers?: ReadonlyArray<ContainerIR>;
     /** The single `defineEnv(...)` contract declared in `lunora/env.ts` — applies the accessor to the worker `env` to populate `ctx.env`. */
     env?: EnvIR;
-    /** Statically-discovered `ctx.flags.&lt;type>("key")` reads — the studio Flags page + reactive evaluation iterate these. */
+    /** Statically-discovered `ctx.flags.<type>("key")` reads — the studio Flags page + reactive evaluation iterate these. */
     flagKeys?: ReadonlyArray<{ key: string; type: "boolean" | "number" | "object" | "string" }>;
     /** A `lunora/` source reads `ctx.access` — wires the verified Cloudflare Access facade onto every ctx. */
     hasAccessFacade?: boolean;
@@ -5619,7 +5619,7 @@ interface DrizzleColumn {
     mode?: "bigint" | "boolean" | "buffer" | "json";
     /** Tracks whether the column should carry `.notNull()`. */
     notNull: boolean;
-    /** `.$type&lt;…>()` annotation rendered after the constructor. */
+    /** `.$type<…>()` annotation rendered after the constructor. */
     typeAnnotation?: string;
 }
 
@@ -5794,13 +5794,13 @@ interface DrizzleImports {
     indexes: string[];
     /** True when any column emits a `.references()` FK, which is return-annotated. */
     needsAnyColumn: boolean;
-    /** True when any `.$type&lt;…>()` annotation spells an `Id&lt;"table">`. */
+    /** True when any `.$type<…>()` annotation spells an `Id<"table">`. */
     needsId: boolean;
 }
 
 /**
- * `.$type&lt;…>()` inlines the rendered TS type, and `validatorToType` spells a
- * nested `v.id()` as `Id&lt;"table">` — so a `v.object` / `v.union` column
+ * `.$type<…>()` inlines the rendered TS type, and `validatorToType` spells a
+ * nested `v.id()` as `Id<"table">` — so a `v.object` / `v.union` column
  * carrying an id makes the file reference `Id` even though no column is an id
  * at the top level.
  */

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -283,7 +283,7 @@ export interface FunctionIR {
     /**
      * Set by the `.expose({ rest: true })` builder modifier (plan 167). When
      * `rest` is `true` the function is published on the public REST surface, so the
-     * OpenAPI emitter describes it as a real `/_lunora/rest/&lt;namespace>/&lt;fn>` path
+     * OpenAPI emitter describes it as a real `/_lunora/rest/<namespace>/<fn>` path
      * (the single source of truth the runtime router also derives from). Absent →
      * RPC-only (the default; not on the REST surface).
      *
@@ -293,7 +293,7 @@ export interface FunctionIR {
      * computed value is simply absent (the spec under-documents rather than lies).
      */
     expose?: { cache?: ExposeCacheIR; rest?: boolean };
-    /** Path relative to `&lt;projectRoot>/lunora/` without extension, e.g. "messages". */
+    /** Path relative to `<projectRoot>/lunora/` without extension, e.g. "messages". */
     filePath: string;
     kind: "action" | "mutation" | "query" | "stream";
 
@@ -317,7 +317,7 @@ export interface FunctionIR {
     output?: ValidatorIR;
 
     /**
-     * Serialized TS source for the handler's return type, with `Promise&lt;T>`
+     * Serialized TS source for the handler's return type, with `Promise<T>`
      * unwrapped so callers see `T` directly. Defaults to `"unknown"` when
      * ts-morph cannot resolve the type (typically because the consuming
      * project lacks a tsconfig that can reach `@lunora/server`).
@@ -341,7 +341,7 @@ export interface FunctionIR {
 export interface MigrationIR {
     /** Export binding name, used to reference the module member in generated imports. */
     exportName: string;
-    /** Path relative to `&lt;projectRoot>/lunora/` without extension, e.g. "migrations". */
+    /** Path relative to `<projectRoot>/lunora/` without extension, e.g. "migrations". */
     filePath: string;
     /** Stable migration id — the registry key and per-shard run-state key. */
     id: string;
@@ -361,12 +361,12 @@ export interface ShapeIR {
     /**
      * The shape's `args` validator map — its partition selector. Lifted so
      * `_generated/collections.ts` can type the selector a caller passes instead of
-     * widening it to `Record&lt;string, unknown>`. `{}` for a parameterless shape.
+     * widening it to `Record<string, unknown>`. `{}` for a parameterless shape.
      */
     args: Record<string, ValidatorIR>;
     /** Export binding name — the shape's registry key and import member. */
     exportName: string;
-    /** Path relative to `&lt;projectRoot>/lunora/` without extension — always `"shapes"`. */
+    /** Path relative to `<projectRoot>/lunora/` without extension — always `"shapes"`. */
     filePath: string;
 
     /**
@@ -416,19 +416,19 @@ export interface EnvIR {
 export interface MutatorIR {
     /**
      * The mutator's `args` validator map, parsed exactly as a procedure's is, so
-     * the emitted `api.mutators.&lt;name>` reference carries the arg type a client
+     * the emitted `api.mutators.<name>` reference carries the arg type a client
      * `defineMutator` infers instead of restating. `{}` for a parameterless
      * mutator (or one whose `args` isn't an inline object literal).
      */
     args: Record<string, ValidatorIR>;
     /** Export binding name — the mutator's registry key and import member. */
     exportName: string;
-    /** Path relative to `&lt;projectRoot>/lunora/` without extension — always `"mutators"`. */
+    /** Path relative to `<projectRoot>/lunora/` without extension — always `"mutators"`. */
     filePath: string;
 
     /**
      * Serialized TS source for the authoritative `server` impl's return type,
-     * `Promise&lt;T>` unwrapped. `"unknown"` when ts-morph can't resolve it — same
+     * `Promise<T>` unwrapped. `"unknown"` when ts-morph can't resolve it — same
      * contract as {@link FunctionIR.returnType}.
      */
     returnType: string;
@@ -708,7 +708,7 @@ export interface FlagsIR {
 export interface WorkflowCallIR {
     /** Export binding name of the function performing the call, e.g. `create`. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension (the api namespace). */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension (the api namespace). */
     file: string;
     /** 1-based line of the `get(...)` call. */
     line: number;
@@ -725,7 +725,7 @@ export interface WorkflowCallIR {
 export interface QueryReadIR {
     /** Exported procedure the read sits in, or `""` at module scope. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
 
     /**
@@ -746,7 +746,7 @@ export interface QueryReadIR {
 }
 
 /**
- * A `ctx.authApi.&lt;method>(...)` call discovered in a function body, attributed
+ * A `ctx.authApi.<method>(...)` call discovered in a function body, attributed
  * to the exported function (and its file = api namespace) that performs it.
  * Structurally identical to `AdvisorAuthApiCall` so it passes straight through
  * to the advisor lint without conversion, exactly as `InsertWriteIR` does for
@@ -755,7 +755,7 @@ export interface QueryReadIR {
 export interface AuthApiCallIR {
     /** Export binding name of the function performing the call, e.g. "createOrg". */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** True when the call's argument object includes a `headers` property. */
     hasHeaders: boolean;
@@ -775,7 +775,7 @@ export interface AuthApiCallIR {
 export interface InsertWriteIR {
     /** Export binding name of the function performing the insert, e.g. "send". */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension (the api namespace). */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension (the api namespace). */
     file: string;
     /** 1-based line of the `insert(...)` call. */
     line: number;
@@ -797,7 +797,7 @@ export interface NondeterministicCallIR {
     callee: string;
     /** Export binding name of the function performing the call, e.g. `sendMessage`. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension (the api namespace). */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension (the api namespace). */
     file: string;
     /** Which procedure kind the call lives in — only `query`/`mutation` handlers are recorded. */
     kind: "mutation" | "query";
@@ -836,7 +836,7 @@ export interface R2sqlCallIR {
 export interface RlsProcedureIR {
     /** Export binding name of the procedure (e.g. `listDocuments`). */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
 
     /**
@@ -864,7 +864,7 @@ export interface RlsProcedureIR {
 export interface MaskProcedureIR {
     /** Export binding name of the procedure (e.g. `listUsers`). */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
 
     /**
@@ -926,9 +926,9 @@ export interface MaskMetadataIR {
 export interface MaskStrategyIR {
     /** Masked column name. */
     column: string;
-    /** Export binding name of the procedure whose `.use(mask(...))` chain declared this column, or `"&lt;module>"` when declared at file scope. */
+    /** Export binding name of the procedure whose `.use(mask(...))` chain declared this column, or `"<module>"` when declared at file scope. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the masked column's strategy property. */
     line: number;
@@ -1009,7 +1009,7 @@ export interface StorageRulesMetadataIR {
 }
 
 /**
- * A typed REST route declared with the `httpRoute.&lt;verb>("/path")…` builder in
+ * A typed REST route declared with the `httpRoute.<verb>("/path")…` builder in
  * `@lunora/server` and mounted on `httpRouter()`. Captured statically from the
  * builder chain so the OpenAPI emitter can render a real `paths` entry: the verb
  * + path become the operation's method + URL, and the accumulated validator maps
@@ -1024,13 +1024,13 @@ export interface HttpRouteIR {
      * handler yields — inferred from the handler via the type checker. Present
      * only when {@link HttpRouteIR.stream} is `true`; `"unknown"` when the
      * checker can't resolve enough context. Feeds the emitted
-     * `HttpStreamRef&lt;Chunk, …>` so the chunk type flows to the client.
+     * `HttpStreamRef<Chunk, …>` so the chunk type flows to the client.
      * @experimental Part of the HTTP-SSE stream surface (the `httpStreams.*` emission).
      */
     chunkType?: string;
     /** Export binding name of the route handler (used only for diagnostics / dedupe). */
     exportName: string;
-    /** Path relative to `&lt;projectRoot>/lunora/` without extension, e.g. "http". */
+    /** Path relative to `<projectRoot>/lunora/` without extension, e.g. "http". */
     filePath: string;
     /** HTTP verb the route binds to (uppercased), e.g. `"GET"`. */
     method: string;
@@ -1038,7 +1038,7 @@ export interface HttpRouteIR {
     output?: ValidatorIR;
     /** `v.*` validators decoding the hono path params (`.params({...})`), keyed by `:name`. */
     params: Record<string, ValidatorIR>;
-    /** The route path passed to `httpRoute.&lt;verb>(path)`, e.g. `/api/todos/:id`. */
+    /** The route path passed to `httpRoute.<verb>(path)`, e.g. `/api/todos/:id`. */
     path: string;
     /** `v.*` validators decoding the URL query string (`.searchParams({...})`), keyed by name. */
     searchParams: Record<string, ValidatorIR>;
@@ -1081,7 +1081,7 @@ export interface ProcedureMiddlewareIR {
     /** `true` when the handler fans work out to a privileged, cost-bearing dispatch surface (scheduler `runAfter`/`runAt`, a queue producer send, or a workflow create). Feeds the privileged-fanout lint. `undefined` when `analyzableBody` is `false`. */
     fanOut?: boolean;
 
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** `true` when the handler wraps work in `try`/`catch`. */
     handlesErrors?: boolean;
@@ -1137,7 +1137,7 @@ export interface ArgumentValidatorIR {
     anyArgs: string[];
     /** Export binding name of the procedure (e.g. `updateProfile`). */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the registration call, or `0` when unknown. */
     line: number;
@@ -1157,7 +1157,7 @@ export interface ConfigCallIR {
     analyzable: boolean;
     /** The factory function or constructor name at the call site, e.g. `createPayment` / `RateLimiter`. */
     callee: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the call site, or `0` when unknown. */
     line: number;
@@ -1174,7 +1174,7 @@ export interface ConfigCallIR {
  * Structurally identical to `AdvisorSecretLiteral`.
  */
 export interface SecretLiteralIR {
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** Heuristic that matched, e.g. `stripe_live_key` / `aws_access_key` / `pem_private_key` / `high_entropy`. */
     kind: string;
@@ -1196,7 +1196,7 @@ export interface SecretLiteralIR {
 export interface SqlInterpolationIR {
     /** Export binding name of the procedure performing the `ctx.sql` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the interpolation, or `0` when unknown. */
     line: number;
@@ -1214,14 +1214,14 @@ export interface SqlInterpolationIR {
 export interface ArgumentDerivedFetchIR {
     /** Export binding name of the action performing the `ctx.fetch` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.fetch` call, or `0` when unknown. */
     line: number;
 }
 
 /**
- * One `ctx.kv.&lt;method>(key, …)` call whose namespace key is derived from the
+ * One `ctx.kv.<method>(key, …)` call whose namespace key is derived from the
  * handler's `args` with no server-side scoping — the `kv_unscoped_user_key_idor`
  * lint input. Workers KV is a single flat namespace, so a key taken straight from
  * request input lets any caller read, overwrite, or delete another user's entry
@@ -1233,7 +1233,7 @@ export interface ArgumentDerivedFetchIR {
 export interface KvKeyAccessIR {
     /** Export binding name of the procedure performing the `ctx.kv` access. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.kv` call, or `0` when unknown. */
     line: number;
@@ -1262,7 +1262,7 @@ export interface KvKeyAccessIR {
 export interface UnrestrictedWhereBranchIR {
     /** Export binding name of the shape / policy the predicate belongs to. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** Which unrestricted form was returned. */
     form: "empty-object" | "undefined";
@@ -1279,7 +1279,7 @@ export interface OwnerFieldWriteIR {
     exportName: string;
     /** The identity column being written from `args` (e.g. `userId`). */
     field: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.db` write call, or `0` when unknown. */
     line: number;
@@ -1297,7 +1297,7 @@ export interface OwnerFieldWriteIR {
 }
 
 /**
- * One `ctx.storage.&lt;bucket>.&lt;method>(key, …)` call whose R2 object key is derived
+ * One `ctx.storage.<bucket>.<method>(key, …)` call whose R2 object key is derived
  * from the handler's `args` with no server-side scoping — the
  * `storage_key_from_user_args` lint input. The bucket read/write/URL/delete methods
  * key by their first argument, so an object key taken straight from request input is
@@ -1309,7 +1309,7 @@ export interface OwnerFieldWriteIR {
 export interface StorageKeyAccessIR {
     /** Export binding name of the procedure performing the storage call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the storage call, or `0` when unknown. */
     line: number;
@@ -1327,7 +1327,7 @@ export interface StorageKeyAccessIR {
 }
 
 /**
- * One `ctx.containers.&lt;exportName>.get(name, …)` call whose instance key is derived
+ * One `ctx.containers.<exportName>.get(name, …)` call whose instance key is derived
  * from the handler's `args` with no server-side scoping — the
  * `container_instance_key_from_user_input` lint input. Each container definition's
  * `.get(name)` accessor routes to one instance per `name`, so a key taken straight from
@@ -1340,7 +1340,7 @@ export interface StorageKeyAccessIR {
 export interface ContainerKeyAccessIR {
     /** Export binding name of the procedure performing the `ctx.containers` access. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.containers.*.get` call, or `0` when unknown. */
     line: number;
@@ -1361,14 +1361,14 @@ export interface ContainerKeyAccessIR {
 export interface AiRawRunIR {
     /** Export binding name of the procedure performing the `ctx.ai.run` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.ai.run` call, or `0` when unknown. */
     line: number;
 }
 
 /**
- * One `ctx.vectors.&lt;method>(indexName, input)` call whose `input.namespace` is derived
+ * One `ctx.vectors.<method>(indexName, input)` call whose `input.namespace` is derived
  * from the handler's `args` with no server-side scoping — the
  * `vectors_namespace_from_user_input` lint input. A Vectorize namespace partitions one
  * index into isolated sub-collections, so a namespace taken straight from request input
@@ -1380,7 +1380,7 @@ export interface AiRawRunIR {
 export interface VectorNamespaceAccessIR {
     /** Export binding name of the procedure performing the `ctx.vectors` access. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.vectors` call, or `0` when unknown. */
     line: number;
@@ -1401,7 +1401,7 @@ export interface VectorNamespaceAccessIR {
 export interface MailRecipientAccessIR {
     /** Export binding name of the procedure performing the `ctx.mail`/`ctx.email` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.mail`/`ctx.email` call, or `0` when unknown. */
     line: number;
@@ -1410,7 +1410,7 @@ export interface MailRecipientAccessIR {
 }
 
 /**
- * One `ctx.browser.&lt;method>(url, …)` call whose navigation URL (`arguments[0]`)
+ * One `ctx.browser.<method>(url, …)` call whose navigation URL (`arguments[0]`)
  * is derived from the handler's `args` with no server-side scoping — the
  * `browser_user_url_without_allowlist` lint input. The lint additionally
  * cross-references `createBrowser` config-call evidence to suppress findings
@@ -1420,7 +1420,7 @@ export interface MailRecipientAccessIR {
 export interface BrowserUrlAccessIR {
     /** Export binding name of the procedure performing the `ctx.browser` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.browser` call, or `0` when unknown. */
     line: number;
@@ -1429,8 +1429,8 @@ export interface BrowserUrlAccessIR {
 }
 
 /**
- * One runtime container-override call: a `&lt;handle>.start({ enableInternet: true, … })`
- * launch override, or a `&lt;handle>.egress.&lt;method>(...)` runtime firewall mutation
+ * One runtime container-override call: a `<handle>.start({ enableInternet: true, … })`
+ * launch override, or a `<handle>.egress.<method>(...)` runtime firewall mutation
  * (`allow` / `deny` / `setAllowed`) — the `container_start_enable_internet_override`
  * and `container_runtime_egress_relaxation` lint input. Both shapes re-open network
  * access the static `defineContainer` declaration (and its `container_public_internet`
@@ -1442,7 +1442,7 @@ export interface ContainerOverrideIR {
     detail: string;
     /** Export binding name of the procedure performing the call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** Which override shape matched. */
     kind: "egress_relaxation" | "enable_internet";
@@ -1466,7 +1466,7 @@ export interface ContainerOverrideIR {
 export interface ImageDeliveryUrlAccessIR {
     /** Export binding name of the procedure performing the `buildImageDeliveryUrl` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `buildImageDeliveryUrl` call, or `0` when unknown. */
     line: number;
@@ -1493,7 +1493,7 @@ export interface AuthConfigIR {
     emailPasswordEnabled: boolean;
     /** Export binding name enclosing the `createAuth(...)` call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `createAuth(...)` call, or `0` when unknown. */
     line: number;
@@ -1527,7 +1527,7 @@ export interface RatelimitKeySelectorIR {
     callee: string;
     /** Export binding name of the procedure whose `.use(...)` chain carries the call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** The rate limit's `name` argument (the second positional argument), or `""` when not a string literal. */
     limitName: string;
@@ -1549,7 +1549,7 @@ export interface RatelimitKeySelectorIR {
 export interface PrivilegedDispatchIR {
     /** `"queue"` for a `defineQueue` handler, `"workflow"` for a `defineWorkflow` handler. */
     dispatchKind: "queue" | "workflow";
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** Export binding name of the handler performing the dispatch. */
     handlerExport: string;
@@ -1562,7 +1562,7 @@ export interface PrivilegedDispatchIR {
 }
 
 /**
- * One discovered `httpRoute.&lt;verb>("/admin/…")` route on an admin/privileged-looking
+ * One discovered `httpRoute.<verb>("/admin/…")` route on an admin/privileged-looking
  * path, with whether its builder chain references an auth/admin guard — the
  * `admin_route_without_guard` lint input. Structurally identical to
  * `AdvisorAdminRoute`.
@@ -1570,7 +1570,7 @@ export interface PrivilegedDispatchIR {
 export interface AdminRouteIR {
     /** Export binding name of the route handler. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** HTTP verb the route binds to (uppercased), e.g. `"POST"`. */
     method: string;
@@ -1581,7 +1581,7 @@ export interface AdminRouteIR {
 }
 
 /**
- * One tracked `ctx.storage.&lt;bucket>.&lt;method>(...)` upload/signing call — the
+ * One tracked `ctx.storage.<bucket>.<method>(...)` upload/signing call — the
  * shared input for the storage config-hygiene security lints
  * (`storage_upload_without_content_type_allowlist`, `storage_upload_without_max_size`,
  * `storage_generate_upload_url_no_content_type_pin`, `storage_presigned_url_for_private_content`).
@@ -1599,7 +1599,7 @@ export interface StorageUploadIR {
     expiresInSeconds?: number;
     /** Export binding name of the procedure performing the call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the call, or `0` when unknown. */
     line: number;
@@ -1621,9 +1621,9 @@ export interface StorageUploadIR {
  * `AdvisorHttpActionGuard`.
  */
 export interface HttpActionGuardIR {
-    /** Export binding name of the handler (or `"&lt;module>"` when mounted inline / not a named binding). */
+    /** Export binding name of the handler (or `"<module>"` when mounted inline / not a named binding). */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** Which HTTP surface the handler is: a raw `httpAction` or a typed `httpRoute` route. */
     kind: "httpAction" | "httpRoute";
@@ -1633,7 +1633,7 @@ export interface HttpActionGuardIR {
     method?: string;
     /** `true` when the handler reads `ctx.auth` (a direct member access or a `const { auth } = ctx` destructure). */
     readsAuth: boolean;
-    /** The first side effect found, as a stable label: `runMutation`, `runAction`, or `db.&lt;method>`. */
+    /** The first side effect found, as a stable label: `runMutation`, `runAction`, or `db.<method>`. */
     sideEffect: string;
 }
 
@@ -1652,9 +1652,9 @@ export interface HttpActionGuardIR {
  * identical to `AdvisorHttpHeaderWrite`.
  */
 export interface HttpHeaderWriteIR {
-    /** Export binding name of the enclosing handler, or `"&lt;module>"` when mounted inline. */
+    /** Export binding name of the enclosing handler, or `"<module>"` when mounted inline. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** The header name being written (`"location"`), or `""` when the key is not a string literal. */
     headerName: string;
@@ -1678,11 +1678,11 @@ export interface HttpHeaderWriteIR {
 export interface FailOpenGuardIR {
     /** The middleware factory at the call site: `rateLimit` / `dbRateLimit` / `verifyTurnstileMiddleware`. */
     callee: string;
-    /** Export binding name of the procedure the guard is attached to, or `"&lt;module>"` at file scope. */
+    /** Export binding name of the procedure the guard is attached to, or `"<module>"` at file scope. */
     exportName: string;
     /** `true` only when the options literal set `failOpen: true` as a boolean literal; a non-literal or absent option is treated as fail-closed. */
     failOpen: boolean;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** The rate-limit `name` (second string argument) for `rateLimit`/`dbRateLimit`; `""` for `verifyTurnstileMiddleware`. */
     limitName: string;
@@ -1693,7 +1693,7 @@ export interface FailOpenGuardIR {
 /* eslint-disable no-secrets/no-secrets -- the referenced advisor evidence type name in the doc comment, not a credential */
 
 /**
- * One `ctx.flags.boolean("key", &lt;boolean-literal>)` read in `lunora/` — the
+ * One `ctx.flags.boolean("key", <boolean-literal>)` read in `lunora/` — the
  * `flag_gates_security_with_unsafe_default` lint input. OpenFeature returns the
  * `defaultValue` when the provider errors, so a fail-open default on a
  * security-shaped key silently opens access during an outage. Only reads with a
@@ -1704,9 +1704,9 @@ export interface FailOpenGuardIR {
 export interface FlagSecurityDefaultIR {
     /** The boolean-literal default returned on a provider outage (fail-open value). */
     defaultValue: boolean;
-    /** Export binding name of the procedure performing the flag read, or `"&lt;module>"` at file scope. */
+    /** Export binding name of the procedure performing the flag read, or `"<module>"` at file scope. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** The flag key — the first string-literal argument of `ctx.flags.boolean`. */
     key: string;
@@ -1727,7 +1727,7 @@ export interface FlagSecurityDefaultIR {
 export interface AiToolSideEffectIR {
     /** Export binding name of the procedure performing the call. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the generation call, or `0` when unknown. */
     line: number;
@@ -1740,9 +1740,9 @@ export interface AiToolSideEffectIR {
 }
 
 /**
- * One `&lt;receiver>.identity.&lt;key>` claim read in `lunora/`, where `&lt;receiver>` is
+ * One `<receiver>.identity.<key>` claim read in `lunora/`, where `<receiver>` is
  * an RLS/mask policy `auth` (or `ctx.auth`/`context.auth`). `declared` records
- * whether `&lt;key>` is in the app's `defineIdentity({ ... })` contract (or the
+ * whether `<key>` is in the app's `defineIdentity({ ... })` contract (or the
  * always-present `userId`); the `identity_undeclared_claim_trusted` lint fires on
  * the undeclared reads. Emitted only when a resolvable identity contract exists.
  * Structurally identical to `AdvisorIdentityClaimRead`.
@@ -1750,9 +1750,9 @@ export interface AiToolSideEffectIR {
 export interface IdentityClaimReadIR {
     /** `true` when `key` is a declared claim (in the `defineIdentity` contract, or the always-present `userId`). */
     declared: boolean;
-    /** Export binding name of the enclosing declaration (`&lt;module>` at file scope). */
+    /** Export binding name of the enclosing declaration (`<module>` at file scope). */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** The claim key read off the identity bag. */
     key: string;
@@ -1771,9 +1771,9 @@ export interface IdentityClaimReadIR {
 export interface PaymentWebhookIR {
     /** The adapter factory invoked. */
     callee: "createAutumnAdapter" | "createDodoPaymentsAdapter" | "createPolarAdapter" | "createStripeAdapter";
-    /** Export binding name of the enclosing declaration (`&lt;module>` at file scope). */
+    /** Export binding name of the enclosing declaration (`<module>` at file scope). */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the construction, or `0` when unknown. */
     line: number;
@@ -1782,7 +1782,7 @@ export interface PaymentWebhookIR {
 }
 
 /**
- * One `ctx.db.&lt;table>.findMany({ includeDeleted })` list read whose
+ * One `ctx.db.<table>.findMany({ includeDeleted })` list read whose
  * `includeDeleted` is either a hardcoded `true` or derived from the handler's
  * `args` — the `soft_delete_include_deleted_from_args` lint input. The lint joins
  * `table` against the schema's soft-delete tables and `visibility` against
@@ -1792,7 +1792,7 @@ export interface PaymentWebhookIR {
 export interface SoftDeleteReadIR {
     /** Export binding name of the procedure performing the read. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** `true` when `includeDeleted` was derived from the handler's `args` (any caller can flip it). */
     fromArgs: boolean;
@@ -1807,7 +1807,7 @@ export interface SoftDeleteReadIR {
 }
 
 /**
- * One `ctx.db.&lt;table>.findMany({ with: { &lt;rel> } })` relation-hydrating list read
+ * One `ctx.db.<table>.findMany({ with: { <rel> } })` relation-hydrating list read
  * — the `masked_relation_leak_via_with` lint input. Column masking does not
  * descend into `with`-hydrated relations, so a masked table surfaced only through
  * a `with` on an unprotected parent read is returned in the clear. The lint
@@ -1818,7 +1818,7 @@ export interface SoftDeleteReadIR {
 export interface RelationLoadIR {
     /** Export binding name of the procedure performing the read. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the read call. */
     line: number;
@@ -1834,8 +1834,8 @@ export interface RelationLoadIR {
 
 /**
  * One `query` handler whose `return` hands back the raw rows of a table — the
- * result of a `ctx.db.&lt;table>.findMany()` / `.findFirst()` / `.get()` read, or a
- * `ctx.db.query("&lt;table>")…collect()` fluent chain — returned directly (or through
+ * result of a `ctx.db.<table>.findMany()` / `.findFirst()` / `.get()` read, or a
+ * `ctx.db.query("<table>")…collect()` fluent chain — returned directly (or through
  * one local `const` hop) with no hand-built projection. The
  * `output_projection_missing_on_public_read` lint keeps only `visibility ===
  * "public"` rows with no `.output(...)` / `.use(mask(...))` on the chain, then
@@ -1846,7 +1846,7 @@ export interface RelationLoadIR {
 export interface RawRowReturnIR {
     /** Export binding name of the query returning the raw rows. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `return` (or concise-body) expression. */
     line: number;
@@ -1878,7 +1878,7 @@ export interface RawRowReturnIR {
 export interface NormalizeIdAuthorizationIR {
     /** Export binding name of the procedure performing the normalize-then-access. */
     exportName: string;
-    /** Source file relative to `&lt;projectRoot>/lunora/`, without extension. */
+    /** Source file relative to `<projectRoot>/lunora/`, without extension. */
     file: string;
     /** 1-based line of the `ctx.db.normalizeId(...)` call the access is gated on. */
     line: number;
@@ -1919,7 +1919,7 @@ export interface WranglerVariableIR {
 export interface ProjectIR {
     crons: ReadonlyArray<CronJobIR>;
     functions: ReadonlyArray<FunctionIR>;
-    /** Typed REST routes discovered from `httpRoute.&lt;verb>(...)` builder chains. */
+    /** Typed REST routes discovered from `httpRoute.<verb>(...)` builder chains. */
     httpRoutes: ReadonlyArray<HttpRouteIR>;
     migrations: ReadonlyArray<MigrationIR>;
     schema: SchemaIR;

--- a/packages/codegen/src/openapi.ts
+++ b/packages/codegen/src/openapi.ts
@@ -123,7 +123,7 @@ const httpRouteOperation = (route: HttpRouteIR): Record<string, unknown> => {
  * Build the single RPC operation for one query/mutation/action. Every RPC call
  * is `POST /_lunora/rpc`; to list each function individually in Swagger UI (oRPC
  * pattern: one operation per procedure) we synthesise a distinct path suffix
- * `/_lunora/rpc#&lt;functionPath>` — the `#`-fragment is ignored by the transport
+ * `/_lunora/rpc#<functionPath>` — the `#`-fragment is ignored by the transport
  * (all still POST to `/_lunora/rpc`) but gives each operation a unique path key
  * so they render as separate entries. The requestBody pins `functionPath` to a
  * `const`, types `args` from the function's validators, and allows an optional
@@ -233,7 +233,7 @@ const cacheResponseHeaders = (cache: ExposeCacheIR | undefined, method: "get" | 
 /**
  * Build the OpenAPI operation for one `.expose({ rest: true })` procedure (plan
  * 167). Unlike the synthetic RPC operations, these are REAL REST endpoints on
- * `/_lunora/rest/&lt;namespace>/&lt;fn>` — the exact path + method the runtime router
+ * `/_lunora/rest/<namespace>/<fn>` — the exact path + method the runtime router
  * mints (both derive from the shared `restPathForFunction` contract, so the spec
  * cannot drift from the live surface). A `query` maps to `GET` with its args as
  * query parameters; a `mutation`/`action` maps to `POST` with a JSON request body.

--- a/packages/codegen/src/platform-target.ts
+++ b/packages/codegen/src/platform-target.ts
@@ -21,7 +21,7 @@
  *
  * Cloudflare and Node are registered (their matrices live in `@lunora/platform`
  * as `CLOUDFLARE_CAPABILITIES` / `NODE_CAPABILITIES`); other hosts register
- * their matrices as their per-target `@lunora/platform-&lt;target>` packages land.
+ * their matrices as their per-target `@lunora/platform-<target>` packages land.
  * An unregistered `target` is a configuration error, reported as
  * `platform_unknown_target` — and, crucially, the usage set is left untouched
  * so codegen never silently omits a surface against a matrix it does not have.
@@ -59,7 +59,7 @@ const DEFAULT_TARGET = "cloudflare";
 const PROJECT_CONFIG_FILE = "lunora.json";
 
 /**
- * Read `target` from `&lt;projectRoot>/lunora.json`.
+ * Read `target` from `<projectRoot>/lunora.json`.
  *
  * This lives in `@lunora/codegen` rather than `@lunora/config` — where the rest
  * of the `lunora.json` reading lives — because `@lunora/config` depends on

--- a/packages/codegen/src/run-codegen.ts
+++ b/packages/codegen/src/run-codegen.ts
@@ -118,7 +118,7 @@ const writeIfChanged = (filePath: string, content: string): void => {
  * "not applicable") the feature is not in use, so any file left at `filePath`
  * from a prior run — when the feature WAS in use — is removed. Without this, a
  * removed feature (last container/workflow/queue deleted, `@lunora/db` /
- * `@lunora/seed` uninstalled) would leave a lingering `_generated/&lt;feature>.ts`
+ * `@lunora/seed` uninstalled) would leave a lingering `_generated/<feature>.ts`
  * that imports a now-absent package and breaks the build. `force: true` no-ops
  * when the file never existed. Only ever called for the known conditional set
  * (containers/workflows/queues/seed/collections and the openapi/openrpc spec
@@ -395,8 +395,8 @@ export const refreshCodegenProject = (project: Project, lunoraDirectory: string)
 };
 
 /**
- * Top-level codegen entry. Parses `&lt;projectRoot>/lunora/schema.ts` and every
- * function file under `&lt;projectRoot>/lunora/`, then writes
+ * Top-level codegen entry. Parses `<projectRoot>/lunora/schema.ts` and every
+ * function file under `<projectRoot>/lunora/`, then writes
  * `_generated/{api,server,dataModel}.ts` next to them.
  *
  * When `LUNORA_CODEGEN_TIMING` is set (truthy), a single diagnostic summary

--- a/packages/config/__tests__/agent-rules.test.ts
+++ b/packages/config/__tests__/agent-rules.test.ts
@@ -8,7 +8,7 @@ import { AGENT_RULES_DIR, AGENT_RULES_HINT_ENV, claimAgentRulesHint, detectAgent
 
 let workdir: string;
 
-/** Write `&lt;workdir>/.agents/skills/&lt;name>/SKILL.md`. */
+/** Write `<workdir>/.agents/skills/<name>/SKILL.md`. */
 const installSkill = (name: string): void => {
     const directory = join(workdir, AGENT_RULES_DIR, name);
 

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/config/src/agent-rules.ts
+++ b/packages/config/src/agent-rules.ts
@@ -61,10 +61,10 @@ interface AgentRulesStatus {
      * still counts as installed and isn't nagged.
      */
     readonly installed: boolean;
-    /** Skill names with no `SKILL.md` under `&lt;root>/.agents/skills/&lt;name>/`. */
+    /** Skill names with no `SKILL.md` under `<root>/.agents/skills/<name>/`. */
     readonly missing: ReadonlyArray<string>;
 
-    /** Skill names found under `&lt;root>/.agents/skills/&lt;name>/SKILL.md`. */
+    /** Skill names found under `<root>/.agents/skills/<name>/SKILL.md`. */
     readonly present: ReadonlyArray<string>;
 }
 

--- a/packages/config/src/cloudflare/reconcile-bindings.ts
+++ b/packages/config/src/cloudflare/reconcile-bindings.ts
@@ -692,16 +692,16 @@ const reconcileQueues = (text: string, parsed: WranglerShape, queues: ReadonlyAr
  * config already satisfies the inferred needs.
  *
  * `environment`, when passed, does NOT change where this writes — every step
- * below still only touches the TOP-LEVEL config; wrangler's `env.&lt;name>`
+ * below still only touches the TOP-LEVEL config; wrangler's `env.<name>`
  * blocks have no auto-provisioning path today. It is used only to emit an
  * advisory warning, because bindings (`durable_objects`, `d1_databases`, …)
  * are non-inheritable (see `wrangler-validator.ts`'s `NON_INHERITABLE_KEYS`):
  * a `--env production` deploy needs its OWN copy of each one, and silently
  * writing only to the top level would leave that gap unmentioned. Extending
- * the JSONC writer itself to target `env.&lt;name>.*` idempotently for every
+ * the JSONC writer itself to target `env.<name>.*` idempotently for every
  * binding kind here is a separate, larger change (each of the ~10 pipeline
  * steps below reads AND writes the top-level path) that this fix does not
- * attempt — `lunora deploy --env &lt;name>` now VALIDATES the env-scoped view
+ * attempt — `lunora deploy --env <name>` now VALIDATES the env-scoped view
  * (closing the reported gap), it just doesn't yet auto-provision it.
  */
 const reconcileWranglerBindings = (projectRoot: string, inferred: InferredBindings, environment?: string): ReconcileBindingsResult => {

--- a/packages/config/src/cloudflare/remote-bindings.ts
+++ b/packages/config/src/cloudflare/remote-bindings.ts
@@ -237,7 +237,7 @@ const remoteConfigBasename = (): string => `.wrangler.lunora-remote.${String(pro
 
 /**
  * Produce a temporary wrangler config with `"remote": true` on every eligible
- * binding, so `lunora dev` can run `wrangler dev --config &lt;temp>` against the
+ * binding, so `lunora dev` can run `wrangler dev --config <temp>` against the
  * deployed D1/KV/R2 without touching the user's file.
  *
  * The temp file is written as a sibling of the source `wrangler.jsonc` (in the

--- a/packages/config/src/cloudflare/wrangler-secret-variables.ts
+++ b/packages/config/src/cloudflare/wrangler-secret-variables.ts
@@ -124,7 +124,7 @@ const scanWranglerVariablesForSecrets = (variables: Record<string, unknown> | un
  * for the `plaintext_secret_in_wrangler_vars` lint. Returns `[]` when there is no
  * wrangler config, it doesn't parse, or nothing looks like a secret. Scans the
  * top-level `vars` block (mirroring the existing `validateCorsVariables` scope);
- * per-environment `env.&lt;name>.vars` overrides are out of scope for now.
+ * per-environment `env.<name>.vars` overrides are out of scope for now.
  */
 const collectWranglerSecretVariables = (projectRoot: string): WranglerVariableIR[] => {
     const wranglerPath = findWranglerFile(projectRoot);

--- a/packages/config/src/cloudflare/wrangler-validator.ts
+++ b/packages/config/src/cloudflare/wrangler-validator.ts
@@ -193,7 +193,7 @@ interface WranglerValidationReport {
 }
 
 /**
- * `env.&lt;name>` keys confirmed NON-inheritable by the current Cloudflare docs
+ * `env.<name>` keys confirmed NON-inheritable by the current Cloudflare docs
  * (`workers/wrangler/configuration/`, "Non-inheritable keys" section, checked
  * 2026-07-31): wrangler does NOT fall back to the top-level value for these
  * when a declared environment omits one — each must be redeclared per
@@ -227,7 +227,7 @@ const NON_INHERITABLE_KEYS = [
 ] as const satisfies ReadonlyArray<keyof WranglerConfig>;
 
 /**
- * `env.&lt;name>` keys confirmed INHERITABLE by the same docs section: an
+ * `env.<name>` keys confirmed INHERITABLE by the same docs section: an
  * environment that does not override one still gets the top-level value.
  * Limited to the keys this validator actually reads — the docs' "Inheritable
  * keys" list is longer (`name`, `route`, `triggers`, …) but this project does
@@ -246,7 +246,7 @@ const INHERITABLE_KEYS = [
 ] as const satisfies ReadonlyArray<keyof WranglerConfig>;
 
 interface WranglerEnvironmentMerge {
-    /** Set when `environment` names no `env.&lt;name>` block declared in the config — the caller should treat this as a hard validation failure. */
+    /** Set when `environment` names no `env.<name>` block declared in the config — the caller should treat this as a hard validation failure. */
     error?: string;
     /** The env-scoped view: `wrangler` unchanged when `environment` is `undefined`, otherwise merged per {@link NON_INHERITABLE_KEYS} / {@link INHERITABLE_KEYS}. */
     merged: WranglerConfig;
@@ -256,13 +256,13 @@ interface WranglerEnvironmentMerge {
      * cannot verify (not in either table above) — validated against the
      * TOP-LEVEL value only, per the "do not guess" rule; the override is
      * silently ignored for validation purposes. The caller logs this ONCE
-     * (not per key) so an unusual `env.&lt;name>` block doesn't spam warnings.
+     * (not per key) so an unusual `env.<name>` block doesn't spam warnings.
      */
     unverifiedKeys: string[];
 }
 
 /**
- * Resolve the config view `wrangler deploy --env &lt;environment>` will actually
+ * Resolve the config view `wrangler deploy --env <environment>` will actually
  * use. Undefined `environment` returns `wrangler` unchanged — the top-level
  * config is what a plain `wrangler deploy` reads, same as today.
  *
@@ -1184,7 +1184,7 @@ const resolveEnvironmentView = (
  * Pure validator: given a parsed `WranglerConfig` object and an optional
  * `SchemaInfo`, produce a structured report. Performs no I/O.
  *
- * `environment`, when set, validates the `env.&lt;environment>` view
+ * `environment`, when set, validates the `env.<environment>` view
  * ({@link mergeWranglerEnvironment}) instead of the top-level config — e.g. a
  * `durable_objects` binding present only at the top level is a validation
  * FAILURE for `--env production` if `env.production` doesn't repeat it,
@@ -1300,7 +1300,7 @@ const validateWrangler: typeof validateWranglerConfig = validateWranglerConfig;
 
 interface WranglerProjectValidationOptions {
     /**
-     * Cloudflare environment to validate against `env.&lt;name>` in
+     * Cloudflare environment to validate against `env.<name>` in
      * wrangler.jsonc. See {@link mergeWranglerEnvironment} for which keys
      * inherit the top-level value vs must be redeclared per environment.
      * Omit to validate the top-level config only (unchanged default).
@@ -1399,7 +1399,7 @@ const EXPORT_DECLARATION_RE = /^(?:class|const|function|let|var)\s+(?<name>[$A-Z
  *
  * This is the generated app builder's OWN pattern, so it is not an exotic form:
  * `apps/playground/src/server/index.ts` ships exactly this. A scanner that only
- * understood `export const &lt;identifier&gt;` reported the repo's own playground as
+ * understood `export const <identifier>` reported the repo's own playground as
  * missing `ShardDO`.
  */
 const EXPORT_DESTRUCTURE_RE = /^\s*(?:const|let|var)\s*\{/u;

--- a/packages/config/src/container-logs.ts
+++ b/packages/config/src/container-logs.ts
@@ -2,7 +2,7 @@
  * Stream a project's local dev container logs into the dev terminal.
  *
  * During `lunora dev` / `vite dev`, wrangler builds and runs each declared
- * container locally via Docker, naming the image `cloudflare-dev/&lt;class>:&lt;id>`
+ * container locally via Docker, naming the image `cloudflare-dev/<class>:<id>`
  * (the lowercased Durable Object class name — see wrangler's
  * `getDevContainerImageName`). Wrangler forwards the *worker's* console output,
  * but never the container process's own stdout/stderr, so a developer can't see
@@ -19,7 +19,7 @@
 import { Writable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 
-/** Prefix of every image wrangler builds for a local dev container (`cloudflare-dev/&lt;class>:&lt;id>`). */
+/** Prefix of every image wrangler builds for a local dev container (`cloudflare-dev/<class>:<id>`). */
 const DEV_CONTAINER_IMAGE_PREFIX = "cloudflare-dev/";
 
 /** How often to poll Docker for newly-started (or replaced) dev containers, in ms. */
@@ -30,7 +30,7 @@ type ContainerLogLevel = "error" | "info";
 
 /** One declared container to follow, identified by the names codegen lifts from `defineContainer`. */
 interface ContainerLogSource {
-    /** Generated Durable Object class name, e.g. `TranscoderContainer`. Wrangler's dev image is `cloudflare-dev/&lt;lowercased>`. */
+    /** Generated Durable Object class name, e.g. `TranscoderContainer`. Wrangler's dev image is `cloudflare-dev/<lowercased>`. */
     className: string;
     /** The `lunora/containers.ts` export name, e.g. `transcoder` — used as the display tag. */
     exportName: string;
@@ -87,7 +87,7 @@ const createDefaultDocker = async (): Promise<DockerLike> => {
     return new Dockerode() as unknown as DockerLike;
 };
 
-/** Extract the lowercased class segment from a `cloudflare-dev/&lt;class>:&lt;id>` image, or `undefined` for any other image. */
+/** Extract the lowercased class segment from a `cloudflare-dev/<class>:<id>` image, or `undefined` for any other image. */
 const classFromImage = (image: string): string | undefined => {
     if (!image.startsWith(DEV_CONTAINER_IMAGE_PREFIX)) {
         return undefined;

--- a/packages/config/src/dev-server-state.ts
+++ b/packages/config/src/dev-server-state.ts
@@ -110,7 +110,7 @@ const isProcessAlive = (pid: number): boolean => {
 const START_TIME_SKEW_MS = 10_000;
 
 /**
- * Kernel clock-tick rate backing `/proc/&lt;pid>/stat`'s `starttime` field.
+ * Kernel clock-tick rate backing `/proc/<pid>/stat`'s `starttime` field.
  * Linux fixes `USER_HZ` at 100 for userspace on every mainstream platform,
  * independent of the kernel's internal HZ.
  */
@@ -119,7 +119,7 @@ const LINUX_CLOCK_TICKS_PER_SECOND = 100;
 /**
  * Wall-clock start time of `pid` in epoch ms, or `undefined` where the
  * platform doesn't expose it cheaply (non-Linux) or the read fails. Combines
- * `/proc/&lt;pid>/stat` field 22 (`starttime`, in clock ticks since boot) with
+ * `/proc/<pid>/stat` field 22 (`starttime`, in clock ticks since boot) with
  * `/proc/stat`'s `btime` (boot time, epoch seconds).
  */
 const processStartTimeMs = (pid: number): number | undefined => {

--- a/packages/config/src/infer-bindings.ts
+++ b/packages/config/src/infer-bindings.ts
@@ -579,7 +579,7 @@ const isTypeOnlyExportRegexFallback = (code: string, className: string): boolean
 /**
  * Whether the worker entry exports each definition's generated class: a named
  * export of the class (covered by `es-module-lexer`'s export list) or the
- * conventional `export * from "./lunora/_generated/&lt;generatedModule>"` star
+ * conventional `export * from "./lunora/_generated/<generatedModule>"` star
  * re-export — the way a worker entry re-exports every generated class of one
  * kind at once. `es-module-lexer` lists the module request but not the names a
  * star re-export forwards, so the path itself is the signal that every class

--- a/packages/config/src/linked-project.ts
+++ b/packages/config/src/linked-project.ts
@@ -38,7 +38,7 @@ const LINKED_PROJECT_FILE: string = join(LINKED_PROJECT_DIR, "project.json");
 interface LinkedProject {
     /** Cloudflare account id the worker lives under, when known. */
     account?: string;
-    /** Cloudflare environment name (`wrangler … --env &lt;env>`), when scoped. */
+    /** Cloudflare environment name (`wrangler … --env <env>`), when scoped. */
     env?: string;
     /** ISO-8601 timestamp recorded when the link was written. */
     linkedAt?: string;

--- a/packages/config/src/log-format.ts
+++ b/packages/config/src/log-format.ts
@@ -55,7 +55,7 @@ interface LunoraEvent {
     error?: unknown;
     /** `type: "container"` — the lifecycle transition (`start`/`stop`/`error`). */
     event?: unknown;
-    /** `type: "log"` — structured fields from `ctx.log.&lt;level>(msg, fields)` / `ctx.log.with(fields)`. */
+    /** `type: "log"` — structured fields from `ctx.log.<level>(msg, fields)` / `ctx.log.with(fields)`. */
     fields?: unknown;
     function?: unknown;
     /** `type: "container"` — the per-instance id (Durable Object id). */
@@ -165,7 +165,7 @@ const formatRequest = (event: LunoraEvent, functionPath: string): LunoraFormatte
 };
 
 /**
- * Format a `type: "container"` lifecycle event: `container:&lt;name>#&lt;short-id> &lt;event> &lt;detail>`.
+ * Format a `type: "container"` lifecycle event: `container:<name>#<short-id> <event> <detail>`.
  * The instance id is truncated to keep the line readable — it's a correlation
  * hint, not a value to copy. Errors surface on the `error` channel.
  */

--- a/packages/config/src/lunora-reporter.ts
+++ b/packages/config/src/lunora-reporter.ts
@@ -95,7 +95,7 @@ export default class LunoraReporter {
     }
 
     /**
-     * Frame `text` under `badge`: `&lt;badge> &lt;first line>`, with any further lines
+     * Frame `text` under `badge`: `<badge> <first line>`, with any further lines
      * indented to align beneath the message. Without a badge (unknown type) the
      * message is written plain.
      */

--- a/packages/config/src/scaffold-dev-variables.ts
+++ b/packages/config/src/scaffold-dev-variables.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc quotes the `KEY="<placeholder>"` .dev.vars grammar, not a credential. */
+
 import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -122,7 +124,7 @@ const defaultRandomHex = (bytes: number): string => randomBytes(bytes).toString(
 /**
  * Provider-issued secret keys we CANNOT mint locally — you obtain them from a
  * third-party dashboard (Resend, Stripe, Polar, …). Derived from the registry:
- * a secret-keyed entry whose placeholder is an angle-bracket `&lt;your-…>` marker
+ * a secret-keyed entry whose placeholder is an angle-bracket `<your-…>` marker
  * (rather than the `openssl rand` marker) is a provider key. Generating a random
  * value for one would be actively wrong (the provider would reject it).
  */
@@ -535,7 +537,7 @@ const ensureDevVariables = async (deps: EnsureDevVariablesDeps): Promise<EnsureD
 /**
  * The block of text that represents a single {@link SecretEntry} in a
  * `.dev.vars.example` file: a comment block (description + docs URL) followed
- * by the `KEY="&lt;placeholder>"` assignment.
+ * by the `KEY="<placeholder>"` assignment.
  *
  * Written through the dev-variables-format grammar so the format stays
  * consistent with every other reader/writer. The value is always a placeholder

--- a/packages/config/src/schema-edit/mutate.ts
+++ b/packages/config/src/schema-edit/mutate.ts
@@ -52,7 +52,7 @@ const VALIDATOR_METHODS = new Set([
 
 /**
  * True when `node` is a side-effect-free `v.*` validator expression — a call on
- * `v.&lt;method>` (method in {@link VALIDATOR_METHODS}) whose arguments are
+ * `v.<method>` (method in {@link VALIDATOR_METHODS}) whose arguments are
  * themselves validator expressions or safe literals (string/number/boolean/null,
  * object literals of validators, arrays of validators). Anything else — a bare
  * identifier, a `require(...)`/`fetch(...)` call, a comma/assignment expression,

--- a/packages/config/src/schema-edit/policy-scaffold.ts
+++ b/packages/config/src/schema-edit/policy-scaffold.ts
@@ -37,7 +37,7 @@ interface ScaffoldPolicyEdit {
     readonly table: string;
 }
 
-/** Append `.use(rls(&lt;policies>))` to an existing procedure's builder chain. */
+/** Append `.use(rls(<policies>))` to an existing procedure's builder chain. */
 interface WireRlsEdit {
     /** Exported procedure name to wire, e.g. `listInvoices`. */
     readonly exportName: string;
@@ -201,7 +201,7 @@ const chainHasRls = (receiver: Node): boolean => {
 };
 
 /**
- * Append `.use(rls(&lt;policies>))` to a procedure's builder chain, preserving the
+ * Append `.use(rls(<policies>))` to a procedure's builder chain, preserving the
  * terminal `.query(handler)` (and its handler body) byte-for-byte. Only the
  * **builder** form can be wired; the bare-factory form (`query({ handler })`)
  * has no chain and is reported `unsupported-procedure-shape` so the editor can

--- a/packages/config/src/studio-host/render-html.ts
+++ b/packages/config/src/studio-host/render-html.ts
@@ -2,7 +2,7 @@ import type { StudioHtmlConfig } from "./types";
 
 /**
  * Serialise a string for safe inline-script embedding: JSON-encode it, then
- * neutralise `&lt;` so a `&lt;/script>` (or comment opener) in the value can't end the
+ * neutralise `<` so a `</script>` (or comment opener) in the value can't end the
  * tag early.
  */
 const forInlineScript = (value: string): string => JSON.stringify(value).replaceAll("<", String.raw`\u003c`);

--- a/packages/config/src/studio-host/write-atomic.ts
+++ b/packages/config/src/studio-host/write-atomic.ts
@@ -6,7 +6,7 @@
  * target. The rename is atomic within a filesystem, so a crash mid-write can
  * never leave a half-written file at `path`. On any failure the temp file is
  * removed before the error propagates, so a crashed rename doesn't leave a stray
- * `&lt;path>.lunora-tmp` behind.
+ * `<path>.lunora-tmp` behind.
  *
  * The `.dev.vars` writers in `scaffold-dev-variables` use their own exclusive-
  * create / `0o600` / compare-and-swap variants for their concurrency and secret-

--- a/packages/config/src/tui-theme.ts
+++ b/packages/config/src/tui-theme.ts
@@ -6,14 +6,14 @@
  *
  * Framework-free (no React, no pail) — just data plus a `@visulima/colorize`
  * string painter — so any consumer can import it. The CLI's tui prompts read the
- * same `BadgeSpec` colors to render badges as `&lt;Text>` elements on a TTY.
+ * same `BadgeSpec` colors to render badges as `<Text>` elements on a TTY.
  */
 
 import colorize from "@visulima/colorize";
 
 /**
  * A badge: the short colored label that prefixes a line. `bg`/`fg` are hex so the
- * same value drives both colorize's `bgHex().hex()` and the tui `&lt;Text>` props.
+ * same value drives both colorize's `bgHex().hex()` and the tui `<Text>` props.
  */
 interface BadgeSpec {
     bg: `#${string}`;

--- a/packages/container/__tests__/workerd/container-smoke.workerd.test.ts
+++ b/packages/container/__tests__/workerd/container-smoke.workerd.test.ts
@@ -10,7 +10,7 @@
  * to `@cloudflare/containers`' own guard — the constructor's directed
  * "Containers have not been enabled" error surfaces through a real DO stub
  * call, proving the class boots in workerd right up to the missing container
- * runtime. On top of that, the `ctx.containers.&lt;name>` surface
+ * runtime. On top of that, the `ctx.containers.<name>` surface
  * (`createContainerContext`) resolves real Durable Object namespace bindings
  * and exposes the `.get`/`.any`/`.pool` handles (a missing binding degrades to
  * a directed error), and the container→Lunora bridge client

--- a/packages/container/eslint.config.js
+++ b/packages/container/eslint.config.js
@@ -67,4 +67,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/container/src/bridge.ts
+++ b/packages/container/src/bridge.ts
@@ -43,7 +43,7 @@ interface ContainerBridgeOptions {
     fetch?: FetchLike;
 
     /**
-     * Bearer token sent as `Authorization: Bearer &lt;token>`. Your Worker's
+     * Bearer token sent as `Authorization: Bearer <token>`. Your Worker's
      * `resolveIdentity` maps it to the identity the called functions run as.
      * Pass it to the container as a `secret`, never bake it into the image.
      */

--- a/packages/container/src/client.ts
+++ b/packages/container/src/client.ts
@@ -158,7 +158,7 @@ interface ContainerEgressControls {
 }
 
 /**
- * The per-definition accessor exposed as `ctx.containers.&lt;exportName>`.
+ * The per-definition accessor exposed as `ctx.containers.<exportName>`.
  * @experimental
  */
 interface ContainerAccessor {

--- a/packages/container/src/define-container.ts
+++ b/packages/container/src/define-container.ts
@@ -26,7 +26,7 @@ const DURATION_UNIT_SECONDS: Readonly<Record<string, number>> = { h: 3600, m: 60
 
 /**
  * Parse a `sleepAfter`/`hardTimeout` duration into whole seconds. A `number` is
- * treated as seconds (floored); a string follows the `&lt;digits>&lt;s|m|h>` grammar
+ * treated as seconds (floored); a string follows the `<digits><s|m|h>` grammar
  * {@link SLEEP_AFTER_PATTERN} enforces. Shared by the runtime DO so the wire
  * value the container sees is derived from the exact same logic that validates
  * it. Throws on an unparseable string (already rejected by `defineContainer`).
@@ -68,7 +68,7 @@ const dirname = (path: string): string => {
  * A local-path string whose basename starts with `Dockerfile` (so
  * `Dockerfile.dev` also counts) is used as-is with its directory as the build
  * context; any other path is treated as the build-context directory and the
- * Dockerfile is expected at `&lt;dir>/Dockerfile`.
+ * Dockerfile is expected at `<dir>/Dockerfile`.
  * @experimental
  */
 const normalizeContainerImage = (image: ContainerImageSource): NormalizedContainerImage => {

--- a/packages/container/src/do/index.ts
+++ b/packages/container/src/do/index.ts
@@ -125,7 +125,7 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
     }
 
     /**
-     * Proxy entry for every `ctx.containers.&lt;name>` fetch. Resolves the
+     * Proxy entry for every `ctx.containers.<name>` fetch. Resolves the
      * `secretsStore` bindings into `envVars` before delegating, so the values
      * are present when the base implicitly starts the container for this
      * request — a no-op when `secretsStore` is unset.
@@ -137,7 +137,7 @@ class LunoraContainer<Env = unknown> extends Container<Env> {
     }
 
     /**
-     * Explicit start (`ctx.containers.&lt;name>.get(id).start()`). Resolves the
+     * Explicit start (`ctx.containers.<name>.get(id).start()`). Resolves the
      * `secretsStore` bindings into `envVars` first, mirroring
      * {@link containerFetch}. A per-instance `start({ envVars })` replaces the
      * env set wholesale (base behavior), so the injected values only apply to a

--- a/packages/container/src/otel.ts
+++ b/packages/container/src/otel.ts
@@ -138,7 +138,7 @@ interface ContainerTelemetryOptions {
      * under the Worker's trace instead of forming a fresh, disconnected trace.
      *
      * `@lunora/container` stamps this trace context as the **`traceparent` request
-     * header** on every proxied fetch (`ctx.containers.&lt;name>.…`), so a container
+     * header** on every proxied fetch (`ctx.containers.<name>.…`), so a container
      * that serves many requests should read it per request and create a telemetry
      * instance scoped to that request — the trace context differs each call, so a
      * single process-lifetime instance can't carry it:

--- a/packages/container/src/types.ts
+++ b/packages/container/src/types.ts
@@ -68,7 +68,7 @@ interface BuildImageSource {
 /**
  * Where the container image comes from. A `string` is a **local path** —
  * either a directory containing a `Dockerfile` (normalized to
- * `&lt;dir>/Dockerfile` with the directory as the build context) or a path to
+ * `<dir>/Dockerfile` with the directory as the build context) or a path to
  * the Dockerfile itself — while `{ registry }` is a pre-built image reference.
  * @experimental
  */
@@ -216,7 +216,7 @@ interface ContainerConfig {
 
     /**
      * Application-level readiness probes that gate request proxying: a
-     * `ctx.containers.&lt;name>` fetch waits until every probe responds with its
+     * `ctx.containers.<name>` fetch waits until every probe responds with its
      * expected status before the request reaches the container — on top of the
      * platform's port/`pingEndpoint` health wait. All probes run in parallel.
      * Use these for readiness an open-port check can't see (migrations applied,

--- a/packages/d1/__bench__/search-inverted.bench.ts
+++ b/packages/d1/__bench__/search-inverted.bench.ts
@@ -54,7 +54,7 @@ const searchSchema: SchemaLike = {
 
 /**
  * A corpus where term frequency is deliberately skewed: every document carries
- * `common`, one in ten carries `frequent`, and each has a unique `rare&lt;n>` —
+ * `common`, one in ten carries `frequent`, and each has a unique `rare<n>` —
  * so one query can touch the whole index and another exactly one row.
  *
  * The rare token is **zero-padded to a fixed width** on purpose. A query's final

--- a/packages/d1/eslint.config.js
+++ b/packages/d1/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/d1/src/admin-export-import.ts
+++ b/packages/d1/src/admin-export-import.ts
@@ -177,7 +177,7 @@ interface ImportGlobalArgs {
     /**
      * Optional direct exec handle to the same D1 database the writer targets.
      * When supplied, the conflict pre-probe issues a single
-     * `SELECT 1 FROM &lt;table> WHERE id = ? LIMIT 1` against the row's declared
+     * `SELECT 1 FROM <table> WHERE id = ? LIMIT 1` against the row's declared
      * table instead of falling back to `writer.get(id)`, which scans every
      * global table looking for the id. Strongly recommended for large schemas
      * — the writer-fallback is O(N tables) per row.

--- a/packages/d1/src/d1-ctx-db.ts
+++ b/packages/d1/src/d1-ctx-db.ts
@@ -35,13 +35,13 @@ const createD1ContextDatabase = (options: D1ContextDatabaseOptions): ReturnType<
 /** Auto-provision the schema's `.global()` tables in D1 (idempotent `CREATE TABLE IF NOT EXISTS`). */
 const runD1GlobalTableMigrations = (exec: SqlCtxExec, schema: SchemaLike): Promise<void> => runSqlGlobalTableMigrations(exec, schema, sqliteDialect);
 
-/** Materialize the `__agg_&lt;index>` companion tables for the schema's aggregate indexes. */
+/** Materialize the `__agg_<index>` companion tables for the schema's aggregate indexes. */
 const runD1AggregateMigrations = (exec: SqlCtxExec, schema: SchemaLike): Promise<void> => runSqlAggregateMigrations(exec, schema, sqliteDialect);
 
-/** Materialize the `__rank_&lt;index>` companion tables for the schema's rank indexes. */
+/** Materialize the `__rank_<index>` companion tables for the schema's rank indexes. */
 const runD1RankMigrations = (exec: SqlCtxExec, schema: SchemaLike): Promise<void> => runSqlRankMigrations(exec, schema, sqliteDialect);
 
-/** Materialize (and backfill) the `__fts_&lt;index>` fts5 shadow tables for the schema's search indexes. */
+/** Materialize (and backfill) the `__fts_<index>` fts5 shadow tables for the schema's search indexes. */
 const runD1SearchMigrations = (exec: SqlCtxExec, schema: SchemaLike): Promise<void> => runSqlSearchMigrations(exec, schema, sqliteDialect);
 
 /** Index existing rows into every search companion, including the `staged: true` ones migrations leave empty. */

--- a/packages/d1/src/dialect.ts
+++ b/packages/d1/src/dialect.ts
@@ -72,7 +72,7 @@ export const columnRef = (field: string): string => {
     return quoteIdentifier(field);
 };
 
-/** Physical index identifier — `&lt;table>_&lt;name>`, so two tables' like-named indexes don't collide in SQLite's flat index namespace. */
+/** Physical index identifier — `<table>_<name>`, so two tables' like-named indexes don't collide in SQLite's flat index namespace. */
 export const physicalIndexName = (tableName: string, indexName: string): string => quoteIdentifier(`${tableName}_${indexName}`);
 
 export { quoteIdentifier } from "../../../shared/quote-identifier";

--- a/packages/db/eslint.config.js
+++ b/packages/db/eslint.config.js
@@ -52,4 +52,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -81,7 +81,7 @@ type AnyDef = CollectionDef<any, any>;
 
 /**
  * The public row type a collection exposes — the element type of its `list`
- * query's return, with no `& Row`: a `Collection&lt;T>` is invariant in `T`, so the
+ * query's return, with no `& Row`: a `Collection<T>` is invariant in `T`, so the
  * exposed type must be exactly the document type, not a subtype.
  */
 type RowOf<C extends AnyDef> = C["list"] extends FunctionReference<infer _K, infer _A, infer R> ? Element<R> : never;

--- a/packages/db/src/define-mutators.ts
+++ b/packages/db/src/define-mutators.ts
@@ -31,11 +31,11 @@ export const DIRECT_TRANSACTION_METADATA_KEY = "__tanstack_db_direct";
  * A map of wired collections, keyed by the name the optimistic bodies address them
  * by.
  *
- * The row type is `any` on purpose. `Collection&lt;T, string>` is **invariant** in
+ * The row type is `any` on purpose. `Collection<T, string>` is **invariant** in
  * `T` (its methods both consume and produce rows), so a concrete
- * `Collection&lt;Doc&lt;"nodes"> & Row>` is NOT assignable to `Collection&lt;Row>` — which
- * is why the previous `Record&lt;string, Collection&lt;Row, string>>` forced an
- * `as never` cast on every entry, and left `context.collections.&lt;name>` too
+ * `Collection<Doc<"nodes"> & Row>` is NOT assignable to `Collection<Row>` — which
+ * is why the previous `Record<string, Collection<Row, string>>` forced an
+ * `as never` cast on every entry, and left `context.collections.<name>` too
  * untyped to be worth using. Projects recover the concrete types by binding them
  * once through {@link initMutators}.
  */
@@ -65,7 +65,7 @@ export interface MutatorReference<TArgs = unknown> {
 /**
  * A generated reference with its arg type erased — the widest shape the runtime
  * actually reads. Used on the implementation side (and by {@link mutatorPath}),
- * where narrowing to a concrete `MutatorReference&lt;TArgs>` would make the typed
+ * where narrowing to a concrete `MutatorReference<TArgs>` would make the typed
  * overload's parameter fail the contravariant assignability check against the
  * implementation signature.
  */
@@ -129,7 +129,7 @@ const mutatorPath = (serverRef: AnyMutatorReference | string): string => {
  *
  * `context.collections` is typed by whatever map it is bound to — which for this
  * standalone form is the widest one. Bind the concrete collections once with
- * {@link initMutators} to get `collections.&lt;name>` typed inside `apply`.
+ * {@link initMutators} to get `collections.<name>` typed inside `apply`.
  */
 export const defineMutator: {
     <TArgs = Record<string, unknown>>(definition: { apply: (context: ClientMutatorContext, args: TArgs) => void; serverRef: string }): ClientMutatorDef<TArgs>;
@@ -459,17 +459,17 @@ export interface BoundMutatorApi<TCollections extends CollectionMap> {
  * Bind the mutator surface to **this project's** collections map, once.
  *
  * `Collection` is invariant in its row type, so a shared
- * `Record&lt;string, Collection&lt;Row, string>>` could neither accept a generated
+ * `Record<string, Collection<Row, string>>` could neither accept a generated
  * collection without an `as never` cast nor hand a usable type back to `apply` —
  * which is why optimistic bodies tended to ignore `context.collections` and close
  * over module-scope collection variables instead. Declaring the map once here
  * fixes both ends: `bindMutators` takes the concrete collections cast-free, and
- * `apply` reads `collections.&lt;name>` at its real row type.
+ * `apply` reads `collections.<name>` at its real row type.
  *
  * Runtime-identical to the standalone {@link defineMutator} / {@link bindMutators}
  * (this returns those very functions); only the types narrow.
  * @example
- * const { bindMutators, defineMutator } = initMutators&lt;{ nodes: typeof wholeOutlineCollection }>();
+ * const { bindMutators, defineMutator } = initMutators<{ nodes: typeof wholeOutlineCollection }>();
  * const setText = defineMutator({ apply: ({ collections }, args) => collections.nodes.update(args.id, setter), serverRef: api.mutators.setText });
  */
 export const initMutators = <TCollections extends CollectionMap>(): BoundMutatorApi<TCollections> =>

--- a/packages/dispatch/eslint.config.js
+++ b/packages/dispatch/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/dispatch/src/create-dispatch-logger.ts
+++ b/packages/dispatch/src/create-dispatch-logger.ts
@@ -1,7 +1,7 @@
 /**
  * `createDispatchLogger` — a console-backed logger prefixed for correlation,
- * shared by the dispatch consumers (`@lunora/workflow` → `[workflow:&lt;name>]`,
- * `@lunora/queue` → `[queue:&lt;name>]`). The runtime routes the console output to
+ * shared by the dispatch consumers (`@lunora/workflow` → `[workflow:<name>]`,
+ * `@lunora/queue` → `[queue:<name>]`). The runtime routes the console output to
  * wrangler tail / Studio.
  */
 import type { DispatchLogger } from "./types";

--- a/packages/do/__bench__/keyset-vs-offset.bench.ts
+++ b/packages/do/__bench__/keyset-vs-offset.bench.ts
@@ -9,7 +9,7 @@ import createSqliteExec from "../__tests__/_helpers/node-sqlite";
  * pagination walks `offset + limit` rows. Apples-to-apples across the same
  * `findMany` API:
  *
- * - **keyset** — second page with `cursor: &lt;seq=4999, _id=t04999>` and
+ * - **keyset** — second page with `cursor: <seq=4999, _id=t04999>` and
  * `limit: 50`. SQLite walks ~50 rows via the SEEK predicate the keyset
  * helper compiles (`(seq, _id) > (?, ?)`).
  * - **offset-style** — same depth modelled as `limit: 5050` without a

--- a/packages/do/__bench__/lookup-by-id-probe.bench.ts
+++ b/packages/do/__bench__/lookup-by-id-probe.bench.ts
@@ -10,7 +10,7 @@ import createSqliteExec from "../__tests__/_helpers/node-sqlite";
  * - **sequential** — one `SELECT ... WHERE id = ?` per table, stopping at the
  * first hit (the prior implementation). Worst case is T statements on a
  * T-table schema when the row lives in the last-probed table.
- * - **union** — one `SELECT '&lt;t>' AS __t__, ... UNION ALL ... LIMIT 1` that
+ * - **union** — one `SELECT '<t>' AS __t__, ... UNION ALL ... LIMIT 1` that
  * locates the row regardless of table count in a single round-trip (the new
  * implementation).
  *

--- a/packages/do/__bench__/upsert.bench.ts
+++ b/packages/do/__bench__/upsert.bench.ts
@@ -4,7 +4,7 @@ import { beforeAll, bench, describe } from "vitest";
 import { makeWriter } from "./shared";
 
 /**
- * The work behind `ctx.db.&lt;table>.upsert(...)` — a `findFirst` by the unique
+ * The work behind `ctx.db.<table>.upsert(...)` — a `findFirst` by the unique
  * `target` followed by a `patch` (match) or `insert` (miss). The facade is a
  * thin wrapper over exactly these calls, so this engine-level pair is a faithful
  * measure of upsert's cost. The `by_email` UNIQUE index backs the lookup.

--- a/packages/do/__tests__/shard-do.client-watermark.test.ts
+++ b/packages/do/__tests__/shard-do.client-watermark.test.ts
@@ -10,7 +10,7 @@ import createSqliteExec from "./_helpers/node-sqlite";
  * End-to-end custom-mutator ordering over the real dispatch path. A push that
  * carries a `clientId` + numeric `clientSeq` on a registered mutator is
  * classified against `__client_watermark` BEFORE the handler runs:
- * - `seq &lt;= watermark` → already processed (ack, handler not re-run);
+ * - `seq <= watermark` → already processed (ack, handler not re-run);
  * - `seq == watermark + 1` → run authoritatively + advance the watermark;
  * - `seq > watermark + 1` → out-of-order halt (409, handler not run).
  *

--- a/packages/do/__tests__/shard-do.mutator-watermark-selfheal.test.ts
+++ b/packages/do/__tests__/shard-do.mutator-watermark-selfheal.test.ts
@@ -12,8 +12,8 @@ import createSqliteExec from "./_helpers/node-sqlite";
  * Core invariants exercised:
  *
  * 1. A handler that throws does NOT advance `__client_watermark` — the sequence is not consumed; the retry re-runs.
- * 2. A succeeded write is idempotent: a re-sent push with seq &lt;= watermark is ack'd without re-running the handler.
- * 3. Out-of-order pushes (seq &gt; watermark + 1) are halted before the handler runs.
+ * 2. A succeeded write is idempotent: a re-sent push with seq <= watermark is ack'd without re-running the handler.
+ * 3. Out-of-order pushes (seq > watermark + 1) are halted before the handler runs.
  * 4. Advance-gap self-heal: if the dedup row committed but the watermark is stale, a retry re-advances via the idempotency cache.
  *
  * These tests drive the full dispatch path through a real in-memory SQLite engine.

--- a/packages/do/__tests__/shard-do.shape-resume-matrix.test.ts
+++ b/packages/do/__tests__/shard-do.shape-resume-matrix.test.ts
@@ -8,9 +8,9 @@
  * 1. `cdcEnabled()` — the `__cdc_log` table exists (CDC was on when the shard was migrated)
  * 2. `shape.sinceSeq !== undefined` — the client supplied a checkpoint hint
  * 3. `shape.sinceEpoch === epoch` — both sides are on the same CDC timeline
- * 4. `shape.sinceSeq &lt;= cursor` — the client is not ahead of the server
+ * 4. `shape.sinceSeq <= cursor` — the client is not ahead of the server
  * 5a. `shape.sinceSeq === cursor` — trivial: already at cursor, nothing missed; OR
- * 5b. `floor !== undefined &amp;&amp; floor &lt;= shape.sinceSeq + 1` — the oldest retained op still covers the client's gap
+ * 5b. `floor !== undefined && floor <= shape.sinceSeq + 1` — the oldest retained op still covers the client's gap
  *
  * **Observable distinction (wire protocol):**
  * - **Resume** — `pokeStart.baseCheckpoint` is a number (`=== shape.sinceSeq`); `rowsPatch` holds only the diff ops for `(sinceSeq, cursor]`.

--- a/packages/do/eslint.config.js
+++ b/packages/do/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/do/src/admin-rpc-args.ts
+++ b/packages/do/src/admin-rpc-args.ts
@@ -34,14 +34,14 @@ import { ADMIN_FUNCTION_PREFIX, tableFromDepKey } from "@lunora/shard-engine";
 import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
 import { decodeIdentityHeader } from "../../../shared/identity-header";
 
-/** Recovers the process exit code embedded in a container `stop` message as `(exit &lt;n>)`. */
+/** Recovers the process exit code embedded in a container `stop` message as `(exit <n>)`. */
 const CONTAINER_EXIT_CODE_PATTERN = /\(exit (\d+)\)/;
 
 /**
  * The mapped {@link LogEntry} one container lifecycle event becomes once parsed.
- * `functionPath` is the synthetic `container:&lt;name>` source so the Studio Logs
+ * `functionPath` is the synthetic `container:<name>` source so the Studio Logs
  * panel renders the row alongside `ctx.log` lines; `level` is folded to the
- * buffer's level set; `message` is a compact `&lt;event>` / `&lt;event>: &lt;detail>`.
+ * buffer's level set; `message` is a compact `<event>` / `<event>: <detail>`.
  */
 type ContainerLogEntry = LogEntry & { functionPath: string };
 
@@ -185,7 +185,7 @@ interface RunShardRankPageArgs {
 }
 
 /**
- * The trailing `,"cursor":&lt;n>,"epoch":"&lt;e>"` fragment appended to a
+ * The trailing `,"cursor":<n>,"epoch":"<e>"` fragment appended to a
  * `data`/`delta`/`resume` frame so a client can persist a resume position it can
  * prove still belongs to this shard's timeline (see `evaluateResume`). Each part
  * is omitted when absent, keeping the wire byte-identical to the pre-cursor /
@@ -521,7 +521,7 @@ const parseRecordAuthEventArgs = (args: Record<string, unknown>): { outcome: "fa
  * `reportContainerLifecycle`). The reserved op carries the same envelope
  * `emitContainerLifecycle` prints to the dev terminal under `args.event`, so the
  * terminal and the Studio Logs panel never diverge. Maps it to a {@link LogEntry}
- * with `functionPath: "container:&lt;name>"`. A malformed envelope throws a 400
+ * with `functionPath: "container:<name>"`. A malformed envelope throws a 400
  * `LunoraError`, matching the other admin write parsers.
  */
 const parseRecordContainerEventArgs = (args: Record<string, unknown>): ContainerLogEntry => {
@@ -908,7 +908,7 @@ const badRequest = (message: string): never => {
     throw new LunoraError("BAD_REQUEST", message);
 };
 
-/** Narrow a required non-empty string admin arg or 400 with `&lt;field> is required`. */
+/** Narrow a required non-empty string admin arg or 400 with `<field> is required`. */
 const requireNonEmptyString = (value: unknown, field: string): string => {
     if (typeof value !== "string" || value.trim() === "") {
         badRequest(`rankPage: \`${field}\` is required`);

--- a/packages/do/src/session-do.ts
+++ b/packages/do/src/session-do.ts
@@ -15,8 +15,8 @@
  * with one of:
  *
  * POST   /create   body: { token, userId, ttlSeconds }
- * GET    /get      header: `x-lunora-session-token: &lt;token>`
- * DELETE /revoke   header: `x-lunora-session-token: &lt;token>`
+ * GET    /get      header: `x-lunora-session-token: <token>`
+ * DELETE /revoke   header: `x-lunora-session-token: <token>`
  *
  * Every request must additionally carry an `x-lunora-session-secret` header
  * whose value matches `env.SESSION_DO_SECRET`. The DO is reachable from any

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -782,7 +782,7 @@ abstract class ShardDO {
     /**
      * Upper bound on a `.global()`-shape's materialized membership. Each global
      * shape keeps its ENTIRE current membership as a per-socket snapshot
-     * (`Map&lt;rowKey, hash&gt;`) so the poll loop can diff it; that snapshot — and the
+     * (`Map<rowKey, hash>`) so the poll loop can diff it; that snapshot — and the
      * read buffer feeding it — scale with the membership size, multiplied by every
      * subscribed socket. An unbounded membership (a global table with no narrowing
      * shape predicate or RLS read scope) would grow them without limit and evict
@@ -1237,7 +1237,7 @@ abstract class ShardDO {
 
     /**
      * Per-function execution counters surfaced by the
-     * `__lunora_admin__:getFunctionStats` RPC, keyed by `&lt;file>:&lt;function>`
+     * `__lunora_admin__:getFunctionStats` RPC, keyed by `<file>:<function>`
      * path. Shares the `metrics` lifecycle: in-memory, reset on
      * hibernation/restart. The map is naturally bounded by the app's registered
      * function count (a finite set), so no eviction is needed. Maintained by
@@ -2113,7 +2113,7 @@ abstract class ShardDO {
      * Evaluate every statically-discovered feature flag under `context` for the
      * studio's read-only Flags page (`__lunora_admin__:listFlags`). The flag keys
      * + value types are discovered by `@lunora/codegen` from the app's
-     * `ctx.flags.&lt;type>("key", …)` reads and evaluated through the configured
+     * `ctx.flags.<type>("key", …)` reads and evaluated through the configured
      * `@lunora/flags` provider — work only the codegen subclass can do, so it
      * overrides this. The base class wires no provider and reports
      * `configured: false` with zero flags (an un-generated `ShardDO` has none).
@@ -2560,7 +2560,7 @@ abstract class ShardDO {
      * high-watermark for `currentRequestClientId`. The watermark is the highest
      * per-client sequence the DO has applied, so the push is exactly one of:
      *
-     * - `"already"` — `seq &lt;= watermark`: a replay of a confirmed (or in-flight,
+     * - `"already"` — `seq <= watermark`: a replay of a confirmed (or in-flight,
      * now-resent) mutation. The handler must NOT re-run; the dispatch path returns
      * a benign ack so the client drops the pending overlay.
      * - `"next"` — `seq == watermark + 1`: the next mutation in order. Run the
@@ -3206,14 +3206,16 @@ abstract class ShardDO {
         this.recordShapeError(`source:${table}`, error);
     }
 
+    /* eslint-disable no-secrets/no-secrets -- JSDoc names the `AsyncIterable<unknown>` type, not a credential */
+
     /**
      * Look up a streaming-query function and return a thunk that produces the
-     * `AsyncIterable&lt;unknown>` when handed an {@link AbortSignal}. The codegen
+     * `AsyncIterable<unknown>` when handed an {@link AbortSignal}. The codegen
      * subclass overrides this to dispatch via `LUNORA_FUNCTIONS`; the base
      * default returns `null`, which surfaces as `{type:"error", code:"NOT_FOUND"}`
      * to the client.
      *
-     * The deferred-iterator shape (`(signal) => AsyncIterable&lt;unknown>`) keeps
+     * The deferred-iterator shape (`(signal) => AsyncIterable<unknown>`) keeps
      * the cancel signal pluggable per-call without coupling this signature to
      * the wire-frame loop in `handleStream`.
      */
@@ -3222,6 +3224,8 @@ abstract class ShardDO {
         // eslint-disable-next-line unicorn/no-null -- base default: `null` = "no such streaming function"; the codegen subclass overrides and also returns null
         return null;
     }
+
+    /* eslint-enable no-secrets/no-secrets */
 
     /**
      * Wrap a query handler in the reactive cache. The subclass passes the
@@ -5753,7 +5757,7 @@ abstract class ShardDO {
      * surfaces in the Studio Logs panel — not just the dev terminal. The
      * Container DO pushes this best-effort (its `console` print stays the source
      * of truth), so a missing/garbage envelope is rejected up front (400) rather
-     * than corrupting the buffer. Mapped to `functionPath: "container:&lt;name>"` so
+     * than corrupting the buffer. Mapped to `functionPath: "container:<name>"` so
      * the panel renders it alongside `ctx.log` lines. Admin-gated by
      * `handleAdminRpc`'s caller (the same `LUNORA_ADMIN_TOKEN` bearer as every
      * other admin write).
@@ -6314,7 +6318,7 @@ abstract class ShardDO {
     /**
      * Append one structured entry to the durable request log (`request-log.ts`)
      * for a `/rpc` dispatch that just completed — the per-request readout
-     * (`&lt;file>:&lt;function>`, shard key, acting user/identity, redacted args,
+     * (`<file>:<function>`, shard key, acting user/identity, redacted args,
      * outcome, duration, tables read/written, cache hit) that Cloudflare cannot
      * attribute (PLAN3 §1.1). When `LUNORA_REQUEST_LOG_EMIT` is set, the same
      * entry is ALSO emitted as a structured console event for CF Workers Logs /
@@ -8740,8 +8744,8 @@ abstract class ShardDO {
      * not suitable for production.
      * 2. Bearer token via `env.LUNORA_WS_BEARER`. When set, the upgrade
      * must present a matching token. We accept either an
-     * `Authorization: Bearer &lt;token>` header (preferred) or a
-     * `?token=&lt;token>` query parameter (the only escape hatch for
+     * `Authorization: Bearer <token>` header (preferred) or a
+     * `?token=<token>` query parameter (the only escape hatch for
      * browsers, which can't customise headers on the WebSocket
      * constructor). The match runs in constant time to avoid leaking
      * the token via response-timing differences.

--- a/packages/do/src/shard-registry-do.ts
+++ b/packages/do/src/shard-registry-do.ts
@@ -10,7 +10,7 @@
  * `ShardRegistryDO` is the persistent source of truth. A worker:
  *
  * - calls `POST /register {table, shardKey}` when a sharded table first
- * sees a write on a new key (typically from `ctx.db.&lt;table>.insert` via
+ * sees a write on a new key (typically from `ctx.db.<table>.insert` via
  * the worker's onWrite hook, fired through `ctx.waitUntil` so the
  * user-facing write doesn't pay the registry round-trip);
  * - calls `POST /unregister {table, shardKey}` when a shard is decommissioned;
@@ -21,7 +21,7 @@
  *
  * Single-instance contract: deploy one DO instance per environment, by
  * convention named {@link SHARD_REGISTRY_DO_NAME}. The DO is small (just a
- * `Map&lt;table, Set&lt;shardKey>>`) and writes are infrequent (only on first-seen
+ * `Map<table, Set<shardKey>>`) and writes are infrequent (only on first-seen
  * shardKey per table), so a single instance is sufficient up to tens of
  * thousands of distinct shard keys.
  *

--- a/packages/errors/eslint.config.js
+++ b/packages/errors/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -696,7 +696,7 @@ const hasStandaloneNumber = (haystack: string, code: string): boolean => {
 };
 
 /**
- * True when `haystack` carries Cloudflare's own `Error &lt;code>` / `Error: &lt;code>`
+ * True when `haystack` carries Cloudflare's own `Error <code>` / `Error: <code>`
  * phrasing for `code`, with `code` a whole token.
  *
  * The trailing-digit check matters as much here as in the loose matcher. Without
@@ -747,12 +747,12 @@ const cloudflarePlatformSolution = (entry: CloudflarePlatformError): Solution =>
 /**
  * Recognize a Cloudflare platform-error {@link CloudflarePlatformError} in a raw
  * error message, conservatively: the message must carry Cloudflare's own
- * `Error &lt;code>` phrasing, or mention `cloudflare` alongside the standalone
+ * `Error <code>` phrasing, or mention `cloudflare` alongside the standalone
  * code. That keeps a bare number (`expected 520 items`) from false-matching a 5xx
  * code, at the cost of missing a context-free code — the safe trade for a
  * grounded hint. Returns the matched code's {@link Solution}, or `undefined`.
  *
- * Matching runs in two passes, strongest first: Cloudflare's own `Error &lt;code>`
+ * Matching runs in two passes, strongest first: Cloudflare's own `Error <code>`
  * phrasing is unambiguous, so it must win over the weaker "mentions cloudflare
  * near some number" heuristic regardless of table order. A single pass let a weak
  * match on an earlier entry beat an explicit match on a later one — `"Cloudflare

--- a/packages/flags/eslint.config.js
+++ b/packages/flags/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/hyperdrive/eslint.config.js
+++ b/packages/hyperdrive/eslint.config.js
@@ -148,4 +148,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/lunora/__tests__/re-exports.test.ts
+++ b/packages/lunora/__tests__/re-exports.test.ts
@@ -59,10 +59,10 @@ const OPT_OUT = new Map<string, string>([
 
 /**
  * Upstream subpaths the umbrella re-exports under a DIFFERENT suffix than the
- * upstream's own subpath — `@lunora/flags`'s `./providers/&lt;name>` collapses
- * to `lunorash/flags/&lt;name>`, the umbrella's own naming choice. Maps
- * `&lt;upstream package name>&lt;upstream subpath>` to the umbrella suffix (the
- * part after `lunorash/&lt;prefix>`) it resolves to instead of the verbatim
+ * upstream's own subpath — `@lunora/flags`'s `./providers/<name>` collapses
+ * to `lunorash/flags/<name>`, the umbrella's own naming choice. Maps
+ * `<upstream package name><upstream subpath>` to the umbrella suffix (the
+ * part after `lunorash/<prefix>`) it resolves to instead of the verbatim
  * upstream subpath.
  */
 const ALIAS_SUFFIX = new Map<string, string>([

--- a/packages/lunora/eslint.config.js
+++ b/packages/lunora/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/mail/__tests__/testing.test.ts
+++ b/packages/mail/__tests__/testing.test.ts
@@ -72,7 +72,7 @@ describe("@lunora/mail/testing", () => {
     it("extractLink decodes the &amp; entity that HTML renderers escape into hrefs", () => {
         expect.assertions(2);
 
-        // @react-email/render escapes `&` as `&amp;` inside href attributes, so a
+        // @react-email/render escapes `&` as `&` inside href attributes, so a
         // multi-query-param reset link must be decoded before it can be followed.
         const escaped = mail({ html: '<a href="https://x.test/reset?uid=1&amp;token=abc">reset</a>' });
 

--- a/packages/mail/eslint.config.js
+++ b/packages/mail/eslint.config.js
@@ -155,4 +155,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/mail/src/address.ts
+++ b/packages/mail/src/address.ts
@@ -39,7 +39,7 @@ const assertSafeHeaderValue = (label: string, value: string): void => {
     }
 };
 
-/** Validate the bracketed `name &lt;email>` form captured by `ADDRESS_PATTERN`. */
+/** Validate the bracketed `name <email>` form captured by `ADDRESS_PATTERN`. */
 const toBracketedAddress = (name: string, email: string): { email: string; name?: string } => {
     if (name.length > MAX_NAME_LENGTH) {
         throw new LunoraError("INTERNAL", `@lunora/mail: address name must be <= ${String(MAX_NAME_LENGTH)} characters`);

--- a/packages/mail/src/inbound/parse.ts
+++ b/packages/mail/src/inbound/parse.ts
@@ -106,7 +106,7 @@ const safe = (label: string, value: string | undefined): string | undefined => {
     return value;
 };
 
-/** Render a parser `Address` (mailbox or group) as a single `name &lt;addr>` string. */
+/** Render a parser `Address` (mailbox or group) as a single `name <addr>` string. */
 const formatAddress = (entry: { address?: string; group?: { address?: string; name?: string }[]; name?: string }): string => {
     if (entry.address !== undefined && entry.address !== "") {
         return entry.name ? `${entry.name} <${entry.address}>` : entry.address;

--- a/packages/mail/src/testing.ts
+++ b/packages/mail/src/testing.ts
@@ -113,14 +113,14 @@ const waitForMail = async (options: WaitForMailOptions): Promise<CapturedMail> =
 // http(s) URL up to the first whitespace, quote, or angle bracket.
 const URL_PATTERN = /https?:\/\/[^\s"'<>)]+/g;
 
-/** Ampersand entity (named + numeric decimal/hex forms) an HTML renderer escapes `&amp;` to. */
+/** Ampersand entity (named + numeric decimal/hex forms) an HTML renderer escapes `&` to. */
 const AMPERSAND_ENTITY = /&(?:amp|#0*38|#x0*26);/giu;
 
 /**
  * Decode the ampersand entity in an extracted URL. `@react-email/render` (the
- * package's own render path) escapes `&amp;` as `&amp;` inside `href` attributes, so
- * a multi-query-param link (`?uid=1&amp;token=abc`) is captured as
- * `?uid=1&amp;token=abc` — following it would send a param literally named
+ * package's own render path) escapes `&` as `&` inside `href` attributes, so
+ * a multi-query-param link (`?uid=1&token=abc`) is captured as
+ * `?uid=1&token=abc` — following it would send a param literally named
  * `amp;token`. Text bodies are not entity-escaped, so this only affects html.
  */
 const decodeUrlEntities = (url: string): string => url.replaceAll(AMPERSAND_ENTITY, "&");

--- a/packages/mail/src/types.ts
+++ b/packages/mail/src/types.ts
@@ -54,7 +54,7 @@ export interface LunoraMailOptions {
      * `transport` is set.
      */
     cloudflareSend?: (from: string, to: string, raw: string) => Promise<void>;
-    /** Default sender (`Name &lt;addr@host>` or bare email). */
+    /** Default sender (`Name <addr@host>` or bare email). */
     from: string;
     /** Default queue binding for `mailer.queue()`. */
     queue?: QueueLike;

--- a/packages/mcp/eslint.config.js
+++ b/packages/mcp/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/mcp/src/agent-tools.ts
+++ b/packages/mcp/src/agent-tools.ts
@@ -12,9 +12,9 @@ import type { ToolDefinition, ToolInputSchema, ToolResult } from "./tools";
 interface McpAgentExposure {
     /** What the agent does — shown to the calling model, which decides from it. */
     description: string;
-    /** The agent's export name (its `ctx.agents.&lt;name>` / `AGENT_&lt;NAME>` binding). */
+    /** The agent's export name (its `ctx.agents.<name>` / `AGENT_<NAME>` binding). */
     name: string;
-    /** Override the model-facing tool name (default `agent_&lt;name>`). */
+    /** Override the model-facing tool name (default `agent_<name>`). */
     toolName?: string;
 }
 
@@ -67,7 +67,7 @@ const AGENT_STATUS_INPUT_SCHEMA: ToolInputSchema = {
     type: "object",
 };
 
-/** The model-facing tool name for an exposure (`toolName` override or `agent_&lt;name>`). */
+/** The model-facing tool name for an exposure (`toolName` override or `agent_<name>`). */
 const agentToolName = (exposure: McpAgentExposure): string => exposure.toolName ?? `agent_${exposure.name}`;
 
 /**

--- a/packages/mcp/src/compose.ts
+++ b/packages/mcp/src/compose.ts
@@ -4,7 +4,7 @@
  * Compose several independent tool surfaces into one MCP server.
  *
  * `createLunoraMcpServer` hard-wires the deployment surface because it also has
- * to route dynamically-named `agent_&lt;name>` tools. Everything else in this
+ * to route dynamically-named `agent_<name>` tools. Everything else in this
  * package — the documentation tools, and the CLI's local dev tools — is a flat
  * list of `(definition, handler)` pairs, and those compose by concatenation.
  * {@link createToolServer} is that composition: one `ListTools` answer, one

--- a/packages/mcp/src/docs/fumadocs-hits.ts
+++ b/packages/mcp/src/docs/fumadocs-hits.ts
@@ -28,7 +28,7 @@ interface FumadocsSearchResult {
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 /**
- * Strip the `&lt;mark>` highlight tags fumadocs wraps around matched terms. They
+ * Strip the `<mark>` highlight tags fumadocs wraps around matched terms. They
  * are UI markup; leaving them in makes the model treat them as content (and
  * sometimes echo them back into generated code).
  */

--- a/packages/mcp/src/docs/remote-index.ts
+++ b/packages/mcp/src/docs/remote-index.ts
@@ -7,7 +7,7 @@
  * than the MCP endpoint the same site serves:
  *
  * - `GET /api/search?query=…` — the fumadocs (Orama) search index
- * - `GET /llms.mdx/docs/&lt;slug>` — one page as Markdown
+ * - `GET /llms.mdx/docs/<slug>` — one page as Markdown
  * - `GET /llms.txt` — the page index
  *
  * That keeps a locally-run server (the CLI's `lunora mcp serve`) working

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -10,7 +10,7 @@
  * is read-only by default — the write tools are exposed only when `allowWrites`
  * (or the `LUNORA_MCP_ALLOW_WRITES` env) is set, and every run tool is
  * allowlisted against the deployment's discovered public functions. It can also
- * front durable `@lunora/agent` runs as `agent_&lt;name>` tools when `allowAgents`
+ * front durable `@lunora/agent` runs as `agent_<name>` tools when `allowAgents`
  * (or `LUNORA_MCP_ALLOW_AGENTS` + `LUNORA_MCP_AGENTS`) is set. Run the
  * `lunora-mcp` binary (configured via the `LUNORA_URL`, `LUNORA_ADMIN_TOKEN`,
  * and `LUNORA_MCP_ALLOW_WRITES` env vars) for the stdio transport, serve the

--- a/packages/mcp/src/run-bin.ts
+++ b/packages/mcp/src/run-bin.ts
@@ -9,7 +9,7 @@ import { connectStdio } from "./server";
  * - `LUNORA_URL` (required) — base URL of the deployed Worker.
  * - `LUNORA_ADMIN_TOKEN` (optional, but effectively required to be the admin bearer) — bearer token sent on every RPC. It must be the deployment's admin token: every tool depends on admin-gated introspection (`/_lunora/admin/*`), so a scoped/app token 403s (`ADMIN_FORBIDDEN`) on the first call. The read-only guarantee is enforced in-process via `LUNORA_MCP_ALLOW_WRITES` defaulting off — NOT by the token's scope.
  * - `LUNORA_MCP_ALLOW_WRITES` (optional) — set to `1`/`true`/`yes`/`on` to expose the mutation/action tools. Default: read-only (writes disabled).
- * - `LUNORA_MCP_ALLOW_AGENTS` (optional) — set to `1`/`true`/`yes`/`on` to expose the `agent_&lt;name>` tools. Default: agent tools disabled.
+ * - `LUNORA_MCP_ALLOW_AGENTS` (optional) — set to `1`/`true`/`yes`/`on` to expose the `agent_<name>` tools. Default: agent tools disabled.
  * - `LUNORA_MCP_AGENTS` (optional) — `;`-separated `name:description` pairs (e.g. `"support:Support questions;billing:Billing help"`) selecting which agents to expose.
  * - `LUNORA_MCP_AGENT_TIMEOUT_MS` (optional) — wall-clock budget a single agent tool call awaits before returning a pending result.
  */

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -68,7 +68,7 @@ interface LunoraMcpServerOptions {
     agents?: ReadonlyArray<McpAgentExposure>;
 
     /**
-     * Expose the per-agent tools (`agent_&lt;name>` + the generic
+     * Expose the per-agent tools (`agent_<name>` + the generic
      * `lunora_agent_status`). Defaults to `false`, mirroring `allowWrites`:
      * starting a durable agent run is a side effect, so the agent tools are
      * omitted from the advertised list AND refused at dispatch unless explicitly

--- a/packages/notify/__tests__/helpers.ts
+++ b/packages/notify/__tests__/helpers.ts
@@ -111,7 +111,7 @@ const compareById = (a: { id: string }, b: { id: string }): number => {
 /**
  * A minimal functional fake of the D1 slice the subscription store uses. Branches
  * on the statement text (CREATE/INSERT…ON CONFLICT/SELECT/DELETE/UPDATE) against
- * an in-memory row map — enough to exercise the store's row&lt;->object mapping,
+ * an in-memory row map — enough to exercise the store's row<->object mapping,
  * upsert-preserves-createdAt, and filtered listing.
  */
 /** Options for {@link fakeD1}. `failOn` injects a store error on the matching SQL verb. */

--- a/packages/notify/eslint.config.js
+++ b/packages/notify/eslint.config.js
@@ -160,4 +160,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/notify/src/notify.ts
+++ b/packages/notify/src/notify.ts
@@ -442,7 +442,7 @@ export const createNotify = (definition: NotifyDefinition, env: NotifyEnv, optio
      * iteration until it empties out.
      *
      * A non-positive `filter.limit` (zero or negative) short-circuits to an
-     * empty page — `{ nextCursor: undefined, result: &lt;all-zero> }` — without
+     * empty page — `{ nextCursor: undefined, result: <all-zero> }` — without
      * calling the store or `deliverPage`. This differs from the STORE layer's
      * `limit` convention (non-positive means "no cap"): here `limit` is an
      * audience cap, so its zero-floor is zero deliveries, not an unbounded page.

--- a/packages/notify/src/queue.ts
+++ b/packages/notify/src/queue.ts
@@ -18,7 +18,7 @@ export interface PushBroadcastJob {
     type: "lunora.push.broadcast";
 }
 
-/** The structural slice of a `@lunora/queue` producer (`ctx.queues.&lt;name>`) used here. */
+/** The structural slice of a `@lunora/queue` producer (`ctx.queues.<name>`) used here. */
 export interface QueueProducerLike {
     send: (body: PushBroadcastJob) => Promise<void>;
 }

--- a/packages/notify/src/subscriptions/normalize.ts
+++ b/packages/notify/src/subscriptions/normalize.ts
@@ -23,7 +23,7 @@ const MAX_METADATA_BYTES = 4096;
  * Validate a `register()` input's `metadata` (NOTIFY-02) before it is
  * STORED: must be a plain object (not an array, class instance, or
  * primitive — those are legal `typeof "object"` values a client could send
- * despite the `Record&lt;string, unknown&gt;` type, since the input crosses an RPC
+ * despite the `Record<string, unknown>` type, since the input crosses an RPC
  * boundary untyped at runtime), must be JSON-serialisable (a circular
  * reference or a `BigInt` value makes `JSON.stringify` throw), and its
  * serialised form must not exceed {@link MAX_METADATA_BYTES}.

--- a/packages/nuxt/eslint.config.js
+++ b/packages/nuxt/eslint.config.js
@@ -114,4 +114,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -1,7 +1,7 @@
 /**
  * The Lunora **Nuxt module** — single-worker composition, the inverse of the
  * old two-worker split. Instead of Lunora owning the Cloudflare worker entry, it
- * is mounted *inside* Nitro: a server route at `&lt;prefix>/**` (default
+ * is mounted *inside* Nitro: a server route at `<prefix>/**` (default
  * `/_lunora/**`) forwards every RPC / WebSocket / admin request to the project's
  * Lunora app (`createWorker(...)` / `defineApp().build()`), which runs in the
  * same worker Nuxt deploys as. The `ShardDO` Durable Object class is carried to
@@ -203,7 +203,7 @@ export interface ModuleOptions {
 }
 
 /**
- * Return type of `defineNuxtModule&lt;ModuleOptions>({...})` — the value overload of
+ * Return type of `defineNuxtModule<ModuleOptions>({...})` — the value overload of
  * `defineNuxtModule` (the one taking a definition), extracted structurally so the
  * default export has a locally-nameable type under `isolatedDeclarations` without
  * importing `NuxtModule` from `@nuxt/schema` (not a resolvable dependency here).

--- a/packages/observability/eslint.config.js
+++ b/packages/observability/eslint.config.js
@@ -142,4 +142,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/observability/src/function-metrics.ts
+++ b/packages/observability/src/function-metrics.ts
@@ -1,7 +1,7 @@
 /**
  * Per-shard durable function-call metrics.
  *
- * A reserved table that accumulates per-`&lt;file>:&lt;function>` call counters and
+ * A reserved table that accumulates per-`<file>:<function>` call counters and
  * latency aggregates so they survive DO hibernation/restart — the in-memory
  * `metrics`/`functionStats` on `ShardDO` reset on every cold start, which is
  * fine for a "since this instance woke" readout but loses the lifetime picture
@@ -182,7 +182,7 @@ interface RecordFunctionMetricInput {
      * dispatch used no declared index, keeping the hot path unchanged.
      */
     indexHits?: ReadonlyArray<IndexHit>;
-    /** The `&lt;file>:&lt;function>` identifier. */
+    /** The `<file>:<function>` identifier. */
     path: string;
 
     /**

--- a/packages/observability/src/issue-explainer.ts
+++ b/packages/observability/src/issue-explainer.ts
@@ -97,7 +97,7 @@ export interface AiRunBinding {
 
 /** Parsed `__lunora_admin__:explainIssue` payload: the folded Issue's identifying facts, plus an optional model override. */
 export interface ExplainIssueArgs {
-    /** The Issue's culprit (`&lt;file>:&lt;function>` or `container:&lt;name>`), for grounding context. */
+    /** The Issue's culprit (`<file>:<function>` or `container:<name>`), for grounding context. */
     culprit?: string;
     /** Per-request model-id override; falls back to the caller's `defaultModel`, then {@link DEFAULT_EXPLAIN_ISSUE_MODEL}. */
     model?: string;

--- a/packages/observability/src/log-buffer.ts
+++ b/packages/observability/src/log-buffer.ts
@@ -19,7 +19,7 @@ type LogLevel = ContextLogLevel;
  */
 interface LogEntry {
     exitCode?: number;
-    /** Structured fields from a `ctx.log.&lt;level>(message, fields)` / `ctx.log.with(fields)` call, when present. */
+    /** Structured fields from a `ctx.log.<level>(message, fields)` / `ctx.log.with(fields)` call, when present. */
     fields?: Record<string, unknown>;
     functionPath?: string;
     instance?: string;

--- a/packages/observability/src/request-log.ts
+++ b/packages/observability/src/request-log.ts
@@ -3,7 +3,7 @@
  *
  * A reserved, append-only table that records every lunora-function dispatch
  * with the app-level context Cloudflare structurally cannot attribute: the
- * `&lt;file>:&lt;function>` path, the shard key (the DO id name), the acting user /
+ * `<file>:<function>` path, the shard key (the DO id name), the acting user /
  * identity, the (redacted) call args, the outcome + (redacted) error message,
  * the handler execution time, the tables the handler read and wrote, whether
  * the result came from the reactive cache, and how many subscriptions the
@@ -55,7 +55,7 @@ interface RequestLogEntry {
     durationMs: number;
     /** Error message when `outcome === "error"`, redacted like args/identity; absent on success. */
     errorMessage?: string;
-    /** The `&lt;file>:&lt;function>` identifier dispatched, e.g. `messages:list`. */
+    /** The `<file>:<function>` identifier dispatched, e.g. `messages:list`. */
     functionPath: string;
     /** Identity-claim envelope forwarded by the runtime, JSON-decoded; leaf values are redacted (the claims are PII), so only the shape survives. Absent for anonymous requests. Correlate on `userId` instead. */
     identity?: Record<string, unknown>;
@@ -106,7 +106,7 @@ interface RequestLogWriteOptions {
 
 /** Filters for {@link readRequestLog}, all AND-combined; every value is a bound SQL parameter, so nothing here injects SQL. */
 interface ReadRequestLogOptions {
-    /** Functions whose path begins with this prefix (a `&lt;file>:` or `&lt;file>:&lt;fn>` correlation). */
+    /** Functions whose path begins with this prefix (a `<file>:` or `<file>:<fn>` correlation). */
     functionPathPrefix?: string;
     /** Upper bound on returned rows, clamped to [1, 10000]. */
     limit?: number;
@@ -138,7 +138,7 @@ interface ErrorIssue {
     assignee?: string;
     /** Number of `error` rows folded into this Issue within the scanned window. */
     count: number;
-    /** The `&lt;file>:&lt;function>` (or `container:&lt;name>`) the errors came from. */
+    /** The `<file>:<function>` (or `container:<name>`) the errors came from. */
     culprit: string;
     /** Wall-clock millis of the oldest folded row. */
     firstSeen: number;
@@ -182,7 +182,7 @@ interface IssuesResult {
 
 /** Filters for {@link readErrorIssues}; forwarded to {@link readRequestLog} with `outcome` forced to `error`. */
 interface ReadIssuesOptions {
-    /** Functions whose path begins with this prefix (a `&lt;file>:` or `&lt;file>:&lt;fn>` correlation). */
+    /** Functions whose path begins with this prefix (a `<file>:` or `<file>:<fn>` correlation). */
     functionPathPrefix?: string;
     /** Upper bound on error rows scanned before grouping, clamped to [1, 10000]. */
     limit?: number;
@@ -215,7 +215,7 @@ const runSql = <Row = Record<string, unknown>>(sql: SqlExec, query: string, ...p
  * STRING — which is what `errorMessage`/log `fields`-as-rendered-text are —
  * only pattern-shaped matches apply: emails, long digit runs / structured
  * numeric IDs (credit-card, phone, SSN, AWS-access-key-style), and an explicit
- * `Bearer &lt;token>` / `token=…`-shaped substring. A free-text `password=hunter2`
+ * `Bearer <token>` / `token=…`-shaped substring. A free-text `password=hunter2`
  * or a bare provider API key embedded in prose (e.g. `sk-live-…`) is NOT
  * caught on a plain string — there is no key to match against, and neither is
  * a recognized value pattern. So this is a PII-pattern net for rendered text,
@@ -316,8 +316,8 @@ const cacheHitColumn = (cacheHit: boolean | undefined): null | number => {
  * it's redacted below, and the resulting hash is persisted in
  * `error_fingerprint`. `readErrorIssues` groups off that stored hash instead of
  * recomputing `fingerprintError` from the (redacted) `error_message` column, so
- * masking a PII-bearing value — e.g. two different `&lt;n>`-bucketed IDs that
- * redact to two different tag lengths (`&lt;DL>` vs `&lt;BANKACC>`) — can't split an
+ * masking a PII-bearing value — e.g. two different `<n>`-bucketed IDs that
+ * redact to two different tag lengths (`<DL>` vs `<BANKACC>`) — can't split an
  * existing Issue or change its identity.
  */
 const appendRequestLogEntry = (sql: SqlExec, entry: AppendRequestLogEntry, options: RequestLogWriteOptions = {}): void => {
@@ -474,7 +474,7 @@ const isLogFields = (value: unknown): value is LogFields => {
 };
 
 /**
- * Split a `ctx.log.&lt;level>(...)` call's raw arguments into a display `message`
+ * Split a `ctx.log.<level>(...)` call's raw arguments into a display `message`
  * and optional structured `fields`. The structured form — a message string plus
  * a plain-object fields bag — is matched only for exactly `(string, object)`;
  * every other shape is console-style and rendered whole (so existing
@@ -697,7 +697,7 @@ const readRequestLog = (sql: SqlExec, options: ReadRequestLogOptions = {}): Requ
  * per-occurrence noise — a route-scanner sweep (`/wp-admin`, `/.env`), a
  * per-request id in the message (`user 12345 not found`) — onto one Issue.
  * Container crashes fold in too, since they land as `error` rows under
- * `functionPath: "container:&lt;name>"`.
+ * `functionPath: "container:<name>"`.
  *
  * The grouping hash used per row is `row.error_fingerprint` when present —
  * computed by {@link appendRequestLogEntry} from the RAW message, before

--- a/packages/payment/eslint.config.js
+++ b/packages/payment/eslint.config.js
@@ -152,4 +152,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/payment/src/database-store.ts
+++ b/packages/payment/src/database-store.ts
@@ -5,7 +5,7 @@
  * `paymentTables` are merged into the app schema and this store reads/writes them through a small
  * `PaymentDb` port that `ctx.db` satisfies. That inherits Lunora's OCC, reactivity, sharding, and
  * `.global()`/D1 read path for free. The codecs below are the single source of truth for the
- * domain ⇄ row mapping (money split into `amountMinor` + `currency`, id ⇄ `provider&lt;Thing>Id`).
+ * domain ⇄ row mapping (money split into `amountMinor` + `currency`, id ⇄ `provider<Thing>Id`).
  */
 import { money } from "./money";
 import type { PaymentStore } from "./store";

--- a/packages/payment/src/webhook.ts
+++ b/packages/payment/src/webhook.ts
@@ -64,7 +64,7 @@ export interface VerifyStandardWebhookInput {
     readonly toleranceSeconds?: number;
     /** `webhook-id` header. */
     readonly webhookId: string;
-    /** `webhook-signature` header — space-separated `v1,&lt;base64>` entries. */
+    /** `webhook-signature` header — space-separated `v1,<base64>` entries. */
     readonly webhookSignature: string;
     /** `webhook-timestamp` header — unix seconds as a string. */
     readonly webhookTimestamp: string;

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.tag-budget.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.tag-budget.test.ts
@@ -5,7 +5,7 @@ import { createSocketHost } from "../src/cloudflare-host";
 
 /**
  * The Cloudflare socket host reserves one `acceptWebSocket` tag slot for its
- * own identity tag (`lunora-socket:&lt;uuid>`, see `cloudflare-host.ts`'s
+ * own identity tag (`lunora-socket:<uuid>`, see `cloudflare-host.ts`'s
  * `ID_TAG_PREFIX`), so Cloudflare's documented cap of 10 tags / 256 characters
  * per tag (developers.cloudflare.com/durable-objects/api/state/) becomes a
  * caller-visible budget of 9 usable tags. These tests pin that the adapter

--- a/packages/platform-cloudflare/eslint.config.js
+++ b/packages/platform-cloudflare/eslint.config.js
@@ -180,4 +180,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/platform-cloudflare/src/index.ts
+++ b/packages/platform-cloudflare/src/index.ts
@@ -5,7 +5,7 @@
  * `@lunora/platform` says what a host must provide; this says how Cloudflare
  * provides it, over `DurableObjectState`, hibernatable WebSockets, and a
  * `DurableObjectNamespace`. A second target ships the same surface from its own
- * `@lunora/platform-&lt;target>` package, so adding one is a sibling rather than a
+ * `@lunora/platform-<target>` package, so adding one is a sibling rather than a
  * refactor of `@lunora/do`.
  *
  * # Why this depends on nothing but the contracts

--- a/packages/platform-node/eslint.config.js
+++ b/packages/platform-node/eslint.config.js
@@ -191,4 +191,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/platform/eslint.config.js
+++ b/packages/platform/eslint.config.js
@@ -180,4 +180,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/platform/src/bindings.ts
+++ b/packages/platform/src/bindings.ts
@@ -408,16 +408,16 @@ export interface MessageSendRequestLike<Body = unknown> {
 }
 
 /**
- * Minimal structural projection of workers-types' `Queue&lt;Body>` (the producer
+ * Minimal structural projection of workers-types' `Queue<Body>` (the producer
  * binding). The real binding's `send`/`sendBatch` resolve to a metadata object;
- * we widen the return to `Promise&lt;unknown>` so a plain-object fake satisfies it.
+ * we widen the return to `Promise<unknown>` so a plain-object fake satisfies it.
  */
 export interface QueueBindingLike<Body = unknown> {
     send: (message: Body, options?: QueueSendOptions) => Promise<unknown>;
     sendBatch: (messages: Iterable<MessageSendRequestLike<Body>>, options?: QueueSendBatchOptions) => Promise<unknown>;
 }
 
-/** Structural mirror of workers-types' `Message&lt;Body>` (one delivered message). */
+/** Structural mirror of workers-types' `Message<Body>` (one delivered message). */
 export interface MessageLike<Body = unknown> {
     /** Acknowledge this message so it is not redelivered. */
     ack: () => void;
@@ -429,7 +429,7 @@ export interface MessageLike<Body = unknown> {
     readonly timestamp: Date;
 }
 
-/** Structural mirror of workers-types' `MessageBatch&lt;Body>` handed to a consumer. */
+/** Structural mirror of workers-types' `MessageBatch<Body>` handed to a consumer. */
 export interface MessageBatchLike<Body = unknown> {
     /** Acknowledge every message in the batch. */
     ackAll: () => void;

--- a/packages/queue/__tests__/workerd/queue-smoke.workerd.test.ts
+++ b/packages/queue/__tests__/workerd/queue-smoke.workerd.test.ts
@@ -3,7 +3,7 @@
  *
  * The Node unit suite exercises the producer/dispatcher against plain-object
  * doubles; this suite proves the same code boots and runs against the real
- * runtime objects. Covered: the typed `ctx.queues.&lt;name>` producer sends
+ * runtime objects. Covered: the typed `ctx.queues.<name>` producer sends
  * through a real Cloudflare `Queue` binding (Miniflare-backed); the generated
  * worker `queue()` consumer path (`dispatchQueueBatch`) consumes a real workerd
  * `MessageBatch` and its `ack()` disposition is visible to the runtime

--- a/packages/queue/eslint.config.js
+++ b/packages/queue/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/queue/src/create-queue-context.ts
+++ b/packages/queue/src/create-queue-context.ts
@@ -15,7 +15,7 @@ import type { QueueBindingLike, QueueBindingSpec, Queues } from "./types";
  * Build the `ctx.queues` map for a request: resolve every spec's `env[binding]`
  * into the `exportName → Queue binding` map and wrap it in {@link createQueues}.
  * A spec whose binding is absent from `env` is skipped here — the helpful "no
- * queue named …" error is raised lazily by `ctx.queues.&lt;name>.send(...)` when
+ * queue named …" error is raised lazily by `ctx.queues.<name>.send(...)` when
  * the missing queue is actually used.
  */
 // eslint-disable-next-line import/prefer-default-export -- named export by package convention; the index re-exports it

--- a/packages/queue/src/define-queue.ts
+++ b/packages/queue/src/define-queue.ts
@@ -24,7 +24,7 @@ const queueDefaultName = (exportName: string): string => exportName.replaceAll(/
 
 /**
  * Declare a Cloudflare Queue deployed alongside the app. Pure validation +
- * branding: codegen discovers the export, emits the typed `ctx.queues.&lt;name>`
+ * branding: codegen discovers the export, emits the typed `ctx.queues.<name>`
  * producer and (for push consumers) the worker `queue()` dispatch; the config
  * layer reconciles the wrangler `queues.producers[]` / `queues.consumers[]`
  * entries from the same definition.
@@ -34,7 +34,7 @@ const queueDefaultName = (exportName: string): string => exportName.replaceAll(/
  * import { defineQueue } from "@lunora/queue";
  * import { api } from "./_generated/api";
  *
- * export const emailQueue = defineQueue&lt;{ to: string }>({
+ * export const emailQueue = defineQueue<{ to: string }>({
  *     handler: async (ctx, batch) => {
  *         for (const message of batch.messages) {
  *             await ctx.run(api.email.send, { to: message.body.to });

--- a/packages/queue/src/dispatch.ts
+++ b/packages/queue/src/dispatch.ts
@@ -23,7 +23,7 @@ interface QueueRegistryEntry {
      * The `defineQueue` result (carries the push handler). The body type is
      * erased to `any` here because the registry is heterogeneous — different
      * queues carry different message bodies, and the handler param is
-     * contravariant, so a precise `QueueDefinition&lt;Body>` would not be assignable
+     * contravariant, so a precise `QueueDefinition<Body>` would not be assignable
      * to a shared `unknown`-bodied slot. Runtime dispatch passes the delivered
      * batch straight through, so the erasure is type-only.
      */

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -14,7 +14,7 @@ import type { DispatchLogger, DispatchRunFunction } from "@lunora/dispatch";
 import type { MessageBatchLike, MessageSendRequestLike, QueueBindingLike, QueueSendBatchOptions, QueueSendOptions } from "@lunora/platform";
 
 /**
- * The typed producer bound to `ctx.queues.&lt;name>`. Sending is a side effect, so
+ * The typed producer bound to `ctx.queues.<name>`. Sending is a side effect, so
  * the generated context exposes this only on `MutationCtx` / `ActionCtx` (never
  * the deterministic `QueryCtx`), mirroring `ctx.scheduler` / `ctx.workflows`.
  */
@@ -103,8 +103,8 @@ export interface QueueConfig<Body = unknown> extends QueueConsumerTuning {
 export interface QueueDefinition<Body = unknown> extends QueueConfig<Body> {
     /**
      * Phantom carrier for the message body type, so codegen can type the
-     * generated `ctx.queues.&lt;name>` producer as `QueueProducer&lt;Body>` from
-     * `typeof &lt;export>`. Never assigned at runtime (type-only).
+     * generated `ctx.queues.<name>` producer as `QueueProducer<Body>` from
+     * `typeof <export>`. Never assigned at runtime (type-only).
      */
     readonly __lunoraBody?: Body;
     /** Runtime brand identifying a `defineQueue` result. */

--- a/packages/ratelimit/eslint.config.js
+++ b/packages/ratelimit/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/ratelimit/src/plugin.ts
+++ b/packages/ratelimit/src/plugin.ts
@@ -20,7 +20,7 @@ export interface RatelimitApiContext<Context> {
  *
  * ```ts
  * const limiter = new RateLimiter({ config: { send: { kind: "token bucket", rate: 5, period: 60_000, capacity: 5 } } });
- * const c = initLunora.dataModel&lt;DataModel>().create();
+ * const c = initLunora.dataModel<DataModel>().create();
  * export const send = c.mutation
  *     .use(ratelimitPlugin(limiter).middleware!)
  *     .mutation(async ({ ctx, args }) => {

--- a/packages/react-native/eslint.config.js
+++ b/packages/react-native/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/react/eslint.config.js
+++ b/packages/react/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/react/src/lunora-provider.tsx
+++ b/packages/react/src/lunora-provider.tsx
@@ -19,7 +19,7 @@ interface LunoraProviderProps {
      * route through the offline queue on the client), and `gcTime: 5min` (keep
      * results around for a short return-to-view window).
      *
-     * If a parent `&lt;QueryClientProvider>` is already mounted, the provider
+     * If a parent `<QueryClientProvider>` is already mounted, the provider
      * uses *that* client and does NOT install an inner one (so apps with their
      * own setup don't double-wrap).
      */
@@ -73,7 +73,7 @@ const LunoraProvider = ({ children, client, queryClient }: LunoraProviderProps):
 };
 
 /**
- * Read the {@link LunoraClient} from the nearest `&lt;LunoraProvider>`. Kept
+ * Read the {@link LunoraClient} from the nearest `<LunoraProvider>`. Kept
  * colocated with the provider for back-compat.
  */
 const useLunora = (): LunoraClient => {

--- a/packages/react/src/use-agent-chat.ts
+++ b/packages/react/src/use-agent-chat.ts
@@ -113,7 +113,7 @@ interface UseAgentChatOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link UseAgentChatResult.cancel} is a
      * no-op.
      */
@@ -123,7 +123,7 @@ interface UseAgentChatOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link UseAgentChatOptions.sendArgs} and the per-call args.
      */
     send: FunctionReference<"mutation">;

--- a/packages/react/src/use-agent.ts
+++ b/packages/react/src/use-agent.ts
@@ -51,7 +51,7 @@ interface UseAgentOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link UseAgentResult.cancel} is a
      * no-op.
      */
@@ -59,7 +59,7 @@ interface UseAgentOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link UseAgentOptions.runArgs} and the per-call args.
      */
     run: FunctionReference<"mutation">;
@@ -101,7 +101,7 @@ const NO_MUTATION_REF: FunctionReference<"mutation"> = { __lunoraRef: "" };
  * `useAgentChat`.
  *
  * `run` and `cancel` stay generic over the app-defined mutations that wrap
- * `ctx.agents.&lt;name>.run` / `.cancel`, so the hook hard-codes no function names
+ * `ctx.agents.<name>.run` / `.cancel`, so the hook hard-codes no function names
  * beyond the `agents:*` surface.
  */
 const useAgent = (options: UseAgentOptions): UseAgentResult => {

--- a/packages/react/src/use-http-stream.ts
+++ b/packages/react/src/use-http-stream.ts
@@ -66,7 +66,7 @@ const reducer = function <T>(state: State<T>, action: Action<T>): State<T> {
 };
 
 /**
- * Consume an **HTTP-SSE route stream** (`httpRoute.&lt;verb>(path).stream()`) via
+ * Consume an **HTTP-SSE route stream** (`httpRoute.<verb>(path).stream()`) via
  * `client.httpStream`. Distinct from `useStream`, which consumes the WS
  * procedure stream (`kind: "stream"`). Returns the chunks received so far plus
  * a lifecycle status and a cancel function. Changing the route or the

--- a/packages/react/src/use-voice-agent.ts
+++ b/packages/react/src/use-voice-agent.ts
@@ -29,9 +29,9 @@ type VoiceServerFrame =
 type VoiceClientFrame = { text: string; type: "text" } | { type: "commit" } | { type: "interrupt" };
 
 /**
- * The `agents.&lt;name>Voice` reference codegen emits for a voice-enabled agent — a
+ * The `agents.<name>Voice` reference codegen emits for a voice-enabled agent — a
  * live, WS-backed session keyed by `threadKey`. A structural subset of the
- * generated member, so passing `api.agents.&lt;name>Voice` type-checks.
+ * generated member, so passing `api.agents.<name>Voice` type-checks.
  */
 type VoiceReference = FunctionReference<"stream", { threadKey: string }, Record<string, unknown>>;
 
@@ -75,7 +75,7 @@ interface UseVoiceAgentOptions {
     silenceThreshold?: number;
     /** The thread to converse on — shared with the agent's text turns. */
     threadKey: string;
-    /** The generated `api.agents.&lt;name>Voice` reference — identifies the voice DO endpoint. */
+    /** The generated `api.agents.<name>Voice` reference — identifies the voice DO endpoint. */
     voice: VoiceReference;
 }
 
@@ -127,7 +127,7 @@ const deriveWebSocketUrl = (url: string): string => {
 
 /**
  * Derive the agent's export name from its voice reference. Codegen emits the
- * member as `agents.&lt;name>Voice` (ref `agents:&lt;name>Voice`), so strip the
+ * member as `agents.<name>Voice` (ref `agents:<name>Voice`), so strip the
  * `agents:` namespace and the `Voice` suffix.
  */
 const agentNameFromReference = (voice: VoiceReference): string => {
@@ -168,7 +168,7 @@ interface VoiceConnection {
  * WebSocket to the agent's `VoiceSessionDO`, captures mic audio as 16 kHz PCM,
  * streams the agent's synthesized speech back through the browser's audio output,
  * and mirrors the call lifecycle (`status`, `transcript`, `interimTranscript`,
- * `audioLevel`) to React state. Pass the generated `api.agents.&lt;name>Voice`
+ * `audioLevel`) to React state. Pass the generated `api.agents.<name>Voice`
  * reference (never a string), matching `useAgentChat`'s reference-passing style.
  *
  * v1 transport is plain binary WebSocket frames with push-to-talk / silence-timer

--- a/packages/replica/__tests__/adapters.test.ts
+++ b/packages/replica/__tests__/adapters.test.ts
@@ -33,7 +33,7 @@ const makeBetterSqlite3 = (): SqliteAdapter => createBetterSqlite3Adapter(new Da
  *
  * REPLICA-01 STOP: this fixture matches the DOCUMENTED real `oo1.DB` wire
  * shape — `exec({ returnValue: "resultRows", rowMode: "object" })` returns
- * rows directly (`Record&lt;string, unknown>[]`, NOT sql.js's
+ * rows directly (`Record<string, unknown>[]`, NOT sql.js's
  * `{ columns, values }[]`), and `selectValue()` returns a single scalar — but
  * it is backed by a REAL sql.js engine underneath (every statement is still
  * parsed/executed by real SQLite), with a thin re-shaping layer translating

--- a/packages/replica/eslint.config.js
+++ b/packages/replica/eslint.config.js
@@ -160,4 +160,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/replica/src/adapters/sqlite-wasm.ts
+++ b/packages/replica/src/adapters/sqlite-wasm.ts
@@ -11,7 +11,7 @@ import type { SqliteAdapter } from "./types";
  * IMPORTANT (REPLICA-01): the real `oo1.DB.exec()` does NOT return sql.js's
  * `{ columns, values }[]` result shape — with `rowMode: "object"` and
  * `returnValue: "resultRows"` it returns the rows directly, as
- * `Record&lt;string, unknown>[]`. This adapter is written against that real
+ * `Record<string, unknown>[]`. This adapter is written against that real
  * shape; `lastInsertRowId` uses the driver's `selectValue()` convenience
  * method (a single-scalar query helper) rather than parsing a result-row
  * array.
@@ -19,7 +19,7 @@ import type { SqliteAdapter } from "./types";
  * @param database.close Tear down the database connection.
  * @param database.exec Execute SQL with optional bind params. With
  * `{ returnValue: "resultRows", rowMode: "object" }` it returns the matched
- * rows directly (`Record&lt;string, unknown>[]`); otherwise (DDL/DML/BEGIN/
+ * rows directly (`Record<string, unknown>[]`); otherwise (DDL/DML/BEGIN/
  * COMMIT/ROLLBACK) its return value is unused here.
  * @param database.selectValue Run a query and return the first column of the
  * first row as a single scalar — used for `SELECT last_insert_rowid()`.

--- a/packages/replica/src/apply-diff.ts
+++ b/packages/replica/src/apply-diff.ts
@@ -250,7 +250,7 @@ const applyDiffs = (current: ReadonlyMap<string, Record<string, unknown>>, diffs
 /**
  * Merge the row-level effect of a {@link TableDiff} into plain JSON
  * state keyed by table name, returning a new snapshot.
- * @param snapshot Current snapshot, e.g. `{ users: Map&lt;id, row>, posts: Map&lt;id, row> }`.
+ * @param snapshot Current snapshot, e.g. `{ users: Map<id, row>, posts: Map<id, row> }`.
  * @param diff Contains the target table name and the row-level changes to merge.
  * @returns A shallow copy of `snapshot` with `diff.table`'s map updated.
  * @experimental

--- a/packages/replica/src/define-events.ts
+++ b/packages/replica/src/define-events.ts
@@ -112,7 +112,7 @@ export interface DefineEventsOptions {
     /**
      * Optional version prefix for all event types.
      *
-     * When set, every qualified event type is prefixed with `"v&lt;N>."`, enabling
+     * When set, every qualified event type is prefixed with `"v<N>."`, enabling
      * versioned event naming like `"v1.chat.messageSent"` or `"v2.chat.messageSent"`.
      * This allows materializers to evolve their handling logic based on the event
      * version without breaking backward compatibility.

--- a/packages/replica/src/define-materializer.ts
+++ b/packages/replica/src/define-materializer.ts
@@ -110,9 +110,9 @@ const defineMaterializer = <S>(definition: MaterializerDef<S>): Materializer<S> 
  * A materializer of any state shape. The {@link MaterializerRuntime} holds a
  * heterogeneous collection and only ever calls `apply(entry)` / `setState(...)`
  * (with cast values) / reads `def.name` — it never needs the concrete state
- * type. `Materializer&lt;unknown>` won't do: `setState(state: S)` makes
- * `Materializer&lt;S>` invariant in `S`, so `Materializer&lt;number>` isn't assignable
- * to `Materializer&lt;unknown>`. Erasing the type param is the idiomatic fix.
+ * type. `Materializer<unknown>` won't do: `setState(state: S)` makes
+ * `Materializer<S>` invariant in `S`, so `Materializer<number>` isn't assignable
+ * to `Materializer<unknown>`. Erasing the type param is the idiomatic fix.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentional type erasure for a heterogeneous store; see above.
 type AnyMaterializer = Materializer<any>;

--- a/packages/replica/src/event-log-do.ts
+++ b/packages/replica/src/event-log-do.ts
@@ -12,7 +12,7 @@
  * |--------|--------------------|--------------------------------------|
  * | POST   | `/append`          | Insert events, return assigned seqs  |
  * | GET    | `/since?seq=N`     | Events with `seq >= N`               |
- * | GET    | `/range?from=N&amp;limit=M` | Paginated read               |
+ * | GET    | `/range?from=N&limit=M` | Paginated read               |
  * | GET    | `/size`            | Number of stored events              |
  * | GET    | `/state`           | Full event log state (for recovery)  |
  */
@@ -474,7 +474,7 @@ export class EventLogDO {
         );
     }
 
-    /** GET /range?from=N&amp;limit=M — paginated read (default limit 50). */
+    /** GET /range?from=N&limit=M — paginated read (default limit 50). */
     #handleRange(url: URL): Response {
         const fromParameter = url.searchParams.get("from");
         const fromSeq = fromParameter === null ? 0 : Number(fromParameter);

--- a/packages/replica/src/event-source.ts
+++ b/packages/replica/src/event-source.ts
@@ -23,8 +23,8 @@ export type UnknownEventHandling = "warn" | "ignore" | "fail" | ((entry: EventLo
  * Events emitted by the {@link EventSource} runtime.
  *
  * A `type` (not `interface`) so it satisfies `EventEmitter`'s
- * `Record&lt;string, unknown>` constraint — interfaces have no implicit index
- * signature and aren't assignable to `Record&lt;string, unknown>`.
+ * `Record<string, unknown>` constraint — interfaces have no implicit index
+ * signature and aren't assignable to `Record<string, unknown>`.
  * @experimental
  */
 export type EventSourceEvents = {

--- a/packages/replica/src/local-mirror.ts
+++ b/packages/replica/src/local-mirror.ts
@@ -128,7 +128,7 @@ const inferColumnAffinity = (value: unknown): ColumnAffinity => {
  * mirror.applyDiff(someDiff);
  *
  * // Query locally:
- * const rows = mirror.query&lt;{ id: string; name: string }>(
+ * const rows = mirror.query<{ id: string; name: string }>(
  *   "SELECT id, name FROM users WHERE name LIKE ?",
  *   ["alice%"],
  * );

--- a/packages/replica/src/seq.ts
+++ b/packages/replica/src/seq.ts
@@ -74,7 +74,7 @@ export const isClientSeq = (seq: Seq): seq is ClientSeq => typeof seq !== "numbe
  *
  * ```ts
  * const event = events.chat.messageSent({ channelId: "c1", text: "hello" });
- * // event: InputEvent&lt;"chat.messageSent", { channelId: string; text: string }>
+ * // event: InputEvent<"chat.messageSent", { channelId: string; text: string }>
  * ```
  * @experimental
  */

--- a/packages/runtime/__tests__/body-readers.test.ts
+++ b/packages/runtime/__tests__/body-readers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { readJsonBodyWithLimit } from "../src/body-readers";
 
 /**
- * `readJsonBodyWithLimit` promised `Record&lt;string, unknown>` but only checked
+ * `readJsonBodyWithLimit` promised `Record<string, unknown>` but only checked
  * that the body was valid JSON — `null`, `[1, 2]`, and a bare scalar all parse
  * cleanly and used to satisfy the `as` cast, so a caller that dereferenced a
  * property on the "object" (every admin route does) would 500 on what should

--- a/packages/runtime/__tests__/query-coordinator.rank-page.test.ts
+++ b/packages/runtime/__tests__/query-coordinator.rank-page.test.ts
@@ -14,7 +14,7 @@ interface ShardCall {
  * A fake shard that serves a fixed list of rank rows (already in local rank
  * order), honoring the coordinator's `take` and `after` resume key the same way
  * the real shard-do `rankPage` reader does: it walks past the `after` key with
- * the byte-identical `(__partition__, __sort_k&lt;i>__, __id__)` comparison and
+ * the byte-identical `(__partition__, __sort_k<i>__, __id__)` comparison and
  * returns up to `take` rows plus a `hasMore` flag. This is the structural
  * contract `__lunora_admin__:rankPage` fulfills server-side.
  */

--- a/packages/runtime/__tests__/rest-routes.test.ts
+++ b/packages/runtime/__tests__/rest-routes.test.ts
@@ -5,7 +5,7 @@ import type { ShardNamespaceLike } from "../src/resolve-shard";
 import { argsFromQuery } from "../src/rest-routes";
 
 /**
- * The public REST surface (`/_lunora/rest/&lt;namespace>/&lt;fn>`, plan 167) — RUNTIME-02
+ * The public REST surface (`/_lunora/rest/<namespace>/<fn>`, plan 167) — RUNTIME-02
  * (advisor 226). REST skipped the `args`-shape guard `/_lunora/rpc` enforces via
  * `parseEnvelope`, and `argsFromQuery` assigned into a plain `{}` so a `__proto__`
  * query key could reparent the args object. Both are now the same

--- a/packages/runtime/eslint.config.js
+++ b/packages/runtime/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/runtime/src/body-readers.ts
+++ b/packages/runtime/src/body-readers.ts
@@ -142,7 +142,7 @@ const readBodyBytesWithLimit = async (request: Request, limit: number = MAX_BODY
  * slip past the cap) and maps a 413 through unchanged while turning any other
  * parse failure into a 400. Returns `{}` for an empty body.
  *
- * The return type promises `Record&lt;string, unknown>`, but `JSON.parse` alone
+ * The return type promises `Record<string, unknown>`, but `JSON.parse` alone
  * cannot deliver that — `null`, `[1, 2]`, and a bare scalar all parse cleanly
  * and would previously satisfy the `as` cast, letting a caller downstream
  * dereference a property on a value that was never an object (a 500, not the

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -60,7 +60,7 @@ import { buildWorkflowsAdminRoutes } from "./workflows-admin-routes";
 /**
  * Wire-format RPC envelope. Posted to `POST /_lunora/rpc`.
  *
- * `functionPath` is the `&lt;file>:&lt;function>` identifier emitted by codegen,
+ * `functionPath` is the `<file>:<function>` identifier emitted by codegen,
  * e.g. `"messages:list"`. `shardKey` is optional — when omitted the runtime
  * routes to {@link WorkerOptions.defaultShardKey} (default `"__root__"`).
  *
@@ -233,7 +233,7 @@ interface FunctionDescriptor {
     /** The function's declared argument schema, derived from its `v.*` validators. */
     args: FunctionArgumentDescriptor[];
     kind: "action" | "mutation" | "query";
-    /** The `&lt;file>:&lt;function>` identifier, e.g. `messages:list`. */
+    /** The `<file>:<function>` identifier, e.g. `messages:list`. */
     path: string;
     /** `"internal"` functions are never exposed by the discovery endpoint; absence === public. */
     visibility?: "internal" | "public";
@@ -247,7 +247,7 @@ interface FunctionRegistryEntry {
     /**
      * Opt-in public-surface tag set by the `.expose({ rest: true })` builder
      * modifier (plan 167). Present only on procedures deliberately published over
-     * REST; the runtime builds a `/_lunora/rest/&lt;namespace>/&lt;fn>` route for each,
+     * REST; the runtime builds a `/_lunora/rest/<namespace>/<fn>` route for each,
      * routing THROUGH the procedure so auth/RLS/validators are enforced. Rides
      * along on the registered function's identity (like `fn.x402` / `fn.rls`), so
      * reading it needs no change to the generated registry shape.
@@ -533,7 +533,7 @@ interface BackupStore {
 
 /**
  * Manifest sidecar written next to each scheduled backup's NDJSON object (at
- * `&lt;file>.manifest.json`). Mirrors the manifest entry the CLI records for local
+ * `<file>.manifest.json`). Mirrors the manifest entry the CLI records for local
  * backups so both backup planes describe a snapshot the same way;
  * `cron`/`scheduledTime` additionally record which trigger produced it.
  */
@@ -791,7 +791,7 @@ interface WorkerOptions {
 
     /**
      * Key prefix the scheduled backup writes under (default `"backups/"`). The
-     * NDJSON object lands at `&lt;prefix>lunora-backup-&lt;id>.ndjson` and its manifest
+     * NDJSON object lands at `<prefix>lunora-backup-<id>.ndjson` and its manifest
      * at the same key plus `.manifest.json`.
      */
     backupPrefix?: string;
@@ -1261,7 +1261,7 @@ interface WorkerOptions {
      * Voice-session Durable Object namespaces, keyed by the agent's
      * `lunora/agents.ts` export name (e.g. `{ support: env.VOICE_SUPPORT }`).
      * Codegen wires this for every voice-enabled agent. When set, the worker
-     * exposes `/_lunora/voice/&lt;agentExportName>` — a WebSocket upgrade that
+     * exposes `/_lunora/voice/<agentExportName>` — a WebSocket upgrade that
      * resolves the caller's identity, forwards it on the server-minted
      * `x-lunora-userid` / `x-lunora-identity` headers, and hands the socket to
      * the agent's `VoiceSessionDO`. Omit it (voice-free apps) and the route does
@@ -1390,7 +1390,7 @@ const requestTelemetryMeta = (request: Request): RequestTelemetryMeta => {
         userAgent,
     };
 };
-/** Prefix for a voice-enabled agent's real-time session upgrade — `/_lunora/voice/&lt;agentExportName>` (dynamic, so matched by prefix not the exact-path table). */
+/** Prefix for a voice-enabled agent's real-time session upgrade — `/_lunora/voice/<agentExportName>` (dynamic, so matched by prefix not the exact-path table). */
 const VOICE_PATH_PREFIX = "/_lunora/voice/";
 const SCHEDULER_DISPATCH_PATH = "/_lunora/scheduler/dispatch";
 /** Admin-gated POST that manually fires one code-defined cron job by name (studio "Run now"). */
@@ -2540,7 +2540,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
      * authenticated by an HMAC-SHA-256 (base64url) signature over the exact body
      * in the `x-lunora-scheduler-signature` header (secret in
      * `env.LUNORA_SCHEDULER_SECRET`), or — when no HMAC secret is configured on
-     * the scheduler — an `authorization: Bearer &lt;admin token>` fallback. An
+     * the scheduler — an `authorization: Bearer <admin token>` fallback. An
      * unsigned/forged request is rejected with 403; we never run a job we can't
      * authenticate.
      *
@@ -2639,7 +2639,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         return response;
     };
 
-    /** The `&lt;CODE>_NOT_CONFIGURED` 400 a guarded admin route throws when its backing option is absent. */
+    /** The `<CODE>_NOT_CONFIGURED` 400 a guarded admin route throws when its backing option is absent. */
     interface NotConfiguredError {
         code: string;
         message: string;
@@ -3256,7 +3256,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     };
 
     /**
-     * Handle a voice-session WebSocket upgrade for `/_lunora/voice/&lt;agentExportName>`.
+     * Handle a voice-session WebSocket upgrade for `/_lunora/voice/<agentExportName>`.
      * Only registered when `options.voiceAgents` is provided (a voice-free app has
      * no route). Mirrors {@link handleWebSocketUpgrade}: enforce the WS origin
      * guard, resolve the caller's identity once, and forward the socket to the

--- a/packages/runtime/src/data-movement-admin-routes.ts
+++ b/packages/runtime/src/data-movement-admin-routes.ts
@@ -302,7 +302,7 @@ const buildDataMovementAdminRoutes = (deps: DataMovementAdminRouteDeps): Record<
     };
 
     /**
-     * Replay endpoint behind `lunora backup restore --to &lt;time>`. Accepts
+     * Replay endpoint behind `lunora backup restore --to <time>`. Accepts
      * per-shard pre-bucketed batches (the shape `/sync` emits, so the caller
      * just forwards each shard's changes back to the same shard — no
      * re-bucketing, which also sidesteps deletes carrying no shard-key field)

--- a/packages/runtime/src/export-tap.ts
+++ b/packages/runtime/src/export-tap.ts
@@ -317,7 +317,7 @@ interface R2PutLike {
 
 /**
  * Built-in R2 sink: write each shard's changes as an NDJSON object under
- * `&lt;prefix>/&lt;shardKey>/&lt;cursor>.ndjson`. The cursor in the key makes each object
+ * `<prefix>/<shardKey>/<cursor>.ndjson`. The cursor in the key makes each object
  * content-addressed by watermark, so an at-least-once replay overwrites the same
  * key rather than duplicating (idempotent at the object level). A `put` rejection
  * propagates so the tap retries.
@@ -363,7 +363,7 @@ interface KvLike {
 
 /**
  * KV-backed durable cursor store. The watermark key mirrors the CDC-in
- * convention (`__lunora_source_cursor`): `__lunora_source_cursor:export:&lt;sink>`.
+ * convention (`__lunora_source_cursor`): `__lunora_source_cursor:export:<sink>`.
  * A missing / malformed value reads as the empty map (drain from the beginning),
  * so a fresh sink or a corrupted key can never crash the pass.
  */

--- a/packages/runtime/src/query-coordinator.ts
+++ b/packages/runtime/src/query-coordinator.ts
@@ -705,7 +705,7 @@ const rollUpRank = (results: ReadonlyArray<ShardRpcOutcome>): RankFanOutResult =
  * SQLite storage-class ordering for a single serialized rank-key value.
  * `serializeSqlValue` only ever produces `null | number | string`, and SQLite's
  * `ORDER BY` ranks NULL < numbers < text, then by value within a class. The
- * shard's companion btree (`ORDER BY __partition__, __sort_k&lt;i>__, __id__`) uses
+ * shard's companion btree (`ORDER BY __partition__, __sort_k<i>__, __id__`) uses
  * exactly this order, so to merge shard slices without gaps or dupes at a
  * boundary the coordinator must compare the same way — a naive `a < b` would
  * mis-order `null` vs numbers and number-vs-string mixes.
@@ -765,7 +765,7 @@ const compareRankValueAsc = (a: unknown, b: unknown): number => {
 
 /**
  * Total order over two rank keys, byte-identical to the shard companion's
- * `ORDER BY __partition__ ASC, __sort_k&lt;i>__ &lt;dir>, __id__ ASC`. Partition and
+ * `ORDER BY __partition__ ASC, __sort_k<i>__ <dir>, __id__ ASC`. Partition and
  * the `__id__` tiebreak are always ascending; each sort column honors its
  * declared direction (`directions[i]`, default `asc`).
  */

--- a/packages/runtime/src/shard-client.ts
+++ b/packages/runtime/src/shard-client.ts
@@ -58,7 +58,7 @@ interface ShardFunctionReference<Args = unknown, Return = unknown> {
     readonly __lunoraRef: string;
 }
 
-/** Args type of a {@link ShardFunctionReference} (`Record&lt;string, unknown>` for an untyped ref). */
+/** Args type of a {@link ShardFunctionReference} (`Record<string, unknown>` for an untyped ref). */
 type ShardCallArgs<F> = F extends ShardFunctionReference<infer A, infer _R> ? A : Record<string, unknown>;
 
 /** Return type of a {@link ShardFunctionReference} (`unknown` for an untyped ref). */

--- a/packages/scheduler/__tests__/scheduler-do.test.ts
+++ b/packages/scheduler/__tests__/scheduler-do.test.ts
@@ -304,7 +304,7 @@ describe("schedulerDO — live subscriptions", () => {
 });
 
 describe("schedulerDO — bounded listing", () => {
-    /** Directly seed `id:&lt;prefix>-NNNN` headers, bypassing /schedule for speed with large counts. */
+    /** Directly seed `id:<prefix>-NNNN` headers, bypassing /schedule for speed with large counts. */
     const seedHeaders = (state: ReturnType<typeof createFakeState>, count: number, options: { pool?: string; prefix?: string } = {}): void => {
         const prefix = options.prefix ?? "job";
 

--- a/packages/scheduler/eslint.config.js
+++ b/packages/scheduler/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/scheduler/src/create-workpool.ts
+++ b/packages/scheduler/src/create-workpool.ts
@@ -8,7 +8,7 @@ import type { ArgsOf, EnqueueOptions, FunctionReference, Workpool, WorkpoolOptio
  * `@convex-dev/workpool`. Mirrors `createScheduler`'s `namespace` /
  * `originUrl` / `instanceName` options and is built on the SAME `SchedulerDO`:
  * a workpool is just a NAMED logical pool inside that DO (concurrency counter
- * keyed by {@link WorkpoolOptions.name} under the `pool:&lt;name>` storage key).
+ * keyed by {@link WorkpoolOptions.name} under the `pool:<name>` storage key).
  * It needs no extra Durable Object or wrangler binding beyond the SchedulerDO
  * the scheduler already uses.
  *

--- a/packages/scheduler/src/jobs.ts
+++ b/packages/scheduler/src/jobs.ts
@@ -16,7 +16,7 @@
  * ```
  *
  * A job's target may be a function reference (a one-shot dispatch, above) or a
- * durable workflow — passing the generated `workflows.&lt;name>` reference starts a
+ * durable workflow — passing the generated `workflows.<name>` reference starts a
  * fresh, multi-step, retried workflow INSTANCE on each fire, and the args are
  * type-checked against the workflow's `params`:
  *
@@ -303,20 +303,20 @@ interface CronJobsBuilder {
     /**
      * Raw cron expression escape hatch (5- or 6-field, full cron-parser grammar).
      * The target may be a function (`internal.file.fn`) or a durable workflow
-     * (`workflows.&lt;name>`); a workflow's `args` are inferred from its `params`.
+     * (`workflows.<name>`); a workflow's `args` are inferred from its `params`.
      */
     cron: <T extends CronTarget>(name: string, cronExpr: string, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
-    /** Daily at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    /** Daily at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.<name>`). */
     daily: <T extends CronTarget>(name: string, schedule: DailySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
-    /** Hourly at `minuteUTC` past the hour. The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    /** Hourly at `minuteUTC` past the hour. The target may be a function or a durable workflow (`workflows.<name>`). */
     hourly: <T extends CronTarget>(name: string, schedule: HourlySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
-    /** Every `{ seconds | minutes | hours }`. The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    /** Every `{ seconds | minutes | hours }`. The target may be a function or a durable workflow (`workflows.<name>`). */
     interval: <T extends CronTarget>(name: string, schedule: IntervalSchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
     /** Snapshot of the registered jobs, in declaration order. */
     jobs: () => ReadonlyArray<CronJob>;
-    /** Monthly on `day` at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    /** Monthly on `day` at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.<name>`). */
     monthly: <T extends CronTarget>(name: string, schedule: MonthlySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
-    /** Weekly on `dayOfWeek` at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.&lt;name>`). */
+    /** Weekly on `dayOfWeek` at `hourUTC:minuteUTC` (UTC). The target may be a function or a durable workflow (`workflows.<name>`). */
     weekly: <T extends CronTarget>(name: string, schedule: WeeklySchedule, target: T, args?: CronTargetArgs<T>) => CronJobsBuilder;
 }
 

--- a/packages/scheduler/src/scheduler-do.ts
+++ b/packages/scheduler/src/scheduler-do.ts
@@ -42,7 +42,7 @@ interface SchedulerEnv {
     /**
      * Fallback bearer token attached to the dispatch when
      * {@link SchedulerEnv.LUNORA_SCHEDULER_SECRET} is not configured. Sent as
-     * `authorization: Bearer &lt;token>`.
+     * `authorization: Bearer <token>`.
      */
     /* eslint-enable no-secrets/no-secrets */
     LUNORA_ADMIN_TOKEN?: string;
@@ -138,7 +138,7 @@ interface ScheduleRequestBody {
 
     /**
      * Workpool concurrency cap, sent alongside `pool` by `Workpool.enqueue`.
-     * Persisted on the pool's `pool:&lt;name>` storage row so the alarm-time
+     * Persisted on the pool's `pool:<name>` storage row so the alarm-time
      * concurrency gate has a value even if the in-memory client is gone.
      */
     maxConcurrency?: number;
@@ -166,7 +166,7 @@ interface ScheduleRequestBody {
     workflow?: string;
 }
 
-/** Durable per-pool state stored under `pool:&lt;name>`. */
+/** Durable per-pool state stored under `pool:<name>`. */
 interface PoolState {
     /** Jobs currently dispatched-but-not-yet-completed. The concurrency semaphore. */
     inFlight: number;
@@ -194,7 +194,7 @@ interface SchedulerPoolStatus {
     inFlight: number;
     /** The pool's concurrency cap. */
     maxConcurrency: number;
-    /** The logical workpool name (the `pool:&lt;name>` suffix). */
+    /** The logical workpool name (the `pool:<name>` suffix). */
     name: string;
     /** Pending jobs routed to this pool but not yet dispatched. */
     queued: number;
@@ -210,7 +210,7 @@ interface SchedulerStatus {
     backlog: number;
     /** Sum of every pool's `inFlight` count — the total held concurrency slots. */
     inFlight: number;
-    /** Per-pool backlog breakdown, one entry per `pool:&lt;name>` record. */
+    /** Per-pool backlog breakdown, one entry per `pool:<name>` record. */
     pools: SchedulerPoolStatus[];
 }
 
@@ -221,7 +221,7 @@ interface CancelRequestBody {
 /**
  * Durable Object that stores pending scheduled invocations sorted by their
  * `scheduledFor` time and fires them via HTTP on alarm. Storage layout:
- * `id:&lt;id>` maps to {@link ScheduleRecord}; `t:&lt;paddedTime>:&lt;id>` maps to the
+ * `id:<id>` maps to {@link ScheduleRecord}; `t:<paddedTime>:<id>` maps to the
  * id (used as a sorted index).
  *
  * On every mutation the DO recomputes the earliest pending task and updates
@@ -913,7 +913,7 @@ class SchedulerDO {
         await this.state.storage.put(SchedulerDO.indexKey(nextScheduledFor, record.id), record.id);
     }
 
-    /** Read the durable `pool:&lt;name>` row, defaulting to a fresh `inFlight: 0` pool. */
+    /** Read the durable `pool:<name>` row, defaulting to a fresh `inFlight: 0` pool. */
     private async loadPool(name: string, maxConcurrencyHint?: number): Promise<PoolState> {
         const stored = await this.state.storage.get<PoolState>(`${POOL_PREFIX}${name}`);
 
@@ -1005,7 +1005,7 @@ class SchedulerDO {
 
     /**
      * `GET /status` — the app-level backlog signal that powers the studio's
-     * SLO view. Enumerates every durable `pool:&lt;name>` row for its `inFlight`/
+     * SLO view. Enumerates every durable `pool:<name>` row for its `inFlight`/
      * `maxConcurrency` semaphore, counts the pending (not-yet-dispatched) jobs
      * routed to each pool with the same single-pass scan {@link handlePoolStatus}
      * uses, and rolls those up into app-wide `backlog` (sum of `queued`) and
@@ -1014,7 +1014,7 @@ class SchedulerDO {
      * Pools that have rows but no queued jobs still appear (with `queued: 0`) so
      * a saturated-but-idle pool stays visible; a pool that only ever existed as
      * queued jobs without a persisted row is unreachable here (the schedule path
-     * always writes a `pool:&lt;name>` row before the job's header), so a single
+     * always writes a `pool:<name>` row before the job's header), so a single
      * scan over `pool:` plus a cursor loop over `id:` is sufficient.
      */
     private async handleStatus(): Promise<Response> {
@@ -1173,7 +1173,7 @@ class SchedulerDO {
 
     /**
      * `GET /dead` — list the dead-letter records: jobs that exhausted their
-     * retry budget ({@link recordRetry}) and were parked under `dead:&lt;id>`
+     * retry budget ({@link recordRetry}) and were parked under `dead:<id>`
      * instead of being silently dropped. These never appear in `/list` (their
      * `id:` header is deleted on park), so this is the ONLY way the studio can
      * surface — and recover — a permanently-failed job.
@@ -1238,7 +1238,7 @@ class SchedulerDO {
     }
 
     /**
-     * Resolve a single pending job by id via a direct `id:&lt;id>` storage read —
+     * Resolve a single pending job by id via a direct `id:<id>` storage read —
      * O(1), versus scanning the whole `/list` view. Responds `{ record }` on a
      * hit and `{}` on a miss (an absent `record` field — JSON has no `undefined`
      * — which the client reads back as `null`).

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -17,7 +17,7 @@ export type ArgsOf<F extends FunctionReference> = F extends { _args?: infer A } 
 
 /**
  * Typed reference to a Lunora durable workflow — either the generated
- * `workflows.&lt;name>` reference object (`_generated/api.ts`, which carries the
+ * `workflows.<name>` reference object (`_generated/api.ts`, which carries the
  * `WORKFLOW_*` binding + export name) or, structurally, a `defineWorkflow()`
  * result imported directly. Both are matched by the `isLunoraWorkflow` brand and
  * carry the workflow's `params` in the phantom `__params`, so a `cronJobs()`
@@ -35,7 +35,7 @@ export type ArgsOf<F extends FunctionReference> = F extends { _args?: infer A } 
 export interface WorkflowReference<Params = Record<string, unknown>> {
     /** Phantom carrier for the workflow's `params` type — drives `cronJobs()` arg inference. Never read at runtime. */
     readonly __params?: Params;
-    /** The `WORKFLOW_*` binding name (present on a generated `workflows.&lt;name>` ref). */
+    /** The `WORKFLOW_*` binding name (present on a generated `workflows.<name>` ref). */
     readonly binding?: string;
     readonly isLunoraWorkflow: true;
     /** The workflow's export/stable name (present on a generated ref; a `defineWorkflow({ name })` override otherwise). */
@@ -176,8 +176,8 @@ export interface Scheduler {
     /**
      * Schedule `target` to run once, `delayMs` from now. `target` is a function
      * {@link FunctionReference} (dispatched as a one-shot) or a durable
-     * {@link WorkflowReference} — the generated `workflows.&lt;name>` /
-     * `agents.&lt;name>` ref — which starts a fresh instance on fire (args become
+     * {@link WorkflowReference} — the generated `workflows.<name>` /
+     * `agents.<name>` ref — which starts a fresh instance on fire (args become
      * its `params`). {@link ScheduleTargetArgs} infers the accepted args from
      * whichever target was passed.
      */
@@ -271,7 +271,7 @@ export interface WorkpoolOptions extends LunoraSchedulerOptions {
 
     /**
      * Pool name — the concurrency counter is keyed by this inside the
-     * SchedulerDO storage (`pool:&lt;name>`). Default `default`.
+     * SchedulerDO storage (`pool:<name>`). Default `default`.
      */
     name?: string;
 }
@@ -292,7 +292,7 @@ export interface Workpool {
      * is at capacity).
      */
     enqueue: <F extends FunctionReference>(function_: F, args: ArgsOf<F>, options?: EnqueueOptions) => Promise<{ id: string; scheduledFor: number }>;
-    /** The pool's name (the `pool:&lt;name>` storage key suffix). */
+    /** The pool's name (the `pool:<name>` storage key suffix). */
     readonly name: string;
     /** Inspect the pool's current state — `inFlight` slots used and the configured `maxConcurrency`. */
     status: () => Promise<{ inFlight: number; maxConcurrency: number; queued: number }>;

--- a/packages/search-core/eslint.config.js
+++ b/packages/search-core/eslint.config.js
@@ -58,4 +58,13 @@ export default createConfig(
             "unicorn/number-literal-case": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/seed/eslint.config.js
+++ b/packages/seed/eslint.config.js
@@ -83,4 +83,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/server/__tests__/facade.test.ts
+++ b/packages/server/__tests__/facade.test.ts
@@ -6,7 +6,7 @@ import { bindTableFacade } from "../src/facade";
 
 /**
  * `bindTableFacade` pins a `tableName` on the structural writer so the per-table
- * accessor (`ctx.db.&lt;table>.*`) forwards it as `expectedTable` on by-id calls —
+ * accessor (`ctx.db.<table>.*`) forwards it as `expectedTable` on by-id calls —
  * the IDOR guard. These tests assert the batch forms (added alongside `insertMany`)
  * forward the bound table, and that `patchMany` maps the facade's `values` payload
  * onto the writer's `{ id, patch }` shape.

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { parseValidatorMap } from "../src/functions";
 import { clampLimit, defineListArgs } from "../src/list-args";
 
-/** Stand-in for a generated `Doc&lt;"messages">`; binding it is what makes typos compile errors. */
+/** Stand-in for a generated `Doc<"messages">`; binding it is what makes typos compile errors. */
 interface Message {
     _creationTime: number;
     authorId: string;

--- a/packages/server/__tests__/mask-shape-registry.test.ts
+++ b/packages/server/__tests__/mask-shape-registry.test.ts
@@ -21,7 +21,7 @@ const builders = initLunora.dataModel<unknown>().create();
 const maskedQuery = (policies: Parameters<typeof mask>[0], options?: Parameters<typeof mask>[1]) =>
     (builders.query as unknown as { use: (m: unknown) => { query: (h: () => unknown) => unknown } }).use(mask(policies, options)).query(() => null);
 
-/** Flatten a `MaskTag`/registry's `Map&lt;table, Set&lt;column>>` into a plain, order-independent object for assertions. */
+/** Flatten a `MaskTag`/registry's `Map<table, Set<column>>` into a plain, order-independent object for assertions. */
 const toPlainObject = (columns: ReadonlyMap<string, ReadonlySet<string>>): Record<string, string[]> =>
     Object.fromEntries([...columns.entries()].map(([table, cols]) => [table, [...cols].toSorted((a, b) => a.localeCompare(b))]));
 

--- a/packages/server/__tests__/rls.test.ts
+++ b/packages/server/__tests__/rls.test.ts
@@ -18,7 +18,7 @@ import { definePermission, definePolicies, definePolicy, defineRole, initLunora,
  * shape is a superset (it also accepts the new `baseWhere` /
  * `restrictsCounts` count signature) so TS rejects the direct widening.
  * Pin a permissive cast once here so each test reads cleanly without
- * scattering `as unknown as Middleware&lt;…>` at every call site.
+ * scattering `as unknown as Middleware<…>` at every call site.
  */
 const rlsForTest = <Context>(policies: ReadonlyArray<Policy<Context>>): Middleware<any, any> =>
     (rls as unknown as (p: ReadonlyArray<Policy<Context>>) => Middleware<any, any>)(policies);

--- a/packages/server/eslint.config.js
+++ b/packages/server/eslint.config.js
@@ -147,4 +147,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/server/src/builder/index.ts
+++ b/packages/server/src/builder/index.ts
@@ -95,7 +95,7 @@ const makeHandler =
 
 /**
  * Wrap a streaming user handler in the same arg-validation + middleware shell
- * as `makeHandler`, but return the user's `AsyncIterable&lt;R>` directly so the
+ * as `makeHandler`, but return the user's `AsyncIterable<R>` directly so the
  * runtime can drive it frame-by-frame. The handler receives an `AbortSignal`
  * the caller flips when they unsubscribe; it's the user's responsibility to
  * honour it (or to wire it into any awaited I/O).
@@ -303,7 +303,7 @@ const makeBuilder = (kind: FunctionKind, state: BuilderState, visibility?: "inte
 };
 
 /**
- * Entry point for the procedure builder. `dataModel&lt;DM>()` binds the generated
+ * Entry point for the procedure builder. `dataModel<DM>()` binds the generated
  * `DataModel` (phantom for now), and `.create()` yields the public root builders
  * plus their `internal*` counterparts.
  */

--- a/packages/server/src/builder/types.ts
+++ b/packages/server/src/builder/types.ts
@@ -38,7 +38,7 @@ export interface MiddlewareNext<ContextIn> {
  */
 export type Middleware<ContextIn, ContextOut> = (options: { ctx: ContextIn; next: MiddlewareNext<ContextIn> }) => ContextOut | Promise<ContextOut>;
 
-/** Options accepted by `initLunora.dataModel&lt;DM>().create(...)`. Reserved for transformer/error-formatter wiring. */
+/** Options accepted by `initLunora.dataModel<DM>().create(...)`. Reserved for transformer/error-formatter wiring. */
 export type CreateOptions = Record<never, never>;
 
 /**
@@ -55,7 +55,7 @@ export interface QueryBuilder<Context, Args extends ArgsValidator, Output = unde
 
     /**
      * Publish this query on the opt-in public REST surface (plan 167) — the
-     * runtime mints `GET /_lunora/rest/&lt;namespace>/&lt;fn>` (and `POST`), dispatching
+     * runtime mints `GET /_lunora/rest/<namespace>/<fn>` (and `POST`), dispatching
      * THROUGH the procedure so `ctx.auth` / RLS / validators are enforced, and the
      * generated OpenAPI describes it. Default-closed: omit to keep it RPC-only.
      */
@@ -80,7 +80,7 @@ export interface QueryBuilder<Context, Args extends ArgsValidator, Output = unde
 
     /**
      * Terminal: declare this procedure as a streaming query. The handler is an
-     * async generator (or any function returning an `AsyncIterable&lt;R>`) that
+     * async generator (or any function returning an `AsyncIterable<R>`) that
      * yields one chunk per server-pushed frame. The third `signal` argument is
      * tripped when the client cancels — break out of the loop or check
      * `signal.aborted` between yields. `.output()` does not apply: per-chunk
@@ -105,7 +105,7 @@ export interface MutationBuilder<Context, Args extends ArgsValidator, Output = u
 
     /**
      * Publish this mutation on the opt-in public REST surface (plan 167) — the
-     * runtime mints `POST /_lunora/rest/&lt;namespace>/&lt;fn>`, dispatching THROUGH the
+     * runtime mints `POST /_lunora/rest/<namespace>/<fn>`, dispatching THROUGH the
      * procedure so `ctx.auth` / RLS / validators are enforced, and the generated
      * OpenAPI describes it. Default-closed: omit to keep it RPC-only.
      */
@@ -146,7 +146,7 @@ export interface ActionBuilder<Context, Args extends ArgsValidator, Output = und
 
     /**
      * Publish this action on the opt-in public REST surface (plan 167) — the
-     * runtime mints `POST /_lunora/rest/&lt;namespace>/&lt;fn>`, dispatching THROUGH the
+     * runtime mints `POST /_lunora/rest/<namespace>/<fn>`, dispatching THROUGH the
      * procedure so `ctx.auth` / RLS / validators are enforced, and the generated
      * OpenAPI describes it. Default-closed: omit to keep it RPC-only.
      */

--- a/packages/server/src/create-secrets.ts
+++ b/packages/server/src/create-secrets.ts
@@ -12,7 +12,7 @@ import type { Secrets, SecretsStoreSecretLike } from "./types";
 
 /**
  * Methods that disambiguate a *non*-Secrets-Store binding from a Secrets Store
- * one. A `SecretsStoreSecret`'s entire surface is `get(): Promise&lt;string>`, but
+ * one. A `SecretsStoreSecret`'s entire surface is `get(): Promise<string>`, but
  * `.get` is NOT unique to it — a KV namespace (`get(key)`), an R2 bucket
  * (`get(key)`), a Durable Object namespace (`get(id)`), a Queue producer, and an
  * Analytics dataset all expose `.get` or other methods. So a bare `{ get }`
@@ -38,7 +38,7 @@ const NON_SECRET_BINDING_METHODS = [
     "createBatch", // Workflows binding
 ] as const;
 
-/** True when a value structurally matches a Secrets Store binding (`{ get(): Promise&lt;string> }`) and not another `.get`-bearing binding. */
+/** True when a value structurally matches a Secrets Store binding (`{ get(): Promise<string> }`) and not another `.get`-bearing binding. */
 const isSecretBinding = (value: unknown): value is SecretsStoreSecretLike => {
     if (typeof value !== "object" || value === null) {
         return false;

--- a/packages/server/src/data-model.ts
+++ b/packages/server/src/data-model.ts
@@ -107,7 +107,7 @@ type RelationWhere<DM, REL extends Record<keyof DM, object>, T extends keyof DM>
 /**
  * Relation-aware `where` tree — the column predicates of {@link Where} plus
  * Prisma-style relation predicates resolved by the `@lunora/do` pre-resolver.
- * `Where&lt;DM[T]>` stays the column-only structural mirror for back-compat; the
+ * `Where<DM[T]>` stays the column-only structural mirror for back-compat; the
  * table facade threads `REL` through this richer form.
  */
 export type WhereOf<DM, REL extends Record<keyof DM, object>, T extends keyof DM> = RelationWhere<DM, REL, T> & {
@@ -194,7 +194,7 @@ type ProjectDoc<DM, T extends keyof DM, S> =
     S extends ReadonlyArray<infer K> ? (K extends keyof DM[T] ? Pick<DM[T], (K & keyof DM[T]) | SelectAlwaysKeep<DM, T>> : DM[T]) : DM[T];
 
 /**
- * `Doc&lt;T>` narrowed to exactly the relations requested in the with-arg `W` and,
+ * `Doc<T>` narrowed to exactly the relations requested in the with-arg `W` and,
  * when a `select` tuple `S` is supplied, to its projected columns. `S` defaults
  * to `undefined` so the 4-argument form (the codegen-emitted callers) keeps the
  * full document.
@@ -231,7 +231,7 @@ export interface RestrictableQueryOptionsOf<DM, REL extends Record<keyof DM, obj
     where?: WhereOf<DM, REL, T>;
 }
 
-/** Args for `ctx.db.&lt;table>.aggregate({ op, field?, where? })`. */
+/** Args for `ctx.db.<table>.aggregate({ op, field?, where? })`. */
 export interface TableAggregateOptions<TDocument> extends RestrictableQueryOptions<TDocument> {
     field?: keyof TDocument & string;
     op: AggregateOp;
@@ -243,7 +243,7 @@ export interface TableAggregateOptionsOf<DM, REL extends Record<keyof DM, object
     op: AggregateOp;
 }
 
-/** Args for `ctx.db.&lt;table>.groupBy({ by, agg?, where? })`. */
+/** Args for `ctx.db.<table>.groupBy({ by, agg?, where? })`. */
 export interface TableGroupByOptions<TDocument> extends RestrictableQueryOptions<TDocument> {
     agg?: { field?: keyof TDocument & string; op: AggregateOp };
     by: ReadonlyArray<keyof TDocument & string>;
@@ -261,7 +261,7 @@ export interface GroupByEntry<TDocument> {
     value: null | number;
 }
 
-/** Args for `ctx.db.&lt;table>.rank(name, args)`. `row` is either an id or a row doc. */
+/** Args for `ctx.db.<table>.rank(name, args)`. `row` is either an id or a row doc. */
 export interface TableRankOptions<TDocument> extends RestrictableQueryOptions<TDocument> {
     row: string | TDocument;
 }
@@ -272,7 +272,7 @@ export interface RankResult {
     total: number;
 }
 
-/** Args for `ctx.db.&lt;table>.rankPage(name, args)`. */
+/** Args for `ctx.db.<table>.rankPage(name, args)`. */
 export interface TableRankPageOptions<TDocument> extends RestrictableQueryOptions<TDocument> {
     cursor?: null | string;
     take?: number;
@@ -359,7 +359,7 @@ export interface GeoReader<TDocument> {
     unique: () => Promise<TDocument | null>;
 }
 
-/** Read-only typed table accessor exposed on `QueryCtx.db.&lt;table>`. */
+/** Read-only typed table accessor exposed on `QueryCtx.db.<table>`. */
 export interface TableReaderFacade<
     DM,
     REL extends Record<keyof DM, object>,
@@ -436,7 +436,7 @@ export interface TableReaderFacade<
     withSearchIndex: (indexName: SEARCH[T], search: (q: SearchFilterBuilder<DM[T]>) => SearchFilterBuilder<DM[T]>) => SearchReader<DM[T]>;
 }
 
-/** Read-write typed table accessor exposed on `MutationCtx.db.&lt;table>` / `ActionCtx.db.&lt;table>`. */
+/** Read-write typed table accessor exposed on `MutationCtx.db.<table>` / `ActionCtx.db.<table>`. */
 export interface TableWriterFacade<
     DM,
     IM extends Record<keyof DM, object>,
@@ -519,7 +519,7 @@ export interface TableWriterFacade<
 /** Conflict target for `upsert`/`upsertMany`: one column of table `T`, or a tuple of them. */
 export type UpsertTargetOf<DM, T extends keyof DM> = ReadonlyArray<keyof DM[T] & string> | (keyof DM[T] & string);
 
-/** Per-table read facade — `ctx.db.&lt;table>` on a `QueryCtx`. */
+/** Per-table read facade — `ctx.db.<table>` on a `QueryCtx`. */
 export type DatabaseReaderFacade<
     DM,
     REL extends Record<keyof DM, object>,
@@ -530,7 +530,7 @@ export type DatabaseReaderFacade<
     readonly [T in keyof DM]: TableReaderFacade<DM, REL, RANK, SEARCH, T, GEO>;
 };
 
-/** Per-table read-write facade — `ctx.db.&lt;table>` on a `MutationCtx` / `ActionCtx`. */
+/** Per-table read-write facade — `ctx.db.<table>` on a `MutationCtx` / `ActionCtx`. */
 export type DatabaseWriterFacade<
     DM,
     IM extends Record<keyof DM, object>,

--- a/packages/server/src/facade.ts
+++ b/packages/server/src/facade.ts
@@ -129,7 +129,7 @@ export interface FacadeEntry {
      * Insert many documents into this table in one call. With
      * `{ skipDuplicates: true }`, UNIQUE breaches resolve to `null` for that row
      * instead of failing the batch. The typed facade narrows the return to
-     * `Id&lt;T>[]` when skipDuplicates is not requested.
+     * `Id<T>[]` when skipDuplicates is not requested.
      */
     insertMany: (documents: ReadonlyArray<Record<string, unknown>>, options?: { limit?: number; skipDuplicates?: boolean }) => Promise<(string | null)[]>;
     // NOTE: `insertManyUnsafe` is DELIBERATELY absent from the per-table facade
@@ -196,7 +196,7 @@ export interface UpsertManyArgs {
  *
  * The by-id accessors (`get`/`delete`/`patch`/`replace`) forward the bound
  * `tableName` as `expectedTable` so the underlying writer scopes its id lookup
- * to this table. Without it, a branded `Id&lt;"posts">` carrying another table's
+ * to this table. Without it, a branded `Id<"posts">` carrying another table's
  * id would resolve cross-table (the writer probes every table by id), letting
  * `ctx.db.posts.get(foreignId)` read — or `.delete`/`.patch`/`.replace`
  * mutate — a row in an unrelated table (IDOR). Writers that ignore the second

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -173,7 +173,7 @@ interface HttpRouteBuilder<SearchParams extends ArgsValidator, Body extends Args
     /**
      * Terminal: declare this route as a streaming Server-Sent Events endpoint.
      * The handler is an async generator (or any function returning an
-     * `AsyncIterable&lt;R>`) that yields one chunk per SSE `data:` frame; on
+     * `AsyncIterable<R>`) that yields one chunk per SSE `data:` frame; on
      * iterator completion the route writes a final `event: complete` frame; on
      * throw, an `event: error` frame is written with `{code, message}` before
      * the stream closes. The chunks are JSON-encoded; `R` is inferred from the
@@ -267,7 +267,7 @@ const coerceScalar = (kind: ValidatorKind, raw: string): unknown => {
 /**
  * Decode one declared query parameter from the hono request. Absent →
  * `undefined` (so `v.optional` passes and a required validator fails). An
- * `array` validator collects every repeated occurrence (`?tag=a&amp;tag=b`) via
+ * `array` validator collects every repeated occurrence (`?tag=a&tag=b`) via
  * `c.req.queries`, coercing each element.
  */
 const coerceSearchParameter = (validator: Validator, c: Context<LunoraHttpEnv>, key: string): unknown => {

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -144,7 +144,7 @@ interface ListArgsSpec<TDocument, F, O extends string> {
      * `limit` clamped into `[1, maxLimit]`, `orderBy` reshaped from
      * `{ field, direction }[]` into `ctx.db`'s `{ column: direction }[]`.
      *
-     * Returns `QueryArgs&lt;Doc>` — bound to the table, not free — so a mismatch
+     * Returns `QueryArgs<Doc>` — bound to the table, not free — so a mismatch
      * between what this helper declares and what the table actually holds is a
      * compile error at the `findMany` call site.
      */
@@ -260,10 +260,10 @@ const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<s
 
 /**
  * Declare the filter / sort / page arguments for a list endpoint, plus the
- * translation into `ctx.db.&lt;table>.findMany(...)` options. See the module docs
+ * translation into `ctx.db.<table>.findMany(...)` options. See the module docs
  * for the shape and the reasoning behind it.
  *
- * Curried on the document type: `defineListArgs&lt;Doc&lt;"messages">>()({ … })`. The
+ * Curried on the document type: `defineListArgs<Doc<"messages">>()({ … })`. The
  * extra `()` buys the thing that matters — with `Doc` bound, `filter` keys and
  * `orderBy` entries are checked against the table's real columns, so a typo or a
  * column renamed out from under the endpoint is a COMPILE error instead of a

--- a/packages/server/src/mask/middleware.ts
+++ b/packages/server/src/mask/middleware.ts
@@ -75,7 +75,7 @@
  * 5. **Fail closed** — a `MaskFn` that throws redacts the cell to `null` rather
  * than leak the raw value.
  *
- * Signature-compatible with the builder's `Middleware&lt;>`, so `.use(mask(...))`
+ * Signature-compatible with the builder's `Middleware<>`, so `.use(mask(...))`
  * slots in like any other middleware. Composes with `rls()` in either order:
  * each wraps `ctx.db` and forwards it via `next({ ctx: { db } })`, so
  * `.use(rls(...)).use(mask(...))` yields rows that are both row-filtered and
@@ -708,7 +708,7 @@ const wrapDatabase = <Context>(
      * rank oracle across pages. Fail closed when an `orderBy` entry references a
      * masked column, mirroring `assertWhereAllowed` and the index-reader guard
      * (`order()` over a masked `withIndex` already throws). `orderBy` is a
-     * `Partial&lt;Record&lt;column, "asc" | "desc">>[]`, so each entry's keys are the
+     * `Partial<Record<column, "asc" | "desc">>[]`, so each entry's keys are the
      * ordered columns.
      */
     const assertOrderByAllowed = (tableName: string, orderBy: unknown, method: string): void => {

--- a/packages/server/src/plugin.ts
+++ b/packages/server/src/plugin.ts
@@ -7,7 +7,7 @@
  * triggers) that the host app's schema merges in.
  * 2. **Middleware** — a builder-compatible middleware that runs on every
  * procedure that opts in via `.use(plugin.middleware)`. By convention it
- * extends `ctx.api.&lt;key>` with helpers the plugin exposes. Install several at
+ * extends `ctx.api.<key>` with helpers the plugin exposes. Install several at
  * once with `composePluginMiddleware([...])` (one `.use(...)`) and
  * `installPlugins(schema, [...])` (one schema fold).
  * 3. **Functions** — registered queries/mutations/actions bundled on a
@@ -32,7 +32,7 @@
  * export const schema = defineSchema({ todos: ... }).extend(ratelimit.extension);
  *
  * // procedure that uses the plugin:
- * const c = initLunora.dataModel&lt;DataModel>().create();
+ * const c = initLunora.dataModel<DataModel>().create();
  * export const rateLimitedQuery = c.query.use(ratelimit.middleware);
  * ```
  *
@@ -53,7 +53,7 @@
  *     name — silent shadow would let one plugin invisibly hijack another's
  *     data.
  *   - **Middleware composability.** Plugins re-export middleware as
- *     plain `Middleware&lt;...>` values; users compose them via the
+ *     plain `Middleware<...>` values; users compose them via the
  *     existing `.use(...)` chain. No "install" verb that consumes the
  *     builder — each consumer decides which plugin middlewares to attach.
  */
@@ -148,7 +148,7 @@ type InstalledTables<T extends Record<string, TableDefinition>, Plugins extends 
 
 /**
  * Union every plugin's `ContextOut` in a tuple — the type-level mirror of the
- * `ctx.api.&lt;key>` additions {@link composePluginMiddleware} accumulates as each
+ * `ctx.api.<key>` additions {@link composePluginMiddleware} accumulates as each
  * plugin middleware runs. Independent of the incoming context, which the builder
  * infers at the `.use(...)` site.
  */
@@ -221,7 +221,7 @@ export interface Plugin<TExtension extends Record<string, TableDefinition> = Rec
     /**
      * Optional middleware. Users attach with `c.query.use(plugin.middleware)`.
      * The middleware can extend `ctx`; convention is to attach helpers under
-     * `ctx.api.&lt;key>`, e.g.
+     * `ctx.api.<key>`, e.g.
      *
      * ```ts
      * middleware: ({ ctx, next }) =>
@@ -491,7 +491,7 @@ export const installPlugins = <T extends Record<string, TableDefinition>, const 
  * Compose every plugin's middleware into a single middleware you attach with one
  * `.use(...)`. Plugins without middleware (schema-only) are skipped; the rest run
  * in array order, each seeing the context the previous one widened, so the final
- * `next({ ctx })` the builder receives carries every plugin's `ctx.api.&lt;key>`
+ * `next({ ctx })` the builder receives carries every plugin's `ctx.api.<key>`
  * additions. Equivalent to `.use(a.middleware).use(b.middleware)…` but as one
  * value, the middleware sibling of {@link installPlugins}.
  *

--- a/packages/server/src/rls/define.ts
+++ b/packages/server/src/rls/define.ts
@@ -16,7 +16,7 @@ export const definePolicy = <Context = unknown>(input: DefinePolicyInput<Context
 /**
  * Build a project-bound, relation-aware `definePolicy` typed against the
  * generated `DataModel` (`DM`) + `Relations` (`REL`) maps. Codegen emits a
- * `createPolicyDsl&lt;DataModel, Relations>()` binding into `_generated/server.ts`,
+ * `createPolicyDsl<DataModel, Relations>()` binding into `_generated/server.ts`,
  * so importing `definePolicy` from the generated module constrains `table` to a
  * real table name and type-checks the `when` predicate — including Prisma-style
  * relation predicates (`is`/`some`/…) the `@lunora/do` pre-resolver now resolves

--- a/packages/server/src/rls/index.ts
+++ b/packages/server/src/rls/index.ts
@@ -6,7 +6,7 @@
  * ```ts
  * import { definePolicy, definePolicies, defineRole, rls } from "@lunora/server";
  *
- * const userPolicy = definePolicy&lt;MyCtx>({
+ * const userPolicy = definePolicy<MyCtx>({
  *     table: "documents",
  *     on: "read",
  *     when: ({ auth }) => ({ ownerId: auth.userId }),
@@ -14,7 +14,7 @@
  *
  * const policies = definePolicies([userPolicy]);
  *
- * const builders = initLunora.dataModel&lt;DataModel>().create();
+ * const builders = initLunora.dataModel<DataModel>().create();
  * const guardedQuery = builders.query.use(rls(policies));
  * ```
  *
@@ -24,7 +24,7 @@
  *
  * `count()` against a policy-restricted table throws
  * `LunoraError("COUNT_RLS_UNSUPPORTED")` (422). Document this in any
- * code that wraps `ctx.db.&lt;table>.count`.
+ * code that wraps `ctx.db.<table>.count`.
  *
  * Permissions let a policy check a named capability instead of enumerating
  * roles. Declare them with `definePermission`, grant them via a role's
@@ -35,7 +35,7 @@
  * const deletePosts = definePermission("posts:delete");
  * const admin = defineRole("admin", { permissions: [deletePosts] });
  *
- * const policy = definePolicy&lt;MyCtx>({
+ * const policy = definePolicy<MyCtx>({
  *     table: "posts",
  *     on: "delete",
  *     when: ({ auth }) => auth.can(deletePosts),

--- a/packages/server/src/rls/middleware.ts
+++ b/packages/server/src/rls/middleware.ts
@@ -39,7 +39,7 @@
  * - `count()` is intercepted only on tables with an active read policy —
  * unrelated tables count freely.
  *
- * The middleware is signature-compatible with the builder's `Middleware&lt;>`,
+ * The middleware is signature-compatible with the builder's `Middleware<>`,
  * so `.use(rls(policies))` slots in like any other middleware.
  */
 import type { Middleware } from "../builder/types";

--- a/packages/server/src/rls/types.ts
+++ b/packages/server/src/rls/types.ts
@@ -53,7 +53,7 @@ export type PolicyDecision = WhereInput | boolean | undefined;
  * generated `DataModel` (`DM`) + `Relations` (`REL`) maps and a table `T`. A
  * read policy may now return a Prisma-style relation predicate (the
  * `@lunora/do` pre-resolver resolves it via a semijoin), so the typed
- * authoring surface accepts `WhereOf&lt;DM, REL, T>` — column predicates **and**
+ * authoring surface accepts `WhereOf<DM, REL, T>` — column predicates **and**
  * `is`/`isNot`/`some`/`none`/`every` over `T`'s declared relations — in
  * addition to the `boolean`/`undefined` decisions. Used by the project-bound
  * `definePolicy` from `createPolicyDsl`.

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -194,7 +194,7 @@ interface TableBuilder<Shape extends Record<string, Validator> = Record<string, 
 
     /**
      * Turn on soft delete. Adds a nullable timestamp column (`options.field`,
-     * default `deletedAt`) and changes `ctx.db.&lt;table>.delete()` to **set** it
+     * default `deletedAt`) and changes `ctx.db.<table>.delete()` to **set** it
      * instead of removing the row; `onDelete: "cascade"` children are recursively
      * soft-deleted too. **List reads** (`findMany`/`findFirst`/`query()`/`count`/
      * `aggregate`/relation loads) then hide soft-deleted rows unless they pass
@@ -875,7 +875,7 @@ const validateExternalSources = (tables: Record<string, TableDefinition>): void 
 const SYSTEM_INDEX_FIELDS = ["_creationTime", "_id"] as const;
 
 /**
- * Runtime lookup form of {@link SYSTEM_INDEX_FIELDS}. Typed `Set&lt;string>`
+ * Runtime lookup form of {@link SYSTEM_INDEX_FIELDS}. Typed `Set<string>`
  * (rather than inferring the literal-union element type) because it is
  * probed with an arbitrary user-declared `IndexDefinition["fields"]` entry,
  * not one already narrowed to the system-field union.

--- a/packages/server/src/storage/index.ts
+++ b/packages/server/src/storage/index.ts
@@ -5,7 +5,7 @@
  * ```ts
  * import { defineStorageRule, defineStorageRules, storageRules } from "@lunora/server";
  *
- * const ownAvatars = defineStorageRule&lt;MyCtx>({
+ * const ownAvatars = defineStorageRule<MyCtx>({
  *     bucket: "avatars",
  *     on: "read",
  *     prefix: "user/",
@@ -14,7 +14,7 @@
  *
  * const rules = defineStorageRules([ownAvatars]);
  *
- * const builders = initLunora.dataModel&lt;DataModel>().create();
+ * const builders = initLunora.dataModel<DataModel>().create();
  * const guardedAction = builders.action.use(storageRules(rules));
  * ```
  *

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `RegisteredFunction<ArgsValidator, …>` type, not a credential. */
+
 // The declared analysis languages and storage strategies. Inlined by the
 // bundler from `shared/search` rather than depended on, so the schema builder
 // still stands up without the DO runtime — it just no longer restates the
@@ -398,7 +400,7 @@ interface TableDefinition<Shape extends Record<string, Validator> = Record<strin
      * data field doesn't collide with the fluent `.softDelete()` builder method —
      * same convention as `shardBy()`/`shardMode`). When present, the table carries
      * a nullable timestamp column (`field`, default `deletedAt`):
-     * `ctx.db.&lt;table>.delete()` flips it instead of physically removing the row,
+     * `ctx.db.<table>.delete()` flips it instead of physically removing the row,
      * and **list reads** (`findMany`/`findFirst`/`query()`/`count`/`aggregate`/
      * relation loads) hide rows whose `field` is set unless
      * `includeDeleted: true` is passed. By-id `get`/`patch`/`replace` and
@@ -513,7 +515,7 @@ type RestCacheConfig = RestCachePolicy;
 /**
  * Opt-in public-surface tag attached by the `.expose({ rest: true })` builder
  * modifier (plan 167). Marks a procedure as deliberately published over the
- * public REST surface: the runtime mints a `/_lunora/rest/&lt;namespace>/&lt;fn>` route
+ * public REST surface: the runtime mints a `/_lunora/rest/<namespace>/<fn>` route
  * that dispatches THROUGH the procedure (so `ctx.auth` / RLS / validators are
  * enforced), and the generated OpenAPI describes it. Everything is default-closed
  * — a procedure without this tag is unreachable over REST.
@@ -569,7 +571,7 @@ type RegisteredAction<A extends ArgsValidator, R> = RegisteredFunction<A, R, "ac
 
 /**
  * Structural mirror of `@lunora/client`'s `FunctionReference` — the handle the
- * generated `api` / `internal` objects hand you, carrying `&lt;file>:&lt;function>`
+ * generated `api` / `internal` objects hand you, carrying `<file>:<function>`
  * in `__lunoraRef`. Redeclared here so `@lunora/server` needs no dependency on
  * the client package, exactly as {@link Scheduler} avoids one on
  * `@lunora/scheduler`. `RegisteredFunction` has no `__lunoraRef`, so the two
@@ -604,8 +606,8 @@ interface FunctionHandle<Kind extends "action" | "mutation" | "query" | "stream"
  * contextually type a parameter against a multi-signature type, so a hand-built
  * ctx object must annotate its `(reference, args)` explicitly — see
  * `@lunora/testing`'s harness). It does not work: a concrete
- * `RegisteredQuery&lt;{…}, number>` is not assignable to a
- * `RegisteredFunction&lt;ArgsValidator, …>` constraint, because `handler`'s args
+ * `RegisteredQuery<{…}, number>` is not assignable to a
+ * `RegisteredFunction<ArgsValidator, …>` constraint, because `handler`'s args
  * are in a contravariant position. Two inference sites it is.
  */
 interface RunQuery {
@@ -653,7 +655,7 @@ type RegisteredLifecycleHook = RegisteredFunction<Record<string, never>, void, "
 
 /**
  * A streaming query registration. Unlike {@link RegisteredFunction} the handler
- * returns an `AsyncIterable&lt;R>` synchronously (it does NOT `Promise&lt;R>`); the
+ * returns an `AsyncIterable<R>` synchronously (it does NOT `Promise<R>`); the
  * runtime drives it frame by frame and forwards each chunk to the caller. The
  * third `signal` argument is wired to the caller's cancel signal so the handler
  * can stop early — break out of the loop or check `signal.aborted` between
@@ -715,7 +717,7 @@ interface SystemQuery<T extends SystemTableName> {
  * Read-only reader over Lunora's system tables (`_scheduled_functions`,
  * `_storage`), exposed as `ctx.db.system`. Mirrors Convex's `ctx.db.system`.
  *
- * **Best-effort and eventually consistent.** Unlike `ctx.db.&lt;table>` — which
+ * **Best-effort and eventually consistent.** Unlike `ctx.db.<table>` — which
  * reads the shard's transactional SQLite snapshot — the data behind these tables
  * lives OUTSIDE the shard (scheduled functions in the `SchedulerDO`, storage
  * objects in R2). Every `collect()` / `get()` reaches across to that source.
@@ -756,7 +758,7 @@ interface DatabaseReader {
      *
      * This is the **parse boundary** for an id that arrived as a plain `string`: a
      * wire payload, a mutator's args, a change plan computed on the client. The
-     * alternative is `value as Id&lt;"table">` at every such call site — an assertion,
+     * alternative is `value as Id<"table">` at every such call site — an assertion,
      * not a check, and one that has to be repeated for every table a helper is
      * generic over:
      *
@@ -829,8 +831,8 @@ interface PaginationResult<T = Record<string, unknown>> {
 
 /**
  * The fluent `ctx.db.query(table)` reader. Generic over the document type
- * `Row` so the generated `ctx.db` can bind it to `Doc&lt;table>` (the chain and
- * every terminal then resolve typed rows — no `as unknown as Doc&lt;...>` casts),
+ * `Row` so the generated `ctx.db` can bind it to `Doc<table>` (the chain and
+ * every terminal then resolve typed rows — no `as unknown as Doc<...>` casts),
  * and over the table's declared index names so `.withIndex()` / `.withSearchIndex()`
  * / `.withGeoIndex()` reject a name the table does not declare.
  *
@@ -850,9 +852,9 @@ interface PaginationResult<T = Record<string, unknown>> {
  * **Why `with*` are method signatures and everything else is a property.**
  * Narrowing a parameter makes the enclosing type contravariant in it, so as
  * function properties these would make a BOUND reader
- * (`TableReader&lt;Doc, "by_x">`, what `ctx.db.query(t)` returns) unassignable to
- * the unbound `TableReader&lt;Doc>` — quietly breaking every helper factored as
- * `(reader: TableReader&lt;Doc&lt;"users">>) => …`, which is the obvious way to share
+ * (`TableReader<Doc, "by_x">`, what `ctx.db.query(t)` returns) unassignable to
+ * the unbound `TableReader<Doc>` — quietly breaking every helper factored as
+ * `(reader: TableReader<Doc<"users">>) => …`, which is the obvious way to share
  * query logic. A method signature is bivariant in its parameters, which keeps
  * that direction working while the narrow parameter still rejects an undeclared
  * name at the call site. Both directions are pinned in `types.test-d.ts`.
@@ -1176,8 +1178,8 @@ interface ScheduledJob {
 }
 
 /**
- * A schedulable durable-workflow reference — the generated `workflows.&lt;name>` /
- * `agents.&lt;name>` object, which carries its `WORKFLOW_*`/`AGENT_*` binding and
+ * A schedulable durable-workflow reference — the generated `workflows.<name>` /
+ * `agents.<name>` object, which carries its `WORKFLOW_*`/`AGENT_*` binding and
  * stable name. Structural mirror of `@lunora/scheduler`'s `WorkflowReference` so
  * `ctx.scheduler` can target a workflow/agent without a dependency on
  * `@lunora/scheduler` / `@lunora/workflow`. A scheduled workflow target starts a
@@ -1201,8 +1203,8 @@ interface Scheduler {
 
     /**
      * Schedule a one-shot run `delayMs` from now. `target` is a function path
-     * (`"ns:fn"`) dispatched as a one-shot, or a generated `workflows.&lt;name>` /
-     * `agents.&lt;name>` reference which starts a fresh durable instance on fire
+     * (`"ns:fn"`) dispatched as a one-shot, or a generated `workflows.<name>` /
+     * `agents.<name>` reference which starts a fresh durable instance on fire
      * (the args become its `params`).
      */
     runAfter: (delayMs: number, target: SchedulableWorkflowReference | string, args?: Record<string, unknown>) => Promise<string>;
@@ -1444,12 +1446,12 @@ interface TriggerRankPageOptions {
 /**
  * Portable, table/id-addressed ORM writer handed to trigger handlers via
  * `ctx.db`. Mirrors `@lunora/do`'s runtime `DatabaseWriterLike` surface — it is
- * **not** the generated per-table `ctx.db.&lt;table>` facade (which can't be typed
+ * **not** the generated per-table `ctx.db.<table>` facade (which can't be typed
  * from inside `defineTable`, where the full schema isn't known).
  *
  * `aggregate`/`groupBy`/`count`/`rank`/`rankPage` route through the same
  * trigger-maintained counter and rank tables the user-facing reader uses, so
- * a handler's `ctx.db.&lt;table>.aggregate(...)` observes the just-staged write
+ * a handler's `ctx.db.<table>.aggregate(...)` observes the just-staged write
  * within the same DO transaction (the counter step happens before the trigger
  * fires).
  */
@@ -1654,7 +1656,7 @@ interface VectorSearch<IndexName extends string = string> extends VectorSearchRe
 
 /**
  * Structured, filterable key/value fields attached to a log line — the second
- * argument of a `ctx.log.&lt;level>(message, fields)` call, or the fields bound by
+ * argument of a `ctx.log.<level>(message, fields)` call, or the fields bound by
  * `ctx.log.with(fields)`. They travel to an `ObservabilitySink`'s `onLog` and,
  * for a network sink, become OTLP log-record attributes a log pipeline (or the
  * Cloud log viewer) can filter and index on. Primitive values pass through;
@@ -1783,7 +1785,7 @@ interface SpanHandle {
 
     /**
      * Attach an AI **evaluation** verdict to this (generation) span as the
-     * `gen_ai.evaluation.&lt;name>.score` / `.label` OpenTelemetry attributes, so a
+     * `gen_ai.evaluation.<name>.score` / `.label` OpenTelemetry attributes, so a
      * scorer's grade rides the same trace as the generation it graded. Convenience
      * over {@link SpanHandle.setAttributes} that owns the key format; privacy-safe —
      * only the name, score, and optional label are emitted. Throws on an empty name

--- a/packages/shard-engine/__tests__/ctx-db.by-id-table-scope.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.by-id-table-scope.test.ts
@@ -5,10 +5,10 @@ import { createShardCtxDb as createShardContextDatabase, runShardMigrations } fr
 import createSqliteExec from "./_helpers/node-sqlite";
 
 /**
- * Regression for the per-table by-id IDOR: the `ctx.db.&lt;table>.get/delete/
+ * Regression for the per-table by-id IDOR: the `ctx.db.<table>.get/delete/
  * patch/replace` facade pins a `tableName`, which is forwarded to the writer as
  * `expectedTable`. Row ids are globally-unique random UUIDs with no embedded
- * table, so without scoping a branded `Id&lt;"posts">` carrying another table's id
+ * table, so without scoping a branded `Id<"posts">` carrying another table's id
  * would resolve cross-table — letting `ctx.db.posts.get(usersId)` read, or
  * `.delete`/`.patch`/`.replace` mutate, a `users` row. With the bound table
  * forwarded, a foreign id must resolve to "absent" (read → null, write → no-op)

--- a/packages/shard-engine/__tests__/ctx-db.triggers.aggregates-rank.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.triggers.aggregates-rank.test.ts
@@ -8,7 +8,7 @@ import createSqliteExec from "./_helpers/node-sqlite";
 /**
  * Triggers run inline within the DO transaction; the counter / rank
  * companions are stepped BEFORE the after-trigger fires (see ctx-db.ts), so a
- * handler's `ctx.db.&lt;table>.aggregate(...)` / `count(...)` / `rank(...)` MUST
+ * handler's `ctx.db.<table>.aggregate(...)` / `count(...)` / `rank(...)` MUST
  * observe the just-staged write. These tests enforce that contract.
  */
 

--- a/packages/shard-engine/__tests__/index-key-codec.test.ts
+++ b/packages/shard-engine/__tests__/index-key-codec.test.ts
@@ -14,16 +14,16 @@ const enc = (value: unknown): string => {
 };
 
 /**
- * Does `a` sort before `b` under the plain lexicographic `&lt;` the invalidation
+ * Does `a` sort before `b` under the plain lexicographic `<` the invalidation
  * layer uses? Expressed as a named predicate because `toBeLessThan` is typed
  * for numbers only — these are encoded strings.
  */
 const sortsBefore = (a: unknown, b: unknown): boolean => enc(a) < enc(b);
 
-/** Do the raw (unencoded) strings sort in this order under JS `&lt;`? */
+/** Do the raw (unencoded) strings sort in this order under JS `<`? */
 const rawSortsBefore = (a: string, b: string): boolean => a < b;
 
-/** Sort a copy with plain lexicographic `&lt;`, the comparison the codec must make correct. */
+/** Sort a copy with plain lexicographic `<`, the comparison the codec must make correct. */
 const lexSorted = (values: unknown[]): unknown[] => values.toSorted((a, b) => (enc(a) < enc(b) ? -1 : 1));
 
 describe("encodeIndexValue", () => {

--- a/packages/shard-engine/eslint.config.js
+++ b/packages/shard-engine/eslint.config.js
@@ -133,4 +133,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/shard-engine/src/ctx-db-client-watermark.ts
+++ b/packages/shard-engine/src/ctx-db-client-watermark.ts
@@ -22,7 +22,7 @@
  * guards against once they authenticate.
  *
  * The dispatch contract the watermark enforces (see the DO push path):
- * - `id &lt;= watermark` → already processed (skip, return ok);
+ * - `id <= watermark` → already processed (skip, return ok);
  * - `id == watermark + 1` → run the server impl authoritatively and advance the
  * watermark **in the same transaction** as the writes;
  * - `id > watermark + 1` → an out-of-order gap; the batch halts so the client

--- a/packages/shard-engine/src/ctx-db-rank-page.ts
+++ b/packages/shard-engine/src/ctx-db-rank-page.ts
@@ -75,7 +75,7 @@ const resolveRankSeekTuple = (options: { after?: RankPageRowKey; cursor?: null |
 /**
  * Build the lexicographic strict-after seek branch + its bound params from a
  * decoded `[partitionKey, ...sortValues, id]` tuple, honoring each sort key's
- * direction (`&lt;` for desc, `>` for asc; `__partition__` and the `__id__`
+ * direction (`<` for desc, `>` for asc; `__partition__` and the `__id__`
  * tiebreak are always ascending). Returns `undefined` when there's no cursor or
  * the tuple's arity doesn't match the index (a malformed cursor pages from the
  * start, matching the shard-local reader).
@@ -141,7 +141,7 @@ const buildRankContinueCursor = (last: Record<string, unknown> | undefined, sort
 
 /**
  * Project a shard-local rank-companion slice into `{ doc, key }` rows. Each
- * key forwards the stored `__partition__` / `__sort_k&lt;i>__` columns verbatim
+ * key forwards the stored `__partition__` / `__sort_k<i>__` columns verbatim
  * (byte-identical to what the cross-shard coordinator's comparator orders on),
  * with the hydrated doc looked up from `byId`. Rows whose doc didn't hydrate
  * (a torn read) are skipped.
@@ -243,7 +243,7 @@ const hydrateDocsById = (deps: RankPageDeps, tableName: string, ids: ReadonlyArr
  * Shared shard-local ranked-page reader behind both the user-facing
  * `rankPage()` (which projects only `{ page, continueCursor, isDone }`) and
  * the cross-shard `rankPageRows()` (which additionally attaches each row's
- * rank-key tuple). Walks the rank companion in `(__partition__, __sort_k&lt;i>__,
+ * rank-key tuple). Walks the rank companion in `(__partition__, __sort_k<i>__,
  * __id__)` order, keyset-paginates with the opaque `cursor`, hydrates the
  * page's docs in one `IN (...)` query, and returns the keyed rows so the
  * query coordinator's k-way merge can order rows across shards without

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -244,7 +244,7 @@ interface CtxDbOptions {
      * it, cross-backend cascades throw — same behaviour as v1.
      *
      * Generated `shard.ts` passes the same D1-backed writer it uses for
-     * `ctx.db.&lt;globalTable>` reads/writes, so cascades and direct writes share
+     * `ctx.db.<globalTable>` reads/writes, so cascades and direct writes share
      * one D1 round-trip path. Non-transactional across backends: the local
      * delete commits before the global cascade fires, so a failure on the
      * global side leaves the local row gone — document at the call site.
@@ -1038,7 +1038,7 @@ const makeRelationExistsSqlStrategy = (onRead: ReadHook): WhereSqlStrategy => {
     return strategy;
 };
 
-/** Drizzle ORDER BY for the DO: each key as `&lt;jsonPath> ASC|DESC`, with an `id ASC` tiebreak unless an id field is already ordered (keeps paging deterministic). The drizzle twin of `compileOrderBy`. */
+/** Drizzle ORDER BY for the DO: each key as `<jsonPath> ASC|DESC`, with an `id ASC` tiebreak unless an id field is already ordered (keeps paging deterministic). The drizzle twin of `compileOrderBy`. */
 const compileOrderBySql = (keys: OrderKey[]): SQL => {
     const parts = keys.map((key) => dsql`${jsonPathSql(key.field)} ${dsql.raw(key.direction === "desc" ? "DESC" : "ASC")}`);
 
@@ -1785,7 +1785,7 @@ const runGuardedWrite = (sql: SqlExec, table: string, query: SQL): void => {
  * SQL so the two paths can never drift.
  *
  * `serializedSortValues[i]` must be the already-{@link serializeSqlValue}d
- * value for the i-th sort key — i.e. the exact bytes stored in `__sort_k&lt;i>__`
+ * value for the i-th sort key — i.e. the exact bytes stored in `__sort_k<i>__`
  * by `syncRankIndexEntry` (in `./ctx-db-companions`) — so the per-key comparison
  * matches the companion's BLOB column regardless of which shard supplied the value.
  *
@@ -1794,7 +1794,7 @@ const runGuardedWrite = (sql: SqlExec, table: string, query: SQL): void => {
  * (k0 < v0)
  * OR (k0 = v0 AND k1 < v1)
  * OR (k0 = v0 AND k1 = v1 AND __id__ < rowId)
- * where `&lt;` flips to `>` for desc keys.
+ * where `<` flips to `>` for desc keys.
  */
 const countRankBefore = (
     sql: SqlExec,
@@ -2042,14 +2042,14 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
     /**
      * Route a *table-name-addressed* op (`insert`/`query`/`findMany`/`count`/…)
      * to the backend that owns the table. A `.global()` table lives in D1, so
-     * its generic `ctx.db.&lt;op&gt;("&lt;table&gt;", …)` call must reach the D1-backed
+     * its generic `ctx.db.<op>("<table>", …)` call must reach the D1-backed
      * `globalDb` writer — where the table is provisioned and read-your-writes
      * apply — instead of this DO's local SQLite, which has no such table.
      *
      * Returns `undefined` for shard-local tables so the caller runs its normal
      * local path; throws a clear wiring error if a global table is reached
      * without a `globalDb` (mirroring {@link routeBackend}). This is the generic
-     * twin of the property-style `ctx.db.&lt;globalTable&gt;` facade: both land global
+     * twin of the property-style `ctx.db.<globalTable>` facade: both land global
      * access on D1, so `ctx.db.insert("t", …)` and `ctx.db.t.insert(…)` agree.
      * @returns the global D1 writer for the table, or `undefined` for shard-local tables
      */

--- a/packages/shard-engine/src/do-sql.ts
+++ b/packages/shard-engine/src/do-sql.ts
@@ -98,7 +98,7 @@ const qualifiedJsonPath = (table: string, field: string): string => {
 /** Table-qualified twin of {@link jsonPathSql} for EXISTS correlation refs. */
 const qualifiedJsonPathSql = (table: string, field: string): SQL => dsql.raw(qualifiedJsonPath(table, field));
 
-/** A `CREATE [UNIQUE] INDEX IF NOT EXISTS &lt;name> ON &lt;table> (&lt;columns>)` — the DO-local twin of sql-store's `createIndexIfNotExists` (single-engine SQLite, so no per-engine branching). */
+/** A `CREATE [UNIQUE] INDEX IF NOT EXISTS <name> ON <table> (<columns>)` — the DO-local twin of sql-store's `createIndexIfNotExists` (single-engine SQLite, so no per-engine branching). */
 const createIndexSql = (name: string, table: string, columns: SQL, unique: boolean): SQL =>
     dsql`CREATE ${unique ? dsql`UNIQUE ` : dsql``}INDEX IF NOT EXISTS ${dsql.identifier(name)} ON ${dsql.identifier(table)} (${columns})`;
 
@@ -108,8 +108,8 @@ const AGG_VALUE: Name = dsql.identifier("__value__");
 const AGG_COUNT: Name = dsql.identifier("__count__");
 
 /**
- * An aggregate-counter upsert: `INSERT INTO &lt;agg> (__key__, __value__, __count__)
- * VALUES (key, value, count) ON CONFLICT(__key__) DO UPDATE SET &lt;set>`. The
+ * An aggregate-counter upsert: `INSERT INTO <agg> (__key__, __value__, __count__)
+ * VALUES (key, value, count) ON CONFLICT(__key__) DO UPDATE SET <set>`. The
  * seeded value/count and the conflict-merge `set` vary per reducer (count / sum /
  * avg / min / max); the INSERT + ON CONFLICT scaffold is shared here.
  */

--- a/packages/shard-engine/src/external-source-cursor.ts
+++ b/packages/shard-engine/src/external-source-cursor.ts
@@ -38,8 +38,8 @@ interface SourceCursorState {
 /**
  * Serialize a cursor value to a type-tagged string so its native type survives
  * SQLite TEXT storage and rehydrates identically when bound back into the query.
- * `Date` → `d:&lt;iso>`, `bigint` → `b:&lt;digits>`, `number` → `n:&lt;num>`, everything
- * else → `s:&lt;string>`.
+ * `Date` → `d:<iso>`, `bigint` → `b:<digits>`, `number` → `n:<num>`, everything
+ * else → `s:<string>`.
  */
 const serializeCursor = (value: CursorValue): string => {
     if (value instanceof Date) {

--- a/packages/shard-engine/src/introspect.ts
+++ b/packages/shard-engine/src/introspect.ts
@@ -10,7 +10,7 @@ import type { SortDirection } from "./schema-types";
  * over the same `/_lunora/rpc` → shard `/rpc` path as ordinary functions, but
  * `ShardDO` intercepts them before user dispatch and serves them from the
  * helpers below. The `__lunora_` namespace is reserved (it also backs the FTS
- * capability probe), so a real generated `&lt;file>:&lt;function>` can never collide.
+ * capability probe), so a real generated `<file>:<function>` can never collide.
  */
 const ADMIN_FUNCTION_PREFIX = "__lunora_admin__:";
 
@@ -36,7 +36,7 @@ const RELATION_FUNCTION_PREFIX = "__lunora_relation__:";
  * evaluates the flag through the app's OpenFeature provider under the socket's
  * verified identity. Like the other reserved prefixes it is NOT admin-gated (a
  * flag read is public, scoped to the subscriber's own targeting context), and
- * the `__lunora_` namespace is reserved so a real `&lt;file>:&lt;function>` can't
+ * the `__lunora_` namespace is reserved so a real `<file>:<function>` can't
  * collide. Re-evaluated on every write-flush so values stay live within a
  * session (provider-side flips with no intervening write surface on reconnect).
  */
@@ -139,7 +139,7 @@ interface AuditLogResult {
 /**
  * One live subscription tracked on a shard's WebSocket, as surfaced by
  * `__lunora_admin__:listSubscriptions`. Mirrors the persisted `SubscriptionQuery`
- * attachment shape: `functionPath` is the `&lt;file>:&lt;function>` query re-run on a
+ * attachment shape: `functionPath` is the `<file>:<function>` query re-run on a
  * matching write (absent on legacy delta-only subscriptions), `table` is the
  * table the raw-delta fan-out matches against, and `args` are the query args.
  */
@@ -189,7 +189,7 @@ interface FunctionScanAttribution {
 
 /**
  * Per-function execution counters served by `__lunora_admin__:getFunctionStats`,
- * one entry per `&lt;file>:&lt;function>` path dispatched since this DO instance woke.
+ * one entry per `<file>:<function>` path dispatched since this DO instance woke.
  * Like `getMetrics`'s counters these are in-memory and reset on
  * hibernation/restart — a "since this instance woke" readout, not a durable
  * time series. Durations are wall-clock milliseconds of the handler call itself
@@ -222,7 +222,7 @@ interface FunctionCallStat {
     lastErrorMessage: null | string;
     /** Slowest single dispatch, in milliseconds. */
     maxDurationMs: number;
-    /** The `&lt;file>:&lt;function>` identifier, e.g. `messages:list`. */
+    /** The `<file>:<function>` identifier, e.g. `messages:list`. */
     path: string;
 
     /**
@@ -523,18 +523,18 @@ interface StudioFeaturesResult {
  * One feature flag evaluated under a supplied targeting context, surfaced by
  * `__lunora_admin__:listFlags` for the studio's read-only Flags page. The `key`
  * and `type` are statically discovered by `@lunora/codegen` from the app's
- * `ctx.flags.&lt;type>("key", …)` reads; `value`/`reason`/`variant`/`errorCode`
+ * `ctx.flags.<type>("key", …)` reads; `value`/`reason`/`variant`/`errorCode`
  * come from the live OpenFeature evaluation (the codegen subclass overrides the
  * base `evaluateFlags` hook). `value` is the resolved flag value as JSON.
  */
 interface FlagEvaluation {
     /** OpenFeature `errorCode` when the evaluation failed (the value falls back to the default). */
     errorCode?: string;
-    /** The discovered flag key (the first argument of a `ctx.flags.&lt;type>(...)` read). */
+    /** The discovered flag key (the first argument of a `ctx.flags.<type>(...)` read). */
     key: string;
     /** OpenFeature `reason` for the resolution (`TARGETING_MATCH`, `DEFAULT`, `ERROR`, …). */
     reason?: string;
-    /** The flag's value type, derived from which `ctx.flags.&lt;type>` method read it. */
+    /** The flag's value type, derived from which `ctx.flags.<type>` method read it. */
     type: "boolean" | "number" | "object" | "string";
     /** The resolved value (JSON), or the type default when unconfigured / on error. */
     value: unknown;
@@ -584,7 +584,7 @@ interface WorkflowsResult {
  * not Durable Objects and carry no runtime state in the shard, so this is pure
  * declaration metadata. `binding` is the generated `QUEUE_*` producer binding,
  * `name` the deployed `queues.producers[].queue`, `exportName` the
- * `lunora/queues.ts` export (`ctx.queues.&lt;exportName>`), `mode` whether the
+ * `lunora/queues.ts` export (`ctx.queues.<exportName>`), `mode` whether the
  * queue is consumed by a worker (`push`) or polled externally (`pull`), and
  * `deadLetterQueue` the optional DLQ a push consumer dead-letters to.
  */
@@ -1308,8 +1308,8 @@ const knownDisplayColumns = (sql: SqlExec, quotedTable: string, physicalColumns:
 
 /**
  * Summarise the distinct values of one displayed column over the **active view** —
- * Datasette-style faceting. Read-only: a `SELECT &lt;col> AS value, COUNT(*) AS count
- * … GROUP BY &lt;col> ORDER BY count DESC LIMIT N+1` with every value and JSON path
+ * Datasette-style faceting. Read-only: a `SELECT <col> AS value, COUNT(*) AS count
+ * … GROUP BY <col> ORDER BY count DESC LIMIT N+1` with every value and JSON path
  * bound, never interpolated. `column` is validated against the table's known
  * displayed columns (rejected with a typed 404 if unknown) and resolved through the
  * SAME {@link resolveColumnExpression} allowlist as filters/order-by, so a

--- a/packages/shard-engine/src/rank.ts
+++ b/packages/shard-engine/src/rank.ts
@@ -17,7 +17,7 @@
  *
  * Storage layout (per declared rankIndex):
  *
- * T__rank_&lt;name> (
+ * T__rank_<name> (
  * __id__         TEXT PRIMARY KEY,
  * __partition__  TEXT NOT NULL,   -- canonical-JSON tuple of partitionBy keys (or "")
  * __sort_k0__    BLOB,            -- one column per sortBy key (typeless)
@@ -25,8 +25,8 @@
  * ...
  * );
  *
- * CREATE INDEX T__rank_&lt;name>__btree
- * ON T__rank_&lt;name> (__partition__, __sort_k0__ &lt;dir0>, ..., __id__ ASC);
+ * CREATE INDEX T__rank_<name>__btree
+ * ON T__rank_<name> (__partition__, __sort_k0__ <dir0>, ..., __id__ ASC);
  *
  * Auto-backfill: a rank companion is **lazily** populated on the first read
  * or write that targets an empty companion, by scanning the source table
@@ -195,7 +195,7 @@ const rankTableName = (table: string, indexName: string): string => `${table}__r
  * The values mirror what the trigger seam (`syncRankIndexEntry`) stores:
  *
  * - `partitionKey` === `encodePartitionKey(index.partitionBy ?? [], doc)`, the same canonical-JSON tuple filed in `__partition__`.
- * - `sortValues[i]` === `serializeSqlValue(doc[index.sortBy[i].field])` — the same transform `syncRankIndexEntry` applies to the stored `__sort_k&lt;i>__` column, so the comparison is byte-for-byte (and JSON-safe for the cross-shard wire) regardless of which shard owns the row. `rankBefore` re-applies it idempotently, so a direct caller passing raw values still works.
+ * - `sortValues[i]` === `serializeSqlValue(doc[index.sortBy[i].field])` — the same transform `syncRankIndexEntry` applies to the stored `__sort_k<i>__` column, so the comparison is byte-for-byte (and JSON-safe for the cross-shard wire) regardless of which shard owns the row. `rankBefore` re-applies it idempotently, so a direct caller passing raw values still works.
  * - `rowId` === `doc._id`, the `__id__` tiebreak.
  */
 const rankKeyFromDocument = (

--- a/packages/shard-engine/src/reactive-cache.ts
+++ b/packages/shard-engine/src/reactive-cache.ts
@@ -11,7 +11,7 @@
  *
  * Lifetime + storage model:
  *
- * - In-memory `Map&lt;key, CacheEntry>`. Insertion-order is the LRU order; we
+ * - In-memory `Map<key, CacheEntry>`. Insertion-order is the LRU order; we
  * delete and re-set an entry on every read so the freshest one sits at
  * the tail of the map. No timers — eviction runs purely on the
  * set/delete paths.
@@ -22,7 +22,7 @@
  * savings. (Durable Object hibernation drops in-memory state anyway.)
  *
  * - Two indexes: the main `entries` map (key -> entry) and `tableIndex`
- * (`table:id` -> Set&lt;key>) so `ReactiveCache.invalidate` is O(deps)
+ * (`table:id` -> Set<key>) so `ReactiveCache.invalidate` is O(deps)
  * instead of O(entries).
  *
  * Eviction:
@@ -158,7 +158,7 @@ class ReactiveCache {
      *
      * The callback is awaited inside the cache so concurrent callers for the
      * same key still race the underlying handler — a real Convex-style
-     * "in-flight dedup" would add a `Map&lt;key, Promise>`; we keep this simpler
+     * "in-flight dedup" would add a `Map<key, Promise>`; we keep this simpler
      * and accept that the first uncached hit may run the handler twice when
      * two callers arrive on the same tick. The single-DO concurrency model
      * makes that race vanishingly rare in practice.

--- a/packages/shard-engine/src/read-write-set.ts
+++ b/packages/shard-engine/src/read-write-set.ts
@@ -68,7 +68,7 @@ const EQUALITY = "=";
 /** `>` / `>=` constrain the slice from BELOW (they raise `lo`). */
 const GREATER_THAN = new Set([">", ">="]);
 
-/** `&lt;` / `&lt;=` constrain the slice from ABOVE (they lower `hi`). */
+/** `<` / `<=` constrain the slice from ABOVE (they lower `hi`). */
 const LESS_THAN = new Set(["<", "<="]);
 
 /**
@@ -85,7 +85,7 @@ interface ParsedConditions {
     lowerExclusive: boolean;
     /** Serialized upper bound, when one was staged. */
     upper?: unknown;
-    /** `true` for `&lt;` (exclusive), `false` for `&lt;=`. */
+    /** `true` for `<` (exclusive), `false` for `<=`. */
     upperExclusive: boolean;
 }
 

--- a/packages/shard-engine/src/schema-types.ts
+++ b/packages/shard-engine/src/schema-types.ts
@@ -91,8 +91,8 @@ export type TriggerTimingLike = "after" | "before";
 export type TriggerOpLike = "delete" | "insert" | "update";
 
 /**
- * A schedulable durable-workflow reference — the generated `workflows.&lt;name>` /
- * `agents.&lt;name>` object (carries its `WORKFLOW_*`/`AGENT_*` binding + stable
+ * A schedulable durable-workflow reference — the generated `workflows.<name>` /
+ * `agents.<name>` object (carries its `WORKFLOW_*`/`AGENT_*` binding + stable
  * name). Structural mirror so a scheduled target can be a workflow/agent, not
  * just a function path, without this package depending on `@lunora/scheduler`.
  */
@@ -141,7 +141,7 @@ export interface GuardableSchema {
     readonly tables: Record<string, { readonly isPublic?: boolean }>;
 }
 
-/** Minimal subset of `@lunora/server`'s `Schema&lt;T>` the adapter reads. */
+/** Minimal subset of `@lunora/server`'s `Schema<T>` the adapter reads. */
 export interface SchemaLike {
     readonly rlsMode?: "required";
     readonly tables: Record<string, TableDefinitionLike>;
@@ -375,7 +375,7 @@ export interface SearchScoredDocument {
     score: number;
 }
 
-/** A `ctx.db.&lt;table>` reader facade. */
+/** A `ctx.db.<table>` reader facade. */
 export interface TableReaderLike {
     /** Lazy row iteration — see the implementation note in `ctx-db.ts`. */
     [Symbol.asyncIterator]: () => AsyncIterator<Record<string, unknown>>;

--- a/packages/shard-engine/src/serialize-sql.ts
+++ b/packages/shard-engine/src/serialize-sql.ts
@@ -1,6 +1,6 @@
 /**
  * Canonicalise a JS value into the SQL-bindable primitive the DO stores in a
- * column / `__sort_k&lt;i>__` blob. The output is always `null`, a `string`, or a
+ * column / `__sort_k<i>__` blob. The output is always `null`, a `string`, or a
  * `number` — never a `boolean`, `bigint`, `Date`, or object — which makes it
  * both bindable and **JSON-safe** (so it survives the cross-shard RPC wire),
  * and the function is **idempotent** (`serializeSqlValue(serializeSqlValue(x))

--- a/packages/shard-engine/src/shard-ring.ts
+++ b/packages/shard-engine/src/shard-ring.ts
@@ -100,7 +100,7 @@ const fnv1a64 = (input: string): bigint => {
  * that growing `buckets` moves the minimum possible number of keys and nothing
  * else is disturbed. No memory, no lookup table — just the jump loop.
  *
- * Returns `0` for `buckets &lt;= 1`, which keeps the degenerate one-bucket case
+ * Returns `0` for `buckets <= 1`, which keeps the degenerate one-bucket case
  * from needing a caller-side branch.
  */
 const jumpConsistentHash = (key: string, buckets: number): number => {

--- a/packages/shard-engine/src/system-reader.ts
+++ b/packages/shard-engine/src/system-reader.ts
@@ -6,7 +6,7 @@
  * `_storage`, ...) through `ctx.db.system`. Lunora mirrors that surface, but with
  * one load-bearing caveat: **the data these tables expose does not live in the
  * shard's SQLite**. Scheduled functions live in the `SchedulerDO`; storage
- * objects live in R2. So unlike `ctx.db.&lt;table>` — which reads the same
+ * objects live in R2. So unlike `ctx.db.<table>` — which reads the same
  * transactional SQLite snapshot the mutation writes into — `ctx.db.system`
  * reaches across a network/DO boundary on every call.
  *
@@ -212,7 +212,7 @@ const toStorageMetadata = (object: Record<string, unknown>): StorageMetadata => 
 /**
  * Build the read-only {@link SystemDatabaseReader} assigned to `ctx.db.system`.
  * Reads route to the supplied backing sources; an unconfigured source throws a
- * clear `ctx.db.system.&lt;table>: no &lt;source> configured` error (mirroring the
+ * clear `ctx.db.system.<table>: no <source> configured` error (mirroring the
  * generated `storageStub` / `schedulerStub` "no X configured" stubs) rather than
  * silently returning empty — a missing source is a wiring bug, not an empty
  * table.

--- a/packages/shard-engine/src/types.ts
+++ b/packages/shard-engine/src/types.ts
@@ -4,7 +4,7 @@ export interface SubscriptionQuery {
     args?: Record<string, unknown>;
 
     /**
-     * `&lt;file>:&lt;function>` identifier of the query to re-run server-side when
+     * `<file>:<function>` identifier of the query to re-run server-side when
      * a write touches a table it reads. Present on subscriptions that opt into
      * server re-execution; absent on legacy delta-only subscriptions, which
      * are matched by `table` alone.

--- a/packages/shard-engine/src/where-types.ts
+++ b/packages/shard-engine/src/where-types.ts
@@ -30,7 +30,7 @@ interface FieldOperators {
 
 /**
  * Structural runtime shape of the `where` argument. The codegen facade layers a
- * table-typed `Where&lt;Doc>` on top; this is the untyped surface the compiler
+ * table-typed `Where<Doc>` on top; this is the untyped surface the compiler
  * walks. A non-structural key is a field whose value is either a literal
  * (equality shorthand) or a {@link FieldOperators} object.
  */

--- a/packages/solid/eslint.config.js
+++ b/packages/solid/eslint.config.js
@@ -51,4 +51,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/solid/src/context.ts
+++ b/packages/solid/src/context.ts
@@ -7,7 +7,7 @@ import { createContext, useContext } from "solid-js";
  * Solid context carrying the framework-neutral {@link LunoraClient}. Every
  * reactive primitive in this adapter (`createQuery`, `createMutation`,
  * `hydratePreloaded`) reads the client from here, so a single
- * `&lt;LunoraProvider client={…}>` at the root of the tree wires the whole app.
+ * `<LunoraProvider client={…}>` at the root of the tree wires the whole app.
  *
  * Defaults to `undefined` so {@link useLunora} can throw a helpful error when a
  * primitive is used outside a provider rather than dereferencing it.
@@ -15,7 +15,7 @@ import { createContext, useContext } from "solid-js";
 export const LunoraContext: Context<LunoraClient | undefined> = createContext<LunoraClient | undefined>();
 
 /**
- * Read the {@link LunoraClient} from the nearest `&lt;LunoraProvider>`.
+ * Read the {@link LunoraClient} from the nearest `<LunoraProvider>`.
  *
  * Throws when called outside a provider — the client is required to open the
  * HTTP/WS transport, so there is no sensible fallback. The React adapter's

--- a/packages/solid/src/create-agent-chat.ts
+++ b/packages/solid/src/create-agent-chat.ts
@@ -114,7 +114,7 @@ interface CreateAgentChatOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link CreateAgentChatResult.cancel} is
      * a no-op.
      */
@@ -124,7 +124,7 @@ interface CreateAgentChatOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link CreateAgentChatOptions.sendArgs} and the per-call args.
      */
     send: FunctionReference<"mutation">;

--- a/packages/solid/src/create-agent.ts
+++ b/packages/solid/src/create-agent.ts
@@ -55,7 +55,7 @@ interface CreateAgentOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link CreateAgentResult.cancel} is a
      * no-op.
      */
@@ -63,7 +63,7 @@ interface CreateAgentOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link CreateAgentOptions.runArgs} and the per-call args.
      */
     run: FunctionReference<"mutation">;
@@ -108,7 +108,7 @@ const resolveMaybe = <T>(value: MaybeAccessor<T>): T => (typeof value === "funct
  * `createAgentChat`.
  *
  * `run` and `cancel` stay generic over the app-defined mutations that wrap
- * `ctx.agents.&lt;name>.run` / `.cancel`, so the primitive hard-codes no function
+ * `ctx.agents.<name>.run` / `.cancel`, so the primitive hard-codes no function
  * names beyond the `agents:*` surface. `threadKey` may be an accessor — a changing
  * key re-subscribes to the new thread.
  */

--- a/packages/solid/src/create-mutation.ts
+++ b/packages/solid/src/create-mutation.ts
@@ -60,7 +60,7 @@ export const createMutationForClient = <F extends FunctionReference>(client: Mut
 /**
  * Returns a reactive handle `{ mutate, pending, data, error, reset }` for the
  * given mutation reference, bound to the `LunoraClient` from the nearest
- * `&lt;LunoraProvider>`.
+ * `<LunoraProvider>`.
  *
  * Optimistic updates stay client-owned: the `optimistic` / `optimisticUpdate`
  * call options pass straight through to `client.mutation`, which applies and

--- a/packages/solid/src/create-query.ts
+++ b/packages/solid/src/create-query.ts
@@ -25,7 +25,7 @@ export interface CreateQueryOptions {
  *
  * ```tsx
  * const messages = createQuery(api.messages.list, () => ({ channelId: channelId() }));
- * return &lt;For each={messages()?.messages}>{(m) => &lt;li>{m.text}&lt;/li>}&lt;/For>;
+ * return <For each={messages()?.messages}>{(m) => <li>{m.text}</li>}</For>;
  * ```
  */
 export const createQuery = <F extends FunctionReference>(

--- a/packages/solid/src/create-voice-agent.ts
+++ b/packages/solid/src/create-voice-agent.ts
@@ -30,9 +30,9 @@ type VoiceServerFrame =
 type VoiceClientFrame = { text: string; type: "text" } | { type: "commit" } | { type: "interrupt" };
 
 /**
- * The `agents.&lt;name>Voice` reference codegen emits for a voice-enabled agent — a
+ * The `agents.<name>Voice` reference codegen emits for a voice-enabled agent — a
  * live, WS-backed session keyed by `threadKey`. A structural subset of the
- * generated member, so passing `api.agents.&lt;name>Voice` type-checks.
+ * generated member, so passing `api.agents.<name>Voice` type-checks.
  */
 type VoiceReference = FunctionReference<"stream", { threadKey: string }, Record<string, unknown>>;
 
@@ -76,7 +76,7 @@ interface CreateVoiceAgentOptions {
     silenceThreshold?: number;
     /** The thread to converse on — shared with the agent's text turns. May be a plain value or accessor (resolved when the call opens). */
     threadKey: MaybeAccessor<string>;
-    /** The generated `api.agents.&lt;name>Voice` reference — identifies the voice DO endpoint. */
+    /** The generated `api.agents.<name>Voice` reference — identifies the voice DO endpoint. */
     voice: VoiceReference;
 }
 
@@ -128,7 +128,7 @@ const deriveWebSocketUrl = (url: string): string => {
 
 /**
  * Derive the agent's export name from its voice reference. Codegen emits the
- * member as `agents.&lt;name>Voice` (ref `agents:&lt;name>Voice`), so strip the
+ * member as `agents.<name>Voice` (ref `agents:<name>Voice`), so strip the
  * `agents:` namespace and the `Voice` suffix.
  */
 const agentNameFromReference = (voice: VoiceReference): string => {
@@ -169,7 +169,7 @@ interface VoiceConnection {
  * WebSocket to the agent's `VoiceSessionDO`, captures mic audio as 16 kHz PCM,
  * streams the agent's synthesized speech back through the browser's audio output,
  * and mirrors the call lifecycle (`status`, `transcript`, `interimTranscript`,
- * `audioLevel`) to Solid signals. Pass the generated `api.agents.&lt;name>Voice`
+ * `audioLevel`) to Solid signals. Pass the generated `api.agents.<name>Voice`
  * reference (never a string), matching `createAgentChat`'s reference-passing style.
  * The Solid counterpart to React's `useVoiceAgent`, re-expressed with signals; the
  * per-call connection lives in a closure variable (a primitive runs once per

--- a/packages/solid/src/hydrate-preloaded.ts
+++ b/packages/solid/src/hydrate-preloaded.ts
@@ -19,7 +19,7 @@ import { useLunora } from "./context";
  * ```tsx
  * // route loader (server): const preloaded = await preloadQuery(client, api.messages.list, args);
  * const messages = hydratePreloaded(preloaded); // seeded from SSR, then live
- * return &lt;pre>{JSON.stringify(messages())}&lt;/pre>;
+ * return <pre>{JSON.stringify(messages())}</pre>;
  * ```
  *
  * Effects do not run on the server during SSR (Solid only runs them after

--- a/packages/solid/src/lunora-provider.tsx
+++ b/packages/solid/src/lunora-provider.tsx
@@ -28,9 +28,9 @@ export interface LunoraProviderProps {
  * const client = new LunoraClient({ url: window.location.origin });
  *
  * render(() => (
- *     &lt;LunoraProvider client={client}>
- *         &lt;App />
- *     &lt;/LunoraProvider>
+ *     <LunoraProvider client={client}>
+ *         <App />
+ *     </LunoraProvider>
  * ), root);
  * ```
  */

--- a/packages/sql-store/eslint.config.js
+++ b/packages/sql-store/eslint.config.js
@@ -151,4 +151,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/sql-store/src/ctx-db.ts
+++ b/packages/sql-store/src/ctx-db.ts
@@ -7,7 +7,7 @@
  * cursor logic is identical to the DO path: it reuses the shared keyset/order
  * helpers from `@lunora/do`, but compiles `WHERE` through the drizzle-emitting
  * `compileWhereSql` with a `WhereSqlStrategy` (column refs + value
- * serialization) so the generated `ctx.db.&lt;table>` facade (1.2.7) is
+ * serialization) so the generated `ctx.db.<table>` facade (1.2.7) is
  * backend-agnostic.
  */
 /* eslint-disable unicorn/prevent-abbreviations -- "d1-ctx-db" is the established public module name: src/index.ts and every test import it as "./d1-ctx-db.js", and it deliberately mirrors @lunora/do's "ctx-db.ts" twin. Renaming would break those importers. */
@@ -109,8 +109,8 @@ const ID_ORDER_FIELDS = new Set(["_id", "id"]);
 
 /**
  * NULL-safe equality for a bound value, rendered per engine: SQLite `IS`,
- * Postgres `IS NOT DISTINCT FROM`, MySQL's `&lt;=>` null-safe-equal operator. A bare
- * `col IS &lt;literal>` is SQLite-only — it is a syntax error on Postgres/MySQL — so
+ * Postgres `IS NOT DISTINCT FROM`, MySQL's `<=>` null-safe-equal operator. A bare
+ * `col IS <literal>` is SQLite-only — it is a syntax error on Postgres/MySQL — so
  * every cross-dialect equality predicate (the OCC guard and the rank seek/before
  * builders) must route through this rather than emitting `IS` directly.
  */
@@ -128,7 +128,7 @@ const nullSafeEqualsSql = (engine: SqlDialect["name"], reference: SQL, value: un
 
 /**
  * Drizzle `ORDER BY` list — the SQL-object twin of `@lunora/do`'s string
- * `compileOrderBy`: each key as `&lt;col> ASC|DESC`, with an `id ASC` tiebreak
+ * `compileOrderBy`: each key as `<col> ASC|DESC`, with an `id ASC` tiebreak
  * appended unless an id field is already ordered (keeps paging deterministic).
  */
 const compileOrderBySql = (keys: ReadonlyArray<{ direction?: string; field: string }>): SQL => {
@@ -707,7 +707,7 @@ const runSqlGlobalTableMigrations = async (exec: SqlCtxExec, schema: SchemaLike,
 };
 
 /**
- * Materialize the `__agg_&lt;index>` companion tables for every declared
+ * Materialize the `__agg_<index>` companion tables for every declared
  * `aggregateIndex` on a global table. Global tables in Lunora ship their own
  * DDL — counter tables are opt-in so production hosts can decide where they
  * live. Tests and dev hosts can call this once after their schema migration to
@@ -801,7 +801,7 @@ const rankSortColumnDefs = (dialect: SqlDialect, index: RankIndexDefinitionLike,
     });
 
 /**
- * Materialize the `__rank_&lt;index>` companion tables for every declared
+ * Materialize the `__rank_<index>` companion tables for every declared
  * `rankIndex` on a global table. Mirrors `runSqlAggregateMigrations` — same
  * opt-in pattern so production hosts decide whether to spend the DDL.
  *
@@ -956,10 +956,10 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
     const nullSafeEquals = (reference: SQL, value: unknown): SQL => nullSafeEqualsSql(dialect.name, reference, value);
 
     /**
-     * Build an `INSERT … VALUES … &lt;conflict clause>` upsert as a drizzle SQL for
-     * the aggregate counters. SQLite/Postgres emit `ON CONFLICT(&lt;key>) DO UPDATE
+     * Build an `INSERT … VALUES … <conflict clause>` upsert as a drizzle SQL for
+     * the aggregate counters. SQLite/Postgres emit `ON CONFLICT(<key>) DO UPDATE
      * SET …`; MySQL emits `ON DUPLICATE KEY UPDATE …` (keyed off `dialect.name`).
-     * The `set` callback returns `{ &lt;unquoted column>: &lt;update expression> }`
+     * The `set` callback returns `{ <unquoted column>: <update expression> }`
      * pairs, building expressions from `excluded(col)` (the proposed row) and
      * `current(col)` (the existing row — qualified with the table name on Postgres,
      * where a bare reference is ambiguous between the target and `excluded`).
@@ -1095,7 +1095,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
     const backfilled = new Map<string, boolean>();
 
     /**
-     * Whether `table` has a corresponding `__agg_&lt;index>` companion table on
+     * Whether `table` has a corresponding `__agg_<index>` companion table on
      * the D1 binding. Global tables ship with their own DDL — counter tables
      * are opt-in: if the user hasn't defined one, we silently fall back to a
      * SCAN-based count. The same opt-in shape is what `runSqlAggregateMigrations`
@@ -1752,7 +1752,7 @@ const createSqlCtxDb = (options: SqlCtxDbOptions): DatabaseWriterLike => {
      * Run an optimistic-concurrency-guarded write — the D1 twin of the DO
      * dialect's `runGuardedWrite`. D1 stores rows as real columns (no `__doc__`
      * blob) and `SqlCtxExec.run` returns no rows-affected count, so the CAS is
-     * expressed as `WHERE "id" IS ? AND "&lt;col>" IS ? ... RETURNING "id"` run via
+     * expressed as `WHERE "id" IS ? AND "<col>" IS ? ... RETURNING "id"` run via
      * `exec.all` (both D1 and node:sqlite support `RETURNING`). The bound values
      * are the RAW column values captured at read time ({@link rawRow}) so the
      * comparison is faithful; `IS` gives NULL-safe equality. An empty RETURNING

--- a/packages/sql-store/src/dialect.ts
+++ b/packages/sql-store/src/dialect.ts
@@ -117,7 +117,7 @@ export interface SqlDialect {
     /**
      * Optional: the key-prefix length an indexed column of this `kind` needs.
      * MySQL/InnoDB can't index a `TEXT`/`LONGTEXT`/`BLOB` column without a prefix
-     * (the store appends `(&lt;n>)` to the column reference); SQLite/Postgres index
+     * (the store appends `(<n>)` to the column reference); SQLite/Postgres index
      * text columns directly and omit this hook (or return `undefined`). `kind` is
      * the column's effective validator kind.
      */

--- a/packages/storage/eslint.config.js
+++ b/packages/storage/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -71,7 +71,7 @@ export interface SignedUrlOptions {
     /**
      * Pin the `Content-Type` an uploader must send on a `method: "PUT"` URL.
      * Baked into the HMAC canonical so the signature only authorizes a PUT with
-     * exactly this content-type; mirrored on the URL as `&amp;ct=...`. Ignored for
+     * exactly this content-type; mirrored on the URL as `&ct=...`. Ignored for
      * `GET` URLs (a download has no request body content-type to pin).
      */
     contentType?: string;

--- a/packages/storage/src/upload-handler.ts
+++ b/packages/storage/src/upload-handler.ts
@@ -119,8 +119,8 @@ interface R2UploadStorageOptions {
 
     /**
      * Explicit R2 S3 endpoint. Defaults to
-     * `https://&lt;accountId>.r2.cloudflarestorage.com`. Pass this to pin a
-     * jurisdiction (e.g. `&lt;accountId>.eu.r2.cloudflarestorage.com`).
+     * `https://<accountId>.r2.cloudflarestorage.com`. Pass this to pin a
+     * jurisdiction (e.g. `<accountId>.eu.r2.cloudflarestorage.com`).
      */
     endpoint?: string;
     /** Client-side multipart part size (bytes or a size string like `"16MB"`). */

--- a/packages/studio/__tests__/features/containers/fold-container-instances.test.ts
+++ b/packages/studio/__tests__/features/containers/fold-container-instances.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { foldContainerInstances, parseContainerMessage } from "../../../src/features/containers/fold-container-instances";
 import type { LogEntry } from "../../../src/lib/admin";
 
-/** Build a `container:&lt;name>` log entry the ShardDO emits for one lifecycle transition. */
+/** Build a `container:<name>` log entry the ShardDO emits for one lifecycle transition. */
 const containerEntry = (name: string, message: string, timestamp: number, level: LogEntry["level"] = "info"): LogEntry => {
     return {
         functionPath: `container:${name}`,

--- a/packages/studio/eslint.config.js
+++ b/packages/studio/eslint.config.js
@@ -189,4 +189,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/studio/src/app/app.tsx
+++ b/packages/studio/src/app/app.tsx
@@ -73,7 +73,7 @@ interface StudioAppBodyProps {
 /**
  * The composed studio plus its error boundary. Kept separate from {@link
  * StudioApp} because its `useT` (for the error-boundary label) must read the
- * `StudioI18nProvider` the app renders above it. The composed `&lt;Studio>`
+ * `StudioI18nProvider` the app renders above it. The composed `<Studio>`
  * inherits that same provider, so it isn't handed an instance here.
  */
 const StudioAppBody = ({ basePath, chrome, studio }: StudioAppBodyProps): ReactElement => {
@@ -114,7 +114,7 @@ interface StudioShellProps {
  * and applies the `.dark` class to its OWN container (not `document.documentElement`),
  * so the studio can be embedded inside a host app without recoloring the host.
  * Builds the app-owned {@link StudioChrome} (header theme toggle, footer
- * admin-token popover, rules banner) handed to the composed `&lt;Studio>`.
+ * admin-token popover, rules banner) handed to the composed `<Studio>`.
  */
 const StudioShell = ({ basePath, clearToken, client, i18n, onTokenChange, rulesInstalled, studio, token }: StudioShellProps): ReactElement => {
     // The resolved light/dark is applied to this scoped root (not `<html>`).
@@ -142,7 +142,7 @@ const StudioShell = ({ basePath, clearToken, client, i18n, onTokenChange, rulesI
 
 /**
  * A fully self-contained studio page: it constructs a {@link LunoraClient}
- * pointed at the worker, wires it through a `&lt;LunoraProvider>`, manages the
+ * pointed at the worker, wires it through a `<LunoraProvider>`, manages the
  * admin token + theme, and renders the composed {@link Studio} — handing it the
  * top-bar/sidebar {@link StudioChrome} (theme toggle, admin-token popover, rules
  * banner) so those affordances render inside the sidebar shell.
@@ -150,7 +150,7 @@ const StudioShell = ({ basePath, clearToken, client, i18n, onTokenChange, rulesI
  * Mount this directly (the standalone app and the `@lunora/vite` dev route both
  * do) when you want the batteries-included page rather than composing panels
  * yourself. For embedding into an existing admin UI, use the individual panels
- * or `&lt;Studio>` under your own provider instead.
+ * or `<Studio>` under your own provider instead.
  */
 const StudioApp = ({ adminToken, basePath, baseUrl, client: injectedClient, rulesInstalled, studio, locale }: StudioAppProps = {}): ReactElement => {
     // Seed from the prop, else a token persisted in a prior session (so a reload

--- a/packages/studio/src/app/studio.tsx
+++ b/packages/studio/src/app/studio.tsx
@@ -162,7 +162,7 @@ interface StudioProps {
     /**
      * App-owned top-bar + sidebar-footer chrome (theme toggle, admin-token
      * popover, rules banner). The batteries-included `StudioApp` supplies
-     * this; composing `&lt;Studio>` bare omits those affordances. See {@link StudioChrome}.
+     * this; composing `<Studio>` bare omits those affordances. See {@link StudioChrome}.
      */
     readonly chrome?: StudioChrome;
 
@@ -253,7 +253,7 @@ type StudioShellProps = Omit<StudioProps, "i18n" | "locale">;
  * token state, the rules banner) but which renders *inside* the router-owned
  * {@link StudioLayout} (the header and sidebar footer). The layout is a route
  * component with no props, so it reads this from context rather than threading
- * it through the router. Absent (composing `&lt;Studio>` bare) the layout simply
+ * it through the router. Absent (composing `<Studio>` bare) the layout simply
  * omits those affordances.
  */
 interface StudioChrome {
@@ -588,7 +588,7 @@ const CollapsedGroupNav = ({
 
 /**
  * The bottom-pinned profile / connection card. Without app-owned `chrome`
- * (composing `&lt;Studio>` bare) it's a static avatar; with it, it's the trigger
+ * (composing `<Studio>` bare) it's a static avatar; with it, it's the trigger
  * for the admin-token popover. Extracted from {@link StudioSidebar} to keep that
  * component's branching shallow.
  */
@@ -666,7 +666,7 @@ const SidebarFooterProfile = ({
  * presentation: **expanded** shows the full labelled nav (each row's one-line
  * description as a hover tooltip); **collapsed** shows one icon per domain, each
  * opening a hover flyout of that domain's pages — so every page stays reachable
- * from the narrow icon rail. Rendered inside `&lt;SidebarProvider>` so it can call
+ * from the narrow icon rail. Rendered inside `<SidebarProvider>` so it can call
  * {@link useSidebar}.
  */
 const StudioSidebar = ({ chrome, connected, current, groupLabel, groups, selectTab, tabDescription, tabLabel }: StudioSidebarProps): ReactElement => {
@@ -765,7 +765,7 @@ const RoutePending = (): ReactElement => (
 
 /**
  * Persistent shell rendered by the router's root route: the grouped sidebar
- * ({@link StudioSidebar}) and the routed panel area (`&lt;Outlet />`). The active
+ * ({@link StudioSidebar}) and the routed panel area (`<Outlet />`). The active
  * tab is derived from the URL, so deep links and the browser back/forward
  * buttons drive which panel shows.
  */
@@ -922,7 +922,7 @@ const StudioLayout = (): ReactElement => (
 );
 
 /**
- * Schema tab wrapper that lifts the optional `?table=&lt;name>` search param off
+ * Schema tab wrapper that lifts the optional `?table=<name>` search param off
  * the URL and forwards it to {@link SchemaViewer} as `initialTable`. This is the
  * landing target of the Insights "add the index" deep-link: navigating to
  * `/schema?table=posts` auto-expands `posts`'s index list. Read with

--- a/packages/studio/src/components/evilcharts/charts/bar-chart.tsx
+++ b/packages/studio/src/components/evilcharts/charts/bar-chart.tsx
@@ -56,8 +56,8 @@ type BarAnimationType = "none" | "left-to-right" | "right-to-left" | "center-out
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Shared state for every part of the chart. Lifted into &lt;EvilBarChart /> so that
- * &lt;Bar />, &lt;XAxis />, &lt;Legend />, and friends can read it without prop drilling.
+ * Shared state for every part of the chart. Lifted into <EvilBarChart /> so that
+ * <Bar />, <XAxis />, <Legend />, and friends can read it without prop drilling.
  * Sub-components are composed freely — the provider is the single source of truth.
  */
 type BarChartContextValue = {
@@ -257,7 +257,7 @@ type BarProps = {
 };
 
 /**
- * A single bar series. Each &lt;Bar /> is fully self-contained: it generates its
+ * A single bar series. Each <Bar /> is fully self-contained: it generates its
  * own gradient/pattern definitions under a unique id, so any number of bars —
  * each with its own variant, radius, glow, and clickability — can live in one
  * chart without style collisions.
@@ -468,7 +468,7 @@ type LegendProps = {
 
 /**
  * The series legend. When `isClickable` is set, each entry toggles selection of
- * its series, driving the shared selection state read by every &lt;Bar />.
+ * its series, driving the shared selection state read by every <Bar />.
  */
 export const Legend = ({ variant, align = "right", verticalAlign = "top", isClickable = false }: LegendProps): React.ReactElement => {
     const { selectedDataKey, selectDataKey } = useBarChart();
@@ -520,7 +520,7 @@ type CustomBarProps = BarShapeProps & {
 };
 
 /**
- * Custom bar shape. Renders the visible bar painted by the owning &lt;Bar />'s
+ * Custom bar shape. Renders the visible bar painted by the owning <Bar />'s
  * variant pattern, with an invisible full-height rectangle behind it to keep
  * the whole column hoverable and clickable.
  */

--- a/packages/studio/src/components/shard-input.tsx
+++ b/packages/studio/src/components/shard-input.tsx
@@ -16,7 +16,7 @@ export interface ShardInputProps {
 
 /**
  * Shard-key text field shared by every shard-scoped panel. Backed by a
- * `&lt;datalist>` of recently-used shard keys (see {@link loadRecentShards}) so an
+ * `<datalist>` of recently-used shard keys (see {@link loadRecentShards}) so an
  * operator can pick a shard they've visited instead of retyping it — the closest
  * to a shard picker possible without server-side shard enumeration, which
  * Durable Objects don't support. Panels remain responsible for recording a shard

--- a/packages/studio/src/components/theme-provider.tsx
+++ b/packages/studio/src/components/theme-provider.tsx
@@ -68,8 +68,8 @@ const ThemeProvider = ({ children, defaultTheme = "system" }: ThemeProviderProps
  * Render `children` under a theme context, creating a {@link ThemeProvider}
  * only when the host didn't already mount one. `StudioApp` owns a provider (so
  * its login page and scoped root share the preference), but the composable
- * `&lt;Studio>` is a public export an embedder mounts bare — without this its
- * header `&lt;ThemeToggle>` would throw. Mirrors the inherit-or-own pattern the
+ * `<Studio>` is a public export an embedder mounts bare — without this its
+ * header `<ThemeToggle>` would throw. Mirrors the inherit-or-own pattern the
  * i18n provider uses.
  */
 const EnsureThemeProvider = ({ children }: { readonly children: ReactNode }): ReactNode => {

--- a/packages/studio/src/features/auth/organization-dialogs.tsx
+++ b/packages/studio/src/features/auth/organization-dialogs.tsx
@@ -23,7 +23,7 @@ const parseJsonObject = (text: string): Record<string, unknown> => {
     return parsed as Record<string, unknown>;
 };
 
-/** Parse + validate a permission grant (`Record&lt;resource, actions[]>`) from a textarea. */
+/** Parse + validate a permission grant (`Record<resource, actions[]>`) from a textarea. */
 const parsePermission = (text: string): Record<string, string[]> => {
     const object = parseJsonObject(text);
     const grant: Record<string, string[]> = {};
@@ -52,7 +52,7 @@ const jsonInitial = (value: unknown): string => {
     return JSON.stringify(value, null, 2);
 };
 
-/** One labelled `&lt;input>` row. */
+/** One labelled `<input>` row. */
 const Field = ({ children, htmlFor, label }: { children: ReactNode; htmlFor: string; label: string }): ReactElement => (
     <div className="flex flex-col gap-1">
         <Label htmlFor={htmlFor}>{label}</Label>

--- a/packages/studio/src/features/auth/user-create-dialog.tsx
+++ b/packages/studio/src/features/auth/user-create-dialog.tsx
@@ -19,7 +19,7 @@ interface UserCreateDialogProps {
     readonly onCreated: () => void;
 }
 
-/** The `&lt;input type>` for a plugin field's value control (booleans get a checkbox instead). */
+/** The `<input type>` for a plugin field's value control (booleans get a checkbox instead). */
 const INPUT_TYPE_BY_FIELD: Record<AuthUserFieldSpec["type"], string> = {
     boolean: "checkbox",
     date: "datetime-local",

--- a/packages/studio/src/features/containers/containers-panel.tsx
+++ b/packages/studio/src/features/containers/containers-panel.tsx
@@ -45,7 +45,7 @@ const entriesOf = (result: unknown): LogEntry[] => {
  * Data-source note: the lifecycle envelope carries `name` + the per-instance
  * Durable Object id + transition + detail (and a process `exitCode` on a stop) —
  * `@lunora/do` folds the Container DO's push to `functionPath:
- * "container:&lt;name>"` and carries the instance id through, so this is a
+ * "container:<name>"` and carries the instance id through, so this is a
  * per-instance view. The envelope has no ports/health, so those aren't surfaced
  * (they live in static `defineContainer` config, not the runtime stream). It
  * streams live over the same admin WS the Logs panel uses.

--- a/packages/studio/src/features/containers/fold-container-instances.ts
+++ b/packages/studio/src/features/containers/fold-container-instances.ts
@@ -25,14 +25,14 @@ const EVENT_STATE: Record<string, ContainerLifecycleState> = {
  * The log envelope now carries the per-instance Durable Object id
  * (`entry.instance`) and, for a `stop`, the process `exitCode`; `@lunora/do`
  * maps the Container DO's best-effort lifecycle push to `functionPath:
- * "container:&lt;name>"` + a `&lt;event>` / `&lt;event>: &lt;detail>` message. So this view
+ * "container:<name>"` + a `<event>` / `<event>: <detail>` message. So this view
  * is keyed per `(name, instance)` — many concurrent instances of one container
  * fold into their own rows instead of collapsing into a single lane. An entry
  * with no instance id (older buffers, or a pre-instance transition) folds under
  * a synthetic single-lane key so it still renders.
  */
 interface ContainerInstanceRow {
-    /** Detail after the `&lt;event>:` marker (a stop reason / error message), when present. */
+    /** Detail after the `<event>:` marker (a stop reason / error message), when present. */
     readonly detail?: string;
     /** The raw lifecycle transition token that produced the current state (`start`/`stop`/`sleep`/`error`). */
     readonly event: string;
@@ -52,7 +52,7 @@ interface ContainerInstanceRow {
 
 /**
  * Split a folded container log message into its transition token + optional
- * detail. `@lunora/do` writes `"&lt;event>"` or `"&lt;event>: &lt;detail>"` (e.g.
+ * detail. `@lunora/do` writes `"<event>"` or `"<event>: <detail>"` (e.g.
  * `"stop: hard timeout reached"`), so the first `:` bounds the token.
  */
 const parseContainerMessage = (message: string): { detail?: string; event: string } => {
@@ -73,7 +73,7 @@ const parseContainerMessage = (message: string): { detail?: string; event: strin
 /**
  * Reduce a shard's log entries (newest-first, as `getLogs` returns them) to the
  * current state of each container instance — the panel's "current containers"
- * view. Only `container:&lt;name>` entries are considered; rows are keyed per
+ * view. Only `container:<name>` entries are considered; rows are keyed per
  * `(name, instance)` so concurrent instances stay distinct, and for each key the
  * entry with the greatest timestamp wins. An entry with no instance id folds
  * under the container name alone. Pure + order-independent, so it is

--- a/packages/studio/src/features/data/table-list-sidebar.tsx
+++ b/packages/studio/src/features/data/table-list-sidebar.tsx
@@ -62,7 +62,7 @@ interface TableListSidebarProps {
     /** Optional reload control rendered in the sidebar header. */
     readonly onReload?: () => void;
     readonly onSelect: (name: string) => void;
-    /** Scopes `data-testid`s: `{prefix}-table-list`, `{prefix}-table-&lt;name>`, `{prefix}-load-tables`. */
+    /** Scopes `data-testid`s: `{prefix}-table-list`, `{prefix}-table-<name>`, `{prefix}-load-tables`. */
     readonly prefix: string;
     readonly reloadLabel?: string;
     readonly selected: null | string;

--- a/packages/studio/src/features/flags/flags-panel.tsx
+++ b/packages/studio/src/features/flags/flags-panel.tsx
@@ -56,7 +56,7 @@ const formatValue = (evaluation: FlagEvaluation): string => {
 
 /**
  * The Flags inspector — lists the deployment's statically-discovered feature
- * flags (`ctx.flags.&lt;type>("key")` reads) and their live evaluation under an
+ * flags (`ctx.flags.<type>("key")` reads) and their live evaluation under an
  * editable targeting context. Flags evaluate through whatever OpenFeature
  * provider the app wired in `lunora/flags.ts`; the studio renders read-only
  * inspection (the source of truth — e.g. Cloudflare Flagship — owns editing).

--- a/packages/studio/src/features/functions/function-signature.ts
+++ b/packages/studio/src/features/functions/function-signature.ts
@@ -1,7 +1,7 @@
 import type { FunctionArgumentDescriptor } from "../../lib/types";
 
 /**
- * The display type of one argument: `id&lt;table>` for foreign keys, `kind[]`
+ * The display type of one argument: `id<table>` for foreign keys, `kind[]`
  * for arrays whose element kind is known, otherwise the bare validator kind.
  */
 const argumentType = (argument: FunctionArgumentDescriptor): string => {
@@ -18,7 +18,7 @@ const argumentType = (argument: FunctionArgumentDescriptor): string => {
 
 /**
  * A one-line, human-readable function signature from its argument descriptors,
- * e.g. `(channelId: id&lt;channels>, text: string, limit?: number)`. Optional
+ * e.g. `(channelId: id<channels>, text: string, limit?: number)`. Optional
  * arguments are marked with `?`. Returns `()` when there are no arguments.
  */
 const formatSignature = (arguments_: FunctionArgumentDescriptor[] | undefined): string => {

--- a/packages/studio/src/features/issues/issues-panel.tsx
+++ b/packages/studio/src/features/issues/issues-panel.tsx
@@ -402,7 +402,7 @@ const IssueRow = ({ busy, issue, rowError, runTriage, shardKey }: IssueRowProps)
 /**
  * The Issues observability page — grouped error triage over the durable request
  * log, now with a triage workflow (resolve / ignore / reopen, assignee, and
- * severity). Every `error`-outcome row (a Worker throw or a `container:&lt;name>`
+ * severity). Every `error`-outcome row (a Worker throw or a `container:<name>`
  * crash) that shares a fingerprint (`functionPath :: bucket(message)`) folds into
  * a single Issue: title, culprit, event count, first/last-seen, plus the
  * persisted triage state joined in server-side. The same grouping hash a cloud

--- a/packages/studio/src/features/kv/kv-browser.tsx
+++ b/packages/studio/src/features/kv/kv-browser.tsx
@@ -15,7 +15,7 @@ interface KvBrowserProps {
      * Load the worker's registered KV namespaces. Defaults to
      * `client.listKvNamespaces`, which hits the admin-gated
      * `GET /_lunora/admin/kv/namespaces` endpoint — so the panel works out of
-     * the box under `&lt;LunoraProvider>`, provided the worker is built with a
+     * the box under `<LunoraProvider>`, provided the worker is built with a
      * `kvIntrospector` and `adminToken`.
      */
     readonly loadNamespaces?: () => Promise<KvNamespaceSummary[]>;

--- a/packages/studio/src/features/logs/cron-triggers-panel.tsx
+++ b/packages/studio/src/features/logs/cron-triggers-panel.tsx
@@ -16,7 +16,7 @@ interface CronTriggersPanelProps {
     /**
      * Load the code-defined cron triggers. Defaults to `client.getCronJobs`,
      * which hits the worker's admin-gated `/_lunora/admin/cron-jobs` endpoint —
-     * so the panel works out of the box under `&lt;LunoraProvider>`, provided the
+     * so the panel works out of the box under `<LunoraProvider>`, provided the
      * worker is built with a `cronJobs` map and `adminToken`. Override it to
      * source triggers from elsewhere (e.g. tests).
      */

--- a/packages/studio/src/features/logs/dead-letter-jobs.tsx
+++ b/packages/studio/src/features/logs/dead-letter-jobs.tsx
@@ -34,7 +34,7 @@ const formatScheduledFor = (value: number): string => (Number.isFinite(value) ? 
  * change only on the infrequent retry-exhaustion event), so this polls on the
  * shared auto-refresh interval and refetches after each operator action.
  *
- * Works out of the box under `&lt;LunoraProvider>` via the client's dead-letter
+ * Works out of the box under `<LunoraProvider>` via the client's dead-letter
  * admin methods; pass the props to override the transport (e.g. a read-only
  * view supplies only `loadJobs`).
  */

--- a/packages/studio/src/features/logs/log-drains-panel.tsx
+++ b/packages/studio/src/features/logs/log-drains-panel.tsx
@@ -12,7 +12,7 @@ import { copyToClipboard, errorMessage, fireAndForget } from "../../lib/internal
 interface DestinationCard {
     /** Translated one-line explainer. */
     readonly description: string;
-    /** Stable id; also keys the copy button testid (`drain-copy-&lt;id>`). */
+    /** Stable id; also keys the copy button testid (`drain-copy-<id>`). */
     readonly id: string;
     /** A `wrangler.jsonc` / setup snippet the operator copies into their project. */
     readonly snippet: string;

--- a/packages/studio/src/features/logs/scheduled-jobs.tsx
+++ b/packages/studio/src/features/logs/scheduled-jobs.tsx
@@ -24,7 +24,7 @@ interface ScheduledJobsProps {
     /**
      * Load the pending scheduled jobs. Defaults to `client.listScheduledJobs`,
      * which hits the worker's admin-gated `/_lunora/admin/scheduled` endpoint —
-     * so the panel works out of the box under `&lt;LunoraProvider>`, provided the
+     * so the panel works out of the box under `<LunoraProvider>`, provided the
      * worker is built with a `schedulerDO` namespace and `adminToken`. Override
      * it to source jobs from elsewhere.
      */
@@ -55,7 +55,7 @@ const jobCanceller = (
  * scheduler. Cron *triggers* are static wrangler config and don't appear here;
  * this lists the dynamic, in-flight schedule only.
  *
- * Works out of the box under `&lt;LunoraProvider>` via the client's scheduler
+ * Works out of the box under `<LunoraProvider>` via the client's scheduler
  * admin methods; pass {@link ScheduledJobsProps.loadJobs} /
  * {@link ScheduledJobsProps.cancelJob} to override the transport.
  */

--- a/packages/studio/src/features/schema/database-schema-node.tsx
+++ b/packages/studio/src/features/schema/database-schema-node.tsx
@@ -28,7 +28,7 @@ interface DatabaseSchemaColumn {
 
 /**
  * Node data for the table node. A `type` alias (not an interface) so it
- * satisfies React Flow's `Record&lt;string, unknown>` data constraint.
+ * satisfies React Flow's `Record<string, unknown>` data constraint.
  */
 type DatabaseSchemaNodeData = {
     columns: ReadonlyArray<DatabaseSchemaColumn>;

--- a/packages/studio/src/features/schema/schema-viewer.tsx
+++ b/packages/studio/src/features/schema/schema-viewer.tsx
@@ -21,7 +21,7 @@ interface SchemaViewerProps {
 
     /**
      * Table to auto-expand once the shard's tables load. Set by the Insights
-     * "add the index" deep-link (`/schema?table=&lt;name>`) so the operator lands
+     * "add the index" deep-link (`/schema?table=<name>`) so the operator lands
      * directly on the scanned table's index list instead of hunting for it.
      * Re-applied whenever the value changes, so following the link a second time
      * (same tab already open) re-expands the target.
@@ -63,9 +63,9 @@ interface TableEntryProps {
     readonly name: string;
     readonly onToggle: () => void;
     readonly rowCount: number;
-    /** `data-testid` for the `&lt;li>`. */
+    /** `data-testid` for the `<li>`. */
     readonly rowTestId: string;
-    /** `data-testid` for the toggle `&lt;button>`. */
+    /** `data-testid` for the toggle `<button>`. */
     readonly toggleTestId: string;
 }
 

--- a/packages/studio/src/features/vectors/vector-browser.tsx
+++ b/packages/studio/src/features/vectors/vector-browser.tsx
@@ -15,7 +15,7 @@ interface VectorBrowserProps {
     /**
      * Load the schema's vector indexes. Defaults to `client.listVectorIndexes`,
      * which hits the worker's admin-gated `/_lunora/admin/vector/indexes`
-     * endpoint — so the panel works out of the box under `&lt;LunoraProvider>`,
+     * endpoint — so the panel works out of the box under `<LunoraProvider>`,
      * provided the worker is built with a `vectorIntrospector` and `adminToken`.
      */
     readonly loadIndexes?: () => Promise<VectorIndexSummary[]>;

--- a/packages/studio/src/features/workflows/workflow-instances.tsx
+++ b/packages/studio/src/features/workflows/workflow-instances.tsx
@@ -61,7 +61,7 @@ const formatStepPayload = (step: { error?: unknown; output?: unknown }): string 
  * older worker reports `WORKFLOWS_NOT_CONFIGURED` instead) and this renders a
  * "set credentials" state while the workflows keep running.
  *
- * Works under `&lt;LunoraProvider>` via the client's workflow methods; pass the
+ * Works under `<LunoraProvider>` via the client's workflow methods; pass the
  * loader props to override the transport (a custom `loadInstances` ⇒ read-only).
  */
 export const WorkflowInstanceHistory = ({ loadDetail, loadInstances, readOnly, runAction, workflowName }: WorkflowInstanceHistoryProps): ReactElement => {

--- a/packages/studio/src/lib/admin.ts
+++ b/packages/studio/src/lib/admin.ts
@@ -617,7 +617,7 @@ export interface WorkflowsResult {
  * One declared Cloudflare Queue, hand-mirroring `@lunora/do`'s `QueueMetadata`.
  * `binding` is the generated `QUEUE_*` producer binding, `name` the deployed
  * `queues.producers[].queue`, `exportName` the `lunora/queues.ts` export
- * (`ctx.queues.&lt;exportName>`), `mode` whether the queue is consumed by a worker
+ * (`ctx.queues.<exportName>`), `mode` whether the queue is consumed by a worker
  * (`push`) or polled externally (`pull`), and `deadLetterQueue` the optional DLQ.
  */
 export interface QueueMetadata {
@@ -691,7 +691,7 @@ export interface ReplayQueueMessageResult {
 /**
  * One feature flag evaluated under a targeting context, hand-mirroring
  * `@lunora/do`'s `FlagEvaluation` (the studio can't import `@lunora/do`). `key`
- * and `type` are statically discovered from the app's `ctx.flags.&lt;type>("key")`
+ * and `type` are statically discovered from the app's `ctx.flags.<type>("key")`
  * reads; `value`/`reason`/`variant`/`errorCode` come from the live OpenFeature
  * evaluation. A key-exhaustiveness drift guard in this package's tests (and
  * `@lunora/do`'s) fails the build if these keys diverge from the source contract.
@@ -755,7 +755,7 @@ export type LogLevel = "debug" | "error" | "fatal" | "info" | "log" | "trace" | 
  */
 export interface LogEntry {
     exitCode?: number;
-    /** Structured fields from a `ctx.log.&lt;level>(message, fields)` / `ctx.log.with(fields)` call, when present. */
+    /** Structured fields from a `ctx.log.<level>(message, fields)` / `ctx.log.with(fields)` call, when present. */
     fields?: Record<string, unknown>;
     functionPath?: string;
     instance?: string;
@@ -820,7 +820,7 @@ export interface AuthAuditLogResult {
 /**
  * One live subscription tracked on a shard's WebSocket, returned by
  * `__lunora_admin__:listSubscriptions` and mirroring `@lunora/do`'s
- * `SubscriptionInfo`. `functionPath` is the `&lt;file>:&lt;function>` query re-run on
+ * `SubscriptionInfo`. `functionPath` is the `<file>:<function>` query re-run on
  * a matching write (absent on legacy delta-only subscriptions), `table` the
  * table the raw-delta fan-out matches, and `args` the query args.
  */
@@ -911,7 +911,7 @@ export type RequestOutcome = "error" | "ok";
  * One structured `/rpc` dispatch returned by `__lunora_admin__:getRequestLog`,
  * mirroring `@lunora/do`'s `RequestLogEntry`. Unlike the in-memory `getLogs`
  * error buffer, the request log is durable and records EVERY dispatch with the
- * app-level context Cloudflare cannot attribute: the `&lt;file>:&lt;function>` path,
+ * app-level context Cloudflare cannot attribute: the `<file>:<function>` path,
  * the shard key, the acting `userId`/identity, the (server-side redacted) args,
  * the outcome + error message, the handler duration, the tables read/written,
  * and whether the result came from the reactive cache. `seq` is a monotonic
@@ -924,7 +924,7 @@ export interface RequestLogEntry {
     durationMs: number;
     /** Error message when `outcome === "error"`; absent on success. */
     errorMessage?: string;
-    /** The `&lt;file>:&lt;function>` identifier dispatched. */
+    /** The `<file>:<function>` identifier dispatched. */
     functionPath: string;
     /** Identity claims forwarded by the runtime; absent for anonymous requests. */
     identity?: Record<string, unknown>;
@@ -975,7 +975,7 @@ export type IssueSeverity = "critical" | "high" | "low" | "medium";
 /**
  * One grouped error **Issue** returned by `__lunora_admin__:getIssues`, mirroring
  * `@lunora/do`'s `ErrorIssue`. Many `error`-outcome request-log rows (Worker
- * throws and `container:&lt;name>` crashes alike) that share a fingerprint fold into
+ * throws and `container:<name>` crashes alike) that share a fingerprint fold into
  * a single triage row. The `hash` is the same stable key a cloud Incident groups
  * on, so a local Issue and a cloud Incident are the same object.
  */
@@ -984,7 +984,7 @@ export interface ErrorIssue {
     assignee?: string;
     /** Number of `error` rows folded into this Issue within the scanned window. */
     count: number;
-    /** The `&lt;file>:&lt;function>` (or `container:&lt;name>`) the errors came from. */
+    /** The `<file>:<function>` (or `container:<name>`) the errors came from. */
     culprit: string;
     /** Epoch-ms of the oldest folded row. */
     firstSeen: number;
@@ -1069,7 +1069,7 @@ export interface TraceSpan {
 export interface TraceSummary {
     /** Wall-clock span of the whole trace (root start → last span end), in ms. May be 0. */
     durationMs: number;
-    /** The `&lt;file>:&lt;function>` the trace's root span was recorded under. */
+    /** The `<file>:<function>` the trace's root span was recorded under. */
     functionPath: string;
     /** `false` when the root or any descendant span errored. */
     ok: boolean;

--- a/packages/studio/src/lib/data-view-params.ts
+++ b/packages/studio/src/lib/data-view-params.ts
@@ -78,7 +78,7 @@ const isFilterClause = (entry: unknown): entry is FilterClause => {
     return typeof candidate.column === "string" && typeof candidate.operator === "string" && VALID_OPERATORS.has(candidate.operator as FilterOperator);
 };
 
-/** Read the structured filters out of a `?filters=&lt;json>` param, tolerating absence/garbage. */
+/** Read the structured filters out of a `?filters=<json>` param, tolerating absence/garbage. */
 const parseFilters = (raw: unknown): FilterClause[] => {
     if (typeof raw !== "string" || raw === "") {
         return [];
@@ -93,7 +93,7 @@ const parseFilters = (raw: unknown): FilterClause[] => {
     }
 };
 
-/** Read the `?order=&lt;column>:&lt;asc|desc>` param into an `orderBy`, or `undefined` when absent/malformed. */
+/** Read the `?order=<column>:<asc|desc>` param into an `orderBy`, or `undefined` when absent/malformed. */
 const parseOrder = (raw: unknown): DataView["orderBy"] => {
     if (typeof raw !== "string" || raw === "") {
         return undefined;

--- a/packages/studio/src/lib/operation-log.ts
+++ b/packages/studio/src/lib/operation-log.ts
@@ -20,7 +20,7 @@
  * `JSON.stringify(args)` is exactly how row data would leak in.
  *
  * The one thing stored verbatim is a rejection's `message`, which the server
- * writes and which CAN echo user data (SQLite's `near "&lt;token&gt;": syntax error`
+ * writes and which CAN echo user data (SQLite's `near "<token>": syntax error`
  * quotes the statement; a constraint violation can quote a value). That is a
  * deliberate trade — the message is the diagnosis, it is already on screen in the
  * error alert, and the tape is memory-only, never persisted or transmitted. The

--- a/packages/studio/src/lib/types.ts
+++ b/packages/studio/src/lib/types.ts
@@ -27,7 +27,7 @@ export interface FunctionArgumentDescriptor {
 export interface FunctionDescriptor {
     args?: FunctionArgumentDescriptor[];
     kind: FunctionKind;
-    /** The `&lt;file>:&lt;function>` identifier, e.g. `messages:list`. */
+    /** The `<file>:<function>` identifier, e.g. `messages:list`. */
     path: string;
 }
 

--- a/packages/studio/src/mount.tsx
+++ b/packages/studio/src/mount.tsx
@@ -18,7 +18,7 @@ export interface MountStudioOptions extends StudioAppProps {
  * Mount the batteries-included {@link StudioApp} into the DOM and return the
  * React root (call `.unmount()` to tear it down). This is the entry the
  * standalone app's `main.tsx` and the `@lunora/vite` dev route both call — it
- * keeps the host HTML to a single `&lt;div id="root">` plus one script.
+ * keeps the host HTML to a single `<div id="root">` plus one script.
  */
 export const mountStudio = (options: MountStudioOptions = {}): Root => {
     const { container = "#root", ...appProps } = options;

--- a/packages/svelte/eslint.config.js
+++ b/packages/svelte/eslint.config.js
@@ -79,4 +79,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/svelte/src/agent-state.ts
+++ b/packages/svelte/src/agent-state.ts
@@ -43,7 +43,7 @@ interface AgentStateHandle<T> {
  * `state` updates only on a real `setState`. The Svelte counterpart to React's
  * `useAgentState`, re-expressed as stores you read with `$`.
  *
- * Generic over the app's state shape (`agentState&lt;SupportState>(...)`, itself a
+ * Generic over the app's state shape (`agentState<SupportState>(...)`, itself a
  * record) — the reference is typed as an optional record because codegen cannot
  * see the per-agent state type; the generic casts to `T`. The `state`/`error`
  * stores are lazy, so the subscription opens on the first subscriber to `state`

--- a/packages/svelte/src/presence.ts
+++ b/packages/svelte/src/presence.ts
@@ -182,7 +182,7 @@ const createPresenceHandle = <H extends HeartbeatReference, L extends ListPresen
  * Open a live presence handle.
  *
  * Pass `client` explicitly, or omit it to resolve the ambient client from the
- * Svelte context (requires calling inside a component's `&lt;script>` block or
+ * Svelte context (requires calling inside a component's `<script>` block or
  * inside a function called during component initialisation).
  *
  * Teardown (stop heartbeats, remove the visibility listener, release the

--- a/packages/svelte/src/voice-agent.ts
+++ b/packages/svelte/src/voice-agent.ts
@@ -29,9 +29,9 @@ type VoiceServerFrame =
 type VoiceClientFrame = { text: string; type: "text" } | { type: "commit" } | { type: "interrupt" };
 
 /**
- * The `agents.&lt;name>Voice` reference codegen emits for a voice-enabled agent — a
+ * The `agents.<name>Voice` reference codegen emits for a voice-enabled agent — a
  * live, WS-backed session keyed by `threadKey`. A structural subset of the
- * generated member, so passing `api.agents.&lt;name>Voice` type-checks.
+ * generated member, so passing `api.agents.<name>Voice` type-checks.
  */
 type VoiceReference = FunctionReference<"stream", { threadKey: string }, Record<string, unknown>>;
 
@@ -75,7 +75,7 @@ interface VoiceAgentOptions {
     silenceThreshold?: number;
     /** The thread to converse on — shared with the agent's text turns. */
     threadKey: string;
-    /** The generated `api.agents.&lt;name>Voice` reference — identifies the voice DO endpoint. */
+    /** The generated `api.agents.<name>Voice` reference — identifies the voice DO endpoint. */
     voice: VoiceReference;
 }
 
@@ -127,7 +127,7 @@ const deriveWebSocketUrl = (url: string): string => {
 
 /**
  * Derive the agent's export name from its voice reference. Codegen emits the
- * member as `agents.&lt;name>Voice` (ref `agents:&lt;name>Voice`), so strip the
+ * member as `agents.<name>Voice` (ref `agents:<name>Voice`), so strip the
  * `agents:` namespace and the `Voice` suffix.
  */
 const agentNameFromReference = (voice: VoiceReference): string => {
@@ -462,7 +462,7 @@ const createVoiceAgentHandle = (client: LunoraClient, options: VoiceAgentOptions
  * streams the agent's synthesized speech back through the browser's audio output,
  * and mirrors the call lifecycle (`status`, `transcript`, `interimTranscript`,
  * `audioLevel`) to Svelte readable stores you read with `$`. Pass the generated
- * `api.agents.&lt;name>Voice` reference (never a string), matching `agentChat`'s
+ * `api.agents.<name>Voice` reference (never a string), matching `agentChat`'s
  * reference-passing style. The Svelte counterpart to React's `useVoiceAgent`,
  * re-expressed as stores; the per-call connection lives in a closure variable (a
  * handle is created once per component, so no store-of-store indirection is

--- a/packages/testing/__tests__/rls-enforcement.test.ts
+++ b/packages/testing/__tests__/rls-enforcement.test.ts
@@ -36,7 +36,7 @@ const insertUnguarded = mutation.input({ body: v.string() }).mutation(async ({ a
  * outside of codegen's generated, per-project facade types. `@lunora/server`'s
  * own RLS tests (`__tests__/rls.test.ts`, `rls-secure-by-default.test.ts`) pin
  * a permissive cast once for exactly this reason — mirrored here rather than
- * scattering `as unknown as Middleware&lt;…>` at every call site.
+ * scattering `as unknown as Middleware<…>` at every call site.
  */
 const rlsForTest = <Context>(policies: ReadonlyArray<Policy<Context>>): Middleware<any, any> =>
     (rls as unknown as (p: ReadonlyArray<Policy<Context>>) => Middleware<any, any>)(policies);

--- a/packages/testing/__tests__/soft-delete-facade.test.ts
+++ b/packages/testing/__tests__/soft-delete-facade.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createSqlExec } from "../src/node-sqlite";
 
 /**
- * The per-table facade's soft-delete surface (`ctx.db.&lt;table>.delete()` →
+ * The per-table facade's soft-delete surface (`ctx.db.<table>.delete()` →
  * soft, `.restore()`, `.hardDelete()`, `findMany({ includeDeleted })`) over the
  * REAL `@lunora/do` writer — proving `bindTableFacade` wires `delete`'s `hard`
  * option and `restore` end to end.

--- a/packages/testing/eslint.config.js
+++ b/packages/testing/eslint.config.js
@@ -154,4 +154,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/testing/src/evaluation-telemetry.ts
+++ b/packages/testing/src/evaluation-telemetry.ts
@@ -9,7 +9,7 @@
  * and an optional short label leave, never the graded prompt or completion:
  *
  * Attach to a generation span by passing the post-hoc `SpanHandle` a
- * `ctx.trace(name, (trace, span) =&gt; …)` body receives as `span`, and the score
+ * `ctx.trace(name, (trace, span) => …)` body receives as `span`, and the score
  * lands on that generation's span. Or omit `span` and use the returned attribute
  * bag as a standalone eval event/metric payload — e.g. `recordEvaluation({ label:
  * "pass", name: "exact-match", score: 1 })` returns

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -70,7 +70,7 @@ type InlineActionFunction<R> = (context: ActionCtx) => Promise<R> | R;
  * The value type uses `any` because `RegisteredFunction` is contravariant in its
  * args type parameter — a `RegisteredMutation` with concrete args is not assignable
  * to `RegisteredMutation` with `ArgsValidator` at the type level even though at
- * runtime it is sound (the fake scheduler passes `Record&lt;string, unknown>` to
+ * runtime it is sound (the fake scheduler passes `Record<string, unknown>` to
  * `handler` and ignores the return value).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural erasure at registry boundary; see comment above

--- a/packages/testing/src/scorer.ts
+++ b/packages/testing/src/scorer.ts
@@ -151,7 +151,7 @@ const parseJudgeScore = (raw: string): ScoreResult => {
 };
 
 /**
- * An LLM-as-judge scorer. `judge` is INJECTED — a `(prompt) => Promise&lt;string>`
+ * An LLM-as-judge scorer. `judge` is INJECTED — a `(prompt) => Promise<string>`
  * you wire to your model (e.g. via `ctx.ai` / `generateText`), so this module
  * stays model-agnostic and the judge is mockable in tests. It returns the model's
  * numeric verdict (`[0, 1]`) plus its reason.

--- a/packages/values/eslint.config.js
+++ b/packages/values/eslint.config.js
@@ -146,4 +146,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -3,7 +3,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { describeValue, formatPath, ValidationError } from "./errors";
 
-/** Branded id type, e.g. `Id&lt;"users">`. */
+/** Branded id type, e.g. `Id<"users">`. */
 type Id<TableName extends string> = string & { readonly __table: TableName };
 
 /**
@@ -179,7 +179,7 @@ interface ColumnValidator<TSelect, TInsert> extends Column<TSelect, TInsert>, Va
     $defaultFn: (function_: () => TSelect) => ColumnValidator<TSelect, TInsert | undefined>;
     /** Recompute the field on every patch/replace when not explicitly provided. */
     $onUpdateFn: (function_: () => TSelect) => ColumnValidator<TSelect, TInsert>;
-    /** Override the inferred select/insert type without changing runtime parsing (e.g. `v.string().$type&lt;Id&lt;"users">>()`). */
+    /** Override the inferred select/insert type without changing runtime parsing (e.g. `v.string().$type<Id<"users">>()`). */
     $type: <TOverride>() => ColumnValidator<TOverride, TOverride>;
     /** Refinement predicate run after parsing — see {@link Validator.check}. Chainable; preserves column modifiers. */
     check: (predicate: (value: TSelect) => boolean, options?: CheckOptions | string) => ColumnValidator<TSelect, TInsert>;

--- a/packages/values/src/validator-map.ts
+++ b/packages/values/src/validator-map.ts
@@ -73,7 +73,7 @@ const installCompiledValidatorMap = (validators: object, compiled: CompiledValid
 
 /**
  * Validate each declared field of `source` through its validator, re-wrapping
- * any {@link ValidationError} with a `label.&lt;key>:` prefix and the rebuilt path
+ * any {@link ValidationError} with a `label.<key>:` prefix and the rebuilt path
  * `[key, ...error.path]` so the failure points at the offending field. Optional
  * fields absent from the source are skipped (so `v.optional` passes and a
  * required validator fails on `undefined`).

--- a/packages/vite/eslint.config.js
+++ b/packages/vite/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/vite/src/container-logs-plugin.ts
+++ b/packages/vite/src/container-logs-plugin.ts
@@ -10,11 +10,11 @@ import type { ResolvedLunoraPluginOptions } from "./types";
  * Vite terminal.
  *
  * `@cloudflare/vite-plugin` builds and runs each declared container locally via
- * Docker (image `cloudflare-dev/&lt;class>:&lt;id>`) but only forwards the *worker's*
+ * Docker (image `cloudflare-dev/<class>:<id>`) but only forwards the *worker's*
  * console — the container process's own output is otherwise invisible. This
  * plugin attaches to those Docker log streams (via `@lunora/config`'s
  * `streamContainerLogs`, which lazy-loads `dockerode`) and prints each line
- * through Vite's logger, branded and tagged `container:&lt;name>`.
+ * through Vite's logger, branded and tagged `container:<name>`.
  *
  * A no-op when the project declares no containers (the common case): discovery
  * returns an empty list, so `dockerode` is never imported and no Docker work

--- a/packages/vue/eslint.config.js
+++ b/packages/vue/eslint.config.js
@@ -51,4 +51,13 @@ export default createConfig(
             "perfectionist/sort-objects": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/vue/src/use-agent-chat.ts
+++ b/packages/vue/src/use-agent-chat.ts
@@ -114,7 +114,7 @@ interface UseAgentChatOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link UseAgentChatResult.cancel} is a
      * no-op.
      */
@@ -124,7 +124,7 @@ interface UseAgentChatOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link UseAgentChatOptions.sendArgs} and the per-call args.
      */
     send: FunctionReference<"mutation">;

--- a/packages/vue/src/use-agent.ts
+++ b/packages/vue/src/use-agent.ts
@@ -52,7 +52,7 @@ interface UseAgentOptions {
 
     /**
      * Optional app mutation over the agent's cancel path
-     * (`ctx.agents.&lt;name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
+     * (`ctx.agents.<name>.cancel(id)`). Called with `{ instanceId, threadKey }`.
      * When omitted (or no run is in flight) {@link UseAgentResult.cancel} is a
      * no-op.
      */
@@ -60,7 +60,7 @@ interface UseAgentOptions {
 
     /**
      * The app mutation that starts (or continues) a run — a thin wrapper over
-     * `ctx.agents.&lt;name>.run(...)`. Called with `{ threadKey, input }` merged with
+     * `ctx.agents.<name>.run(...)`. Called with `{ threadKey, input }` merged with
      * {@link UseAgentOptions.runArgs} and the per-call args.
      */
     run: FunctionReference<"mutation">;
@@ -102,7 +102,7 @@ const NO_MUTATION_REF: FunctionReference<"mutation"> = { __lunoraRef: "" };
  * (durable history + streaming + approvals) use `useAgentChat`.
  *
  * `run` and `cancel` stay generic over the app-defined mutations that wrap
- * `ctx.agents.&lt;name>.run` / `.cancel`, so the composable hard-codes no function
+ * `ctx.agents.<name>.run` / `.cancel`, so the composable hard-codes no function
  * names beyond the `agents:*` surface. `threadKey` may be reactive — a changing
  * key re-subscribes to the new thread.
  */

--- a/packages/vue/src/use-voice-agent.ts
+++ b/packages/vue/src/use-voice-agent.ts
@@ -28,9 +28,9 @@ type VoiceServerFrame =
 type VoiceClientFrame = { text: string; type: "text" } | { type: "commit" } | { type: "interrupt" };
 
 /**
- * The `agents.&lt;name>Voice` reference codegen emits for a voice-enabled agent — a
+ * The `agents.<name>Voice` reference codegen emits for a voice-enabled agent — a
  * live, WS-backed session keyed by `threadKey`. A structural subset of the
- * generated member, so passing `api.agents.&lt;name>Voice` type-checks.
+ * generated member, so passing `api.agents.<name>Voice` type-checks.
  */
 type VoiceReference = FunctionReference<"stream", { threadKey: string }, Record<string, unknown>>;
 
@@ -74,7 +74,7 @@ interface UseVoiceAgentOptions {
     silenceThreshold?: number;
     /** The thread to converse on — shared with the agent's text turns. May be a plain value, `ref`, or getter (resolved when the call opens). */
     threadKey: MaybeRefOrGetter<string>;
-    /** The generated `api.agents.&lt;name>Voice` reference — identifies the voice DO endpoint. */
+    /** The generated `api.agents.<name>Voice` reference — identifies the voice DO endpoint. */
     voice: VoiceReference;
 }
 
@@ -126,7 +126,7 @@ const deriveWebSocketUrl = (url: string): string => {
 
 /**
  * Derive the agent's export name from its voice reference. Codegen emits the
- * member as `agents.&lt;name>Voice` (ref `agents:&lt;name>Voice`), so strip the
+ * member as `agents.<name>Voice` (ref `agents:<name>Voice`), so strip the
  * `agents:` namespace and the `Voice` suffix.
  */
 const agentNameFromReference = (voice: VoiceReference): string => {
@@ -167,7 +167,7 @@ interface VoiceConnection {
  * WebSocket to the agent's `VoiceSessionDO`, captures mic audio as 16 kHz PCM,
  * streams the agent's synthesized speech back through the browser's audio output,
  * and mirrors the call lifecycle (`status`, `transcript`, `interimTranscript`,
- * `audioLevel`) to Vue refs. Pass the generated `api.agents.&lt;name>Voice`
+ * `audioLevel`) to Vue refs. Pass the generated `api.agents.<name>Voice`
  * reference (never a string), matching `useAgentChat`'s reference-passing style.
  * The Vue counterpart to React's `useVoiceAgent`, re-expressed with refs; the
  * per-call connection lives in a closure variable (a composable runs once per

--- a/packages/workflow/eslint.config.js
+++ b/packages/workflow/eslint.config.js
@@ -145,4 +145,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/packages/workflow/src/define-workflow.ts
+++ b/packages/workflow/src/define-workflow.ts
@@ -41,7 +41,7 @@ const workflowDefaultName = (exportName: string): string => exportName.replaceAl
  * import { defineWorkflow } from "@lunora/workflow";
  * import { api } from "./_generated/api";
  *
- * export const orderPipeline = defineWorkflow&lt;{ orderId: string }>({
+ * export const orderPipeline = defineWorkflow<{ orderId: string }>({
  *     handler: async (ctx) => {
  *         const order = await ctx.step.do("load", () => ctx.run(api.orders.get, { id: ctx.params.orderId }));
  *         await ctx.step.sleep("cool-off", "1 minute");

--- a/packages/workflow/src/do/index.ts
+++ b/packages/workflow/src/do/index.ts
@@ -25,7 +25,7 @@ import type { WorkflowDefinition, WorkflowStepLike } from "../types";
  *
  * ```ts
  * export class OrderPipelineWorkflow extends LunoraWorkflow {
- *     constructor(ctx: ExecutionContext, env: Record&lt;string, unknown>) {
+ *     constructor(ctx: ExecutionContext, env: Record<string, unknown>) {
  *         super(ctx, env, orderPipeline, "orderPipeline");
  *     }
  * }

--- a/packages/workflow/src/run-step.ts
+++ b/packages/workflow/src/run-step.ts
@@ -26,7 +26,7 @@ import type {
 
 /**
  * Validate a step's args through its validator map, prefixing any
- * `ValidationError` with `step args.&lt;key>` so the failure points at the
+ * `ValidationError` with `step args.<key>` so the failure points at the
  * offending field. Delegates to `@lunora/values`' shared {@link parseValidatorMap}
  * — the same parser the procedure builder and HTTP routes use — so the
  * optional-skip and error-prefix semantics stay in lockstep across the framework.

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -70,7 +70,7 @@ export interface WorkflowBindingLike<Params = Record<string, unknown>> {
     get: (id: string) => Promise<WorkflowInstanceLike>;
 }
 
-/** The `event` argument a workflow `run` receives. Mirrors `WorkflowEvent&lt;T>`. */
+/** The `event` argument a workflow `run` receives. Mirrors `WorkflowEvent<T>`. */
 export interface WorkflowEventLike<Params = Record<string, unknown>> {
     readonly instanceId: string;
     readonly payload: Readonly<Params>;
@@ -130,10 +130,10 @@ export interface WorkflowStepRollbackOptionsLike<T = unknown> {
  * `do`'s two overloads mirror Cloudflare's: an optional leading `config` and an
  * optional trailing `rollback` (compensation run when a later step fails).
  *
- * Known mirror gap: Cloudflare constrains `do&lt;T extends Rpc.Serializable&lt;T>>` so
+ * Known mirror gap: Cloudflare constrains `do<T extends Rpc.Serializable<T>>` so
  * a non-serializable step result (a function, `Map`, class instance, …) is a
  * compile error there. `Rpc.Serializable` lives in `@cloudflare/workers-types`
- * and is not Node-importable, so this Node-safe mirror uses a bare `&lt;T>` and
+ * and is not Node-importable, so this Node-safe mirror uses a bare `<T>` and
  * cannot enforce that — a non-serializable result type-checks here but fails at
  * runtime on the platform. Keep step results JSON-serialisable.
  */
@@ -330,7 +330,7 @@ export interface WorkflowBranch<Output = unknown> {
  * ordinary declared workflow, so it can `ctx.runStep(...)` its own undo logic.
  */
 export interface BranchCompensationParams {
-    /** Index signature: this is a workflow `params` bag, so it is a valid `Record&lt;string, unknown>` payload. */
+    /** Index signature: this is a workflow `params` bag, so it is a valid `Record<string, unknown>` payload. */
     [key: string]: unknown;
     /** The export name of the completed branch being compensated. */
     branch: string;

--- a/packages/x402/eslint.config.js
+++ b/packages/x402/eslint.config.js
@@ -118,4 +118,13 @@ export default createConfig(
             "vitest/prefer-expect-type-of": "off",
         },
     },
+    // `jsdoc/text-escaping` escapes `<` and `&` in doc comments into HTML entities and
+    // offers no way to exempt code spans, so its autofix turns `Doc<T>` into `Doc&lt;T>` —
+    // which is then what every reader sees on hover. Last in the list so it applies to
+    // every file, including the scoped blocks above.
+    {
+        rules: {
+            "jsdoc/text-escaping": "off",
+        },
+    },
 );

--- a/registry/auth-emails/emails.tsx
+++ b/registry/auth-emails/emails.tsx
@@ -7,20 +7,20 @@
  * # Why these live here and not beside the cards
  *
  * They are rendered by the **Worker**, not by the UI: `sendAuthEmail` in
- * `lunora/auth/index.ts` calls `renderEmail(&lt;VerifyEmail … />)` from
+ * `lunora/auth/index.ts` calls `renderEmail(<VerifyEmail … />)` from
  * `@lunora/mail`. That makes them framework-agnostic in the way that matters —
  * a Vue or Svelte app sends exactly the same mail — even though they are written
  * in TSX, because `@react-email/render` is what turns them into HTML + text.
  *
  * They ship as the separate `auth-emails` registry item rather than inside
- * `auth-ui-&lt;framework>`, so a project only takes on `react` +
+ * `auth-ui-<framework>`, so a project only takes on `react` +
  * `@react-email/render` when it actually wants styled mail. Without the item,
  * the base `auth` item's plain-text bodies still work.
  *
  * # Styling
  *
  * Inline styles only, and a table-free single-column layout. Every serious mail
- * client strips `&lt;style>` blocks and most ignore flexbox and grid; `@media` is
+ * client strips `<style>` blocks and most ignore flexbox and grid; `@media` is
  * unreliable. This is the subset that renders the same in Gmail, Outlook and
  * Apple Mail, so resist moving it to a stylesheet.
  */

--- a/registry/auth-ui-angular/angular/account-cards.ts
+++ b/registry/auth-ui-angular/angular/account-cards.ts
@@ -118,7 +118,7 @@ class LinkedAccountsCardComponent {
 /**
  * Avatar upload. Rendered only when the app configured an `avatar.upload`
  * handler — without one there is nowhere to put the bytes, and
- * `&lt;lunora-profile-card>`'s URL field is the honest fallback.
+ * `<lunora-profile-card>`'s URL field is the honest fallback.
  */
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/registry/auth-ui-angular/angular/extras.ts
+++ b/registry/auth-ui-angular/angular/extras.ts
@@ -156,7 +156,7 @@ class OneTapComponent {
 
 /**
  * Upload an organization's logo. Renders only when the app configured an
- * `avatar.upload` handler — without one, `&lt;lunora-organization-settings-card>`'s
+ * `avatar.upload` handler — without one, `<lunora-organization-settings-card>`'s
  * logo URL field is the fallback.
  */
 @Component({

--- a/registry/auth-ui-angular/angular/index.ts
+++ b/registry/auth-ui-angular/angular/index.ts
@@ -23,7 +23,7 @@ export * from "../core";
  * // a route component
  * import { SignInCardComponent } from "./lunora/auth-ui/angular";
  *
- * `@Component`({ imports: [SignInCardComponent], template: `&lt;lunora-sign-in-card />` })
+ * `@Component`({ imports: [SignInCardComponent], template: `<lunora-sign-in-card />` })
  * export class SignInPage {}
  * ```
  */

--- a/registry/auth-ui-angular/angular/plugin-cards.ts
+++ b/registry/auth-ui-angular/angular/plugin-cards.ts
@@ -29,7 +29,7 @@ import { UserViewComponent } from "./user-button";
 /**
  * The accounts signed in on *this device*, with switch and sign-out-just-this.
  *
- * Not `&lt;lunora-sessions-card>`, which lists this account's sessions across every
+ * Not `<lunora-sessions-card>`, which lists this account's sessions across every
  * device. The two are a keystroke apart in better-auth's API and mean opposite
  * things.
  */

--- a/registry/auth-ui-angular/angular/primitives.ts
+++ b/registry/auth-ui-angular/angular/primitives.ts
@@ -167,7 +167,7 @@ class FormBannerComponent {
  * server discovery on, is whatever `socialProviders` the deployment configured.
  *
  * The provider's brand mark is left to CSS: each button carries a
- * `lunora-auth-social__icon--&lt;provider>` class, so an app drops in its own icon
+ * `lunora-auth-social__icon--<provider>` class, so an app drops in its own icon
  * set with a stylesheet rule and this package ships no SVG payload for a list of
  * providers it can't know in advance.
  */
@@ -243,7 +243,7 @@ class AuthDividerComponent {
     readonly label = input("or");
 }
 
-/** Internal link using the provider's `link` hook when present, else a plain `&lt;a>`. */
+/** Internal link using the provider's `link` hook when present, else a plain `<a>`. */
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: "lunora-auth-link",

--- a/registry/auth-ui-angular/angular/provider.ts
+++ b/registry/auth-ui-angular/angular/provider.ts
@@ -2,7 +2,7 @@
  * Angular provider for the auth UI. `provideAuthUI(config)` returns the
  * environment providers that expose the resolved {@link ControllerContext}
  * (plus an optional client-side navigation hook for internal links) through the
- * {@link AUTH_UI_CONTEXT} injection token. Mirrors React's `&lt;AuthUIProvider>`:
+ * {@link AUTH_UI_CONTEXT} injection token. Mirrors React's `<AuthUIProvider>`:
  * one base component set serves every meta-framework — pass your router into
  * `nav`/`link` and the cards navigate through it.
  */
@@ -26,7 +26,7 @@ interface AuthUIAngularConfig extends Omit<AuthUIConfig, "nav"> {
     /**
      * Client-side navigation for internal auth links (router `navigate`, etc.).
      * When set, `AuthLinkComponent` intercepts the click and calls this
-     * instead of a full page load; when omitted the link is a plain `&lt;a href>`.
+     * instead of a full page load; when omitted the link is a plain `<a href>`.
      */
     link?: (href: string) => void;
     /** Router bridge for programmatic redirects; defaults to {@link defaultNav}. */

--- a/registry/auth-ui-angular/angular/user-button.ts
+++ b/registry/auth-ui-angular/angular/user-button.ts
@@ -96,7 +96,7 @@ const nextId = (prefix: string): string => {
  * The avatar menu: who is signed in, plus sign-out and whatever the app hangs
  * off it.
  *
- * It is a disclosure rather than a `&lt;menu>` because its contents are app-defined
+ * It is a disclosure rather than a `<menu>` because its contents are app-defined
  * — links, an organization switcher, a theme row — and forcing those into menu
  * item semantics would mislabel them. Escape and outside-click close it, and
  * focus returns to the trigger, which is the part hand-rolled dropdowns usually

--- a/registry/auth-ui-angular/core/accounts.ts
+++ b/registry/auth-ui-angular/core/accounts.ts
@@ -21,7 +21,7 @@ import type { AuthAccount, Controller } from "./types";
 /**
  * Providers that are not OAuth links and must never be offered for unlinking as
  * if they were: `credential` is the password itself, and the passkey rows are
- * managed by `&lt;PasskeysCard>`.
+ * managed by `<PasskeysCard>`.
  */
 const NON_SOCIAL_PROVIDERS = new Set(["credential", "email", "passkey"]);
 

--- a/registry/auth-ui-angular/core/captcha.ts
+++ b/registry/auth-ui-angular/core/captcha.ts
@@ -7,7 +7,7 @@
  * the client, and they belong in different places.
  *
  * **Rendering the widget and capturing a token** is {@link renderCaptcha}, driven
- * by each port's `&lt;Captcha>` component.
+ * by each port's `<Captcha>` component.
  *
  * **Attaching the token to auth requests** is *not* done here. Every flow would
  * have to thread fetch options through, and better-auth already has one place for
@@ -42,7 +42,7 @@ const CAPTCHA_HEADER = "x-captcha-response";
  *
  * The token must only be attached to these. `fetchOptions.onRequest` runs for
  * every* auth call, and `captchaHeaders()` consumes on read — so without this
- * filter a background `getSession` (a session refetch on focus, a `&lt;UserButton>`
+ * filter a background `getSession` (a session refetch on focus, a `<UserButton>`
  * elsewhere in the shell) spends the token on a route that ignores it, and the
  * sign-in the user then clicks arrives with no header at all.
  *
@@ -126,7 +126,7 @@ const setCaptchaToken = (token: string | undefined): void => {
     store.set({ token });
 };
 
-/** The bit of a `&lt;script>` element this module sets, named so the DOM lib isn't needed. */
+/** The bit of a `<script>` element this module sets, named so the DOM lib isn't needed. */
 interface ScriptElement {
     addEventListener: (type: string, listener: () => void) => void;
     async: boolean;

--- a/registry/auth-ui-angular/core/config.ts
+++ b/registry/auth-ui-angular/core/config.ts
@@ -1,7 +1,7 @@
 /**
  * The framework-agnostic configuration + resolved controller context.
  *
- * A framework provider (`&lt;AuthUIProvider>`) collects the user-facing
+ * A framework provider (`<AuthUIProvider>`) collects the user-facing
  * {@link AuthUIConfig}, then {@link resolveContext} normalizes it into a
  * {@link ControllerContext} — the fully-defaulted object every controller
  * receives. Keeping resolution here means the five framework providers share one
@@ -74,7 +74,7 @@ interface RedirectConfig {
 }
 
 /**
- * URL segments `&lt;AuthView>` maps to cards, so an app can host every auth screen
+ * URL segments `<AuthView>` maps to cards, so an app can host every auth screen
  * on one route (`/auth/:view`) instead of wiring ten of them.
  */
 interface ViewPaths {
@@ -103,7 +103,7 @@ interface AvatarConfig {
     upload?: (file: File) => Promise<string>;
 }
 
-/** The user-facing config passed to a framework `&lt;AuthUIProvider>`. */
+/** The user-facing config passed to a framework `<AuthUIProvider>`. */
 interface AuthUIConfig {
     authClient: AnyAuthClient;
     avatar?: AvatarConfig;
@@ -172,7 +172,7 @@ interface AuthUIConfig {
          * Needed because teams are detected from the server's table map and
          * have no client-side equivalent to fall back on: a deployment that
          * withholds the organization block (`uiConfig({ expose })`) would
-         * otherwise lose `&lt;TeamsCard>` from every port with no way to restore it.
+         * otherwise lose `<TeamsCard>` from every port with no way to restore it.
          */
         teams?: boolean;
     };

--- a/registry/auth-ui-angular/core/create-resource-controller.ts
+++ b/registry/auth-ui-angular/core/create-resource-controller.ts
@@ -19,7 +19,7 @@ import type { FlowStatus } from "./types";
  * one snapshot, one stable reference, and no flow having to re-implement the
  * engine to carry two more properties.
  *
- * A nested field rather than an intersection: `Partial&lt;A & B>` is not assignable
+ * A nested field rather than an intersection: `Partial<A & B>` is not assignable
  * from `{ busy: true }` while `B` is an unresolved generic, so an intersection
  * would need a cast at every internal update. Nesting keeps all of them honest.
  */

--- a/registry/auth-ui-angular/core/default-nav.ts
+++ b/registry/auth-ui-angular/core/default-nav.ts
@@ -1,6 +1,6 @@
 /**
  * The zero-config navigation fallback. When an app doesn't wire its router into
- * `&lt;AuthUIProvider nav={...}>`, the components still work by driving
+ * `<AuthUIProvider nav={...}>`, the components still work by driving
  * `globalThis.location` directly. Meta-frameworks should override this with
  * their own router for client-side transitions.
  */

--- a/registry/auth-ui-angular/core/discovery.ts
+++ b/registry/auth-ui-angular/core/discovery.ts
@@ -89,8 +89,8 @@ const PLUGIN_ID_TO_FLOW: Readonly<Record<string, string>> = {
  * `unavailable` until they remount. A successful answer stays cached, because
  * it cannot change.
  *
- * Module-level rather than per-provider so mounting `&lt;SignInCard>` and
- * `&lt;UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
+ * Module-level rather than per-provider so mounting `<SignInCard>` and
+ * `<UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
  * URL, so an app talking to two deployments still gets two answers.
  */
 const handles = new Map<string, DiscoveryHandle>();

--- a/registry/auth-ui-angular/core/flow-gate.ts
+++ b/registry/auth-ui-angular/core/flow-gate.ts
@@ -1,7 +1,7 @@
 /**
  * Which optional flows are available — and therefore which cards render.
  *
- * A card like `&lt;MagicLinkCard>` only works if the matching better-auth client
+ * A card like `<MagicLinkCard>` only works if the matching better-auth client
  * plugin is installed, so the cards need to know which are. They cannot ask the
  * client: `createAuthClient` returns a dynamic-path `Proxy`, so
  * `typeof client.organization?.list === "function"` is true for a plugin-free

--- a/registry/auth-ui-angular/core/notify-error.ts
+++ b/registry/auth-ui-angular/core/notify-error.ts
@@ -1,13 +1,13 @@
 /**
  * Report an error that has no card to land in.
  *
- * Most flows put their failures on a `&lt;FormBanner>`. A handful can't: social
+ * Most flows put their failures on a `<FormBanner>`. A handful can't: social
  * sign-in, account linking, sign-out and anonymous sign-in all resolve rather
  * than reject, because the ports call them from click handlers with `void` — so
  * before this, a failure was a button that did nothing at all.
  *
  * This keeps `onError` behaving exactly as it did and adds a toast beside it,
- * which `&lt;ErrorToaster>` renders if the app mounted one.
+ * which `<ErrorToaster>` renders if the app mounted one.
  */
 import type { ControllerContext } from "./config";
 import { mapAuthError } from "./map-error";

--- a/registry/auth-ui-angular/core/organization-logo.ts
+++ b/registry/auth-ui-angular/core/organization-logo.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 /**
  * Organization logo upload — the org-side counterpart to `avatar.ts`.
  *
  * Same shape and the same reasoning: better-auth stores `organization.logo` as a
  * string, so where the bytes live is the app's decision and comes in through
- * `avatar.upload`. Without an upload handler `&lt;OrganizationSettingsCard>`'s URL
+ * `avatar.upload`. Without an upload handler `<OrganizationSettingsCard>`'s URL
  * field is still the fallback, and this card doesn't render.
  *
  * It is a separate controller rather than a parameter on the avatar one because

--- a/registry/auth-ui-angular/core/redirect-to.ts
+++ b/registry/auth-ui-angular/core/redirect-to.ts
@@ -3,7 +3,7 @@
  * on purpose.
  *
  * `invitations.ts` bounces a signed-out invitee through the sign-in screen with
- * `?redirectTo=&lt;the invitation>`, and an app's own route guard usually does the
+ * `?redirectTo=<the invitation>`, and an app's own route guard usually does the
  * same. Without this the parameter is written and never read, so the user signs
  * in and lands on the generic post-login page with the invitation forgotten —
  * the bounce looks like it worked and quietly didn't.

--- a/registry/auth-ui-angular/core/session.ts
+++ b/registry/auth-ui-angular/core/session.ts
@@ -1,6 +1,6 @@
 /**
- * The signed-in user, for the chrome rather than a form: `&lt;UserButton>`,
- * `&lt;UserAvatar>`, `&lt;UserView>`, and any card that needs to know whether anyone
+ * The signed-in user, for the chrome rather than a form: `<UserButton>`,
+ * `<UserAvatar>`, `<UserView>`, and any card that needs to know whether anyone
  * is signed in at all.
  *
  * better-auth's framework clients each ship their own reactive `useSession`, but

--- a/registry/auth-ui-angular/core/theme.ts
+++ b/registry/auth-ui-angular/core/theme.ts
@@ -38,7 +38,7 @@ interface ThemeTokens {
     success: string;
 }
 
-/** Mirrors the `var(--token, &lt;fallback>)` fallbacks in `styles/auth-ui.css`. */
+/** Mirrors the `var(--token, <fallback>)` fallbacks in `styles/auth-ui.css`. */
 const DEFAULT_THEME_TOKENS: ThemeTokens = {
     background: "hsl(0 0% 100%)",
     border: "hsl(228 16% 88%)",

--- a/registry/auth-ui-angular/core/toast.ts
+++ b/registry/auth-ui-angular/core/toast.ts
@@ -1,14 +1,14 @@
 /**
  * Transient error messages for the flows that have nowhere to put one.
  *
- * Most flows own a card, and a card owns a `&lt;FormBanner>` — that is where their
+ * Most flows own a card, and a card owns a `<FormBanner>` — that is where their
  * errors belong, and this store deliberately does not duplicate them. What it
  * exists for is the handful of actions with **no visible surface at the moment
  * they fail**: social sign-in and account linking (a redirect that never
  * happens), sign-out, anonymous sign-in. Those call `context.onError` and then
  * resolve, so today a failure is a page that simply does nothing.
  *
- * `&lt;ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
+ * `<ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
  * with its own toast system reads the same store instead, or keeps passing
  * `onError` and ignores this entirely.
  */
@@ -25,7 +25,7 @@ interface ToastState {
 }
 
 /**
- * Module-level, like `discovery.ts`: `&lt;ErrorToaster>` is mounted once in an app
+ * Module-level, like `discovery.ts`: `<ErrorToaster>` is mounted once in an app
  * shell while the flows that push to it live anywhere in the tree, so a
  * per-provider store would need threading through every controller to reach it.
  */

--- a/registry/auth-ui-angular/core/types.ts
+++ b/registry/auth-ui-angular/core/types.ts
@@ -159,7 +159,7 @@ interface SessionData {
 }
 
 /**
- * What a consumer actually passes to `&lt;AuthUIProvider>`.
+ * What a consumer actually passes to `<AuthUIProvider>`.
  *
  * Deliberately almost-empty. A real better-auth client's type contains only the
  * plugins it was built with — a client without `adminClient()` has no

--- a/registry/auth-ui-angular/core/username.ts
+++ b/registry/auth-ui-angular/core/username.ts
@@ -2,7 +2,7 @@
  * Username sign-in, and setting a username from account settings.
  *
  * The `username` plugin doesn't replace email sign-in, it adds a second door, so
- * `&lt;SignInCard>` keeps its email field and this is a separate card rather than a
+ * `<SignInCard>` keeps its email field and this is a separate card rather than a
  * mode switch inside it. Which one an app shows is an app decision.
  */
 import type { ControllerContext } from "./config";

--- a/registry/auth-ui-react/core/accounts.ts
+++ b/registry/auth-ui-react/core/accounts.ts
@@ -21,7 +21,7 @@ import type { AuthAccount, Controller } from "./types";
 /**
  * Providers that are not OAuth links and must never be offered for unlinking as
  * if they were: `credential` is the password itself, and the passkey rows are
- * managed by `&lt;PasskeysCard>`.
+ * managed by `<PasskeysCard>`.
  */
 const NON_SOCIAL_PROVIDERS = new Set(["credential", "email", "passkey"]);
 

--- a/registry/auth-ui-react/core/captcha.ts
+++ b/registry/auth-ui-react/core/captcha.ts
@@ -7,7 +7,7 @@
  * the client, and they belong in different places.
  *
  * **Rendering the widget and capturing a token** is {@link renderCaptcha}, driven
- * by each port's `&lt;Captcha>` component.
+ * by each port's `<Captcha>` component.
  *
  * **Attaching the token to auth requests** is *not* done here. Every flow would
  * have to thread fetch options through, and better-auth already has one place for
@@ -42,7 +42,7 @@ const CAPTCHA_HEADER = "x-captcha-response";
  *
  * The token must only be attached to these. `fetchOptions.onRequest` runs for
  * every* auth call, and `captchaHeaders()` consumes on read — so without this
- * filter a background `getSession` (a session refetch on focus, a `&lt;UserButton>`
+ * filter a background `getSession` (a session refetch on focus, a `<UserButton>`
  * elsewhere in the shell) spends the token on a route that ignores it, and the
  * sign-in the user then clicks arrives with no header at all.
  *
@@ -126,7 +126,7 @@ const setCaptchaToken = (token: string | undefined): void => {
     store.set({ token });
 };
 
-/** The bit of a `&lt;script>` element this module sets, named so the DOM lib isn't needed. */
+/** The bit of a `<script>` element this module sets, named so the DOM lib isn't needed. */
 interface ScriptElement {
     addEventListener: (type: string, listener: () => void) => void;
     async: boolean;

--- a/registry/auth-ui-react/core/config.ts
+++ b/registry/auth-ui-react/core/config.ts
@@ -1,7 +1,7 @@
 /**
  * The framework-agnostic configuration + resolved controller context.
  *
- * A framework provider (`&lt;AuthUIProvider>`) collects the user-facing
+ * A framework provider (`<AuthUIProvider>`) collects the user-facing
  * {@link AuthUIConfig}, then {@link resolveContext} normalizes it into a
  * {@link ControllerContext} — the fully-defaulted object every controller
  * receives. Keeping resolution here means the five framework providers share one
@@ -74,7 +74,7 @@ interface RedirectConfig {
 }
 
 /**
- * URL segments `&lt;AuthView>` maps to cards, so an app can host every auth screen
+ * URL segments `<AuthView>` maps to cards, so an app can host every auth screen
  * on one route (`/auth/:view`) instead of wiring ten of them.
  */
 interface ViewPaths {
@@ -103,7 +103,7 @@ interface AvatarConfig {
     upload?: (file: File) => Promise<string>;
 }
 
-/** The user-facing config passed to a framework `&lt;AuthUIProvider>`. */
+/** The user-facing config passed to a framework `<AuthUIProvider>`. */
 interface AuthUIConfig {
     authClient: AnyAuthClient;
     avatar?: AvatarConfig;
@@ -172,7 +172,7 @@ interface AuthUIConfig {
          * Needed because teams are detected from the server's table map and
          * have no client-side equivalent to fall back on: a deployment that
          * withholds the organization block (`uiConfig({ expose })`) would
-         * otherwise lose `&lt;TeamsCard>` from every port with no way to restore it.
+         * otherwise lose `<TeamsCard>` from every port with no way to restore it.
          */
         teams?: boolean;
     };

--- a/registry/auth-ui-react/core/create-resource-controller.ts
+++ b/registry/auth-ui-react/core/create-resource-controller.ts
@@ -19,7 +19,7 @@ import type { FlowStatus } from "./types";
  * one snapshot, one stable reference, and no flow having to re-implement the
  * engine to carry two more properties.
  *
- * A nested field rather than an intersection: `Partial&lt;A & B>` is not assignable
+ * A nested field rather than an intersection: `Partial<A & B>` is not assignable
  * from `{ busy: true }` while `B` is an unresolved generic, so an intersection
  * would need a cast at every internal update. Nesting keeps all of them honest.
  */

--- a/registry/auth-ui-react/core/default-nav.ts
+++ b/registry/auth-ui-react/core/default-nav.ts
@@ -1,6 +1,6 @@
 /**
  * The zero-config navigation fallback. When an app doesn't wire its router into
- * `&lt;AuthUIProvider nav={...}>`, the components still work by driving
+ * `<AuthUIProvider nav={...}>`, the components still work by driving
  * `globalThis.location` directly. Meta-frameworks should override this with
  * their own router for client-side transitions.
  */

--- a/registry/auth-ui-react/core/discovery.ts
+++ b/registry/auth-ui-react/core/discovery.ts
@@ -89,8 +89,8 @@ const PLUGIN_ID_TO_FLOW: Readonly<Record<string, string>> = {
  * `unavailable` until they remount. A successful answer stays cached, because
  * it cannot change.
  *
- * Module-level rather than per-provider so mounting `&lt;SignInCard>` and
- * `&lt;UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
+ * Module-level rather than per-provider so mounting `<SignInCard>` and
+ * `<UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
  * URL, so an app talking to two deployments still gets two answers.
  */
 const handles = new Map<string, DiscoveryHandle>();

--- a/registry/auth-ui-react/core/flow-gate.ts
+++ b/registry/auth-ui-react/core/flow-gate.ts
@@ -1,7 +1,7 @@
 /**
  * Which optional flows are available — and therefore which cards render.
  *
- * A card like `&lt;MagicLinkCard>` only works if the matching better-auth client
+ * A card like `<MagicLinkCard>` only works if the matching better-auth client
  * plugin is installed, so the cards need to know which are. They cannot ask the
  * client: `createAuthClient` returns a dynamic-path `Proxy`, so
  * `typeof client.organization?.list === "function"` is true for a plugin-free

--- a/registry/auth-ui-react/core/notify-error.ts
+++ b/registry/auth-ui-react/core/notify-error.ts
@@ -1,13 +1,13 @@
 /**
  * Report an error that has no card to land in.
  *
- * Most flows put their failures on a `&lt;FormBanner>`. A handful can't: social
+ * Most flows put their failures on a `<FormBanner>`. A handful can't: social
  * sign-in, account linking, sign-out and anonymous sign-in all resolve rather
  * than reject, because the ports call them from click handlers with `void` — so
  * before this, a failure was a button that did nothing at all.
  *
  * This keeps `onError` behaving exactly as it did and adds a toast beside it,
- * which `&lt;ErrorToaster>` renders if the app mounted one.
+ * which `<ErrorToaster>` renders if the app mounted one.
  */
 import type { ControllerContext } from "./config";
 import { mapAuthError } from "./map-error";

--- a/registry/auth-ui-react/core/organization-logo.ts
+++ b/registry/auth-ui-react/core/organization-logo.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 /**
  * Organization logo upload — the org-side counterpart to `avatar.ts`.
  *
  * Same shape and the same reasoning: better-auth stores `organization.logo` as a
  * string, so where the bytes live is the app's decision and comes in through
- * `avatar.upload`. Without an upload handler `&lt;OrganizationSettingsCard>`'s URL
+ * `avatar.upload`. Without an upload handler `<OrganizationSettingsCard>`'s URL
  * field is still the fallback, and this card doesn't render.
  *
  * It is a separate controller rather than a parameter on the avatar one because

--- a/registry/auth-ui-react/core/redirect-to.ts
+++ b/registry/auth-ui-react/core/redirect-to.ts
@@ -3,7 +3,7 @@
  * on purpose.
  *
  * `invitations.ts` bounces a signed-out invitee through the sign-in screen with
- * `?redirectTo=&lt;the invitation>`, and an app's own route guard usually does the
+ * `?redirectTo=<the invitation>`, and an app's own route guard usually does the
  * same. Without this the parameter is written and never read, so the user signs
  * in and lands on the generic post-login page with the invitation forgotten —
  * the bounce looks like it worked and quietly didn't.

--- a/registry/auth-ui-react/core/session.ts
+++ b/registry/auth-ui-react/core/session.ts
@@ -1,6 +1,6 @@
 /**
- * The signed-in user, for the chrome rather than a form: `&lt;UserButton>`,
- * `&lt;UserAvatar>`, `&lt;UserView>`, and any card that needs to know whether anyone
+ * The signed-in user, for the chrome rather than a form: `<UserButton>`,
+ * `<UserAvatar>`, `<UserView>`, and any card that needs to know whether anyone
  * is signed in at all.
  *
  * better-auth's framework clients each ship their own reactive `useSession`, but

--- a/registry/auth-ui-react/core/theme.ts
+++ b/registry/auth-ui-react/core/theme.ts
@@ -38,7 +38,7 @@ interface ThemeTokens {
     success: string;
 }
 
-/** Mirrors the `var(--token, &lt;fallback>)` fallbacks in `styles/auth-ui.css`. */
+/** Mirrors the `var(--token, <fallback>)` fallbacks in `styles/auth-ui.css`. */
 const DEFAULT_THEME_TOKENS: ThemeTokens = {
     background: "hsl(0 0% 100%)",
     border: "hsl(228 16% 88%)",

--- a/registry/auth-ui-react/core/toast.ts
+++ b/registry/auth-ui-react/core/toast.ts
@@ -1,14 +1,14 @@
 /**
  * Transient error messages for the flows that have nowhere to put one.
  *
- * Most flows own a card, and a card owns a `&lt;FormBanner>` — that is where their
+ * Most flows own a card, and a card owns a `<FormBanner>` — that is where their
  * errors belong, and this store deliberately does not duplicate them. What it
  * exists for is the handful of actions with **no visible surface at the moment
  * they fail**: social sign-in and account linking (a redirect that never
  * happens), sign-out, anonymous sign-in. Those call `context.onError` and then
  * resolve, so today a failure is a page that simply does nothing.
  *
- * `&lt;ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
+ * `<ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
  * with its own toast system reads the same store instead, or keeps passing
  * `onError` and ignores this entirely.
  */
@@ -25,7 +25,7 @@ interface ToastState {
 }
 
 /**
- * Module-level, like `discovery.ts`: `&lt;ErrorToaster>` is mounted once in an app
+ * Module-level, like `discovery.ts`: `<ErrorToaster>` is mounted once in an app
  * shell while the flows that push to it live anywhere in the tree, so a
  * per-provider store would need threading through every controller to reach it.
  */

--- a/registry/auth-ui-react/core/types.ts
+++ b/registry/auth-ui-react/core/types.ts
@@ -159,7 +159,7 @@ interface SessionData {
 }
 
 /**
- * What a consumer actually passes to `&lt;AuthUIProvider>`.
+ * What a consumer actually passes to `<AuthUIProvider>`.
  *
  * Deliberately almost-empty. A real better-auth client's type contains only the
  * plugins it was built with — a client without `adminClient()` has no

--- a/registry/auth-ui-react/core/username.ts
+++ b/registry/auth-ui-react/core/username.ts
@@ -2,7 +2,7 @@
  * Username sign-in, and setting a username from account settings.
  *
  * The `username` plugin doesn't replace email sign-in, it adds a second door, so
- * `&lt;SignInCard>` keeps its email field and this is a separate card rather than a
+ * `<SignInCard>` keeps its email field and this is a separate card rather than a
  * mode switch inside it. Which one an app shows is an app decision.
  */
 import type { ControllerContext } from "./config";

--- a/registry/auth-ui-react/react/account-cards.tsx
+++ b/registry/auth-ui-react/react/account-cards.tsx
@@ -92,7 +92,7 @@ const LinkedAccountsCard = (): ReactElement => {
 
 /**
  * Avatar upload. Rendered only when the app configured an `avatar.upload`
- * handler — without one there is nowhere to put the bytes, and `&lt;ProfileCard>`'s
+ * handler — without one there is nowhere to put the bytes, and `<ProfileCard>`'s
  * URL field is the honest fallback.
  */
 const AvatarCard = (): ReactElement | null => {

--- a/registry/auth-ui-react/react/extras.tsx
+++ b/registry/auth-ui-react/react/extras.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 import type { ReactElement } from "react";
 import { useEffect, useRef, useSyncExternalStore } from "react";
 
@@ -111,7 +113,7 @@ const OneTap = (): null => {
 
 /**
  * Upload an organization's logo. Renders only when the app configured an
- * `avatar.upload` handler — without one, `&lt;OrganizationSettingsCard>`'s logo URL
+ * `avatar.upload` handler — without one, `<OrganizationSettingsCard>`'s logo URL
  * field is the fallback.
  */
 interface OrganizationLogoCardProps {

--- a/registry/auth-ui-react/react/plugin-cards.tsx
+++ b/registry/auth-ui-react/react/plugin-cards.tsx
@@ -26,7 +26,7 @@ const onSubmit =
 /**
  * The accounts signed in on *this device*, with switch and sign-out-just-this.
  *
- * Not `&lt;SessionsCard>`, which lists this account's sessions across every device.
+ * Not `<SessionsCard>`, which lists this account's sessions across every device.
  * The two are a keystroke apart in better-auth's API and mean opposite things.
  */
 const MultiSessionCard = (): ReactElement | null => {

--- a/registry/auth-ui-react/react/primitives.tsx
+++ b/registry/auth-ui-react/react/primitives.tsx
@@ -127,7 +127,7 @@ const FormBanner = ({ error, success }: FormBannerProps): ReactElement | null =>
     return null;
 };
 
-/** Internal link using the provider's framework `Link` when present, else `&lt;a>`. */
+/** Internal link using the provider's framework `Link` when present, else `<a>`. */
 interface AuthLinkProps {
     children: ReactNode;
     href: string;
@@ -155,7 +155,7 @@ const AuthLink = ({ children, href }: AuthLinkProps): ReactElement => {
  * A "last used" marker, shown against whichever sign-in route the user took
  * last time.
  *
- * A standalone primitive rather than something only `&lt;SocialButtons>` renders,
+ * A standalone primitive rather than something only `<SocialButtons>` renders,
  * because better-auth records `email`, `magic-link` and `passkey` as well as
  * provider ids: badging only the OAuth buttons makes the feature invisible for
  * the most common case there is.
@@ -171,7 +171,7 @@ const LastUsedBadge = (): ReactElement => {
  * server discovery on, is whatever `socialProviders` the deployment configured.
  *
  * The provider's brand mark is left to CSS: each button carries a
- * `lunora-auth-social__icon--&lt;provider>` class, so an app drops in its own icon
+ * `lunora-auth-social__icon--<provider>` class, so an app drops in its own icon
  * set with a stylesheet rule and this package ships no SVG payload for a list of
  * providers it can't know in advance.
  */

--- a/registry/auth-ui-react/react/provider.tsx
+++ b/registry/auth-ui-react/react/provider.tsx
@@ -34,7 +34,7 @@ interface AuthUIProviderProps extends Omit<AuthUIConfig, "nav"> {
 
     /**
      * Framework `Link` component for internal links (Next `Link`, react-router
-     * `Link`, …). Falls back to a plain `&lt;a>` when omitted.
+     * `Link`, …). Falls back to a plain `<a>` when omitted.
      */
     Link?: ComponentType<{ children: ReactNode; className?: string; href: string }>;
     /** Router bridge; defaults to a `location`-based fallback. */

--- a/registry/auth-ui-react/react/user-button.tsx
+++ b/registry/auth-ui-react/react/user-button.tsx
@@ -82,7 +82,7 @@ const UserView = ({ compact, user }: UserViewProps): ReactElement => (
  * The avatar menu: who is signed in, plus sign-out and whatever the app hangs
  * off it.
  *
- * It is a disclosure rather than a `&lt;menu>` because its contents are app-defined
+ * It is a disclosure rather than a `<menu>` because its contents are app-defined
  * — links, an organization switcher, a theme row — and forcing those into menu
  * item semantics would mislabel them. Escape and outside-click close it, and
  * focus returns to the trigger, which is the part hand-rolled dropdowns usually

--- a/registry/auth-ui-solid/core/accounts.ts
+++ b/registry/auth-ui-solid/core/accounts.ts
@@ -21,7 +21,7 @@ import type { AuthAccount, Controller } from "./types";
 /**
  * Providers that are not OAuth links and must never be offered for unlinking as
  * if they were: `credential` is the password itself, and the passkey rows are
- * managed by `&lt;PasskeysCard>`.
+ * managed by `<PasskeysCard>`.
  */
 const NON_SOCIAL_PROVIDERS = new Set(["credential", "email", "passkey"]);
 

--- a/registry/auth-ui-solid/core/captcha.ts
+++ b/registry/auth-ui-solid/core/captcha.ts
@@ -7,7 +7,7 @@
  * the client, and they belong in different places.
  *
  * **Rendering the widget and capturing a token** is {@link renderCaptcha}, driven
- * by each port's `&lt;Captcha>` component.
+ * by each port's `<Captcha>` component.
  *
  * **Attaching the token to auth requests** is *not* done here. Every flow would
  * have to thread fetch options through, and better-auth already has one place for
@@ -42,7 +42,7 @@ const CAPTCHA_HEADER = "x-captcha-response";
  *
  * The token must only be attached to these. `fetchOptions.onRequest` runs for
  * every* auth call, and `captchaHeaders()` consumes on read — so without this
- * filter a background `getSession` (a session refetch on focus, a `&lt;UserButton>`
+ * filter a background `getSession` (a session refetch on focus, a `<UserButton>`
  * elsewhere in the shell) spends the token on a route that ignores it, and the
  * sign-in the user then clicks arrives with no header at all.
  *
@@ -126,7 +126,7 @@ const setCaptchaToken = (token: string | undefined): void => {
     store.set({ token });
 };
 
-/** The bit of a `&lt;script>` element this module sets, named so the DOM lib isn't needed. */
+/** The bit of a `<script>` element this module sets, named so the DOM lib isn't needed. */
 interface ScriptElement {
     addEventListener: (type: string, listener: () => void) => void;
     async: boolean;

--- a/registry/auth-ui-solid/core/config.ts
+++ b/registry/auth-ui-solid/core/config.ts
@@ -1,7 +1,7 @@
 /**
  * The framework-agnostic configuration + resolved controller context.
  *
- * A framework provider (`&lt;AuthUIProvider>`) collects the user-facing
+ * A framework provider (`<AuthUIProvider>`) collects the user-facing
  * {@link AuthUIConfig}, then {@link resolveContext} normalizes it into a
  * {@link ControllerContext} — the fully-defaulted object every controller
  * receives. Keeping resolution here means the five framework providers share one
@@ -74,7 +74,7 @@ interface RedirectConfig {
 }
 
 /**
- * URL segments `&lt;AuthView>` maps to cards, so an app can host every auth screen
+ * URL segments `<AuthView>` maps to cards, so an app can host every auth screen
  * on one route (`/auth/:view`) instead of wiring ten of them.
  */
 interface ViewPaths {
@@ -103,7 +103,7 @@ interface AvatarConfig {
     upload?: (file: File) => Promise<string>;
 }
 
-/** The user-facing config passed to a framework `&lt;AuthUIProvider>`. */
+/** The user-facing config passed to a framework `<AuthUIProvider>`. */
 interface AuthUIConfig {
     authClient: AnyAuthClient;
     avatar?: AvatarConfig;
@@ -172,7 +172,7 @@ interface AuthUIConfig {
          * Needed because teams are detected from the server's table map and
          * have no client-side equivalent to fall back on: a deployment that
          * withholds the organization block (`uiConfig({ expose })`) would
-         * otherwise lose `&lt;TeamsCard>` from every port with no way to restore it.
+         * otherwise lose `<TeamsCard>` from every port with no way to restore it.
          */
         teams?: boolean;
     };

--- a/registry/auth-ui-solid/core/create-resource-controller.ts
+++ b/registry/auth-ui-solid/core/create-resource-controller.ts
@@ -19,7 +19,7 @@ import type { FlowStatus } from "./types";
  * one snapshot, one stable reference, and no flow having to re-implement the
  * engine to carry two more properties.
  *
- * A nested field rather than an intersection: `Partial&lt;A & B>` is not assignable
+ * A nested field rather than an intersection: `Partial<A & B>` is not assignable
  * from `{ busy: true }` while `B` is an unresolved generic, so an intersection
  * would need a cast at every internal update. Nesting keeps all of them honest.
  */

--- a/registry/auth-ui-solid/core/default-nav.ts
+++ b/registry/auth-ui-solid/core/default-nav.ts
@@ -1,6 +1,6 @@
 /**
  * The zero-config navigation fallback. When an app doesn't wire its router into
- * `&lt;AuthUIProvider nav={...}>`, the components still work by driving
+ * `<AuthUIProvider nav={...}>`, the components still work by driving
  * `globalThis.location` directly. Meta-frameworks should override this with
  * their own router for client-side transitions.
  */

--- a/registry/auth-ui-solid/core/discovery.ts
+++ b/registry/auth-ui-solid/core/discovery.ts
@@ -89,8 +89,8 @@ const PLUGIN_ID_TO_FLOW: Readonly<Record<string, string>> = {
  * `unavailable` until they remount. A successful answer stays cached, because
  * it cannot change.
  *
- * Module-level rather than per-provider so mounting `&lt;SignInCard>` and
- * `&lt;UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
+ * Module-level rather than per-provider so mounting `<SignInCard>` and
+ * `<UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
  * URL, so an app talking to two deployments still gets two answers.
  */
 const handles = new Map<string, DiscoveryHandle>();

--- a/registry/auth-ui-solid/core/flow-gate.ts
+++ b/registry/auth-ui-solid/core/flow-gate.ts
@@ -1,7 +1,7 @@
 /**
  * Which optional flows are available — and therefore which cards render.
  *
- * A card like `&lt;MagicLinkCard>` only works if the matching better-auth client
+ * A card like `<MagicLinkCard>` only works if the matching better-auth client
  * plugin is installed, so the cards need to know which are. They cannot ask the
  * client: `createAuthClient` returns a dynamic-path `Proxy`, so
  * `typeof client.organization?.list === "function"` is true for a plugin-free

--- a/registry/auth-ui-solid/core/notify-error.ts
+++ b/registry/auth-ui-solid/core/notify-error.ts
@@ -1,13 +1,13 @@
 /**
  * Report an error that has no card to land in.
  *
- * Most flows put their failures on a `&lt;FormBanner>`. A handful can't: social
+ * Most flows put their failures on a `<FormBanner>`. A handful can't: social
  * sign-in, account linking, sign-out and anonymous sign-in all resolve rather
  * than reject, because the ports call them from click handlers with `void` — so
  * before this, a failure was a button that did nothing at all.
  *
  * This keeps `onError` behaving exactly as it did and adds a toast beside it,
- * which `&lt;ErrorToaster>` renders if the app mounted one.
+ * which `<ErrorToaster>` renders if the app mounted one.
  */
 import type { ControllerContext } from "./config";
 import { mapAuthError } from "./map-error";

--- a/registry/auth-ui-solid/core/organization-logo.ts
+++ b/registry/auth-ui-solid/core/organization-logo.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 /**
  * Organization logo upload — the org-side counterpart to `avatar.ts`.
  *
  * Same shape and the same reasoning: better-auth stores `organization.logo` as a
  * string, so where the bytes live is the app's decision and comes in through
- * `avatar.upload`. Without an upload handler `&lt;OrganizationSettingsCard>`'s URL
+ * `avatar.upload`. Without an upload handler `<OrganizationSettingsCard>`'s URL
  * field is still the fallback, and this card doesn't render.
  *
  * It is a separate controller rather than a parameter on the avatar one because

--- a/registry/auth-ui-solid/core/redirect-to.ts
+++ b/registry/auth-ui-solid/core/redirect-to.ts
@@ -3,7 +3,7 @@
  * on purpose.
  *
  * `invitations.ts` bounces a signed-out invitee through the sign-in screen with
- * `?redirectTo=&lt;the invitation>`, and an app's own route guard usually does the
+ * `?redirectTo=<the invitation>`, and an app's own route guard usually does the
  * same. Without this the parameter is written and never read, so the user signs
  * in and lands on the generic post-login page with the invitation forgotten —
  * the bounce looks like it worked and quietly didn't.

--- a/registry/auth-ui-solid/core/session.ts
+++ b/registry/auth-ui-solid/core/session.ts
@@ -1,6 +1,6 @@
 /**
- * The signed-in user, for the chrome rather than a form: `&lt;UserButton>`,
- * `&lt;UserAvatar>`, `&lt;UserView>`, and any card that needs to know whether anyone
+ * The signed-in user, for the chrome rather than a form: `<UserButton>`,
+ * `<UserAvatar>`, `<UserView>`, and any card that needs to know whether anyone
  * is signed in at all.
  *
  * better-auth's framework clients each ship their own reactive `useSession`, but

--- a/registry/auth-ui-solid/core/theme.ts
+++ b/registry/auth-ui-solid/core/theme.ts
@@ -38,7 +38,7 @@ interface ThemeTokens {
     success: string;
 }
 
-/** Mirrors the `var(--token, &lt;fallback>)` fallbacks in `styles/auth-ui.css`. */
+/** Mirrors the `var(--token, <fallback>)` fallbacks in `styles/auth-ui.css`. */
 const DEFAULT_THEME_TOKENS: ThemeTokens = {
     background: "hsl(0 0% 100%)",
     border: "hsl(228 16% 88%)",

--- a/registry/auth-ui-solid/core/toast.ts
+++ b/registry/auth-ui-solid/core/toast.ts
@@ -1,14 +1,14 @@
 /**
  * Transient error messages for the flows that have nowhere to put one.
  *
- * Most flows own a card, and a card owns a `&lt;FormBanner>` — that is where their
+ * Most flows own a card, and a card owns a `<FormBanner>` — that is where their
  * errors belong, and this store deliberately does not duplicate them. What it
  * exists for is the handful of actions with **no visible surface at the moment
  * they fail**: social sign-in and account linking (a redirect that never
  * happens), sign-out, anonymous sign-in. Those call `context.onError` and then
  * resolve, so today a failure is a page that simply does nothing.
  *
- * `&lt;ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
+ * `<ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
  * with its own toast system reads the same store instead, or keeps passing
  * `onError` and ignores this entirely.
  */
@@ -25,7 +25,7 @@ interface ToastState {
 }
 
 /**
- * Module-level, like `discovery.ts`: `&lt;ErrorToaster>` is mounted once in an app
+ * Module-level, like `discovery.ts`: `<ErrorToaster>` is mounted once in an app
  * shell while the flows that push to it live anywhere in the tree, so a
  * per-provider store would need threading through every controller to reach it.
  */

--- a/registry/auth-ui-solid/core/types.ts
+++ b/registry/auth-ui-solid/core/types.ts
@@ -159,7 +159,7 @@ interface SessionData {
 }
 
 /**
- * What a consumer actually passes to `&lt;AuthUIProvider>`.
+ * What a consumer actually passes to `<AuthUIProvider>`.
  *
  * Deliberately almost-empty. A real better-auth client's type contains only the
  * plugins it was built with — a client without `adminClient()` has no

--- a/registry/auth-ui-solid/core/username.ts
+++ b/registry/auth-ui-solid/core/username.ts
@@ -2,7 +2,7 @@
  * Username sign-in, and setting a username from account settings.
  *
  * The `username` plugin doesn't replace email sign-in, it adds a second door, so
- * `&lt;SignInCard>` keeps its email field and this is a separate card rather than a
+ * `<SignInCard>` keeps its email field and this is a separate card rather than a
  * mode switch inside it. Which one an app shows is an app decision.
  */
 import type { ControllerContext } from "./config";

--- a/registry/auth-ui-solid/solid/account-cards.tsx
+++ b/registry/auth-ui-solid/solid/account-cards.tsx
@@ -94,7 +94,7 @@ const LinkedAccountsCard = (): JSX.Element => {
 
 /**
  * Avatar upload. Rendered only when the app configured an `avatar.upload`
- * handler — without one there is nowhere to put the bytes, and `&lt;ProfileCard>`'s
+ * handler — without one there is nowhere to put the bytes, and `<ProfileCard>`'s
  * URL field is the honest fallback.
  */
 const AvatarCard = (): JSX.Element => {

--- a/registry/auth-ui-solid/solid/extras.tsx
+++ b/registry/auth-ui-solid/solid/extras.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 import type { JSX } from "solid-js";
 import { createEffect, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 
@@ -131,7 +133,7 @@ const OneTap = (): JSX.Element => {
 
 /**
  * Upload an organization's logo. Renders only when the app configured an
- * `avatar.upload` handler — without one, `&lt;OrganizationSettingsCard>`'s logo URL
+ * `avatar.upload` handler — without one, `<OrganizationSettingsCard>`'s logo URL
  * field is the fallback.
  */
 interface OrganizationLogoCardProps {

--- a/registry/auth-ui-solid/solid/plugin-cards.tsx
+++ b/registry/auth-ui-solid/solid/plugin-cards.tsx
@@ -24,7 +24,7 @@ const onSubmit =
 /**
  * The accounts signed in on *this device*, with switch and sign-out-just-this.
  *
- * Not `&lt;SessionsCard>`, which lists this account's sessions across every device.
+ * Not `<SessionsCard>`, which lists this account's sessions across every device.
  * The two are a keystroke apart in better-auth's API and mean opposite things.
  */
 const MultiSessionCard = (): JSX.Element => {

--- a/registry/auth-ui-solid/solid/primitives.tsx
+++ b/registry/auth-ui-solid/solid/primitives.tsx
@@ -138,7 +138,7 @@ const FormBanner = (props: FormBannerProps): JSX.Element => (
     </Show>
 );
 
-/** Internal link using the provider's framework `Link` when present, else `&lt;a>`. */
+/** Internal link using the provider's framework `Link` when present, else `<a>`. */
 interface AuthLinkProps {
     children: JSX.Element;
     href: string;
@@ -167,7 +167,7 @@ const AuthLink = (props: AuthLinkProps): JSX.Element => {
  * server discovery on, is whatever `socialProviders` the deployment configured.
  *
  * The provider's brand mark is left to CSS: each button carries a
- * `lunora-auth-social__icon--&lt;provider>` class, so an app drops in its own icon
+ * `lunora-auth-social__icon--<provider>` class, so an app drops in its own icon
  * set with a stylesheet rule and this package ships no SVG payload for a list of
  * providers it can't know in advance.
  */

--- a/registry/auth-ui-solid/solid/provider.tsx
+++ b/registry/auth-ui-solid/solid/provider.tsx
@@ -8,7 +8,7 @@ import { defaultNav } from "../core/default-nav";
 import type { DiscoveredConfig } from "../core/discovery";
 import { discoverAuthConfig } from "../core/discovery";
 
-/** A framework `Link` component for internal navigation (Solid Router `A`, plain `&lt;a>`, …). */
+/** A framework `Link` component for internal navigation (Solid Router `A`, plain `<a>`, …). */
 type AuthUILink = Component<{ children: JSX.Element; class?: string; href: string }>;
 
 /** The Solid context also carries an optional framework `Link` for internal navigation. */
@@ -24,7 +24,7 @@ interface AuthUIProviderProps extends Omit<AuthUIConfig, "nav"> {
 
     /**
      * Framework `Link` component for internal links (Solid Router `A`, …). Falls
-     * back to a plain `&lt;a>` when omitted.
+     * back to a plain `<a>` when omitted.
      */
     Link?: AuthUILink;
     /** Router bridge; defaults to a `location`-based fallback. */
@@ -41,7 +41,7 @@ interface AuthUIProviderProps extends Omit<AuthUIConfig, "nav"> {
  * card. Configure the provider at mount, as you would a router.
  *
  * The one exception is server discovery, which by definition answers *after*
- * mount. Its answer produces a **new** context object, and the keyed `&lt;Show>`
+ * mount. Its answer produces a **new** context object, and the keyed `<Show>`
  * below re-creates the tree on that new identity. That is load-bearing rather
  * than incidental: every card resolves its gate once in its body
  * (`const enabled = isFlowEnabled(context, …)`) and passes the answer to its

--- a/registry/auth-ui-solid/solid/use-controller.ts
+++ b/registry/auth-ui-solid/solid/use-controller.ts
@@ -15,7 +15,7 @@ import { useAuthUI } from "./provider";
  * Unlike the React `useController` there is no dependency array: a Solid
  * component body runs once, so any options the factory closes over are captured
  * at creation. Cards that need to react to changing props should be re-keyed by
- * the caller (`&lt;Show keyed>` / a `key` on the route) instead.
+ * the caller (`<Show keyed>` / a `key` on the route) instead.
  * @param create Builds the controller from the resolved context.
  */
 const createController = <TState extends object, TActions>(create: (context: ControllerContext) => Controller<TState, TActions>): [TState, TActions] => {

--- a/registry/auth-ui-solid/solid/user-button.tsx
+++ b/registry/auth-ui-solid/solid/user-button.tsx
@@ -95,7 +95,7 @@ const UserView = (props: UserViewProps): JSX.Element => (
  * The avatar menu: who is signed in, plus sign-out and whatever the app hangs
  * off it.
  *
- * It is a disclosure rather than a `&lt;menu>` because its contents are app-defined
+ * It is a disclosure rather than a `<menu>` because its contents are app-defined
  * — links, an organization switcher, a theme row — and forcing those into menu
  * item semantics would mislabel them. Escape and outside-click close it, and
  * focus returns to the trigger, which is the part hand-rolled dropdowns usually

--- a/registry/auth-ui-svelte/core/accounts.ts
+++ b/registry/auth-ui-svelte/core/accounts.ts
@@ -21,7 +21,7 @@ import type { AuthAccount, Controller } from "./types";
 /**
  * Providers that are not OAuth links and must never be offered for unlinking as
  * if they were: `credential` is the password itself, and the passkey rows are
- * managed by `&lt;PasskeysCard>`.
+ * managed by `<PasskeysCard>`.
  */
 const NON_SOCIAL_PROVIDERS = new Set(["credential", "email", "passkey"]);
 

--- a/registry/auth-ui-svelte/core/captcha.ts
+++ b/registry/auth-ui-svelte/core/captcha.ts
@@ -7,7 +7,7 @@
  * the client, and they belong in different places.
  *
  * **Rendering the widget and capturing a token** is {@link renderCaptcha}, driven
- * by each port's `&lt;Captcha>` component.
+ * by each port's `<Captcha>` component.
  *
  * **Attaching the token to auth requests** is *not* done here. Every flow would
  * have to thread fetch options through, and better-auth already has one place for
@@ -42,7 +42,7 @@ const CAPTCHA_HEADER = "x-captcha-response";
  *
  * The token must only be attached to these. `fetchOptions.onRequest` runs for
  * every* auth call, and `captchaHeaders()` consumes on read — so without this
- * filter a background `getSession` (a session refetch on focus, a `&lt;UserButton>`
+ * filter a background `getSession` (a session refetch on focus, a `<UserButton>`
  * elsewhere in the shell) spends the token on a route that ignores it, and the
  * sign-in the user then clicks arrives with no header at all.
  *
@@ -126,7 +126,7 @@ const setCaptchaToken = (token: string | undefined): void => {
     store.set({ token });
 };
 
-/** The bit of a `&lt;script>` element this module sets, named so the DOM lib isn't needed. */
+/** The bit of a `<script>` element this module sets, named so the DOM lib isn't needed. */
 interface ScriptElement {
     addEventListener: (type: string, listener: () => void) => void;
     async: boolean;

--- a/registry/auth-ui-svelte/core/config.ts
+++ b/registry/auth-ui-svelte/core/config.ts
@@ -1,7 +1,7 @@
 /**
  * The framework-agnostic configuration + resolved controller context.
  *
- * A framework provider (`&lt;AuthUIProvider>`) collects the user-facing
+ * A framework provider (`<AuthUIProvider>`) collects the user-facing
  * {@link AuthUIConfig}, then {@link resolveContext} normalizes it into a
  * {@link ControllerContext} — the fully-defaulted object every controller
  * receives. Keeping resolution here means the five framework providers share one
@@ -74,7 +74,7 @@ interface RedirectConfig {
 }
 
 /**
- * URL segments `&lt;AuthView>` maps to cards, so an app can host every auth screen
+ * URL segments `<AuthView>` maps to cards, so an app can host every auth screen
  * on one route (`/auth/:view`) instead of wiring ten of them.
  */
 interface ViewPaths {
@@ -103,7 +103,7 @@ interface AvatarConfig {
     upload?: (file: File) => Promise<string>;
 }
 
-/** The user-facing config passed to a framework `&lt;AuthUIProvider>`. */
+/** The user-facing config passed to a framework `<AuthUIProvider>`. */
 interface AuthUIConfig {
     authClient: AnyAuthClient;
     avatar?: AvatarConfig;
@@ -172,7 +172,7 @@ interface AuthUIConfig {
          * Needed because teams are detected from the server's table map and
          * have no client-side equivalent to fall back on: a deployment that
          * withholds the organization block (`uiConfig({ expose })`) would
-         * otherwise lose `&lt;TeamsCard>` from every port with no way to restore it.
+         * otherwise lose `<TeamsCard>` from every port with no way to restore it.
          */
         teams?: boolean;
     };

--- a/registry/auth-ui-svelte/core/create-resource-controller.ts
+++ b/registry/auth-ui-svelte/core/create-resource-controller.ts
@@ -19,7 +19,7 @@ import type { FlowStatus } from "./types";
  * one snapshot, one stable reference, and no flow having to re-implement the
  * engine to carry two more properties.
  *
- * A nested field rather than an intersection: `Partial&lt;A & B>` is not assignable
+ * A nested field rather than an intersection: `Partial<A & B>` is not assignable
  * from `{ busy: true }` while `B` is an unresolved generic, so an intersection
  * would need a cast at every internal update. Nesting keeps all of them honest.
  */

--- a/registry/auth-ui-svelte/core/default-nav.ts
+++ b/registry/auth-ui-svelte/core/default-nav.ts
@@ -1,6 +1,6 @@
 /**
  * The zero-config navigation fallback. When an app doesn't wire its router into
- * `&lt;AuthUIProvider nav={...}>`, the components still work by driving
+ * `<AuthUIProvider nav={...}>`, the components still work by driving
  * `globalThis.location` directly. Meta-frameworks should override this with
  * their own router for client-side transitions.
  */

--- a/registry/auth-ui-svelte/core/discovery.ts
+++ b/registry/auth-ui-svelte/core/discovery.ts
@@ -89,8 +89,8 @@ const PLUGIN_ID_TO_FLOW: Readonly<Record<string, string>> = {
  * `unavailable` until they remount. A successful answer stays cached, because
  * it cannot change.
  *
- * Module-level rather than per-provider so mounting `&lt;SignInCard>` and
- * `&lt;UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
+ * Module-level rather than per-provider so mounting `<SignInCard>` and
+ * `<UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
  * URL, so an app talking to two deployments still gets two answers.
  */
 const handles = new Map<string, DiscoveryHandle>();

--- a/registry/auth-ui-svelte/core/flow-gate.ts
+++ b/registry/auth-ui-svelte/core/flow-gate.ts
@@ -1,7 +1,7 @@
 /**
  * Which optional flows are available — and therefore which cards render.
  *
- * A card like `&lt;MagicLinkCard>` only works if the matching better-auth client
+ * A card like `<MagicLinkCard>` only works if the matching better-auth client
  * plugin is installed, so the cards need to know which are. They cannot ask the
  * client: `createAuthClient` returns a dynamic-path `Proxy`, so
  * `typeof client.organization?.list === "function"` is true for a plugin-free

--- a/registry/auth-ui-svelte/core/notify-error.ts
+++ b/registry/auth-ui-svelte/core/notify-error.ts
@@ -1,13 +1,13 @@
 /**
  * Report an error that has no card to land in.
  *
- * Most flows put their failures on a `&lt;FormBanner>`. A handful can't: social
+ * Most flows put their failures on a `<FormBanner>`. A handful can't: social
  * sign-in, account linking, sign-out and anonymous sign-in all resolve rather
  * than reject, because the ports call them from click handlers with `void` — so
  * before this, a failure was a button that did nothing at all.
  *
  * This keeps `onError` behaving exactly as it did and adds a toast beside it,
- * which `&lt;ErrorToaster>` renders if the app mounted one.
+ * which `<ErrorToaster>` renders if the app mounted one.
  */
 import type { ControllerContext } from "./config";
 import { mapAuthError } from "./map-error";

--- a/registry/auth-ui-svelte/core/organization-logo.ts
+++ b/registry/auth-ui-svelte/core/organization-logo.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 /**
  * Organization logo upload — the org-side counterpart to `avatar.ts`.
  *
  * Same shape and the same reasoning: better-auth stores `organization.logo` as a
  * string, so where the bytes live is the app's decision and comes in through
- * `avatar.upload`. Without an upload handler `&lt;OrganizationSettingsCard>`'s URL
+ * `avatar.upload`. Without an upload handler `<OrganizationSettingsCard>`'s URL
  * field is still the fallback, and this card doesn't render.
  *
  * It is a separate controller rather than a parameter on the avatar one because

--- a/registry/auth-ui-svelte/core/redirect-to.ts
+++ b/registry/auth-ui-svelte/core/redirect-to.ts
@@ -3,7 +3,7 @@
  * on purpose.
  *
  * `invitations.ts` bounces a signed-out invitee through the sign-in screen with
- * `?redirectTo=&lt;the invitation>`, and an app's own route guard usually does the
+ * `?redirectTo=<the invitation>`, and an app's own route guard usually does the
  * same. Without this the parameter is written and never read, so the user signs
  * in and lands on the generic post-login page with the invitation forgotten —
  * the bounce looks like it worked and quietly didn't.

--- a/registry/auth-ui-svelte/core/session.ts
+++ b/registry/auth-ui-svelte/core/session.ts
@@ -1,6 +1,6 @@
 /**
- * The signed-in user, for the chrome rather than a form: `&lt;UserButton>`,
- * `&lt;UserAvatar>`, `&lt;UserView>`, and any card that needs to know whether anyone
+ * The signed-in user, for the chrome rather than a form: `<UserButton>`,
+ * `<UserAvatar>`, `<UserView>`, and any card that needs to know whether anyone
  * is signed in at all.
  *
  * better-auth's framework clients each ship their own reactive `useSession`, but

--- a/registry/auth-ui-svelte/core/theme.ts
+++ b/registry/auth-ui-svelte/core/theme.ts
@@ -38,7 +38,7 @@ interface ThemeTokens {
     success: string;
 }
 
-/** Mirrors the `var(--token, &lt;fallback>)` fallbacks in `styles/auth-ui.css`. */
+/** Mirrors the `var(--token, <fallback>)` fallbacks in `styles/auth-ui.css`. */
 const DEFAULT_THEME_TOKENS: ThemeTokens = {
     background: "hsl(0 0% 100%)",
     border: "hsl(228 16% 88%)",

--- a/registry/auth-ui-svelte/core/toast.ts
+++ b/registry/auth-ui-svelte/core/toast.ts
@@ -1,14 +1,14 @@
 /**
  * Transient error messages for the flows that have nowhere to put one.
  *
- * Most flows own a card, and a card owns a `&lt;FormBanner>` — that is where their
+ * Most flows own a card, and a card owns a `<FormBanner>` — that is where their
  * errors belong, and this store deliberately does not duplicate them. What it
  * exists for is the handful of actions with **no visible surface at the moment
  * they fail**: social sign-in and account linking (a redirect that never
  * happens), sign-out, anonymous sign-in. Those call `context.onError` and then
  * resolve, so today a failure is a page that simply does nothing.
  *
- * `&lt;ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
+ * `<ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
  * with its own toast system reads the same store instead, or keeps passing
  * `onError` and ignores this entirely.
  */
@@ -25,7 +25,7 @@ interface ToastState {
 }
 
 /**
- * Module-level, like `discovery.ts`: `&lt;ErrorToaster>` is mounted once in an app
+ * Module-level, like `discovery.ts`: `<ErrorToaster>` is mounted once in an app
  * shell while the flows that push to it live anywhere in the tree, so a
  * per-provider store would need threading through every controller to reach it.
  */

--- a/registry/auth-ui-svelte/core/types.ts
+++ b/registry/auth-ui-svelte/core/types.ts
@@ -159,7 +159,7 @@ interface SessionData {
 }
 
 /**
- * What a consumer actually passes to `&lt;AuthUIProvider>`.
+ * What a consumer actually passes to `<AuthUIProvider>`.
  *
  * Deliberately almost-empty. A real better-auth client's type contains only the
  * plugins it was built with — a client without `adminClient()` has no

--- a/registry/auth-ui-svelte/core/username.ts
+++ b/registry/auth-ui-svelte/core/username.ts
@@ -2,7 +2,7 @@
  * Username sign-in, and setting a username from account settings.
  *
  * The `username` plugin doesn't replace email sign-in, it adds a second door, so
- * `&lt;SignInCard>` keeps its email field and this is a separate card rather than a
+ * `<SignInCard>` keeps its email field and this is a separate card rather than a
  * mode switch inside it. Which one an app shows is an app decision.
  */
 import type { ControllerContext } from "./config";

--- a/registry/auth-ui-svelte/svelte/context.ts
+++ b/registry/auth-ui-svelte/svelte/context.ts
@@ -12,13 +12,13 @@ import { getContext, setContext } from "svelte";
 import type { ControllerContext } from "../core/config";
 
 /**
- * A framework `Link` component (SvelteKit's `&lt;a>` wrapper, a custom router link,
+ * A framework `Link` component (SvelteKit's `<a>` wrapper, a custom router link,
  * …) accepting the same props the base cards pass: `href`, an optional `class`,
- * and its `children` snippet. Falls back to a plain `&lt;a>` when omitted.
+ * and its `children` snippet. Falls back to a plain `<a>` when omitted.
  */
 type AuthUILinkComponent = Component<{ children?: Snippet; class?: string; href: string }>;
 
-/** The value published on the Svelte context tree by `&lt;AuthUIProvider>`. */
+/** The value published on the Svelte context tree by `<AuthUIProvider>`. */
 interface AuthUISvelteContext {
     core: ControllerContext;
     Link?: AuthUILinkComponent;
@@ -28,7 +28,7 @@ const AUTH_UI_CONTEXT_KEY = Symbol("lunora.auth-ui");
 
 /**
  * Publish the resolved auth-UI context on the Svelte component tree. Called once
- * by `&lt;AuthUIProvider>` during its initialisation (the `setContext` constraint),
+ * by `<AuthUIProvider>` during its initialisation (the `setContext` constraint),
  * exactly like React's provider mounts once.
  */
 const setAuthUIContext = (value: AuthUISvelteContext): AuthUISvelteContext => {
@@ -38,7 +38,7 @@ const setAuthUIContext = (value: AuthUISvelteContext): AuthUISvelteContext => {
 };
 
 /**
- * Read the resolved core controller context from the nearest `&lt;AuthUIProvider>`.
+ * Read the resolved core controller context from the nearest `<AuthUIProvider>`.
  * Throws — loud and early — when no provider is mounted, mirroring React's
  * `useAuthUI` guard. Must be called during component initialisation.
  */

--- a/registry/auth-ui-svelte/svelte/index.ts
+++ b/registry/auth-ui-svelte/svelte/index.ts
@@ -10,15 +10,15 @@ export * from "../core";
  * Usage after `lunora add auth-ui`:
  *
  * ```svelte
- * &lt;script lang="ts">
+ * <script lang="ts">
  *     import { AuthUIProvider, SignInCard } from "./lunora/auth-ui/svelte";
  *     import { authClient } from "./lunora/auth-ui/client";
  *     import "./lunora/auth-ui/styles.css";
- * &lt;/script>
+ * </script>
  *
- * &lt;AuthUIProvider {authClient}>
- *     &lt;SignInCard />
- * &lt;/AuthUIProvider>
+ * <AuthUIProvider {authClient}>
+ *     <SignInCard />
+ * </AuthUIProvider>
  * ```
  */
 

--- a/registry/auth-ui-vue/core/accounts.ts
+++ b/registry/auth-ui-vue/core/accounts.ts
@@ -21,7 +21,7 @@ import type { AuthAccount, Controller } from "./types";
 /**
  * Providers that are not OAuth links and must never be offered for unlinking as
  * if they were: `credential` is the password itself, and the passkey rows are
- * managed by `&lt;PasskeysCard>`.
+ * managed by `<PasskeysCard>`.
  */
 const NON_SOCIAL_PROVIDERS = new Set(["credential", "email", "passkey"]);
 

--- a/registry/auth-ui-vue/core/captcha.ts
+++ b/registry/auth-ui-vue/core/captcha.ts
@@ -7,7 +7,7 @@
  * the client, and they belong in different places.
  *
  * **Rendering the widget and capturing a token** is {@link renderCaptcha}, driven
- * by each port's `&lt;Captcha>` component.
+ * by each port's `<Captcha>` component.
  *
  * **Attaching the token to auth requests** is *not* done here. Every flow would
  * have to thread fetch options through, and better-auth already has one place for
@@ -42,7 +42,7 @@ const CAPTCHA_HEADER = "x-captcha-response";
  *
  * The token must only be attached to these. `fetchOptions.onRequest` runs for
  * every* auth call, and `captchaHeaders()` consumes on read — so without this
- * filter a background `getSession` (a session refetch on focus, a `&lt;UserButton>`
+ * filter a background `getSession` (a session refetch on focus, a `<UserButton>`
  * elsewhere in the shell) spends the token on a route that ignores it, and the
  * sign-in the user then clicks arrives with no header at all.
  *
@@ -126,7 +126,7 @@ const setCaptchaToken = (token: string | undefined): void => {
     store.set({ token });
 };
 
-/** The bit of a `&lt;script>` element this module sets, named so the DOM lib isn't needed. */
+/** The bit of a `<script>` element this module sets, named so the DOM lib isn't needed. */
 interface ScriptElement {
     addEventListener: (type: string, listener: () => void) => void;
     async: boolean;

--- a/registry/auth-ui-vue/core/config.ts
+++ b/registry/auth-ui-vue/core/config.ts
@@ -1,7 +1,7 @@
 /**
  * The framework-agnostic configuration + resolved controller context.
  *
- * A framework provider (`&lt;AuthUIProvider>`) collects the user-facing
+ * A framework provider (`<AuthUIProvider>`) collects the user-facing
  * {@link AuthUIConfig}, then {@link resolveContext} normalizes it into a
  * {@link ControllerContext} — the fully-defaulted object every controller
  * receives. Keeping resolution here means the five framework providers share one
@@ -74,7 +74,7 @@ interface RedirectConfig {
 }
 
 /**
- * URL segments `&lt;AuthView>` maps to cards, so an app can host every auth screen
+ * URL segments `<AuthView>` maps to cards, so an app can host every auth screen
  * on one route (`/auth/:view`) instead of wiring ten of them.
  */
 interface ViewPaths {
@@ -103,7 +103,7 @@ interface AvatarConfig {
     upload?: (file: File) => Promise<string>;
 }
 
-/** The user-facing config passed to a framework `&lt;AuthUIProvider>`. */
+/** The user-facing config passed to a framework `<AuthUIProvider>`. */
 interface AuthUIConfig {
     authClient: AnyAuthClient;
     avatar?: AvatarConfig;
@@ -172,7 +172,7 @@ interface AuthUIConfig {
          * Needed because teams are detected from the server's table map and
          * have no client-side equivalent to fall back on: a deployment that
          * withholds the organization block (`uiConfig({ expose })`) would
-         * otherwise lose `&lt;TeamsCard>` from every port with no way to restore it.
+         * otherwise lose `<TeamsCard>` from every port with no way to restore it.
          */
         teams?: boolean;
     };

--- a/registry/auth-ui-vue/core/create-resource-controller.ts
+++ b/registry/auth-ui-vue/core/create-resource-controller.ts
@@ -19,7 +19,7 @@ import type { FlowStatus } from "./types";
  * one snapshot, one stable reference, and no flow having to re-implement the
  * engine to carry two more properties.
  *
- * A nested field rather than an intersection: `Partial&lt;A & B>` is not assignable
+ * A nested field rather than an intersection: `Partial<A & B>` is not assignable
  * from `{ busy: true }` while `B` is an unresolved generic, so an intersection
  * would need a cast at every internal update. Nesting keeps all of them honest.
  */

--- a/registry/auth-ui-vue/core/default-nav.ts
+++ b/registry/auth-ui-vue/core/default-nav.ts
@@ -1,6 +1,6 @@
 /**
  * The zero-config navigation fallback. When an app doesn't wire its router into
- * `&lt;AuthUIProvider nav={...}>`, the components still work by driving
+ * `<AuthUIProvider nav={...}>`, the components still work by driving
  * `globalThis.location` directly. Meta-frameworks should override this with
  * their own router for client-side transitions.
  */

--- a/registry/auth-ui-vue/core/discovery.ts
+++ b/registry/auth-ui-vue/core/discovery.ts
@@ -89,8 +89,8 @@ const PLUGIN_ID_TO_FLOW: Readonly<Record<string, string>> = {
  * `unavailable` until they remount. A successful answer stays cached, because
  * it cannot change.
  *
- * Module-level rather than per-provider so mounting `&lt;SignInCard>` and
- * `&lt;UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
+ * Module-level rather than per-provider so mounting `<SignInCard>` and
+ * `<UserButton>` under two providers doesn't fetch twice. Keyed by the resolved
  * URL, so an app talking to two deployments still gets two answers.
  */
 const handles = new Map<string, DiscoveryHandle>();

--- a/registry/auth-ui-vue/core/flow-gate.ts
+++ b/registry/auth-ui-vue/core/flow-gate.ts
@@ -1,7 +1,7 @@
 /**
  * Which optional flows are available — and therefore which cards render.
  *
- * A card like `&lt;MagicLinkCard>` only works if the matching better-auth client
+ * A card like `<MagicLinkCard>` only works if the matching better-auth client
  * plugin is installed, so the cards need to know which are. They cannot ask the
  * client: `createAuthClient` returns a dynamic-path `Proxy`, so
  * `typeof client.organization?.list === "function"` is true for a plugin-free

--- a/registry/auth-ui-vue/core/notify-error.ts
+++ b/registry/auth-ui-vue/core/notify-error.ts
@@ -1,13 +1,13 @@
 /**
  * Report an error that has no card to land in.
  *
- * Most flows put their failures on a `&lt;FormBanner>`. A handful can't: social
+ * Most flows put their failures on a `<FormBanner>`. A handful can't: social
  * sign-in, account linking, sign-out and anonymous sign-in all resolve rather
  * than reject, because the ports call them from click handlers with `void` — so
  * before this, a failure was a button that did nothing at all.
  *
  * This keeps `onError` behaving exactly as it did and adds a toast beside it,
- * which `&lt;ErrorToaster>` renders if the app mounted one.
+ * which `<ErrorToaster>` renders if the app mounted one.
  */
 import type { ControllerContext } from "./config";
 import { mapAuthError } from "./map-error";

--- a/registry/auth-ui-vue/core/organization-logo.ts
+++ b/registry/auth-ui-vue/core/organization-logo.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-secrets/no-secrets -- JSDoc names the `<OrganizationSettingsCard>` component, not a credential. */
+
 /**
  * Organization logo upload — the org-side counterpart to `avatar.ts`.
  *
  * Same shape and the same reasoning: better-auth stores `organization.logo` as a
  * string, so where the bytes live is the app's decision and comes in through
- * `avatar.upload`. Without an upload handler `&lt;OrganizationSettingsCard>`'s URL
+ * `avatar.upload`. Without an upload handler `<OrganizationSettingsCard>`'s URL
  * field is still the fallback, and this card doesn't render.
  *
  * It is a separate controller rather than a parameter on the avatar one because

--- a/registry/auth-ui-vue/core/redirect-to.ts
+++ b/registry/auth-ui-vue/core/redirect-to.ts
@@ -3,7 +3,7 @@
  * on purpose.
  *
  * `invitations.ts` bounces a signed-out invitee through the sign-in screen with
- * `?redirectTo=&lt;the invitation>`, and an app's own route guard usually does the
+ * `?redirectTo=<the invitation>`, and an app's own route guard usually does the
  * same. Without this the parameter is written and never read, so the user signs
  * in and lands on the generic post-login page with the invitation forgotten —
  * the bounce looks like it worked and quietly didn't.

--- a/registry/auth-ui-vue/core/session.ts
+++ b/registry/auth-ui-vue/core/session.ts
@@ -1,6 +1,6 @@
 /**
- * The signed-in user, for the chrome rather than a form: `&lt;UserButton>`,
- * `&lt;UserAvatar>`, `&lt;UserView>`, and any card that needs to know whether anyone
+ * The signed-in user, for the chrome rather than a form: `<UserButton>`,
+ * `<UserAvatar>`, `<UserView>`, and any card that needs to know whether anyone
  * is signed in at all.
  *
  * better-auth's framework clients each ship their own reactive `useSession`, but

--- a/registry/auth-ui-vue/core/theme.ts
+++ b/registry/auth-ui-vue/core/theme.ts
@@ -38,7 +38,7 @@ interface ThemeTokens {
     success: string;
 }
 
-/** Mirrors the `var(--token, &lt;fallback>)` fallbacks in `styles/auth-ui.css`. */
+/** Mirrors the `var(--token, <fallback>)` fallbacks in `styles/auth-ui.css`. */
 const DEFAULT_THEME_TOKENS: ThemeTokens = {
     background: "hsl(0 0% 100%)",
     border: "hsl(228 16% 88%)",

--- a/registry/auth-ui-vue/core/toast.ts
+++ b/registry/auth-ui-vue/core/toast.ts
@@ -1,14 +1,14 @@
 /**
  * Transient error messages for the flows that have nowhere to put one.
  *
- * Most flows own a card, and a card owns a `&lt;FormBanner>` — that is where their
+ * Most flows own a card, and a card owns a `<FormBanner>` — that is where their
  * errors belong, and this store deliberately does not duplicate them. What it
  * exists for is the handful of actions with **no visible surface at the moment
  * they fail**: social sign-in and account linking (a redirect that never
  * happens), sign-out, anonymous sign-in. Those call `context.onError` and then
  * resolve, so today a failure is a page that simply does nothing.
  *
- * `&lt;ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
+ * `<ErrorToaster>` renders whatever lands here. Mounting it is opt-in; an app
  * with its own toast system reads the same store instead, or keeps passing
  * `onError` and ignores this entirely.
  */
@@ -25,7 +25,7 @@ interface ToastState {
 }
 
 /**
- * Module-level, like `discovery.ts`: `&lt;ErrorToaster>` is mounted once in an app
+ * Module-level, like `discovery.ts`: `<ErrorToaster>` is mounted once in an app
  * shell while the flows that push to it live anywhere in the tree, so a
  * per-provider store would need threading through every controller to reach it.
  */

--- a/registry/auth-ui-vue/core/types.ts
+++ b/registry/auth-ui-vue/core/types.ts
@@ -159,7 +159,7 @@ interface SessionData {
 }
 
 /**
- * What a consumer actually passes to `&lt;AuthUIProvider>`.
+ * What a consumer actually passes to `<AuthUIProvider>`.
  *
  * Deliberately almost-empty. A real better-auth client's type contains only the
  * plugins it was built with — a client without `adminClient()` has no

--- a/registry/auth-ui-vue/core/username.ts
+++ b/registry/auth-ui-vue/core/username.ts
@@ -2,7 +2,7 @@
  * Username sign-in, and setting a username from account settings.
  *
  * The `username` plugin doesn't replace email sign-in, it adds a second door, so
- * `&lt;SignInCard>` keeps its email field and this is a separate card rather than a
+ * `<SignInCard>` keeps its email field and this is a separate card rather than a
  * mode switch inside it. Which one an app shows is an app decision.
  */
 import type { ControllerContext } from "./config";

--- a/registry/auth-ui-vue/vue/index.ts
+++ b/registry/auth-ui-vue/vue/index.ts
@@ -20,9 +20,9 @@ export * from "../core";
  * ```
  *
  * ```vue
- * &lt;script setup lang="ts">
+ * <script setup lang="ts">
  * import { SignInCard } from "./lunora/auth-ui/vue";
- * &lt;/script>
+ * </script>
  * ```
  */
 

--- a/registry/auth-ui-vue/vue/provider.ts
+++ b/registry/auth-ui-vue/vue/provider.ts
@@ -52,7 +52,7 @@ interface AuthUIProviderProps {
 
     /**
      * Framework `Link` component for internal links (`NuxtLink`, `RouterLink`,
-     * …). Falls back to a plain `&lt;a>` when omitted.
+     * …). Falls back to a plain `<a>` when omitted.
      */
     Link?: Component;
     localization?: Partial<Localization>;
@@ -69,7 +69,7 @@ interface AuthUIProviderProps {
     social?: ReadonlyArray<string>;
     /** Retint the cards from config; see `core/theme.ts`. */
     theme?: AuthUIConfig["theme"];
-    /** URL segments `&lt;AuthView>` maps to cards; see `core/config.ts`. */
+    /** URL segments `<AuthView>` maps to cards; see `core/config.ts`. */
     viewPaths?: ViewPaths;
 }
 
@@ -199,7 +199,7 @@ const buildContext = (config: AuthUIProviderProps): AuthUIVueContext => {
  * `autoLoad`, the social provider list — are read *through* that ref, so they
  * re-evaluate when the server answers. Neither form needs a component boundary
  * to make that happen. Choose between them on scope: this one is app-wide,
- * `&lt;AuthUIProvider>` scopes the context to a subtree.
+ * `<AuthUIProvider>` scopes the context to a subtree.
  */
 const createAuthUI = (config: AuthUIProviderProps): { install: (app: App) => void } => {
     const context = buildContext(config);
@@ -215,7 +215,7 @@ const createAuthUI = (config: AuthUIProviderProps): { install: (app: App) => voi
  * Composition-API form: call inside a parent component's `setup()` to provide
  * the context to its subtree. The counterpart to `app.use(createAuthUI(config))`
  * when you'd rather scope the context to a subtree than the whole app. Backs the
- * `&lt;AuthUIProvider>` SFC. Must run synchronously inside `setup()`.
+ * `<AuthUIProvider>` SFC. Must run synchronously inside `setup()`.
  */
 const provideAuthUI = (config: AuthUIProviderProps): ShallowRef<ControllerContext> => {
     const context = buildContext(config);
@@ -228,7 +228,7 @@ const provideAuthUI = (config: AuthUIProviderProps): ShallowRef<ControllerContex
 /**
  * The context ref from the nearest provider — use this whenever what you read
  * has to *follow* the one identity change discovery makes: the plugin flags,
- * `credentials`, `social`, `organization`. Bound in `&lt;script setup>` the template
+ * `credentials`, `social`, `organization`. Bound in `<script setup>` the template
  * unwraps it on every read, so `v-if="context.plugins.passkey"` is reactive
  * without further ceremony; in script, wrap the read in a `computed`.
  *


### PR DESCRIPTION
## What

`jsdoc/text-escaping` escapes every `<` and `&` in a JSDoc description into an HTML entity. Its only options are `escapeHTML` and `escapeMarkdown` — **there is no way to exempt a code span**. So its autofix rewrites

```ts
/** The `ctx.authApi.<method>` that was called without `headers`. */
```

into

```ts
/** The `ctx.authApi.&lt;method>` that was called without `headers`. */
```

and that entity is what every reader then sees — on hover, in an editor tooltip, and in any tool that reads the comment. For a codebase whose doc comments are dense with generic type syntax (`Id<"users">`, `ColumnValidator<TSelect, TInsert>`, `AsyncIterable<T>`), the rule damages far more than it protects, and it re-applies the damage on every `eslint --fix`.

It had reached **1,416 entities across 497 files**. One package had already turned the rule off locally for exactly this reason.

## Two commits

**`35ddd84` turns the rule off** in all 57 configs. Appended as the *last* block rather than merged into an existing one: in 31 of these packages the first `rules:` block is scoped to `files: ["**/__tests__/**"]`, so an override placed there reaches test files only — which is how a first attempt left 120 errors standing in `src/`. Fixing the rule first matters; otherwise the next `eslint --fix` simply reinstates all of it.

**`7601072` reverts the entities.**

## Comments only — by construction and by check

The repo contains a real HTML escaper (`config/src/studio-host/render-html.ts`), tests that assert on `&quot;`, and JSX text carrying entities. All of those must keep theirs, so a regex sweep would have corrupted the escaper and broken tests. The rewrite takes its ranges from the TypeScript parser instead, and never touches anything that is not comment trivia.

Verified **independently** of that logic: every touched file was transpiled before and after with `removeComments: true` and the emitted code compared.

```
checked 497 files, 0 with changed code
```

That check was proven non-vacuous by corrupting a class name and confirming it fails (`CODE CHANGED: packages/auth/src/middleware.ts`).

> An earlier scanner-based version of the same check reported **96 false positives**, because a bare scanner has no parser context and desynchronizes on template literals, JSX and regex literals — it began tokenizing comment text as code. The mechanism that looked cheaper was the one that was wrong.

## `no-secrets` fallout

Ten doc comments then tripped `no-secrets`, which scans comments and reads a restored `` `AsyncIterable<unknown>` `` or `` `<Name>AgentWorkflow` `` as high-entropy. Each gets a suppression naming the actual token, matching the ~100 the repo already carries for this class — their wording (*"framework API type names quoted in doc comments, not credentials"*) describes precisely this.

I considered configuring the rule with `ignoreContent` instead. It works, but it makes ~102 existing suppressions unused and changes a security rule's config in 54 places — a much larger blast radius than the problem. The per-site form keeps the rule maximally strict; a `postgres://user:pw@host` test fixture keeps its own separate suppression and stays flagged by default.

## Verification

Full-repo `lint:eslint` exit 0 (from 128 errors mid-change) · `lint:types` exit 0 · `lint:prettier` clean · `api:check` 44/44 · `lint:package-json` clean · `lint:registry:sync` clean (auth-ui sources and their `registry/` copies re-synced together) · full `pnpm run test` exit 0.

Two tests failed on one full-suite run and passed in isolation and on re-run — the documented parallel-contention flakiness, confirmed against a clean baseline before attributing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)