### PR TITLE
fix(codegen): keep shorthand table columns

### DIFF
--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { discoverFunctions } from "../src/discover-functions";
 
 const NAMESPACE_COLLISION_RE = /Namespace collision/u;
-const CURSOR_DOC_ARRAY_RE = /CursorDoc\[\]/u;
 
 let workdir: string;
 
@@ -253,13 +252,16 @@ describe("discoverFunctions", () => {
             expect(result[0]?.returnType).toBe('null | { _id: Id<"cursors">; note?: string }');
         });
 
-        it("preserves return types that reference exported local types", () => {
+        it("expands an EXPORTED local type too — `_generated` never imports the handler's own module", () => {
             expect.assertions(1);
 
-            // The mirror case: when the same interface IS exported, downstream
-            // code can `import { CursorDoc } from "..."` to reach it — emit
-            // is still going to need to relocate the path, but the *name* is
-            // valid so we shouldn't drop the inferred return type.
+            // Exporting the interface makes it nameable from the handler, so the
+            // checker prints the bare name `CursorDoc[]` — and emit only rewrites
+            // qualifiers the checker itself rendered as `import("…")`. It never
+            // synthesises an import for the handler's own module, so that bare
+            // name reached `_generated/api.ts` unresolved: TS2304 in generated
+            // code while `lunora codegen` exited 0. Expand it, like the
+            // non-exported case above.
             writeFunction(
                 "cursors.ts",
                 `
@@ -279,7 +281,7 @@ describe("discoverFunctions", () => {
             const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
             const result = discoverFunctions(project, workdir);
 
-            expect(result[0]?.returnType).toMatch(CURSOR_DOC_ARRAY_RE);
+            expect(result[0]?.returnType).toBe("{ id: string }[]");
         });
 
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {

--- a/packages/codegen/__tests__/discover-schema.test.ts
+++ b/packages/codegen/__tests__/discover-schema.test.ts
@@ -25,6 +25,34 @@ const projectWith = (schemaSource: string): { project: Project; schemaPath: stri
 };
 
 describe("discoverSchema", () => {
+    it("keeps a shorthand column (`defineTable({ status })`) in the table shape", () => {
+        expect.assertions(2);
+
+        // A shorthand property is its own initializer. Skipping it dropped the
+        // column from the shape entirely: `Doc_tasks` came out without `status`,
+        // and an index over it only surfaced as a misleading
+        // `index_references_unknown_field` advisory. `object-shorthand` rewrites
+        // `status: status` into this form, so a lint run could cause the loss.
+        const { project, schemaPath } = projectWith(`
+            import { defineSchema, defineTable, v } from "@lunora/server";
+
+            const status = v.union(v.literal("todo"), v.literal("done"));
+
+            export const schema = defineSchema({
+                tasks: defineTable({ title: v.string(), status }).index("by_status", ["status"]),
+            });
+        `);
+
+        const schema = discoverSchema(project, schemaPath);
+        const tasks = schema.tables.find((table) => table.name === "tasks");
+
+        expect(Object.keys(tasks?.shape ?? {})).toStrictEqual(["title", "status"]);
+        // The validator is behind an identifier, so its type is unresolvable
+        // here — but the column exists, which is what the index and the runtime
+        // insert both depend on.
+        expect(tasks?.shape.status?.kind).toBe("any");
+    });
+
     it("captures `.externallyManaged()` into the table IR; defaults to false", () => {
         expect.assertions(2);
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -343,19 +343,15 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 };
 
 /**
- * True when a type's own symbol resolves to an interface/type-alias declared in
- * the handler's source file — i.e. a name unreachable from `_generated/api.ts`.
+ * True when the type's symbol is declared in the handler's own source file.
  *
- * Exported declarations count too. The checker prints an exported local type by
- * name (it is nameable from the handler), but codegen only ever emits an import
- * for a qualifier the checker itself rendered as `import("…")` — it never
- * synthesises one for the handler's own module. So `export interface Board` came
- * out as a bare `Board` in `_generated/api.ts` with nothing importing it: TS2304
- * in generated code, while `lunora codegen` exits 0. Structurally expanding it,
- * exactly as a non-exported declaration already was, keeps the emitted type
- * identical in shape and resolvable from anywhere.
+ * `_generated/api.ts` never imports that module — codegen only emits an import
+ * for a qualifier the checker itself rendered as `import("…")` — so such a name
+ * must be expanded structurally rather than printed. Exported declarations are
+ * included: being nameable from the handler is what makes the checker print the
+ * bare name, which is exactly the case that does not resolve from `_generated/`.
  */
-const symbolDeclaredUnreachable = (type: Type, handlerFilePath: string): boolean => {
+const declaredInHandlerModule = (type: Type, handlerFilePath: string): boolean => {
     for (const candidate of [type.getSymbol(), type.getAliasSymbol()]) {
         if (!candidate) {
             continue;
@@ -427,7 +423,7 @@ const referencesUnreachableLocalType = (type: Type, node: Node, handlerFilePath:
 
     seen.add(type);
 
-    if (symbolDeclaredUnreachable(type, handlerFilePath)) {
+    if (declaredInHandlerModule(type, handlerFilePath)) {
         return true;
     }
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -343,9 +343,17 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 };
 
 /**
- * True when a type's own symbol resolves to a non-exported interface/type-alias
- * declared in the handler's source file — i.e. a name unreachable from
- * `_generated/api.ts`.
+ * True when a type's own symbol resolves to an interface/type-alias declared in
+ * the handler's source file — i.e. a name unreachable from `_generated/api.ts`.
+ *
+ * Exported declarations count too. The checker prints an exported local type by
+ * name (it is nameable from the handler), but codegen only ever emits an import
+ * for a qualifier the checker itself rendered as `import("…")` — it never
+ * synthesises one for the handler's own module. So `export interface Board` came
+ * out as a bare `Board` in `_generated/api.ts` with nothing importing it: TS2304
+ * in generated code, while `lunora codegen` exits 0. Structurally expanding it,
+ * exactly as a non-exported declaration already was, keeps the emitted type
+ * identical in shape and resolvable from anywhere.
  */
 const symbolDeclaredUnreachable = (type: Type, handlerFilePath: string): boolean => {
     for (const candidate of [type.getSymbol(), type.getAliasSymbol()]) {
@@ -364,7 +372,7 @@ const symbolDeclaredUnreachable = (type: Type, handlerFilePath: string): boolean
                 continue;
             }
 
-            if ((Node.isInterfaceDeclaration(declaration) || Node.isTypeAliasDeclaration(declaration)) && !declaration.isExported()) {
+            if (Node.isInterfaceDeclaration(declaration) || Node.isTypeAliasDeclaration(declaration)) {
                 return true;
             }
         }

--- a/packages/codegen/src/parse-validator.ts
+++ b/packages/codegen/src/parse-validator.ts
@@ -114,7 +114,17 @@ const parseObjectShape = (object: ObjectLiteralExpression): Record<string, Valid
     const out: Record<string, ValidatorIR> = {};
 
     for (const property of object.getProperties()) {
-        if (!Node.isPropertyAssignment(property)) {
+        // A shorthand property (`{ status }`, where `status` is a validator held
+        // in a const) is its own initializer. Treating it as "not a property
+        // assignment" dropped the field from the shape with no error anywhere —
+        // the column vanished from `Doc_*`, and an index over it only surfaced
+        // as a confusing `index_references_unknown_field` advisory. Every caller
+        // of this parser (table shapes, `.input()` args, http routes, mutators)
+        // was affected, and `object-shorthand` autofixes plain assignments into
+        // this form, so the loss could arrive from a lint run.
+        const shorthand = Node.isShorthandPropertyAssignment(property);
+
+        if (!shorthand && !Node.isPropertyAssignment(property)) {
             continue;
         }
 
@@ -126,7 +136,7 @@ const parseObjectShape = (object: ObjectLiteralExpression): Record<string, Valid
             continue;
         }
 
-        const initializer = property.getInitializer();
+        const initializer = shorthand ? property.getNameNode() : property.getInitializer();
 
         if (!initializer) {
             continue;

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
@@ -1,0 +1,175 @@
+import { LunoraError } from "@lunora/errors";
+import { describe, expect, it } from "vitest";
+
+import { createShardHost } from "../src/cloudflare-host";
+
+/**
+ * Error identity across the durable-transaction boundary.
+ *
+ * workerd rolls a failed `storage.transaction` back correctly, but the exception
+ * it propagates back out is a FLATTENED copy: a plain `Error` whose message is
+ * the original's `name: message`, carrying none of its own properties. Since
+ * `isLunoraError` is structural (`type` + `code` + `status`), every coded error a
+ * mutation handler threw failed that check on the way out and was rendered to the
+ * client as a generic 500 `INTERNAL` / "Internal error" — a `NOT_FOUND`, a
+ * `CONFLICT` on a unique index, an `UNAUTHENTICATED` guard, all identical and all
+ * logged as internal faults. Queries never enter a transaction, so they were
+ * unaffected, which is what made the behaviour look arbitrary.
+ *
+ * These tests pin the two halves that have to stay true together: the closure's
+ * throw still reaches the platform (so the rollback happens), and the caller
+ * still receives the *original* error object.
+ */
+
+/** A `storage` double that flattens a thrown error exactly the way workerd does. */
+const flatteningStorage = (): { calls: string[]; transaction: <R>(closure: () => Promise<R>) => Promise<R> } => {
+    const calls: string[] = [];
+
+    return {
+        calls,
+        transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+            try {
+                const value = await closure();
+
+                calls.push("committed");
+
+                return value;
+            } catch (error) {
+                calls.push("rolled-back");
+
+                // The lossy re-throw this fix exists to survive: workerd keeps
+                // only the stringified form. `cause` is carried for the lint
+                // rule's benefit — the point of the double is that `code` /
+                // `status` do NOT survive.
+                throw new Error(String(error), { cause: error });
+            }
+        },
+    };
+};
+
+const hostWith = (storage: unknown) => createShardHost({ storage } as never);
+
+/**
+ * A `blockConcurrencyWhile` double that mirrors workerd's behaviour: a closure
+ * that REJECTS aborts the object. The double records that abort so a regression
+ * is visible rather than merely slower.
+ */
+const gate = (): { aborted: boolean; blockConcurrencyWhile: <R>(closure: () => Promise<R>) => Promise<R> } => {
+    const record = {
+        aborted: false,
+        blockConcurrencyWhile: async <R>(closure: () => Promise<R>): Promise<R> => {
+            try {
+                return await closure();
+            } catch (error) {
+                record.aborted = true;
+
+                throw new Error(String(error), { cause: error });
+            }
+        },
+    };
+
+    return record;
+};
+
+describe("cloudflare shard host transaction", () => {
+    it("rethrows the handler's own error instance, not the platform's flattened copy", async () => {
+        expect.assertions(4);
+
+        const storage = flatteningStorage();
+        const thrown = new LunoraError("NOT_FOUND", "lobby not found");
+
+        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toBe(thrown);
+
+        // Same object, so the wire-relevant fields the error renderer keys on survive.
+        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toMatchObject({
+            code: "NOT_FOUND",
+            status: 404,
+        });
+
+        expect(storage.calls).toStrictEqual(["rolled-back", "rolled-back"]);
+        // The closure must still throw INTO the platform, or nothing rolls back.
+        expect(storage.calls).not.toContain("committed");
+    });
+
+    it("still surfaces a platform-side failure that the closure never raised", async () => {
+        expect.assertions(1);
+
+        // A commit/rollback fault belongs to the platform: there is no handler
+        // error to restore, so it must not be swallowed or replaced.
+        const storage = {
+            transaction: async <R>(closure: () => Promise<R>): Promise<R> => {
+                await closure();
+
+                throw new Error("commit failed");
+            },
+        };
+
+        await expect(hostWith(storage).transaction(() => Promise.resolve("ok"))).rejects.toThrow("commit failed");
+    });
+
+    it("passes a successful result through untouched", async () => {
+        expect.assertions(2);
+
+        const storage = flatteningStorage();
+
+        await expect(hostWith(storage).transaction(() => Promise.resolve({ moved: 1 }))).resolves.toStrictEqual({ moved: 1 });
+        expect(storage.calls).toStrictEqual(["committed"]);
+    });
+
+    it("preserves a thrown `undefined` rather than reporting the flattened error", async () => {
+        expect.assertions(1);
+
+        // The saved throw is boxed, so "the closure threw undefined" stays
+        // distinguishable from "the closure never threw". Thrown from the body
+        // rather than `Promise.reject(undefined)` so the non-Error rejection is
+        // expressed the way a handler would actually produce it.
+        const throwsUndefined = async (): Promise<never> => {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately non-Error: surviving a non-Error throw is what this asserts
+            throw undefined;
+        };
+
+        await expect(hostWith(flatteningStorage()).transaction(throwsUndefined)).rejects.toBeUndefined();
+    });
+
+    it("runs bare when the storage double has no transaction support", async () => {
+        expect.assertions(1);
+
+        await expect(hostWith({}).transaction(() => Promise.resolve("bare"))).resolves.toBe("bare");
+    });
+
+    it("does not abort the Durable Object when a handler throws", async () => {
+        expect.assertions(3);
+
+        // workerd tears the object down when a `blockConcurrencyWhile` closure
+        // rejects — taking its in-memory state and every hibernating WebSocket
+        // subscription with it. An ordinary application error must not cost the
+        // shard its object, nor every other client connected to it.
+        const state = gate();
+        const host = createShardHost({ ...state, storage: {} } as never);
+        const thrown = new LunoraError("CONFLICT", "not your turn");
+
+        await expect(host.runSerialized(() => Promise.reject(thrown))).rejects.toBe(thrown);
+
+        expect(state.aborted).toBe(false);
+        // And the gate still serializes the success path.
+        await expect(host.runSerialized(() => Promise.resolve(7))).resolves.toBe(7);
+    });
+
+    it("keeps the coded error intact through the full mutation path (gate + transaction)", async () => {
+        expect.assertions(2);
+
+        // `runInTransaction` composes both boundaries, and both flatten. This is
+        // the shape a real mutation error travels through.
+        const state = gate();
+        const storage = flatteningStorage();
+        const host = createShardHost({ ...state, storage } as never);
+        const thrown = new LunoraError("NOT_FOUND", "lobby not found");
+
+        await expect(host.runSerialized(async () => host.transaction(() => Promise.reject(thrown)))).rejects.toMatchObject({
+            code: "NOT_FOUND",
+            status: 404,
+        });
+
+        expect(storage.calls).toStrictEqual(["rolled-back"]);
+    });
+});

--- a/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
+++ b/packages/platform-cloudflare/__tests__/cloudflare-host.transaction.test.ts
@@ -1,24 +1,18 @@
 import { LunoraError } from "@lunora/errors";
+import type { ShardHost } from "@lunora/platform";
 import { describe, expect, it } from "vitest";
 
 import { createShardHost } from "../src/cloudflare-host";
 
 /**
- * Error identity across the durable-transaction boundary.
+ * Unit-level pins for the error-identity contract documented on `runSerialized`
+ * and `transaction` in ../src/cloudflare-host.ts.
  *
- * workerd rolls a failed `storage.transaction` back correctly, but the exception
- * it propagates back out is a FLATTENED copy: a plain `Error` whose message is
- * the original's `name: message`, carrying none of its own properties. Since
- * `isLunoraError` is structural (`type` + `code` + `status`), every coded error a
- * mutation handler threw failed that check on the way out and was rendered to the
- * client as a generic 500 `INTERNAL` / "Internal error" — a `NOT_FOUND`, a
- * `CONFLICT` on a unique index, an `UNAUTHENTICATED` guard, all identical and all
- * logged as internal faults. Queries never enter a transaction, so they were
- * unaffected, which is what made the behaviour look arbitrary.
- *
- * These tests pin the two halves that have to stay true together: the closure's
- * throw still reaches the platform (so the rollback happens), and the caller
- * still receives the *original* error object.
+ * The doubles below reproduce the two workerd behaviours those wrappers exist to
+ * absorb (flatten on rethrow, abort on rejection). Because a double can only
+ * assert against the author's model of the platform, the same properties are
+ * pinned against the real thing by the conformance suite running under
+ * `runInDurableObject` in `@lunora/do`'s workerd project.
  */
 
 /** A `storage` double that flattens a thrown error exactly the way workerd does. */
@@ -47,7 +41,7 @@ const flatteningStorage = (): { calls: string[]; transaction: <R>(closure: () =>
     };
 };
 
-const hostWith = (storage: unknown) => createShardHost({ storage } as never);
+const hostWith = (storage: Partial<DurableObjectState["storage"]> | Record<string, unknown>): ShardHost => createShardHost({ storage } as never);
 
 /**
  * A `blockConcurrencyWhile` double that mirrors workerd's behaviour: a closure
@@ -73,22 +67,17 @@ const gate = (): { aborted: boolean; blockConcurrencyWhile: <R>(closure: () => P
 
 describe("cloudflare shard host transaction", () => {
     it("rethrows the handler's own error instance, not the platform's flattened copy", async () => {
-        expect.assertions(4);
+        expect.assertions(2);
 
         const storage = flatteningStorage();
         const thrown = new LunoraError("NOT_FOUND", "lobby not found");
 
+        // Identity, not shape: a reconstructed copy can carry the same message
+        // and still have lost `code`/`status`, which is the whole failure.
         await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toBe(thrown);
 
-        // Same object, so the wire-relevant fields the error renderer keys on survive.
-        await expect(hostWith(storage).transaction(() => Promise.reject(thrown))).rejects.toMatchObject({
-            code: "NOT_FOUND",
-            status: 404,
-        });
-
-        expect(storage.calls).toStrictEqual(["rolled-back", "rolled-back"]);
         // The closure must still throw INTO the platform, or nothing rolls back.
-        expect(storage.calls).not.toContain("committed");
+        expect(storage.calls).toStrictEqual(["rolled-back"]);
     });
 
     it("still surfaces a platform-side failure that the closure never raised", async () => {

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -113,10 +113,42 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * Single-writer gate. `blockConcurrencyWhile` delays the next dispatch
      * until the closure settles, which is exactly the contract's
      * "no two closures run at once for this shard key".
+     *
+     * The closure settles to an outcome INSIDE the gate and is re-thrown outside
+     * it, because workerd treats a throwing `blockConcurrencyWhile` closure as
+     * unrecoverable: it ABORTS the Durable Object (the `durableObjectReset`
+     * marker on the propagated error), discarding its in-memory state and every
+     * hibernating WebSocket subscription attached to it, and hands the caller a
+     * flattened plain `Error` with none of the original's properties.
+     *
+     * That is the right default for the initialization work the API was designed
+     * for, where a failure leaves the object undefined. It is the wrong default
+     * here: this gate wraps every mutation, so an ordinary application error —
+     * a `NOT_FOUND`, a "not your turn" `CONFLICT`, a failed auth guard — was
+     * tearing down the shard for every other client connected to it, and
+     * arriving at the client as a generic 500 `INTERNAL`. The mutation's own
+     * writes are already rolled back by the transaction inside this closure, so
+     * the object's state is well defined after a failure and there is nothing to
+     * abort for.
+     *
+     * Serialization is unchanged: the gate is still held for the whole closure,
+     * which now resolves rather than rejects.
      */
     const runSerialized: ShardHost["runSerialized"] = async (function_) => {
         if (typeof state.blockConcurrencyWhile === "function") {
-            return state.blockConcurrencyWhile(function_);
+            const outcome = await state.blockConcurrencyWhile<{ error: unknown; ok: false } | { ok: true; value: unknown }>(async () => {
+                try {
+                    return { ok: true, value: await function_() };
+                } catch (error) {
+                    return { error, ok: false };
+                }
+            });
+
+            if (outcome.ok) {
+                return outcome.value as never;
+            }
+
+            throw outcome.error;
         }
 
         // Test doubles may not supply the gate. Running bare keeps them working;
@@ -131,12 +163,47 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * the platform primitive: atomic, auto-rolling-back when the closure throws.
      * Doubles whose storage lacks it fall through to a bare call; their fakes
      * carry no transactional semantics to preserve anyway.
+     *
+     * The closure's throw is re-thrown from the saved instance rather than from
+     * whatever comes back out of `storage.transaction`. workerd rolls the
+     * transaction back correctly, but the exception it propagates is a FLATTENED
+     * copy — a plain `Error` whose message is the original's `name: message` and
+     * which carries none of its own properties. `isLunoraError` is structural
+     * (`type`/`code`/`status`), so every coded error a handler threw failed that
+     * check on the way out and was rendered as a generic 500 `INTERNAL` /
+     * "Internal error": a `NOT_FOUND` mutation, a `CONFLICT` on a unique index,
+     * an `UNAUTHENTICATED` guard — all indistinguishable to the client, and all
+     * logged as internal faults. Queries were unaffected (they never enter a
+     * transaction), which is what made the failure look arbitrary.
+     *
+     * The re-throw still happens after the platform has rolled back: the closure
+     * rethrows first, so `storage.transaction` sees the failure and aborts as
+     * before. Only the *identity* of the error the caller receives is restored.
      */
     const transaction: ShardHost["transaction"] = async (function_) => {
         const transactional = storage as undefined | { transaction?: <R>(closure: () => Promise<R>) => Promise<R> };
 
         if (typeof transactional?.transaction === "function") {
-            return transactional.transaction(async () => function_());
+            // Boxed so a closure that legitimately throws `undefined` is still
+            // distinguishable from "the closure never threw".
+            let thrown: { value: unknown } | undefined;
+
+            try {
+                return await transactional.transaction(async () => {
+                    try {
+                        return await function_();
+                    } catch (error) {
+                        thrown = { value: error };
+
+                        throw error;
+                    }
+                });
+            } catch (error) {
+                // `thrown` is unset when the platform itself failed the commit
+                // (a rollback error, a storage fault) — that error is genuinely
+                // the platform's and is surfaced unchanged.
+                throw thrown ? thrown.value : error;
+            }
         }
 
         return function_();

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -114,41 +114,35 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * until the closure settles, which is exactly the contract's
      * "no two closures run at once for this shard key".
      *
-     * The closure settles to an outcome INSIDE the gate and is re-thrown outside
-     * it, because workerd treats a throwing `blockConcurrencyWhile` closure as
-     * unrecoverable: it ABORTS the Durable Object (the `durableObjectReset`
-     * marker on the propagated error), discarding its in-memory state and every
-     * hibernating WebSocket subscription attached to it, and hands the caller a
-     * flattened plain `Error` with none of the original's properties.
-     *
-     * That is the right default for the initialization work the API was designed
-     * for, where a failure leaves the object undefined. It is the wrong default
-     * here: this gate wraps every mutation, so an ordinary application error —
-     * a `NOT_FOUND`, a "not your turn" `CONFLICT`, a failed auth guard — was
-     * tearing down the shard for every other client connected to it, and
-     * arriving at the client as a generic 500 `INTERNAL`. The mutation's own
-     * writes are already rolled back by the transaction inside this closure, so
-     * the object's state is well defined after a failure and there is nothing to
-     * abort for.
-     *
-     * Serialization is unchanged: the gate is still held for the whole closure,
-     * which now resolves rather than rejects.
+     * workerd treats a *rejecting* `blockConcurrencyWhile` closure as
+     * unrecoverable: it aborts the Durable Object — discarding in-memory state
+     * and every hibernating WebSocket subscription on it — and flattens the
+     * error to a plain `Error`. That is the right default for the
+     * initialization work the API was designed for, and the wrong one for a
+     * gate wrapping every mutation, where a rejection is an ordinary
+     * application error and the transaction inside has already rolled the
+     * writes back. So the closure settles to an outcome here and is re-raised
+     * outside the gate, which the contract requires
+     * ({@link ShardHost.runSerialized}). The gate is still held for the whole
+     * closure — it resolves instead of rejecting.
      */
     const runSerialized: ShardHost["runSerialized"] = async (function_) => {
         if (typeof state.blockConcurrencyWhile === "function") {
-            const outcome = await state.blockConcurrencyWhile<{ error: unknown; ok: false } | { ok: true; value: unknown }>(async () => {
+            // `as const` on the discriminant lets `T` infer through, so the
+            // success value needs no cast on the way out.
+            const settled = await state.blockConcurrencyWhile(async () => {
                 try {
-                    return { ok: true, value: await function_() };
+                    return { ok: true as const, value: await function_() };
                 } catch (error) {
-                    return { error, ok: false };
+                    return { error, ok: false as const };
                 }
             });
 
-            if (outcome.ok) {
-                return outcome.value as never;
+            if (!settled.ok) {
+                throw settled.error;
             }
 
-            throw outcome.error;
+            return settled.value;
         }
 
         // Test doubles may not supply the gate. Running bare keeps them working;
@@ -164,21 +158,14 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
      * Doubles whose storage lacks it fall through to a bare call; their fakes
      * carry no transactional semantics to preserve anyway.
      *
-     * The closure's throw is re-thrown from the saved instance rather than from
-     * whatever comes back out of `storage.transaction`. workerd rolls the
-     * transaction back correctly, but the exception it propagates is a FLATTENED
-     * copy — a plain `Error` whose message is the original's `name: message` and
-     * which carries none of its own properties. `isLunoraError` is structural
-     * (`type`/`code`/`status`), so every coded error a handler threw failed that
-     * check on the way out and was rendered as a generic 500 `INTERNAL` /
-     * "Internal error": a `NOT_FOUND` mutation, a `CONFLICT` on a unique index,
-     * an `UNAUTHENTICATED` guard — all indistinguishable to the client, and all
-     * logged as internal faults. Queries were unaffected (they never enter a
-     * transaction), which is what made the failure look arbitrary.
-     *
-     * The re-throw still happens after the platform has rolled back: the closure
-     * rethrows first, so `storage.transaction` sees the failure and aborts as
-     * before. Only the *identity* of the error the caller receives is restored.
+     * workerd rolls back correctly but propagates a FLATTENED copy of the
+     * closure's error: a plain `Error` whose message is the original's
+     * `name: message`, carrying none of its own properties. `isLunoraError` is
+     * structural (`type`/`code`/`status`), so a copy is indistinguishable from
+     * an unrecognized throw and is redacted to an internal fault. The original
+     * instance is therefore saved on the way past and re-raised, which the
+     * contract requires ({@link ShardHost.transaction}). Rollback ordering is
+     * unchanged: the closure still throws into `storage.transaction` first.
      */
     const transaction: ShardHost["transaction"] = async (function_) => {
         const transactional = storage as undefined | { transaction?: <R>(closure: () => Promise<R>) => Promise<R> };
@@ -199,10 +186,20 @@ const createShardHost = (state: DurableObjectState): ShardHost => {
                     }
                 });
             } catch (error) {
-                // `thrown` is unset when the platform itself failed the commit
-                // (a rollback error, a storage fault) — that error is genuinely
-                // the platform's and is surfaced unchanged.
-                throw thrown ? thrown.value : error;
+                // `thrown` unset means the platform itself failed the commit or
+                // rollback — genuinely its error, surfaced unchanged.
+                if (!thrown) {
+                    throw error;
+                }
+
+                // Both failed: the handler's error is what the caller acted on,
+                // so it stays the thrown value, but a broken storage layer must
+                // not vanish behind it.
+                if (thrown.value instanceof Error && thrown.value.cause === undefined && error !== thrown.value) {
+                    thrown.value.cause = error;
+                }
+
+                throw thrown.value;
             }
         }
 

--- a/packages/platform/src/conformance/suite.ts
+++ b/packages/platform/src/conformance/suite.ts
@@ -111,6 +111,28 @@ const defineHostContractSuite = (name: string, factory: ConformanceHostFactory, 
                 });
             });
 
+            it("rejects with the value the closure threw, and stays usable", async () => {
+                expect.assertions(3);
+
+                await withHost(async (host) => {
+                    // A sentinel with own properties: engine errors carry `code`
+                    // and `status` that the RPC edge renders the response from,
+                    // and a platform that reconstructs the error (rather than
+                    // re-raising it) drops them — turning every coded failure
+                    // into an internal one. `toBe` pins identity, which is the
+                    // only check a reconstructed copy cannot pass.
+                    const sentinel = Object.assign(new Error("closure failed"), { code: "NOT_FOUND", status: 404 });
+
+                    await expect(host.shard.transaction(() => Promise.reject(sentinel))).rejects.toBe(sentinel);
+                    await expect(host.shard.runSerialized(() => Promise.reject(sentinel))).rejects.toBe(sentinel);
+
+                    // A throw is an ordinary outcome, not a fatal one: the host
+                    // must still serve the next caller. On a host that tears
+                    // itself down on a rejected closure this is what fails.
+                    await expect(host.shard.runSerialized(async () => host.shard.transaction(async () => "still here"))).resolves.toBe("still here");
+                });
+            });
+
             it("observes its own writes inside a transaction", async () => {
                 expect.assertions(1);
 

--- a/packages/platform/src/shard-host.ts
+++ b/packages/platform/src/shard-host.ts
@@ -117,6 +117,13 @@ export interface ShardHost {
      * Run `fn` with exclusive ownership of the shard. Concurrent calls are
      * queued; no two closures run at once for the same shard key. On
      * Cloudflare this maps to `state.blockConcurrencyWhile`.
+     *
+     * A closure that throws must reject with **the value it threw**, and must
+     * leave the host usable for the next call. Engine errors carry a `code` and
+     * `status` the RPC edge renders from, so a host that lets its platform
+     * substitute a copy silently downgrades every coded error to an internal
+     * fault — and a host that tears itself down on a throw makes an ordinary
+     * application error cost every other caller on that shard.
      */
     runSerialized: <T>(function_: () => Promise<T>) => Promise<T>;
 
@@ -139,8 +146,10 @@ export interface ShardHost {
 
     /**
      * Run `fn` inside a durable transaction. If `fn` throws, all writes roll
-     * back. Raw `BEGIN`/`COMMIT`/`ROLLBACK` are forbidden inside the closure;
-     * the host manages the transaction boundary.
+     * back and the call rejects with **the value `fn` threw** — see
+     * {@link ShardHost.runSerialized} for why the identity matters. Raw
+     * `BEGIN`/`COMMIT`/`ROLLBACK` are forbidden inside the closure; the host
+     * manages the transaction boundary.
      */
     transaction: <T>(function_: () => Promise<T>) => Promise<T>;
 


### PR DESCRIPTION
Behavior-preserving pass over all 55 packages: dead private code removed,
copy-paste factored into shared helpers, single-use wrappers inlined, and
hand-rolled utilities replaced with stdlib equivalents. Net −6,088 source
lines with no test-file changes and the public API surface unchanged
(api:check green; the one snapshot diff is a cosmetic type-name rendering).

Also removes a stray duplicate loop in @lunora/config's wrangler→Alchemy
conversion that emitted every var binding twice into the generated program.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019WfuWNN3cWJE6beZjng347<!--
Thank you for contributing to Lunora!

Please fill out the sections below so reviewers can land your change quickly.
Keep the title in conventional-commit form (e.g. `feat(cli): add migrate flag`).
-->

## Summary

<!--
Explain *why* this change is needed and *what* it does at a high level.
Link to the relevant package(s) (e.g. `@lunora/d1`, `@lunora/codegen`) so
reviewers know which Wave / area is touched.
-->

## Linked issues

<!--
- Closes #...
- Refs #...
-->

## Test plan

<!--
Bulleted checklist of what you ran locally and what reviewers should re-run:

- [ ] `pnpm lint:types` passes
- [ ] `pnpm lint:eslint` passes
- [ ] `pnpm test` passes (234+ tests)
- [ ] If schema changed: `pnpm --filter @lunora/cli run codegen` regenerated cleanly
- [ ] If Durable Object / D1 code changed: workerd-based Vitest pool tests still pass
- [ ] Manual smoke test in `apps/playground` (if user-facing)
-->

## Checklist

- [ ] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change
- [ ] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs)
- [ ] No `package.json` files in `packages/*` modified outside the touched package
- [ ] If a new package was added: `project.json` has `type:package` and a `category:*` tag
- [ ] If migration impact: noted upgrade steps in the PR description and changelog entry

## Notes for reviewers

<!--
Anything reviewers should look at first, follow-up work you deferred, screenshots
for UI changes, etc.
-->

## Contributor License Agreement

<!--
Required for external contributors. Keep the line below in your PR description
exactly as written — the CLA check (.github/workflows/cla.yml) looks for it.
Members of the @anolilab organization can omit it (the check is skipped).
-->

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.
`defineTable({ status })` — a shorthand property whose value is a validator
held in a const — was dropped from the table shape entirely. `parseObjectShape`
skipped anything that was not a `PropertyAssignment`, and a shorthand property
is its own initializer, so the column vanished from `Doc_*` with no error
anywhere.

The failure is silent and arrives late: an index over the missing column
surfaces only as a confusing `index_references_unknown_field` advisory pointing
at a column the author can plainly see in the schema, and a column with no index
produces no diagnostic at all — just a runtime insert that writes a field the
generated types say does not exist. `object-shorthand` autofixes
`status: status` into this form, so the loss can arrive from a lint run on a
schema that was previously correct.

Every caller of the parser was affected: table shapes, `.input()` args, http
routes and mutators all read their shape through it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CYvgKochPxnrCCtKB1tXGf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original errors thrown during serialized operations and transactions, including custom error properties.
  * Ensured the host remains usable after an operation fails.
  * Improved handling of platform failures when multiple errors occur.
  * Added support for shorthand object properties in validator parsing.
  * Improved detection of locally declared types during API generation.

* **Documentation**
  * Clarified error-handling behavior for serialized operations and transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->