### PR TITLE
fix(ci): bump codecov-action to v5.5.5 for GPG key fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@
             - "name": "Upload coverage to Codecov"
               "if": "matrix.node_version == '22.15' && (github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository)"
               "continue-on-error": true
-              "uses": "codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7" # v5.5.1
+              "uses": "codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac" # v5.5.5
               "with":
                   "token": "${{ secrets.CODECOV_TOKEN }}"
                   "fail_ci_if_error": false


### PR DESCRIPTION
## Summary

The `codecov-action` installer fails to verify the CLI's GPG signature because Codecov's signing key (`27034E7FDB850E0BBC2C62FF806BB28AED779869`) was on the deleted `codecovsecurity` keybase.io account — the runner can't import the public key, so the `SHA256SUM.sig` check fails with "Can't check signature: No public key".

[v5.5.5](https://github.com/codecov/codecov-action/releases/tag/v5.5.5) is a patch release that fixes exactly this — its only change is the keybase.io key migration to the `codecovsecops` account (using the original GPG key). No other changes, no breaking risk.

- `codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7` (v5.5.1) → `codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac` (v5.5.5)

## Test plan

- [x] YAML validates
- [ ] CI run shows "Codecov: OK" with no GPG warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code coverage reporting workflow to use a newer Codecov Action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->