### PR TITLE
feat(db): guard against duplicate table bindings

### DIFF
--- a/apps/docs/src/content/docs/concepts/local-first.mdx
+++ b/apps/docs/src/content/docs/concepts/local-first.mdx
@@ -201,6 +201,14 @@ and `bindMutators` runs the optimistic transaction + the watermarked server push
 Framework adapters add a thin `useMutator(handle)` hook over the bound handle —
 reads stay on the existing `useLiveQuery`, no new query hook needed.
 
+The synced collection is the **one source of truth** for its rows. Don't mirror
+them into a parallel store of your own — a write, a rollback, or a sync delta
+lands only on the Lunora collection, so a derived index (a tree, a search index,
+an undo capture) built from a copy can silently read stale rows while the UI
+renders through `useLiveQuery`. When you adopt Lunora over an existing store,
+delete the old read paths rather than keeping both. See [One source of truth per
+table](/docs/packages/db#one-source-of-truth-per-table).
+
 Each server mutator is generated as a typed reference on `api.mutators.<name>`,
 so the client body **binds to it** rather than naming it in a string:
 

--- a/packages/cli/skills/lunora-realtime/SKILL.md
+++ b/packages/cli/skills/lunora-realtime/SKILL.md
@@ -167,6 +167,13 @@ schema + functions into live TanStack DB collections). Reach for it when the app
 needs client-side indexes/joins or a persistent optimistic outbox; raw `useQuery`
 /`useMutation` are enough for straightforward live lists.
 
+Call `defineCollections` **once** at module scope and treat the returned
+collections as the single source of truth for each table. Don't mirror rows into
+a parallel store, and never build derived indexes (trees, search, undo captures)
+from a copy — optimistic writes and sync deltas land only on the Lunora
+collection, so code reading a copy silently reads stale rows while `useLiveQuery`
+renders fresh data.
+
 ## Common Pitfalls
 
 1. **Creating `LunoraClient` inside a component.** It re-opens the socket every
@@ -178,6 +185,10 @@ needs client-side indexes/joins or a persistent optimistic outbox; raw `useQuery
 4. **Optimistic shape drift.** The provisional value must match the query's
    element shape (including `_id`/`_creationTime`) or the UI flickers when the
    real delta lands.
+5. **Two sources of truth for the same rows.** `defineCollections` more than once
+   per table (or a parallel store of your own) mints copies that drift — reads
+   through `useLiveQuery` look fine while derived indexes built from the copy
+   silently miss or stale rows. One instance, one collection per table.
 
 ## Checklist
 
@@ -188,3 +199,5 @@ needs client-side indexes/joins or a persistent optimistic outbox; raw `useQuery
 - [ ] Query `args` scoped narrowly to avoid over-broad re-renders.
 - [ ] Pagination via `usePaginatedQuery`/`useInfiniteQuery` over `.paginate`.
 - [ ] Considered `@lunora/db` if the app needs local indexes/joins or an outbox.
+- [ ] `@lunora/db`: one `defineCollections` instance; no parallel copy of rows;
+      derived indexes built from the same collection the UI renders.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -85,6 +85,12 @@ export const createCollections = (client: LunoraClient) =>
 
 > `vis generate lunora-collections` scaffolds this from your `schema.ts` + functions.
 
+Keep a **single `db` instance**, and treat its collections as the one source of
+truth per table — don't mirror rows into your own store. A derived index (a tree,
+a search index, an undo capture) built from a copy of the rows can silently read
+stale data while the UI renders through `useLiveQuery`. See [One source of truth
+per table](https://lunora.sh/docs/addons/db#one-source-of-truth-per-table).
+
 ### Local-first sync engine
 
 Beyond whole-table collections, the `@lunora/db/collections` and

--- a/packages/db/__tests__/define-collections.test.ts
+++ b/packages/db/__tests__/define-collections.test.ts
@@ -392,4 +392,29 @@ describe(defineCollections, () => {
             vi.unstubAllGlobals();
         }
     });
+
+    it("warns once when a table is bound by a second defineCollections call on the same client", () => {
+        const { client } = makeClient();
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        try {
+            const first = defineCollections(client, { users: { list: usersList } } as never);
+            executors.push(first.executor);
+
+            // A disjoint table on the same client is legitimate — no warning.
+            const disjoint = defineCollections(client, { messages: { list: messagesList } } as never);
+            executors.push(disjoint.executor);
+
+            expect(warn).not.toHaveBeenCalled();
+
+            // Re-binding `users` on the same client mints a second live copy.
+            const duplicate = defineCollections(client, { users: { list: usersList } } as never);
+            executors.push(duplicate.executor);
+
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(String(warn.mock.calls[0]?.[0])).toContain("users");
+        } finally {
+            warn.mockRestore();
+        }
+    });
 });

--- a/packages/db/docs/index.mdx
+++ b/packages/db/docs/index.mdx
@@ -96,7 +96,8 @@ export const createCollections = (client: LunoraClient) =>
 ```
 
 Build it once (it owns the outbox, so keep a single instance) and use it in your
-components:
+components. The collections it returns are the single source of truth per table —
+see [One source of truth per table](#one-source-of-truth-per-table):
 
 ```tsx
 import { useLiveQuery } from "@tanstack/react-db";
@@ -116,6 +117,33 @@ function Chat({ channelId }: { channelId: Id<"channels"> }) {
     return; /* … */
 }
 ```
+
+## One source of truth per table
+
+Each table's rows live in exactly one place: the collection `defineCollections`
+created for it. Keep a **single `db` instance** and never mirror a collection's
+rows into a parallel store of your own — a hand-rolled cache, a global store, or
+a second `createCollection`. The two can only diverge: an optimistic write, a
+rollback, or an incoming sync delta is applied to the Lunora collection, not to
+your copy.
+
+The failure is quiet. Code that reads the copy doesn't error — it reads **stale**
+rows. A derived index (a tree, a search index, an undo capture) built from the
+copy runs against data that no longer matches what the UI renders through
+`useLiveQuery`, so the symptom is "this command does nothing" or a confusing
+refusal, not a crash. When Lunora collections are the live read path, make them
+the _only_ read path:
+
+- Read through `db.collections.*` / `useLiveQuery` everywhere. Don't re-export
+  rows from your own store into code that is supposed to be Lunora-backed.
+- Don't copy a collection out to "cache" it — it already is the live, indexed
+  cache. Copy only for a concrete snapshot you pass by value (an export, a
+  payload).
+- When adopting Lunora over an existing store, delete the old read paths rather
+  than keeping both. Code left on the old path is precisely what silently misses
+  rows after a migration.
+- Build derived indexes from the same collection you render from, so an index and
+  the UI that consumes it can't disagree.
 
 ## Reads — live, indexed queries
 

--- a/packages/db/src/define-collections.ts
+++ b/packages/db/src/define-collections.ts
@@ -89,6 +89,42 @@ type RowOf<C extends AnyDef> = C["list"] extends FunctionReference<infer _K, inf
 /** The action input type, inferred structurally from the def's optimistic insert. */
 type InputOf<C> = C extends { insert: { optimistic: (input: infer I, id: string) => unknown } } ? I : never;
 
+/**
+ * One-shot diagnostic for a table bound by more than one `defineCollections`
+ * call on the same client. Each call mints its own live collection *and* its own
+ * outbox for that table, so the copies can only drift — an optimistic write or
+ * sync delta lands on one, and code that reads the other silently reads stale
+ * rows (the quiet failure the "One source of truth per table" docs section warns
+ * about). Keyed by client + table name, so a fresh client or a split into two
+ * calls with *disjoint* tables is never penalised.
+ */
+const duplicateTableBindings = new WeakMap<LunoraClient, Map<string, number>>();
+
+const warnDuplicateTable = (client: LunoraClient, name: string): void => {
+    let bindings = duplicateTableBindings.get(client);
+
+    if (bindings === undefined) {
+        bindings = new Map();
+        duplicateTableBindings.set(client, bindings);
+    }
+
+    const count = bindings.get(name) ?? 0;
+
+    bindings.set(name, count + 1);
+
+    // Warn exactly when the second binding happens (the first is legitimate).
+    if (count !== 1) {
+        return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+        `[@lunora/db] table "${name}" is bound by more than one defineCollections call on this client. Each call creates its ` +
+            `own live collection and outbox for the table, so the two can drift and derived indexes built from one can silently ` +
+            `read stale rows. Bind every table in a single defineCollections call (see the "One source of truth per table" docs section).`,
+    );
+};
+
 /** A queued write that was permanently dropped, passed to {@link DefineCollectionsOptions.onWriteRejected}. */
 export interface WriteRejectedEvent {
     /**
@@ -182,6 +218,11 @@ export interface LunoraDb<D extends Record<string, AnyDef>> {
  *
  * This is the hand-written form; `@lunora/codegen` can emit a fully-typed call to
  * it from `schema.ts`, so an app writes nothing.
+ *
+ * Keep a single instance and treat the returned collections as the one source of
+ * truth per table — do not mirror rows into a parallel store, or derived indexes
+ * built from the copy can silently read stale data (see the `@lunora/db` docs,
+ * "One source of truth per table").
  */
 export const defineCollections = <D extends Record<string, AnyDef>>(client: LunoraClient, defs: D, options: DefineCollectionsOptions = {}): LunoraDb<D> => {
     const collections: Record<string, Collection<Row, string>> = {};
@@ -192,6 +233,8 @@ export const defineCollections = <D extends Record<string, AnyDef>>(client: Luno
 
     for (const [name, definition] of entries) {
         const insert = definition.insert as InsertBinding<Row, unknown> | undefined;
+
+        warnDuplicateTable(client, name);
 
         // Build the live-sync read path from the shared collection-options core
         // (same diff-into-channel + auto-index + scoped-resubscribe behavior).


### PR DESCRIPTION
## Summary

Closes a quiet client-data footgun in `@lunora/db`: a table's rows can end up
living in two places — a second `defineCollections` call on the same client, or
a parallel store the app keeps alongside the synced collection. Optimistic
writes, rollbacks and sync deltas land on the Lunora collection, never on the
copy, so anything that builds a derived index (a tree, a search index, an undo
capture) from the copy silently reads stale rows while `useLiveQuery` renders
fresh data. The symptom is "this command does nothing" or a confusing refusal,
not a crash — there is no error to chase.

This change has two parts:

- **Runtime diagnostic** (`@lunora/db`): `defineCollections` now emits a one-shot
  `console.warn` when a table is bound by a second call on the same client —
  each call mints its own live collection *and* its own outbox for that table.
  Keyed by client + table name via a `WeakMap`, so splitting a single binding
  into two calls with *disjoint* tables is never penalised. No public API
  change; the helper is module-private, so `api:check` is unaffected.
- **Docs** (`@lunora/db` docs + README, the `local-first` concept page, and the
  `lunora-realtime` skill): a "One source of truth per table" section naming the
  failure mode and the rules (read only `db.collections.*` / `useLiveQuery`,
  don't mirror rows to cache them, delete old read paths when adopting Lunora,
  build derived indexes from the same collection you render from).

## Linked issues

None

## Test plan

- [x] `pnpm --filter @lunora/db run lint:types` passes
- [x] `pnpm --filter @lunora/db run test` passes (86 tests, incl. the new
      duplicate-binding warning test)
- [x] Prettier clean on all touched files
- [x] ESLint clean on the touched source/test files (the package's remaining
      `lint:eslint` errors are pre-existing in files not touched here)

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [x] Added or updated tests covering the change
- [x] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs)
- [x] No `package.json` files in `packages/*` modified outside the touched package
- [ ] If a new package was added: `project.json` has `type:package` and a `category:*` tag
- [ ] If migration impact: noted upgrade steps in the PR description and changelog entry

## Notes for reviewers

- The warning is unconditional (not gated on `NODE_ENV`), matching the package's
  existing one-shot `console.warn` precedent for the checkpoint fallback — a
  duplicate binding is a real misconfiguration, not just a DX nicety.
- The `docs(db)` commit carries `packages/cli/skills/lunora-realtime/SKILL.md` —
  that file is tracked under the CLI package but is guidance content about
  `@lunora/db`, so it rides the `db` scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance recommending synced collections as the single source of truth for table data.
  * Clarified how to avoid stale parallel stores, copied data, and legacy read paths.
  * Added best practices for maintaining one database instance and building indexes from live collections.
  * Updated quick-start and realtime guidance with migration tips and implementation checklists.

* **Bug Fixes**
  * Added a warning when the same table is bound more than once for a client, helping identify potentially conflicting data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->