### PR TITLE
fix(repo): empty the stale project.json allowlist

### DIFF
--- a/scripts/check-project-json-targets.js
+++ b/scripts/check-project-json-targets.js
@@ -42,7 +42,7 @@ import { fileURLToPath } from "node:url";
  * fails when an allowlisted project is CLEAN or gone, so the entry cannot
  * outlive the fix it points at.
  */
-const KNOWN_UNMIGRATED = new Map([["packages/svelte/project.json", "plan 302 phase 6 — un-skip once its eslint findings are cleared"]]);
+const KNOWN_UNMIGRATED = new Map();
 
 /** The pnpm workspace globs, minus the trailing `/*` — every project.json lives under one. */
 const WORKSPACE_DIRECTORIES = ["apps", "examples", "packages", "tests"];


### PR DESCRIPTION
## What

`alpha` is red on `Lint (eslint)` → `Check project.json target shapes`, and every open PR inherits it through `refs/pull/N/merge`.

```
❌ 1 entr(y/ies) in KNOWN_UNMIGRATED describe an already-clean project:
   packages/svelte/project.json — remove it from scripts/check-project-json-targets.js
```

This empties the allowlist. One line.

## Why it fired

The check fails on a **stale** entry as well as a missing one — deliberately, because that is what stops an allowlist decaying into a permanent exemption. #364 added the guard with `packages/svelte` listed as still-unmigrated; #363 made `packages/svelte` clean. Each was correct alone, and the pair was fine in either order until **both** landed. The second merge turned the debt marker into a lie and the check said so.

This was called out as a merge-order dependency in both PR bodies — whichever landed second had to empty the map — and was not done at merge time. The mechanism is working as designed; this is the follow-through it was waiting for.

## Verification

Against `origin/alpha` before the change: `node scripts/check-project-json-targets.js` → exit 1 with the message above. After: `✅ 72 of 72 project.json files declare no silently-skipped target.`, exit 0. Prettier clean.

The guard keeps its teeth — the stale-entry branch is untouched, so the next allowlist entry still cannot outlive its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sk9BLaUZDkPVAZ1sKhuDP
