### PR TITLE
fix(shard-engine): quote json path segments that misparse

### DIFF
--- a/packages/shard-engine/__tests__/do-sql.json-path.test.ts
+++ b/packages/shard-engine/__tests__/do-sql.json-path.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { jsonPath, qualifiedJsonPath } from "../src/do-sql";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * A document holding BOTH a flat `"a.b"` key and a nested `a: { b }` — the pair
+ * the unquoted `$.a.b` path conflated.
+ */
+const DOCUMENT = JSON.stringify({
+    a: { b: "nested" },
+    "a.b": "flat",
+    "back\\slash": "bs",
+    "br[k]": "bracket",
+    "it's": "apostrophe",
+    'q"x': "quote",
+    status: "open",
+});
+
+/** Read a document key through the path `jsonPath` builds for it, on a real SQLite build. */
+const readThroughPath = (field: string): unknown => {
+    const { close, raw } = createSqliteExec();
+
+    try {
+        return raw(`SELECT ${jsonPath(field).replace("__doc__", "?")} AS value`, DOCUMENT)[0]?.["value"];
+    } finally {
+        close();
+    }
+};
+
+describe("jsonPath", () => {
+    it("emits the historical bare path for an identifier-safe field, byte for byte", () => {
+        expect.assertions(4);
+
+        // These strings are the expression text of the CREATE INDEXes already on
+        // disk in every deployed shard. SQLite matches an expression index to a
+        // query by comparing that text, so a change here silently unuses them.
+        expect(jsonPath("status")).toBe("json_extract(__doc__, '$.status')");
+        expect(jsonPath("authorId")).toBe("json_extract(__doc__, '$.authorId')");
+        expect(jsonPath("_deletedAt")).toBe("json_extract(__doc__, '$._deletedAt')");
+        expect(jsonPath("$ref")).toBe("json_extract(__doc__, '$.$ref')");
+    });
+
+    it("keeps mapping the internal columns to their stored columns", () => {
+        expect.assertions(3);
+
+        expect(jsonPath("_id")).toBe("id");
+        expect(jsonPath("id")).toBe("id");
+        expect(jsonPath("_creationTime")).toBe("_creationTime");
+    });
+
+    it("quotes a field the bare JSON-path grammar would misparse", () => {
+        expect.assertions(4);
+
+        expect(jsonPath("a.b")).toBe(`json_extract(__doc__, '$."a.b"')`);
+        expect(jsonPath("br[k]")).toBe(`json_extract(__doc__, '$."br[k]"')`);
+        expect(jsonPath("sp ace")).toBe(`json_extract(__doc__, '$."sp ace"')`);
+        expect(jsonPath("it's")).toBe(`json_extract(__doc__, '$."it''s"')`);
+    });
+
+    it("escapes both JSON-string metacharacters inside the quoted segment", () => {
+        expect.assertions(2);
+
+        expect(jsonPath('q"x')).toBe(String.raw`json_extract(__doc__, '$."q\"x"')`);
+        expect(jsonPath(String.raw`back\slash`)).toBe(String.raw`json_extract(__doc__, '$."back\\slash"')`);
+    });
+});
+
+describe("qualifiedJsonPath", () => {
+    it("qualifies the bare form without otherwise changing it", () => {
+        expect.assertions(2);
+
+        expect(qualifiedJsonPath("messages", "status")).toBe(`json_extract("messages".__doc__, '$.status')`);
+        expect(qualifiedJsonPath("messages", "_id")).toBe(`"messages".id`);
+    });
+
+    it("quotes the segment on the qualified path too (EXISTS correlation refs)", () => {
+        expect.assertions(1);
+
+        expect(qualifiedJsonPath("messages", "a.b")).toBe(`json_extract("messages".__doc__, '$."a.b"')`);
+    });
+});
+
+describe("jsonPath against a real SQLite build", () => {
+    it("addresses the flat key rather than traversing into the nested one", () => {
+        expect.assertions(2);
+
+        // The defect: `$.a.b` reads `a` then `b`, so this used to return "nested".
+        expect(readThroughPath("a.b")).toBe("flat");
+        expect(readThroughPath("a")).toBe(`{"b":"nested"}`);
+    });
+
+    it("round-trips every field the bare grammar cannot carry", () => {
+        expect.assertions(4);
+
+        expect(readThroughPath("br[k]")).toBe("bracket");
+        expect(readThroughPath('q"x')).toBe("quote");
+        expect(readThroughPath(String.raw`back\slash`)).toBe("bs");
+        expect(readThroughPath("it's")).toBe("apostrophe");
+    });
+
+    it("still reads an ordinary field", () => {
+        expect.assertions(1);
+
+        expect(readThroughPath("status")).toBe("open");
+    });
+});

--- a/packages/shard-engine/__tests__/introspect.test.ts
+++ b/packages/shard-engine/__tests__/introspect.test.ts
@@ -173,6 +173,24 @@ describe("introspect", () => {
             expect(page.rows.map((row) => row["title"])).toEqual(["alpha", "beta", "gamma"]);
         });
 
+        it("addresses a __doc__ field whose name the bare JSON-path grammar cannot carry", () => {
+            expect.assertions(2);
+
+            // `a.b` used to become `$.a.b` (the nested key) and `q"x` was escaped
+            // with the SQL-identifier `""` doubling, which is not a JSON-path
+            // escape at all — both read NULL or the wrong slot.
+            database.raw(`CREATE TABLE "odd" ("id" TEXT PRIMARY KEY, "_creationTime" INTEGER, "__doc__" TEXT)`);
+            database.raw(
+                String.raw`INSERT INTO "odd" VALUES ('o1', 1, '{"a.b":"flat","a":{"b":"nested"},"q\"x":"beta"}'), ('o2', 2, '{"a.b":"flatter","a":{"b":"nested"},"q\"x":"alpha"}')`,
+            );
+
+            const byFlat = readTablePage(database.sql, { orderBy: { column: "a.b", direction: "asc" }, table: "odd" });
+            const byQuoted = readTablePage(database.sql, { orderBy: { column: 'q"x', direction: "asc" }, table: "odd" });
+
+            expect(byFlat.rows.map((row) => row["a.b"])).toEqual(["flat", "flatter"]);
+            expect(byQuoted.rows.map((row) => row["id"])).toEqual(["o2", "o1"]);
+        });
+
         it("rejects an unknown table", () => {
             expect.assertions(1);
 

--- a/packages/shard-engine/src/do-sql.ts
+++ b/packages/shard-engine/src/do-sql.ts
@@ -16,6 +16,7 @@
 import type { Name, SQL } from "drizzle-orm";
 import { sql as dsql } from "drizzle-orm";
 
+import { jsonPathSegment } from "../../../shared/json-path-segment";
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { ColumnMetaLike, SqlExec, TableDefinitionLike } from "./ctx-db";
@@ -65,7 +66,11 @@ const documentPath = (prefix: string, field: string): string => {
         return `${prefix}_creationTime`;
     }
 
-    return `json_extract(${prefix}${DOC_COLUMN}, '$.${field.replaceAll("'", "''")}')`;
+    // Two grammars, both owed, in this order: `jsonPathSegment` quotes for
+    // SQLite's JSON-path grammar (`a.b` is one key, not a nested lookup), then
+    // `'` doubling escapes the finished path for the SQL string literal it sits
+    // in. Doing only the second is what let `$.a.b` read the wrong slot.
+    return `json_extract(${prefix}${DOC_COLUMN}, '$.${jsonPathSegment(field).replaceAll("'", "''")}')`;
 };
 
 const jsonPath = (field: string): string => documentPath("", field);
@@ -74,8 +79,15 @@ const jsonPath = (field: string): string => documentPath("", field);
  * Drizzle field reference for the DO store. Wraps the string {@link jsonPath} in
  * `dsql.raw` to keep the **literal** `json_extract(__doc__, '$.field')` path —
  * binding the path as a parameter would defeat SQLite's expression indexes.
- * Field names come from schema-defined query keys (already `'`-escaped), so the
- * raw embed is injection-safe.
+ *
+ * The raw embed is injection-safe because {@link documentPath} escapes the name
+ * for both grammars it crosses — not because the name is trusted. Do not read
+ * the older "field names come from schema-defined query keys" claim back into
+ * this: it holds for the schema-sourced callers (indexes, TTL, relations), but
+ * `ctx.db.<table>.findMany({ where, orderBy })` passes its keys through
+ * `where-sql.ts`'s storage-blind compiler with no `definition.shape` lookup, so
+ * a procedure that spreads an argument into `where` reaches here with a name off
+ * the wire.
  */
 const jsonPathSql = (field: string): SQL => dsql.raw(jsonPath(field));
 

--- a/packages/shard-engine/src/introspect.ts
+++ b/packages/shard-engine/src/introspect.ts
@@ -1,5 +1,6 @@
 import { LunoraError } from "@lunora/errors";
 
+import { jsonPathSegment } from "../../../shared/json-path-segment";
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import type { AuditEntry } from "./audit-log";
 import type { SqlExec } from "./ctx-db";
@@ -1008,7 +1009,7 @@ const resolveColumnExpression = (column: string, physicalColumns: string[]): und
 
     return isPhysical
         ? { expression: quoteIdentifier(column), params: [] }
-        : { expression: `json_extract(${quoteIdentifier(DOC_COLUMN)}, ?)`, params: [`$."${column.replaceAll('"', '""')}"`] };
+        : { expression: `json_extract(${quoteIdentifier(DOC_COLUMN)}, ?)`, params: [`$.${jsonPathSegment(column)}`] };
 };
 
 /**

--- a/shared/json-path-segment.ts
+++ b/shared/json-path-segment.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical SQLite JSON-path object-label quoter — the JSON-path twin of
+ * `shared/quote-identifier.ts`, and needed for the same reason: two modules of
+ * the DO store splice a field name into a `json_extract` path, and byte-identical
+ * copies of the escape rule are exactly what drifts. They already had, in
+ * opposite directions — `do-sql.ts` escaped the field for the SQL string literal
+ * and not for the path at all, while `introspect.ts` doubled `"` as if it were a
+ * SQL identifier. Both mis-address the document.
+ *
+ * SQLite reads a bare `.label` up to the next `.` or `[`, so a field named `a.b`
+ * in `$.a.b` resolves as the *nested* key `b` under `a` — a different value, or
+ * none, with nothing raised. `$."a.b"` addresses the real key. Inside the quoted
+ * form SQLite applies JSON string escapes, so `\` and `"` must BOTH be escaped
+ * (`\\` / `\"`); an unescaped `\` silently yields NULL, and the `""` doubling
+ * that quotes a SQL identifier is not a JSON-path escape at all.
+ *
+ * Quoting is applied only when the bare form would misparse. That is not
+ * cosmetic: these paths are the expression text of the DO store's `CREATE INDEX`
+ * statements, and SQLite matches an expression index to a query by comparing that
+ * text. Quoting unconditionally would leave every index already on disk unmatched
+ * and silently unused, degrading each affected query to a scan with nothing
+ * failing. The bare shape below is deliberately the same identifier shape
+ * `@lunora/codegen`'s `parseValidatorObject` (`FIELD_NAME_RE` in
+ * `parse-validator.ts`) already enforces on every schema-declared field, so every
+ * path this store has ever emitted keeps its exact spelling.
+ *
+ * Callers embedding the result in a SQL *string literal* still owe it the `'`
+ * doubling on top; callers binding it as a parameter do not.
+ *
+ * Like `shared/quote-identifier.ts` this is deliberately **not** a package —
+ * consumers import it by relative path and the bundler inlines it. Keep it
+ * genuinely zero-dependency.
+ */
+const BARE_JSON_PATH_LABEL = /^[A-Za-z_$][\w$]*$/u;
+
+export const jsonPathSegment = (field: string): string =>
+    BARE_JSON_PATH_LABEL.test(field) ? field : `"${field.replaceAll("\\", String.raw`\\`).replaceAll('"', String.raw`\"`)}"`;


### PR DESCRIPTION
## The defect

The DO row store splices a field name into a `json_extract` path in two places, and both got the escaping wrong — in opposite directions.

**`documentPath`** (`packages/shard-engine/src/do-sql.ts`) escaped the name for the SQL string literal and not for SQLite's JSON-path grammar:

```ts
return `json_extract(${prefix}${DOC_COLUMN}, '$.${field.replaceAll("'", "''")}')`;
```

SQLite reads a bare `.label` up to the next `.` or `[`, so a field named `a.b` becomes `$.a.b` and resolves as the *nested* key `b` under `a`, not the top-level key `a.b`. Nothing raises. Verified against a real build (SQLite 3.53.0) on a document holding both:

| path | reads |
| --- | --- |
| `$.a.b` | `"nested"` — the wrong slot |
| `$."a.b"` | `"flat"` — correct |

Same class for `[`. This feeds `jsonPath` / `jsonPathSql` / `qualifiedJsonPath`, so it reached `where` compilation, `ORDER BY`, aggregates, the EXISTS correlation refs, and the `CREATE INDEX` expressions.

**`resolveColumnExpression`** (`packages/shard-engine/src/introspect.ts`) did quote, but escaped `"` by doubling it — `column.replaceAll('"', '""')` — as if it were a SQL identifier. Inside a quoted JSON-path label SQLite applies JSON *string* escapes, so `""` is not an escape at all and the path resolves to NULL. `\` has the same problem, and neither site escaped it:

| path | reads a doc with key `q"x` / `back\slash` |
| --- | --- |
| `$."q""x"` | `null` |
| `$."q\"x"` | the value |
| `$."back\slash"` | `null` |
| `$."back\\slash"` | the value |

## Reachability — what I found

This is the part worth reading, and it went the less comfortable way.

**No layer between the wire and `jsonPathSql` compares a field name against `definition.shape`.** The build-time guard (`FIELD_NAME_RE` in `packages/codegen/src/parse-validator.ts:247`) does reject a non-identifier *schema* field name, but the shard engine receives the schema object at runtime and re-derives paths from it; nothing at the runtime boundary re-checks, and nothing checks names that never came from the schema at all.

Every *framework-owned* inbound path is nevertheless closed:

| path | field-name origin | reaches the path builder? |
| --- | --- | --- |
| `defineListArgs` (`packages/server/src/list-args.ts`) | allow-list, compile-checked | yes, declared names only — `sanitizeWhere` iterates **from** the allow-list, and `toQueryArgs` re-filters `orderBy` against `sortable` because it is exported |
| Admin RPCs (`readTablePage`, `facetColumn`, `deleteRows`) | arbitrary, admin-bearer gated | no — they route to `introspect.ts`'s own resolver, which binds the path as `?` |
| `runSql` | arbitrary SQL, admin-bearer gated | no |
| `@lunora/db` | no field names on the wire at all | no |
| `@lunora/studio` | grid column id | no — lands on `readTablePage` |
| Relation / EXISTS correlation refs | `relationMap`, from the schema | yes, schema-only |
| Secondary indexes, TTL, soft-delete | schema | yes, schema-only |

**The one open door is the plain `ctx.db.<table>.findMany({ where, orderBy })` API.** `where-sql.ts` documents itself as a storage-blind compiler and is exactly that — `compileNode` iterates `Object.entries(where)` and hands every non-structural key to `strategy.fieldRef`, which is `jsonPathSql`. `orderBy` is the same through `query-args.ts`. So a procedure that spreads one of its own arguments into `where` or `orderBy` reaches the path builder with a string straight off the wire, gated only by whatever `v.*` validator the author declared for it. Nothing in `packages/`, `examples/`, or `templates/` does this today — it is a latent capability of the API, not a live bug in-repo. RLS does not help: `assertOrderByAllowed` in the mask middleware rejects *masked* columns; an unknown name passes.

**Severity, plainly.** It is not an injection, and never was — the `'` doubling closed the SQL-string escape and drizzle binds every value. But before this change such a name steered `json_extract` into the document's *nested* keys, which is a filter oracle over data the caller was never handed: `where: { "settings.apiKey": { gt: "m" } }` on a doc whose `settings` object is not in the projected result set. Correct quoting closes that outright — `$."settings.apiKey"` names a top-level key that does not exist, so the predicate is simply unsatisfied rather than traversing.

So: **a correctness bug for schema-declared names, and a narrow information-disclosure vector on the one API surface that forwards caller-supplied names.** Quoting at the choke point is the fix for both, which is why there is no separate validation layer here — a rejecting guard would additionally contradict the fact that quoting *makes* such a field work.

## The fix

`shared/json-path-segment.ts` — one definition of the rule, for the same reason and under the same no-dependency-edge constraint as the neighbouring `shared/quote-identifier.ts`. Two copies free to drift is precisely how these two sites ended up wrong in different ways.

```ts
const BARE_JSON_PATH_LABEL = /^[A-Za-z_$][\w$]*$/u;

export const jsonPathSegment = (field: string): string =>
    BARE_JSON_PATH_LABEL.test(field) ? field : `"${field.replaceAll("\\", String.raw`\\`).replaceAll('"', String.raw`\"`)}"`;
```

### Why it quotes conditionally

These paths are the expression text of the store's `CREATE INDEX` statements, and SQLite matches an expression index to a query by comparing that text. Quoting unconditionally would leave every index already on disk unmatched and silently unused — every affected query degrades to a scan with nothing failing.

The bare shape above is deliberately the same identifier shape codegen already enforces on every schema-declared field, so **every path this store has ever emitted keeps its exact spelling**. That is asserted, not assumed: `do-sql.json-path.test.ts` pins the literal strings, and reverting only `do-sql.ts` leaves those four assertions green while the five defect assertions fail.

`introspect.ts`'s path is a *bound* parameter, so it was never index-matching and the conditional quoting is free there.

## Tests

`packages/shard-engine/__tests__/do-sql.json-path.test.ts` (new, 9 tests):

- identifier-safe fields emit the historical bare path byte for byte, and `_id` / `id` / `_creationTime` keep their stored-column mapping;
- `.`, `[`, space, `'`, `"`, `\` each produce the quoted form, with both JSON escapes;
- against a real `node:sqlite` build, `jsonPath("a.b")` reads the flat key while `jsonPath("a")` still reads the nested object, and every awkward name round-trips.

`introspect.test.ts` gains a `readTablePage` case ordering by `a.b` and by `q"x`.

Negative control run both ways: reverting `src/do-sql.ts` fails 5 of 9 and passes the 4 byte-identity ones; reverting `src/introspect.ts` fails the new `q"x` ordering.

## Gates

`@lunora/shard-engine` 992 ✓ · `@lunora/do` 522 ✓ · `@lunora/codegen` 1068 ✓ · `@lunora/server` 570 ✓ · `lint:types` ✓ · `lint:eslint --max-warnings=0` ✓ · `api:check` (47 snapshots, unchanged — the helper is not public surface) ✓ · `lint:package-json` ✓ · `build:packages` ✓.

`dist:check` fails on `packages/studio`'s dev-build JSX factory, which is what `build:packages` (not `build:packages:prod`) produces and is unrelated to this change.

## Note for `fix/265-wire-codec-query-parity`

That branch's `reprojection-backfill.ts` carries a local `jsonPathSegment` with a comment calling this a known gap. It should drop the local copy for the shared one on merge — and note the local copy does not escape `\`, which is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queries involving document fields with dots or other special characters.
  * Improved handling of untrusted field names in raw SQL expressions.
  * Ensured document field paths are escaped correctly for reliable SQLite JSON access.

* **Documentation**
  * Clarified escaping requirements when embedding raw SQL with document field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->