### PR TITLE
refactor(shard-engine): drop the duplicated json path quoter

### DIFF
--- a/packages/shard-engine/__tests__/reprojection-backfill.test.ts
+++ b/packages/shard-engine/__tests__/reprojection-backfill.test.ts
@@ -2,18 +2,12 @@ import { DatabaseSync } from "node:sqlite";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { jsonPathSegment } from "../../../shared/json-path-segment";
 import type { DatabaseWriterLike, SchemaLike } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
 import { runDataMigration } from "../src/data-migration";
 import { encodeDocJson } from "../src/do-sql";
-import {
-    buildReprojectionMigration,
-    countLegacyRows,
-    jsonPathSegment,
-    reprojectableFields,
-    reprojectionMigrationId,
-    reprojectionTables,
-} from "../src/reprojection-backfill";
+import { buildReprojectionMigration, countLegacyRows, reprojectableFields, reprojectionMigrationId, reprojectionTables } from "../src/reprojection-backfill";
 import createSqliteExec from "./_helpers/node-sqlite";
 
 /**

--- a/packages/shard-engine/src/reprojection-backfill.ts
+++ b/packages/shard-engine/src/reprojection-backfill.ts
@@ -24,6 +24,7 @@
  * affected, whether a given row is one of them, and a transform that re-encodes.
  */
 
+import { jsonPathSegment } from "../../../shared/json-path-segment";
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import { reprojectionMigrationTable } from "../../../shared/reprojection-id";
 import { encodeWire } from "../../../shared/wire-codec";
@@ -42,43 +43,6 @@ import { mayHoldProjectedValue } from "./sql-projection";
  * `bigint` yields `[TAG, "bigint", "0"]`, so element 0 IS the sentinel.
  */
 const WIRE_TAG = (encodeWire(0n) as unknown[])[0] as string;
-
-/**
- * Field names codegen admits without quoting — the regex `parse-validator.ts`
- * enforces on every schema field, so anything matching it is already known to be
- * a bare-safe JSON-path segment.
- */
-const BARE_PATH_SEGMENT_RE = /^[A-Za-z_$][\w$]*$/u;
-
-/**
- * One JSON-path object key, quoted when the bare form would misparse. Without
- * this a field named `amount.minor` becomes `$.amount.minor`, which resolves to
- * a *nested* key and silently matches nothing.
- *
- * `\` is escaped BEFORE `"`, or the backslash inserted by the quote escape would
- * itself be re-escaped. Getting that order wrong is not theoretical: a field
- * holding a backslash yields `$."back\slash"`, which SQLite 3.53 resolves to
- * NULL rather than erroring — the same shape of silent miss the quoting exists
- * to prevent.
- *
- * Deliberately behaviour-identical to `shared/json-path-segment.ts` (introduced
- * on the branch that fixes this repo-wide) rather than importing it: that file
- * does not exist here, and importing it would couple two otherwise independent
- * PRs. Whichever merges second deletes this copy, and because the two agree
- * exactly, that deletion is a no-op refactor rather than a behaviour change.
- * Neither difference was reachable from here — schema field names come from
- * codegen, which already constrains them to identifiers — but two copies of an
- * escaping rule drifting in opposite directions is precisely the defect the
- * shared helper exists to fix, and being unreachable today is how that survives
- * to become reachable later.
- *
- * Known gap, deliberately not widened here: `documentPath` in `do-sql.ts` does
- * not quote at all, so such a field is already unaddressable everywhere in this
- * store. Fixing it there is the root-cause edit, but it changes the expression
- * text of every `CREATE INDEX`, so it needs a rebuild story of its own.
- */
-const jsonPathSegment = (field: string): string =>
-    BARE_PATH_SEGMENT_RE.test(field) ? field : `"${field.replaceAll("\\", String.raw`\\`).replaceAll('"', String.raw`\"`)}"`;
 
 /**
  * Field names on `definition` that could hold a projected value.
@@ -242,8 +206,6 @@ const buildReprojectionMigration = (id: string, schema: SchemaLike, sql: SqlExec
     };
 };
 
-// `jsonPathSegment` is exported for its own test only — deliberately NOT
-// re-exported from the package barrel, so it stays off the public API surface.
-export { buildReprojectionMigration, countLegacyRows, jsonPathSegment, reprojectableFields, reprojectionTables };
+export { buildReprojectionMigration, countLegacyRows, reprojectableFields, reprojectionTables };
 
 export { REPROJECTION_MIGRATION_PREFIX, reprojectionMigrationId } from "../../../shared/reprojection-id";


### PR DESCRIPTION
## What

#365 and #371 both landed, so `alpha` now carries **two copies of the same JSON-path escaping rule**: the local `jsonPathSegment` in `reprojection-backfill.ts` and the shared `shared/json-path-segment.ts`. This deletes the local one.

Both PR bodies flagged this as the merge-order follow-through, and the two implementations were deliberately made **byte-identical** before either merged — verified by extracting and diffing the function bodies — so this is a no-op refactor rather than a behaviour change. Net −44 lines.

## It also removes a comment that stopped being true

The local docblock carried:

> Known gap, deliberately not widened here: `documentPath` in `do-sql.ts` does not quote at all, so such a field is already unaddressable everywhere in this store.

That was accurate when written. #371 made `documentPath` quote (`do-sql.ts:182`), so it is now false. Deleting the duplicate takes the stale claim with it — which matters here, because a comment asserting a property the code does not have is the exact defect class this whole line of work kept turning up.

## Verification

`@lunora/shard-engine` 67 files / **1040 passed**, `lint:eslint --max-warnings=0` exit 0, `lint:types` clean, Prettier clean, `api:check` ✅ 47 snapshots unchanged (the helper was never on the public surface — it was exported from the module for its own test only, and the test now imports the shared one directly).

Two process notes, since both cost a cycle here and are worth knowing:

- **Run repo tooling from inside the worktree.** `pnpm exec eslint <path>` from the repo root resolves the root `tsconfig.json`, whose `include` is `[]`, and fails with `TS18003: No inputs were found` — which looks like a code error and is not. The package script (`eslint .`, cwd = package) is the one that reports real findings.
- **Build before measuring.** A worktree that has never run `build:packages` fails *every* test file, not just the changed ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sk9BLaUZDkPVAZ1sKhuDP
