### PR TITLE
feat(runtime): preview what backup retention would delete

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -3589,6 +3589,10 @@ Re-exported from `@lunora/runtime` — signature tracked at its source.
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.
 
+### `BackupRetentionPreview` (interface)
+
+Re-exported from `@lunora/runtime` — signature tracked at its source.
+
 ### `BackupStore` (interface)
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -362,6 +362,18 @@ interface BackupManifestEntry {
 }
 ```
 
+### `BackupRetentionPreview` (interface)
+
+```ts
+interface BackupRetentionPreview {
+    cron?: string;
+    eligible: number;
+    keep: number;
+    prefix: string;
+    wouldDelete: string[];
+}
+```
+
 ### `BackupStore` (interface)
 
 ```ts

--- a/apps/docs/src/content/docs/concepts/backups.mdx
+++ b/apps/docs/src/content/docs/concepts/backups.mdx
@@ -149,6 +149,12 @@ way the answer is `--tables` / `backupTables`, or `--dir` plus
 
 ### Scheduled backups into R2
 
+<Callout>
+    Retention deletes, and an R2 delete has no undo. `lunora backup retention` reports what the next scheduled run would remove — from the same selection the
+    prune uses, so the preview cannot drift from the deletion — and removes nothing itself. Run it after changing `backupRetain`, and on any bucket that
+    predates the feature: snapshots written before retention learned to mark its own are never eligible, so it may own fewer of them than the bucket holds.
+</Callout>
+
 For a schedule that runs on the platform itself rather than in CI, the worker
 can take its own snapshots on a Cron Trigger and write them to an R2 bucket in
 your account. Wire `backupStore`, `backupCron`, and `backupRetain` on

--- a/packages/cli/__tests__/commands/backup.test.ts
+++ b/packages/cli/__tests__/commands/backup.test.ts
@@ -456,6 +456,112 @@ describe("lunora backup", () => {
         expect(result.code).toBe(1);
     });
 
+    describe("retention", () => {
+        const previewFetch =
+            (body: unknown, calls: { method: string; url: string }[] = []): FetchLike =>
+            async (url, init) => {
+                calls.push({ method: init?.method ?? "GET", url });
+
+                return {
+                    headers: new Headers({ "content-type": "application/json" }),
+                    json: async () => body,
+                    ok: true,
+                    status: 200,
+                    text: async () => JSON.stringify(body),
+                };
+            };
+
+        it("prints what retention would delete, phrased like the cron's own record", async () => {
+            expect.assertions(4);
+
+            const { logger, logs } = capturingLogger();
+            const calls: { method: string; url: string }[] = [];
+
+            const result = await runBackupCommand({
+                cwd: workDir,
+                logger,
+                pitrFetch: previewFetch(
+                    {
+                        cron: "0 3 * * *",
+                        eligible: 5,
+                        keep: 3,
+                        prefix: "backups/",
+                        wouldDelete: ["backups/lunora-backup-2026-06-01T03-00-00-000Z.ndjson.manifest.json"],
+                    },
+                    calls,
+                ),
+                subcommand: "retention",
+                token: "t",
+                url: "http://localhost:8787",
+            });
+
+            expect(result.code).toBe(0);
+            // A read, and only a read.
+            expect(calls).toStrictEqual([{ method: "GET", url: "http://localhost:8787/_lunora/admin/backup/retention" }]);
+            expect(logs.some((line) => line.includes("would keep the newest 3 of 5 under backups/ and delete 1"))).toBe(true);
+            // The snapshot is named, not its sidecar — that is the file an
+            // operator would go looking for.
+            expect(logs.some((line) => line.includes("  backups/lunora-backup-2026-06-01T03-00-00-000Z.ndjson"))).toBe(true);
+        });
+
+        it("says so when retention is off rather than reporting an empty deletion", async () => {
+            expect.assertions(2);
+
+            const { logger, logs } = capturingLogger();
+
+            const result = await runBackupCommand({
+                cwd: workDir,
+                logger,
+                pitrFetch: previewFetch({ cron: "0 3 * * *", eligible: 4, keep: 0, prefix: "backups/", wouldDelete: [] }),
+                subcommand: "retention",
+                token: "t",
+                url: "http://localhost:8787",
+            });
+
+            expect(result.code).toBe(0);
+            expect(logs.some((line) => line.includes("retention is off"))).toBe(true);
+        });
+
+        it("explains an empty selection on a bucket this cron never wrote to", async () => {
+            expect.assertions(2);
+
+            const { logger, logs } = capturingLogger();
+
+            const result = await runBackupCommand({
+                cwd: workDir,
+                logger,
+                // The legacy-bucket case: snapshots exist, none carry the marker.
+                pitrFetch: previewFetch({ cron: "0 3 * * *", eligible: 0, keep: 3, prefix: "backups/", wouldDelete: [] }),
+                subcommand: "retention",
+                token: "t",
+                url: "http://localhost:8787",
+            });
+
+            expect(result.code).toBe(0);
+            expect(logs.some((line) => line.includes("was written by this cron"))).toBe(true);
+        });
+
+        it("requires an admin token", async () => {
+            expect.assertions(2);
+
+            const { logger, logs } = capturingLogger();
+            const previous = process.env.LUNORA_ADMIN_TOKEN;
+
+            delete process.env.LUNORA_ADMIN_TOKEN;
+
+            try {
+                const result = await runBackupCommand({ cwd: workDir, logger, subcommand: "retention", url: "http://localhost:8787" });
+
+                expect(result.code).toBe(1);
+                expect(logs.some((line) => line.includes("admin token required"))).toBe(true);
+            } finally {
+                if (previous !== undefined) {
+                    process.env.LUNORA_ADMIN_TOKEN = previous;
+                }
+            }
+        });
+    });
+
     describe("pitr", () => {
         interface PitrCall {
             body: string;

--- a/packages/cli/docs/index.mdx
+++ b/packages/cli/docs/index.mdx
@@ -588,6 +588,7 @@ Managed snapshot backups and native point-in-time recovery (PITR):
 lunora backup create                   # snapshot the running shard
 lunora backup list                     # list available snapshots
 lunora backup restore <id>             # restore a snapshot
+lunora backup retention                # what the platform's retention would delete next
 lunora backup pitr --at 2024-06-01T12:00:00Z   # read PITR bookmark
 lunora backup pitr --at 2024-06-01T12:00:00Z --restore --yes   # restore to that point
 ```

--- a/packages/cli/src/commands/backup/handler.ts
+++ b/packages/cli/src/commands/backup/handler.ts
@@ -20,7 +20,7 @@
  */
 import { join } from "node:path";
 
-import type { BackupManifestEntry } from "@lunora/runtime";
+import type { BackupManifestEntry, BackupRetentionPreview } from "@lunora/runtime";
 
 import { resolveAdminBearer } from "../../util/admin-token";
 import { resolveAdminBaseUrl } from "../../util/admin-url";
@@ -40,12 +40,18 @@ import { createR2Destination } from "./r2-destination";
 /** Default directory (relative to cwd) backups and their manifest live in. */
 const DEFAULT_BACKUP_DIR = ".lunora-backups";
 
+/** `".manifest.json"`, trimmed off a sidecar key to name the snapshot it describes. */
+const MANIFEST_SUFFIX_LENGTH = ".manifest.json".length;
+
+/** Read-only worker endpoint reporting what the platform's retention would delete next (see `@lunora/runtime`). */
+const RETENTION_ENDPOINT_PATH = "/_lunora/admin/backup/retention";
+
 /** Worker endpoint that forwards a per-shard native-PITR admin op (see `@lunora/runtime`). */
 const PITR_ENDPOINT_PATH = "/_lunora/admin/pitr";
 const GET_PITR_BOOKMARK_OP = "__lunora_admin__:getPitrBookmark";
 const PITR_RESTORE_OP = "__lunora_admin__:pitrRestore";
 
-type BackupSubcommand = "create" | "list" | "pitr" | "restore";
+type BackupSubcommand = "create" | "list" | "pitr" | "restore" | "retention";
 
 interface BackupCommandOptions {
     /** `pitr`: restore to the bookmark nearest this time (ISO or epoch-ms), within 30 days. */
@@ -94,6 +100,8 @@ interface BackupCommandResult {
     code: number;
     /** Set on `create` — the written backup's manifest entry. */
     entry?: BackupManifestEntry;
+    /** Set on `retention` — what the worker reported it would delete next. */
+    preview?: BackupRetentionPreview;
 }
 
 /**
@@ -412,14 +420,99 @@ const resolveDestination = (options: BackupCommandOptions, cwd: string): BackupD
     });
 };
 
+/**
+ * `lunora backup retention` — what the platform's own retention would delete on
+ * its next run, and nothing else.
+ *
+ * A read. Retention itself stays on the cron; there is no `--apply` here and no
+ * code path in this command deletes an object. The worker answers because it is
+ * the only party that knows its own `backupCron` and `backupRetain`, and
+ * because eligibility turns on a marker the CLI cannot see from a listing.
+ */
+const runBackupRetention = async (options: BackupCommandOptions): Promise<BackupCommandResult> => {
+    const token = options.token ?? process.env.LUNORA_ADMIN_TOKEN;
+
+    if (!token) {
+        options.logger.error("admin token required — pass --token or set LUNORA_ADMIN_TOKEN");
+
+        return { code: 1 };
+    }
+
+    if (options.prod === true && options.url === undefined) {
+        options.logger.error("--prod requires an explicit --url (refusing to target the implicit localhost worker)");
+
+        return { code: 1 };
+    }
+
+    const baseUrl = resolveAdminBaseUrl(options.url, options.logger, options.cwd);
+
+    if (baseUrl === undefined) {
+        return { code: 1 };
+    }
+
+    const fetchImpl: FetchLike = options.pitrFetch ?? (globalThis as unknown as { fetch: FetchLike }).fetch;
+
+    if (typeof fetchImpl !== "function") {
+        throw new TypeError("no fetch implementation available — pass pitrFetch or run on Node >= 18");
+    }
+
+    const response = await fetchImpl(`${baseUrl}${RETENTION_ENDPOINT_PATH}`, {
+        headers: { authorization: `Bearer ${token}` },
+        method: "GET",
+    });
+
+    if (!response.ok) {
+        await readAndLogBody(response, options.logger);
+
+        return { code: 1 };
+    }
+
+    const preview = (await response.json()) as BackupRetentionPreview;
+
+    if (preview.cron === undefined) {
+        options.logger.info("no scheduled backup is configured (`backupCron`), so retention would delete nothing");
+
+        return { code: 0, preview };
+    }
+
+    if (preview.keep <= 0) {
+        options.logger.info(`retention is off for cron "${preview.cron}" (\`backupRetain\` unset) — every snapshot under ${preview.prefix} is kept`);
+
+        return { code: 0, preview };
+    }
+
+    // Phrased like the line the cron writes after it prunes, so a preview and
+    // the record of a real run read as one story.
+    options.logger.info(
+        `backup retention would keep the newest ${preview.keep.toString()} of ${preview.eligible.toString()} under ${preview.prefix} and delete ${preview.wouldDelete.length.toString()}`,
+    );
+
+    for (const key of preview.wouldDelete) {
+        options.logger.info(`  ${key.slice(0, -MANIFEST_SUFFIX_LENGTH)}`);
+    }
+
+    if (preview.eligible === 0) {
+        // The likeliest surprise on a real bucket: snapshots exist, but none
+        // carry this cron's marker, so retention owns none of them.
+        options.logger.info(`no snapshot under ${preview.prefix} was written by this cron, so retention has nothing of its own to remove`);
+    }
+
+    return { code: 0, preview };
+};
+
 const runBackupCommand = async (options: BackupCommandOptions): Promise<BackupCommandResult> => {
     const cwd = options.cwd ?? process.cwd();
 
     try {
-        // `pitr` is the in-place tier and reads no snapshot at all, so it is
-        // answered before any destination exists.
+        // `pitr` is the in-place tier and reads no snapshot at all, and
+        // `retention` asks the worker about its own config — neither reads a
+        // destination, so both are answered before one exists.
         if (options.subcommand === "pitr") {
             return await runBackupPitr(options);
+        }
+
+        if (options.subcommand === "retention") {
+            return await runBackupRetention(options);
         }
 
         const destination = resolveDestination(options, cwd);
@@ -447,7 +540,8 @@ const runBackupCommand = async (options: BackupCommandOptions): Promise<BackupCo
 };
 
 /** Narrow a raw argument to a known {@link BackupSubcommand}. */
-const isBackupSubcommand = (value: unknown): value is BackupSubcommand => value === "create" || value === "list" || value === "pitr" || value === "restore";
+const isBackupSubcommand = (value: unknown): value is BackupSubcommand =>
+    value === "create" || value === "list" || value === "pitr" || value === "restore" || value === "retention";
 
 /** `lunora backup <subcommand>` handler (lazy-loaded via the command's `loader`). */
 const execute: CommandHandler<BackupOptions> = defineHandler<BackupOptions>(({ argument, cwd, logger, options }) => {

--- a/packages/cli/src/commands/backup/index.ts
+++ b/packages/cli/src/commands/backup/index.ts
@@ -1,7 +1,7 @@
 import type { Command, CommandExecute, CreateOptions, Toolbox } from "@visulima/cerebro";
 
 const backupCommand: Command = {
-    argument: { description: "create | list | restore <id|file> | pitr", name: "subcommand", type: String },
+    argument: { description: "create | list | restore <id|file> | retention | pitr", name: "subcommand", type: String },
     description: "Managed snapshot backups (create | list | restore) to a directory or an R2 bucket, plus native point-in-time recovery (pitr)",
     examples: [
         ["lunora backup create", "Snapshot every table to a backup file"],
@@ -9,6 +9,7 @@ const backupCommand: Command = {
         ["lunora backup restore <id>", "Restore a snapshot by id"],
         ["lunora backup create --bucket default", "Snapshot into an R2 bucket instead of a directory"],
         ["lunora backup restore <id> --bucket default --verify", "Restore from R2, checksum first"],
+        ["lunora backup retention", "Show what the platform's retention would delete next"],
         ["lunora backup pitr --at 2026-06-01T00:00:00Z", "Point-in-time recovery (≤30 days)"],
     ],
     group: "Data",

--- a/packages/runtime/__tests__/scheduled-backup.test.ts
+++ b/packages/runtime/__tests__/scheduled-backup.test.ts
@@ -123,6 +123,9 @@ const memoryBackupStore = (): BackupStore & {
 const sha256Hex = async (text: string): Promise<string> =>
     [...new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text)))].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 
+/** The execution context `fetch` needs; nothing under test uses either hook. */
+const fakeContext = { passThroughOnException: () => undefined, waitUntil: () => undefined };
+
 const fire = async (worker: ReturnType<typeof createWorker>, controller: ScheduledControllerLike): Promise<void> => {
     await worker.scheduled(controller, {}, { passThroughOnException: () => undefined, waitUntil: () => undefined });
 };
@@ -486,6 +489,175 @@ describe("createWorker — scheduled backup", () => {
         expect(store.objects.has("backups/lunora-backup-2026-06-01T00-00-00-000Z.ndjson")).toBe(false);
         expect(store.objects.has("backups/lunora-backup-2026-06-02T00-00-00-000Z.ndjson")).toBe(true);
         expect(store.objects.has("backups/lunora-backup-2026-06-03T12-00-00-000Z.ndjson")).toBe(true);
+    });
+
+    /**
+     * One bucket, seeded with every case that makes eligibility subtle, read
+     * two ways: the preview route, and a real cron fire. If those can ever
+     * disagree, the preview is worse than nothing — an operator would plan
+     * around an answer the prune does not honour.
+     */
+    const seedMixedBucket = (store: ReturnType<typeof memoryBackupStore>): void => {
+        const seed = (id: string, marker: string | undefined): string => {
+            const key = `backups/lunora-backup-${id.replaceAll(/[.:]/gu, "-")}.ndjson`;
+
+            store.objects.set(key, "rows\n");
+            store.objects.set(`${key}.manifest.json`, JSON.stringify({ file: key, id }));
+
+            if (marker !== undefined) {
+                store.metadata.set(`${key}.manifest.json`, { lunoraBackupCron: marker });
+            }
+
+            return key;
+        };
+
+        // Ours, oldest first. The last one is keyed at SCHEDULED_TIME, which is
+        // the key the fire itself writes — so the fire overwrites it rather than
+        // adding a snapshot, and the prune sees exactly the population the
+        // preview saw. Without that the two would be answering about different
+        // buckets, and an equal/unequal result would mean nothing.
+        seed("2026-06-01T03:00:00.000Z", BACKUP_CRON);
+        seed("2026-06-02T03:00:00.000Z", BACKUP_CRON);
+        seed(new Date(SCHEDULED_TIME).toISOString(), BACKUP_CRON);
+        // A legacy sidecar: written before the marker existed, indistinguishable
+        // from an operator's, so never eligible.
+        seed("2026-05-01T03:00:00.000Z", undefined);
+        // Another deployment backing up into the same bucket.
+        seed("2026-05-02T09:30:00.000Z", "*/30 * * * *");
+        // An operator's own snapshot, taken with `lunora backup create --bucket`.
+        seed("2026-05-03T11:00:00.000Z", undefined);
+    };
+
+    const previewOf = async (store: ReturnType<typeof memoryBackupStore>): Promise<{ eligible: number; keep: number; wouldDelete: string[] }> => {
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            backupCron: BACKUP_CRON,
+            backupRetain: 1,
+            backupStore: store,
+            queryCoordinator: coordinatorWithExport([{ doc: { _id: "u1" }, table: "users" }]),
+            shardDO: noopNamespace,
+        });
+
+        const response = await worker.fetch(
+            new Request("https://app.example/_lunora/admin/backup/retention", { headers: { authorization: `Bearer ${ADMIN_TOKEN}` }, method: "GET" }),
+            {},
+            fakeContext,
+        );
+
+        expect(response.status).toBe(200);
+
+        return response.json();
+    };
+
+    it("previews exactly what the prune then deletes", async () => {
+        expect.assertions(6);
+
+        const previewStore = memoryBackupStore();
+        const pruneStore = memoryBackupStore();
+
+        seedMixedBucket(previewStore);
+        seedMixedBucket(pruneStore);
+
+        const preview = await previewOf(previewStore);
+
+        // The preview must not have touched anything.
+        expect([...previewStore.objects.keys()].toSorted((a, b) => a.localeCompare(b))).toStrictEqual(
+            [...pruneStore.objects.keys()].toSorted((a, b) => a.localeCompare(b)),
+        );
+
+        const before = new Set(pruneStore.objects.keys());
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            backupCron: BACKUP_CRON,
+            backupRetain: 1,
+            backupStore: pruneStore,
+            queryCoordinator: coordinatorWithExport([{ doc: { _id: "u1" }, table: "users" }]),
+            shardDO: noopNamespace,
+        });
+
+        await fire(worker, { cron: BACKUP_CRON, scheduledTime: SCHEDULED_TIME });
+
+        // What the fire actually removed, minus the snapshot it added.
+        const deleted = [...before].filter((key) => !pruneStore.objects.has(key)).filter((key) => key.endsWith(".manifest.json"));
+
+        expect(deleted.toSorted((a, b) => a.localeCompare(b))).toStrictEqual(preview.wouldDelete.toSorted((a, b) => a.localeCompare(b)));
+
+        // And the answer is the interesting one: our two older snapshots go, the
+        // legacy sidecar, the other deployment's, and the operator's stay.
+        expect(preview.wouldDelete).toStrictEqual([
+            "backups/lunora-backup-2026-06-02T03-00-00-000Z.ndjson.manifest.json",
+            "backups/lunora-backup-2026-06-01T03-00-00-000Z.ndjson.manifest.json",
+        ]);
+        expect(preview.eligible).toBe(3);
+        expect(preview.keep).toBe(1);
+    });
+
+    it("reports what would go without removing a byte of it", async () => {
+        expect.assertions(3);
+
+        const store = memoryBackupStore();
+
+        seedMixedBucket(store);
+
+        const before = new Map(store.objects);
+        const preview = await previewOf(store);
+
+        expect(preview.wouldDelete.length).toBeGreaterThan(0);
+        // Byte-for-byte: same keys, same contents. Nothing in this route deletes.
+        expect([...store.objects.entries()]).toStrictEqual([...before.entries()]);
+    });
+
+    it("refuses the retention preview without an admin bearer, and leaks nothing", async () => {
+        expect.assertions(2);
+
+        const store = memoryBackupStore();
+
+        seedMixedBucket(store);
+
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            backupCron: BACKUP_CRON,
+            backupRetain: 1,
+            backupStore: store,
+            queryCoordinator: coordinatorWithExport([]),
+            shardDO: noopNamespace,
+        });
+
+        const response = await worker.fetch(new Request("https://app.example/_lunora/admin/backup/retention", { method: "GET" }), {}, fakeContext);
+
+        expect(response.status).toBe(403);
+        // The gate runs before the bucket is read, so the body cannot carry an
+        // object key.
+        await expect(response.text()).resolves.not.toContain("lunora-backup-");
+    });
+
+    it("reports an empty selection when retention is not configured", async () => {
+        expect.assertions(3);
+
+        const store = memoryBackupStore();
+
+        seedMixedBucket(store);
+
+        const worker = createWorker({
+            adminToken: ADMIN_TOKEN,
+            backupCron: BACKUP_CRON,
+            // No `backupRetain`: retention is off, so nothing is ever deleted.
+            backupStore: store,
+            queryCoordinator: coordinatorWithExport([]),
+            shardDO: noopNamespace,
+        });
+
+        const response = await worker.fetch(
+            new Request("https://app.example/_lunora/admin/backup/retention", { headers: { authorization: `Bearer ${ADMIN_TOKEN}` }, method: "GET" }),
+            {},
+            fakeContext,
+        );
+
+        const preview: { keep: number; wouldDelete: string[] } = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(preview.keep).toBe(0);
+        expect(preview.wouldDelete).toStrictEqual([]);
     });
 
     it("honors a custom backupPrefix and backupTables", async () => {

--- a/packages/runtime/docs/index.mdx
+++ b/packages/runtime/docs/index.mdx
@@ -200,6 +200,25 @@ Register your own cron handlers via `crons` (keyed by the exact expression);
 they run independently of — and, on a shared expression, alongside — the
 built-in backup.
 
+### Seeing what retention will do
+
+`backupRetain` deletes, R2 deletes have no undo, and the thing being deleted is
+a backup — so before trusting a retention setting on a real bucket, ask what it
+would do:
+
+```bash
+lunora backup retention --url https://api.example.com   # reads; deletes nothing
+```
+
+It answers from the worker, because the worker is the only party that knows its
+own `backupCron` and `backupRetain`, and because eligibility depends on a marker
+that is not visible in a plain object listing. The answer comes from the same
+selection the prune itself runs, so the two cannot disagree.
+
+This is worth doing on any bucket that predates the marker: those sidecars are
+never eligible, so retention may own far fewer snapshots than the bucket
+contains — the preview says exactly how many.
+
 Retention only ever removes snapshots **this** cron wrote: each sidecar is
 stamped with its cron expression, and the prune matches on it. Snapshots taken
 by hand, and snapshots from a second deployment sharing the bucket, are left

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -49,7 +49,7 @@ import { createResourceAttributeResolver } from "./resource-detect";
 import type { RestInvoke, RestRateLimit } from "./rest-routes";
 import { buildRestRoutes } from "./rest-routes";
 import { buildScheduledAdminRoutes } from "./scheduled-admin-routes";
-import { runScheduledBackup } from "./scheduled-backup";
+import { previewBackupRetention, runScheduledBackup } from "./scheduled-backup";
 import type { SecurityOptions } from "./security-headers";
 import { decorateResponse, enforceOrigin, enforceWebSocketOrigin, handleCorsPreflight, resolveSecurity } from "./security-headers";
 import { buildStorageAdminRoutes, STORAGE_PATH, STORAGE_UPLOAD_MAX_BODY_BYTES } from "./storage-admin-routes";
@@ -1365,6 +1365,9 @@ interface RpcContext {
     request: Request;
     shardKey: string;
 }
+
+/** Read-only: what backup retention would delete on its next run. Never deletes anything. */
+const BACKUP_RETENTION_PATH = "/_lunora/admin/backup/retention";
 
 const RPC_PATH = "/_lunora/rpc";
 const RPC_BATCH_PATH = "/_lunora/rpc-batch";
@@ -4288,6 +4291,29 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             const minted = await mintWsAdminToken(signingSecret);
 
             return Response.json(minted, { headers: { "cache-control": "no-store" } });
+        },
+
+        /**
+         * What `backupRetain` would remove on the next cron fire, computed by
+         * the same selection the prune itself runs.
+         *
+         * A read, and only a read — the deletes stay on the cron, and this
+         * route calls no code that can delete. It exists because retention's
+         * deletes are irreversible and its eligibility rule is genuinely
+         * non-obvious on a real bucket (legacy sidecars carry no marker and are
+         * never eligible), so "let it run and see what is gone" was the only
+         * way to find out. Admin-gated before it reads anything, so an
+         * unauthenticated caller learns nothing about which objects exist.
+         */
+        [BACKUP_RETENTION_PATH]: async (request) => {
+            assertMethod(request, "GET", "Backup-retention");
+
+            requireAdminOption(request, options.backupStore, {
+                code: "BACKUP_NOT_CONFIGURED",
+                message: "backup retention preview requires a `backupStore` on the worker",
+            });
+
+            return Response.json(await previewBackupRetention(options), { headers: { "cache-control": "no-store" } });
         },
         // Extracted handler clusters built above, merged in (mirroring the auth
         // plane below): orchestration (migrate / rank / rankpage / shard-traffic /

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -155,6 +155,7 @@ export { applyJurisdiction, resolveShard } from "./resolve-shard";
 export { applyRestCache, requestCarriesCredentials, restCacheHeaders } from "./rest-cache";
 export type { RateLimiterLike, RestInvoke, RestRateLimit, RestRegistryEntry, RestRegistryLike, RestRoute, RestRouteDeps } from "./rest-routes";
 export { argsFromQuery, buildRestRoutes, createRestRateLimit, readShardKey, restSurfaceFromRegistry } from "./rest-routes";
+export type { BackupRetentionPreview } from "./scheduled-backup";
 export type { CorsOptions, CsrfOptions, ResolvedSecurity, SecurityHeadersOptions, SecurityOptions } from "./security-headers";
 export { decorateResponse, enforceOrigin, handleCorsPreflight, resolveSecurity } from "./security-headers";
 export type {

--- a/packages/runtime/src/scheduled-backup.ts
+++ b/packages/runtime/src/scheduled-backup.ts
@@ -53,6 +53,27 @@ const BACKUP_CRON_METADATA_KEY = "lunoraBackupCron";
  */
 const MAX_SCHEDULED_BACKUP_BYTES: number = 24 * 1_048_576;
 
+/** What {@link selectStaleBackups} found: every sidecar this cron owns, and the subset past the retention window. */
+interface StaleBackups {
+    /** Sidecars under the prefix carrying this cron's marker — the population retention chooses from. */
+    eligible: number;
+    /** The ones past the window, newest-first ordering already applied. */
+    stale: string[];
+}
+
+/** What retention would delete on the next run, and the configuration that decides it. */
+interface BackupRetentionPreview {
+    /** The trigger retention belongs to. `undefined` when no scheduled backup is configured. */
+    cron?: string;
+    /** Snapshots this cron owns — legacy sidecars and other writers' are not counted, because retention never touches them. */
+    eligible: number;
+    /** `backupRetain`; `0` when unset, which is what makes the selection empty. */
+    keep: number;
+    prefix: string;
+    /** Sidecar keys, newest-first. Each names a snapshot at the same key without the suffix. */
+    wouldDelete: string[];
+}
+
 /** A snapshot the scheduled backup took: the shared fields plus which trigger produced it. */
 interface BackupManifest extends BackupManifestEntry {
     cron: string;
@@ -74,8 +95,13 @@ const concatChunks = (chunks: ReadonlyArray<Uint8Array>, totalBytes: number): Ui
 };
 
 /**
- * Enforce `backupRetain` by keeping only the newest N snapshots **this cron**
- * wrote, deleting the older ones plus their sidecars.
+ * The sidecars this cron's retention would delete, newest-first ordering
+ * already applied — the selection, with no deletion in it.
+ *
+ * Retention and `GET /_lunora/admin/backup/retention` both call this, and that
+ * is the point: a preview that can disagree with the prune is worse than no
+ * preview, and this branch has already shown twice what happens when one rule
+ * gets written in two places. Nothing here deletes, so the preview cannot.
  *
  * The writer check is the whole point. Both backup writers share this prefix
  * and this sidecar suffix so `lunora backup list --bucket` shows one history —
@@ -97,12 +123,13 @@ const concatChunks = (chunks: ReadonlyArray<Uint8Array>, totalBytes: number): Ui
  * the safe direction. Delete those by hand once.
  *
  * Backup keys embed an ISO timestamp with `:`/`.` swapped for `-`, which sorts
- * lexicographically by recency, so a descending sort is a recency sort. A
- * no-op when retention is unset or non-positive.
+ * lexicographically by recency, so a descending sort is a recency sort. Empty
+ * when retention is unset or non-positive — nothing is ever deleted without
+ * `backupRetain`.
  */
-const pruneBackups = async (store: BackupStore, prefix: string, retain: number | undefined, cron: string): Promise<void> => {
+const selectStaleBackups = async (store: BackupStore, prefix: string, retain: number | undefined, cron: string): Promise<StaleBackups> => {
     if (retain === undefined || retain <= 0) {
-        return;
+        return { eligible: 0, stale: [] };
     }
 
     const mine: string[] = [];
@@ -126,21 +153,55 @@ const pruneBackups = async (store: BackupStore, prefix: string, retain: number |
     }
 
     // Newest first; everything past the retention window goes.
+    return { eligible: mine.length, stale: mine.toSorted((a, b) => b.localeCompare(a)).slice(retain) };
+};
+
+/**
+ * Enforce `backupRetain` by deleting every snapshot {@link selectStaleBackups}
+ * picks, plus its sidecar.
+ */
+const pruneBackups = async (store: BackupStore, prefix: string, retain: number | undefined, cron: string): Promise<void> => {
+    const { stale } = await selectStaleBackups(store, prefix, retain, cron);
+
     await Promise.all(
-        mine
-            .toSorted((a, b) => b.localeCompare(a))
-            .slice(retain)
-            .map(async (manifestKey) => {
-                // Snapshot first, sidecar second. A sidecar without its snapshot
-                // is a listable entry that fails to restore; a snapshot without
-                // its sidecar is invisible to retention forever, because the
-                // marker retention prunes on lives on the sidecar. If only one
-                // delete lands, this order is the recoverable one — the next run
-                // sees the sidecar again and retries.
-                await store.delete(backupObjectKeyOfManifest(manifestKey));
-                await store.delete(manifestKey);
-            }),
+        stale.map(async (manifestKey) => {
+            // Snapshot first, sidecar second. A sidecar without its snapshot
+            // is a listable entry that fails to restore; a snapshot without
+            // its sidecar is invisible to retention forever, because the
+            // marker retention prunes on lives on the sidecar. If only one
+            // delete lands, this order is the recoverable one — the next run
+            // sees the sidecar again and retries.
+            await store.delete(backupObjectKeyOfManifest(manifestKey));
+            await store.delete(manifestKey);
+        }),
     );
+};
+
+/**
+ * What retention would do on the next run, without doing any of it.
+ *
+ * The worker is the only party that knows its own `backupCron` and
+ * `backupRetain`, so this cannot be computed client-side — and the answer is
+ * not obvious even to an operator reading the config, because eligibility turns
+ * on the `lunoraBackupCron` marker that legacy sidecars lack. Until now the only
+ * way to find out was to let a run happen and read what was gone.
+ */
+const previewBackupRetention = async (options: WorkerOptions): Promise<BackupRetentionPreview> => {
+    const store = options.backupStore;
+
+    if (!store) {
+        throw new LunoraError("backup retention preview requires a `backupStore` on the worker", { code: "BACKUP_NOT_CONFIGURED", status: 500 });
+    }
+
+    const prefix = normalizeBackupPrefix(options.backupPrefix ?? BACKUP_KEY_PREFIX);
+    const cron = options.backupCron;
+    // No cron means no scheduled backup, so nothing carries this worker's
+    // marker and retention has nothing of its own to delete. Reported as an
+    // empty selection rather than an error: "it would delete nothing" is the
+    // true answer, and the config it comes from is in the response.
+    const { eligible, stale } = cron === undefined ? { eligible: 0, stale: [] } : await selectStaleBackups(store, prefix, options.backupRetain, cron);
+
+    return { cron, eligible, keep: options.backupRetain ?? 0, prefix, wouldDelete: stale };
 };
 
 /**
@@ -258,5 +319,5 @@ const runScheduledBackup = async (
     }
 };
 
-export type { BackupManifest };
-export { runScheduledBackup };
+export type { BackupManifest, BackupRetentionPreview };
+export { previewBackupRetention, runScheduledBackup };

--- a/plans/313-r2-backup-tier.md
+++ b/plans/313-r2-backup-tier.md
@@ -1,7 +1,7 @@
 # Plan 313 — Put the long-term backup tier on object storage instead of someone's disk
 
 **Baseline:** `38ffc2ea7` (2026-08-08)
-**Status:** PHASES 0-1 + WS5 SHIPPED in #375 (12 commits, three thermo rounds). WS4 deliberately deviated from — see §10. WS6 docs shipped.
+**Status:** PHASES 0-1 + WS5 SHIPPED in #375 (12 commits, three thermo rounds). WS4 part-shipped: the retention **preview** landed separately; the explicit operator-invoked prune remains open — see §10. WS6 docs shipped.
 **Priority:** P2 · **Effort:** M · **Risk:** MED · **Category:** data/durability
 
 > **Executor instructions**: almost everything this needs already exists — the
@@ -86,11 +86,13 @@ that: no new auth surface for this.
    into a second store.
 4. **Retention is explicit**, not clever: a `--keep <n>` / age-based prune the
    operator invokes or schedules. No silent deletion of anything.
-   **Amended 2026-08-09 — this is not what shipped.** `backupRetain` still
-   deletes inside the cron run. It only prunes snapshots carrying its own
-   cron expression and keeps anything ambiguous, so it is safe, but it is
-   narrower rather than explicit. §10 has the reasoning; WS4 remains open
-   and is the work that would make this decision true.
+   **Amended 2026-08-09 — half of this shipped.** `backupRetain` still deletes
+   inside the cron run, so the deletion is not yet something an operator
+   invokes. It only prunes snapshots carrying its own cron expression and keeps
+   anything ambiguous, so it is safe but narrower rather than explicit. The
+   _preview_ half is done: `lunora backup retention` reports what the next run
+   would delete, from the same selection the prune uses. What remains of WS4 is
+   the deletion becoming an invoked step. §10 has the reasoning.
 5. **Phase 2's scheduled backup runs in-platform** (cron trigger → action →
    export → R2), which is the point of the plan: no external machine in the
    durability path.
@@ -102,7 +104,7 @@ that: no new auth surface for this.
 | 1   | Destination interface + fs implementation refactored behind it, no behaviour change (`create`/`list`/`restore` identical output)                      | S    |
 | 2   | R2 implementation via `@lunora/storage`; bucket/prefix from config or flag                                                                            | M    |
 | 3   | `--verify` on restore: checksum the object before importing, mirroring plan 304's verified upload                                                     | S    |
-| 4   | Retention (`--keep`, `--older-than`), prune as its own verb so it is never implicit                                                                   | S    |
+| 4   | Retention: **preview shipped** (`lunora backup retention`, read-only); an operator-invoked prune verb remains open                                    | S    |
 | 5   | Phase 2 — in-platform scheduled backup: a cron-triggered action that exports and writes to R2, with failures surfaced as issues rather than swallowed | M    |
 | 6   | Docs: which tier answers which question (30-day in-place vs long-term portable), and how to restore from a bucket when the CLI machine is gone        | S    |
 
@@ -182,9 +184,21 @@ and read off the listing, so two deployments sharing a prefix keep the retention
 each configured and pre-marker sidecars are never pruned. That is safe. It is
 still not what §4.4 promised.
 
-**Left open deliberately**, as either a follow-up plan or a WS4 phase: a `prune`
-verb with a dry run, so the destructive step is something an operator invokes
-and can preview rather than a side effect of a backup succeeding.
+**The preview half has since shipped** as `lunora backup retention`
+(`GET /_lunora/admin/backup/retention`): a read-only answer to "what would
+retention delete right now", computed by the same selection the prune runs, so
+the two cannot disagree. That closes the half of §4.4 about being able to _see_
+the deletion coming — and it was the half worth doing first, because both
+data-loss defects in this branch were in retention and both were silent, and
+because eligibility depends on a metadata marker that legacy sidecars lack, so
+the behaviour on a pre-existing bucket is not deducible from the config.
+
+**Still open**, as a follow-up plan or a later WS4 phase: retention as a step an
+operator _invokes_. `backupRetain` still deletes inside every cron run, which is
+what §4.4 rules out; the preview makes it visible in advance and #387's log makes
+it visible afterwards, but neither makes it explicit. The remaining work is a
+verb that performs the deletion on demand, and a way to run the cron backup
+without the prune attached to it.
 
 ### Three rounds of review, and the pattern worth carrying forward
 


### PR DESCRIPTION
## What

`lunora backup retention` — what the platform's retention would delete on its
next run, and nothing else.

```bash
$ lunora backup retention --url https://api.example.com
backup retention would keep the newest 3 of 5 under backups/ and delete 2
  backups/lunora-backup-2026-06-01T03-00-00-000Z.ndjson
  backups/lunora-backup-2026-06-02T03-00-00-000Z.ndjson
```

Backed by `GET /_lunora/admin/backup/retention`, admin-gated like the storage
read route.

## Why this and not a log

`backupRetain` deletes on every cron run, an R2 delete has no undo, and the
thing deleted is the backup. #387 records what *was* destroyed; nothing could
say what *will* be. So the only way to learn what a retention setting does on a
real bucket was to let it run and read the aftermath.

That matters more than usual here because eligibility depends on the
`lunoraBackupCron` metadata marker, which sidecars written before that feature
lack. On a pre-existing bucket, retention may own a fraction of what the bucket
holds — and no amount of reading the config tells you which fraction. The
preview does, and says so explicitly when the answer is zero.

## The surface, and why

**`lunora backup retention`** — a report verb, not `prune --dry-run`.

- A verb named `prune` that refuses to prune is confusing, and one that previews
  by default with a `--apply` behind it advertises a deleter this PR does not
  build. `retention` names what it reports on, implies nothing destructive, and
  leaves `prune` unclaimed for the actual deleter when WS4's remaining half
  lands — so that name is not spent on something that refuses.
- Not a flag on `list`, because it answers a different question from a different
  source: `list` reads the bucket, this reads the worker's own configuration.
  `list` also works against a `--dir` destination, where retention does not
  exist.
- Nothing in this PR deletes, so there is no unsafe path to default away from.

## Preview and prune are the same selection

`pruneBackups` already computed its set before deleting. That computation is now
`selectStaleBackups`, and both the prune and the preview call it — the preview
does not re-derive eligibility, because a preview that can disagree with the
prune is worse than no preview, and this subsystem has twice produced the bug
where one rule was written in two places.

The test that matters seeds **one** bucket with every case that makes
eligibility subtle — a legacy sidecar with no marker, a sidecar carrying another
deployment's cron expression, an operator-written snapshot — then runs the
preview and a real cron fire against identical bucket state and asserts the sets
are equal. Getting the inputs genuinely identical took care: the fire writes a
snapshot before it prunes, so the seed includes a snapshot at the fire's own key
and the fire overwrites it rather than adding one. Without that the two would be
answering about different buckets and an equal result would mean nothing.

**Non-vacuity checked both ways.** Perturbing `selectStaleBackups` moves both
sides together and the parity test stays green (correctly — that is what sharing
the code buys); perturbing *only* the preview fails it immediately.

## Nothing here deletes

- The route is `GET`, calls only the selection, and never reaches a `delete`.
- A test asserts the bucket is byte-for-byte unchanged after a preview — same
  keys, same contents.
- Retention itself stays on the cron. No second deleter.
- Unauthenticated → 403 before the bucket is read, so no object key can leak;
  asserted.

## Plan

Plan 313's §4.4 amendment claimed WS4 was wholly open. Narrowed: the preview
half shipped, the deletion becoming an operator-invoked step is what remains,
along with a way to run the cron backup without the prune attached.

## Note for the merge order

#387 (the retention log) is still open and touches the same function. It
refactors `pruneBackups` into "compute `stale`, then delete, then log"; this PR
moves that same computation into `selectStaleBackups`. Whichever lands second
keeps both — the log line and the shared selection are independent. The preview's
output is deliberately phrased like #387's log line, so a prediction and the
record of a real run read as one story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sk9BLaUZDkPVAZ1sKhuDP
