### PR TITLE
feat(runtime): serve queries and sockets from the caller's region

### DIFF
--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -468,6 +468,14 @@ const ERROR_CATALOG: {
         readonly status: 429;
         readonly title: "Rate limited";
     };
+    readonly REPLICA_NOT_READY: {
+        readonly status: 421;
+        readonly title: "Replica not caught up";
+    };
+    readonly REPLICA_READ_ONLY: {
+        readonly status: 421;
+        readonly title: "Replica is read-only";
+    };
     readonly SERVICE_UNAVAILABLE: {
         readonly status: 503;
         readonly title: "Service unavailable";

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -3313,6 +3313,10 @@ Re-exported from `@lunora/platform` — signature tracked at its source.
 
 Re-exported from `@lunora/platform` — signature tracked at its source.
 
+### `ShardRegionHint` (type)
+
+Re-exported from `@lunora/platform` — signature tracked at its source.
+
 ### `ShardSqlCursor` (interface)
 
 Re-exported from `@lunora/platform` — signature tracked at its source.

--- a/api-snapshots/platform.api.md
+++ b/api-snapshots/platform.api.md
@@ -101,8 +101,8 @@ interface D1SessionLike {
 
 ```ts
 interface DirectShardDirectory {
-    get?: (id: unknown) => ShardStub;
-    getByName: (name: string) => ShardStub;
+    get?: (id: unknown, locationHint?: ShardRegionHint) => ShardStub;
+    getByName: (name: string, locationHint?: ShardRegionHint) => ShardStub;
     idForName?: (name: string) => unknown;
     jurisdiction?: (jurisdiction: ShardJurisdiction) => ShardDirectory;
 }
@@ -267,6 +267,8 @@ interface PlatformCapabilities {
         secrets?: Capability;
         shardAlarms?: Capability;
         shardedState?: Capability;
+        shardPlacement?: Capability;
+        shardReadReplicas?: Capability;
         vectorStore?: Capability;
         websocketHibernation?: Capability;
         workflows?: Capability;
@@ -565,6 +567,12 @@ interface ShardKvStore {
 }
 ```
 
+### `ShardRegionHint` (type)
+
+```ts
+type ShardRegionHint = RegionHint;
+```
+
 ### `ShardSqlCursor` (interface)
 
 ```ts
@@ -626,7 +634,7 @@ type SqlRow = Record<string, unknown>;
 
 ```ts
 interface TwoStepShardDirectory {
-    get: (id: unknown) => ShardStub;
+    get: (id: unknown, locationHint?: ShardRegionHint) => ShardStub;
     getByName?: undefined;
     idForName: (name: string) => unknown;
     jurisdiction?: (jurisdiction: ShardJurisdiction) => ShardDirectory;
@@ -747,7 +755,7 @@ interface VectorizeVector {
 ### `resolveShard` (const)
 
 ```ts
-const resolveShard: (directory: ShardDirectory, name: string) => ShardStub;
+const resolveShard: (directory: ShardDirectory, name: string, locationHint?: ShardRegionHint) => ShardStub;
 ```
 
 ## `@lunora/platform/conformance`

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -1913,10 +1913,10 @@ type ShardNamespaceInput = ShardDirectory | ShardNamespaceLike;
 
 ```ts
 interface ShardNamespaceLike {
-    get: (id: unknown) => {
+    get: (id: unknown, options?: ShardGetOptions) => {
         fetch: (request: Request) => Promise<Response>;
     };
-    getByName?: (name: string) => {
+    getByName?: (name: string, options?: ShardGetOptions) => {
         fetch: (request: Request) => Promise<Response>;
     };
     idFromName: (name: string) => unknown;
@@ -2180,6 +2180,7 @@ interface WorkerOptions {
     passThroughOnException?: boolean;
     queryCoordinator?: QueryCoordinator;
     queue?: QueueConsumerHandler;
+    replicaReads?: boolean;
     requireEphemeralWsToken?: boolean;
     resolveIdentity?: (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
     resolveTableSharding?: AdminTableResolver;
@@ -2190,6 +2191,7 @@ interface WorkerOptions {
     schedulerInstanceName?: string;
     security?: SecurityOptions;
     shardDO: ShardNamespaceLike;
+    shardRegion?: (shardKey: string) => RegionHint | undefined;
     storage?: (env: unknown) => unknown;
     storageBuckets?: string[];
     storageDelete?: StorageDeleteFunction;
@@ -2522,7 +2524,7 @@ const resolveSecurity: (security: SecurityOptions | undefined, env?: Record<stri
 ### `resolveShard` (const)
 
 ```ts
-const resolveShard: (namespace: ShardNamespaceInput, shardKey: string) => ResolvedShard;
+const resolveShard: (namespace: ShardNamespaceInput, shardKey: string, locationHint?: RegionHint) => ResolvedShard;
 ```
 
 ### `restCacheHeaders` (const)

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -1882,6 +1882,38 @@ interface RenderedSql {
 }
 ```
 
+### `ReplicaFollowerHost` (interface)
+
+```ts
+interface ReplicaFollowerHost extends ShardSiblingHost {
+    applyChanges: (changes: ReadonlyArray<CdcChange>) => Promise<number>;
+    importRows: (rows: ReadonlyArray<ExportRow>) => Promise<{
+        errors: ReadonlyArray<unknown>;
+    }>;
+}
+```
+
+### `ReplicaOwnerHost` (interface)
+
+```ts
+interface ReplicaOwnerHost extends ShardSiblingHost {
+    exportRows: () => Promise<ExportRow[]>;
+    ownerCursor: () => number | undefined;
+    ownerEpoch: () => string | undefined;
+    ownerFloor: () => number | undefined;
+    readChanges: (sinceSeq: number, limit: number) => {
+        changes: CdcChange[];
+        cursor: number;
+    };
+}
+```
+
+### `ReplicaReadiness` (type)
+
+```ts
+type ReplicaReadiness = "fresh" | "stale" | "unavailable";
+```
+
 ### `ResolveRelationPredicatesOptions` (interface)
 
 ```ts
@@ -2250,6 +2282,17 @@ interface ShardRunnerOptions {
         handleAlarm?: () => Promise<void>;
         handleFetch?: (request: Request) => Promise<Response>;
     };
+}
+```
+
+### `ShardSiblingHost` (interface)
+
+```ts
+interface ShardSiblingHost {
+    doName: () => string | undefined;
+    env: () => unknown;
+    shardBinding: () => string | undefined;
+    sql: () => SqlExec;
 }
 ```
 
@@ -3137,6 +3180,12 @@ const createReadFootprint: () => ReadFootprint;
 const createRelayLink: (host: RelayHost) => OwnerRelay | RelayMember | undefined;
 ```
 
+### `createReplicaLink` (const)
+
+```ts
+const createReplicaLink: (host: ReplicaFollowerHost) => ShardReplica | undefined;
+```
+
 ### `createShardCtxDb` (const)
 
 ```ts
@@ -3278,6 +3327,12 @@ const findStorageReferences: (sql: SqlExec, storageColumns: Record<string, strin
 const foldAggregateTally: (tallies: Map<string, AggregateTally>, encoded: string, index: AggregateIndexDefinitionLike, record: Record<string, unknown>) => void;
 ```
 
+### `gateReplicaDispatch` (const)
+
+```ts
+const gateReplicaDispatch: (replica: ShardReplica, request: Request, functionPath: string) => Promise<Response | undefined>;
+```
+
 ### `geoTableName` (const)
 
 ```ts
@@ -3288,6 +3343,12 @@ const geoTableName: (table: string, indexName: string) => string;
 
 ```ts
 const guardWriter: <W>(raw: W, schema: GuardableSchema, tableOfId: TableOfId, tablesOfIds?: TablesOfIds) => W;
+```
+
+### `handleReplicaControl` (const)
+
+```ts
+const handleReplicaControl: (host: ReplicaOwnerHost, request: Request) => Promise<Response>;
 ```
 
 ### `hasTrigger` (const)

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -1905,6 +1905,7 @@ interface ReplicaOwnerHost extends ShardSiblingHost {
         changes: CdcChange[];
         cursor: number;
     };
+    rowCount: () => number;
 }
 ```
 

--- a/apps/docs/src/content/docs/concepts/read-replicas.mdx
+++ b/apps/docs/src/content/docs/concepts/read-replicas.mdx
@@ -52,9 +52,26 @@ the caller's region:
 ```ts
 export default createWorker({
     shardDO: env.SHARD,
+    // The registry is what tells the worker which calls are queries. Codegen
+    // threads it for you; a hand-written worker must pass it, or nothing is
+    // eligible and every read stays on the owner.
+    functions: LUNORA_FUNCTIONS,
     replicaReads: true,
 });
 ```
+
+Four things all have to hold before a read is served from a replica, and each
+one falls back to the owner rather than failing:
+
+1. `replicaReads: true`.
+2. `functions` is passed, and the call is a registered **query** — a mutation,
+   action or stream is never eligible.
+3. Cloudflare could geolocate the request. A caller it cannot place has no
+   region to be near, so there is no replica to prefer.
+4. The shard has a changelog (see below) and its replica is caught up.
+
+Set the whole thing up and watch reads still go to the owner, and it is almost
+always (2) or (4).
 
 A replica is a second Durable Object, named after the shard it follows, that
 replays the shard's CDC changelog into its own SQLite. It is a follower in the

--- a/apps/docs/src/content/docs/concepts/read-replicas.mdx
+++ b/apps/docs/src/content/docs/concepts/read-replicas.mdx
@@ -1,0 +1,151 @@
+---
+title: Read replicas & placement
+description: Serve one-shot queries from a copy of the shard in the caller's region, pin where a shard is created, and terminate sockets near the client.
+---
+
+A shard lives in exactly one place. That is what makes its writes serialized and
+its reads consistent — and it is also why a reader on the other side of the
+world pays the round trip. This page covers the three controls that move work
+closer to the reader, and what each one costs.
+
+None of them are on by default. A single-region app should leave them alone.
+
+## Where a shard is created
+
+By default Cloudflare creates a Durable Object in the data centre nearest the
+request that first touched it. That is usually right — the first request is
+normally a user's — but not always: a shard first materialized by a cron fire, a
+migration fan-out, a seeding run, or the Studio lands wherever _that_ ran, and
+stays there for its whole life.
+
+`shardRegion` decides for those cases:
+
+```ts
+export default createWorker({
+    shardDO: env.SHARD,
+    // A tenant whose region you already know, pinned regardless of who touches
+    // it first.
+    shardRegion: (shardKey) => tenantRegions[shardKey],
+});
+```
+
+Return `undefined` for a key you have no opinion about and the default applies.
+The hint is honoured only by the resolution that **creates** the object, so
+changing this later does not move a shard that already exists — moving one is an
+[export → import](/docs/concepts/backups) job.
+
+This is placement, not residency. If you need a hard guarantee about where data
+lives, use [`.jurisdiction()`](/docs/concepts/data-residency), which constrains
+rather than hints.
+
+## Replica reads
+
+`replicaReads` serves one-shot **queries** from a copy of the shard placed in
+the caller's region:
+
+```ts
+export default createWorker({
+    shardDO: env.SHARD,
+    replicaReads: true,
+});
+```
+
+A replica is a second Durable Object, named after the shard it follows, that
+replays the shard's CDC changelog into its own SQLite. It is a follower in the
+strict sense: it never accepts a write, never originates a row, and refuses any
+dispatch the runtime did not explicitly route to it as a read.
+
+**Requires CDC.** The changelog _is_ the replication feed. Without it a replica
+has nothing to follow, reports itself unavailable, and every read falls back to
+the owner — correct, but one wasted hop per read.
+
+### What stays on the owner
+
+Everything except one-shot queries:
+
+| Dispatch                         | Served by                                             |
+| -------------------------------- | ----------------------------------------------------- |
+| `query`                          | The region-local replica, when it can                 |
+| `mutation` / `action` / `stream` | The owner, always                                     |
+| Live subscriptions               | The owner (or its [relays](#sockets-near-the-client)) |
+| Fan-out, admin, PITR, export     | The owner                                             |
+
+### Consistency
+
+Read-your-writes is preserved **per client**, automatically. The server echoes
+the cursor each write committed at; `@lunora/client` remembers it per shard and
+sends it back on later calls, and a replica that has not caught up to it sends
+the read to the owner instead of answering from an older copy.
+
+What you are trading away is freshness for _other people's_ writes: a read that
+carries no cursor may be up to `LUNORA_REPLICA_MAX_STALENESS_MS` (default
+`1000`) behind. If a query must never be behind anyone's write, do not enable
+this — or keep that query on a live subscription, which is owner-served and
+pushed.
+
+A replica reports itself unusable, and reads fall back to the owner, when it
+cannot reconcile with its owner at all:
+
+- the owner's changelog timeline **forked** (a reset or a point-in-time
+  rollback), so replay would fabricate a state neither side held;
+- the changelog was **compacted** past the replica's position, so the gap cannot
+  be replayed;
+- the shard is **too large to snapshot** in one response, so bootstrapping would
+  leave the replica with an arbitrary prefix of it.
+
+All three are dead ends, and a Durable Object is never destroyed — so in
+practice a replica that diverges stays diverged, and every read in that region
+pays a wasted hop to it before falling back for as long as the deployment
+lives. Reads stay correct throughout; they just stop being local, quietly.
+
+### Cost
+
+Each replica is another Durable Object holding a full copy of the shard: storage
+per region, plus the changelog traffic to keep it current. Replicas are created
+on demand, one per region that actually reads, so the bill follows your traffic
+rather than your region list.
+
+Three costs worth knowing before you turn it on:
+
+- **Below roughly one read per second per region, a replica is _slower_ than the
+  owner.** Outside the staleness window the first read pays a catch-up round
+  trip to the owner — the same cross-world hop it exists to avoid — and then
+  answers locally. The tier pays for itself under steady read traffic, not under
+  a trickle.
+- **Query telemetry follows the DO that served it.** Request logs, function
+  metrics and issue grouping are written into the serving shard's own storage,
+  so replica-served reads land in per-region replicas that the Studio's pages
+  (which read the owner) do not show.
+- **`::replica::` is a reserved infix in a shard key**, exactly like `::relay::`.
+  A key containing it addresses a DO that will refuse every dispatch, whether or
+  not `replicaReads` is on.
+
+## Sockets near the client
+
+Live subscriptions are owner-served, so a client's WebSocket normally terminates
+wherever the shard lives. Once a shard is hot enough to promote to the
+[relay tier](/docs/concepts/realtime), that changes: connections spread across
+relay DOs, and each relay is **created in the region of the client that first
+reached it**. A single-region app therefore ends up with every relay in its own
+region; a multi-region one spreads them across the regions actually generating
+load. The socket terminates near the client, and only the owner→relay hop
+crosses the world — once per relay rather than once per connection.
+
+The spread itself stays random on purpose. Routing a whole region to one relay
+would give tighter locality and pile that region's entire connection load onto a
+single DO — re-creating the fan-out wall promotion exists to escape.
+
+There is nothing to configure; it applies automatically above the promotion
+threshold.
+
+<Callout type="info">
+    **One socket per shard.** A client subscribing across several shards still opens one socket per shard. Collapsing those onto a single connection is not
+    implemented.
+</Callout>
+
+## See also
+
+- [Sharding](/docs/concepts/sharding)
+- [Data residency](/docs/concepts/data-residency)
+- [Realtime](/docs/concepts/realtime)
+- [Backups](/docs/concepts/backups)

--- a/apps/docs/src/content/docs/concepts/read-replicas.mdx
+++ b/apps/docs/src/content/docs/concepts/read-replicas.mdx
@@ -38,6 +38,12 @@ This is placement, not residency. If you need a hard guarantee about where data
 lives, use [`.jurisdiction()`](/docs/concepts/data-residency), which constrains
 rather than hints.
 
+<Callout type="warn">
+    **A jurisdiction turns every region hint off.** On a deployment pinned with `.jurisdiction(...)`, `shardRegion` and the replica/relay hints are not sent —
+    the jurisdiction already constrains placement, and it is the constraint that must hold. The worker logs this once so an ignored `shardRegion` is never a
+    silent surprise.
+</Callout>
+
 ## Replica reads
 
 `replicaReads` serves one-shot **queries** from a copy of the shard placed in

--- a/apps/docs/src/content/docs/meta.json
+++ b/apps/docs/src/content/docs/meta.json
@@ -40,6 +40,7 @@
         "concepts/occ",
         "concepts/sharding",
         "concepts/data-residency",
+        "concepts/read-replicas",
         "concepts/ttl",
         "concepts/migrations",
         "concepts/backups",

--- a/packages/client/__tests__/replica-bookmark.test.ts
+++ b/packages/client/__tests__/replica-bookmark.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { LunoraClient } from "../src/lunora-client";
+import type { FunctionReference } from "../src/types";
+
+/**
+ * Read-your-writes across region-local read replicas.
+ *
+ * The server echoes the CDC cursor a write committed at (`commitCursor`); this
+ * client remembers it per shard and sends it back as `x-lunora-min-seq`, which
+ * is what stops a replica from answering a later read from a copy that predates
+ * that write. Everything here is inert on a deployment with `replicaReads` off —
+ * the header is simply ignored.
+ */
+
+const fnRef = (ref: string): FunctionReference => {
+    return { __lunoraRef: ref };
+};
+
+class NoopSocket {
+    public readonly readyState = 0;
+}
+
+const client = (fetchImpl: typeof fetch): LunoraClient =>
+    new LunoraClient({ fetch: fetchImpl, url: "https://app.example", WebSocket: NoopSocket as unknown as typeof WebSocket });
+
+/** The `x-lunora-min-seq` header on the nth captured request, or `undefined` when absent. */
+const minSeqOf = (fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, index: number): string | undefined => {
+    const [, init] = fetchMock.mock.calls[index] as unknown as [string, RequestInit];
+
+    return (init.headers as Record<string, string>)["x-lunora-min-seq"];
+};
+
+describe("replica read-your-writes bookmark", () => {
+    it("sends no bookmark before the client has written anything", async () => {
+        expect.assertions(1);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ result: [] }));
+
+        await client(fetchMock).query(fnRef("posts:list"), {});
+
+        // Nothing to require yet — the read may be served from any replica
+        // inside the staleness window.
+        expect(minSeqOf(fetchMock, 0)).toBeUndefined();
+    });
+
+    it("requires at least the cursor its own write committed at", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ commitCursor: 17, result: null }));
+        const instance = client(fetchMock);
+
+        await instance.mutation(fnRef("posts:add"), { title: "hi" });
+
+        expect(minSeqOf(fetchMock, 0)).toBeUndefined();
+
+        await instance.query(fnRef("posts:list"), {});
+
+        expect(minSeqOf(fetchMock, 1)).toBe("17");
+    });
+
+    it("never moves the requirement backwards", async () => {
+        expect.assertions(1);
+
+        // Responses can land out of order; taking the lower cursor would let a
+        // read be answered from a copy predating a write this client has seen.
+        const cursors = [30, 12];
+        const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ commitCursor: cursors.shift(), result: null }));
+        const instance = client(fetchMock);
+
+        await instance.mutation(fnRef("posts:add"), {});
+        await instance.mutation(fnRef("posts:add"), {});
+        await instance.query(fnRef("posts:list"), {});
+
+        expect(minSeqOf(fetchMock, 2)).toBe("30");
+    });
+
+    it("keeps the cursor per shard", async () => {
+        expect.assertions(2);
+
+        const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ commitCursor: 9, result: null }));
+        const instance = client(fetchMock);
+
+        await instance.mutation(fnRef("posts:add"), {}, { shardKey: "tenant-a" });
+        await instance.query(fnRef("posts:list"), {}, { shardKey: "tenant-a" });
+
+        expect(minSeqOf(fetchMock, 1)).toBe("9");
+
+        // A different shard has its own timeline; requiring tenant-a's cursor
+        // there would demand a position that shard's log may never reach.
+        await instance.query(fnRef("posts:list"), {}, { shardKey: "tenant-b" });
+
+        expect(minSeqOf(fetchMock, 2)).toBeUndefined();
+    });
+});

--- a/packages/client/__tests__/replica-bookmark.test.ts
+++ b/packages/client/__tests__/replica-bookmark.test.ts
@@ -75,6 +75,33 @@ describe("replica read-your-writes bookmark", () => {
         expect(minSeqOf(fetchMock, 2)).toBe("30");
     });
 
+    it("treats an implicit shard and the server's default-shard name as one shard", async () => {
+        expect.assertions(2);
+
+        // Only the server knows that omitting `shardKey` and naming its
+        // configured default are the same shard, so it says which key it
+        // resolved. Without that, one shard's cursor splits across two client
+        // entries and a write under one spelling stops constraining a read under
+        // the other.
+        const fetchMock = vi.fn<typeof fetch>(
+            async () => Response.json({ commitCursor: 21, result: null }, { headers: { "x-lunora-shard-key": "__root__" } }),
+        );
+        const instance = client(fetchMock);
+
+        // Write with no shard key at all; the response names the shard.
+        await instance.mutation(fnRef("posts:add"), {});
+
+        // Read naming that same shard explicitly — the requirement must carry.
+        await instance.query(fnRef("posts:list"), {}, { shardKey: "__root__" });
+
+        expect(minSeqOf(fetchMock, 1)).toBe("21");
+
+        // …and the other way around, from the explicit name back to the implicit call.
+        await instance.query(fnRef("posts:list"), {});
+
+        expect(minSeqOf(fetchMock, 2)).toBe("21");
+    });
+
     it("keeps the cursor per shard", async () => {
         expect.assertions(2);
 

--- a/packages/client/__tests__/replica-bookmark.test.ts
+++ b/packages/client/__tests__/replica-bookmark.test.ts
@@ -83,9 +83,7 @@ describe("replica read-your-writes bookmark", () => {
         // resolved. Without that, one shard's cursor splits across two client
         // entries and a write under one spelling stops constraining a read under
         // the other.
-        const fetchMock = vi.fn<typeof fetch>(
-            async () => Response.json({ commitCursor: 21, result: null }, { headers: { "x-lunora-shard-key": "__root__" } }),
-        );
+        const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ commitCursor: 21, result: null }, { headers: { "x-lunora-shard-key": "__root__" } }));
         const instance = client(fetchMock);
 
         // Write with no shard key at all; the response names the shard.

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -1904,6 +1904,24 @@ class LunoraClient {
             throw new LunoraError("INTERNAL", `LunoraClient: batch request failed (status ${response.status.toString()})`);
         }
 
+        // Each entry is dispatched as an independent single call server-side, so
+        // each carries its own commit cursor — recorded under its OWN shard, or a
+        // batched write would leave no read-your-writes requirement behind at
+        // all. Read off the raw envelopes because `demuxBatchResults` keeps only
+        // the result value.
+        //
+        // No outbound `x-lunora-min-seq` per entry: the batch route forwards
+        // straight to the owner shard and is never replica-served, so a
+        // per-entry freshness requirement would constrain nothing. What these
+        // cursors constrain is the SINGLE reads that follow.
+        for (const entry of body.results ?? []) {
+            const commitCursor = (entry.body as { commitCursor?: unknown } | undefined)?.commitCursor;
+
+            if (typeof entry.id === "number" && typeof commitCursor === "number") {
+                this.recordShardCursor(calls[entry.id]?.shardKey, commitCursor);
+            }
+        }
+
         return demuxBatchResults(body.results ?? [], calls.length);
     }
 

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -748,6 +748,18 @@ class LunoraClient {
     private readonly clientId: string;
 
     /**
+     * Highest CDC cursor this client has seen a write commit at, per shard key
+     * (`""` for the default shard) — the read-your-writes bookmark sent as
+     * `x-lunora-min-seq`.
+     *
+     * In memory only, and deliberately: it exists to keep THIS session's reads
+     * behind THIS session's writes. Persisting it across reloads would pin a
+     * fresh page to a cursor it has no reason to require and force needless
+     * fallbacks to the owner.
+     */
+    private readonly shardCursors = new Map<string, number>();
+
+    /**
      * `true` when the constructor's hydration microtask has finished loading the
      * durable read cache (Pillar 2) into `hydratedQueryCache`. Signals that
      * the cache is ready for synchronous `peekHydratedQuery` reads.
@@ -4165,8 +4177,23 @@ class LunoraClient {
      * so a mutation the server already committed returns its cached result
      * instead of running twice.
      */
-    private rpcRequestHeaders(flags: { attachBookmark?: boolean; clientId?: string; clientSeq?: number; mutationId?: string }): Record<string, string> {
+    private rpcRequestHeaders(
+        flags: { attachBookmark?: boolean; clientId?: string; clientSeq?: number; mutationId?: string },
+        shardKey?: string,
+    ): Record<string, string> {
         const headers: Record<string, string> = { "content-type": "application/json" };
+
+        // Read-your-writes across region-local read replicas: the cursor this
+        // client's last write to this shard committed at. A worker with
+        // `replicaReads` on will only answer from a replica that has caught up
+        // to it; everywhere else the header is inert. Sent on every call rather
+        // than only on reads — a write is routed to the owner regardless, so
+        // there is no branch here that could get the two out of step.
+        const shardCursor = this.shardCursors.get(shardKey ?? "");
+
+        if (shardCursor !== undefined) {
+            headers["x-lunora-min-seq"] = shardCursor.toString();
+        }
 
         if (this.authToken) {
             headers["authorization"] = `Bearer ${this.authToken}`;
@@ -4224,7 +4251,7 @@ class LunoraClient {
             throw new LunoraError("INTERNAL", "LunoraClient: no `fetch` implementation available");
         }
 
-        const headers = this.rpcRequestHeaders(flags);
+        const headers = this.rpcRequestHeaders(flags, shardKey);
 
         const response = await this.fetchImpl(joinUrl(this.url, RPC_PATH), {
             // `encodeWire` tags leaves plain JSON can't carry (`bigint`,
@@ -4270,6 +4297,12 @@ class LunoraClient {
 
         flags.onMutationAck?.(body.lastMutationId);
         flags.onCommitCursor?.(body.commitCursor);
+
+        // Remember how far this shard had committed, so a later read can demand
+        // at least this much from a replica. Monotonic: responses can land out
+        // of order, and moving the requirement BACKWARDS would let a read be
+        // answered from a copy that predates a write this client already saw.
+        this.recordShardCursor(shardKey, body.commitCursor);
 
         return decodeWire(body.result);
     }
@@ -5779,9 +5812,33 @@ class LunoraClient {
     /** Settle a write that replayed successfully: confirm its optimistic layer against the echoed commit cursor BEFORE resolving, so the gapless drop is in place when the awaiter (and any confirming frame) observes the settle. */
     private settleReplaySuccess(item: QueuedMutation, value: unknown, commitCursor: number | undefined): void {
         this.unpersist(item.id);
+        // A replayed write commits like any other, so it advances this shard's
+        // read-your-writes bookmark too. Recorded HERE rather than only in
+        // `rpc()` because the batched replay never goes through it — and a
+        // client flushing its queue after a reconnect, then reading, is exactly
+        // the case the bookmark exists for.
+        this.recordShardCursor(item.shardKey, commitCursor);
         item.onCommit?.(commitCursor);
         item.resolve(value);
         this.emitItemSettled(item, "committed");
+    }
+
+    /**
+     * Record the cursor a write committed at as this shard's read-your-writes
+     * requirement.
+     *
+     * Monotonic: responses can land out of order, and moving the requirement
+     * BACKWARDS would let a later read be answered from a replica copy that
+     * predates a write this client already saw.
+     */
+    private recordShardCursor(shardKey: string | undefined, commitCursor: number | undefined): void {
+        if (typeof commitCursor !== "number") {
+            return;
+        }
+
+        const key = shardKey ?? "";
+
+        this.shardCursors.set(key, Math.max(this.shardCursors.get(key) ?? 0, commitCursor));
     }
 
     /** Settle a write the server reached a coded verdict on: replaying would re-trigger the same failure (a poison-message loop), so drop it. */
@@ -5884,6 +5941,11 @@ class LunoraClient {
                         };
                     }),
                 }),
+                // No shard key: a batch's entries may target several shards, and
+                // one outbound `x-lunora-min-seq` cannot state a requirement for
+                // all of them. Writes go to the owner regardless, so omitting it
+                // costs nothing — the per-entry cursors are recorded on the way
+                // back out (`settleReplaySuccess`).
                 headers: this.rpcRequestHeaders({ attachBookmark: true }),
                 method: "POST",
             });

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -760,6 +760,14 @@ class LunoraClient {
     private readonly shardCursors = new Map<string, number>();
 
     /**
+     * The server's own name for the default shard (`defaultShardKey`), learned
+     * from the first response to a call that named no shard. `undefined` until
+     * then, which is why `cursorKeyFor` falls back to a placeholder entry that
+     * `learnDefaultShardKey` folds in once the name arrives.
+     */
+    private defaultShardKey: string | undefined;
+
+    /**
      * `true` when the constructor's hydration microtask has finished loading the
      * durable read cache (Pillar 2) into `hydratedQueryCache`. Signals that
      * the cache is ready for synchronous `peekHydratedQuery` reads.
@@ -4189,7 +4197,7 @@ class LunoraClient {
         // to it; everywhere else the header is inert. Sent on every call rather
         // than only on reads — a write is routed to the owner regardless, so
         // there is no branch here that could get the two out of step.
-        const shardCursor = this.shardCursors.get(shardKey ?? "");
+        const shardCursor = this.shardCursors.get(this.cursorKeyFor(shardKey));
 
         if (shardCursor !== undefined) {
             headers["x-lunora-min-seq"] = shardCursor.toString();
@@ -4299,9 +4307,9 @@ class LunoraClient {
         flags.onCommitCursor?.(body.commitCursor);
 
         // Remember how far this shard had committed, so a later read can demand
-        // at least this much from a replica. Monotonic: responses can land out
-        // of order, and moving the requirement BACKWARDS would let a read be
-        // answered from a copy that predates a write this client already saw.
+        // at least this much from a replica — filed under the one key both an
+        // implicit call and an explicit default-shard call resolve to.
+        this.learnDefaultShardKey(response, shardKey);
         this.recordShardCursor(shardKey, body.commitCursor);
 
         return decodeWire(body.result);
@@ -5824,6 +5832,47 @@ class LunoraClient {
     }
 
     /**
+     * The entry a shard's cursor lives under.
+     *
+     * Only the server knows that an omitted `shardKey` and an explicit one
+     * spelling out its configured default name are the same shard — the default
+     * is server-side configuration the client never sees. Keying on what was
+     * SENT would split one shard's cursor across two entries, so a write under
+     * one spelling would stop constraining a read under the other. Resolving
+     * `undefined` through the learned name is what keeps both spellings on one
+     * entry.
+     */
+    private cursorKeyFor(shardKey: string | undefined): string {
+        return shardKey ?? this.defaultShardKey ?? "";
+    }
+
+    /**
+     * Learn the server's own name for the default shard from a response to a
+     * call that named no shard.
+     *
+     * Any cursor recorded before the name was known sits under the placeholder
+     * entry, so it is folded in rather than stranded — otherwise the requirement
+     * from a client's first write would be lost exactly once, which is the kind
+     * of gap that only shows up as a stale read under load.
+     */
+    private learnDefaultShardKey(response: { headers: { get: (name: string) => null | string } }, shardKey: string | undefined): void {
+        const canonical = response.headers.get("x-lunora-shard-key");
+
+        if (canonical === null || shardKey !== undefined || this.defaultShardKey === canonical) {
+            return;
+        }
+
+        this.defaultShardKey = canonical;
+
+        const pending = this.shardCursors.get("");
+
+        if (pending !== undefined) {
+            this.shardCursors.set(canonical, Math.max(this.shardCursors.get(canonical) ?? 0, pending));
+            this.shardCursors.delete("");
+        }
+    }
+
+    /**
      * Record the cursor a write committed at as this shard's read-your-writes
      * requirement.
      *
@@ -5836,7 +5885,7 @@ class LunoraClient {
             return;
         }
 
-        const key = shardKey ?? "";
+        const key = this.cursorKeyFor(shardKey);
 
         this.shardCursors.set(key, Math.max(this.shardCursors.get(key) ?? 0, commitCursor));
     }

--- a/packages/do/__tests__/shard-do.replica-role.test.ts
+++ b/packages/do/__tests__/shard-do.replica-role.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ShardDOState } from "../src/shard-do";
+import { ShardDO } from "../src/shard-do";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * What a replica-role DO refuses.
+ *
+ * A replica runs the owner's class — same generated subclass, same alarm tiers,
+ * same routes — and its role is known only from its name. Everything that
+ * belongs to the single writer therefore has to be turned off explicitly here,
+ * and each of these is a behaviour the engine-level suite cannot see because it
+ * is about the DO's wiring rather than the follow loop.
+ */
+class RoleShard extends ShardDO {
+    public readonly dispatched: string[] = [];
+
+    public override async handleRpc(functionPath: string): Promise<unknown> {
+        this.dispatched.push(functionPath);
+
+        return { ok: true };
+    }
+
+    /** Drive the alarm entry the runner delegates to. */
+    public async driveAlarm(): Promise<void> {
+        await this.handleAlarmCloudflare();
+    }
+}
+
+/**
+ * Count the alarm's first tier without declaring an override.
+ *
+ * `pollGlobalShapes` is private on the base class, so a subclass cannot declare
+ * it — but dispatch is dynamic, and what is under test is precisely whether the
+ * alarm DISPATCHES it at all. Installing the counter on the instance keeps the
+ * production surface unchanged and still observes the thing that matters.
+ */
+const countAlarmWork = (shard: RoleShard): { runs: number } => {
+    const seen = { runs: 0 };
+
+    Object.assign(shard, {
+        pollGlobalShapes: async () => {
+            seen.runs += 1;
+
+            return 0;
+        },
+    });
+
+    return seen;
+};
+
+const rpc = (headers: Record<string, string> = {}): Request =>
+    new Request("https://shard.internal/rpc", { body: JSON.stringify({ args: {}, functionPath: "posts:list" }), headers, method: "POST" });
+
+describe("shardDO replica role", () => {
+    let harness: ReturnType<typeof createSqliteExec>;
+
+    const shardNamed = (name?: string): RoleShard =>
+        new RoleShard(
+            {
+                getWebSockets: () => [],
+                ...(name === undefined ? {} : { id: { name } }),
+                storage: { sql: harness.sql },
+            } as unknown as ShardDOState,
+            {},
+        );
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    it("refuses a dispatch the runtime did not mark as a replica read", async () => {
+        expect.assertions(2);
+
+        const shard = shardNamed("tenant-7::replica::weur");
+        const response = await shard.fetch(rpc());
+
+        expect(response.status).toBe(421);
+        // The gate runs before user code: a mutation that slipped through the
+        // routing must not have executed by the time it is rejected.
+        expect(shard.dispatched).toStrictEqual([]);
+    });
+
+    it("refuses a WebSocket upgrade", async () => {
+        expect.assertions(1);
+
+        // A replica advances only when a read triggers a catch-up, so a
+        // subscription served here would be a live query that mostly is not.
+        const response = await shardNamed("tenant-7::replica::weur").fetch(new Request("https://shard.internal/ws", { headers: { Upgrade: "websocket" } }));
+
+        expect(response.status).toBe(421);
+    });
+
+    it("runs no background work on the alarm", async () => {
+        expect.assertions(1);
+
+        const shard = shardNamed("tenant-7::replica::weur");
+        const work = countAlarmWork(shard);
+
+        await shard.driveAlarm();
+
+        // Every alarm tier the schema arms — external-source polling above all,
+        // which resolves its tenant from this DO's own name — would otherwise
+        // fire against a copy.
+        expect(work.runs).toBe(0);
+    });
+
+    it("leaves an owner-role DO untouched", async () => {
+        expect.assertions(3);
+
+        const shard = shardNamed("tenant-7");
+        const work = countAlarmWork(shard);
+        const response = await shard.fetch(rpc());
+
+        await shard.driveAlarm();
+
+        expect(response.status).toBe(200);
+        expect(shard.dispatched).toStrictEqual(["posts:list"]);
+        // The guard is role-specific, not a blanket disable.
+        expect(work.runs).toBe(1);
+    });
+
+    it("leaves an unnamed single-DO shard untouched", async () => {
+        expect.assertions(1);
+
+        const shard = shardNamed();
+
+        await shard.fetch(rpc());
+
+        expect(shard.dispatched).toStrictEqual(["posts:list"]);
+    });
+});

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -97,6 +97,7 @@ import type {
     ReadFootprint,
     RelayHost,
     RelayMember,
+    ReplicaOwnerHost,
     ResolvedShape,
     RlsPoliciesResult,
     RpcRequest,
@@ -105,6 +106,7 @@ import type {
     ShapeRowOp,
     ShapeSubscriptionQuery,
     ShardRankPageResult,
+    ShardSiblingHost,
     ShardSocketLike,
     SocketAttachment,
     SqlExec,
@@ -139,6 +141,7 @@ import {
     createFanoutCounters,
     createReadFootprint,
     createRelayLink,
+    createReplicaLink,
     DATA_MIGRATION_STATE_TABLE,
     DEFAULT_MAX_RELAYS,
     deleteGlobalShapeSnapshot,
@@ -148,6 +151,8 @@ import {
     facetColumn,
     findStorageReferences,
     FLAGS_FUNCTION_PREFIX,
+    gateReplicaDispatch,
+    handleReplicaControl,
     isDevEnvironment,
     isLossyBody,
     listTables,
@@ -1301,6 +1306,20 @@ abstract class ShardDO {
     private readonly relay: OwnerRelay | RelayMember | undefined;
 
     /**
+     * The read-replica collaborator — set only on a DO whose name marks it as a
+     * replica of another shard, `undefined` on an owner (and on an unnamed
+     * single-DO shard, where there is nothing to replicate from).
+     */
+    private readonly replica: ReturnType<typeof createReplicaLink>;
+
+    /**
+     * The owner half of the replica seam — what answers `/_lunora/replica` for
+     * the replicas following this shard. Present on every DO, because a DO
+     * cannot know whether anything follows it until something asks.
+     */
+    private readonly replicaOwnerHost: ReplicaOwnerHost;
+
+    /**
      * Declared indexes (`table:index`) a query has exercised since this instance
      * woke, stamped by `getCtxDbIndexUseHook`. In-memory and reset on
      * hibernation/restart — drives the `unused_index` runtime advisory.
@@ -1466,15 +1485,24 @@ abstract class ShardDO {
             this.reactiveCache = new ReactiveCache(options.reactiveCache);
         }
 
+        // What every internal tier needs from this DO: its own name (the role
+        // signal), the env, the namespace binding, and SQLite. Built once and
+        // spread into each tier's host so the four can never drift apart.
+        const sibling: ShardSiblingHost = {
+            doName: () => this.runner.shardKey,
+            env: () => this.env,
+            shardBinding: () => this.shardBinding,
+            sql: () => this.sql as SqlExec,
+        };
+
         // The relay tier reaches this DO back through a narrow adapter; the role-typed
         // collaborator (owner vs relay) is fixed once from the DO name (plan 075).
         const host: RelayHost = {
+            ...sibling,
             buildShapeDiff: (resolved, fromCursor, toCursor) => this.buildShapeDiff(this.sql as SqlExec, resolved, fromCursor, toCursor),
             computeOpLogShapeSeed: (shape, resolved) => this.computeOpLogShapeSeed(shape, resolved),
             currentCdcEpoch: () => this.currentCdcEpoch(),
             deliverWhisperLocal: (topic, frame, exclude) => this.deliverWhisperLocal(topic, frame, exclude),
-            doName: () => this.runner.shardKey,
-            env: () => this.env,
             getWebSockets: () => this.runner.sockets(),
             maskMetadata: () => this.maskMetadata(),
             nextPokeId: () => {
@@ -1488,11 +1516,40 @@ abstract class ShardDO {
             },
             resolveShape: (name, args, identity) => this.resolveShape(name, args, identity),
             rlsMetadata: () => this.rlsMetadata(),
-            shardBinding: () => this.shardBinding,
-            sql: () => this.sql as SqlExec,
         };
 
         this.relay = createRelayLink(host);
+
+        // Region-local read replicas. Same rule as the relay tier: the role is
+        // fixed once from the DO name. The owner half is what SERVES
+        // `/_lunora/replica`; `this.replica` is set only on a DO that follows one.
+        //
+        // The three CDC readers pass `undefined` straight through — it means
+        // "this shard has no changelog", and the replica tier refuses to
+        // replicate a shard that cannot be followed rather than inventing a
+        // timeline out of a sentinel.
+        this.replicaOwnerHost = {
+            ...sibling,
+            exportRows: async () => this.runShardExport({}),
+            ownerCursor: () => this.currentCdcCursor(),
+            ownerEpoch: () => this.currentCdcEpoch(),
+            ownerFloor: () => (this.cdcEnabled() ? minCdcSeq(this.sql as SqlExec) : undefined),
+            readChanges: (sinceSeq, limit) => this.runShardCdcSync({ limit, sinceSeq }),
+        };
+        this.replica = createReplicaLink({
+            ...sibling,
+            applyChanges: async (changes) => {
+                const { applied } = await this.runShardApplyCdc({ changes });
+
+                // Same post-replay step the `applyCdc` admin RPC takes: replayed
+                // rows are real writes, so any live subscriber on this DO has to
+                // see them.
+                await this.flushChangedTables();
+
+                return applied;
+            },
+            importRows: async (rows) => this.runShardImport({ rows }),
+        });
 
         this.armWebSocketKeepalive();
     }
@@ -4333,6 +4390,16 @@ abstract class ShardDO {
             return jsonResponse({ error: { code: "BAD_REQUEST", message: "invalid JSON body" } }, 400);
         }
 
+        // A replica serves ONLY the reads the runtime explicitly routed to it,
+        // and only once it has caught up far enough to answer them.
+        if (this.replica !== undefined) {
+            const refusal = await gateReplicaDispatch(this.replica, request, payload.functionPath);
+
+            if (refusal !== undefined) {
+                return refusal;
+            }
+        }
+
         // Reserved admin-introspection RPCs are intercepted before user
         // dispatch — they read raw SQLite directly rather than running a
         // registered function, and carry their own bearer-token gate.
@@ -4680,6 +4747,17 @@ abstract class ShardDO {
      * as the host-specific handler while the engine is progressively extracted.
      */
     protected async handleAlarmCloudflare(): Promise<void> {
+        // A replica runs the owner's class, so every background tier the schema
+        // arms — external-source polling, TTL sweeps, global-shape polls — would
+        // otherwise fire here too, against a COPY. The damage is not theoretical:
+        // an external source resolves its tenant from `currentShardKey()`, which
+        // on a replica is the replica's own name, so a full pull would match
+        // nothing and diff every replicated row into a delete. Background work
+        // belongs to the single writer; a follower only ever replays.
+        if (this.replica !== undefined) {
+            return;
+        }
+
         // Captured before the first `await`, then passed by value everywhere below:
         // this handler is the alarm's own scope, so nothing has interleaved yet.
         // `undefined` when the alarm ran outside `withTriggerTrace` (a direct call
@@ -9031,6 +9109,14 @@ abstract class ShardDO {
             return this.relay ? await this.relay.handleControl(request) : new Response("relay tier inactive", { status: 404 });
         }
 
+        // The replica follow channel: a replica pulls its owner's changelog (or
+        // takes a bootstrap snapshot) here. Authenticated by the same
+        // `LUNORA_RELAY_SECRET` HMAC as the relay channel, and refused by a DO
+        // that is itself a replica.
+        if (url.pathname === "/_lunora/replica" && request.method === "POST") {
+            return handleReplicaControl(this.replicaOwnerHost, request);
+        }
+
         // Promotion probe (plan 075 Phase 2): the runtime asks the owner how many
         // relays to spread new connections across before a WS upgrade. Internal —
         // reachable only via the runtime's worker-side forward, returns just a count.
@@ -9053,6 +9139,15 @@ abstract class ShardDO {
     }
 
     private async handleWebSocketUpgrade(request: Request): Promise<Response> {
+        // A replica has no live pipeline: its rows advance only when a READ
+        // happens to trigger a catch-up, so a subscription served from here
+        // would be a live query that mostly is not. Nothing routes an upgrade to
+        // a replica name — only a hand-written `?shard=` can reach this — and it
+        // is refused for the same reason the dispatch gate refuses writes.
+        if (this.replica !== undefined) {
+            return new Response("replica does not serve subscriptions", { status: 421 });
+        }
+
         if (!(await this.isUpgradeAllowed(request))) {
             return new Response("Forbidden", { status: 403 });
         }

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -1535,6 +1535,10 @@ abstract class ShardDO {
             ownerEpoch: () => this.currentCdcEpoch(),
             ownerFloor: () => (this.cdcEnabled() ? minCdcSeq(this.sql as SqlExec) : undefined),
             readChanges: (sinceSeq, limit) => this.runShardCdcSync({ limit, sinceSeq }),
+            // `COUNT(*)` per user table — cheap next to building the snapshot,
+            // which is the whole point: the bootstrap cap has to be decided
+            // before the rows are materialized, not after.
+            rowCount: () => listTables(this.sql as SqlExec).reduce((total, table) => total + table.rowCount, 0),
         };
         this.replica = createReplicaLink({
             ...sibling,

--- a/packages/errors/src/catalog.ts
+++ b/packages/errors/src/catalog.ts
@@ -300,6 +300,15 @@ export const ERROR_CATALOG = {
     GLOBAL_NOT_CONFIGURED: { status: 400, title: "Global table import not configured" },
     INVALID_INPUT: { status: 400, title: "Invalid input" },
     RATE_LIMITED: { status: 429, title: "Rate limited" },
+
+    /**
+     * A read replica could not answer at the freshness the caller required. `421`
+     * rather than an error class: it is a ROUTING verdict the runtime turns into
+     * one retry against the owner, and a caller never sees it.
+     */
+    REPLICA_NOT_READY: { status: 421, title: "Replica not caught up" },
+    /** A write reached a read replica. Same `421` routing verdict — writes belong to the owner. */
+    REPLICA_READ_ONLY: { status: 421, title: "Replica is read-only" },
     /** Thrown by `@lunora/auth` (Turnstile) and `@lunora/ratelimit` — an upstream dependency didn't respond. Fixed, safe message. */
     SERVICE_UNAVAILABLE: { status: 503, title: "Service unavailable" },
     SHAPE_CROSS_SHARD_JOIN: { status: 400, title: "Shape cross-shard join is unsupported" },

--- a/packages/platform-cloudflare/src/cloudflare-host.ts
+++ b/packages/platform-cloudflare/src/cloudflare-host.ts
@@ -22,6 +22,7 @@ import type {
     ShardHost,
     ShardJurisdiction,
     ShardKvStore,
+    ShardRegionHint,
     ShardSqlExec,
     ShardStub,
     SocketHandle,
@@ -566,9 +567,19 @@ const createShardDirectory = (namespace: DurableObjectNamespace): ShardDirectory
         };
     };
 
+    // `locationHint` is honoured only by the resolution that CREATES the object,
+    // and workers-types spells the region set identically to the contract's, so
+    // it passes straight through. Dropping it here would leave the capability
+    // matrix advertising `shardPlacement: native` for a host that silently
+    // ignores every hint — the exact contract/implementation drift the
+    // platform-parity rule exists to catch.
+    type GetOptions = NonNullable<Parameters<DurableObjectNamespace["get"]>[1]>;
+
+    const toOptions = (locationHint?: ShardRegionHint): GetOptions | undefined => (locationHint === undefined ? undefined : { locationHint });
+
     const directory: ShardDirectory = {
-        get: (id) => toStub(namespace.get(id as ReturnType<DurableObjectNamespace["idFromName"]>)),
-        getByName: (name) => toStub(namespace.get(namespace.idFromName(name))),
+        get: (id, locationHint) => toStub(namespace.get(id as ReturnType<DurableObjectNamespace["idFromName"]>, toOptions(locationHint))),
+        getByName: (name, locationHint) => toStub(namespace.get(namespace.idFromName(name), toOptions(locationHint))),
         idForName: (name) => namespace.idFromName(name),
         jurisdiction: (jurisdiction: ShardJurisdiction) =>
             createShardDirectory(namespace.jurisdiction(jurisdiction as Parameters<DurableObjectNamespace["jurisdiction"]>[0])),

--- a/packages/platform/src/capabilities.ts
+++ b/packages/platform/src/capabilities.ts
@@ -71,6 +71,10 @@ export interface PlatformCapabilities {
         shardAlarms?: Capability;
         /** Durable Object-style sharded state. */
         shardedState?: Capability;
+        /** Geographic placement of a shard (`ShardPlacement.locationHint`). */
+        shardPlacement?: Capability;
+        /** Region-local read replicas of a shard, for one-shot queries. */
+        shardReadReplicas?: Capability;
         /** Vector database (Vectorize / pgvector / Pinecone). */
         vectorStore?: Capability;
         /** Hibernated WebSocket subscriptions. */
@@ -102,6 +106,14 @@ export const CLOUDFLARE_CAPABILITIES: PlatformCapabilities = {
         websocketHibernation: { level: "native", note: "DO WebSocket hibernation" },
         localSql: { level: "native", note: "state.storage.sql (SQLite)" },
         shardAlarms: { level: "native", note: "state.storage.setAlarm" },
+        shardPlacement: {
+            level: "native",
+            note: "DurableObjectNamespace.get/getByName locationHint — best-effort, and honoured only by the resolution that creates the object",
+        },
+        shardReadReplicas: {
+            level: "emulated",
+            note: "Lunora follows the shard's CDC changelog into a replica DO placed in the reader's region; the platform replicates for durability, not for reads, so the follow loop is ours",
+        },
         crossShardFanout: { level: "emulated", note: "Lunora query coordinator + relay tier over Durable Objects" },
         queues: { level: "native", note: "Cloudflare Queues" },
         workflows: { level: "native", note: "Cloudflare Workflows" },
@@ -187,6 +199,11 @@ export const NODE_CAPABILITIES: PlatformCapabilities = {
         shardAlarms: {
             level: "emulated",
             note: "setTimeout over a durable row, dispatched to onAlarm and re-armed on construction, so an alarm survives a restart and one whose time elapsed while the process was down fires late rather than never",
+        },
+        shardPlacement: { level: "unsupported", note: "One process — every shard lives where the process does, so a location hint has nowhere to place it" },
+        shardReadReplicas: {
+            level: "unsupported",
+            note: "One process and one region: a replica here would be a second copy of a database already on the same disk",
         },
         crossShardFanout: {
             level: "emulated",

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -89,7 +89,7 @@ export type { ShardKvListOptions, ShardKvStore } from "./kv-store";
 export type { ScheduledJob, ScheduledJobStatus, ScheduleOptions, SchedulerHost } from "./scheduler-host";
 
 // Shard directory
-export type { DirectShardDirectory, ShardDirectory, ShardJurisdiction, ShardStub, TwoStepShardDirectory } from "./shard-directory";
+export type { DirectShardDirectory, ShardDirectory, ShardJurisdiction, ShardRegionHint, ShardStub, TwoStepShardDirectory } from "./shard-directory";
 export { resolveShard } from "./shard-directory";
 // Shard host
 export type { ShardAlarms, ShardAsyncSqlExec, ShardHost, ShardSqlCursor, ShardSqlExec, SqlRow } from "./shard-host";

--- a/packages/platform/src/shard-directory.ts
+++ b/packages/platform/src/shard-directory.ts
@@ -14,6 +14,8 @@
  * unsupported per the capability matrix.
  */
 
+import type { RegionHint } from "../../../shared/region-hint";
+
 /**
  * Cloudflare Durable Object jurisdictions restrict where a DO runs and
  * persists data, for data-residency / compliance regimes (GDPR, FedRAMP, US
@@ -26,6 +28,24 @@
  * leave them unsupported.
  */
 export type ShardJurisdiction = "eu" | "fedramp" | "us" | (Record<never, never> & string);
+
+/**
+ * A geographic placement region — where a shard should be created, when the
+ * caller has an opinion.
+ *
+ * One vocabulary, defined once: `shared/region-hint.ts` owns the region list
+ * (it is also what derives a region from edge geography), and this contract
+ * re-exports it rather than restating the strings. A second list is how the two
+ * ends of a placement request drift apart.
+ *
+ * Unlike a jurisdiction — a hard constraint the caller must fail closed on — a
+ * region is **best effort and advisory**: a provider may ignore it, and on
+ * Cloudflare it is honoured only by the call that first creates the object.
+ * Everything downstream must work identically whether the hint was honoured,
+ * ignored, or never supplied, and no caller may treat a resolved stub's
+ * location as known.
+ */
+export type ShardRegionHint = RegionHint;
 
 /**
  * A resolved shard stub. The engine calls `fetch` (or an equivalent RPC
@@ -44,10 +64,10 @@ export interface ShardStub {
  */
 export interface DirectShardDirectory {
     /** Resolve an opaque id (from `idForName`) to a stub, when the provider has ids. */
-    get?: (id: unknown) => ShardStub;
+    get?: (id: unknown, locationHint?: ShardRegionHint) => ShardStub;
 
     /** Resolve a shard key to a stub. */
-    getByName: (name: string) => ShardStub;
+    getByName: (name: string, locationHint?: ShardRegionHint) => ShardStub;
 
     /** Derive a stable, opaque shard id from a shard key, when the provider has ids. */
     idForName?: (name: string) => unknown;
@@ -63,7 +83,7 @@ export interface DirectShardDirectory {
  */
 export interface TwoStepShardDirectory {
     /** Resolve an opaque id (from `idForName`) to a stub. */
-    get: (id: unknown) => ShardStub;
+    get: (id: unknown, locationHint?: ShardRegionHint) => ShardStub;
 
     /**
      * Absent — the discriminant that selects the two-step branch.
@@ -101,11 +121,16 @@ export type ShardDirectory = DirectShardDirectory | TwoStepShardDirectory;
  * Resolve a shard key to a stub against either directory shape. Uses direct
  * name lookup when the provider has it, and falls back to the two-step
  * `idForName` + `get` dance otherwise.
+ *
+ * `locationHint` is forwarded to whichever branch runs. It is advisory in
+ * both: a provider with no placement concept ignores the extra argument, which
+ * is exactly what an implementation written against the pre-placement
+ * signature does.
  */
-export const resolveShard = (directory: ShardDirectory, name: string): ShardStub => {
+export const resolveShard = (directory: ShardDirectory, name: string, locationHint?: ShardRegionHint): ShardStub => {
     if (directory.getByName !== undefined) {
-        return directory.getByName(name);
+        return directory.getByName(name, locationHint);
     }
 
-    return directory.get(directory.idForName(name));
+    return directory.get(directory.idForName(name), locationHint);
 };

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -709,7 +709,9 @@ describe("createWorker", () => {
                 idFromName: (name: string) => name,
             };
             const namespace: ShardNamespaceLike = {
-                get: () => {return { fetch: async () => new Response("unused") }},
+                get: () => {
+                    return { fetch: async () => new Response("unused") };
+                },
                 idFromName: (name: string) => name,
                 jurisdiction: () => pinned,
             };

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -511,11 +511,215 @@ describe("createWorker", () => {
             fakeContext,
         );
 
-        expect(namespace.getByName).toHaveBeenCalledWith("a");
+        // Second argument is the placement bag, absent here since no
+        // `shardRegion` policy is configured.
+        expect(namespace.getByName).toHaveBeenCalledWith("a", undefined);
         expect(namespace.idFromName).not.toHaveBeenCalled();
         // Confirms the stub returned by getByName received the forwarded RPC,
         // i.e. dispatch went through getByName rather than the idFromName + get fallback.
         expect(stub.fetch).toHaveBeenCalledWith(expect.any(Request));
+    });
+
+    describe("replica reads", () => {
+        /** A namespace that records every resolved name + placement and answers with a per-name scripted stub. */
+        const createReplicaNamespace = (
+            respond: (name: string, request: Request) => Response,
+        ): { calls: { name: string; options: unknown }[]; namespace: ShardNamespaceLike } => {
+            const calls: { name: string; options: unknown }[] = [];
+
+            return {
+                calls,
+                namespace: {
+                    get: () => {
+                        return { fetch: async () => new Response("unused") };
+                    },
+                    getByName: (name: string, options?: unknown) => {
+                        calls.push({ name, options });
+
+                        return {
+                            fetch: async (request: Request) => respond(name, request),
+                        };
+                    },
+                    idFromName: (name: string) => name,
+                },
+            };
+        };
+
+        /** An RPC request carrying edge geography, so the runtime can pick a region for it. */
+        const geoRpc = (functionPath: string, headers: Record<string, string> = {}): Request =>
+            Object.assign(
+                new Request("https://app.example/_lunora/rpc", {
+                    body: JSON.stringify({ functionPath, shardKey: "tenant-7" }),
+                    headers,
+                    method: "POST",
+                }),
+                { cf: { continent: "EU", longitude: "2.35" } },
+            );
+
+        const functions = { "posts:list": { kind: "query" as const }, "posts:add": { kind: "mutation" as const } };
+
+        it("routes a query to a replica in the caller's region, and places it there", async () => {
+            expect.assertions(5);
+
+            let marker: null | string = null;
+            let binding: null | string = null;
+            const { calls, namespace } = createReplicaNamespace((_name, request) => {
+                marker = request.headers.get("x-lunora-replica-read");
+                binding = request.headers.get("x-lunora-shard-binding");
+
+                return Response.json({ result: [] });
+            });
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, replicaReads: true, shardDO: namespace });
+
+            const response = await worker.fetch(geoRpc("posts:list"), { SHARD: namespace }, fakeContext);
+
+            expect(response.status).toBe(200);
+            expect(calls[0]?.name).toBe("tenant-7::replica::weur");
+            // The hint is what puts the replica near the reader; without it the
+            // copy would be created wherever this request happened to run.
+            expect(calls[0]?.options).toStrictEqual({ locationHint: "weur" });
+            // The marker is the single thing the DO gate keys on: drop it and
+            // every replica read 421s back to the owner — correct results, and a
+            // feature that is silently dead with every test still green.
+            expect(marker).toBe("1");
+            // Without the binding the replica cannot address the owner it follows.
+            expect(binding).toBe("SHARD");
+        });
+
+        it("sends writes to the owner even when replica reads are on", async () => {
+            expect.assertions(1);
+
+            const { calls, namespace } = createReplicaNamespace(() => Response.json({ result: null }));
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, replicaReads: true, shardDO: namespace });
+
+            await worker.fetch(geoRpc("posts:add"), {}, fakeContext);
+
+            expect(calls.map((call) => call.name)).toStrictEqual(["tenant-7"]);
+        });
+
+        it("retries against the owner once when the replica cannot serve the read", async () => {
+            expect.assertions(2);
+
+            const { calls, namespace } = createReplicaNamespace((name) =>
+                name.includes("::replica::")
+                    ? Response.json(
+                          { error: { code: "REPLICA_NOT_READY", message: "stale" } },
+                          { headers: { "x-lunora-replica-fallback": "stale" }, status: 421 },
+                      )
+                    : Response.json({ result: ["from-owner"] }),
+            );
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, replicaReads: true, shardDO: namespace });
+
+            const response = await worker.fetch(geoRpc("posts:list"), {}, fakeContext);
+
+            expect(calls.map((call) => call.name)).toStrictEqual(["tenant-7::replica::weur", "tenant-7"]);
+            await expect(response.json()).resolves.toStrictEqual({ result: ["from-owner"] });
+        });
+
+        it("forwards the caller's read-your-writes bookmark to the replica", async () => {
+            expect.assertions(2);
+
+            let seen: string | null = null;
+            const { namespace } = createReplicaNamespace((_name, request) => {
+                seen = request.headers.get("x-lunora-min-seq");
+
+                return Response.json({ result: [] });
+            });
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, replicaReads: true, shardDO: namespace });
+
+            await worker.fetch(geoRpc("posts:list", { "x-lunora-min-seq": "42" }), {}, fakeContext);
+
+            expect(seen).toBe("42");
+
+            // A non-numeric bookmark is dropped rather than forwarded: the header
+            // reaches the replica's integer parse, and garbage there would read as
+            // "no requirement" — the one reading that silently weakens the
+            // guarantee the caller asked for.
+            await worker.fetch(geoRpc("posts:list", { "x-lunora-min-seq": "not-a-number" }), {}, fakeContext);
+
+            expect(seen).toBeNull();
+        });
+
+        it("keeps reads on the owner when the request has no geography", async () => {
+            expect.assertions(1);
+
+            const { calls, namespace } = createReplicaNamespace(() => Response.json({ result: [] }));
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, replicaReads: true, shardDO: namespace });
+
+            await worker.fetch(
+                new Request("https://app.example/_lunora/rpc", { body: JSON.stringify({ functionPath: "posts:list", shardKey: "tenant-7" }), method: "POST" }),
+                {},
+                fakeContext,
+            );
+
+            expect(calls.map((call) => call.name)).toStrictEqual(["tenant-7"]);
+        });
+
+        it("never re-targets a shard key that already carries a reserved role infix", async () => {
+            expect.assertions(1);
+
+            const { calls, namespace } = createReplicaNamespace(() => Response.json({ result: [] }));
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, replicaReads: true, shardDO: namespace });
+
+            await worker.fetch(
+                Object.assign(
+                    new Request("https://app.example/_lunora/rpc", {
+                        body: JSON.stringify({ functionPath: "posts:list", shardKey: "tenant-7::replica::weur" }),
+                        method: "POST",
+                    }),
+                    { cf: { continent: "EU", longitude: "2.35" } },
+                ),
+                {},
+                fakeContext,
+            );
+
+            // A replica of a replica follows a DO nobody feeds.
+            expect(calls.map((call) => call.name)).toStrictEqual(["tenant-7::replica::weur"]);
+        });
+
+        it("stays on the owner when replica reads are off", async () => {
+            expect.assertions(1);
+
+            const { calls, namespace } = createReplicaNamespace(() => Response.json({ result: [] }));
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, functions, shardDO: namespace });
+
+            await worker.fetch(geoRpc("posts:list"), {}, fakeContext);
+
+            expect(calls.map((call) => call.name)).toStrictEqual(["tenant-7"]);
+        });
+    });
+
+    it("applies the `shardRegion` placement policy to the forward path", async () => {
+        expect.assertions(2);
+
+        const stub = { fetch: vi.fn<(request: Request) => Promise<Response>>(async () => new Response("ok")) };
+        const namespace: ShardNamespaceLike = {
+            get: vi.fn<NonNullable<ShardNamespaceLike["get"]>>(),
+            getByName: vi.fn<NonNullable<ShardNamespaceLike["getByName"]>>(() => stub),
+            idFromName: vi.fn<NonNullable<ShardNamespaceLike["idFromName"]>>(),
+        };
+
+        const worker = createWorker({
+            allowUnauthenticatedShardAccess: true,
+            shardDO: namespace,
+            shardRegion: (shardKey) => (shardKey === "tenant-eu" ? "weur" : undefined),
+        });
+
+        const call = async (shardKey: string): Promise<void> => {
+            await worker.fetch(
+                new Request("https://app.example/_lunora/rpc", { body: JSON.stringify({ functionPath: "x:y", shardKey }), method: "POST" }),
+                {},
+                fakeContext,
+            );
+        };
+
+        await call("tenant-eu");
+        await call("tenant-unknown");
+
+        expect(namespace.getByName).toHaveBeenNthCalledWith(1, "tenant-eu", { locationHint: "weur" });
+        // A key the policy has no opinion about keeps the platform default
+        // (create near the first request) rather than being pinned anywhere.
+        expect(namespace.getByName).toHaveBeenNthCalledWith(2, "tenant-unknown", undefined);
     });
 
     it("forwards resolveIdentity userId on the x-lunora-userid header", async () => {
@@ -2066,6 +2270,39 @@ describe("createWorker — relay-tier routing (plan 075 Phase 2)", () => {
         expect(forwards).toHaveLength(1);
         expect(forwards[0]?.name).toMatch(/^promoted-a::relay::[01]$/u); // routed to a relay
         expect(forwards[0]?.binding).toBe("SHARD"); // told the DO its namespace binding
+    });
+
+    it("spreads connections across the relay set and hints the client's region", async () => {
+        expect.assertions(3);
+
+        const placements: unknown[] = [];
+        const forwards: Forward[] = [];
+        const base = routingNamespace(4, forwards);
+        const namespace: ShardNamespaceLike = {
+            ...base,
+            get: (id, options) => {
+                placements.push(options);
+
+                return base.get(id);
+            },
+        };
+        const worker = createWorker({ allowUnauthenticatedShardAccess: true, shardDO: namespace });
+        const fromParis = (): Request => Object.assign(upgrade("promoted-r"), { cf: { continent: "EU", longitude: "2.35" } });
+
+        // Enough connections that a spread over four relays is overwhelmingly
+        // likely to touch more than one — the point being that a whole region
+        // must NOT collapse onto a single relay, which is the wall promotion
+        // exists to escape.
+        for (let attempt = 0; attempt < 40; attempt += 1) {
+            // eslint-disable-next-line no-await-in-loop -- sequential upgrades: each one's routing decision is what is under test
+            await worker.fetch(fromParis(), { SHARD: namespace }, fakeContext);
+        }
+
+        expect(new Set(forwards.map((forward) => forward.name)).size).toBeGreaterThan(1);
+        expect(forwards.every((forward) => /^promoted-r::relay::[0-3]$/u.test(forward.name))).toBe(true);
+        // Every relay is nonetheless CREATED in the caller's region — that is
+        // what puts the socket near the client without pinning load.
+        expect(placements).toContainEqual({ locationHint: "weur" });
     });
 
     it("keeps a new WS connection on the owner when the shard is not promoted", async () => {

--- a/packages/runtime/__tests__/create-worker.test.ts
+++ b/packages/runtime/__tests__/create-worker.test.ts
@@ -677,6 +677,61 @@ describe("createWorker", () => {
             expect(calls.map((call) => call.name)).toStrictEqual(["tenant-7::replica::weur"]);
         });
 
+        it("names the shard it resolved, so the client can key one cursor for it", async () => {
+            expect.assertions(2);
+
+            const { namespace } = createReplicaNamespace(() => Response.json({ commitCursor: 4, result: null }));
+            const worker = createWorker({ allowUnauthenticatedShardAccess: true, defaultShardKey: "__root__", functions, shardDO: namespace });
+
+            const response = await worker.fetch(
+                new Request("https://app.example/_lunora/rpc", { body: JSON.stringify({ functionPath: "posts:add" }), method: "POST" }),
+                {},
+                fakeContext,
+            );
+
+            // The caller named no shard; the worker resolved its configured
+            // default, and only the worker knows those are the same shard.
+            expect(response.headers.get("x-lunora-shard-key")).toBe("__root__");
+            // The shard's own response headers survive the stamp.
+            await expect(response.json()).resolves.toStrictEqual({ commitCursor: 4, result: null });
+        });
+
+        it("does not send a region hint when the deployment is pinned to a jurisdiction", async () => {
+            expect.assertions(2);
+
+            const placements: unknown[] = [];
+            const pinned: ShardNamespaceLike = {
+                get: (_id, options) => {
+                    placements.push(options);
+
+                    return { fetch: async () => Response.json({ result: [] }) };
+                },
+                idFromName: (name: string) => name,
+            };
+            const namespace: ShardNamespaceLike = {
+                get: () => {return { fetch: async () => new Response("unused") }},
+                idFromName: (name: string) => name,
+                jurisdiction: () => pinned,
+            };
+
+            const worker = createWorker({
+                allowUnauthenticatedShardAccess: true,
+                functions,
+                jurisdiction: "eu",
+                shardDO: namespace,
+                shardRegion: () => "weur",
+            });
+
+            await worker.fetch(geoRpc("posts:list"), {}, fakeContext);
+
+            // Residency is a hard constraint and the region only a hint, and the
+            // pairing cannot be exercised on any runtime available to us
+            // (workerd does not implement jurisdictions at all). The hint is
+            // dropped rather than shipped untested.
+            expect(placements).toHaveLength(1);
+            expect(placements[0]).toBeUndefined();
+        });
+
         it("stays on the owner when replica reads are off", async () => {
             expect.assertions(1);
 

--- a/packages/runtime/__tests__/region-hint.test.ts
+++ b/packages/runtime/__tests__/region-hint.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { isRegionHint, regionHintFromGeo, regionHintFromRequest } from "../../../shared/region-hint";
+
+describe("regionHintFromGeo", () => {
+    it.each([
+        ["NA", -122.4, undefined, "wnam"],
+        ["NA", -74, undefined, "enam"],
+        // Exactly on the meridian falls east — the split is `< -100`.
+        ["NA", -100, undefined, "enam"],
+        ["EU", 2.35, undefined, "weur"],
+        ["EU", 21, undefined, "eeur"],
+        ["SA", -46.6, undefined, "sam"],
+        ["OC", 151.2, undefined, "oc"],
+        ["AF", 18.4, undefined, "afr"],
+        ["AS", 139.7, "JP", "apac"],
+        ["AS", 55.3, "AE", "me"],
+    ] as const)("maps continent %s at %s to %s", (continent, longitude, country, expected) => {
+        expect.assertions(1);
+
+        expect(regionHintFromGeo({ continent, country, longitude })).toBe(expected);
+    });
+
+    it("falls back to the continent's coarse region when longitude is missing or unparseable", () => {
+        expect.assertions(2);
+
+        expect(regionHintFromGeo({ continent: "NA" })).toBe("enam");
+        expect(regionHintFromGeo({ continent: "EU", longitude: "not-a-number" })).toBe("weur");
+    });
+
+    it("reads Cloudflare's stringified longitude", () => {
+        expect.assertions(1);
+
+        expect(regionHintFromGeo({ continent: "NA", longitude: "-122.4194" })).toBe("wnam");
+    });
+
+    it("returns no hint for geography it cannot place", () => {
+        expect.assertions(3);
+
+        // Antarctica has no region; an absent/unknown continent must not be
+        // guessed at, or every ungeolocatable request would drag its shard to
+        // whichever region we picked as the default.
+        expect(regionHintFromGeo({ continent: "AN" })).toBeUndefined();
+        expect(regionHintFromGeo({})).toBeUndefined();
+        expect(regionHintFromGeo({ continent: "XX" })).toBeUndefined();
+    });
+
+    it("only ever returns a known placement region", () => {
+        expect.assertions(1);
+
+        const produced = new Set(
+            ["AF", "AS", "EU", "NA", "OC", "SA", "AN"].flatMap((continent) =>
+                [-180, -100, 0, 15, 180].map((longitude) => regionHintFromGeo({ continent, longitude })),
+            ),
+        );
+
+        produced.delete(undefined);
+
+        expect([...produced].every((hint) => isRegionHint(hint))).toBe(true);
+    });
+});
+
+describe("regionHintFromRequest", () => {
+    it("reads the region off request.cf", () => {
+        expect.assertions(1);
+
+        const request = Object.assign(new Request("https://example.com/"), { cf: { continent: "EU", longitude: "21.0" } });
+
+        expect(regionHintFromRequest(request)).toBe("eeur");
+    });
+
+    it("returns no hint for a synthesized subrequest with no cf", () => {
+        expect.assertions(1);
+
+        // Every internal hop (the shard RPC envelope, an admin fan-out) is in
+        // this class, which is why the client's region has to be threaded
+        // through rather than re-read downstream.
+        expect(regionHintFromRequest(new Request("https://shard.internal/rpc"))).toBeUndefined();
+    });
+});

--- a/packages/runtime/__tests__/resolve-shard.test.ts
+++ b/packages/runtime/__tests__/resolve-shard.test.ts
@@ -93,7 +93,7 @@ describe("resolveShard", () => {
 
         resolveShard(namespace, "room-7");
 
-        expect(getByName).toHaveBeenCalledWith("room-7");
+        expect(getByName).toHaveBeenCalledWith("room-7", undefined);
         expect(idFromName).not.toHaveBeenCalled();
     });
 
@@ -150,7 +150,32 @@ describe("resolveShard", () => {
         resolveShard(namespace, "room-7");
 
         expect(idFromName).toHaveBeenCalledWith("room-7");
-        expect(get).toHaveBeenCalledWith(id);
+        // No placement asked for → no options bag, so the call is
+        // indistinguishable from the pre-placement `get(id)`.
+        expect(get).toHaveBeenCalledWith(id, undefined);
+    });
+
+    it("passes a location hint to the direct branch", () => {
+        expect.assertions(1);
+
+        const getByName = vi.fn<() => typeof fakeStub>(() => fakeStub);
+        const namespace: ShardNamespaceLike = { get: () => fakeStub, getByName, idFromName: (name) => name };
+
+        resolveShard(namespace, "room-7", "weur");
+
+        expect(getByName).toHaveBeenCalledWith("room-7", { locationHint: "weur" });
+    });
+
+    it("passes a location hint to the two-step branch", () => {
+        expect.assertions(1);
+
+        const id = { __id: 1 };
+        const get = vi.fn<() => typeof fakeStub>(() => fakeStub);
+        const namespace: ShardNamespaceLike = { get, idFromName: () => id };
+
+        resolveShard(namespace, "room-7", "apac");
+
+        expect(get).toHaveBeenCalledWith(id, { locationHint: "apac" });
     });
 
     it("resolves against a jurisdiction-pinned subnamespace", () => {

--- a/packages/runtime/__tests__/security-headers.test.ts
+++ b/packages/runtime/__tests__/security-headers.test.ts
@@ -290,6 +290,27 @@ describe("handleCorsPreflight", () => {
         expect(allowHeaders.toLowerCase()).not.toContain("x-evil");
     });
 
+    it("exposes the response headers the SDK reads back", () => {
+        expect.hasAssertions();
+
+        // A browser hides every non-safelisted response header unless it is
+        // named here, and `headers.get(...)` then returns `null` with no error
+        // anywhere. So a header the client consumes but that is unexposed does
+        // not fail loudly — it silently drops the guarantee it carries:
+        // `x-d1-bookmark` is D1 read-your-writes, `x-lunora-shard-key` is what
+        // keys the replica bookmark.
+        const out = decorateResponse(
+            Response.json({ ok: true }),
+            httpsRequest({ headers: { origin: "https://app.example.com" } }),
+            resolveSecurity({ cors: { allowedOrigins: ["https://app.example.com"] } }),
+        );
+
+        const exposed = (out.headers.get("access-control-expose-headers") ?? "").toLowerCase();
+
+        expect(exposed).toContain("x-d1-bookmark");
+        expect(exposed).toContain("x-lunora-shard-key");
+    });
+
     it("ignores non-preflight OPTIONS and disabled CORS", () => {
         expect.hasAssertions();
 

--- a/packages/runtime/__tests__/workerd/placement.workerd.test.ts
+++ b/packages/runtime/__tests__/workerd/placement.workerd.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Real-workerd checks for shard placement.
+ *
+ * A location hint is advisory and unobservable — nothing in the API reports
+ * where an object actually landed — so what these tests pin is the part that a
+ * mock cannot answer: that the real runtime accepts a hint at all, and that a
+ * hinted resolution still addresses the same object as an unhinted one.
+ *
+ * They also record what the runtime CANNOT answer. Pairing a hint with a
+ * jurisdiction type-checks (a jurisdictional view has the same namespace type,
+ * so the options bag is identical), but workerd implements no jurisdictions at
+ * all, so the pairing is unreachable in dev, in CI, and here. That is the
+ * evidence behind the runtime preferring residency over the hint.
+ */
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { ShardNamespaceLike } from "../../src/resolve-shard";
+import { applyJurisdiction, resolveShard } from "../../src/resolve-shard";
+
+const shardNamespace = (): ShardNamespaceLike => env.SHARD as unknown as ShardNamespaceLike;
+
+/** Ask the resolved stub for something, so the assertion covers a real dispatch rather than just construction. */
+const probe = async (stub: { fetch: (request: Request) => Promise<Response> }): Promise<Response> =>
+    stub.fetch(new Request("https://shard.internal/rpc", { body: JSON.stringify({ args: {}, functionPath: "messages:list" }), method: "POST" }));
+
+describe("shard placement (workerd)", () => {
+    it("accepts a location hint on a plain namespace", async () => {
+        expect.assertions(1);
+
+        const response = await probe(resolveShard(shardNamespace(), "placement-plain", "weur"));
+
+        expect(response.ok).toBe(true);
+    });
+
+    it("cannot pin a jurisdiction at all, which is why placement defers to residency", () => {
+        expect.assertions(1);
+
+        // The combination of a jurisdiction and a location hint is UNREACHABLE
+        // locally: workerd does not implement jurisdictions, so it is not that
+        // the pairing is untested here — it cannot be tested here, or in CI, or
+        // in `lunora dev`. It would first execute in production, on exactly the
+        // deployments that chose residency because correctness matters most.
+        //
+        // That is the evidence behind `placementUnderResidency` in
+        // `create-worker.ts`: rather than ship an unexercised pairing, a pinned
+        // deployment sends no region hint and lets the jurisdiction decide. This
+        // test exists to keep the reason on the record — and to fail loudly if a
+        // future workerd implements jurisdictions, at which point the pairing
+        // becomes testable and the trade can be revisited.
+        expect(() => applyJurisdiction(shardNamespace(), "eu")).toThrow(/not implemented in workerd/i);
+    });
+
+    it("resolves the same object for a key whether or not a hint is passed", async () => {
+        expect.assertions(1);
+
+        // A hint influences CREATION only, so it must never change addressing:
+        // the same key has to reach the same object, or a hinted read and an
+        // unhinted write would silently target different shards.
+        const namespace = shardNamespace();
+
+        await probe(resolveShard(namespace, "placement-identity", "apac"));
+        const second = await probe(resolveShard(namespace, "placement-identity"));
+
+        await expect(second.text()).resolves.toContain("messages:list");
+    });
+});

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -10,7 +10,10 @@ import { NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
 import { signCanonical } from "../../../shared/hmac-url";
 import { encodeIdentityHeader, encodeUserIdHeader } from "../../../shared/identity-header";
 import { otlpRandomHex } from "../../../shared/otlp";
-import { relayName } from "../../../shared/relay-name";
+import type { RegionHint } from "../../../shared/region-hint";
+import { regionHintFromRequest } from "../../../shared/region-hint";
+import { RELAY_NAME_INFIX, relayName } from "../../../shared/relay-name";
+import { parseMinSeq, REPLICA_NAME_INFIX, replicaName } from "../../../shared/replica-name";
 import type { RestExposure } from "../../../shared/rest-surface";
 import type { TraceSamplingConfig } from "../../../shared/sampling";
 import { isEnvFlagEnabled, mintWsAdminToken, verifyWsAdminToken } from "../../../shared/ws-admin-token";
@@ -1093,6 +1096,27 @@ interface WorkerOptions {
      */
     queue?: QueueConsumerHandler;
 
+    /**
+     * Serve one-shot **queries** from a read replica placed in the caller's
+     * region instead of from the shard owner. Off by default.
+     *
+     * What it buys: a query answered near the reader rather than across an
+     * ocean. What it costs: a query that names no bookmark may be up to
+     * `LUNORA_REPLICA_MAX_STALENESS_MS` (default 1000) behind the owner, and
+     * every replica is a second Durable Object holding a copy of the shard.
+     *
+     * Read-your-writes is preserved for callers that pass the `commitCursor`
+     * their last write returned back as `x-lunora-min-seq`: the replica catches
+     * up to at least that cursor or the read falls back to the owner. Mutations,
+     * actions, streams, subscriptions, and fan-outs are never replica-routed.
+     *
+     * Requires CDC to be enabled on the schema — the changelog IS the
+     * replication feed. Without it a replica has nothing to follow, reports
+     * itself unavailable, and every read falls back to the owner (correct, and
+     * one wasted hop per read).
+     */
+    replicaReads?: boolean;
+
     /* eslint-disable no-secrets/no-secrets -- the env-var NAME below is a config key, not a credential */
 
     /**
@@ -1200,6 +1224,24 @@ interface WorkerOptions {
 
     /** Namespace binding for the shard Durable Object (typically `env.SHARD`). */
     shardDO: ShardNamespaceLike;
+
+    /**
+     * Where a shard should be created, by shard key — a per-tenant placement
+     * policy (`(key) => "weur"` for a European tenant, say).
+     *
+     * The platform already creates a shard near whichever request first touches
+     * it, so this exists for the cases where that request is the wrong signal:
+     * a shard first materialized by a cron fire, a migration fan-out, a seeding
+     * run, or the Studio lands wherever that ran, and stays there for life. A
+     * key whose region is not known yet returns `undefined`, which restores the
+     * default (place near the first request).
+     *
+     * Advisory in both directions: the hint is honoured only by the resolution
+     * that CREATES the object — changing this callback later does not move a
+     * shard that already exists — and even then the platform places near the
+     * hinted region rather than exactly in it.
+     */
+    shardRegion?: (shardKey: string) => RegionHint | undefined;
 
     /**
      * Resolve the app-facing storage capability from the worker `env` — the same
@@ -1939,12 +1981,6 @@ const parseEnvelope = async (request: Request): Promise<RpcEnvelope> => {
     };
 };
 
-const forwardToShard = async (namespace: ShardNamespaceLike, shardKey: string, request: Request): Promise<Response> => {
-    const stub = resolveShard(namespace, shardKey);
-
-    return stub.fetch(request);
-};
-
 /** Per-isolate cache of a shard's relay count (the promotion probe), TTL-bounded so a promoted shard doesn't add a round-trip to every WS upgrade. */
 interface RelayProbeEntry {
     expiresMs: number;
@@ -2241,6 +2277,20 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     const shardDO = applyJurisdiction(options.shardDO, options.jurisdiction);
     const schedulerDO = options.schedulerDO === undefined ? undefined : applyJurisdiction(options.schedulerDO, options.jurisdiction);
 
+    /**
+     * Every worker→shard hop, with the app's placement policy applied in one
+     * place. A shard that already exists ignores the hint, so this is safe to
+     * call on the hot path; a shard being created for the first time lands
+     * where `options.shardRegion` says instead of wherever the creating request
+     * happened to run.
+     */
+    const forwardToShard = async (
+        namespace: ShardNamespaceLike,
+        shardKey: string,
+        request: Request,
+        locationHint: RegionHint | undefined = options.shardRegion?.(shardKey),
+    ): Promise<Response> => resolveShard(namespace, shardKey, locationHint).fetch(request);
+
     // Effective admin bearer for the request-time `/_lunora/admin/*` gates: the
     // explicit `options.adminToken`, or — when unset (the `composeWorker` default,
     // since the generated worker entry doesn't thread it) — `env.LUNORA_ADMIN_TOKEN`.
@@ -2261,8 +2311,22 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     // master-token-in-URL behaviour.
     let envRequireEphemeralWsToken: boolean | undefined;
     const effectiveRequireEphemeralWsToken = (): boolean => options.requireEphemeralWsToken ?? envRequireEphemeralWsToken ?? true;
-    const resolveAdminTokenFromEnv = (env: unknown): void => {
+    // The env binding name holding the shard namespace, resolved once per isolate
+    // from the first request's env (same env-is-constant reasoning as the admin
+    // token). A replica needs it to address its owner — it is the only way a DO
+    // learns how to reach a sibling — so a replica-routed read carries it the way
+    // the WS-upgrade path already does for the relay tier.
+    let shardBindingName: string | undefined;
+
+    /**
+     * Capture everything the worker derives from `env` once per isolate, on the
+     * first request (env is constant within an isolate): the admin bearer, the
+     * ephemeral-WS-token knob, and the shard namespace binding name.
+     */
+    const captureEnvDerivedConfig = (env: unknown): void => {
         const record = (env ?? {}) as Record<string, unknown>;
+
+        shardBindingName ??= resolveShardBindingName(env, options.shardDO);
 
         if (envRequireEphemeralWsToken === undefined && options.requireEphemeralWsToken === undefined) {
             const raw = record["LUNORA_REQUIRE_EPHEMERAL_WS_TOKEN"];
@@ -2331,6 +2395,19 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     // posture was warn-once-then-allow, which meant a production misconfig was
     // silent after the first request per isolate.
     let warnedUnauthenticatedShardAccess = false;
+
+    /** One log line per isolate for a `replicaReads` that cannot take effect (see {@link replicaTargetFor}). */
+    let warnedReplicaReadsWithoutRegistry = false;
+    const warnReplicaReadsWithoutRegistry = (): void => {
+        if (warnedReplicaReadsWithoutRegistry) {
+            return;
+        }
+
+        warnedReplicaReadsWithoutRegistry = true;
+
+        // eslint-disable-next-line no-console -- a silently inert feature flag is worse than a log line
+        console.warn("[lunora] `replicaReads: true` has no effect without `functions` — read eligibility is decided from the function registry.");
+    };
 
     const guardUnauthenticatedShardAccess = (kind: "fan-out" | "shard"): void => {
         if (!options.allowUnauthenticatedShardAccess) {
@@ -3297,10 +3374,23 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             const relayCount = await probeRelayCount(shardDO, shardKey);
 
             if (relayCount > 0) {
+                // Spread connections across the relay set at random, and hint
+                // the client's region so a relay is CREATED near real traffic.
+                //
+                // The spread is load-levelling and stays random on purpose: the
+                // relay tier exists because per-flush fan-out on one DO becomes
+                // the bottleneck at ~8k sockets, so routing a whole region to
+                // `hash(region) % relayCount` would pile a single-region app —
+                // the common case — back onto one relay and re-create the exact
+                // wall promotion was meant to escape. Locality rides on the hint
+                // instead: each relay lands in the region of whichever client
+                // first drew it, so a single-region app gets every relay in its
+                // own region, and a multi-region one spreads them across the
+                // regions actually generating load.
                 // eslint-disable-next-line sonarjs/pseudo-random -- load distribution across relays, not a security-sensitive value
                 const target = relayName(shardKey, Math.floor(Math.random() * relayCount));
 
-                return forwardToShard(shardDO, target, new Request(request, { headers: upgradeHeaders }));
+                return forwardToShard(shardDO, target, new Request(request, { headers: upgradeHeaders }), regionHintFromRequest(request));
             }
         }
 
@@ -3490,6 +3580,92 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     };
 
     /**
+     * The region-local replica that should answer this read, or `undefined` when
+     * the read belongs on the owner.
+     *
+     * Deliberately narrow. Only a **query** is eligible: a mutation or action
+     * has to run where the single writer is, and a `stream` is a long-lived
+     * dispatch a follower has no business serving. Only a request Cloudflare
+     * could geolocate is eligible, because the replica's whole point is being
+     * near *this* caller. And a shard key that already carries a reserved role
+     * infix is never re-targeted — that would build a replica of a replay of a
+     * relay, addressing a DO nobody follows.
+     */
+    const replicaTargetFor = (request: Request, functionPath: string, shardKey: string): undefined | { name: string; region: RegionHint } => {
+        if (options.replicaReads !== true) {
+            return undefined;
+        }
+
+        // Eligibility is decided from the function registry, so a worker that
+        // enables the feature without threading `functions` would get it
+        // silently disabled — every read quietly owner-served, indistinguishable
+        // from a replica tier that is simply cold. Say so once.
+        if (options.functions === undefined) {
+            warnReplicaReadsWithoutRegistry();
+
+            return undefined;
+        }
+
+        if (options.functions[functionPath]?.kind !== "query") {
+            return undefined;
+        }
+
+        if (shardKey.includes(REPLICA_NAME_INFIX) || shardKey.includes(RELAY_NAME_INFIX)) {
+            return undefined;
+        }
+
+        const region = regionHintFromRequest(request);
+
+        return region === undefined ? undefined : { name: replicaName(shardKey, region), region };
+    };
+
+    /**
+     * Send one RPC to the shard that should serve it: a region-local replica for
+     * an eligible read, the owner for everything else.
+     *
+     * A replica answers `421` when it cannot serve the read at the required
+     * freshness (behind the caller's bookmark, or unable to follow its owner at
+     * all). That is a routing answer, not a failure: the read is retried once
+     * against the owner, which always can. There is exactly one retry — the
+     * owner is the terminal target, so a second hop could only loop.
+     */
+    const forwardRpcToShard = async (
+        request: Request,
+        functionPath: string,
+        args: Record<string, unknown>,
+        shardKey: string,
+        outgoingHeaders: Record<string, string>,
+    ): Promise<Response> => {
+        const replica = replicaTargetFor(request, functionPath, shardKey);
+
+        if (replica !== undefined) {
+            const replicaHeaders: Record<string, string> = {
+                ...outgoingHeaders,
+                "x-lunora-replica-read": "1",
+                ...(shardBindingName === undefined ? {} : { "x-lunora-shard-binding": shardBindingName }),
+            };
+
+            // The caller's read-your-writes bookmark: the `commitCursor` its last
+            // write returned. Client-supplied, and safe to trust because it can
+            // only ever make this read STRICTER — an inflated value costs the
+            // caller a fallback to the owner, it never surfaces older data.
+            const minSeq = parseMinSeq(request.headers.get("x-lunora-min-seq"));
+
+            if (minSeq !== undefined) {
+                replicaHeaders["x-lunora-min-seq"] = String(minSeq);
+            }
+
+            const fromReplica = await forwardToShard(shardDO, replica.name, shardRpcRequest(functionPath, args, replicaHeaders), replica.region);
+
+            if (fromReplica.status !== 421) {
+                return fromReplica;
+            }
+        }
+
+        return forwardToShard(shardDO, shardKey, shardRpcRequest(functionPath, args, outgoingHeaders));
+    };
+
+    /**
      * Dispatch a single-shard RPC envelope to its owning shard and return the
      * shard's `Response` (with the `x-d1-bookmark` propagated). Extracted from
      * {@link handleRpc} so the in-process `serverQuery` fast-path (PLAN4 §2.2 /
@@ -3535,11 +3711,10 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
         injectTraceContext(trace, outgoingHeaders);
 
-        // Re-emit the RPC body to the shard at its `/rpc` route.
-        const forwarded = shardRpcRequest(functionPath, args, outgoingHeaders);
-
         try {
-            const response = await forwardToShard(shardDO, shardKey, forwarded);
+            // Re-emit the RPC body at the shard's `/rpc` route — on a region-local
+            // replica when this read is eligible for one, else on the owner.
+            const response = await forwardRpcToShard(request, functionPath, args, shardKey, outgoingHeaders);
 
             // A non-2xx from the shard is reported as ok=false even though no
             // exception was thrown — the user-visible result is still an error
@@ -4103,7 +4278,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         // A cron can fire on an isolate that never served a `fetch`, so resolve
         // `env.LUNORA_ADMIN_TOKEN` here too — the built-in backup authenticates its
         // per-shard export fan-out with `effectiveAdminToken()`.
-        resolveAdminTokenFromEnv(env);
+        captureEnvDerivedConfig(env);
 
         const errors: Error[] = [];
         const toError = (error: unknown): Error => (error instanceof Error ? error : new Error(String(error)));
@@ -4469,7 +4644,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             // Pick up `env.LUNORA_ADMIN_TOKEN` for the admin gates (see top of
             // createWorker), so the Studio's admin calls authenticate when the
             // token lives only in env (the composed-worker default).
-            resolveAdminTokenFromEnv(env);
+            captureEnvDerivedConfig(env);
 
             // CORS preflight is answered up front for allowlisted origins; its
             // own response already carries the `Access-Control-Allow-*` headers,

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -2284,12 +2284,50 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
      * where `options.shardRegion` says instead of wherever the creating request
      * happened to run.
      */
+    /** One log line per isolate when a residency pin makes the placement hints inert. */
+    let warnedPlacementUnderResidency = false;
+
+    /**
+     * Drop a region hint when the deployment is pinned to a jurisdiction.
+     *
+     * A jurisdiction is a hard residency constraint; a region is an advisory
+     * hint. Composing them would mean asking the platform to honour both, and
+     * that pairing is not something any runtime available here can answer:
+     * workerd rejects `.jurisdiction()` outright ("Jurisdiction restrictions are
+     * not implemented in workerd" — see `placement.workerd.test.ts`), so the
+     * combination is unreachable in dev, in CI, and in every test, and would
+     * first execute in production on exactly the deployments that chose
+     * residency because correctness matters most to them.
+     *
+     * Shipping the untested pairing risks failing every dispatch to buy a
+     * placement refinement; dropping the hint costs only the refinement, and the
+     * jurisdiction already constrains placement to the region that matters. So
+     * residency wins, and the operator is told once rather than left to wonder
+     * why `shardRegion` reads as ignored.
+     */
+    const placementUnderResidency = (locationHint: RegionHint | undefined): RegionHint | undefined => {
+        if (locationHint === undefined || options.jurisdiction === undefined) {
+            return locationHint;
+        }
+
+        if (!warnedPlacementUnderResidency) {
+            warnedPlacementUnderResidency = true;
+
+            // eslint-disable-next-line no-console -- a silently ignored placement policy is worse than a log line
+            console.warn(
+                `[lunora] jurisdiction "${options.jurisdiction}" pins placement, so region hints (\`shardRegion\`, replica and relay placement) are not sent. Residency wins.`,
+            );
+        }
+
+        return undefined;
+    };
+
     const forwardToShard = async (
         namespace: ShardNamespaceLike,
         shardKey: string,
         request: Request,
         locationHint: RegionHint | undefined = options.shardRegion?.(shardKey),
-    ): Promise<Response> => resolveShard(namespace, shardKey, locationHint).fetch(request);
+    ): Promise<Response> => resolveShard(namespace, shardKey, placementUnderResidency(locationHint)).fetch(request);
 
     // Effective admin bearer for the request-time `/_lunora/admin/*` gates: the
     // explicit `options.adminToken`, or — when unset (the `composeWorker` default,
@@ -3743,11 +3781,23 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             );
 
             // The DO's `x-d1-bookmark` header (which lets the client pin reads
-            // after a write) is already on the shard `response`, so returning it
-            // verbatim propagates the bookmark. No rebuild is needed — copying the
-            // headers only to re-set that same header would be a pure allocation
-            // (and would drop `statusText`).
-            return response;
+            // after a write) is already on the shard `response`. The one thing
+            // the shard cannot know is which key the WORKER resolved it under:
+            // a caller that omits `shardKey` and one that spells out the
+            // configured default reach the same shard, and only this side knows
+            // they are the same. Stamping it lets the client file its
+            // read-your-writes cursor under one canonical key instead of two —
+            // which is the difference between a bookmark that constrains the
+            // next read and one that quietly does not.
+            //
+            // `response.headers` is immutable on a `fetch` result, so this is
+            // the one place a rebuild is warranted; `statusText` is carried over
+            // explicitly because a bare `Response(body, { status })` drops it.
+            const stamped = new Response(response.body, { headers: response.headers, status: response.status, statusText: response.statusText });
+
+            stamped.headers.set("x-lunora-shard-key", shardKey);
+
+            return stamped;
         } catch (error) {
             emitRpcEvent(
                 observability,

--- a/packages/runtime/src/resolve-shard.ts
+++ b/packages/runtime/src/resolve-shard.ts
@@ -1,6 +1,8 @@
 import type { ShardDirectory, ShardJurisdiction } from "@lunora/platform";
 import { resolveShard as resolveShardStub } from "@lunora/platform";
 
+import type { RegionHint } from "../../../shared/region-hint";
+
 /**
  * The Cloudflare-binding members {@link toDirectory} reads.
  *
@@ -8,7 +10,7 @@ import { resolveShard as resolveShardStub } from "@lunora/platform";
  * that point is a binding, where `get` and `idFromName` are required.
  */
 type ShardNamespaceParts = {
-    getByName?: (name: string) => { fetch: (request: Request) => Promise<Response> };
+    getByName?: (name: string, options?: ShardGetOptions) => { fetch: (request: Request) => Promise<Response> };
     jurisdiction?: (jurisdiction: DurableObjectJurisdiction) => ShardNamespaceLike;
 };
 
@@ -42,6 +44,17 @@ const directoryCache = new WeakMap<object, ShardDirectory>();
  * shard at all, and silently substituting the raw name would route every key to
  * whatever object that string happens to address.
  */
+
+/**
+ * Wrap a region in the Cloudflare options bag, or `undefined` when there is
+ * nothing to ask for.
+ *
+ * Returning `undefined` rather than `{}` for an absent hint is deliberate:
+ * `get(id, {})` and `get(id)` behave identically today, but passing a bag the
+ * caller did not ask for would make every resolution look like a placement
+ * request in traces and under any future option Cloudflare gives a default.
+ */
+const toGetOptions = (locationHint?: RegionHint): ShardGetOptions | undefined => (locationHint === undefined ? undefined : { locationHint });
 
 /**
  * `idFromName` is the one member only a Cloudflare binding has — the contract
@@ -78,19 +91,19 @@ const toDirectory = (input: ShardNamespaceInput): ShardDirectory => {
     const directory: ShardDirectory =
         typeof namespace.getByName === "function"
             ? {
-                  get: (id) => namespace.get(id),
+                  get: (id, locationHint) => namespace.get(id, toGetOptions(locationHint)),
                   // Wrapped, NOT passed by reference: `DurableObjectNamespace`'s
                   // methods are native and require their own receiver, so handing
                   // the bare function to the contract calls it with the directory
                   // as `this` and workerd rejects it with "Illegal invocation".
                   // Plain-object test doubles tolerate the detached reference,
                   // which is why only the workerd suites caught this.
-                  getByName: (name) => (namespace.getByName as NonNullable<ShardNamespaceParts["getByName"]>)(name),
+                  getByName: (name, locationHint) => (namespace.getByName as NonNullable<ShardNamespaceParts["getByName"]>)(name, toGetOptions(locationHint)),
                   idForName: (name) => namespace.idFromName(name),
                   jurisdiction,
               }
             : {
-                  get: (id) => namespace.get(id),
+                  get: (id, locationHint) => namespace.get(id, toGetOptions(locationHint)),
                   idForName: (name) => namespace.idFromName(name),
                   jurisdiction,
               };
@@ -110,20 +123,30 @@ const toDirectory = (input: ShardNamespaceInput): ShardDirectory => {
 export type DurableObjectJurisdiction = "eu" | "fedramp" | "us";
 
 /**
+ * The options bag Cloudflare's `DurableObjectNamespace.get` / `getByName`
+ * accept. Only `locationHint` is modelled: it is the one member the runtime
+ * sets, and it is honoured **only by the call that creates the object** — every
+ * later resolution of the same name reaches the object where it already lives.
+ */
+export interface ShardGetOptions {
+    locationHint?: RegionHint;
+}
+
+/**
  * Structural projection of the bits of `DurableObjectNamespace` the runtime
  * needs. Real workers-types defines a much wider surface; this lets us pass
  * unit-test doubles without coupling to `@cloudflare/workers-types`.
  */
 export interface ShardNamespaceLike {
-    /** Materialize a stub from an opaque id. */
-    get: (id: unknown) => { fetch: (request: Request) => Promise<Response> };
+    /** Materialize a stub from an opaque id, optionally hinting where to create it. */
+    get: (id: unknown, options?: ShardGetOptions) => { fetch: (request: Request) => Promise<Response> };
 
     /**
      * `getByName` is the friendlier API but isn't on every workers-types
      * release yet. We prefer it when available and fall back to
      * `idFromName` + `get` for compatibility.
      */
-    getByName?: (name: string) => { fetch: (request: Request) => Promise<Response> };
+    getByName?: (name: string, options?: ShardGetOptions) => { fetch: (request: Request) => Promise<Response> };
 
     /** Cloudflare's `DurableObjectNamespace` spelling of `idForName`. */
     idFromName: (name: string) => unknown;
@@ -190,5 +213,11 @@ export const applyJurisdiction = (namespace: ShardNamespaceLike, jurisdiction?: 
  * contract. Preserves the historical preference — `getByName` when present,
  * else `idFromName` + `get` — but the preference now lives in one place (the
  * contract's `resolveShard`) rather than being restated per resolution path.
+ *
+ * `locationHint` asks the platform to create the object in that region. It is
+ * advisory and only the *creating* resolution can honour it, so it is safe to
+ * pass on every call and never safe to depend on: callers must behave
+ * identically when the shard turns out to live somewhere else entirely.
  */
-export const resolveShard = (namespace: ShardNamespaceInput, shardKey: string): ResolvedShard => resolveShardStub(toDirectory(namespace), shardKey);
+export const resolveShard = (namespace: ShardNamespaceInput, shardKey: string, locationHint?: RegionHint): ResolvedShard =>
+    resolveShardStub(toDirectory(namespace), shardKey, locationHint);

--- a/packages/runtime/src/security-headers.ts
+++ b/packages/runtime/src/security-headers.ts
@@ -164,7 +164,25 @@ const htmlCspFor = (frameOptions: string | undefined): string => {
 const DEFAULT_PERMISSIONS_POLICY =
     "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
 
-const DEFAULT_CORS_HEADERS = ["Authorization", "Content-Type", "X-D1-Bookmark", "X-Lunora-Mutation-Id"];
+/**
+ * Request headers a cross-origin caller may send by default.
+ *
+ * This is the allowlist the preflight intersects against, with no wildcard, so
+ * every header `@lunora/client` attaches on its own has to be here — a browser
+ * blocks the whole request over one unlisted name. That makes the list part of
+ * the client's wire contract, not a security knob to trim: each entry is a
+ * header the SDK sends unprompted, and omitting one breaks exactly the apps
+ * that configure `security.cors` (i.e. those on a separate frontend domain).
+ */
+const DEFAULT_CORS_HEADERS = [
+    "Authorization",
+    "Content-Type",
+    "X-D1-Bookmark",
+    "X-Lunora-Client-Id",
+    "X-Lunora-Client-Seq",
+    "X-Lunora-Min-Seq",
+    "X-Lunora-Mutation-Id",
+];
 
 const DEFAULT_CORS_METHODS = ["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT"];
 

--- a/packages/runtime/src/security-headers.ts
+++ b/packages/runtime/src/security-headers.ts
@@ -548,11 +548,28 @@ const enforceWebSocketOrigin = (request: Request, resolved: ResolvedSecurity): R
     return forbiddenOriginResponse("cross-origin websocket upgrade", source, selfOrigin);
 };
 
+/**
+ * Response headers a cross-origin caller may READ.
+ *
+ * A browser hides every response header except the CORS-safelisted ones unless
+ * it is named here, and `response.headers.get(...)` then returns `null` with no
+ * error anywhere. That failure is silent by construction, so this list is not a
+ * policy knob: it is exactly the set of headers `@lunora/client` reads back,
+ * and a header the SDK consumes but that is missing here does not break loudly
+ * — it degrades the guarantee the header exists to provide.
+ *
+ * `x-d1-bookmark` carries D1 read-your-writes; `x-lunora-shard-key` is the
+ * canonical shard a dispatch resolved to, which the client keys its replica
+ * bookmark by.
+ */
+const DEFAULT_CORS_EXPOSED_HEADERS = ["X-D1-Bookmark", "X-Lunora-Shard-Key"];
+
 /** Build the `Access-Control-Allow-*` headers for an allowed cross-origin request. */
 const corsResponseHeaders = (origin: string, cors: ResolvedCors): Headers => {
     const headers = new Headers();
 
     headers.set("access-control-allow-origin", origin);
+    headers.set("access-control-expose-headers", DEFAULT_CORS_EXPOSED_HEADERS.join(", "));
     headers.append("vary", "Origin");
 
     if (cors.allowCredentials) {

--- a/packages/shard-engine/__tests__/replica.test.ts
+++ b/packages/shard-engine/__tests__/replica.test.ts
@@ -1,0 +1,446 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExportRow } from "../src/admin-export-import";
+import type { SqlExec } from "../src/ctx-db";
+import type { CdcChange } from "../src/ctx-db-cdc";
+import type { ReplicaFollowerHost, ReplicaOwnerHost } from "../src/replica";
+import { createReplicaLink, gateReplicaDispatch, handleReplicaControl } from "../src/replica";
+import createSqliteExec from "./_helpers/node-sqlite";
+
+/**
+ * Region-local read replicas: the follow loop, the freshness contract, and
+ * every condition under which a replica must refuse to answer.
+ *
+ * The replica's own follow-position row is exercised against a real SQLite
+ * build (see `_helpers/node-sqlite.ts`) so the upsert and the survival of the
+ * cursor across calls behave the way they will inside a Durable Object; the
+ * owner is a scripted double, because what is under test here is the follower's
+ * decisions, not the changelog it reads.
+ */
+
+/** An owner double: a changelog it serves, an epoch, a floor, and a snapshot, all settable by the test. */
+interface Owner {
+    changes: CdcChange[];
+    /** The OWNER's env — where the bootstrap cap is read, since the owner decides what it will serve. */
+    env: Record<string, unknown>;
+    /** `undefined` models a shard with CDC off — the DEFAULT — which has no changelog at all. */
+    epoch: string | undefined;
+    /** `undefined` models an empty log; a number models a log compacted up to it. */
+    floor: number | undefined;
+    pulls: number;
+    /** The owner half of the control channel, as a replica reaches it. */
+    serve: (frame: unknown) => Promise<Response>;
+    snapshot: ExportRow[];
+    snapshots: number;
+}
+
+const createOwner = (): Owner => {
+    const owner: Owner = {
+        changes: [],
+        env: {},
+        epoch: "epoch-1",
+        floor: undefined,
+        pulls: 0,
+        snapshot: [],
+        snapshots: 0,
+        serve: async (frame: unknown): Promise<Response> => {
+            const host: ReplicaOwnerHost = {
+                doName: () => "tenant-7",
+                env: () => owner.env,
+                exportRows: async () => {
+                    owner.snapshots += 1;
+
+                    return owner.snapshot;
+                },
+                ownerCursor: () => owner.changes.at(-1)?.seq ?? 0,
+                ownerEpoch: () => owner.epoch,
+                ownerFloor: () => owner.floor,
+                readChanges: (sinceSeq: number, limit: number) => {
+                    owner.pulls += 1;
+
+                    const page = owner.changes.filter((change) => change.seq > sinceSeq).slice(0, limit);
+
+                    return { changes: page, cursor: page.at(-1)?.seq ?? sinceSeq };
+                },
+                shardBinding: () => "SHARD",
+                sql: () => ({}) as SqlExec,
+            };
+
+            return handleReplicaControl(host, new Request("https://replica.internal/_lunora/replica", { body: JSON.stringify(frame), method: "POST" }));
+        },
+    };
+
+    return owner;
+};
+
+const change = (seq: number, id: string): CdcChange => {
+    return { doc: { _id: id, title: `row-${String(seq)}` }, id, op: "insert", seq, table: "posts", ts: seq };
+};
+
+const replicaRead = (headers: Record<string, string> = {}): Request =>
+    new Request("https://shard.internal/rpc", { headers: { "x-lunora-replica-read": "1", ...headers }, method: "POST" });
+
+describe("read replicas", () => {
+    let harness: ReturnType<typeof createSqliteExec>;
+    let sql: SqlExec;
+    let owner: Owner;
+    let applied: CdcChange[];
+    let imported: ExportRow[];
+    let importErrors: unknown[];
+    let env: Record<string, unknown>;
+    let host: ReplicaFollowerHost;
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+        sql = harness.sql;
+        owner = createOwner();
+        applied = [];
+        imported = [];
+        importErrors = [];
+
+        // The follow loop addresses its owner through `env[binding]`, which is
+        // exactly the seam a test can stand in for: this namespace routes every
+        // sibling hop into the owner double.
+        const toOwner = { fetch: async (_url: string, init?: RequestInit) => owner.serve(JSON.parse(typeof init?.body === "string" ? init.body : "{}")) };
+
+        env = { SHARD: { get: () => toOwner, getByName: () => toOwner, idFromName: (name: string) => name } };
+
+        host = {
+            applyChanges: async (changes: ReadonlyArray<CdcChange>) => {
+                applied.push(...changes);
+
+                return changes.length;
+            },
+            doName: () => "tenant-7::replica::weur",
+            env: () => env,
+            importRows: async (rows: ReadonlyArray<ExportRow>) => {
+                imported.push(...rows);
+
+                return { errors: importErrors };
+            },
+            shardBinding: () => "SHARD",
+            sql: () => sql,
+        };
+    });
+
+    afterEach(() => {
+        harness.close();
+        vi.useRealTimers();
+    });
+
+    it("is built only for a replica-named DO", () => {
+        expect.assertions(3);
+
+        const replica = createReplicaLink(host);
+
+        expect(replica?.ownerKey).toBe("tenant-7");
+        expect(replica?.region).toBe("weur");
+        // An owner name and an unnamed single-DO shard both get no collaborator.
+        expect(createReplicaLink({ ...host, doName: () => "tenant-7" })).toBeUndefined();
+    });
+
+    it("bootstraps from the owner's snapshot on first use, then serves the read", async () => {
+        expect.assertions(4);
+
+        owner.snapshot = [{ doc: { _id: "a", title: "first" }, table: "posts" }];
+        owner.changes = [change(4, "a")];
+
+        const replica = createReplicaLink(host);
+
+        // The end-to-end success path: the gate lets a caught-up replica through.
+        await expect(gateReplicaDispatch(replica!, replicaRead(), "posts:list")).resolves.toBeUndefined();
+        expect(imported).toStrictEqual(owner.snapshot);
+        // The snapshot's cursor is the owner's high-watermark at the time it was
+        // taken, so the follow loop resumes from there rather than replaying the
+        // whole log it already contains.
+        expect(replica?.appliedSeq()).toBe(4);
+        expect(replica?.isDivergent()).toBe(false);
+    });
+
+    it("applies the changelog past its cursor and remembers where it got to", async () => {
+        expect.assertions(3);
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        owner.changes = [change(1, "a"), change(2, "b")];
+
+        await expect(replica?.ensureFresh(2)).resolves.toBe("fresh");
+        expect(applied.map((entry) => entry.seq)).toStrictEqual([1, 2]);
+        expect(replica?.appliedSeq()).toBe(2);
+    });
+
+    it("serves inside the staleness window without touching the owner", async () => {
+        expect.assertions(2);
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        owner.changes = [change(1, "a")];
+        const before = owner.pulls;
+
+        // No cursor requirement and a just-synced replica: the read is answered
+        // locally, which is the entire point of the tier.
+        await expect(replica?.ensureFresh()).resolves.toBe("fresh");
+        expect(owner.pulls).toBe(before);
+    });
+
+    it("catches up past the staleness window even with no cursor requirement", async () => {
+        expect.assertions(1);
+
+        vi.useFakeTimers();
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        owner.changes = [change(1, "a")];
+        vi.advanceTimersByTime(5000);
+
+        await replica?.ensureFresh();
+
+        expect(applied.map((entry) => entry.seq)).toStrictEqual([1]);
+    });
+
+    it("refuses to follow a shard that has no changelog", async () => {
+        expect.assertions(3);
+
+        // CDC is opt-in, so this is the DEFAULT shape of a shard. Coercing the
+        // absent epoch to a sentinel would let the replica bootstrap once, agree
+        // with every later empty page that it is caught up, and serve that first
+        // snapshot for the life of the DO.
+        owner.epoch = undefined;
+        owner.snapshot = [{ doc: { _id: "a" }, table: "posts" }];
+
+        const replica = createReplicaLink(host);
+
+        await expect(replica?.ensureFresh()).resolves.toBe("unavailable");
+        expect(imported).toStrictEqual([]);
+        expect(replica?.isDivergent()).toBe(false);
+    });
+
+    it("reports unavailable when the owner's timeline has forked", async () => {
+        expect.assertions(3);
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        // A reset / point-in-time rollback on the owner mints a new epoch. Its
+        // `seq` numbers restart low, so replaying its log onto our rows would
+        // fabricate a state neither side ever held.
+        owner.epoch = "epoch-2";
+        owner.changes = [change(1, "z")];
+
+        await expect(replica?.ensureFresh(1)).resolves.toBe("unavailable");
+        expect(applied).toStrictEqual([]);
+        // Sticky: re-checking on every read would re-pay the round trip to learn
+        // the same answer.
+        expect(replica?.isDivergent()).toBe(true);
+    });
+
+    it("reports unavailable when the log was compacted past its position", async () => {
+        expect.assertions(2);
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        owner.changes = [change(9, "i")];
+        owner.floor = 9;
+
+        await expect(replica?.ensureFresh(9)).resolves.toBe("unavailable");
+        expect(applied).toStrictEqual([]);
+    });
+
+    it("reports unavailable when the log was compacted away entirely", async () => {
+        expect.assertions(1);
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        // An emptied log reports no floor at all, but its high-watermark is still
+        // ahead of us — writes happened and were compacted before we saw them.
+        owner.changes = [];
+        owner.floor = undefined;
+        (owner as { serve: Owner["serve"] }).serve = async () => Response.json({ changes: [], cursor: 100, epoch: "epoch-1" });
+
+        await expect(replica?.ensureFresh(100)).resolves.toBe("unavailable");
+    });
+
+    it("refuses a snapshot too large to copy in one response", async () => {
+        expect.assertions(2);
+
+        owner.env["LUNORA_REPLICA_MAX_BOOTSTRAP_ROWS"] = "1";
+        owner.snapshot = [
+            { doc: { _id: "a" }, table: "posts" },
+            { doc: { _id: "b" }, table: "posts" },
+        ];
+
+        const replica = createReplicaLink(host);
+
+        await expect(replica?.ensureFresh()).resolves.toBe("unavailable");
+        // A partial copy of the shard is worse than no replica at all.
+        expect(imported).toStrictEqual([]);
+    });
+
+    it("refuses a snapshot whose rows did not all land", async () => {
+        expect.assertions(2);
+
+        // The import surfaces per-row failures rather than aborting, so an
+        // incomplete snapshot would otherwise be recorded as a complete one.
+        importErrors = [{ line: 2, message: "validation failed" }];
+        owner.snapshot = [{ doc: { _id: "a" }, table: "posts" }];
+
+        const replica = createReplicaLink(host);
+
+        await expect(replica?.ensureFresh()).resolves.toBe("unavailable");
+        expect(replica?.isDivergent()).toBe(true);
+    });
+
+    it("collapses concurrent first reads onto one bootstrap", async () => {
+        expect.assertions(2);
+
+        owner.snapshot = [{ doc: { _id: "a" }, table: "posts" }];
+
+        const replica = createReplicaLink(host);
+        const readiness = await Promise.all([replica?.ensureFresh(), replica?.ensureFresh(), replica?.ensureFresh()]);
+
+        // A DO's input gate does not hold requests across an await, so without
+        // the single-flight latch each caller would make the owner export the
+        // whole shard again.
+        expect(owner.snapshots).toBe(1);
+        expect(readiness).toStrictEqual(["fresh", "fresh", "fresh"]);
+    });
+
+    it("stops pulling as soon as the owner has nothing more", async () => {
+        expect.assertions(2);
+
+        const replica = createReplicaLink(host);
+
+        await replica?.ensureFresh();
+
+        const before = owner.pulls;
+
+        // An unreachable cursor — a stale bookmark, or one a caller supplied —
+        // must not turn a single read into ten sequential cross-region pulls.
+        await expect(replica?.ensureFresh(999_999)).resolves.toBe("stale");
+        expect(owner.pulls - before).toBe(1);
+    });
+
+    it("reports unavailable when the owner cannot be reached", async () => {
+        expect.assertions(1);
+
+        const unreachable: ReplicaFollowerHost = {
+            ...host,
+            env: () => {return {
+                SHARD: {
+                    get: () => {return {
+                        fetch: async () => {
+                            throw new Error("no route to owner");
+                        },
+                    }},
+                    idFromName: (name: string) => name,
+                },
+            }},
+        };
+
+        // Nothing bootstrapped means no rows at all, so there is nothing here to
+        // answer a read from — the caller must go to the owner.
+        await expect(createReplicaLink(unreachable)?.ensureFresh()).resolves.toBe("unavailable");
+    });
+
+    it("refuses to serve the control channel from a replica", async () => {
+        expect.assertions(1);
+
+        // A replica's local `seq` numbers are its own; answering a pull would
+        // hand a follower cursors that mean nothing on the owner's log.
+        const response = await handleReplicaControl(
+            {
+                ...host,
+                exportRows: async () => [],
+                ownerCursor: () => 0,
+                ownerEpoch: () => "e",
+                ownerFloor: () => undefined,
+                readChanges: () => {return { changes: [], cursor: 0 }},
+            },
+            new Request("https://replica.internal/_lunora/replica", { body: JSON.stringify({ sinceSeq: 0, type: "replica_pull" }), method: "POST" }),
+        );
+
+        expect(response.status).toBe(409);
+    });
+
+    it("rejects an unsigned frame when a control-channel secret is configured", async () => {
+        expect.assertions(1);
+
+        const ownerHost: ReplicaOwnerHost = {
+            doName: () => "tenant-7",
+            env: () => {return { LUNORA_RELAY_SECRET: "s3cret" }},
+            exportRows: async () => [],
+            ownerCursor: () => 0,
+            ownerEpoch: () => "epoch-1",
+            ownerFloor: () => undefined,
+            readChanges: () => {return { changes: [], cursor: 0 }},
+            shardBinding: () => "SHARD",
+            sql: () => sql,
+        };
+
+        const response = await handleReplicaControl(
+            ownerHost,
+            new Request("https://replica.internal/_lunora/replica", { body: JSON.stringify({ sinceSeq: 0, type: "replica_pull" }), method: "POST" }),
+        );
+
+        expect(response.status).toBe(403);
+    });
+});
+
+describe("replica dispatch gate", () => {
+    let harness: ReturnType<typeof createSqliteExec>;
+
+    beforeEach(() => {
+        harness = createSqliteExec();
+    });
+
+    afterEach(() => {
+        harness.close();
+    });
+
+    const followerHost = (): ReplicaFollowerHost => {
+        return {
+            applyChanges: async () => 0,
+            doName: () => "tenant-7::replica::weur",
+            env: () => {return {}},
+            importRows: async () => {
+                return { errors: [] };
+            },
+            shardBinding: () => undefined,
+            sql: () => harness.sql,
+        };
+    };
+
+    it("refuses any dispatch the runtime did not mark as a replica read", async () => {
+        expect.assertions(2);
+
+        const replica = createReplicaLink(followerHost());
+        const response = await gateReplicaDispatch(replica!, new Request("https://shard.internal/rpc", { method: "POST" }), "posts:add");
+        const body: { error: { code: string } } = await response!.json();
+
+        expect(response?.status).toBe(421);
+        expect(body.error.code).toBe("REPLICA_READ_ONLY");
+    });
+
+    it("reports the fallback reason when it cannot serve the read", async () => {
+        expect.assertions(2);
+
+        // No shard binding, so the follow loop cannot address its owner and the
+        // replica has nothing bootstrapped to answer from.
+        const replica = createReplicaLink(followerHost());
+        const response = await gateReplicaDispatch(replica!, replicaRead(), "posts:list");
+
+        expect(response?.status).toBe(421);
+        expect(response?.headers.get("x-lunora-replica-fallback")).toBe("unavailable");
+    });
+});

--- a/packages/shard-engine/__tests__/replica.test.ts
+++ b/packages/shard-engine/__tests__/replica.test.ts
@@ -28,8 +28,8 @@ interface Owner {
     /** `undefined` models an empty log; a number models a log compacted up to it. */
     floor: number | undefined;
     pulls: number;
-    /** The owner half of the control channel, as a replica reaches it. */
-    serve: (frame: unknown) => Promise<Response>;
+    /** The owner half of the control channel, reached with the follower's real body and headers. */
+    serve: (body: string, headers: HeadersInit | undefined) => Promise<Response>;
     snapshot: ExportRow[];
     snapshots: number;
 }
@@ -37,13 +37,13 @@ interface Owner {
 const createOwner = (): Owner => {
     const owner: Owner = {
         changes: [],
-        env: {},
+        env: { LUNORA_RELAY_SECRET: "s3cret" },
         epoch: "epoch-1",
         floor: undefined,
         pulls: 0,
         snapshot: [],
         snapshots: 0,
-        serve: async (frame: unknown): Promise<Response> => {
+        serve: async (body: string, headers: HeadersInit | undefined): Promise<Response> => {
             const host: ReplicaOwnerHost = {
                 doName: () => "tenant-7",
                 env: () => owner.env,
@@ -62,11 +62,16 @@ const createOwner = (): Owner => {
 
                     return { changes: page, cursor: page.at(-1)?.seq ?? sinceSeq };
                 },
+                rowCount: () => owner.snapshot.length,
                 shardBinding: () => "SHARD",
                 sql: () => ({}) as SqlExec,
             };
 
-            return handleReplicaControl(host, new Request("https://replica.internal/_lunora/replica", { body: JSON.stringify(frame), method: "POST" }));
+            // The follower's bytes and headers verbatim: the control channel
+            // authenticates the exact body it received, so a harness that
+            // re-serialized the frame or dropped the signature would be testing
+            // a request no replica ever sends.
+            return handleReplicaControl(host, new Request("https://replica.internal/_lunora/replica", { body, headers, method: "POST" }));
         },
     };
 
@@ -101,9 +106,9 @@ describe("read replicas", () => {
         // The follow loop addresses its owner through `env[binding]`, which is
         // exactly the seam a test can stand in for: this namespace routes every
         // sibling hop into the owner double.
-        const toOwner = { fetch: async (_url: string, init?: RequestInit) => owner.serve(JSON.parse(typeof init?.body === "string" ? init.body : "{}")) };
+        const toOwner = { fetch: async (_url: string, init?: RequestInit) => owner.serve(typeof init?.body === "string" ? init.body : "{}", init?.headers) };
 
-        env = { SHARD: { get: () => toOwner, getByName: () => toOwner, idFromName: (name: string) => name } };
+        env = { LUNORA_RELAY_SECRET: "s3cret", SHARD: { get: () => toOwner, getByName: () => toOwner, idFromName: (name: string) => name } };
 
         host = {
             applyChanges: async (changes: ReadonlyArray<CdcChange>) => {
@@ -271,22 +276,6 @@ describe("read replicas", () => {
         await expect(replica?.ensureFresh(100)).resolves.toBe("unavailable");
     });
 
-    it("refuses a snapshot too large to copy in one response", async () => {
-        expect.assertions(2);
-
-        owner.env["LUNORA_REPLICA_MAX_BOOTSTRAP_ROWS"] = "1";
-        owner.snapshot = [
-            { doc: { _id: "a" }, table: "posts" },
-            { doc: { _id: "b" }, table: "posts" },
-        ];
-
-        const replica = createReplicaLink(host);
-
-        await expect(replica?.ensureFresh()).resolves.toBe("unavailable");
-        // A partial copy of the shard is worse than no replica at all.
-        expect(imported).toStrictEqual([]);
-    });
-
     it("refuses a snapshot whose rows did not all land", async () => {
         expect.assertions(2);
 
@@ -336,16 +325,20 @@ describe("read replicas", () => {
 
         const unreachable: ReplicaFollowerHost = {
             ...host,
-            env: () => {return {
-                SHARD: {
-                    get: () => {return {
-                        fetch: async () => {
-                            throw new Error("no route to owner");
+            env: () => {
+                return {
+                    SHARD: {
+                        get: () => {
+                            return {
+                                fetch: async () => {
+                                    throw new Error("no route to owner");
+                                },
+                            };
                         },
-                    }},
-                    idFromName: (name: string) => name,
-                },
-            }},
+                        idFromName: (name: string) => name,
+                    },
+                };
+            },
         };
 
         // Nothing bootstrapped means no rows at all, so there is nothing here to
@@ -365,7 +358,10 @@ describe("read replicas", () => {
                 ownerCursor: () => 0,
                 ownerEpoch: () => "e",
                 ownerFloor: () => undefined,
-                readChanges: () => {return { changes: [], cursor: 0 }},
+                readChanges: () => {
+                    return { changes: [], cursor: 0 };
+                },
+                rowCount: () => 0,
             },
             new Request("https://replica.internal/_lunora/replica", { body: JSON.stringify({ sinceSeq: 0, type: "replica_pull" }), method: "POST" }),
         );
@@ -373,17 +369,55 @@ describe("read replicas", () => {
         expect(response.status).toBe(409);
     });
 
+    it("refuses to replicate at all when no control-channel secret is configured", async () => {
+        expect.assertions(2);
+
+        // The relay channel tolerates a missing secret for back-compat; this one
+        // hands back every row of the shard, and the feature is new, so an
+        // unconfigured deployment gets no replication rather than an
+        // unauthenticated snapshot endpoint.
+        owner.env = {};
+
+        const replica = createReplicaLink(host);
+
+        await expect(replica?.ensureFresh()).resolves.toBe("unavailable");
+        expect(imported).toStrictEqual([]);
+    });
+
+    it("refuses a snapshot larger than the cap without building it", async () => {
+        expect.assertions(2);
+
+        owner.env["LUNORA_REPLICA_MAX_BOOTSTRAP_ROWS"] = "1";
+        owner.snapshot = [
+            { doc: { _id: "a" }, table: "posts" },
+            { doc: { _id: "b" }, table: "posts" },
+        ];
+
+        const replica = createReplicaLink(host);
+
+        await expect(replica?.ensureFresh()).resolves.toBe("unavailable");
+        // The cap protects the OWNER's memory budget, so it has to be decided
+        // from a row count — materializing the snapshot first and measuring it
+        // afterwards would have already spent what the cap exists to save.
+        expect(owner.snapshots).toBe(0);
+    });
+
     it("rejects an unsigned frame when a control-channel secret is configured", async () => {
         expect.assertions(1);
 
         const ownerHost: ReplicaOwnerHost = {
             doName: () => "tenant-7",
-            env: () => {return { LUNORA_RELAY_SECRET: "s3cret" }},
+            env: () => {
+                return { LUNORA_RELAY_SECRET: "s3cret" };
+            },
             exportRows: async () => [],
             ownerCursor: () => 0,
             ownerEpoch: () => "epoch-1",
             ownerFloor: () => undefined,
-            readChanges: () => {return { changes: [], cursor: 0 }},
+            readChanges: () => {
+                return { changes: [], cursor: 0 };
+            },
+            rowCount: () => 0,
             shardBinding: () => "SHARD",
             sql: () => sql,
         };
@@ -412,7 +446,9 @@ describe("replica dispatch gate", () => {
         return {
             applyChanges: async () => 0,
             doName: () => "tenant-7::replica::weur",
-            env: () => {return {}},
+            env: () => {
+                return {};
+            },
             importRows: async () => {
                 return { errors: [] };
             },

--- a/packages/shard-engine/docs/index.mdx
+++ b/packages/shard-engine/docs/index.mdx
@@ -25,7 +25,8 @@ import { createShardCtxDb, runShardMigrations } from "@lunora/shard-engine";
 | ------------------ | --------------------------------------------------------------------------------------- |
 | Reactive reads     | `ctx-db*`, `dependency-tracker`, `reactive-cache`, `query-args`                         |
 | Change propagation | `ctx-db-cdc` (the `__cdc_log` op-log), `subscription-delivery`, `shape-*`               |
-| Fan-out            | `relay`, `relay-hub`, `socket-pool`                                                     |
+| Fan-out            | `relay`, `relay-hub`, `socket-pool`, `sibling-channel`                                  |
+| Read replicas      | `replica` (follows `__cdc_log` into a region-local copy)                                |
 | Indexes            | `aggregates`, `rank`, `geo`, search (via the bundled `@lunora/search-core`)             |
 | Access control     | `rls-guard`, relation predicates                                                        |
 | Admin & ops        | `admin-export-import`, `data-migration`, `pitr`, `sql-console`, `settings`, `ttl-sweep` |

--- a/packages/shard-engine/src/env-int.ts
+++ b/packages/shard-engine/src/env-int.ts
@@ -7,18 +7,31 @@
  * integer.
  */
 
-/** Read a positive integer env var by `key`, falling back to `fallback` when unset/invalid. */
+/**
+ * Read a positive integer env var by `key`, falling back to `fallback` when
+ * unset or invalid.
+ *
+ * The whole string has to be an integer. `Number.parseInt` stops at the first
+ * character it cannot use, so it reads `"1500ms"` as `1500` and `"1.5"` as `1`
+ * — quietly accepting a value the operator wrote wrong, at a number they did
+ * not choose. A knob that silently reinterprets its input is worse than one
+ * that ignores it, because the documented fallback is at least a value someone
+ * decided on.
+ */
+/** A whole-string non-negative integer, with no trailing units or fraction. */
+const INTEGER_PATTERN = /^\d+$/;
+
 const envPositiveInt = (env: unknown, key: string, fallback: number): number => {
     const raw = (env as Record<string, unknown> | undefined)?.[key];
     let parsed = Number.NaN;
 
-    if (typeof raw === "string") {
-        parsed = Number.parseInt(raw, 10);
+    if (typeof raw === "string" && INTEGER_PATTERN.test(raw.trim())) {
+        parsed = Number(raw.trim());
     } else if (typeof raw === "number") {
         parsed = raw;
     }
 
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 };
 
 export default envPositiveInt;

--- a/packages/shard-engine/src/env-int.ts
+++ b/packages/shard-engine/src/env-int.ts
@@ -1,0 +1,24 @@
+/**
+ * Deployment tuning knobs read off the worker `env`.
+ *
+ * Its own module because every tier that has a knob needs it — the relay tier's
+ * fan and thresholds, the replica tier's staleness window and bootstrap cap —
+ * and none of them should have to import another tier's module to read an
+ * integer.
+ */
+
+/** Read a positive integer env var by `key`, falling back to `fallback` when unset/invalid. */
+const envPositiveInt = (env: unknown, key: string, fallback: number): number => {
+    const raw = (env as Record<string, unknown> | undefined)?.[key];
+    let parsed = Number.NaN;
+
+    if (typeof raw === "string") {
+        parsed = Number.parseInt(raw, 10);
+    } else if (typeof raw === "number") {
+        parsed = raw;
+    }
+
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export default envPositiveInt;

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -234,6 +234,8 @@ export type {
 export { clampPromotionThresholds, DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, relayCountFor, shapeRoutingKey } from "./relay";
 export type { RelayHost } from "./relay-hub";
 export { createRelayLink, DEFAULT_MAX_RELAYS, OwnerRelay, RelayMember } from "./relay-hub";
+export type { ReplicaFollowerHost, ReplicaOwnerHost, ReplicaReadiness, ShardSiblingHost } from "./replica";
+export { createReplicaLink, gateReplicaDispatch, handleReplicaControl } from "./replica";
 export {
     buildReprojectionMigration,
     countLegacyRows,

--- a/packages/shard-engine/src/relay-hub.ts
+++ b/packages/shard-engine/src/relay-hub.ts
@@ -23,15 +23,17 @@
 
 import { LunoraError, toErrorBody } from "@lunora/errors";
 
-import { constantTimeEqual } from "../../../shared/constant-time-equal";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import type { SqlExec } from "./ctx-db";
+import envPositiveInt from "./env-int";
 import type { MaskPoliciesResult, RlsPoliciesResult } from "./introspect";
 import { stableWireKey } from "./reactive-cache";
 import type { OwnerRelayFrame, PromotionState, RelayFrame, RelayShapePoke, RelayShapeSeed, RelayShapeSubscribe } from "./relay";
 import { clampPromotionThresholds, DEFAULT_PROMOTION_THRESHOLDS, nextPromotionState, parseRelayName, relayName, shapeRoutingKey } from "./relay";
 import type { ShapeRowOp } from "./shape-global-diff";
 import { buildPokeFrames, encodeRowsPatch } from "./shape-global-diff";
+import type { SiblingStub } from "./sibling-channel";
+import { RELAY_SIGNATURE_HEADER, siblingSecretOf, siblingStub, signSiblingBody, verifySiblingBody } from "./sibling-channel";
 import { awaitWsDrain, trySendFrame } from "./subscription-delivery";
 import type { ResolvedShape, ShapeSubscriptionQuery, ShardSocketLike, SocketAttachment, SubscriptionIdentity } from "./types";
 
@@ -40,50 +42,6 @@ const DEFAULT_RELAY_FAN = 2;
 
 /** Hard ceiling on relays per shard (per-deployment via `LUNORA_MAX_RELAYS`) — the cost cap a viral shard can never exceed. */
 const DEFAULT_MAX_RELAYS = 8;
-
-/** Env var carrying the optional relay control-channel HMAC secret. */
-const RELAY_SECRET_KEY = "LUNORA_RELAY_SECRET";
-
-/** Header carrying the hex HMAC-SHA256 of the relay control-frame body. */
-const RELAY_SIGNATURE_HEADER = "x-lunora-relay-sig";
-
-/** The relay control-channel secret, or `undefined` when message authentication is not configured. */
-const relaySecretOf = (env: unknown): string | undefined => {
-    const value = (env as Record<string, unknown> | undefined)?.[RELAY_SECRET_KEY];
-
-    return typeof value === "string" && value.length > 0 ? value : undefined;
-};
-
-/**
- * HMAC-SHA256 of `body` under `secret`, hex-encoded. Authenticates the internal
- * `/_lunora/relay` control channel (L6): without it, safety rests solely on DO
- * network isolation, so any DO in the namespace (or a future custom route that
- * forwarded a client path+body to a shard) could inject forged relay frames —
- * e.g. deliver an arbitrary `rowsPatch` to another subscriber's socket. Opt-in:
- * only enforced when `LUNORA_RELAY_SECRET` is set, so existing deployments are
- * unaffected until they provision the secret.
- */
-const signRelayBody = async (secret: string, body: string): Promise<string> => {
-    const encoder = new TextEncoder();
-    const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { hash: "SHA-256", name: "HMAC" }, false, ["sign"]);
-    const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
-
-    return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-};
-
-/** Read a positive integer env var by `key`, falling back to `fallback` when unset/invalid. */
-const envPositiveInt = (env: unknown, key: string, fallback: number): number => {
-    const raw = (env as Record<string, unknown> | undefined)?.[key];
-    let parsed = Number.NaN;
-
-    if (typeof raw === "string") {
-        parsed = Number.parseInt(raw, 10);
-    } else if (typeof raw === "number") {
-        parsed = raw;
-    }
-
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-};
 
 /**
  * The identity the owner computes a relay-multicast shape delta under (plan 075
@@ -99,29 +57,6 @@ const RELAY_MULTICAST_IDENTITY: SubscriptionIdentity = {};
 /** Exhaustiveness guard for the {@link OwnerRelayFrame} dispatch — an unhandled member is a compile error here, and an impossible runtime frame throws rather than silently mis-routing. */
 const assertNeverFrame = (frame: never): never => {
     throw new LunoraError("INTERNAL", `unhandled relay frame: ${JSON.stringify(frame)}`);
-};
-
-/** Minimal Durable Object stub surface the relay tier needs to POST a control frame to a sibling. */
-interface RelayStub {
-    fetch: (url: string, init?: RequestInit) => Promise<Response>;
-}
-
-/** Minimal Durable Object namespace surface for addressing sibling owners/relays by name. */
-interface RelayNamespaceLike {
-    get: (id: unknown) => RelayStub;
-    getByName?: (name: string) => RelayStub;
-    idFromName: (name: string) => unknown;
-}
-
-/** Duck-type a value as a DO namespace, or `undefined` when it isn't one (single-DO mode / unbound). */
-const asRelayNamespace = (value: unknown): RelayNamespaceLike | undefined => {
-    if (value === null || typeof value !== "object") {
-        return undefined;
-    }
-
-    const candidate = value as Partial<RelayNamespaceLike>;
-
-    return typeof candidate.idFromName === "function" && typeof candidate.get === "function" ? (candidate as RelayNamespaceLike) : undefined;
 };
 
 /**
@@ -209,15 +144,8 @@ abstract class RelayLink {
         // When a relay secret is configured, require a valid HMAC over the raw
         // body. Fail closed on a missing/mismatched signature so a forged frame
         // can't reach the dispatch below. Unconfigured ⇒ legacy network-trust.
-        const secret = relaySecretOf(this.host.env());
-
-        if (secret !== undefined) {
-            const supplied = request.headers.get(RELAY_SIGNATURE_HEADER);
-            const expected = await signRelayBody(secret, raw);
-
-            if (supplied === null || !constantTimeEqual(supplied, expected)) {
-                return new Response("forbidden", { status: 403 });
-            }
+        if (!(await verifySiblingBody(this.host.env(), request.headers.get(RELAY_SIGNATURE_HEADER), raw))) {
+            return new Response("forbidden", { status: 403 });
         }
 
         let message: OwnerRelayFrame;
@@ -277,20 +205,19 @@ abstract class RelayLink {
         return envPositiveInt(this.host.env(), "LUNORA_MAX_RELAYS", DEFAULT_MAX_RELAYS);
     }
 
-    /** Whether this DO can currently address its siblings (a namespace binding has been learned) — the relay tier is inert in single-DO mode. */
+    /**
+     * Whether this DO can currently address its siblings (a namespace binding
+     * has been learned) — the relay tier is inert in single-DO mode. Probed
+     * through the same resolution the sends use, so "can address" and "did
+     * address" can never disagree.
+     */
     protected canAddressSiblings(): boolean {
-        return this.relayNamespace() !== undefined;
+        return this.siblingStub(this.roleId.ownerKey) !== undefined;
     }
 
-    /** Resolve this DO's own namespace binding so it can address sibling owners/relays, or `undefined` when unknown. */
-    protected relayNamespace(): RelayNamespaceLike | undefined {
-        const binding = this.host.shardBinding();
-
-        if (binding === undefined) {
-            return undefined;
-        }
-
-        return asRelayNamespace((this.host.env() as Record<string, unknown> | undefined)?.[binding]);
+    /** Resolve a sibling owner/relay by name off this DO's namespace binding. */
+    protected siblingStub(targetName: string): SiblingStub | undefined {
+        return siblingStub(this.host.env(), this.host.shardBinding(), targetName);
     }
 
     /** POST a control frame to a sibling by name, fire-and-forget. Best-effort: a transient cross-DO failure drops the frame rather than throwing into the handler. */
@@ -305,22 +232,21 @@ abstract class RelayLink {
      * @returns the sibling's response, or `undefined` when it can't be reached
      */
     protected async requestRelayMessage(targetName: string, message: OwnerRelayFrame): Promise<Response | undefined> {
-        const namespace = this.relayNamespace();
+        const stub = this.siblingStub(targetName);
 
-        if (namespace === undefined) {
+        if (stub === undefined) {
             return undefined;
         }
 
-        const stub = typeof namespace.getByName === "function" ? namespace.getByName(targetName) : namespace.get(namespace.idFromName(targetName));
         const body = JSON.stringify(message);
         const headers: Record<string, string> = { "content-type": "application/json", "x-lunora-shard-binding": this.host.shardBinding() ?? "" };
 
         // Sign the control-frame body when a relay secret is configured (L6), so
         // the receiver can authenticate it. Signed over the exact bytes we send.
-        const secret = relaySecretOf(this.host.env());
+        const secret = siblingSecretOf(this.host.env());
 
         if (secret !== undefined) {
-            headers[RELAY_SIGNATURE_HEADER] = await signRelayBody(secret, body);
+            headers[RELAY_SIGNATURE_HEADER] = await signSiblingBody(secret, body);
         }
 
         try {

--- a/packages/shard-engine/src/replica.ts
+++ b/packages/shard-engine/src/replica.ts
@@ -1,0 +1,628 @@
+/**
+ * Region-local read replicas — a shard's rows, followed into a second DO placed
+ * near the reader, so a one-shot query is answered locally instead of crossing
+ * an ocean to the owner.
+ *
+ * A DO's role is fixed for its whole life by its name (the same rule the relay
+ * tier follows): an un-suffixed name is the **owner**, a `…::replica::<region>`
+ * name is a **replica** of that owner. The owner is the sole writer and the
+ * source of the changelog; a replica never accepts a write and never originates
+ * data — everything it holds arrived through `__cdc_log`.
+ *
+ * The feed is the CDC changelog that already exists for streaming export and
+ * delta-resume subscriptions (`ctx-db-cdc.ts`), which is why this module is
+ * small: the owner pages its log, the replica replays the page through the same
+ * `applyCdcChanges` writer that point-in-time recovery uses, and the log's
+ * `seq` doubles as the replication cursor (the LSN) and the read-your-writes
+ * bookmark handed back to clients.
+ *
+ * Consistency, precisely:
+ *
+ * **Read-your-writes** is preserved by the caller passing the `minSeq` it got
+ * from its last write. The replica catches up to at least that cursor before
+ * answering, and reports `stale` if it cannot — never a silently older row.
+ *
+ * **Without** a `minSeq` a read may be up to `LUNORA_REPLICA_MAX_STALENESS_MS`
+ * behind, which is the whole trade being made.
+ *
+ * A shard with **no changelog at all** (CDC is opt-in, so this is the default)
+ * cannot be followed, and the owner refuses the control channel outright rather
+ * than handing back a synthetic timeline a follower would agree with forever.
+ *
+ * A **forked timeline** (the owner was reset or rolled back, so its CDC epoch
+ * changed) or a **compacted log** the replica has fallen behind cannot be
+ * reconciled by replay, so the replica reports `unavailable` and the caller
+ * sends the read to the owner.
+ * ponytail: divergence is a dead end, not a self-heal — and since a Durable
+ * Object is never destroyed, "for this DO's lifetime" means indefinitely, at
+ * the cost of one wasted hop per read in that region. Wiring
+ * `storage.deleteAll()` + a fresh bootstrap is the upgrade path if resets stop
+ * being rare, operator-driven events.
+ */
+
+import type { RegionHint } from "../../../shared/region-hint";
+import { parseMinSeq, parseReplicaName } from "../../../shared/replica-name";
+import type { ExportRow } from "./admin-export-import";
+import type { SqlExec } from "./ctx-db";
+import type { CdcChange } from "./ctx-db-cdc";
+import envPositiveInt from "./env-int";
+import { RELAY_SIGNATURE_HEADER, siblingSecretOf, siblingStub, signSiblingBody, verifySiblingBody } from "./sibling-channel";
+
+/** How stale a replica read may be when the caller names no cursor (per-deployment via `LUNORA_REPLICA_MAX_STALENESS_MS`). */
+const DEFAULT_MAX_STALENESS_MS = 1000;
+
+/** Changelog entries pulled per round trip. */
+const PULL_PAGE_SIZE = 1000;
+
+/**
+ * Pull rounds one `ensureFresh` will run before giving up and reporting `stale`.
+ * Bounds the work a single read can do: a replica far enough behind that ten
+ * pages don't close the gap is better served by sending the read to the owner
+ * while it keeps catching up in the background.
+ */
+const MAX_PULL_ROUNDS = 10;
+
+/**
+ * Rows a bootstrap will accept in one response (per-deployment via
+ * `LUNORA_REPLICA_MAX_BOOTSTRAP_ROWS`). The owner's export RPC is not
+ * paginated, so the whole snapshot crosses in a single reply — past this it
+ * would risk the DO's memory budget, and a replica that cannot bootstrap
+ * reports `unavailable` (reads go to the owner) rather than serving a partial
+ * copy of the shard.
+ * ponytail: single-response bootstrap; page it when shards outgrow this.
+ */
+const DEFAULT_MAX_BOOTSTRAP_ROWS = 50_000;
+
+const maxBootstrapRows = (env: unknown): number => envPositiveInt(env, "LUNORA_REPLICA_MAX_BOOTSTRAP_ROWS", DEFAULT_MAX_BOOTSTRAP_ROWS);
+
+/** Reserved table holding a replica's follow position. Owner-role DOs never create it. */
+const REPLICA_STATE_TABLE = "__replica_state";
+
+/** Ask the owner for the changelog past `sinceSeq`. */
+interface ReplicaPullFrame {
+    sinceSeq: number;
+    type: "replica_pull";
+}
+
+/** Ask the owner for a full snapshot, for a replica that has never followed it. */
+interface ReplicaBootstrapFrame {
+    type: "replica_bootstrap";
+}
+
+type ReplicaFrame = ReplicaBootstrapFrame | ReplicaPullFrame;
+
+/** The owner's answer to a pull: a page of the changelog plus the timeline it belongs to. */
+interface ReplicaPullResult {
+    changes: CdcChange[];
+    cursor: number;
+    epoch: string;
+
+    /**
+     * Oldest `seq` the owner still retains, or `undefined` when its log holds
+     * nothing. Distinct on purpose: `0` would read as "retains everything", so
+     * a compaction that emptied the log would look like a complete history.
+     */
+    floor?: number;
+}
+
+/** The owner's answer to a bootstrap: the snapshot plus the cursor it was taken at. */
+interface ReplicaBootstrapResult {
+    cursor: number;
+    epoch: string;
+    rows: ExportRow[];
+    /** Set when the shard holds more rows than one response may carry, in which case `rows` must not be used. */
+    truncated?: boolean;
+}
+
+/** Why a replica could not answer a read locally. */
+type ReplicaReadiness =
+    /** Caught up far enough — serve the read here. */
+    | "fresh"
+    /** Behind the caller's required cursor after exhausting its pull rounds — send the read to the owner. */
+    | "stale"
+    /** Cannot follow this owner at all (forked timeline, compacted gap, owner unreachable) — send the read to the owner. */
+    | "unavailable";
+
+/**
+ * What the replica tier needs from ANY DO it runs on: its own name (the role
+ * signal), the worker `env` (the control-channel secret and the tuning knobs),
+ * and its SQLite handle. Both halves extend it, and `shard-do.ts` builds it once
+ * and spreads it into the relay host and this one.
+ */
+interface ShardSiblingHost {
+    /** This DO's own name, or `undefined` for an unnamed (single-DO) shard. */
+    doName: () => string | undefined;
+    /** The worker `env`. */
+    env: () => unknown;
+    /** The env binding name holding the shard namespace, so a DO can address a sibling. */
+    shardBinding: () => string | undefined;
+    /** This DO's SQLite handle. */
+    sql: () => SqlExec;
+}
+
+/**
+ * The owner half: what a shard needs to SERVE the replicas following it.
+ *
+ * `ownerCursor` / `ownerEpoch` / `ownerFloor` are all optional-returning, and
+ * that is load-bearing rather than defensive. `undefined` means "this shard has
+ * no changelog" — CDC is opt-in, and without it there is nothing to follow.
+ * Collapsing that into a sentinel (`0`, `""`) makes "no log" indistinguishable
+ * from "empty log", and a follower comparing `"" === ""` concludes it is caught
+ * up with a timeline that does not exist.
+ */
+interface ReplicaOwnerHost extends ShardSiblingHost {
+    /** Every row of the shard, for a bootstrap snapshot. */
+    exportRows: () => Promise<ExportRow[]>;
+    /** The changelog high-watermark, or `undefined` when this shard has no changelog. */
+    ownerCursor: () => number | undefined;
+    /** This shard's CDC epoch, or `undefined` when this shard has no changelog. */
+    ownerEpoch: () => string | undefined;
+    /** The oldest retained `seq`, `undefined` when the log is empty or absent. */
+    ownerFloor: () => number | undefined;
+    /** One page of the changelog past `sinceSeq`. */
+    readChanges: (sinceSeq: number, limit: number) => { changes: CdcChange[]; cursor: number };
+}
+
+/**
+ * The follower half: what a replica needs to APPLY what its owner sends.
+ */
+interface ReplicaFollowerHost extends ShardSiblingHost {
+    /** Replay a changelog page through the schema-aware writer (the `applyCdc` path). */
+    applyChanges: (changes: ReadonlyArray<CdcChange>) => Promise<number>;
+    /** Insert a bootstrap snapshot verbatim (explicit ids preserved), reporting what did not land. */
+    importRows: (rows: ReadonlyArray<ExportRow>) => Promise<{ errors: ReadonlyArray<unknown> }>;
+}
+
+/** A replica's durable follow position. */
+interface ReplicaState {
+    appliedSeq: number;
+    epoch: string;
+    syncedAtMs: number;
+}
+
+const migrateReplicaState = (sql: SqlExec): void => {
+    sql.exec(
+        `CREATE TABLE IF NOT EXISTS ${REPLICA_STATE_TABLE} (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            epoch TEXT NOT NULL,
+            applied_seq INTEGER NOT NULL,
+            synced_at REAL NOT NULL
+        )`,
+    );
+};
+
+const readReplicaState = (sql: SqlExec): ReplicaState | undefined => {
+    migrateReplicaState(sql);
+
+    const rows = sql.exec(`SELECT epoch, applied_seq AS appliedSeq, synced_at AS syncedAtMs FROM ${REPLICA_STATE_TABLE} WHERE id = 1`).toArray() as {
+        appliedSeq: number;
+        epoch: string;
+        syncedAtMs: number;
+    }[];
+
+    return rows[0];
+};
+
+const writeReplicaState = (sql: SqlExec, state: ReplicaState): void => {
+    migrateReplicaState(sql);
+
+    sql.exec(
+        `INSERT INTO ${REPLICA_STATE_TABLE} (id, epoch, applied_seq, synced_at) VALUES (1, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET epoch = excluded.epoch, applied_seq = excluded.applied_seq, synced_at = excluded.synced_at`,
+        state.epoch,
+        state.appliedSeq,
+        state.syncedAtMs,
+    );
+};
+
+/**
+ * Serve the owner half of the `/_lunora/replica` control channel: authenticate
+ * the frame, then answer a pull or a bootstrap. Stateless — an owner keeps no
+ * per-replica bookkeeping, because a replica's position lives with the replica
+ * and the changelog it reads is the one the shard already keeps.
+ *
+ * A replica must never serve this route: it holds a *copy* of a timeline, and
+ * its local `seq` numbers are its own, so answering a pull would hand a
+ * follower cursors that mean nothing on the owner's log.
+ */
+const handleReplicaControl = async (host: ReplicaOwnerHost, request: Request): Promise<Response> => {
+    const name = host.doName();
+
+    if (name !== undefined && parseReplicaName(name) !== undefined) {
+        return new Response("replica cannot serve replicas", { status: 409 });
+    }
+
+    // No changelog, nothing to follow. CDC is opt-in, so this is the DEFAULT
+    // shape of a shard, and it has to be refused at the source: a follower given
+    // a synthetic epoch would bootstrap once, then agree with every later empty
+    // page that it is caught up, and serve that first snapshot forever.
+    const epoch = host.ownerEpoch();
+
+    if (epoch === undefined) {
+        return new Response("shard has no changelog to replicate", { status: 409 });
+    }
+
+    let raw: string;
+
+    try {
+        raw = await request.text();
+    } catch {
+        return new Response("bad request", { status: 400 });
+    }
+
+    if (!(await verifySiblingBody(host.env(), request.headers.get(RELAY_SIGNATURE_HEADER), raw))) {
+        return new Response("forbidden", { status: 403 });
+    }
+
+    // Typed as the raw wire shape rather than as {@link ReplicaFrame}: this is
+    // untrusted input, so the `type` is a value to test, not a fact to narrow on.
+    let frame: { sinceSeq?: unknown; type?: unknown };
+
+    try {
+        frame = JSON.parse(raw) as { sinceSeq?: unknown; type?: unknown };
+    } catch {
+        return new Response("bad request", { status: 400 });
+    }
+
+    if (frame.type === "replica_bootstrap") {
+        // Read the cursor BEFORE the snapshot: a write that lands mid-export may
+        // or may not be in `rows`, and replaying it again from `cursor` is
+        // harmless (both the upsert and the delete replay are idempotent).
+        // Reading it after would skip anything committed during the export.
+        const cursor = host.ownerCursor() ?? 0;
+        const rows = await host.exportRows();
+
+        if (rows.length > maxBootstrapRows(host.env())) {
+            return Response.json({ cursor, epoch, rows: [], truncated: true } satisfies ReplicaBootstrapResult);
+        }
+
+        return Response.json({ cursor, epoch, rows } satisfies ReplicaBootstrapResult);
+    }
+
+    if (frame.type === "replica_pull") {
+        const sinceSeq = typeof frame.sinceSeq === "number" && Number.isInteger(frame.sinceSeq) && frame.sinceSeq >= 0 ? frame.sinceSeq : 0;
+        const { changes, cursor } = host.readChanges(sinceSeq, PULL_PAGE_SIZE);
+        const floor = host.ownerFloor();
+
+        return Response.json({ changes, cursor, epoch, ...(floor === undefined ? {} : { floor }) } satisfies ReplicaPullResult);
+    }
+
+    return new Response("unknown replica frame", { status: 400 });
+};
+
+/**
+ * A replica's follow loop. One instance per replica DO, built once from the
+ * DO name; owner-role DOs never have one.
+ */
+class ShardReplica {
+    /**
+     * Set once the replica proves it cannot follow this owner (forked timeline
+     * or compacted gap). Sticky for the DO's lifetime: re-checking on every read
+     * would re-pay the round trip to learn the same answer, and the condition is
+     * not one that clears itself.
+     */
+    private divergent = false;
+
+    /**
+     * The catch-up currently in flight, if any — the single-flight latch.
+     *
+     * The follow loop awaits cross-DO fetches, and a Durable Object's input gate
+     * does NOT hold other requests across an await. Without this, a burst of
+     * first reads in a cold region each issues its own bootstrap (making the
+     * owner export the whole shard once per caller), and concurrent catch-ups
+     * write `__replica_state` out of order — regressing `appliedSeq` and
+     * re-applying an older page over newer changes, while a third caller has
+     * already been told `fresh` on the higher cursor.
+     */
+    private inFlight: Promise<ReplicaReadiness> | undefined;
+
+    public constructor(
+        private readonly host: ReplicaFollowerHost,
+        /** The shard this replica follows. */
+        public readonly ownerKey: string,
+        /** The region this replica serves. */
+        public readonly region: RegionHint,
+    ) {}
+
+    /**
+     * Bring the replica far enough forward to answer a read, and say whether it
+     * got there.
+     *
+     * `minSeq` is the caller's read-your-writes bookmark — the owner cursor its
+     * last write returned. When it is set, "fresh enough" means *at least* that
+     * cursor and nothing weaker; when it is absent, the staleness window
+     * applies and a recently-synced replica answers with no round trip at all.
+     */
+    public async ensureFresh(minSeq?: number): Promise<ReplicaReadiness> {
+        if (this.divergent) {
+            return "unavailable";
+        }
+
+        // The fast path — already caught up — is synchronous and takes no latch:
+        // it is the case the whole tier exists for, and it cannot race anything
+        // because it neither fetches nor writes.
+        if (this.isCaughtUp(minSeq)) {
+            return "fresh";
+        }
+
+        // Everything else joins the one in-flight advance.
+        this.inFlight ??= this.advance(minSeq).finally(() => {
+            this.inFlight = undefined;
+        });
+
+        const readiness = await this.inFlight;
+
+        // The run we joined may have been started for a weaker requirement than
+        // ours, so its verdict is re-checked against the durable cursor:
+        // joining can delay a read, never under-serve it.
+        return readiness === "fresh" && !this.isCaughtUp(minSeq) ? "stale" : readiness;
+    }
+
+    /** The cursor this replica has applied, for diagnostics and the outbound bookmark header. */
+    public appliedSeq(): number {
+        return readReplicaState(this.host.sql())?.appliedSeq ?? 0;
+    }
+
+    /** Whether this replica has given up on following its owner. */
+    public isDivergent(): boolean {
+        return this.divergent;
+    }
+
+    /** Bootstrap if this replica holds nothing yet, then page the changelog forward. */
+    private async advance(minSeq: number | undefined): Promise<ReplicaReadiness> {
+        let state = readReplicaState(this.host.sql());
+
+        if (state === undefined) {
+            const bootstrapped = await this.bootstrap();
+
+            if (bootstrapped === undefined) {
+                // No snapshot means no rows at all — there is nothing here to
+                // serve a read from, stale or otherwise.
+                return "unavailable";
+            }
+
+            state = bootstrapped;
+        }
+
+        return this.catchUp(state, minSeq);
+    }
+
+    /** Whether the durable follow position already satisfies this read. */
+    private isCaughtUp(minSeq: number | undefined): boolean {
+        const state = readReplicaState(this.host.sql());
+
+        return state !== undefined && this.isFreshEnough(state, minSeq);
+    }
+
+    /**
+     * Page the owner's changelog forward from `state` until the read can be
+     * answered, the pages run out, or the follow proves impossible.
+     *
+     * Applying a page is one atomic step from the follower's point of view:
+     * changes are replayed in commit order, then the position is written. A
+     * crash between the two re-applies the page, which is safe — every replay
+     * is an upsert or a delete by id.
+     */
+    private async catchUp(from: ReplicaState, minSeq: number | undefined): Promise<ReplicaReadiness> {
+        let state = from;
+
+        for (let round = 0; round < MAX_PULL_ROUNDS; round += 1) {
+            // eslint-disable-next-line no-await-in-loop -- catching up is inherently sequential: each page's cursor is the next page's `sinceSeq`.
+            const page = await this.pull(state.appliedSeq);
+
+            if (page === undefined) {
+                // The owner is unreachable. Anything already applied is still
+                // valid, so a read with no cursor requirement can still be
+                // served from it; one that needs a newer cursor cannot.
+                return minSeq === undefined && this.isFreshEnough(state, undefined) ? "fresh" : "unavailable";
+            }
+
+            if (this.hasDiverged(state, page)) {
+                return "unavailable";
+            }
+
+            // An empty page means the owner has nothing more, so stop rather than
+            // loop: running to `MAX_PULL_ROUNDS` against an empty log is how an
+            // unreachable `minSeq` (a stale bookmark, or one a caller supplied)
+            // turns a single query into ten sequential cross-region round trips.
+            const exhausted = page.changes.length < PULL_PAGE_SIZE;
+
+            // eslint-disable-next-line no-await-in-loop -- see above: pages must be applied in commit order.
+            state = await this.applyPage(page);
+
+            if (exhausted || this.isFreshEnough(state, minSeq)) {
+                return this.isFreshEnough(state, minSeq) ? "fresh" : "stale";
+            }
+        }
+
+        return this.isFreshEnough(state, minSeq) ? "fresh" : "stale";
+    }
+
+    /**
+     * Replay one page and record the position it reached. Applying and recording
+     * are one step from the follower's point of view: a crash between them
+     * re-applies the page, which is safe because every replay is an upsert or a
+     * delete by id.
+     */
+    private async applyPage(page: ReplicaPullResult): Promise<ReplicaState> {
+        if (page.changes.length > 0) {
+            await this.host.applyChanges(page.changes);
+        }
+
+        const state: ReplicaState = { appliedSeq: page.cursor, epoch: page.epoch, syncedAtMs: Date.now() };
+
+        writeReplicaState(this.host.sql(), state);
+
+        return state;
+    }
+
+    /**
+     * Whether `page` can no longer be replayed onto `state` — the owner's
+     * timeline forked under us, or its log was compacted past our position.
+     * Either way replay cannot reconstruct the gap, and applying the page
+     * anyway would fabricate a state neither side ever held.
+     *
+     * Latches {@link divergent} as a side effect: the condition does not clear
+     * itself, so re-deciding it on every read would only re-pay the round trip.
+     */
+    private hasDiverged(state: ReplicaState, page: ReplicaPullResult): boolean {
+        // An absent `floor` means the owner's log holds nothing right now: a
+        // shard that has never written (fine — we are at 0 as well), or one whose
+        // log was compacted away entirely, which leaves nothing to replay the gap
+        // from. What separates them is that the second one hands back an EMPTY
+        // page whose high-watermark is nevertheless ahead of us: writes happened
+        // and were compacted before we saw them. A page WITH changes and a
+        // cursor ahead is just an ordinary catch-up.
+        const compactedEmpty = page.changes.length === 0 && page.cursor > state.appliedSeq;
+        const floor = page.floor ?? (compactedEmpty ? page.cursor : 0);
+        const compactedPastUs = floor > 0 && floor > state.appliedSeq + 1;
+
+        if (page.epoch === state.epoch && !compactedPastUs) {
+            return false;
+        }
+
+        this.divergent = true;
+
+        return true;
+    }
+
+    /** Take the owner's snapshot, or `undefined` when it can't be had (unreachable, or too large for one response). */
+    private async bootstrap(): Promise<ReplicaState | undefined> {
+        const response = await this.request({ type: "replica_bootstrap" });
+
+        if (response === undefined) {
+            return undefined;
+        }
+
+        const result = (await response.json()) as ReplicaBootstrapResult;
+
+        if (result.truncated === true) {
+            // Too big to copy in one reply. Reads go to the owner rather than to
+            // a replica holding an arbitrary prefix of the shard.
+            this.divergent = true;
+
+            return undefined;
+        }
+
+        const { errors } = await this.host.importRows(result.rows);
+
+        if (errors.length > 0) {
+            // The import surfaces per-row failures rather than aborting, so a
+            // snapshot that lost rows to validation drift would otherwise be
+            // recorded as complete and then served as `fresh` for good.
+            this.divergent = true;
+
+            return undefined;
+        }
+
+        const state: ReplicaState = { appliedSeq: result.cursor, epoch: result.epoch, syncedAtMs: Date.now() };
+
+        writeReplicaState(this.host.sql(), state);
+
+        return state;
+    }
+
+    /** Whether `state` already satisfies the read: past the caller's cursor, or inside the staleness window when there is none. */
+    private isFreshEnough(state: ReplicaState, minSeq: number | undefined): boolean {
+        if (minSeq !== undefined) {
+            return state.appliedSeq >= minSeq;
+        }
+
+        return Date.now() - state.syncedAtMs <= envPositiveInt(this.host.env(), "LUNORA_REPLICA_MAX_STALENESS_MS", DEFAULT_MAX_STALENESS_MS);
+    }
+
+    /** One page of the owner's changelog, or `undefined` when the owner can't be reached. */
+    private async pull(sinceSeq: number): Promise<ReplicaPullResult | undefined> {
+        const response = await this.request({ sinceSeq, type: "replica_pull" });
+
+        return response === undefined ? undefined : ((await response.json()) as ReplicaPullResult);
+    }
+
+    /**
+     * POST a frame to the owner over the authenticated sibling channel.
+     * Best-effort: an unreachable owner returns `undefined` and the caller
+     * degrades to an owner-served read rather than throwing into the dispatch.
+     */
+    private async request(frame: ReplicaFrame): Promise<Response | undefined> {
+        const binding = this.host.shardBinding();
+        const stub = siblingStub(this.host.env(), binding, this.ownerKey);
+
+        if (stub === undefined) {
+            return undefined;
+        }
+
+        const body = JSON.stringify(frame);
+        const headers: Record<string, string> = { "content-type": "application/json", "x-lunora-shard-binding": binding ?? "" };
+        const secret = siblingSecretOf(this.host.env());
+
+        if (secret !== undefined) {
+            headers[RELAY_SIGNATURE_HEADER] = await signSiblingBody(secret, body);
+        }
+
+        try {
+            const response = await stub.fetch("https://replica.internal/_lunora/replica", { body, headers, method: "POST" });
+
+            return response.ok ? response : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+/**
+ * Build the replica collaborator for a DO, chosen ONCE from its name: a
+ * `…::replica::<region>` name follows that owner, anything else is an owner (or
+ * an unnamed single-DO shard) and gets none.
+ * @returns the collaborator, or `undefined` for an owner-role name
+ */
+const createReplicaLink = (host: ReplicaFollowerHost): ShardReplica | undefined => {
+    const name = host.doName();
+
+    if (name === undefined) {
+        return undefined;
+    }
+
+    const parsed = parseReplicaName(name);
+
+    return parsed === undefined ? undefined : new ShardReplica(host, parsed.ownerKey, parsed.region);
+};
+
+/**
+ * Decide whether `replica` may serve a dispatch, or the caller must be sent back
+ * to the owner. Returns the refusal response, or `undefined` to proceed.
+ *
+ * Two independent refusals, both fail-closed.
+ *
+ * **Anything the runtime did not mark as a replica read.** A replica cannot
+ * classify a `functionPath` — the generated dispatch owns that knowledge — so
+ * rather than guessing which calls are writes it refuses every call without the
+ * runtime's explicit read marker. A mutation reaching a replica by any route is
+ * rejected instead of applied to a copy the owner will never see.
+ *
+ * **A read it cannot answer at the required freshness.** Anything short of
+ * `fresh` is a `421` carrying the reason, which the runtime turns into one
+ * retry against the owner.
+ * @returns the refusal response, or `undefined` when the replica may serve it
+ */
+const gateReplicaDispatch = async (replica: ShardReplica, request: Request, functionPath: string): Promise<Response | undefined> => {
+    if (request.headers.get("x-lunora-replica-read") !== "1") {
+        return Response.json(
+            { error: { code: "REPLICA_READ_ONLY", message: `"${functionPath}" is a write and cannot run on a read replica` } },
+            { status: 421 },
+        );
+    }
+
+    const readiness = await replica.ensureFresh(parseMinSeq(request.headers.get("x-lunora-min-seq")));
+
+    if (readiness === "fresh") {
+        return undefined;
+    }
+
+    return Response.json(
+        { error: { code: "REPLICA_NOT_READY", message: `replica is ${readiness} for this read` } },
+        { headers: { "x-lunora-replica-fallback": readiness }, status: 421 },
+    );
+};
+
+export type { ReplicaFollowerHost, ReplicaOwnerHost, ReplicaReadiness, ShardSiblingHost };
+export { createReplicaLink, gateReplicaDispatch, handleReplicaControl };

--- a/packages/shard-engine/src/replica.ts
+++ b/packages/shard-engine/src/replica.ts
@@ -153,6 +153,7 @@ interface ShardSiblingHost {
 interface ReplicaOwnerHost extends ShardSiblingHost {
     /** Every row of the shard, for a bootstrap snapshot. */
     exportRows: () => Promise<ExportRow[]>;
+
     /** The changelog high-watermark, or `undefined` when this shard has no changelog. */
     ownerCursor: () => number | undefined;
     /** This shard's CDC epoch, or `undefined` when this shard has no changelog. */
@@ -161,6 +162,17 @@ interface ReplicaOwnerHost extends ShardSiblingHost {
     ownerFloor: () => number | undefined;
     /** One page of the changelog past `sinceSeq`. */
     readChanges: (sinceSeq: number, limit: number) => { changes: CdcChange[]; cursor: number };
+
+    /**
+     * How many rows a snapshot would carry, WITHOUT building one.
+     *
+     * The cap exists to protect the owner's memory budget, and checking it
+     * against an already-materialized `exportRows()` would protect nothing: an
+     * over-cap shard exhausts memory producing the snapshot, long before the
+     * refusal could be returned. A count is a `COUNT(*)` per table, which is
+     * what makes the refusal arrive first.
+     */
+    rowCount: () => number;
 }
 
 /**
@@ -180,7 +192,22 @@ interface ReplicaState {
     syncedAtMs: number;
 }
 
+/**
+ * SQL handles whose replica-state table is known to exist.
+ *
+ * The DDL is idempotent, but it is not free, and it sits on the hot path: the
+ * fast "already caught up" check reads the follow position on every
+ * replica-routed request, which is the one path the whole tier exists to keep
+ * short. A DO's handle is stable for its lifetime, so one statement per DO is
+ * enough; keyed weakly so a discarded handle does not pin an entry.
+ */
+const migratedHandles = new WeakSet<object>();
+
 const migrateReplicaState = (sql: SqlExec): void => {
+    if (migratedHandles.has(sql)) {
+        return;
+    }
+
     sql.exec(
         `CREATE TABLE IF NOT EXISTS ${REPLICA_STATE_TABLE} (
             id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -189,6 +216,8 @@ const migrateReplicaState = (sql: SqlExec): void => {
             synced_at REAL NOT NULL
         )`,
     );
+
+    migratedHandles.add(sql);
 };
 
 const readReplicaState = (sql: SqlExec): ReplicaState | undefined => {
@@ -216,31 +245,58 @@ const writeReplicaState = (sql: SqlExec, state: ReplicaState): void => {
 };
 
 /**
- * Serve the owner half of the `/_lunora/replica` control channel: authenticate
- * the frame, then answer a pull or a bootstrap. Stateless — an owner keeps no
- * per-replica bookkeeping, because a replica's position lives with the replica
- * and the changelog it reads is the one the shard already keeps.
+ * Whether this DO may serve the control channel at all, decided before a byte
+ * of the request is read. Three refusals, none of which depend on the frame.
  *
- * A replica must never serve this route: it holds a *copy* of a timeline, and
- * its local `seq` numbers are its own, so answering a pull would hand a
- * follower cursors that mean nothing on the owner's log.
+ * **A replica cannot serve replicas.** It holds a *copy* of a timeline, so its
+ * local `seq` numbers are its own and would mean nothing to a follower.
+ *
+ * **No changelog, nothing to follow.** CDC is opt-in, so this is the DEFAULT
+ * shape of a shard, and it must be refused at the source: a follower handed a
+ * synthetic epoch would bootstrap once, agree with every later empty page that
+ * it is caught up, and serve that first snapshot forever.
+ *
+ * **No control-channel secret.** Unlike the relay channel — which treats a
+ * missing `LUNORA_RELAY_SECRET` as legacy network-trust, because tightening it
+ * would break deployments predating the secret — replica reads have no such
+ * history, and the prize is different in kind: a forged relay frame delivers a
+ * bogus poke, a forged frame here returns **every row of the shard**. An
+ * unconfigured deployment gets no replication rather than a weaker default.
+ * @returns the refusal, or `undefined` when the channel may proceed
  */
-const handleReplicaControl = async (host: ReplicaOwnerHost, request: Request): Promise<Response> => {
+const replicaControlRefusal = (host: ReplicaOwnerHost): Response | undefined => {
     const name = host.doName();
 
     if (name !== undefined && parseReplicaName(name) !== undefined) {
         return new Response("replica cannot serve replicas", { status: 409 });
     }
 
-    // No changelog, nothing to follow. CDC is opt-in, so this is the DEFAULT
-    // shape of a shard, and it has to be refused at the source: a follower given
-    // a synthetic epoch would bootstrap once, then agree with every later empty
-    // page that it is caught up, and serve that first snapshot forever.
-    const epoch = host.ownerEpoch();
-
-    if (epoch === undefined) {
+    if (host.ownerEpoch() === undefined) {
         return new Response("shard has no changelog to replicate", { status: 409 });
     }
+
+    if (siblingSecretOf(host.env()) === undefined) {
+        return new Response("replica control requires LUNORA_RELAY_SECRET", { status: 403 });
+    }
+
+    return undefined;
+};
+
+/**
+ * Serve the owner half of the `/_lunora/replica` control channel: authenticate
+ * the frame, then answer a pull or a bootstrap. Stateless — an owner keeps no
+ * per-replica bookkeeping, because a replica's position lives with the replica
+ * and the changelog it reads is the one the shard already keeps.
+ */
+const handleReplicaControl = async (host: ReplicaOwnerHost, request: Request): Promise<Response> => {
+    const refusal = replicaControlRefusal(host);
+
+    if (refusal !== undefined) {
+        return refusal;
+    }
+
+    // Non-`undefined` past the preflight, which is what checked it.
+    const epoch = host.ownerEpoch() as string;
 
     let raw: string;
 
@@ -265,16 +321,19 @@ const handleReplicaControl = async (host: ReplicaOwnerHost, request: Request): P
     }
 
     if (frame.type === "replica_bootstrap") {
+        // Refuse BEFORE building the snapshot: the cap is the owner's memory
+        // budget, and a shard past it would exhaust that budget producing rows
+        // nobody is allowed to receive.
+        if (host.rowCount() > maxBootstrapRows(host.env())) {
+            return Response.json({ cursor: 0, epoch, rows: [], truncated: true } satisfies ReplicaBootstrapResult);
+        }
+
         // Read the cursor BEFORE the snapshot: a write that lands mid-export may
         // or may not be in `rows`, and replaying it again from `cursor` is
         // harmless (both the upsert and the delete replay are idempotent).
         // Reading it after would skip anything committed during the export.
         const cursor = host.ownerCursor() ?? 0;
         const rows = await host.exportRows();
-
-        if (rows.length > maxBootstrapRows(host.env())) {
-            return Response.json({ cursor, epoch, rows: [], truncated: true } satisfies ReplicaBootstrapResult);
-        }
 
         return Response.json({ cursor, epoch, rows } satisfies ReplicaBootstrapResult);
     }

--- a/packages/shard-engine/src/sibling-channel.ts
+++ b/packages/shard-engine/src/sibling-channel.ts
@@ -1,0 +1,109 @@
+/**
+ * The authenticated DO→DO control channel, shared by every internal tier that
+ * addresses a sibling shard: the relay hub (`/_lunora/relay`) and the read
+ * replicas (`/_lunora/replica`).
+ *
+ * All of it — the namespace duck-type, the HMAC over the raw body, the
+ * constant-time verify — exists once here rather than per tier. A second copy
+ * of a signing primitive is how two channels end up with two different
+ * definitions of "authenticated", and the weaker one is the one that gets
+ * exploited.
+ *
+ * The env var and header keep their original `RELAY` spelling: they are
+ * operator-facing configuration on deployments that already provision them, and
+ * one secret authenticates the whole internal channel regardless of which tier
+ * sends the frame.
+ */
+
+import { constantTimeEqual } from "../../../shared/constant-time-equal";
+
+/** Env var carrying the optional internal control-channel HMAC secret. */
+const RELAY_SECRET_KEY = "LUNORA_RELAY_SECRET";
+
+/** Header carrying the hex HMAC-SHA256 of an internal control-frame body. */
+const RELAY_SIGNATURE_HEADER = "x-lunora-relay-sig";
+
+/** The internal control-channel secret, or `undefined` when message authentication is not configured. */
+const siblingSecretOf = (env: unknown): string | undefined => {
+    const value = (env as Record<string, unknown> | undefined)?.[RELAY_SECRET_KEY];
+
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+/**
+ * HMAC-SHA256 of `body` under `secret`, hex-encoded. Authenticates the internal
+ * control channel (L6): without it, safety rests solely on DO network
+ * isolation, so any DO in the namespace (or a future custom route that
+ * forwarded a client path+body to a shard) could inject forged frames — e.g.
+ * deliver an arbitrary `rowsPatch` to another subscriber's socket, or feed a
+ * replica a fabricated change batch. Opt-in: only enforced when
+ * `LUNORA_RELAY_SECRET` is set, so existing deployments are unaffected until
+ * they provision the secret.
+ */
+const signSiblingBody = async (secret: string, body: string): Promise<string> => {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { hash: "SHA-256", name: "HMAC" }, false, ["sign"]);
+    const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+
+    return [...new Uint8Array(signature)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+/**
+ * Whether `raw` may be dispatched: true when no secret is configured (legacy
+ * network-trust), or when `supplied` is a valid signature over the exact bytes
+ * received. Fails closed on a missing or mismatched signature.
+ */
+const verifySiblingBody = async (env: unknown, supplied: null | string, raw: string): Promise<boolean> => {
+    const secret = siblingSecretOf(env);
+
+    if (secret === undefined) {
+        return true;
+    }
+
+    if (supplied === null) {
+        return false;
+    }
+
+    return constantTimeEqual(supplied, await signSiblingBody(secret, raw));
+};
+
+/** Minimal Durable Object stub surface an internal tier needs to POST a control frame to a sibling. */
+interface SiblingStub {
+    fetch: (url: string, init?: RequestInit) => Promise<Response>;
+}
+
+/** Minimal Durable Object namespace surface for addressing siblings by name. */
+interface SiblingNamespaceLike {
+    get: (id: unknown) => SiblingStub;
+    getByName?: (name: string) => SiblingStub;
+    idFromName: (name: string) => unknown;
+}
+
+/** Duck-type a value as a DO namespace, or `undefined` when it isn't one (single-DO mode / unbound). */
+const asSiblingNamespace = (value: unknown): SiblingNamespaceLike | undefined => {
+    if (value === null || typeof value !== "object") {
+        return undefined;
+    }
+
+    const candidate = value as Partial<SiblingNamespaceLike>;
+
+    return typeof candidate.idFromName === "function" && typeof candidate.get === "function" ? (candidate as SiblingNamespaceLike) : undefined;
+};
+
+/** Resolve a sibling stub by name off the shard namespace binding, or `undefined` when the binding is unknown/unbound. */
+const siblingStub = (env: unknown, binding: string | undefined, name: string): SiblingStub | undefined => {
+    if (binding === undefined) {
+        return undefined;
+    }
+
+    const namespace = asSiblingNamespace((env as Record<string, unknown> | undefined)?.[binding]);
+
+    if (namespace === undefined) {
+        return undefined;
+    }
+
+    return typeof namespace.getByName === "function" ? namespace.getByName(name) : namespace.get(namespace.idFromName(name));
+};
+
+export type { SiblingNamespaceLike, SiblingStub };
+export { asSiblingNamespace, RELAY_SECRET_KEY, RELAY_SIGNATURE_HEADER, siblingSecretOf, siblingStub, signSiblingBody, verifySiblingBody };

--- a/shared/region-hint.ts
+++ b/shared/region-hint.ts
@@ -1,0 +1,114 @@
+/**
+ * Edge geography → placement region, shared by `@lunora/runtime` (which reads
+ * `request.cf` to pick where a shard, replica, or region-local socket should
+ * live) and `@lunora/do` (which parses a region out of its own DO name). Kept
+ * here — inlined into each consumer's bundle — so the two sides can never drift
+ * on the region vocabulary without creating a runtime dependency edge between
+ * the packages.
+ *
+ * The values are Cloudflare's Durable Object location hints, which is also the
+ * only vocabulary a Lunora deployment needs today: a region is *only* ever used
+ * as a placement hint and as a name segment, never as data. Wrong-but-close is
+ * fine by construction — a misrouted read is one longer hop, never a wrong
+ * answer — so this maps coarsely and returns `undefined` rather than guessing
+ * when the request carries no usable geography.
+ *
+ * Zero-dependency by design (see the repo's `shared/` rules): only relative /
+ * builtin imports, named exports, no `.js` extensions.
+ */
+
+/**
+ * The placement regions a name may carry and a hint may request — Cloudflare's
+ * `DurableObjectLocationHint` values, listed so the set can be validated at a
+ * trust boundary (a region parsed out of a DO name is attacker-influenced input
+ * on any route that mints names from a client-supplied shard key).
+ */
+const REGION_HINTS = ["wnam", "enam", "sam", "weur", "eeur", "apac", "apac-ne", "apac-se", "oc", "afr", "me"] as const;
+
+/** One placement region. Structurally identical to Cloudflare's `DurableObjectLocationHint`. */
+type RegionHint = (typeof REGION_HINTS)[number];
+
+const REGION_HINT_SET: ReadonlySet<string> = new Set<string>(REGION_HINTS);
+
+/** Whether `value` is one of the known placement regions. */
+const isRegionHint = (value: unknown): value is RegionHint => typeof value === "string" && REGION_HINT_SET.has(value);
+
+/**
+ * The geography fields Cloudflare puts on `request.cf`. All optional: `cf` is
+ * absent entirely for a synthesized subrequest, and individual fields are absent
+ * for traffic Cloudflare could not geolocate.
+ */
+interface EdgeGeo {
+    /** `request.cf.continent` — `AF` `AN` `AS` `EU` `NA` `OC` `SA`. */
+    continent?: string;
+    /** `request.cf.country` — ISO 3166-1 alpha-2. */
+    country?: string;
+    /** `request.cf.longitude` — Cloudflare sends a stringified float. */
+    longitude?: number | string;
+}
+
+/**
+ * Countries the `me` region serves better than `apac`. Cloudflare has no
+ * "Middle East" continent code, so the country is the only signal that
+ * separates the two.
+ */
+const MIDDLE_EAST: ReadonlySet<string> = new Set(["AE", "BH", "IL", "IQ", "IR", "JO", "KW", "LB", "OM", "PS", "QA", "SA", "SY", "TR", "YE"]);
+
+/** Longitude splitting `wnam` from `enam`: the 100th meridian, which divides the continent's population usefully. */
+const NORTH_AMERICA_MERIDIAN = -100;
+
+/** Longitude splitting `weur` from `eeur`: ~15°E, roughly Berlin/Vienna. */
+const EUROPE_MERIDIAN = 15;
+
+/**
+ * Map edge geography to a placement region, or `undefined` when the request
+ * carries no continent (or one with no region — `AN`). `undefined` means "no
+ * hint": the caller then leaves placement to the platform's own default, which
+ * on Cloudflare is the data centre nearest the first request. Defaulting to a
+ * fixed region instead would be strictly worse — it would drag every
+ * ungeolocatable request's shard to one continent.
+ */
+const regionHintFromGeo = (geo: EdgeGeo): RegionHint | undefined => {
+    const longitude = Number(geo.longitude ?? Number.NaN);
+
+    switch (geo.continent) {
+        case "AF": {
+            return "afr";
+        }
+        case "AS": {
+            return geo.country !== undefined && MIDDLE_EAST.has(geo.country) ? "me" : "apac";
+        }
+        case "EU": {
+            return Number.isFinite(longitude) && longitude > EUROPE_MERIDIAN ? "eeur" : "weur";
+        }
+        case "NA": {
+            return Number.isFinite(longitude) && longitude < NORTH_AMERICA_MERIDIAN ? "wnam" : "enam";
+        }
+        case "OC": {
+            return "oc";
+        }
+        case "SA": {
+            return "sam";
+        }
+        default: {
+            return undefined;
+        }
+    }
+};
+
+/**
+ * The placement region for the caller behind `request`, read off Cloudflare's
+ * `request.cf`. Returns `undefined` for a request with no `cf` — every
+ * synthesized subrequest (the shard RPC envelope, an internal admin fan-out) is
+ * in that class, which is why callers that need the *client's* region must
+ * derive it from the inbound request and pass it down rather than re-reading it
+ * from whatever request they happen to be forwarding.
+ */
+const regionHintFromRequest = (request: Request): RegionHint | undefined => {
+    const geo = (request as { cf?: EdgeGeo }).cf;
+
+    return geo === undefined ? undefined : regionHintFromGeo(geo);
+};
+
+export type { EdgeGeo, RegionHint };
+export { isRegionHint, REGION_HINTS, regionHintFromGeo, regionHintFromRequest };

--- a/shared/replica-name.ts
+++ b/shared/replica-name.ts
@@ -1,0 +1,76 @@
+/**
+ * The owner↔replica DO-name contract for region-local read replicas, shared by
+ * `@lunora/runtime` (which MINTS replica names when routing a read) and
+ * `@lunora/do` (which PARSES its own name to learn its role). Kept here —
+ * inlined into each consumer's bundle — so the two sides can never drift on the
+ * format without creating a runtime dependency edge between the packages.
+ *
+ * Deliberately the same shape as `shared/relay-name.ts`: a DO's role is fixed
+ * for its whole life by its name, which is the only role signal available
+ * before any request arrives.
+ *
+ * Zero-dependency by design (see the repo's `shared/` rules): only relative /
+ * builtin imports, named exports, no `.js` extensions.
+ */
+
+import type { RegionHint } from "./region-hint";
+import { isRegionHint } from "./region-hint";
+
+/** The `::replica::` infix marking a DO name as a read replica of an owner shard. Reserved — only the runtime mints replica names. */
+const REPLICA_NAME_INFIX = "::replica::";
+
+/** Build the replica DO name serving `ownerKey` in `region` — the deterministic name any worker/DO can compute without shared state. */
+const replicaName = (ownerKey: string, region: RegionHint): string => `${ownerKey}${REPLICA_NAME_INFIX}${region}`;
+
+/**
+ * Parse a DO name into its owner key + region, or `undefined` when the name is
+ * an owner (no `::replica::` infix) or carries a region that is not a known
+ * placement region.
+ *
+ * The region check is a trust boundary, not a formality: replica names are
+ * minted from a client-supplied shard key, so an unvalidated region would let a
+ * caller address `tenant::replica::<anything>` and have the DO treat itself as
+ * a replica of `tenant` — an unbounded set of extra DOs replicating one shard.
+ * @returns the owner key + region, or `undefined` for an owner-role name
+ */
+const parseReplicaName = (name: string): undefined | { ownerKey: string; region: RegionHint } => {
+    const at = name.lastIndexOf(REPLICA_NAME_INFIX);
+
+    if (at === -1) {
+        return undefined;
+    }
+
+    const ownerKey = name.slice(0, at);
+    const region = name.slice(at + REPLICA_NAME_INFIX.length);
+
+    if (ownerKey.length === 0 || !isRegionHint(region)) {
+        return undefined;
+    }
+
+    return { ownerKey, region };
+};
+
+/**
+ * Parse the `x-lunora-min-seq` read-your-writes bookmark, or `undefined` when
+ * there is no usable requirement.
+ *
+ * Defined once and used at BOTH ends — the runtime deciding whether to forward
+ * the header, and the replica deciding what freshness to hold itself to. Two
+ * parses of one header is how the two ends end up disagreeing about its domain,
+ * and the disagreement always resolves the unsafe way: the sender forwards a
+ * value the receiver reads as "no requirement".
+ *
+ * `0` is not a requirement — it is the cursor of a shard that has never
+ * committed anything, so treating it as one would only cost a round trip.
+ */
+const parseMinSeq = (raw: null | string | undefined): number | undefined => {
+    if (raw === null || raw === undefined || !/^\d+$/.test(raw)) {
+        return undefined;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+export { parseMinSeq, parseReplicaName, REPLICA_NAME_INFIX, replicaName };


### PR DESCRIPTION
A shard lives in exactly one place. That is what makes its writes serialized and its reads consistent — and it is why a reader on the other side of the world pays the round trip on every query, and holds a socket that terminates wherever the shard happens to live.

This adds three opt-in controls that move work closer to the reader. All are off by default; a single-region app is unaffected.

## Placement

Shard resolution now carries an advisory region through the `ShardDirectory` contract, and `shardRegion` pins a shard by key:

```ts
createWorker({ shardDO: env.SHARD, shardRegion: (key) => tenantRegions[key] });
```

The platform already creates a shard near its first request, so this exists for the cases where that request is the wrong signal: a cron fire, a migration fan-out, a seeding run, the Studio. Those all land wherever they happened to run, and stay there for the shard's life.

## Read replicas (`replicaReads: true`)

A `…::replica::<region>` Durable Object follows the owner's existing `__cdc_log` and answers one-shot **queries** locally. The changelog, its epoch, and `applyCdcChanges` were already there for point-in-time recovery and streaming export, which is why the follow loop is small.

Writes, streams, subscriptions, fan-out and admin stay on the owner. A replica also:

- refuses anything the runtime did not explicitly mark as a read, so it never classifies a function path and never applies a write;
- serves no subscriptions — its rows advance only when a read triggers a catch-up, so a live query from a replica would mostly not be live;
- runs no background work. This one is not theoretical: an external-source pull resolves its tenant from the DO's own name, so on a replica a full pull would match nothing and diff **every replicated row into a delete**.

**CDC is opt-in, so a shard without a changelog cannot be followed at all** — the owner refuses the control channel rather than handing back a synthetic timeline a follower would agree with forever. A forked epoch, a compacted log, or a snapshot too large for one response likewise report unavailable, and reads fall back to the owner. Correct throughout; just not local.

### Consistency

Read-your-writes is preserved per client, automatically. The server already echoed the cursor each write committed at; the client now remembers it per shard — including across a batched offline replay — and sends it back, and a replica that has not caught up sends the read to the owner instead of answering from an older copy. Catch-up is single-flighted, so a cold region bootstraps once rather than once per concurrent reader, and it stops at the first empty page so an unreachable cursor cannot amplify one read into ten cross-region round trips.

What you trade away is freshness for *other people's* writes: a read carrying no cursor may be up to `LUNORA_REPLICA_MAX_STALENESS_MS` (default 1000) behind.

## Sockets near the client

A promoted shard now hints the client's region on the relay it routes to, so each relay is created where its traffic is. The spread across relays stays random deliberately — routing a whole region to one relay would pile a single-region app's entire connection load onto one DO, which is the fan-out wall promotion exists to escape.

## Two pre-existing bugs found on the way

- **No `Access-Control-Expose-Headers` anywhere**, while the client reads `x-d1-bookmark` off every mutation response. A browser hides non-safelisted response headers, so **D1 read-your-writes has been silently inoperative for every cross-origin app**. Fixed, along with three request headers the SDK sends that were missing from the allowlist.
- The Cloudflare host dropped the placement argument while the capability matrix advertised `shardPlacement: native` — the contract/implementation drift the platform-parity rule exists to catch.

## Not included

Collapsing a client's per-shard sockets onto one connection. That needs a relay role bound to many owners plus a client protocol change; it is called out as a gap in the docs.

## A deliberate limitation

Placement does **not** compose with residency. Pairing a location hint with a jurisdiction type-checks, and it is unreachable on every runtime available: workerd implements no jurisdictions at all, so the combination cannot be exercised in dev, in CI, or in a test, and would first execute in production on the deployments that chose residency precisely because correctness matters most to them. A pinned deployment therefore sends no region hint and logs once. `placement.workerd.test.ts` asserts jurisdictions are unimplemented, so this fails the day that changes and the trade can be revisited.

## Review

Both thermo-nuclear passes ran against the first commit; the second commit is the fixes. The one they agreed on was real: coercing "this shard has no changelog" to a sentinel let a replica bootstrap once and then agree with every empty page forever — serving a frozen snapshot while reporting itself fresh, on the default (CDC-off) shard shape.

## Verification

- New: 18 engine tests (CDC-off, single-flight, import errors, compaction, empty-page exit, end-to-end serve), 5 DO-role tests, 3 real-workerd placement tests, plus runtime and client coverage.
- 3,178 tests pass across the touched packages, types clean, lint clean, API snapshots updated.
- Full-suite runs show one `@lunora/studio` React Testing Library timeout, a **different** test each run, each passing in isolation — load-dependent flakiness in a package this branch does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added region-aware shard placement and automatic relay placement for improved locality.
  * Added read replicas with CDC-based synchronization, bounded staleness, read-your-writes consistency, and owner fallback.
  * Added configuration options for replica reads and shard-region selection.
  * Added platform capability reporting for shard placement and read replicas.
  * Improved CORS support for sequencing and shard-related headers.

* **Documentation**
  * Added comprehensive read-replica and shard-placement guidance, including costs, limitations, consistency, and configuration.
  * Documented replica modules and replication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->