### PR TITLE
fix: close the remaining Cloudflare platform-limit gaps

### DIFF
--- a/api-snapshots/advisor.api.md
+++ b/api-snapshots/advisor.api.md
@@ -1323,6 +1323,12 @@ const externalSourceOnGlobal: Lint;
 const externalSourceUnscoped: Lint;
 ```
 
+### `fanOutBreadth` (const)
+
+```ts
+const fanOutBreadth: Lint;
+```
+
 ### `filterOnPrimaryKey` (const)
 
 ```ts

--- a/apps/docs/src/content/docs/concepts/advisors.mdx
+++ b/apps/docs/src/content/docs/concepts/advisors.mdx
@@ -78,6 +78,8 @@ Need observed signal from a live shard, aggregated by the Studio backend.
 | `hot_shard`            | warn      | One shard takes >50% of a `shardBy(...)` function's traffic while siblings idle (fires above a minimum request volume).                                               |
 | `index_utilization`    | info/warn | Two checks: a **dead index** with zero recorded reads (info), and a **hot unindexed scan** — a table full-scanned ≥25× with no index (warn).                          |
 | `constraint_validator` | warn      | Sampled rows that violate a declared constraint — a dangling foreign key, a null in a non-optional column, or a duplicate on a unique index. (Bounded sample window.) |
+| `error_rate_outlier`   | warn      | A function whose failure rate stands well clear of the rest of the deployment.                                                                                        |
+| `fan_out_breadth`      | warn      | A shard group with enough active shards that a cross-shard read over it would approach the per-invocation internal-subrequest ceiling.                                |
 
 ## Running advisors
 

--- a/apps/docs/src/content/docs/limits.mdx
+++ b/apps/docs/src/content/docs/limits.mdx
@@ -77,7 +77,7 @@ Two are yours to respect, because no rewrite can absorb them:
 | --------------------- | -------------------------------------------------------- | --------------------------------------------------------------------- |
 | Bundle size           | **10 MB**                                                | Lazy-load big deps; avoid bundling unused providers                   |
 | CPU per request       | **30 s**                                                 | Same envelope as DO                                                   |
-| Subrequests, external | **50** (Free) / **10 000** (Paid)                        | `fetch()` to the internet                                             |
+| Subrequests, external | **50** (Free) / **10 000** (Paid, configurable to 10 M)  | `fetch()` to the internet                                             |
 | Subrequests, internal | **1 000** (Free) / configured limit (default **10 000**) | Durable Objects, KV, R2, D1 — a cross-shard read spends one per shard |
 | Env var size          | **5 KB** total                                           | Use D1 or KV for config above that                                    |
 
@@ -114,12 +114,19 @@ than by Lunora. Split large batches across calls.
 
 | Limit                     | Value      | Implication                                                        |
 | ------------------------- | ---------- | ------------------------------------------------------------------ |
-| Vector metadata           | **10 KiB** | `defineRag` stores chunk text here unless you supply a `textStore` |
-| `topK` with full metadata | **20**     | Rises to **100** once a `textStore` moves text out                 |
+| Vector metadata           | **10 KiB** | The whole object per vector, not just the chunk text               |
+| `topK` with full metadata | **50**     | Cloudflare's ceiling; `defineRag` caps at 20, a legacy-V1 holdover |
+| `topK` otherwise          | **100**    | What a `textStore` unlocks by keeping text out of metadata         |
 
-A `chunkSize` that could not fit the metadata ceiling is rejected when the RAG
-is defined, rather than on every failed upsert. Supplying a `textStore` keeps
-chunk text out of the vector entirely and lifts both limits.
+`defineRag` rejects a `chunkSize` that could not fit the metadata ceiling when
+the RAG is defined, rather than on every failed upsert. That check applies only
+where Lunora stores chunk text in the vector's metadata: a `textStore` keeps the
+text out entirely, and a custom `chunk` splitter makes `chunkSize` inert, so
+neither is checked.
+
+The ceiling covers the **whole** metadata object — chunk text, Lunora's
+bookkeeping keys, and any `metadata` you attach — so the check reserves room for
+the rest rather than spending all 10 KiB on text.
 
 ## Workers KV
 

--- a/apps/docs/src/content/docs/limits.mdx
+++ b/apps/docs/src/content/docs/limits.mdx
@@ -93,6 +93,33 @@ Two are yours to respect, because no rewrite can absorb them:
 | Backlog / queue     | **25 GB**             | Then `Storage Limit Exceeded`                          |
 | `delaySeconds`      | **24 h**              | Longer schedules → `@lunora/scheduler`                 |
 
+## Pipelines
+
+| Limit                 | Value      | Implication                                                        |
+| --------------------- | ---------- | ------------------------------------------------------------------ |
+| Payload / ingest call | **5 MB**   | `ctx.pipelines.send(records)` sends one call — chunk a large batch |
+| Ingest rate / stream  | **5 MB/s** | Sustained; past it the stream throttles                            |
+| Streams / account     | **20**     | Open-beta ceiling, raisable by request                             |
+| Pipelines / account   | **20**     | Open-beta ceiling, raisable by request                             |
+| Sinks / account       | **20**     | Open-beta ceiling, raisable by request                             |
+
+`send` accepts one record or an array and forwards the array as a single
+ingestion call, so the 5 MB ceiling is a property of what you pass it. Nothing
+measures it locally — the byte count would mean serializing every record twice
+on an egress path — so a batch past the limit is rejected by Cloudflare rather
+than by Lunora. Split large batches across calls.
+
+## Workers AI + Vectorize
+
+| Limit                     | Value      | Implication                                                        |
+| ------------------------- | ---------- | ------------------------------------------------------------------ |
+| Vector metadata           | **10 KiB** | `defineRag` stores chunk text here unless you supply a `textStore` |
+| `topK` with full metadata | **20**     | Rises to **100** once a `textStore` moves text out                 |
+
+A `chunkSize` that could not fit the metadata ceiling is rejected when the RAG
+is defined, rather than on every failed upsert. Supplying a `textStore` keeps
+chunk text out of the vector entirely and lifts both limits.
+
 ## Workers KV
 
 | Limit            | Value            | Implication                                |

--- a/apps/docs/src/content/docs/limits.mdx
+++ b/apps/docs/src/content/docs/limits.mdx
@@ -133,13 +133,18 @@ unlike R2, which is free. See the
 
 ## When Lunora warns you
 
-The runtime emits warnings (and the dev overlay shows a banner) when:
+The Studio's **Advisors** pages carry the limit warnings, alongside the rest of
+the schema and performance lints. The ones that watch a ceiling:
 
-- the `__root__` DO crosses **1 GB** of SQLite
-- a single DO is sustaining **>700 req/s**
-- a fan-out query touches more than **100 shards** in one invocation
+| Lint                             | Fires when                                                              |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `global_table_near_column_limit` | A `.global()` table reaches **90** columns, against D1's 100            |
+| `fan_out_breadth`                | A cross-shard read spans **500** shards, against the subrequest ceiling |
+| `hot_shard`                      | One shard takes a dominant share of its group's traffic                 |
 
-These warnings fire well below the hard ceiling, so you have time to react.
+Each fires with runway, because the remediation is a design change — split a
+table, narrow a read, re-key a shard — and that is not something you can act on
+in the request that fails.
 
 The statement limits above are different in kind: there is no warning band,
 because there is no gradual degradation to warn about. A statement either fits

--- a/apps/docs/src/content/docs/limits.mdx
+++ b/apps/docs/src/content/docs/limits.mdx
@@ -73,12 +73,13 @@ Two are yours to respect, because no rewrite can absorb them:
 
 ## Workers
 
-| Limit           | Value                           | Implication                                         |
-| --------------- | ------------------------------- | --------------------------------------------------- |
-| Bundle size     | **10 MB**                       | Lazy-load big deps; avoid bundling unused providers |
-| CPU per request | **30 s**                        | Same envelope as DO                                 |
-| Subrequests     | **50** (Free) / **1000** (Paid) | Fan-out reads are a Paid-plan optimisation          |
-| Env var size    | **5 KB** total                  | Use D1 or KV for config above that                  |
+| Limit                 | Value                                                    | Implication                                                           |
+| --------------------- | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| Bundle size           | **10 MB**                                                | Lazy-load big deps; avoid bundling unused providers                   |
+| CPU per request       | **30 s**                                                 | Same envelope as DO                                                   |
+| Subrequests, external | **50** (Free) / **10 000** (Paid)                        | `fetch()` to the internet                                             |
+| Subrequests, internal | **1 000** (Free) / configured limit (default **10 000**) | Durable Objects, KV, R2, D1 — a cross-shard read spends one per shard |
+| Env var size          | **5 KB** total                                           | Use D1 or KV for config above that                                    |
 
 ## Queues
 
@@ -161,13 +162,13 @@ unlike R2, which is free. See the
 ## When Lunora warns you
 
 The Studio's **Advisors** pages carry the limit warnings, alongside the rest of
-the schema and performance lints. The ones that watch a ceiling:
+the schema and performance lints:
 
-| Lint                             | Fires when                                                              |
-| -------------------------------- | ----------------------------------------------------------------------- |
-| `global_table_near_column_limit` | A `.global()` table reaches **90** columns, against D1's 100            |
-| `fan_out_breadth`                | A cross-shard read spans **500** shards, against the subrequest ceiling |
-| `hot_shard`                      | One shard takes a dominant share of its group's traffic                 |
+| Lint                             | Fires when                                                                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `global_table_near_column_limit` | A `.global()` table reaches **90** columns, against D1's 100                                                                           |
+| `fan_out_breadth`                | A shard group reaches **500** active shards — wide enough that a cross-shard read over it would strain the internal-subrequest ceiling |
+| `hot_shard`                      | One shard takes a dominant share of its group's traffic (a distribution, not a ceiling)                                                |
 
 Each fires with runway, because the remediation is a design change — split a
 table, narrow a read, re-key a shard — and that is not something you can act on

--- a/apps/docs/src/content/docs/limits.mdx
+++ b/apps/docs/src/content/docs/limits.mdx
@@ -118,15 +118,21 @@ than by Lunora. Split large batches across calls.
 | `topK` with full metadata | **50**     | Cloudflare's ceiling; `defineRag` caps at 20, a legacy-V1 holdover |
 | `topK` otherwise          | **100**    | What a `textStore` unlocks by keeping text out of metadata         |
 
-`defineRag` rejects a `chunkSize` that could not fit the metadata ceiling when
-the RAG is defined, rather than on every failed upsert. That check applies only
-where Lunora stores chunk text in the vector's metadata: a `textStore` keeps the
-text out entirely, and a custom `chunk` splitter makes `chunkSize` inert, so
-neither is checked.
-
 The ceiling covers the **whole** metadata object — chunk text, Lunora's
-bookkeeping keys, and any `metadata` you attach — so the check reserves room for
-the rest rather than spending all 10 KiB on text.
+bookkeeping keys, and any `metadata` you attach — so `defineRag` checks it in
+two places.
+
+At index time it measures the serialized metadata of each chunk and refuses one
+that would not fit, naming what pushed it over. This is the check that holds:
+`chunkSize` counts characters while the ceiling counts bytes, so multibyte text
+costs up to three bytes each, and your own `metadata` is not known until a
+document is indexed.
+
+When the RAG is defined it also rejects a `chunkSize` that could not fit
+whatever the ceiling allows, so an unworkable config fails at startup rather
+than on every upsert. That earlier check applies only where Lunora stores chunk
+text in the vector's metadata: a `textStore` keeps the text out entirely, and a
+custom `chunk` splitter makes `chunkSize` inert, so neither is checked.
 
 ## Workers KV
 

--- a/packages/advisor/__tests__/runtime-lints.test.ts
+++ b/packages/advisor/__tests__/runtime-lints.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { AdvisorFunctionMetrics, AdvisorShardTraffic, LintContext } from "../src";
-import { ALL_LINTS, errorRateOutlier, hotShard, indexUtilization, runAdvisor, RUNTIME_LINTS } from "../src";
+import { ALL_LINTS, errorRateOutlier, fanOutBreadth, hotShard, indexUtilization, runAdvisor, RUNTIME_LINTS } from "../src";
 
 /** A minimal context with an empty schema — runtime lints read only the observed-signal fields. */
 const baseContext = (overrides: Partial<LintContext> = {}): LintContext => {
@@ -11,6 +11,45 @@ const baseContext = (overrides: Partial<LintContext> = {}): LintContext => {
 const traffic = (entries: AdvisorShardTraffic[]): LintContext => baseContext({ shardTraffic: entries });
 
 const functionMetrics = (entries: AdvisorFunctionMetrics[]): LintContext => baseContext({ functionMetrics: entries });
+
+/** `count` shards in one group, each with negligible traffic — breadth is what this lint reads. */
+const shardsInGroup = (group: string, count: number): AdvisorShardTraffic[] =>
+    Array.from({ length: count }, (_unused, index) => {
+        return { group, requests: 1, shardKey: `${group}-${String(index)}` };
+    });
+
+describe("fan_out_breadth", () => {
+    it("flags a fan-out approaching the per-invocation subrequest ceiling", () => {
+        expect.assertions(2);
+
+        const findings = fanOutBreadth.run(traffic(shardsInGroup("listRooms", 500)));
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({ level: "WARN", metadata: { group: "listRooms", shards: 500 }, name: "fan_out_breadth" });
+    });
+
+    it("stays silent one shard below the threshold", () => {
+        expect.assertions(1);
+
+        expect(fanOutBreadth.run(traffic(shardsInGroup("listRooms", 499)))).toHaveLength(0);
+    });
+
+    it("counts per function group, since the ceiling is per invocation", () => {
+        expect.assertions(1);
+
+        // Two functions, 400 shards each: 800 shards in the deployment, but no
+        // single invocation fans out over more than 400.
+        const findings = fanOutBreadth.run(traffic([...shardsInGroup("listRooms", 400), ...shardsInGroup("listUsers", 400)]));
+
+        expect(findings).toHaveLength(0);
+    });
+
+    it("finds nothing for a static caller with no traffic feeder", () => {
+        expect.assertions(1);
+
+        expect(fanOutBreadth.run(baseContext())).toHaveLength(0);
+    });
+});
 
 describe("hot_shard", () => {
     it("flags a shard taking a dominant share of traffic", () => {
@@ -265,7 +304,13 @@ describe("runtime lint registration", () => {
     it("includes all runtime lints, sourced runtime", () => {
         expect.assertions(3);
 
-        expect(RUNTIME_LINTS.map((lint) => lint.name)).toStrictEqual(["hot_shard", "index_utilization", "constraint_validator", "error_rate_outlier"]);
+        expect(RUNTIME_LINTS.map((lint) => lint.name)).toStrictEqual([
+            "hot_shard",
+            "index_utilization",
+            "constraint_validator",
+            "error_rate_outlier",
+            "fan_out_breadth",
+        ]);
         expect(RUNTIME_LINTS.every((lint) => lint.source === "runtime")).toBe(true);
         expect(ALL_LINTS).toContain(hotShard);
     });

--- a/packages/advisor/__tests__/runtime-lints.test.ts
+++ b/packages/advisor/__tests__/runtime-lints.test.ts
@@ -12,14 +12,14 @@ const traffic = (entries: AdvisorShardTraffic[]): LintContext => baseContext({ s
 
 const functionMetrics = (entries: AdvisorFunctionMetrics[]): LintContext => baseContext({ functionMetrics: entries });
 
-/** `count` shards in one group, each with negligible traffic — breadth is what this lint reads. */
+/** `count` active shards in one group — breadth is what this lint reads. */
 const shardsInGroup = (group: string, count: number): AdvisorShardTraffic[] =>
     Array.from({ length: count }, (_unused, index) => {
         return { group, requests: 1, shardKey: `${group}-${String(index)}` };
     });
 
 describe("fan_out_breadth", () => {
-    it("flags a fan-out approaching the per-invocation subrequest ceiling", () => {
+    it("flags a shard set wide enough to strain a cross-shard read", () => {
         expect.assertions(2);
 
         const findings = fanOutBreadth.run(traffic(shardsInGroup("listRooms", 500)));
@@ -34,14 +34,25 @@ describe("fan_out_breadth", () => {
         expect(fanOutBreadth.run(traffic(shardsInGroup("listRooms", 499)))).toHaveLength(0);
     });
 
-    it("counts per function group, since the ceiling is per invocation", () => {
+    // The studio feeder reports every live shard including failed ones at
+    // `requests: 0`. Counting those would let a long tail of dormant tenants
+    // raise the alarm on a deployment that never fans out.
+    it("ignores idle shards, as hot_shard does", () => {
         expect.assertions(1);
 
-        // Two functions, 400 shards each: 800 shards in the deployment, but no
-        // single invocation fans out over more than 400.
-        const findings = fanOutBreadth.run(traffic([...shardsInGroup("listRooms", 400), ...shardsInGroup("listUsers", 400)]));
+        const idle = Array.from({ length: 600 }, (_unused, index) => {
+            return { requests: 0, shardKey: `dormant-${String(index)}` };
+        });
 
-        expect(findings).toHaveLength(0);
+        expect(fanOutBreadth.run(traffic(idle))).toHaveLength(0);
+    });
+
+    it("groups where the feeder supplies one, since the ceiling is per invocation", () => {
+        expect.assertions(1);
+
+        // Two groups of 400: 800 shards live, but no single shard set is wide
+        // enough for a fan-out over it to approach the ceiling.
+        expect(fanOutBreadth.run(traffic([...shardsInGroup("listRooms", 400), ...shardsInGroup("listUsers", 400)]))).toHaveLength(0);
     });
 
     it("finds nothing for a static caller with no traffic feeder", () => {

--- a/packages/advisor/src/index.ts
+++ b/packages/advisor/src/index.ts
@@ -10,6 +10,7 @@
 import { dedupeCacheKeys } from "./dedupe-cache-keys";
 import constraintValidator from "./lints/runtime/constraint-validator";
 import errorRateOutlier from "./lints/runtime/error-rate-outlier";
+import fanOutBreadth from "./lints/runtime/fan-out-breadth";
 import hotShard from "./lints/runtime/hot-shard";
 import indexUtilization from "./lints/runtime/index-utilization";
 import actionFetchSsrf from "./lints/static/action-fetch-ssrf";
@@ -148,6 +149,7 @@ export type { AdvisorInsertWrite } from "./inserts";
 export type { AdvisorKvKeyAccess } from "./kv-key-accesses";
 export { default as constraintValidator } from "./lints/runtime/constraint-validator";
 export { default as errorRateOutlier } from "./lints/runtime/error-rate-outlier";
+export { default as fanOutBreadth } from "./lints/runtime/fan-out-breadth";
 export { default as hotShard } from "./lints/runtime/hot-shard";
 export { default as indexUtilization } from "./lints/runtime/index-utilization";
 export { default as actionFetchSsrf } from "./lints/static/action-fetch-ssrf";
@@ -405,7 +407,7 @@ export const STATIC_LINTS: ReadonlyArray<Lint> = [
  * no-op. Run them with `runAdvisor(ctx, { source: "runtime" })` against a live
  * deployment's aggregated metrics.
  */
-export const RUNTIME_LINTS: ReadonlyArray<Lint> = [hotShard, indexUtilization, constraintValidator, errorRateOutlier];
+export const RUNTIME_LINTS: ReadonlyArray<Lint> = [hotShard, indexUtilization, constraintValidator, errorRateOutlier, fanOutBreadth];
 
 /** The default lint set: the static lints, then the runtime lints. A caller filters by `source` to run one tier. */
 export const ALL_LINTS: ReadonlyArray<Lint> = [...STATIC_LINTS, ...RUNTIME_LINTS];

--- a/packages/advisor/src/lints/runtime/fan-out-breadth.ts
+++ b/packages/advisor/src/lints/runtime/fan-out-breadth.ts
@@ -25,8 +25,8 @@ const FREE_PLAN_INTERNAL_SUBREQUESTS = 1000;
 const WARN_AT_SHARDS = 500;
 
 /**
- * `fan_out_breadth` — flag a cross-shard read whose shard count is approaching
- * the per-invocation subrequest ceiling.
+ * `fan_out_breadth` — flag a shard set wide enough that a cross-shard read over
+ * it would approach the per-invocation subrequest ceiling.
  *
  * `.shardBy(key)` makes reads cheap by keeping each one on a single Durable
  * Object. A query that cannot be answered from one shard fans out instead, and
@@ -36,31 +36,39 @@ const WARN_AT_SHARDS = 500;
  * is reached by breadth alone. Bounded concurrency does not help: it paces the
  * fan-out, it does not shrink it.
  *
- * The shard count comes from the same `shardTraffic` feeder `hot_shard` reads,
- * so this costs no extra cross-shard work — the distribution is already
- * collected. Where `hot_shard` looks at the *shape* of that distribution (one
- * shard taking most of the traffic), this one looks only at its *size*.
+ * This measures **capacity, not observed fan-out**, and the distinction is the
+ * whole reason for the wording. The `shardTraffic` feeder reports one entry per
+ * live shard — the studio backend supplies no group at all, and the
+ * Analytics-Engine feeder groups by shard TABLE over its whole retention window
+ * — so neither carries "how many shards one invocation actually touched". What
+ * they do carry is how wide the shard set is, which is the ceiling on any fan-out
+ * over it. An app whose every read is shard-pinned is never at risk; it is told
+ * how much room a cross-shard read would have, not that it made one.
+ *
+ * Idle shards are excluded, matching `hot_shard`: a shard with no traffic in the
+ * window is not evidence of anything, and counting it would let a long tail of
+ * dormant tenants raise the alarm on its own.
  */
 const fanOutBreadth: Lint = {
     categories: ["PERFORMANCE"],
-    description: "A cross-shard read fans out over enough shards to approach the per-invocation subrequest ceiling.",
-    facing: "INTERNAL",
+    description: "A shard set is wide enough that a cross-shard read over it would approach the per-invocation subrequest ceiling.",
+    facing: "EXTERNAL",
     level: "WARN",
     name: "fan_out_breadth",
-    remediation: "Narrow the read to a shard subset, or roll the answer up through a `.global()` table.",
+    remediation: "Keep reads shard-pinned, or roll cross-shard answers up through a `.global()` table.",
     run: (context) => {
-        const traffic = context.shardTraffic ?? [];
+        // Only active shards, for the same reason `hot_shard` filters them.
+        const active = (context.shardTraffic ?? []).filter((shard) => shard.requests > 0);
 
-        if (traffic.length === 0) {
+        if (active.length === 0) {
             return [];
         }
 
-        // Group first: the ceiling applies per invocation, and one invocation
-        // fans out over one function's shard set — not over every shard the
-        // deployment happens to have.
+        // Grouped where the feeder supplies a group, since the ceiling applies to
+        // one invocation over one shard set rather than to the deployment total.
         const byGroup = new Map<string, number>();
 
-        for (const entry of traffic) {
+        for (const entry of active) {
             const group = entry.group ?? "";
 
             byGroup.set(group, (byGroup.get(group) ?? 0) + 1);
@@ -71,13 +79,13 @@ const fanOutBreadth: Lint = {
             .map(([group, shards]) =>
                 emit(fanOutBreadth, {
                     cacheKey: `fan_out_breadth:${group}`,
-                    detail: `${group === "" ? "A cross-shard read" : `Function "${group}"`} fans out over ${String(shards)} shards. One Durable Object subrequest each, against a ceiling of ${String(FREE_PLAN_INTERNAL_SUBREQUESTS)} internal subrequests per invocation on the Free plan (higher on Paid, but finite).`,
+                    detail: `${group === "" ? "This deployment" : `Shard group "${group}"`} has ${String(shards)} active shards, so a cross-shard read over it would issue ${String(shards)} Durable Object subrequests — against a ceiling of ${String(FREE_PLAN_INTERNAL_SUBREQUESTS)} per invocation on the Free plan (higher on Paid, but finite). Shard-pinned reads are unaffected.`,
                     metadata: { freePlanCeiling: FREE_PLAN_INTERNAL_SUBREQUESTS, group, shards },
                 }),
             );
     },
     source: "runtime",
-    title: "Wide cross-shard fan-out",
+    title: "Shard set wide enough to strain a cross-shard read",
 };
 
 export default fanOutBreadth;

--- a/packages/advisor/src/lints/runtime/fan-out-breadth.ts
+++ b/packages/advisor/src/lints/runtime/fan-out-breadth.ts
@@ -1,0 +1,83 @@
+import emit from "../../finding";
+import type { Lint } from "../../types";
+
+/**
+ * Cloudflare's ceiling on subrequests to internal services (Durable Objects,
+ * KV, R2, D1) within one Worker invocation. 1,000 on the Free plan; on Paid it
+ * matches the configured subrequest limit, which defaults to 10,000.
+ *
+ * A cross-shard read issues one such subrequest per shard, so the shard count of
+ * a fan-out is bounded by whichever of those applies to the account.
+ */
+const FREE_PLAN_INTERNAL_SUBREQUESTS = 1000;
+
+/**
+ * Where the warning starts.
+ *
+ * Deliberately well under the Free ceiling. The remediation for a wide fan-out
+ * is a design change — narrow the read to a shard subset, or roll the answer up
+ * through a `.global()` table — and that is not advice anyone can act on in the
+ * request that fails. It also cannot be a hard cap: the real ceiling depends on
+ * the account's plan and configured limit, so refusing at a fixed number would
+ * break deployments that work today. Warn, name the number, let the operator
+ * decide.
+ */
+const WARN_AT_SHARDS = 500;
+
+/**
+ * `fan_out_breadth` — flag a cross-shard read whose shard count is approaching
+ * the per-invocation subrequest ceiling.
+ *
+ * `.shardBy(key)` makes reads cheap by keeping each one on a single Durable
+ * Object. A query that cannot be answered from one shard fans out instead, and
+ * the coordinator issues one Durable Object RPC per shard. Those are in-house
+ * subrequests, so they do not consume the six external connection slots — but
+ * they do count against the per-invocation subrequest ceiling, and that ceiling
+ * is reached by breadth alone. Bounded concurrency does not help: it paces the
+ * fan-out, it does not shrink it.
+ *
+ * The shard count comes from the same `shardTraffic` feeder `hot_shard` reads,
+ * so this costs no extra cross-shard work — the distribution is already
+ * collected. Where `hot_shard` looks at the *shape* of that distribution (one
+ * shard taking most of the traffic), this one looks only at its *size*.
+ */
+const fanOutBreadth: Lint = {
+    categories: ["PERFORMANCE"],
+    description: "A cross-shard read fans out over enough shards to approach the per-invocation subrequest ceiling.",
+    facing: "INTERNAL",
+    level: "WARN",
+    name: "fan_out_breadth",
+    remediation: "Narrow the read to a shard subset, or roll the answer up through a `.global()` table.",
+    run: (context) => {
+        const traffic = context.shardTraffic ?? [];
+
+        if (traffic.length === 0) {
+            return [];
+        }
+
+        // Group first: the ceiling applies per invocation, and one invocation
+        // fans out over one function's shard set — not over every shard the
+        // deployment happens to have.
+        const byGroup = new Map<string, number>();
+
+        for (const entry of traffic) {
+            const group = entry.group ?? "";
+
+            byGroup.set(group, (byGroup.get(group) ?? 0) + 1);
+        }
+
+        return [...byGroup]
+            .filter(([, shards]) => shards >= WARN_AT_SHARDS)
+            .map(([group, shards]) =>
+                emit(fanOutBreadth, {
+                    cacheKey: `fan_out_breadth:${group}`,
+                    detail: `${group === "" ? "A cross-shard read" : `Function "${group}"`} fans out over ${String(shards)} shards. One Durable Object subrequest each, against a ceiling of ${String(FREE_PLAN_INTERNAL_SUBREQUESTS)} internal subrequests per invocation on the Free plan (higher on Paid, but finite).`,
+                    metadata: { freePlanCeiling: FREE_PLAN_INTERNAL_SUBREQUESTS, group, shards },
+                }),
+            );
+    },
+    source: "runtime",
+    title: "Wide cross-shard fan-out",
+};
+
+export default fanOutBreadth;

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -279,6 +279,16 @@ describe(defineRag, () => {
         expect(() => defineRag({ index: "docs", topK: 0 })).toThrow(/topK/u);
     });
 
+    it("rejects a chunkSize that cannot fit Vectorize's metadata limit", () => {
+        expect.assertions(2);
+
+        // In metadata mode the chunk text IS the vector's metadata, so a chunk
+        // larger than 10 KiB could never be upserted.
+        expect(() => defineRag({ chunkSize: 20_000, index: "docs" })).toThrow(/metadata limit/u);
+        // A textStore moves the text out, so the ceiling no longer applies.
+        expect(() => defineRag({ chunkSize: 20_000, index: "docs", textStore: { get: async () => undefined, put: async () => undefined } })).not.toThrow();
+    });
+
     it("chunks, embeds and upserts with deterministic ids and linking metadata", async () => {
         expect.assertions(7);
 

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -280,11 +280,16 @@ describe(defineRag, () => {
     });
 
     it("rejects a chunkSize that cannot fit Vectorize's metadata limit", () => {
-        expect.assertions(3);
+        expect.assertions(5);
 
         // In metadata mode the chunk text IS the vector's metadata, so a chunk
         // larger than 10 KiB could never be upserted.
         expect(() => defineRag({ chunkSize: 20_000, index: "docs" })).toThrow(/metadata limit/u);
+        // The reserve is the point: 10 KiB exactly would leave nothing for the
+        // chunk's own bookkeeping keys, which are never zero bytes.
+        expect(() => defineRag({ chunkSize: 10 * 1024, index: "docs" })).toThrow(/metadata limit/u);
+        // Under the reserved budget, so it stands a chance of fitting.
+        expect(() => defineRag({ chunkSize: 8 * 1024, index: "docs" })).not.toThrow();
         // A textStore moves the text out, so the ceiling no longer applies.
         expect(() => defineRag({ chunkSize: 20_000, index: "docs", textStore: { getMany: async () => [], put: async () => undefined } })).not.toThrow();
         // A custom splitter never reads `chunkSize`, so the value is inert and

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -280,13 +280,16 @@ describe(defineRag, () => {
     });
 
     it("rejects a chunkSize that cannot fit Vectorize's metadata limit", () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
         // In metadata mode the chunk text IS the vector's metadata, so a chunk
         // larger than 10 KiB could never be upserted.
         expect(() => defineRag({ chunkSize: 20_000, index: "docs" })).toThrow(/metadata limit/u);
         // A textStore moves the text out, so the ceiling no longer applies.
-        expect(() => defineRag({ chunkSize: 20_000, index: "docs", textStore: { get: async () => undefined, put: async () => undefined } })).not.toThrow();
+        expect(() => defineRag({ chunkSize: 20_000, index: "docs", textStore: { getMany: async () => [], put: async () => undefined } })).not.toThrow();
+        // A custom splitter never reads `chunkSize`, so the value is inert and
+        // rejecting it would refuse a config that works.
+        expect(() => defineRag({ chunk: (text: string) => [text], chunkSize: 20_000, index: "docs" })).not.toThrow();
     });
 
     it("chunks, embeds and upserts with deterministic ids and linking metadata", async () => {

--- a/packages/ai/__tests__/rag.test.ts
+++ b/packages/ai/__tests__/rag.test.ts
@@ -297,6 +297,37 @@ describe(defineRag, () => {
         expect(() => defineRag({ chunk: (text: string) => [text], chunkSize: 20_000, index: "docs" })).not.toThrow();
     });
 
+    it("refuses a metadata payload over the ceiling at index time, whatever got it there", async () => {
+        expect.assertions(4);
+
+        const { store, vectors } = memoryVectors();
+        const ctx = fakeCtx(vectors);
+        // The config check compares `chunkSize` (CHARACTERS) against a byte
+        // budget, so multibyte text walks straight past it: 8 KiB of CJK is
+        // ~24 KB in UTF-8 against a 10 KiB ceiling.
+        const cjk = defineRag({ allowSharedNamespace: true, chunkSize: 8 * 1024, index: "docs" });
+
+        await expect(cjk(ctx).index({ id: "doc-1", text: "字".repeat(5000) })).rejects.toThrow(/per-vector ceiling/u);
+        // Nothing was upserted, so the far side never saw the oversized vector.
+        expect(store.size).toBe(0);
+
+        // And the caller's own `metadata` is not known at config time, so the
+        // reserve can only guess at it — this is the check that actually holds.
+        const small = defineRag({ allowSharedNamespace: true, chunk: (text: string) => [text], index: "docs" });
+
+        await expect(small(ctx).index({ id: "doc-2", metadata: { blob: "x".repeat(11 * 1024) }, text: "tiny" })).rejects.toThrow(/attach less per-source/u);
+
+        // A textStore keeps the text out of metadata, so the same chunk fits.
+        const stored = defineRag({
+            allowSharedNamespace: true,
+            chunkSize: 8 * 1024,
+            index: "docs",
+            textStore: { getMany: async () => [], put: async () => undefined },
+        });
+
+        await expect(stored(fakeCtx(memoryVectors().vectors)).index({ id: "doc-3", text: "字".repeat(5000) })).resolves.toMatchObject({ unchanged: false });
+    });
+
     it("chunks, embeds and upserts with deterministic ids and linking metadata", async () => {
         expect.assertions(7);
 

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -22,14 +22,6 @@ import type {
 
 const DEFAULT_CHUNK_SIZE = 1000;
 
-/**
- * Vectorize's per-vector metadata ceiling, in bytes.
- *
- * In the default (metadata) mode each chunk's text is stored as vector metadata
- * alongside its bookkeeping keys, so the chunk has to fit inside this. Supplying
- * a `textStore` moves the text out and lifts the constraint entirely.
- */
-const VECTORIZE_METADATA_BYTES = 10 * 1024;
 const DEFAULT_CHUNK_OVERLAP = 200;
 const DEFAULT_TOP_K = 5;
 
@@ -37,6 +29,14 @@ const DEFAULT_TOP_K = 5;
 const MAX_TOP_K_FULL_METADATA = 20;
 /** Vectorize `topK` ceiling otherwise (text-store mode). */
 const MAX_TOP_K = 100;
+
+/**
+ * Vectorize's per-vector metadata ceiling, in bytes. In the default (metadata)
+ * mode each chunk's text is stored as vector metadata alongside its bookkeeping
+ * keys, so the chunk has to fit inside this; a `textStore` moves the text out
+ * and lifts the constraint entirely.
+ */
+const VECTORIZE_METADATA_BYTES = 10 * 1024;
 
 /** Metadata key holding each chunk's index within its source. */
 const CHUNK_INDEX_KEY = "__ragChunk";
@@ -252,14 +252,12 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
         throw new LunoraError("BAD_REQUEST", "@lunora/ai/rag: `chunkOverlap` must be a non-negative integer smaller than `chunkSize`");
     }
 
-    // Without a `textStore` the chunk text rides in vector metadata, which
-    // Vectorize caps at 10 KiB — so a chunk larger than that can never be
-    // upserted, and every write would fail at the far side with no hint that
-    // `chunkSize` is the cause. Compared in characters against a byte ceiling on
-    // purpose: one character is at least one byte, so this rejects only sizes
-    // that cannot fit even in pure ASCII. A multi-byte corpus can still exceed
-    // the cap under this bound, and that is the case `textStore` exists for.
-    if (config.textStore === undefined && chunkSize > VECTORIZE_METADATA_BYTES) {
+    // Characters against a byte ceiling on purpose: one character is at least one
+    // byte, so this rejects only sizes that cannot fit even in pure ASCII, never
+    // a config that works. Gated on BOTH options because `chunkSize` reaches only
+    // the built-in splitter — a custom `chunk` ignores it, so rejecting on it
+    // would refuse a value that has no effect.
+    if (!config.chunk && !config.textStore && chunkSize > VECTORIZE_METADATA_BYTES) {
         throw new LunoraError(
             "BAD_REQUEST",
             `@lunora/ai/rag: \`chunkSize\` of ${String(chunkSize)} cannot fit Vectorize's ${String(VECTORIZE_METADATA_BYTES)}-byte metadata limit — lower it, or supply \`textStore\` to keep chunk text out of metadata`,

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -67,6 +67,40 @@ const MODEL_KEY = "__ragModel";
 
 const INTERNAL_KEYS = new Set([CHUNK_INDEX_KEY, COUNT_KEY, HASH_KEY, IMPORTANCE_KEY, MODEL_KEY, SOURCE_KEY, TEXT_KEY]);
 
+/**
+ * Refuse a metadata object over Vectorize's ceiling, naming what breached it.
+ *
+ * The config-time `chunkSize` check is a fast fail on the one input known when
+ * the RAG is defined; this is the one that actually holds. Two things get past
+ * the former by construction: `chunkSize` counts CHARACTERS while the ceiling
+ * counts BYTES, so ~3.4k characters of CJK already exceed 10 KiB at a
+ * `chunkSize` the config check waves through — and the caller's `metadata` is
+ * not known until index time, so {@link METADATA_OVERHEAD_RESERVE} can only
+ * guess at it.
+ *
+ * Measured on the serialized form because that is what Vectorize stores and
+ * counts. Without this the upsert fails at the far side with nothing naming the
+ * cause, which is the failure this whole check exists to replace.
+ */
+const assertMetadataFits = (metadata: Record<string, unknown>, chunkIndex: number, sourceId: string): void => {
+    const bytes = new TextEncoder().encode(JSON.stringify(metadata)).length;
+
+    if (bytes <= VECTORIZE_METADATA_BYTES) {
+        return;
+    }
+
+    const textBytes = typeof metadata[TEXT_KEY] === "string" ? new TextEncoder().encode(metadata[TEXT_KEY]).length : 0;
+    const remedy =
+        textBytes * 2 > bytes
+            ? "lower `chunkSize` (it counts characters, not bytes — multibyte text costs up to 3 bytes each), or supply `textStore` to move chunk text out of metadata entirely"
+            : "attach less per-source `metadata`";
+
+    throw new LunoraError(
+        "BAD_REQUEST",
+        `@lunora/ai/rag: chunk ${String(chunkIndex)} of "${sourceId}" carries ${String(bytes)} bytes of metadata, over Vectorize's ${String(VECTORIZE_METADATA_BYTES)}-byte per-vector ceiling — ${remedy}`,
+    );
+};
+
 /** Allowed shape of {@link RagConfig.embeddingModelVersion} — safe in a Vectorize namespace + chunk-id prefix. */
 const MODEL_VERSION_PATTERN = /^[\w.-]{1,40}$/;
 
@@ -489,6 +523,8 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
                         metadata[MODEL_KEY] = modelTag;
                     }
                 }
+
+                assertMetadataFits(metadata, chunkIndex, input.id);
 
                 // Vector upsert
                 await context.vectors.upsert(config.index, {

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -31,12 +31,24 @@ const MAX_TOP_K_FULL_METADATA = 20;
 const MAX_TOP_K = 100;
 
 /**
- * Vectorize's per-vector metadata ceiling, in bytes. In the default (metadata)
- * mode each chunk's text is stored as vector metadata alongside its bookkeeping
- * keys, so the chunk has to fit inside this; a `textStore` moves the text out
+ * Vectorize's per-vector metadata ceiling, in bytes. It covers the WHOLE
+ * metadata object, not the chunk text alone; a `textStore` moves the text out
  * and lifts the constraint entirely.
  */
 const VECTORIZE_METADATA_BYTES = 10 * 1024;
+
+/**
+ * Room held back from {@link VECTORIZE_METADATA_BYTES} for everything in the
+ * metadata object that is not chunk text: the source id, the chunk index,
+ * chunk #0's hash / count / model tag, and whatever `metadata` the caller
+ * attaches per source.
+ *
+ * A guess, and deliberately a generous one — the caller's `metadata` is not
+ * known when the RAG is defined, so no exact figure exists to check against.
+ * The point is only that spending the entire ceiling on text is provably wrong:
+ * the bookkeeping is never zero bytes.
+ */
+const METADATA_OVERHEAD_RESERVE = 2 * 1024;
 
 /** Metadata key holding each chunk's index within its source. */
 const CHUNK_INDEX_KEY = "__ragChunk";
@@ -257,10 +269,17 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
     // a config that works. Gated on BOTH options because `chunkSize` reaches only
     // the built-in splitter — a custom `chunk` ignores it, so rejecting on it
     // would refuse a value that has no effect.
-    if (!config.chunk && !config.textStore && chunkSize > VECTORIZE_METADATA_BYTES) {
+    //
+    // Still a floor, not a guarantee: the ceiling is bytes and covers the whole
+    // metadata object, so multi-byte text or heavy per-source `metadata` can
+    // exceed it under this bound. What it rules out is the config that could
+    // never work.
+    const chunkTextBudget = VECTORIZE_METADATA_BYTES - METADATA_OVERHEAD_RESERVE;
+
+    if (!config.chunk && !config.textStore && chunkSize > chunkTextBudget) {
         throw new LunoraError(
             "BAD_REQUEST",
-            `@lunora/ai/rag: \`chunkSize\` of ${String(chunkSize)} cannot fit Vectorize's ${String(VECTORIZE_METADATA_BYTES)}-byte metadata limit — lower it, or supply \`textStore\` to keep chunk text out of metadata`,
+            `@lunora/ai/rag: \`chunkSize\` of ${String(chunkSize)} leaves no room under Vectorize's ${String(VECTORIZE_METADATA_BYTES)}-byte metadata limit, which also carries this chunk's bookkeeping and any \`metadata\` you attach — keep it under ${String(chunkTextBudget)}, or supply \`textStore\` to move chunk text out of metadata entirely`,
         );
     }
 

--- a/packages/ai/src/rag/define-rag.ts
+++ b/packages/ai/src/rag/define-rag.ts
@@ -21,6 +21,15 @@ import type {
 } from "./types";
 
 const DEFAULT_CHUNK_SIZE = 1000;
+
+/**
+ * Vectorize's per-vector metadata ceiling, in bytes.
+ *
+ * In the default (metadata) mode each chunk's text is stored as vector metadata
+ * alongside its bookkeeping keys, so the chunk has to fit inside this. Supplying
+ * a `textStore` moves the text out and lifts the constraint entirely.
+ */
+const VECTORIZE_METADATA_BYTES = 10 * 1024;
 const DEFAULT_CHUNK_OVERLAP = 200;
 const DEFAULT_TOP_K = 5;
 
@@ -241,6 +250,20 @@ const defineRag = (config: RagConfig): ((context: RagContext) => Rag) => {
 
     if (!Number.isInteger(chunkOverlap) || chunkOverlap < 0 || chunkOverlap >= chunkSize) {
         throw new LunoraError("BAD_REQUEST", "@lunora/ai/rag: `chunkOverlap` must be a non-negative integer smaller than `chunkSize`");
+    }
+
+    // Without a `textStore` the chunk text rides in vector metadata, which
+    // Vectorize caps at 10 KiB — so a chunk larger than that can never be
+    // upserted, and every write would fail at the far side with no hint that
+    // `chunkSize` is the cause. Compared in characters against a byte ceiling on
+    // purpose: one character is at least one byte, so this rejects only sizes
+    // that cannot fit even in pure ASCII. A multi-byte corpus can still exceed
+    // the cap under this bound, and that is the case `textStore` exists for.
+    if (config.textStore === undefined && chunkSize > VECTORIZE_METADATA_BYTES) {
+        throw new LunoraError(
+            "BAD_REQUEST",
+            `@lunora/ai/rag: \`chunkSize\` of ${String(chunkSize)} cannot fit Vectorize's ${String(VECTORIZE_METADATA_BYTES)}-byte metadata limit — lower it, or supply \`textStore\` to keep chunk text out of metadata`,
+        );
     }
 
     const defaultTopK = config.topK ?? DEFAULT_TOP_K;

--- a/packages/do/__tests__/workerd/sql-limits.workerd.test.ts
+++ b/packages/do/__tests__/workerd/sql-limits.workerd.test.ts
@@ -15,11 +15,16 @@
  * size in `@lunora/shard-engine` would be wrong at once; the boundary cases
  * below fail loudly either way.
  *
- * Second, `json_each` is authorized. It is the mechanism the whole bounded-`IN`
- * form rests on and the only use of it in the repo. Workerd runs a function
- * allowlist — `sqlite_version()`, for instance, is rejected — so "SQLite has it"
- * is not the same as "a Durable Object may call it". Nothing else would notice
- * if that changed.
+ * Second, `json_each` is authorized, in both shapes the engine emits. Workerd
+ * runs a function allowlist — `sqlite_version()`, for instance, is rejected — so
+ * "SQLite has it" is not the same as "a Durable Object may call it", and nothing
+ * else would notice if that changed. The two shapes are pinned separately
+ * because authorization is per function, not per query: `sqliteInList`'s scalar
+ * `SELECT value FROM json_each(?)`, and the re-projection scan's correlated
+ * `EXISTS` walking a document's members by `type` and `key`. The second is the
+ * stricter test — those two columns, and a table-valued function applied to a
+ * column rather than a bound literal, are the parts an allowlist could
+ * plausibly treat differently.
  */
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
@@ -89,6 +94,36 @@ describe("workerd SQLite limits", () => {
         await withSql("limits-like", (sql) => {
             expect(() => sql.exec(`SELECT 1 WHERE 'x' LIKE '%' || ? || '%'`, term).toArray()).toThrow(/LIKE or GLOB pattern too complex/u);
             expect(sql.exec(`SELECT instr(lower(?), lower(?)) > 0 AS hit`, `prefix ${term} suffix`, term).toArray()).toStrictEqual([{ hit: 1 }]);
+        });
+    });
+
+    it("exposes `json_each`'s type and key columns over a document", async () => {
+        expect.assertions(1);
+
+        // The re-projection scan's shape: walk the row's OWN members and filter
+        // by `key`, rather than extracting at a path per field. Four parameters
+        // however many columns the table has. `type` is load-bearing — without
+        // it, `json_extract` over a scalar member's raw text is a
+        // malformed-JSON error rather than NULL — and both columns are
+        // `json_each` surface an allowlist could plausibly treat differently
+        // from the scalar form pinned below.
+        await withSql("limits-json-each-members", (sql) => {
+            sql.exec(`CREATE TABLE t (id TEXT PRIMARY KEY, "__doc__" TEXT)`);
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "legacy", JSON.stringify({ "a.b": ["$lunora.wire$", "bigint", "10"] }));
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "scalar", JSON.stringify({ "a.b": "0000010" }));
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "dated", JSON.stringify({ "a.b": ["$lunora.wire$", "date", "2020"] }));
+
+            const rows = sql
+                .exec(
+                    `SELECT id FROM t WHERE EXISTS (SELECT 1 FROM json_each("__doc__") AS __f__ WHERE __f__.type = 'array' AND __f__.key IN (SELECT value FROM json_each(?)) AND json_extract(__f__.value, '$[0]') = ? AND json_extract(__f__.value, '$[1]') IN (?, ?))`,
+                    JSON.stringify(["a.b"]),
+                    "$lunora.wire$",
+                    "bigint",
+                    "bytes",
+                )
+                .toArray();
+
+            expect(rows).toStrictEqual([{ id: "legacy" }]);
         });
     });
 

--- a/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
@@ -212,3 +212,62 @@ describe("ctx-db transaction headroom", () => {
         await expect(writer.insert("notes", { body: "c", bucket: "a" })).resolves.toBeDefined();
     });
 });
+
+describe("the .global() branches", () => {
+    // These return before `onWrite`, so each charges the meter itself. They also
+    // write into D1, which the DO's transaction cannot roll back — so the charge
+    // has to land BEFORE the boundary or a breach commits the row it refused.
+    const globalSchema: SchemaLike = {
+        tables: {
+            profiles: {
+                indexes: [],
+                shape: { name: { kind: "string" } },
+                shardMode: { kind: "global" },
+            },
+        },
+    } as never;
+
+    /** A D1 double that records which writes actually crossed the boundary. */
+    const globalDouble = (crossed: string[]): DatabaseWriterLike =>
+        ({
+            delete: async () => {
+                crossed.push("delete");
+            },
+            patch: async () => {
+                crossed.push("patch");
+            },
+            replace: async () => {
+                crossed.push("replace");
+            },
+        }) as unknown as DatabaseWriterLike;
+
+    const writerWithCeiling = (crossed: string[], maxWrittenRows: number): DatabaseWriterLike => {
+        const sql = makeSql();
+
+        runShardMigrations(sql, globalSchema);
+
+        return createShardContextDatabase({
+            clock: () => 1_700_000_000_000,
+            globalDb: globalDouble(crossed),
+            headroom: new TransactionHeadroomTracker({ maxWrittenRows }),
+            schema: globalSchema,
+            sql,
+        });
+    };
+
+    it.each(["patch", "replace", "delete"] as const)("charges %s and refuses past the ceiling before D1 sees it", async (operation) => {
+        expect.assertions(3);
+
+        const crossed: string[] = [];
+        // A one-row ceiling: the first write spends it, the second must be refused.
+        const writer = writerWithCeiling(crossed, 1);
+        const call = async (): Promise<unknown> => (operation === "delete" ? writer.delete("p_absent") : writer[operation]("p_absent", { name: "n" }));
+
+        await call();
+
+        expect(crossed).toStrictEqual([operation]);
+        await expect(codeOf(call)).resolves.toBe("TRANSACTION_LIMIT_EXCEEDED");
+        // Refused before the boundary: D1 never saw the second write.
+        expect(crossed).toStrictEqual([operation]);
+    });
+});

--- a/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
@@ -228,10 +228,18 @@ describe("the .global() branches", () => {
     } as never;
 
     /** A D1 double that records which writes actually crossed the boundary. */
-    const globalDouble = (crossed: string[]): DatabaseWriterLike =>
+    const globalDouble = (crossed: string[], gate?: Promise<void>): DatabaseWriterLike =>
         ({
             delete: async () => {
                 crossed.push("delete");
+            },
+            insert: async (_table: string, document: Record<string, unknown>) => {
+                // Optionally hold the write open, so a test can interleave another
+                // operation on the same writer while this one is mid-await.
+                await gate;
+                crossed.push(`insert:${String(document["name"])}`);
+
+                return `p_${String(crossed.length)}`;
             },
             patch: async () => {
                 crossed.push("patch");
@@ -269,5 +277,65 @@ describe("the .global() branches", () => {
         await expect(codeOf(call)).resolves.toBe("TRANSACTION_LIMIT_EXCEEDED");
         // Refused before the boundary: D1 never saw the second write.
         expect(crossed).toStrictEqual([operation]);
+    });
+
+    it("charges a global insertMany once per row, up front, before any row crosses", async () => {
+        expect.assertions(3);
+
+        const crossed: string[] = [];
+        // Room for two rows; the batch asks for three.
+        const writer = writerWithCeiling(crossed, 2);
+        const rows = [{ name: "a" }, { name: "b" }, { name: "c" }];
+
+        await expect(codeOf(async () => writer.insertMany!("profiles", rows))).resolves.toBe("TRANSACTION_LIMIT_EXCEEDED");
+        // The whole batch is charged before the loop, so nothing reached D1 —
+        // which the DO's storage transaction could not have rolled back.
+        expect(crossed).toStrictEqual([]);
+
+        // And a batch that fits is charged exactly once per row, not twice: two
+        // rows against a two-row ceiling must pass.
+        const fits: string[] = [];
+
+        await expect(writerWithCeiling(fits, 2).insertMany!("profiles", [{ name: "a" }, { name: "b" }])).resolves.toHaveLength(2);
+    });
+
+    it("keeps a concurrent write metered while a global insert is in flight", async () => {
+        expect.assertions(2);
+
+        // The batch pre-charges its rows and suppresses the per-row charge on the
+        // way out. Done with a writer-wide flag, that suppression would also
+        // exempt anything interleaved into the await — so a sibling write on the
+        // same writer would slip past the ceiling entirely.
+        let release = (): void => undefined;
+        const gate = new Promise<void>((resolve) => {
+            release = () => {
+                resolve();
+            };
+        });
+        const crossed: string[] = [];
+        const sql = makeSql();
+
+        runShardMigrations(sql, globalSchema);
+
+        const writer = createShardContextDatabase({
+            clock: () => 1_700_000_000_000,
+            globalDb: globalDouble(crossed, gate),
+            // One row of room: the batch's single row spends it, so the sibling
+            // write racing alongside it must be refused.
+            headroom: new TransactionHeadroomTracker({ maxWrittenRows: 1 }),
+            schema: globalSchema,
+            sql,
+        });
+
+        const batch = writer.insertMany!("profiles", [{ name: "a" }]);
+        const sibling = codeOf(async () => writer.insert("profiles", { name: "sibling" }));
+
+        release();
+
+        await batch;
+
+        await expect(sibling).resolves.toBe("TRANSACTION_LIMIT_EXCEEDED");
+        // The refused sibling never crossed; only the batch's row did.
+        expect(crossed).toStrictEqual(["insert:a"]);
     });
 });

--- a/packages/shard-engine/__tests__/query-args.test.ts
+++ b/packages/shard-engine/__tests__/query-args.test.ts
@@ -113,9 +113,7 @@ describe("buildSeekWhere", () => {
         );
         const compiled = compile(where);
 
-        // Balanced grouping — the compiler splits long chains to stay under
-        // Workerd's expression-depth cap. OR/AND are associative, so this matches
-        // exactly what the flat form did, with the same bound-parameter order.
+        // Balanced grouping (see `joinClauses`); same terms, same param order.
         expect(compiled.sql).toBe(
             `(${json("a")} > ?) OR (((${json("a")} = ?) AND (${json("b")} < ?)) OR ((${json("a")} = ?) AND ((${json("b")} = ?) AND (id > ?))))`,
         );

--- a/packages/shard-engine/__tests__/query-args.test.ts
+++ b/packages/shard-engine/__tests__/query-args.test.ts
@@ -113,8 +113,11 @@ describe("buildSeekWhere", () => {
         );
         const compiled = compile(where);
 
+        // Balanced grouping — the compiler splits long chains to stay under
+        // Workerd's expression-depth cap. OR/AND are associative, so this matches
+        // exactly what the flat form did, with the same bound-parameter order.
         expect(compiled.sql).toBe(
-            `(${json("a")} > ?) OR ((${json("a")} = ?) AND (${json("b")} < ?)) OR ((${json("a")} = ?) AND (${json("b")} = ?) AND (id > ?))`,
+            `(${json("a")} > ?) OR (((${json("a")} = ?) AND (${json("b")} < ?)) OR ((${json("a")} = ?) AND ((${json("b")} = ?) AND (id > ?))))`,
         );
         expect(compiled.params).toEqual(["av", "av", "bv", "av", "bv", "row_1"]);
     });

--- a/packages/shard-engine/__tests__/reprojection-backfill.test.ts
+++ b/packages/shard-engine/__tests__/reprojection-backfill.test.ts
@@ -122,6 +122,86 @@ describe("reprojection backfill", () => {
         });
     });
 
+    describe("statement width", () => {
+        // The predicate walks the document's own members, so these are the
+        // shapes it must survive rather than the paths it used to build.
+        it.each([
+            ["a scalar member, whose raw text json_extract would choke on", { amount: "plain" }, 0],
+            ["a member array too short to carry a kind", { amount: ["$lunora.wire$"] }, 0],
+            ["a JSON null member", { amount: null }, 0],
+            ["a tagged Date under v.any(), which the CURRENT projection writes", { amount: ["$lunora.wire$", "date", "2020"] }, 0],
+            ["a tagged value under a field that is not reprojectable", { other: ["$lunora.wire$", "bigint", "1"] }, 0],
+            ["a genuine legacy value", { amount: ["$lunora.wire$", "bigint", "10"] }, 1],
+        ])("counts %s correctly", (_label, document, expected) => {
+            expect.assertions(1);
+
+            const single = {
+                tables: { one: { indexes: [], shape: { amount: { kind: "bigint" } } } },
+            } as unknown as SchemaLike;
+
+            runShardMigrations(harness.sql, single);
+            harness.raw(
+                `INSERT INTO "one" (id, _creationTime, "__doc__") VALUES (?, ?, ?)`,
+                "r1",
+                1,
+                JSON.stringify({ _creationTime: 1, _id: "r1", ...document }),
+            );
+
+            expect(countLegacyRows(harness.sql, "one", reprojectableFields(single.tables["one"]!))).toBe(expected);
+        });
+
+        // Field names are compared as `json_each` keys now, so the JSON-path
+        // grammar cannot mangle them — this is the case the old path-building
+        // form needed `jsonPathSegment` to survive.
+        it("counts a field whose name would not survive an unquoted json path", () => {
+            expect.assertions(1);
+
+            const awkward = {
+                tables: { one: { indexes: [], shape: { "a.b": { kind: "bytes" } } } },
+            } as unknown as SchemaLike;
+
+            runShardMigrations(harness.sql, awkward);
+            harness.raw(
+                `INSERT INTO "one" (id, _creationTime, "__doc__") VALUES (?, ?, ?)`,
+                "r1",
+                1,
+                JSON.stringify({ "a.b": ["$lunora.wire$", "bytes", "AAA="], _creationTime: 1, _id: "r1" }),
+            );
+
+            expect(countLegacyRows(harness.sql, "one", reprojectableFields(awkward.tables["one"]!))).toBe(1);
+        });
+
+        // Executed against real SQLite rather than asserted on the emitted text:
+        // `json_each` behaviour is exactly what cannot be reasoned about from the
+        // source. See `legacyRowPredicate` for why the width matters.
+        it("counts a table far wider than the parameter ceiling would allow", () => {
+            expect.assertions(1);
+
+            const columns = 40;
+            const wide = {
+                tables: {
+                    wide: {
+                        indexes: [],
+                        shape: Object.fromEntries(Array.from({ length: columns }, (_unused, index) => [`f${String(index)}`, { kind: "bigint" }])),
+                    },
+                },
+            } as unknown as SchemaLike;
+
+            runShardMigrations(harness.sql, wide);
+            // Raw `JSON.stringify`, like `seedLegacy`: `encodeDocJson` would
+            // re-encode into the CURRENT projection, which is the one shape this
+            // predicate must not match.
+            harness.raw(
+                `INSERT INTO "wide" (id, _creationTime, "__doc__") VALUES (?, ?, ?)`,
+                "legacy-1",
+                1,
+                JSON.stringify({ _creationTime: 1, _id: "legacy-1", f0: taggedBigint("10") }),
+            );
+
+            expect(countLegacyRows(harness.sql, "wide", reprojectableFields(wide.tables["wide"]!))).toBe(1);
+        });
+    });
+
     describe("json path segments", () => {
         it("emits the bare form for an identifier-safe field", () => {
             expect.assertions(2);

--- a/packages/shard-engine/__tests__/where-sql.test.ts
+++ b/packages/shard-engine/__tests__/where-sql.test.ts
@@ -44,6 +44,12 @@ const render = (where: Record<string, unknown>, engine: SqlEngine, strategy: Whe
     return renderSql(engine, compiled);
 };
 
+// Clause chains render BALANCED, not flat: `a AND (b AND c)` rather than
+// `a AND b AND c`. SQLite parses a flat chain left-deep, one expression-tree
+// node per clause, against Workerd's depth cap of 100 — so the compiler splits
+// the chain in half recursively. AND/OR are associative under three-valued
+// logic, so the grouping is invisible to what matches, and placeholder
+// numbering stays left-to-right.
 describe("compileWhereSql — per-engine rendering", () => {
     it("renders equality shorthand with the engine's identifier quoting + placeholder style", () => {
         expect.assertions(3);
@@ -80,7 +86,7 @@ describe("compileWhereSql — per-engine rendering", () => {
 
         expect(render({ a: { eq: null }, b: 2, c: null }, "postgres")).toEqual({
             params: [2],
-            sql: `("a" IS NULL) AND ("b" = $1) AND ("c" IS NULL)`,
+            sql: `("a" IS NULL) AND (("b" = $1) AND ("c" IS NULL))`,
         });
     });
 
@@ -95,7 +101,7 @@ describe("compileWhereSql — per-engine rendering", () => {
 
         expect(render(where, "postgres")).toEqual({
             params: [1, "high", "open", "blocked", "p1"],
-            sql: `(NOT ("archived" = $1)) AND (("priority" = $2) OR ("status" IN ($3, $4))) AND ("projectId" = $5)`,
+            sql: `(NOT ("archived" = $1)) AND ((("priority" = $2) OR ("status" IN ($3, $4))) AND ("projectId" = $5))`,
         });
     });
 

--- a/packages/shard-engine/__tests__/where-sql.test.ts
+++ b/packages/shard-engine/__tests__/where-sql.test.ts
@@ -44,12 +44,7 @@ const render = (where: Record<string, unknown>, engine: SqlEngine, strategy: Whe
     return renderSql(engine, compiled);
 };
 
-// Clause chains render BALANCED, not flat: `a AND (b AND c)` rather than
-// `a AND b AND c`. SQLite parses a flat chain left-deep, one expression-tree
-// node per clause, against Workerd's depth cap of 100 — so the compiler splits
-// the chain in half recursively. AND/OR are associative under three-valued
-// logic, so the grouping is invisible to what matches, and placeholder
-// numbering stays left-to-right.
+// Clause chains render BALANCED, not flat — see `joinClauses` for why.
 describe("compileWhereSql — per-engine rendering", () => {
     it("renders equality shorthand with the engine's identifier quoting + placeholder style", () => {
         expect.assertions(3);

--- a/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
+++ b/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import type { SchemaLike, SqlExec } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import { runSql } from "../src/do-exec";
 import { renderSql, sqliteInList, unionAll } from "../src/drizzle";
 import { compileWhereSql } from "../src/where-sql";
 import createSqliteExec from "./_helpers/node-sqlite";
@@ -340,40 +341,123 @@ describe("bound-parameter cap", () => {
     });
 });
 
-/** Deepest run of unclosed `(` in `text` — the parse-tree depth SQLite bounds. */
-const deepestNesting = (text: string): number => {
+/**
+ * The longest run of `connector`-joined terms at any ONE paren depth in `text` —
+ * the quantity that becomes expression-tree depth.
+ *
+ * Mirrors {@link widestCompound}, and for the same reason: total paren nesting
+ * says nothing useful here, because a FLAT `(a) AND (b) AND (c)` chain nests
+ * only one deep while being exactly the shape that blows the depth cap. What
+ * matters is how many terms share a level.
+ */
+const widestChain = (text: string, connector: "AND" | "OR"): number => {
+    const termsAtDepth = new Map<number, number>();
     let depth = 0;
-    let deepest = 0;
+    let widest = 1;
 
-    for (const character of text) {
-        if (character === "(") {
-            depth += 1;
-            deepest = Math.max(deepest, depth);
-        } else if (character === ")") {
-            depth -= 1;
+    for (const token of text.split(/\s+/u)) {
+        for (const character of token) {
+            if (character === "(") {
+                depth += 1;
+                termsAtDepth.set(depth, 1);
+            } else if (character === ")") {
+                depth -= 1;
+            }
+        }
+
+        if (token === connector) {
+            const terms = (termsAtDepth.get(depth) ?? 1) + 1;
+
+            termsAtDepth.set(depth, terms);
+            widest = Math.max(widest, terms);
         }
     }
 
-    return deepest;
+    return widest;
 };
+
+describe("the statement backstop", () => {
+    // Every builder sizes its own statement, so these fire only when one
+    // regressed or a caller hand-wrote SQL — which is exactly when a message
+    // naming the limit beats a bare SQLITE_ERROR from prepare.
+    const neverRuns = {
+        exec: () => {
+            throw new Error("the backstop must reject before the statement reaches SQLite");
+        },
+    } as unknown as SqlExec;
+
+    it("rejects a statement past the bound-parameter ceiling", () => {
+        expect.assertions(1);
+
+        expect(() => runSql(neverRuns, "SELECT 1", ...(Array.from({ length: 101 }).fill(0) as number[]))).toThrow(/101 parameters/u);
+    });
+
+    it("allows a statement exactly at the ceiling", () => {
+        expect.assertions(1);
+
+        // 100 is the limit, not one past it — the boundary the `>` turns on.
+        expect(() => runSql(neverRuns, "SELECT 1", ...(Array.from({ length: 100 }).fill(0) as number[]))).toThrow(/must reject before/u);
+    });
+
+    it("rejects statement text past the length ceiling", () => {
+        expect.assertions(1);
+
+        expect(() => runSql(neverRuns, `SELECT ${"x".repeat(100_001)}`)).toThrow(/character limit/u);
+    });
+});
 
 describe("expression-depth cap", () => {
     // eslint-disable-next-line no-restricted-syntax -- a drizzle identifier chunk, not a string conversion; the rule misfires on the inner TemplateLiteral
     const depthFieldRef = (field: string): SQL => dsql`${dsql.identifier(field)}`;
+    const wideWhere = Object.fromEntries(Array.from({ length: 200 }, (_unused, index) => [`f${String(index)}`, index]));
+    const compileWide = (): { params: unknown[]; sql: string } =>
+        renderSql("sqlite", compileWhereSql(wideWhere, { fieldRef: depthFieldRef, inList: sqliteInList, serialize: (value: unknown) => value })!);
 
-    // A flat `a AND b AND c …` parses left-deep — one tree node per clause —
-    // against Workerd's cap of 100. Balanced grouping makes it log2(n) instead.
-    it("nests a long clause chain logarithmically, not linearly", () => {
-        expect.assertions(2);
+    it("measures terms per level, not total nesting", () => {
+        // The flat form this replaced — the one that blows the cap — nests only
+        // one paren deep, so a nesting count would have called it healthy.
+        expect(widestChain("(a) AND (b) AND (c)", "AND")).toBe(3);
+        expect(widestChain("((a) AND (b)) AND ((c) AND (d))", "AND")).toBe(2);
+    });
 
-        const where = Object.fromEntries(Array.from({ length: 200 }, (_unused, index) => [`f${String(index)}`, index]));
-        const compiled = compileWhereSql(where, { fieldRef: depthFieldRef, inList: sqliteInList, serialize: (value: unknown) => value });
-        const { params, sql: text } = renderSql("sqlite", compiled!);
+    it("never puts more than two terms at one level, however wide the where", () => {
+        expect.assertions(1);
 
-        // log2(200) is about 8; allow room for the one paren wrapping each leaf.
-        expect(deepestNesting(text)).toBeLessThan(20);
-        // Regrouping must not drop or reorder a single clause.
-        expect(params).toStrictEqual(Array.from({ length: 200 }, (_unused, index) => index));
+        // Halving pairs every level, so no level ever chains: this is the
+        // assertion a flat `sql.join` fails at 200.
+        expect(widestChain(compileWide().sql, "AND")).toBe(2);
+    });
+
+    it("keeps every clause, in order", () => {
+        expect.assertions(1);
+
+        expect(compileWide().params).toStrictEqual(Array.from({ length: 200 }, (_unused, index) => index));
+    });
+
+    it("still matches the same rows on a real SQLite build", async () => {
+        const harness = createSqliteExec();
+
+        try {
+            const schema = schemaWith(1);
+
+            runShardMigrations(harness.sql, schema);
+
+            const writer = createShardContextDatabase({ clock: () => 1_700_000_000_000, schema, sql: harness.sql });
+
+            await writer.insert("t0", { title: "kept" });
+
+            // 200 AND'd conditions the row satisfies, then one it does not.
+            const satisfied = Object.fromEntries(Array.from({ length: 200 }, () => ["title", "kept"]));
+            const rows = await writer.findMany("t0", { where: satisfied });
+
+            expect(rows.page).toHaveLength(1);
+
+            const contradicted = await writer.findMany("t0", { where: { ...satisfied, title: "absent" } });
+
+            expect(contradicted.page).toHaveLength(0);
+        } finally {
+            harness.close();
+        }
     });
 });
 

--- a/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
+++ b/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
@@ -340,6 +340,43 @@ describe("bound-parameter cap", () => {
     });
 });
 
+/** Deepest run of unclosed `(` in `text` — the parse-tree depth SQLite bounds. */
+const deepestNesting = (text: string): number => {
+    let depth = 0;
+    let deepest = 0;
+
+    for (const character of text) {
+        if (character === "(") {
+            depth += 1;
+            deepest = Math.max(deepest, depth);
+        } else if (character === ")") {
+            depth -= 1;
+        }
+    }
+
+    return deepest;
+};
+
+describe("expression-depth cap", () => {
+    // eslint-disable-next-line no-restricted-syntax -- a drizzle identifier chunk, not a string conversion; the rule misfires on the inner TemplateLiteral
+    const depthFieldRef = (field: string): SQL => dsql`${dsql.identifier(field)}`;
+
+    // A flat `a AND b AND c …` parses left-deep — one tree node per clause —
+    // against Workerd's cap of 100. Balanced grouping makes it log2(n) instead.
+    it("nests a long clause chain logarithmically, not linearly", () => {
+        expect.assertions(2);
+
+        const where = Object.fromEntries(Array.from({ length: 200 }, (_unused, index) => [`f${String(index)}`, index]));
+        const compiled = compileWhereSql(where, { fieldRef: depthFieldRef, inList: sqliteInList, serialize: (value: unknown) => value });
+        const { params, sql: text } = renderSql("sqlite", compiled!);
+
+        // log2(200) is about 8; allow room for the one paren wrapping each leaf.
+        expect(deepestNesting(text)).toBeLessThan(20);
+        // Regrouping must not drop or reorder a single clause.
+        expect(params).toStrictEqual(Array.from({ length: 200 }, (_unused, index) => index));
+    });
+});
+
 describe("`LIKE` pattern-length cap", () => {
     it("matches the same rows through a position test as `LIKE` did, and takes a wildcard literally", async () => {
         expect.assertions(2);

--- a/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
+++ b/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
@@ -414,6 +414,8 @@ describe("expression-depth cap", () => {
         renderSql("sqlite", compileWhereSql(wideWhere, { fieldRef: depthFieldRef, inList: sqliteInList, serialize: (value: unknown) => value })!);
 
     it("measures terms per level, not total nesting", () => {
+        expect.assertions(2);
+
         // The flat form this replaced — the one that blows the cap — nests only
         // one paren deep, so a nesting count would have called it healthy.
         expect(widestChain("(a) AND (b) AND (c)", "AND")).toBe(3);
@@ -435,6 +437,8 @@ describe("expression-depth cap", () => {
     });
 
     it("still matches the same rows on a real SQLite build", async () => {
+        expect.assertions(2);
+
         const harness = createSqliteExec();
 
         try {

--- a/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
+++ b/packages/shard-engine/__tests__/workerd-sql-limits.test.ts
@@ -402,7 +402,20 @@ describe("the statement backstop", () => {
     it("rejects statement text past the length ceiling", () => {
         expect.assertions(1);
 
-        expect(() => runSql(neverRuns, `SELECT ${"x".repeat(100_001)}`)).toThrow(/character limit/u);
+        expect(() => runSql(neverRuns, `SELECT ${"x".repeat(100_001)}`)).toThrow(/byte limit/u);
+    });
+
+    // The ceiling is bytes; `String.length` is UTF-16 units. A statement of
+    // multi-byte text can sit under the character count and still breach.
+    it("measures the ceiling in bytes, not characters", () => {
+        expect.assertions(2);
+
+        // 40,000 three-byte characters = 120,000 bytes, well over the limit,
+        // while `length` reads 40,000 — a third of it.
+        const multiByte = `SELECT '${"→".repeat(40_000)}'`;
+
+        expect(multiByte.length).toBeLessThan(100_000);
+        expect(() => runSql(neverRuns, multiByte)).toThrow(/byte limit/u);
     });
 });
 

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -2107,6 +2107,77 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
         return globalDb;
     };
 
+    /**
+     * The `.global()` half of `insert`: put the row on the meter, forward it to
+     * the global (D1) writer, then refresh this DO's subscribers.
+     *
+     * Charge BEFORE the write, not after. The global branch returns before
+     * `onWrite`, which is where the meter normally charges, so it has to charge
+     * itself or a transaction could write unbounded rows to a `.global()` table
+     * without consuming its ceiling. The order matters because this write lands
+     * in ANOTHER backend: a mutation runs inside the DO's `storage.transaction`,
+     * which rolls back the DO's SQLite and nothing else. Charging after meant a
+     * ceiling breach threw with the D1 row already committed and no way to undo
+     * it.
+     *
+     * The trade is a charge for a row that was never written when the throw is
+     * caught — `insertMany`'s `skipDuplicates` swallows the D1 unique violation,
+     * so a re-run over mostly-duplicate rows now consumes ceiling for the skips.
+     * Failing closed is the right side of that: over-counting costs a retry,
+     * under-counting costs an isolate.
+     *
+     * What is charged is the caller's document, not the row D1 ends up storing —
+     * the global writer applies its own defaults, `_creationTime` and id on the
+     * far side, and reproducing that here would duplicate the far-side default
+     * pipeline for an estimate. So `writtenBytes` runs light by whatever those
+     * add, a bounded per-row amount; `writtenRows`, which is the ceiling that
+     * actually protects the isolate, is charged exactly.
+     * `charge` is `false` when the caller already charged this row — today
+     * `insertMany`, which pre-charges the whole batch so a mid-loop breach
+     * cannot leave earlier rows committed in a backend the DO transaction
+     * cannot roll back. A parameter rather than `runUnmetered`, deliberately:
+     * `meterExempt` is writer-wide for the duration of its await, so a routine
+     * `Promise.all([ctx.db.insertMany("<global>", rows), ctx.db.insert(…)])`
+     * would silently exempt the sibling write too. `deleteAll` accepts that
+     * trade for an unusual pattern; a global `insertMany` is ordinary.
+     */
+    const insertGlobal = async (
+        global: DatabaseWriterLike,
+        tableName: string,
+        document: Record<string, unknown>,
+        insertOptions: Parameters<DatabaseWriterLike["insert"]>[2],
+        charge: boolean,
+    ): Promise<string> => {
+        if (charge) {
+            meterWrite(document);
+        }
+
+        const id = await global.insert(tableName, document, insertOptions);
+
+        // A `.global()` (D1) write lands in another backend, but live
+        // subscriptions on this DO that read the table still need to be
+        // refreshed — so notify them via the same `broadcast` channel the
+        // local path uses (the DO maps it to `recordChangedTable`). Without
+        // this, `ctx.db.insert("<global>", …)` would never push a delta to
+        // subscribers of that global table's query.
+        //
+        // Deliberately NO `indexKeys`: the global writer applied its own
+        // defaults and `_creationTime` on the far side, so the image here
+        // is not the row that was stored. An index covering a defaulted
+        // field would encode a position the row does not occupy, which
+        // could prove a write outside a slice that actually contains it —
+        // suppressing an invalidation. Omitting them falls back to
+        // whole-table, which is always sound.
+        broadcast({
+            key: id,
+            op: "insert",
+            row: { ...document, _id: id },
+            table: tableName,
+        });
+
+        return id;
+    };
+
     // For *id-addressed* ops (`get`/`patch`/`replace`/`delete`): a bare id
     // carries no table, so they probe this DO's local tables first; a global
     // row's id never lives here, so on a local miss they fall back to
@@ -3370,48 +3441,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             const global = globalWriterFor(tableName, "insert");
 
             if (global) {
-                // Charge BEFORE the write, not after. The global branch returns
-                // before `onWrite`, which is where the meter normally charges, so
-                // it has to charge itself or a transaction could write unbounded
-                // rows to a `.global()` table without consuming its ceiling. The
-                // order matters because this write lands in ANOTHER backend: a
-                // mutation runs inside the DO's `storage.transaction`, which
-                // rolls back the DO's SQLite and nothing else. Charging after
-                // meant a ceiling breach threw with the D1 row already committed
-                // and no way to undo it.
-                //
-                // The trade is a charge for a row that was never written when the
-                // throw is caught — `insertMany`'s `skipDuplicates` swallows the
-                // D1 unique violation, so a re-run over mostly-duplicate rows now
-                // consumes ceiling for the skips. Failing closed is the right side
-                // of that: over-counting costs a retry, under-counting costs an
-                // isolate.
-                meterWrite(document);
-
-                const id = await global.insert(tableName, document, insertOptions);
-
-                // A `.global()` (D1) write lands in another backend, but live
-                // subscriptions on this DO that read the table still need to be
-                // refreshed — so notify them via the same `broadcast` channel the
-                // local path uses (the DO maps it to `recordChangedTable`). Without
-                // this, `ctx.db.insert("<global>", …)` would never push a delta to
-                // subscribers of that global table's query.
-                //
-                // Deliberately NO `indexKeys`: the global writer applied its own
-                // defaults and `_creationTime` on the far side, so the image here
-                // is not the row that was stored. An index covering a defaulted
-                // field would encode a position the row does not occupy, which
-                // could prove a write outside a slice that actually contains it —
-                // suppressing an invalidation. Omitting them falls back to
-                // whole-table, which is always sound.
-                broadcast({
-                    key: id,
-                    op: "insert",
-                    row: { ...document, _id: id },
-                    table: tableName,
-                });
-
-                return id;
+                return insertGlobal(global, tableName, document, insertOptions, true);
             }
 
             const definition = schema.tables[tableName];
@@ -3612,20 +3642,23 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // as `insertManyUnsafe`'s global branch does — refuses it while none
             // of it has crossed.
             //
-            // The loop then runs unmetered, or every row would be charged twice:
-            // once here and once by its own `insert`. Shard-local batches keep
-            // the per-row charge untouched, since the DO transaction rewinds them
-            // and there is nothing to pre-empt.
-            const precharged = globalWriterFor(tableName, "insert") !== undefined;
+            // The loop then forwards each row through `insertGlobal` with the
+            // charge suppressed, or every row would be charged twice: once here
+            // and once on its way out. Suppressing it per call rather than with
+            // the writer-wide `runUnmetered` keeps a concurrent write on this
+            // same writer metered (see `insertGlobal`'s `charge` parameter).
+            // Shard-local batches keep the per-row charge untouched, since the DO
+            // transaction rewinds them and there is nothing to pre-empt.
+            const global = globalWriterFor(tableName, "insert");
 
-            if (precharged) {
+            if (global) {
                 for (const document of documents) {
                     meterWrite(document);
                 }
             }
 
             const insertOne = async (document: Record<string, unknown>): Promise<string> =>
-                precharged ? runUnmetered(async () => writer.insert(tableName, document)) : writer.insert(tableName, document);
+                global ? insertGlobal(global, tableName, document, undefined, false) : writer.insert(tableName, document);
 
             for (const document of documents) {
                 try {

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -3605,11 +3605,32 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // preserved so an FK reference to an earlier row in the same batch resolves.
             const skipDuplicates = batchOptions?.skipDuplicates === true;
             const ids: (string | null)[] = [];
+            // On a `.global()` table the per-row `insert` charges its own row
+            // immediately before pushing it to D1, so a breach part-way down this
+            // loop leaves every earlier row committed in a backend the DO's
+            // transaction cannot roll back. Charging the whole batch up front —
+            // as `insertManyUnsafe`'s global branch does — refuses it while none
+            // of it has crossed.
+            //
+            // The loop then runs unmetered, or every row would be charged twice:
+            // once here and once by its own `insert`. Shard-local batches keep
+            // the per-row charge untouched, since the DO transaction rewinds them
+            // and there is nothing to pre-empt.
+            const precharged = globalWriterFor(tableName, "insert") !== undefined;
+
+            if (precharged) {
+                for (const document of documents) {
+                    meterWrite(document);
+                }
+            }
+
+            const insertOne = async (document: Record<string, unknown>): Promise<string> =>
+                precharged ? runUnmetered(async () => writer.insert(tableName, document)) : writer.insert(tableName, document);
 
             for (const document of documents) {
                 try {
                     // eslint-disable-next-line no-await-in-loop -- sequential by design: preserves insert order + the single-threaded SQLite transaction
-                    ids.push(await writer.insert(tableName, document));
+                    ids.push(await insertOne(document));
                 } catch (error) {
                     if (skipDuplicates && error instanceof ConflictError && error.kind === "unique") {
                         // Preserve the input-order slot with null so callers can

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -1990,10 +1990,25 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
      * mutation can bypass the meter. A delete carries no document: it still
      * costs a row, just no bytes.
      */
-    const onWrite: WriteHook = async (event) => {
+
+    /**
+     * Charge one written document against the transaction meter, unless this
+     * writer is running unmetered (see `meterExempt`).
+     *
+     * Named rather than inlined because the `.global()` branches cannot reach
+     * `onWrite` — they return before it — so each one has to charge itself, and
+     * "did this branch remember?" is invisible when the answer is a three-line
+     * ritual repeated six times across 700 lines. One call is an obvious
+     * absence.
+     */
+    const meterWrite = (row: unknown): void => {
         if (!meterExempt) {
-            headroom?.recordWrite(event.doc);
+            headroom?.recordWrite(row);
         }
+    };
+
+    const onWrite: WriteHook = async (event) => {
+        meterWrite(event.doc);
 
         await reportWrite(event);
     };
@@ -2700,6 +2715,16 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
+                    // A delete carries no document, so it costs a row and no
+                    // bytes — exactly what `onWrite` charges for the local paths
+                    // (see its docblock). Charged here because this branch
+                    // returns before that hook, and before the boundary because
+                    // D1 does not roll back with the DO's transaction. Without
+                    // it, `deleteWhere` over a `.global()` table — which routes
+                    // through `deleteMany` to here — was free of the meter
+                    // entirely, however many rows it removed.
+                    meterWrite(undefined);
+
                     await global.delete(id, undefined, deleteOptions);
                 }
 
@@ -3361,9 +3386,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // consumes ceiling for the skips. Failing closed is the right side
                 // of that: over-counting costs a retry, under-counting costs an
                 // isolate.
-                if (!meterExempt) {
-                    headroom?.recordWrite(document);
-                }
+                meterWrite(document);
 
                 const id = await global.insert(tableName, document, insertOptions);
 
@@ -3477,10 +3500,8 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // mid-loop would leave every earlier row committed with no way to
                 // undo them. Metering up front means the batch is refused while
                 // that is still true of none of them.
-                if (!meterExempt) {
-                    for (const document of documents) {
-                        headroom?.recordWrite(document);
-                    }
+                for (const document of documents) {
+                    meterWrite(document);
                 }
 
                 for (const document of documents) {
@@ -3533,10 +3554,8 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // only after the multi-row INSERT has already landed, so metering
             // there would let one oversized batch materialize in full — which
             // is exactly the isolate exhaustion the meter exists to prevent.
-            if (!meterExempt) {
-                for (const row of rows) {
-                    headroom?.recordWrite(row.document);
-                }
+            for (const row of rows) {
+                meterWrite(row.document);
             }
 
             // Multi-row INSERTs — the throughput win over `insertMany`'s N
@@ -3623,6 +3642,16 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
+                    // Same reason as the global `insert` branch. The DELTA is
+                    // charged, not the merged row: the row lives in D1, and
+                    // reading it back to size it would double the round-trips on
+                    // every global patch. That meters a global patch lighter than
+                    // the shard-local path, which charges the whole merged
+                    // document — under-counting by the untouched fields is the
+                    // right side of that trade, since the delta is what this call
+                    // actually sends.
+                    meterWrite(patch);
+
                     await global.patch(id, patch);
                     return;
                 }
@@ -4037,6 +4066,11 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
+                    // Same reason as the global `patch` branch — and here the
+                    // whole replacement document is in hand, so the charge is
+                    // exact rather than a delta.
+                    meterWrite(document);
+
                     await global.replace(id, document, undefined, replaceOptions);
                     return;
                 }

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -3353,8 +3353,14 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // mutation runs inside the DO's `storage.transaction`, which
                 // rolls back the DO's SQLite and nothing else. Charging after
                 // meant a ceiling breach threw with the D1 row already committed
-                // and no way to undo it — a rollback that silently kept half the
-                // write.
+                // and no way to undo it.
+                //
+                // The trade is a charge for a row that was never written when the
+                // throw is caught — `insertMany`'s `skipDuplicates` swallows the
+                // D1 unique violation, so a re-run over mostly-duplicate rows now
+                // consumes ceiling for the skips. Failing closed is the right side
+                // of that: over-counting costs a retry, under-counting costs an
+                // isolate.
                 if (!meterExempt) {
                     headroom?.recordWrite(document);
                 }
@@ -3465,19 +3471,23 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // per-row global writer (the throughput win is shard-local only).
                 const globalIds: string[] = [];
 
+                // Charge the WHOLE batch before writing any of it, the way the
+                // shard-local branch below does. These rows land in D1, which the
+                // DO's `storage.transaction` cannot roll back, so a breach found
+                // mid-loop would leave every earlier row committed with no way to
+                // undo them. Metering up front means the batch is refused while
+                // that is still true of none of them.
+                if (!meterExempt) {
+                    for (const document of documents) {
+                        headroom?.recordWrite(document);
+                    }
+                }
+
                 for (const document of documents) {
                     // Forward `allowExplicitId` so a trusted import preserves the
                     // supplied `_id` across the D1 boundary too — mirrors the single
                     // `insert` global branch; without it the D1 writer would silently
                     // re-key every row (thermos HIGH).
-                    // Charged before the write for the same reason as the single
-                    // `insert` global branch: the row lands in D1, which the DO's
-                    // transaction cannot roll back. Charging after would leave
-                    // every row up to the breach committed in another backend.
-                    if (!meterExempt) {
-                        headroom?.recordWrite(document);
-                    }
-
                     // eslint-disable-next-line no-await-in-loop -- the D1 global writer has no batch primitive; sequential per row
                     const globalId = await global.insert(tableName, document, { allowExplicitId: batchOptions?.allowExplicitId });
 

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -3345,15 +3345,21 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             const global = globalWriterFor(tableName, "insert");
 
             if (global) {
-                const id = await global.insert(tableName, document, insertOptions);
-
-                // The global branch returns before `onWrite`, which is where the
-                // meter normally charges — so charge here, or a transaction could
-                // write unbounded rows to a `.global()` table without ever
-                // consuming its ceiling.
+                // Charge BEFORE the write, not after. The global branch returns
+                // before `onWrite`, which is where the meter normally charges, so
+                // it has to charge itself or a transaction could write unbounded
+                // rows to a `.global()` table without consuming its ceiling. The
+                // order matters because this write lands in ANOTHER backend: a
+                // mutation runs inside the DO's `storage.transaction`, which
+                // rolls back the DO's SQLite and nothing else. Charging after
+                // meant a ceiling breach threw with the D1 row already committed
+                // and no way to undo it — a rollback that silently kept half the
+                // write.
                 if (!meterExempt) {
                     headroom?.recordWrite(document);
                 }
+
+                const id = await global.insert(tableName, document, insertOptions);
 
                 // A `.global()` (D1) write lands in another backend, but live
                 // subscriptions on this DO that read the table still need to be
@@ -3464,14 +3470,16 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                     // supplied `_id` across the D1 boundary too — mirrors the single
                     // `insert` global branch; without it the D1 writer would silently
                     // re-key every row (thermos HIGH).
-                    // eslint-disable-next-line no-await-in-loop -- the D1 global writer has no batch primitive; sequential per row
-                    const globalId = await global.insert(tableName, document, { allowExplicitId: batchOptions?.allowExplicitId });
-
-                    // Same reason as the single-insert global branch: this loop
-                    // never reaches `onWrite`, so it must charge the meter itself.
+                    // Charged before the write for the same reason as the single
+                    // `insert` global branch: the row lands in D1, which the DO's
+                    // transaction cannot roll back. Charging after would leave
+                    // every row up to the breach committed in another backend.
                     if (!meterExempt) {
                         headroom?.recordWrite(document);
                     }
+
+                    // eslint-disable-next-line no-await-in-loop -- the D1 global writer has no batch primitive; sequential per row
+                    const globalId = await global.insert(tableName, document, { allowExplicitId: batchOptions?.allowExplicitId });
 
                     broadcast({
                         key: globalId,

--- a/packages/shard-engine/src/do-exec.ts
+++ b/packages/shard-engine/src/do-exec.ts
@@ -8,10 +8,19 @@
  * The `SqlExec`/`SqlCursor` shapes are owned by `ctx-db.ts`; we import them
  * type-only (erased at runtime, so no import cycle).
  */
+import { LunoraError } from "@lunora/errors";
 import type { SQL } from "drizzle-orm";
 
 import type { SqlCursor, SqlExec } from "./ctx-db";
 import { renderSql } from "./drizzle";
+
+/**
+ * Workerd's `SQLITE_LIMIT_SQL_LENGTH` (stock SQLite allows 1 GB) and
+ * `SQLITE_LIMIT_VARIABLE_NUMBER` (stock allows 500,000). Past either, SQLite
+ * refuses to prepare the statement.
+ */
+const MAX_SQL_TEXT_LENGTH = 100_000;
+const MAX_BOUND_PARAMS = 100;
 
 /**
  * Run a raw SQL statement. Routes through a `.call(sql, ...)` indirection rather
@@ -19,6 +28,28 @@ import { renderSql } from "./drizzle";
  * `.exec(` references, and the right fix is to not type the string at all.
  */
 export const runSql = <Row = Record<string, unknown>>(sql: SqlExec, query: string, ...params: unknown[]): SqlCursor<Row> => {
+    // Backstop, not the primary defence. Every builder in this package sizes its
+    // own statement — compounds nest, long `IN` lists bind one JSON parameter,
+    // batch INSERTs chunk — so reaching either ceiling means a builder regressed
+    // or a caller hand-wrote SQL. Both are worth a message that names the limit
+    // instead of a bare `SQLITE_ERROR` from prepare.
+    //
+    // Both checks are O(1) on values already in hand, so this costs nothing on
+    // the hot path. `length` counts UTF-16 units rather than the UTF-8 bytes
+    // SQLite measures; statement text is identifiers and placeholders (values
+    // are bound, not inlined), so the two agree in practice, and where they
+    // diverge this under-reports — it can miss a violation, never invent one.
+    if (query.length > MAX_SQL_TEXT_LENGTH) {
+        throw new LunoraError(
+            "INTERNAL",
+            `SQL statement is ${String(query.length)} characters, over this runtime's ${String(MAX_SQL_TEXT_LENGTH)}-character limit`,
+        );
+    }
+
+    if (params.length > MAX_BOUND_PARAMS) {
+        throw new LunoraError("INTERNAL", `SQL statement binds ${String(params.length)} parameters, over this runtime's limit of ${String(MAX_BOUND_PARAMS)}`);
+    }
+
     const runner = sql.exec as (this: SqlExec, query: string, ...rest: unknown[]) => SqlCursor<Row>;
 
     return runner.call(sql, query, ...params);

--- a/packages/shard-engine/src/do-exec.ts
+++ b/packages/shard-engine/src/do-exec.ts
@@ -12,15 +12,7 @@ import { LunoraError } from "@lunora/errors";
 import type { SQL } from "drizzle-orm";
 
 import type { SqlCursor, SqlExec } from "./ctx-db";
-import { renderSql } from "./drizzle";
-
-/**
- * Workerd's `SQLITE_LIMIT_SQL_LENGTH` (stock SQLite allows 1 GB) and
- * `SQLITE_LIMIT_VARIABLE_NUMBER` (stock allows 500,000). Past either, SQLite
- * refuses to prepare the statement.
- */
-const MAX_SQL_TEXT_LENGTH = 100_000;
-const MAX_BOUND_PARAMS = 100;
+import { renderSql, WORKERD_SQLITE_LIMITS } from "./drizzle";
 
 /**
  * Run a raw SQL statement. Routes through a `.call(sql, ...)` indirection rather
@@ -39,15 +31,18 @@ export const runSql = <Row = Record<string, unknown>>(sql: SqlExec, query: strin
     // SQLite measures; statement text is identifiers and placeholders (values
     // are bound, not inlined), so the two agree in practice, and where they
     // diverge this under-reports — it can miss a violation, never invent one.
-    if (query.length > MAX_SQL_TEXT_LENGTH) {
+    if (query.length > WORKERD_SQLITE_LIMITS.sqlTextLength) {
         throw new LunoraError(
             "INTERNAL",
-            `SQL statement is ${String(query.length)} characters, over this runtime's ${String(MAX_SQL_TEXT_LENGTH)}-character limit`,
+            `SQL statement is ${String(query.length)} characters, over this runtime's ${String(WORKERD_SQLITE_LIMITS.sqlTextLength)}-character limit`,
         );
     }
 
-    if (params.length > MAX_BOUND_PARAMS) {
-        throw new LunoraError("INTERNAL", `SQL statement binds ${String(params.length)} parameters, over this runtime's limit of ${String(MAX_BOUND_PARAMS)}`);
+    if (params.length > WORKERD_SQLITE_LIMITS.boundParams) {
+        throw new LunoraError(
+            "INTERNAL",
+            `SQL statement binds ${String(params.length)} parameters, over this runtime's limit of ${String(WORKERD_SQLITE_LIMITS.boundParams)}`,
+        );
     }
 
     const runner = sql.exec as (this: SqlExec, query: string, ...rest: unknown[]) => SqlCursor<Row>;

--- a/packages/shard-engine/src/do-exec.ts
+++ b/packages/shard-engine/src/do-exec.ts
@@ -26,16 +26,23 @@ export const runSql = <Row = Record<string, unknown>>(sql: SqlExec, query: strin
     // or a caller hand-wrote SQL. Both are worth a message that names the limit
     // instead of a bare `SQLITE_ERROR` from prepare.
     //
-    // Both checks are O(1) on values already in hand, so this costs nothing on
-    // the hot path. `length` counts UTF-16 units rather than the UTF-8 bytes
-    // SQLite measures; statement text is identifiers and placeholders (values
-    // are bound, not inlined), so the two agree in practice, and where they
-    // diverge this under-reports — it can miss a violation, never invent one.
-    if (query.length > WORKERD_SQLITE_LIMITS.sqlTextLength) {
-        throw new LunoraError(
-            "INTERNAL",
-            `SQL statement is ${String(query.length)} characters, over this runtime's ${String(WORKERD_SQLITE_LIMITS.sqlTextLength)}-character limit`,
-        );
+    // The parameter check is O(1) on a value already in hand; the length check
+    // is O(1) too on every statement this package emits (see below).
+    // `SQLITE_LIMIT_SQL_LENGTH` counts BYTES, and `String.length` counts UTF-16
+    // code units, so a non-ASCII statement can pass the cheap check and still be
+    // refused by SQLite. One UTF-16 unit is at most three UTF-8 bytes, so a
+    // statement under a third of the limit cannot possibly breach it — that is
+    // the common case and it costs one comparison. Only the remainder pays for
+    // an encode, which is exactly when accuracy is worth its price.
+    if (query.length * 3 > WORKERD_SQLITE_LIMITS.sqlTextLength) {
+        const bytes = new TextEncoder().encode(query).length;
+
+        if (bytes > WORKERD_SQLITE_LIMITS.sqlTextLength) {
+            throw new LunoraError(
+                "INTERNAL",
+                `SQL statement is ${String(bytes)} bytes, over this runtime's ${String(WORKERD_SQLITE_LIMITS.sqlTextLength)}-byte limit`,
+            );
+        }
     }
 
     if (params.length > WORKERD_SQLITE_LIMITS.boundParams) {

--- a/packages/shard-engine/src/drizzle.ts
+++ b/packages/shard-engine/src/drizzle.ts
@@ -42,6 +42,8 @@ const WORKERD_SQLITE_LIMITS = {
     compoundSelect: 5,
     /** `SQLITE_LIMIT_LIKE_PATTERN_LENGTH` — bytes in a `LIKE`/`GLOB` pattern. Stock SQLite allows 50,000. */
     likePattern: 50,
+    /** `SQLITE_LIMIT_SQL_LENGTH` — characters of statement text. Stock SQLite allows 1 GB. */
+    sqlTextLength: 100_000,
 } as const;
 
 /**

--- a/packages/shard-engine/src/drizzle.ts
+++ b/packages/shard-engine/src/drizzle.ts
@@ -42,7 +42,7 @@ const WORKERD_SQLITE_LIMITS = {
     compoundSelect: 5,
     /** `SQLITE_LIMIT_LIKE_PATTERN_LENGTH` — bytes in a `LIKE`/`GLOB` pattern. Stock SQLite allows 50,000. */
     likePattern: 50,
-    /** `SQLITE_LIMIT_SQL_LENGTH` — characters of statement text. Stock SQLite allows 1 GB. */
+    /** `SQLITE_LIMIT_SQL_LENGTH` — BYTES of statement text, not characters. Stock SQLite allows 1 GB. */
     sqlTextLength: 100_000,
 } as const;
 

--- a/packages/shard-engine/src/reprojection-backfill.ts
+++ b/packages/shard-engine/src/reprojection-backfill.ts
@@ -24,7 +24,6 @@
  * affected, whether a given row is one of them, and a transform that re-encodes.
  */
 
-import { jsonPathSegment } from "../../../shared/json-path-segment";
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import { reprojectionMigrationTable } from "../../../shared/reprojection-id";
 import { encodeWire } from "../../../shared/wire-codec";
@@ -94,19 +93,33 @@ const reprojectionTables = (schema: SchemaLike): string[] =>
  * forever, so `countLegacyRows` would never reach zero and every deploy would
  * rewrite every shard. Testing only the sentinel would do exactly that.
  *
- * `json_extract` returns `NULL` for a current projection (a JSON string, so
- * `$.field[0]` does not resolve), which is why a NULL-safe `=` is enough.
+ * Walks the document's own top-level members rather than extracting at a path
+ * per field, which is what keeps the statement a fixed width: four bound
+ * parameters and one `EXISTS`, whatever the column count. Extracting per field
+ * cost five placeholders each and OR'd a clause each, so a table with 21
+ * `v.bigint()`/`v.bytes()` columns exceeded Workerd's 100-parameter cap — and
+ * its 100-term `OR` would have hit the expression-depth ceiling on the way.
  *
- * Paths are **bound**, which defeats SQL injection but NOT SQLite's JSON-path
- * grammar — an unquoted `.` in a field name would still parse as a nested key.
- * Hence {@link jsonPathSegment}. Binding costs nothing here: this is a one-off
- * scan, not an indexed lookup whose expression has to match an index.
+ * Walking also removes the JSON-path grammar from the question entirely. A
+ * field name is compared as `json_each`'s `key`, a plain string, so a field
+ * literally called `a.b` (or one carrying a quote, a bracket, or an emoji)
+ * needs no escaping and cannot re-parse as a nested key.
+ *
+ * `type = 'array'` is load-bearing rather than an optimisation: `json_each`
+ * hands back a scalar member's raw SQL text, and `json_extract('abc', '$[0]')`
+ * is a malformed-JSON error, not `NULL`. It also preserves the exclusion above —
+ * a current projection is a JSON string, so it never reaches the element tests.
  */
 const legacyRowPredicate = (fields: ReadonlyArray<string>): { params: unknown[]; sql: string } => {
-    const clauses = fields.map(() => `(json_extract(${quoteIdentifier(DOC_COLUMN)}, ?) = ? AND json_extract(${quoteIdentifier(DOC_COLUMN)}, ?) IN (?, ?))`);
-    const params = fields.flatMap((field) => [`$.${jsonPathSegment(field)}[0]`, WIRE_TAG, `$.${jsonPathSegment(field)}[1]`, "bigint", "bytes"]);
+    // `__f__.value` is the member itself, so both slots are fixed paths into the
+    // two-element wire tuple.
+    const member = `json_each(${quoteIdentifier(DOC_COLUMN)}) AS __f__`;
+    const reprojectable = `__f__.type = 'array' AND __f__.key IN (SELECT value FROM json_each(?))`;
 
-    return { params, sql: clauses.join(" OR ") };
+    return {
+        params: [JSON.stringify(fields), WIRE_TAG, "bigint", "bytes"],
+        sql: `EXISTS (SELECT 1 FROM ${member} WHERE ${reprojectable} AND json_extract(__f__.value, '$[0]') = ? AND json_extract(__f__.value, '$[1]') IN (?, ?))`,
+    };
 };
 
 /**

--- a/packages/shard-engine/src/where-sql.ts
+++ b/packages/shard-engine/src/where-sql.ts
@@ -186,20 +186,48 @@ const compileField = (field: string, value: unknown, strategy: WhereSqlStrategy)
     return [sql`${reference} = ${strategy.serialize(value)}`];
 };
 
-/** Join compiled clauses with a boolean connector, wrapping each in parens. */
+/**
+ * Join compiled clauses with a boolean connector, wrapping each in parens.
+ *
+ * Balanced rather than flat, because SQLite parses `a AND b AND c` left-deep:
+ * the expression tree is one node deep per clause, and Workerd caps
+ * `SQLITE_LIMIT_EXPR_DEPTH` at 100 where stock SQLite allows 1,000. A `where`
+ * assembled programmatically — a filter builder, an RLS policy merged into a
+ * caller's predicate, an `OR` over a long id list — reaches that in a way no
+ * hand-written predicate would, and fails to parse rather than running slowly.
+ *
+ * Splitting the chain in half recursively makes the tree log₂(n) deep instead:
+ * 200 clauses go from depth 200 to depth 8. `AND` and `OR` are associative
+ * under SQL's three-valued logic, so regrouping cannot change what matches —
+ * `(a AND b) AND c` and `a AND (b AND c)` agree on true, false, and NULL alike.
+ */
 const joinClauses = (clauses: SQL[], connector: "AND" | "OR"): SQL | undefined => {
     if (clauses.length === 0) {
         return undefined;
     }
 
-    if (clauses.length === 1) {
-        return clauses[0];
+    const first = clauses[0];
+
+    if (clauses.length === 1 && first) {
+        return first;
     }
 
-    return sql.join(
-        clauses.map((clause) => sql`(${clause})`),
-        sql` ${sql.raw(connector)} `,
-    );
+    if (clauses.length === 2) {
+        return sql.join(
+            clauses.map((clause) => sql`(${clause})`),
+            sql` ${sql.raw(connector)} `,
+        );
+    }
+
+    const middle = Math.floor(clauses.length / 2);
+    const left = joinClauses(clauses.slice(0, middle), connector);
+    const right = joinClauses(clauses.slice(middle), connector);
+
+    if (!left || !right) {
+        return left ?? right;
+    }
+
+    return sql`(${left}) ${sql.raw(connector)} (${right})`;
 };
 
 const compileGroup = (value: unknown, connector: "AND" | "OR", strategy: WhereSqlStrategy): SQL | undefined => {

--- a/packages/shard-engine/src/where-sql.ts
+++ b/packages/shard-engine/src/where-sql.ts
@@ -189,45 +189,34 @@ const compileField = (field: string, value: unknown, strategy: WhereSqlStrategy)
 /**
  * Join compiled clauses with a boolean connector, wrapping each in parens.
  *
- * Balanced rather than flat, because SQLite parses `a AND b AND c` left-deep:
- * the expression tree is one node deep per clause, and Workerd caps
- * `SQLITE_LIMIT_EXPR_DEPTH` at 100 where stock SQLite allows 1,000. A `where`
+ * Split in half rather than chained flat, because SQLite parses `a AND b AND c`
+ * left-deep: one expression-tree node per clause, against Workerd's
+ * `SQLITE_LIMIT_EXPR_DEPTH` of 100 where stock SQLite allows 1,000. A `where`
  * assembled programmatically — a filter builder, an RLS policy merged into a
  * caller's predicate, an `OR` over a long id list — reaches that in a way no
  * hand-written predicate would, and fails to parse rather than running slowly.
+ * Halving makes the tree log2(n) deep: 200 clauses go from 200 to 8.
  *
- * Splitting the chain in half recursively makes the tree log₂(n) deep instead:
- * 200 clauses go from depth 200 to depth 8. `AND` and `OR` are associative
- * under SQL's three-valued logic, so regrouping cannot change what matches —
- * `(a AND b) AND c` and `a AND (b AND c)` agree on true, false, and NULL alike.
+ * `AND` and `OR` are associative under SQL's three-valued logic, so regrouping
+ * cannot change what matches — `(a AND b) AND c` and `a AND (b AND c)` agree on
+ * true, false and NULL alike — and the left half always comes first, so bound
+ * parameters number exactly as they did flat. SQLite's own `whereSplit` recurses
+ * into both children of an `AND` node, so the planner decomposes a balanced tree
+ * into the same term set it got from a chain: index selection is unaffected.
+ *
+ * Solves the same shape of problem as `unionAll` in `./drizzle`, which nests the
+ * compound-`SELECT` chain against its own ceiling.
  */
 const joinClauses = (clauses: SQL[], connector: "AND" | "OR"): SQL | undefined => {
-    if (clauses.length === 0) {
-        return undefined;
-    }
-
-    const first = clauses[0];
-
-    if (clauses.length === 1 && first) {
-        return first;
-    }
-
-    if (clauses.length === 2) {
-        return sql.join(
-            clauses.map((clause) => sql`(${clause})`),
-            sql` ${sql.raw(connector)} `,
-        );
+    // Both halves of a split are non-empty and strictly smaller, so the
+    // recursion always reaches this case.
+    if (clauses.length <= 1) {
+        return clauses[0];
     }
 
     const middle = Math.floor(clauses.length / 2);
-    const left = joinClauses(clauses.slice(0, middle), connector);
-    const right = joinClauses(clauses.slice(middle), connector);
 
-    if (!left || !right) {
-        return left ?? right;
-    }
-
-    return sql`(${left}) ${sql.raw(connector)} (${right})`;
+    return sql`(${joinClauses(clauses.slice(0, middle), connector)}) ${sql.raw(connector)} (${joinClauses(clauses.slice(middle), connector)})`;
 };
 
 const compileGroup = (value: unknown, connector: "AND" | "OR", strategy: WhereSqlStrategy): SQL | undefined => {


### PR DESCRIPTION
Closes the platform-limit gaps left open by #396 and #397, and finishes the audit of every package that calls a Cloudflare API.

## Correctness

**The meter charged after the cross-backend write.** A `.global()` insert returns before `onWrite`, so the global branch charges the transaction meter itself — but it charged *after* `global.insert` resolved. That row lands in D1, and a mutation's rollback is `state.storage.transaction`, which rewinds the Durable Object's SQLite and nothing else. A ceiling breach therefore threw with the D1 row committed and no way to undo it. `insertMany` now charges the whole batch up front, the way its shard-local sibling already did, so a breach is found while none of the rows exist.

**Expression depth.** SQLite parses `a AND b AND c` left-deep — one expression-tree node per clause — against Workerd's `SQLITE_LIMIT_EXPR_DEPTH` of 100, where stock SQLite allows 1,000. A `where` assembled programmatically reaches that in a way no hand-written predicate would: a filter builder over a wide form, an RLS policy merged into a caller's predicate, an `OR` across a long id list. Verified against a real SQLite with the limit lowered — 200 flat terms raise `Expression tree is too large`, the same 200 balanced parse fine.

`joinClauses` now splits in half, so 200 clauses nest 8 deep instead of 200. `AND`/`OR` are associative under three-valued logic, so regrouping cannot change what matches, and the left half always comes first so bound parameters number exactly as before. SQLite's own `whereSplit` recurses into both children of an `AND`, so the planner decomposes a balanced tree into the same term set — index selection is unaffected.

## Guards

**Statement backstop.** `runSql` is the one place every statement passes through; it now rejects text over 100,000 characters or 100 bound parameters, both O(1) reads on values already in hand. Deliberately a backstop rather than the defence — every builder sizes its own statement, so this fires only when one regressed or a caller hand-wrote SQL, which is exactly when a message naming the limit beats a bare `SQLITE_ERROR` from prepare.

**Vectorize metadata.** `defineRag` stores each chunk's text as vector metadata unless a `textStore` is supplied, and Vectorize caps that at 10 KiB. `chunkSize` was unchecked, so a value above the cap meant every upsert failed at the far side with nothing naming the cause. The ceiling was already in the package's own docblock — documented, not enforced. Skipped when a custom `chunk` splitter makes `chunkSize` inert, and when a `textStore` moves text out.

## Visibility

`fan_out_breadth` warns when a shard group has enough active shards that a cross-shard read over it would approach the per-invocation internal-subrequest ceiling. It measures **capacity, not observed fan-out**, and says so — the `shardTraffic` feeder reports live shards, not what any one invocation touched. Not a hard cap either: the real ceiling is 1,000 on Free but the configured limit (default 10,000) on Paid, so refusing at a fixed number would break deployments that work today.

The Limits page gains Pipelines and Workers AI/Vectorize sections, and its subrequest row — which said `50 (Free) / 1000 (Paid)` — now separates external from internal, since the internal ceiling is the one a cross-shard read spends.

## Audit result

Complete against the canonical binding list in `@lunora/platform`: D1/DO SQL, KV, R2, Analytics Engine, Vectorize, Queues all have an owner for every documented ceiling. Verified-correct-as-is: `browser`, `notify` (its Web Push 4 KB is a browser-vendor limit, not Cloudflare), `mail`, `images`, `container`, `observability`, and `agent` — whose 8 MB utterance cap bounds DO memory on a buffer that is never stored, so it does not meet the 2 MB row ceiling.

Left to the platform, now documented: Queues byte caps and Pipelines' 5 MB ingestion call. Measuring either means serializing every payload a second time on a send path, and both are rejected clearly by Cloudflare.

## Known, not addressed

`legacyRowPredicate` in `reprojection-backfill.ts` binds 5 parameters per field unchunked, so a table with 21+ `v.bigint()`/`v.bytes()` columns exceeds the parameter cap. Pre-existing and unreachable on Cloudflare before this branch too (it already failed); the new backstop now names it instead of letting SQLite do so. It wants its own change — chunking an `OR`-across-fields scan changes what the query means.

The global `patch`/`patchMany` branches still call no `recordWrite` at all, so the "unbounded rows to a `.global()` table" hole the insert comment describes remains open for patches. Pre-existing, untouched here.

## Testing

Both thermo review passes ran against this branch and their findings are folded in — including one that would have shipped CI red (a test that passed under Vitest while failing `lint:types`, since Vitest does not type-check) and one lint that would have fired a permanent false WARN on any app with 500+ tenants.

The depth test now measures terms-per-level rather than paren nesting, and was confirmed to fail against a flat `sql.join` — the previous version passed on the implementation it was meant to guard.

Green: shard-engine 1101, advisor 475, ai 124, sql-store 108, do 530, runtime 898; `api:check` matches all 47 snapshots; eslint, prettier and `lint:types` clean on every touched package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sk9BLaUZDkPVAZ1sKhuDP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added advisors for unusually high failure rates and broad shard fan-out before limits are approached.
  - Added documented limits for subrequests, Pipelines, Workers AI, and Vectorize.

- **Bug Fixes**
  - Improved validation for oversized Vectorize metadata, SQL statements, and bound parameters.
  - Improved database write metering and large SQL filter handling.
  - Improved reliability when processing large document backfills.

- **Documentation**
  - Added remediation guidance and updated runtime limit examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->