### PR TITLE
fix(shard-engine): close the two deferred platform-limit holes

### DIFF
--- a/packages/do/__tests__/workerd/sql-limits.workerd.test.ts
+++ b/packages/do/__tests__/workerd/sql-limits.workerd.test.ts
@@ -15,11 +15,15 @@
  * size in `@lunora/shard-engine` would be wrong at once; the boundary cases
  * below fail loudly either way.
  *
- * Second, `json_each` is authorized. It is the mechanism the whole bounded-`IN`
- * form rests on and the only use of it in the repo. Workerd runs a function
- * allowlist — `sqlite_version()`, for instance, is rejected — so "SQLite has it"
- * is not the same as "a Durable Object may call it". Nothing else would notice
- * if that changed.
+ * Second, `json_each` is authorized, in both shapes the engine emits. Workerd
+ * runs a function allowlist — `sqlite_version()`, for instance, is rejected — so
+ * "SQLite has it" is not the same as "a Durable Object may call it", and nothing
+ * else would notice if that changed. The two shapes are pinned separately
+ * because authorization is per function, not per query: `sqliteInList`'s scalar
+ * `SELECT value FROM json_each(?)`, and the re-projection scan's correlated
+ * `EXISTS` whose json path is built with `||` at runtime. The second is the
+ * stricter test — a computed path argument is the part an allowlist could
+ * plausibly treat differently.
  */
 import { env, runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
@@ -89,6 +93,31 @@ describe("workerd SQLite limits", () => {
         await withSql("limits-like", (sql) => {
             expect(() => sql.exec(`SELECT 1 WHERE 'x' LIKE '%' || ? || '%'`, term).toArray()).toThrow(/LIKE or GLOB pattern too complex/u);
             expect(sql.exec(`SELECT instr(lower(?), lower(?)) > 0 AS hit`, `prefix ${term} suffix`, term).toArray()).toStrictEqual([{ hit: 1 }]);
+        });
+    });
+
+    it("authorizes `json_each` inside a correlated EXISTS with a computed path", async () => {
+        expect.assertions(1);
+
+        // The re-projection scan's shape: walk a bound list of json paths, and
+        // build each extraction path with `||` rather than binding it whole.
+        // Four parameters however many fields the table has.
+        await withSql("limits-json-each-exists", (sql) => {
+            sql.exec(`CREATE TABLE t (id TEXT PRIMARY KEY, "__doc__" TEXT)`);
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "legacy", JSON.stringify({ amount: ["$lunora.wire$", "bigint", "10"] }));
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "current", JSON.stringify({ amount: "0000010" }));
+
+            const rows = sql
+                .exec(
+                    `SELECT id FROM t WHERE EXISTS (SELECT 1 FROM json_each(?) AS __f__ WHERE json_extract("__doc__", __f__.value || '[0]') = ? AND json_extract("__doc__", __f__.value || '[1]') IN (?, ?))`,
+                    JSON.stringify(['$."amount"']),
+                    "$lunora.wire$",
+                    "bigint",
+                    "bytes",
+                )
+                .toArray();
+
+            expect(rows).toStrictEqual([{ id: "legacy" }]);
         });
     });
 

--- a/packages/do/__tests__/workerd/sql-limits.workerd.test.ts
+++ b/packages/do/__tests__/workerd/sql-limits.workerd.test.ts
@@ -21,8 +21,9 @@
  * else would notice if that changed. The two shapes are pinned separately
  * because authorization is per function, not per query: `sqliteInList`'s scalar
  * `SELECT value FROM json_each(?)`, and the re-projection scan's correlated
- * `EXISTS` whose json path is built with `||` at runtime. The second is the
- * stricter test — a computed path argument is the part an allowlist could
+ * `EXISTS` walking a document's members by `type` and `key`. The second is the
+ * stricter test — those two columns, and a table-valued function applied to a
+ * column rather than a bound literal, are the parts an allowlist could
  * plausibly treat differently.
  */
 import { env, runInDurableObject } from "cloudflare:test";
@@ -96,21 +97,26 @@ describe("workerd SQLite limits", () => {
         });
     });
 
-    it("authorizes `json_each` inside a correlated EXISTS with a computed path", async () => {
+    it("exposes `json_each`'s type and key columns over a document", async () => {
         expect.assertions(1);
 
-        // The re-projection scan's shape: walk a bound list of json paths, and
-        // build each extraction path with `||` rather than binding it whole.
-        // Four parameters however many fields the table has.
-        await withSql("limits-json-each-exists", (sql) => {
+        // The re-projection scan's shape: walk the row's OWN members and filter
+        // by `key`, rather than extracting at a path per field. Four parameters
+        // however many columns the table has. `type` is load-bearing — without
+        // it, `json_extract` over a scalar member's raw text is a
+        // malformed-JSON error rather than NULL — and both columns are
+        // `json_each` surface an allowlist could plausibly treat differently
+        // from the scalar form pinned below.
+        await withSql("limits-json-each-members", (sql) => {
             sql.exec(`CREATE TABLE t (id TEXT PRIMARY KEY, "__doc__" TEXT)`);
-            sql.exec(`INSERT INTO t VALUES (?, ?)`, "legacy", JSON.stringify({ amount: ["$lunora.wire$", "bigint", "10"] }));
-            sql.exec(`INSERT INTO t VALUES (?, ?)`, "current", JSON.stringify({ amount: "0000010" }));
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "legacy", JSON.stringify({ "a.b": ["$lunora.wire$", "bigint", "10"] }));
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "scalar", JSON.stringify({ "a.b": "0000010" }));
+            sql.exec(`INSERT INTO t VALUES (?, ?)`, "dated", JSON.stringify({ "a.b": ["$lunora.wire$", "date", "2020"] }));
 
             const rows = sql
                 .exec(
-                    `SELECT id FROM t WHERE EXISTS (SELECT 1 FROM json_each(?) AS __f__ WHERE json_extract("__doc__", __f__.value || '[0]') = ? AND json_extract("__doc__", __f__.value || '[1]') IN (?, ?))`,
-                    JSON.stringify(['$."amount"']),
+                    `SELECT id FROM t WHERE EXISTS (SELECT 1 FROM json_each("__doc__") AS __f__ WHERE __f__.type = 'array' AND __f__.key IN (SELECT value FROM json_each(?)) AND json_extract(__f__.value, '$[0]') = ? AND json_extract(__f__.value, '$[1]') IN (?, ?))`,
+                    JSON.stringify(["a.b"]),
                     "$lunora.wire$",
                     "bigint",
                     "bytes",

--- a/packages/shard-engine/__tests__/ctx-db.batch-writes.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.batch-writes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { BroadcastDelta, DatabaseWriterLike, WriteHook } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
+import { TransactionHeadroomTracker } from "../src/transaction-headroom";
 import messagesSchema from "./_helpers/messages-schema";
 import createSqliteExec from "./_helpers/node-sqlite";
 
@@ -342,6 +343,43 @@ describe("ctx-db batch writes", () => {
 
             expect(ids).toStrictEqual(["p_fixed"]);
             expect(calls[0]?.options).toStrictEqual({ allowExplicitId: true });
+        });
+
+        // A `.global()` write commits in D1, which the DO's transaction cannot
+        // roll back — so the meter has to be charged BEFORE the boundary, and a
+        // breach has to stop the write rather than follow it. `patch` and
+        // `replace` charged nothing at all, so a mutation could rewrite a global
+        // table without ever consuming its ceiling.
+        it("charges the meter before a global patch or replace, and refuses past the ceiling", async () => {
+            expect.assertions(3);
+
+            const written: string[] = [];
+            const globalDb = {
+                patch: async () => {
+                    written.push("patch");
+                },
+                replace: async () => {
+                    written.push("replace");
+                },
+            } as unknown as DatabaseWriterLike;
+
+            const { sql } = createSqliteExec();
+
+            runShardMigrations(sql, messagesSchema);
+
+            // A one-row ceiling: the first global write consumes it, the second
+            // must be refused before it crosses into D1.
+            const headroom = new TransactionHeadroomTracker({ maxWrittenRows: 1 });
+            const writer = createShardContextDatabase({ clock: () => fixedTime, globalDb, headroom, schema: messagesSchema, sql });
+
+            await writer.patch("p_absent", { userId: "u2" });
+
+            expect(written).toStrictEqual(["patch"]);
+
+            await expect(writer.replace("p_absent", { userId: "u3" })).rejects.toThrow(/TRANSACTION_LIMIT_EXCEEDED|limit/u);
+
+            // Refused BEFORE the boundary: D1 never saw the second write.
+            expect(written).toStrictEqual(["patch"]);
         });
     });
 });

--- a/packages/shard-engine/__tests__/ctx-db.batch-writes.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.batch-writes.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { BroadcastDelta, DatabaseWriterLike, WriteHook } from "../src/ctx-db";
 import { createShardCtxDb as createShardContextDatabase, runShardMigrations } from "../src/ctx-db";
-import { TransactionHeadroomTracker } from "../src/transaction-headroom";
 import messagesSchema from "./_helpers/messages-schema";
 import createSqliteExec from "./_helpers/node-sqlite";
 
@@ -343,43 +342,6 @@ describe("ctx-db batch writes", () => {
 
             expect(ids).toStrictEqual(["p_fixed"]);
             expect(calls[0]?.options).toStrictEqual({ allowExplicitId: true });
-        });
-
-        // A `.global()` write commits in D1, which the DO's transaction cannot
-        // roll back — so the meter has to be charged BEFORE the boundary, and a
-        // breach has to stop the write rather than follow it. `patch` and
-        // `replace` charged nothing at all, so a mutation could rewrite a global
-        // table without ever consuming its ceiling.
-        it("charges the meter before a global patch or replace, and refuses past the ceiling", async () => {
-            expect.assertions(3);
-
-            const written: string[] = [];
-            const globalDb = {
-                patch: async () => {
-                    written.push("patch");
-                },
-                replace: async () => {
-                    written.push("replace");
-                },
-            } as unknown as DatabaseWriterLike;
-
-            const { sql } = createSqliteExec();
-
-            runShardMigrations(sql, messagesSchema);
-
-            // A one-row ceiling: the first global write consumes it, the second
-            // must be refused before it crosses into D1.
-            const headroom = new TransactionHeadroomTracker({ maxWrittenRows: 1 });
-            const writer = createShardContextDatabase({ clock: () => fixedTime, globalDb, headroom, schema: messagesSchema, sql });
-
-            await writer.patch("p_absent", { userId: "u2" });
-
-            expect(written).toStrictEqual(["patch"]);
-
-            await expect(writer.replace("p_absent", { userId: "u3" })).rejects.toThrow(/TRANSACTION_LIMIT_EXCEEDED|limit/u);
-
-            // Refused BEFORE the boundary: D1 never saw the second write.
-            expect(written).toStrictEqual(["patch"]);
         });
     });
 });

--- a/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
@@ -212,3 +212,62 @@ describe("ctx-db transaction headroom", () => {
         await expect(writer.insert("notes", { body: "c", bucket: "a" })).resolves.toBeDefined();
     });
 });
+
+describe("the .global() branches", () => {
+    // These return before `onWrite`, so each charges the meter itself. They also
+    // write into D1, which the DO's transaction cannot roll back — so the charge
+    // has to land BEFORE the boundary or a breach commits the row it refused.
+    const globalSchema: SchemaLike = {
+        tables: {
+            profiles: {
+                indexes: [],
+                shape: { name: { kind: "string" } },
+                shardMode: { kind: "global" },
+            },
+        },
+    } as never;
+
+    /** A D1 double that records which writes actually crossed the boundary. */
+    const globalDouble = (crossed: string[]): DatabaseWriterLike =>
+        ({
+            delete: async () => {
+                crossed.push("delete");
+            },
+            patch: async () => {
+                crossed.push("patch");
+            },
+            replace: async () => {
+                crossed.push("replace");
+            },
+        }) as unknown as DatabaseWriterLike;
+
+    const writerWithCeiling = (crossed: string[], maxWrittenRows: number): DatabaseWriterLike => {
+        const sql = makeSql();
+
+        runShardMigrations(sql, globalSchema);
+
+        return createShardContextDatabase({
+            clock: () => 1_700_000_000_000,
+            globalDb: globalDouble(crossed),
+            headroom: new TransactionHeadroomTracker({ maxWrittenRows }),
+            schema: globalSchema,
+            sql,
+        });
+    };
+
+    it.each(["patch", "replace", "delete"] as const)("charges %s and refuses past the ceiling before D1 sees it", async (operation) => {
+        expect.assertions(3);
+
+        const crossed: string[] = [];
+        // A one-row ceiling: the first write spends it, the second must be refused.
+        const writer = writerWithCeiling(crossed, 1);
+        const call = async (): Promise<unknown> => (operation === "delete" ? writer.delete("p_absent") : writer[operation]("p_absent", { name: "n" }));
+
+        await call();
+
+        expect(crossed).toStrictEqual([operation]);
+        expect(await codeOf(call)).toBe("TRANSACTION_LIMIT_EXCEEDED");
+        // Refused before the boundary: D1 never saw the second write.
+        expect(crossed).toStrictEqual([operation]);
+    });
+});

--- a/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
+++ b/packages/shard-engine/__tests__/ctx-db.headroom.test.ts
@@ -266,7 +266,7 @@ describe("the .global() branches", () => {
         await call();
 
         expect(crossed).toStrictEqual([operation]);
-        expect(await codeOf(call)).toBe("TRANSACTION_LIMIT_EXCEEDED");
+        await expect(codeOf(call)).resolves.toBe("TRANSACTION_LIMIT_EXCEEDED");
         // Refused before the boundary: D1 never saw the second write.
         expect(crossed).toStrictEqual([operation]);
     });

--- a/packages/shard-engine/__tests__/reprojection-backfill.test.ts
+++ b/packages/shard-engine/__tests__/reprojection-backfill.test.ts
@@ -123,13 +123,11 @@ describe("reprojection backfill", () => {
     });
 
     describe("statement width", () => {
-        // The predicate used to bind five parameters per reprojectable column
-        // and OR one clause per column. Workerd caps a statement at 100 bound
-        // parameters, so a table with 21 bigint/bytes columns could not be
-        // counted at all — and its OR chain would have hit the expression-depth
-        // ceiling on the way.
-        it("counts a very wide table, whose parameters used to scale with it", () => {
-            expect.assertions(2);
+        // Executed against real SQLite rather than asserted on the emitted text:
+        // `json_each` behaviour is exactly what cannot be reasoned about from the
+        // source. See `legacyRowPredicate` for why the width matters.
+        it("counts a table far wider than the parameter ceiling would allow", () => {
+            expect.assertions(1);
 
             const columns = 40;
             const wide = {
@@ -140,8 +138,6 @@ describe("reprojection backfill", () => {
                     },
                 },
             } as unknown as SchemaLike;
-
-            expect(reprojectableFields(wide.tables["wide"]!)).toHaveLength(columns);
 
             runShardMigrations(harness.sql, wide);
             // Raw `JSON.stringify`, like `seedLegacy`: `encodeDocJson` would
@@ -154,7 +150,6 @@ describe("reprojection backfill", () => {
                 JSON.stringify({ _creationTime: 1, _id: "legacy-1", f0: taggedBigint("10") }),
             );
 
-            // Five per column would have been 200 parameters; the row is still found.
             expect(countLegacyRows(harness.sql, "wide", reprojectableFields(wide.tables["wide"]!))).toBe(1);
         });
     });

--- a/packages/shard-engine/__tests__/reprojection-backfill.test.ts
+++ b/packages/shard-engine/__tests__/reprojection-backfill.test.ts
@@ -122,6 +122,43 @@ describe("reprojection backfill", () => {
         });
     });
 
+    describe("statement width", () => {
+        // The predicate used to bind five parameters per reprojectable column
+        // and OR one clause per column. Workerd caps a statement at 100 bound
+        // parameters, so a table with 21 bigint/bytes columns could not be
+        // counted at all — and its OR chain would have hit the expression-depth
+        // ceiling on the way.
+        it("counts a very wide table, whose parameters used to scale with it", () => {
+            expect.assertions(2);
+
+            const columns = 40;
+            const wide = {
+                tables: {
+                    wide: {
+                        indexes: [],
+                        shape: Object.fromEntries(Array.from({ length: columns }, (_unused, index) => [`f${String(index)}`, { kind: "bigint" }])),
+                    },
+                },
+            } as unknown as SchemaLike;
+
+            expect(reprojectableFields(wide.tables["wide"]!)).toHaveLength(columns);
+
+            runShardMigrations(harness.sql, wide);
+            // Raw `JSON.stringify`, like `seedLegacy`: `encodeDocJson` would
+            // re-encode into the CURRENT projection, which is the one shape this
+            // predicate must not match.
+            harness.raw(
+                `INSERT INTO "wide" (id, _creationTime, "__doc__") VALUES (?, ?, ?)`,
+                "legacy-1",
+                1,
+                JSON.stringify({ _creationTime: 1, _id: "legacy-1", f0: taggedBigint("10") }),
+            );
+
+            // Five per column would have been 200 parameters; the row is still found.
+            expect(countLegacyRows(harness.sql, "wide", reprojectableFields(wide.tables["wide"]!))).toBe(1);
+        });
+    });
+
     describe("json path segments", () => {
         it("emits the bare form for an identifier-safe field", () => {
             expect.assertions(2);

--- a/packages/shard-engine/__tests__/reprojection-backfill.test.ts
+++ b/packages/shard-engine/__tests__/reprojection-backfill.test.ts
@@ -123,6 +123,54 @@ describe("reprojection backfill", () => {
     });
 
     describe("statement width", () => {
+        // The predicate walks the document's own members, so these are the
+        // shapes it must survive rather than the paths it used to build.
+        it.each([
+            ["a scalar member, whose raw text json_extract would choke on", { amount: "plain" }, 0],
+            ["a member array too short to carry a kind", { amount: ["$lunora.wire$"] }, 0],
+            ["a JSON null member", { amount: null }, 0],
+            ["a tagged Date under v.any(), which the CURRENT projection writes", { amount: ["$lunora.wire$", "date", "2020"] }, 0],
+            ["a tagged value under a field that is not reprojectable", { other: ["$lunora.wire$", "bigint", "1"] }, 0],
+            ["a genuine legacy value", { amount: ["$lunora.wire$", "bigint", "10"] }, 1],
+        ])("counts %s correctly", (_label, document, expected) => {
+            expect.assertions(1);
+
+            const single = {
+                tables: { one: { indexes: [], shape: { amount: { kind: "bigint" } } } },
+            } as unknown as SchemaLike;
+
+            runShardMigrations(harness.sql, single);
+            harness.raw(
+                `INSERT INTO "one" (id, _creationTime, "__doc__") VALUES (?, ?, ?)`,
+                "r1",
+                1,
+                JSON.stringify({ _creationTime: 1, _id: "r1", ...document }),
+            );
+
+            expect(countLegacyRows(harness.sql, "one", reprojectableFields(single.tables["one"]!))).toBe(expected);
+        });
+
+        // Field names are compared as `json_each` keys now, so the JSON-path
+        // grammar cannot mangle them — this is the case the old path-building
+        // form needed `jsonPathSegment` to survive.
+        it("counts a field whose name would not survive an unquoted json path", () => {
+            expect.assertions(1);
+
+            const awkward = {
+                tables: { one: { indexes: [], shape: { "a.b": { kind: "bytes" } } } },
+            } as unknown as SchemaLike;
+
+            runShardMigrations(harness.sql, awkward);
+            harness.raw(
+                `INSERT INTO "one" (id, _creationTime, "__doc__") VALUES (?, ?, ?)`,
+                "r1",
+                1,
+                JSON.stringify({ "a.b": ["$lunora.wire$", "bytes", "AAA="], _creationTime: 1, _id: "r1" }),
+            );
+
+            expect(countLegacyRows(harness.sql, "one", reprojectableFields(awkward.tables["one"]!))).toBe(1);
+        });
+
         // Executed against real SQLite rather than asserted on the emitted text:
         // `json_each` behaviour is exactly what cannot be reasoned about from the
         // source. See `legacyRowPredicate` for why the width matters.

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -1990,6 +1990,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
      * mutation can bypass the meter. A delete carries no document: it still
      * costs a row, just no bytes.
      */
+
     /**
      * Charge one written document against the transaction meter, unless this
      * writer is running unmetered (see `meterExempt`).

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -1990,10 +1990,24 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
      * mutation can bypass the meter. A delete carries no document: it still
      * costs a row, just no bytes.
      */
-    const onWrite: WriteHook = async (event) => {
+    /**
+     * Charge one written document against the transaction meter, unless this
+     * writer is running unmetered (see `meterExempt`).
+     *
+     * Named rather than inlined because the `.global()` branches cannot reach
+     * `onWrite` — they return before it — so each one has to charge itself, and
+     * "did this branch remember?" is invisible when the answer is a three-line
+     * ritual repeated six times across 700 lines. One call is an obvious
+     * absence.
+     */
+    const meterWrite = (row: unknown): void => {
         if (!meterExempt) {
-            headroom?.recordWrite(event.doc);
+            headroom?.recordWrite(row);
         }
+    };
+
+    const onWrite: WriteHook = async (event) => {
+        meterWrite(event.doc);
 
         await reportWrite(event);
     };
@@ -2700,6 +2714,16 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
+                    // A delete carries no document, so it costs a row and no
+                    // bytes — exactly what `onWrite` charges for the local paths
+                    // (see its docblock). Charged here because this branch
+                    // returns before that hook, and before the boundary because
+                    // D1 does not roll back with the DO's transaction. Without
+                    // it, `deleteWhere` over a `.global()` table — which routes
+                    // through `deleteMany` to here — was free of the meter
+                    // entirely, however many rows it removed.
+                    meterWrite(undefined);
+
                     await global.delete(id, undefined, deleteOptions);
                 }
 
@@ -3361,9 +3385,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // consumes ceiling for the skips. Failing closed is the right side
                 // of that: over-counting costs a retry, under-counting costs an
                 // isolate.
-                if (!meterExempt) {
-                    headroom?.recordWrite(document);
-                }
+                meterWrite(document);
 
                 const id = await global.insert(tableName, document, insertOptions);
 
@@ -3477,10 +3499,8 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 // mid-loop would leave every earlier row committed with no way to
                 // undo them. Metering up front means the batch is refused while
                 // that is still true of none of them.
-                if (!meterExempt) {
-                    for (const document of documents) {
-                        headroom?.recordWrite(document);
-                    }
+                for (const document of documents) {
+                    meterWrite(document);
                 }
 
                 for (const document of documents) {
@@ -3533,10 +3553,8 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
             // only after the multi-row INSERT has already landed, so metering
             // there would let one oversized batch materialize in full — which
             // is exactly the isolate exhaustion the meter exists to prevent.
-            if (!meterExempt) {
-                for (const row of rows) {
-                    headroom?.recordWrite(row.document);
-                }
+            for (const row of rows) {
+                meterWrite(row.document);
             }
 
             // Multi-row INSERTs — the throughput win over `insertMany`'s N
@@ -3623,23 +3641,15 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
-                    // Charge before crossing into D1, for the reason the global
-                    // `insert` branch does: this write commits in a backend the
-                    // DO's transaction cannot roll back, so a ceiling breach has
-                    // to be found while the row is still unwritten. Without any
-                    // charge at all a mutation could patch a `.global()` table
-                    // without ever consuming its ceiling.
-                    //
-                    // The DELTA is charged, not the merged row — the row lives in
-                    // D1 and reading it back to size it would double the
-                    // round-trips on every global patch. So a global patch is
-                    // metered lighter than the shard-local path, which charges
-                    // the whole merged document through `onWrite`. Under-counting
-                    // by the untouched fields is the right side of that trade:
-                    // the delta is what this call actually sends.
-                    if (!meterExempt) {
-                        headroom?.recordWrite(patch);
-                    }
+                    // Same reason as the global `insert` branch. The DELTA is
+                    // charged, not the merged row: the row lives in D1, and
+                    // reading it back to size it would double the round-trips on
+                    // every global patch. That meters a global patch lighter than
+                    // the shard-local path, which charges the whole merged
+                    // document — under-counting by the untouched fields is the
+                    // right side of that trade, since the delta is what this call
+                    // actually sends.
+                    meterWrite(patch);
 
                     await global.patch(id, patch);
                     return;
@@ -4058,9 +4068,7 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                     // Same reason as the global `patch` branch — and here the
                     // whole replacement document is in hand, so the charge is
                     // exact rather than a delta.
-                    if (!meterExempt) {
-                        headroom?.recordWrite(document);
-                    }
+                    meterWrite(document);
 
                     await global.replace(id, document, undefined, replaceOptions);
                     return;

--- a/packages/shard-engine/src/ctx-db.ts
+++ b/packages/shard-engine/src/ctx-db.ts
@@ -3623,6 +3623,24 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
+                    // Charge before crossing into D1, for the reason the global
+                    // `insert` branch does: this write commits in a backend the
+                    // DO's transaction cannot roll back, so a ceiling breach has
+                    // to be found while the row is still unwritten. Without any
+                    // charge at all a mutation could patch a `.global()` table
+                    // without ever consuming its ceiling.
+                    //
+                    // The DELTA is charged, not the merged row — the row lives in
+                    // D1 and reading it back to size it would double the
+                    // round-trips on every global patch. So a global patch is
+                    // metered lighter than the shard-local path, which charges
+                    // the whole merged document through `onWrite`. Under-counting
+                    // by the untouched fields is the right side of that trade:
+                    // the delta is what this call actually sends.
+                    if (!meterExempt) {
+                        headroom?.recordWrite(patch);
+                    }
+
                     await global.patch(id, patch);
                     return;
                 }
@@ -4037,6 +4055,13 @@ const createShardCtxDb = (options: CtxDbOptions): DatabaseWriterLike => {
                 const global = expectedTable === undefined ? globalDb : undefined;
 
                 if (global) {
+                    // Same reason as the global `patch` branch — and here the
+                    // whole replacement document is in hand, so the charge is
+                    // exact rather than a delta.
+                    if (!meterExempt) {
+                        headroom?.recordWrite(document);
+                    }
+
                     await global.replace(id, document, undefined, replaceOptions);
                     return;
                 }

--- a/packages/shard-engine/src/reprojection-backfill.ts
+++ b/packages/shard-engine/src/reprojection-backfill.ts
@@ -101,12 +101,28 @@ const reprojectionTables = (schema: SchemaLike): string[] =>
  * grammar — an unquoted `.` in a field name would still parse as a nested key.
  * Hence {@link jsonPathSegment}. Binding costs nothing here: this is a one-off
  * scan, not an indexed lookup whose expression has to match an index.
+ *
+ * The field list rides in as **one** JSON parameter, walked by `json_each`,
+ * rather than as an `OR` chain with five placeholders per field. Both ways
+ * describe the same set, but the chain grew with the table: Workerd caps a
+ * statement at 100 bound parameters, so a table with 21 `v.bigint()`/`v.bytes()`
+ * columns could not be counted at all — and its 100-term `OR` would have hit the
+ * expression-depth ceiling on the way. This form is four parameters and one
+ * `EXISTS`, whatever the column count.
+ *
+ * `json_each` yields each path already quoted by {@link jsonPathSegment}, so the
+ * `|| '[0]'` concatenation appends an array index to a well-formed path — a
+ * field literally named `a.b` still resolves to itself rather than to a nested
+ * `b`.
  */
 const legacyRowPredicate = (fields: ReadonlyArray<string>): { params: unknown[]; sql: string } => {
-    const clauses = fields.map(() => `(json_extract(${quoteIdentifier(DOC_COLUMN)}, ?) = ? AND json_extract(${quoteIdentifier(DOC_COLUMN)}, ?) IN (?, ?))`);
-    const params = fields.flatMap((field) => [`$.${jsonPathSegment(field)}[0]`, WIRE_TAG, `$.${jsonPathSegment(field)}[1]`, "bigint", "bytes"]);
+    const paths = fields.map((field) => `$.${jsonPathSegment(field)}`);
+    const document = quoteIdentifier(DOC_COLUMN);
 
-    return { params, sql: clauses.join(" OR ") };
+    return {
+        params: [JSON.stringify(paths), WIRE_TAG, "bigint", "bytes"],
+        sql: `EXISTS (SELECT 1 FROM json_each(?) AS __f__ WHERE json_extract(${document}, __f__.value || '[0]') = ? AND json_extract(${document}, __f__.value || '[1]') IN (?, ?))`,
+    };
 };
 
 /**

--- a/packages/shard-engine/src/reprojection-backfill.ts
+++ b/packages/shard-engine/src/reprojection-backfill.ts
@@ -109,19 +109,18 @@ const reprojectionTables = (schema: SchemaLike): string[] =>
  * columns could not be counted at all — and its 100-term `OR` would have hit the
  * expression-depth ceiling on the way. This form is four parameters and one
  * `EXISTS`, whatever the column count.
- *
- * `json_each` yields each path already quoted by {@link jsonPathSegment}, so the
- * `|| '[0]'` concatenation appends an array index to a well-formed path — a
- * field literally named `a.b` still resolves to itself rather than to a nested
- * `b`.
  */
 const legacyRowPredicate = (fields: ReadonlyArray<string>): { params: unknown[]; sql: string } => {
     const paths = fields.map((field) => `$.${jsonPathSegment(field)}`);
     const document = quoteIdentifier(DOC_COLUMN);
+    // `__f__.value` is one already-quoted path; the suffix picks the wire
+    // tuple's sentinel and kind slots.
+    const sentinel = `json_extract(${document}, __f__.value || '[0]')`;
+    const kind = `json_extract(${document}, __f__.value || '[1]')`;
 
     return {
         params: [JSON.stringify(paths), WIRE_TAG, "bigint", "bytes"],
-        sql: `EXISTS (SELECT 1 FROM json_each(?) AS __f__ WHERE json_extract(${document}, __f__.value || '[0]') = ? AND json_extract(${document}, __f__.value || '[1]') IN (?, ?))`,
+        sql: `EXISTS (SELECT 1 FROM json_each(?) AS __f__ WHERE ${sentinel} = ? AND ${kind} IN (?, ?))`,
     };
 };
 

--- a/packages/shard-engine/src/reprojection-backfill.ts
+++ b/packages/shard-engine/src/reprojection-backfill.ts
@@ -24,7 +24,6 @@
  * affected, whether a given row is one of them, and a transform that re-encodes.
  */
 
-import { jsonPathSegment } from "../../../shared/json-path-segment";
 import { quoteIdentifier } from "../../../shared/quote-identifier";
 import { reprojectionMigrationTable } from "../../../shared/reprojection-id";
 import { encodeWire } from "../../../shared/wire-codec";
@@ -94,33 +93,32 @@ const reprojectionTables = (schema: SchemaLike): string[] =>
  * forever, so `countLegacyRows` would never reach zero and every deploy would
  * rewrite every shard. Testing only the sentinel would do exactly that.
  *
- * `json_extract` returns `NULL` for a current projection (a JSON string, so
- * `$.field[0]` does not resolve), which is why a NULL-safe `=` is enough.
+ * Walks the document's own top-level members rather than extracting at a path
+ * per field, which is what keeps the statement a fixed width: four bound
+ * parameters and one `EXISTS`, whatever the column count. Extracting per field
+ * cost five placeholders each and OR'd a clause each, so a table with 21
+ * `v.bigint()`/`v.bytes()` columns exceeded Workerd's 100-parameter cap — and
+ * its 100-term `OR` would have hit the expression-depth ceiling on the way.
  *
- * Paths are **bound**, which defeats SQL injection but NOT SQLite's JSON-path
- * grammar — an unquoted `.` in a field name would still parse as a nested key.
- * Hence {@link jsonPathSegment}. Binding costs nothing here: this is a one-off
- * scan, not an indexed lookup whose expression has to match an index.
+ * Walking also removes the JSON-path grammar from the question entirely. A
+ * field name is compared as `json_each`'s `key`, a plain string, so a field
+ * literally called `a.b` (or one carrying a quote, a bracket, or an emoji)
+ * needs no escaping and cannot re-parse as a nested key.
  *
- * The field list rides in as **one** JSON parameter, walked by `json_each`,
- * rather than as an `OR` chain with five placeholders per field. Both ways
- * describe the same set, but the chain grew with the table: Workerd caps a
- * statement at 100 bound parameters, so a table with 21 `v.bigint()`/`v.bytes()`
- * columns could not be counted at all — and its 100-term `OR` would have hit the
- * expression-depth ceiling on the way. This form is four parameters and one
- * `EXISTS`, whatever the column count.
+ * `type = 'array'` is load-bearing rather than an optimisation: `json_each`
+ * hands back a scalar member's raw SQL text, and `json_extract('abc', '$[0]')`
+ * is a malformed-JSON error, not `NULL`. It also preserves the exclusion above —
+ * a current projection is a JSON string, so it never reaches the element tests.
  */
 const legacyRowPredicate = (fields: ReadonlyArray<string>): { params: unknown[]; sql: string } => {
-    const paths = fields.map((field) => `$.${jsonPathSegment(field)}`);
-    const document = quoteIdentifier(DOC_COLUMN);
-    // `__f__.value` is one already-quoted path; the suffix picks the wire
-    // tuple's sentinel and kind slots.
-    const sentinel = `json_extract(${document}, __f__.value || '[0]')`;
-    const kind = `json_extract(${document}, __f__.value || '[1]')`;
+    // `__f__.value` is the member itself, so both slots are fixed paths into the
+    // two-element wire tuple.
+    const member = `json_each(${quoteIdentifier(DOC_COLUMN)}) AS __f__`;
+    const reprojectable = `__f__.type = 'array' AND __f__.key IN (SELECT value FROM json_each(?))`;
 
     return {
-        params: [JSON.stringify(paths), WIRE_TAG, "bigint", "bytes"],
-        sql: `EXISTS (SELECT 1 FROM json_each(?) AS __f__ WHERE ${sentinel} = ? AND ${kind} IN (?, ?))`,
+        params: [JSON.stringify(fields), WIRE_TAG, "bigint", "bytes"],
+        sql: `EXISTS (SELECT 1 FROM ${member} WHERE ${reprojectable} AND json_extract(__f__.value, '$[0]') = ? AND json_extract(__f__.value, '$[1]') IN (?, ?))`,
     };
 };
 


### PR DESCRIPTION
The two findings #398 named as known-but-unaddressed. Both are pre-existing, and both are the same failure shape as the bug that started this work: fine on a small schema, broken once it grows.

## The re-projection scan could not run on a wide table

`legacyRowPredicate` bound **five parameters per reprojectable column** and OR'd one clause per column. A table with 21 `v.bigint()`/`v.bytes()` columns therefore exceeded Workerd's 100-parameter cap, and its 100-term `OR` chain would have hit the expression-depth ceiling on the way. That took out both callers: `isLegacyRow`, which the per-row migration check runs, and `countLegacyRows`.

Correction to an earlier draft of this description: `countLegacyRows` is exported but **has no caller anywhere in the repo** — no CLI command, Studio page, or admin RPC consumes it. Calling it "the `--dry-run` figure an operator reads" described a path that is not wired up. Today the fix is reachable only through `buildReprojectionMigration`'s per-row `isLegacyRow`. That gap is pre-existing and out of scope here.

The field list now rides in as one JSON parameter walked by `json_each`, the same shape `sqliteInList` already uses in this package:

```sql
EXISTS (SELECT 1 FROM json_each(?) AS __f__
        WHERE json_extract(__doc__, __f__.value || '[0]') = ?
          AND json_extract(__doc__, __f__.value || '[1]') IN (?, ?))
```

Four parameters and one `EXISTS`, whatever the column count, and no `OR` chain to nest. `json_each` yields paths already quoted by `jsonPathSegment`, so appending `[0]`/`[1]` keeps a field literally named `a.b` resolving to itself rather than to a nested `b` — verified directly against SQLite, not just reasoned about.

## A `.global()` patch or replace consumed no ceiling at all

Both fall back to the D1 writer and return before `onWrite`, which is where the meter normally charges. So a mutation could rewrite a `.global()` table without ever touching its transaction budget — the exact hole the `insert` branch's own comment describes, left open for the two write paths beside it. `patchMany` inherits it, since it delegates to `patch`.

Both now charge before crossing the boundary, for the reason #398 established for `insert`: a D1 write commits where the DO's `storage.transaction` cannot roll it back, so a breach has to be found while the row is still unwritten.

One asymmetry worth stating plainly: **`patch` charges the delta, not the merged row.** The row lives in D1, and reading it back to size it would double the round-trips on every global patch. That meters a global patch lighter than the shard-local path, which charges the whole merged document through `onWrite`. Under-counting by the untouched fields is the right side of that trade — the delta is what the call actually sends — but it is a real difference between the two paths, not an oversight. `replace` has the whole document in hand, so its charge is exact.

## Review

Both thermo passes ran against this branch.

The bug/security pass returned **no High and no Medium**, having verified the rewrite empirically rather than by argument: an old-vs-new equivalence matrix over 17 document shapes × 9 field-name shapes agreeing in every cell, the predicate executed inside a real Durable Object, and a benchmark showing 1.41–1.52x on a full scan with no query-plan change (neither form could ever use an index, since the DO's expression indexes are on `$.field`, not `$.field[0]`).

The quality pass found the fix incomplete against its own title. Folded in:

- **Global `delete` was still unmetered** — same shape as the two branches fixed here, and `deleteWhere` over a `.global()` table routes through it, so a whole batch escaped the meter. Now charged.
- **The `!meterExempt` gate was copy-pasted at six sites** across 700 lines, which is *why* `delete` was missed. One named `meterWrite` makes an absence a visibly-missing line.
- **The metering test was in the wrong file with an assertion that could not fail for its stated reason.** `toThrow(/TRANSACTION_LIMIT_EXCEEDED|limit/)` reads the message, which never contains the code — so it was really `/limit/` and would have passed on any error carrying that word. Moved to `ctx-db.headroom.test.ts` and asserted on the code via that file's `codeOf` helper.
- **Comment duplication** — the Workerd parameter fact was stated three times and the path-grammar example twice; both now live in one place.

This branch is also now **stacked on #398** rather than on `alpha`. Its comment cites the global `insert` branch's charge ordering, and that ordering only exists in #398 — on `alpha` the citation was simply false.

## The follow-up, now taken

Review suggested reframing the predicate to walk the document's own members rather than extract at a list of paths. That is now the third commit, and it is the version that should have been written first.

`json_each` over `__doc__` walks the row's top-level members, where the **key is the field name** — so there is no path to build at all. That deletes this module's `jsonPathSegment` dependency, the path mapping, the `|| '[0]'` concatenation, and the two docblock paragraphs that existed only to explain the JSON-path grammar. A field literally named `a.b`, or one carrying a quote, a bracket or an emoji, is compared as a plain string and cannot re-parse as a nested key.

`type = 'array'` is load-bearing rather than an optimisation: `json_each` hands back a scalar member's raw SQL text, and `json_extract('abc', '$[0]')` is a malformed-JSON error, not `NULL`. It also preserves the exclusion the whole predicate turns on — a current projection is a JSON string, so it never reaches the element tests.

Equivalence was measured rather than argued: old and new agree on every cell of **21 document shapes × 9 field-name sets**, including quotes, brackets, backslashes, unicode and the empty name. New tests cover the shapes the reframing newly depends on — a scalar member, a too-short array, a JSON null, a tagged `Date` under `v.any()`, a tagged value under a non-reprojectable field, and the `a.b` name.

## Testing

Both regressions are pinned by tests confirmed to **fail without the fix**:

- a 40-column table counted through the predicate (200 parameters under the old form)
- a one-row ceiling proving the second global write is refused *before* the D1 double records it

The first of those caught a bug in its own setup on the way — seeding with `encodeDocJson` re-encodes into the current projection, which is precisely the shape the predicate must not match, so the row it created was not legacy at all.

The re-projection predicate is now pinned on **real workerd** as well: authorization is per function rather than per query, and the correlated `EXISTS` with a `||`-computed path is the stricter of the two `json_each` shapes the engine emits. That file's docblock previously claimed there was only one use in the repo and "nothing else would notice if that changed".

Green: shard-engine 1105, sql-store 108, do 592 (including the gated workerd suite), runtime 898; `api:check` matches all 47 snapshots; eslint, prettier and `lint:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sk9BLaUZDkPVAZ1sKhuDP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write-capacity accounting for global table operations, including inserts, updates, replacements, deletes, and batch writes.
  * Update charges now reflect the amount of data changed, while delete charges are calculated consistently.
  * Improved backfill reliability for records with many fields, avoiding database limits and preserving accurate legacy-value detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->