### PR TITLE
docs: correct the claims the platform-limit guards outdated

### DIFF
--- a/apps/docs/src/content/docs/concepts/vector-search.mdx
+++ b/apps/docs/src/content/docs/concepts/vector-search.mdx
@@ -102,7 +102,12 @@ reactive `query`.
 ### Similarity search
 
 `query` takes either a precomputed `vector` or an `input` plus an `embed`
-function. `topK` is capped at 100; `filter` and `namespace` scope the search.
+function. `filter` and `namespace` scope the search.
+
+`topK` is capped at 100 for id/score-only queries, and at 20 once the query also
+asks for the heavy payload — `returnValues: true` or `returnMetadata: "all"`.
+Over either ceiling the call is refused locally with a message naming which one
+applied, rather than being silently capped at the far side.
 
 ```ts
 // lunora/searchDocs.ts

--- a/packages/ai/docs/index.mdx
+++ b/packages/ai/docs/index.mdx
@@ -121,11 +121,22 @@ What you get beyond the manual loop:
   on the trace waterfall. A hand-built context without `ctx.trace` embeds untraced.
 
 Chunk text lives in vector metadata by default (`returnMetadata: "all"`, `topK`
-capped at 20 by Vectorize, ~10 KiB metadata per vector). For long documents or
-deeper retrieval, supply a `textStore` (`{ put, getMany, remove? }` — a DO table,
-KV, …): text moves out of metadata and the `topK` ceiling lifts to 100. The
-default chunker is a fixed 1000-char window with 200 overlap; pass `chunk` for
+capped at 20, 10 KiB of metadata per vector). For long documents or deeper
+retrieval, supply a `textStore` (`{ put, getMany, remove? }` — a DO table, KV,
+…): text moves out of metadata and the `topK` ceiling lifts to 100. The default
+chunker is a fixed 1000-char window with 200 overlap; pass `chunk` for
 token/sentence/semantic strategies.
+
+The 10 KiB is Vectorize's, and it covers the **whole** metadata object — chunk
+text, Lunora's bookkeeping keys, and any `metadata` you attach. `defineRag`
+measures each chunk's metadata as it is assembled and refuses one that would not
+fit, rather than letting the upsert fail at Vectorize with nothing naming the
+cause. It also rejects an unworkable `chunkSize` up front, though that earlier
+check can only compare characters against a byte ceiling — multibyte text costs
+up to three bytes each, so the index-time measurement is the one that holds.
+
+The `topK` 20 is **Lunora's** cap, not Vectorize's: Vectorize allows 50 with
+full metadata. Ours is a legacy-V1 holdover.
 
 ### Bring your own embeddings — no `env.AI` binding
 

--- a/packages/server/docs/index.mdx
+++ b/packages/server/docs/index.mdx
@@ -257,7 +257,7 @@ Three constraints are deliberate:
   publish. Keep the list to indexed columns; `@lunora/advisor`'s
   `filter-without-index` lint flags the static cases. This bounds _which_ columns
   are reachable, not the cost of every operator: `contains` compiles to a
-  leading-wildcard `LIKE`, and `ne` / `notIn` / `isNull: false` are non-sargable
+  substring position test, and `ne` / `notIn` / `isNull: false` are non-sargable
   too, so all of them scan regardless of the index.
 - **No `AND` / `OR` / `NOT` trees.** A flat field⇒predicate map keeps every
   filter routable to an index. Compose richer logic inside the procedure.
@@ -265,8 +265,9 @@ Three constraints are deliberate:
 `limit` is clamped into `[1, maxLimit]` rather than rejected, and `orderBy`
 fields outside the allow-list are refused by the validator and re-checked in
 `toQueryArgs`. `in` / `notIn` arrays are capped at `maxInValues` (default 100)
-because each element becomes a bound parameter, and `orderBy` at `maxOrderBy`
-(default 8).
+to bound request size and the scan the predicate costs — not to stay under the
+statement's parameter ceiling, which the `where` compiler handles by binding a
+long list as one JSON parameter. `orderBy` is capped at `maxOrderBy` (default 8).
 
 `lunora introspect` emits `list` procedures built on this helper — see the
 [CLI docs](/docs/packages/cli#lunora-introspect).


### PR DESCRIPTION
Three pages still described behaviour that has since changed. Each is the
package-level copy of a claim whose site-level twin was already corrected, so
the two now disagreed with each other as well as with the code.

## `@lunora/ai`

Attributed its own `topK` cap of 20 to Vectorize. Vectorize allows **50** with
full metadata — the 20 is ours, a legacy-V1 holdover. This is the same
conflation the Limits page was corrected for; the package copy was missed.

It also said nothing about the metadata ceiling being checked. It now describes
both the index-time measurement and, explicitly, what the config-time
`chunkSize` check cannot see: `chunkSize` counts characters against a byte
ceiling, so multibyte text costs up to three bytes each and the index-time
measurement is the one that holds.

## `@lunora/server`

Still said `contains` compiles to a leading-wildcard `LIKE`. It compiles to a
substring position test — the source docblock was corrected, its docs copy was
not.

The neighbouring claim that `maxInValues` exists "because each element becomes a
bound parameter" is no longer the reason either: a long list binds as one JSON
parameter. The cap is real and still wanted, but it bounds request size and scan
cost.

## Vector search

Documented `topK`'s ceiling of 100 without the tighter bound of **20** that
`ctx.vectors.query` actually throws on when the query asks for values or full
metadata — so the page described a call the binding refuses.

## Not changed

`MAX_TOP_K_FULL_METADATA` (`@lunora/ai`) and `MAX_TOP_K_WITH_VALUES`
(`@lunora/bindings`) both still cap at 20 where Cloudflare now allows 50 for
`returnMetadata: "all"`. Raising either is a behaviour change and the two
constants conflate `returnValues` with `returnMetadata`, which may not share a
ceiling — that wants its own change. Both are now documented as ours rather than
the platform's, which is what made them look like facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified similarity-search `topK` limits based on the requested response fields, with clear errors for values exceeding the applicable limit.
  - Documented RAG metadata size limits, chunk validation, multibyte-character considerations, and `topK` enforcement.
  - Clarified which list predicates scan independently of indexes and how list-size limits affect request and scan costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->