### PR TITLE
test(templates): close the template typecheck floor

### DIFF
--- a/scripts/template-build-smoke.sh
+++ b/scripts/template-build-smoke.sh
@@ -193,11 +193,28 @@ run_typecheck() {
         } catch { process.stdout.write('no'); }
     " 2>/dev/null)"
 
+    # Returns the checker's exit status — callers need it. A `|| true` here would
+    # make "the checker refused to run" (missing binary, a failed `lunora codegen`
+    # inside a template's own `typecheck` script) indistinguishable from a clean
+    # pass, because neither produces an `error TS` line to grep for.
     if [[ "$has_script" == "yes" ]]; then
-        (cd "$scaffold_dir" && pnpm run typecheck 2>&1) > "$log" || true
+        (cd "$scaffold_dir" && pnpm run typecheck 2>&1) > "$log"
     else
-        (cd "$scaffold_dir" && pnpm exec tsc --noEmit 2>&1) > "$log" || true
+        (cd "$scaffold_dir" && pnpm exec tsc --noEmit 2>&1) > "$log"
     fi
+}
+
+# ---------------------------------------------------------------------------
+# A nonzero typecheck exit is only interesting when NOTHING was reported: `tsc`
+# exits 1 whenever it finds type errors, and those are gated (and printed) by the
+# caller. An exit with no diagnostic at all means the checker never got as far as
+# reading source, so a green result would prove nothing.
+# ---------------------------------------------------------------------------
+typecheck_never_ran() {
+    local status="$1"
+    local log="$2"
+
+    [[ "$status" -ne 0 ]] && ! grep -q 'error TS' "$log"
 }
 
 is_typecheck_unsupported() {
@@ -485,7 +502,15 @@ for tname in "${TEMPLATES[@]}"; do
         fi
 
         typecheck_log="$RESULTS_DIR/${tname}-typecheck.log"
-        run_typecheck "$scaffold_dir" "$typecheck_log"
+        typecheck_status=0
+        run_typecheck "$scaffold_dir" "$typecheck_log" || typecheck_status=$?
+
+        if typecheck_never_ran "$typecheck_status" "$typecheck_log"; then
+            echo "  FAIL: the typecheck command in $tname exited $typecheck_status without reporting a diagnostic (see $typecheck_log)"
+            tail -20 "$typecheck_log" | sed 's/^/    /'
+            FAIL+=("$tname(typecheck:never-ran)")
+            continue
+        fi
 
         ts_errors="$(grep -c 'error TS' "$typecheck_log" || true)"
         if [[ "$ts_errors" -gt 0 ]]; then
@@ -531,7 +556,15 @@ for tname in "${TEMPLATES[@]}"; do
         else
             echo "  ==> typecheck (compiling the copied screens)"
             typecheck_log="$RESULTS_DIR/${tname}-typecheck.log"
-            run_typecheck "$scaffold_dir" "$typecheck_log"
+            typecheck_status=0
+            run_typecheck "$scaffold_dir" "$typecheck_log" || typecheck_status=$?
+
+            if typecheck_never_ran "$typecheck_status" "$typecheck_log"; then
+                echo "  FAIL: the typecheck command in $tname exited $typecheck_status without reporting a diagnostic (see $typecheck_log)"
+                tail -20 "$typecheck_log" | sed 's/^/    /'
+                FAIL+=("$tname(typecheck:never-ran)")
+                continue
+            fi
 
             ts_errors="$(grep -c 'error TS' "$typecheck_log" || true)"
             if [[ "$ts_errors" -gt 0 ]]; then

--- a/scripts/template-build-smoke.sh
+++ b/scripts/template-build-smoke.sh
@@ -10,9 +10,10 @@
 #   3. Runs `pnpm install`.
 #   4. For React templates, runs `lunora add auth-ui` and asserts the copy-in
 #      screens landed and their deps were injected (then re-installs).
-#   5. Runs `pnpm run build` (skipped with a notice if no build script) — which
-#      is what proves the copied auth screens actually compile in a real app.
-#   5. Records PASS / XFAIL(expected failure) / XPASS(unexpected pass) / FAIL.
+#   5. Runs `pnpm run build` — which is what proves the copied auth screens
+#      actually compile in a real app. A template with no build script instead
+#      runs `pnpm run codegen` + `tsc --noEmit` over everything it ships.
+#   6. Records PASS / XFAIL(expected failure) / XPASS(unexpected pass) / FAIL.
 #
 # Exit codes:
 #   0  — all results were PASS or XFAIL
@@ -43,7 +44,10 @@
 # What this does NOT cover:
 #   - The remote giget fetch path (needs network + a published template ref).
 #   - Starting the Vite+workerd dev server (long-running, needs a real CF account).
-#   - Running codegen on the scaffolded project (covered by clean-machine-smoke.sh).
+#   - Running codegen on the *buildable* templates' scaffolds — their bundler
+#     runs it via the Vite plugin / astro integration. Only the no-build path
+#     invokes `lunora codegen` directly here; clean-machine-smoke.sh covers it
+#     against a tarball-installed CLI.
 
 set -euo pipefail
 
@@ -431,8 +435,39 @@ for tname in "${TEMPLATES[@]}"; do
     " 2>/dev/null)"
 
     if [[ "$build_script" != "yes" ]]; then
-        echo "  ==> NOTICE: no build script in $tname — skipping build"
+        # A template with no bundler had nothing compiled at all: scaffold +
+        # install was the whole gate, so any type error it ships — including one
+        # introduced by a breaking change in `@lunora/*` — passed silently.
+        # Run its own `codegen` script (every source file imports
+        # `#lunora/_generated/*`, which only exists afterwards), then typecheck.
+        #
+        # Unlike the auth-ui gate below this fails on ANY diagnostic rather than
+        # only ones under `lunora/auth-ui/`. That is affordable exactly because
+        # there is no build: no framework-generated route types to trip over, and
+        # the tsconfig `include` covers precisely the files the template ships.
+        echo "  ==> NOTICE: no build script in $tname — codegen + tsc --noEmit instead"
         SKIP_BUILD+=("$tname")
+
+        codegen_log="$RESULTS_DIR/${tname}-codegen.log"
+        if ! (cd "$scaffold_dir" && pnpm run codegen 2>&1) > "$codegen_log"; then
+            echo "  FAIL: codegen failed for $tname (see $codegen_log)"
+            tail -20 "$codegen_log" | sed 's/^/    /'
+            FAIL+=("$tname(codegen)")
+            continue
+        fi
+
+        typecheck_log="$RESULTS_DIR/${tname}-typecheck.log"
+        (cd "$scaffold_dir" && pnpm exec tsc --noEmit 2>&1) > "$typecheck_log" || true
+
+        ts_errors="$(grep -c 'error TS' "$typecheck_log" || true)"
+        if [[ "$ts_errors" -gt 0 ]]; then
+            echo "  FAIL: $ts_errors type error(s) in $tname (see $typecheck_log)"
+            grep 'error TS' "$typecheck_log" | head -25 | sed 's/^/    /'
+            FAIL+=("$tname(typecheck)")
+            continue
+        fi
+
+        echo "  ==> codegen + typecheck OK"
         PASS+=("$tname")
         continue
     fi
@@ -523,9 +558,15 @@ for t in "${TEMPLATES[@]}"; do
     fi
     result="unknown"
     for p in "${PASS[@]+"${PASS[@]}"}"; do [[ "$p" == "$t" ]] && result="PASS" && break; done
-    for f in "${FAIL[@]+"${FAIL[@]}"}"; do [[ "$f" == "${t}(install)" ]] && result="FAIL(install)" && break; done
-    for f in "${FAIL[@]+"${FAIL[@]}"}"; do [[ "$f" == "${t}(auth-ui:typecheck)" ]] && result="FAIL(typecheck)" && break; done
-    for f in "${FAIL[@]+"${FAIL[@]}"}"; do [[ "$f" == "$t" ]] && result="FAIL(build)" && break; done
+    # A bare template name means the build step failed; anything else is recorded
+    # as `<template>(<stage>)` and renders as `FAIL(<stage>)` — so a new stage
+    # cannot show up in the table as "unknown".
+    for f in "${FAIL[@]+"${FAIL[@]}"}"; do
+        case "$f" in
+            "$t") result="FAIL(build)" && break ;;
+            "$t("*) result="FAIL${f#"$t"}" && break ;;
+        esac
+    done
     for x in "${XFAIL[@]+"${XFAIL[@]}"}"; do [[ "$x" == "$t" ]] && result="XFAIL(expected)" && break; done
     for x in "${XPASS[@]+"${XPASS[@]}"}"; do [[ "$x" == "$t" ]] && result="XPASS(unexpected)" && break; done
     printf "%-20s  %s\n" "$t" "$result"

--- a/scripts/template-build-smoke.sh
+++ b/scripts/template-build-smoke.sh
@@ -172,6 +172,34 @@ typecheck_skip_reason() {
 
 TYPECHECK_UNSUPPORTED=("astro" "nuxt" "sveltekit")
 
+# ---------------------------------------------------------------------------
+# Typecheck a scaffold, preferring the template's OWN `typecheck` script.
+#
+# A bare `tsc --noEmit` is wrong for frameworks that emit route types from a
+# separate generator: react-router ships
+# `lunora codegen && react-router typegen && tsc`, and without the typegen step
+# every `./+types/<route>` import fails to resolve. The template already knows
+# the right incantation — run it rather than second-guessing it here.
+# ---------------------------------------------------------------------------
+run_typecheck() {
+    local scaffold_dir="$1"
+    local log="$2"
+    local has_script
+
+    has_script="$(node -e "
+        try {
+            const p = require('$scaffold_dir/package.json');
+            process.stdout.write(p.scripts && p.scripts.typecheck ? 'yes' : 'no');
+        } catch { process.stdout.write('no'); }
+    " 2>/dev/null)"
+
+    if [[ "$has_script" == "yes" ]]; then
+        (cd "$scaffold_dir" && pnpm run typecheck 2>&1) > "$log" || true
+    else
+        (cd "$scaffold_dir" && pnpm exec tsc --noEmit 2>&1) > "$log" || true
+    fi
+}
+
 is_typecheck_unsupported() {
     local name="$1"
     for s in "${TYPECHECK_UNSUPPORTED[@]+"${TYPECHECK_UNSUPPORTED[@]}"}"; do
@@ -457,7 +485,7 @@ for tname in "${TEMPLATES[@]}"; do
         fi
 
         typecheck_log="$RESULTS_DIR/${tname}-typecheck.log"
-        (cd "$scaffold_dir" && pnpm exec tsc --noEmit 2>&1) > "$typecheck_log" || true
+        run_typecheck "$scaffold_dir" "$typecheck_log"
 
         ts_errors="$(grep -c 'error TS' "$typecheck_log" || true)"
         if [[ "$ts_errors" -gt 0 ]]; then
@@ -489,37 +517,31 @@ for tname in "${TEMPLATES[@]}"; do
     # the framework's own route types, and without those `tsc` drowns in
     # `Cannot find module '#lunora/_generated/server.js'`.
     #
-    # Only diagnostics whose path is under `lunora/auth-ui/` fail the run. The
-    # templates carry unrelated type errors of their own (a `fontFamily` in the
-    # Solid template's `__root.tsx`, route types that need a build that failed) and
-    # this gate is not the place to litigate them — it answers one question: does
-    # the payload compile under this meta-framework's tsconfig? Unrelated errors
-    # are counted and printed so they stay visible.
+    # EVERY diagnostic fails the run, not just ones under `lunora/auth-ui/`. This
+    # used to gate the payload only and merely count the templates' own errors,
+    # on the reasoning that they were somebody else's problem — which let nine of
+    # them accumulate, two of which were real defects (a `LunoraProvider url=`
+    # prop that does not exist, so the provider mounted without a client). They
+    # are all fixed now, so the cheapest way to keep them fixed is to stop
+    # distinguishing.
     if [[ "$AUTHUI_ADDED" == "yes" ]]; then
         if is_typecheck_unsupported "$tname"; then
             echo "  ==> NOTICE: no in-scaffold typecheck for $tname ($(typecheck_skip_reason "$tname"))"
             TYPECHECK_SKIPPED+=("$tname")
         else
-            echo "  ==> tsc --noEmit (compiling the copied screens)"
+            echo "  ==> typecheck (compiling the copied screens)"
             typecheck_log="$RESULTS_DIR/${tname}-typecheck.log"
-            (cd "$scaffold_dir" && pnpm exec tsc --noEmit 2>&1) > "$typecheck_log" || true
+            run_typecheck "$scaffold_dir" "$typecheck_log"
 
-            authui_errors="$(grep -c '^lunora/auth-ui/' "$typecheck_log" || true)"
-            other_errors="$(grep -c 'error TS' "$typecheck_log" || true)"
-            other_errors=$((other_errors - authui_errors))
-
-            if [[ "$authui_errors" -gt 0 ]]; then
-                echo "  FAIL: $authui_errors type error(s) in the copied auth-ui screens in $tname (see $typecheck_log)"
-                grep '^lunora/auth-ui/' "$typecheck_log" | head -25 | sed 's/^/    /'
-                FAIL+=("$tname(auth-ui:typecheck)")
+            ts_errors="$(grep -c 'error TS' "$typecheck_log" || true)"
+            if [[ "$ts_errors" -gt 0 ]]; then
+                echo "  FAIL: $ts_errors type error(s) in $tname (see $typecheck_log)"
+                grep 'error TS' "$typecheck_log" | head -25 | sed 's/^/    /'
+                FAIL+=("$tname(typecheck)")
                 continue
             fi
 
-            if [[ "$other_errors" -gt 0 ]]; then
-                echo "  ==> typecheck OK for lunora/auth-ui/** ($other_errors pre-existing error(s) elsewhere in $tname, not gated here)"
-            else
-                echo "  ==> typecheck OK"
-            fi
+            echo "  ==> typecheck OK"
         fi
     fi
 

--- a/templates/analog/package.json
+++ b/templates/analog/package.json
@@ -36,6 +36,7 @@
         "@cloudflare/workers-types": "^4.20260611.1",
         "@lunora/studio": "^0.0.0",
         "@lunora/vite": "^0.0.0",
+        "h3": "^1.15.11",
         "typescript": "~5.8.3",
         "vite": "^6.3.5",
         "wrangler": "^4.100.0"

--- a/templates/analog/tsconfig.json
+++ b/templates/analog/tsconfig.json
@@ -11,7 +11,7 @@
         "noEmit": true,
         "experimentalDecorators": false,
         "useDefineForClassFields": false,
-        "types": ["@cloudflare/workers-types"]
+        "types": ["@cloudflare/workers-types", "vite/client"]
     },
     // Angular's AOT compiler options (read by @angular/compiler-cli).
     "angularCompilerOptions": {

--- a/templates/analog/vite.config.ts
+++ b/templates/analog/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest" />
 import { existsSync } from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/templates/react-router/.env.example
+++ b/templates/react-router/.env.example
@@ -2,7 +2,7 @@
 # Vite statically replaces `import.meta.env.VITE_LUNORA_URL` at `vite dev` / build.
 #
 # Leave it unset for single-worker dev: the browser uses the page origin and SSR
-# loops back to the local worker (http://localhost:8787). Set it to point the
-# client at a deployed or standalone Worker:
+# loops back to this same dev server, whose port `vite.config.ts` injects for you
+# (so `--port` works). Set it to point the client at a deployed Worker:
 #
 # VITE_LUNORA_URL=https://my-app.example.workers.dev

--- a/templates/react-router/app/root.tsx
+++ b/templates/react-router/app/root.tsx
@@ -1,4 +1,6 @@
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
+import { useState } from "react";
 import { isRouteErrorResponse, Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 
 import type { Route } from "./+types/root";
@@ -28,19 +30,26 @@ export function Layout({ children }: { children: React.ReactNode }) {
     );
 }
 
-// Lunora endpoint. `VITE_LUNORA_URL` (statically replaced by Vite at dev/build)
-// wins so you can point at a deployed Worker; otherwise the browser uses the page
-// origin and SSR loops back to the local worker (same worker, via the composed
-// `virtual:lunora/worker` entry).
-const lunoraUrl = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? (typeof window === "undefined" ? "http://localhost:8787" : window.location.origin);
+// Lunora endpoint. `VITE_LUNORA_URL` wins so you can point at a deployed
+// Worker; `vite.config.ts` otherwise defines it as the dev server's resolved
+// origin, because the composed `virtual:lunora/worker` entry serves Lunora from
+// this same worker. The literal below is only a last resort if that plugin is
+// removed.
+const isServer = typeof globalThis.window === "undefined";
+const lunoraUrl = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? (isServer ? "http://localhost:5173" : globalThis.location.origin);
 
 /**
  * Root route component. Mounts the LunoraProvider so every child route can call
  * `useQuery` / `useMutation` / `useSubscription`.
  */
 export default function App() {
+    // Built per render tree, NOT at module scope: on the server a module-level
+    // client is shared by every concurrent request, so one visitor's cached
+    // results — and eventually their identity — leak into the next render.
+    const [lunoraClient] = useState(() => new LunoraClient({ url: lunoraUrl }));
+
     return (
-        <LunoraProvider url={lunoraUrl}>
+        <LunoraProvider client={lunoraClient}>
             <Outlet />
         </LunoraProvider>
     );

--- a/templates/react-router/tsconfig.json
+++ b/templates/react-router/tsconfig.json
@@ -11,7 +11,7 @@
         "isolatedModules": true,
         "verbatimModuleSyntax": true,
         "noEmit": true,
-        "types": ["@cloudflare/workers-types", "@react-router/dev"],
+        "types": ["@cloudflare/workers-types", "vite/client"],
         "rootDirs": [".", "./.react-router/types"],
         "paths": {
             "~/*": ["./app/*"]

--- a/templates/react-router/vite.config.ts
+++ b/templates/react-router/vite.config.ts
@@ -1,7 +1,34 @@
 import { lunora } from "@lunora/vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { reactRouter } from "@react-router/dev/vite";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
+
+/**
+ * Tells the SSR render which origin to call Lunora on.
+ *
+ * The browser can use `location.origin`; a server render has no page to be
+ * relative to, so it needs an absolute URL. There is no second worker here —
+ * `virtual:lunora/worker` composes Lunora and the SSR handler into one worker,
+ * so that origin is this very dev server. Hardcoding a port means the app
+ * breaks the moment it runs on another one (`vite --port 3000`, a second app on
+ * the same machine, a preview deploy); reading Vite's *resolved* port covers all
+ * of those, and an explicit `VITE_LUNORA_URL` still wins.
+ */
+const ssrOrigin = (): Plugin => ({
+    config(userConfig) {
+        if (process.env.VITE_LUNORA_URL) {
+            return undefined;
+        }
+
+        // `--port` is merged into the config before plugin `config` hooks run,
+        // so this is the port the server will actually bind.
+        const port = userConfig.server?.port ?? 5173;
+
+        return { define: { "import.meta.env.VITE_LUNORA_URL": JSON.stringify(`http://localhost:${port}`) } };
+    },
+    name: "lunora-ssr-origin",
+});
 
 /**
  * Plugin ordering is load-bearing on Cloudflare:
@@ -40,5 +67,10 @@ export default defineConfig({
     // `.shardBy(...)` demo needs this to work — data is protected by per-row RLS.
     // A PRODUCTION sharded app should drop it and configure `authorizeShard` in a
     // hand-written worker instead.
-    plugins: [cloudflare({ viteEnvironment: { name: "ssr" } }), reactRouter(), lunora({ allowUnauthenticatedShardAccess: true, cloudflare: false })],
+    plugins: [
+        cloudflare({ viteEnvironment: { name: "ssr" } }),
+        reactRouter(),
+        lunora({ allowUnauthenticatedShardAccess: true, cloudflare: false }),
+        ssrOrigin(),
+    ],
 });

--- a/templates/tanstack-start-react/.env.example
+++ b/templates/tanstack-start-react/.env.example
@@ -2,7 +2,7 @@
 # Vite statically replaces `import.meta.env.VITE_LUNORA_URL` at `vite dev` / build.
 #
 # Leave it unset for single-worker dev: the browser uses the page origin and SSR
-# loops back to the local worker (http://localhost:8787). Set it to point the
-# client at a deployed or standalone Worker:
+# loops back to this same dev server, whose port `vite.config.ts` injects for you
+# (so `--port` works). Set it to point the client at a deployed Worker:
 #
 # VITE_LUNORA_URL=https://my-app.example.workers.dev

--- a/templates/tanstack-start-react/src/routes/__root.tsx
+++ b/templates/tanstack-start-react/src/routes/__root.tsx
@@ -1,6 +1,8 @@
 import { LunoraProvider } from "@lunora/react";
+import { LunoraClient } from "lunorash/client";
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import { useState } from "react";
 
 interface RouterContext {
     queryClient: QueryClient;
@@ -20,13 +22,20 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     ),
 });
 
-// Lunora endpoint. `VITE_LUNORA_URL` (statically replaced by Vite at dev/build)
-// wins so you can point at a deployed Worker; otherwise the browser uses the
-// page origin and SSR loops back to the local dev worker.
-const lunoraUrl = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? (typeof window === "undefined" ? "http://localhost:8787" : window.location.origin);
+// Lunora endpoint. `VITE_LUNORA_URL` wins so you can point at a deployed
+// Worker; `vite.config.ts` otherwise defines it as the dev server's resolved
+// origin, because `virtual:lunora/worker` serves Lunora from this same worker.
+// The literal below is only a last resort if that plugin is removed.
+const isServer = typeof globalThis.window === "undefined";
+const lunoraUrl = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? (isServer ? "http://localhost:5173" : globalThis.location.origin);
 
 function RootComponent() {
     const { queryClient } = Route.useRouteContext();
+
+    // Built per render tree, NOT at module scope: on the server a module-level
+    // client is shared by every concurrent request, so one visitor's cached
+    // results — and eventually their identity — leak into the next render.
+    const [lunoraClient] = useState(() => new LunoraClient({ url: lunoraUrl }));
 
     return (
         <html lang="en">
@@ -35,7 +44,7 @@ function RootComponent() {
             </head>
             <body>
                 <QueryClientProvider client={queryClient}>
-                    <LunoraProvider url={lunoraUrl}>
+                    <LunoraProvider client={lunoraClient}>
                         <Outlet />
                     </LunoraProvider>
                 </QueryClientProvider>

--- a/templates/tanstack-start-react/tsconfig.json
+++ b/templates/tanstack-start-react/tsconfig.json
@@ -10,7 +10,7 @@
         "skipLibCheck": true,
         "isolatedModules": true,
         "noEmit": true,
-        "types": ["@cloudflare/workers-types"],
+        "types": ["@cloudflare/workers-types", "vite/client"],
         "paths": {
             "~/*": ["./src/*"]
         }

--- a/templates/tanstack-start-react/vite.config.ts
+++ b/templates/tanstack-start-react/vite.config.ts
@@ -2,7 +2,34 @@ import { lunora } from "@lunora/vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
+
+/**
+ * Tells the SSR render which origin to call Lunora on.
+ *
+ * The browser can use `location.origin`; a server render has no page to be
+ * relative to, so it needs an absolute URL. There is no second worker here —
+ * `virtual:lunora/worker` composes Lunora and the SSR handler into one worker,
+ * so that origin is this very dev server. Hardcoding a port means the app
+ * breaks the moment it runs on another one (`vite --port 3000`, a second app on
+ * the same machine, a preview deploy); reading Vite's *resolved* port covers all
+ * of those, and an explicit `VITE_LUNORA_URL` still wins.
+ */
+const ssrOrigin = (): Plugin => ({
+    config(userConfig) {
+        if (process.env.VITE_LUNORA_URL) {
+            return undefined;
+        }
+
+        // `--port` is merged into the config before plugin `config` hooks run,
+        // so this is the port the server will actually bind.
+        const port = userConfig.server?.port ?? 5173;
+
+        return { define: { "import.meta.env.VITE_LUNORA_URL": JSON.stringify(`http://localhost:${port}`) } };
+    },
+    name: "lunora-ssr-origin",
+});
 
 /**
  * Plugin ordering is load-bearing on Cloudflare:
@@ -30,5 +57,11 @@ export default defineConfig({
     // `.shardBy(...)` demo needs this to work — data is protected by per-row RLS.
     // A PRODUCTION sharded app should drop it and configure `authorizeShard` in a
     // hand-written worker instead.
-    plugins: [cloudflare({ viteEnvironment: { name: "ssr" } }), tanstackStart(), react(), lunora({ allowUnauthenticatedShardAccess: true, cloudflare: false })],
+    plugins: [
+        cloudflare({ viteEnvironment: { name: "ssr" } }),
+        tanstackStart(),
+        react(),
+        lunora({ allowUnauthenticatedShardAccess: true, cloudflare: false }),
+        ssrOrigin(),
+    ],
 });

--- a/templates/tanstack-start-solid/.env.example
+++ b/templates/tanstack-start-solid/.env.example
@@ -2,7 +2,7 @@
 # Vite statically replaces `import.meta.env.VITE_LUNORA_URL` at `vite dev` / build.
 #
 # Leave it unset for single-worker dev: the browser uses the page origin and SSR
-# loops back to the local worker (http://localhost:8787). Set it to point the
-# client at a deployed or standalone Worker:
+# loops back to this same dev server, whose port `vite.config.ts` injects for you
+# (so `--port` works). Set it to point the client at a deployed Worker:
 #
 # VITE_LUNORA_URL=https://my-app.example.workers.dev

--- a/templates/tanstack-start-solid/src/routes/__root.tsx
+++ b/templates/tanstack-start-solid/src/routes/__root.tsx
@@ -4,19 +4,13 @@ import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from "@tanst
 import { Suspense } from "solid-js";
 import { HydrationScript } from "solid-js/web";
 
-/**
- * One LunoraClient per app, constructed at module scope. The constructor opens
- * no socket — connections are established on the first `createQuery` /
- * `hydratePreloaded` subscription, and those effects only run on the client —
- * so a single shared instance is SSR-safe. On the server `window` is undefined,
- * so we fall back to the loopback worker origin; the browser uses the page origin.
- */
-const lunoraClient = new LunoraClient({
-    // `VITE_LUNORA_URL` (statically replaced by Vite at dev/build) wins so you can
-    // point at a deployed Worker; otherwise the browser uses the page origin and
-    // SSR loops back to the local dev worker.
-    url: (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? (typeof window === "undefined" ? "http://localhost:8787" : window.location.origin),
-});
+// Lunora endpoint. `VITE_LUNORA_URL` wins so you can point at a deployed
+// Worker; `vite.config.ts` otherwise defines it as the dev server's resolved
+// origin, because the composed `virtual:lunora/worker` entry serves Lunora from
+// this same worker. The literal below is only a last resort if that plugin is
+// removed.
+const isServer = typeof globalThis.window === "undefined";
+const lunoraUrl = (import.meta.env.VITE_LUNORA_URL as string | undefined) ?? (isServer ? "http://localhost:5173" : globalThis.location.origin);
 
 export const Route = createRootRouteWithContext()({
     head: () => ({
@@ -24,7 +18,7 @@ export const Route = createRootRouteWithContext()({
     }),
     shellComponent: RootComponent,
     notFoundComponent: () => (
-        <main style={{ fontFamily: "system-ui", padding: "3rem", textAlign: "center" }}>
+        <main style={{ "font-family": "system-ui", padding: "3rem", "text-align": "center" }}>
             <h1>404</h1>
             <p>This page could not be found.</p>
             <a href="/">Go home</a>
@@ -33,6 +27,11 @@ export const Route = createRootRouteWithContext()({
 });
 
 function RootComponent() {
+    // Built per render tree, NOT at module scope: on the server a module-level
+    // client is shared by every concurrent request, so one visitor's cached
+    // results — and eventually their identity — leak into the next render.
+    const lunoraClient = new LunoraClient({ url: lunoraUrl });
+
     return (
         <html lang="en">
             <head>

--- a/templates/tanstack-start-solid/vite.config.ts
+++ b/templates/tanstack-start-solid/vite.config.ts
@@ -2,7 +2,34 @@ import { lunora } from "@lunora/vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { tanstackStart } from "@tanstack/solid-start/plugin/vite";
 import solidPlugin from "vite-plugin-solid";
+import type { Plugin } from "vite";
 import { defineConfig } from "vite";
+
+/**
+ * Tells the SSR render which origin to call Lunora on.
+ *
+ * The browser can use `location.origin`; a server render has no page to be
+ * relative to, so it needs an absolute URL. There is no second worker here —
+ * `virtual:lunora/worker` composes Lunora and the SSR handler into one worker,
+ * so that origin is this very dev server. Hardcoding a port means the app
+ * breaks the moment it runs on another one (`vite --port 3000`, a second app on
+ * the same machine, a preview deploy); reading Vite's *resolved* port covers all
+ * of those, and an explicit `VITE_LUNORA_URL` still wins.
+ */
+const ssrOrigin = (): Plugin => ({
+    config(userConfig) {
+        if (process.env.VITE_LUNORA_URL) {
+            return undefined;
+        }
+
+        // `--port` is merged into the config before plugin `config` hooks run,
+        // so this is the port the server will actually bind.
+        const port = userConfig.server?.port ?? 5173;
+
+        return { define: { "import.meta.env.VITE_LUNORA_URL": JSON.stringify(`http://localhost:${port}`) } };
+    },
+    name: "lunora-ssr-origin",
+});
 
 /**
  * Plugin ordering is load-bearing on Cloudflare:
@@ -35,5 +62,6 @@ export default defineConfig({
         tanstackStart(),
         solidPlugin({ ssr: true }),
         lunora({ allowUnauthenticatedShardAccess: true, cloudflare: false }),
+        ssrOrigin(),
     ],
 });


### PR DESCRIPTION
## Why

The template smoke matrix had two holes that let real defects through.

`standalone` is the only template with no `build` script, so it was recorded `PASS` on scaffold + install alone — nothing ever compiled the code it ships. It also has no framework dependency, so the auth-ui payload gate skipped it too.

Everywhere else the gate failed only on diagnostics under `lunora/auth-ui/**` and merely *counted* each template's own errors as somebody else's problem. Nine had accumulated that way. Two were real defects, not missing declarations.

## What changed

**The build-less path now compiles.** `standalone` runs its own `codegen` script (every source file imports `#lunora/_generated/*`, which does not exist before that) and then `tsc --noEmit`.

**Two real defects, in three templates:**

- `LunoraProvider` takes `client`, not `url`. `react-router` and `tanstack-start-react` passed `url`, so the provider mounted with an undefined client and every `useQuery` below it resolved against nothing.
- Supplying a client exposed the next problem: building it at module scope shares one instance across concurrent server renders, so one visitor's cached results — and eventually their identity — leak into the next request's HTML. All three single-worker Vite templates now build it inside the component, per render tree, matching `templates/next`.

**A dev-only bug on the same lines.** Their SSR fallback origin pointed at `http://localhost:8787`, copied from the two-worker templates where a separate `wrangler dev` really does listen there. These compose Lunora into the SSR worker via `virtual:lunora/worker`, so nothing serves that port and every server-side query in dev hit a closed socket — invisible from the browser, which uses `location.origin`. A `vite.config.ts` plugin (ported from `examples/tanstack-start`) now defines `VITE_LUNORA_URL` from Vite's *resolved* port, so `--port` and a second app on the same machine both work.

**Missing declarations:** `vite/client` in three tsconfigs; an undeclared `h3` import in analog's Nitro route; a vestigial `/// <reference types="vitest" />` with no vitest; `@react-router/dev` in a `types` slot where it has no root entry point — that last one was aborting the semantic pass and masking two further errors.

**The gate then tightened.** Typechecking prefers a template's own `typecheck` script when it has one — a bare `tsc` skips `react-router typegen` and every `./+types/<route>` fails to resolve. With every typecheckable template at zero, the two-tier `lunora/auth-ui/**`-only logic is deleted: any diagnostic now fails the run.

## Verification

Full matrix under the strict gate: **9 PASS, 0 FAIL**.

The gate was proven to fail, not just to run — injecting one bad assignment into `lunora/messages.ts` and one into `src/server.ts` reports both and exits 1, which is what shows both trees are actually in scope.

## Not covered

`astro`, `nuxt` and `sveltekit` still have no in-scaffold typecheck (they need `@astrojs/check` / `vue-tsc` / `svelte-check`); the matrix prints that list on every run so a green result cannot be read as more than it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sk9BLaUZDkPVAZ1sKhuDP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template validation by running code generation and type checks for templates without build scripts.
  * Buildable templates now fail when any TypeScript diagnostics are detected during authentication UI checks.
  * Validation failures now identify the specific stage that failed.

* **Documentation**
  * Updated template validation documentation to describe the enhanced checks and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->