### PR TITLE
fix(codegen): keep an args parameter when no model can be named

### DIFF
--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -755,6 +755,7 @@ interface SdkMethod {
     namespace: string;
     resultType: string | undefined;
     summary: string;
+    takesArgs: boolean;
     verb: RuntimeVerb;
 }
 ```

--- a/packages/codegen/__tests__/sdk-targets.test.ts
+++ b/packages/codegen/__tests__/sdk-targets.test.ts
@@ -407,13 +407,19 @@ describe.each(targets.map((target) => [target.id, target] as const))("target: %s
         // The function is reported as carrying an unrepresentable type...
         expect(reported).toContain("wallet:credit");
 
-        // ...and its generated method still takes an argument, so the caller has
-        // somewhere to put the wire value. Every target spells the parameter
-        // differently, so this asserts the one thing they share: the call site
-        // forwards a value rather than a hardcoded empty payload.
-        const emptyPayloads = ['"wallet:credit", {}', '"wallet:credit", nil', '"wallet:credit", {})'];
+        // ...and the call site FORWARDS that argument. Asserted positively rather
+        // than by listing empty-payload spellings: the first version of this test
+        // enumerated `{}` and `nil` and so missed Rust, which accepted `args` and
+        // sent `&WireValue::Object(Vec::new())` — a parameter silently discarded,
+        // which is worse than the missing parameter it replaced, because passing
+        // arguments then compiles and does nothing.
+        const forwarded = surface
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.includes('"wallet:credit"'))
+            .filter((line) => /\bargs\b/u.test(line));
 
-        expect(emptyPayloads.some((empty) => surface.includes(empty))).toBe(false);
+        expect(forwarded.length).toBeGreaterThan(0);
     });
 
     it("reports the result types its backend could not name", async () => {

--- a/packages/codegen/__tests__/sdk-targets.test.ts
+++ b/packages/codegen/__tests__/sdk-targets.test.ts
@@ -373,6 +373,49 @@ describe.each(targets.map((target) => [target.id, target] as const))("target: %s
         expect(sources).not.toContain(String.raw`"messages:co"unt"`);
     });
 
+    // A schema no model can express still TAKES arguments. Five languages used to
+    // drop the parameter entirely, so a `v.bigint()` function was uncallable with
+    // arguments at all — while the CLI advised passing wire values "directly",
+    // through a parameter that did not exist. The JVM targets always kept one.
+    it("still accepts arguments when no model can be named for them", async () => {
+        expect.assertions(2);
+
+        const unrepresentable: OpenRpcDocument = {
+            methods: [
+                {
+                    name: "wallet:credit",
+                    params: [
+                        {
+                            name: "args",
+                            // v.bigint() — deliberately gets no model, because a typed
+                            // field would send a plain number where the wire needs the
+                            // tagged form.
+                            schema: { properties: { amount: { format: "int64", type: "integer" } }, required: ["amount"], type: "object" },
+                        },
+                    ],
+                    "x-lunora-function-kind": "mutation",
+                },
+            ],
+        };
+
+        const { files, unrepresentable: reported } = await generateSdk(unrepresentable, target);
+        const surface = Object.entries(files)
+            .filter(([path]) => !path.toLowerCase().includes("models"))
+            .map(([, contents]) => contents)
+            .join("\n");
+
+        // The function is reported as carrying an unrepresentable type...
+        expect(reported).toContain("wallet:credit");
+
+        // ...and its generated method still takes an argument, so the caller has
+        // somewhere to put the wire value. Every target spells the parameter
+        // differently, so this asserts the one thing they share: the call site
+        // forwards a value rather than a hardcoded empty payload.
+        const emptyPayloads = ['"wallet:credit", {}', '"wallet:credit", nil', '"wallet:credit", {})'];
+
+        expect(emptyPayloads.some((empty) => surface.includes(empty))).toBe(false);
+    });
+
     it("reports the result types its backend could not name", async () => {
         expect.assertions(1);
 

--- a/packages/codegen/src/sdk/spec.ts
+++ b/packages/codegen/src/sdk/spec.ts
@@ -42,7 +42,15 @@ type RuntimeVerb = "action" | "mutation" | "query";
 
 /** One RPC function, parsed and language-neutral. */
 interface SdkMethod {
-    /** Generated args model name, or `undefined` when the function takes none. */
+    /**
+     * Generated args model name, or `undefined` when NO model could be named for
+     * this function's arguments.
+     *
+     * `undefined` does NOT mean "takes no arguments" — see {@link SdkMethod.takesArgs}.
+     * A schema carrying a `v.bigint()` or `v.bytes()` gets no model deliberately
+     * (`hasUnrepresentableWireType`), and a backend that cannot name a shape leaves
+     * it undeclared. Both still take arguments, just untyped ones.
+     */
     argsType: string | undefined;
     /** Raw exported function name (`"list"`), before any naming convention. */
     functionName: string;
@@ -54,6 +62,17 @@ interface SdkMethod {
     resultType: string | undefined;
     /** Human summary for the doc comment. */
     summary: string;
+
+    /**
+     * Whether this function declares arguments at all, independent of whether a
+     * model could be named for them.
+     *
+     * A target emits three shapes from this: a TYPED parameter when `argsType` is
+     * set, an UNTYPED wire-shaped parameter when it is not but this is true, and no
+     * parameter at all when this is false. Collapsing the middle case into the last
+     * is what made `v.bigint()` functions uncallable with arguments.
+     */
+    takesArgs: boolean;
     /** Which runtime verb this dispatches to. */
     verb: RuntimeVerb;
 }
@@ -216,6 +235,25 @@ const DOLLAR_ESCAPE = ["$", "{", "'", "$", "'", "}"].join("");
  */
 const kotlinLiteral = (value: string): string => stringLiteral(value).split("$").join(DOLLAR_ESCAPE);
 
+/**
+ * Pick one of the three argument shapes a target must emit for a method.
+ *
+ * `typed` — a model was named, take it. `untyped` — the function takes arguments
+ * that no model can express (`v.bigint()`/`v.bytes()`, or a shape the backend could
+ * not name), so take a wire-shaped value. `none` — the function takes no arguments.
+ *
+ * Named rather than left as a conditional at each call site because collapsing
+ * `untyped` into `none` is precisely the bug this exists to prevent: five targets
+ * did that and made those functions uncallable with arguments.
+ */
+const argsChoice = <T>(method: SdkMethod, choices: { none: T; typed: (type: string) => T; untyped: T }): T => {
+    if (method.argsType !== undefined) {
+        return choices.typed(method.argsType);
+    }
+
+    return method.takesArgs ? choices.untyped : choices.none;
+};
+
 /** Parse one OpenRPC method. Model names are derived HERE and nowhere else. */
 const parseMethod = (method: OpenRpcMethod): SdkMethod => {
     const [namespace = "", functionName = ""] = method.name.split(":");
@@ -229,6 +267,7 @@ const parseMethod = (method: OpenRpcMethod): SdkMethod => {
     // server's validator. The caller passes wire values directly instead.
     return {
         argsType: isTypedSchema(argsSchema) && !hasUnrepresentableWireType(argsSchema) ? `${base}Args` : undefined,
+        takesArgs: isTypedSchema(argsSchema),
         functionName,
         functionPath: method.name,
         namespace,
@@ -451,6 +490,7 @@ const referencedModels = (namespaces: ReadonlyArray<SdkNamespace>): ReadonlyArra
 
 export {
     allMethods,
+    argsChoice,
     assertGeneratable,
     commentText,
     generatedHeaderLines,

--- a/packages/codegen/src/sdk/targets/go.ts
+++ b/packages/codegen/src/sdk/targets/go.ts
@@ -39,7 +39,7 @@
  */
 
 import type { SdkMethod, SdkNamespace } from "../spec";
-import { commentText, generatedHeaderLines, stringLiteral, toPascalCase } from "../spec";
+import { argsChoice, commentText, generatedHeaderLines, stringLiteral, toPascalCase } from "../spec";
 import type { SdkRenderInput, SdkTarget } from "../target";
 
 const GENERATED_HEADER = `${generatedHeaderLines("go")
@@ -69,10 +69,14 @@ const GO_DIRECTIVE = "1.22";
  */
 const memberName = (raw: string): string => toPascalCase(raw);
 
+// A function whose args no model can express (a `v.bigint()`/`v.bytes()` schema, or
+// a shape this backend could not name) still TAKES arguments — wire-shaped ones.
+// Dropping the parameter made those functions uncallable with arguments, which is
+// what the JVM targets already got right.
 /** One function as an exported method posting the RPC envelope. */
 const renderCall = (namespaceType: string, method: SdkMethod): string => {
-    const argument = method.argsType === undefined ? "" : `args ${method.argsType}, `;
-    const payload = method.argsType === undefined ? "nil" : "args";
+    const argument = argsChoice(method, { none: "", typed: (type) => `args ${type}, `, untyped: "args any, " });
+    const payload = argsChoice(method, { none: "nil", typed: () => "args", untyped: "args" });
     const returns = method.resultType ?? "any";
     // The verb crosses into the runtime as a typed constant, not a string: a
     // typo here would otherwise compile and route a read over the write path.
@@ -92,8 +96,8 @@ const renderCall = (namespaceType: string, method: SdkMethod): string => {
  * frame names a query the server re-runs on every write to the tables it read.
  */
 const renderSubscribe = (namespaceType: string, method: SdkMethod): string => {
-    const argument = method.argsType === undefined ? "" : `args ${method.argsType}, `;
-    const payload = method.argsType === undefined ? "nil" : "args";
+    const argument = argsChoice(method, { none: "", typed: (type) => `args ${type}, `, untyped: "args any, " });
+    const payload = argsChoice(method, { none: "nil", typed: () => "args", untyped: "args" });
     const name = `Subscribe${memberName(method.functionName)}`;
 
     return [

--- a/packages/codegen/src/sdk/targets/python.ts
+++ b/packages/codegen/src/sdk/targets/python.ts
@@ -21,7 +21,7 @@
  */
 
 import type { SdkMethod, SdkNamespace } from "../spec";
-import { allMethods, commentText, generatedHeaderLines, referencedModels, stringLiteral, toPascalCase, toSnakeCase } from "../spec";
+import { allMethods, argsChoice, commentText, generatedHeaderLines, referencedModels, stringLiteral, toPascalCase, toSnakeCase } from "../spec";
 import type { SdkRenderInput, SdkTarget } from "../target";
 
 /** Python reserved words a function name could collide with. */
@@ -79,11 +79,26 @@ const memberName = (raw: string): string => {
     return PYTHON_KEYWORDS.has(snake) ? `${snake}_` : snake;
 };
 
+/**
+ * The three arg shapes: typed model, untyped wire value, or none at all.
+ *
+ * `to_dict()` only exists on a generated model, so an untyped parameter is passed
+ * through unchanged — it is already the wire-shaped mapping the transport encodes.
+ */
+const argsPayload = (method: SdkMethod): string => argsChoice(method, { none: "{}", typed: () => "args.to_dict()", untyped: "args" });
+
+const argsParameter = (method: SdkMethod, none: string, typed: (type: string) => string, untyped: string): string =>
+    argsChoice(method, { none, typed, untyped });
+
 /** One function as an `async def` posting the RPC envelope. */
 const renderCall = (method: SdkMethod): string => {
     const returns = method.resultType ?? "Any";
-    const parameters = method.argsType === undefined ? "self" : `self, args: ${method.argsType}`;
-    const payload = method.argsType === undefined ? "{}" : "args.to_dict()";
+    // A function whose args no model can express (a `v.bigint()`/`v.bytes()` schema,
+    // or a shape this backend could not name) still TAKES arguments — it just takes
+    // them wire-shaped. Dropping the parameter made those functions uncallable with
+    // arguments, which is what the JVM targets already got right.
+    const parameters = argsParameter(method, "self", (type) => `self, args: ${type}`, "self, args: Any");
+    const payload = argsPayload(method);
     const call = `await self._client.${method.verb}("${stringLiteral(method.functionPath)}", ${payload}, shard_key)`;
 
     return [
@@ -99,11 +114,11 @@ const renderCall = (method: SdkMethod): string => {
  * tables it read, and a write has nothing to re-run.
  */
 const renderSubscribe = (method: SdkMethod): string => {
-    const payload = method.argsType === undefined ? "{}" : "args.to_dict()";
+    const payload = argsPayload(method);
 
     const parameters = [
         "self",
-        ...(method.argsType === undefined ? [] : [`args: ${method.argsType}`]),
+        ...argsChoice<ReadonlyArray<string>>(method, { none: [], typed: (type) => [`args: ${type}`], untyped: ["args: Any"] }),
         "on_data: Callback",
         "on_error: Optional[ErrorCallback] = None",
         "*",

--- a/packages/codegen/src/sdk/targets/ruby.ts
+++ b/packages/codegen/src/sdk/targets/ruby.ts
@@ -27,7 +27,7 @@
  */
 
 import type { SdkMethod, SdkNamespace } from "../spec";
-import { allMethods, commentText, generatedHeaderLines, stringLiteral, toPascalCase, toSnakeCase } from "../spec";
+import { allMethods, argsChoice, commentText, generatedHeaderLines, stringLiteral, toPascalCase, toSnakeCase } from "../spec";
 import type { SdkRenderInput, SdkTarget } from "../target";
 
 const GENERATED_HEADER = `${generatedHeaderLines("ruby")
@@ -114,10 +114,19 @@ const WIRE_ARGS_HELPER = `  def self.wire_args(model)
 
 `;
 
+// A function whose args no model can express (a `v.bigint()`/`v.bytes()` schema, or
+// a shape this backend could not name) still TAKES arguments — wire-shaped ones.
+// Dropping the parameter made those functions uncallable with arguments, which is
+// what the JVM targets already got right.
+//
+// `wire_args` calls `to_dynamic`, which only a generated model has, so an untyped
+// argument is passed through — it is already the wire-shaped hash.
+const rubyPayload = (method: SdkMethod): string => argsChoice(method, { none: "{}", typed: () => "LunoraApi.wire_args(args)", untyped: "args" });
+
 /** One function as a method posting the RPC envelope. */
 const renderCall = (method: SdkMethod): string => {
-    const parameters = method.argsType === undefined ? "shard_key: nil" : "args, shard_key: nil";
-    const payload = method.argsType === undefined ? "{}" : "LunoraApi.wire_args(args)";
+    const parameters = method.argsType === undefined && !method.takesArgs ? "shard_key: nil" : "args, shard_key: nil";
+    const payload = rubyPayload(method);
     const call = `@client.${method.verb}("${rubyLiteral(method.functionPath)}", ${payload}, shard_key)`;
     // A typed result routes the decoded payload through the model's own
     // constructor; an untyped one is handed back as-is.
@@ -131,8 +140,9 @@ const renderCall = (method: SdkMethod): string => {
  * frame names a query the server re-runs on every write to the tables it read.
  */
 const renderSubscribe = (method: SdkMethod): string => {
-    const parameters = method.argsType === undefined ? "on_data, on_error = nil, shard_key: nil" : "args, on_data, on_error = nil, shard_key: nil";
-    const payload = method.argsType === undefined ? "{}" : "LunoraApi.wire_args(args)";
+    const parameters =
+        method.argsType === undefined && !method.takesArgs ? "on_data, on_error = nil, shard_key: nil" : "args, on_data, on_error = nil, shard_key: nil";
+    const payload = rubyPayload(method);
 
     return [
         `    # live ${commentText(method.summary)} — re-runs on every write to the tables it reads.`,

--- a/packages/codegen/src/sdk/targets/rust.ts
+++ b/packages/codegen/src/sdk/targets/rust.ts
@@ -151,10 +151,11 @@ const renderCall = (method: SdkMethod): string => {
         typed: (type) => `&self, args: &${type}, shard_key: Option<&str>`,
         untyped: "&self, args: &WireValue, shard_key: Option<&str>",
     });
-    const payload =
-        method.argsType === undefined
-            ? "&WireValue::Object(Vec::new())"
-            : "&from_model_json(&serde_json::to_value(args).map_err(|error| ClientError::Transport(error.to_string()))?)";
+    const payload = argsChoice(method, {
+        none: "&WireValue::Object(Vec::new())",
+        typed: () => "&from_model_json(&serde_json::to_value(args).map_err(|error| ClientError::Transport(error.to_string()))?)",
+        untyped: "args",
+    });
     const call = `self.client.call(${verbConstant(method.verb)}, "${stringLiteral(method.functionPath)}", ${payload}, shard_key)`;
 
     // A typed result is deserialised into the model; an untyped one is handed
@@ -184,10 +185,11 @@ const renderCall = (method: SdkMethod): string => {
  */
 const renderSubscribe = (method: SdkMethod): string => {
     const argument = argsChoice(method, { none: "", typed: (type) => `args: &${type}, `, untyped: "args: &WireValue, " });
-    const payload =
-        method.argsType === undefined
-            ? "WireValue::Object(Vec::new())"
-            : "from_model_json(&serde_json::to_value(args).map_err(|error| ClientError::Transport(error.to_string()))?)";
+    const payload = argsChoice(method, {
+        none: "WireValue::Object(Vec::new())",
+        typed: () => "from_model_json(&serde_json::to_value(args).map_err(|error| ClientError::Transport(error.to_string()))?)",
+        untyped: "args.clone()",
+    });
 
     return [
         `    /// live ${commentText(method.summary)} — re-runs on every write to the tables it reads.`,

--- a/packages/codegen/src/sdk/targets/rust.ts
+++ b/packages/codegen/src/sdk/targets/rust.ts
@@ -39,7 +39,7 @@
  */
 
 import type { SdkMethod, SdkNamespace } from "../spec";
-import { commentText, generatedHeaderLines, stringLiteral, toPascalCase, toSnakeCase } from "../spec";
+import { argsChoice, commentText, generatedHeaderLines, stringLiteral, toPascalCase, toSnakeCase } from "../spec";
 import type { SdkRenderInput, SdkTarget } from "../target";
 
 const GENERATED_HEADER = `${generatedHeaderLines("rust")
@@ -142,7 +142,15 @@ const verbConstant = (verb: string): string => `Verb::${toPascalCase(verb)}`;
 
 /** One function as a method posting the RPC envelope. */
 const renderCall = (method: SdkMethod): string => {
-    const parameters = method.argsType === undefined ? "&self, shard_key: Option<&str>" : `&self, args: &${method.argsType}, shard_key: Option<&str>`;
+    // A function whose args no model can express (a `v.bigint()`/`v.bytes()` schema, or
+    // a shape this backend could not name) still TAKES arguments — wire-shaped ones.
+    // Dropping the parameter made those functions uncallable with arguments, which is
+    // what the JVM targets already got right.
+    const parameters = argsChoice(method, {
+        none: "&self, shard_key: Option<&str>",
+        typed: (type) => `&self, args: &${type}, shard_key: Option<&str>`,
+        untyped: "&self, args: &WireValue, shard_key: Option<&str>",
+    });
     const payload =
         method.argsType === undefined
             ? "&WireValue::Object(Vec::new())"
@@ -175,7 +183,7 @@ const renderCall = (method: SdkMethod): string => {
  * frame names a query the server re-runs on every write to the tables it read.
  */
 const renderSubscribe = (method: SdkMethod): string => {
-    const argument = method.argsType === undefined ? "" : `args: &${method.argsType}, `;
+    const argument = argsChoice(method, { none: "", typed: (type) => `args: &${type}, `, untyped: "args: &WireValue, " });
     const payload =
         method.argsType === undefined
             ? "WireValue::Object(Vec::new())"

--- a/packages/codegen/src/sdk/targets/swift.ts
+++ b/packages/codegen/src/sdk/targets/swift.ts
@@ -40,7 +40,7 @@
  */
 
 import type { SdkMethod, SdkNamespace } from "../spec";
-import { commentText, generatedHeaderLines, stringLiteral, toPascalCase } from "../spec";
+import { argsChoice, commentText, generatedHeaderLines, stringLiteral, toPascalCase } from "../spec";
 import type { SdkRenderInput, SdkTarget } from "../target";
 
 const GENERATED_HEADER = `${generatedHeaderLines("swift")
@@ -154,10 +154,22 @@ const memberName = (raw: string): string => {
     return SWIFT_KEYWORDS.has(camel) ? `\`${camel}\`` : camel;
 };
 
+// `wireValue` projects a Codable model; an untyped argument is already a wire
+// value and is passed through.
+const swiftPayload = (method: SdkMethod): string => argsChoice(method, { none: "nil", typed: () => "try LunoraClient.wireValue(args)", untyped: "args" });
+
 /** One function as a method posting the RPC envelope. */
 const renderCall = (method: SdkMethod): string => {
-    const parameters = method.argsType === undefined ? "shardKey: String? = nil" : `_ args: ${method.argsType}, shardKey: String? = nil`;
-    const payload = method.argsType === undefined ? "nil" : "try LunoraClient.wireValue(args)";
+    // A function whose args no model can express (a `v.bigint()`/`v.bytes()` schema, or
+    // a shape this backend could not name) still TAKES arguments — wire-shaped ones.
+    // Dropping the parameter made those functions uncallable with arguments, which is
+    // what the JVM targets already got right.
+    const parameters = argsChoice(method, {
+        none: "shardKey: String? = nil",
+        typed: (type) => `_ args: ${type}, shardKey: String? = nil`,
+        untyped: "_ args: Any, shardKey: String? = nil",
+    });
+    const payload = swiftPayload(method);
     const returns = method.resultType ?? "Any";
     const call = `try client.${method.verb}("${stringLiteral(method.functionPath)}", args: ${payload}, shardKey: shardKey)`;
     // A typed result is re-decoded into the model; an untyped one is handed back.
@@ -186,8 +198,8 @@ const renderCall = (method: SdkMethod): string => {
  * frame names a query the server re-runs on every write to the tables it read.
  */
 const renderSubscribe = (method: SdkMethod): string => {
-    const argument = method.argsType === undefined ? "" : `_ args: ${method.argsType}, `;
-    const payload = method.argsType === undefined ? "nil" : "try LunoraClient.wireValue(args)";
+    const argument = argsChoice(method, { none: "", typed: (type) => `_ args: ${type}, `, untyped: "_ args: Any, " });
+    const payload = swiftPayload(method);
 
     return [
         `    /// live ${commentText(method.summary)} — re-runs on every write to the tables it reads.`,


### PR DESCRIPTION
`argsType === undefined` meant two different things, and every non-JVM target read it as one: *"this function takes no arguments."*

It is also what a function gets when its arguments **cannot be typed** — a `v.bigint()`/`v.bytes()` schema is refused a model deliberately (a typed field would send a plain number where the wire needs the tagged form), and a backend that cannot name a shape leaves it undeclared.

So Go, Python, Ruby, Rust and Swift emitted those methods with **no parameter** and a hardcoded empty payload:

```python
# before — nowhere to put the arguments
async def credit(self, *, shard_key=None) -> Any:
    return await self._client.mutation("wallet:credit", {}, shard_key)
```

Meanwhile the CLI told the user their *"parameters stay untyped, so pass wire values directly"* — through a parameter that did not exist. The JVM targets always kept one, which is how the asymmetry surfaced.

## The change

`SdkMethod` gains `takesArgs`, so the three cases are finally distinct:

| case | parameter |
| --- | --- |
| a model was named | typed (`args: MessagesListArgs`) |
| arguments exist, no model possible | untyped, wire-shaped (`args: Any`, `args any`, `args: &WireValue`, …) |
| no arguments | none |

`argsChoice` in `spec.ts` names that decision once instead of leaving seven targets to re-derive it — collapsing the middle case into the last is the entire bug, and it is much easier to make in an inline conditional than in a named branch. Its `typed` arm is a callback so the narrowed `argsType` is passed in; a record literal evaluates all three arms and leaves `string | undefined` in a template expression.

## Verification

Reverted Python and Go to the old two-way branch — the new test fails for **exactly those two** and passes when restored:

```
FAIL  target: go > still accepts arguments when no model can be named for them
FAIL  target: python > still accepts arguments when no model can be named for them
Tests  2 failed | 113 passed (115)
```

All seven SDKs still generate, compile and **run a call** from a scratch directory outside the repo. 125 SDK codegen tests, conformance 7/7, lint 7/7, `api:check` green after a one-line snapshot update (`takesArgs: boolean`).

Found while closing the JVM typed-models gap in #393.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generated Go, Python, Ruby, Rust, and Swift SDKs now support methods and subscriptions with untyped arguments.
  - Untyped wire values are preserved and passed through without being dropped or incorrectly transformed.
  - Generated interfaces now distinguish between methods with no arguments, typed arguments, and untyped arguments.
  - Typed arguments continue using their existing language-specific models and encoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->