### PR TITLE
feat(plugins): package the agent skills as a plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,16 @@
+{
+    "name": "lunora",
+    "interface": {
+        "displayName": "Lunora"
+    },
+    "plugins": [
+        {
+            "name": "lunora",
+            "source": {
+                "source": "local",
+                "path": "./plugins/lunora"
+            },
+            "category": "Engineering"
+        }
+    ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+    "name": "lunora",
+    "description": "Plugins for building on Lunora — a type-safe, real-time backend on Cloudflare Workers + Durable Objects.",
+    "owner": {
+        "name": "Anolilab",
+        "email": "d.bannert@anolilab.de",
+        "url": "https://github.com/anolilab"
+    },
+    "plugins": [
+        {
+            "name": "lunora",
+            "source": "./plugins/lunora",
+            "category": "Engineering",
+            "tags": ["backend", "cloudflare", "realtime", "typescript"]
+        }
+    ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ pnpm workspaces are `apps/*`, `packages/*`, `examples/*`, `tests/*`. The rest of
 | `api-snapshots/` | Committed public-API snapshots, one `<pkg>.api.md` per package — gated by `pnpm run api:check`.                                       |
 | `shared/`        | Bundler-inlined helpers, **not** a package. See [Top-level `shared/`](#top-level-shared--bundler-inlined-source-not-a-package).       |
 | `protocol/`      | Wire-protocol spec + shared fixtures.                                                                                                 |
+| `plugins/*`      | The Claude Code / Codex agent plugin (`plugins/lunora`) — the `packages/cli/skills` payload + the end-of-turn `lunora verify` hook.   |
 | `plans/`         | Implementation plans handed to agents; `plans/README.md` is the index.                                                                |
 | `sdks/`          | Non-JS client SDKs (`python`, `go`, `ruby`, `rust`, `swift`, `java`, `kotlin`) + `lunora sdk generate` targets. See `sdks/README.md`. |
 | `patches/`       | pnpm patches applied to third-party deps.                                                                                             |

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "lint:types": "vis run lint:types && pnpm run lint:types:registry",
         "lint:types:registry": "pnpm run build:packages && tsc -p registry/tsconfig.json",
         "multi-semantic-release": "multi-semantic-release",
-        "postinstall": "node scripts/generate-package-og-images.js && node scripts/generate-labeler-config.js --skip-ci && node scripts/check-cerebro-peer-lockstep.js && node scripts/check-sibling-peer-ranges.js && node scripts/check-skill-mirrors.js && node scripts/check-registry-catalog-ranges.js && node scripts/check-agents-md-packages.js && node scripts/check-roadmap-tiers.js && node scripts/no-nul-bytes.mjs",
+        "postinstall": "node scripts/generate-package-og-images.js && node scripts/generate-labeler-config.js --skip-ci && node scripts/check-cerebro-peer-lockstep.js && node scripts/check-sibling-peer-ranges.js && node scripts/check-skill-mirrors.js && node scripts/check-registry-catalog-ranges.js && node scripts/check-agents-md-packages.js && node scripts/check-roadmap-tiers.js && node scripts/no-nul-bytes.mjs && node --test --test-reporter=dot plugins/lunora/scripts/verify-turn.test.mjs",
         "prepare": "vis hook install",
         "test": "vis run test --query \"project!=lunora-e2e&&project!=lunora-playground\"",
         "test:affected": "vis affected test --fail-fast --query \"project!=lunora-e2e&&project!=lunora-playground\"",

--- a/packages/cli/skills/README.md
+++ b/packages/cli/skills/README.md
@@ -43,4 +43,5 @@ ln -s ../../../packages/cli/skills/<name> plugins/lunora/skills/<name>
 `scripts/check-skill-mirrors.js` (run on every `pnpm install`) fails if a mirror
 is missing, dangling, or has become a real directory — a copied directory keeps
 resolving while it silently drifts from the source, so it is treated as an
-error rather than a warning.
+error rather than a warning. Forget a hop and it prints the exact `ln -s` for
+the one you missed, so `pnpm install` is the shortest path to the right command.

--- a/packages/cli/skills/lunora/SKILL.md
+++ b/packages/cli/skills/lunora/SKILL.md
@@ -69,17 +69,16 @@ anything:
 
 ```bash
 lunora verify    # wrangler config + codegen dry-run + tsc --noEmit
-lunora advisor   # ~95 static + runtime lints, scored per procedure
+lunora advisor   # the static + runtime lint set, scored per procedure
 ```
 
-`lunora advisor` is the security/quality review: RLS coverage
-(`rls-procedures`, `procedure-protections`), ownership and identity checks
-(`owner-field-writes`, `normalize-id-authorization`, `identity-claim-reads`,
-`fail-open-guards`), input validators, unindexed reads, non-deterministic
-calls in queries, SQL interpolation, and leaked secrets. Use
-`--entry <file>#<export>` to inspect one procedure and `--min-score` /
-`--baseline` to gate CI. Only after it is clean is a by-hand pass over
-`lunora-functions` worth the tokens.
+`lunora advisor` is the security/quality review: RLS coverage, ownership and
+identity checks, fail-open guards, input validators, unindexed reads,
+non-deterministic calls in queries, SQL interpolation, and leaked secrets. It
+prints each finding's own lint id and category, so read its output rather than
+grepping for rule names. Use `--entry <file>#<export>` to inspect one procedure
+and `--min-score` / `--baseline` to gate CI. Only after it is clean is a by-hand
+pass over `lunora-functions` worth the tokens.
 
 If one of those clearly matches the user's goal, switch to it instead of staying
 in this skill.

--- a/plugins/lunora/.claude-plugin/plugin.json
+++ b/plugins/lunora/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+    "name": "lunora",
+    "displayName": "Lunora",
+    "version": "0.1.0",
+    "description": "Build type-safe, real-time Lunora backends on Cloudflare Workers + Durable Objects — the first-party agent skills plus an end-of-turn `lunora verify` gate that hands back its own compiler errors. Run `lunora mcp install` for the MCP server.",
+    "author": {
+        "name": "Anolilab",
+        "email": "d.bannert@anolilab.de",
+        "url": "https://github.com/anolilab"
+    },
+    "homepage": "https://lunora.sh",
+    "repository": "https://github.com/anolilab/lunora",
+    "license": "FSL-1.1-Apache-2.0",
+    "keywords": ["lunora", "cloudflare", "workers", "durable-objects", "realtime", "backend", "typescript", "vite"],
+    "hooks": "./hooks/hooks.json"
+}

--- a/plugins/lunora/.codex-plugin/plugin.json
+++ b/plugins/lunora/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+    "name": "lunora",
+    "version": "0.1.0",
+    "description": "Build type-safe, real-time Lunora backends on Cloudflare Workers + Durable Objects — the first-party agent skills. Run `lunora mcp install` to add the MCP server over your dev deployment (schema, data, logs, advisories, docs search).",
+    "author": {
+        "name": "Anolilab",
+        "email": "d.bannert@anolilab.de",
+        "url": "https://github.com/anolilab"
+    },
+    "repository": "https://github.com/anolilab/lunora",
+    "license": "FSL-1.1-Apache-2.0",
+    "keywords": ["lunora", "cloudflare", "workers", "durable-objects", "realtime", "backend", "typescript", "vite"],
+    "interface": {
+        "displayName": "Lunora",
+        "shortDescription": "Type-safe real-time backends on Cloudflare.",
+        "developerName": "Anolilab",
+        "category": "Developer Tools"
+    },
+    "skills": "./skills/"
+}

--- a/plugins/lunora/README.md
+++ b/plugins/lunora/README.md
@@ -1,0 +1,91 @@
+# Lunora agent plugin
+
+The first-party Lunora plugin for Claude Code and Codex. It ships two things:
+
+| Component  | What it is                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------------- |
+| **Skills** | The 14 first-party skills from `packages/cli/skills/`, symlinked in — `lunora` routes, the rest do the work.    |
+| **Hook**   | A `Stop` gate that re-runs `lunora verify` at turn end and blocks with the compiler's own errors when it fails. |
+
+## Install
+
+**Claude Code**
+
+```bash
+/plugin marketplace add anolilab/lunora
+/plugin install lunora@lunora
+```
+
+**Codex** — search for `lunora` in the plugin directory, or add this repo as a
+marketplace (`.agents/plugins/marketplace.json`).
+
+**Neither** — `lunora rules install` copies the same skills into the project's
+`.agents/skills/`, which Cursor, Copilot and Codex all read. That path gives you
+the skills without the hook.
+
+## MCP is a separate install, on purpose
+
+The plugin declares **no** MCP server. `lunora mcp install` already owns that
+job, and it makes two decisions a plugin manifest cannot express: it spawns the
+_project's_ binary through the project's package manager (a plugin-level `npx`
+would fetch whatever is newest on npm and point a mismatched CLI at this
+project's `.lunora/dev.json`), and it deliberately refuses to write a
+machine-wide `lunora` entry, because the stdio spec carries no `cwd` and one
+global entry would serve whichever directory the editor happened to start in.
+See the comments on `McpServerPlan` in `packages/cli/src/commands/mcp/install.ts`.
+
+```bash
+lunora mcp install          # every MCP client configured on this machine
+lunora mcp install --print  # show what it would write
+```
+
+## The `Stop` hook
+
+`scripts/verify-turn.mjs` is the only new behaviour here. The skills already
+say "run `lunora verify` before you call it done"; agents skip it, and the type
+error surfaces on the user's next `lunora dev` instead of in the turn that
+caused it. The hook makes the rule a mechanism: on turn end it runs the same
+command and, on failure, blocks the stop with the output, so the next turn
+starts from the real errors.
+
+It stays quiet unless it has something to say:
+
+- No `lunora/` directory **next to a wrangler config** → not a Lunora project,
+  exit. The walk up stops at the enclosing `.git`, so a sibling checkout named
+  `lunora` can't capture an unrelated repo.
+- `git status --porcelain -- lunora` clean → the turn didn't touch the backend,
+  so skip without paying for a `tsc` run. Non-git projects always verify.
+- `stop_hook_active` → Claude Code is already continuing because this hook
+  blocked. It also caps a hook at 8 consecutive blocks, which is why there is no
+  counter here to get wrong.
+- No `lunora` in the project's (or a parent's) `node_modules/.bin` → an
+  environment fact, not a type error.
+
+A verify that times out or cannot be spawned returns a `systemMessage` rather
+than a silent `{}`, so "could not check" never reads as "checked, and it
+passed".
+
+```bash
+node --test plugins/lunora/scripts/verify-turn.test.mjs   # also runs in postinstall
+```
+
+## Adding a skill
+
+Skills are **not** authored here. `packages/cli/skills/<name>/` is the source of
+truth; this directory holds symlinks, as do `.agents/skills/` and
+`.claude/skills/`. See `packages/cli/skills/README.md` for the hops — or just
+run `pnpm install`, and `scripts/check-skill-mirrors.js` prints the exact
+`ln -s` command for whichever mirror is missing.
+
+Claude Code dereferences symlinks that resolve inside the marketplace when it
+copies a plugin into its cache, so installed users get file contents, not links.
+
+## Not included, and why
+
+- **A reviewer skill.** `lunora advisor` already runs the static and runtime
+  lint set — RLS coverage, ownership checks, validators, index usage, secrets —
+  and scores them per procedure. A markdown checklist restating a working linter
+  is a checklist that drifts from it. The `lunora` router skill points at the
+  command instead.
+- **A runtime-error monitor.** Plugin monitors need something to tail, and
+  `lunora dev` writes no error log. Add one when it does.

--- a/plugins/lunora/hooks/hooks.json
+++ b/plugins/lunora/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+    "hooks": {
+        "Stop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/verify-turn.mjs\"",
+                        "timeout": 180
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/plugins/lunora/scripts/verify-turn.mjs
+++ b/plugins/lunora/scripts/verify-turn.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * `Stop` hook — turn the "run `lunora verify` before you call it done" rule into
+ * a mechanism instead of an instruction.
+ *
+ * The skills already say to verify. Agents skip it, and the failure mode is
+ * quiet: the turn ends, the user reads a confident summary, and the type error
+ * surfaces on their next `lunora dev`. This hook re-runs the check at turn end
+ * and, when it fails, blocks the stop with the compiler's own output so the
+ * next turn starts from the real errors rather than from a re-description.
+ *
+ * `lunora verify` is the whole gate in one command: wrangler config validation,
+ * a codegen dry-run (so `lunora/_generated/` staleness is caught, not inherited)
+ * and `tsc --noEmit`.
+ *
+ * Four guards keep it from becoming a nag:
+ *
+ * 1. **Not a Lunora project** — a `lunora/` directory NEXT TO a wrangler config,
+ *    the same pair `lunora mcp install` treats as the marker. The directory
+ *    alone is not enough: this repo alone has a `packages/lunora`, a `lunora`
+ *    under four of the SDKs and one under every template, and a developer with
+ *    a `lunora` checkout beside their other projects would otherwise turn every
+ *    unrelated repo into a Lunora one.
+ * 2. **Nothing changed under `lunora/`** — the working tree is clean there, so
+ *    whatever the turn did, it didn't touch the backend. Skipped without paying
+ *    for a `tsc` run. Non-git projects verify unconditionally.
+ * 3. **`stop_hook_active`** — Claude Code sets this once it is already
+ *    continuing because of a stop hook, which is the documented way to avoid
+ *    blocking forever. It also caps a hook at 8 consecutive blocks on its own,
+ *    so there is no counter to keep here.
+ * 4. **No project-local `lunora`** — an environment fact, not a type error.
+ *
+ * Contract: stdin is the hook event JSON, stdout is the hook result JSON.
+ * Anything unexpected exits 0 with `{}` — a broken hook must never wedge a
+ * session.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** How much of the verify output to hand back. Enough for a real error list, not the whole log. */
+const MAX_REASON_CHARS = 2000;
+
+/** Directories to walk up while looking for the project root. */
+const MAX_WALK_UP = 8;
+
+/** Candidate wrangler config filenames, mirroring `WRANGLER_FILES` in `@lunora/config`. */
+const WRANGLER_FILES = ["wrangler.jsonc", "wrangler.json"];
+
+/** A `lunora/` directory next to a wrangler config — the marker `lunora mcp install` uses. */
+const isLunoraProject = (directory, exists) => exists(join(directory, "lunora")) && WRANGLER_FILES.some((name) => exists(join(directory, name)));
+
+/**
+ * Nearest ancestor of `startDirectory` (inclusive) that looks like a Lunora
+ * project — the root `lunora verify` needs to run from. `undefined` when there
+ * is none, which is the "not a Lunora project" exit.
+ *
+ * The walk stops at a `.git` directory. Without that boundary it escapes the
+ * repository entirely and can select a sibling checkout's parent as "the
+ * project root".
+ */
+const findProjectRoot = (startDirectory, exists = existsSync) => {
+    let directory = startDirectory;
+
+    for (let index = 0; index < MAX_WALK_UP; index += 1) {
+        if (isLunoraProject(directory, exists)) {
+            return directory;
+        }
+
+        const parent = dirname(directory);
+
+        if (parent === directory || exists(join(directory, ".git"))) {
+            return undefined;
+        }
+
+        directory = parent;
+    }
+
+    return undefined;
+};
+
+/**
+ * Whether the turn plausibly touched the backend.
+ *
+ * `git status --porcelain -- lunora` empty means the backend is committed as-is,
+ * so a `tsc` run would only re-prove what the pre-commit gate already proved.
+ * A git failure (no repo, no git binary) returns `true`: verifying is the safe
+ * answer when we cannot tell.
+ */
+const backendIsDirty = (root, run = spawnSync) => {
+    const result = run("git", ["status", "--porcelain", "--", "lunora"], { cwd: root, encoding: "utf8" });
+
+    if (result.error !== undefined || result.status !== 0) {
+        return true;
+    }
+
+    return result.stdout.trim().length > 0;
+};
+
+/**
+ * The project's own `lunora` binary, walking up for a hoisted `node_modules` in
+ * a monorepo. `undefined` means `@lunora/cli` isn't a dependency here.
+ *
+ * Deliberately not `npx`: `npx -y @lunora/cli` resolves the `latest` dist-tag,
+ * which for this package is an empty `0.0.0` placeholder with no `bin` at all,
+ * and `npx --no-install lunora` still round-trips to the registry for a package
+ * name that does not exist there. Both fail on every turn end.
+ */
+const findLunoraBin = (root, exists = existsSync) => {
+    let directory = root;
+
+    for (let index = 0; index < MAX_WALK_UP; index += 1) {
+        for (const name of ["lunora", "lunora.cmd"]) {
+            const binary = join(directory, "node_modules", ".bin", name);
+
+            if (exists(binary)) {
+                return binary;
+            }
+        }
+
+        const parent = dirname(directory);
+
+        if (parent === directory) {
+            return undefined;
+        }
+
+        directory = parent;
+    }
+
+    return undefined;
+};
+
+/**
+ * `shell: true` for the Windows `.cmd` shim only. Node refuses to spawn a
+ * `.cmd`/`.bat` without a shell (the CVE-2024-27980 hardening), so the Windows
+ * branch of {@link findLunoraBin} would otherwise resolve a binary the hook can
+ * never execute — a gate that silently never runs. `binary` is a path we built
+ * ourselves from `node_modules/.bin`, not anything from the event payload.
+ */
+const runVerify = (binary, root) => spawnSync(binary, ["verify"], { cwd: root, encoding: "utf8", shell: binary.endsWith(".cmd"), timeout: 170_000 });
+
+/**
+ * Turn a verify result into a hook decision. Split out from the I/O so the
+ * block and pass branches are testable without spawning anything.
+ *
+ * The reason takes the TAIL of the output: `lunora verify` streams wrangler and
+ * codegen progress first and prints its `verify: errors:` summary last, so the
+ * head is the noise and the tail is the answer.
+ */
+const decide = ({ output, status }) => {
+    if (status === 0) {
+        return { block: false };
+    }
+
+    return {
+        block: true,
+        reason:
+            "`lunora verify` failed after that turn (wrangler config + codegen dry-run + `tsc --noEmit`). " +
+            "Fix the errors below, re-run `lunora verify` until it is clean, then finish. " +
+            "If an error pre-dates this turn and is out of scope, say so to the user rather than silently leaving it:\n\n" +
+            output.trim().slice(-MAX_REASON_CHARS),
+    };
+};
+
+const readStdin = async () => {
+    const chunks = [];
+
+    for await (const chunk of process.stdin) {
+        chunks.push(chunk);
+    }
+
+    return Buffer.concat(chunks).toString("utf8");
+};
+
+const main = async () => {
+    let event = {};
+
+    try {
+        event = JSON.parse(await readStdin());
+    } catch {
+        return {};
+    }
+
+    // Plan mode writes nothing, and `stop_hook_active` means we already blocked
+    // once and Claude Code is continuing because of it.
+    if (event.permission_mode === "plan" || event.stop_hook_active === true) {
+        return {};
+    }
+
+    const root = findProjectRoot(event.cwd ?? process.cwd());
+
+    if (root === undefined || !backendIsDirty(root)) {
+        return {};
+    }
+
+    const binary = findLunoraBin(root);
+
+    if (binary === undefined) {
+        return {};
+    }
+
+    const result = runVerify(binary, root);
+
+    // A timed-out or un-spawnable verify proves nothing either way. Say so
+    // instead of returning a bare `{}`, which reads as "checked, and it passed".
+    if (result.error !== undefined) {
+        return { systemMessage: `lunora verify could not run (${result.error.message}) — the backend was NOT type-checked this turn.` };
+    }
+
+    const decision = decide({ output: `${result.stdout ?? ""}${result.stderr ?? ""}`, status: result.status });
+
+    return decision.block ? { decision: "block", reason: decision.reason } : {};
+};
+
+// Only when executed directly — the test file imports the helpers above.
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        process.stdout.write(`${JSON.stringify(await main())}\n`);
+    } catch {
+        process.stdout.write("{}\n");
+    }
+}
+
+export { backendIsDirty, decide, findLunoraBin, findProjectRoot };

--- a/plugins/lunora/scripts/verify-turn.test.mjs
+++ b/plugins/lunora/scripts/verify-turn.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * `node --test plugins/lunora/scripts/verify-turn.test.mjs` — the branches of
+ * the Stop-hook gate that decide whether a turn gets blocked. Everything here
+ * is pure; the filesystem and spawn calls are injected.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { backendIsDirty, decide, findLunoraBin, findProjectRoot } from "./verify-turn.mjs";
+
+/** An `existsSync` double over a fixed set of paths. */
+const fs = (...paths) => {
+    const set = new Set(paths);
+
+    return (path) => set.has(path);
+};
+
+test("findProjectRoot needs a lunora/ directory AND a wrangler config", () => {
+    assert.equal(findProjectRoot("/repo", fs("/repo/lunora", "/repo/wrangler.jsonc")), "/repo");
+    assert.equal(findProjectRoot("/repo", fs("/repo/lunora", "/repo/wrangler.json")), "/repo");
+    // A bare `lunora/` is not a project — packages/lunora, sdks/*/lunora, a
+    // sibling checkout named `lunora`.
+    assert.equal(findProjectRoot("/repo", fs("/repo/lunora")), undefined);
+});
+
+test("findProjectRoot walks up from a subdirectory", () => {
+    assert.equal(findProjectRoot("/repo/src/features", fs("/repo/lunora", "/repo/wrangler.jsonc")), "/repo");
+});
+
+test("findProjectRoot stops at the repository boundary", () => {
+    // A sibling checkout at /work/lunora + /work/wrangler.jsonc must not be
+    // selected from inside an unrelated repo at /work/other.
+    const layout = fs("/work/other/.git", "/work/lunora", "/work/wrangler.jsonc");
+
+    assert.equal(findProjectRoot("/work/other/src", layout), undefined);
+});
+
+test("backendIsDirty verifies when git cannot answer", () => {
+    assert.equal(
+        backendIsDirty("/repo", () => ({ error: new Error("no git"), status: null, stdout: "" })),
+        true,
+    );
+    assert.equal(
+        backendIsDirty("/repo", () => ({ status: 128, stdout: "" })),
+        true,
+    );
+});
+
+test("backendIsDirty skips a clean backend and runs on a dirty one", () => {
+    assert.equal(
+        backendIsDirty("/repo", () => ({ status: 0, stdout: "\n" })),
+        false,
+    );
+    assert.equal(
+        backendIsDirty("/repo", () => ({ status: 0, stdout: " M lunora/schema.ts\n" })),
+        true,
+    );
+});
+
+test("a clean verify does not block", () => {
+    assert.deepEqual(decide({ output: "verify: project is valid", status: 0 }), { block: false });
+});
+
+test("a failed verify blocks and hands back the TAIL of the output", () => {
+    // `lunora verify` streams progress first and prints its error summary last,
+    // so a head-slice would drop the part that names the failing step.
+    const output = `${"codegen progress noise\n".repeat(500)}lunora/messages.ts(12,5): error TS2345: nope\nverify: errors:\n  - type errors: tsc --noEmit exited 2`;
+    const decision = decide({ output, status: 1 });
+
+    assert.equal(decision.block, true);
+    assert.match(decision.reason, /verify: errors:/u);
+    assert.match(decision.reason, /error TS2345: nope/u);
+});
+
+test("findLunoraBin walks up to a hoisted node_modules and gives up when there is none", () => {
+    assert.equal(findLunoraBin("/repo/apps/web", fs("/repo/node_modules/.bin/lunora")), "/repo/node_modules/.bin/lunora");
+    assert.equal(findLunoraBin("/repo/apps/web", fs("/repo/node_modules/.bin/lunora.cmd")), "/repo/node_modules/.bin/lunora.cmd");
+    assert.equal(
+        findLunoraBin("/repo/apps/web", () => false),
+        undefined,
+    );
+});

--- a/plugins/lunora/skills/lunora
+++ b/plugins/lunora/skills/lunora
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora

--- a/plugins/lunora/skills/lunora-create-package
+++ b/plugins/lunora/skills/lunora-create-package
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-create-package

--- a/plugins/lunora/skills/lunora-deploy
+++ b/plugins/lunora/skills/lunora-deploy
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-deploy

--- a/plugins/lunora/skills/lunora-functions
+++ b/plugins/lunora/skills/lunora-functions
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-functions

--- a/plugins/lunora/skills/lunora-migration-helper
+++ b/plugins/lunora/skills/lunora-migration-helper
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-migration-helper

--- a/plugins/lunora/skills/lunora-performance-audit
+++ b/plugins/lunora/skills/lunora-performance-audit
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-performance-audit

--- a/plugins/lunora/skills/lunora-quickstart
+++ b/plugins/lunora/skills/lunora-quickstart
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-quickstart

--- a/plugins/lunora/skills/lunora-realtime
+++ b/plugins/lunora/skills/lunora-realtime
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-realtime

--- a/plugins/lunora/skills/lunora-setup-auth
+++ b/plugins/lunora/skills/lunora-setup-auth
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-setup-auth

--- a/plugins/lunora/skills/lunora-setup-hyperdrive
+++ b/plugins/lunora/skills/lunora-setup-hyperdrive
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-setup-hyperdrive

--- a/plugins/lunora/skills/lunora-setup-hyperdrive-global
+++ b/plugins/lunora/skills/lunora-setup-hyperdrive-global
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-setup-hyperdrive-global

--- a/plugins/lunora/skills/lunora-setup-mail
+++ b/plugins/lunora/skills/lunora-setup-mail
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-setup-mail

--- a/plugins/lunora/skills/lunora-setup-scheduler
+++ b/plugins/lunora/skills/lunora-setup-scheduler
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-setup-scheduler

--- a/plugins/lunora/skills/lunora-setup-storage
+++ b/plugins/lunora/skills/lunora-setup-storage
@@ -1,0 +1,1 @@
+../../../packages/cli/skills/lunora-setup-storage

--- a/scripts/check-skill-mirrors.js
+++ b/scripts/check-skill-mirrors.js
@@ -2,12 +2,14 @@
  * Guards the first-party Agent Skill mirrors against silent rot.
  *
  * The source of truth is `packages/cli/skills/` (shipped in the `@lunora/cli`
- * tarball via the `files` allowlist). It is mirrored twice so agents working
- * inside this repo pick the skills up directly:
+ * tarball via the `files` allowlist). It is mirrored three times — twice so
+ * agents working inside this repo pick the skills up directly, and once as the
+ * payload of the Claude Code / Codex plugin:
  *
  *     packages/cli/skills/<name>  <-  .agents/skills/<name>  <-  .claude/skills/<name>
+ *                                 <-  plugins/lunora/skills/<name>
  *
- * Both hops are symlinks, and both are tracked in git — which is exactly why
+ * Every hop is a symlink, and every one is tracked in git — which is exactly why
  * they rot invisibly. The `cirrus` -> `lunora` rename renamed the link NAMES
  * but not their TARGETS, leaving 11 of 14 skills dangling in both mirrors for
  * over a month: `git status` stays clean, nothing typechecks a symlink, and the
@@ -32,7 +34,7 @@
  * Run on every `pnpm install` via the root `postinstall` script.
  */
 
-import { existsSync, lstatSync, readdirSync, readlinkSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -43,7 +45,7 @@ const rootDir = join(__dirname, "..");
 const sourceDir = join(rootDir, "packages", "cli", "skills");
 
 /**
- * The mirror chain, in resolution order. Each entry links to the PREVIOUS
+ * The mirror chain, in resolution order. The in-repo hops link to the PREVIOUS
  * layer, not directly to the source: `.claude/skills` -> `.agents/skills` ->
  * `packages/cli/skills`. Keeping the hops relative means a worktree checkout
  * resolves without any absolute-path rewriting.
@@ -55,6 +57,15 @@ const MIRRORS = [
         // whose name has no source directory is stale by definition.
         staleWhenDangling: false,
         targetPrefix: "../../packages/cli/skills/",
+    },
+    {
+        // The Claude Code / Codex plugin's payload. This one links straight to
+        // the source rather than through `.agents`: Claude Code dereferences a
+        // symlink when it copies the plugin into its cache, and a link through a
+        // second link is one more hop to get wrong for zero benefit.
+        dir: join(rootDir, "plugins", "lunora", "skills"),
+        staleWhenDangling: false,
+        targetPrefix: "../../../packages/cli/skills/",
     },
     {
         dir: join(rootDir, ".claude", "skills"),
@@ -149,9 +160,58 @@ function isSymlink(path) {
     }
 }
 
+/**
+ * The plugin ships one manifest per host (`.claude-plugin/plugin.json` for
+ * Claude Code, `.codex-plugin/plugin.json` for Codex) and neither host reads the
+ * other's. Their shared identity fields are therefore hand-copied, and nothing
+ * else in the repo would notice one being bumped without the other — the
+ * marketplace would then advertise two different versions of the same plugin.
+ * `description` is deliberately excluded: the two hosts describe different
+ * feature sets.
+ */
+const LOCKSTEP_FIELDS = ["name", "version", "license", "repository", "keywords"];
+
+const checkPluginManifestLockstep = () => {
+    const paths = {
+        claude: join(rootDir, "plugins", "lunora", ".claude-plugin", "plugin.json"),
+        codex: join(rootDir, "plugins", "lunora", ".codex-plugin", "plugin.json"),
+    };
+
+    const manifests = {};
+
+    for (const [host, path] of Object.entries(paths)) {
+        try {
+            manifests[host] = JSON.parse(readFileSync(path, "utf8"));
+        } catch (error) {
+            fail(`${path.slice(rootDir.length + 1)} is missing or not valid JSON (${error.message})`);
+
+            return;
+        }
+    }
+
+    for (const field of LOCKSTEP_FIELDS) {
+        const claude = JSON.stringify(manifests.claude[field]);
+        const codex = JSON.stringify(manifests.codex[field]);
+
+        if (claude !== codex) {
+            fail(`plugins/lunora: "${field}" differs between the Claude (${claude}) and Codex (${codex}) manifests — they describe one plugin`);
+        }
+    }
+
+    if (JSON.stringify(manifests.claude.author) !== JSON.stringify(manifests.codex.author)) {
+        fail(`plugins/lunora: "author" differs between the Claude and Codex manifests`);
+    }
+};
+
+checkPluginManifestLockstep();
+
+const mirrorList = MIRRORS.map(({ dir }) => dir.slice(rootDir.length + 1)).join(", ");
+
 if (hasFailure) {
-    console.error("\ncheck-skill-mirrors: the .agents/.claude skill mirrors are out of sync with packages/cli/skills.\n");
+    console.error(
+        `\ncheck-skill-mirrors: fix the problems above — the mirrors (${mirrorList}) and the plugin manifests must agree with packages/cli/skills.\n`,
+    );
     process.exit(1);
 }
 
-console.log(`check-skill-mirrors: ${skills.length} skills mirrored correctly into .agents/skills and .claude/skills`);
+console.log(`check-skill-mirrors: ${skills.length} skills mirrored correctly into ${mirrorList}; plugin manifests in lockstep`);


### PR DESCRIPTION
Packages the first-party agent skills as an installable Claude Code / Codex plugin, and adds one new mechanism on top: an end-of-turn `lunora verify` gate.

Stacked on `feat/ai-first-class` because two of the touched skill files are modified by that branch.

## What's here

`plugins/lunora` — the plugin — plus the marketplace entries for both hosts:

```bash
/plugin marketplace add anolilab/lunora
/plugin install lunora@lunora
```

**Skills are not authored here.** `packages/cli/skills/` stays the source of truth; the plugin's `skills/` is a third symlink mirror of it, next to `.agents/skills/` and `.claude/skills/`. `check-skill-mirrors.js` gains that mirror, so a new skill can't ship into two of three places. Claude Code dereferences symlinks resolving inside the marketplace when it caches a plugin, so installed users get file contents rather than links.

**The `Stop` hook is the only new behaviour.** The skills already say to run `lunora verify` before calling backend work done. Agents skip it, and the type error then surfaces on the user's next `lunora dev` instead of in the turn that caused it. The hook re-runs the command at turn end and blocks the stop with the compiler's own output, so the next turn starts from the real errors rather than a re-description of them.

It stays silent unless it has something to say:

| Guard | Why |
| --- | --- |
| `lunora/` **next to a wrangler config**, walk stops at `.git` | The bare directory name is not a marker — this repo alone has several, and a sibling checkout named `lunora` would otherwise capture every unrelated repo. Same pair `lunora mcp install` uses. |
| `git status --porcelain -- lunora` non-empty | The turn didn't touch the backend, so don't pay for a `tsc` run. Non-git projects always verify. |
| `stop_hook_active` | The documented re-entry signal. Claude Code also caps a hook at 8 consecutive blocks, which is why there's no counter of our own to get wrong. |
| `lunora` resolves from the project's `node_modules/.bin` | An environment fact, not a type error. |

A verify that times out or can't spawn returns a `systemMessage` saying it could not check, rather than a bare `{}` that reads as "checked, and it passed".

## Two deliberate omissions

**No MCP server.** `lunora mcp install` already owns that, and it makes two decisions a plugin manifest can't express: it spawns the *project's* binary through the project's package manager, and it deliberately refuses a machine-wide entry because the stdio spec carries no `cwd` and one global entry would serve whichever directory the editor started in. A plugin-level `npx -y @lunora/cli` would also be dead on arrival — the `latest` dist-tag for that package is an empty `0.0.0` placeholder with no `bin`.

**No reviewer skill.** `lunora advisor` already runs the static and runtime lint set — RLS coverage, ownership checks, validators, index usage, secrets — scored per procedure. A markdown checklist restating a working linter is a checklist that drifts from it, so the `lunora` router skill points at the command instead.

## Gates

`check-skill-mirrors.js` also asserts the two host manifests agree on their shared identity fields — they're hand-maintained and neither host reads the other's. It caught a stale keyword on its first run.

The hook's tests run from `postinstall`, because `plugins/` sits outside the project graph `vis affected` walks and would otherwise be vacuously green.

```
node --test plugins/lunora/scripts/verify-turn.test.mjs   # 8 pass
claude plugin validate ./plugins/lunora --strict          # pass
claude plugin validate . --strict                         # pass
node scripts/check-skill-mirrors.js                       # 14 mirrored, manifests in lockstep
prettier --check / lint:package-json                      # clean
```

Both blocking and skipping paths were exercised end to end against a scratch project, not just unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7xe5PYB3zzmRrRod9eMTn