### PR TITLE
fix(do): size subscription frames before sending them

### DIFF
--- a/api-snapshots/advisor.api.md
+++ b/api-snapshots/advisor.api.md
@@ -520,6 +520,7 @@ interface AdvisorQueryRead {
     hasIndex: boolean;
     line: number;
     table: string;
+    terminal?: string;
 }
 ```
 

--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -558,6 +558,7 @@ interface QueryReadIR {
     hasIndex: boolean;
     line: number;
     table: string;
+    terminal?: string;
 }
 ```
 

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -4152,12 +4152,6 @@ const selectShapeMemberIds: (sql: SqlExec, table: string, effectiveWhere: WhereI
 const selectShapeRows: (sql: SqlExec, table: string, effectiveWhere: WhereInput | undefined) => ShapeRow[];
 ```
 
-### `sendDeltaFrames` (const)
-
-```ts
-const sendDeltaFrames: (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string, lastMutationId?: number) => boolean;
-```
-
 ### `serializeSqlValue` (const)
 
 ```ts
@@ -4200,6 +4194,12 @@ const stableStringify: (value: unknown) => string;
 
 ```ts
 const stableWireKey: (value: unknown) => string;
+```
+
+### `subscriptionFrames` (const)
+
+```ts
+const subscriptionFrames: (input: SubscriptionFrameInput) => string[];
 ```
 
 ### `subscriptionListDeltas` (const)

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -372,6 +372,26 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
+        "cacheKey": "unbounded_collect:players:32:profiles",
+        "categories": [
+            "PERFORMANCE"
+        ],
+        "description": "A query calls `.collect()` with no `.withIndex()` and no `.filter()`, so it materializes every row of the table. Any live subscription over it also re-sends that whole result to every subscribed client on every write to the table.",
+        "detail": "Query on \"profiles\" at players:32 calls .collect() with no index and no filter — it loads every row of \"profiles\" from the root Durable Object's SQLite into memory. A live subscription over this query records a whole-table dependency, so every write to \"profiles\" re-runs it and re-sends the full result to each subscribed socket.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "list",
+            "file": "players",
+            "line": 32,
+            "shardKind": "root",
+            "table": "profiles"
+        },
+        "name": "unbounded_collect",
+        "remediation": "Narrow the read with `.withIndex(\"name\", (q) => q.eq(...))`, cap it with `.take(n)`, or page it with `.paginate(args.paginationOpts)` so neither the scan nor the subscription payload grows with the table.",
+        "title": "Unbounded collect"
+    },
+    {
         "cacheKey": "nondeterministic_query_mutation:games:99:Date.now",
         "categories": [
             "SCHEMA"

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -287,6 +287,26 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
+        "cacheKey": "unbounded_collect:feedback:47:feedback",
+        "categories": [
+            "PERFORMANCE"
+        ],
+        "description": "A query calls `.collect()` with no `.withIndex()` and no `.filter()`, so it materializes every row of the table. Any live subscription over it also re-sends that whole result to every subscribed client on every write to the table.",
+        "detail": "Query on \"feedback\" at feedback:47 calls .collect() with no index and no filter — it loads every row of \"feedback\" from the root Durable Object's SQLite into memory. A live subscription over this query records a whole-table dependency, so every write to \"feedback\" re-runs it and re-sends the full result to each subscribed socket.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "list",
+            "file": "feedback",
+            "line": 47,
+            "shardKind": "root",
+            "table": "feedback"
+        },
+        "name": "unbounded_collect",
+        "remediation": "Narrow the read with `.withIndex(\"name\", (q) => q.eq(...))`, cap it with `.take(n)`, or page it with `.paginate(args.paginationOpts)` so neither the scan nor the subscription payload grows with the table.",
+        "title": "Unbounded collect"
+    },
+    {
         "cacheKey": "nondeterministic_query_mutation:summaries:90:Date.now",
         "categories": [
             "SCHEMA"

--- a/packages/advisor/__tests__/unbounded-collect.test.ts
+++ b/packages/advisor/__tests__/unbounded-collect.test.ts
@@ -1,0 +1,98 @@
+import { defineSchema, defineTable } from "@lunora/server";
+import { v } from "@lunora/values";
+import { describe, expect, it } from "vitest";
+
+import { fromServerSchema } from "../src";
+import filterWithoutIndex from "../src/lints/static/filter-without-index";
+import unboundedCollect from "../src/lints/static/unbounded-collect";
+import type { AdvisorQueryRead } from "../src/queries";
+
+/** One table per storage tier, so the lint's tier wording can be exercised across all three. */
+const schema = () =>
+    fromServerSchema(
+        defineSchema({
+            catalog: defineTable({ sku: v.string() }).global(),
+            notes: defineTable({ text: v.string() }),
+            threadAccess: defineTable({ role: v.string(), userId: v.string() }).shardBy("userId"),
+        }),
+    );
+
+/** A bare `ctx.db.query(table).collect()` — no index, no filter. */
+const read = (table: string, overrides: Partial<AdvisorQueryRead> = {}): AdvisorQueryRead => {
+    return { exportName: "list", file: "notes", hasFilter: false, hasIndex: false, line: 4, table, terminal: "collect", ...overrides };
+};
+
+describe("unbounded_collect", () => {
+    it("flags an unindexed, unfiltered collect on a root table and names the subscription cost", () => {
+        expect.assertions(3);
+
+        const findings = unboundedCollect.run({ queries: [read("notes")], schema: schema() });
+
+        expect(findings[0]).toMatchObject({ cacheKey: "unbounded_collect:notes:4:notes", level: "WARN", name: "unbounded_collect" });
+        expect(findings[0]?.detail).toContain("root Durable Object's SQLite");
+        // The WebSocket half is the point of the lint, not a footnote: an
+        // unindexed read records a whole-table dependency, so the DO's refresh
+        // gate cannot skip it and re-sends the full result per socket per write.
+        expect(findings[0]?.detail).toContain("re-sends the full result to each subscribed socket");
+    });
+
+    it("keeps a global table at WARN and names the cross-region cost", () => {
+        expect.assertions(2);
+
+        const findings = unboundedCollect.run({ queries: [read("catalog")], schema: schema() });
+
+        expect(findings[0]).toMatchObject({ level: "WARN", metadata: { shardKind: "global" } });
+        expect(findings[0]?.detail).toContain("whole D1 table");
+    });
+
+    it("drops a shardBy table to INFO — the read is scoped to one shard", () => {
+        expect.assertions(2);
+
+        const findings = unboundedCollect.run({ queries: [read("threadAccess")], schema: schema() });
+
+        expect(findings[0]).toMatchObject({ level: "INFO", metadata: { shardKind: "shardBy" } });
+        expect(findings[0]?.detail).toContain("one shard's rows");
+    });
+
+    it("defers to filter_without_index rather than double-reporting a filtered read", () => {
+        expect.assertions(2);
+
+        // Both would otherwise fire on `.filter(...).collect()` with no index,
+        // and both remediations name the same `.withIndex(...)`. One finding.
+        const filtered = read("notes", { hasFilter: true });
+
+        expect(unboundedCollect.run({ queries: [filtered], schema: schema() })).toHaveLength(0);
+        expect(filterWithoutIndex.run({ queries: [filtered], schema: schema() })).toHaveLength(1);
+    });
+
+    it("says nothing about a bounded or narrowed read", () => {
+        expect.assertions(4);
+
+        // `.withIndex(...)` narrows the scan AND lets the refresh gate skip the
+        // subscription when the write lands outside the slice.
+        expect(unboundedCollect.run({ queries: [read("notes", { hasIndex: true })], schema: schema() })).toHaveLength(0);
+        // A capped or paged terminal never materializes the table.
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: "take" })], schema: schema() })).toHaveLength(0);
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: "paginate" })], schema: schema() })).toHaveLength(0);
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: "first" })], schema: schema() })).toHaveLength(0);
+    });
+
+    it("stays silent for a dynamic table, a feeder without terminals, and a runtime caller", () => {
+        expect.assertions(3);
+
+        // A non-literal `query(expr)` gives no table to name.
+        expect(unboundedCollect.run({ queries: [read("")], schema: schema() })).toHaveLength(0);
+        // `terminal` is optional; absent means "unknown", not "collect".
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: undefined })], schema: schema() })).toHaveLength(0);
+        expect(unboundedCollect.run({ schema: schema() })).toHaveLength(0);
+    });
+
+    it("falls back to neutral wording for a table whose tier is not recognised", () => {
+        expect.assertions(1);
+
+        // The `Map`-vs-object-literal prototype safety this shares with
+        // `filter_without_index` is asserted once, exhaustively, in
+        // `filter-scope.test.ts` — it is a property of `Map`, not of either lint.
+        expect(unboundedCollect.run({ queries: [read("unknownTable")], schema: schema() })[0]?.detail).toContain("loads every row");
+    });
+});

--- a/packages/advisor/docs/index.mdx
+++ b/packages/advisor/docs/index.mdx
@@ -138,14 +138,15 @@ Storage, AI, containers & payments:
 
 ### Performance
 
-| Lint                           | Level  | Flags                                                  |
-| ------------------------------ | ------ | ------------------------------------------------------ |
-| `filter_without_index`         | `WARN` | A query filter on a column no index covers             |
-| `shape_targets_global_table`   | `WARN` | A shape replicating from a global (cross-shard) table  |
-| `unindexed_foreign_key`        | `INFO` | A foreign-key column with no index on the owning table |
-| `unindexed_relation_target`    | `INFO` | The `many`-side foreign key of a relation is unindexed |
-| `duplicate_index`              | `INFO` | A redundant index already covered by another           |
-| `container_oversized_instance` | `INFO` | A container instance larger than its workload needs    |
+| Lint                           | Level  | Flags                                                                                                         |
+| ------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------- |
+| `filter_without_index`         | `WARN` | A query filter on a column no index covers                                                                    |
+| `unbounded_collect`            | `WARN` | A `.collect()` with no index and no filter — the whole table, re-sent to every live subscriber on every write |
+| `shape_targets_global_table`   | `WARN` | A shape replicating from a global (cross-shard) table                                                         |
+| `unindexed_foreign_key`        | `INFO` | A foreign-key column with no index on the owning table                                                        |
+| `unindexed_relation_target`    | `INFO` | The `many`-side foreign key of a relation is unindexed                                                        |
+| `duplicate_index`              | `INFO` | A redundant index already covered by another                                                                  |
+| `container_oversized_instance` | `INFO` | A container instance larger than its workload needs                                                           |
 
 ### Schema
 

--- a/packages/advisor/src/index.ts
+++ b/packages/advisor/src/index.ts
@@ -101,6 +101,7 @@ import storageUploadWithoutContentTypeAllowlist from "./lints/static/storage-upl
 import storageUploadWithoutMaxSize from "./lints/static/storage-upload-without-max-size";
 import tableWithoutInsert from "./lints/static/table-without-insert";
 import ttlFieldNotTimestamp from "./lints/static/ttl-field-not-timestamp";
+import unboundedCollect from "./lints/static/unbounded-collect";
 import unboundedStringArgument from "./lints/static/unbounded-string-argument";
 import unindexedForeignKey from "./lints/static/unindexed-foreign-key";
 import unindexedRelationTarget from "./lints/static/unindexed-relation-target";
@@ -325,6 +326,7 @@ export const STATIC_LINTS: ReadonlyArray<Lint> = [
     queueWithoutDlq,
     filterOnPrimaryKey,
     filterWithoutIndex,
+    unboundedCollect,
     shapeTargetsGlobalTable,
     mutatorFullRowReplace,
     nondeterministicQueryMutation,

--- a/packages/advisor/src/lints/helpers.ts
+++ b/packages/advisor/src/lints/helpers.ts
@@ -1,5 +1,6 @@
 import type { AdvisorProcedureProtection } from "../procedure-protections";
-import type { AdvisorTable } from "../schema";
+import type { AdvisorQueryRead } from "../queries";
+import type { AdvisorSchema, AdvisorTable } from "../schema";
 
 /**
  * Ownership / tenancy columns whose presence marks a table as holding user- or
@@ -76,3 +77,21 @@ export const tableColumnSet = (table: AdvisorTable): ReadonlySet<string> => new 
  */
 export const isPublicWrite = (procedure: Pick<AdvisorProcedureProtection, "kind" | "visibility">): boolean =>
     procedure.visibility === "public" && (procedure.kind === "mutation" || procedure.kind === "action");
+
+/**
+ * Where a discovered query read sits, as the `file:line` string the query lints
+ * put in their `detail`. Falls back to the bare file when the feeder could not
+ * resolve a line (`0`), so the text never reads `messages:0`.
+ */
+export const queryReadLocation = (read: Pick<AdvisorQueryRead, "file" | "line">): string =>
+    read.line > 0 ? `${read.file}:${read.line.toString()}` : read.file;
+
+/**
+ * Table name -> declared storage tier, for the query lints that word a finding
+ * by where the rows actually live (`shardBy` reads one Durable Object, `global`
+ * reads D1, `root` reads the single DO). A `Map` so a table named `toString`
+ * resolves to `undefined` and takes the neutral fallback, rather than to an
+ * inherited `Object.prototype` member.
+ */
+export const shardKindsByTable = (schema: AdvisorSchema): ReadonlyMap<string, string | undefined> =>
+    new Map(schema.tables.map((table) => [table.name, table.shardKind]));

--- a/packages/advisor/src/lints/static/filter-on-primary-key.ts
+++ b/packages/advisor/src/lints/static/filter-on-primary-key.ts
@@ -1,5 +1,6 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { queryReadLocation } from "../helpers";
 
 /**
  * Flags `ctx.db.query("t").filter((d) => d._id === x)` — a full scan for a row
@@ -33,7 +34,7 @@ const filterOnPrimaryKey: Lint = {
         (context.queries ?? [])
             .filter((read) => read.filtersPrimaryKey === true && read.table !== "")
             .map((read) => {
-                const location = read.line > 0 ? `${read.file}:${read.line.toString()}` : read.file;
+                const location = queryReadLocation(read);
 
                 return emit(filterOnPrimaryKey, {
                     cacheKey: `filter_on_primary_key:${read.file}:${read.line.toString()}:${read.table}`,

--- a/packages/advisor/src/lints/static/filter-without-index.ts
+++ b/packages/advisor/src/lints/static/filter-without-index.ts
@@ -1,5 +1,6 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { queryReadLocation, shardKindsByTable } from "../helpers";
 
 /**
  * Flags a query read that calls `.filter()` without first narrowing with
@@ -23,7 +24,7 @@ const filterWithoutIndex: Lint = {
     remediation: 'Narrow the read with `.withIndex("name", (q) => q.eq(...))` first, then `.filter()` only for what the index cannot express.',
     run: (context) => {
         const findings = [];
-        const shardKindByTable = new Map(context.schema.tables.map((table) => [table.name, table.shardKind]));
+        const shardKindByTable = shardKindsByTable(context.schema);
 
         for (const read of context.queries ?? []) {
             // Only an *unindexed* filter on a known table is a scan we can name.
@@ -38,7 +39,7 @@ const filterWithoutIndex: Lint = {
                 continue;
             }
 
-            const location = read.line > 0 ? `${read.file}:${read.line.toString()}` : read.file;
+            const location = queryReadLocation(read);
             const shardKind = shardKindByTable.get(read.table);
             const metadata = { exportName: read.exportName, file: read.file, line: read.line, shardKind: shardKind ?? "unknown", table: read.table };
             const cacheKey = `filter_without_index:${read.file}:${read.line.toString()}:${read.table}`;

--- a/packages/advisor/src/lints/static/unbounded-collect.ts
+++ b/packages/advisor/src/lints/static/unbounded-collect.ts
@@ -1,0 +1,105 @@
+import emit from "../../finding";
+import type { Level, Lint } from "../../types";
+import { queryReadLocation, shardKindsByTable } from "../helpers";
+
+/**
+ * How a finding is worded and rated per storage tier — what the read actually
+ * costs, and how much of the dataset it is bounded by.
+ *
+ * A `Map`, not an object literal: `shardKind` reaches this as data, so a table
+ * whose kind is `"toString"` would resolve to an inherited `Object.prototype`
+ * member on an object and skip the neutral fallback below.
+ */
+const TIERS = new Map<string, { level: Level; scope: (table: string) => string }>([
+    ["global", { level: "WARN", scope: (table) => `it reads the whole D1 table "${table}" over a cross-region round trip` }],
+    // `root` is the default single-Durable-Object table (its own SQLite), not D1.
+    ["root", { level: "WARN", scope: (table) => `it loads every row of "${table}" from the root Durable Object's SQLite into memory` }],
+    // A `.shardBy()` table's rows are partitioned across Durable Objects and the
+    // read runs inside ONE of them, so this collects a single tenant's rows
+    // rather than the dataset. Still unbounded within that tenant — a busy one is
+    // exactly where the fan-out hurts — but not the same order of problem.
+    [
+        "shardBy",
+        {
+            level: "INFO",
+            scope: (table) =>
+                `"${table}" is \`.shardBy()\`, so this collects one shard's rows rather than the whole table — bounded by a single tenant's row count`,
+        },
+    ],
+]);
+
+/** An unrecognised tier gets wording that claims nothing about storage we cannot see. */
+const UNKNOWN_TIER = { level: "WARN" as Level, scope: (table: string) => `it loads every row of "${table}"` };
+
+/**
+ * Flags `ctx.db.query("table").collect()` with no `.withIndex()` and no
+ * `.filter()` — a read of every row, materialized in full.
+ *
+ * `filter_without_index` deliberately does not see this: it gates on
+ * `hasFilter`, so the widest read of all — the one that doesn't even filter —
+ * falls through it.
+ *
+ * The cost is not only the scan. A `query`'s result is what a live subscription
+ * pushes over the WebSocket, and the DO's refresh gate can only skip a
+ * subscription whose reads were confined to index slices. An unindexed
+ * `.collect()` records a whole-table dependency instead, so **every** write to
+ * the table re-runs the query and re-sends the entire table to **every**
+ * subscribed socket, individually. A table that grows to a few thousand rows
+ * turns a one-row edit into megabytes of fan-out.
+ *
+ * The reads come from the codegen feeder, which parses `ctx.db.query("table")…`
+ * chains out of function bodies. Runtime callers supply no `queries`, so this
+ * lint is a no-op there — as it is for a feeder that predates `terminal`.
+ */
+const unboundedCollect: Lint = {
+    categories: ["PERFORMANCE"],
+    description:
+        "A query calls `.collect()` with no `.withIndex()` and no `.filter()`, so it materializes every row of the table. Any live subscription over it also re-sends that whole result to every subscribed client on every write to the table.",
+    facing: "EXTERNAL",
+    level: "WARN",
+    name: "unbounded_collect",
+    remediation:
+        'Narrow the read with `.withIndex("name", (q) => q.eq(...))`, cap it with `.take(n)`, or page it with `.paginate(args.paginationOpts)` so neither the scan nor the subscription payload grows with the table.',
+    run: (context) => {
+        const findings = [];
+        const shardKinds = shardKindsByTable(context.schema);
+
+        for (const read of context.queries ?? []) {
+            // Not a candidate at all: bounded or narrowed, or a dynamic table we
+            // cannot name.
+            if (read.terminal !== "collect" || read.hasIndex || read.table === "") {
+                continue;
+            }
+
+            // A candidate, but `filter_without_index` already reports it and its
+            // remediation names the same index — one read must not produce two
+            // findings pointing at one fix.
+            if (read.hasFilter) {
+                continue;
+            }
+
+            const shardKind = shardKinds.get(read.table);
+            const { level, scope } = TIERS.get(shardKind ?? "") ?? UNKNOWN_TIER;
+            const location = queryReadLocation(read);
+            const subscriptionCost =
+                level === "WARN"
+                    ? ` A live subscription over this query records a whole-table dependency, so every write to "${read.table}" re-runs it and re-sends the full result to each subscribed socket.`
+                    : " Cap it with `.take(n)` if that count can grow.";
+
+            findings.push(
+                emit(unboundedCollect, {
+                    cacheKey: `unbounded_collect:${read.file}:${read.line.toString()}:${read.table}`,
+                    detail: `Query on "${read.table}" at ${location} calls .collect() with no index and no filter — ${scope(read.table)}.${subscriptionCost}`,
+                    level,
+                    metadata: { exportName: read.exportName, file: read.file, line: read.line, shardKind: shardKind ?? "unknown", table: read.table },
+                }),
+            );
+        }
+
+        return findings;
+    },
+    source: "static",
+    title: "Unbounded collect",
+};
+
+export default unboundedCollect;

--- a/packages/advisor/src/queries.ts
+++ b/packages/advisor/src/queries.ts
@@ -1,8 +1,9 @@
 /**
  * One query read discovered in a function body — the input the
- * `filter_without_index` lint consumes. Produced by the codegen feeder (which
- * parses `ctx.db.query("table")…` chains from the AST); runtime callers don't
- * supply it, so the lint simply finds nothing there.
+ * `filter_without_index` / `filter_on_primary_key` / `unbounded_collect` lints
+ * consume. Produced by the codegen feeder (which parses `ctx.db.query("table")…`
+ * chains from the AST); runtime callers don't supply it, so those lints simply
+ * find nothing there.
  */
 export interface AdvisorQueryRead {
     /**
@@ -33,4 +34,17 @@ export interface AdvisorQueryRead {
     line: number;
     /** The queried table; empty when the `query(...)` argument is not a string literal. */
     table: string;
+
+    /**
+     * The materializing call the chain ends in — `"collect"`, `"take"`,
+     * `"paginate"`, `"first"`, `"unique"`, … — i.e. how much of the narrowed set
+     * the read actually loads.
+     *
+     * `undefined` when the chain reaches no recognised terminal (a reader passed
+     * on, a bare `query(...)`) AND when a feeder predating this field produced
+     * the read. The two are deliberately not distinguished: no consumer could act
+     * on the difference, so the terminal-shaped lints skip the read either way
+     * rather than guessing a terminal.
+     */
+    terminal?: string;
 }

--- a/packages/codegen/__tests__/discover-queries.test.ts
+++ b/packages/codegen/__tests__/discover-queries.test.ts
@@ -22,6 +22,17 @@ const FUNCTIONS = `
     export const noFilter = query({ args: {}, handler: (ctx) => ctx.db.query("messages").collect() });
 
     export const dynamic = query({ args: {}, handler: (ctx) => ctx.db.query(dynamicTable).filter((row) => row.read).collect() });
+
+    export const geo = query({
+        args: {},
+        handler: (ctx) => ctx.db.query("places").withGeoIndex("byLocation", (q) => q.near({ lat: 1, lng: 2 }, 500)).collect(),
+    });
+
+    export const thenned = query({ args: {}, handler: (ctx) => ctx.db.query("messages").collect().then((rows) => rows.slice(0, 5)) });
+
+    export const capped = query({ args: {}, handler: (ctx) => ctx.db.query("messages").take(10) });
+
+    export const handedOn = query({ args: {}, handler: (ctx) => ctx.db.query("messages").order("desc") });
 `;
 
 let workdir: string;
@@ -39,28 +50,65 @@ describe("discoverQueries", () => {
         rmSync(workdir, { force: true, recursive: true });
     });
 
-    it("returns only filtered reads, tagging index presence and table", () => {
+    /** The single read discovered inside a given exported query. */
+    const readIn = (exportName: string) => discoverQueries(project, join(workdir, "lunora")).find((read) => read.exportName === exportName);
+
+    it("returns every read, tagging filter, index presence, and table", () => {
         expect.assertions(4);
 
         const reads = discoverQueries(project, join(workdir, "lunora"));
 
-        // `noFilter` is dropped; the other three filter.
-        expect(reads).toHaveLength(3);
-
-        const unindexed = reads.filter((read) => !read.hasIndex && read.table === "messages");
+        // Every read, including the unfiltered ones: they are not
+        // `filter_without_index` candidates (that lint gates on `hasFilter`), but
+        // a bare unindexed `.collect()` is exactly what `unbounded_collect` looks
+        // for, and dropping it here is what made that read invisible to any lint.
+        expect(reads).toHaveLength(8);
 
         // `scan` (no index) is flaggable; `indexed` has a `.withIndex` so it is not.
-        expect(unindexed).toHaveLength(1);
+        expect(reads.filter((read) => !read.hasIndex && read.hasFilter && read.table === "messages")).toHaveLength(1);
         expect(reads.some((read) => read.hasIndex && read.table === "messages")).toBe(true);
         // `dynamic` keeps `table: ""` because the argument is not a string literal.
         expect(reads.some((read) => read.table === "")).toBe(true);
+    });
+
+    it("reports the unfiltered, unindexed collect that unbounded_collect consumes", () => {
+        expect.assertions(1);
+
+        expect(readIn("noFilter")).toMatchObject({ hasFilter: false, hasIndex: false, table: "messages", terminal: "collect" });
+    });
+
+    it("counts withGeoIndex as narrowing, so an idiomatic geo read is not an unbounded scan", () => {
+        expect.assertions(1);
+
+        // A geo read resolves a geohash-prefix range plus a distance refine, and
+        // is normally written with no `.filter()` — so without this it would land
+        // on `unbounded_collect`'s exact trigger. `geo_index_unused` remediates by
+        // telling authors to write this very chain.
+        expect(readIn("geo")).toMatchObject({ hasIndex: true, table: "places" });
+    });
+
+    it("reports the last recognised terminal, not the last chained call", () => {
+        expect.assertions(2);
+
+        // `.collect().then(...)` keeps the chain walk going, so the literal last
+        // method is a promise combinator. The read is still an unbounded collect.
+        expect(readIn("thenned")?.terminal).toBe("collect");
+        expect(readIn("capped")?.terminal).toBe("take");
+    });
+
+    it("leaves the terminal undefined when the chain reaches none", () => {
+        expect.assertions(1);
+
+        // A reader handed on without being materialized: nothing to judge, so the
+        // terminal-shaped lints skip it rather than being handed a guess.
+        expect(readIn("handedOn")?.terminal).toBeUndefined();
     });
 
     it("records the file (relative, no extension) and a 1-based line", () => {
         expect.assertions(2);
 
         const reads = discoverQueries(project, join(workdir, "lunora"));
-        const scan = reads.find((read) => !read.hasIndex && read.table === "messages");
+        const scan = reads.find((read) => !read.hasIndex && read.hasFilter && read.table === "messages");
 
         expect(scan?.file).toBe("messages");
         expect(scan?.line).toBeGreaterThan(0);

--- a/packages/codegen/src/discover-queries.ts
+++ b/packages/codegen/src/discover-queries.ts
@@ -5,8 +5,32 @@ import { enclosingExportName } from "./argument-taint";
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { QueryReadIR } from "./ir";
 
-/** Chain methods that narrow a read so it is not a full scan. */
-const INDEX_METHODS = new Set(["withIndex", "withSearchIndex"]);
+/**
+ * Chain methods that narrow a read so it is not a full scan.
+ *
+ * `withGeoIndex` belongs here for the same reason as the other two: it resolves
+ * a geohash-prefix range plus a distance refine, never a table scan. It was
+ * missing while this feeder only reported `.filter()` reads — a geo query is
+ * normally written without one, so nothing could observe the gap. Once
+ * unfiltered reads are reported (for `unbounded_collect`), omitting it would
+ * flag the idiomatic `withGeoIndex(...).collect()` as an unbounded scan, which
+ * `geo_index_unused` tells authors to write in the first place.
+ */
+const INDEX_METHODS = new Set(["withGeoIndex", "withIndex", "withSearchIndex"]);
+
+/**
+ * Chain methods that MATERIALIZE a read — the point at which how much of the
+ * narrowed set is actually loaded gets decided.
+ *
+ * Matched as a known set rather than taken as the chain's last call.
+ * {@link chainMethods} follows any property-access-then-call parent, and a
+ * terminal returns a Promise, so `.collect().then(...)` / `.catch(...)` keep the
+ * walk going and the last call is a combinator rather than the terminal. Taking
+ * the last RECOGNISED terminal reports `collect` for that chain instead of
+ * `then`; a chain with none (`.order("desc")` handed on, or a bare
+ * `query(...)`) reports `undefined`, which the terminal-shaped lints skip.
+ */
+const TERMINAL_METHODS = new Set(["collect", "collectWithScores", "first", "paginate", "take", "unique"]);
 
 /**
  * True for a `ctx.db.query(...)` (or bare `db.query(...)`) call — the database
@@ -116,10 +140,13 @@ const tableOf = (queryCall: CallExpression): string => {
 };
 
 /**
- * Discover `ctx.db.query("table")…` reads under the lunora source directory and
- * reduce each to a {@link QueryReadIR}. Only reads that call `.filter()` are
- * returned — an unfiltered read is never a `filter_without_index` candidate, so
- * dropping the rest keeps the lint input small.
+ * Discover every `ctx.db.query("table")…` read under the lunora source directory
+ * and reduce each to a {@link QueryReadIR}.
+ *
+ * Reads without a `.filter()` are kept too. They are never
+ * `filter_without_index` candidates (that lint gates on `hasFilter`), but an
+ * unfiltered, unindexed `.collect()` is the read `unbounded_collect` exists for
+ * — and dropping it here is precisely why nothing could see it.
  */
 const discoverQueries = (project: Project, lunoraDirectory: string): QueryReadIR[] => {
     const reads: QueryReadIR[] = [];
@@ -134,19 +161,17 @@ const discoverQueries = (project: Project, lunoraDirectory: string): QueryReadIR
             }
 
             const methods = chainMethods(call);
-
-            if (!methods.includes("filter")) {
-                continue;
-            }
+            const hasFilter = methods.includes("filter");
 
             reads.push({
                 exportName: enclosingExportName(call),
                 file: relativePath,
-                filtersPrimaryKey: filtersPrimaryKeyOf(call),
-                hasFilter: true,
+                filtersPrimaryKey: hasFilter && filtersPrimaryKeyOf(call),
+                hasFilter,
                 hasIndex: methods.some((method) => INDEX_METHODS.has(method)),
                 line: call.getStartLineNumber(),
                 table: tableOf(call),
+                terminal: methods.findLast((method) => TERMINAL_METHODS.has(method)),
             });
         }
     }

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -718,9 +718,10 @@ export interface WorkflowCallIR {
 
 /**
  * A `ctx.db.query("table")…` read discovered in a function body, reduced to what
- * the `filter_without_index` advisor lint needs: which table, whether the chain
- * narrows with an index, and whether it filters. `table` is `""` when the
- * `query(...)` argument is not a string literal (a dynamic table — not lintable).
+ * the query advisor lints need: which table, whether the chain narrows with an
+ * index, whether it filters, and which terminal materializes the result.
+ * `table` is `""` when the `query(...)` argument is not a string literal (a
+ * dynamic table — not lintable).
  */
 export interface QueryReadIR {
     /** Exported procedure the read sits in, or `""` at module scope. */
@@ -743,6 +744,19 @@ export interface QueryReadIR {
     line: number;
     /** Queried table name, or `""` when the argument is not a string literal. */
     table: string;
+
+    /**
+     * The materializing call the chain ends in — `"collect"`, `"take"`,
+     * `"paginate"`, `"first"`, `"unique"`, … — i.e. how much of the narrowed set
+     * the read actually loads.
+     *
+     * `undefined` when the chain reaches no recognised terminal (a reader passed
+     * on, a bare `query(...)`) AND when a feeder predating this field produced
+     * the read. The two are deliberately not distinguished: no consumer could act
+     * on the difference, so the terminal-shaped lints skip the read either way
+     * rather than guessing a terminal.
+     */
+    terminal?: string;
 }
 
 /**

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -1145,14 +1145,18 @@ describe("subscriptionListDeltas", () => {
         expect(subscriptionListDeltas(prev, next, "messages")).toBeUndefined();
     });
 
-    it("returns the snapshot sentinel on a near-total change where deltas would exceed the new length", () => {
+    it("still decomposes a near-total change — cost is not this function's call", () => {
         expect.assertions(1);
 
-        // 2 deletes + 1 insert = 3 deltas for a new array of length 1 → snapshot.
+        // 2 deletes + 1 insert against a new array of length 1. This used to
+        // return the snapshot sentinel via a row-count cap, which was a cost
+        // heuristic living in a function that cannot see the wire. The diff is
+        // expressible, so it is returned; `subscriptionFrames` decides whether
+        // sending it is cheaper than the snapshot, by measuring the real frames.
         const prev = JSON.stringify([row("a"), row("b")]);
         const next = [row("c")];
 
-        expect(subscriptionListDeltas(prev, next, "messages")).toBeUndefined();
+        expect(subscriptionListDeltas(prev, next, "messages")).toHaveLength(3);
     });
 
     it("falls back to a non-empty table name when the read-table set is empty", () => {
@@ -1175,8 +1179,7 @@ describe("subscriptionListDeltas", () => {
     it("the frames sink yields bodies byte-identical to JSON.stringify(delta) across insert/update/delete", () => {
         expect.assertions(2);
 
-        // One delete (c), one update (a), one insert (d) — exercises all three
-        // branches while staying at/under the chattiness cap (3 deltas, length-3 next).
+        // One delete (c), one update (a), one insert (d) — exercises all three branches.
         const prev = JSON.stringify([row("a", { text: "old" }), row("b"), row("c")]);
         const next = [row("a", { text: "new" }), row("b"), row("d", { text: "fresh" })];
 
@@ -1234,6 +1237,21 @@ describe("shardDO subscription delta push", () => {
         return { _creationTime: 1, _id: id, ...rest };
     };
 
+    /**
+     * `count` rows that never change, prepended to a fixture so the list is long
+     * enough for a handful of deltas to be the cheaper encoding.
+     *
+     * These cases assert WHICH frame type goes out, and `subscriptionFrames`
+     * decides that by measuring the rendered frames — a few deltas against a
+     * two-row list genuinely cost more than re-sending it, so without a
+     * list-sized baseline the snapshot branch wins and the delta assertions have
+     * nothing to look at. Length is the only lever used (never row width), so
+     * these stay in the delta regime by a wide margin under any change to the
+     * frame envelope. The threshold itself is pinned directly, without a DO or a
+     * socket, by the `subscriptionFrames` unit tests in `@lunora/shard-engine`.
+     */
+    const filler = (count: number): Record<string, unknown>[] => Array.from({ length: count }, (_, index) => idRow(`fill-${String(index)}`));
+
     const subscribeMessages = (shard: ReexecShard, ws: FakeWebSocket): Promise<void> =>
         shard.driveMessage(ws, { id: "sub-1", query: { args: {}, functionPath: "messages:list" }, type: "subscribe" });
 
@@ -1244,13 +1262,13 @@ describe("shardDO subscription delta push", () => {
         const ws = createFakeWebSocket();
 
         shard.registerSocket(ws);
-        shard.outcomes.set("messages:list", { result: [idRow("a")], tables: new Set(["messages"]) });
+        shard.outcomes.set("messages:list", { result: [...filler(16), idRow("a")], tables: new Set(["messages"]) });
 
         await subscribeMessages(shard, ws);
 
-        expect(JSON.parse(ws.sent.at(-1)!)).toEqual({ data: [idRow("a")], id: "sub-1", type: "data" });
+        expect(JSON.parse(ws.sent.at(-1)!)).toEqual({ data: [...filler(16), idRow("a")], id: "sub-1", type: "data" });
 
-        shard.outcomes.set("messages:list", { result: [idRow("a"), idRow("b", { text: "hi" })], tables: new Set(["messages"]) });
+        shard.outcomes.set("messages:list", { result: [...filler(16), idRow("a"), idRow("b", { text: "hi" })], tables: new Set(["messages"]) });
         shard.changedTableOnRpc = "messages";
         await shard.writeRpc();
 
@@ -1280,6 +1298,42 @@ describe("shardDO subscription delta push", () => {
         expect(JSON.parse(ws.sent.at(-1)!)).toEqual({ data: { count: 2 }, id: "sub-1", type: "data" });
     });
 
+    it("takes the snapshot when the delta frames would out-weigh it on the wire", async () => {
+        expect.assertions(3);
+
+        const shard = new ReexecShard(state, {});
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws);
+
+        const before = filler(20);
+
+        shard.outcomes.set("messages:list", { result: before, tables: new Set(["messages"]) });
+        await subscribeMessages(shard, ws);
+
+        const sentBefore = ws.sent.length;
+
+        // Every row changes. `subscriptionListDeltas` accepts this — 20 deltas
+        // for a 20-row result is within its own row-count cap — but each frame
+        // re-pays the `{"type":"delta","id":…,"table":…}` envelope that one
+        // snapshot pays once, so 20 frames carry MORE bytes than the single
+        // `{type:"data"}` frame holding the same rows. Row count cannot see
+        // that; the byte comparison in `pushSubscriptionData` can.
+        const after = before.map((row) => {
+            return { ...row, text: "edited" };
+        });
+
+        shard.outcomes.set("messages:list", { result: after, tables: new Set(["messages"]) });
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        const frames = ws.sent.slice(sentBefore).map((line) => JSON.parse(line) as { data?: unknown; type: string });
+
+        expect(frames.filter((frame) => frame.type === "delta")).toHaveLength(0);
+        expect(frames.filter((frame) => frame.type === "data")).toHaveLength(1);
+        expect(frames.find((frame) => frame.type === "data")?.data).toEqual(after);
+    });
+
     it("applying the pushed delta frames to the prior snapshot yields the new result", async () => {
         expect.assertions(1);
 
@@ -1287,15 +1341,16 @@ describe("shardDO subscription delta push", () => {
         const ws = createFakeWebSocket();
 
         shard.registerSocket(ws);
-        shard.outcomes.set("messages:list", { result: [idRow("a"), idRow("b"), idRow("c")], tables: new Set(["messages"]) });
+        shard.outcomes.set("messages:list", { result: [...filler(16), idRow("a"), idRow("b"), idRow("c")], tables: new Set(["messages"]) });
 
         await subscribeMessages(shard, ws);
 
         const baseline = (JSON.parse(ws.sent.at(-1)!) as { data: Record<string, unknown>[] }).data;
         const sentBefore = ws.sent.length;
 
-        // Delete c, update a, insert d — 3 deltas for a length-3 result (under the cap).
-        const nextResult = [idRow("a", { text: "edited" }), idRow("b"), idRow("d")];
+        // Delete c, update a, insert d — 3 deltas against a 19-row list, so the
+        // three frames stay well under the snapshot they are weighed against.
+        const nextResult = [...filler(16), idRow("a", { text: "edited" }), idRow("b"), idRow("d")];
 
         shard.outcomes.set("messages:list", { result: nextResult, tables: new Set(["messages"]) });
         shard.changedTableOnRpc = "messages";
@@ -1338,7 +1393,7 @@ describe("shardDO subscription delta push", () => {
 
         shard.registerSocket(ws);
 
-        const prevResult = [idRow("a", { text: "old" }), idRow("b"), idRow("c")];
+        const prevResult = [...filler(16), idRow("a", { text: "old" }), idRow("b"), idRow("c")];
 
         shard.outcomes.set("messages:list", { result: prevResult, tables: new Set(["messages"]) });
         await subscribeMessages(shard, ws);
@@ -1346,8 +1401,8 @@ describe("shardDO subscription delta push", () => {
         const sentBefore = ws.sent.length;
 
         // delete c, update a, insert d — all three delta branches in one refresh,
-        // 3 deltas for a length-3 next result (under the chattiness cap).
-        const nextResult = [idRow("a", { text: "new" }), idRow("b"), idRow("d", { text: "hi" })];
+        // 3 deltas against a 19-row list, so the delta path stays cheaper.
+        const nextResult = [...filler(16), idRow("a", { text: "new" }), idRow("b"), idRow("d", { text: "hi" })];
 
         shard.outcomes.set("messages:list", { result: nextResult, tables: new Set(["messages"]) });
         shard.changedTableOnRpc = "messages";

--- a/packages/do/__tests__/subscription-data-watermark.test.ts
+++ b/packages/do/__tests__/subscription-data-watermark.test.ts
@@ -207,13 +207,13 @@ describe("shardDO: plain data frame carries the per-client lastMutationId (plan 
 
 /**
  * Thermos H1 — the snapshot-only stamp above left the DELTA path (the
- * `{type:"delta"}` frames `sendDeltaFrames` emits) unstamped, and a
+ * `{type:"delta"}` frames `subscriptionFrames` renders) unstamped, and a
  * `@lunora/db` list collection is exactly the id-keyed, order-preserving
  * shape `subscriptionListDeltas` accepts — so after the first snapshot,
  * EVERY subsequent write for it goes out as deltas. Growing the row set by
- * one ID each write (keeping every prior row as a survivor) is what makes
- * `subscriptionListDeltas` accept the change instead of falling back to a
- * full snapshot (see its "near-total change" guard).
+ * one id per write (keeping every prior row as a survivor) keeps the change
+ * both expressible as deltas and cheaper than a snapshot, which is what puts
+ * a delta frame on the wire for the assertions to read.
  */
 class GrowingListShard extends ShardDO {
     private readonly rows: { _id: string; text: string }[] = [];
@@ -222,9 +222,8 @@ class GrowingListShard extends ShardDO {
 
     public override handleRpc(functionPath: string): Promise<unknown> {
         return this.runInTransaction(() => {
-            this.nextRow += 1;
-            this.rows.push({ _id: `m${String(this.nextRow)}`, text: `row ${String(this.nextRow)}` });
-            this.recordChangedTable("messages");
+            this.appendRow();
+            this.recordChangedTable("messages"); // GrowingListShard
 
             const result = { ok: true, path: functionPath };
 
@@ -243,6 +242,25 @@ class GrowingListShard extends ShardDO {
         return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
     }
 
+    /**
+     * Lengthen the list WITHOUT going through a write.
+     *
+     * `subscriptionFrames` chooses deltas over a snapshot by measuring both, so a
+     * one-row insert only takes the delta path against a list-sized baseline —
+     * and this test needs the delta path to have a frame to assert on. Seeding
+     * through `pushMutatorWrite` under a second `clientId` would also produce the
+     * rows, but it would make the setup depend on per-client watermark
+     * isolation, which is the very property the assertions verify: a regression
+     * in it would poison the fixture, and the test could no longer tell "the
+     * watermark leaked" from "the seeding leaked". Writing straight to the
+     * fixture keeps the subject out of the setup.
+     */
+    public seedRows(count: number): void {
+        for (let index = 0; index < count; index += 1) {
+            this.appendRow();
+        }
+    }
+
     // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
     protected override isCustomMutator(functionPath: string): boolean {
         return functionPath === "messages:sendMutator";
@@ -253,6 +271,12 @@ class GrowingListShard extends ShardDO {
         // not by reference, but a fresh array also matches how a real query
         // re-run would produce a fresh result object.
         return Promise.resolve({ result: [...this.rows], tables: new Set(["messages"]) });
+    }
+
+    /** Append one row to the in-memory list `executeSubscription` reports. */
+    private appendRow(): void {
+        this.nextRow += 1;
+        this.rows.push({ _id: `m${String(this.nextRow)}`, text: `row ${String(this.nextRow)}` });
     }
 }
 
@@ -278,6 +302,12 @@ describe("shardDO: delta frames also carry the per-client lastMutationId (thermo
             const ws = createFakeWebSocket();
 
             shard.registerSocket(ws, { clientId: "client-A", subs: {}, userId: "" });
+
+            // Deepen the list so the single-row change below is genuinely cheaper
+            // as a delta than as a snapshot — see `seedRows`, which deliberately
+            // bypasses the write path so the setup does not lean on the watermark
+            // isolation these assertions exist to check.
+            shard.seedRows(16);
 
             // Seed row + subscribe: the FIRST frame is always a snapshot
             // (nothing to diff against yet).

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -194,11 +194,10 @@ import {
     selectMatchingIds,
     selectShapeMemberIds,
     selectShapeRows,
-    sendDeltaFrames,
     ShardRunner,
     stableStringify,
     stableWireKey,
-    subscriptionListDeltas,
+    subscriptionFrames,
     summarizeFanoutTopics,
     summarizeSubscriptions,
     TransactionHeadroomTracker,
@@ -9017,11 +9016,11 @@ abstract class ShardDO {
      * so dependency tracking stays current even when the value is unchanged.
      *
      * When the result is a diffable list (Convex-parity live-pagination, gap
-     * #20), emit one `{type:"delta"}` frame per changed row instead of a full
-     * `{type:"data"}` snapshot — see {@link subscriptionListDeltas} for the
-     * five conditions under which deltas are safe. The first send (and any
-     * non-list / large-change result) falls back to the snapshot. The memo is
-     * always advanced to the new `lastJson`/`tables` regardless of path.
+     * #20), the push can go out as one `{type:"delta"}` frame per changed row
+     * instead of a full `{type:"data"}` snapshot. Which of the two is sent is
+     * `subscriptionFrames`' call, made by rendering both and measuring them —
+     * this method just sends what it is handed. The memo is always advanced to
+     * the new `lastJson`/`tables` regardless of path.
      *
      * `cursor` (when supplied) is the `__cdc_log` high-watermark this frame
      * covers; it is appended to the emitted `data`/`delta` JSON so a client can
@@ -9079,46 +9078,37 @@ abstract class ShardDO {
             return;
         }
 
-        // Try an incremental delta push when there's a prior list to diff
-        // against. `undefined` => not diffable, fall back to the snapshot below.
-        // `deltaFrames` receives the pre-serialized `delta` body for each delta
-        // (finding #6) so we never re-`JSON.stringify` a row that the diff has
-        // already fingerprinted.
-        const deltaFrames: string[] = [];
-        const deltas =
-            existing === undefined
-                ? undefined
-                : subscriptionListDeltas(existing.lastJson, outcome.result, outcome.tables.values().next().value ?? "", deltaFrames);
-
-        // Stamp this socket's per-mutator watermark on the plain `data` frame
-        // the same way the `settled` branch above does, so the client's
-        // checkpoint gate can trust what THIS frame's rows actually reflect
-        // instead of a provisional RPC-ack signal that can race ahead of it
-        // (plan 266 finding d: write A's data frame arriving after write B's
-        // ack has already landed, but before B's own rows synced, must not
-        // resolve B's overlay early). The delta branch below stamps the SAME
-        // watermark on every delta frame it sends (not a follow-up: a
-        // `@lunora/db` list collection is exactly the id-keyed shape the
-        // delta path targets, so after the first snapshot EVERY subsequent
-        // write for it goes out as deltas — leaving them unstamped would
-        // starve the checkpoint gate of a frame-carried watermark for the
-        // common case, not a rare one).
-        const lastMutationIdField = clientWatermark === undefined ? "" : `,"lastMutationId":${String(clientWatermark)}`;
+        // Row deltas or the full snapshot — `subscriptionFrames` renders both and
+        // returns whichever is smaller on the wire, so the frame layout and the
+        // choice between the two stay in one place (this method has no business
+        // re-deriving the delta envelope just to size it). `existing?.lastJson`
+        // is the last value that actually LEFT the socket, so a first send — or
+        // one whose predecessor was dropped — has no baseline and gets the
+        // snapshot. `clientWatermark` rides on every frame either way, so the
+        // client's checkpoint gate can trust what THIS frame's rows reflect
+        // instead of a provisional RPC-ack that can race ahead of it (plan 266
+        // finding d).
+        const frames = subscriptionFrames({
+            cursorSuffix,
+            lastMutationId: clientWatermark,
+            nextResult: outcome.result,
+            previousJson: existing?.lastJson,
+            snapshotJson: json,
+            subId,
+            table: outcome.tables.values().next().value ?? "",
+        });
 
         // At-least-once delivery: advance the diff BASELINE (`lastJson`) only once
-        // the frame(s) for this value actually leave the socket. `ws.send` throws
-        // when the socket has closed or its outbound buffer is gone. Advancing the
-        // baseline unconditionally (the prior behavior) would diff the NEXT value
-        // against a value the client never received, so a single dropped frame
-        // silently lost that update until the client reconnected. By keeping the
-        // last *delivered* baseline on failure, the next write-flush that touches a
-        // read table re-sends — and the reconnect resume path (`evaluateResume`)
-        // still covers a fully-gone socket. `tables` always advances so dependency
-        // tracking stays accurate even when delivery failed.
-        const delivered =
-            deltas === undefined
-                ? trySendFrame(ws, `{"type":"data","id":${JSON.stringify(subId)},"data":${json}${lastMutationIdField}${cursorSuffix}}`)
-                : sendDeltaFrames(ws, subId, deltaFrames, cursorSuffix, clientWatermark);
+        // EVERY frame for this value has left the socket. `ws.send` throws when the
+        // socket has closed or its outbound buffer is gone, and a partial delta run
+        // must keep the baseline at the last fully-delivered value so the next flush
+        // re-diffs the whole change (keyed list deltas are idempotent on replay, so
+        // re-sending an already-applied row is harmless). Advancing unconditionally
+        // would diff the NEXT value against one the client never received, silently
+        // losing that update until it reconnected. `.map` before `.every` on purpose:
+        // every frame is attempted, and only then is the verdict taken. `tables`
+        // always advances so dependency tracking stays accurate even on failure.
+        const delivered = frames.map((frame) => trySendFrame(ws, frame)).every(Boolean);
 
         memos.set(subId, { lastJson: delivered ? json : (existing?.lastJson ?? UNDELIVERED_BASELINE), ranges: outcome.ranges, tables: outcome.tables });
     }

--- a/packages/shard-engine/__bench__/subscription-frames.bench.ts
+++ b/packages/shard-engine/__bench__/subscription-frames.bench.ts
@@ -1,0 +1,91 @@
+import { bench, describe } from "vitest";
+
+import { encodeWire } from "../../../shared/wire-codec";
+import { subscriptionFrames } from "../src/subscription-delivery";
+
+/**
+ * `subscriptionFrames` runs once per `(socket, subscription)` on every
+ * write-flush that touches a live query's read tables — the hottest CPU on the
+ * WebSocket fan-out path. It re-parses the previously-delivered snapshot,
+ * indexes both lists by `_id`, fingerprints every row of the new result, then
+ * renders the candidate frames and measures them.
+ *
+ * The cost scales with the LIST length, not with how much changed, and that
+ * asymmetry is the thing to watch: a one-row edit to a 200-row list still pays a
+ * 200-row diff, and it pays it again for every subscribed socket.
+ *
+ * The cases hold the list length fixed and vary the change ratio, so a
+ * regression in either half is visible:
+ *
+ * - **1 of N changed** — the case the delta path exists for. Dominated by the
+ * `JSON.parse` of the baseline plus N `JSON.stringify(encodeWire(row))`
+ * fingerprints; one frame is rendered and wins.
+ * - **half of N changed** — fingerprints unchanged, frame rendering scales up.
+ * - **all of N changed** — every row renders a frame, and the measurement then
+ * rejects them all in favour of the snapshot. This is the cost of *deciding*
+ * not to use deltas, and it is the case the old row-count rule got wrong.
+ * - **reordered** — survivors moved, so `survivorsKeepOrder` rejects before any
+ * frame is built. The early-out must not cost a full diff.
+ * - **not a list** — the paginated `{ page, isDone, continueCursor }` shape
+ * `usePaginatedQuery` subscribes to. It fails the `Array.isArray` precondition
+ * immediately, so every write re-sends the whole page as a snapshot; the bench
+ * records what that rejection costs today.
+ *
+ * Pure functions over plain data — no DO, no socket, no SQLite.
+ */
+
+const row = (index: number, revision: number): Record<string, unknown> => {
+    return {
+        _creationTime: 1_700_000_000_000 + index,
+        _id: `msg_${String(index).padStart(6, "0")}`,
+        authorId: `user_${String(index % 50)}`,
+        body: `message body number ${String(index)} — ${"lorem ipsum dolor sit amet ".repeat(4)}`,
+        channelId: "channels:general",
+        editedAt: revision,
+    };
+};
+
+/** The frame envelope a real CDC-backed shard stamps, so the measurement is not free of it. */
+const envelope = { cursorSuffix: `,"cursor":998877,"epoch":"epoch-0000-0000-0001"`, lastMutationId: 42, subId: "sub_12", table: "messages" };
+
+/** A baseline list and a next list in which the first `changed` rows carry a new revision. */
+const buildCase = (total: number, changed: number): { nextResult: Record<string, unknown>[]; previousJson: string } => {
+    const previous = Array.from({ length: total }, (_, index) => row(index, 1));
+
+    return {
+        nextResult: previous.map((existing, index) => (index < changed ? row(index, 2) : existing)),
+        previousJson: JSON.stringify(encodeWire(previous)),
+    };
+};
+
+const LIST_LENGTH = 200;
+
+describe("subscriptionFrames — change ratio", () => {
+    for (const changed of [1, LIST_LENGTH / 2, LIST_LENGTH]) {
+        const { nextResult, previousJson } = buildCase(LIST_LENGTH, changed);
+        const snapshotJson = JSON.stringify(encodeWire(nextResult));
+
+        bench(`${String(changed)} of ${String(LIST_LENGTH)} rows changed`, () => {
+            subscriptionFrames({ ...envelope, nextResult, previousJson, snapshotJson });
+        });
+    }
+});
+
+describe("subscriptionFrames — snapshot fallbacks", () => {
+    const { nextResult, previousJson } = buildCase(LIST_LENGTH, 0);
+    const reordered = nextResult.toReversed();
+
+    bench(`${String(LIST_LENGTH)} rows, survivors reordered → rejected`, () => {
+        subscriptionFrames({ ...envelope, nextResult: reordered, previousJson, snapshotJson: JSON.stringify(encodeWire(reordered)) });
+    });
+
+    // The shape `.paginate()` returns, and therefore what every `usePaginatedQuery`
+    // page subscribes to: an object wrapping the array, not the array itself.
+    const paginatedNext = { continueCursor: "c_200", isDone: false, page: nextResult };
+    const paginatedPreviousJson = JSON.stringify(encodeWire({ continueCursor: "c_200", isDone: false, page: JSON.parse(previousJson) }));
+    const paginatedSnapshotJson = JSON.stringify(encodeWire(paginatedNext));
+
+    bench(`paginated { page, isDone, continueCursor } → rejected (not an array)`, () => {
+        subscriptionFrames({ ...envelope, nextResult: paginatedNext, previousJson: paginatedPreviousJson, snapshotJson: paginatedSnapshotJson });
+    });
+});

--- a/packages/shard-engine/__bench__/subscription-frames.bench.ts
+++ b/packages/shard-engine/__bench__/subscription-frames.bench.ts
@@ -74,9 +74,14 @@ describe("subscriptionFrames — change ratio", () => {
 describe("subscriptionFrames — snapshot fallbacks", () => {
     const { nextResult, previousJson } = buildCase(LIST_LENGTH, 0);
     const reordered = nextResult.toReversed();
+    // Precomputed, like every other case: the production caller builds the
+    // snapshot payload once before calling in (see `pushSubscriptionData`), so
+    // encoding it inside the bench body would fold a full 200-row encode plus
+    // stringify into the number and overstate what the early-out costs.
+    const reorderedSnapshotJson = JSON.stringify(encodeWire(reordered));
 
     bench(`${String(LIST_LENGTH)} rows, survivors reordered → rejected`, () => {
-        subscriptionFrames({ ...envelope, nextResult: reordered, previousJson, snapshotJson: JSON.stringify(encodeWire(reordered)) });
+        subscriptionFrames({ ...envelope, nextResult: reordered, previousJson, snapshotJson: reorderedSnapshotJson });
     });
 
     // The shape `.paginate()` returns, and therefore what every `usePaginatedQuery`

--- a/packages/shard-engine/__tests__/subscription-frames.test.ts
+++ b/packages/shard-engine/__tests__/subscription-frames.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { subscriptionFrames } from "../src/subscription-delivery";
+
+/**
+ * `subscriptionFrames` owns two things the rest of the delivery path relies on:
+ * the exact `{type:"data"}` / `{type:"delta"}` wire layout, and the choice
+ * between them. Both are pinned here — no Durable Object, no socket, no
+ * fixture tuned to sit on one side of a threshold. The DO-level tests in
+ * `@lunora/do` assert that the chosen frames reach the socket; this file
+ * asserts which frames get chosen and what they look like.
+ */
+
+const row = (id: string, rest: Record<string, unknown> = {}): Record<string, unknown> => {
+    return { _creationTime: 1, _id: id, ...rest };
+};
+
+/** The fixed inputs every case shares; each test overrides what it is about. */
+const base = { cursorSuffix: "", subId: "sub-1", table: "messages" };
+
+const framesFor = (previous: Record<string, unknown>[] | undefined, next: unknown, extra: Record<string, unknown> = {}): string[] =>
+    subscriptionFrames({
+        ...base,
+        ...extra,
+        nextResult: next,
+        previousJson: previous === undefined ? undefined : JSON.stringify(previous),
+        snapshotJson: JSON.stringify(next),
+    });
+
+const typesOf = (frames: string[]): string[] => frames.map((frame) => (JSON.parse(frame) as { type: string }).type);
+
+describe("subscriptionFrames — frame layout", () => {
+    it("renders the snapshot with no baseline to diff against", () => {
+        expect.assertions(1);
+
+        expect(framesFor(undefined, [row("a")])).toStrictEqual([`{"type":"data","id":"sub-1","data":[{"_creationTime":1,"_id":"a"}]}`]);
+    });
+
+    it("renders one delta frame per changed row, deletes before upserts", () => {
+        expect.assertions(2);
+
+        // Long enough that a single delta is unambiguously the cheaper encoding.
+        const previous = Array.from({ length: 20 }, (_, index) => row(`r${String(index)}`));
+        const frames = framesFor(previous, [...previous, row("new")]);
+
+        expect(frames).toHaveLength(1);
+        expect(frames[0]).toBe(`{"type":"delta","id":"sub-1","delta":{"key":"new","op":"insert","row":{"_creationTime":1,"_id":"new"},"table":"messages"}}`);
+    });
+
+    it("stamps the watermark and cursor suffix on every frame of a multi-delta batch", () => {
+        expect.assertions(2);
+
+        // A client's checkpoint gate reads whichever frame it happens to observe,
+        // so a batch whose later frames lack the watermark starves it (plan 266
+        // finding d). Every frame carries it, not just the last.
+        const previous = Array.from({ length: 20 }, (_, index) => row(`r${String(index)}`));
+        const next = previous.map((existing, index) => (index < 3 ? row(`r${String(index)}`, { edited: true }) : existing));
+        const frames = framesFor(previous, next, { cursorSuffix: `,"cursor":42,"epoch":"e1"`, lastMutationId: 7 });
+
+        expect(frames).toHaveLength(3);
+        expect(frames.every((frame) => frame.endsWith(`,"lastMutationId":7,"cursor":42,"epoch":"e1"}`))).toBe(true);
+    });
+});
+
+describe("subscriptionFrames — delta vs snapshot", () => {
+    it("takes the deltas when they are smaller than the snapshot", () => {
+        expect.assertions(1);
+
+        const previous = Array.from({ length: 50 }, (_, index) => row(`r${String(index)}`));
+        const next = previous.map((existing, index) => (index === 0 ? row("r0", { edited: true }) : existing));
+
+        expect(typesOf(framesFor(previous, next))).toStrictEqual(["delta"]);
+    });
+
+    it("takes the snapshot when every row changed, even though the diff is expressible", () => {
+        expect.assertions(2);
+
+        // The row-count rule this replaced allowed exactly this: 20 deltas for a
+        // 20-row result is "no more deltas than rows". But each frame re-pays the
+        // envelope the snapshot pays once, so the deltas are the larger payload.
+        const previous = Array.from({ length: 20 }, (_, index) => row(`r${String(index)}`));
+        const next = previous.map((existing) => {
+            return { ...existing, edited: true };
+        });
+        const frames = framesFor(previous, next);
+
+        expect(typesOf(frames)).toStrictEqual(["data"]);
+        expect(frames).toHaveLength(1);
+    });
+
+    it("takes the snapshot for a single delta into a short list of small rows", () => {
+        expect.assertions(1);
+
+        // The other direction the row count cannot see: one delta is well under
+        // the cap, but its envelope alone outweighs re-sending both rows.
+        expect(typesOf(framesFor([row("a")], [row("a"), row("b")]))).toStrictEqual(["data"]);
+    });
+
+    it("takes the deltas for the same single change once the rows are fat enough", () => {
+        expect.assertions(1);
+
+        // Identical row COUNT to the case above — only the row width differs, which
+        // is exactly the input a count-based rule is blind to.
+        const wide = (id: string) => row(id, { body: "lorem ipsum dolor sit amet ".repeat(8) });
+
+        expect(typesOf(framesFor([wide("a")], [wide("a"), wide("b")]))).toStrictEqual(["delta"]);
+    });
+
+    it("takes the snapshot when the result is not a diffable list", () => {
+        expect.assertions(2);
+
+        // The paginated shape `.paginate()` returns: an object wrapping the array,
+        // so there is no id-keyed list to diff and every write re-sends the page.
+        expect(typesOf(framesFor([row("a")], { continueCursor: null, isDone: true, page: [row("a"), row("b")] }))).toStrictEqual(["data"]);
+        // A reordered survivor cannot be expressed as in-place merges either.
+        expect(typesOf(framesFor([row("a"), row("b")], [row("b"), row("a")]))).toStrictEqual(["data"]);
+    });
+});

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -331,7 +331,7 @@ export type { SqlConsoleResult } from "./sql-console";
 export type { SqlLintResult } from "./sql-console";
 export { assertReadonly, MAX_SQL_ROWS, runReadonlySql } from "./sql-console";
 export { lintReadonlySql } from "./sql-console";
-export { awaitWsDrain, sendDeltaFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
+export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
 export type { ChangedKeys, SubscriptionReadFootprint } from "./subscription-range-gate";
 export { mergeChangedKeys, recordChangedKeys, writeTouchesMemo } from "./subscription-range-gate";
 export type {

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -150,19 +150,21 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
 };
 
 /**
- * Diff the previously-sent list snapshot (`previousJson`, the memo's
- * `lastJson`) against the new query result and produce per-row
- * {@link MutationDelta}s the client can merge in place via `applyDelta` —
- * Convex-parity live-pagination deltas (server half of gap #20).
+ * Diff the previously-sent list snapshot against the new query result, keyed by
+ * `_id`, returning each changed row paired with its pre-serialized frame body.
  *
- * Returns `undefined` (caller falls back to a full `{type:"data"}` snapshot)
+ * Returns `undefined` (the value is not expressible as row deltas at all)
  * unless ALL of these hold:
  *
  * 1. `previousJson` parses to an array (there IS a previous list to diff against).
  * 2. `nextResult` is also an array.
  * 3. Every row in both arrays is a plain object carrying a string `_id`.
  * 4. Order preservation — rows present in BOTH arrays appear in the same relative order.
- * 5. Chattiness cap — the number of deltas does not exceed the new array length (a near-total change is cheaper as a snapshot).
+ *
+ * These are EXPRESSIBILITY conditions only. Whether the deltas are the cheaper
+ * thing to put on the wire is a separate question, answered by
+ * {@link subscriptionFrames} against the frames it is about to send — see the
+ * note there on why no row-count proxy stands in for it.
  *
  * Diff is keyed by `_id`: rows only in prev → `delete`; rows only in next →
  * `insert`; rows in both whose JSON differs → `update`. Insert/update carry the
@@ -170,17 +172,12 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
  * parses). Deltas are ordered deletes-then-inserts/updates so the client never
  * sees a transient over-length page.
  *
- * Per-row serialization is done exactly **once** per refresh (finding #6). Each
+ * Per-row serialization is done exactly **once** per refresh (finding #6): each
  * row is stringified a single time into a fingerprint reused for both the
- * `prev !== next` change-detection compare and — when the caller passes the
- * optional `frames` sink — the pre-serialized delta frame body. The returned
- * `MutationDelta[]` shape is unchanged; `frames`, when supplied, receives the
- * exact `JSON.stringify(delta)` string for each returned delta, in the same
- * order, so the caller can splice it straight into the `{type:"delta"}` frame
- * without serializing the delta (and the row inside it) a second time.
- * @returns the per-row deltas to send, or `undefined` when any precondition fails and a full snapshot should be sent instead
+ * `prev !== next` change-detection compare and the frame body.
+ * @returns the changed rows with their frame bodies, or `undefined` when the change is not expressible as row deltas
  */
-const subscriptionListDeltas = (previousJson: string, nextResult: unknown, table: string, frames?: string[]): MutationDelta[] | undefined => {
+const collectFramedDeltas = (previousJson: string, nextResult: unknown, table: string): FramedDelta[] | undefined => {
     let parsed: unknown;
 
     try {
@@ -208,11 +205,30 @@ const subscriptionListDeltas = (previousJson: string, nextResult: unknown, table
 
     const deltaTable = table === "" ? DELTA_FALLBACK_TABLE : table;
     const tableJson = JSON.stringify(deltaTable);
-    // Deletes precede upserts so the client never sees a transient over-length page.
-    const framed = [...collectDeleteDeltas(previous, next, deltaTable, tableJson), ...collectUpsertDeltas(previous, next, deltaTable, tableJson)];
 
-    // (5): a near-total change is better sent as a single snapshot.
-    if (framed.length > next.order.length) {
+    // Deletes precede upserts so the client never sees a transient over-length page.
+    return [...collectDeleteDeltas(previous, next, deltaTable, tableJson), ...collectUpsertDeltas(previous, next, deltaTable, tableJson)];
+};
+
+/**
+ * The per-row {@link MutationDelta}s a change decomposes into, or `undefined`
+ * when it is not expressible as row deltas — see {@link collectFramedDeltas}
+ * for the four conditions.
+ *
+ * This is the diff as a VALUE, for callers that want to inspect it (and for the
+ * unit tests that pin the diff's semantics). The delivery path does not use it:
+ * {@link subscriptionFrames} needs the frame strings, not the delta objects, and
+ * building both would allocate a `MutationDelta` per row per socket per
+ * write-flush that nothing reads.
+ *
+ * `frames`, when supplied, receives the exact `JSON.stringify(delta)` string for
+ * each returned delta, in the same order.
+ * @returns the per-row deltas, or `undefined` when the change is not expressible as row deltas
+ */
+const subscriptionListDeltas = (previousJson: string, nextResult: unknown, table: string, frames?: string[]): MutationDelta[] | undefined => {
+    const framed = collectFramedDeltas(previousJson, nextResult, table);
+
+    if (framed === undefined) {
         return undefined;
     }
 
@@ -262,36 +278,73 @@ const trySendFrame = (ws: FrameSink, frame: string): boolean => {
     }
 };
 
-/**
- * Send every delta frame for one subscription. Reports `delivered` only when ALL
- * frames left the socket: a partial failure must keep the diff baseline at the
- * last fully-delivered value so the next flush re-diffs the whole change. Keyed
- * list deltas are idempotent on replay, so re-sending an already-applied row is
- * harmless.
- *
- * `lastMutationId` (when supplied) is stamped on EVERY delta frame in this
- * batch, not just the last — a client's checkpoint gate reads whichever frame
- * it happens to observe, and re-stamping the same value on each is a no-op
- * for a client that already saw an earlier one (idempotent, monotonic
- * `Math.max` on the read side). Without this, a `@lunora/db` list collection
- * — the exact id-keyed shape this delta path exists for — never sees a
- * per-frame watermark past its first snapshot, permanently starving the
- * checkpoint gate of the frame-carried signal `pushSubscriptionData`'s
- * snapshot branch provides (plan 266 finding d's fix was incomplete without
- * this — the delta path is this feature's common case, not a rare fallback).
- */
-const sendDeltaFrames = (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string, lastMutationId?: number): boolean => {
-    const idJson = JSON.stringify(subId);
-    const watermarkSuffix = lastMutationId === undefined ? "" : `,"lastMutationId":${String(lastMutationId)}`;
-    let delivered = true;
+/** Everything {@link subscriptionFrames} needs to render one subscription's frames. */
+interface SubscriptionFrameInput {
+    /** The trailing `,"cursor":<n>,"epoch":"<e>"` fragment, or `""` on a non-CDC shard. */
+    cursorSuffix: string;
+    /** This socket's custom-mutator watermark, stamped on every frame; omitted when the socket has none. */
+    lastMutationId?: number;
+    /** The fresh query result, unencoded — diffed row-wise against `previousJson`. */
+    nextResult: unknown;
+    /** The wire form of the value last DELIVERED for this subscription; `undefined` on a first send. */
+    previousJson?: string;
+    /** `JSON.stringify(encodeWire(nextResult))` — the exact `data` frame payload, built once by the caller. */
+    snapshotJson: string;
+    /** The subscription id the frames are addressed to. */
+    subId: string;
+    /** The table stamped on each delta; `""` falls back to {@link DELTA_FALLBACK_TABLE}. */
+    table: string;
+}
 
-    for (const deltaBody of deltaFrames) {
-        if (!trySendFrame(ws, `{"type":"delta","id":${idJson},"delta":${deltaBody}${watermarkSuffix}${cursorSuffix}}`)) {
-            delivered = false;
-        }
+/**
+ * Render the frames that carry one subscription's new value: either a run of
+ * `{type:"delta"}` frames or the single `{type:"data"}` snapshot, whichever is
+ * smaller on the wire.
+ *
+ * **Why the choice lives here.** Every delta frame re-pays the whole
+ * `{"type":"delta","id":…}` + `"table":…` + cursor/epoch/watermark envelope
+ * around ONE row body, which the snapshot pays once for the entire list. So the
+ * deltas stop being the cheaper encoding well before they stop being a valid
+ * one, and where that happens depends on the row size, the row count, and the
+ * envelope width together. No row-count proxy ("no more deltas than rows") can
+ * express that: it is blind to fat rows, to a wide envelope, and to a list of
+ * tiny rows where a single delta already costs more than re-sending everything.
+ * Rendering the frames first and summing their real lengths is exact, needs no
+ * heuristic, and cannot drift from the format — because it IS the format. That
+ * is also why the envelope is written in exactly one place (here) rather than
+ * modelled a second time by the caller doing the sizing.
+ *
+ * Lengths are UTF-16 code units, not UTF-8 bytes. Both sides carry the same row
+ * content, so a multi-byte payload inflates them together and the comparison
+ * holds; it only shifts the crossover slightly toward the snapshot, which is the
+ * safe direction (one frame is also one `ws.send` and one client apply). A tie
+ * goes to the snapshot for the same reason.
+ *
+ * `lastMutationId` is stamped on EVERY frame, not just the last — a client's
+ * checkpoint gate reads whichever frame it happens to observe, and re-stamping
+ * the same value is a no-op for one that already saw an earlier one (idempotent,
+ * monotonic `Math.max` on the read side). Without it a `@lunora/db` list
+ * collection — the exact id-keyed shape the delta path targets, so every write
+ * after its first snapshot goes out as deltas — would never see a frame-carried
+ * watermark again (plan 266 finding d).
+ * @returns the frames to send in order; always at least one unless the diff found no changed rows
+ */
+const subscriptionFrames = (input: SubscriptionFrameInput): string[] => {
+    const { cursorSuffix, lastMutationId, nextResult, previousJson, snapshotJson, subId, table } = input;
+    const idJson = JSON.stringify(subId);
+    const suffix = (lastMutationId === undefined ? "" : `,"lastMutationId":${String(lastMutationId)}`) + cursorSuffix;
+    const snapshot = `{"type":"data","id":${idJson},"data":${snapshotJson}${suffix}}`;
+    // No baseline (first send, or the last send never left the socket) — there is
+    // nothing to diff against, so the snapshot is the only option.
+    const framed = previousJson === undefined ? undefined : collectFramedDeltas(previousJson, nextResult, table);
+
+    if (framed === undefined) {
+        return [snapshot];
     }
 
-    return delivered;
+    const deltas = framed.map(({ frame }) => `{"type":"delta","id":${idJson},"delta":${frame}${suffix}}`);
+
+    return deltas.reduce((total, frame) => total + frame.length, 0) < snapshot.length ? deltas : [snapshot];
 };
 
 /**
@@ -320,5 +373,5 @@ const awaitWsDrain = async (ws: DrainableSink): Promise<void> => {
     }
 };
 
-export type { DrainableSink, FrameSink };
-export { awaitWsDrain, sendDeltaFrames, subscriptionListDeltas, trySendFrame };
+export type { DrainableSink, FrameSink, SubscriptionFrameInput };
+export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame };

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -342,9 +342,28 @@ const subscriptionFrames = (input: SubscriptionFrameInput): string[] => {
         return [snapshot];
     }
 
-    const deltas = framed.map(({ frame }) => `{"type":"delta","id":${idJson},"delta":${frame}${suffix}}`);
+    const deltas: string[] = [];
+    let total = 0;
 
-    return deltas.reduce((total, frame) => total + frame.length, 0) < snapshot.length ? deltas : [snapshot];
+    for (const { frame } of framed) {
+        const delta = `{"type":"delta","id":${idJson},"delta":${frame}${suffix}}`;
+
+        total += delta.length;
+
+        // The running total only grows, so once it reaches the snapshot the
+        // snapshot has already won and the remaining envelopes would be built
+        // only to be thrown away. Bailing here is not a different rule — it is
+        // the same comparison, decided as early as it can be — and it matters
+        // most in exactly the case this function exists to catch: a near-total
+        // change, where otherwise every row allocates a frame that loses.
+        if (total >= snapshot.length) {
+            return [snapshot];
+        }
+
+        deltas.push(delta);
+    }
+
+    return deltas;
 };
 
 /**


### PR DESCRIPTION
## Summary

Live-query fan-out (`@lunora/shard-engine`, `@lunora/do`) was sending more
bytes than it needed to, in two distinct ways. Both are fixed here, plus an
advisor lint (`@lunora/advisor`, `@lunora/codegen`) for the third — the one
only the app author can fix.

### 1. Delta-vs-snapshot was decided by row count

A refresh went out as one `{type:"delta"}` frame per changed row whenever
the diff was expressible, capped only by *"no more deltas than rows"*.

Every delta frame re-pays the whole `{"type":"delta","id":…}` + `"table":…`
+ cursor/epoch/watermark envelope around **one** row body — which the
snapshot pays once for the entire list. So the deltas stop being the cheaper
encoding well before they stop being a valid one, and a row count cannot see
where. Measured, 100-row list of ~290-byte rows:

| changed | snapshot | deltas | ratio |
| ------- | -------- | ------ | ----- |
| 1       | 29,060 B | 438 B  | 0.02x |
| 50      | 29,060 B | 21,980 B | 0.76x |
| 100     | 29,060 B | **43,970 B across 100 frames** | **1.51x** |

The cap was blind in the other direction too: a single delta into a short
list of small rows already costs more than re-sending the list, and it
allowed that as well.

Now both candidates are rendered and the smaller one is sent — stopping the
render as soon as the running delta total reaches the snapshot, so a
near-total change does not allocate envelopes that lose. `subscriptionFrames`
owns the frame layout and the choice together, so the sizing cannot drift
from the format — it *is* the format. Ties go to the snapshot, since one
frame is also one `ws.send` and one client apply.

`subscriptionListDeltas` keeps only its four expressibility conditions.
Whether sending the diff is worth it was never something a function with no
view of the wire could answer.

### 2. `unbounded_collect` (new advisor lint)

`filter_without_index` gates on `hasFilter`, so the widest read of all —
`ctx.db.query("t").collect()` with no index and no filter — fell straight
through it. The codegen feeder made that structural: it discarded every
discovered read without a `.filter()`, so no lint could have seen one.

An unindexed read records a whole-table dependency, so the refresh gate can
never skip it: every write to the table re-runs the query and re-sends the
whole table to every subscribed socket. Two of this repo's own examples trip
it, both on live-subscribed list queries.

The feeder now reports every read plus the materializing terminal, matched
against a known terminal set rather than the last chained method —
`.collect().then(...)` keeps the chain walk going, so the literal last call
is a combinator. `withGeoIndex` also joins the narrowing methods: it was
missing while only filtered reads were reported (a geo query is normally
written without one), and would otherwise have flagged the exact chain
`geo_index_unused` tells authors to write.

## Linked issues

None — found by a WebSocket payload audit of the subscription fan-out path.

## Test plan

- [x] `pnpm run lint:affected:types` — 73 projects, 0 errors
- [x] `pnpm run lint:eslint` — `@lunora/do`, `@lunora/shard-engine`, `@lunora/advisor`, `@lunora/codegen`
- [x] `pnpm exec prettier --write` on every touched file
- [x] `@lunora/do` 537 tests, `@lunora/shard-engine` 1123 (+8 new), `@lunora/codegen` 1202, `@lunora/advisor` 482
- [x] `pnpm run api:check` — 47/47 snapshots match (3 updated in this PR: `sendDeltaFrames` → `subscriptionFrames`, plus the new `terminal` field on `QueryReadIR` / `AdvisorQueryRead`)
- [x] Durable Object code changed → the workerd-pool `@lunora/do` suite is the one above, all green
- [x] Schema/codegen changed → every `examples/*` and `apps/playground` regenerated; only the two expected advisory diffs (`examples/chess`, `examples/feedback-board`), and nothing further after the rebase onto `alpha`
- [x] `pnpm --filter @lunora/shard-engine exec vitest bench` — the new bench runs clean

Reviewers should re-run `pnpm run api:check` and the `@lunora/do` suite.

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [x] Added or updated tests covering the change
- [x] Updated relevant docs in `apps/docs` (or `README.md` for package-local docs) — `packages/advisor/docs/index.mdx` gained the `unbounded_collect` row; the `apps/docs` copy is generated from it by `copy-package-docs.js` and is gitignored
- [x] No `package.json` files in `packages/*` modified outside the touched package
- [x] If a new package was added: n/a
- [x] If migration impact: see the breaking-change note below

## Notes for reviewers

**Start with `packages/shard-engine/src/subscription-delivery.ts`** — the
whole delta-vs-snapshot decision lives in `subscriptionFrames`, and
`pushSubscriptionData` now just sends what it is handed.

**Breaking (pre-1.0, `alpha`):** `sendDeltaFrames` is removed from
`@lunora/shard-engine` in favour of `subscriptionFrames`, which returns the
frames rather than sending them. `subscriptionListDeltas` no longer returns
`undefined` for a near-total change — it decomposes any expressible diff.
Both are internal to the shard/engine boundary; no app code imports them.

**Frame-type flips are one-directional.** The new predicate is a strict
subset of the old one, so no socket that previously got a snapshot can now
get deltas — only the reverse. That is what keeps the seven non-JS SDKs
under `sdks/` safe: they handle `"data"` and `"delta"` in one arm and replace
wholesale, so this strictly reduces their exposure to that pre-existing
limitation.

### Deferred: paginated queries never diff

`.paginate()` returns `{ page, isDone, continueCursor }` — an object, so both
`subscriptionListDeltas` and the client's `applyDelta` reject it. A one-row
edit re-sends the entire page (measured 7,279 B for a ~290 B change, 25x),
and `usePaginatedQuery` holds **one subscription per loaded page**.

Not fixed here because it cannot be done safely without protocol work: a
client whose `applyDelta` bails replaces the whole query value with the raw
delta object, so page-deltas need a capability announced on the `connect`
frame and honoured by all seven SDKs. It is the largest remaining over-send
and worth doing, but as its own change. The new bench keeps a case measuring
what the rejection costs today.

### Measured, not changed

`subscriptionFrames` cost scales with **list length**, not with how much
changed: ~0.74 ms for a one-row edit to a 200-row list, paid per
`(socket, subscription)`. At 100 subscribers that is ~74 ms of
single-threaded shard time per write. Inherent to the current design
(identity-dependent queries cannot share a result under RLS); the bench pins
it so a regression shows up.

## Contributor License Agreement

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyG8dyPFieGYzRd7y1MMme
