### PR TITLE
perf(do): stop over-sending on the live-query WebSocket path

### DIFF
--- a/api-snapshots/advisor.api.md
+++ b/api-snapshots/advisor.api.md
@@ -520,6 +520,7 @@ interface AdvisorQueryRead {
     hasIndex: boolean;
     line: number;
     table: string;
+    terminal?: string;
 }
 ```
 

--- a/api-snapshots/client.api.md
+++ b/api-snapshots/client.api.md
@@ -1469,7 +1469,7 @@ const anyApi: Record<string, Record<string, unknown>>;
 ### `applyDelta` (const)
 
 ```ts
-const applyDelta: (current: unknown, delta: MutationDelta) => undefined | unknown[];
+const applyDelta: (current: unknown, delta: MutationDelta) => Record<string, unknown> | undefined | unknown[];
 ```
 
 ### `createAsyncStoragePersistence` (const)

--- a/api-snapshots/codegen.api.md
+++ b/api-snapshots/codegen.api.md
@@ -558,6 +558,7 @@ interface QueryReadIR {
     hasIndex: boolean;
     line: number;
     table: string;
+    terminal?: string;
 }
 ```
 

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -1379,12 +1379,6 @@ class OwnerRelay extends RelayLink {
 type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame | RelayShapePoke | RelayShapeSubscribe;
 ```
 
-### `PAGE_DELTA_CAPABILITY` (const)
-
-```ts
-const PAGE_DELTA_CAPABILITY = "pageDelta";
-```
-
 ### `PaginationOptions` (interface)
 
 ```ts
@@ -2392,13 +2386,13 @@ interface ShardSocketLike {
 ```ts
 interface SocketAttachment {
     admin?: boolean;
-    caps?: string[];
     clientId?: string;
     connected?: boolean;
     connectionId?: string;
     context?: Record<string, unknown>;
     expiresAt?: number;
     identity?: Record<string, unknown>;
+    pageDeltas?: boolean;
     shapes?: Record<string, ShapeSubscriptionQuery>;
     subs: Record<string, SubscriptionQuery>;
     userId?: string;

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -4152,12 +4152,6 @@ const selectShapeMemberIds: (sql: SqlExec, table: string, effectiveWhere: WhereI
 const selectShapeRows: (sql: SqlExec, table: string, effectiveWhere: WhereInput | undefined) => ShapeRow[];
 ```
 
-### `sendDeltaFrames` (const)
-
-```ts
-const sendDeltaFrames: (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string, lastMutationId?: number) => boolean;
-```
-
 ### `serializeSqlValue` (const)
 
 ```ts
@@ -4200,6 +4194,12 @@ const stableStringify: (value: unknown) => string;
 
 ```ts
 const stableWireKey: (value: unknown) => string;
+```
+
+### `subscriptionFrames` (const)
+
+```ts
+const subscriptionFrames: (input: SubscriptionFrameInput) => string[];
 ```
 
 ### `subscriptionListDeltas` (const)

--- a/api-snapshots/shard-engine.api.md
+++ b/api-snapshots/shard-engine.api.md
@@ -1379,6 +1379,12 @@ class OwnerRelay extends RelayLink {
 type OwnerRelayFrame = RelayAttach | RelayDetach | RelayFrame | RelayShapePoke | RelayShapeSubscribe;
 ```
 
+### `PAGE_DELTA_CAPABILITY` (const)
+
+```ts
+const PAGE_DELTA_CAPABILITY = "pageDelta";
+```
+
 ### `PaginationOptions` (interface)
 
 ```ts
@@ -2386,6 +2392,7 @@ interface ShardSocketLike {
 ```ts
 interface SocketAttachment {
     admin?: boolean;
+    caps?: string[];
     clientId?: string;
     connected?: boolean;
     connectionId?: string;
@@ -2559,6 +2566,7 @@ interface SubscriptionConnection {
 
 ```ts
 interface SubscriptionEnvelope {
+    caps?: string[];
     clientId?: string;
     context?: Record<string, unknown>;
     data?: unknown;

--- a/examples/chess/lunora/_generated/shard.ts
+++ b/examples/chess/lunora/_generated/shard.ts
@@ -372,6 +372,26 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
+        "cacheKey": "unbounded_collect:players:32:profiles",
+        "categories": [
+            "PERFORMANCE"
+        ],
+        "description": "A query calls `.collect()` with no `.withIndex()` and no `.filter()`, so it materializes every row of the table. Any live subscription over it also re-sends that whole result to every subscribed client on every write to the table.",
+        "detail": "Query on \"profiles\" at players:32 calls .collect() with no index and no filter — it loads every row of \"profiles\" from the root Durable Object's SQLite into memory. A live subscription over this query records a whole-table dependency, so every write to \"profiles\" re-runs it and re-sends the full result to each subscribed socket.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "list",
+            "file": "players",
+            "line": 32,
+            "shardKind": "root",
+            "table": "profiles"
+        },
+        "name": "unbounded_collect",
+        "remediation": "Narrow the read with `.withIndex(\"name\", (q) => q.eq(...))`, cap it with `.take(n)`, or page it with `.paginate(args.paginationOpts)` so neither the scan nor the subscription payload grows with the table.",
+        "title": "Unbounded collect"
+    },
+    {
         "cacheKey": "nondeterministic_query_mutation:games:99:Date.now",
         "categories": [
             "SCHEMA"

--- a/examples/feedback-board/lunora/_generated/shard.ts
+++ b/examples/feedback-board/lunora/_generated/shard.ts
@@ -287,6 +287,26 @@ const LUNORA_TTL_SWEEPS: Array<{ after?: number; field: string; softDeleteField?
 /** Static schema advisories (computed by @lunora/advisor at codegen time) served via `__lunora_admin__:getAdvisories`. */
 const LUNORA_ADVISORIES: AdvisoryFinding[] = [
     {
+        "cacheKey": "unbounded_collect:feedback:47:feedback",
+        "categories": [
+            "PERFORMANCE"
+        ],
+        "description": "A query calls `.collect()` with no `.withIndex()` and no `.filter()`, so it materializes every row of the table. Any live subscription over it also re-sends that whole result to every subscribed client on every write to the table.",
+        "detail": "Query on \"feedback\" at feedback:47 calls .collect() with no index and no filter — it loads every row of \"feedback\" from the root Durable Object's SQLite into memory. A live subscription over this query records a whole-table dependency, so every write to \"feedback\" re-runs it and re-sends the full result to each subscribed socket.",
+        "facing": "EXTERNAL",
+        "level": "WARN",
+        "metadata": {
+            "exportName": "list",
+            "file": "feedback",
+            "line": 47,
+            "shardKind": "root",
+            "table": "feedback"
+        },
+        "name": "unbounded_collect",
+        "remediation": "Narrow the read with `.withIndex(\"name\", (q) => q.eq(...))`, cap it with `.take(n)`, or page it with `.paginate(args.paginationOpts)` so neither the scan nor the subscription payload grows with the table.",
+        "title": "Unbounded collect"
+    },
+    {
         "cacheKey": "nondeterministic_query_mutation:summaries:90:Date.now",
         "categories": [
             "SCHEMA"

--- a/packages/advisor/__tests__/unbounded-collect.test.ts
+++ b/packages/advisor/__tests__/unbounded-collect.test.ts
@@ -1,0 +1,98 @@
+import { defineSchema, defineTable } from "@lunora/server";
+import { v } from "@lunora/values";
+import { describe, expect, it } from "vitest";
+
+import { fromServerSchema } from "../src";
+import filterWithoutIndex from "../src/lints/static/filter-without-index";
+import unboundedCollect from "../src/lints/static/unbounded-collect";
+import type { AdvisorQueryRead } from "../src/queries";
+
+/** One table per storage tier, so the lint's tier wording can be exercised across all three. */
+const schema = () =>
+    fromServerSchema(
+        defineSchema({
+            catalog: defineTable({ sku: v.string() }).global(),
+            notes: defineTable({ text: v.string() }),
+            threadAccess: defineTable({ role: v.string(), userId: v.string() }).shardBy("userId"),
+        }),
+    );
+
+/** A bare `ctx.db.query(table).collect()` — no index, no filter. */
+const read = (table: string, overrides: Partial<AdvisorQueryRead> = {}): AdvisorQueryRead => {
+    return { exportName: "list", file: "notes", hasFilter: false, hasIndex: false, line: 4, table, terminal: "collect", ...overrides };
+};
+
+describe("unbounded_collect", () => {
+    it("flags an unindexed, unfiltered collect on a root table and names the subscription cost", () => {
+        expect.assertions(3);
+
+        const findings = unboundedCollect.run({ queries: [read("notes")], schema: schema() });
+
+        expect(findings[0]).toMatchObject({ cacheKey: "unbounded_collect:notes:4:notes", level: "WARN", name: "unbounded_collect" });
+        expect(findings[0]?.detail).toContain("root Durable Object's SQLite");
+        // The WebSocket half is the point of the lint, not a footnote: an
+        // unindexed read records a whole-table dependency, so the DO's refresh
+        // gate cannot skip it and re-sends the full result per socket per write.
+        expect(findings[0]?.detail).toContain("re-sends the full result to each subscribed socket");
+    });
+
+    it("keeps a global table at WARN and names the cross-region cost", () => {
+        expect.assertions(2);
+
+        const findings = unboundedCollect.run({ queries: [read("catalog")], schema: schema() });
+
+        expect(findings[0]).toMatchObject({ level: "WARN", metadata: { shardKind: "global" } });
+        expect(findings[0]?.detail).toContain("whole D1 table");
+    });
+
+    it("drops a shardBy table to INFO — the read is scoped to one shard", () => {
+        expect.assertions(2);
+
+        const findings = unboundedCollect.run({ queries: [read("threadAccess")], schema: schema() });
+
+        expect(findings[0]).toMatchObject({ level: "INFO", metadata: { shardKind: "shardBy" } });
+        expect(findings[0]?.detail).toContain("one shard's rows");
+    });
+
+    it("defers to filter_without_index rather than double-reporting a filtered read", () => {
+        expect.assertions(2);
+
+        // Both would otherwise fire on `.filter(...).collect()` with no index,
+        // and both remediations name the same `.withIndex(...)`. One finding.
+        const filtered = read("notes", { hasFilter: true });
+
+        expect(unboundedCollect.run({ queries: [filtered], schema: schema() })).toHaveLength(0);
+        expect(filterWithoutIndex.run({ queries: [filtered], schema: schema() })).toHaveLength(1);
+    });
+
+    it("says nothing about a bounded or narrowed read", () => {
+        expect.assertions(4);
+
+        // `.withIndex(...)` narrows the scan AND lets the refresh gate skip the
+        // subscription when the write lands outside the slice.
+        expect(unboundedCollect.run({ queries: [read("notes", { hasIndex: true })], schema: schema() })).toHaveLength(0);
+        // A capped or paged terminal never materializes the table.
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: "take" })], schema: schema() })).toHaveLength(0);
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: "paginate" })], schema: schema() })).toHaveLength(0);
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: "first" })], schema: schema() })).toHaveLength(0);
+    });
+
+    it("stays silent for a dynamic table, a feeder without terminals, and a runtime caller", () => {
+        expect.assertions(3);
+
+        // A non-literal `query(expr)` gives no table to name.
+        expect(unboundedCollect.run({ queries: [read("")], schema: schema() })).toHaveLength(0);
+        // `terminal` is optional; absent means "unknown", not "collect".
+        expect(unboundedCollect.run({ queries: [read("notes", { terminal: undefined })], schema: schema() })).toHaveLength(0);
+        expect(unboundedCollect.run({ schema: schema() })).toHaveLength(0);
+    });
+
+    it("falls back to neutral wording for a table whose tier is not recognised", () => {
+        expect.assertions(1);
+
+        // The `Map`-vs-object-literal prototype safety this shares with
+        // `filter_without_index` is asserted once, exhaustively, in
+        // `filter-scope.test.ts` — it is a property of `Map`, not of either lint.
+        expect(unboundedCollect.run({ queries: [read("unknownTable")], schema: schema() })[0]?.detail).toContain("loads every row");
+    });
+});

--- a/packages/advisor/docs/index.mdx
+++ b/packages/advisor/docs/index.mdx
@@ -138,14 +138,15 @@ Storage, AI, containers & payments:
 
 ### Performance
 
-| Lint                           | Level  | Flags                                                  |
-| ------------------------------ | ------ | ------------------------------------------------------ |
-| `filter_without_index`         | `WARN` | A query filter on a column no index covers             |
-| `shape_targets_global_table`   | `WARN` | A shape replicating from a global (cross-shard) table  |
-| `unindexed_foreign_key`        | `INFO` | A foreign-key column with no index on the owning table |
-| `unindexed_relation_target`    | `INFO` | The `many`-side foreign key of a relation is unindexed |
-| `duplicate_index`              | `INFO` | A redundant index already covered by another           |
-| `container_oversized_instance` | `INFO` | A container instance larger than its workload needs    |
+| Lint                           | Level  | Flags                                                                                                         |
+| ------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------- |
+| `filter_without_index`         | `WARN` | A query filter on a column no index covers                                                                    |
+| `unbounded_collect`            | `WARN` | A `.collect()` with no index and no filter — the whole table, re-sent to every live subscriber on every write |
+| `shape_targets_global_table`   | `WARN` | A shape replicating from a global (cross-shard) table                                                         |
+| `unindexed_foreign_key`        | `INFO` | A foreign-key column with no index on the owning table                                                        |
+| `unindexed_relation_target`    | `INFO` | The `many`-side foreign key of a relation is unindexed                                                        |
+| `duplicate_index`              | `INFO` | A redundant index already covered by another                                                                  |
+| `container_oversized_instance` | `INFO` | A container instance larger than its workload needs                                                           |
 
 ### Schema
 

--- a/packages/advisor/src/index.ts
+++ b/packages/advisor/src/index.ts
@@ -101,6 +101,7 @@ import storageUploadWithoutContentTypeAllowlist from "./lints/static/storage-upl
 import storageUploadWithoutMaxSize from "./lints/static/storage-upload-without-max-size";
 import tableWithoutInsert from "./lints/static/table-without-insert";
 import ttlFieldNotTimestamp from "./lints/static/ttl-field-not-timestamp";
+import unboundedCollect from "./lints/static/unbounded-collect";
 import unboundedStringArgument from "./lints/static/unbounded-string-argument";
 import unindexedForeignKey from "./lints/static/unindexed-foreign-key";
 import unindexedRelationTarget from "./lints/static/unindexed-relation-target";
@@ -325,6 +326,7 @@ export const STATIC_LINTS: ReadonlyArray<Lint> = [
     queueWithoutDlq,
     filterOnPrimaryKey,
     filterWithoutIndex,
+    unboundedCollect,
     shapeTargetsGlobalTable,
     mutatorFullRowReplace,
     nondeterministicQueryMutation,

--- a/packages/advisor/src/lints/helpers.ts
+++ b/packages/advisor/src/lints/helpers.ts
@@ -1,5 +1,6 @@
 import type { AdvisorProcedureProtection } from "../procedure-protections";
-import type { AdvisorTable } from "../schema";
+import type { AdvisorQueryRead } from "../queries";
+import type { AdvisorSchema, AdvisorTable } from "../schema";
 
 /**
  * Ownership / tenancy columns whose presence marks a table as holding user- or
@@ -76,3 +77,21 @@ export const tableColumnSet = (table: AdvisorTable): ReadonlySet<string> => new 
  */
 export const isPublicWrite = (procedure: Pick<AdvisorProcedureProtection, "kind" | "visibility">): boolean =>
     procedure.visibility === "public" && (procedure.kind === "mutation" || procedure.kind === "action");
+
+/**
+ * Where a discovered query read sits, as the `file:line` string the query lints
+ * put in their `detail`. Falls back to the bare file when the feeder could not
+ * resolve a line (`0`), so the text never reads `messages:0`.
+ */
+export const queryReadLocation = (read: Pick<AdvisorQueryRead, "file" | "line">): string =>
+    read.line > 0 ? `${read.file}:${read.line.toString()}` : read.file;
+
+/**
+ * Table name -> declared storage tier, for the query lints that word a finding
+ * by where the rows actually live (`shardBy` reads one Durable Object, `global`
+ * reads D1, `root` reads the single DO). A `Map` so a table named `toString`
+ * resolves to `undefined` and takes the neutral fallback, rather than to an
+ * inherited `Object.prototype` member.
+ */
+export const shardKindsByTable = (schema: AdvisorSchema): ReadonlyMap<string, string | undefined> =>
+    new Map(schema.tables.map((table) => [table.name, table.shardKind]));

--- a/packages/advisor/src/lints/static/filter-on-primary-key.ts
+++ b/packages/advisor/src/lints/static/filter-on-primary-key.ts
@@ -1,5 +1,6 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { queryReadLocation } from "../helpers";
 
 /**
  * Flags `ctx.db.query("t").filter((d) => d._id === x)` — a full scan for a row
@@ -33,7 +34,7 @@ const filterOnPrimaryKey: Lint = {
         (context.queries ?? [])
             .filter((read) => read.filtersPrimaryKey === true && read.table !== "")
             .map((read) => {
-                const location = read.line > 0 ? `${read.file}:${read.line.toString()}` : read.file;
+                const location = queryReadLocation(read);
 
                 return emit(filterOnPrimaryKey, {
                     cacheKey: `filter_on_primary_key:${read.file}:${read.line.toString()}:${read.table}`,

--- a/packages/advisor/src/lints/static/filter-without-index.ts
+++ b/packages/advisor/src/lints/static/filter-without-index.ts
@@ -1,5 +1,6 @@
 import emit from "../../finding";
 import type { Lint } from "../../types";
+import { queryReadLocation, shardKindsByTable } from "../helpers";
 
 /**
  * Flags a query read that calls `.filter()` without first narrowing with
@@ -23,7 +24,7 @@ const filterWithoutIndex: Lint = {
     remediation: 'Narrow the read with `.withIndex("name", (q) => q.eq(...))` first, then `.filter()` only for what the index cannot express.',
     run: (context) => {
         const findings = [];
-        const shardKindByTable = new Map(context.schema.tables.map((table) => [table.name, table.shardKind]));
+        const shardKindByTable = shardKindsByTable(context.schema);
 
         for (const read of context.queries ?? []) {
             // Only an *unindexed* filter on a known table is a scan we can name.
@@ -38,7 +39,7 @@ const filterWithoutIndex: Lint = {
                 continue;
             }
 
-            const location = read.line > 0 ? `${read.file}:${read.line.toString()}` : read.file;
+            const location = queryReadLocation(read);
             const shardKind = shardKindByTable.get(read.table);
             const metadata = { exportName: read.exportName, file: read.file, line: read.line, shardKind: shardKind ?? "unknown", table: read.table };
             const cacheKey = `filter_without_index:${read.file}:${read.line.toString()}:${read.table}`;

--- a/packages/advisor/src/lints/static/unbounded-collect.ts
+++ b/packages/advisor/src/lints/static/unbounded-collect.ts
@@ -1,0 +1,105 @@
+import emit from "../../finding";
+import type { Level, Lint } from "../../types";
+import { queryReadLocation, shardKindsByTable } from "../helpers";
+
+/**
+ * How a finding is worded and rated per storage tier — what the read actually
+ * costs, and how much of the dataset it is bounded by.
+ *
+ * A `Map`, not an object literal: `shardKind` reaches this as data, so a table
+ * whose kind is `"toString"` would resolve to an inherited `Object.prototype`
+ * member on an object and skip the neutral fallback below.
+ */
+const TIERS = new Map<string, { level: Level; scope: (table: string) => string }>([
+    ["global", { level: "WARN", scope: (table) => `it reads the whole D1 table "${table}" over a cross-region round trip` }],
+    // `root` is the default single-Durable-Object table (its own SQLite), not D1.
+    ["root", { level: "WARN", scope: (table) => `it loads every row of "${table}" from the root Durable Object's SQLite into memory` }],
+    // A `.shardBy()` table's rows are partitioned across Durable Objects and the
+    // read runs inside ONE of them, so this collects a single tenant's rows
+    // rather than the dataset. Still unbounded within that tenant — a busy one is
+    // exactly where the fan-out hurts — but not the same order of problem.
+    [
+        "shardBy",
+        {
+            level: "INFO",
+            scope: (table) =>
+                `"${table}" is \`.shardBy()\`, so this collects one shard's rows rather than the whole table — bounded by a single tenant's row count`,
+        },
+    ],
+]);
+
+/** An unrecognised tier gets wording that claims nothing about storage we cannot see. */
+const UNKNOWN_TIER = { level: "WARN" as Level, scope: (table: string) => `it loads every row of "${table}"` };
+
+/**
+ * Flags `ctx.db.query("table").collect()` with no `.withIndex()` and no
+ * `.filter()` — a read of every row, materialized in full.
+ *
+ * `filter_without_index` deliberately does not see this: it gates on
+ * `hasFilter`, so the widest read of all — the one that doesn't even filter —
+ * falls through it.
+ *
+ * The cost is not only the scan. A `query`'s result is what a live subscription
+ * pushes over the WebSocket, and the DO's refresh gate can only skip a
+ * subscription whose reads were confined to index slices. An unindexed
+ * `.collect()` records a whole-table dependency instead, so **every** write to
+ * the table re-runs the query and re-sends the entire table to **every**
+ * subscribed socket, individually. A table that grows to a few thousand rows
+ * turns a one-row edit into megabytes of fan-out.
+ *
+ * The reads come from the codegen feeder, which parses `ctx.db.query("table")…`
+ * chains out of function bodies. Runtime callers supply no `queries`, so this
+ * lint is a no-op there — as it is for a feeder that predates `terminal`.
+ */
+const unboundedCollect: Lint = {
+    categories: ["PERFORMANCE"],
+    description:
+        "A query calls `.collect()` with no `.withIndex()` and no `.filter()`, so it materializes every row of the table. Any live subscription over it also re-sends that whole result to every subscribed client on every write to the table.",
+    facing: "EXTERNAL",
+    level: "WARN",
+    name: "unbounded_collect",
+    remediation:
+        'Narrow the read with `.withIndex("name", (q) => q.eq(...))`, cap it with `.take(n)`, or page it with `.paginate(args.paginationOpts)` so neither the scan nor the subscription payload grows with the table.',
+    run: (context) => {
+        const findings = [];
+        const shardKinds = shardKindsByTable(context.schema);
+
+        for (const read of context.queries ?? []) {
+            // Not a candidate at all: bounded or narrowed, or a dynamic table we
+            // cannot name.
+            if (read.terminal !== "collect" || read.hasIndex || read.table === "") {
+                continue;
+            }
+
+            // A candidate, but `filter_without_index` already reports it and its
+            // remediation names the same index — one read must not produce two
+            // findings pointing at one fix.
+            if (read.hasFilter) {
+                continue;
+            }
+
+            const shardKind = shardKinds.get(read.table);
+            const { level, scope } = TIERS.get(shardKind ?? "") ?? UNKNOWN_TIER;
+            const location = queryReadLocation(read);
+            const subscriptionCost =
+                level === "WARN"
+                    ? ` A live subscription over this query records a whole-table dependency, so every write to "${read.table}" re-runs it and re-sends the full result to each subscribed socket.`
+                    : " Cap it with `.take(n)` if that count can grow.";
+
+            findings.push(
+                emit(unboundedCollect, {
+                    cacheKey: `unbounded_collect:${read.file}:${read.line.toString()}:${read.table}`,
+                    detail: `Query on "${read.table}" at ${location} calls .collect() with no index and no filter — ${scope(read.table)}.${subscriptionCost}`,
+                    level,
+                    metadata: { exportName: read.exportName, file: read.file, line: read.line, shardKind: shardKind ?? "unknown", table: read.table },
+                }),
+            );
+        }
+
+        return findings;
+    },
+    source: "static",
+    title: "Unbounded collect",
+};
+
+export default unboundedCollect;

--- a/packages/advisor/src/queries.ts
+++ b/packages/advisor/src/queries.ts
@@ -1,8 +1,9 @@
 /**
  * One query read discovered in a function body — the input the
- * `filter_without_index` lint consumes. Produced by the codegen feeder (which
- * parses `ctx.db.query("table")…` chains from the AST); runtime callers don't
- * supply it, so the lint simply finds nothing there.
+ * `filter_without_index` / `filter_on_primary_key` / `unbounded_collect` lints
+ * consume. Produced by the codegen feeder (which parses `ctx.db.query("table")…`
+ * chains from the AST); runtime callers don't supply it, so those lints simply
+ * find nothing there.
  */
 export interface AdvisorQueryRead {
     /**
@@ -33,4 +34,17 @@ export interface AdvisorQueryRead {
     line: number;
     /** The queried table; empty when the `query(...)` argument is not a string literal. */
     table: string;
+
+    /**
+     * The materializing call the chain ends in — `"collect"`, `"take"`,
+     * `"paginate"`, `"first"`, `"unique"`, … — i.e. how much of the narrowed set
+     * the read actually loads.
+     *
+     * `undefined` when the chain reaches no recognised terminal (a reader passed
+     * on, a bare `query(...)`) AND when a feeder predating this field produced
+     * the read. The two are deliberately not distinguished: no consumer could act
+     * on the difference, so the terminal-shaped lints skip the read either way
+     * rather than guessing a terminal.
+     */
+    terminal?: string;
 }

--- a/packages/client/__tests__/delta-merge.test.ts
+++ b/packages/client/__tests__/delta-merge.test.ts
@@ -191,4 +191,25 @@ describe("applyDelta — paginated results", () => {
 
         expect(applyDelta(paginated([{ name: "x" }]), { key: "a", op: "delete", table: "m" })).toBeUndefined();
     });
+
+    it("falls back (undefined) for a non-plain wrapper rather than flattening it", () => {
+        expect.assertions(2);
+
+        // Merging re-spreads the wrapper to swap its page, which would turn a
+        // class instance into a plain object and quietly change the value's
+        // shape. The guard is the wire codec's `isPlainObject`, so the only
+        // wrappers accepted are the ones that could have crossed the wire.
+        class PageResult {
+            public isDone = false;
+
+            public page = [row("a")];
+        }
+
+        expect(applyDelta(new PageResult(), { key: "b", op: "insert", row: row("b"), table: "m" })).toBeUndefined();
+        // The same fields as a plain object merge normally — the prototype is the only difference.
+        expect(applyDelta({ isDone: false, page: [row("a")] }, { key: "b", op: "insert", row: row("b"), table: "m" })).toStrictEqual({
+            isDone: false,
+            page: [row("a"), row("b")],
+        });
+    });
 });

--- a/packages/client/__tests__/delta-merge.test.ts
+++ b/packages/client/__tests__/delta-merge.test.ts
@@ -122,11 +122,13 @@ describe("applyDelta", () => {
         expect(result).not.toBe(current);
     });
 
-    it("falls back (undefined) when current isn't an array", () => {
-        expect.assertions(2);
+    it("falls back (undefined) when current holds no row array", () => {
+        expect.assertions(3);
 
         expect(applyDelta({ count: 1 }, { key: "a", op: "insert", row: row("a"), table: "m" })).toBeUndefined();
         expect(applyDelta(undefined, { key: "a", op: "delete", table: "m" })).toBeUndefined();
+        // An object with a `page` that isn't an array is not the paginated shape.
+        expect(applyDelta({ page: 3 }, { key: "a", op: "delete", table: "m" })).toBeUndefined();
     });
 
     it("falls back (undefined) when array elements lack a stable _id", () => {
@@ -141,5 +143,52 @@ describe("applyDelta", () => {
 
         expect(applyDelta([row("a")], { key: "b", op: "insert", table: "m" })).toBeUndefined();
         expect(applyDelta([row("a")], { key: "a", op: "update", table: "m" })).toBeUndefined();
+    });
+});
+
+/**
+ * `.paginate()` returns `{ page, isDone, continueCursor }`, which is what every
+ * `usePaginatedQuery` page holds. Merging into `page` is what lets the server
+ * answer a paginated live query with one row delta instead of re-sending the
+ * whole page on every write to the table.
+ */
+describe("applyDelta — paginated results", () => {
+    const paginated = (rows: Record<string, unknown>[]): Record<string, unknown> => {
+        return { continueCursor: "cursor-2", isDone: false, page: rows };
+    };
+
+    it("merges an update into the page and keeps the surrounding fields", () => {
+        expect.assertions(1);
+
+        const current = paginated([row("a"), row("b")]);
+        const merged = applyDelta(current, { key: "b", op: "update", row: row("b", { text: "edited" }), table: "m" });
+
+        expect(merged).toStrictEqual({ continueCursor: "cursor-2", isDone: false, page: [row("a"), row("b", { text: "edited" })] });
+    });
+
+    it("merges an insert and a delete into the page", () => {
+        expect.assertions(2);
+
+        expect(applyDelta(paginated([row("a")]), { key: "b", op: "insert", row: row("b"), table: "m" })).toStrictEqual(paginated([row("a"), row("b")]));
+        expect(applyDelta(paginated([row("a"), row("b")]), { key: "a", op: "delete", table: "m" })).toStrictEqual(paginated([row("b")]));
+    });
+
+    it("never mutates the cached value or its page", () => {
+        expect.assertions(3);
+
+        const page = [row("a")];
+        const current = paginated(page);
+        const snapshot = { continueCursor: "cursor-2", isDone: false, page: [row("a")] };
+        const merged = applyDelta(current, { key: "b", op: "insert", row: row("b"), table: "m" });
+
+        expect(current).toStrictEqual(snapshot);
+        expect(page).toHaveLength(1);
+        expect(merged).not.toBe(current);
+    });
+
+    it("falls back (undefined) when the page holds rows without a stable _id", () => {
+        expect.assertions(1);
+
+        expect(applyDelta(paginated([{ name: "x" }]), { key: "a", op: "delete", table: "m" })).toBeUndefined();
     });
 });

--- a/packages/client/__tests__/delta-round-trip.test.ts
+++ b/packages/client/__tests__/delta-round-trip.test.ts
@@ -1,0 +1,115 @@
+import { subscriptionFrames } from "@lunora/shard-engine";
+import { describe, expect, it } from "vitest";
+
+import type { MutationDelta } from "../src/delta-merge";
+import { applyDelta } from "../src/delta-merge";
+
+/** The fixed frame-envelope inputs every case shares. */
+const base = { cursorSuffix: "", subId: "sub-1", table: "messages" };
+
+const typesOf = (frames: string[]): string[] => frames.map((frame) => (JSON.parse(frame) as { type: string }).type);
+
+/**
+ * The property the whole delta path rests on: whichever frames the server picks,
+ * a client that applies them ends up holding EXACTLY the value the server would
+ * otherwise have sent as a snapshot.
+ *
+ * Tested against the two halves together, not each alone, because they can each
+ * be self-consistent and still disagree — and when they do the server advances
+ * its diff baseline to the value it BELIEVES the client now holds, so the
+ * divergence persists silently until a reconnect. `applyDelta` is imported from
+ * `@lunora/client` on purpose: this asserts against the real merge rather than a
+ * re-implementation that could drift with it.
+ */
+describe("subscriptionFrames — server/client round-trip", () => {
+    /** Apply the chosen frames the way a real client does, and return the value it lands on. */
+    const clientValueAfter = (previous: unknown, next: unknown, pageDeltas?: boolean): unknown => {
+        const frames = subscriptionFrames({
+            ...base,
+            nextResult: next,
+            pageDeltas,
+            previousJson: JSON.stringify(previous),
+            snapshotJson: JSON.stringify(next),
+        });
+
+        let value = previous;
+
+        for (const frame of frames) {
+            const parsed = JSON.parse(frame) as { data?: unknown; delta?: MutationDelta; type: string };
+
+            // A `data` frame replaces wholesale; a `delta` merges in place.
+            value = parsed.type === "data" ? parsed.data : (applyDelta(value, parsed.delta as MutationDelta) ?? value);
+        }
+
+        return value;
+    };
+
+    const roundTrips = (previous: unknown, next: unknown, pageDeltas?: boolean): void => {
+        expect(clientValueAfter(previous, next, pageDeltas)).toStrictEqual(next);
+    };
+
+    const list = (count: number): Record<string, unknown>[] =>
+        Array.from({ length: count }, (_, index) => {
+            return { _creationTime: 1000 + index, _id: `r${String(index)}` };
+        });
+
+    const asPage = (rows: Record<string, unknown>[]): Record<string, unknown> => {
+        return { continueCursor: "c", isDone: false, page: rows };
+    };
+
+    it("round-trips an update, an insert, and a delete on a bare list", () => {
+        expect.assertions(3);
+
+        const previous = list(20);
+
+        roundTrips(previous, [...previous.slice(0, 19), { ...previous[19], edited: true }]);
+        roundTrips(previous, [...previous, { _creationTime: 9999, _id: "new" }]);
+        roundTrips(previous, previous.slice(1));
+    });
+
+    it("round-trips the same three changes on a paginated result", () => {
+        expect.assertions(3);
+
+        const previous = asPage(list(20));
+
+        roundTrips(previous, asPage([...list(20).slice(0, 19), { ...list(20)[19], edited: true }]), true);
+        roundTrips(previous, asPage([...list(20), { _creationTime: 9999, _id: "new" }]), true);
+        roundTrips(previous, asPage(list(20).slice(1)), true);
+    });
+
+    it("round-trips an insert into a list ordered by something other than _creationTime", () => {
+        expect.assertions(1);
+
+        // The case that made this check necessary. `.withIndex(...).paginate()`
+        // orders by the index fields, so the server's position for a new row need
+        // not be where the client's `_creationTime` heuristic would splice it.
+        // Here the newcomer sorts mid-list by `priority` but is the NEWEST row, so
+        // the heuristic alone would put it at the front of this newest-first list
+        // and the two sides would silently disagree from then on.
+        const previous = [
+            { _creationTime: 5000, _id: "a", priority: 10 },
+            { _creationTime: 1000, _id: "b", priority: 20 },
+            { _creationTime: 2000, _id: "c", priority: 30 },
+        ];
+
+        roundTrips(previous, [previous[0]!, { _creationTime: 9000, _id: "n", priority: 15 }, previous[1]!, previous[2]!]);
+    });
+
+    it("still sends a newest-first feed's insert as a delta", () => {
+        expect.assertions(2);
+
+        // The case the heuristic exists FOR: a newest-first feed where the new row
+        // genuinely belongs at the front. This must stay on the delta path — the
+        // order check must not have turned every insert into a snapshot.
+        const previous = Array.from({ length: 20 }, (_, index) => {
+            return { _creationTime: 9000 - index, _id: `r${String(index)}` };
+        });
+        const next = [{ _creationTime: 9999, _id: "new" }, ...previous];
+
+        expect(
+            typesOf(subscriptionFrames({ ...base, nextResult: next, previousJson: JSON.stringify(previous), snapshotJson: JSON.stringify(next) })),
+        ).toStrictEqual(["delta"]);
+
+        roundTrips(previous, next);
+    });
+});

--- a/packages/client/__tests__/lunora-client.test.ts
+++ b/packages/client/__tests__/lunora-client.test.ts
@@ -738,7 +738,7 @@ describe("lunoraClient", () => {
 
             const connect = JSON.parse(socket.sent[0]!);
 
-            expect(connect).toEqual({ clientId: "client-A", id: "connect", type: "connect" });
+            expect(connect).toEqual({ caps: ["pageDelta"], clientId: "client-A", id: "connect", type: "connect" });
             // The connect frame leads, then the subscribe — order matters so the
             // hook runs with any context in place before subscriptions replay.
             expect(JSON.parse(socket.sent[1]!).type).toBe("subscribe");
@@ -764,7 +764,13 @@ describe("lunoraClient", () => {
 
             socket.open();
 
-            expect(JSON.parse(socket.sent[0]!)).toEqual({ clientId: "client-A", context: { roomId: "room-1" }, id: "connect", type: "connect" });
+            expect(JSON.parse(socket.sent[0]!)).toEqual({
+                caps: ["pageDelta"],
+                clientId: "client-A",
+                context: { roomId: "room-1" },
+                id: "connect",
+                type: "connect",
+            });
 
             client.close();
         });

--- a/packages/client/__tests__/protocol-conformance.test.ts
+++ b/packages/client/__tests__/protocol-conformance.test.ts
@@ -218,6 +218,8 @@ const makeWsClient = (): LunoraClient =>
     });
 
 interface WsServerCase {
+    /** Cached value the frame is applied ON TOP of; absent means the frame replaces wholesale. */
+    baseWire?: unknown;
     expect: { code?: string; kind: string; message?: string; valueWire?: unknown };
     frame: Record<string, unknown>;
     name: string;
@@ -225,6 +227,8 @@ interface WsServerCase {
 
 interface WsFixtures {
     clientFrames: Record<string, unknown>;
+    /** Merge cases, only for a client that announced the `pageDelta` capability. */
+    pageDeltaFrames: WsServerCase[];
     serverFrames: WsServerCase[];
     shape: {
         expectedRows: Record<string, unknown>[];
@@ -283,6 +287,27 @@ describe("ws-frames fixtures", () => {
 
         expect(values).toHaveLength(1);
         expect(encodeWire(values[0])).toStrictEqual(testCase.expect.valueWire);
+    });
+
+    // `pageDeltaFrames`, not `serverFrames`: these apply ON TOP of a cached
+    // value instead of replacing it, and every SDK iterates `serverFrames`
+    // wholesale — putting a merge case there fails all seven of them. Only an
+    // SDK that announced `pageDelta` should run these. Each seeds `baseWire`
+    // via a `data` frame, then asserts the merged result; together they pin the
+    // insert PLACEMENT the server relies on every client sharing (README 5.1.1).
+    it.each(ws.pageDeltaFrames.map((testCase) => [testCase.name, testCase] as const))("merges delta frame %s into the cached value", (_name, testCase) => {
+        expect.hasAssertions();
+
+        const client = makeWsClient();
+        const values: unknown[] = [];
+
+        client.subscribe(fnRef("messages:list"), { channel: "general" }, (value) => values.push(value));
+        latestSocket().open();
+        latestSocket().receive({ data: testCase.baseWire, id: testCase.frame["id"], type: "data" });
+        latestSocket().receive(testCase.frame);
+
+        expect(values).toHaveLength(2);
+        expect(encodeWire(values[1])).toStrictEqual(testCase.expect.valueWire);
     });
 
     const errorFrames = ws.serverFrames.filter((testCase) => testCase.expect.kind === "error");

--- a/packages/client/__tests__/protocol-conformance.test.ts
+++ b/packages/client/__tests__/protocol-conformance.test.ts
@@ -246,7 +246,11 @@ describe("ws-frames fixtures", () => {
 
         const sent = latestSocket().sent.map((raw) => JSON.parse(raw));
 
-        expect(sent[0]).toStrictEqual(ws.clientFrames.connect);
+        // The reference client implements `pageDelta`, so it emits the
+        // capability-announcing form. The plain `connect` fixture stays the
+        // conforming shape for an SDK that implements no tokens — see the
+        // fixture file's `$comment` and protocol README 5.1.1.
+        expect(sent[0]).toStrictEqual(ws.clientFrames["connect-with-caps"]);
         expect(sent[1]).toStrictEqual(ws.clientFrames["subscribe-cold"]);
     });
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -94,6 +94,7 @@
         "@codspeed/vitest-plugin": "catalog:test",
         "@lunora/do": "1.0.0-alpha.82",
         "@lunora/runtime": "1.0.0-alpha.61",
+        "@lunora/shard-engine": "1.0.0-alpha.25",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:build",
         "@vitest/coverage-v8": "catalog:test",

--- a/packages/client/src/delta-merge.ts
+++ b/packages/client/src/delta-merge.ts
@@ -136,14 +136,44 @@ const isMutationDelta = (value: unknown): value is MutationDelta => {
     );
 };
 
+/** The row-array field a `.paginate()` result carries its page in. */
+const PAGE_FIELD = "page";
+
 /**
- * Apply a structured `MutationDelta` to a cached array result, returning a new
- * array (never mutating the input). Returns `undefined` when the delta can't be
+ * The row array inside a cached query value, or `undefined` when there is none.
+ *
+ * Two mergeable shapes:
+ *
+ * - the value IS the array — `db.query(...).collect()`;
+ * - the value is `{ page: [...], isDone, continueCursor }` — what `.paginate()`
+ * yields, and therefore what every `usePaginatedQuery` page holds.
+ *
+ * The server only ever sends row deltas for the paginated shape when the fields
+ * around the page are unchanged, so merging into `page` and leaving the rest of
+ * the object untouched reproduces the server's value exactly.
+ * @returns the row array to merge into, or `undefined` when the value holds none
+ */
+const pageOf = (current: unknown): undefined | unknown[] => {
+    if (Array.isArray(current)) {
+        return current as unknown[];
+    }
+
+    if (typeof current === "object" && current !== null && Array.isArray((current as Record<string, unknown>)[PAGE_FIELD])) {
+        return (current as Record<string, unknown>)[PAGE_FIELD] as unknown[];
+    }
+
+    return undefined;
+};
+
+/**
+ * Apply a structured `MutationDelta` to a cached list result, returning a new
+ * value (never mutating the input). Returns `undefined` when the delta can't be
  * applied cleanly — the caller should then fall back to the existing
  * full-replacement behaviour (or trust the next snapshot to reconcile).
  *
- * Mergeable shape: a plain array of id-bearing row objects, e.g. the result of
- * `db.query().collect()`.
+ * Mergeable shapes: an array of id-bearing row objects, or a `.paginate()`
+ * result wrapping one in `page` (see {@link pageOf}). A paginated value keeps
+ * its other fields and comes back as a new object with a new `page`.
  *
  * Insert / update / delete are matched by row `_id`:
  * - `insert`: appended (or placed by `_creationTime` order) if absent; treated
@@ -152,19 +182,26 @@ const isMutationDelta = (value: unknown): value is MutationDelta => {
  * - `update`: replaces the matching row in place, preserving its position.
  * - `delete`: removes the matching row.
  *
- * Returns `undefined` when `current` isn't an array of id-keyable objects, or
+ * Returns `undefined` when `current` holds no array of id-keyable objects, or
  * when an `insert`/`update` delta carries no `row` to splice in.
  */
-const applyDelta = (current: unknown, delta: MutationDelta): undefined | unknown[] => {
-    if (!Array.isArray(current)) {
+const applyDelta = (current: unknown, delta: MutationDelta): Record<string, unknown> | undefined | unknown[] => {
+    const list = pageOf(current);
+
+    if (list === undefined) {
         return undefined;
     }
+
+    // Re-wrap the merged rows the way they arrived: a bare array stays an array,
+    // a paginated result keeps `isDone`/`continueCursor` and swaps its page.
+    const rewrap = (next: unknown[]): Record<string, unknown> | unknown[] =>
+        Array.isArray(current) ? next : { ...(current as Record<string, unknown>), [PAGE_FIELD]: next };
 
     // Only merge when every element is an id-bearing object; an array of
     // scalars (or rows without `_id`) has no stable key to splice against.
     const rows: Record<string, unknown>[] = [];
 
-    for (const element of current) {
+    for (const element of list) {
         const id = rowId(element);
 
         if (id === undefined) {
@@ -182,7 +219,7 @@ const applyDelta = (current: unknown, delta: MutationDelta): undefined | unknown
         // No row matched: the delete is a no-op for this page. Return the
         // (copied) list unchanged rather than bailing — a delete for a row this
         // page never held is legitimately nothing to do.
-        return next.length === rows.length ? [...rows] : next;
+        return rewrap(next.length === rows.length ? [...rows] : next);
     }
 
     // insert / update both need the new row body to splice in.
@@ -198,7 +235,7 @@ const applyDelta = (current: unknown, delta: MutationDelta): undefined | unknown
 
         next.splice(insertionIndex(rows, row), 0, row);
 
-        return next;
+        return rewrap(next);
     }
 
     // Present → replace in place (covers `update`, and an `insert` whose row a
@@ -207,7 +244,7 @@ const applyDelta = (current: unknown, delta: MutationDelta): undefined | unknown
 
     next[existingIndex] = row;
 
-    return next;
+    return rewrap(next);
 };
 
 export { applyDelta, isMutationDelta };

--- a/packages/client/src/delta-merge.ts
+++ b/packages/client/src/delta-merge.ts
@@ -15,10 +15,17 @@
  * replaced the whole cached value with it on every message — which only made
  * sense for the rare delta payloads that already carried the full result. This
  * module lets the client recognise a structured delta and merge it into the
- * existing array (preserving order, no dup/loss), falling back to full
+ * existing list (preserving order, no dup/loss), falling back to full
  * replacement when the payload isn't a recognisable row delta or can't be
  * applied cleanly against the current cached shape.
+ *
+ * The list shape and the insert-position rule come from `shared/page-result.ts`
+ * rather than being defined here: the server runs the SAME functions to decide
+ * whether a delta is safe to send at all, and a divergence between the two
+ * would corrupt a live query silently. See that module's header.
  */
+
+import { ID_FIELD, insertionIndexFor, PAGE_FIELD, rowListOf } from "../../../shared/page-result";
 
 /**
  * One row change as emitted by `@lunora/do`'s `broadcastDelta`. Mirrors
@@ -34,12 +41,6 @@ interface MutationDelta {
     table: string;
 }
 
-/** Identity field every Lunora document row carries. */
-const ID_FIELD = "_id";
-
-/** Creation-time field used as the default sort key for inserts. */
-const CREATION_FIELD = "_creationTime";
-
 /** Read a row's `_id`, coercing to string; `undefined` when the row has none. */
 const rowId = (row: unknown): string | undefined => {
     if (typeof row !== "object" || row === null) {
@@ -49,70 +50,6 @@ const rowId = (row: unknown): string | undefined => {
     const id = (row as Record<string, unknown>)[ID_FIELD];
 
     return typeof id === "string" ? id : undefined;
-};
-
-/**
- * Detect the ordering direction of a cached list from its existing rows'
- * `_creationTime` run. Returns `true` when the list is sorted descending
- * (newest-first — the common chat/feed shape), `false` for ascending or when the
- * direction is indeterminate (0/1 numeric rows, or an all-equal run). We read the
- * FIRST strictly-ordered adjacent numeric pair, so a single out-of-order row
- * doesn't flip the verdict.
- */
-const isDescending = (list: Record<string, unknown>[]): boolean => {
-    let previous: number | undefined;
-
-    for (const existingRow of list) {
-        const existing = existingRow[CREATION_FIELD];
-
-        if (typeof existing !== "number") {
-            continue;
-        }
-
-        if (previous !== undefined) {
-            if (existing < previous) {
-                return true;
-            }
-
-            if (existing > previous) {
-                return false;
-            }
-        }
-
-        previous = existing;
-    }
-
-    return false;
-};
-
-/**
- * Decide where to insert a new row into an already-ordered list so the merge
- * preserves the cached ordering. When both the new row and the neighbours carry a
- * numeric `_creationTime` we honour the list's OWN direction — ascending (the
- * server's default sort) inserts before the first larger neighbour; descending
- * (a newest-first feed) inserts before the first smaller one, so a freshly
- * inserted newest row lands at the front instead of being appended to the end.
- * With no usable ordering we append, keeping insertion order and never reordering
- * existing rows.
- */
-const insertionIndex = (list: Record<string, unknown>[], row: Record<string, unknown>): number => {
-    const creation = row[CREATION_FIELD];
-
-    if (typeof creation !== "number") {
-        return list.length;
-    }
-
-    const descending = isDescending(list);
-
-    for (const [index, existingRow] of list.entries()) {
-        const existing = existingRow[CREATION_FIELD];
-
-        if (typeof existing === "number" && (descending ? existing < creation : existing > creation)) {
-            return index;
-        }
-    }
-
-    return list.length;
 };
 
 /**
@@ -136,75 +73,25 @@ const isMutationDelta = (value: unknown): value is MutationDelta => {
     );
 };
 
-/** The row-array field a `.paginate()` result carries its page in. */
-const PAGE_FIELD = "page";
-
 /**
- * The row array inside a cached query value, or `undefined` when there is none.
+ * Merge one row delta into an id-keyed row list, returning a new array.
  *
- * Two mergeable shapes:
- *
- * - the value IS the array — `db.query(...).collect()`;
- * - the value is `{ page: [...], isDone, continueCursor }` — what `.paginate()`
- * yields, and therefore what every `usePaginatedQuery` page holds.
- *
- * The server only ever sends row deltas for the paginated shape when the fields
- * around the page are unchanged, so merging into `page` and leaving the rest of
- * the object untouched reproduces the server's value exactly.
- * @returns the row array to merge into, or `undefined` when the value holds none
- */
-const pageOf = (current: unknown): undefined | unknown[] => {
-    if (Array.isArray(current)) {
-        return current as unknown[];
-    }
-
-    if (typeof current === "object" && current !== null && Array.isArray((current as Record<string, unknown>)[PAGE_FIELD])) {
-        return (current as Record<string, unknown>)[PAGE_FIELD] as unknown[];
-    }
-
-    return undefined;
-};
-
-/**
- * Apply a structured `MutationDelta` to a cached list result, returning a new
- * value (never mutating the input). Returns `undefined` when the delta can't be
- * applied cleanly — the caller should then fall back to the existing
- * full-replacement behaviour (or trust the next snapshot to reconcile).
- *
- * Mergeable shapes: an array of id-bearing row objects, or a `.paginate()`
- * result wrapping one in `page` (see {@link pageOf}). A paginated value keeps
- * its other fields and comes back as a new object with a new `page`.
- *
- * Insert / update / delete are matched by row `_id`:
- * - `insert`: appended (or placed by `_creationTime` order) if absent; treated
- * as an update if a row with the same id already exists (idempotent — guards
+ * Matched by `_id`:
+ * - `insert`: spliced at {@link insertionIndexFor} if absent; treated as an
+ * update when a row with the same id is already present (idempotent — guards
  * against a delta replayed after a snapshot already included it).
  * - `update`: replaces the matching row in place, preserving its position.
- * - `delete`: removes the matching row.
- *
- * Returns `undefined` when `current` holds no array of id-keyable objects, or
- * when an `insert`/`update` delta carries no `row` to splice in.
+ * - `delete`: removes the matching row; a delete for a row this list never held
+ * is a legitimate no-op, not a failure.
+ * @returns the merged rows, or `undefined` when the list isn't id-keyable or an insert/update carries no row
  */
-const applyDelta = (current: unknown, delta: MutationDelta): Record<string, unknown> | undefined | unknown[] => {
-    const list = pageOf(current);
-
-    if (list === undefined) {
-        return undefined;
-    }
-
-    // Re-wrap the merged rows the way they arrived: a bare array stays an array,
-    // a paginated result keeps `isDone`/`continueCursor` and swaps its page.
-    const rewrap = (next: unknown[]): Record<string, unknown> | unknown[] =>
-        Array.isArray(current) ? next : { ...(current as Record<string, unknown>), [PAGE_FIELD]: next };
-
-    // Only merge when every element is an id-bearing object; an array of
-    // scalars (or rows without `_id`) has no stable key to splice against.
+const mergeRows = (list: ReadonlyArray<unknown>, delta: MutationDelta): undefined | unknown[] => {
+    // Only merge when every element is an id-bearing object; a list of scalars
+    // (or rows without `_id`) has no stable key to splice against.
     const rows: Record<string, unknown>[] = [];
 
     for (const element of list) {
-        const id = rowId(element);
-
-        if (id === undefined) {
+        if (rowId(element) === undefined) {
             return undefined;
         }
 
@@ -216,10 +103,7 @@ const applyDelta = (current: unknown, delta: MutationDelta): Record<string, unkn
     if (op === "delete") {
         const next = rows.filter((existing) => existing[ID_FIELD] !== key);
 
-        // No row matched: the delete is a no-op for this page. Return the
-        // (copied) list unchanged rather than bailing — a delete for a row this
-        // page never held is legitimately nothing to do.
-        return rewrap(next.length === rows.length ? [...rows] : next);
+        return next.length === rows.length ? [...rows] : next;
     }
 
     // insert / update both need the new row body to splice in.
@@ -227,24 +111,48 @@ const applyDelta = (current: unknown, delta: MutationDelta): Record<string, unkn
         return undefined;
     }
 
+    const next = [...rows];
     const existingIndex = rows.findIndex((existing) => existing[ID_FIELD] === key);
 
     if (existingIndex === -1) {
-        // Absent → insert at the order-preserving position.
-        const next = [...rows];
-
-        next.splice(insertionIndex(rows, row), 0, row);
-
-        return rewrap(next);
+        next.splice(insertionIndexFor(rows, row), 0, row);
+    } else {
+        next[existingIndex] = row;
     }
 
-    // Present → replace in place (covers `update`, and an `insert` whose row a
-    // snapshot already delivered — idempotent).
-    const next = [...rows];
+    return next;
+};
 
-    next[existingIndex] = row;
+/**
+ * Apply a structured `MutationDelta` to a cached list result, returning a new
+ * value (never mutating the input). Returns `undefined` when the delta can't be
+ * applied cleanly — the caller should then fall back to the existing
+ * full-replacement behaviour (or trust the next snapshot to reconcile).
+ *
+ * Mergeable shapes: an array of id-bearing row objects, or a `.paginate()`
+ * result wrapping one in `page` (see `rowListOf`). A paginated value keeps its
+ * other fields and comes back as a new object with a new `page` — the server
+ * only sends row deltas for that shape when everything outside the page is
+ * unchanged, so the merged value matches the snapshot it chose not to send.
+ * @returns the merged value, or `undefined` when the delta cannot be applied
+ */
+const applyDelta = (current: unknown, delta: MutationDelta): Record<string, unknown> | undefined | unknown[] => {
+    const list = rowListOf(current);
 
-    return rewrap(next);
+    if (list === undefined) {
+        return undefined;
+    }
+
+    const next = mergeRows(list, delta);
+
+    // Re-wrap the way it arrived: a bare array stays an array, a paginated
+    // result keeps `isDone`/`continueCursor` and swaps its page. One wrap point,
+    // so no merge outcome can accidentally skip it.
+    if (next === undefined || Array.isArray(current)) {
+        return next;
+    }
+
+    return { ...(current as Record<string, unknown>), [PAGE_FIELD]: next };
 };
 
 export { applyDelta, isMutationDelta };

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -2,6 +2,7 @@ import { LunoraError } from "@lunora/errors";
 
 import { MAX_BATCH_ENTRIES } from "../../../shared/batch-wire";
 import { evictOldestEntry } from "../../../shared/evict-oldest";
+import { PAGE_DELTA_CAPABILITY } from "../../../shared/page-result";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import { stableWireKey } from "../../../shared/wire-key";
 import createInMemoryBookmarkStorage from "./bookmark";
@@ -453,15 +454,18 @@ const withQuery = (path: string, params: Record<string, number | string | undefi
 };
 
 /**
- * Capability tokens this client announces on its `connect` frame.
+ * Capability tokens this client announces on its `connect` frame — wire
+ * behaviours it can handle that an older client cannot.
  *
- * `"pageDelta"` says `applyDelta` can merge a row delta into the `page` of a
- * `.paginate()` result, so the server may answer a paginated live query with row
- * deltas instead of re-sending the whole page on every write. Strictly additive:
- * a server that does not recognise a token ignores it and keeps sending what it
- * always did.
+ * `PAGE_DELTA_CAPABILITY` says `applyDelta` can merge a row delta into the
+ * `page` of a `.paginate()` result, so the server may answer a paginated live
+ * query with row deltas instead of re-sending the whole page on every write.
+ *
+ * Strictly additive: a server that does not recognise a token ignores it and
+ * keeps sending what it always did. The token comes from `shared/` rather than
+ * being retyped here, so a mismatch with the server's gate is impossible.
  */
-const CLIENT_CAPABILITIES: ReadonlyArray<string> = ["pageDelta"];
+const CLIENT_CAPABILITIES = [PAGE_DELTA_CAPABILITY] as const;
 
 /** Map a shard key to its connection-map key (the default shard uses `""`). */
 const connectionKey = (shardKey: string | undefined): string => shardKey ?? "";
@@ -4472,12 +4476,7 @@ class LunoraClient {
         const context = this.effectiveConnectionContext(connectionKey(conn.shardKey));
 
         sendOn(conn, {
-            // Wire behaviours this client can handle that an older one cannot,
-            // so the server can use them without breaking anyone who can't. It
-            // has to be announced rather than assumed: a client that cannot
-            // merge a row delta into a paginated result does not ignore one —
-            // `applyDelta` bails and the value is replaced by the raw delta —
-            // so the server must know before it sends the first page delta.
+            // See {@link CLIENT_CAPABILITIES}.
             caps: CLIENT_CAPABILITIES,
             // Lets the server scope this connection's `__client_watermark` so
             // custom-mutator pokes can echo this client's `lastMutationId`.

--- a/packages/client/src/lunora-client.ts
+++ b/packages/client/src/lunora-client.ts
@@ -452,6 +452,17 @@ const withQuery = (path: string, params: Record<string, number | string | undefi
     return query === "" ? path : `${path}?${query}`;
 };
 
+/**
+ * Capability tokens this client announces on its `connect` frame.
+ *
+ * `"pageDelta"` says `applyDelta` can merge a row delta into the `page` of a
+ * `.paginate()` result, so the server may answer a paginated live query with row
+ * deltas instead of re-sending the whole page on every write. Strictly additive:
+ * a server that does not recognise a token ignores it and keeps sending what it
+ * always did.
+ */
+const CLIENT_CAPABILITIES: ReadonlyArray<string> = ["pageDelta"];
+
 /** Map a shard key to its connection-map key (the default shard uses `""`). */
 const connectionKey = (shardKey: string | undefined): string => shardKey ?? "";
 
@@ -4461,6 +4472,13 @@ class LunoraClient {
         const context = this.effectiveConnectionContext(connectionKey(conn.shardKey));
 
         sendOn(conn, {
+            // Wire behaviours this client can handle that an older one cannot,
+            // so the server can use them without breaking anyone who can't. It
+            // has to be announced rather than assumed: a client that cannot
+            // merge a row delta into a paginated result does not ignore one —
+            // `applyDelta` bails and the value is replaced by the raw delta —
+            // so the server must know before it sends the first page delta.
+            caps: CLIENT_CAPABILITIES,
             // Lets the server scope this connection's `__client_watermark` so
             // custom-mutator pokes can echo this client's `lastMutationId`.
             clientId: this.clientId,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -517,6 +517,22 @@ export interface ClientUnsubscribeMessage {
  */
 export interface ClientConnectMessage {
     /**
+     * Wire behaviours this client can handle that an older one cannot, so the
+     * server can use them without breaking clients that can't.
+     *
+     * Currently just `"pageDelta"` — this client can merge a row delta into the
+     * `page` of a `.paginate()` result. It is announced rather than assumed
+     * because a client that can't do that merge does not IGNORE such a delta: it
+     * replaces the whole query value with the raw delta object. An SDK that
+     * sends no `caps` therefore keeps receiving full snapshots, exactly as
+     * before.
+     *
+     * Additive in both directions: a server that does not recognise a token
+     * ignores it.
+     */
+    caps?: ReadonlyArray<string>;
+
+    /**
      * Stable per-client id (persisted alongside the outbox). Lets the server
      * scope this connection's `__client_watermark` so custom-mutator pokes can
      * echo the right per-client `lastMutationId`. Omitted by clients that don't

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -518,17 +518,9 @@ export interface ClientUnsubscribeMessage {
 export interface ClientConnectMessage {
     /**
      * Wire behaviours this client can handle that an older one cannot, so the
-     * server can use them without breaking clients that can't.
-     *
-     * Currently just `"pageDelta"` — this client can merge a row delta into the
-     * `page` of a `.paginate()` result. It is announced rather than assumed
-     * because a client that can't do that merge does not IGNORE such a delta: it
-     * replaces the whole query value with the raw delta object. An SDK that
-     * sends no `caps` therefore keeps receiving full snapshots, exactly as
-     * before.
-     *
-     * Additive in both directions: a server that does not recognise a token
-     * ignores it.
+     * server can use them without breaking clients that can't. Currently just
+     * `"pageDelta"`; see `shared/page-result.ts` for what it promises and why it
+     * must be announced rather than assumed. Omitting it is always safe.
      */
     caps?: ReadonlyArray<string>;
 

--- a/packages/codegen/__tests__/discover-queries.test.ts
+++ b/packages/codegen/__tests__/discover-queries.test.ts
@@ -22,6 +22,17 @@ const FUNCTIONS = `
     export const noFilter = query({ args: {}, handler: (ctx) => ctx.db.query("messages").collect() });
 
     export const dynamic = query({ args: {}, handler: (ctx) => ctx.db.query(dynamicTable).filter((row) => row.read).collect() });
+
+    export const geo = query({
+        args: {},
+        handler: (ctx) => ctx.db.query("places").withGeoIndex("byLocation", (q) => q.near({ lat: 1, lng: 2 }, 500)).collect(),
+    });
+
+    export const thenned = query({ args: {}, handler: (ctx) => ctx.db.query("messages").collect().then((rows) => rows.slice(0, 5)) });
+
+    export const capped = query({ args: {}, handler: (ctx) => ctx.db.query("messages").take(10) });
+
+    export const handedOn = query({ args: {}, handler: (ctx) => ctx.db.query("messages").order("desc") });
 `;
 
 let workdir: string;
@@ -39,28 +50,65 @@ describe("discoverQueries", () => {
         rmSync(workdir, { force: true, recursive: true });
     });
 
-    it("returns only filtered reads, tagging index presence and table", () => {
+    /** The single read discovered inside a given exported query. */
+    const readIn = (exportName: string) => discoverQueries(project, join(workdir, "lunora")).find((read) => read.exportName === exportName);
+
+    it("returns every read, tagging filter, index presence, and table", () => {
         expect.assertions(4);
 
         const reads = discoverQueries(project, join(workdir, "lunora"));
 
-        // `noFilter` is dropped; the other three filter.
-        expect(reads).toHaveLength(3);
-
-        const unindexed = reads.filter((read) => !read.hasIndex && read.table === "messages");
+        // Every read, including the unfiltered ones: they are not
+        // `filter_without_index` candidates (that lint gates on `hasFilter`), but
+        // a bare unindexed `.collect()` is exactly what `unbounded_collect` looks
+        // for, and dropping it here is what made that read invisible to any lint.
+        expect(reads).toHaveLength(8);
 
         // `scan` (no index) is flaggable; `indexed` has a `.withIndex` so it is not.
-        expect(unindexed).toHaveLength(1);
+        expect(reads.filter((read) => !read.hasIndex && read.hasFilter && read.table === "messages")).toHaveLength(1);
         expect(reads.some((read) => read.hasIndex && read.table === "messages")).toBe(true);
         // `dynamic` keeps `table: ""` because the argument is not a string literal.
         expect(reads.some((read) => read.table === "")).toBe(true);
+    });
+
+    it("reports the unfiltered, unindexed collect that unbounded_collect consumes", () => {
+        expect.assertions(1);
+
+        expect(readIn("noFilter")).toMatchObject({ hasFilter: false, hasIndex: false, table: "messages", terminal: "collect" });
+    });
+
+    it("counts withGeoIndex as narrowing, so an idiomatic geo read is not an unbounded scan", () => {
+        expect.assertions(1);
+
+        // A geo read resolves a geohash-prefix range plus a distance refine, and
+        // is normally written with no `.filter()` — so without this it would land
+        // on `unbounded_collect`'s exact trigger. `geo_index_unused` remediates by
+        // telling authors to write this very chain.
+        expect(readIn("geo")).toMatchObject({ hasIndex: true, table: "places" });
+    });
+
+    it("reports the last recognised terminal, not the last chained call", () => {
+        expect.assertions(2);
+
+        // `.collect().then(...)` keeps the chain walk going, so the literal last
+        // method is a promise combinator. The read is still an unbounded collect.
+        expect(readIn("thenned")?.terminal).toBe("collect");
+        expect(readIn("capped")?.terminal).toBe("take");
+    });
+
+    it("leaves the terminal undefined when the chain reaches none", () => {
+        expect.assertions(1);
+
+        // A reader handed on without being materialized: nothing to judge, so the
+        // terminal-shaped lints skip it rather than being handed a guess.
+        expect(readIn("handedOn")?.terminal).toBeUndefined();
     });
 
     it("records the file (relative, no extension) and a 1-based line", () => {
         expect.assertions(2);
 
         const reads = discoverQueries(project, join(workdir, "lunora"));
-        const scan = reads.find((read) => !read.hasIndex && read.table === "messages");
+        const scan = reads.find((read) => !read.hasIndex && read.hasFilter && read.table === "messages");
 
         expect(scan?.file).toBe("messages");
         expect(scan?.line).toBeGreaterThan(0);

--- a/packages/codegen/src/discover-queries.ts
+++ b/packages/codegen/src/discover-queries.ts
@@ -5,8 +5,32 @@ import { enclosingExportName } from "./argument-taint";
 import { listLunoraSourceFiles, lunoraRelativePath } from "./discover-functions";
 import type { QueryReadIR } from "./ir";
 
-/** Chain methods that narrow a read so it is not a full scan. */
-const INDEX_METHODS = new Set(["withIndex", "withSearchIndex"]);
+/**
+ * Chain methods that narrow a read so it is not a full scan.
+ *
+ * `withGeoIndex` belongs here for the same reason as the other two: it resolves
+ * a geohash-prefix range plus a distance refine, never a table scan. It was
+ * missing while this feeder only reported `.filter()` reads — a geo query is
+ * normally written without one, so nothing could observe the gap. Once
+ * unfiltered reads are reported (for `unbounded_collect`), omitting it would
+ * flag the idiomatic `withGeoIndex(...).collect()` as an unbounded scan, which
+ * `geo_index_unused` tells authors to write in the first place.
+ */
+const INDEX_METHODS = new Set(["withGeoIndex", "withIndex", "withSearchIndex"]);
+
+/**
+ * Chain methods that MATERIALIZE a read — the point at which how much of the
+ * narrowed set is actually loaded gets decided.
+ *
+ * Matched as a known set rather than taken as the chain's last call.
+ * {@link chainMethods} follows any property-access-then-call parent, and a
+ * terminal returns a Promise, so `.collect().then(...)` / `.catch(...)` keep the
+ * walk going and the last call is a combinator rather than the terminal. Taking
+ * the last RECOGNISED terminal reports `collect` for that chain instead of
+ * `then`; a chain with none (`.order("desc")` handed on, or a bare
+ * `query(...)`) reports `undefined`, which the terminal-shaped lints skip.
+ */
+const TERMINAL_METHODS = new Set(["collect", "collectWithScores", "first", "paginate", "take", "unique"]);
 
 /**
  * True for a `ctx.db.query(...)` (or bare `db.query(...)`) call — the database
@@ -116,10 +140,13 @@ const tableOf = (queryCall: CallExpression): string => {
 };
 
 /**
- * Discover `ctx.db.query("table")…` reads under the lunora source directory and
- * reduce each to a {@link QueryReadIR}. Only reads that call `.filter()` are
- * returned — an unfiltered read is never a `filter_without_index` candidate, so
- * dropping the rest keeps the lint input small.
+ * Discover every `ctx.db.query("table")…` read under the lunora source directory
+ * and reduce each to a {@link QueryReadIR}.
+ *
+ * Reads without a `.filter()` are kept too. They are never
+ * `filter_without_index` candidates (that lint gates on `hasFilter`), but an
+ * unfiltered, unindexed `.collect()` is the read `unbounded_collect` exists for
+ * — and dropping it here is precisely why nothing could see it.
  */
 const discoverQueries = (project: Project, lunoraDirectory: string): QueryReadIR[] => {
     const reads: QueryReadIR[] = [];
@@ -134,19 +161,17 @@ const discoverQueries = (project: Project, lunoraDirectory: string): QueryReadIR
             }
 
             const methods = chainMethods(call);
-
-            if (!methods.includes("filter")) {
-                continue;
-            }
+            const hasFilter = methods.includes("filter");
 
             reads.push({
                 exportName: enclosingExportName(call),
                 file: relativePath,
-                filtersPrimaryKey: filtersPrimaryKeyOf(call),
-                hasFilter: true,
+                filtersPrimaryKey: hasFilter && filtersPrimaryKeyOf(call),
+                hasFilter,
                 hasIndex: methods.some((method) => INDEX_METHODS.has(method)),
                 line: call.getStartLineNumber(),
                 table: tableOf(call),
+                terminal: methods.findLast((method) => TERMINAL_METHODS.has(method)),
             });
         }
     }

--- a/packages/codegen/src/ir.ts
+++ b/packages/codegen/src/ir.ts
@@ -718,9 +718,10 @@ export interface WorkflowCallIR {
 
 /**
  * A `ctx.db.query("table")…` read discovered in a function body, reduced to what
- * the `filter_without_index` advisor lint needs: which table, whether the chain
- * narrows with an index, and whether it filters. `table` is `""` when the
- * `query(...)` argument is not a string literal (a dynamic table — not lintable).
+ * the query advisor lints need: which table, whether the chain narrows with an
+ * index, whether it filters, and which terminal materializes the result.
+ * `table` is `""` when the `query(...)` argument is not a string literal (a
+ * dynamic table — not lintable).
  */
 export interface QueryReadIR {
     /** Exported procedure the read sits in, or `""` at module scope. */
@@ -743,6 +744,19 @@ export interface QueryReadIR {
     line: number;
     /** Queried table name, or `""` when the argument is not a string literal. */
     table: string;
+
+    /**
+     * The materializing call the chain ends in — `"collect"`, `"take"`,
+     * `"paginate"`, `"first"`, `"unique"`, … — i.e. how much of the narrowed set
+     * the read actually loads.
+     *
+     * `undefined` when the chain reaches no recognised terminal (a reader passed
+     * on, a bare `query(...)`) AND when a feeder predating this field produced
+     * the read. The two are deliberately not distinguished: no consumer could act
+     * on the difference, so the terminal-shaped lints skip the read either way
+     * rather than guessing a terminal.
+     */
+    terminal?: string;
 }
 
 /**

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -1145,14 +1145,18 @@ describe("subscriptionListDeltas", () => {
         expect(subscriptionListDeltas(prev, next, "messages")).toBeUndefined();
     });
 
-    it("returns the snapshot sentinel on a near-total change where deltas would exceed the new length", () => {
+    it("still decomposes a near-total change — cost is not this function's call", () => {
         expect.assertions(1);
 
-        // 2 deletes + 1 insert = 3 deltas for a new array of length 1 → snapshot.
+        // 2 deletes + 1 insert against a new array of length 1. This used to
+        // return the snapshot sentinel via a row-count cap, which was a cost
+        // heuristic living in a function that cannot see the wire. The diff is
+        // expressible, so it is returned; `subscriptionFrames` decides whether
+        // sending it is cheaper than the snapshot, by measuring the real frames.
         const prev = JSON.stringify([row("a"), row("b")]);
         const next = [row("c")];
 
-        expect(subscriptionListDeltas(prev, next, "messages")).toBeUndefined();
+        expect(subscriptionListDeltas(prev, next, "messages")).toHaveLength(3);
     });
 
     it("falls back to a non-empty table name when the read-table set is empty", () => {
@@ -1175,8 +1179,7 @@ describe("subscriptionListDeltas", () => {
     it("the frames sink yields bodies byte-identical to JSON.stringify(delta) across insert/update/delete", () => {
         expect.assertions(2);
 
-        // One delete (c), one update (a), one insert (d) — exercises all three
-        // branches while staying at/under the chattiness cap (3 deltas, length-3 next).
+        // One delete (c), one update (a), one insert (d) — exercises all three branches.
         const prev = JSON.stringify([row("a", { text: "old" }), row("b"), row("c")]);
         const next = [row("a", { text: "new" }), row("b"), row("d", { text: "fresh" })];
 
@@ -1234,6 +1237,21 @@ describe("shardDO subscription delta push", () => {
         return { _creationTime: 1, _id: id, ...rest };
     };
 
+    /**
+     * `count` rows that never change, prepended to a fixture so the list is long
+     * enough for a handful of deltas to be the cheaper encoding.
+     *
+     * These cases assert WHICH frame type goes out, and `subscriptionFrames`
+     * decides that by measuring the rendered frames — a few deltas against a
+     * two-row list genuinely cost more than re-sending it, so without a
+     * list-sized baseline the snapshot branch wins and the delta assertions have
+     * nothing to look at. Length is the only lever used (never row width), so
+     * these stay in the delta regime by a wide margin under any change to the
+     * frame envelope. The threshold itself is pinned directly, without a DO or a
+     * socket, by the `subscriptionFrames` unit tests in `@lunora/shard-engine`.
+     */
+    const filler = (count: number): Record<string, unknown>[] => Array.from({ length: count }, (_, index) => idRow(`fill-${String(index)}`));
+
     const subscribeMessages = (shard: ReexecShard, ws: FakeWebSocket): Promise<void> =>
         shard.driveMessage(ws, { id: "sub-1", query: { args: {}, functionPath: "messages:list" }, type: "subscribe" });
 
@@ -1244,13 +1262,13 @@ describe("shardDO subscription delta push", () => {
         const ws = createFakeWebSocket();
 
         shard.registerSocket(ws);
-        shard.outcomes.set("messages:list", { result: [idRow("a")], tables: new Set(["messages"]) });
+        shard.outcomes.set("messages:list", { result: [...filler(16), idRow("a")], tables: new Set(["messages"]) });
 
         await subscribeMessages(shard, ws);
 
-        expect(JSON.parse(ws.sent.at(-1)!)).toEqual({ data: [idRow("a")], id: "sub-1", type: "data" });
+        expect(JSON.parse(ws.sent.at(-1)!)).toEqual({ data: [...filler(16), idRow("a")], id: "sub-1", type: "data" });
 
-        shard.outcomes.set("messages:list", { result: [idRow("a"), idRow("b", { text: "hi" })], tables: new Set(["messages"]) });
+        shard.outcomes.set("messages:list", { result: [...filler(16), idRow("a"), idRow("b", { text: "hi" })], tables: new Set(["messages"]) });
         shard.changedTableOnRpc = "messages";
         await shard.writeRpc();
 
@@ -1280,6 +1298,42 @@ describe("shardDO subscription delta push", () => {
         expect(JSON.parse(ws.sent.at(-1)!)).toEqual({ data: { count: 2 }, id: "sub-1", type: "data" });
     });
 
+    it("takes the snapshot when the delta frames would out-weigh it on the wire", async () => {
+        expect.assertions(3);
+
+        const shard = new ReexecShard(state, {});
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws);
+
+        const before = filler(20);
+
+        shard.outcomes.set("messages:list", { result: before, tables: new Set(["messages"]) });
+        await subscribeMessages(shard, ws);
+
+        const sentBefore = ws.sent.length;
+
+        // Every row changes. `subscriptionListDeltas` accepts this — 20 deltas
+        // for a 20-row result is within its own row-count cap — but each frame
+        // re-pays the `{"type":"delta","id":…,"table":…}` envelope that one
+        // snapshot pays once, so 20 frames carry MORE bytes than the single
+        // `{type:"data"}` frame holding the same rows. Row count cannot see
+        // that; the byte comparison in `pushSubscriptionData` can.
+        const after = before.map((row) => {
+            return { ...row, text: "edited" };
+        });
+
+        shard.outcomes.set("messages:list", { result: after, tables: new Set(["messages"]) });
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        const frames = ws.sent.slice(sentBefore).map((line) => JSON.parse(line) as { data?: unknown; type: string });
+
+        expect(frames.filter((frame) => frame.type === "delta")).toHaveLength(0);
+        expect(frames.filter((frame) => frame.type === "data")).toHaveLength(1);
+        expect(frames.find((frame) => frame.type === "data")?.data).toEqual(after);
+    });
+
     it("applying the pushed delta frames to the prior snapshot yields the new result", async () => {
         expect.assertions(1);
 
@@ -1287,15 +1341,16 @@ describe("shardDO subscription delta push", () => {
         const ws = createFakeWebSocket();
 
         shard.registerSocket(ws);
-        shard.outcomes.set("messages:list", { result: [idRow("a"), idRow("b"), idRow("c")], tables: new Set(["messages"]) });
+        shard.outcomes.set("messages:list", { result: [...filler(16), idRow("a"), idRow("b"), idRow("c")], tables: new Set(["messages"]) });
 
         await subscribeMessages(shard, ws);
 
         const baseline = (JSON.parse(ws.sent.at(-1)!) as { data: Record<string, unknown>[] }).data;
         const sentBefore = ws.sent.length;
 
-        // Delete c, update a, insert d — 3 deltas for a length-3 result (under the cap).
-        const nextResult = [idRow("a", { text: "edited" }), idRow("b"), idRow("d")];
+        // Delete c, update a, insert d — 3 deltas against a 19-row list, so the
+        // three frames stay well under the snapshot they are weighed against.
+        const nextResult = [...filler(16), idRow("a", { text: "edited" }), idRow("b"), idRow("d")];
 
         shard.outcomes.set("messages:list", { result: nextResult, tables: new Set(["messages"]) });
         shard.changedTableOnRpc = "messages";
@@ -1338,7 +1393,7 @@ describe("shardDO subscription delta push", () => {
 
         shard.registerSocket(ws);
 
-        const prevResult = [idRow("a", { text: "old" }), idRow("b"), idRow("c")];
+        const prevResult = [...filler(16), idRow("a", { text: "old" }), idRow("b"), idRow("c")];
 
         shard.outcomes.set("messages:list", { result: prevResult, tables: new Set(["messages"]) });
         await subscribeMessages(shard, ws);
@@ -1346,8 +1401,8 @@ describe("shardDO subscription delta push", () => {
         const sentBefore = ws.sent.length;
 
         // delete c, update a, insert d — all three delta branches in one refresh,
-        // 3 deltas for a length-3 next result (under the chattiness cap).
-        const nextResult = [idRow("a", { text: "new" }), idRow("b"), idRow("d", { text: "hi" })];
+        // 3 deltas against a 19-row list, so the delta path stays cheaper.
+        const nextResult = [...filler(16), idRow("a", { text: "new" }), idRow("b"), idRow("d", { text: "hi" })];
 
         shard.outcomes.set("messages:list", { result: nextResult, tables: new Set(["messages"]) });
         shard.changedTableOnRpc = "messages";

--- a/packages/do/__tests__/shard-do.test.ts
+++ b/packages/do/__tests__/shard-do.test.ts
@@ -1255,6 +1255,65 @@ describe("shardDO subscription delta push", () => {
     const subscribeMessages = (shard: ReexecShard, ws: FakeWebSocket): Promise<void> =>
         shard.driveMessage(ws, { id: "sub-1", query: { args: {}, functionPath: "messages:list" }, type: "subscribe" });
 
+    /** A `.paginate()` result: the shape every `usePaginatedQuery` page subscribes to. */
+    const paginated = (rows: Record<string, unknown>[]): Record<string, unknown> => {
+        return { continueCursor: "cursor-16", isDone: false, page: rows };
+    };
+
+    /** Drive the one-shot `connect` frame, optionally announcing capabilities. */
+    const connect = (shard: ReexecShard, ws: FakeWebSocket, caps?: string[]): Promise<void> =>
+        shard.driveMessage(ws, { id: "connect", type: "connect", ...(caps === undefined ? {} : { caps }) });
+
+    it("re-sends a whole page to a socket that announced no capabilities", async () => {
+        expect.assertions(2);
+
+        // The behaviour every client had before `pageDelta`, and the one all
+        // seven non-JS SDKs still get — they send `connect` with no `caps`.
+        const shard = new ReexecShard(state, {});
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws);
+        await connect(shard, ws);
+        shard.outcomes.set("messages:list", { result: paginated(filler(16)), tables: new Set(["messages"]) });
+        await subscribeMessages(shard, ws);
+
+        const sentBefore = ws.sent.length;
+        const next = paginated([...filler(16), idRow("new")]);
+
+        shard.outcomes.set("messages:list", { result: next, tables: new Set(["messages"]) });
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        const frames = ws.sent.slice(sentBefore).map((line) => JSON.parse(line) as { data?: unknown; type: string });
+
+        expect(frames.filter((frame) => frame.type === "delta")).toHaveLength(0);
+        expect(frames.find((frame) => frame.type === "data")?.data).toStrictEqual(next);
+    });
+
+    it("sends one page delta to a socket that announced pageDelta", async () => {
+        expect.assertions(3);
+
+        const shard = new ReexecShard(state, {});
+        const ws = createFakeWebSocket();
+
+        shard.registerSocket(ws);
+        await connect(shard, ws, ["pageDelta"]);
+        shard.outcomes.set("messages:list", { result: paginated(filler(16)), tables: new Set(["messages"]) });
+        await subscribeMessages(shard, ws);
+
+        const sentBefore = ws.sent.length;
+
+        shard.outcomes.set("messages:list", { result: paginated([...filler(16), idRow("new")]), tables: new Set(["messages"]) });
+        shard.changedTableOnRpc = "messages";
+        await shard.writeRpc();
+
+        const frames = ws.sent.slice(sentBefore).map((line) => JSON.parse(line) as { delta?: unknown; type: string });
+
+        expect(frames.filter((frame) => frame.type === "data")).toHaveLength(0);
+        expect(frames.filter((frame) => frame.type === "delta")).toHaveLength(1);
+        expect(frames[0]?.delta).toStrictEqual({ key: "new", op: "insert", row: idRow("new"), table: "messages" });
+    });
+
     it("first push is a data snapshot; an additive change pushes a delta frame", async () => {
         expect.assertions(3);
 

--- a/packages/do/__tests__/subscription-data-watermark.test.ts
+++ b/packages/do/__tests__/subscription-data-watermark.test.ts
@@ -207,13 +207,13 @@ describe("shardDO: plain data frame carries the per-client lastMutationId (plan 
 
 /**
  * Thermos H1 — the snapshot-only stamp above left the DELTA path (the
- * `{type:"delta"}` frames `sendDeltaFrames` emits) unstamped, and a
+ * `{type:"delta"}` frames `subscriptionFrames` renders) unstamped, and a
  * `@lunora/db` list collection is exactly the id-keyed, order-preserving
  * shape `subscriptionListDeltas` accepts — so after the first snapshot,
  * EVERY subsequent write for it goes out as deltas. Growing the row set by
- * one ID each write (keeping every prior row as a survivor) is what makes
- * `subscriptionListDeltas` accept the change instead of falling back to a
- * full snapshot (see its "near-total change" guard).
+ * one id per write (keeping every prior row as a survivor) keeps the change
+ * both expressible as deltas and cheaper than a snapshot, which is what puts
+ * a delta frame on the wire for the assertions to read.
  */
 class GrowingListShard extends ShardDO {
     private readonly rows: { _id: string; text: string }[] = [];
@@ -222,9 +222,8 @@ class GrowingListShard extends ShardDO {
 
     public override handleRpc(functionPath: string): Promise<unknown> {
         return this.runInTransaction(() => {
-            this.nextRow += 1;
-            this.rows.push({ _id: `m${String(this.nextRow)}`, text: `row ${String(this.nextRow)}` });
-            this.recordChangedTable("messages");
+            this.appendRow();
+            this.recordChangedTable("messages"); // GrowingListShard
 
             const result = { ok: true, path: functionPath };
 
@@ -243,6 +242,25 @@ class GrowingListShard extends ShardDO {
         return this.webSocketMessage(ws as unknown as WebSocket, JSON.stringify(envelope));
     }
 
+    /**
+     * Lengthen the list WITHOUT going through a write.
+     *
+     * `subscriptionFrames` chooses deltas over a snapshot by measuring both, so a
+     * one-row insert only takes the delta path against a list-sized baseline —
+     * and this test needs the delta path to have a frame to assert on. Seeding
+     * through `pushMutatorWrite` under a second `clientId` would also produce the
+     * rows, but it would make the setup depend on per-client watermark
+     * isolation, which is the very property the assertions verify: a regression
+     * in it would poison the fixture, and the test could no longer tell "the
+     * watermark leaked" from "the seeding leaked". Writing straight to the
+     * fixture keeps the subject out of the setup.
+     */
+    public seedRows(count: number): void {
+        for (let index = 0; index < count; index += 1) {
+            this.appendRow();
+        }
+    }
+
     // eslint-disable-next-line class-methods-use-this -- test stub override: classifies by `functionPath` alone, no instance state.
     protected override isCustomMutator(functionPath: string): boolean {
         return functionPath === "messages:sendMutator";
@@ -253,6 +271,12 @@ class GrowingListShard extends ShardDO {
         // not by reference, but a fresh array also matches how a real query
         // re-run would produce a fresh result object.
         return Promise.resolve({ result: [...this.rows], tables: new Set(["messages"]) });
+    }
+
+    /** Append one row to the in-memory list `executeSubscription` reports. */
+    private appendRow(): void {
+        this.nextRow += 1;
+        this.rows.push({ _id: `m${String(this.nextRow)}`, text: `row ${String(this.nextRow)}` });
     }
 }
 
@@ -278,6 +302,12 @@ describe("shardDO: delta frames also carry the per-client lastMutationId (thermo
             const ws = createFakeWebSocket();
 
             shard.registerSocket(ws, { clientId: "client-A", subs: {}, userId: "" });
+
+            // Deepen the list so the single-row change below is genuinely cheaper
+            // as a delta than as a snapshot — see `seedRows`, which deliberately
+            // bypasses the write path so the setup does not lean on the watermark
+            // isolation these assertions exist to check.
+            shard.seedRows(16);
 
             // Seed row + subscribe: the FIRST frame is always a snapshot
             // (nothing to diff against yet).

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -163,7 +163,6 @@ import {
     mergeChangedKeys,
     migrateClientWatermark,
     minCdcSeq,
-    PAGE_DELTA_CAPABILITY,
     parseExportShardArgs,
     parseImportShardArgs,
     projectColumns,
@@ -221,6 +220,7 @@ import type { LogSinkContext } from "../../../shared/log-event";
 import type { LogFields } from "../../../shared/log-fields";
 import type { MetricEvent } from "../../../shared/metric-event";
 import { LUNORA_ATTR, parseTraceparent } from "../../../shared/otlp";
+import { PAGE_DELTA_CAPABILITY } from "../../../shared/page-result";
 import type { SpanEvent, SpanHandle } from "../../../shared/span-event";
 import { decodeWire, encodeWire } from "../../../shared/wire-codec";
 import { isEnvFlagEnabled, verifyWsAdminToken } from "../../../shared/ws-admin-token";
@@ -4255,13 +4255,17 @@ abstract class ShardDO {
                 attachment.clientId = envelope.clientId;
             }
 
-            // Capability tokens gate wire behaviours an older client would
-            // mis-apply rather than ignore (see `PAGE_DELTA_CAPABILITY`), so
-            // they are recorded fail-closed: only a well-formed array of
-            // strings counts, and anything else leaves the socket on the
-            // behaviour every client already understood.
+            // Resolve the announced capabilities to the decisions they gate,
+            // rather than persisting the raw tokens. `caps` is client-supplied
+            // and otherwise unbounded — the sibling attachment arrays (`subs`,
+            // `whispers`) are both explicitly capped for exactly that reason,
+            // and an over-large one here would either starve `subs` or make
+            // `serializeAttachment` throw, dropping the whole attachment. A
+            // fixed set of booleans is bounded by construction, and nothing
+            // reads an unrecognised token back: the server can only act on ones
+            // it understands, so keeping them would store input with no reader.
             if (Array.isArray(envelope.caps)) {
-                attachment.caps = envelope.caps.filter((capability) => typeof capability === "string");
+                attachment.pageDeltas = envelope.caps.includes(PAGE_DELTA_CAPABILITY);
             }
 
             attachment.connected = true;
@@ -8022,7 +8026,7 @@ abstract class ShardDO {
             // Resolved once per socket per flush, not once per affected
             // subscription below — both depend only on this socket, and are
             // identical for every subscription on it. See {@link SocketDelivery}.
-            const delivery = this.socketDelivery(ws, attachment);
+            const delivery = this.socketDelivery(attachment);
 
             for (const [subId, query] of Object.entries(attachment.subs)) {
                 const { functionPath } = query;
@@ -8159,18 +8163,29 @@ abstract class ShardDO {
             return;
         }
 
-        this.pushSubscriptionData(ws, subId, outcome, resume?.cursor ?? this.currentCdcCursor(), epoch, this.socketDelivery(ws));
+        // A FRESH attachment read, not the one captured above: that one predates
+        // the `resolveReactiveOutcome` await, and a `connect` envelope can land
+        // during it. The identity above is deliberately by-value (see there);
+        // the delivery facts are not, and reading them stale would drop a
+        // `clientId`/capability this socket has since announced.
+        this.pushSubscriptionData(ws, subId, outcome, resume?.cursor ?? this.currentCdcCursor(), epoch, this.socketDelivery(this.readAttachment(ws)));
     }
 
     /**
-     * Resolve the per-socket delivery facts a subscription push needs. Pass
-     * `attachment` when the caller has already read it (the refresh loop has),
-     * so a hot flush does not deserialize it twice.
+     * Resolve the per-socket delivery facts a subscription push needs, from the
+     * attachment the caller already holds.
+     *
+     * Takes the attachment rather than the socket deliberately: neither field
+     * needs anything else from `ws`, and every caller has just read one. An
+     * earlier shape took `ws` with the attachment as an optional hint, which
+     * did not do what it claimed — `socketClientWatermark` read the attachment
+     * again internally, so the "already read it" fast path still deserialized
+     * twice on the refresh path and three times on the seed path.
      */
-    private socketDelivery(ws: ShardSocketLike, attachment?: SocketAttachment): SocketDelivery {
+    private socketDelivery(attachment: SocketAttachment): SocketDelivery {
         return {
-            clientWatermark: this.socketClientWatermark(ws),
-            pageDeltas: (attachment ?? this.readAttachment(ws)).caps?.includes(PAGE_DELTA_CAPABILITY) === true,
+            clientWatermark: this.socketClientWatermark(attachment),
+            pageDeltas: attachment.pageDeltas === true,
         };
     }
 
@@ -8988,7 +9003,13 @@ abstract class ShardDO {
     ): boolean {
         this.pokeSequence += 1;
         const pokeId = `poke-${String(this.pokeSequence)}`;
-        const frames = buildPokeFrames(parts, { baseCheckpoint, checkpoint, epoch, lastMutationId: this.socketClientWatermark(ws), pokeId });
+        const frames = buildPokeFrames(parts, {
+            baseCheckpoint,
+            checkpoint,
+            epoch,
+            lastMutationId: this.socketClientWatermark(this.readAttachment(ws)),
+            pokeId,
+        });
 
         try {
             for (const frame of frames) {
@@ -9008,8 +9029,7 @@ abstract class ShardDO {
      * (a client that doesn't use custom mutators — nothing to drop an overlay
      * for). Read off the attachment so it survives hibernation.
      */
-    private socketClientWatermark(ws: ShardSocketLike): number | undefined {
-        const attachment = this.readAttachment(ws);
+    private socketClientWatermark(attachment: SocketAttachment): number | undefined {
         const { clientId } = attachment;
 
         if (clientId === undefined) {

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -163,6 +163,7 @@ import {
     mergeChangedKeys,
     migrateClientWatermark,
     minCdcSeq,
+    PAGE_DELTA_CAPABILITY,
     parseExportShardArgs,
     parseImportShardArgs,
     projectColumns,
@@ -668,6 +669,23 @@ interface ShardDOOptions {
      * re-run their queries in response always observe the post-write state.
      */
     reactiveCache?: ReactiveCacheOptions;
+}
+
+/**
+ * The per-SOCKET facts a subscription push needs, resolved once per socket per
+ * write-flush rather than once per subscription.
+ *
+ * Both depend only on the socket, never on the subscription being pushed, and a
+ * single flush pushes many subscriptions down one socket — so recomputing them
+ * inside {@link ShardDO.pushSubscriptionData} would repeat a
+ * `__client_watermark` SELECT and an attachment read per subscription.
+ */
+interface SocketDelivery {
+    /** This socket's custom-mutator watermark, stamped on every outgoing frame. */
+    clientWatermark: number | undefined;
+
+    /** Whether this socket announced {@link PAGE_DELTA_CAPABILITY} on `connect`. */
+    pageDeltas: boolean;
 }
 
 /** Per-subscription memo used to suppress no-op pushes. */
@@ -4235,6 +4253,15 @@ abstract class ShardDO {
             // echo its `__client_watermark` as `lastMutationId` (overlay-drop).
             if (envelope.clientId !== undefined) {
                 attachment.clientId = envelope.clientId;
+            }
+
+            // Capability tokens gate wire behaviours an older client would
+            // mis-apply rather than ignore (see `PAGE_DELTA_CAPABILITY`), so
+            // they are recorded fail-closed: only a well-formed array of
+            // strings counts, and anything else leaves the socket on the
+            // behaviour every client already understood.
+            if (Array.isArray(envelope.caps)) {
+                attachment.caps = envelope.caps.filter((capability) => typeof capability === "string");
             }
 
             attachment.connected = true;
@@ -7992,12 +8019,10 @@ abstract class ShardDO {
 
             const attachment = this.readAttachment(ws);
 
-            // Read once per socket per flush, not once per affected
-            // subscription below — the value depends only on this socket's
-            // announced `clientId`/`userId`, identical for every subscription
-            // on it, so re-reading it per subscription was a redundant
-            // `SELECT … FROM __client_watermark` per subscription per flush.
-            const clientWatermark = this.socketClientWatermark(ws);
+            // Resolved once per socket per flush, not once per affected
+            // subscription below — both depend only on this socket, and are
+            // identical for every subscription on it. See {@link SocketDelivery}.
+            const delivery = this.socketDelivery(ws, attachment);
 
             for (const [subId, query] of Object.entries(attachment.subs)) {
                 const { functionPath } = query;
@@ -8056,7 +8081,7 @@ abstract class ShardDO {
                     // eslint-disable-next-line no-await-in-loop -- intentional per-socket backpressure: drain before pushing the next subscription's frame
                     await awaitWsDrain(ws);
 
-                    this.pushSubscriptionData(ws, subId, outcome, frameCursor, frameEpoch, clientWatermark);
+                    this.pushSubscriptionData(ws, subId, outcome, frameCursor, frameEpoch, delivery);
                 } catch (error) {
                     // A throwing subscription must not abort the refresh of its
                     // siblings, nor fail the mutation that triggered it. The memo
@@ -8134,7 +8159,19 @@ abstract class ShardDO {
             return;
         }
 
-        this.pushSubscriptionData(ws, subId, outcome, resume?.cursor ?? this.currentCdcCursor(), epoch, this.socketClientWatermark(ws));
+        this.pushSubscriptionData(ws, subId, outcome, resume?.cursor ?? this.currentCdcCursor(), epoch, this.socketDelivery(ws));
+    }
+
+    /**
+     * Resolve the per-socket delivery facts a subscription push needs. Pass
+     * `attachment` when the caller has already read it (the refresh loop has),
+     * so a hot flush does not deserialize it twice.
+     */
+    private socketDelivery(ws: ShardSocketLike, attachment?: SocketAttachment): SocketDelivery {
+        return {
+            clientWatermark: this.socketClientWatermark(ws),
+            pageDeltas: (attachment ?? this.readAttachment(ws)).caps?.includes(PAGE_DELTA_CAPABILITY) === true,
+        };
     }
 
     /**
@@ -9028,13 +9065,13 @@ abstract class ShardDO {
      * (Pillar 1b). Omitted on shards without CDC, keeping the wire byte-identical
      * to the pre-cursor format.
      *
-     * `clientWatermark` is this socket's `socketClientWatermark(ws)` — read
-     * ONCE by the caller and passed in, not recomputed here. A single
-     * write-flush can call this method many times for the same socket (once
-     * per affected subscription — see `refreshOne`), and the watermark
-     * depends only on `ws`, never on `subId`/`outcome`, so recomputing it per
-     * subscription was a redundant `SELECT … FROM __client_watermark` per
-     * subscription per socket per flush.
+     * `delivery` carries the facts that depend on the SOCKET and not on the
+     * subscription — read once by the caller and passed in, never recomputed
+     * here. A single write-flush calls this method many times for one socket
+     * (once per affected subscription — see `refreshOne`), and both fields are
+     * identical across those calls: `clientWatermark` would otherwise be a
+     * redundant `SELECT … FROM __client_watermark` per subscription, and
+     * `pageDeltas` a redundant attachment read.
      */
     private pushSubscriptionData(
         ws: ShardSocketLike,
@@ -9042,10 +9079,11 @@ abstract class ShardDO {
         outcome: SubscriptionOutcome,
         cursor: number | undefined,
         epoch: string | undefined,
-        clientWatermark: number | undefined,
+        delivery: SocketDelivery,
     ): void {
         const memos = socketMap(this.subMemos, ws);
         const cursorSuffix = cdcSuffix(cursor, epoch);
+        const { clientWatermark, pageDeltas } = delivery;
 
         // Wire-encode the result so a `bytes`/`bigint` column survives the frame
         // (raw `JSON.stringify` drops a buffer to `{}` / throws on a bigint). A
@@ -9092,6 +9130,7 @@ abstract class ShardDO {
             cursorSuffix,
             lastMutationId: clientWatermark,
             nextResult: outcome.result,
+            pageDeltas,
             previousJson: existing?.lastJson,
             snapshotJson: json,
             subId,

--- a/packages/do/src/shard-do.ts
+++ b/packages/do/src/shard-do.ts
@@ -194,11 +194,10 @@ import {
     selectMatchingIds,
     selectShapeMemberIds,
     selectShapeRows,
-    sendDeltaFrames,
     ShardRunner,
     stableStringify,
     stableWireKey,
-    subscriptionListDeltas,
+    subscriptionFrames,
     summarizeFanoutTopics,
     summarizeSubscriptions,
     TransactionHeadroomTracker,
@@ -9017,11 +9016,11 @@ abstract class ShardDO {
      * so dependency tracking stays current even when the value is unchanged.
      *
      * When the result is a diffable list (Convex-parity live-pagination, gap
-     * #20), emit one `{type:"delta"}` frame per changed row instead of a full
-     * `{type:"data"}` snapshot — see {@link subscriptionListDeltas} for the
-     * five conditions under which deltas are safe. The first send (and any
-     * non-list / large-change result) falls back to the snapshot. The memo is
-     * always advanced to the new `lastJson`/`tables` regardless of path.
+     * #20), the push can go out as one `{type:"delta"}` frame per changed row
+     * instead of a full `{type:"data"}` snapshot. Which of the two is sent is
+     * `subscriptionFrames`' call, made by rendering both and measuring them —
+     * this method just sends what it is handed. The memo is always advanced to
+     * the new `lastJson`/`tables` regardless of path.
      *
      * `cursor` (when supplied) is the `__cdc_log` high-watermark this frame
      * covers; it is appended to the emitted `data`/`delta` JSON so a client can
@@ -9079,46 +9078,37 @@ abstract class ShardDO {
             return;
         }
 
-        // Try an incremental delta push when there's a prior list to diff
-        // against. `undefined` => not diffable, fall back to the snapshot below.
-        // `deltaFrames` receives the pre-serialized `delta` body for each delta
-        // (finding #6) so we never re-`JSON.stringify` a row that the diff has
-        // already fingerprinted.
-        const deltaFrames: string[] = [];
-        const deltas =
-            existing === undefined
-                ? undefined
-                : subscriptionListDeltas(existing.lastJson, outcome.result, outcome.tables.values().next().value ?? "", deltaFrames);
-
-        // Stamp this socket's per-mutator watermark on the plain `data` frame
-        // the same way the `settled` branch above does, so the client's
-        // checkpoint gate can trust what THIS frame's rows actually reflect
-        // instead of a provisional RPC-ack signal that can race ahead of it
-        // (plan 266 finding d: write A's data frame arriving after write B's
-        // ack has already landed, but before B's own rows synced, must not
-        // resolve B's overlay early). The delta branch below stamps the SAME
-        // watermark on every delta frame it sends (not a follow-up: a
-        // `@lunora/db` list collection is exactly the id-keyed shape the
-        // delta path targets, so after the first snapshot EVERY subsequent
-        // write for it goes out as deltas — leaving them unstamped would
-        // starve the checkpoint gate of a frame-carried watermark for the
-        // common case, not a rare one).
-        const lastMutationIdField = clientWatermark === undefined ? "" : `,"lastMutationId":${String(clientWatermark)}`;
+        // Row deltas or the full snapshot — `subscriptionFrames` renders both and
+        // returns whichever is smaller on the wire, so the frame layout and the
+        // choice between the two stay in one place (this method has no business
+        // re-deriving the delta envelope just to size it). `existing?.lastJson`
+        // is the last value that actually LEFT the socket, so a first send — or
+        // one whose predecessor was dropped — has no baseline and gets the
+        // snapshot. `clientWatermark` rides on every frame either way, so the
+        // client's checkpoint gate can trust what THIS frame's rows reflect
+        // instead of a provisional RPC-ack that can race ahead of it (plan 266
+        // finding d).
+        const frames = subscriptionFrames({
+            cursorSuffix,
+            lastMutationId: clientWatermark,
+            nextResult: outcome.result,
+            previousJson: existing?.lastJson,
+            snapshotJson: json,
+            subId,
+            table: outcome.tables.values().next().value ?? "",
+        });
 
         // At-least-once delivery: advance the diff BASELINE (`lastJson`) only once
-        // the frame(s) for this value actually leave the socket. `ws.send` throws
-        // when the socket has closed or its outbound buffer is gone. Advancing the
-        // baseline unconditionally (the prior behavior) would diff the NEXT value
-        // against a value the client never received, so a single dropped frame
-        // silently lost that update until the client reconnected. By keeping the
-        // last *delivered* baseline on failure, the next write-flush that touches a
-        // read table re-sends — and the reconnect resume path (`evaluateResume`)
-        // still covers a fully-gone socket. `tables` always advances so dependency
-        // tracking stays accurate even when delivery failed.
-        const delivered =
-            deltas === undefined
-                ? trySendFrame(ws, `{"type":"data","id":${JSON.stringify(subId)},"data":${json}${lastMutationIdField}${cursorSuffix}}`)
-                : sendDeltaFrames(ws, subId, deltaFrames, cursorSuffix, clientWatermark);
+        // EVERY frame for this value has left the socket. `ws.send` throws when the
+        // socket has closed or its outbound buffer is gone, and a partial delta run
+        // must keep the baseline at the last fully-delivered value so the next flush
+        // re-diffs the whole change (keyed list deltas are idempotent on replay, so
+        // re-sending an already-applied row is harmless). Advancing unconditionally
+        // would diff the NEXT value against one the client never received, silently
+        // losing that update until it reconnected. `.map` before `.every` on purpose:
+        // every frame is attempted, and only then is the verdict taken. `tables`
+        // always advances so dependency tracking stays accurate even on failure.
+        const delivered = frames.map((frame) => trySendFrame(ws, frame)).every(Boolean);
 
         memos.set(subId, { lastJson: delivered ? json : (existing?.lastJson ?? UNDELIVERED_BASELINE), ranges: outcome.ranges, tables: outcome.tables });
     }

--- a/packages/shard-engine/__bench__/subscription-frames.bench.ts
+++ b/packages/shard-engine/__bench__/subscription-frames.bench.ts
@@ -1,0 +1,91 @@
+import { bench, describe } from "vitest";
+
+import { encodeWire } from "../../../shared/wire-codec";
+import { subscriptionFrames } from "../src/subscription-delivery";
+
+/**
+ * `subscriptionFrames` runs once per `(socket, subscription)` on every
+ * write-flush that touches a live query's read tables — the hottest CPU on the
+ * WebSocket fan-out path. It re-parses the previously-delivered snapshot,
+ * indexes both lists by `_id`, fingerprints every row of the new result, then
+ * renders the candidate frames and measures them.
+ *
+ * The cost scales with the LIST length, not with how much changed, and that
+ * asymmetry is the thing to watch: a one-row edit to a 200-row list still pays a
+ * 200-row diff, and it pays it again for every subscribed socket.
+ *
+ * The cases hold the list length fixed and vary the change ratio, so a
+ * regression in either half is visible:
+ *
+ * - **1 of N changed** — the case the delta path exists for. Dominated by the
+ * `JSON.parse` of the baseline plus N `JSON.stringify(encodeWire(row))`
+ * fingerprints; one frame is rendered and wins.
+ * - **half of N changed** — fingerprints unchanged, frame rendering scales up.
+ * - **all of N changed** — every row renders a frame, and the measurement then
+ * rejects them all in favour of the snapshot. This is the cost of *deciding*
+ * not to use deltas, and it is the case the old row-count rule got wrong.
+ * - **reordered** — survivors moved, so `survivorsKeepOrder` rejects before any
+ * frame is built. The early-out must not cost a full diff.
+ * - **not a list** — the paginated `{ page, isDone, continueCursor }` shape
+ * `usePaginatedQuery` subscribes to. It fails the `Array.isArray` precondition
+ * immediately, so every write re-sends the whole page as a snapshot; the bench
+ * records what that rejection costs today.
+ *
+ * Pure functions over plain data — no DO, no socket, no SQLite.
+ */
+
+const row = (index: number, revision: number): Record<string, unknown> => {
+    return {
+        _creationTime: 1_700_000_000_000 + index,
+        _id: `msg_${String(index).padStart(6, "0")}`,
+        authorId: `user_${String(index % 50)}`,
+        body: `message body number ${String(index)} — ${"lorem ipsum dolor sit amet ".repeat(4)}`,
+        channelId: "channels:general",
+        editedAt: revision,
+    };
+};
+
+/** The frame envelope a real CDC-backed shard stamps, so the measurement is not free of it. */
+const envelope = { cursorSuffix: `,"cursor":998877,"epoch":"epoch-0000-0000-0001"`, lastMutationId: 42, subId: "sub_12", table: "messages" };
+
+/** A baseline list and a next list in which the first `changed` rows carry a new revision. */
+const buildCase = (total: number, changed: number): { nextResult: Record<string, unknown>[]; previousJson: string } => {
+    const previous = Array.from({ length: total }, (_, index) => row(index, 1));
+
+    return {
+        nextResult: previous.map((existing, index) => (index < changed ? row(index, 2) : existing)),
+        previousJson: JSON.stringify(encodeWire(previous)),
+    };
+};
+
+const LIST_LENGTH = 200;
+
+describe("subscriptionFrames — change ratio", () => {
+    for (const changed of [1, LIST_LENGTH / 2, LIST_LENGTH]) {
+        const { nextResult, previousJson } = buildCase(LIST_LENGTH, changed);
+        const snapshotJson = JSON.stringify(encodeWire(nextResult));
+
+        bench(`${String(changed)} of ${String(LIST_LENGTH)} rows changed`, () => {
+            subscriptionFrames({ ...envelope, nextResult, previousJson, snapshotJson });
+        });
+    }
+});
+
+describe("subscriptionFrames — snapshot fallbacks", () => {
+    const { nextResult, previousJson } = buildCase(LIST_LENGTH, 0);
+    const reordered = nextResult.toReversed();
+
+    bench(`${String(LIST_LENGTH)} rows, survivors reordered → rejected`, () => {
+        subscriptionFrames({ ...envelope, nextResult: reordered, previousJson, snapshotJson: JSON.stringify(encodeWire(reordered)) });
+    });
+
+    // The shape `.paginate()` returns, and therefore what every `usePaginatedQuery`
+    // page subscribes to: an object wrapping the array, not the array itself.
+    const paginatedNext = { continueCursor: "c_200", isDone: false, page: nextResult };
+    const paginatedPreviousJson = JSON.stringify(encodeWire({ continueCursor: "c_200", isDone: false, page: JSON.parse(previousJson) }));
+    const paginatedSnapshotJson = JSON.stringify(encodeWire(paginatedNext));
+
+    bench(`paginated { page, isDone, continueCursor } → rejected (not an array)`, () => {
+        subscriptionFrames({ ...envelope, nextResult: paginatedNext, previousJson: paginatedPreviousJson, snapshotJson: paginatedSnapshotJson });
+    });
+});

--- a/packages/shard-engine/__bench__/subscription-frames.bench.ts
+++ b/packages/shard-engine/__bench__/subscription-frames.bench.ts
@@ -74,9 +74,14 @@ describe("subscriptionFrames — change ratio", () => {
 describe("subscriptionFrames — snapshot fallbacks", () => {
     const { nextResult, previousJson } = buildCase(LIST_LENGTH, 0);
     const reordered = nextResult.toReversed();
+    // Precomputed, like every other case: the production caller builds the
+    // snapshot payload once before calling in (see `pushSubscriptionData`), so
+    // encoding it inside the bench body would fold a full 200-row encode plus
+    // stringify into the number and overstate what the early-out costs.
+    const reorderedSnapshotJson = JSON.stringify(encodeWire(reordered));
 
     bench(`${String(LIST_LENGTH)} rows, survivors reordered → rejected`, () => {
-        subscriptionFrames({ ...envelope, nextResult: reordered, previousJson, snapshotJson: JSON.stringify(encodeWire(reordered)) });
+        subscriptionFrames({ ...envelope, nextResult: reordered, previousJson, snapshotJson: reorderedSnapshotJson });
     });
 
     // The shape `.paginate()` returns, and therefore what every `usePaginatedQuery`

--- a/packages/shard-engine/__tests__/subscription-frames.test.ts
+++ b/packages/shard-engine/__tests__/subscription-frames.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { subscriptionFrames } from "../src/subscription-delivery";
+
+/**
+ * `subscriptionFrames` owns two things the rest of the delivery path relies on:
+ * the exact `{type:"data"}` / `{type:"delta"}` wire layout, and the choice
+ * between them. Both are pinned here — no Durable Object, no socket, no
+ * fixture tuned to sit on one side of a threshold. The DO-level tests in
+ * `@lunora/do` assert that the chosen frames reach the socket; this file
+ * asserts which frames get chosen and what they look like.
+ */
+
+const row = (id: string, rest: Record<string, unknown> = {}): Record<string, unknown> => {
+    return { _creationTime: 1, _id: id, ...rest };
+};
+
+/** The fixed inputs every case shares; each test overrides what it is about. */
+const base = { cursorSuffix: "", subId: "sub-1", table: "messages" };
+
+const framesFor = (previous: Record<string, unknown>[] | undefined, next: unknown, extra: Record<string, unknown> = {}): string[] =>
+    subscriptionFrames({
+        ...base,
+        ...extra,
+        nextResult: next,
+        previousJson: previous === undefined ? undefined : JSON.stringify(previous),
+        snapshotJson: JSON.stringify(next),
+    });
+
+const typesOf = (frames: string[]): string[] => frames.map((frame) => (JSON.parse(frame) as { type: string }).type);
+
+describe("subscriptionFrames — frame layout", () => {
+    it("renders the snapshot with no baseline to diff against", () => {
+        expect.assertions(1);
+
+        expect(framesFor(undefined, [row("a")])).toStrictEqual([`{"type":"data","id":"sub-1","data":[{"_creationTime":1,"_id":"a"}]}`]);
+    });
+
+    it("renders one delta frame per changed row, deletes before upserts", () => {
+        expect.assertions(2);
+
+        // Long enough that a single delta is unambiguously the cheaper encoding.
+        const previous = Array.from({ length: 20 }, (_, index) => row(`r${String(index)}`));
+        const frames = framesFor(previous, [...previous, row("new")]);
+
+        expect(frames).toHaveLength(1);
+        expect(frames[0]).toBe(`{"type":"delta","id":"sub-1","delta":{"key":"new","op":"insert","row":{"_creationTime":1,"_id":"new"},"table":"messages"}}`);
+    });
+
+    it("stamps the watermark and cursor suffix on every frame of a multi-delta batch", () => {
+        expect.assertions(2);
+
+        // A client's checkpoint gate reads whichever frame it happens to observe,
+        // so a batch whose later frames lack the watermark starves it (plan 266
+        // finding d). Every frame carries it, not just the last.
+        const previous = Array.from({ length: 20 }, (_, index) => row(`r${String(index)}`));
+        const next = previous.map((existing, index) => (index < 3 ? row(`r${String(index)}`, { edited: true }) : existing));
+        const frames = framesFor(previous, next, { cursorSuffix: `,"cursor":42,"epoch":"e1"`, lastMutationId: 7 });
+
+        expect(frames).toHaveLength(3);
+        expect(frames.every((frame) => frame.endsWith(`,"lastMutationId":7,"cursor":42,"epoch":"e1"}`))).toBe(true);
+    });
+});
+
+describe("subscriptionFrames — delta vs snapshot", () => {
+    it("takes the deltas when they are smaller than the snapshot", () => {
+        expect.assertions(1);
+
+        const previous = Array.from({ length: 50 }, (_, index) => row(`r${String(index)}`));
+        const next = previous.map((existing, index) => (index === 0 ? row("r0", { edited: true }) : existing));
+
+        expect(typesOf(framesFor(previous, next))).toStrictEqual(["delta"]);
+    });
+
+    it("takes the snapshot when every row changed, even though the diff is expressible", () => {
+        expect.assertions(2);
+
+        // The row-count rule this replaced allowed exactly this: 20 deltas for a
+        // 20-row result is "no more deltas than rows". But each frame re-pays the
+        // envelope the snapshot pays once, so the deltas are the larger payload.
+        const previous = Array.from({ length: 20 }, (_, index) => row(`r${String(index)}`));
+        const next = previous.map((existing) => {
+            return { ...existing, edited: true };
+        });
+        const frames = framesFor(previous, next);
+
+        expect(typesOf(frames)).toStrictEqual(["data"]);
+        expect(frames).toHaveLength(1);
+    });
+
+    it("takes the snapshot for a single delta into a short list of small rows", () => {
+        expect.assertions(1);
+
+        // The other direction the row count cannot see: one delta is well under
+        // the cap, but its envelope alone outweighs re-sending both rows.
+        expect(typesOf(framesFor([row("a")], [row("a"), row("b")]))).toStrictEqual(["data"]);
+    });
+
+    it("takes the deltas for the same single change once the rows are fat enough", () => {
+        expect.assertions(1);
+
+        // Identical row COUNT to the case above — only the row width differs, which
+        // is exactly the input a count-based rule is blind to.
+        const wide = (id: string) => row(id, { body: "lorem ipsum dolor sit amet ".repeat(8) });
+
+        expect(typesOf(framesFor([wide("a")], [wide("a"), wide("b")]))).toStrictEqual(["delta"]);
+    });
+
+    it("takes the snapshot when the result is not a diffable list", () => {
+        expect.assertions(2);
+
+        // The paginated shape `.paginate()` returns: an object wrapping the array,
+        // so there is no id-keyed list to diff and every write re-sends the page.
+        expect(typesOf(framesFor([row("a")], { continueCursor: null, isDone: true, page: [row("a"), row("b")] }))).toStrictEqual(["data"]);
+        // A reordered survivor cannot be expressed as in-place merges either.
+        expect(typesOf(framesFor([row("a"), row("b")], [row("b"), row("a")]))).toStrictEqual(["data"]);
+    });
+});

--- a/packages/shard-engine/__tests__/subscription-frames.test.ts
+++ b/packages/shard-engine/__tests__/subscription-frames.test.ts
@@ -109,10 +109,95 @@ describe("subscriptionFrames — delta vs snapshot", () => {
     it("takes the snapshot when the result is not a diffable list", () => {
         expect.assertions(2);
 
-        // The paginated shape `.paginate()` returns: an object wrapping the array,
-        // so there is no id-keyed list to diff and every write re-sends the page.
+        // Shape change (array → paginated object) is not a row-level diff.
         expect(typesOf(framesFor([row("a")], { continueCursor: null, isDone: true, page: [row("a"), row("b")] }))).toStrictEqual(["data"]);
         // A reordered survivor cannot be expressed as in-place merges either.
         expect(typesOf(framesFor([row("a"), row("b")], [row("b"), row("a")]))).toStrictEqual(["data"]);
+    });
+});
+
+/**
+ * A `.paginate()` result is `{ page, isDone, continueCursor }` — an object, so
+ * the row diff has to reach inside it. That is gated on the socket having
+ * announced `pageDelta`, because a client that cannot merge into `page` does not
+ * ignore such a delta: it replaces the whole query value with the raw delta
+ * object.
+ */
+describe("subscriptionFrames — paginated results", () => {
+    /** A page of `count` rows; `revision` bumps every row's body. */
+    const page = (count: number, revision = 1): Record<string, unknown>[] =>
+        Array.from({ length: count }, (_, index) => row(`r${String(index)}`, { revision }));
+
+    const paginated = (rows: Record<string, unknown>[], rest: Record<string, unknown> = {}): Record<string, unknown> => {
+        return { continueCursor: "cursor-20", isDone: false, page: rows, ...rest };
+    };
+
+    const paginatedFrames = (previous: Record<string, unknown>, next: Record<string, unknown>, pageDeltas?: boolean): string[] =>
+        subscriptionFrames({
+            ...base,
+            nextResult: next,
+            pageDeltas,
+            previousJson: JSON.stringify(previous),
+            snapshotJson: JSON.stringify(next),
+        });
+
+    it("sends the whole page as a snapshot when the socket did not announce the capability", () => {
+        expect.assertions(1);
+
+        // The pre-capability behaviour, and what every non-JS SDK still gets:
+        // they send `connect` with no `caps` at all.
+        const previous = paginated(page(20));
+        const next = paginated([...page(20).slice(0, 19), row("r19", { revision: 2 })]);
+
+        expect(typesOf(paginatedFrames(previous, next))).toStrictEqual(["data"]);
+    });
+
+    it("diffs the page for a socket that announced it", () => {
+        expect.assertions(2);
+
+        const previous = paginated(page(20));
+        const next = paginated([...page(20).slice(0, 19), row("r19", { revision: 2 })]);
+        const frames = paginatedFrames(previous, next, true);
+
+        expect(typesOf(frames)).toStrictEqual(["delta"]);
+        expect(JSON.parse(frames[0]!)).toMatchObject({ delta: { key: "r19", op: "update", table: "messages" } });
+    });
+
+    it("falls back to the snapshot when a field outside the page moved", () => {
+        expect.assertions(3);
+
+        // A row-delta stream can only describe rows. `continueCursor` and
+        // `isDone` are how a paginated client knows whether to keep loading, so
+        // a change to either has no way to reach it through deltas — sending
+        // them would silently strand the client on a stale cursor.
+        const previous = paginated(page(20));
+        const rows = [...page(20).slice(0, 19), row("r19", { revision: 2 })];
+
+        expect(typesOf(paginatedFrames(previous, paginated(rows, { continueCursor: "cursor-40" }), true))).toStrictEqual(["data"]);
+        expect(typesOf(paginatedFrames(previous, paginated(rows, { isDone: true }), true))).toStrictEqual(["data"]);
+        // A new field appearing outside the page is a change too.
+        expect(typesOf(paginatedFrames(previous, paginated(rows, { splitCursor: "cursor-30" }), true))).toStrictEqual(["data"]);
+    });
+
+    it("ignores property order in the envelope comparison", () => {
+        expect.assertions(1);
+
+        // `previous` was parsed back out of the delivered frame and `next` is a
+        // fresh handler result, so their key order is not guaranteed to match.
+        // Comparing them stably keeps that from forcing a pointless snapshot.
+        const previous = { continueCursor: "cursor-20", isDone: false, page: page(20) };
+        const next = { isDone: false, page: [...page(20).slice(0, 19), row("r19", { revision: 2 })], continueCursor: "cursor-20" };
+
+        expect(typesOf(paginatedFrames(previous, next, true))).toStrictEqual(["delta"]);
+    });
+
+    it("still prefers the snapshot when the whole page changed", () => {
+        expect.assertions(1);
+
+        // The size comparison applies to the paginated path exactly as it does
+        // to a bare array — the capability opens the diff, it does not force it.
+        const previous = paginated(page(20));
+
+        expect(typesOf(paginatedFrames(previous, paginated(page(20, 2)), true))).toStrictEqual(["data"]);
     });
 });

--- a/packages/shard-engine/__tests__/subscription-frames.test.ts
+++ b/packages/shard-engine/__tests__/subscription-frames.test.ts
@@ -200,4 +200,59 @@ describe("subscriptionFrames — paginated results", () => {
 
         expect(typesOf(paginatedFrames(previous, paginated(page(20, 2)), true))).toStrictEqual(["data"]);
     });
+
+    it("still emits a frame when the diff comes back empty", () => {
+        expect.assertions(2);
+
+        // The caller only suppresses a push when the new snapshot is BYTE-identical
+        // to the last, but the envelope here is compared with keys sorted. So a
+        // result re-serialized in a different key order arrives with nothing to
+        // diff AND a changed snapshot — and returning zero frames would let the
+        // caller advance its baseline while this flush's cursor/epoch/watermark
+        // never reached the client, stranding its resume position.
+        const rows = page(20);
+        const previous = { continueCursor: "cursor-20", isDone: false, page: rows };
+        const next = { isDone: false, page: rows, continueCursor: "cursor-20" };
+
+        expect(JSON.stringify(previous)).not.toBe(JSON.stringify(next));
+
+        const frames = subscriptionFrames({
+            ...base,
+            cursorSuffix: `,"cursor":4242,"epoch":"e1"`,
+            nextResult: next,
+            pageDeltas: true,
+            previousJson: JSON.stringify(previous),
+            snapshotJson: JSON.stringify(next),
+        });
+
+        expect(frames).toStrictEqual([`{"type":"data","id":"sub-1","data":${JSON.stringify(next)},"cursor":4242,"epoch":"e1"}`]);
+    });
+
+    it("does not treat a non-plain object as a paginated result", () => {
+        expect.assertions(2);
+
+        // `applyDelta` re-spreads the wrapper to swap its page, which would
+        // flatten a class instance into a plain object. The shape test is the
+        // wire codec's own `isPlainObject`, so anything it rejects — which is
+        // anything that could not have crossed the wire as this shape — takes
+        // the snapshot instead.
+        class PageResult {
+            public continueCursor = "cursor-20";
+
+            public isDone = false;
+
+            public page = page(20);
+        }
+
+        const changedPage = [...page(20).slice(0, 19), row("r19", { revision: 2 })];
+        const next = new PageResult();
+
+        next.page = changedPage;
+
+        expect(
+            typesOf(paginatedFrames(new PageResult() as unknown as Record<string, unknown>, next as unknown as Record<string, unknown>, true)),
+        ).toStrictEqual(["data"]);
+        // The same fields as a plain object ARE diffed — the prototype is the only difference.
+        expect(typesOf(paginatedFrames(paginated(page(20)), paginated(changedPage), true))).toStrictEqual(["delta"]);
+    });
 });

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -331,7 +331,7 @@ export type { SqlConsoleResult } from "./sql-console";
 export type { SqlLintResult } from "./sql-console";
 export { assertReadonly, MAX_SQL_ROWS, runReadonlySql } from "./sql-console";
 export { lintReadonlySql } from "./sql-console";
-export { awaitWsDrain, PAGE_DELTA_CAPABILITY, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
+export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
 export type { ChangedKeys, SubscriptionReadFootprint } from "./subscription-range-gate";
 export { mergeChangedKeys, recordChangedKeys, writeTouchesMemo } from "./subscription-range-gate";
 export type {

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -331,7 +331,7 @@ export type { SqlConsoleResult } from "./sql-console";
 export type { SqlLintResult } from "./sql-console";
 export { assertReadonly, MAX_SQL_ROWS, runReadonlySql } from "./sql-console";
 export { lintReadonlySql } from "./sql-console";
-export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
+export { awaitWsDrain, PAGE_DELTA_CAPABILITY, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
 export type { ChangedKeys, SubscriptionReadFootprint } from "./subscription-range-gate";
 export { mergeChangedKeys, recordChangedKeys, writeTouchesMemo } from "./subscription-range-gate";
 export type {

--- a/packages/shard-engine/src/index.ts
+++ b/packages/shard-engine/src/index.ts
@@ -331,7 +331,7 @@ export type { SqlConsoleResult } from "./sql-console";
 export type { SqlLintResult } from "./sql-console";
 export { assertReadonly, MAX_SQL_ROWS, runReadonlySql } from "./sql-console";
 export { lintReadonlySql } from "./sql-console";
-export { awaitWsDrain, sendDeltaFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
+export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame } from "./subscription-delivery";
 export type { ChangedKeys, SubscriptionReadFootprint } from "./subscription-range-gate";
 export { mergeChangedKeys, recordChangedKeys, writeTouchesMemo } from "./subscription-range-gate";
 export type {

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -150,19 +150,21 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
 };
 
 /**
- * Diff the previously-sent list snapshot (`previousJson`, the memo's
- * `lastJson`) against the new query result and produce per-row
- * {@link MutationDelta}s the client can merge in place via `applyDelta` —
- * Convex-parity live-pagination deltas (server half of gap #20).
+ * Diff the previously-sent list snapshot against the new query result, keyed by
+ * `_id`, returning each changed row paired with its pre-serialized frame body.
  *
- * Returns `undefined` (caller falls back to a full `{type:"data"}` snapshot)
+ * Returns `undefined` (the value is not expressible as row deltas at all)
  * unless ALL of these hold:
  *
  * 1. `previousJson` parses to an array (there IS a previous list to diff against).
  * 2. `nextResult` is also an array.
  * 3. Every row in both arrays is a plain object carrying a string `_id`.
  * 4. Order preservation — rows present in BOTH arrays appear in the same relative order.
- * 5. Chattiness cap — the number of deltas does not exceed the new array length (a near-total change is cheaper as a snapshot).
+ *
+ * These are EXPRESSIBILITY conditions only. Whether the deltas are the cheaper
+ * thing to put on the wire is a separate question, answered by
+ * {@link subscriptionFrames} against the frames it is about to send — see the
+ * note there on why no row-count proxy stands in for it.
  *
  * Diff is keyed by `_id`: rows only in prev → `delete`; rows only in next →
  * `insert`; rows in both whose JSON differs → `update`. Insert/update carry the
@@ -170,17 +172,12 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
  * parses). Deltas are ordered deletes-then-inserts/updates so the client never
  * sees a transient over-length page.
  *
- * Per-row serialization is done exactly **once** per refresh (finding #6). Each
+ * Per-row serialization is done exactly **once** per refresh (finding #6): each
  * row is stringified a single time into a fingerprint reused for both the
- * `prev !== next` change-detection compare and — when the caller passes the
- * optional `frames` sink — the pre-serialized delta frame body. The returned
- * `MutationDelta[]` shape is unchanged; `frames`, when supplied, receives the
- * exact `JSON.stringify(delta)` string for each returned delta, in the same
- * order, so the caller can splice it straight into the `{type:"delta"}` frame
- * without serializing the delta (and the row inside it) a second time.
- * @returns the per-row deltas to send, or `undefined` when any precondition fails and a full snapshot should be sent instead
+ * `prev !== next` change-detection compare and the frame body.
+ * @returns the changed rows with their frame bodies, or `undefined` when the change is not expressible as row deltas
  */
-const subscriptionListDeltas = (previousJson: string, nextResult: unknown, table: string, frames?: string[]): MutationDelta[] | undefined => {
+const collectFramedDeltas = (previousJson: string, nextResult: unknown, table: string): FramedDelta[] | undefined => {
     let parsed: unknown;
 
     try {
@@ -208,11 +205,30 @@ const subscriptionListDeltas = (previousJson: string, nextResult: unknown, table
 
     const deltaTable = table === "" ? DELTA_FALLBACK_TABLE : table;
     const tableJson = JSON.stringify(deltaTable);
-    // Deletes precede upserts so the client never sees a transient over-length page.
-    const framed = [...collectDeleteDeltas(previous, next, deltaTable, tableJson), ...collectUpsertDeltas(previous, next, deltaTable, tableJson)];
 
-    // (5): a near-total change is better sent as a single snapshot.
-    if (framed.length > next.order.length) {
+    // Deletes precede upserts so the client never sees a transient over-length page.
+    return [...collectDeleteDeltas(previous, next, deltaTable, tableJson), ...collectUpsertDeltas(previous, next, deltaTable, tableJson)];
+};
+
+/**
+ * The per-row {@link MutationDelta}s a change decomposes into, or `undefined`
+ * when it is not expressible as row deltas — see {@link collectFramedDeltas}
+ * for the four conditions.
+ *
+ * This is the diff as a VALUE, for callers that want to inspect it (and for the
+ * unit tests that pin the diff's semantics). The delivery path does not use it:
+ * {@link subscriptionFrames} needs the frame strings, not the delta objects, and
+ * building both would allocate a `MutationDelta` per row per socket per
+ * write-flush that nothing reads.
+ *
+ * `frames`, when supplied, receives the exact `JSON.stringify(delta)` string for
+ * each returned delta, in the same order.
+ * @returns the per-row deltas, or `undefined` when the change is not expressible as row deltas
+ */
+const subscriptionListDeltas = (previousJson: string, nextResult: unknown, table: string, frames?: string[]): MutationDelta[] | undefined => {
+    const framed = collectFramedDeltas(previousJson, nextResult, table);
+
+    if (framed === undefined) {
         return undefined;
     }
 
@@ -262,36 +278,73 @@ const trySendFrame = (ws: FrameSink, frame: string): boolean => {
     }
 };
 
-/**
- * Send every delta frame for one subscription. Reports `delivered` only when ALL
- * frames left the socket: a partial failure must keep the diff baseline at the
- * last fully-delivered value so the next flush re-diffs the whole change. Keyed
- * list deltas are idempotent on replay, so re-sending an already-applied row is
- * harmless.
- *
- * `lastMutationId` (when supplied) is stamped on EVERY delta frame in this
- * batch, not just the last — a client's checkpoint gate reads whichever frame
- * it happens to observe, and re-stamping the same value on each is a no-op
- * for a client that already saw an earlier one (idempotent, monotonic
- * `Math.max` on the read side). Without this, a `@lunora/db` list collection
- * — the exact id-keyed shape this delta path exists for — never sees a
- * per-frame watermark past its first snapshot, permanently starving the
- * checkpoint gate of the frame-carried signal `pushSubscriptionData`'s
- * snapshot branch provides (plan 266 finding d's fix was incomplete without
- * this — the delta path is this feature's common case, not a rare fallback).
- */
-const sendDeltaFrames = (ws: FrameSink, subId: string, deltaFrames: ReadonlyArray<string>, cursorSuffix: string, lastMutationId?: number): boolean => {
-    const idJson = JSON.stringify(subId);
-    const watermarkSuffix = lastMutationId === undefined ? "" : `,"lastMutationId":${String(lastMutationId)}`;
-    let delivered = true;
+/** Everything {@link subscriptionFrames} needs to render one subscription's frames. */
+interface SubscriptionFrameInput {
+    /** The trailing `,"cursor":<n>,"epoch":"<e>"` fragment, or `""` on a non-CDC shard. */
+    cursorSuffix: string;
+    /** This socket's custom-mutator watermark, stamped on every frame; omitted when the socket has none. */
+    lastMutationId?: number;
+    /** The fresh query result, unencoded — diffed row-wise against `previousJson`. */
+    nextResult: unknown;
+    /** The wire form of the value last DELIVERED for this subscription; `undefined` on a first send. */
+    previousJson?: string;
+    /** `JSON.stringify(encodeWire(nextResult))` — the exact `data` frame payload, built once by the caller. */
+    snapshotJson: string;
+    /** The subscription id the frames are addressed to. */
+    subId: string;
+    /** The table stamped on each delta; `""` falls back to {@link DELTA_FALLBACK_TABLE}. */
+    table: string;
+}
 
-    for (const deltaBody of deltaFrames) {
-        if (!trySendFrame(ws, `{"type":"delta","id":${idJson},"delta":${deltaBody}${watermarkSuffix}${cursorSuffix}}`)) {
-            delivered = false;
-        }
+/**
+ * Render the frames that carry one subscription's new value: either a run of
+ * `{type:"delta"}` frames or the single `{type:"data"}` snapshot, whichever is
+ * smaller on the wire.
+ *
+ * **Why the choice lives here.** Every delta frame re-pays the whole
+ * `{"type":"delta","id":…}` + `"table":…` + cursor/epoch/watermark envelope
+ * around ONE row body, which the snapshot pays once for the entire list. So the
+ * deltas stop being the cheaper encoding well before they stop being a valid
+ * one, and where that happens depends on the row size, the row count, and the
+ * envelope width together. No row-count proxy ("no more deltas than rows") can
+ * express that: it is blind to fat rows, to a wide envelope, and to a list of
+ * tiny rows where a single delta already costs more than re-sending everything.
+ * Rendering the frames first and summing their real lengths is exact, needs no
+ * heuristic, and cannot drift from the format — because it IS the format. That
+ * is also why the envelope is written in exactly one place (here) rather than
+ * modelled a second time by the caller doing the sizing.
+ *
+ * Lengths are UTF-16 code units, not UTF-8 bytes. Both sides carry the same row
+ * content, so a multi-byte payload inflates them together and the comparison
+ * holds; it only shifts the crossover slightly toward the snapshot, which is the
+ * safe direction (one frame is also one `ws.send` and one client apply). A tie
+ * goes to the snapshot for the same reason.
+ *
+ * `lastMutationId` is stamped on EVERY frame, not just the last — a client's
+ * checkpoint gate reads whichever frame it happens to observe, and re-stamping
+ * the same value is a no-op for one that already saw an earlier one (idempotent,
+ * monotonic `Math.max` on the read side). Without it a `@lunora/db` list
+ * collection — the exact id-keyed shape the delta path targets, so every write
+ * after its first snapshot goes out as deltas — would never see a frame-carried
+ * watermark again (plan 266 finding d).
+ * @returns the frames to send in order; always at least one unless the diff found no changed rows
+ */
+const subscriptionFrames = (input: SubscriptionFrameInput): string[] => {
+    const { cursorSuffix, lastMutationId, nextResult, previousJson, snapshotJson, subId, table } = input;
+    const idJson = JSON.stringify(subId);
+    const suffix = (lastMutationId === undefined ? "" : `,"lastMutationId":${String(lastMutationId)}`) + cursorSuffix;
+    const snapshot = `{"type":"data","id":${idJson},"data":${snapshotJson}${suffix}}`;
+    // No baseline (first send, or the last send never left the socket) — there is
+    // nothing to diff against, so the snapshot is the only option.
+    const framed = previousJson === undefined ? undefined : collectFramedDeltas(previousJson, nextResult, table);
+
+    if (framed === undefined) {
+        return [snapshot];
     }
 
-    return delivered;
+    const deltas = framed.map(({ frame }) => `{"type":"delta","id":${idJson},"delta":${frame}${suffix}}`);
+
+    return deltas.reduce((total, frame) => total + frame.length, 0) < snapshot.length ? deltas : [snapshot];
 };
 
 /**
@@ -320,5 +373,5 @@ const awaitWsDrain = async (ws: DrainableSink): Promise<void> => {
     }
 };
 
-export type { DrainableSink, FrameSink };
-export { awaitWsDrain, sendDeltaFrames, subscriptionListDeltas, trySendFrame };
+export type { DrainableSink, FrameSink, SubscriptionFrameInput };
+export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame };

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -342,9 +342,28 @@ const subscriptionFrames = (input: SubscriptionFrameInput): string[] => {
         return [snapshot];
     }
 
-    const deltas = framed.map(({ frame }) => `{"type":"delta","id":${idJson},"delta":${frame}${suffix}}`);
+    const deltas: string[] = [];
+    let total = 0;
 
-    return deltas.reduce((total, frame) => total + frame.length, 0) < snapshot.length ? deltas : [snapshot];
+    for (const { frame } of framed) {
+        const delta = `{"type":"delta","id":${idJson},"delta":${frame}${suffix}}`;
+
+        total += delta.length;
+
+        // The running total only grows, so once it reaches the snapshot the
+        // snapshot has already won and the remaining envelopes would be built
+        // only to be thrown away. Bailing here is not a different rule — it is
+        // the same comparison, decided as early as it can be — and it matters
+        // most in exactly the case this function exists to catch: a near-total
+        // change, where otherwise every row allocates a frame that loses.
+        if (total >= snapshot.length) {
+            return [snapshot];
+        }
+
+        deltas.push(delta);
+    }
+
+    return deltas;
 };
 
 /**

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -15,7 +15,7 @@
 
 import { ID_FIELD, insertionIndexFor, PAGE_DELTA_CAPABILITY, PAGE_FIELD } from "../../../shared/page-result";
 import { stableStringify } from "../../../shared/stable-key";
-import { encodeWire } from "../../../shared/wire-codec";
+import { encodeWire, isPlainObject } from "../../../shared/wire-codec";
 import type { MutationDelta } from "./types";
 
 /**
@@ -149,9 +149,6 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
     return out;
 };
 
-/** A plain (non-array, non-null) object — the shape a `.paginate()` result is. */
-const isPlainRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
-
 /**
  * The two row lists to diff, or `undefined` when this pair of results is not
  * row-diffable at all.
@@ -176,7 +173,7 @@ const diffableLists = (previous: unknown, next: unknown): undefined | { next: un
         return { next: next as unknown[], previous: previous as unknown[] };
     }
 
-    if (!isPlainRecord(previous) || !isPlainRecord(next)) {
+    if (!isPlainObject(previous) || !isPlainObject(next)) {
         return undefined;
     }
 
@@ -454,7 +451,17 @@ const subscriptionFrames = (input: SubscriptionFrameInput): string[] => {
     const diffable = previousJson !== undefined && (pageDeltas === true || Array.isArray(nextResult));
     const framed = diffable ? collectFramedDeltas(previousJson, nextResult, table) : undefined;
 
-    if (framed === undefined) {
+    // An EMPTY diff must still put a frame on the wire, so the two are handled
+    // together. The caller only suppresses a push when the new snapshot is
+    // BYTE-identical to the last one, but `diffableLists` compares a paginated
+    // envelope with `stableStringify` — key-order insensitive. So a result whose
+    // non-`page` fields were re-serialized in a different order reaches here
+    // with nothing to diff and yet a changed `snapshotJson`. Returning no frames
+    // would let the caller advance its baseline while the client never receives
+    // this flush's `cursor`/`epoch`/`lastMutationId`, stranding its resume
+    // position and leaving a pending optimistic layer masked until some later
+    // visible change. One snapshot in a rare case is the cheap, honest answer.
+    if (framed === undefined || framed.length === 0) {
         return [snapshot];
     }
 

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -1,17 +1,19 @@
 /**
  * Subscription wire-delivery for the DO store: the keyed list-diff encoder
- * (`subscriptionListDeltas` + its row-indexing helpers) and the best-effort
- * frame senders (`trySendFrame`/`sendDeltaFrames`).
+ * (`subscriptionListDeltas` + its row-indexing helpers), the frame renderer that
+ * chooses between deltas and a snapshot (`subscriptionFrames`), and the
+ * best-effort sender (`trySendFrame`).
  *
  * Extracted from `shard-do.ts` as a cohesive unit — these are pure functions
  * with no `this`/instance state: they turn a previous-vs-next query result into
- * the `{type:"delta"}` row deltas the client merges in place, and push frames
- * onto a hibernatable `WebSocket`, reporting whether each frame left the socket
- * so the caller can protect its diff baseline. `shard-do.ts` imports these and
- * re-exports `subscriptionListDeltas` so existing import sites (the index
- * barrel, tests) are unchanged.
+ * the frames a client merges in place, and push them onto a hibernatable
+ * `WebSocket`, reporting whether each frame left the socket so the caller can
+ * protect its diff baseline. `shard-do.ts` imports these and re-exports
+ * `subscriptionListDeltas` so existing import sites (the index barrel, tests)
+ * are unchanged.
  */
 
+import { stableStringify } from "../../../shared/stable-key";
 import { encodeWire } from "../../../shared/wire-codec";
 import type { MutationDelta } from "./types";
 
@@ -149,6 +151,80 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
     return out;
 };
 
+/** The row-array field a `.paginate()` result carries its page in. */
+const PAGE_FIELD = "page";
+
+/**
+ * The `connect`-frame capability token a client sends to say it can merge a row
+ * delta into the `page` of a `{ page, isDone, continueCursor }` result.
+ *
+ * Opt-in, and it has to be: an unmergeable delta is not ignored by a client that
+ * predates this — `applyDelta` bails and the caller replaces the whole query
+ * value with the raw delta object. A client that never announces this keeps
+ * receiving snapshots, which is what every client did before and what the seven
+ * non-JS SDKs still do (they send `connect` with no `caps` at all).
+ */
+const PAGE_DELTA_CAPABILITY = "pageDelta";
+
+/** A plain (non-array, non-null) object — the shape a `.paginate()` result is. */
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * The row array to diff out of a query result, or `undefined` when the result
+ * has no diffable list in it.
+ *
+ * Two accepted shapes:
+ *
+ * - the result IS the array (`ctx.db.query(...).collect()`);
+ * - the result is `{ page: [...], … }` — what `.paginate()` yields, and
+ * therefore what every `usePaginatedQuery` page subscribes to.
+ *
+ * For the paginated shape the caller must also confirm the fields AROUND the
+ * page are unchanged; see {@link paginationEnvelopeMatches}. A row-delta stream
+ * can only describe rows, so a moved `continueCursor` or a flipped `isDone` has
+ * no way to reach the client and must force the snapshot.
+ * @returns the row array to diff, or `undefined` when the result carries none
+ */
+const rowsOf = (value: unknown): unknown[] | undefined => {
+    if (Array.isArray(value)) {
+        return value as unknown[];
+    }
+
+    if (isPlainRecord(value) && Array.isArray(value[PAGE_FIELD])) {
+        return value[PAGE_FIELD] as unknown[];
+    }
+
+    return undefined;
+};
+
+/**
+ * True when two paginated results agree on everything except their `page`.
+ *
+ * Both sides are compared in their WIRE form with keys sorted, so the check is
+ * insensitive to property order (`previous` was parsed back out of the last
+ * delivered frame; `next` is a fresh handler result) and treats a `bigint` or
+ * `Date` cursor the same way the frame would. Non-paginated (bare array)
+ * results have no envelope and trivially match.
+ * @returns `true` when the two results differ only in their `page`
+ */
+const paginationEnvelopeMatches = (previous: unknown, next: unknown): boolean => {
+    if (Array.isArray(previous) && Array.isArray(next)) {
+        return true;
+    }
+
+    if (!isPlainRecord(previous) || !isPlainRecord(next)) {
+        return false;
+    }
+
+    const withoutPage = (value: Record<string, unknown>): Record<string, unknown> =>
+        Object.fromEntries(Object.entries(value).filter(([key]) => key !== PAGE_FIELD));
+
+    // `previous` is already wire-encoded (it was parsed out of the delivered
+    // frame); `next` is raw, so it is encoded here — exactly the asymmetry the
+    // per-row fingerprints use.
+    return stableStringify(withoutPage(previous)) === stableStringify(encodeWire(withoutPage(next)));
+};
+
 /**
  * Diff the previously-sent list snapshot against the new query result, keyed by
  * `_id`, returning each changed row paired with its pre-serialized frame body.
@@ -156,10 +232,10 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
  * Returns `undefined` (the value is not expressible as row deltas at all)
  * unless ALL of these hold:
  *
- * 1. `previousJson` parses to an array (there IS a previous list to diff against).
- * 2. `nextResult` is also an array.
- * 3. Every row in both arrays is a plain object carrying a string `_id`.
- * 4. Order preservation — rows present in BOTH arrays appear in the same relative order.
+ * 1. `previousJson` parses to a diffable list — an array, or a `{ page: [...] }` result (see {@link rowsOf}).
+ * 2. `nextResult` carries a list of the same kind, and (when paginated) an identical envelope around it.
+ * 3. Every row in both lists is a plain object carrying a string `_id`.
+ * 4. Order preservation — rows present in BOTH lists appear in the same relative order.
  *
  * These are EXPRESSIBILITY conditions only. Whether the deltas are the cheaper
  * thing to put on the wire is a separate question, answered by
@@ -186,13 +262,22 @@ const collectFramedDeltas = (previousJson: string, nextResult: unknown, table: s
         return undefined;
     }
 
-    // (1) + (2): both sides must be arrays. (3): both must be id-keyable.
-    if (!Array.isArray(parsed) || !Array.isArray(nextResult)) {
+    // (1) + (2): both sides must carry a diffable list, of the same kind, and a
+    // paginated pair must agree on everything outside the page.
+    const previousRows = rowsOf(parsed);
+    const nextRows = rowsOf(nextResult);
+
+    if (previousRows === undefined || nextRows === undefined || Array.isArray(parsed) !== Array.isArray(nextResult)) {
         return undefined;
     }
 
-    const previous = indexRowsById(parsed);
-    const next = indexRowsById(nextResult);
+    if (!paginationEnvelopeMatches(parsed, nextResult)) {
+        return undefined;
+    }
+
+    // (3): both must be id-keyable.
+    const previous = indexRowsById(previousRows);
+    const next = indexRowsById(nextRows);
 
     if (previous === undefined || next === undefined) {
         return undefined;
@@ -286,6 +371,21 @@ interface SubscriptionFrameInput {
     lastMutationId?: number;
     /** The fresh query result, unencoded — diffed row-wise against `previousJson`. */
     nextResult: unknown;
+
+    /**
+     * Whether this socket announced {@link PAGE_DELTA_CAPABILITY} on its
+     * `connect` frame, i.e. whether it can merge a row delta into the `page` of
+     * a `{ page, isDone, continueCursor }` result.
+     *
+     * Load-bearing, and fail-closed by default. A client that cannot do that
+     * merge does not IGNORE a page delta — `@lunora/client`'s `applyDelta`
+     * returns `undefined` for an unmergeable shape and the caller then replaces
+     * the whole query value with the raw delta object. So sending page deltas
+     * unconditionally would corrupt the value on every client that predates
+     * this, including all seven non-JS SDKs. Absent means snapshots, which is
+     * exactly the behaviour those clients have today.
+     */
+    pageDeltas?: boolean;
     /** The wire form of the value last DELIVERED for this subscription; `undefined` on a first send. */
     previousJson?: string;
     /** `JSON.stringify(encodeWire(nextResult))` — the exact `data` frame payload, built once by the caller. */
@@ -327,16 +427,23 @@ interface SubscriptionFrameInput {
  * collection — the exact id-keyed shape the delta path targets, so every write
  * after its first snapshot goes out as deltas — would never see a frame-carried
  * watermark again (plan 266 finding d).
+ *
+ * A `{ page, … }` result is only ever diffed for a socket that announced
+ * {@link PAGE_DELTA_CAPABILITY} — see {@link SubscriptionFrameInput.pageDeltas}
+ * for why that gate is a correctness requirement and not a tuning knob.
  * @returns the frames to send in order; always at least one unless the diff found no changed rows
  */
 const subscriptionFrames = (input: SubscriptionFrameInput): string[] => {
-    const { cursorSuffix, lastMutationId, nextResult, previousJson, snapshotJson, subId, table } = input;
+    const { cursorSuffix, lastMutationId, nextResult, pageDeltas, previousJson, snapshotJson, subId, table } = input;
     const idJson = JSON.stringify(subId);
     const suffix = (lastMutationId === undefined ? "" : `,"lastMutationId":${String(lastMutationId)}`) + cursorSuffix;
     const snapshot = `{"type":"data","id":${idJson},"data":${snapshotJson}${suffix}}`;
     // No baseline (first send, or the last send never left the socket) — there is
-    // nothing to diff against, so the snapshot is the only option.
-    const framed = previousJson === undefined ? undefined : collectFramedDeltas(previousJson, nextResult, table);
+    // nothing to diff against, so the snapshot is the only option. A paginated
+    // result is additionally gated on the socket having announced that it can
+    // merge into `page`; without that the diff is never even attempted.
+    const diffable = previousJson !== undefined && (pageDeltas === true || Array.isArray(nextResult));
+    const framed = diffable ? collectFramedDeltas(previousJson, nextResult, table) : undefined;
 
     if (framed === undefined) {
         return [snapshot];
@@ -393,4 +500,4 @@ const awaitWsDrain = async (ws: DrainableSink): Promise<void> => {
 };
 
 export type { DrainableSink, FrameSink, SubscriptionFrameInput };
-export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame };
+export { awaitWsDrain, PAGE_DELTA_CAPABILITY, subscriptionFrames, subscriptionListDeltas, trySendFrame };

--- a/packages/shard-engine/src/subscription-delivery.ts
+++ b/packages/shard-engine/src/subscription-delivery.ts
@@ -13,12 +13,10 @@
  * are unchanged.
  */
 
+import { ID_FIELD, insertionIndexFor, PAGE_DELTA_CAPABILITY, PAGE_FIELD } from "../../../shared/page-result";
 import { stableStringify } from "../../../shared/stable-key";
 import { encodeWire } from "../../../shared/wire-codec";
 import type { MutationDelta } from "./types";
-
-/** Identity field every Lunora document row carries. */
-const ROW_ID_FIELD = "_id";
 
 /**
  * Fallback table name stamped on a delta when the subscription's read-table
@@ -37,7 +35,7 @@ const readRowId = (row: unknown): string | undefined => {
         return undefined;
     }
 
-    const id = (row as Record<string, unknown>)[ROW_ID_FIELD];
+    const id = (row as Record<string, unknown>)[ID_FIELD];
 
     return typeof id === "string" ? id : undefined;
 };
@@ -151,78 +149,97 @@ const collectUpsertDeltas = (previous: RowIndex, next: RowIndex, deltaTable: str
     return out;
 };
 
-/** The row-array field a `.paginate()` result carries its page in. */
-const PAGE_FIELD = "page";
-
-/**
- * The `connect`-frame capability token a client sends to say it can merge a row
- * delta into the `page` of a `{ page, isDone, continueCursor }` result.
- *
- * Opt-in, and it has to be: an unmergeable delta is not ignored by a client that
- * predates this — `applyDelta` bails and the caller replaces the whole query
- * value with the raw delta object. A client that never announces this keeps
- * receiving snapshots, which is what every client did before and what the seven
- * non-JS SDKs still do (they send `connect` with no `caps` at all).
- */
-const PAGE_DELTA_CAPABILITY = "pageDelta";
-
 /** A plain (non-array, non-null) object — the shape a `.paginate()` result is. */
 const isPlainRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
 
 /**
- * The row array to diff out of a query result, or `undefined` when the result
- * has no diffable list in it.
+ * The two row lists to diff, or `undefined` when this pair of results is not
+ * row-diffable at all.
  *
- * Two accepted shapes:
+ * Both sides must carry a list of the same KIND — two bare arrays, or two
+ * `{ page: [...] }` results. For the paginated pair everything outside `page`
+ * must also be byte-identical: a row-delta stream can only describe rows, so a
+ * moved `continueCursor` or a flipped `isDone` (how a paginated client decides
+ * whether to keep loading) has no way to reach the client and must force the
+ * snapshot instead.
  *
- * - the result IS the array (`ctx.db.query(...).collect()`);
- * - the result is `{ page: [...], … }` — what `.paginate()` yields, and
- * therefore what every `usePaginatedQuery` page subscribes to.
- *
- * For the paginated shape the caller must also confirm the fields AROUND the
- * page are unchanged; see {@link paginationEnvelopeMatches}. A row-delta stream
- * can only describe rows, so a moved `continueCursor` or a flipped `isDone` has
- * no way to reach the client and must force the snapshot.
- * @returns the row array to diff, or `undefined` when the result carries none
+ * The envelope comparison runs on the WIRE form with keys sorted, so it is
+ * insensitive to property order — `previous` was parsed back out of the last
+ * delivered frame, `next` is a fresh handler result — and a `bigint` or `Date`
+ * cursor is compared the way the frame would carry it. `previous` is already
+ * encoded; `next` is encoded here, the same asymmetry the per-row fingerprints
+ * use.
+ * @returns the previous and next row lists, or `undefined` when the pair is not diffable
  */
-const rowsOf = (value: unknown): unknown[] | undefined => {
-    if (Array.isArray(value)) {
-        return value as unknown[];
-    }
-
-    if (isPlainRecord(value) && Array.isArray(value[PAGE_FIELD])) {
-        return value[PAGE_FIELD] as unknown[];
-    }
-
-    return undefined;
-};
-
-/**
- * True when two paginated results agree on everything except their `page`.
- *
- * Both sides are compared in their WIRE form with keys sorted, so the check is
- * insensitive to property order (`previous` was parsed back out of the last
- * delivered frame; `next` is a fresh handler result) and treats a `bigint` or
- * `Date` cursor the same way the frame would. Non-paginated (bare array)
- * results have no envelope and trivially match.
- * @returns `true` when the two results differ only in their `page`
- */
-const paginationEnvelopeMatches = (previous: unknown, next: unknown): boolean => {
+const diffableLists = (previous: unknown, next: unknown): undefined | { next: unknown[]; previous: unknown[] } => {
     if (Array.isArray(previous) && Array.isArray(next)) {
-        return true;
+        return { next: next as unknown[], previous: previous as unknown[] };
     }
 
     if (!isPlainRecord(previous) || !isPlainRecord(next)) {
-        return false;
+        return undefined;
+    }
+
+    const previousPage = previous[PAGE_FIELD];
+    const nextPage = next[PAGE_FIELD];
+
+    if (!Array.isArray(previousPage) || !Array.isArray(nextPage)) {
+        return undefined;
     }
 
     const withoutPage = (value: Record<string, unknown>): Record<string, unknown> =>
         Object.fromEntries(Object.entries(value).filter(([key]) => key !== PAGE_FIELD));
 
-    // `previous` is already wire-encoded (it was parsed out of the delivered
-    // frame); `next` is raw, so it is encoded here — exactly the asymmetry the
-    // per-row fingerprints use.
-    return stableStringify(withoutPage(previous)) === stableStringify(encodeWire(withoutPage(next)));
+    if (stableStringify(withoutPage(previous)) !== stableStringify(encodeWire(withoutPage(next)))) {
+        return undefined;
+    }
+
+    return { next: nextPage as unknown[], previous: previousPage as unknown[] };
+};
+
+/**
+ * Would a client merging these deltas end up with the row order the server
+ * actually has?
+ *
+ * `update` and `delete` are positionally exact — they name a row that already
+ * exists. An `insert` is not: the delta carries no index, so the client places
+ * it with {@link insertionIndexFor}, which orders by `_creationTime`. A page
+ * ordered by a `.withIndex()` field instead (`paginateOrderKeys` in `ctx-db.ts`
+ * orders by the staged index fields, falling back to `_creationTime` only when
+ * there are none) can legitimately want the row somewhere else — a leaderboard
+ * by score, a queue by priority. `survivorsKeepOrder` does not catch it, because
+ * the survivors DID keep their order; only the newcomer is misplaced.
+ *
+ * Left unchecked that desyncs silently and permanently: the server advances its
+ * diff baseline to the value it believes the client now holds, so every later
+ * `update` lands in place at an index the client has wrong, and nothing
+ * reconciles until a reconnect or a forced snapshot.
+ *
+ * So replay the inserts here — against the same shared helper the client will
+ * use — and report whether the resulting order matches. Only ids are replayed:
+ * the row VALUES are exact by construction (each delta carries the full new
+ * row), so order is the only thing in doubt.
+ * @returns `true` when the client's merge will reproduce the server's row order
+ */
+const clientOrderMatches = (previous: RowIndex, next: RowIndex, framed: ReadonlyArray<FramedDelta>): boolean => {
+    const inserts = framed.filter(({ delta }) => delta.op === "insert");
+
+    // No insert, no ambiguity — updates and deletes are placed by id.
+    if (inserts.length === 0) {
+        return true;
+    }
+
+    // Start from the surviving prev rows in prev order (what the client holds
+    // once the deletes have been applied), then splice each insert in.
+    const rows: Record<string, unknown>[] = previous.order.filter((id) => next.byId.has(id)).map((id) => previous.byId.get(id) as Record<string, unknown>);
+
+    for (const { delta } of inserts) {
+        const row = delta.row as Record<string, unknown>;
+
+        rows.splice(insertionIndexFor(rows, row), 0, row);
+    }
+
+    return rows.length === next.order.length && rows.every((row, index) => row[ID_FIELD] === next.order[index]);
 };
 
 /**
@@ -232,10 +249,10 @@ const paginationEnvelopeMatches = (previous: unknown, next: unknown): boolean =>
  * Returns `undefined` (the value is not expressible as row deltas at all)
  * unless ALL of these hold:
  *
- * 1. `previousJson` parses to a diffable list — an array, or a `{ page: [...] }` result (see {@link rowsOf}).
- * 2. `nextResult` carries a list of the same kind, and (when paginated) an identical envelope around it.
- * 3. Every row in both lists is a plain object carrying a string `_id`.
- * 4. Order preservation — rows present in BOTH lists appear in the same relative order.
+ * 1. Both sides carry a row list of the same kind, with an identical envelope when paginated (see {@link diffableLists}).
+ * 2. Every row in both lists is a plain object carrying a string `_id`.
+ * 3. Order preservation — rows present in BOTH lists appear in the same relative order.
+ * 4. Insert placement — a merging client lands any inserted row where the server has it (see {@link clientOrderMatches}).
  *
  * These are EXPRESSIBILITY conditions only. Whether the deltas are the cheaper
  * thing to put on the wire is a separate question, answered by
@@ -262,37 +279,37 @@ const collectFramedDeltas = (previousJson: string, nextResult: unknown, table: s
         return undefined;
     }
 
-    // (1) + (2): both sides must carry a diffable list, of the same kind, and a
-    // paginated pair must agree on everything outside the page.
-    const previousRows = rowsOf(parsed);
-    const nextRows = rowsOf(nextResult);
+    // (1): both sides must carry a row list of the same kind, and a paginated
+    // pair must agree on everything outside the page.
+    const lists = diffableLists(parsed, nextResult);
 
-    if (previousRows === undefined || nextRows === undefined || Array.isArray(parsed) !== Array.isArray(nextResult)) {
+    if (lists === undefined) {
         return undefined;
     }
 
-    if (!paginationEnvelopeMatches(parsed, nextResult)) {
-        return undefined;
-    }
-
-    // (3): both must be id-keyable.
-    const previous = indexRowsById(previousRows);
-    const next = indexRowsById(nextRows);
+    // (2): both must be id-keyable.
+    const previous = indexRowsById(lists.previous);
+    const next = indexRowsById(lists.next);
 
     if (previous === undefined || next === undefined) {
         return undefined;
     }
 
-    // (4): survivors keep their relative order.
+    // (3): survivors keep their relative order.
     if (!survivorsKeepOrder(previous, next)) {
         return undefined;
     }
 
     const deltaTable = table === "" ? DELTA_FALLBACK_TABLE : table;
     const tableJson = JSON.stringify(deltaTable);
-
     // Deletes precede upserts so the client never sees a transient over-length page.
-    return [...collectDeleteDeltas(previous, next, deltaTable, tableJson), ...collectUpsertDeltas(previous, next, deltaTable, tableJson)];
+    const framed = [...collectDeleteDeltas(previous, next, deltaTable, tableJson), ...collectUpsertDeltas(previous, next, deltaTable, tableJson)];
+
+    // (4): the client's insert placement agrees with ours. Checked LAST because
+    // it needs the deltas themselves; a mismatch discards them and sends the
+    // snapshot, which is the only encoding that can carry an order the delta
+    // protocol cannot express.
+    return clientOrderMatches(previous, next, framed) ? framed : undefined;
 };
 
 /**
@@ -373,17 +390,9 @@ interface SubscriptionFrameInput {
     nextResult: unknown;
 
     /**
-     * Whether this socket announced {@link PAGE_DELTA_CAPABILITY} on its
-     * `connect` frame, i.e. whether it can merge a row delta into the `page` of
-     * a `{ page, isDone, continueCursor }` result.
-     *
-     * Load-bearing, and fail-closed by default. A client that cannot do that
-     * merge does not IGNORE a page delta — `@lunora/client`'s `applyDelta`
-     * returns `undefined` for an unmergeable shape and the caller then replaces
-     * the whole query value with the raw delta object. So sending page deltas
-     * unconditionally would corrupt the value on every client that predates
-     * this, including all seven non-JS SDKs. Absent means snapshots, which is
-     * exactly the behaviour those clients have today.
+     * Whether this socket announced {@link PAGE_DELTA_CAPABILITY}. Absent means
+     * a paginated result is never diffed for it — fail-closed, and load-bearing
+     * rather than a tuning knob; see that constant for why.
      */
     pageDeltas?: boolean;
     /** The wire form of the value last DELIVERED for this subscription; `undefined` on a first send. */
@@ -500,4 +509,4 @@ const awaitWsDrain = async (ws: DrainableSink): Promise<void> => {
 };
 
 export type { DrainableSink, FrameSink, SubscriptionFrameInput };
-export { awaitWsDrain, PAGE_DELTA_CAPABILITY, subscriptionFrames, subscriptionListDeltas, trySendFrame };
+export { awaitWsDrain, subscriptionFrames, subscriptionListDeltas, trySendFrame };

--- a/packages/shard-engine/src/types.ts
+++ b/packages/shard-engine/src/types.ts
@@ -66,14 +66,13 @@ export interface ShapeSubscriptionQuery {
 
 export interface SubscriptionEnvelope {
     /**
-     * Optional capability tokens carried by the `connect` envelope, naming
-     * wire behaviours this client can handle that older ones cannot (currently
-     * only `"pageDelta"` — see `PAGE_DELTA_CAPABILITY`). Recorded on the socket
-     * attachment; unknown tokens are kept verbatim and simply never matched, so
-     * a newer client talking to an older server degrades silently.
-     *
-     * Everything here is strictly opt-in: absent means the server keeps to the
-     * wire behaviour every client already understood.
+     * Optional capability tokens carried by the `connect` envelope, naming wire
+     * behaviours this client can handle that older ones cannot (currently only
+     * `"pageDelta"` — see `shared/page-result.ts`). Resolved to the decisions
+     * they gate and recorded on the attachment; an unrecognised token is simply
+     * never matched, so a newer client talking to an older server degrades
+     * silently. Strictly opt-in: absent means the server keeps to the wire
+     * behaviour every client already understood.
      */
     caps?: string[];
 
@@ -200,15 +199,6 @@ export interface SocketAttachment {
     admin?: boolean;
 
     /**
-     * Capability tokens this socket announced on its `connect` envelope (see
-     * {@link SubscriptionEnvelope.caps}). Persisted so it survives hibernation:
-     * `connect` is one-shot, so a capability lost across a hibernation wake
-     * could never be re-announced, and the socket would silently fall back to
-     * snapshots for the rest of its life.
-     */
-    caps?: string[];
-
-    /**
      * Stable per-client id from the `connect` envelope (the same id the client
      * stamps on its custom-mutator pushes). Lets a shape poke echo this client's
      * `__client_watermark` as the poke's `lastMutationId`, so a `@lunora/db`
@@ -256,6 +246,19 @@ export interface SocketAttachment {
      * hooks so they run under the connecting user.
      */
     identity?: Record<string, unknown>;
+
+    /**
+     * `true` when the socket's `connect` envelope announced the `pageDelta`
+     * capability — i.e. this client can merge a row delta into the `page` of a
+     * paginated result, so the server may diff one instead of re-sending it.
+     *
+     * The resolved DECISION, not the announced token list: `caps` is
+     * client-supplied and unbounded, and nothing ever reads an unrecognised
+     * token back. Persisted so it survives hibernation — `connect` is one-shot,
+     * so a capability lost across a wake could never be re-announced and the
+     * socket would quietly fall back to snapshots for the rest of its life.
+     */
+    pageDeltas?: boolean;
 
     /**
      * Live shape subscriptions registered on this socket, keyed by the

--- a/packages/shard-engine/src/types.ts
+++ b/packages/shard-engine/src/types.ts
@@ -66,6 +66,18 @@ export interface ShapeSubscriptionQuery {
 
 export interface SubscriptionEnvelope {
     /**
+     * Optional capability tokens carried by the `connect` envelope, naming
+     * wire behaviours this client can handle that older ones cannot (currently
+     * only `"pageDelta"` — see `PAGE_DELTA_CAPABILITY`). Recorded on the socket
+     * attachment; unknown tokens are kept verbatim and simply never matched, so
+     * a newer client talking to an older server degrades silently.
+     *
+     * Everything here is strictly opt-in: absent means the server keeps to the
+     * wire behaviour every client already understood.
+     */
+    caps?: string[];
+
+    /**
      * Stable per-client id carried by the `connect` envelope. Recorded on the
      * socket attachment so a shape poke can echo this client's
      * `__client_watermark` as its `lastMutationId`. Ignored on other envelope
@@ -186,6 +198,15 @@ export interface SocketAttachment {
      * user-subscription sockets, which may never read admin data over the wire.
      */
     admin?: boolean;
+
+    /**
+     * Capability tokens this socket announced on its `connect` envelope (see
+     * {@link SubscriptionEnvelope.caps}). Persisted so it survives hibernation:
+     * `connect` is one-shot, so a capability lost across a hibernation wake
+     * could never be re-announced, and the socket would silently fall back to
+     * snapshots for the rest of its life.
+     */
+    caps?: string[];
 
     /**
      * Stable per-client id from the `connect` envelope (the same id the client

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2743,6 +2743,9 @@ importers:
       '@lunora/runtime':
         specifier: workspace:*
         version: link:../runtime
+      '@lunora/shard-engine':
+        specifier: workspace:*
+        version: link:../shard-engine
       '@types/node':
         specifier: catalog:types
         version: 26.1.1

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -229,6 +229,29 @@ page deltas when every field outside `page` is byte-identical to the last
 delivered value, so a moved `continueCursor` or a flipped `isDone` always arrives
 as a full `data` snapshot instead.
 
+**Insert placement.** An `insert` op carries no index, so a merging client
+decides the position itself: if the new row and its neighbours all carry a
+numeric `_creationTime`, insert before the first neighbour that breaks the
+list's own direction (ascending → first larger, descending → first smaller);
+otherwise append. This rule is normative, and the server depends on it — before
+sending any batch containing an `insert` it replays this exact placement and
+falls back to a `data` snapshot when the result would not match the order its
+query returned. A read ordered by a `.withIndex()` field rather than by
+`_creationTime` is the common case where it does not match.
+
+That is what makes the merge exact: apply the frames for one push and a
+conforming client holds precisely the value the `data` snapshot would have
+carried. An SDK that implements a _different_ placement rule breaks the
+guarantee silently — the server will have cleared a batch your merge then
+misplaces, and it advances its diff baseline as if you had applied it — so
+implement this rule as written, and assert it against the `pageDeltaFrames`
+goldens in [`fixtures/ws-frames.json`](./fixtures/ws-frames.json).
+
+Those cases live under their own key rather than in `serverFrames` because they
+**merge** into a cached `baseWire` instead of replacing it, and an SDK that has
+not implemented `pageDelta` must keep applying `serverFrames` by replacement.
+Run `pageDeltaFrames` only once you announce the token.
+
 ### 5.2 Server → client frames
 
 | `type`     | Shape                                                          | Effect                                                                    |

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -175,16 +175,16 @@ are ignored by the client parser.
 
 ### 5.1 Client → server frames
 
-| `type`                                      | Shape                                                                        |
-| ------------------------------------------- | ---------------------------------------------------------------------------- |
-| `connect`                                   | `{ type, id: "connect", clientId?, context? }` — one-shot, first on open     |
-| `subscribe`                                 | `{ type, id, query: { functionPath, args, table, sinceSeq?, sinceEpoch? } }` |
-| `unsubscribe`                               | `{ type, id }`                                                               |
-| `shape_subscribe`                           | `{ type, id, shape: { name, args? }, sinceCheckpoint?, sinceEpoch? }`        |
-| `shape_unsubscribe`                         | `{ type, id }`                                                               |
-| `stream`                                    | `{ type, id, query: { functionPath, args?, shardKey? }, sinceChunk? }`       |
-| `whisper_subscribe` / `whisper_unsubscribe` | `{ type, topic }`                                                            |
-| `whisper`                                   | `{ type, topic, data? }`                                                     |
+| `type`                                      | Shape                                                                           |
+| ------------------------------------------- | ------------------------------------------------------------------------------- |
+| `connect`                                   | `{ type, id: "connect", clientId?, caps?, context? }` — one-shot, first on open |
+| `subscribe`                                 | `{ type, id, query: { functionPath, args, table, sinceSeq?, sinceEpoch? } }`    |
+| `unsubscribe`                               | `{ type, id }`                                                                  |
+| `shape_subscribe`                           | `{ type, id, shape: { name, args? }, sinceCheckpoint?, sinceEpoch? }`           |
+| `shape_unsubscribe`                         | `{ type, id }`                                                                  |
+| `stream`                                    | `{ type, id, query: { functionPath, args?, shardKey? }, sinceChunk? }`          |
+| `whisper_subscribe` / `whisper_unsubscribe` | `{ type, topic }`                                                               |
+| `whisper`                                   | `{ type, topic, data? }`                                                        |
 
 `subscribe.query.args` is `encodeWire(args)`. `table` defaults to
 `functionPath` (unless codegen surfaced a distinct table). `sinceSeq` /
@@ -201,6 +201,33 @@ durable ignores `sinceChunk` and emits chunks without `seq`.
 
 The `connect` frame is sent once per socket open, **before** resubscribing, so
 `onConnect`/`onDisconnect` lifecycle hooks fire symmetrically.
+
+#### 5.1.1 `connect.caps` — capability negotiation
+
+`caps` is an optional array of string tokens naming wire behaviours the client
+can handle that older clients cannot. **Omitting it is always safe**, and it is
+what an SDK should do until it implements a token: the server then keeps to the
+behaviour every client has always understood. A server that does not recognise a
+token ignores it, so the field is additive in both directions.
+
+| Token       | The client guarantees                                                                     |
+| ----------- | ----------------------------------------------------------------------------------------- |
+| `pageDelta` | It can merge a `delta` frame's `RowOp` into the `page` array of a paginated query result. |
+
+**`pageDelta` in detail.** A paginated read (`.paginate()`) returns
+`{ page: [...], isDone, continueCursor }` — an object, not an array. Without this
+token the server must re-send that whole object as a `data` snapshot on every
+write touching the query's tables, because a client that cannot merge into `page`
+does not _ignore_ such a delta — the reference client replaces the entire query
+value with the raw delta object. Announcing `pageDelta` lets the server send one
+`delta` per changed row instead.
+
+A conforming `pageDelta` client applies a delta to a paginated value by merging
+the `RowOp` into `page` **by `_id`**, exactly as it would for a bare array
+result, and returning the surrounding fields unchanged. The server only sends
+page deltas when every field outside `page` is byte-identical to the last
+delivered value, so a moved `continueCursor` or a flipped `isDone` always arrives
+as a full `data` snapshot instead.
 
 ### 5.2 Server → client frames
 

--- a/protocol/fixtures/ws-frames.json
+++ b/protocol/fixtures/ws-frames.json
@@ -1,7 +1,8 @@
 {
-    "$comment": "Golden fixtures for the WebSocket subscription protocol (GET /_lunora/ws). `clientFrames` are frames a client MUST emit; a conforming client's builders produce these (compared as parsed JSON, key order irrelevant). `serverFrames` are frames a client MUST consume; each `expect` describes the observable effect (`valueWire` is the wire form of the value delivered to the callback, so encode(received) == valueWire). `shape` covers the poke-based partial-replication path.",
+    "$comment": "Golden fixtures for the WebSocket subscription protocol (GET /_lunora/ws). `clientFrames` are frames a client MUST emit; a conforming client's builders produce these (compared as parsed JSON, key order irrelevant). `serverFrames` are frames a client MUST consume; each `expect` describes the observable effect (`valueWire` is the wire form of the value delivered to the callback, so encode(received) == valueWire). `shape` covers the poke-based partial-replication path. `connect-with-caps` is the OPTIONAL capability-announcing form of the connect frame (protocol README 5.1.1) — an SDK that implements no capability tokens emits plain `connect` and is fully conforming, so only an SDK that has actually implemented a token should assert against it.",
     "clientFrames": {
         "connect": { "clientId": "client-test", "id": "connect", "type": "connect" },
+        "connect-with-caps": { "caps": ["pageDelta"], "clientId": "client-test", "id": "connect", "type": "connect" },
         "connect-with-context": { "clientId": "client-test", "id": "connect", "type": "connect", "context": { "roomId": "general" } },
         "subscribe-cold": {
             "id": "sub_1",

--- a/protocol/fixtures/ws-frames.json
+++ b/protocol/fixtures/ws-frames.json
@@ -1,67 +1,325 @@
 {
-    "$comment": "Golden fixtures for the WebSocket subscription protocol (GET /_lunora/ws). `clientFrames` are frames a client MUST emit; a conforming client's builders produce these (compared as parsed JSON, key order irrelevant). `serverFrames` are frames a client MUST consume; each `expect` describes the observable effect (`valueWire` is the wire form of the value delivered to the callback, so encode(received) == valueWire). `shape` covers the poke-based partial-replication path. `connect-with-caps` is the OPTIONAL capability-announcing form of the connect frame (protocol README 5.1.1) — an SDK that implements no capability tokens emits plain `connect` and is fully conforming, so only an SDK that has actually implemented a token should assert against it.",
+    "$comment": "Golden fixtures for the WebSocket subscription protocol (GET /_lunora/ws). `clientFrames` are frames a client MUST emit; a conforming client's builders produce these (compared as parsed JSON, key order irrelevant). `serverFrames` are frames a client MUST consume; each `expect` describes the observable effect (`valueWire` is the wire form of the value delivered to the callback, so encode(received) == valueWire). `shape` covers the poke-based partial-replication path. `pageDeltaFrames` is a SEPARATE set only an SDK that announced the `pageDelta` capability should run: each case applies its `frame` ON TOP of `baseWire` (merging, not replacing) and asserts the merged `valueWire`. It is deliberately not in `serverFrames`, which SDKs iterate wholesale and apply by replacement. `connect-with-caps` is the OPTIONAL capability-announcing form of the connect frame (protocol README 5.1.1) \u2014 an SDK that implements no capability tokens emits plain `connect` and is fully conforming, so only an SDK that has actually implemented a token should assert against it.",
     "clientFrames": {
-        "connect": { "clientId": "client-test", "id": "connect", "type": "connect" },
-        "connect-with-caps": { "caps": ["pageDelta"], "clientId": "client-test", "id": "connect", "type": "connect" },
-        "connect-with-context": { "clientId": "client-test", "id": "connect", "type": "connect", "context": { "roomId": "general" } },
+        "connect": {
+            "clientId": "client-test",
+            "id": "connect",
+            "type": "connect"
+        },
+        "connect-with-caps": {
+            "caps": ["pageDelta"],
+            "clientId": "client-test",
+            "id": "connect",
+            "type": "connect"
+        },
+        "connect-with-context": {
+            "clientId": "client-test",
+            "id": "connect",
+            "type": "connect",
+            "context": {
+                "roomId": "general"
+            }
+        },
         "subscribe-cold": {
             "id": "sub_1",
-            "query": { "args": { "channel": "general" }, "functionPath": "messages:list", "table": "messages:list" },
+            "query": {
+                "args": {
+                    "channel": "general"
+                },
+                "functionPath": "messages:list",
+                "table": "messages:list"
+            },
             "type": "subscribe"
         },
         "subscribe-resume": {
             "id": "sub_1",
-            "query": { "args": { "channel": "general" }, "functionPath": "messages:list", "table": "messages:list", "sinceSeq": 12, "sinceEpoch": "e1" },
+            "query": {
+                "args": {
+                    "channel": "general"
+                },
+                "functionPath": "messages:list",
+                "table": "messages:list",
+                "sinceSeq": 12,
+                "sinceEpoch": "e1"
+            },
             "type": "subscribe"
         },
-        "unsubscribe": { "id": "sub_1", "type": "unsubscribe" }
+        "unsubscribe": {
+            "id": "sub_1",
+            "type": "unsubscribe"
+        }
     },
     "serverFrames": [
-        { "name": "ack", "frame": { "id": "sub_1", "type": "ack" }, "expect": { "kind": "ack", "id": "sub_1" } },
+        {
+            "name": "ack",
+            "frame": {
+                "id": "sub_1",
+                "type": "ack"
+            },
+            "expect": {
+                "kind": "ack",
+                "id": "sub_1"
+            }
+        },
         {
             "name": "data-plain",
-            "frame": { "id": "sub_1", "type": "data", "data": { "messages": ["hi", "there"] }, "cursor": 5, "epoch": "e1" },
-            "expect": { "kind": "data", "id": "sub_1", "valueWire": { "messages": ["hi", "there"] }, "cursor": 5, "epoch": "e1" }
+            "frame": {
+                "id": "sub_1",
+                "type": "data",
+                "data": {
+                    "messages": ["hi", "there"]
+                },
+                "cursor": 5,
+                "epoch": "e1"
+            },
+            "expect": {
+                "kind": "data",
+                "id": "sub_1",
+                "valueWire": {
+                    "messages": ["hi", "there"]
+                },
+                "cursor": 5,
+                "epoch": "e1"
+            }
         },
         {
             "name": "data-typed",
-            "frame": { "id": "sub_1", "type": "data", "data": ["$lunora.wire$", "bigint", "9"] },
-            "expect": { "kind": "data", "id": "sub_1", "valueWire": ["$lunora.wire$", "bigint", "9"] }
+            "frame": {
+                "id": "sub_1",
+                "type": "data",
+                "data": ["$lunora.wire$", "bigint", "9"]
+            },
+            "expect": {
+                "kind": "data",
+                "id": "sub_1",
+                "valueWire": ["$lunora.wire$", "bigint", "9"]
+            }
         },
         {
             "name": "error",
-            "frame": { "id": "sub_1", "type": "error", "error": { "code": "FORBIDDEN_SHARD", "message": "nope" } },
-            "expect": { "kind": "error", "id": "sub_1", "code": "FORBIDDEN_SHARD", "message": "nope" }
+            "frame": {
+                "id": "sub_1",
+                "type": "error",
+                "error": {
+                    "code": "FORBIDDEN_SHARD",
+                    "message": "nope"
+                }
+            },
+            "expect": {
+                "kind": "error",
+                "id": "sub_1",
+                "code": "FORBIDDEN_SHARD",
+                "message": "nope"
+            }
         },
         {
             "name": "resume",
-            "frame": { "id": "sub_1", "type": "resume", "cursor": 20, "epoch": "e1" },
-            "expect": { "kind": "resume", "id": "sub_1", "cursor": 20 }
+            "frame": {
+                "id": "sub_1",
+                "type": "resume",
+                "cursor": 20,
+                "epoch": "e1"
+            },
+            "expect": {
+                "kind": "resume",
+                "id": "sub_1",
+                "cursor": 20
+            }
         },
         {
             "name": "settled",
-            "frame": { "id": "sub_1", "type": "settled", "cursor": 21, "lastMutationId": 3 },
-            "expect": { "kind": "settled", "id": "sub_1", "cursor": 21, "lastMutationId": 3 }
+            "frame": {
+                "id": "sub_1",
+                "type": "settled",
+                "cursor": 21,
+                "lastMutationId": 3
+            },
+            "expect": {
+                "kind": "settled",
+                "id": "sub_1",
+                "cursor": 21,
+                "lastMutationId": 3
+            }
+        }
+    ],
+    "pageDeltaFrames": [
+        {
+            "name": "delta-page-update",
+            "$comment": "pageDelta only. Merge the RowOp into `page` by `_id`; every field outside `page` is unchanged. A client that did NOT announce `pageDelta` never receives this frame \u2014 it gets a full `data` snapshot instead.",
+            "baseWire": {
+                "continueCursor": "c_2",
+                "isDone": false,
+                "page": [
+                    {
+                        "_creationTime": 1001,
+                        "_id": "m1",
+                        "text": "one"
+                    },
+                    {
+                        "_creationTime": 1002,
+                        "_id": "m2",
+                        "text": "two"
+                    }
+                ]
+            },
+            "frame": {
+                "id": "sub_1",
+                "type": "delta",
+                "delta": {
+                    "key": "m2",
+                    "op": "update",
+                    "row": {
+                        "_creationTime": 1002,
+                        "_id": "m2",
+                        "text": "TWO"
+                    },
+                    "table": "messages"
+                },
+                "cursor": 9,
+                "epoch": "e1"
+            },
+            "expect": {
+                "kind": "delta",
+                "id": "sub_1",
+                "valueWire": {
+                    "continueCursor": "c_2",
+                    "isDone": false,
+                    "page": [
+                        {
+                            "_creationTime": 1001,
+                            "_id": "m1",
+                            "text": "one"
+                        },
+                        {
+                            "_creationTime": 1002,
+                            "_id": "m2",
+                            "text": "TWO"
+                        }
+                    ]
+                },
+                "cursor": 9,
+                "epoch": "e1"
+            }
+        },
+        {
+            "name": "delta-page-insert-descending",
+            "$comment": "Insert placement (protocol README 5.1.1): the delta carries no index. This list runs newest-first, and the new row is the newest, so a conforming client splices it at the FRONT. Implementing a different rule desyncs silently \u2014 the server replays this exact placement before it sends the delta.",
+            "baseWire": {
+                "continueCursor": "c_2",
+                "isDone": false,
+                "page": [
+                    {
+                        "_creationTime": 1003,
+                        "_id": "m3",
+                        "text": "three"
+                    },
+                    {
+                        "_creationTime": 1002,
+                        "_id": "m2",
+                        "text": "two"
+                    }
+                ]
+            },
+            "frame": {
+                "id": "sub_1",
+                "type": "delta",
+                "delta": {
+                    "key": "m4",
+                    "op": "insert",
+                    "row": {
+                        "_creationTime": 1004,
+                        "_id": "m4",
+                        "text": "four"
+                    },
+                    "table": "messages"
+                }
+            },
+            "expect": {
+                "kind": "delta",
+                "id": "sub_1",
+                "valueWire": {
+                    "continueCursor": "c_2",
+                    "isDone": false,
+                    "page": [
+                        {
+                            "_creationTime": 1004,
+                            "_id": "m4",
+                            "text": "four"
+                        },
+                        {
+                            "_creationTime": 1003,
+                            "_id": "m3",
+                            "text": "three"
+                        },
+                        {
+                            "_creationTime": 1002,
+                            "_id": "m2",
+                            "text": "two"
+                        }
+                    ]
+                }
+            }
         }
     ],
     "shape": {
-        "shape-subscribe-cold": { "id": "shape_1", "shape": { "name": "roomMessages", "args": { "room": "general" } }, "type": "shape_subscribe" },
+        "shape-subscribe-cold": {
+            "id": "shape_1",
+            "shape": {
+                "name": "roomMessages",
+                "args": {
+                    "room": "general"
+                }
+            },
+            "type": "shape_subscribe"
+        },
         "pokeSequence": [
-            { "type": "pokeStart", "pokeId": "p1", "baseCheckpoint": 0, "epoch": "e1" },
+            {
+                "type": "pokeStart",
+                "pokeId": "p1",
+                "baseCheckpoint": 0,
+                "epoch": "e1"
+            },
             {
                 "type": "pokePart",
                 "pokeId": "p1",
                 "shapeId": "shape_1",
                 "rowsPatch": [
-                    { "op": "insert", "key": "m1", "table": "messages", "value": { "_id": "m1", "text": "hi" } },
-                    { "op": "insert", "key": "m2", "table": "messages", "value": { "_id": "m2", "text": "yo" } }
+                    {
+                        "op": "insert",
+                        "key": "m1",
+                        "table": "messages",
+                        "value": {
+                            "_id": "m1",
+                            "text": "hi"
+                        }
+                    },
+                    {
+                        "op": "insert",
+                        "key": "m2",
+                        "table": "messages",
+                        "value": {
+                            "_id": "m2",
+                            "text": "yo"
+                        }
+                    }
                 ]
             },
-            { "type": "pokeEnd", "pokeId": "p1", "checkpoint": 5, "epoch": "e1" }
+            {
+                "type": "pokeEnd",
+                "pokeId": "p1",
+                "checkpoint": 5,
+                "epoch": "e1"
+            }
         ],
         "expectedRows": [
-            { "_id": "m1", "text": "hi" },
-            { "_id": "m2", "text": "yo" }
+            {
+                "_id": "m1",
+                "text": "hi"
+            },
+            {
+                "_id": "m2",
+                "text": "yo"
+            }
         ]
     }
 }

--- a/shared/page-result.ts
+++ b/shared/page-result.ts
@@ -24,6 +24,8 @@
  * `shared/` contract.
  */
 
+import { isPlainObject } from "./wire-codec";
+
 /** Identity field every Lunora document row carries. */
 const ID_FIELD = "_id";
 
@@ -60,8 +62,14 @@ const rowListOf = (value: unknown): undefined | unknown[] => {
         return value as unknown[];
     }
 
-    if (typeof value === "object" && value !== null && Array.isArray((value as Record<string, unknown>)[PAGE_FIELD])) {
-        return (value as Record<string, unknown>)[PAGE_FIELD] as unknown[];
+    // `isPlainObject`, not a bare `typeof === "object"`: the wrapper is re-spread
+    // to swap its page, which would quietly flatten a class instance or any
+    // other exotic object into a plain one. Reusing the CODEC's definition is
+    // what makes that safe rather than merely defensive — it is exactly the set
+    // of objects that survives the wire, so anything it rejects could not have
+    // reached a client as this shape in the first place.
+    if (isPlainObject(value) && Array.isArray(value[PAGE_FIELD])) {
+        return value[PAGE_FIELD] as unknown[];
     }
 
     return undefined;

--- a/shared/page-result.ts
+++ b/shared/page-result.ts
@@ -1,0 +1,141 @@
+/**
+ * The row-list shape a live query result can carry, and the rules for merging a
+ * row delta into it — shared (bundler-inlined, like {@link file://./stable-key.ts})
+ * by the client SDK (`@lunora/client`) and the reactive engine
+ * (`@lunora/shard-engine`).
+ *
+ * ## Why this is shared rather than mirrored
+ *
+ * `@lunora/client` mirrors the server's `MutationDelta` *type* rather than
+ * importing it, and that is fine: a type drifts loudly, at the next `tsc`.
+ * These are different. They are a **runtime agreement behind a negotiated
+ * capability**, and drift is silent data corruption:
+ *
+ * - if the two sides disagree on what counts as a paginated result, the server
+ *   sends a row delta the client cannot merge, `applyDelta` returns `undefined`,
+ *   and the caller replaces the whole query value with the raw delta object;
+ * - if they disagree on where an inserted row lands, the client's list order
+ *   silently diverges from the server's and STAYS diverged, because the server
+ *   advances its diff baseline to the value it believes the client now holds.
+ *
+ * Guarding against that with two independently-maintained copies of the same
+ * predicate would defeat the point of the capability gate, so both sides import
+ * these instead. Zero dependencies (relative/built-in imports only), per the
+ * `shared/` contract.
+ */
+
+/** Identity field every Lunora document row carries. */
+const ID_FIELD = "_id";
+
+/** Creation-time field used as the default sort key for inserts. */
+const CREATION_FIELD = "_creationTime";
+
+/** The row-array field a `.paginate()` result carries its page in. */
+const PAGE_FIELD = "page";
+
+/**
+ * The `connect`-frame capability token a client sends to say it can merge a row
+ * delta into the `page` of a `{ page, isDone, continueCursor }` result.
+ *
+ * Opt-in, and it has to be: an unmergeable delta is not ignored by a client that
+ * predates this — the merge bails and the caller replaces the whole query value
+ * with the raw delta object. A client that never announces this keeps receiving
+ * full snapshots, which is what every client did before, and what the non-JS
+ * SDKs still do (they send `connect` with no `caps` at all).
+ */
+const PAGE_DELTA_CAPABILITY = "pageDelta";
+
+/**
+ * The row list inside a live query result, or `undefined` when it holds none.
+ *
+ * Two accepted shapes:
+ *
+ * - the result IS the array — `ctx.db.query(...).collect()`;
+ * - the result is `{ page: [...], … }` — what `.paginate()` yields, and
+ *   therefore what every `usePaginatedQuery` page holds.
+ * @returns the row list, or `undefined` when the value carries none
+ */
+const rowListOf = (value: unknown): undefined | unknown[] => {
+    if (Array.isArray(value)) {
+        return value as unknown[];
+    }
+
+    if (typeof value === "object" && value !== null && Array.isArray((value as Record<string, unknown>)[PAGE_FIELD])) {
+        return (value as Record<string, unknown>)[PAGE_FIELD] as unknown[];
+    }
+
+    return undefined;
+};
+
+/**
+ * Detect the ordering direction of a list from its rows' `_creationTime` run.
+ * `true` when the list is sorted descending (newest-first — the common chat/feed
+ * shape), `false` for ascending or when the direction is indeterminate (0/1
+ * numeric rows, or an all-equal run). Reads the FIRST strictly-ordered adjacent
+ * numeric pair, so a single out-of-order row doesn't flip the verdict.
+ * @returns `true` when the list reads newest-first
+ */
+const isDescending = (list: ReadonlyArray<Record<string, unknown>>): boolean => {
+    let previous: number | undefined;
+
+    for (const existingRow of list) {
+        const existing = existingRow[CREATION_FIELD];
+
+        if (typeof existing !== "number") {
+            continue;
+        }
+
+        if (previous !== undefined) {
+            if (existing < previous) {
+                return true;
+            }
+
+            if (existing > previous) {
+                return false;
+            }
+        }
+
+        previous = existing;
+    }
+
+    return false;
+};
+
+/**
+ * Where a merging client will splice a newly-inserted row into an ordered list.
+ *
+ * An `insert` delta carries no position, so this heuristic is the only thing
+ * deciding it: with a numeric `_creationTime` on both the new row and its
+ * neighbours we honour the list's OWN direction — ascending inserts before the
+ * first larger neighbour, descending before the first smaller one, so a fresh
+ * newest row lands at the front of a newest-first feed. With no usable ordering
+ * we append, keeping insertion order and never reordering existing rows.
+ *
+ * The SERVER calls this too, to check the position it would produce matches the
+ * one its query actually returned — a page ordered by a `.withIndex()` field
+ * rather than by `_creationTime` can disagree, and the server then sends a full
+ * snapshot instead of a delta the client would misplace. That check is only
+ * sound while both sides run this exact function, which is why it lives here.
+ * @returns the index the row should be spliced at
+ */
+const insertionIndexFor = (list: ReadonlyArray<Record<string, unknown>>, row: Record<string, unknown>): number => {
+    const creation = row[CREATION_FIELD];
+
+    if (typeof creation !== "number") {
+        return list.length;
+    }
+
+    const descending = isDescending(list);
+
+    for (const [index, existingRow] of list.entries()) {
+        const existing = existingRow[CREATION_FIELD];
+
+        if (typeof existing === "number" && (descending ? existing < creation : existing > creation)) {
+            return index;
+        }
+    }
+
+    return list.length;
+};
+
+export { CREATION_FIELD, ID_FIELD, insertionIndexFor, PAGE_DELTA_CAPABILITY, PAGE_FIELD, rowListOf };


### PR DESCRIPTION
Supersedes #406, which was stacked under this branch and is now folded in and
closed. This PR carries all five commits, rebased onto `alpha`.

## Summary

Live-query fan-out (`@lunora/shard-engine`, `@lunora/do`) was sending more bytes
than it needed to, in three ways. All three are fixed here, plus an advisor lint
(`@lunora/advisor`, `@lunora/codegen`) for the fourth — the one only the app
author can fix — and a correctness bug found while reviewing the third.

### 1. Delta-vs-snapshot was decided by row count

A refresh went out as one `{type:"delta"}` frame per changed row whenever the
diff was expressible, capped only by *"no more deltas than rows"*.

Every delta frame re-pays the whole `{"type":"delta","id":…}` + `"table":…` +
cursor/epoch/watermark envelope around **one** row body — which the snapshot
pays once for the entire list. So the deltas stop being the cheaper encoding
well before they stop being a valid one, and a row count cannot see where.
Measured, 100-row list of ~290-byte rows:

| changed | snapshot | deltas | ratio |
| ------- | -------- | ------ | ----- |
| 1       | 29,060 B | 438 B  | 0.02x |
| 50      | 29,060 B | 21,980 B | 0.76x |
| 100     | 29,060 B | **43,970 B across 100 frames** | **1.51x** |

The cap was blind in the other direction too: a single delta into a short list
of small rows already costs more than re-sending the list, and it allowed that
as well.

Now both candidates are rendered and the smaller one is sent — stopping the
render as soon as the running delta total reaches the snapshot, so a near-total
change does not allocate envelopes that lose. `subscriptionFrames` owns the
frame layout and the choice together, so the sizing cannot drift from the format
— it *is* the format. Ties go to the snapshot, since one frame is also one
`ws.send` and one client apply.

### 2. Paginated live queries never diffed at all

`.paginate()` returns `{ page, isDone, continueCursor }` — an object, so the row
diff rejected it at both ends. Every write re-sent the **whole page**, and
`usePaginatedQuery` holds **one subscription per loaded page**.

Measured, one row **updated**:

| page size | before | after | saved |
| --------- | ------ | ----- | ----- |
| 25 rows   | 6,597 B | 412 B | **93.8%** |
| 50 rows   | 13,072 B | 412 B | **96.8%** |

*Scope caveat:* reactive pagination also returns a `splitCursor` derived from
the page's midpoint row, outside `page`. An insert or delete that shifts the
midpoint changes it and correctly forces a snapshot — so those numbers describe
row **updates**, the common live-query case, not every write.

This needs capability negotiation rather than a version bump: a client that
cannot merge into `page` does not *ignore* a page delta — `applyDelta` returns
`undefined` and the caller replaces the entire query value with the raw delta
object. So `connect` gains an optional `caps: string[]`, and the server only
diffs a paginated result for a socket that announced `"pageDelta"`.

Fail-closed by construction: absent `caps` means snapshots, exactly what every
client did before. The seven non-JS SDKs already send `connect` with no `caps`,
so **they need no changes**. The delta frame format is unchanged too.

### 3. Inserted rows could land in the wrong place

An `insert` delta carries no position, so the client picks one with a
`_creationTime` heuristic — but `paginateOrderKeys` orders a `.withIndex()` page
by the **index fields**. The two can legitimately disagree, and
`survivorsKeepOrder` does not catch it (the survivors *did* keep their order;
only the newcomer moves). Reproduced end to end:

```
server order: a,n,b,c
client order: n,a,b,c
```

This desyncs **permanently**: the server advances its diff baseline to the value
it believes the client holds, so every later update lands at an index the client
has wrong, and nothing reconciles until a reconnect.

The server now replays the client's placement before sending and falls back to a
snapshot on mismatch — using the *same* function the client merges with, so the
two cannot drift. The bug predates paginated deltas (a bare
`.withIndex().collect()` diverged identically), so this fixes that path too.

### 4. `unbounded_collect` (new advisor lint)

`filter_without_index` gates on `hasFilter`, so the widest read of all —
`ctx.db.query("t").collect()` with no index and no filter — fell straight
through it. The codegen feeder made that structural: it discarded every
discovered read without a `.filter()`, so no lint could have seen one.

An unindexed read records a whole-table dependency, so the refresh gate can
never skip it: every write re-runs the query and re-sends the whole table to
every subscribed socket. Two of this repo's own examples trip it.

`withGeoIndex` also joins the narrowing methods — it was missing while only
filtered reads were reported, and would otherwise have flagged the exact chain
`geo_index_unused` tells authors to write.

## Linked issues

None — found by a WebSocket payload audit of the subscription fan-out path.

## Test plan

- [x] `pnpm run lint:affected:types` — 74 projects, 0 errors
- [x] `pnpm run lint:eslint` — `@lunora/client`, `@lunora/do`, `@lunora/shard-engine`, `@lunora/advisor`, `@lunora/codegen`
- [x] `pnpm run lint:package-json` — 74 sorted
- [x] `@lunora/shard-engine` 1128, `@lunora/client` 657, `@lunora/do` 539, `@lunora/codegen` 1202, `@lunora/advisor` 482
- [x] `bash sdks/run-all.sh` — all 7 non-JS SDKs pass, unmodified
- [x] `pnpm run api:check` — 47/47
- [x] Durable Object code changed → the workerd-pool `@lunora/do` suite is the one above
- [x] Schema/codegen changed → every `examples/*` and `apps/playground` regenerated; no drift after the rebase
- [x] Protocol spec + golden fixtures updated
- [x] The ordering fix verified to **fail** the round-trip test when reverted, and pass with it
- [x] Re-verified end to end after rebasing onto the current `alpha`

Reviewers should re-run `bash sdks/run-all.sh` and the `@lunora/do` suite.

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style
- [x] Added or updated tests covering the change
- [x] Updated relevant docs — `protocol/README.md` §5.1.1 (normative, for `connect.caps` and insert placement) and `packages/advisor/docs/index.mdx`
- [x] No `package.json` files in `packages/*` modified outside the touched package (`@lunora/client` gains one **devDependency**, see below)
- [x] If a new package was added: n/a
- [x] If migration impact: none — the wire change is additive and opt-in in both directions

## Notes for reviewers

**Read in commit order** — each builds on the last, and the final one fixes a
bug the third exposed.

**Start at `shared/page-result.ts`.** The row-list shape, the capability token,
and the insert-placement rule live there because both sides must agree at
*runtime*. Mirroring a TYPE across the client boundary is safe (drift fails
`tsc` — that is why `MutationDelta` is mirrored); mirroring a runtime shape
agreement behind a negotiated capability is not, and the two copies had already
diverged on their record check one commit in.

**Two fixture traps, one of which bit me:**

1. `clientFrames.connect` is asserted for exact equality by all seven SDK
   suites, so `caps` went into a new `connect-with-caps` golden.
2. `serverFrames` is *iterated wholesale* by those suites and applied by
   replacement — so the merge goldens went into their own `pageDeltaFrames`
   key. I put them in `serverFrames` first and broke all seven;
   `sdks/run-all.sh` caught it.

**`@lunora/client` gains `@lunora/shard-engine` as a devDependency** for the
round-trip test, which asserts the server's chosen frames and the client's real
`applyDelta` land on the same value. No cycle, and there is precedent — `client`
already devDepends on `@lunora/do`.

**Breaking (pre-1.0, `alpha`):** `sendDeltaFrames` is removed from
`@lunora/shard-engine` in favour of `subscriptionFrames`, which returns the
frames rather than sending them. `subscriptionListDeltas` no longer returns
`undefined` for a near-total change — it decomposes any expressible diff, and
cost is decided by the sender. `SocketAttachment.caps` is stored as the resolved
`pageDeltas?: boolean` instead of unbounded client tokens. All internal to the
shard/engine boundary; no app code imports them.

**Frame-type flips are one-directional** — the new predicate is a strict subset
of the old, so no socket that previously got a snapshot now gets deltas.

### Measured, not changed

`subscriptionFrames`' cost scales with list length rather than change size
(~0.74 ms per 200-row list per `(socket, subscription)`; at 100 subscribers that
is ~74 ms of single-threaded shard time per write). Inherent to the current
design — identity-dependent queries cannot share a result under RLS — and pinned
by the new bench so a regression shows up.

### On CodSpeed

The predecessor branch showed a CodSpeed red for `broadcastWhisper to 1024
members` and an in-batch re-projection. Neither is touched by any commit here —
no whisper/batch/relation lines in the diff — and CodSpeed's own summary reports
*"Different runtime environments detected… may affect the accuracy of the
results"*. Cross-runner noise rather than a regression, but worth a second look
if it reappears here.

## Contributor License Agreement

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyG8dyPFieGYzRd7y1MMme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a performance check for unfiltered, unindexed `.collect()` queries that may resend entire tables to subscribers.
  * Subscription updates now support paginated results and choose the smaller delta or snapshot representation.
  * Improved detection of query filters, indexes, and materialization methods.
* **Bug Fixes**
  * Improved merging of live updates for paginated data while preserving pagination details.
  * Added safer fallbacks when ordering or metadata prevents reliable incremental updates.
* **Documentation**
  * Documented the new performance check and its impact on live subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->