### PR TITLE
fix(vue): scope react doctor off the vue and angular adapters

### DIFF
--- a/packages/angular/doctor.config.jsonc
+++ b/packages/angular/doctor.config.jsonc
@@ -1,0 +1,18 @@
+{
+    "rules": {
+        // This package is entirely Angular. React Doctor scans it because it
+        // globs `.ts`, and `effect-needs-cleanup` then fires on
+        // `client.subscribe` in `paginated-query.ts`, reporting "no cleanup
+        // path". There is one: each `Unsubscribe` is stored on its entry and
+        // released from `destroyRef.onDestroy(...)`, which is Angular's teardown
+        // hook. The rule only recognises a `useEffect` return value, so it cannot
+        // see it.
+        "react-doctor/effect-needs-cleanup": "off",
+        // NOT turned off: `react-doctor/js-index-maps`, which flags an
+        // `array.find()` inside a loop in the same file. That one is
+        // framework-agnostic and a real suggestion, so it should keep reporting.
+        //
+        // The gates that do cover this package: `tsc --noEmit`, ESLint, and the
+        // tests in `__tests__/`.
+    },
+}

--- a/packages/vue/doctor.config.jsonc
+++ b/packages/vue/doctor.config.jsonc
@@ -1,0 +1,40 @@
+{
+    "rules": {
+        // This package is entirely Vue. React Doctor scans it because it globs
+        // `.ts` too, and three of its rule families then describe a runtime that
+        // is not here. Each is scoped off for its own reason; the
+        // framework-agnostic findings are deliberately left on (see the bottom).
+        //
+        // `rules-of-hooks` — fires on `useAuth` inside `setup` and `useLunora`
+        // inside `hydratePreloaded`: "not a component or Hook, so React cannot
+        // attach Hook state to a render". React preserves hook ORDER across
+        // re-renders, so a conditional or nested call desynchronises its state.
+        // A Vue `setup` runs once per component instance and composables are
+        // plain calls that register against the active effect scope — there is
+        // no order to preserve and no React render to attach state to.
+        "react-doctor/rules-of-hooks": "off",
+        // `effect-needs-cleanup` — fires on `setInterval` in `use-rate-limit.ts`
+        // and `client.subscribe` in `use-paginated-core.ts`, reporting "no
+        // cleanup path". Both DO clean up; the rule only recognises a `useEffect`
+        // return value. `use-rate-limit` stores the timer and clears it from
+        // `onScopeDispose(() => stopInterval())`, and `use-paginated-core` keeps
+        // each `Unsubscribe` on its entry and releases them all from
+        // `onScopeDispose(teardownAll)`. `onScopeDispose` is Vue's teardown hook
+        // and is exactly the cleanup path the rule is asking for.
+        "react-doctor/effect-needs-cleanup": "off",
+        // `immutability` / `todo` — both report that "this component misses React
+        // Compiler's automatic memoization & re-renders more than it should".
+        // React Compiler does not compile this package: there is no React
+        // component and no re-render here, so there is no memoization to miss.
+        // Vue's reactivity tracks dependencies at runtime and the reassignments
+        // flagged (in async bodies, after "render") are ordinary composable state.
+        "react-hooks-js/immutability": "off",
+        "react-hooks-js/todo": "off",
+        // NOT turned off: `react-doctor/js-index-maps`, which flags an
+        // `array.find()` inside a loop in `use-paginated-core.ts`. That one is
+        // framework-agnostic and a real suggestion, so it should keep reporting.
+        //
+        // The gates that do cover this package: `vue-tsc`, ESLint with
+        // `eslint-plugin-vue`, and the render tests in `__tests__/`.
+    },
+}


### PR DESCRIPTION
## Summary

React Doctor globs `.ts`, so it scans every framework adapter — not just the React ones — and reports React rules against runtimes that are not React. `packages/vue` had **15 findings** and `packages/angular` **2**, neither with a `doctor.config.jsonc`.

This adds a per-rule config to each. It does **not** blanket-ignore the packages: every rule is scoped off individually with the reason it is false there, and the framework-agnostic findings are deliberately left reporting.

**`react-doctor/rules-of-hooks`** (`@lunora/vue`, 4 findings) — fires on `useAuth` inside `setup` and `useLunora` inside `hydratePreloaded`: *"not a component or Hook, so React cannot attach Hook state to a render."* React preserves hook **order** across re-renders, so a conditional or nested call desynchronises its state. A Vue `setup` runs once per component instance and composables are plain calls registering against the active effect scope — there is no order to preserve and no React render to attach state to.

**`react-doctor/effect-needs-cleanup`** (`@lunora/vue` ×2, `@lunora/angular` ×1) — reports *"no cleanup path"* for a `setInterval` and two `client.subscribe` calls. All three do clean up; the rule only recognises a `useEffect` return value:

| Site | Actual teardown |
| --- | --- |
| `vue/src/use-rate-limit.ts:94` | `onScopeDispose(() => stopInterval())` |
| `vue/src/use-paginated-core.ts:165` | `onScopeDispose(teardownAll)` → `entry.unsub()` |
| `angular/src/paginated-query.ts:158` | `destroyRef.onDestroy(() => entry.unsub())` |

Each site was read before scoping the rule off, specifically so a genuine resource leak would not get silenced along with the noise.

**`react-hooks-js/immutability`** (5) and **`react-hooks-js/todo`** (3) (`@lunora/vue`) — both report that the code *"misses React Compiler's automatic memoization & re-renders more than it should."* React Compiler does not compile this package: there is no React component and no re-render, so there is no memoization to miss. The flagged reassignments (in async bodies, "after render completes") are ordinary composable state, and Vue tracks dependencies at runtime.

### Deliberately left reporting

`react-doctor/js-index-maps` — an `array.find()` inside a loop, in all three paginated implementations (`vue/use-paginated-core.ts:113`, `angular/paginated-query.ts:112`, `svelte/paginated-query.ts:151`). It is framework-agnostic and a real suggestion, so it keeps firing. Worth fixing on its own, but that is a behaviour change to pagination internals and does not belong in a lint-scoping PR.

`packages/svelte` gets **no config** — `js-index-maps` is its only finding.

This follows the pattern already established by `packages/react/doctor.config.jsonc` (rule-scoped) and `packages/auth-ui/doctor.config.jsonc` (directory-scoped, because a React port sits beside the non-React ones).

## Linked issues

None.

## Test plan

Verified by running the scanner itself before and after, since the whole change is about what it reports:

```bash
cd packages/<pkg> && react-doctor . --no-supply-chain --no-dead-code --no-cache --json
```

| Package | Before | After |
| --- | --- | --- |
| `@lunora/vue` | 15 | 1 (`js-index-maps`) |
| `@lunora/angular` | 2 | 1 (`js-index-maps`) |
| `@lunora/svelte` | 1 | 1 (unchanged, no config) |

- [x] React Doctor re-run per package, before and after
- [x] `prettier --check` passes on both new files
- [x] No source files changed — config only, so no type/test surface is affected

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change — n/a, this is scanner configuration; the verification is the before/after scan above
- [ ] Updated relevant docs — n/a, no user-facing surface
- [x] No `package.json` files in `packages/*` modified outside the touched package
- [x] If a new package was added: n/a
- [x] If migration impact: none

## Notes for reviewers

The judgement call worth checking is `effect-needs-cleanup`. Silencing a "you never clean this up" rule is exactly how a real leak hides, so the three sites are listed above with their actual teardown — please spot-check that the `onScopeDispose` / `DestroyRef.onDestroy` paths do cover them.

The same class of false positive exists for the Solid adapters and is fixed separately on `claude/solid-v2-template-54qcpn` (`packages/solid` had 12 `rules-of-hooks` findings, and `packages/auth-ui/src/solid-v2/**` 14). Kept out of this PR to avoid duplicate commits across two branches.

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UUWR9B7HirKRHNYpfWPXzM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Developer Experience**
  - Updated validation settings for the Angular and Vue packages to better align diagnostics with each framework’s conventions.
  - Reduced framework-inapplicable warnings while retaining broadly applicable checks.
  - Added guidance documenting the remaining validation steps for these packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->