### PR TITLE
feat(cloudflare-access): authenticate from Worker-scoped Access policies

### DIFF
--- a/api-snapshots/cloudflare-access.api.md
+++ b/api-snapshots/cloudflare-access.api.md
@@ -18,7 +18,18 @@ interface AccessClaims extends JWTPayload {
     email?: string;
     groups?: string[];
     identity_nonce?: string;
+    name?: string;
     type?: string;
+    user_uuid?: string;
+}
+```
+
+### `AccessJwtFallbackOptions` (interface)
+
+```ts
+interface AccessJwtFallbackOptions extends Omit<RequestVerifyOptions, "aud" | "teamDomain"> {
+    aud?: string | string[];
+    teamDomain?: string;
 }
 ```
 
@@ -31,7 +42,7 @@ type AccessKeySet = CryptoKey | JWTVerifyGetKey | KeyObject | Uint8Array;
 ### `CreateAccessResolverOptions` (interface)
 
 ```ts
-interface CreateAccessResolverOptions extends RequestVerifyOptions {
+interface CreateAccessResolverOptions extends AccessJwtFallbackOptions {
     mapClaims?: (claims: AccessClaims) => Record<string, unknown>;
 }
 ```
@@ -39,7 +50,7 @@ interface CreateAccessResolverOptions extends RequestVerifyOptions {
 ### `ResolveIdentityFunction` (type)
 
 ```ts
-type ResolveIdentityFunction = (request: Request, env?: unknown) => (ResolvedIdentityLike | null) | Promise<ResolvedIdentityLike | null>;
+type ResolveIdentityFunction = (request: Request, env?: unknown, context?: ExecutionContextLike) => (ResolvedIdentityLike | null) | Promise<ResolvedIdentityLike | null>;
 ```
 
 ### `ResolvedAccessIdentity` (interface)
@@ -90,7 +101,7 @@ const composeResolvers: (...resolvers: ResolveIdentityFunction[]) => ResolveIden
 ### `createAccessResolver` (const)
 
 ```ts
-const createAccessResolver: (options: CreateAccessResolverOptions) => ResolveIdentityFunction;
+const createAccessResolver: (options?: CreateAccessResolverOptions) => ResolveIdentityFunction;
 ```
 
 ### `verifyAccessJwt` (const)
@@ -104,7 +115,7 @@ const verifyAccessJwt: (token: string, options: VerifyAccessJwtOptions) => Promi
 ### `AccessAdminGateOptions` (interface)
 
 ```ts
-interface AccessAdminGateOptions extends RequestVerifyOptions {
+interface AccessAdminGateOptions extends AccessJwtFallbackOptions {
     isAdmin: (claims: AccessClaims) => boolean | Promise<boolean>;
 }
 ```
@@ -112,7 +123,7 @@ interface AccessAdminGateOptions extends RequestVerifyOptions {
 ### `accessAdminGate` (const)
 
 ```ts
-const accessAdminGate: (options: AccessAdminGateOptions) => ((request: Request) => Promise<boolean>);
+const accessAdminGate: (options: AccessAdminGateOptions) => ((request: Request, context?: ExecutionContextLike) => Promise<boolean>);
 ```
 
 ## `@lunora/cloudflare-access/context`

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -3545,6 +3545,14 @@ Re-exported from `@lunora/ratelimit` — signature tracked at its source.
 
 ## `lunorash/runtime`
 
+### `AccessContextLike` (interface)
+
+Re-exported from `@lunora/runtime` — signature tracked at its source.
+
+### `AccessIdentityLike` (interface)
+
+Re-exported from `@lunora/runtime` — signature tracked at its source.
+
 ### `AdminTableResolver` (type)
 
 Re-exported from `@lunora/runtime` — signature tracked at its source.

--- a/api-snapshots/platform.api.md
+++ b/api-snapshots/platform.api.md
@@ -112,6 +112,7 @@ interface DirectShardDirectory {
 
 ```ts
 interface ExecutionContextLike {
+    access?: AccessContextLike;
     cache?: {
         purge: (options: {
             purgeEverything?: boolean;

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -1208,6 +1208,7 @@ interface LunoraWorker {
     queue?: (batch: unknown, env: unknown, context: ExecutionContextLike) => Promise<void>;
     scheduled: (controller: ScheduledControllerLike, env: unknown, context: ExecutionContextLike) => Promise<void>;
     serverQuery: (request: Request, env: unknown, reference: unknown, args?: Record<string, unknown>, options?: {
+        context?: ExecutionContextLike;
         shardKey?: string;
         waitUntil?: (promise: Promise<unknown>) => void;
     }) => Promise<Response>;
@@ -1682,9 +1683,7 @@ type RestRegistryLike = Record<string, RestRegistryEntry>;
 ### `RestRoute` (type)
 
 ```ts
-type RestRoute = (request: Request, env: unknown, url?: URL, context?: {
-    waitUntil?: (promise: Promise<unknown>) => void;
-}) => Promise<Response>;
+type RestRoute = (request: Request, env: unknown, url?: URL, context?: ExecutionContextLike) => Promise<Response>;
 ```
 
 ### `RestRouteDeps` (interface)

--- a/api-snapshots/runtime.api.md
+++ b/api-snapshots/runtime.api.md
@@ -9,6 +9,29 @@ here is a public-API change and must be reviewed as one (SemVer applies).
 
 ## `@lunora/runtime`
 
+### `AccessContextLike` (interface)
+
+```ts
+interface AccessContextLike {
+    getIdentity: () => AccessIdentityLike | null | undefined | Promise<AccessIdentityLike | null | undefined>;
+}
+```
+
+### `AccessIdentityLike` (interface)
+
+```ts
+interface AccessIdentityLike {
+    [claim: string]: unknown;
+    common_name?: string;
+    email?: string;
+    exp?: number;
+    groups?: unknown;
+    name?: string;
+    sub?: string;
+    user_uuid?: string;
+}
+```
+
 ### `AdminTableResolver` (type)
 
 ```ts
@@ -570,6 +593,7 @@ interface DynamicShardRegistryOptions {
 
 ```ts
 interface ExecutionContextLike {
+    access?: AccessContextLike;
     cache?: {
         purge: (options: {
             purgeEverything?: boolean;
@@ -967,7 +991,7 @@ interface IdentityContractLike {
 ### `IdentityResolver` (type)
 
 ```ts
-type IdentityResolver = (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
+type IdentityResolver = (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
 ```
 
 ### `IdentityValidation` (type)
@@ -2142,7 +2166,7 @@ interface WebhookSinkOptions extends OnlyErrorsOption {
 
 ```ts
 interface WorkerOptions {
-    adminGate?: (request: Request) => boolean | Promise<boolean>;
+    adminGate?: (request: Request, context?: ExecutionContextLike) => boolean | Promise<boolean>;
     adminToken?: string;
     allowUnauthenticatedShardAccess?: boolean;
     applyGlobals?: GlobalCdcApplyFunction;
@@ -2182,7 +2206,7 @@ interface WorkerOptions {
     queue?: QueueConsumerHandler;
     replicaReads?: boolean;
     requireEphemeralWsToken?: boolean;
-    resolveIdentity?: (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
+    resolveIdentity?: (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
     resolveTableSharding?: AdminTableResolver;
     restRateLimit?: RestRateLimit;
     routes?: Record<string, Route>;
@@ -2223,7 +2247,7 @@ const applyJurisdiction: (namespace: ShardNamespaceLike, jurisdiction?: DurableO
 ### `applyRestCache` (const)
 
 ```ts
-const applyRestCache: (response: Response, policy: RestCachePolicy | undefined, request: Request) => Response;
+const applyRestCache: (response: Response, policy: RestCachePolicy | undefined, request: Request, context?: ExecutionContextLike) => Response;
 ```
 
 ### `argsFromQuery` (const)
@@ -2500,7 +2524,7 @@ const readShardKey: (url: URL, request: Request) => string | undefined;
 ### `requestCarriesCredentials` (const)
 
 ```ts
-const requestCarriesCredentials: (request: Request, policy: RestCachePolicy) => boolean;
+const requestCarriesCredentials: (request: Request, policy: RestCachePolicy, context?: ExecutionContextLike) => boolean;
 ```
 
 ### `resolveLogArchiveFromEnv` (const)
@@ -2530,7 +2554,7 @@ const resolveShard: (namespace: ShardNamespaceInput, shardKey: string, locationH
 ### `restCacheHeaders` (const)
 
 ```ts
-const restCacheHeaders: (policy: RestCachePolicy, request: Request, status: number) => Record<string, string> | undefined;
+const restCacheHeaders: (policy: RestCachePolicy, request: Request, status: number, context?: ExecutionContextLike) => Record<string, string> | undefined;
 ```
 
 ### `restSurfaceFromRegistry` (const)

--- a/apps/docs/src/data/packages.ts
+++ b/apps/docs/src/data/packages.ts
@@ -415,9 +415,9 @@ export const packages: PackageInfo[] = [
     {
         accentColor: categoryColors["Add-ons"]!,
         category: "Add-ons",
-        description: "Cloudflare Access (Zero Trust) identity: verify the Cf-Access-Jwt-Assertion JWT and feed ctx.auth / RLS.",
+        description: "Cloudflare Access (Zero Trust) identity: Worker-scoped Access policies or JWKS-verified Access JWTs, fed into ctx.auth / RLS.",
         docsPath: "/docs/packages/cloudflare-access",
-        features: ["JWKS-verified Access JWTs", "resolveIdentity adapter", "Feeds ctx.auth & RLS"],
+        features: ["Worker-scoped Access policies", "JWKS-verified Access JWTs", "Feeds ctx.auth & RLS"],
         name: "Cloudflare Access",
         npmName: "@lunora/cloudflare-access",
         slug: "cloudflare-access",

--- a/packages/cloudflare-access/__tests__/native.test.ts
+++ b/packages/cloudflare-access/__tests__/native.test.ts
@@ -1,0 +1,140 @@
+import type { CryptoKey } from "jose";
+import { generateKeyPair, SignJWT } from "jose";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AccessIdentityLike, ExecutionContextLike } from "../../../shared/execution-context";
+import { accessAdminGate } from "../src/admin";
+import { createAccessResolver } from "../src/resolver";
+
+const TEAM = "acme";
+const ISSUER = "https://acme.cloudflareaccess.com";
+const AUD = "app-aud-tag";
+
+const { privateKey, publicKey } = await generateKeyPair("RS256");
+
+const sign = async (claims: Record<string, unknown>, key: CryptoKey = privateKey): Promise<string> =>
+    new SignJWT(claims).setProtectedHeader({ alg: "RS256" }).setIssuedAt().setIssuer(ISSUER).setAudience(AUD).setExpirationTime("2h").sign(key);
+
+const request = (headers: Record<string, string> = {}): Request => new Request("https://app.test/_lunora/rpc", { headers });
+
+/** An `ExecutionContext` shaped like the one Cloudflare hands a Worker protected by Access. */
+const contextWith = (identity: AccessIdentityLike | null | undefined): ExecutionContextLike => {
+    return { access: { getIdentity: () => Promise.resolve(identity) } };
+};
+
+describe("createAccessResolver — platform identity (Worker-scoped Access)", () => {
+    it("resolves the identity Access attached to the execution context, with no JWT config at all", async () => {
+        expect.assertions(4);
+
+        const resolve = createAccessResolver();
+
+        const identity = await resolve(request(), undefined, contextWith({ email: "user@acme.test", groups: ["eng"], sub: "user-1" }));
+
+        expect(identity?.userId).toBe("user-1");
+        expect(identity?.email).toBe("user@acme.test");
+        expect(identity?.groups).toEqual(["eng"]);
+        expect((identity?.access as { email?: string }).email).toBe("user@acme.test");
+    });
+
+    it("normalizes object-shaped groups to their names, matching the JWT path", async () => {
+        expect.assertions(1);
+
+        const resolve = createAccessResolver();
+
+        const identity = await resolve(
+            request(),
+            undefined,
+            contextWith({ groups: [{ id: "g1", name: "eng" }, { id: "g2", name: "ops" }, { id: "g3" }, 42], sub: "user-1" }),
+        );
+
+        expect(identity?.groups).toEqual(["eng", "ops"]);
+    });
+
+    it("falls back to user_uuid, then email, when the IdP emits no sub", async () => {
+        expect.assertions(2);
+
+        const resolve = createAccessResolver();
+
+        const byUuid = await resolve(request(), undefined, contextWith({ email: "user@acme.test", sub: "", user_uuid: "uuid-9" }));
+        const byEmail = await resolve(request(), undefined, contextWith({ email: "user@acme.test" }));
+
+        expect(byUuid?.userId).toBe("uuid-9");
+        expect(byEmail?.userId).toBe("user@acme.test");
+    });
+
+    it("is anonymous when Access did not authenticate the request (no ctx.access)", async () => {
+        expect.assertions(2);
+
+        const resolve = createAccessResolver();
+
+        await expect(resolve(request(), undefined, {})).resolves.toBeNull();
+        await expect(resolve(request())).resolves.toBeNull();
+    });
+
+    it("fails closed to anonymous when getIdentity throws or yields nothing", async () => {
+        expect.assertions(2);
+
+        const resolve = createAccessResolver();
+        const throwing: ExecutionContextLike = {
+            access: {
+                getIdentity: () => {
+                    throw new Error("platform read failed");
+                },
+            },
+        };
+
+        await expect(resolve(request(), undefined, throwing)).resolves.toBeNull();
+
+        await expect(resolve(request(), undefined, contextWith(null))).resolves.toBeNull();
+    });
+
+    it("prefers the platform identity over a verifiable JWT on the same request", async () => {
+        expect.assertions(1);
+
+        const resolve = createAccessResolver({ aud: AUD, keySet: publicKey, teamDomain: TEAM });
+        const token = await sign({ email: "jwt@acme.test", sub: "jwt-user" });
+
+        const identity = await resolve(request({ "cf-access-jwt-assertion": token }), undefined, contextWith({ sub: "platform-user" }));
+
+        expect(identity?.userId).toBe("platform-user");
+    });
+
+    it("still verifies the JWT when the request carries no platform identity", async () => {
+        expect.assertions(1);
+
+        const resolve = createAccessResolver({ aud: AUD, keySet: publicKey, teamDomain: TEAM });
+        const token = await sign({ email: "jwt@acme.test", sub: "jwt-user" });
+
+        const identity = await resolve(request({ "cf-access-jwt-assertion": token }), undefined, {});
+
+        expect(identity?.userId).toBe("jwt-user");
+    });
+
+    it("throws at construction when only one half of the JWT config is supplied", () => {
+        expect.assertions(2);
+
+        expect(() => createAccessResolver({ teamDomain: TEAM })).toThrow(/configured together/);
+        expect(() => createAccessResolver({ aud: AUD })).toThrow(/configured together/);
+    });
+});
+
+describe("accessAdminGate — platform identity", () => {
+    it("grants from the execution-context identity with no JWT config", async () => {
+        expect.assertions(2);
+
+        const gate = accessAdminGate({ isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false });
+
+        await expect(gate(request(), contextWith({ groups: ["lunora-admins"], sub: "u1" }))).resolves.toBe(true);
+        await expect(gate(request(), contextWith({ groups: ["eng"], sub: "u1" }))).resolves.toBe(false);
+    });
+
+    it("denies when Access did not authenticate the request", async () => {
+        expect.assertions(2);
+
+        const isAdmin = vi.fn<() => boolean>(() => true);
+        const gate = accessAdminGate({ isAdmin });
+
+        await expect(gate(request(), {})).resolves.toBe(false);
+        expect(isAdmin).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cloudflare-access/__tests__/platform-identity.test.ts
+++ b/packages/cloudflare-access/__tests__/platform-identity.test.ts
@@ -50,16 +50,23 @@ describe("createAccessResolver — platform identity (Worker-scoped Access)", ()
         expect(identity?.groups).toEqual(["eng", "ops"]);
     });
 
-    it("falls back to user_uuid, then email, when the IdP emits no sub", async () => {
-        expect.assertions(2);
+    it("derives userId identically to the JWT path, ignoring the platform-only user_uuid", async () => {
+        expect.assertions(3);
 
         const resolve = createAccessResolver();
 
-        const byUuid = await resolve(request(), undefined, contextWith({ email: "user@acme.test", sub: "", user_uuid: "uuid-9" }));
-        const byEmail = await resolve(request(), undefined, contextWith({ email: "user@acme.test" }));
+        // `userId` is the ownership key RLS and `serverDefault` stamp rows with, so
+        // a deployment switching from a hostname-scoped application to a
+        // Worker-scoped policy must keep resolving each user to the same id.
+        // Preferring `user_uuid` (which only this path emits) would re-key every
+        // user on that switch and orphan their rows behind RLS.
+        const bySub = await resolve(request(), undefined, contextWith({ email: "user@acme.test", sub: "user-1", user_uuid: "uuid-9" }));
+        const byEmail = await resolve(request(), undefined, contextWith({ email: "user@acme.test", sub: "", user_uuid: "uuid-9" }));
+        const byCommonName = await resolve(request(), undefined, contextWith({ common_name: "ci-bot", sub: "" }));
 
-        expect(byUuid?.userId).toBe("uuid-9");
+        expect(bySub?.userId).toBe("user-1");
         expect(byEmail?.userId).toBe("user@acme.test");
+        expect(byCommonName?.userId).toBe("ci-bot");
     });
 
     it("is anonymous when Access did not authenticate the request (no ctx.access)", async () => {
@@ -113,8 +120,27 @@ describe("createAccessResolver — platform identity (Worker-scoped Access)", ()
     it("throws at construction when only one half of the JWT config is supplied", () => {
         expect.assertions(2);
 
-        expect(() => createAccessResolver({ teamDomain: TEAM })).toThrow(/configured together/);
-        expect(() => createAccessResolver({ aud: AUD })).toThrow(/configured together/);
+        expect(() => createAccessResolver({ teamDomain: TEAM })).toThrow(/must both be set/);
+        expect(() => createAccessResolver({ aud: AUD })).toThrow(/must both be set/);
+    });
+
+    it("throws when the JWT options are named but their env values are unset", () => {
+        expect.assertions(2);
+
+        // The classic broken deployment: an app wired for a hostname-scoped Access
+        // application, deployed to an environment where neither secret was set.
+        // Reading the VALUES would make this a worker that boots happily and
+        // resolves every caller to anonymous — the presence of the keys is what
+        // says "this deployment intends to verify JWTs".
+        expect(() => createAccessResolver({ aud: undefined, teamDomain: undefined })).toThrow(/must both be set/);
+        // Naming neither is the legal platform-identity-only mode.
+        expect(() =>
+            createAccessResolver({
+                mapClaims: (claims) => {
+                    return { tenant: claims.email };
+                },
+            }),
+        ).not.toThrow();
     });
 });
 
@@ -136,5 +162,24 @@ describe("accessAdminGate — platform identity", () => {
 
         await expect(gate(request(), {})).resolves.toBe(false);
         expect(isAdmin).not.toHaveBeenCalled();
+    });
+
+    it("does NOT accept a Worker-scoped identity when a dedicated admin aud is configured", async () => {
+        expect.assertions(3);
+
+        // The inverse of the resolver's precedence, and deliberately so. A
+        // configured `aud` is the narrow boundary — a dedicated Access application
+        // over /_lunora/admin. A policy later attached to the Worker is typically
+        // broad ("anyone at the company"); letting it satisfy this gate would hand
+        // the whole admin plane to everyone that policy admits, silently.
+        const isAdmin = vi.fn<() => boolean>(() => true);
+        const gate = accessAdminGate({ aud: AUD, isAdmin, keySet: publicKey, teamDomain: TEAM });
+
+        await expect(gate(request(), contextWith({ groups: ["everyone"], sub: "broad-policy-user" }))).resolves.toBe(false);
+        expect(isAdmin).not.toHaveBeenCalled();
+
+        const token = await sign({ groups: ["lunora-admins"], sub: "admin-user" });
+
+        await expect(gate(request({ "cf-access-jwt-assertion": token }), contextWith({ sub: "broad-policy-user" }))).resolves.toBe(true);
     });
 });

--- a/packages/cloudflare-access/docs/index.mdx
+++ b/packages/cloudflare-access/docs/index.mdx
@@ -50,7 +50,13 @@ export default defineApp<Env>()
 
 > `teamDomain` and `aud` are **all-or-nothing**, and construction throws when only one is present. `aud` is the only claim that scopes a token to _your_ Access application — a token minted for any other app in the same Cloudflare team shares the issuer and JWKS — so an unset `env.CF_ACCESS_AUD` must fail loudly rather than quietly disabling the check. Omitting both is the legal "Worker-scoped policy" mode above.
 
-Either way the resolver is **fail-closed → anonymous**: no identity, or a token that fails verification, resolves to `null`, the request proceeds unauthenticated, and RLS denies. `exp` is forwarded when present so live WebSocket subscriptions expire with the credential.
+Either way the resolver is **fail-closed → anonymous**: no identity, or a token that fails verification, resolves to `null`, the request proceeds unauthenticated, and RLS denies.
+
+> **Socket expiry differs between the two.** An Access JWT always carries `exp`, which is forwarded so a live WebSocket subscription is dropped when the credential lapses. The platform-supplied identity may not, and a socket opened without one stays authenticated for as long as it stays connected — past the Access session expiring, past the user leaving the policy. If you hold long-lived subscriptions under a Worker-scoped policy, mint a bound yourself:
+>
+> ```ts
+> createAccessResolver({ mapClaims: () => ({ exp: Math.floor(Date.now() / 1000) + 3600 }) });
+> ```
 
 Both paths produce the same claim shape, so nothing downstream — `ctx.auth`, `ctx.access`, `accessRoles()`, your RLS policies — branches on how the caller was authenticated. The one wire difference is group membership, which the platform may emit as `{ id, name }` objects; those are normalized to their names to match the JWT's `string[]`.
 
@@ -93,18 +99,20 @@ export default defineApp<Env>()
     .auth({ d1: (env) => env.DB, options: authOptions })
     .extend((env, derived) => ({
         resolveIdentity: composeResolvers(
-            createAccessResolver(),
+            createAccessResolver({ teamDomain: env.CF_ACCESS_TEAM_DOMAIN, aud: env.CF_ACCESS_AUD }),
             derived.resolveIdentity, // the better-auth resolver the .auth() call wired
         ),
     }))
     .build();
 ```
 
+> Composition is for the **hostname-scoped** shape, which is why the example configures the JWT fallback. An Access policy attached to the Worker authenticates _every_ request that reaches your code — there is no "everyone else" left to fall through to the app session, so the second resolver would be unreachable. Use one or the other, not a Worker-scoped policy in front of an app that also signs users in itself.
+
 > The codegen integration (below) wires this composition for you when it detects an Access configuration, so you rarely write it by hand.
 
 ## Claims on `ctx.auth`
 
-`userId` is derived from `sub` (SSO), then Cloudflare's `user_uuid`, then `email`, then `common_name` (service tokens, whose `sub` is empty). The verified claims (`email`, `groups`, `commonName`, and the full raw set under `access`) are available via `ctx.auth.getIdentity()`, so RLS policies can branch on them:
+`userId` is derived from `sub` (SSO) or `common_name` (service tokens), identically on both paths — so a deployment that moves from a hostname-scoped application to a Worker-scoped policy keeps resolving each user to the same id rather than re-keying them and orphaning their rows behind RLS. The verified claims (`email`, `groups`, `commonName`, and the full raw set under `access`) are available via `ctx.auth.getIdentity()`, so RLS policies can branch on them:
 
 ```ts
 definePolicy({
@@ -173,7 +181,7 @@ Either way, an anonymous request gets the anonymous facade (`authenticated: fals
 
 ## Gating the Studio behind Access
 
-`@lunora/cloudflare-access/admin` ships `accessAdminGate()`, which builds a value for the runtime's `WorkerOptions.adminGate`, an async authorization gate for the `/_lunora/admin/*` plane (the Studio's HTTP + WebSocket endpoints), OR-ed with the static `adminToken` bearer. It authenticates the caller the same two ways the resolver does and applies your `isAdmin(claims)` predicate, so an Access identity in the right group can reach the Studio without a shared token. It is fail-closed: no identity, a token that fails verification, or an `isAdmin` returning `false` all deny (the bearer stays the only other path). It runs only on admin routes, never on the RPC/WebSocket data path.
+`@lunora/cloudflare-access/admin` ships `accessAdminGate()`, which builds a value for the runtime's `WorkerOptions.adminGate`, an async authorization gate for the `/_lunora/admin/*` plane (the Studio's HTTP + WebSocket endpoints), OR-ed with the static `adminToken` bearer. It applies your `isAdmin(claims)` predicate, so an Access identity in the right group can reach the Studio without a shared token. It is fail-closed: no identity, a token that fails verification, or an `isAdmin` returning `false` all deny (the bearer stays the only other path). It runs only on admin routes, never on the RPC/WebSocket data path.
 
 Wire it on the generated app builder via `.extend((env) => …)`:
 
@@ -183,7 +191,6 @@ import { accessAdminGate } from "@lunora/cloudflare-access/admin";
 export default defineApp()
     .extend((env) => ({
         adminGate: accessAdminGate({
-            // Omit teamDomain/aud when the Access policy is attached to the Worker.
             teamDomain: env.CF_ACCESS_TEAM_DOMAIN,
             aud: env.CF_ACCESS_ADMIN_AUD, // a dedicated Access app over /_lunora/admin
             isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
@@ -191,6 +198,8 @@ export default defineApp()
     }))
     .build();
 ```
+
+> **The admin gate accepts one proof, and the precedence is the reverse of the resolver's.** Configure `teamDomain` + `aud` and the JWT is the _only_ thing accepted; omit both and the Worker's Access identity is. That is deliberate. A policy attached to the Worker is typically broad — "anyone at the company", covering every route and preview URL — while an admin `aud` is deliberately narrow, and its whole purpose is proving the caller came through _that_ application. If the broad identity could satisfy the gate, attaching a Worker-scoped policy would silently widen the admin plane to everyone it admits. Under a Worker-scoped policy, `isAdmin` is the entire boundary, so write it at least as strictly as the dedicated application's policy would have been.
 
 ## API
 
@@ -202,4 +211,4 @@ export default defineApp()
 - `accessContext()` _(`@lunora/cloudflare-access/context`)_: the explicit per-procedure middleware form of the same `ctx.access` facade.
 - `accessFacade(identity, userId)` _(`@lunora/cloudflare-access/context`)_: the pure factory both forms build on; returns the anonymous facade when no identity is present.
 - `accessRoles(options)` _(`@lunora/cloudflare-access/roles`)_: middleware mapping the verified `groups` claim into `ctx.auth.roles` for RLS.
-- `accessAdminGate(options)` _(`@lunora/cloudflare-access/admin`)_: a `WorkerOptions.adminGate` that authorizes the `/_lunora/admin/*` plane from a verified Access identity. `isAdmin` is required; the JWT config is optional on the same all-or-nothing rule.
+- `accessAdminGate(options)` _(`@lunora/cloudflare-access/admin`)_: a `WorkerOptions.adminGate` that authorizes the `/_lunora/admin/*` plane from a verified Access identity. `isAdmin` is required; supplying the JWT config makes the JWT the only accepted proof, omitting it accepts the Worker's Access identity.

--- a/packages/cloudflare-access/docs/index.mdx
+++ b/packages/cloudflare-access/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "@lunora/cloudflare-access"
-description: Cloudflare Access (Zero Trust) identity for Lunora — verify the Cf-Access-Jwt-Assertion JWT against your team JWKS and feed the verified identity into ctx.auth and RLS via a resolveIdentity adapter.
+description: Cloudflare Access (Zero Trust) identity for Lunora — feed the verified Access identity into ctx.auth and RLS via a resolveIdentity adapter, from a Worker-scoped Access policy or a hostname-scoped application's Cf-Access-Jwt-Assertion JWT.
 ---
 
-`@lunora/cloudflare-access` turns a Cloudflare Access (Cloudflare One / Zero Trust) request into a Lunora identity. It verifies the `Cf-Access-Jwt-Assertion` JWT that Access stamps on every proxied request against your team's JWKS, then maps the verified claims onto the shape `@lunora/runtime` expects. A verified SSO user or service token becomes `ctx.auth` for every query, mutation, and action, and feeds row-level security with no per-procedure wiring.
+`@lunora/cloudflare-access` turns a Cloudflare Access (Cloudflare One / Zero Trust) request into a Lunora identity. A verified SSO user or service token becomes `ctx.auth` for every query, mutation, and action, and feeds row-level security with no per-procedure wiring.
 
 ```sh
 pnpm add @lunora/cloudflare-access
@@ -11,9 +11,15 @@ pnpm add @lunora/cloudflare-access
 
 ## How it fits
 
-Cloudflare Access is an **identity-aware proxy**: it authenticates the caller _before_ the request reaches your Worker and adds a signed JWT header. This package is therefore **not** a better-auth plugin. It is a `resolveIdentity` adapter. The single integration point is the runtime's `resolveIdentity` hook, which already feeds `ctx.auth`, RLS policies, `serverDefault` columns, and live subscriptions.
+Cloudflare Access is an **identity-aware proxy**: it authenticates the caller _before_ the request reaches your Worker. This package is therefore **not** a better-auth plugin. It is a `resolveIdentity` adapter. The single integration point is the runtime's `resolveIdentity` hook, which already feeds `ctx.auth`, RLS policies, `serverDefault` columns, and live subscriptions.
 
-Wire it onto your generated app with the `extend` escape hatch (in your worker entry, e.g. `_generated/server` is consumed by `lunora/server.ts`):
+## Two ways Access reaches your app
+
+Which one you get depends on where the Access policy is attached. `createAccessResolver` handles both and prefers the first, so you configure only what your deployment actually uses.
+
+### Attached to the Worker — nothing to configure
+
+An Access policy attached to the **Worker** protects every hostname that Worker answers on at once: custom domains, routes, `workers.dev`, and preview URLs. Cloudflare then hands the Worker the caller's identity directly on the execution context, and the runtime forwards that context to `resolveIdentity`.
 
 ```ts
 import { createAccessResolver } from "@lunora/cloudflare-access";
@@ -22,22 +28,63 @@ import { defineApp } from "./_generated/server";
 
 export default defineApp<Env>()
     .shard((env) => env.SHARD)
-    .extend((env) => ({
-        resolveIdentity: createAccessResolver({
-            teamDomain: env.CF_ACCESS_TEAM_DOMAIN, // "acme" | "acme.cloudflareaccess.com"
-            aud: env.CF_ACCESS_AUD, // the Access application's AUD tag
-        }),
+    .access() // no team domain, no AUD tag, no JWKS fetch
+    .build();
+```
+
+Nothing is verified on this path because nothing can be forged: the platform authenticated the caller before your code ran, and the identity is absent unless it did. No JWKS round-trip and no audience to get wrong.
+
+### A hostname-scoped Access application — verify the JWT
+
+An Access application scoped to a hostname does **not** populate the execution context. It stamps a signed `Cf-Access-Jwt-Assertion` header (and a `CF_Authorization` cookie on browser navigations) instead, which the resolver verifies against your team's JWKS. Pass `teamDomain` + `aud`:
+
+```ts
+export default defineApp<Env>()
+    .shard((env) => env.SHARD)
+    .access((env) => ({
+        teamDomain: env.CF_ACCESS_TEAM_DOMAIN, // "acme" | "acme.cloudflareaccess.com"
+        aud: env.CF_ACCESS_AUD, // the Access application's AUD tag
     }))
     .build();
 ```
 
-The resolver is **fail-closed → anonymous**: a missing or invalid token resolves to `null`, the request proceeds unauthenticated, and RLS denies. The verified `exp` is forwarded so live WebSocket subscriptions expire with the credential.
+> `teamDomain` and `aud` are **all-or-nothing**, and construction throws when only one is present. `aud` is the only claim that scopes a token to _your_ Access application — a token minted for any other app in the same Cloudflare team shares the issuer and JWKS — so an unset `env.CF_ACCESS_AUD` must fail loudly rather than quietly disabling the check. Omitting both is the legal "Worker-scoped policy" mode above.
 
-> `aud` is mandatory. It is the only claim that scopes a token to _your_ Access application: a token minted for any other app in the same Cloudflare team shares the issuer and JWKS. Verification **refuses to run** (throws, then fails closed to anonymous) when `aud` is missing or empty, so an unset `env.CF_ACCESS_AUD` degrades safely instead of silently accepting cross-app tokens.
+Either way the resolver is **fail-closed → anonymous**: no identity, or a token that fails verification, resolves to `null`, the request proceeds unauthenticated, and RLS denies. `exp` is forwarded when present so live WebSocket subscriptions expire with the credential.
+
+Both paths produce the same claim shape, so nothing downstream — `ctx.auth`, `ctx.access`, `accessRoles()`, your RLS policies — branches on how the caller was authenticated. The one wire difference is group membership, which the platform may emit as `{ id, name }` objects; those are normalized to their names to match the JWT's `string[]`.
+
+### Testing locally
+
+`wrangler dev` (and the Vite plugin) simulate a Worker-scoped Access identity from a `wrangler.jsonc` block, which reaches `ctx.auth` and `ctx.access` exactly like the deployed identity does:
+
+```jsonc
+{
+    "access": {
+        "dev": {
+            "aud": "my-app",
+            "identity": { "email": "admin@example.com" },
+        },
+    },
+}
+```
+
+It affects local runs only — production behaviour comes from the policy you attached in the dashboard.
+
+### Wiring by hand
+
+`.access()` is the generated builder's method. To wire the resolver onto a worker you compose yourself, use the `extend` escape hatch (in your worker entry, e.g. `_generated/server` is consumed by `lunora/server.ts`):
+
+```ts
+export default defineApp<Env>()
+    .shard((env) => env.SHARD)
+    .extend(() => ({ resolveIdentity: createAccessResolver() }))
+    .build();
+```
 
 ## Composing with `@lunora/auth`
 
-When you also run `@lunora/auth`, both want the `resolveIdentity` hook, and a bare `extend` would clobber the better-auth resolver (extend merges _over_ the derived options). Compose them so Access wins when its JWT is present and everyone else falls through to the app session:
+When you also run `@lunora/auth`, both want the `resolveIdentity` hook, and a bare `extend` would clobber the better-auth resolver (extend merges _over_ the derived options). Compose them so Access wins when it authenticated the caller and everyone else falls through to the app session:
 
 ```ts
 import { composeResolvers, createAccessResolver } from "@lunora/cloudflare-access";
@@ -46,7 +93,7 @@ export default defineApp<Env>()
     .auth({ d1: (env) => env.DB, options: authOptions })
     .extend((env, derived) => ({
         resolveIdentity: composeResolvers(
-            createAccessResolver({ teamDomain: env.CF_ACCESS_TEAM_DOMAIN, aud: env.CF_ACCESS_AUD }),
+            createAccessResolver(),
             derived.resolveIdentity, // the better-auth resolver the .auth() call wired
         ),
     }))
@@ -57,7 +104,7 @@ export default defineApp<Env>()
 
 ## Claims on `ctx.auth`
 
-`userId` is derived from `sub` (SSO) or `common_name` (service tokens). The verified claims (`email`, `groups`, `commonName`, and the full raw set under `access`) are available via `ctx.auth.getIdentity()`, so RLS policies can branch on them:
+`userId` is derived from `sub` (SSO), then Cloudflare's `user_uuid`, then `email`, then `common_name` (service tokens, whose `sub` is empty). The verified claims (`email`, `groups`, `commonName`, and the full raw set under `access`) are available via `ctx.auth.getIdentity()`, so RLS policies can branch on them:
 
 ```ts
 definePolicy({
@@ -126,7 +173,7 @@ Either way, an anonymous request gets the anonymous facade (`authenticated: fals
 
 ## Gating the Studio behind Access
 
-`@lunora/cloudflare-access/admin` ships `accessAdminGate()`, which builds a value for the runtime's `WorkerOptions.adminGate`, an async authorization gate for the `/_lunora/admin/*` plane (the Studio's HTTP + WebSocket endpoints), OR-ed with the static `adminToken` bearer. It verifies the request's Access JWT and applies your `isAdmin(claims)` predicate, so a verified Access identity in the right group can reach the Studio without a shared token. It is fail-closed: no token, a token that fails verification, or an `isAdmin` returning `false` all deny (the bearer stays the only other path). It runs only on admin routes, never on the RPC/WebSocket data path.
+`@lunora/cloudflare-access/admin` ships `accessAdminGate()`, which builds a value for the runtime's `WorkerOptions.adminGate`, an async authorization gate for the `/_lunora/admin/*` plane (the Studio's HTTP + WebSocket endpoints), OR-ed with the static `adminToken` bearer. It authenticates the caller the same two ways the resolver does and applies your `isAdmin(claims)` predicate, so an Access identity in the right group can reach the Studio without a shared token. It is fail-closed: no identity, a token that fails verification, or an `isAdmin` returning `false` all deny (the bearer stays the only other path). It runs only on admin routes, never on the RPC/WebSocket data path.
 
 Wire it on the generated app builder via `.extend((env) => …)`:
 
@@ -136,6 +183,7 @@ import { accessAdminGate } from "@lunora/cloudflare-access/admin";
 export default defineApp()
     .extend((env) => ({
         adminGate: accessAdminGate({
+            // Omit teamDomain/aud when the Access policy is attached to the Worker.
             teamDomain: env.CF_ACCESS_TEAM_DOMAIN,
             aud: env.CF_ACCESS_ADMIN_AUD, // a dedicated Access app over /_lunora/admin
             isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
@@ -146,7 +194,7 @@ export default defineApp()
 
 ## API
 
-- `createAccessResolver(options)`: a `resolveIdentity` adapter (header + cookie, verify, map).
+- `createAccessResolver(options?)`: a `resolveIdentity` adapter — reads the platform-supplied identity when the Access policy is attached to the Worker, otherwise verifies the header/cookie JWT (`teamDomain` + `aud`, required together).
 - `composeResolvers(...resolvers)`: first non-null identity wins.
 - `verifyAccessJwt(token, options)`: low-level; verify a token, return its claims (throws on failure).
 - `accessIssuer(teamDomain)`: normalize a team domain to its canonical issuer URL.
@@ -154,4 +202,4 @@ export default defineApp()
 - `accessContext()` _(`@lunora/cloudflare-access/context`)_: the explicit per-procedure middleware form of the same `ctx.access` facade.
 - `accessFacade(identity, userId)` _(`@lunora/cloudflare-access/context`)_: the pure factory both forms build on; returns the anonymous facade when no identity is present.
 - `accessRoles(options)` _(`@lunora/cloudflare-access/roles`)_: middleware mapping the verified `groups` claim into `ctx.auth.roles` for RLS.
-- `accessAdminGate(options)` _(`@lunora/cloudflare-access/admin`)_: a `WorkerOptions.adminGate` that authorizes the `/_lunora/admin/*` plane from a verified Access identity.
+- `accessAdminGate(options)` _(`@lunora/cloudflare-access/admin`)_: a `WorkerOptions.adminGate` that authorizes the `/_lunora/admin/*` plane from a verified Access identity. `isAdmin` is required; the JWT config is optional on the same all-or-nothing rule.

--- a/packages/cloudflare-access/src/admin.ts
+++ b/packages/cloudflare-access/src/admin.ts
@@ -1,5 +1,5 @@
 import type { ExecutionContextLike } from "../../../shared/execution-context";
-import readNativeIdentity from "./native";
+import readPlatformIdentity from "./platform-identity";
 import type { AccessClaims, AccessJwtFallbackOptions } from "./types";
 import { assertJwtFallbackOptions, verifyRequest } from "./verify";
 
@@ -22,11 +22,24 @@ interface AccessAdminGateOptions extends AccessJwtFallbackOptions {
  * instead of — the static admin bearer, so the Studio can sit behind Cloudflare
  * Access.
  *
- * It authenticates the same two ways `createAccessResolver` does, platform
- * identity first: `context.access` when the Access policy is attached to the
- * Worker (nothing to configure, nothing to verify), otherwise the request's
- * `Cf-Access-Jwt-Assertion` JWT against your team JWKS (`teamDomain` + `aud`,
- * required together, for hostname-scoped Access applications).
+ * It accepts exactly one proof, and **which one is your choice, not the
+ * platform's**:
+ *
+ * - Configure `teamDomain` + `aud` and the request's `Cf-Access-Jwt-Assertion`
+ * JWT is the only thing accepted. This is the stricter setup, and the point of
+ * the `aud`: it proves the caller came through the *specific* Access application
+ * you put in front of `/_lunora/admin`, not merely through some application in
+ * the same Cloudflare team.
+ * - Configure neither and the Worker's own Access identity (`context.access`) is
+ * accepted, for a deployment whose Access policy is attached to the Worker.
+ *
+ * Note this is the **opposite** precedence to `createAccessResolver`, which
+ * prefers the platform identity. That is deliberate. A policy attached to the
+ * Worker is typically broad — "anyone at the company", covering every route and
+ * preview URL — while a configured admin `aud` is deliberately narrow. Letting
+ * the broad one satisfy a gate you scoped with the narrow one would widen the
+ * admin plane to everyone the Worker policy admits, silently, the moment that
+ * policy was attached.
  *
  * It is **fail-closed**: no identity, a token that fails verification, or an
  * `isAdmin` that returns `false` all resolve to `false` (the bearer remains the
@@ -36,28 +49,29 @@ interface AccessAdminGateOptions extends AccessJwtFallbackOptions {
  * every admin route.
  *
  * ```ts
- * // Access policy attached to the Worker.
- * options.adminGate = accessAdminGate({
- *     isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
- * });
- *
- * // Hostname-scoped Access application over /_lunora/admin.
+ * // A dedicated Access application over /_lunora/admin — the JWT is the only proof.
  * options.adminGate = accessAdminGate({
  *     teamDomain: env.CF_ACCESS_TEAM_DOMAIN,
  *     aud: env.CF_ACCESS_ADMIN_AUD,
  *     isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
  * });
+ *
+ * // Access policy attached to the Worker — `isAdmin` is the whole boundary, so
+ * // make it at least as strict as a dedicated admin application would have been.
+ * options.adminGate = accessAdminGate({
+ *     isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
+ * });
  * ```
  */
 const accessAdminGate = (options: AccessAdminGateOptions): ((request: Request, context?: ExecutionContextLike) => Promise<boolean>) => {
-    // Validate the static config eagerly so a half-configured deployment (an unset
-    // teamDomain or aud) fails fast here at wiring time instead of denying every
-    // admin request with no signal. `undefined` means "no JWT fallback", a legal
-    // mode when the Worker itself is Access-protected.
+    // Validate the static config eagerly so a half-configured deployment fails
+    // fast here at wiring time instead of denying every admin request with no
+    // signal. `undefined` means "no JWT configured", which selects the platform
+    // identity below rather than adding a fallback to it.
     const jwtOptions = assertJwtFallbackOptions(options);
 
     return async (request: Request, context?: ExecutionContextLike): Promise<boolean> => {
-        const claims = (await readNativeIdentity(context)) ?? (jwtOptions === undefined ? undefined : await verifyRequest(request, jwtOptions));
+        const claims = jwtOptions === undefined ? await readPlatformIdentity(context) : await verifyRequest(request, jwtOptions);
 
         return claims === undefined ? false : options.isAdmin(claims);
     };

--- a/packages/cloudflare-access/src/admin.ts
+++ b/packages/cloudflare-access/src/admin.ts
@@ -1,32 +1,47 @@
-import type { AccessClaims, RequestVerifyOptions } from "./types";
-import { assertVerifyOptions, verifyRequest } from "./verify";
+import type { ExecutionContextLike } from "../../../shared/execution-context";
+import readNativeIdentity from "./native";
+import type { AccessClaims, AccessJwtFallbackOptions } from "./types";
+import { assertJwtFallbackOptions, verifyRequest } from "./verify";
 
-/** Options for {@link accessAdminGate}; extends {@link RequestVerifyOptions}. */
-interface AccessAdminGateOptions extends RequestVerifyOptions {
+/** Options for {@link accessAdminGate}; extends {@link AccessJwtFallbackOptions}. */
+interface AccessAdminGateOptions extends AccessJwtFallbackOptions {
     /**
      * Decide whether the **verified** claims authorize the Studio/admin plane —
      * e.g. `(claims) => claims.groups?.includes("ops") ?? false` or an email-domain
      * check. Required: there is no implicit grant, so a verified-but-unprivileged
-     * identity is denied. Runs only after signature/issuer/audience/expiry pass.
+     * identity is denied. Runs only after the caller is authenticated.
      */
     isAdmin: (claims: AccessClaims) => boolean | Promise<boolean>;
 }
 
 /**
  * Build an admin gate for `@lunora/runtime`'s `WorkerOptions.adminGate`: a
- * request-only predicate that verifies the request's `Cf-Access-Jwt-Assertion`
- * JWT and applies your `isAdmin(claims)` test. When it resolves `true` the
- * request authorizes the `/_lunora/admin/*` plane (the Studio's HTTP + WS
- * endpoints) in addition to — or instead of — the static admin bearer, so the
- * Studio can sit behind Cloudflare Access.
+ * predicate that authenticates the caller through Cloudflare Access and applies
+ * your `isAdmin(claims)` test. When it resolves `true` the request authorizes the
+ * `/_lunora/admin/*` plane (the Studio's HTTP + WS endpoints) in addition to — or
+ * instead of — the static admin bearer, so the Studio can sit behind Cloudflare
+ * Access.
  *
- * It is **fail-closed**: a missing token, a token that fails verification, or an
+ * It authenticates the same two ways `createAccessResolver` does, platform
+ * identity first: `context.access` when the Access policy is attached to the
+ * Worker (nothing to configure, nothing to verify), otherwise the request's
+ * `Cf-Access-Jwt-Assertion` JWT against your team JWKS (`teamDomain` + `aud`,
+ * required together, for hostname-scoped Access applications).
+ *
+ * It is **fail-closed**: no identity, a token that fails verification, or an
  * `isAdmin` that returns `false` all resolve to `false` (the bearer remains the
  * only other path). Verification needs no `env` binding (static team-domain/aud
  * config + the remote JWKS over `fetch`), so the gate takes only the request and
- * the runtime can evaluate it without threading async through every admin route.
+ * its context and the runtime can evaluate it without threading async through
+ * every admin route.
  *
  * ```ts
+ * // Access policy attached to the Worker.
+ * options.adminGate = accessAdminGate({
+ *     isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
+ * });
+ *
+ * // Hostname-scoped Access application over /_lunora/admin.
  * options.adminGate = accessAdminGate({
  *     teamDomain: env.CF_ACCESS_TEAM_DOMAIN,
  *     aud: env.CF_ACCESS_ADMIN_AUD,
@@ -34,14 +49,15 @@ interface AccessAdminGateOptions extends RequestVerifyOptions {
  * });
  * ```
  */
-const accessAdminGate = (options: AccessAdminGateOptions): ((request: Request) => Promise<boolean>) => {
-    // Validate the static config eagerly so a broken deployment (unset teamDomain
-    // or aud) fails fast here at wiring time instead of denying every admin
-    // request with no signal.
-    assertVerifyOptions(options);
+const accessAdminGate = (options: AccessAdminGateOptions): ((request: Request, context?: ExecutionContextLike) => Promise<boolean>) => {
+    // Validate the static config eagerly so a half-configured deployment (an unset
+    // teamDomain or aud) fails fast here at wiring time instead of denying every
+    // admin request with no signal. `undefined` means "no JWT fallback", a legal
+    // mode when the Worker itself is Access-protected.
+    const jwtOptions = assertJwtFallbackOptions(options);
 
-    return async (request: Request): Promise<boolean> => {
-        const claims = await verifyRequest(request, options);
+    return async (request: Request, context?: ExecutionContextLike): Promise<boolean> => {
+        const claims = (await readNativeIdentity(context)) ?? (jwtOptions === undefined ? undefined : await verifyRequest(request, jwtOptions));
 
         return claims === undefined ? false : options.isAdmin(claims);
     };

--- a/packages/cloudflare-access/src/index.ts
+++ b/packages/cloudflare-access/src/index.ts
@@ -1,6 +1,7 @@
 export { composeResolvers, createAccessResolver } from "./resolver";
 export type {
     AccessClaims,
+    AccessJwtFallbackOptions,
     AccessKeySet,
     CreateAccessResolverOptions,
     ResolvedAccessIdentity,

--- a/packages/cloudflare-access/src/native.ts
+++ b/packages/cloudflare-access/src/native.ts
@@ -1,0 +1,86 @@
+import type { AccessContextLike, AccessIdentityLike, ExecutionContextLike } from "../../../shared/execution-context";
+import type { AccessClaims } from "./types";
+
+/**
+ * Read one group entry's name. Access emits group membership either as plain
+ * names or as `{ id, name }` objects depending on the identity provider and the
+ * policy; both normalize to the name, which is what an Access policy is written
+ * against and what `accessRoles()` maps into `ctx.auth.roles`. Anything else
+ * (a number, a nameless object) contributes nothing rather than stringifying
+ * into a role nobody configured.
+ */
+const groupName = (entry: unknown): string | undefined => {
+    if (typeof entry === "string") {
+        return entry.length > 0 ? entry : undefined;
+    }
+
+    if (typeof entry === "object" && entry !== null) {
+        const { name } = entry as { name?: unknown };
+
+        return typeof name === "string" && name.length > 0 ? name : undefined;
+    }
+
+    return undefined;
+};
+
+/**
+ * Normalize whatever the platform put in `groups` to the `string[]` the JWT path
+ * produces, so a policy or `accessRoles()` mapping reads the same regardless of
+ * which path authenticated the caller. A non-array (absent, or a shape we don't
+ * recognize) yields `undefined` — the claim is then simply absent, never `[]`,
+ * which would falsely assert "verified: this user is in no groups".
+ */
+const normalizeGroups = (groups: unknown): string[] | undefined =>
+    Array.isArray(groups) ? groups.map((entry) => groupName(entry)).filter((name): name is string => name !== undefined) : undefined;
+
+/**
+ * Read the identity Cloudflare Access attached to a Worker-protected request and
+ * project it onto {@link AccessClaims} — the same claim shape the
+ * `Cf-Access-Jwt-Assertion` path produces, so everything downstream (identity
+ * mapping, `ctx.access`, `accessRoles()`, RLS policies) is indifferent to which
+ * path authenticated the caller.
+ *
+ * Returns `undefined` when Access did not authenticate this request (`ctx.access`
+ * is absent), when the host supplied no `ExecutionContext` at all, or when
+ * `getIdentity()` yields nothing usable — the same fail-closed "no Access
+ * identity" signal `verifyRequest` returns, so callers treat the two uniformly.
+ *
+ * Nothing is verified here, and nothing needs to be: the platform authenticated
+ * the caller before the Worker ran and the identity arrives out-of-band, not on
+ * the request. There is no token to check a signature or audience against, and
+ * no header a caller could forge to manufacture one — `context.access` simply
+ * does not exist unless Access authorized the call.
+ */
+const readNativeIdentity = async (context: ExecutionContextLike | undefined): Promise<AccessClaims | undefined> => {
+    const access: AccessContextLike | undefined = context?.access;
+
+    if (access === undefined) {
+        return undefined;
+    }
+
+    let identity: AccessIdentityLike | null | undefined;
+
+    try {
+        identity = await access.getIdentity();
+    } catch {
+        // Fail closed to anonymous, matching the JWT path: a platform read that
+        // throws must not 500 the request, and must not be mistaken for an
+        // authenticated caller.
+        return undefined;
+    }
+
+    if (identity === null || typeof identity !== "object") {
+        return undefined;
+    }
+
+    // `groups` is the one field whose wire shape differs between the two paths,
+    // so it is lifted out and re-added normalized; every other field passes
+    // through verbatim (Cloudflare may add more, and dropping them would make
+    // `ctx.access.claims` a lossy view of an identity we do not own).
+    const { groups, ...rest } = identity;
+    const names = normalizeGroups(groups);
+
+    return names === undefined ? rest : { ...rest, groups: names };
+};
+
+export default readNativeIdentity;

--- a/packages/cloudflare-access/src/platform-identity.ts
+++ b/packages/cloudflare-access/src/platform-identity.ts
@@ -51,7 +51,7 @@ const normalizeGroups = (groups: unknown): string[] | undefined =>
  * no header a caller could forge to manufacture one — `context.access` simply
  * does not exist unless Access authorized the call.
  */
-const readNativeIdentity = async (context: ExecutionContextLike | undefined): Promise<AccessClaims | undefined> => {
+const readPlatformIdentity = async (context: ExecutionContextLike | undefined): Promise<AccessClaims | undefined> => {
     const access: AccessContextLike | undefined = context?.access;
 
     if (access === undefined) {
@@ -83,4 +83,4 @@ const readNativeIdentity = async (context: ExecutionContextLike | undefined): Pr
     return names === undefined ? rest : { ...rest, groups: names };
 };
 
-export default readNativeIdentity;
+export default readPlatformIdentity;

--- a/packages/cloudflare-access/src/resolver.ts
+++ b/packages/cloudflare-access/src/resolver.ts
@@ -1,5 +1,7 @@
+import type { ExecutionContextLike } from "../../../shared/execution-context";
+import readNativeIdentity from "./native";
 import type { AccessClaims, CreateAccessResolverOptions, ResolvedAccessIdentity, ResolvedIdentityLike, ResolveIdentityFunction } from "./types";
-import { assertVerifyOptions, verifyRequest } from "./verify";
+import { assertJwtFallbackOptions, verifyRequest } from "./verify";
 
 /**
  * The "anonymous" identity. `null` is the runtime's `resolveIdentity` contract
@@ -21,11 +23,17 @@ const nonEmpty = (value: unknown): string | undefined => (typeof value === "stri
 
 /**
  * Derive the stable caller id from verified claims: the IdP `sub` for SSO users,
- * falling back to `email`, then `common_name` for service tokens (whose `sub` is
- * empty). Returns `undefined` when none is present — the resolver treats that as
- * anonymous rather than minting an identity with no id.
+ * then Cloudflare's `user_uuid` (present on the platform-supplied identity, never
+ * on the JWT), then `email`, then `common_name` for service tokens (whose `sub`
+ * is empty). Returns `undefined` when none is present — the resolver treats that
+ * as anonymous rather than minting an identity with no id.
+ *
+ * `user_uuid` sits ahead of `email` because it is the stable id: an address can
+ * be reassigned within an organization, which would silently hand the new holder
+ * the old one's rows.
  */
-const deriveUserId = (claims: AccessClaims): string | undefined => nonEmpty(claims.sub) ?? nonEmpty(claims.email) ?? nonEmpty(claims.common_name);
+const deriveUserId = (claims: AccessClaims): string | undefined =>
+    nonEmpty(claims.sub) ?? nonEmpty(claims.user_uuid) ?? nonEmpty(claims.email) ?? nonEmpty(claims.common_name);
 
 /**
  * Build the resolved identity from verified claims. Promotes the common Access
@@ -52,36 +60,58 @@ const toIdentity = (claims: AccessClaims, mapClaims?: CreateAccessResolverOption
 };
 
 /**
- * Create a `resolveIdentity` adapter for Cloudflare Access. The returned
- * function reads the Access JWT off the request, verifies it (`verifyAccessJwt`),
- * and maps the claims onto the identity shape `@lunora/runtime` expects — so a
- * verified Access user/service-token becomes `ctx.auth` for every
- * query/mutation/action (and feeds RLS) with no further wiring.
+ * Create a `resolveIdentity` adapter for Cloudflare Access, so a verified Access
+ * user or service token becomes `ctx.auth` for every query/mutation/action (and
+ * feeds RLS) with no further wiring.
  *
- * Behaviour is **fail-closed → anonymous**: a missing token, or a token that
- * fails verification, resolves to `null` (the request proceeds unauthenticated
- * and RLS denies). Use {@link CreateAccessResolverOptions.onError} to observe
- * verification failures.
+ * It authenticates from whichever of the two Access shapes the deployment uses,
+ * **platform identity first**:
+ *
+ * 1. `context.access` — the identity Cloudflare attaches when the Access policy
+ * is attached to the **Worker** (covering its custom domains, routes,
+ * `workers.dev`, and preview URLs at once). Nothing is verified because nothing
+ * can be forged: the platform authenticated the caller before the Worker ran,
+ * and the field is absent unless it did. No JWKS fetch, no `aud` to get wrong.
+ * This is also what `wrangler.jsonc`'s `access.dev` block simulates, so a
+ * locally-simulated identity reaches `ctx.auth` too.
+ * 2. The `Cf-Access-Jwt-Assertion` header (or `CF_Authorization` cookie),
+ * verified against your team JWKS. Needed for **hostname-scoped** Access
+ * applications, which do not populate `context.access`. Configured by passing
+ * `teamDomain` + `aud`; omit both (or pass no options at all) to run
+ * platform-identity-only.
+ *
+ * Behaviour is **fail-closed → anonymous** on both paths: no identity, or a token
+ * that fails verification, resolves to `null` (the request proceeds
+ * unauthenticated and RLS denies). Use {@link CreateAccessResolverOptions.onError}
+ * to observe verification failures.
  *
  * Wire it in your worker entry:
  *
  * ```ts
+ * // Access policy attached to the Worker — nothing to configure.
+ * options.resolveIdentity = createAccessResolver();
+ *
+ * // Hostname-scoped Access application — JWT verification config required.
  * options.resolveIdentity = createAccessResolver({
  *     teamDomain: env.CF_ACCESS_TEAM_DOMAIN, // "acme" | "acme.cloudflareaccess.com"
  *     aud: env.CF_ACCESS_AUD,                // the Access app's AUD tag
  * });
  * ```
  */
-export const createAccessResolver = (options: CreateAccessResolverOptions): ResolveIdentityFunction => {
-    // Validate the static config eagerly so a broken deployment (unset teamDomain
-    // or aud) fails fast here at wiring time instead of degrading to
-    // silent-anonymous — and thus RLS-denied — on every request with no signal.
-    assertVerifyOptions(options);
+export const createAccessResolver = (options?: CreateAccessResolverOptions): ResolveIdentityFunction => {
+    // Validate the static config eagerly so a half-configured deployment (an
+    // unset teamDomain or aud) fails fast here at wiring time instead of
+    // degrading to silent-anonymous — and thus RLS-denied — on every request with
+    // no signal. `undefined` means "no JWT fallback", a legal mode, not a miss.
+    const jwtOptions = assertJwtFallbackOptions(options);
 
-    return async (request: Request): Promise<ResolvedAccessIdentity | null> => {
-        const claims = await verifyRequest(request, options);
+    return async (request: Request, _env?: unknown, context?: ExecutionContextLike): Promise<ResolvedAccessIdentity | null> => {
+        // Platform identity wins when present: it is the stronger of the two
+        // (authenticated by the edge, unforgeable, nothing to re-verify), and on a
+        // Worker-scoped Access deployment it is the only one that exists.
+        const claims = (await readNativeIdentity(context)) ?? (jwtOptions === undefined ? undefined : await verifyRequest(request, jwtOptions));
 
-        return claims === undefined ? ANONYMOUS : toIdentity(claims, options.mapClaims);
+        return claims === undefined ? ANONYMOUS : toIdentity(claims, options?.mapClaims);
     };
 };
 
@@ -95,10 +125,10 @@ export const createAccessResolver = (options: CreateAccessResolverOptions): Reso
  */
 export const composeResolvers =
     (...resolvers: ResolveIdentityFunction[]): ResolveIdentityFunction =>
-    async (request: Request, env?: unknown): Promise<ResolvedIdentityLike | null> => {
+    async (request: Request, env?: unknown, context?: ExecutionContextLike): Promise<ResolvedIdentityLike | null> => {
         for (const resolve of resolvers) {
             // eslint-disable-next-line no-await-in-loop -- ordered fallback: each resolver may early-return, so they cannot run concurrently
-            const identity = await resolve(request, env);
+            const identity = await resolve(request, env, context);
 
             if (identity) {
                 return identity;

--- a/packages/cloudflare-access/src/resolver.ts
+++ b/packages/cloudflare-access/src/resolver.ts
@@ -1,5 +1,5 @@
 import type { ExecutionContextLike } from "../../../shared/execution-context";
-import readNativeIdentity from "./native";
+import readPlatformIdentity from "./platform-identity";
 import type { AccessClaims, CreateAccessResolverOptions, ResolvedAccessIdentity, ResolvedIdentityLike, ResolveIdentityFunction } from "./types";
 import { assertJwtFallbackOptions, verifyRequest } from "./verify";
 
@@ -23,17 +23,19 @@ const nonEmpty = (value: unknown): string | undefined => (typeof value === "stri
 
 /**
  * Derive the stable caller id from verified claims: the IdP `sub` for SSO users,
- * then Cloudflare's `user_uuid` (present on the platform-supplied identity, never
- * on the JWT), then `email`, then `common_name` for service tokens (whose `sub`
- * is empty). Returns `undefined` when none is present — the resolver treats that
- * as anonymous rather than minting an identity with no id.
+ * falling back to `email`, then `common_name` for service tokens (whose `sub` is
+ * empty). Returns `undefined` when none is present — the resolver treats that as
+ * anonymous rather than minting an identity with no id.
  *
- * `user_uuid` sits ahead of `email` because it is the stable id: an address can
- * be reassigned within an organization, which would silently hand the new holder
- * the old one's rows.
+ * Deliberately identical for both authentication paths, and deliberately does NOT
+ * consider `user_uuid` even though the platform-supplied identity carries one:
+ * `userId` is the ownership key RLS and `serverDefault` columns are stamped with,
+ * so a deployment that moves from a hostname-scoped Access application to a
+ * Worker-scoped policy must keep resolving each user to the same id. Preferring a
+ * field only one path emits would silently re-key every user on that switch,
+ * orphaning their existing rows behind RLS.
  */
-const deriveUserId = (claims: AccessClaims): string | undefined =>
-    nonEmpty(claims.sub) ?? nonEmpty(claims.user_uuid) ?? nonEmpty(claims.email) ?? nonEmpty(claims.common_name);
+const deriveUserId = (claims: AccessClaims): string | undefined => nonEmpty(claims.sub) ?? nonEmpty(claims.email) ?? nonEmpty(claims.common_name);
 
 /**
  * Build the resolved identity from verified claims. Promotes the common Access
@@ -99,17 +101,19 @@ const toIdentity = (claims: AccessClaims, mapClaims?: CreateAccessResolverOption
  * ```
  */
 export const createAccessResolver = (options?: CreateAccessResolverOptions): ResolveIdentityFunction => {
-    // Validate the static config eagerly so a half-configured deployment (an
-    // unset teamDomain or aud) fails fast here at wiring time instead of
-    // degrading to silent-anonymous — and thus RLS-denied — on every request with
-    // no signal. `undefined` means "no JWT fallback", a legal mode, not a miss.
+    // Validate the static config eagerly so a half-configured deployment (an unset
+    // CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD) fails fast here at wiring time
+    // instead of degrading to silent-anonymous — and thus RLS-denied — on every
+    // request with no signal. `undefined` means "no JWT fallback", which is a
+    // legal mode only when the caller named neither option.
     const jwtOptions = assertJwtFallbackOptions(options);
 
     return async (request: Request, _env?: unknown, context?: ExecutionContextLike): Promise<ResolvedAccessIdentity | null> => {
         // Platform identity wins when present: it is the stronger of the two
         // (authenticated by the edge, unforgeable, nothing to re-verify), and on a
-        // Worker-scoped Access deployment it is the only one that exists.
-        const claims = (await readNativeIdentity(context)) ?? (jwtOptions === undefined ? undefined : await verifyRequest(request, jwtOptions));
+        // Worker-scoped Access deployment it is the only one that exists. Both
+        // paths fail closed to `undefined`.
+        const claims = (await readPlatformIdentity(context)) ?? (jwtOptions === undefined ? undefined : await verifyRequest(request, jwtOptions));
 
         return claims === undefined ? ANONYMOUS : toIdentity(claims, options?.mapClaims);
     };

--- a/packages/cloudflare-access/src/types.ts
+++ b/packages/cloudflare-access/src/types.ts
@@ -1,7 +1,13 @@
 import type { JWTPayload, JWTVerifyGetKey, KeyObject } from "jose";
 
+import type { ExecutionContextLike } from "../../../shared/execution-context";
+
 /**
- * The claims Cloudflare Access mints into the `Cf-Access-Jwt-Assertion` JWT.
+ * The verified claims of a Cloudflare Access caller — from the
+ * `Cf-Access-Jwt-Assertion` JWT (hostname-scoped Access applications) or from the
+ * platform-supplied `ctx.access.getIdentity()` (Access policies attached to the
+ * Worker). Both paths produce this one shape, so nothing downstream branches on
+ * how the caller was authenticated.
  *
  * Extends the standard `JWTPayload` (`iss`/`aud`/`sub`/`exp`/`iat`/…) with the
  * Access-specific fields. Which optional fields are present depends on the
@@ -10,7 +16,7 @@ import type { JWTPayload, JWTVerifyGetKey, KeyObject } from "jose";
  * Service tokens carry `common_name` and an empty `sub`; there is no `email`.
  *
  * Cloudflare may add further custom claims — they pass through verbatim via the
- * index signature so the claims stay a faithful view of the token.
+ * index signature so the claims stay a faithful view of the identity.
  */
 export interface AccessClaims extends JWTPayload {
     /** Service-token name. Present for non-interactive (machine) callers instead of `email`. */
@@ -23,8 +29,12 @@ export interface AccessClaims extends JWTPayload {
     groups?: string[];
     /** Per-session nonce Cloudflare rotates on re-authentication. */
     identity_nonce?: string;
+    /** Display name from the identity provider. Populated on the platform-supplied identity, not on the JWT. */
+    name?: string;
     /** Token kind, e.g. `"app"`. */
     type?: string;
+    /** Cloudflare's per-user UUID. Populated on the platform-supplied identity, not on the JWT. */
+    user_uuid?: string;
 }
 
 /**
@@ -127,8 +137,38 @@ export interface RequestVerifyOptions extends VerifyAccessJwtOptions {
     onError?: (error: unknown, request: Request) => void;
 }
 
-/** Options for `createAccessResolver`; extends {@link RequestVerifyOptions}. */
-export interface CreateAccessResolverOptions extends RequestVerifyOptions {
+/**
+ * {@link RequestVerifyOptions} with the JWT-verification config made optional,
+ * for the primitives that can also authenticate off the platform-supplied
+ * identity (`ctx.access`) and therefore may legitimately be given no JWT config
+ * at all.
+ *
+ * The two fields are **all-or-nothing**: supply both to enable the
+ * `Cf-Access-Jwt-Assertion` fallback (needed for hostname-scoped Access
+ * applications, which do not populate `ctx.access`), or neither to run
+ * platform-identity-only. Supplying exactly one throws at construction — that is
+ * always a misconfiguration (classically an unset `env.CF_ACCESS_AUD`), and
+ * silently degrading it to "no JWT fallback" would turn a broken deployment into
+ * a quietly anonymous one.
+ */
+export interface AccessJwtFallbackOptions extends Omit<RequestVerifyOptions, "aud" | "teamDomain"> {
+    /**
+     * The Access application **AUD tag(s)**. Required together with `teamDomain`
+     * to enable JWT verification; omit both to authenticate only off the
+     * platform-supplied identity.
+     */
+    aud?: string | string[];
+
+    /**
+     * Your Cloudflare Access team domain. Required together with `aud` to enable
+     * JWT verification; omit both to authenticate only off the platform-supplied
+     * identity.
+     */
+    teamDomain?: string;
+}
+
+/** Options for `createAccessResolver`; extends {@link AccessJwtFallbackOptions}. */
+export interface CreateAccessResolverOptions extends AccessJwtFallbackOptions {
     /**
      * Remap verified claims into the resolved identity. Return an object to
      * shallow-merge over the defaults; return a `userId` to override the derived
@@ -141,5 +181,14 @@ export interface CreateAccessResolverOptions extends RequestVerifyOptions {
  * A `resolveIdentity`-shaped function: maps an inbound request to a verified
  * identity (or `null` for anonymous). Assignable to `@lunora/runtime`'s
  * `WorkerOptions.resolveIdentity`.
+ *
+ * The third argument is the request's `ExecutionContext`, which the runtime
+ * forwards so a resolver can read the identity Cloudflare Access attaches to a
+ * Worker-protected request (`context.access`). It is `undefined` on paths that
+ * have no context to give, so a resolver must handle its absence.
  */
-export type ResolveIdentityFunction = (request: Request, env?: unknown) => (ResolvedIdentityLike | null) | Promise<ResolvedIdentityLike | null>;
+export type ResolveIdentityFunction = (
+    request: Request,
+    env?: unknown,
+    context?: ExecutionContextLike,
+) => (ResolvedIdentityLike | null) | Promise<ResolvedIdentityLike | null>;

--- a/packages/cloudflare-access/src/types.ts
+++ b/packages/cloudflare-access/src/types.ts
@@ -33,7 +33,7 @@ export interface AccessClaims extends JWTPayload {
     name?: string;
     /** Token kind, e.g. `"app"`. */
     type?: string;
-    /** Cloudflare's per-user UUID. Populated on the platform-supplied identity, not on the JWT. */
+    /** Cloudflare's per-user UUID. Populated on the platform-supplied identity, not on the JWT — so `userId` is deliberately never derived from it. */
     user_uuid?: string;
 }
 

--- a/packages/cloudflare-access/src/verify.ts
+++ b/packages/cloudflare-access/src/verify.ts
@@ -107,6 +107,46 @@ const assertVerifyOptions = (options: VerifyAccessJwtOptions): void => {
 };
 
 /**
+ * Resolve the optional JWT-verification half of a primitive's config, for the
+ * primitives that can also authenticate off the platform-supplied `ctx.access`
+ * identity and therefore may legitimately be handed no JWT config at all.
+ *
+ * Returns the options narrowed to a fully-configured verify config when both
+ * `teamDomain` and `aud` are present, `undefined` when both are absent (run
+ * platform-identity-only, with no `Cf-Access-Jwt-Assertion` fallback), and
+ * throws when exactly one is present.
+ *
+ * The all-or-nothing rule is what keeps "no JWT config" an explicit choice
+ * rather than an accident: a half-configured deployment (classically an unset
+ * `env.CF_ACCESS_AUD`, whose `aud` is then `undefined`) is a misconfiguration
+ * that used to fail fast, and must keep failing fast now that a missing config
+ * is otherwise a legal mode — degrading it to "no fallback" would turn a broken
+ * deployment into a silently anonymous one on every hostname-scoped request.
+ */
+const assertJwtFallbackOptions = <T extends Partial<VerifyAccessJwtOptions>>(options: T | undefined): (T & VerifyAccessJwtOptions) | undefined => {
+    if (options === undefined) {
+        return undefined;
+    }
+
+    const { aud, teamDomain } = options;
+
+    if (aud === undefined && teamDomain === undefined) {
+        return undefined;
+    }
+
+    if (aud === undefined || teamDomain === undefined) {
+        throw new LunoraError(
+            "INTERNAL",
+            "@lunora/cloudflare-access: `teamDomain` and `aud` must be configured together — supply both to verify the Cf-Access-Jwt-Assertion JWT, or neither to authenticate only off the Worker's Cloudflare Access identity",
+        );
+    }
+
+    assertVerifyOptions({ ...options, aud, teamDomain });
+
+    return options as T & VerifyAccessJwtOptions;
+};
+
+/**
  * Verify a Cloudflare Access JWT and return its claims.
  *
  * Enforces, in one shot: RS256 signature against the team JWKS, `iss` equal to
@@ -180,4 +220,4 @@ const verifyRequest = async (request: Request, options: RequestVerifyOptions): P
     }
 };
 
-export { accessIssuer, assertVerifyOptions, verifyAccessJwt, verifyRequest };
+export { accessIssuer, assertJwtFallbackOptions, assertVerifyOptions, verifyAccessJwt, verifyRequest };

--- a/packages/cloudflare-access/src/verify.ts
+++ b/packages/cloudflare-access/src/verify.ts
@@ -3,7 +3,7 @@ import type { JWTVerifyGetKey } from "jose";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
 import { DEFAULT_COOKIE, DEFAULT_HEADER, readToken } from "./read-token";
-import type { AccessClaims, RequestVerifyOptions, VerifyAccessJwtOptions } from "./types";
+import type { AccessClaims, AccessJwtFallbackOptions, RequestVerifyOptions, VerifyAccessJwtOptions } from "./types";
 
 /** Cloudflare Access publishes its signing keys at this path under the team domain. */
 const CERTS_PATH = "/cdn-cgi/access/certs";
@@ -111,39 +111,44 @@ const assertVerifyOptions = (options: VerifyAccessJwtOptions): void => {
  * primitives that can also authenticate off the platform-supplied `ctx.access`
  * identity and therefore may legitimately be handed no JWT config at all.
  *
- * Returns the options narrowed to a fully-configured verify config when both
- * `teamDomain` and `aud` are present, `undefined` when both are absent (run
- * platform-identity-only, with no `Cf-Access-Jwt-Assertion` fallback), and
- * throws when exactly one is present.
+ * Returns a fully-configured verify config when both `teamDomain` and `aud` are
+ * supplied, `undefined` when neither key is present at all (run
+ * platform-identity-only, with no `Cf-Access-Jwt-Assertion` fallback), and throws
+ * otherwise.
  *
- * The all-or-nothing rule is what keeps "no JWT config" an explicit choice
- * rather than an accident: a half-configured deployment (classically an unset
- * `env.CF_ACCESS_AUD`, whose `aud` is then `undefined`) is a misconfiguration
- * that used to fail fast, and must keep failing fast now that a missing config
- * is otherwise a legal mode — degrading it to "no fallback" would turn a broken
- * deployment into a silently anonymous one on every hostname-scoped request.
+ * **Presence of the key is the signal, not its value.** `createAccessResolver()`
+ * and `createAccessResolver({ mapClaims })` name neither key and mean "no JWT
+ * fallback". `createAccessResolver({ teamDomain: env.CF_ACCESS_TEAM_DOMAIN, aud:
+ * env.CF_ACCESS_AUD })` names both and means "verify JWTs" — so when those
+ * secrets are unset in some environment and both values arrive `undefined`, that
+ * is a broken deployment and it throws, exactly as it did before a missing config
+ * became a legal mode. Reading the *values* instead would turn that worker into
+ * one that boots happily and resolves every caller to anonymous, with nothing in
+ * the logs pointing at Access.
  */
-const assertJwtFallbackOptions = <T extends Partial<VerifyAccessJwtOptions>>(options: T | undefined): (T & VerifyAccessJwtOptions) | undefined => {
+const assertJwtFallbackOptions = (options: AccessJwtFallbackOptions | undefined): RequestVerifyOptions | undefined => {
     if (options === undefined) {
+        return undefined;
+    }
+
+    if (!("aud" in options) && !("teamDomain" in options)) {
         return undefined;
     }
 
     const { aud, teamDomain } = options;
 
-    if (aud === undefined && teamDomain === undefined) {
-        return undefined;
-    }
-
     if (aud === undefined || teamDomain === undefined) {
         throw new LunoraError(
             "INTERNAL",
-            "@lunora/cloudflare-access: `teamDomain` and `aud` must be configured together — supply both to verify the Cf-Access-Jwt-Assertion JWT, or neither to authenticate only off the Worker's Cloudflare Access identity",
+            "@lunora/cloudflare-access: `teamDomain` and `aud` must both be set to verify the Cf-Access-Jwt-Assertion JWT (check that CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD are set in this environment) — to authenticate only off the Worker's Cloudflare Access identity, omit both options entirely",
         );
     }
 
-    assertVerifyOptions({ ...options, aud, teamDomain });
+    const verifyOptions = { ...options, aud, teamDomain };
 
-    return options as T & VerifyAccessJwtOptions;
+    assertVerifyOptions(verifyOptions);
+
+    return verifyOptions;
 };
 
 /**
@@ -183,15 +188,15 @@ const verifyAccessJwt = async (token: string, options: VerifyAccessJwtOptions): 
 
 /**
  * Read the Access JWT off a request and verify it. Returns the verified claims,
- * or `undefined` when no token is present **or** verification fails — the single
- * fail-closed "no Access identity" signal that both `createAccessResolver` and
- * `accessAdminGate` build their distinct mapping / authorization step on top of.
+ * or `undefined` when no token is present **or** verification fails — the
+ * fail-closed "no Access identity on this request" signal, matching what
+ * `readPlatformIdentity` returns for the other authentication path so callers
+ * treat the two uniformly.
  *
- * This is the package's one place that turns a request into verified claims:
+ * This is the package's one place that turns a *request* into verified claims:
  * header/cookie default resolution, the {@link readToken} read, the
  * {@link verifyAccessJwt} call, and the `onError`-observed fail-closed catch all
- * live here so the resolver and the admin gate carry only their genuinely
- * distinct line. `onError` fires for a present-but-invalid token, never for an
+ * live here. `onError` fires for a present-but-invalid token, never for an
  * absent one.
  */
 const verifyRequest = async (request: Request, options: RequestVerifyOptions): Promise<AccessClaims | undefined> => {

--- a/packages/cloudflare-access/tsconfig.json
+++ b/packages/cloudflare-access/tsconfig.json
@@ -1,10 +1,12 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": ".",
         "moduleResolution": "bundler",
         "types": ["@cloudflare/workers-types", "node"]
+        // Intentionally no `outDir`/`rootDir` (unlike sibling packages): a set
+        // `rootDir` would raise TS6059 for the inlined
+        // `../../../shared/execution-context` import (a file outside this package,
+        // bundled in at build time). See shared/execution-context.ts.
     },
     "include": ["src/**/*", "__tests__/**/*"]
 }

--- a/packages/codegen/__tests__/emit-app-access.test.ts
+++ b/packages/codegen/__tests__/emit-app-access.test.ts
@@ -35,10 +35,20 @@ describe("emitApp — Cloudflare Access", () => {
 
         const output = emitApp({ ...baseOptions, hasAccess: true });
 
-        expect(output).toContain("public access(selector: Selector<Env, CreateAccessResolverOptions>): this");
-        expect(output).toContain("private accessSelector?: Selector<Env, CreateAccessResolverOptions>;");
+        expect(output).toContain("public access(selector?: Selector<Env, CreateAccessResolverOptions>): this");
+        expect(output).toContain("private accessSelector?: Selector<Env, CreateAccessResolverOptions | undefined>;");
         expect(output).toContain('import type { CreateAccessResolverOptions } from "@lunora/cloudflare-access";');
         expect(output).toContain('import { createAccessResolver } from "@lunora/cloudflare-access";');
+    });
+
+    it("makes the selector optional so a Worker-scoped Access policy needs no JWT config", () => {
+        expect.assertions(1);
+
+        const output = emitApp({ ...baseOptions, hasAccess: true });
+
+        // `.access()` with no argument still records the wiring; the resolver then
+        // authenticates purely off the execution-context identity.
+        expect(output).toContain("this.accessSelector = selector ?? (() => undefined);");
     });
 
     it("sets resolveIdentity directly (no compose) when Access is used without auth", () => {

--- a/packages/codegen/src/emit-app.ts
+++ b/packages/codegen/src/emit-app.ts
@@ -319,7 +319,7 @@ interface AuthDeclaration<Env> {
 
 /** Builder instance fields (private state recorded by the fluent methods). */
 const buildFieldLines = (options: EmitAppOptions): string[] => [
-    ...(options.hasAccess ? [`    private accessSelector?: Selector<Env, CreateAccessResolverOptions>;`] : []),
+    ...(options.hasAccess ? [`    private accessSelector?: Selector<Env, CreateAccessResolverOptions | undefined>;`] : []),
     `    private adminToken?: Selector<Env, string>;`,
     ...(options.hasAuth ? [`    private authDeclaration?: AuthDeclaration<Env>;`] : []),
     `    private readonly extendFns: ((env: Env, derived: Readonly<WorkerOptions>) => Partial<WorkerOptions>)[] = [];`,
@@ -348,9 +348,9 @@ const buildLongTailMethods = (options: EmitAppOptions): string[] =>
 const buildMethodBlocks = (options: EmitAppOptions): string[] => [
     ...(options.hasAccess
         ? [
-              `    /** Wire Cloudflare Access (Zero Trust) — verifies the \`Cf-Access-Jwt-Assertion\` JWT and feeds the identity into \`ctx.auth\` / RLS via \`resolveIdentity\`. When \`.auth(...)\` is also configured, Access is composed ahead of it (Access wins when its JWT is present; everyone else falls through to the app session). */
-    public access(selector: Selector<Env, CreateAccessResolverOptions>): this {
-        this.accessSelector = selector;
+              `    /** Wire Cloudflare Access (Zero Trust) — feeds the verified Access identity into \`ctx.auth\` / RLS via \`resolveIdentity\`. Call it with no argument when the Access policy is attached to the Worker (the identity arrives on the execution context; nothing to configure); pass \`teamDomain\` + \`aud\` for a hostname-scoped Access application, whose \`Cf-Access-Jwt-Assertion\` JWT is verified against your team JWKS. When \`.auth(...)\` is also configured, Access is composed ahead of it (Access wins when it authenticated the caller; everyone else falls through to the app session). */
+    public access(selector?: Selector<Env, CreateAccessResolverOptions>): this {
+        this.accessSelector = selector ?? (() => undefined);
 
         return this;
     }`,

--- a/packages/runtime/__tests__/admin-gate.test.ts
+++ b/packages/runtime/__tests__/admin-gate.test.ts
@@ -111,3 +111,42 @@ describe("createWorker — adminGate (async Access-style admin authorization)", 
         expect(adminGate).not.toHaveBeenCalled();
     });
 });
+
+describe("createWorker — adminGate execution context", () => {
+    /**
+     * A context shaped like the one Cloudflare hands a Worker protected by an
+     * Access policy attached to the Worker itself: the caller's identity arrives
+     * out-of-band on `ctx.access`, not on the request, so a gate can only reach it
+     * if the worker forwards the context it was invoked with.
+     */
+    const accessContext: ExecutionContextLike = {
+        ...fakeContext,
+        access: { getIdentity: () => Promise.resolve({ email: "admin@acme.test", sub: "user-1" }) },
+    };
+
+    it("hands the gate the ExecutionContext the request was served with", async () => {
+        expect.assertions(3);
+
+        const adminGate = vi.fn<(request: Request, context?: ExecutionContextLike) => Promise<boolean>>(
+            async (_request, context) => (await context?.access?.getIdentity()) !== undefined,
+        );
+        const worker = createWorker({ adminGate, functions: REGISTRY, shardDO: noopNamespace });
+
+        const response = await worker.fetch(new Request(ADMIN_PATH, { method: "GET" }), {}, accessContext);
+
+        expect(response.status).toBe(200);
+        expect(adminGate).toHaveBeenCalledTimes(1);
+        expect(adminGate.mock.calls[0]?.[1]?.access).toBeDefined();
+    });
+
+    it("denies when the context carries no Access identity", async () => {
+        expect.assertions(1);
+
+        const adminGate = async (_request: Request, context?: ExecutionContextLike): Promise<boolean> => (await context?.access?.getIdentity()) !== undefined;
+        const worker = createWorker({ adminGate, functions: REGISTRY, shardDO: noopNamespace });
+
+        const response = await worker.fetch(new Request(ADMIN_PATH, { method: "GET" }), {}, fakeContext);
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/packages/runtime/__tests__/identity-layer.test.ts
+++ b/packages/runtime/__tests__/identity-layer.test.ts
@@ -306,39 +306,69 @@ describe("execution context forwarded to the identity layer", () => {
         };
     };
 
+    /** A resolver that authenticates ONLY off the context-supplied identity, like `createAccessResolver()` does. */
+    const contextOnlyResolver: IdentityResolver = async (_request, _env, context) => {
+        const identity = await context?.access?.getIdentity();
+
+        return identity ? { email: identity.email, userId: String(identity.sub) } : null;
+    };
+
     it("hands resolveIdentity the ExecutionContext the request was served with", async () => {
         expect.assertions(2);
 
-        const resolveIdentity = vi.fn<IdentityResolver>((_request, _env, context) => {
-            const identity = context?.access?.getIdentity();
-
-             
-            return identity === undefined ? null : Promise.resolve({ userId: "resolved-from-context" });
-        });
-
-        const worker = createWorker({ resolveIdentity, shardDO: shard.namespace });
+        const worker = createWorker({ resolveIdentity: contextOnlyResolver, shardDO: shard.namespace });
 
         const res = await worker.fetch(rpc(), {}, accessContext("user@acme.test"));
 
         expect(res.status).toBe(200);
-        expect(shard.calls[0]?.request.headers.get("x-lunora-userid")).toBe("resolved-from-context");
+        expect(shard.calls[0]?.request.headers.get("x-lunora-userid")).toBe("user-1");
     });
 
-    it("passes undefined rather than throwing when the host supplied no context", async () => {
+    it("resolves anonymous, not an error, when the host supplied a context with no Access identity", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({ resolveIdentity: contextOnlyResolver, shardDO: shard.namespace });
+
+        const res = await worker.fetch(rpc(), {}, fakeContext);
+
+        expect(res.status).toBe(200);
+        expect(shard.calls[0]?.request.headers.has("x-lunora-userid")).toBe(false);
+    });
+
+    it("forwards the exact context object, so a resolver can read anything on it", async () => {
         expect.assertions(1);
 
         const seen: (ExecutionContextLike | undefined)[] = [];
+        const context = accessContext("user@acme.test");
         const worker = createWorker({
-            resolveIdentity: (_request, _env, context) => {
-                seen.push(context);
+            resolveIdentity: (_request, _env, forwarded) => {
+                seen.push(forwarded);
 
                 return { userId: "u1" };
             },
             shardDO: shard.namespace,
         });
 
-        await worker.fetch(rpc(), {}, fakeContext);
+        await worker.fetch(rpc(), {}, context);
 
-        expect(seen[0]).toBe(fakeContext);
+        expect(seen[0]).toBe(context);
+    });
+
+    it("reaches serverQuery only through the explicit callOptions.context", async () => {
+        expect.assertions(2);
+
+        const worker = createWorker({ functions: { "messages:list": { kind: "query" } }, resolveIdentity: contextOnlyResolver, shardDO: shard.namespace });
+        const reference = { __lunoraRef: "messages:list" };
+        const context = accessContext("user@acme.test");
+
+        // `serverQuery` has no `fetch` funnel to have recorded the context, and an
+        // SSR host may hand it a rebuilt Request — so without `callOptions.context`
+        // a Worker-scoped Access caller is anonymous here while their `/_lunora/rpc`
+        // traffic is authenticated. That divergence is what this pins.
+        await worker.serverQuery(rpc(), {}, reference, {});
+        await worker.serverQuery(rpc(), {}, reference, {}, { context });
+
+        expect(shard.calls[0]?.request.headers.has("x-lunora-userid")).toBe(false);
+        expect(shard.calls[1]?.request.headers.get("x-lunora-userid")).toBe("user-1");
     });
 });

--- a/packages/runtime/__tests__/identity-layer.test.ts
+++ b/packages/runtime/__tests__/identity-layer.test.ts
@@ -285,3 +285,60 @@ describe("identity contract trust boundary", () => {
         expect(res.status).toBe(200);
     });
 });
+
+describe("execution context forwarded to the identity layer", () => {
+    let shard: ShardSpy;
+
+    beforeEach(() => {
+        shard = createShardSpy();
+    });
+
+    /**
+     * A context shaped like the one Cloudflare hands a Worker protected by an
+     * Access policy attached to the Worker itself: the caller's identity arrives
+     * out-of-band on `ctx.access`, not on the request, so a resolver can only
+     * reach it if the worker forwards the context it was invoked with.
+     */
+    const accessContext = (email: string): ExecutionContextLike => {
+        return {
+            ...fakeContext,
+            access: { getIdentity: () => Promise.resolve({ email, sub: "user-1" }) },
+        };
+    };
+
+    it("hands resolveIdentity the ExecutionContext the request was served with", async () => {
+        expect.assertions(2);
+
+        const resolveIdentity = vi.fn<IdentityResolver>((_request, _env, context) => {
+            const identity = context?.access?.getIdentity();
+
+             
+            return identity === undefined ? null : Promise.resolve({ userId: "resolved-from-context" });
+        });
+
+        const worker = createWorker({ resolveIdentity, shardDO: shard.namespace });
+
+        const res = await worker.fetch(rpc(), {}, accessContext("user@acme.test"));
+
+        expect(res.status).toBe(200);
+        expect(shard.calls[0]?.request.headers.get("x-lunora-userid")).toBe("resolved-from-context");
+    });
+
+    it("passes undefined rather than throwing when the host supplied no context", async () => {
+        expect.assertions(1);
+
+        const seen: (ExecutionContextLike | undefined)[] = [];
+        const worker = createWorker({
+            resolveIdentity: (_request, _env, context) => {
+                seen.push(context);
+
+                return { userId: "u1" };
+            },
+            shardDO: shard.namespace,
+        });
+
+        await worker.fetch(rpc(), {}, fakeContext);
+
+        expect(seen[0]).toBe(fakeContext);
+    });
+});

--- a/packages/runtime/__tests__/memoize-identity.test.ts
+++ b/packages/runtime/__tests__/memoize-identity.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { ExecutionContextLike } from "../../../shared/execution-context";
+import type { IdentityResolver } from "../src/identity-resolvers";
 import { memoizeIdentity, memoizeIdentityPerRequest } from "../src/memoize-identity";
 
 const authed = (cookie = "session=abc"): Request => new Request("https://app.example/_lunora/rpc", { headers: { cookie }, method: "POST" });
@@ -248,6 +250,54 @@ describe("memoizeIdentity", () => {
 
         // TTL 0 disables the cross-request cache; the per-request layer still applies.
         await Promise.all([memoized(request, {}), memoized(request, {})]);
+
+        expect(resolver).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("memoizeIdentity — platform-supplied Cloudflare Access identity", () => {
+    /** The context Cloudflare hands a Worker its Access policy authenticated. */
+    const accessContext = (sub: string): ExecutionContextLike => {
+        return { access: { getIdentity: () => Promise.resolve({ sub }) } };
+    };
+
+    it("never serves one Access principal's identity to another sharing a credential header", async () => {
+        expect.assertions(3);
+
+        // Both callers present the SAME Authorization header — an app-wide
+        // downstream API key, or any cookie identical across users — so
+        // `credentialKey` yields one non-undefined key for both. Their real
+        // credential is the Access identity, which is NOT on the request, so no
+        // request-derived key could ever tell them apart.
+        const resolver = vi.fn<IdentityResolver>(async (_request, _env, context) => {
+            const identity = await context?.access?.getIdentity();
+
+            return { userId: String(identity?.sub) };
+        });
+        const memoized = memoizeIdentity(resolver);
+        const shared = { authorization: "Bearer shared-downstream-key" }; // secret-scanner:allow -- fake test fixture, not a real credential
+
+        const alice = await memoized(new Request("https://app.example/_lunora/rpc", { headers: shared }), {}, accessContext("alice"));
+        const bob = await memoized(new Request("https://app.example/_lunora/rpc", { headers: shared }), {}, accessContext("bob"));
+
+        expect(alice).toStrictEqual({ userId: "alice" });
+        expect(bob).toStrictEqual({ userId: "bob" });
+        expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it("still collapses duplicate calls within one Access request", async () => {
+        expect.assertions(1);
+
+        const resolver = vi.fn<() => Promise<{ userId: string }>>(async () => {
+            return { userId: "u1" };
+        });
+        const memoized = memoizeIdentity(resolver);
+        const request = authed();
+        const context = accessContext("u1");
+
+        // Bypassing the cross-request cache must not cost the fan-out collapse the
+        // per-request layer exists for.
+        await Promise.all([memoized(request, {}, context), memoized(request, {}, context)]);
 
         expect(resolver).toHaveBeenCalledTimes(1);
     });

--- a/packages/runtime/__tests__/rest-cache.test.ts
+++ b/packages/runtime/__tests__/rest-cache.test.ts
@@ -35,6 +35,19 @@ describe("restCacheHeaders", () => {
         expect(headers?.["cache-control"]).toBe("private, max-age=60");
     });
 
+    it("downgrades scope:public to private for a Cloudflare Access caller carrying no credential header", () => {
+        expect.assertions(2);
+
+        // Under an Access policy attached to the Worker the caller is authenticated
+        // by the edge and their identity arrives on the ExecutionContext — there may
+        // be no Authorization/Cookie/JWT header at all. Labelling that response
+        // `public` would let a shared cache serve one user's data to the next visitor.
+        const context = { access: { getIdentity: () => Promise.resolve({ email: "user@acme.test", sub: "user-1" }) } };
+
+        expect(restCacheHeaders(publicCache, get(), 200, context)?.["cache-control"]).toBe("private, max-age=60");
+        expect(requestCarriesCredentials(get(), publicCache, context)).toBe(true);
+    });
+
     it("includes stale-while-revalidate and a purge tag when declared", () => {
         expect.assertions(2);
 

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -696,11 +696,15 @@ interface WorkerOptions {
      * The intended producer is `@lunora/cloudflare-access`'s `accessAdminGate(...)`,
      * which verifies the request's `Cf-Access-Jwt-Assertion` JWT and applies an
      * `isAdmin(claims)` predicate — so the Studio can sit behind Cloudflare Access
-     * instead of (or alongside) a shared admin token. It takes only the request
-     * (verification needs static team-domain/aud config + the remote JWKS, no env
-     * binding), so it composes without threading async through every admin route.
+     * instead of (or alongside) a shared admin token. It needs no `env` binding
+     * (verification is static team-domain/aud config + the remote JWKS), so it
+     * composes without threading async through every admin route.
+     *
+     * The second argument is the request's `ExecutionContext`, carrying
+     * `context.access` when the Access policy is attached to the Worker rather
+     * than to a hostname. It is `undefined` when the host supplied no context.
      */
-    adminGate?: (request: Request) => boolean | Promise<boolean>;
+    adminGate?: (request: Request, context?: ExecutionContextLike) => boolean | Promise<boolean>;
 
     /**
      * Admin bearer token expected by the export/import endpoints. When unset,
@@ -1150,8 +1154,16 @@ interface WorkerOptions {
      * forwarded as `x-lunora-identity` so `ctx.auth.getIdentity()` can
      * return them. Returning `null` (or omitting this option) means
      * anonymous — no identity headers are injected.
+     *
+     * The third argument is the request's `ExecutionContext`, forwarded so a
+     * resolver can read identity the platform supplies out-of-band rather than
+     * off the request — `context.access` on a Worker protected by Cloudflare
+     * Access is the one that exists today. It is `undefined` on the paths that
+     * have no context to give (a direct {@link LunoraWorker.serverQuery} call, a
+     * host that mounts the worker without one), so a resolver that uses it must
+     * still handle its absence.
      */
-    resolveIdentity?: (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
+    resolveIdentity?: (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
 
     /**
      * Resolve a table's sharding metadata. Required by the import endpoint to
@@ -1713,6 +1725,22 @@ const queueNameOf = (batch: unknown): string => {
     return typeof name === "string" && name.length > 0 ? name : "unknown";
 };
 
+/**
+ * The `ExecutionContext` of the request currently in flight, so the many places
+ * that resolve identity can hand it to `resolveIdentity` without every one of
+ * them (including the extracted admin-route modules, which take
+ * `resolveForwardContext` as an injected dep) having to thread a fourth argument
+ * through its own signature.
+ *
+ * Recorded once, at the single `fetch` funnel in `handle`, and keyed on the
+ * `Request` object — so an entry cannot outlive its request, cannot be read by a
+ * different one, and needs no eviction policy. Same shape and lifetime as the
+ * `accessAdminGrants` WeakSet below. A path with no context recorded (a direct
+ * `serverQuery`, a partial host mount) simply reads `undefined`, which is what
+ * the resolver contract already documents.
+ */
+const executionContextByRequest = new WeakMap<Request, ExecutionContextLike>();
+
 const resolveForwardContext = async (request: Request, env: unknown, resolveIdentity: WorkerOptions["resolveIdentity"]): Promise<ForwardContext> => {
     const headers: Record<string, string> = { "content-type": "application/json" };
     const authorization = request.headers.get("authorization");
@@ -1768,7 +1796,7 @@ const resolveForwardContext = async (request: Request, env: unknown, resolveIden
         return { claims: null, headers, identity: null, userId: null };
     }
 
-    const identity = await resolveIdentity(request, env);
+    const identity = await resolveIdentity(request, env, executionContextByRequest.get(request));
 
     if (!identity || typeof identity.userId !== "string" || identity.userId.length === 0) {
         // eslint-disable-next-line unicorn/no-null -- `claims`/`identity`/`userId` feed the public HttpActionContext + authorize* callback contracts, whose anonymous sentinel is `null`
@@ -4592,7 +4620,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         }
 
         try {
-            if (await options.adminGate(request)) {
+            if (await options.adminGate(request, executionContextByRequest.get(request))) {
                 accessAdminGrants.add(request);
             }
         } catch {
@@ -4601,6 +4629,12 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
     };
 
     const handle = async (request: Request, env: unknown, context: ExecutionContextLike): Promise<Response> => {
+        // Record the context for this request before anything resolves identity:
+        // `resolveIdentity` / `adminGate` read it back through
+        // `executionContextByRequest` to reach platform-supplied identity
+        // (`context.access` under Worker-scoped Cloudflare Access).
+        executionContextByRequest.set(request, context);
+
         const url = new URL(request.url);
 
         // Fast-path reject on a declared `Content-Length` over the cap — cheap
@@ -4938,7 +4972,7 @@ const createLunoraHandler =
 const defineRpcEnvelope = (envelope: RpcEnvelope): RpcEnvelope => envelope;
 
 export { composeWorker, createLunoraHandler, createWorker, defineRpcEnvelope, probeRelayCount, resolveLunoraOptions, withFrameworkWorker };
-export { type ExecutionContextLike, NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
+export { type AccessContextLike, type AccessIdentityLike, type ExecutionContextLike, NOOP_EXECUTION_CONTEXT } from "../../../shared/execution-context";
 export type {
     AuthAdmin,
     AuthCapabilities,

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -1734,14 +1734,30 @@ const queueNameOf = (batch: unknown): string => {
  *
  * Recorded once, at the single `fetch` funnel in `handle`, and keyed on the
  * `Request` object — so an entry cannot outlive its request, cannot be read by a
- * different one, and needs no eviction policy. Same shape and lifetime as the
- * `accessAdminGrants` WeakSet below. A path with no context recorded (a direct
- * `serverQuery`, a partial host mount) simply reads `undefined`, which is what
- * the resolver contract already documents.
+ * different one, and needs no eviction policy.
+ *
+ * Unlike the per-worker `accessAdminGrants` WeakSet, this lives at **module**
+ * scope, because `resolveForwardContext` does. That is safe for the same reason
+ * the WeakSet is — the key is a `Request` identity, which no two isolated
+ * requests share — but it does mean two composed workers in one isolate write to
+ * the same map. The only way that matters is a re-entrant mount (an inner
+ * `lunoraHandler` invoked without a context, for a request an outer worker
+ * already recorded) overwriting the entry mid-flight; nothing re-resolves
+ * identity after dispatch today, so it cannot bite yet. A path that resolves
+ * identity for a `Request` this never saw — notably a caller that rebuilds the
+ * request object before calling `serverQuery` — reads `undefined`, which is why
+ * `serverQuery` also accepts the context explicitly.
  */
 const executionContextByRequest = new WeakMap<Request, ExecutionContextLike>();
 
-const resolveForwardContext = async (request: Request, env: unknown, resolveIdentity: WorkerOptions["resolveIdentity"]): Promise<ForwardContext> => {
+const resolveForwardContext = async (
+    request: Request,
+    env: unknown,
+    resolveIdentity: WorkerOptions["resolveIdentity"],
+    // Defaults to the in-flight context recorded by `handle`. Passed explicitly
+    // only by callers that did not reach here through the `fetch` funnel.
+    context: ExecutionContextLike | undefined = executionContextByRequest.get(request),
+): Promise<ForwardContext> => {
     const headers: Record<string, string> = { "content-type": "application/json" };
     const authorization = request.headers.get("authorization");
     const cookie = request.headers.get("cookie");
@@ -1796,7 +1812,7 @@ const resolveForwardContext = async (request: Request, env: unknown, resolveIden
         return { claims: null, headers, identity: null, userId: null };
     }
 
-    const identity = await resolveIdentity(request, env, executionContextByRequest.get(request));
+    const identity = await resolveIdentity(request, env, context);
 
     if (!identity || typeof identity.userId !== "string" || identity.userId.length === 0) {
         // eslint-disable-next-line unicorn/no-null -- `claims`/`identity`/`userId` feed the public HttpActionContext + authorize* callback contracts, whose anonymous sentinel is `null`
@@ -2226,6 +2242,11 @@ interface LunoraWorker {
      * `__lunoraRef` is the `"namespace:fn"` dispatched.
      * @param args The function arguments.
      * @param options Call options mirroring the RPC envelope.
+     * @param options.context The host's `ExecutionContext`. Required to reach an
+     * identity the platform supplies out-of-band rather than on the
+     * request — `context.access` under a Worker-scoped Cloudflare
+     * Access policy. Omit it there and the call resolves anonymous
+     * while the same user's `/_lunora/rpc` traffic is authenticated.
      * @param options.shardKey Routes to a specific shard (omitted → the worker's
      * `defaultShardKey`).
      * @param options.waitUntil The host's `waitUntil`, so dispatch telemetry
@@ -2236,7 +2257,7 @@ interface LunoraWorker {
         env: unknown,
         reference: unknown,
         args?: Record<string, unknown>,
-        options?: { shardKey?: string; waitUntil?: (promise: Promise<unknown>) => void },
+        options?: { context?: ExecutionContextLike; shardKey?: string; waitUntil?: (promise: Promise<unknown>) => void },
     ) => Promise<Response>;
 }
 
@@ -4250,6 +4271,15 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
      * raw shard {@link Response} (the same object `handleRpc` returns) so callers
      * and tests can compare it byte-for-byte against the HTTP path.
      *
+     * ONE THING THE CALLER MUST SUPPLY. An identity that the platform provides
+     * out-of-band rather than on the request — `context.access` under a
+     * Worker-scoped Cloudflare Access policy — is not reachable from `request`
+     * alone. The HTTP path picks it up from the `fetch` funnel; a direct
+     * `serverQuery` has no funnel, so pass `callOptions.context`. Omit it under
+     * such a policy and this call resolves ANONYMOUS while the same user's
+     * `/_lunora/rpc` traffic is authenticated — an SSR loader renders empty (or
+     * 403s) and then hydrates fine, which is a miserable thing to debug.
+     *
      * Fan-out is intentionally NOT reachable here: it is the cross-shard,
      * coordinator-gated, privileged path. An SSR loader that needs fan-out uses
      * the HTTP `/_lunora/rpc` envelope (with `authorizeFanOut`); this fast-path
@@ -4260,7 +4290,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         env: unknown,
         reference: unknown,
         args: Record<string, unknown> = {},
-        callOptions: { shardKey?: string; waitUntil?: (promise: Promise<unknown>) => void } = {},
+        callOptions: { context?: ExecutionContextLike; shardKey?: string; waitUntil?: (promise: Promise<unknown>) => void } = {},
     ): Promise<Response> => {
         // Error mapping mirrors the top-level `fetch` catch (`toErrorResponse`)
         // EXACTLY: a thrown `LunoraError` (bad reference, a denied `authorizeShard`
@@ -4277,8 +4307,10 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
 
             // Resolve identity off the SAME inbound request the HTTP path uses, so
             // cookies / bearer / bookmark and the derived `x-lunora-*` headers are
-            // byte-identical to `handleRpc`'s.
-            const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity);
+            // byte-identical to `handleRpc`'s. The context is passed explicitly
+            // because this path has no `fetch` funnel to have recorded it, and an
+            // SSR host may well hand us a rebuilt `Request` object.
+            const { headers: forwardedHeaders, identity } = await resolveForwardContext(request, env, publicResolveIdentity, callOptions.context);
 
             // Run the IDENTICAL per-shard authorization gate. A `shardKey` of
             // `undefined` resolves to `defaultShard` for both the gate and the

--- a/packages/runtime/src/identity-resolvers.ts
+++ b/packages/runtime/src/identity-resolvers.ts
@@ -20,6 +20,7 @@
  * separate primitives with distinct names to avoid confusing the two.
  */
 
+import type { ExecutionContextLike } from "../../../shared/execution-context";
 import { LunoraError } from "./errors";
 
 /**
@@ -61,8 +62,13 @@ interface ResolvedIdentity {
  * so `.auth()`'s better-auth session resolver, a signed-preview-link verifier, a
  * per-tenant bearer check, an upstream-JWT reader, … are all just `IdentityResolver`s
  * — the identity layer is generic over every scheme, not coupled to any one.
+ *
+ * The optional third argument is the request's `ExecutionContext`, for a scheme
+ * whose credential the platform supplies out-of-band rather than on the request
+ * (`context.access` under Worker-scoped Cloudflare Access). It is `undefined`
+ * wherever the host gave the worker no context.
  */
-type IdentityResolver = (request: Request, env: unknown) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
+type IdentityResolver = (request: Request, env: unknown, context?: ExecutionContextLike) => Promise<ResolvedIdentity | null> | ResolvedIdentity | null;
 
 /** Error policy for {@link composeIdentityResolvers} when a participant resolver throws. */
 type ComposeIdentityResolversErrorMode = "fail-closed" | "skip";
@@ -92,13 +98,13 @@ interface ComposeIdentityResolversOptions {
 const composeIdentityResolvers = (resolvers: ReadonlyArray<IdentityResolver>, options: ComposeIdentityResolversOptions = {}): IdentityResolver => {
     const onError: ComposeIdentityResolversErrorMode = options.onError ?? "fail-closed";
 
-    return async (request: Request, env: unknown): Promise<ResolvedIdentity | null> => {
+    return async (request: Request, env: unknown, context?: ExecutionContextLike): Promise<ResolvedIdentity | null> => {
         for (const resolver of resolvers) {
             let resolved: ResolvedIdentity | null;
 
             try {
                 // eslint-disable-next-line no-await-in-loop -- ordered first-match-wins: a later resolver must not run until the earlier one has settled (and short-circuit on the first hit)
-                resolved = await resolver(request, env);
+                resolved = await resolver(request, env, context);
             } catch (error: unknown) {
                 if (onError === "skip") {
                     continue;
@@ -133,7 +139,7 @@ const routeIdentityResolvers = (routes: Record<string, IdentityResolver>): Ident
         .filter((key) => key !== "*")
         .toSorted((a, b) => b.length - a.length);
 
-    return (request: Request, env: unknown): Promise<ResolvedIdentity | null> | ResolvedIdentity | null => {
+    return (request: Request, env: unknown, context?: ExecutionContextLike): Promise<ResolvedIdentity | null> | ResolvedIdentity | null => {
         const { pathname } = new URL(request.url);
         const matched = prefixes.find((prefix) => pathname === prefix || pathname.startsWith(prefix.endsWith("/") ? prefix : `${prefix}/`));
         const resolver = matched === undefined ? routes["*"] : routes[matched];
@@ -143,7 +149,7 @@ const routeIdentityResolvers = (routes: Record<string, IdentityResolver>): Ident
             return null;
         }
 
-        return resolver(request, env);
+        return resolver(request, env, context);
     };
 };
 
@@ -191,8 +197,8 @@ const wrapResolverWithContract = (
         return baseResolveIdentity;
     }
 
-    return async (request: Request, env: unknown): Promise<ResolvedIdentity | null> => {
-        const resolved = await baseResolveIdentity(request, env);
+    return async (request: Request, env: unknown, context?: ExecutionContextLike): Promise<ResolvedIdentity | null> => {
+        const resolved = await baseResolveIdentity(request, env, context);
 
         if (!resolved) {
             return resolved;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,8 @@ export {
 export type { AirbyteMessage, ConnectorChange, ConnectorSyncPage, FivetranResponse } from "./connector-format";
 export { toAirbyteMessages, toFivetranResponse } from "./connector-format";
 export type {
+    AccessContextLike,
+    AccessIdentityLike,
     AdminTableResolver,
     AuthAdmin,
     AuthCapabilities,

--- a/packages/runtime/src/memoize-identity.ts
+++ b/packages/runtime/src/memoize-identity.ts
@@ -48,7 +48,7 @@ const memoizeIdentityPerRequest = (resolver: IdentityResolver): IdentityResolver
     // to outlive its request.
     const inFlight = new WeakMap<Request, ReturnType<IdentityResolver>>();
 
-    return (request, env) => {
+    return (request, env, context) => {
         const cached = inFlight.get(request);
 
         if (cached) {
@@ -57,7 +57,7 @@ const memoizeIdentityPerRequest = (resolver: IdentityResolver): IdentityResolver
 
         // Cache the PROMISE, not the result, so two concurrent fan-out legs that both
         // miss share one verification instead of racing two.
-        const pending = Promise.resolve(resolver(request, env));
+        const pending = Promise.resolve(resolver(request, env, context));
 
         inFlight.set(request, pending);
 
@@ -129,10 +129,13 @@ const DEFAULT_MAX_ENTRIES = 500;
  * **Contract — safe ONLY if the resolver reads nothing but `Cookie` / `Authorization`.**
  * This key is the identity of the *credential*, not of the *request*. If the
  * resolver authenticates off any other attribute (an `X-API-Key` header, a client
- * cert, `new URL(request.url).origin`, an Access JWT header, …), two distinct
- * principals sharing (or both lacking) Cookie/Authorization collide onto one entry
- * and the cache serves the WRONG identity. Such a resolver MUST pass
- * {@link MemoizeIdentityOptions.cacheKey} so the key covers exactly what it reads.
+ * cert, `new URL(request.url).origin`, an Access JWT header, the `ExecutionContext`'s
+ * `access` identity, …), two distinct principals sharing (or both lacking)
+ * Cookie/Authorization collide onto one entry and the cache serves the WRONG
+ * identity. Such a resolver MUST pass {@link MemoizeIdentityOptions.cacheKey} so the
+ * key covers exactly what it reads — or, for a credential that lives entirely off the
+ * request (the Worker-scoped Access identity), return `undefined` so it is never
+ * cached across requests at all.
  */
 const credentialKey = (request: Request): string | undefined => {
     const cookie = request.headers.get("cookie") ?? "";
@@ -177,11 +180,11 @@ const memoizeIdentity = (resolver: IdentityResolver, options: MemoizeIdentityOpt
     // Insertion-ordered, so evicting the first key evicts the oldest entry.
     const cache = new Map<string, { expiresAt: number; value: ReturnType<IdentityResolver> }>();
 
-    return (request, env) => {
+    return (request, env, context) => {
         const key = keyOf(request);
 
         if (key === undefined) {
-            return perRequest(request, env);
+            return perRequest(request, env, context);
         }
 
         const now = Date.now();
@@ -191,7 +194,7 @@ const memoizeIdentity = (resolver: IdentityResolver, options: MemoizeIdentityOpt
             return hit.value;
         }
 
-        const pending = Promise.resolve(perRequest(request, env));
+        const pending = Promise.resolve(perRequest(request, env, context));
 
         // A rejected verification must not be cached — the next request has to retry
         // rather than inherit a transient failure for the whole TTL.

--- a/packages/runtime/src/memoize-identity.ts
+++ b/packages/runtime/src/memoize-identity.ts
@@ -183,7 +183,14 @@ const memoizeIdentity = (resolver: IdentityResolver, options: MemoizeIdentityOpt
     return (request, env, context) => {
         const key = keyOf(request);
 
-        if (key === undefined) {
+        // A platform-supplied Cloudflare Access identity is not on the request, so
+        // NO request-derived key can separate two callers presenting it — the
+        // cross-request cache can never be correct for one. `credentialKey` happens
+        // to return `undefined` for a caller sending neither Cookie nor
+        // Authorization, but the moment Access is composed with a session cookie
+        // (the documented composition) that key stops covering what the resolver
+        // read. Fall back to the per-request memo, which is always safe.
+        if (key === undefined || context?.access !== undefined) {
             return perRequest(request, env, context);
         }
 

--- a/packages/runtime/src/rest-cache.ts
+++ b/packages/runtime/src/rest-cache.ts
@@ -21,6 +21,7 @@
  * credential downgrade. It is the lower-level escape hatch; this is the guarded
  * surface. Do not describe them as equivalent.
  */
+import type { ExecutionContextLike } from "../../../shared/execution-context";
 import type { RestCachePolicy } from "../../../shared/rest-surface";
 import { cacheControlValue, cacheVaryValue, credentialHeadersFor, mergeVary } from "../../../shared/rest-surface";
 
@@ -29,9 +30,17 @@ import { cacheControlValue, cacheVaryValue, credentialHeadersFor, mergeVary } fr
  * as caller-specific. Checks the built-in identity headers plus anything the
  * policy declares via `credentialHeaders` — an app whose `resolveIdentity` reads
  * a bespoke header must say so, or its callers read as anonymous here.
+ *
+ * A credential does not have to be on the request at all: under a Cloudflare
+ * Access policy attached to the Worker, the caller is authenticated by the edge
+ * and their identity arrives on the `ExecutionContext` as `access`, with no
+ * header this function could see. Its mere presence means Access authorized this
+ * specific caller, so it counts as a credential — otherwise a per-user response
+ * would be labelled `public` and a shared cache could hand it to the next
+ * visitor.
  */
-const requestCarriesCredentials = (request: Request, policy: RestCachePolicy): boolean =>
-    credentialHeadersFor(policy).some((header) => request.headers.has(header));
+const requestCarriesCredentials = (request: Request, policy: RestCachePolicy, context?: ExecutionContextLike): boolean =>
+    context?.access !== undefined || credentialHeadersFor(policy).some((header) => request.headers.has(header));
 
 /**
  * Build the cache headers for one exchange, or `undefined` when the exchange
@@ -41,12 +50,12 @@ const requestCarriesCredentials = (request: Request, policy: RestCachePolicy): b
  * The effective scope is `policy.scope` narrowed by {@link requestCarriesCredentials};
  * `"public"` survives only for a genuinely anonymous request.
  */
-const restCacheHeaders = (policy: RestCachePolicy, request: Request, status: number): Record<string, string> | undefined => {
+const restCacheHeaders = (policy: RestCachePolicy, request: Request, status: number, context?: ExecutionContextLike): Record<string, string> | undefined => {
     if (request.method !== "GET" || status < 200 || status > 299) {
         return undefined;
     }
 
-    const effectiveScope = policy.scope === "public" && !requestCarriesCredentials(request, policy) ? "public" : "private";
+    const effectiveScope = policy.scope === "public" && !requestCarriesCredentials(request, policy, context) ? "public" : "private";
     const headers: Record<string, string> = { "cache-control": cacheControlValue(policy, effectiveScope) };
 
     if (policy.tag !== undefined && policy.tag !== "") {
@@ -68,12 +77,12 @@ const restCacheHeaders = (policy: RestCachePolicy, request: Request, status: num
  * are carried over, the body is streamed through untouched). When the exchange
  * isn't cacheable the original response is returned as-is — no copy.
  */
-const applyRestCache = (response: Response, policy: RestCachePolicy | undefined, request: Request): Response => {
+const applyRestCache = (response: Response, policy: RestCachePolicy | undefined, request: Request, context?: ExecutionContextLike): Response => {
     if (policy === undefined) {
         return response;
     }
 
-    const headers = restCacheHeaders(policy, request, response.status);
+    const headers = restCacheHeaders(policy, request, response.status, context);
 
     if (headers === undefined) {
         return response;

--- a/packages/runtime/src/rest-routes.ts
+++ b/packages/runtime/src/rest-routes.ts
@@ -197,8 +197,10 @@ const buildRestRoutes = (deps: RestRouteDeps): Record<string, RestRoute> => {
             // Applied AFTER dispatch so the effective `Cache-Control` can account
             // for the real status (an error is never cached) and for whether the
             // caller presented credentials (a credentialed exchange is forced
-            // `private`, see `rest-cache`).
-            return applyRestCache(response, cache, request);
+            // `private`, see `rest-cache`). The context is passed because one
+            // credential — the Cloudflare Access identity under a Worker-scoped
+            // policy — arrives there rather than on the request.
+            return applyRestCache(response, cache, request, context);
         };
     }
 

--- a/packages/runtime/src/rest-routes.ts
+++ b/packages/runtime/src/rest-routes.ts
@@ -16,6 +16,7 @@
  * contract that the OpenAPI emitter also uses, so the published spec and the live
  * surface cannot drift.
  */
+import type { ExecutionContextLike } from "../../../shared/execution-context";
 import type { RestExposure } from "../../../shared/rest-surface";
 import { describeRestSurface } from "../../../shared/rest-surface";
 import { assertArgsObject } from "./assert-args-object";
@@ -53,10 +54,12 @@ type RestRateLimit = (request: Request, functionPath: string) => Promise<Respons
 /**
  * A built REST route. Takes the same `(request, env, url, context)` shape as the
  * runtime's internal route table so it can be spread straight into it; `url` is
- * unused here (the route re-parses it) and `context` is read only for its
- * `waitUntil`, which keeps dispatch telemetry alive past the response.
+ * unused here (the route re-parses it). The context is the real
+ * {@link ExecutionContextLike} rather than a `waitUntil`-only projection, because
+ * the cache decision reads `context.access` too — see the `applyRestCache` call
+ * below.
  */
-type RestRoute = (request: Request, env: unknown, url?: URL, context?: { waitUntil?: (promise: Promise<unknown>) => void }) => Promise<Response>;
+type RestRoute = (request: Request, env: unknown, url?: URL, context?: ExecutionContextLike) => Promise<Response>;
 
 interface RestRouteDeps {
     /** The generated function registry — the source of which procedures are exposed. */

--- a/registry/cloudflare-access/access.ts
+++ b/registry/cloudflare-access/access.ts
@@ -21,21 +21,26 @@
  * CF_ACCESS_AUD in your Cloudflare dashboard (then `wrangler secret put
  * CF_ACCESS_AUD`), and pass them below.
  */
-import { env } from "cloudflare:workers";
-
 import { createAccessResolver } from "@lunora/cloudflare-access";
 
 /**
  * Build the identity resolver. Used by the Worker entry to authenticate every
  * request through Cloudflare Access.
  *
- * The JWT config is passed only when both env vars are set, so this file works
- * unchanged for a Worker-scoped Access policy (where neither exists and the
- * identity comes off the execution context). Supplying exactly one of the two
- * throws at startup rather than silently skipping verification.
+ * Pick ONE of the two forms below and delete the other. They are not
+ * interchangeable, and the difference is deliberate: naming the two options at
+ * all means "verify JWTs", so if you keep the second form in an environment
+ * where the secrets are unset, it throws at startup rather than quietly booting
+ * a worker that authenticates nobody.
  */
-const teamDomain = env.CF_ACCESS_TEAM_DOMAIN as string | undefined;
-const aud = env.CF_ACCESS_AUD as string | undefined;
 
-export const resolveIdentity =
-    teamDomain === undefined && aud === undefined ? createAccessResolver() : createAccessResolver({ aud: aud as string, teamDomain: teamDomain as string });
+// Access policy attached to the Worker — the identity arrives on the execution
+// context and there is nothing to configure or verify.
+export const resolveIdentity = createAccessResolver();
+
+// Hostname-scoped Access application — verify the Cf-Access-Jwt-Assertion JWT.
+// Uncomment, and add `import { env } from "cloudflare:workers";` above.
+// export const resolveIdentity = createAccessResolver({
+//     teamDomain: env.CF_ACCESS_TEAM_DOMAIN as string,
+//     aud: env.CF_ACCESS_AUD as string,
+// });

--- a/registry/cloudflare-access/access.ts
+++ b/registry/cloudflare-access/access.ts
@@ -1,33 +1,41 @@
 /**
  * Cloudflare Access (Zero Trust) — added by `lunora add cloudflare-access`.
  *
- * Verify the Cf-Access-Jwt-Assertion header from Cloudflare Access against
- * your team's JWKS, and feed the verified identity into ctx.auth.
+ * Feed the verified Cloudflare Access identity into ctx.auth, from whichever of
+ * the two Access shapes your deployment uses:
+ *
+ *   - Access policy attached to the WORKER (covers its custom domains, routes,
+ *     workers.dev and preview URLs at once): the identity arrives on the
+ *     execution context. Nothing to configure — call createAccessResolver() with
+ *     no arguments. `wrangler.jsonc`'s `access.dev` block simulates it locally.
+ *   - Hostname-scoped Access APPLICATION: the Cf-Access-Jwt-Assertion header is
+ *     verified against your team's JWKS. Pass teamDomain + aud (both required).
  *
  * Wire this into your Worker entry as the `resolveIdentity` option:
  *
  *   import { createAccessResolver } from "@lunora/cloudflare-access";
  *
- *   createWorker({
- *     resolveIdentity: createAccessResolver({
- *       teamDomain: env.CF_ACCESS_TEAM_DOMAIN,
- *       aud: env.CF_ACCESS_AUD,
- *       // isAdmin: (claims) => claims.groups?.includes("lunora-admins") ?? false,
- *     }),
- *   });
+ *   createWorker({ resolveIdentity: createAccessResolver() });
  *
- * Set CF_ACCESS_TEAM_DOMAIN in .dev.vars and CF_ACCESS_AUD in your
- * Cloudflare dashboard (then `wrangler secret put CF_ACCESS_AUD`).
+ * For the hostname-scoped form, set CF_ACCESS_TEAM_DOMAIN in .dev.vars and
+ * CF_ACCESS_AUD in your Cloudflare dashboard (then `wrangler secret put
+ * CF_ACCESS_AUD`), and pass them below.
  */
 import { env } from "cloudflare:workers";
 
 import { createAccessResolver } from "@lunora/cloudflare-access";
 
 /**
- * Build the identity resolver from env vars. Used by the Worker entry
- * to verify the Cf-Access-Jwt-Assertion on every request.
+ * Build the identity resolver. Used by the Worker entry to authenticate every
+ * request through Cloudflare Access.
+ *
+ * The JWT config is passed only when both env vars are set, so this file works
+ * unchanged for a Worker-scoped Access policy (where neither exists and the
+ * identity comes off the execution context). Supplying exactly one of the two
+ * throws at startup rather than silently skipping verification.
  */
-export const resolveIdentity = createAccessResolver({
-    teamDomain: env.CF_ACCESS_TEAM_DOMAIN as string,
-    aud: env.CF_ACCESS_AUD as string,
-});
+const teamDomain = env.CF_ACCESS_TEAM_DOMAIN as string | undefined;
+const aud = env.CF_ACCESS_AUD as string | undefined;
+
+export const resolveIdentity =
+    teamDomain === undefined && aud === undefined ? createAccessResolver() : createAccessResolver({ aud: aud as string, teamDomain: teamDomain as string });

--- a/shared/execution-context.ts
+++ b/shared/execution-context.ts
@@ -59,9 +59,9 @@ export interface AccessIdentityLike {
     groups?: unknown;
     /** Display name from the identity provider, when it emits one. */
     name?: string;
-    /** Stable per-user id. Empty for service tokens. */
+    /** Stable per-user id, and what consumers key a user on. Empty for service tokens. */
     sub?: string;
-    /** Cloudflare's per-user UUID; the id fallback when the IdP emits no `sub`. */
+    /** Cloudflare's per-user UUID. Carried through, but deliberately not used as an id — only this path emits it, so keying on it would not match the JWT path. */
     user_uuid?: string;
 }
 

--- a/shared/execution-context.ts
+++ b/shared/execution-context.ts
@@ -21,11 +21,62 @@
  * fall back to {@link NOOP_EXECUTION_CONTEXT}.
  */
 export interface ExecutionContextLike {
+    /**
+     * Present only when Cloudflare Access authenticated the request against a
+     * policy attached to the **Worker** (rather than to a hostname). `undefined`
+     * on every unauthenticated request, so its presence is itself the "Access
+     * authorized this caller" signal — see {@link AccessContextLike}.
+     */
+    access?: AccessContextLike;
     cache?: {
         purge: (options: { purgeEverything?: boolean; tags?: string[] }) => Promise<unknown>;
     };
     passThroughOnException?: () => void;
     waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+/**
+ * The identity Cloudflare Access attaches to a Worker-protected request.
+ *
+ * Shape follows the Access application-token payload: `sub` is the stable per-user
+ * id, `email` the verified address, `common_name` the service-token name (machine
+ * callers, whose `sub` is empty), and `exp` the credential expiry in epoch
+ * **seconds**. Group membership is whatever the Access policy emits — a list of
+ * names, or of `{ id, name }` objects — hence `unknown`; normalize before use.
+ *
+ * Cloudflare may add further fields, so the index signature keeps them rather
+ * than dropping them: this is a view of a payload we do not own.
+ */
+export interface AccessIdentityLike {
+    [claim: string]: unknown;
+    /** Service-token name. Present for non-interactive (machine) callers instead of `email`. */
+    common_name?: string;
+    /** Verified user email. Present for interactive (SSO) callers. */
+    email?: string;
+    /** Credential expiry, epoch **seconds**. */
+    exp?: number;
+    /** IdP group membership — names or `{ id, name }` objects, depending on the policy. */
+    groups?: unknown;
+    /** Display name from the identity provider, when it emits one. */
+    name?: string;
+    /** Stable per-user id. Empty for service tokens. */
+    sub?: string;
+    /** Cloudflare's per-user UUID; the id fallback when the IdP emits no `sub`. */
+    user_uuid?: string;
+}
+
+/**
+ * The `ctx.access` facade Cloudflare exposes on a Worker protected by Access.
+ *
+ * Reading the identity from here is preferable to verifying the
+ * `Cf-Access-Jwt-Assertion` header: the platform has already authenticated the
+ * caller, so there is no JWKS fetch, no audience check to get wrong, and nothing
+ * a request can forge — the field simply does not exist unless Access authorized
+ * the call. The header path remains the fallback for hostname-scoped Access
+ * applications, which do not populate this.
+ */
+export interface AccessContextLike {
+    getIdentity: () => AccessIdentityLike | null | undefined | Promise<AccessIdentityLike | null | undefined>;
 }
 
 /**

--- a/shared/rest-surface.ts
+++ b/shared/rest-surface.ts
@@ -31,6 +31,11 @@ type RestFunctionKind = "action" | "mutation" | "query";
  * query parameter, …). An app doing that must declare its own header names via
  * {@link RestCachePolicy.credentialHeaders}, or not mark the endpoint
  * `scope: "public"`.
+ *
+ * One credential is deliberately absent because it is not a header at all: under
+ * a Cloudflare Access policy attached to the Worker, the caller's identity
+ * arrives on the `ExecutionContext`. `@lunora/runtime`'s `requestCarriesCredentials`
+ * checks for that separately.
  */
 const CREDENTIAL_HEADERS = ["authorization", "cf-access-jwt-assertion", "cookie"] as const;
 


### PR DESCRIPTION
## What

Cloudflare Access policies can now be attached to a **Worker** rather than a hostname — one policy covering its custom domains, routes, `workers.dev`, and preview URLs. In that mode Cloudflare authenticates the caller at the edge and hands the Worker the identity on the `ExecutionContext`, **not** in the `Cf-Access-Jwt-Assertion` header that hostname-scoped Access applications stamp.

`@lunora/cloudflare-access` only understood the header. Nothing in the identity layer could reach an execution context — `resolveIdentity(request, env)` never saw one — so a Worker-scoped deployment resolved every caller to anonymous and RLS denied everything.

## How

- `WorkerOptions.resolveIdentity` and `adminGate` gain a trailing `context`. It is recorded once per request at the `fetch` funnel and keyed on the `Request`, so every path that resolves identity — including the extracted admin-route modules that take `resolveForwardContext` as an injected dep — reaches it without threading a fourth argument through ~25 signatures. `serverQuery`, which has no funnel, takes it explicitly via `callOptions.context`.
- `createAccessResolver()` reads the platform identity first and falls back to verifying the JWT. The platform path needs no configuration and verifies nothing, because there is nothing to verify: the edge authenticated the caller before the Worker ran, and the field is absent unless it did.
- `teamDomain`/`aud` are therefore optional — but **all-or-nothing, and keyed on the option's presence rather than its value**, so a worker wired for JWT verification whose secrets are unset still refuses to construct instead of booting as a silently-anonymous one.
- Both paths produce one claim shape. Group membership is normalized from the platform's `{ id, name }` objects to the JWT's names; `userId` derivation is deliberately identical, so moving a deployment between the two modes does not re-key its users.
- `wrangler.jsonc`'s `access.dev` block simulates a Worker-scoped identity locally, and it now reaches `ctx.auth` / `ctx.access` like the deployed one.
- Codegen: `.access()` takes no argument for the Worker-scoped case.

## Security notes

Two consequences of the new path, both fixed here rather than left for later:

- **REST caching.** A caller authenticated by the edge may present no credential header at all, so `scope: "public"` responses were labelled publicly cacheable for a per-user body. `requestCarriesCredentials` counts a context-supplied Access identity as a credential.
- **Identity memoization.** `memoizeIdentity`'s cross-request cache keys on the presented credential; a platform identity is not one, so two Access principals sharing any cookie (or one shared downstream bearer) collided onto a single entry and the second was served the first's identity. The cross-request layer is now bypassed whenever the context carries an Access identity.

The **admin gate deliberately inverts the resolver's precedence**: configure `teamDomain` + `aud` and the JWT is the only accepted proof. That `aud` is a narrow boundary — a dedicated Access application over `/_lunora/admin` — and letting a broad "anyone at the company" Worker policy satisfy it would widen the admin plane to everyone that policy admits, silently, the moment it was attached.

## Breaking

Pre-1.0 on `alpha`. `resolveIdentity` / `adminGate` / the three `rest-cache` exports take an extra optional argument, and `CreateAccessResolverOptions` / `AccessAdminGateOptions` make `teamDomain`/`aud` optional. Existing call sites keep compiling; the admin-gate precedence change is a deliberate behaviour break for anyone who had configured an admin `aud` *and* attached a Worker-scoped policy.

## Verification

`lint:types` exit 0 repo-wide; `eslint --max-warnings=0` clean; runtime (907), cloudflare-access (75), codegen (1204) suites pass; `api:update` run after a fresh build. Reviewed by both thermo passes — every finding is either fixed in the second commit or answered in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare Access identities provided directly by the platform.
  * Added optional JWT verification as a fallback for hostname-scoped Access authentication.
  * Cloudflare Access can now be configured without a selector.
  * Added support for Access identity details, including names and normalized groups.

* **Bug Fixes**
  * Access-authenticated requests are now protected from unsafe public caching.
  * Authentication and admin authorization now fail closed for missing or invalid identities.

* **Documentation**
  * Expanded guidance for Access configuration, local testing, identity resolution, claims, groups, and subscription expiry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->