### PR TITLE
fix(docs): drop an unused type import

### DIFF
--- a/apps/docs/src/pages/home/sections/platform-strip.tsx
+++ b/apps/docs/src/pages/home/sections/platform-strip.tsx
@@ -1,5 +1,5 @@
 import SiCloudflare from "@icons-pack/react-simple-icons/icons/SiCloudflare.mjs";
-import type { CSSProperties, FC } from "react";
+import type { FC } from "react";
 
 import { Kicker, Shell } from "@/kit/layout";
 


### PR DESCRIPTION
## Summary

`CSSProperties` is imported in `apps/docs/src/pages/home/sections/platform-strip.tsx` and never referenced. Both `unused-imports/no-unused-imports` and `sonarjs/unused-import` flag it as an **error**, so `Lint (eslint)` fails wherever it runs.

It has gone unnoticed because the eslint job only runs when the changed paths select the docs app. A branch that touches nothing under `apps/` never sees it. It surfaced on #413, which changed a file under `packages/` and thereby pulled the docs project into the affected set — that PR does not touch `apps/` at all, so the failure is not its own.

One line, no behaviour change: the import was unused, so nothing referenced the type.

## Test plan

- [x] `pnpm exec eslint src/pages/home/sections/platform-strip.tsx` from `apps/docs` — clean (it reports the two errors before this change)

## Linked issues

<!-- none -->

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`fix(scope): subject`)
- [ ] Added or updated tests covering the change — not applicable; this is an unused-import removal caught by the linter itself
- [ ] Updated relevant docs — not applicable
- [x] No `package.json` files modified

> By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and that you can use, modify, copy, and redistribute this contribution under those terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYuhTqTiAJsw5NdF5i1QSQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused internal type import from the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->