### PR TITLE
feat(workflow): add declared workflow events

### DIFF
--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -905,6 +905,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `WorkflowEventDefinition` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `WorkflowHandle` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -5415,6 +5419,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 
+### `WorkflowEventDefinition` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
 ### `WorkflowHandle` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
@@ -7078,6 +7086,10 @@ Re-exported from `@lunora/server` — signature tracked at its source.
 Re-exported from `@lunora/server` — signature tracked at its source.
 
 ### `WorkflowCreateOptions` (interface)
+
+Re-exported from `@lunora/server` — signature tracked at its source.
+
+### `WorkflowEventDefinition` (interface)
 
 Re-exported from `@lunora/server` — signature tracked at its source.
 

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -2440,6 +2440,16 @@ interface WorkflowCreateOptions<Params = Record<string, unknown>> {
 }
 ```
 
+### `WorkflowEventDefinition` (interface)
+
+```ts
+interface WorkflowEventDefinition<Payload = unknown> {
+    readonly isLunoraWorkflowEvent: true;
+    readonly payload: Validator<Payload>;
+    readonly type: string;
+}
+```
+
 ### `WorkflowHandle` (interface)
 
 ```ts
@@ -2447,6 +2457,7 @@ interface WorkflowHandle<Params = Record<string, unknown>> {
     create: (options?: WorkflowCreateOptions<Params>) => Promise<WorkflowInstance>;
     createBatch: (batch: ReadonlyArray<WorkflowCreateOptions<Params>>) => Promise<WorkflowInstance[]>;
     get: (id: string) => Promise<WorkflowInstance>;
+    sendEvent: <Payload>(instanceId: string, event: WorkflowEventDefinition<Payload>, payload: Payload) => Promise<void>;
 }
 ```
 
@@ -5329,6 +5340,16 @@ interface WorkflowCreateOptions<Params = Record<string, unknown>> {
 }
 ```
 
+### `WorkflowEventDefinition` (interface)
+
+```ts
+interface WorkflowEventDefinition<Payload = unknown> {
+    readonly isLunoraWorkflowEvent: true;
+    readonly payload: Validator<Payload>;
+    readonly type: string;
+}
+```
+
 ### `WorkflowHandle` (interface)
 
 ```ts
@@ -5336,6 +5357,7 @@ interface WorkflowHandle<Params = Record<string, unknown>> {
     create: (options?: WorkflowCreateOptions<Params>) => Promise<WorkflowInstance>;
     createBatch: (batch: ReadonlyArray<WorkflowCreateOptions<Params>>) => Promise<WorkflowInstance[]>;
     get: (id: string) => Promise<WorkflowInstance>;
+    sendEvent: <Payload>(instanceId: string, event: WorkflowEventDefinition<Payload>, payload: Payload) => Promise<void>;
 }
 ```
 

--- a/api-snapshots/workflow.api.md
+++ b/api-snapshots/workflow.api.md
@@ -166,6 +166,15 @@ interface StepRunContext {
 }
 ```
 
+### `WaitForEventOptions` (interface)
+
+```ts
+interface WaitForEventOptions {
+    name?: string;
+    timeout?: number | string;
+}
+```
+
 ### `WorkflowBindingLike` (interface)
 
 ```ts
@@ -238,6 +247,16 @@ interface WorkflowDefinition<Params = Record<string, unknown>, Output = unknown>
 }
 ```
 
+### `WorkflowEventDefinition` (interface)
+
+```ts
+interface WorkflowEventDefinition<Payload = unknown> {
+    readonly isLunoraWorkflowEvent: true;
+    readonly payload: Validator<Payload>;
+    readonly type: string;
+}
+```
+
 ### `WorkflowEventLike` (interface)
 
 ```ts
@@ -256,6 +275,7 @@ interface WorkflowHandle<Params = Record<string, unknown>> {
     create: (options?: WorkflowCreateOptions<Params>) => Promise<WorkflowInstanceLike>;
     createBatch: (batch: ReadonlyArray<WorkflowCreateOptions<Params>>) => Promise<WorkflowInstanceLike[]>;
     get: (id: string) => Promise<WorkflowInstanceLike>;
+    sendEvent: <Payload>(instanceId: string, event: WorkflowEventDefinition<Payload>, payload: Payload) => Promise<void>;
 }
 ```
 
@@ -375,6 +395,7 @@ interface WorkflowRunContext<Params = Record<string, unknown>> {
     readonly runStep: WorkflowRunStepFunction;
     readonly spawn: WorkflowSpawnFunction;
     readonly step: WorkflowStepLike;
+    readonly waitForEvent: WorkflowWaitForEventFunction;
 }
 ```
 
@@ -487,6 +508,12 @@ interface WorkflowStepRollbackOptionsLike<T = unknown> {
 }
 ```
 
+### `WorkflowWaitForEventFunction` (type)
+
+```ts
+type WorkflowWaitForEventFunction = <Payload>(event: WorkflowEventDefinition<Payload>, options?: WaitForEventOptions) => Promise<Payload>;
+```
+
 ### `Workflows` (interface)
 
 ```ts
@@ -559,6 +586,12 @@ const convertNonRetryableError: (error: unknown, NativeNonRetryableError: Native
 const createRunStep: (deps: RunStepDeps) => WorkflowRunStepFunction;
 ```
 
+### `createWaitForEvent` (const)
+
+```ts
+const createWaitForEvent: (deps: WaitForEventDeps) => WorkflowWaitForEventFunction;
+```
+
 ### `createWorkflowContext` (const)
 
 ```ts
@@ -595,6 +628,12 @@ const defineStep: <A extends StepArgsValidator, Result>(name: string, config: St
 const defineWorkflow: <Params = Record<string, unknown>, Output = unknown>(config: WorkflowConfig<Params, Output>) => WorkflowDefinition<Params, Output>;
 ```
 
+### `defineWorkflowEvent` (const)
+
+```ts
+const defineWorkflowEvent: <Payload>(type: string, payload: Validator<Payload>) => WorkflowEventDefinition<Payload>;
+```
+
 ### `isNonRetryableError` (const)
 
 ```ts
@@ -611,6 +650,12 @@ const isStepDefinition: (value: unknown) => value is StepDefinition;
 
 ```ts
 const isWorkflowDefinition: (value: unknown) => value is WorkflowDefinition;
+```
+
+### `isWorkflowEventDefinition` (const)
+
+```ts
+const isWorkflowEventDefinition: (value: unknown) => value is WorkflowEventDefinition;
 ```
 
 ### `toNativeNonRetryableError` (const)

--- a/apps/docs/src/data/packages-metadata.json
+++ b/apps/docs/src/data/packages-metadata.json
@@ -51,8 +51,8 @@
     },
     "cloudflare-access": {
         "displayName": "Cloudflare Access",
-        "description": "Cloudflare Access (Zero Trust) identity: verify the Cf-Access-Jwt-Assertion JWT and feed ctx.auth / RLS.",
-        "features": ["JWKS-verified Access JWTs", "resolveIdentity adapter", "Feeds ctx.auth & RLS"]
+        "description": "Cloudflare Access (Zero Trust) identity: Worker-scoped Access policies or JWKS-verified Access JWTs, fed into ctx.auth / RLS.",
+        "features": ["Worker-scoped Access policies", "JWKS-verified Access JWTs", "Feeds ctx.auth & RLS"]
     },
     "codegen": {
         "displayName": "Codegen",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -201,6 +201,7 @@ export type {
     VectorSearchReader,
     VectorUpsertInput,
     WorkflowCreateOptions,
+    WorkflowEventDefinition,
     WorkflowHandle,
     WorkflowInstance,
     WorkflowInstanceStatus,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1278,6 +1278,17 @@ interface WorkflowCreateOptions<Params = Record<string, unknown>> {
     retention?: { errorRetention?: string; successRetention?: string };
 }
 
+/**
+ * One declared external event a workflow waits on. Mirrors `@lunora/workflow`'s
+ * `WorkflowEventDefinition` — the value `defineWorkflowEvent` returns, taken by
+ * both {@link WorkflowInstance.sendEvent} and the workflow's `ctx.waitForEvent`.
+ */
+interface WorkflowEventDefinition<Payload = unknown> {
+    readonly isLunoraWorkflowEvent: true;
+    readonly payload: Validator<Payload>;
+    readonly type: string;
+}
+
 /** A live handle to a single workflow instance. Mirrors `@lunora/workflow`'s `WorkflowInstanceLike`. */
 interface WorkflowInstance {
     readonly id: string;
@@ -1300,6 +1311,8 @@ interface WorkflowHandle<Params = Record<string, unknown>> {
     createBatch: (batch: ReadonlyArray<WorkflowCreateOptions<Params>>) => Promise<WorkflowInstance[]>;
     /** Get a handle to an existing instance by id. */
     get: (id: string) => Promise<WorkflowInstance>;
+    /** Deliver a declared event (`defineWorkflowEvent`) to one instance; the payload is validated before the send. */
+    sendEvent: <Payload>(instanceId: string, event: WorkflowEventDefinition<Payload>, payload: Payload) => Promise<void>;
 }
 
 /**
@@ -2366,6 +2379,7 @@ export type {
     VectorSearchReader,
     VectorUpsertInput,
     WorkflowCreateOptions,
+    WorkflowEventDefinition,
     WorkflowHandle,
     WorkflowInstance,
     WorkflowInstanceStatus,

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -85,9 +85,32 @@ The handler context bundles:
 - `ctx.step` — the native Cloudflare durable-step API (`do` / `sleep` / `sleepUntil` / `waitForEvent`).
 - `ctx.run(ref, args, opts?)` — call a Lunora query / mutation / action; wrap in `ctx.step.do(...)` for durability.
 - `ctx.runStep(step, args, opts?)` — run a reusable, schema-validated `defineStep` as a durable step (see below).
+- `ctx.waitForEvent(event, opts?)` — hibernate until a declared `defineWorkflowEvent` arrives; resolves with its validated payload (see below).
 - `ctx.event` / `ctx.params` — the triggering event and its payload.
 - `ctx.env` — the Worker bindings.
 - `ctx.log` — a workflow-prefixed logger surfaced in `wrangler tail` / Studio.
+
+### Declared events (`defineWorkflowEvent`)
+
+`step.waitForEvent(name, { type })` and `instance.sendEvent({ type })` match on a bare string, and the payload crosses as `unknown` — so a typo hibernates the instance until its timeout with no error anywhere, and a changed payload shape resumes the workflow on garbage. Declare the event once and both ends import the same value:
+
+```ts
+// lunora/events.ts
+import { defineWorkflowEvent } from "@lunora/workflow";
+import { v } from "@lunora/values";
+
+export const orderApproved = defineWorkflowEvent("order-approved", v.object({ approvedBy: v.string() }));
+```
+
+```ts
+// inside the workflow body — typed and parsed
+const { approvedBy } = await ctx.waitForEvent(orderApproved, { name: "await approval", timeout: "7 days" });
+
+// from a mutation/action — validated before the send
+await ctx.workflows.get("orderPipeline").sendEvent(instanceId, orderApproved, { approvedBy });
+```
+
+Pass a stable `{ name }` on any wait that can outlive a deploy: the step is otherwise labelled `event:<type>`, so renaming the event type also renames the durable step and an instance that already recorded the wait replays into a fresh one nothing will satisfy.
 
 ### Reusable steps (`defineStep`)
 
@@ -169,7 +192,7 @@ export const checkout = mutation.input({ orderId: v.string() }).mutation(async (
 });
 ```
 
-A handle exposes `create({ id?, params?, retention? })`, `createBatch([...])`, and `get(id)`. An instance handle exposes its lifecycle: `status()`, `pause()`, `resume()`, `terminate()`, and `sendEvent({ type, payload })` (to satisfy a `waitForEvent`).
+A handle exposes `create({ id?, params?, retention? })`, `createBatch([...])`, `get(id)`, and `sendEvent(instanceId, event, payload)` — the typed delivery of a declared event (see above). `create`/`get` return the native Cloudflare instance, which exposes its own lifecycle: `status()`, `pause()`, `resume()`, `restart()`, `terminate()`, and the untyped `sendEvent({ type, payload })`.
 
 ### Runtime requirements
 

--- a/packages/workflow/__tests__/events.test.ts
+++ b/packages/workflow/__tests__/events.test.ts
@@ -68,13 +68,15 @@ describe("defineWorkflowEvent", () => {
     });
 
     it("rejects an empty type, a reserved type, and a non-validator payload", () => {
-        expect.assertions(4);
+        expect.assertions(5);
 
         expect(() => defineWorkflowEvent("", v.string())).toThrow(/non-empty string/);
         // The `lunora:` namespace carries `ctx.parallel`'s branch-join protocol.
         expect(() => defineWorkflowEvent("lunora:branch:x", v.string())).toThrow(/reserved/);
         expect(() => defineWorkflowEvent("ok", undefined as never)).toThrow(/must be a validator/);
+        // The guard validates the fields it promises the caller, not just the brand.
         expect(isWorkflowEventDefinition({ type: "order-approved" })).toBe(false);
+        expect(isWorkflowEventDefinition({ isLunoraWorkflowEvent: true })).toBe(false);
     });
 });
 

--- a/packages/workflow/__tests__/events.test.ts
+++ b/packages/workflow/__tests__/events.test.ts
@@ -1,0 +1,173 @@
+import { v } from "@lunora/values";
+import { describe, expect, it } from "vitest";
+
+import createWorkflows from "../src/create-workflows";
+import { defineWorkflowEvent, isWorkflowEventDefinition } from "../src/define-event";
+import { isNonRetryableError } from "../src/errors";
+import type { WorkflowBindingLike, WorkflowInstanceLike, WorkflowStepLike } from "../src/types";
+import { createWaitForEvent } from "../src/wait-for-event";
+
+const orderApproved = defineWorkflowEvent("order-approved", v.object({ approvedBy: v.string() }));
+
+/** A `WorkflowStepLike` double whose `waitForEvent` records its args and returns a canned payload. */
+const fakeStep = (payload: unknown): { calls: { name: string; options: { timeout?: number | string; type: string } }[]; step: WorkflowStepLike } => {
+    const calls: { name: string; options: { timeout?: number | string; type: string } }[] = [];
+
+    return {
+        calls,
+        step: {
+            do: async () => undefined,
+            sleep: async () => undefined,
+            sleepUntil: async () => undefined,
+            waitForEvent: async (name: string, options: { timeout?: number | string; type: string }) => {
+                calls.push({ name, options });
+
+                return { payload, type: options.type };
+            },
+        } as WorkflowStepLike,
+    };
+};
+
+/** A `Workflow` binding double recording every `sendEvent` that reaches the native instance. */
+const fakeBinding = (): { binding: WorkflowBindingLike; sent: { id: string; payload: unknown; type: string }[] } => {
+    const sent: { id: string; payload: unknown; type: string }[] = [];
+
+    const instanceFor = (id: string): WorkflowInstanceLike => {
+        return {
+            id,
+            pause: async () => undefined,
+            restart: async () => undefined,
+            resume: async () => undefined,
+            sendEvent: async (event: { payload: unknown; type: string }) => {
+                sent.push({ id, ...event });
+            },
+            status: async () => {
+                return { status: "running" as const };
+            },
+            terminate: async () => undefined,
+        };
+    };
+
+    return {
+        binding: {
+            create: async () => instanceFor("inst-1"),
+            createBatch: async () => [instanceFor("inst-1")],
+            get: async (id: string) => instanceFor(id),
+        },
+        sent,
+    };
+};
+
+describe("defineWorkflowEvent", () => {
+    it("brands the definition and carries the type + validator", () => {
+        expect.assertions(3);
+
+        expect(orderApproved.type).toBe("order-approved");
+        expect(orderApproved.payload.parse({ approvedBy: "u1" })).toStrictEqual({ approvedBy: "u1" });
+        expect(isWorkflowEventDefinition(orderApproved)).toBe(true);
+    });
+
+    it("rejects an empty type, a reserved type, and a non-validator payload", () => {
+        expect.assertions(4);
+
+        expect(() => defineWorkflowEvent("", v.string())).toThrow(/non-empty string/);
+        // The `lunora:` namespace carries `ctx.parallel`'s branch-join protocol.
+        expect(() => defineWorkflowEvent("lunora:branch:x", v.string())).toThrow(/reserved/);
+        expect(() => defineWorkflowEvent("ok", undefined as never)).toThrow(/must be a validator/);
+        expect(isWorkflowEventDefinition({ type: "order-approved" })).toBe(false);
+    });
+});
+
+describe("ctx.waitForEvent", () => {
+    it("waits on the definition's type under a derived step name and returns the parsed payload", async () => {
+        expect.assertions(3);
+
+        const { calls, step } = fakeStep({ approvedBy: "u1" });
+
+        await expect(createWaitForEvent({ step })(orderApproved)).resolves.toStrictEqual({ approvedBy: "u1" });
+        expect(calls[0]?.name).toBe("event:order-approved");
+        expect(calls[0]?.options.type).toBe("order-approved");
+    });
+
+    it("honors an explicit step name and timeout", async () => {
+        expect.assertions(2);
+
+        const { calls, step } = fakeStep({ approvedBy: "u1" });
+
+        await createWaitForEvent({ step })(orderApproved, { name: "await manager sign-off", timeout: "1 hour" });
+
+        expect(calls[0]?.name).toBe("await manager sign-off");
+        expect(calls[0]?.options.timeout).toBe("1 hour");
+    });
+
+    it("fails non-retryably when the delivered payload does not match the validator", async () => {
+        expect.assertions(2);
+
+        const { step } = fakeStep({ approvedBy: 42 });
+
+        // The event is already consumed, so replaying the wait can only hibernate
+        // the instance until its timeout — surface the mismatch instead.
+        const error = await createWaitForEvent({ step })(orderApproved).catch((error_: unknown) => error_);
+
+        expect(isNonRetryableError(error)).toBe(true);
+        expect((error as Error).message).toMatch(/event "order-approved" payload validation failed:/);
+    });
+
+    it("fails non-retryably on a forged definition or a reserved step name, without waiting", async () => {
+        expect.assertions(3);
+
+        const { calls, step } = fakeStep({ approvedBy: "u1" });
+        const waitForEvent = createWaitForEvent({ step });
+
+        await expect(waitForEvent({ type: "order-approved" } as never)).rejects.toThrow(/defineWorkflowEvent/);
+        // `lunora:await:*` is the branch join's own durable-step namespace.
+        await expect(waitForEvent(orderApproved, { name: "lunora:await:x" })).rejects.toThrow(/reserved/);
+        expect(calls).toStrictEqual([]);
+    });
+});
+
+describe("workflows.get(name).sendEvent", () => {
+    it("resolves the instance by id and sends the parsed payload under the definition's type", async () => {
+        expect.assertions(1);
+
+        const { binding, sent } = fakeBinding();
+
+        await createWorkflows({ bindings: { orderPipeline: binding } })
+            .get("orderPipeline")
+            .sendEvent("inst-7", orderApproved, { approvedBy: "u1" });
+
+        expect(sent).toStrictEqual([{ id: "inst-7", payload: { approvedBy: "u1" }, type: "order-approved" }]);
+    });
+
+    it("rejects a bad payload at the producer, before the send", async () => {
+        expect.assertions(2);
+
+        const { binding, sent } = fakeBinding();
+        const handle = createWorkflows({ bindings: { orderPipeline: binding } }).get("orderPipeline");
+
+        await expect(handle.sendEvent("inst-7", orderApproved, { approvedBy: 42 as unknown as string })).rejects.toThrow(/approvedBy/);
+        expect(sent).toStrictEqual([]);
+    });
+
+    it("rejects a forged definition, so a reserved type cannot spoof a branch outcome", async () => {
+        expect.assertions(3);
+
+        const { binding, sent } = fakeBinding();
+        const handle = createWorkflows({ bindings: { orderPipeline: binding } }).get("orderPipeline");
+        // A definition-shaped object built from untrusted data: the brand is a public
+        // boolean, so the send boundary re-checks the fields rather than trusting it.
+        const forged = { isLunoraWorkflowEvent: true, payload: v.any(), type: "lunora:branch:inst-1-c0" } as never;
+
+        await expect(handle.sendEvent("inst-1", forged, { status: "ok" })).rejects.toThrow(/reserved/);
+        await expect(handle.sendEvent("inst-1", { type: "x" } as never, {})).rejects.toThrow(/defineWorkflowEvent/);
+        expect(sent).toStrictEqual([]);
+    });
+
+    it("is resolved per workflow, so an unknown workflow still throws", () => {
+        expect.assertions(1);
+
+        const { binding } = fakeBinding();
+
+        expect(() => createWorkflows({ bindings: { orderPipeline: binding } }).get("nope")).toThrow(/no workflow named/);
+    });
+});

--- a/packages/workflow/__tests__/run-context.test.ts
+++ b/packages/workflow/__tests__/run-context.test.ts
@@ -1,5 +1,7 @@
+import { v } from "@lunora/values";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { defineWorkflowEvent } from "../src/define-event";
 import { createWorkflowRunContext } from "../src/run-context";
 import type { WorkflowEventLike, WorkflowStepLike } from "../src/types";
 
@@ -52,6 +54,21 @@ describe("createWorkflowRunContext", () => {
 
         expect(typeof ctx.parallel).toBe("function");
         expect(typeof ctx.spawn).toBe("function");
+    });
+
+    it("wires ctx.waitForEvent onto the native step API", async () => {
+        expect.assertions(2);
+
+        const step = makeStep();
+        const waitForEvent = step.waitForEvent as unknown as ReturnType<typeof vi.fn>;
+
+        waitForEvent.mockResolvedValue({ payload: { approvedBy: "u1" }, type: "order-approved" });
+
+        const ctx = createWorkflowRunContext({ env: {}, event: makeEvent(), exportName: "orderPipeline", step });
+        const orderApproved = defineWorkflowEvent("order-approved", v.object({ approvedBy: v.string() }));
+
+        await expect(ctx.waitForEvent(orderApproved)).resolves.toStrictEqual({ approvedBy: "u1" });
+        expect(waitForEvent).toHaveBeenCalledWith("event:order-approved", expect.objectContaining({ type: "order-approved" }));
     });
 
     it("spawning a workflow with no matching WORKFLOW_* binding throws a helpful error", async () => {

--- a/packages/workflow/__tests__/server-mirror.test.ts
+++ b/packages/workflow/__tests__/server-mirror.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `@lunora/server` re-declares this package's `ctx.workflows` surface by hand
+ * (`packages/server/src/types.ts`) so the main API package needs no dependency on
+ * `@lunora/workflow`. Nothing else compares the two: they live in separate
+ * api-snapshots, and codegen narrows `ctx.workflows` to *this* package's
+ * `WorkflowHandle` as soon as an app declares a workflow, so the mirror is only
+ * exercised by apps with zero workflows — it can rot for a long time unseen.
+ *
+ * These are type-level assertions: if either side moves, `true` stops being
+ * assignable to the check type and `lint:types` fails here. The runtime `expect`
+ * only exists so the file is a test rather than an unused-symbol lint error.
+ */
+import type {
+    WorkflowCreateOptions as ServerCreateOptions,
+    WorkflowEventDefinition as ServerEventDefinition,
+    WorkflowHandle as ServerHandle,
+    WorkflowInstance as ServerInstance,
+    Workflows as ServerWorkflows,
+    WorkflowStatusResult as ServerStatusResult,
+} from "@lunora/server";
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowCreateOptions, WorkflowEventDefinition, WorkflowHandle, WorkflowInstanceLike, Workflows, WorkflowStatusResult } from "../src/types";
+
+/** `true` only when `A` and `B` are mutually assignable — i.e. the mirror has not drifted. */
+type Mutual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+describe("@lunora/server ctx.workflows mirror", () => {
+    it("stays in lockstep with @lunora/workflow's types", () => {
+        expect.assertions(1);
+
+        const inLockstep: [
+            Mutual<WorkflowCreateOptions, ServerCreateOptions>,
+            Mutual<WorkflowEventDefinition, ServerEventDefinition>,
+            Mutual<WorkflowHandle, ServerHandle>,
+            Mutual<WorkflowInstanceLike, ServerInstance>,
+            Mutual<WorkflowStatusResult, ServerStatusResult>,
+            Mutual<Workflows, ServerWorkflows>,
+        ] = [true, true, true, true, true, true];
+
+        expect(inLockstep).toHaveLength(6);
+    });
+});

--- a/packages/workflow/docs/index.mdx
+++ b/packages/workflow/docs/index.mdx
@@ -65,17 +65,18 @@ export const channelWelcome = defineWorkflow<
 The handler receives one argument bundling the durable-step API and a typed
 function caller:
 
-| Member             | What it is                                                                                          |
-| ------------------ | --------------------------------------------------------------------------------------------------- |
-| `context.params`   | The input passed to `.create({ params })`, typed as `Params`.                                       |
-| `context.step`     | The durable-step API: `do` / `sleep` / `sleepUntil` / `waitForEvent`.                               |
-| `context.run`      | Call a Lunora function (`api.*`) by typed reference; pass `{ shardKey }` to target a shard.         |
-| `context.runStep`  | Run a reusable, schema-validated `defineStep` as a durable step (see below).                        |
-| `context.parallel` | Fan out branches as isolated child workflow instances and await their outputs (see below).          |
-| `context.spawn`    | Fire-and-forget start of a declared child workflow (replay-safe; returns a live handle).            |
-| `context.log`      | Structured logger (`debug`/`info`/`warn`/`error`), captured by `wrangler tail` and the Studio logs. |
-| `context.event`    | The raw triggering event (`id`, `payload`, timestamp).                                              |
-| `context.env`      | The Worker environment bindings.                                                                    |
+| Member                 | What it is                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `context.params`       | The input passed to `.create({ params })`, typed as `Params`.                                          |
+| `context.step`         | The durable-step API: `do` / `sleep` / `sleepUntil` / `waitForEvent`.                                  |
+| `context.run`          | Call a Lunora function (`api.*`) by typed reference; pass `{ shardKey }` to target a shard.            |
+| `context.runStep`      | Run a reusable, schema-validated `defineStep` as a durable step (see below).                           |
+| `context.parallel`     | Fan out branches as isolated child workflow instances and await their outputs (see below).             |
+| `context.spawn`        | Fire-and-forget start of a declared child workflow (replay-safe; returns a live handle).               |
+| `context.waitForEvent` | Hibernate until a declared event (`defineWorkflowEvent`) arrives; resolves with its validated payload. |
+| `context.log`          | Structured logger (`debug`/`info`/`warn`/`error`), captured by `wrangler tail` and the Studio logs.    |
+| `context.event`        | The raw triggering event (`id`, `payload`, timestamp).                                                 |
+| `context.env`          | The Worker environment bindings.                                                                       |
 
 ### Durable steps
 
@@ -96,6 +97,7 @@ await context.step.sleep("cool-off", "1 minute");
 await context.step.sleepUntil("run-at", new Date("2026-07-01T00:00:00Z"));
 
 // Pause until an external event (approvals, webhooks, human-in-the-loop).
+// Prefer `context.waitForEvent` with a declared event — see below.
 const approval = await context.step.waitForEvent<{ approved: boolean }>("await-approval", {
     type: "approval",
     timeout: "7 days",
@@ -106,6 +108,57 @@ const approval = await context.step.waitForEvent<{ approved: boolean }>("await-a
     Steps must be **JSON-serialisable and idempotent**, the same determinism contract Cloudflare (and Convex) impose. A step body may run more than once on
     retry, so don't rely on side effects outside the step's return value.
 </Callout>
+
+### Declared events (`defineWorkflowEvent`)
+
+The native `step.waitForEvent(name, { type })` matches `instance.sendEvent({ type })`
+by a bare string, and the payload crosses as `unknown`. Both ends drift silently:
+a typo'd type hibernates the instance until its timeout (24 hours by default) with
+no error anywhere, and a payload whose shape changed resumes the workflow on
+garbage. Declare the event once instead, so there is no literal to typo and no
+second place to update on a rename, and both ends parse the payload:
+
+```ts
+// lunora/events.ts
+import { defineWorkflowEvent } from "@lunora/workflow";
+import { v } from "@lunora/values";
+
+export const orderApproved = defineWorkflowEvent("order-approved", v.object({ approvedBy: v.string() }));
+```
+
+Wait on it inside the workflow — the payload is typed **and** parsed:
+
+```ts
+const { approvedBy } = await context.waitForEvent(orderApproved, { name: "await approval", timeout: "7 days" });
+```
+
+Send it from a mutation or action with the same definition:
+
+```ts
+export const approve = mutation.input({ approvedBy: v.string(), instanceId: v.string() }).mutation(async ({ ctx, args: { approvedBy, instanceId } }) => {
+    await ctx.workflows.get("orderPipeline").sendEvent(instanceId, orderApproved, { approvedBy });
+});
+```
+
+The payload is validated on **send** (a bad value fails the caller's request,
+before the workflow is woken) and again on **receive**. A payload that fails the
+validator on receive is a non-retryable failure — the event has already been
+consumed, so replaying the wait could only hibernate the instance again.
+
+<Callout type="warn">
+    **Pass a stable `{ name }` on any wait that can outlive a deploy.** The durable step is otherwise labelled `event:<type>`, which couples the step's identity
+    to the wire type: rename the event type and an instance that already recorded the wait replays into a *fresh* step that nothing will ever satisfy — it
+    hibernates to its timeout. An explicit `name` also tells two waits on the same event type apart in the timeline.
+</Callout>
+
+What this does **not** buy is a compile error for every mismatch: two definitions
+with the same payload shape are mutually assignable, so sending `orderRejected`
+where the workflow awaits `orderApproved` still type-checks. What it removes is the
+hand-matched string.
+
+Event types beginning with `lunora:` are reserved for the framework's own
+instance-to-instance protocol (the `context.parallel` branch join) and are rejected
+both when declared and when sent.
 
 ### Reusable steps (`defineStep`)
 
@@ -293,9 +346,13 @@ export const create = mutation.input({ channelId: v.id("channels") }).mutation(a
 - `createBatch([...])`: start many in one batch.
 - `get(id)`: a handle to an existing instance.
 
-An instance handle exposes its lifecycle: `status()` (returns
-`status` + `output`/`error`), `pause()`, `resume()`, `terminate()`, and
-`sendEvent({ type, payload })` (to satisfy a `waitForEvent`).
+- `sendEvent(instanceId, event, payload)`: deliver a
+  [declared event](#declared-events-defineworkflowevent) to one instance, to satisfy
+  its `context.waitForEvent`. The payload is validated before the send.
+
+`create`/`get` hand back the native Cloudflare instance, which exposes its own
+lifecycle: `status()` (returns `status` + `output`/`error`), `pause()`, `resume()`,
+`restart()`, `terminate()`, and the untyped `sendEvent({ type, payload })`.
 
 ### Listing instances and step timelines
 

--- a/packages/workflow/docs/index.mdx
+++ b/packages/workflow/docs/index.mdx
@@ -157,8 +157,9 @@ where the workflow awaits `orderApproved` still type-checks. What it removes is 
 hand-matched string.
 
 Event types beginning with `lunora:` are reserved for the framework's own
-instance-to-instance protocol (the `context.parallel` branch join) and are rejected
-both when declared and when sent.
+instance-to-instance protocol (the `context.parallel` branch join). `defineWorkflowEvent`
+and the typed `sendEvent` above reject them; the native untyped
+`instance.sendEvent({ type, payload })` does not go through that check.
 
 ### Reusable steps (`defineStep`)
 

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -69,6 +69,7 @@
         "@cloudflare/vitest-pool-workers": "catalog:cloudflare",
         "@cloudflare/workers-types": "catalog:cloudflare",
         "@lunora/dispatch": "workspace:*",
+        "@lunora/server": "workspace:*",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:build",
         "@vitest/coverage-v8": "catalog:test",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -69,7 +69,7 @@
         "@cloudflare/vitest-pool-workers": "catalog:cloudflare",
         "@cloudflare/workers-types": "catalog:cloudflare",
         "@lunora/dispatch": "workspace:*",
-        "@lunora/server": "workspace:*",
+        "@lunora/server": "1.0.0-alpha.75",
         "@types/node": "catalog:types",
         "@visulima/packem": "catalog:build",
         "@vitest/coverage-v8": "catalog:test",

--- a/packages/workflow/src/create-workflows.ts
+++ b/packages/workflow/src/create-workflows.ts
@@ -6,7 +6,16 @@
 import { LunoraError } from "@lunora/errors";
 
 import { BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
-import type { LunoraWorkflowsOptions, WorkflowBindingLike, WorkflowCreateOptions, WorkflowHandle, WorkflowInstanceLike, Workflows } from "./types";
+import { eventDefinitionProblem } from "./define-event";
+import type {
+    LunoraWorkflowsOptions,
+    WorkflowBindingLike,
+    WorkflowCreateOptions,
+    WorkflowEventDefinition,
+    WorkflowHandle,
+    WorkflowInstanceLike,
+    Workflows,
+} from "./types";
 
 /**
  * Reject any public create whose params carry the reserved branch-marker key.
@@ -39,6 +48,24 @@ const handleFor = (binding: WorkflowBindingLike): WorkflowHandle => {
             return binding.createBatch(batch);
         },
         get: async (id: string): Promise<WorkflowInstanceLike> => binding.get(id),
+        sendEvent: async <Payload>(instanceId: string, event: WorkflowEventDefinition<Payload>, payload: Payload): Promise<void> => {
+            // The trust boundary, mirroring `rejectReservedParams` above: the brand
+            // on `WorkflowEventDefinition` is a public boolean, so a definition-shaped
+            // object built from untrusted data would otherwise reach the wire — and a
+            // reserved `lunora:` type could forge a `ctx.parallel` branch outcome into
+            // a parent instance.
+            const problem = eventDefinitionProblem(event);
+
+            if (problem !== undefined) {
+                throw new LunoraError("BAD_REQUEST", `@lunora/workflow: sendEvent ${problem}`);
+            }
+
+            const instance = await binding.get(instanceId);
+
+            // Parse before the send: a bad payload fails the caller's request rather
+            // than waking the workflow on a value its `ctx.waitForEvent` will reject.
+            await instance.sendEvent({ payload: event.payload.parse(payload), type: event.type });
+        },
     };
 };
 

--- a/packages/workflow/src/define-event.ts
+++ b/packages/workflow/src/define-event.ts
@@ -1,0 +1,103 @@
+/**
+ * `defineWorkflowEvent` — declare an external event a workflow can wait on.
+ *
+ * Cloudflare matches `instance.sendEvent({ type })` against
+ * `step.waitForEvent(name, { type })` by a bare string, and the payload crosses
+ * as `unknown`. Both ends therefore drift silently: a typo'd type hibernates the
+ * instance until its (24h default) timeout with no error anywhere, and a payload
+ * that changed shape resumes the workflow on garbage. A definition makes the type
+ * and payload shape one value both ends import — no literal to typo, no second
+ * place to update on a rename — and the payload is parsed on send and on receive.
+ *
+ * Pure validation + branding (Node-safe, no Cloudflare runtime imports), mirroring
+ * `defineWorkflow` / `defineStep`.
+ */
+import type { Validator } from "@lunora/values";
+
+import type { WorkflowEventDefinition } from "./types";
+
+/**
+ * The event-type namespace the framework reserves for its own instance-to-instance
+ * protocol — today the `ctx.parallel` branch join, whose `lunora:branch:<childId>`
+ * types are derived from this prefix (see `fan-out.ts`). A user event here could be
+ * mistaken for a branch outcome, so it is rejected both at declaration and at the
+ * send boundary.
+ *
+ * This covers the *workflow* package's protocol only. `@lunora/agent` runs its own
+ * unprefixed event types over its own bindings and is unaffected either way.
+ */
+const RESERVED_EVENT_TYPE_PREFIX = "lunora:";
+
+/**
+ * Why `value` cannot be used as an event definition, or `undefined` when it can.
+ *
+ * Returns the reason rather than throwing so each boundary can raise its own error
+ * type: a `TypeError` while authoring, a `BAD_REQUEST` in a caller's request, a
+ * `NonRetryableError` inside a durable replay. The brand alone is not enough —
+ * `WorkflowEventDefinition` is a public interface with a boolean brand, so a
+ * hand-built object reaches the wire unless the fields are checked too.
+ */
+const eventDefinitionProblem = (value: unknown): string | undefined => {
+    if (typeof value !== "object" || value === null || (value as { isLunoraWorkflowEvent?: unknown }).isLunoraWorkflowEvent !== true) {
+        return "expects a `defineWorkflowEvent` definition";
+    }
+
+    const candidate = value as { payload?: { parse?: unknown }; type?: unknown };
+
+    if (typeof candidate.type !== "string" || candidate.type.length === 0) {
+        return "event `type` must be a non-empty string";
+    }
+
+    if (candidate.type.startsWith(RESERVED_EVENT_TYPE_PREFIX)) {
+        return `event type "${candidate.type}" is reserved — the "${RESERVED_EVENT_TYPE_PREFIX}" prefix is used by the framework's own events`;
+    }
+
+    if (typeof candidate.payload?.parse !== "function") {
+        return "event `payload` must be a validator (e.g. `v.object({ ok: v.boolean() })`)";
+    }
+
+    return undefined;
+};
+
+/**
+ * Declare an external event, its wire type, and its payload shape.
+ *
+ * ```ts
+ * // lunora/events.ts
+ * import { defineWorkflowEvent } from "@lunora/workflow";
+ * import { v } from "@lunora/values";
+ *
+ * export const orderApproved = defineWorkflowEvent("order-approved", v.object({ approvedBy: v.string() }));
+ * ```
+ *
+ * Wait on it inside a workflow body — the payload is typed and validated:
+ *
+ * ```ts
+ * const { approvedBy } = await ctx.waitForEvent(orderApproved, { name: "await approval", timeout: "7 days" });
+ * ```
+ *
+ * …and send it from a mutation/action with the same definition:
+ *
+ * ```ts
+ * await ctx.workflows.get("orderPipeline").sendEvent(instanceId, orderApproved, { approvedBy });
+ * ```
+ */
+const defineWorkflowEvent = <Payload>(type: string, payload: Validator<Payload>): WorkflowEventDefinition<Payload> => {
+    if (typeof type !== "string" || type.length === 0) {
+        throw new TypeError("defineWorkflowEvent: `type` must be a non-empty string (the wire event type)");
+    }
+
+    const problem = eventDefinitionProblem({ isLunoraWorkflowEvent: true, payload, type });
+
+    if (problem !== undefined) {
+        throw new TypeError(`defineWorkflowEvent: ${problem}`);
+    }
+
+    return { isLunoraWorkflowEvent: true, payload, type };
+};
+
+/** True when a value is a `defineWorkflowEvent` result (the runtime brand check). */
+const isWorkflowEventDefinition = (value: unknown): value is WorkflowEventDefinition =>
+    typeof value === "object" && value !== null && (value as { isLunoraWorkflowEvent?: unknown }).isLunoraWorkflowEvent === true;
+
+export { defineWorkflowEvent, eventDefinitionProblem, isWorkflowEventDefinition, RESERVED_EVENT_TYPE_PREFIX };

--- a/packages/workflow/src/define-event.ts
+++ b/packages/workflow/src/define-event.ts
@@ -96,8 +96,11 @@ const defineWorkflowEvent = <Payload>(type: string, payload: Validator<Payload>)
     return { isLunoraWorkflowEvent: true, payload, type };
 };
 
-/** True when a value is a `defineWorkflowEvent` result (the runtime brand check). */
-const isWorkflowEventDefinition = (value: unknown): value is WorkflowEventDefinition =>
-    typeof value === "object" && value !== null && (value as { isLunoraWorkflowEvent?: unknown }).isLunoraWorkflowEvent === true;
+/**
+ * True when a value is usable as an event definition. The brand alone is not the
+ * test: the predicate hands the caller a `type` and a `payload.parse`, so it checks
+ * for both (and for the reserved namespace) rather than trusting a public boolean.
+ */
+const isWorkflowEventDefinition = (value: unknown): value is WorkflowEventDefinition => eventDefinitionProblem(value) === undefined;
 
 export { defineWorkflowEvent, eventDefinitionProblem, isWorkflowEventDefinition, RESERVED_EVENT_TYPE_PREFIX };

--- a/packages/workflow/src/fan-out.ts
+++ b/packages/workflow/src/fan-out.ts
@@ -25,6 +25,7 @@
 import { LunoraError } from "@lunora/errors";
 
 import { BRANCH_MARKER_KEY, BRANCH_MARKER_REJECTION, hasBranchMarker } from "../../../shared/branch-marker";
+import { RESERVED_EVENT_TYPE_PREFIX } from "./define-event";
 import { NonRetryableError } from "./errors";
 import type {
     BranchCompensationParams,
@@ -47,8 +48,13 @@ const AWAIT_STEP_PREFIX = "lunora:await:";
 const SIGNAL_STEP_PREFIX = "lunora:signal:";
 /** Durable-step name prefix for a completed branch's group-saga compensation spawn. */
 const COMPENSATE_STEP_PREFIX = "lunora:compensate:";
-/** Event-type prefix the parent waits on and the child sends. */
-const BRANCH_EVENT_PREFIX = "lunora:branch:";
+
+/**
+ * Event-type prefix the parent waits on and the child sends. Derived from the
+ * reserved namespace rather than re-spelled, so the guard that rejects user events
+ * in that namespace can never stop covering it.
+ */
+const BRANCH_EVENT_PREFIX = `${RESERVED_EVENT_TYPE_PREFIX}branch:`;
 
 /** The completion event a branch child sends to its parent. Discriminated so an `undefined` value is distinguishable from a failure. */
 type BranchOutcome = { error: { message: string; name: string }; status: "error" } | { status: "ok"; value?: unknown };

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -1,6 +1,7 @@
 export type { WorkflowBindingSpec } from "./create-workflow-context";
 export { createWorkflowContext } from "./create-workflow-context";
 export { default as createWorkflows } from "./create-workflows";
+export { defineWorkflowEvent, isWorkflowEventDefinition } from "./define-event";
 export { defineStep, isStepDefinition } from "./define-step";
 export { defineWorkflow, isWorkflowDefinition, workflowBindingName, workflowClassName, workflowDefaultName } from "./define-workflow";
 export type { NativeNonRetryableErrorConstructor } from "./errors";
@@ -33,12 +34,14 @@ export type {
     StepRollbackContext,
     StepRollbackHandler,
     StepRunContext,
+    WaitForEventOptions,
     WorkflowBindingLike,
     WorkflowBranch,
     WorkflowBranchOutputs,
     WorkflowConfig,
     WorkflowCreateOptions,
     WorkflowDefinition,
+    WorkflowEventDefinition,
     WorkflowEventLike,
     WorkflowHandle,
     WorkflowHandler,
@@ -59,4 +62,6 @@ export type {
     WorkflowStepContextLike,
     WorkflowStepLike,
     WorkflowStepRollbackOptionsLike,
+    WorkflowWaitForEventFunction,
 } from "./types";
+export { createWaitForEvent } from "./wait-for-event";

--- a/packages/workflow/src/run-context.ts
+++ b/packages/workflow/src/run-context.ts
@@ -16,6 +16,7 @@ import type { WorkflowBindingResolver } from "./fan-out";
 import { createParallel, createSpawn } from "./fan-out";
 import { createRunStep } from "./run-step";
 import type { WorkflowBindingLike, WorkflowEventLike, WorkflowRunContext, WorkflowRunFunction, WorkflowStepLike } from "./types";
+import { createWaitForEvent } from "./wait-for-event";
 
 interface RunContextOptions<Params> {
     env: Record<string, unknown>;
@@ -88,6 +89,7 @@ const createWorkflowRunContext = <Params = Record<string, unknown>>(options: Run
         runStep: createRunStep({ env: options.env, log, nonRetryableErrorClass: options.nonRetryableErrorClass, run, step: options.step }),
         spawn: createSpawn(fanOutDeps),
         step: options.step,
+        waitForEvent: createWaitForEvent({ nonRetryableErrorClass: options.nonRetryableErrorClass, step: options.step }),
     };
 };
 

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -291,6 +291,60 @@ export type WorkflowRunStepFunction = <A extends StepArgsValidator, Result>(
     options?: RunStepOptions,
 ) => Promise<Result>;
 
+// --- Declared external events (`ctx.waitForEvent` / `instance.sendEvent`) ---
+
+/**
+ * A `defineWorkflowEvent` result — the single source of truth for one external
+ * event's wire `type` and payload shape. Both ends of the exchange import the same
+ * definition (`ctx.waitForEvent(orderApproved)` inside the workflow,
+ * `workflows.get(w).sendEvent(id, orderApproved, payload)` from the caller), so
+ * there is no string to typo and no second place to update on a rename, and the
+ * payload is parsed at both ends instead of crossing as `unknown`.
+ *
+ * It does NOT make every mismatch a compile error: two definitions with the same
+ * payload shape are mutually assignable, so sending `orderRejected` where the
+ * workflow awaits `orderApproved` still type-checks (and still hibernates until
+ * the timeout). What it removes is the hand-matched literal.
+ */
+export interface WorkflowEventDefinition<Payload = unknown> {
+    /** Runtime brand check (see `isWorkflowEventDefinition`). */
+    readonly isLunoraWorkflowEvent: true;
+    /** Validator for the event payload — parsed on send and again on receive. */
+    readonly payload: Validator<Payload>;
+    /** The wire event type Cloudflare matches `sendEvent` against `waitForEvent`. */
+    readonly type: string;
+}
+
+/** Per-call options for {@link WorkflowWaitForEventFunction}. */
+export interface WaitForEventOptions {
+    /**
+     * The durable step label, defaulting to `event:<type>`.
+     *
+     * Cloudflare identifies a memoized step by this name, so the default couples
+     * step identity to the wire type: renaming the event type also renames the
+     * step, and an instance that already recorded the wait replays into a *fresh*
+     * one that nothing will ever satisfy. Pass a stable `name` on any wait that can
+     * outlive a deploy (an approval held for days), and to tell two waits on the
+     * same event type apart in the timeline.
+     */
+    name?: string;
+    /** How long to wait before the wait rejects. Defaults to Cloudflare's 24h. */
+    timeout?: number | string;
+}
+
+/**
+ * Hibernate until a declared event is delivered to this instance, then resolve
+ * with its validated payload. The typed wrapper over
+ * {@link WorkflowStepLike.waitForEvent}: the event's `type` comes from the
+ * definition instead of a hand-written string, and the payload is parsed through
+ * the definition's validator before the workflow resumes on it.
+ *
+ * ```ts
+ * const { approvedBy } = await ctx.waitForEvent(orderApproved, { timeout: "1 hour" });
+ * ```
+ */
+export type WorkflowWaitForEventFunction = <Payload>(event: WorkflowEventDefinition<Payload>, options?: WaitForEventOptions) => Promise<Payload>;
+
 // --- Fan-out: child-workflow isolation (`ctx.parallel` / `ctx.spawn`) -------
 
 /**
@@ -400,6 +454,8 @@ export interface WorkflowRunContext<Params = Record<string, unknown>> {
     readonly spawn: WorkflowSpawnFunction;
     /** The native Cloudflare Workflows durable-step API. */
     readonly step: WorkflowStepLike;
+    /** Hibernate until a declared external event arrives; resolves with its validated payload. */
+    readonly waitForEvent: WorkflowWaitForEventFunction;
 }
 
 /** The workflow body. Receives a {@link WorkflowRunContext}, returns the output. */
@@ -438,7 +494,8 @@ export interface WorkflowDefinition<Params = Record<string, unknown>, Output = u
 
 /**
  * A typed handle to one declared workflow, addressable from `ctx.workflows`.
- * Thin pass-through over the Cloudflare `Workflow` binding.
+ * Thin pass-through over the Cloudflare `Workflow` binding, plus the declared-event
+ * send (which the raw binding cannot type).
  */
 export interface WorkflowHandle<Params = Record<string, unknown>> {
     /** Start a new instance (optionally with an id + params). */
@@ -447,6 +504,18 @@ export interface WorkflowHandle<Params = Record<string, unknown>> {
     createBatch: (batch: ReadonlyArray<WorkflowCreateOptions<Params>>) => Promise<WorkflowInstanceLike[]>;
     /** Get a handle to an existing instance by id. */
     get: (id: string) => Promise<WorkflowInstanceLike>;
+
+    /**
+     * Deliver a declared event to one instance of this workflow — the typed
+     * counterpart of the workflow body's `ctx.waitForEvent`. The wire type comes
+     * from the definition (never a hand-written string) and the payload is parsed
+     * through the definition's validator **before** the send, so a bad value fails
+     * the caller's request instead of waking the workflow on garbage.
+     *
+     * Mirrors `ctx.agents.<name>.sendEvent(id, …)`: the instance is addressed by
+     * id rather than by holding an instance handle, so the common case is one call.
+     */
+    sendEvent: <Payload>(instanceId: string, event: WorkflowEventDefinition<Payload>, payload: Payload) => Promise<void>;
 }
 
 /**

--- a/packages/workflow/src/wait-for-event.ts
+++ b/packages/workflow/src/wait-for-event.ts
@@ -1,0 +1,67 @@
+/**
+ * `ctx.waitForEvent` — the typed wrapper over Cloudflare's `step.waitForEvent`.
+ * Takes a {@link WorkflowEventDefinition} rather than a `(name, { type })` string
+ * pair, so the wire type is shared with the sender by construction, and parses the
+ * delivered payload through the definition's validator before the workflow body
+ * resumes on it.
+ *
+ * Node-safe (the native step API and the native `NonRetryableError` constructor are
+ * injected), so the whole path is unit-testable with plain doubles.
+ */
+import { eventDefinitionProblem, RESERVED_EVENT_TYPE_PREFIX } from "./define-event";
+import type { NativeNonRetryableErrorConstructor } from "./errors";
+import { raiseNonRetryable } from "./errors";
+import type { WaitForEventOptions, WorkflowEventDefinition, WorkflowStepLike, WorkflowWaitForEventFunction } from "./types";
+
+/** Dependencies one workflow invocation's `ctx.waitForEvent` closes over. */
+interface WaitForEventDeps {
+    /** Native `cloudflare:workflows` `NonRetryableError` constructor — injected by `src/do`; absent in Node tests. */
+    nonRetryableErrorClass?: NativeNonRetryableErrorConstructor;
+    /** The native Cloudflare durable-step API. */
+    step: WorkflowStepLike;
+}
+
+/**
+ * Build `ctx.waitForEvent` for one workflow invocation.
+ *
+ * Every failure here is **non-retryable**. A malformed definition or a reserved
+ * step name is a deterministic programmer error, and a payload that fails the
+ * validator has already consumed the event — replaying the wait cannot produce a
+ * different value, it can only hibernate the instance until its timeout. Each is
+ * raised through the shared {@link raiseNonRetryable}, the same classification path
+ * `ctx.runStep` uses, so the native error reaches Cloudflare and the instance fails
+ * fast.
+ */
+const createWaitForEvent =
+    (deps: WaitForEventDeps): WorkflowWaitForEventFunction =>
+    async <Payload>(event: WorkflowEventDefinition<Payload>, options?: WaitForEventOptions): Promise<Payload> => {
+        const problem = eventDefinitionProblem(event);
+
+        if (problem !== undefined) {
+            return raiseNonRetryable(`@lunora/workflow: ctx.waitForEvent ${problem}`, undefined, deps.nonRetryableErrorClass);
+        }
+
+        // The step-name namespace is reserved alongside the event-type namespace:
+        // `lunora:await:*` / `lunora:signal:*` are the branch join's own durable
+        // steps, and a user wait that borrowed one would collide with it.
+        if (options?.name?.startsWith(RESERVED_EVENT_TYPE_PREFIX) === true) {
+            return raiseNonRetryable(
+                `@lunora/workflow: ctx.waitForEvent step name "${options.name}" is reserved — the "${RESERVED_EVENT_TYPE_PREFIX}" prefix is used by the framework's own steps`,
+                undefined,
+                deps.nonRetryableErrorClass,
+            );
+        }
+
+        const received = await deps.step.waitForEvent(options?.name ?? `event:${event.type}`, { timeout: options?.timeout, type: event.type });
+
+        try {
+            return event.payload.parse(received.payload);
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+
+            return raiseNonRetryable(`@lunora/workflow: event "${event.type}" payload validation failed: ${message}`, error, deps.nonRetryableErrorClass);
+        }
+    };
+
+// eslint-disable-next-line import/prefer-default-export -- named export by package convention; index.ts re-exports it
+export { createWaitForEvent };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5051,6 +5051,9 @@ importers:
       '@lunora/dispatch':
         specifier: workspace:*
         version: link:../dispatch
+      '@lunora/server':
+        specifier: workspace:*
+        version: link:../server
       '@types/node':
         specifier: catalog:types
         version: 26.2.0


### PR DESCRIPTION
## Problem

Cloudflare matches `instance.sendEvent({ type })` against `step.waitForEvent(name, { type })` by a bare string, and the payload crosses as `unknown`. Both ends drift silently:

- a typo'd type hibernates the instance until its timeout (24h by default) with no error anywhere;
- a payload whose shape changed resumes the workflow on garbage.

## What this adds

`defineWorkflowEvent(type, payloadValidator)` — one value both ends import, so there is no literal to typo and no second place to update on a rename.

```ts
// lunora/events.ts
export const orderApproved = defineWorkflowEvent("order-approved", v.object({ approvedBy: v.string() }));

// inside the workflow body — typed and parsed
const { approvedBy } = await ctx.waitForEvent(orderApproved, { name: "await approval", timeout: "7 days" });

// from a mutation/action — validated before the send
await ctx.workflows.get("orderPipeline").sendEvent(instanceId, orderApproved, { approvedBy });
```

- **Receive** (`ctx.waitForEvent`): resolves the wire type from the definition and parses the payload. A parse failure is non-retryable — the event is already consumed, so replaying the wait can only hibernate the instance again.
- **Send** (`WorkflowHandle.sendEvent(instanceId, event, payload)`): parses before the send, so a bad value fails the caller's request instead of waking the workflow. Addresses the instance by id, mirroring `ctx.agents.<name>.sendEvent(id, …)`.
- **Both boundaries re-check the definition** rather than trusting its brand (a public boolean), and reject the `lunora:` event-type namespace that the `ctx.parallel` branch join derives its own types from — so a definition-shaped object built from untrusted data cannot forge a branch outcome into a parent instance.

Additive: the native instance surface and the raw `ctx.step` API are unchanged, so the api-snapshot diff is additive too.

## Known sharp edge, documented

The default durable step name is `event:<type>`, which couples step identity to the wire type: renaming the event type also renames the step, and an instance that already recorded the wait replays into a fresh one nothing will satisfy. Docs carry a warn callout and every example passes a stable `{ name }`.

## Also here

A type-level lockstep test for `@lunora/server`'s hand-written mirror of the `ctx.workflows` surface. Nothing compared the two before, and codegen narrows `ctx.workflows` to `@lunora/workflow`'s own types as soon as an app declares a workflow — so the mirror is only exercised by apps with zero workflows and could rot unseen. It caught a stale mirror on its first run.

## Verification

`@lunora/workflow` 94 tests · server 570 · runtime 907 · codegen 1254 · platform-node 144 · `lint:affected:types` (73 projects) · `lint:affected:eslint` (58) · `lint:package-json` · prettier · api snapshots regenerated from a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4ajaDyjxe3homh1sKVB5h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added declared workflow events with typed payload validation.
  - Workflows can wait for events with optional names and timeouts.
  - Added validated event sending to workflow instances.
  - Added safeguards for invalid and reserved event types.
  - Exported event definitions and related helpers for integration.

- **Documentation**
  - Expanded guidance for declaring, waiting for, and sending events.
  - Documented validation, failure behavior, stable wait names, and instance management APIs.
  - Updated package metadata to describe Worker-scoped Access policies and verified Access tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->