### PR TITLE
fix(runtime): return the RPC envelope from worker-served admin ops

### DIFF
--- a/packages/runtime/__tests__/auth-audit-rpc.test.ts
+++ b/packages/runtime/__tests__/auth-audit-rpc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { decodeWire } from "../../../shared/wire-codec";
 import type { AuthAuditEntry, AuthAuditReader, ExecutionContextLike } from "../src/create-worker";
 import { createWorker, GET_AUTH_AUDIT_LOG_OP } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
@@ -76,8 +77,8 @@ describe("createWorker — getAuthAuditLog admin RPC", () => {
         expect(body.error.code).toBe("AUTH_AUDIT_NOT_CONFIGURED");
     });
 
-    it("returns the reader's entries for an admin caller", async () => {
-        expect.assertions(2);
+    it("returns the reader's entries for an admin caller, in the RPC envelope the client decodes", async () => {
+        expect.assertions(3);
 
         const reader = readerSpy();
         const worker = createWorker({ adminToken: ADMIN_TOKEN, authAuditReader: reader, shardDO: failingShard });
@@ -85,7 +86,18 @@ describe("createWorker — getAuthAuditLog admin RPC", () => {
         const response = await worker.fetch(rpc(), {}, fakeContext);
 
         expect(response.status).toBe(200);
-        await expect(response.json()).resolves.toEqual({ entries: ENTRIES });
+
+        // The envelope, not a bare `{ entries }`. This op is served by the WORKER
+        // rather than forwarded to a shard, but the caller is the same
+        // `client.query()`, which reads `decodeWire(body.result)` — so a bare body
+        // decodes to `undefined`, and TanStack Query rejects that outright
+        // ("Query data cannot be undefined") before the panel can render an error.
+        // This assertion used to demand the bare shape, which is how the Studio's
+        // Auth audit page shipped broken.
+        const body: { result: unknown } = await response.json();
+
+        expect(body).toHaveProperty("result");
+        expect(decodeWire(body.result)).toEqual({ entries: ENTRIES });
     });
 
     it("passes actor/event/sinceSeq/limit filters through to the reader", async () => {

--- a/packages/runtime/__tests__/notify-subscriptions-admin.test.ts
+++ b/packages/runtime/__tests__/notify-subscriptions-admin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { decodeWire } from "../../../shared/wire-codec";
 import type { ExecutionContextLike, NotifySubscriptionStoreLike } from "../src/create-worker";
 import { createWorker } from "../src/create-worker";
 import type { ShardNamespaceLike } from "../src/resolve-shard";
@@ -72,6 +73,10 @@ const listRequest = (options: { args?: Record<string, unknown>; token?: string }
     });
 };
 
+// The worker serves this op itself rather than forwarding it to a shard, but the
+// caller is the same `client.query()`, which reads `decodeWire(body.result)`. These
+// assertions used to read a bare `{ subscriptions }` off the response — the shape the
+// client cannot decode, which is how the Studio's Notifications page shipped broken.
 describe("createWorker — __lunora_admin__:listPushSubscriptions", () => {
     it("returns the registered devices for an admin, with delivery secrets stripped", async () => {
         expect.assertions(5);
@@ -86,7 +91,8 @@ describe("createWorker — __lunora_admin__:listPushSubscriptions", () => {
 
         expect(response.status).toBe(200);
 
-        const body: { subscriptions: Record<string, unknown>[] } = await response.json();
+        const envelope: { result: unknown } = await response.json();
+        const body = decodeWire(envelope.result) as { subscriptions: Record<string, unknown>[] };
 
         expect(body.subscriptions).toHaveLength(2);
         // The endpoint/kind/status are surfaced…
@@ -106,7 +112,8 @@ describe("createWorker — __lunora_admin__:listPushSubscriptions", () => {
         });
 
         const response = await worker.fetch(listRequest({ args: { kind: "fcm" }, token: ADMIN_TOKEN }), {}, fakeContext);
-        const body: { subscriptions: Record<string, unknown>[] } = await response.json();
+        const envelope: { result: unknown } = await response.json();
+        const body = decodeWire(envelope.result) as { subscriptions: Record<string, unknown>[] };
 
         expect(body.subscriptions).toHaveLength(1);
         expect(body.subscriptions[0]).toMatchObject({ id: "fcm:1", kind: "fcm" });
@@ -159,7 +166,8 @@ describe("createWorker — __lunora_admin__:listPushSubscriptions", () => {
 
         expect(response.status).toBe(200);
 
-        const body: { subscriptions: unknown[] } = await response.json();
+        const envelope: { result: unknown } = await response.json();
+        const body = decodeWire(envelope.result) as { subscriptions: unknown[] };
 
         expect(body.subscriptions).toStrictEqual([]);
     });

--- a/packages/runtime/src/auth-audit-rpc.ts
+++ b/packages/runtime/src/auth-audit-rpc.ts
@@ -1,3 +1,4 @@
+import { encodeWire } from "../../../shared/wire-codec";
 import { LunoraError } from "./errors";
 
 /**
@@ -152,7 +153,13 @@ const buildGetAuthAuditLog = (deps: AuthAuditRpcDeps): AuthAuditRpcHandler => {
 
         const result: AuthAuditLogResult = { entries };
 
-        return Response.json(result, { headers: { "content-type": "application/json" }, status: 200 });
+        // `{ result: encodeWire(...) }`, not the bare body: this op is served by
+        // the WORKER rather than forwarded to a shard, but the caller is the same
+        // `client.query()`, which reads `decodeWire(body.result)`. A bare body
+        // decodes to `undefined` — which TanStack Query rejects outright ("Query
+        // data cannot be undefined"), so the Studio panel never even renders its
+        // own error state. Mirrors `adminResponse` in `@lunora/do`.
+        return Response.json({ result: encodeWire(result) }, { headers: { "content-type": "application/json" }, status: 200 });
     };
 
     return handle;

--- a/packages/runtime/src/create-worker.ts
+++ b/packages/runtime/src/create-worker.ts
@@ -16,6 +16,7 @@ import { RELAY_NAME_INFIX, relayName } from "../../../shared/relay-name";
 import { parseMinSeq, REPLICA_NAME_INFIX, replicaName } from "../../../shared/replica-name";
 import type { RestExposure } from "../../../shared/rest-surface";
 import type { TraceSamplingConfig } from "../../../shared/sampling";
+import { encodeWire } from "../../../shared/wire-codec";
 import { isEnvFlagEnabled, mintWsAdminToken, verifyWsAdminToken } from "../../../shared/ws-admin-token";
 import { assertArgsObject } from "./assert-args-object";
 import type { AuthAdmin } from "./auth-admin-routes";
@@ -2920,7 +2921,7 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
         const store = options.notifySubscriptionStore;
 
         if (store === undefined) {
-            return Response.json({ subscriptions: [] }, { headers: { "content-type": "application/json" }, status: 200 });
+            return Response.json({ result: encodeWire({ subscriptions: [] }) }, { headers: { "content-type": "application/json" }, status: 200 });
         }
 
         const rawKind = args?.["kind"];
@@ -2964,7 +2965,9 @@ const createWorker = (options: WorkerOptions): LunoraWorker => {
             // endpoint / kind / owner / timestamps + last-send status.
             .map(({ keys: _keys, token: _token, ...device }) => device);
 
-        return Response.json({ subscriptions }, { headers: { "content-type": "application/json" }, status: 200 });
+        // Same envelope as the shard-forwarded admin ops — see the note on
+        // `getAuthAuditLog`. `client.query()` reads `decodeWire(body.result)`.
+        return Response.json({ result: encodeWire({ subscriptions }) }, { headers: { "content-type": "application/json" }, status: 200 });
     };
 
     /**


### PR DESCRIPTION
The Studio's **Auth audit** page rendered a raw TanStack Query error — *"Query data cannot be undefined"* — instead of any data or even its own error state. **Notifications** was broken identically.

## Cause

`client.query()` reads `decodeWire(body.result)` (`packages/client/src/lunora-client.ts:4393`).

Shard-forwarded `__lunora_admin__:*` ops satisfy that contract because the DO wraps them — `adminResponse = (result) => jsonResponse({ result: encodeWire(result) })` (`packages/do/src/shard-do.ts:313`).

The two ops the **worker** serves itself did not:

- `__lunora_admin__:getAuthAuditLog` returned `{ entries }`
- `__lunora_admin__:listPushSubscriptions` returned `{ subscriptions }`

`body.result` was therefore `undefined`, `decodeWire(undefined)` returned `undefined`, and TanStack Query rejects an undefined query result outright — before the panel's own `error` branch can render.

## Scope of the audit

`serveReservedWorkerRpc` is the **only** place the worker answers an admin RPC instead of forwarding it, and it carries exactly these two ops. Every other `__lunora_admin__:*` op goes to the DO and was already correct. That is the whole class — not a sample.

## Why no test caught it

Both suites asserted the bare shape, so they encoded the bug:

- `auth-audit-rpc.test.ts` asserted `{ entries: ENTRIES }`
- `notify-subscriptions-admin.test.ts` read `body.subscriptions` directly

They now assert what the client actually decodes (`decodeWire(body.result)`), so a regression fails instead of re-encoding the defect. Reverting the source change fails 4 tests across the two files.

## Verified

`lint:types`, `api:check`, eslint, prettier; runtime 907 tests and studio 1035 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiK7HSTeqimrtkE63A6NEP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for authentication audit responses by ensuring results are returned in the expected format.
  * Fixed notification subscription responses so empty and populated results are handled consistently by clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->