### PR TITLE
fix(studio): record the command palette's action shape in the snapshot

### DIFF
--- a/api-snapshots/studio.api.md
+++ b/api-snapshots/studio.api.md
@@ -220,7 +220,8 @@ interface CapturedMailResult {
 interface CommandItem {
     readonly group: string;
     readonly label: string;
-    readonly to: string;
+    readonly run?: () => void;
+    readonly to?: string;
 }
 ```
 


### PR DESCRIPTION
`api-snapshots/studio.api.md` is stale on `alpha`.

`CommandItem` gained `run?` (and `to?` became optional) when the command palette learned to reach the operation console, but `pnpm run api:update` was never run alongside it.

**Why it is not already red.** The lint workflow runs on pull requests, not on push to `alpha` — so the drift is latent. The next PR touching `@lunora/studio` would have failed **Lint (api surface)** on a diff it did not cause, which is a confusing place to discover it.

Verified: `pnpm run api:check` passes with this, against a fresh `build:packages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiK7HSTeqimrtkE63A6NEP