### PR TITLE
fix(cloud): price the whole Cloudflare bill in the spend cap

### DIFF
--- a/apps/cloud/__tests__/metering.test.ts
+++ b/apps/cloud/__tests__/metering.test.ts
@@ -75,6 +75,27 @@ describe(createHttpAnalyticsReader, () => {
         await expect(reader.readRequestUsage(0)).resolves.toStrictEqual([{ requests: 42, scriptName: "acme-app" }]);
     });
 
+    /**
+     * The regression this pins: Analytics Engine samples at high write rates,
+     * and `SUM(double1)` counts retained rows rather than the requests they
+     * stand in for. Since sampling engages exactly when a tenant's traffic
+     * spikes, an unsampled sum under-counts hardest in the runaway case the
+     * spend cap downstream exists to catch — so the query must aggregate the
+     * sample interval over the per-tenant index.
+     */
+    it("aggregates the sample interval over the per-tenant index, not the raw double", async () => {
+        const fetchMock = vi.fn().mockResolvedValue(Response.json({ data: [] }, { status: 200 }));
+        const reader = createHttpAnalyticsReader({ accountId: "acc", apiToken: "tok", dataset: "usage", fetch: fetchMock });
+
+        await reader.readRequestUsage(1_700_000_000_000);
+
+        const body = (fetchMock.mock.calls[0]?.[1] as undefined | { body?: string })?.body ?? "";
+
+        expect(body).toContain("SUM(_sample_interval)");
+        expect(body).toContain("index1 AS scriptName");
+        expect(body).not.toContain("SUM(double1)");
+    });
+
     it("throws on a non-ok response", async () => {
         const reader = createHttpAnalyticsReader({
             accountId: "acc",

--- a/apps/cloud/__tests__/reconcile.test.ts
+++ b/apps/cloud/__tests__/reconcile.test.ts
@@ -37,7 +37,9 @@ describe(buildOverageReconcileData, () => {
                 { kind: "requests", organizationId: "org_a", periodStart: 500, quantity: 12 },
                 { kind: "cpuMs", organizationId: "org_a", periodStart: 500, quantity: 7 },
                 { kind: "requests", organizationId: "org_a", periodStart: 499, quantity: 999 }, // other period → ignored
-                { kind: "storageBytes", organizationId: "org_a", periodStart: 500, quantity: 5 }, // wrong kind → ignored
+                // A real meter, but not one the overage rate card prices — the
+                // cap counts it, credits never do. See `buildOverageReconcileData`.
+                { kind: "r2StorageGbMonths", organizationId: "org_a", periodStart: 500, quantity: 5 },
             ],
         });
 

--- a/apps/cloud/__tests__/spend.test.ts
+++ b/apps/cloud/__tests__/spend.test.ts
@@ -1,26 +1,128 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 
-import { DEFAULT_SPEND_CAP_MINOR, estimatedSpendMinor, evaluateSpendCap } from "../src/billing/spend";
+import type { Doc } from "../lunora/_generated/dataModel.js";
+import type { UsageMeter } from "../src/billing/spend";
+import {
+    DEFAULT_SPEND_CAP_MINOR,
+    estimatedSpendMinor,
+    estimatedSpendNanoCents,
+    evaluateSpendCap,
+    isUsageMeter,
+    RATE_CARD,
+    spendBreakdown,
+    USAGE_METERS,
+} from "../src/billing/spend";
 
-/** Aggregate spend caps (GAPS.md C1). */
+/** Aggregate spend caps over the full Cloudflare bill (GAPS.md C1). */
 
-describe(evaluateSpendCap, () => {
-    it("estimates spend at the WfP cost basis", () => {
-        // 100M requests = $30 = 3000 cents; 100M cpu-ms = $2 = 200 cents.
-        expect(estimatedSpendMinor({ cpuMs: 0, requests: 100_000_000 })).toBe(3000);
-        expect(estimatedSpendMinor({ cpuMs: 100_000_000, requests: 0 })).toBe(200);
-        expect(estimatedSpendMinor({ cpuMs: 0, requests: 0 })).toBe(0);
+describe("rate card", () => {
+    /**
+     * The ledger's `kind` union is spelled out in `lunora/schema.ts` (codegen
+     * reads it statically, so it cannot import the type) and priced by
+     * `UsageMeter`. Nothing at runtime couples them, so this assertion is what
+     * turns "added a meter and forgot the schema" into a `lint:types` failure
+     * instead of a row the cap silently skips.
+     */
+    it("prices exactly the meters the ledger can hold", () => {
+        expectTypeOf<Doc<"platformUsage">["kind"]>().toEqualTypeOf<UsageMeter>();
+
+        expect(USAGE_METERS).toHaveLength(Object.keys(RATE_CARD).length);
     });
 
+    it("holds every rate as a positive integer number of nano-cents", () => {
+        for (const meter of USAGE_METERS) {
+            const rate = RATE_CARD[meter];
+
+            expect(Number.isInteger(rate.nanoCentsPerUnit), `${meter} rate must be an integer`).toBe(true);
+            expect(rate.nanoCentsPerUnit).toBeGreaterThan(0);
+            expect(rate.published).not.toBe("");
+            expect(rate.product).not.toBe("");
+        }
+    });
+
+    it("recognizes known meters and rejects unknown ones", () => {
+        expect(isUsageMeter("doRowsWritten")).toBe(true);
+        expect(isUsageMeter("storageBytes")).toBe(false);
+    });
+});
+
+describe(estimatedSpendMinor, () => {
+    it("prices compute at the Workers-for-Platforms basis", () => {
+        // 100M requests = $30 = 3000 cents; 100M CPU-ms = $2 = 200 cents.
+        expect(estimatedSpendMinor({ requests: 100_000_000 })).toBe(3000);
+        expect(estimatedSpendMinor({ cpuMs: 100_000_000 })).toBe(200);
+        expect(estimatedSpendMinor({})).toBe(0);
+    });
+
+    it("prices the storage-shaped dimensions the old model was blind to", () => {
+        // 1M Durable Object rows written at $1.00/M.
+        expect(estimatedSpendMinor({ doRowsWritten: 1_000_000 })).toBe(100);
+        // 100 GB-month of R2 standard storage at $0.015/GB-mo = $1.50.
+        expect(estimatedSpendMinor({ r2StorageGbMonths: 100 })).toBe(150);
+        // 1M Durable Object GB-seconds at $12.50/M GB-s.
+        expect(estimatedSpendMinor({ doDurationGbS: 1_000_000 })).toBe(1250);
+        // 1M R2 Class A operations at $4.50/M.
+        expect(estimatedSpendMinor({ r2ClassAOps: 1_000_000 })).toBe(450);
+        // 1M Neurons at $0.011 / 1,000 = $11.00.
+        expect(estimatedSpendMinor({ workersAiNeurons: 1_000_000 })).toBe(1100);
+    });
+
+    it("sums across meters", () => {
+        expect(estimatedSpendMinor({ cpuMs: 100_000_000, doRowsWritten: 1_000_000, requests: 100_000_000 })).toBe(3000 + 200 + 100);
+    });
+
+    it("accumulates sub-cent meters instead of rounding each to zero", () => {
+        // 10,000 row reads is 1,000,000 nano-cents — a ten-thousandth of a cent.
+        // Rounding per meter would lose it; rounding the nano-cent total keeps it.
+        expect(estimatedSpendNanoCents({ d1RowsRead: 10_000 })).toBe(1_000_000);
+        expect(estimatedSpendMinor({ d1RowsRead: 10_000 })).toBe(0);
+        // 50 billion row reads is $50 — visible only because the small ones added up.
+        expect(estimatedSpendMinor({ d1RowsRead: 50_000_000_000 })).toBe(5000);
+    });
+
+    it("ignores negative and non-finite quantities", () => {
+        expect(estimatedSpendMinor({ requests: -100_000_000 })).toBe(0);
+        expect(estimatedSpendMinor({ requests: Number.NaN })).toBe(0);
+        expect(estimatedSpendMinor({ requests: Number.POSITIVE_INFINITY })).toBe(0);
+    });
+});
+
+describe(spendBreakdown, () => {
+    it("orders lines by cost and omits meters with no usage", () => {
+        const lines = spendBreakdown({ cpuMs: 100_000_000, doRowsWritten: 1_000_000, r2ClassBOps: 0, requests: 100_000_000 });
+
+        expect(lines.map((line) => line.meter)).toStrictEqual(["requests", "cpuMs", "doRowsWritten"]);
+        expect(lines[0]?.product).toBe("Workers for Platforms");
+        expect(lines[0]?.quantity).toBe(100_000_000);
+    });
+
+    it("sums to the same total the cap evaluates", () => {
+        const usage = { cpuMs: 12_345_678, doDurationGbS: 4321, doRowsRead: 987_654_321, requests: 5_555_555 };
+        const summed = spendBreakdown(usage).reduce((total, line) => total + line.nanoCents, 0);
+
+        expect(summed).toBe(estimatedSpendNanoCents(usage));
+    });
+});
+
+describe(evaluateSpendCap, () => {
     it("suspends a free org past the default cap and not below it", () => {
-        const over = evaluateSpendCap({ plan: "free", usage: { cpuMs: 0, requests: 20_000_000 } }); // ~$6
+        const over = evaluateSpendCap({ plan: "free", usage: { requests: 20_000_000 } }); // ~$6
 
         expect(over.suspend).toBe(true);
         expect(over.capMinor).toBe(DEFAULT_SPEND_CAP_MINOR["free"]);
 
-        const under = evaluateSpendCap({ plan: "free", usage: { cpuMs: 0, requests: 1_000_000 } }); // ~$0.30
+        const under = evaluateSpendCap({ plan: "free", usage: { requests: 1_000_000 } }); // ~$0.30
 
         expect(under.suspend).toBe(false);
+    });
+
+    it("catches a runaway that never touches the compute meters", () => {
+        // No requests, no CPU — just Durable Object duration. Under the old
+        // requests+CPU-only model this org was invisible to the cap forever.
+        const decision = evaluateSpendCap({ plan: "free", usage: { doDurationGbS: 10_000_000 } }); // $125
+
+        expect(decision.spendMinor).toBe(12_500);
+        expect(decision.suspend).toBe(true);
     });
 
     it("never suspends enterprise (uncapped default)", () => {
@@ -31,18 +133,18 @@ describe(evaluateSpendCap, () => {
     });
 
     it("honors an org override, and treats an explicit 0 as uncapped", () => {
-        const tightened = evaluateSpendCap({ capMinorOverride: 100, plan: "pro", usage: { cpuMs: 0, requests: 10_000_000 } }); // ~$3
+        const tightened = evaluateSpendCap({ capMinorOverride: 100, plan: "pro", usage: { requests: 10_000_000 } }); // ~$3
 
         expect(tightened.suspend).toBe(true);
 
-        const uncapped = evaluateSpendCap({ capMinorOverride: 0, plan: "free", usage: { cpuMs: 0, requests: 1e12 } });
+        const uncapped = evaluateSpendCap({ capMinorOverride: 0, plan: "free", usage: { requests: 1e12 } });
 
         expect(uncapped.suspend).toBe(false);
         expect(uncapped.capMinor).toBeNull();
     });
 
     it("caps unknown plans at the free default (never uncapped by accident)", () => {
-        const decision = evaluateSpendCap({ plan: "mystery", usage: { cpuMs: 0, requests: 20_000_000 } });
+        const decision = evaluateSpendCap({ plan: "mystery", usage: { requests: 20_000_000 } });
 
         expect(decision.suspend).toBe(true);
         expect(decision.capMinor).toBe(DEFAULT_SPEND_CAP_MINOR["free"]);

--- a/apps/cloud/__tests__/usage.test.ts
+++ b/apps/cloud/__tests__/usage.test.ts
@@ -1,21 +1,47 @@
 import { describe, expect, it } from "vitest";
 
+import { USAGE_METERS } from "../src/billing/spend";
 import type { UsageEvent } from "../src/billing/usage";
-import { aggregateUsage } from "../src/billing/usage";
+import { aggregateUsage, emptyUsageTotals, toPeriodUsage } from "../src/billing/usage";
 
 const events: UsageEvent[] = [
     { kind: "requests", periodStart: 1000, quantity: 5 },
     { kind: "requests", periodStart: 1000, quantity: 3 },
     { kind: "cpuMs", periodStart: 1000, quantity: 120 },
+    { kind: "doRowsWritten", periodStart: 1000, quantity: 42 },
+    { kind: "r2StorageGbMonths", periodStart: 1000, quantity: 7 },
     { kind: "requests", periodStart: 2000, quantity: 99 }, // different period — excluded
 ];
 
 describe(aggregateUsage, () => {
-    it("sums quantities per kind for the given period only", () => {
-        expect(aggregateUsage(events, 1000)).toStrictEqual({ cpuMs: 120, requests: 8, storageBytes: 0 });
+    it("sums quantities per meter for the given period only", () => {
+        const totals = aggregateUsage(events, 1000);
+
+        expect(totals).toStrictEqual({ ...emptyUsageTotals(), cpuMs: 120, doRowsWritten: 42, r2StorageGbMonths: 7, requests: 8 });
     });
 
-    it("returns a zeroed total when nothing matches the period", () => {
-        expect(aggregateUsage(events, 5000)).toStrictEqual({ cpuMs: 0, requests: 0, storageBytes: 0 });
+    it("returns a zeroed total for every meter when nothing matches the period", () => {
+        const totals = aggregateUsage(events, 5000);
+
+        expect(totals).toStrictEqual(emptyUsageTotals());
+        expect(Object.keys(totals)).toHaveLength(USAGE_METERS.length);
+    });
+
+    /**
+     * The cap sweep reads this. A ledger row written by a newer control plane
+     * (a meter this build does not know) must be skipped, not thrown on — the
+     * sweep that stops a runaway bill is the last thing that should crash on
+     * unexpected data.
+     */
+    it("skips rows whose kind is not a known meter", () => {
+        const unknown = [{ kind: "storageBytes", periodStart: 1000, quantity: 999 } as unknown as UsageEvent];
+
+        expect(aggregateUsage(unknown, 1000)).toStrictEqual(emptyUsageTotals());
+    });
+});
+
+describe(toPeriodUsage, () => {
+    it("drops the zero meters so the cost model iterates only real usage", () => {
+        expect(toPeriodUsage(aggregateUsage(events, 1000))).toStrictEqual({ cpuMs: 120, doRowsWritten: 42, r2StorageGbMonths: 7, requests: 8 });
     });
 });

--- a/apps/cloud/lunora/_generated/api.ts
+++ b/apps/cloud/lunora/_generated/api.ts
@@ -145,8 +145,8 @@ export interface ApiTypes {
     };
     usage: {
         ingest: FunctionReference<"mutation", { deployKey: unknown; deploymentId?: Id<"deployments">; kind: unknown; organizationId: Id<"organizations">; periodStart: number; quantity: number }, Id<"platformUsage">>;
-        series: FunctionReference<"query", { organizationId: Id<"organizations">; periodStart: number }, { cpuMs: number; day: number; requests: number; }[]>;
-        summary: FunctionReference<"query", { organizationId: Id<"organizations">; periodStart: number }, Record<"requests" | "cpuMs" | "storageBytes", number>>;
+        series: FunctionReference<"query", { organizationId: Id<"organizations">; periodStart: number }, { costMinor: number; cpuMs: number; day: number; requests: number; }[]>;
+        summary: FunctionReference<"query", { organizationId: Id<"organizations">; periodStart: number }, { aeDataPoints: number; aeReadQueries: number; browserHours: number; containerCpuSeconds: number; containerDiskGbSeconds: number; containerMemoryGibSeconds: number; cpuMs: number; d1RowsRead: number; d1RowsWritten: number; d1StorageGbMonths: number; doDurationGbS: number; doRequests: number; doRowsRead: number; doRowsWritten: number; doStorageGbMonths: number; imagesDelivered: number; imagesStored: number; imagesTransformations: number; kvDeletes: number; kvLists: number; kvReads: number; kvStorageGbMonths: number; kvWrites: number; logEvents: number; logpushRequests: number; queueOperations: number; r2ClassAOps: number; r2ClassBOps: number; r2StorageGbMonths: number; requests: number; vectorizeQueriedDimensions: number; vectorizeStoredDimensions: number; workersAiNeurons: number; workflowSteps: number; workflowStorageGbMonths: number }>;
     };
 }
 

--- a/apps/cloud/lunora/_generated/dataModel.ts
+++ b/apps/cloud/lunora/_generated/dataModel.ts
@@ -279,7 +279,7 @@ export interface Doc_platformUsage {
     _creationTime: number;
     createdAt: number;
     deploymentId?: Id<"deployments">;
-    kind: "requests" | "cpuMs" | "storageBytes";
+    kind: "aeDataPoints" | "aeReadQueries" | "browserHours" | "containerCpuSeconds" | "containerDiskGbSeconds" | "containerMemoryGibSeconds" | "cpuMs" | "d1RowsRead" | "d1RowsWritten" | "d1StorageGbMonths" | "doDurationGbS" | "doRequests" | "doRowsRead" | "doRowsWritten" | "doStorageGbMonths" | "imagesDelivered" | "imagesStored" | "imagesTransformations" | "kvDeletes" | "kvLists" | "kvReads" | "kvStorageGbMonths" | "kvWrites" | "logEvents" | "logpushRequests" | "queueOperations" | "r2ClassAOps" | "r2ClassBOps" | "r2StorageGbMonths" | "requests" | "vectorizeQueriedDimensions" | "vectorizeStoredDimensions" | "workersAiNeurons" | "workflowSteps" | "workflowStorageGbMonths";
     organizationId: Id<"organizations">;
     periodStart: number;
     quantity: number;
@@ -963,7 +963,7 @@ export interface Insert_platformUsage {
     _creationTime?: number;
     createdAt: number;
     deploymentId?: Id<"deployments">;
-    kind: "requests" | "cpuMs" | "storageBytes";
+    kind: "aeDataPoints" | "aeReadQueries" | "browserHours" | "containerCpuSeconds" | "containerDiskGbSeconds" | "containerMemoryGibSeconds" | "cpuMs" | "d1RowsRead" | "d1RowsWritten" | "d1StorageGbMonths" | "doDurationGbS" | "doRequests" | "doRowsRead" | "doRowsWritten" | "doStorageGbMonths" | "imagesDelivered" | "imagesStored" | "imagesTransformations" | "kvDeletes" | "kvLists" | "kvReads" | "kvStorageGbMonths" | "kvWrites" | "logEvents" | "logpushRequests" | "queueOperations" | "r2ClassAOps" | "r2ClassBOps" | "r2StorageGbMonths" | "requests" | "vectorizeQueriedDimensions" | "vectorizeStoredDimensions" | "workersAiNeurons" | "workflowSteps" | "workflowStorageGbMonths";
     organizationId: Id<"organizations">;
     periodStart: number;
     quantity: number;

--- a/apps/cloud/lunora/_generated/drizzle.global.ts
+++ b/apps/cloud/lunora/_generated/drizzle.global.ts
@@ -311,7 +311,7 @@ export const platformUsage = sqliteTable("platformUsage", {
     _creationTime: integer("_creationTime").notNull(),
     createdAt: real("createdAt").notNull(),
     deploymentId: text("deploymentId").references((): AnySQLiteColumn => deployments._id),
-    kind: text("kind", { mode: "json" }).$type<"requests" | "cpuMs" | "storageBytes">().notNull(),
+    kind: text("kind", { mode: "json" }).$type<"aeDataPoints" | "aeReadQueries" | "browserHours" | "containerCpuSeconds" | "containerDiskGbSeconds" | "containerMemoryGibSeconds" | "cpuMs" | "d1RowsRead" | "d1RowsWritten" | "d1StorageGbMonths" | "doDurationGbS" | "doRequests" | "doRowsRead" | "doRowsWritten" | "doStorageGbMonths" | "imagesDelivered" | "imagesStored" | "imagesTransformations" | "kvDeletes" | "kvLists" | "kvReads" | "kvStorageGbMonths" | "kvWrites" | "logEvents" | "logpushRequests" | "queueOperations" | "r2ClassAOps" | "r2ClassBOps" | "r2StorageGbMonths" | "requests" | "vectorizeQueriedDimensions" | "vectorizeStoredDimensions" | "workersAiNeurons" | "workflowSteps" | "workflowStorageGbMonths">().notNull(),
     organizationId: text("organizationId").references((): AnySQLiteColumn => organizations._id).notNull(),
     periodStart: real("periodStart").notNull(),
     quantity: real("quantity").notNull(),

--- a/apps/cloud/lunora/_generated/functions.ts
+++ b/apps/cloud/lunora/_generated/functions.ts
@@ -776,8 +776,8 @@ export interface Caller {
         record: (args: { deploymentId?: Id<"deployments">; kind: unknown; organizationId: Id<"organizations">; periodStart: number; quantity: number }) => Promise<Id<"platformUsage">>;
         recordOverageDebit: (args: { debitedCredits: number; organizationId: Id<"organizations">; periodStart: number }) => Promise<void>;
         rollup: (args?: {}) => Promise<{ compacted: number; }>;
-        series: (args: { organizationId: Id<"organizations">; periodStart: number }) => Promise<{ cpuMs: number; day: number; requests: number; }[]>;
-        summary: (args: { organizationId: Id<"organizations">; periodStart: number }) => Promise<Record<"requests" | "cpuMs" | "storageBytes", number>>;
+        series: (args: { organizationId: Id<"organizations">; periodStart: number }) => Promise<{ costMinor: number; cpuMs: number; day: number; requests: number; }[]>;
+        summary: (args: { organizationId: Id<"organizations">; periodStart: number }) => Promise<{ aeDataPoints: number; aeReadQueries: number; browserHours: number; containerCpuSeconds: number; containerDiskGbSeconds: number; containerMemoryGibSeconds: number; cpuMs: number; d1RowsRead: number; d1RowsWritten: number; d1StorageGbMonths: number; doDurationGbS: number; doRequests: number; doRowsRead: number; doRowsWritten: number; doStorageGbMonths: number; imagesDelivered: number; imagesStored: number; imagesTransformations: number; kvDeletes: number; kvLists: number; kvReads: number; kvStorageGbMonths: number; kvWrites: number; logEvents: number; logpushRequests: number; queueOperations: number; r2ClassAOps: number; r2ClassBOps: number; r2StorageGbMonths: number; requests: number; vectorizeQueriedDimensions: number; vectorizeStoredDimensions: number; workersAiNeurons: number; workflowSteps: number; workflowStorageGbMonths: number }>;
     };
 }
 

--- a/apps/cloud/lunora/schema.ts
+++ b/apps/cloud/lunora/schema.ts
@@ -15,6 +15,53 @@ import { defineSchema, defineTable, v } from "@lunora/server";
 
 const plan = v.union(v.literal("free"), v.literal("pro"), v.literal("enterprise"));
 
+/**
+ * Every billable Cloudflare dimension the platform meters into `platformUsage`.
+ *
+ * This list is spelled out here rather than imported because codegen reads this
+ * file statically — a computed union would emit nothing. The pairing with
+ * `UsageMeter` in `src/billing/spend.ts` (which prices each meter) is held by a
+ * type-level assertion in `__tests__/spend.test.ts`, so adding a meter in one
+ * place and forgetting the other fails `lint:types`, not production.
+ */
+const usageMeter = v.union(
+    v.literal("aeDataPoints"),
+    v.literal("aeReadQueries"),
+    v.literal("browserHours"),
+    v.literal("containerCpuSeconds"),
+    v.literal("containerDiskGbSeconds"),
+    v.literal("containerMemoryGibSeconds"),
+    v.literal("cpuMs"),
+    v.literal("d1RowsRead"),
+    v.literal("d1RowsWritten"),
+    v.literal("d1StorageGbMonths"),
+    v.literal("doDurationGbS"),
+    v.literal("doRequests"),
+    v.literal("doRowsRead"),
+    v.literal("doRowsWritten"),
+    v.literal("doStorageGbMonths"),
+    v.literal("imagesDelivered"),
+    v.literal("imagesStored"),
+    v.literal("imagesTransformations"),
+    v.literal("kvDeletes"),
+    v.literal("kvLists"),
+    v.literal("kvReads"),
+    v.literal("kvStorageGbMonths"),
+    v.literal("kvWrites"),
+    v.literal("logEvents"),
+    v.literal("logpushRequests"),
+    v.literal("queueOperations"),
+    v.literal("r2ClassAOps"),
+    v.literal("r2ClassBOps"),
+    v.literal("r2StorageGbMonths"),
+    v.literal("requests"),
+    v.literal("vectorizeQueriedDimensions"),
+    v.literal("vectorizeStoredDimensions"),
+    v.literal("workersAiNeurons"),
+    v.literal("workflowSteps"),
+    v.literal("workflowStorageGbMonths"),
+);
+
 const cellStatus = v.union(v.literal("active"), v.literal("draining"), v.literal("suspended"));
 
 const memberRole = v.union(v.literal("owner"), v.literal("admin"), v.literal("member"), v.literal("viewer"));
@@ -476,11 +523,13 @@ export default defineSchema({
     // for quota + overage billing. Written by the platform metering ingestion
     // endpoint (`POST /v1/usage`) and the Analytics-Engine stream. Distinct from
     // the `@lunora/payment` `usageEvents` ledger below (which meters *billing*
-    // features); this one meters platform resources (requests/CPU/storage).
+    // features); this one meters platform resources — every Cloudflare billing
+    // dimension in `usageMeter`, not just compute, so a storage- or
+    // DO-duration-shaped runaway is visible to the spend cap.
     platformUsage: defineTable({
         createdAt: v.number(),
         deploymentId: v.optional(v.id("deployments")),
-        kind: v.union(v.literal("requests"), v.literal("cpuMs"), v.literal("storageBytes")),
+        kind: usageMeter,
         organizationId: v.id("organizations"),
         periodStart: v.number(),
         quantity: v.number(),

--- a/apps/cloud/lunora/usage.ts
+++ b/apps/cloud/lunora/usage.ts
@@ -1,6 +1,8 @@
 import { LunoraError } from "@lunora/server";
 
-import { evaluateSpendCap } from "../src/billing/spend";
+import type { PeriodUsage, UsageMeter } from "../src/billing/spend";
+import { estimatedSpendMinor, evaluateSpendCap, isUsageMeter } from "../src/billing/spend";
+import type { UsageTotals } from "../src/billing/usage";
 import { aggregateUsage } from "../src/billing/usage";
 import type { Id } from "./_generated/dataModel.js";
 import { internalMutation, internalQuery, mutation, query, v } from "./_generated/server.js";
@@ -14,9 +16,55 @@ import { boundedString, LIMITS } from "./validators";
  * stream; `summary` rolls a period up for the dashboard/billing. The roll-up
  * logic is the pure `aggregateUsage`. (Distinct from `@lunora/payment`'s usage
  * ledger, which meters billing features via `ctx.payments`.)
+ *
+ * The meter set is the full Cloudflare rate card (`src/billing/spend.ts`), so
+ * the cap sees storage, Durable Object duration, D1 rows, and R2 operations —
+ * not only requests and CPU.
  */
 
-const kind = v.union(v.literal("requests"), v.literal("cpuMs"), v.literal("storageBytes"));
+/**
+ * The metered dimension. Mirrors `usageMeter` in `schema.ts` (which codegen
+ * reads statically) and `UsageMeter` in `src/billing/spend.ts` (which prices
+ * it); the three are pinned together by the type assertion in
+ * `__tests__/spend.test.ts`.
+ */
+const kind = v.union(
+    v.literal("aeDataPoints"),
+    v.literal("aeReadQueries"),
+    v.literal("browserHours"),
+    v.literal("containerCpuSeconds"),
+    v.literal("containerDiskGbSeconds"),
+    v.literal("containerMemoryGibSeconds"),
+    v.literal("cpuMs"),
+    v.literal("d1RowsRead"),
+    v.literal("d1RowsWritten"),
+    v.literal("d1StorageGbMonths"),
+    v.literal("doDurationGbS"),
+    v.literal("doRequests"),
+    v.literal("doRowsRead"),
+    v.literal("doRowsWritten"),
+    v.literal("doStorageGbMonths"),
+    v.literal("imagesDelivered"),
+    v.literal("imagesStored"),
+    v.literal("imagesTransformations"),
+    v.literal("kvDeletes"),
+    v.literal("kvLists"),
+    v.literal("kvReads"),
+    v.literal("kvStorageGbMonths"),
+    v.literal("kvWrites"),
+    v.literal("logEvents"),
+    v.literal("logpushRequests"),
+    v.literal("queueOperations"),
+    v.literal("r2ClassAOps"),
+    v.literal("r2ClassBOps"),
+    v.literal("r2StorageGbMonths"),
+    v.literal("requests"),
+    v.literal("vectorizeQueriedDimensions"),
+    v.literal("vectorizeStoredDimensions"),
+    v.literal("workersAiNeurons"),
+    v.literal("workflowSteps"),
+    v.literal("workflowStorageGbMonths"),
+);
 
 /** Record a metered event. SYSTEM only (internalMutation — cron/metering writer). */
 export const record = internalMutation
@@ -82,7 +130,7 @@ export const ingest = mutation
 interface PlatformUsageRow {
     _id: Id<"platformUsage">;
     createdAt: number;
-    kind: "cpuMs" | "requests" | "storageBytes";
+    kind: UsageMeter;
     organizationId: Id<"organizations">;
     periodStart: number;
     quantity: number;
@@ -153,7 +201,7 @@ export const rollup = internalMutation.mutation(async ({ ctx: context }): Promis
 /** Summed usage for an org over a billing period (members only). */
 export const summary = query
     .input({ organizationId: v.id("organizations"), periodStart: v.number() })
-    .query(async ({ ctx: context, args: { organizationId, periodStart } }): Promise<Record<"cpuMs" | "requests" | "storageBytes", number>> => {
+    .query(async ({ ctx: context, args: { organizationId, periodStart } }): Promise<UsageTotals> => {
         await assertMember(context, organizationId);
 
         const { page } = await context.db.platformUsage.findMany({ where: { organizationId } });
@@ -172,16 +220,21 @@ export const summary = query
 export const enforceSpendCaps = internalMutation.mutation(async ({ ctx: context }): Promise<{ suspended: number; unsuspended: number }> => {
     const periodStart = currentPeriodStart();
     const { page: usageRows } = await context.db.platformUsage.findMany({});
-    const byOrg = new Map<string, { cpuMs: number; requests: number }>();
+    const byOrg = new Map<string, PeriodUsage>();
 
+    // Every meter counts toward the cap, not just requests/CPU — a tenant can
+    // run away on Durable Object duration or R2 operations without moving the
+    // compute meters at all. Unknown kinds (a row from a newer writer) are
+    // skipped rather than throwing: the sweep that protects the platform from a
+    // runaway bill must never be the thing that crashes.
     for (const row of usageRows as unknown as PlatformUsageRow[]) {
-        if (row.periodStart < periodStart || (row.kind !== "requests" && row.kind !== "cpuMs")) {
+        if (row.periodStart < periodStart || !isUsageMeter(row.kind)) {
             continue;
         }
 
-        const bucket = byOrg.get(row.organizationId) ?? { cpuMs: 0, requests: 0 };
+        const bucket = byOrg.get(row.organizationId) ?? {};
 
-        bucket[row.kind] += row.quantity;
+        bucket[row.kind] = (bucket[row.kind] ?? 0) + row.quantity;
         byOrg.set(row.organizationId, bucket);
     }
 
@@ -198,7 +251,7 @@ export const enforceSpendCaps = internalMutation.mutation(async ({ ctx: context 
     let unsuspended = 0;
 
     for (const organization of organizations) {
-        const usage = byOrg.get(organization._id) ?? { cpuMs: 0, requests: 0 };
+        const usage = byOrg.get(organization._id) ?? {};
         const decision = evaluateSpendCap({ capMinorOverride: organization.spendCapMinor, plan: organization.plan, usage });
 
         if (decision.suspend && organization.suspendedAt == null) {
@@ -273,31 +326,36 @@ export const recordOverageDebit = internalMutation
  * chart (GAPS.md ring 3). Buckets raw `platformUsage` events by UTC day of
  * their `createdAt`; compacted history keeps period totals correct, so the
  * series is best-effort recent detail, not an invoice.
+ *
+ * `requests`/`cpuMs` stay as named columns because they are the two the chart
+ * plots, but `costMinor` prices the day's *whole* bucket across the rate card —
+ * otherwise a day whose spend was all Durable Object duration would draw as a
+ * flat line at zero.
  */
 export const series = query
     .input({ organizationId: v.id("organizations"), periodStart: v.number() })
-    .query(async ({ ctx: context, args: { organizationId, periodStart } }): Promise<{ cpuMs: number; day: number; requests: number }[]> => {
+    .query(async ({ ctx: context, args: { organizationId, periodStart } }): Promise<{ costMinor: number; cpuMs: number; day: number; requests: number }[]> => {
         await assertMember(context, organizationId);
 
         const { page } = await context.db.platformUsage.findMany({ where: { organizationId } });
         const dayMs = 24 * 60 * 60 * 1000;
-        const buckets = new Map<number, { cpuMs: number; requests: number }>();
+        const buckets = new Map<number, PeriodUsage>();
 
         for (const row of page as unknown as PlatformUsageRow[]) {
-            if (row.periodStart !== periodStart || (row.kind !== "requests" && row.kind !== "cpuMs")) {
+            if (row.periodStart !== periodStart || !isUsageMeter(row.kind)) {
                 continue;
             }
 
             const day = Math.floor(row.createdAt / dayMs) * dayMs;
-            const bucket = buckets.get(day) ?? { cpuMs: 0, requests: 0 };
+            const bucket = buckets.get(day) ?? {};
 
-            bucket[row.kind] += row.quantity;
+            bucket[row.kind] = (bucket[row.kind] ?? 0) + row.quantity;
             buckets.set(day, bucket);
         }
 
         return [...buckets.entries()]
             .map(([day, bucket]) => {
-                return { day, ...bucket };
+                return { costMinor: estimatedSpendMinor(bucket), cpuMs: bucket.cpuMs ?? 0, day, requests: bucket.requests ?? 0 };
             })
             .toSorted((a, b) => a.day - b.day);
     });

--- a/apps/cloud/src/billing/overage.ts
+++ b/apps/cloud/src/billing/overage.ts
@@ -18,7 +18,16 @@
 
 import type { PeriodUsage } from "./spend";
 
-/** Usage included in each plan per period before overage debits start. */
+/**
+ * Usage included in each plan per period before overage debits start.
+ *
+ * Deliberately narrower than the cost model's meter set: the *cap*
+ * (`src/billing/spend.ts`) prices the whole Cloudflare bill because its job is
+ * blast-radius control, whereas what a customer is *charged* for is a pricing
+ * decision. Today customers are charged on requests + CPU only, so an org can
+ * be capped for spend (storage, DO duration) it was never invoiced for — which
+ * is the intended asymmetry for a prepaid model, not an oversight.
+ */
 export const INCLUDED_USAGE: Record<string, PeriodUsage> = {
     enterprise: { cpuMs: 3_000_000_000, requests: 1_000_000_000 },
     free: { cpuMs: 3_000_000, requests: 1_000_000 },
@@ -40,8 +49,8 @@ export const includedUsageFor = (plan: string): PeriodUsage => INCLUDED_USAGE[pl
  */
 export const overageCreditsOwed = (plan: string, usage: PeriodUsage): number => {
     const included = includedUsageFor(plan);
-    const overRequests = Math.max(0, usage.requests - included.requests);
-    const overCpuMs = Math.max(0, usage.cpuMs - included.cpuMs);
+    const overRequests = Math.max(0, (usage.requests ?? 0) - (included.requests ?? 0));
+    const overCpuMs = Math.max(0, (usage.cpuMs ?? 0) - (included.cpuMs ?? 0));
 
     return Math.floor((overRequests * REQUEST_CREDITS_PER_MILLION + overCpuMs * CPU_MS_CREDITS_PER_MILLION) / 1_000_000);
 };

--- a/apps/cloud/src/billing/reconcile.ts
+++ b/apps/cloud/src/billing/reconcile.ts
@@ -51,6 +51,10 @@ export const buildOverageReconcileData = async (database: ControlPlaneDatabase, 
     const { page: usagePage } = await database.findMany("platformUsage", {});
     const usageByOrg = new Map<string, PeriodUsage>();
 
+    // Only the customer-priced meters are folded in: `overageCreditsOwed` bills
+    // requests + CPU, so summing storage or DO duration here would put usage in
+    // the bucket that no rate ever converts into credits. The *cap* prices the
+    // whole bill (`src/billing/spend.ts`) — that asymmetry is deliberate.
     for (const row of usagePage as UsageRow[]) {
         if (row.periodStart !== periodStart || (row.kind !== "requests" && row.kind !== "cpuMs")) {
             continue;
@@ -58,7 +62,7 @@ export const buildOverageReconcileData = async (database: ControlPlaneDatabase, 
 
         const bucket = usageByOrg.get(row.organizationId) ?? { cpuMs: 0, requests: 0 };
 
-        bucket[row.kind] += row.quantity;
+        bucket[row.kind] = (bucket[row.kind] ?? 0) + row.quantity;
         usageByOrg.set(row.organizationId, bucket);
     }
 

--- a/apps/cloud/src/billing/spend.ts
+++ b/apps/cloud/src/billing/spend.ts
@@ -1,16 +1,219 @@
 /**
- * Aggregate spend caps (GAPS.md C1). Per-invocation runtime limits cap a single
- * request; this caps an org's *aggregate* period spend so a compromised or
- * abusive account can't rack up unbounded usage. Pure: the evaluator takes the
- * period usage and returns a decision; the enforcement cron does the I/O.
+ * Aggregate spend caps (GAPS.md C1) over the **full Cloudflare bill**.
+ * Per-invocation runtime limits cap a single request; this caps an org's
+ * aggregate* period spend so a compromised or abusive account can't rack up
+ * unbounded usage. Pure: the evaluator takes the period usage and returns a
+ * decision; the enforcement cron does the I/O.
  *
- * Spend is estimated from metered platform usage at the WfP cost basis (the
- * same numbers the pricing maps onto): $0.30/M requests + $0.02/M CPU-ms.
+ * **The rate card is the whole bill, not just compute.** Pricing only requests
+ * + CPU-ms left every storage-shaped runaway invisible to the cap: a tenant can
+ * burn far more on Durable Object duration, D1 row reads, or R2 Class A
+ * operations than it ever will on Workers-for-Platforms requests, and the cap
+ * would never notice. {@link RATE_CARD} carries every dimension Lunora Cloud's
+ * products actually consume, with the rate taken from Cloudflare's published
+ * pricing pages.
+ *
+ * **Rates are marginal, and included allowances are deliberately NOT
+ * subtracted.** Cloudflare's free tiers (20M Workers-for-Platforms requests,
+ * 25 billion Durable Object rows read, …) are granted once to *the platform's*
+ * account — not once per tenant. Subtracting a full account allowance per org
+ * would let a hundred free orgs each "spend" the platform's entire included
+ * tier and stay under their cap. So every unit is priced at the marginal
+ * overage rate. That over-estimates a small tenant's true incremental cost,
+ * which is the correct direction for a blast-radius control: the cap fires
+ * early, never late.
+ *
+ * **This is an estimate, not an invoice.** The authoritative number for an org
+ * that has connected its own Cloudflare account is the Billable Usage API
+ * (`lunora/cloudflare-billing.ts`); this model is what the platform can compute
+ * for *every* org, including those that have connected nothing.
+ *
+ * Rates are held as integer **nano-cents per unit** (1 cent = 1e9 nano-cents)
+ * so the cheapest published rate — $0.001 per million rows read, i.e. 100
+ * nano-cents per row — is still an exact integer. Accumulating in nano-cents
+ * and rounding once at the end is what stops a meter whose per-unit price is a
+ * fraction of a cent from rounding to zero on every roll-up.
  */
 
-/** Cents per million units — the WfP cost basis. */
-const REQUEST_CENTS_PER_MILLION = 30; // $0.30 per 1M requests
-const CPU_MS_CENTS_PER_MILLION = 2; // $0.02 per 1M CPU-ms
+/** Nano-cents in one minor unit (cent). */
+const NANO_CENTS_PER_CENT = 1_000_000_000;
+
+/**
+ * Every billable dimension the platform meters. One meter per Cloudflare
+ * billing dimension, named for the product it belongs to — a meter that maps to
+ * two products would make the breakdown lie about where the money went.
+ */
+export type UsageMeter =
+    // Workers for Platforms — the dispatch chain (dispatch → user → outbound
+    // Worker) is billed as ONE request, with CPU summed across all three.
+    // Workflows invocations bill at the same request/CPU rates and fold in here.
+    | "aeDataPoints"
+    | "aeReadQueries"
+    | "browserHours"
+    | "containerCpuSeconds"
+    | "containerDiskGbSeconds"
+    | "containerMemoryGibSeconds"
+    | "cpuMs"
+    // D1 — `.global()` tables.
+    | "d1RowsRead"
+    | "d1RowsWritten"
+    | "d1StorageGbMonths"
+    // Durable Objects — ShardDO / SessionDO / SchedulerDO.
+    | "doDurationGbS"
+    | "doRequests"
+    | "doRowsRead"
+    | "doRowsWritten"
+    | "doStorageGbMonths"
+    | "imagesDelivered"
+    | "imagesStored"
+    | "imagesTransformations"
+    // Workers KV.
+    | "kvDeletes"
+    | "kvLists"
+    | "kvReads"
+    | "kvStorageGbMonths"
+    | "kvWrites"
+    // Logs — Workers Logs events and Logpush delivery.
+    | "logEvents"
+    | "logpushRequests"
+    | "queueOperations"
+    // R2 — `@lunora/storage`. Egress is free and therefore has no meter.
+    | "r2ClassAOps"
+    | "r2ClassBOps"
+    | "r2StorageGbMonths"
+    | "requests"
+    | "vectorizeQueriedDimensions"
+    | "vectorizeStoredDimensions"
+    // Vectorize + Workers AI — `@lunora/ai`.
+    | "workersAiNeurons"
+    // Workflows — steps and state storage are metered on top of request/CPU.
+    | "workflowSteps"
+    | "workflowStorageGbMonths";
+
+/** Period usage keyed by meter. An absent meter reads as zero. */
+export type PeriodUsage = Partial<Record<UsageMeter, number>>;
+
+export interface MeterRate {
+    /** Marginal cost of one unit, in nano-cents (1 cent = 1e9). */
+    nanoCentsPerUnit: number;
+    /** Cloudflare product the meter belongs to — the breakdown groups by this. */
+    product: string;
+    /** The published rate this was derived from, for auditability. */
+    published: string;
+    /** What one unit is. */
+    unit: string;
+}
+
+/**
+ * Marginal cost per unit, per Cloudflare's published pricing. `published` keeps
+ * the source rate next to the derived integer so a rate change is a one-line
+ * diff that can be checked against the pricing page without arithmetic.
+ *
+ * Not metered here, on purpose: Hyperdrive (unlimited queries on Workers Paid,
+ * so no marginal cost), R2 egress (free), and DNS/TLS/bandwidth (included on
+ * all plans). A zero-rate meter would imply the platform tracks something it
+ * does not.
+ */
+export const RATE_CARD: Readonly<Record<UsageMeter, MeterRate>> = {
+    aeDataPoints: { nanoCentsPerUnit: 25_000, published: "$0.25 / million", product: "Analytics Engine", unit: "data point" },
+    aeReadQueries: { nanoCentsPerUnit: 100_000, published: "$1.00 / million", product: "Analytics Engine", unit: "read query" },
+    browserHours: { nanoCentsPerUnit: 9_000_000_000, published: "$0.09 / hour", product: "Browser Rendering", unit: "browser hour" },
+    containerCpuSeconds: { nanoCentsPerUnit: 2_000_000, published: "$0.000020 / vCPU-second", product: "Containers", unit: "vCPU-second" },
+    containerDiskGbSeconds: { nanoCentsPerUnit: 7000, published: "$0.00000007 / GB-second", product: "Containers", unit: "disk GB-second" },
+    containerMemoryGibSeconds: { nanoCentsPerUnit: 250_000, published: "$0.0000025 / GiB-second", product: "Containers", unit: "memory GiB-second" },
+    cpuMs: { nanoCentsPerUnit: 2000, published: "$0.02 / million", product: "Workers for Platforms", unit: "CPU-millisecond" },
+    d1RowsRead: { nanoCentsPerUnit: 100, published: "$0.001 / million", product: "D1", unit: "row read" },
+    d1RowsWritten: { nanoCentsPerUnit: 100_000, published: "$1.00 / million", product: "D1", unit: "row written" },
+    d1StorageGbMonths: { nanoCentsPerUnit: 75_000_000_000, published: "$0.75 / GB-month", product: "D1", unit: "GB-month" },
+    doDurationGbS: { nanoCentsPerUnit: 1_250_000, published: "$12.50 / million GB-s", product: "Durable Objects", unit: "GB-second" },
+    doRequests: { nanoCentsPerUnit: 15_000, published: "$0.15 / million", product: "Durable Objects", unit: "request" },
+    doRowsRead: { nanoCentsPerUnit: 100, published: "$0.001 / million", product: "Durable Objects", unit: "row read" },
+    doRowsWritten: { nanoCentsPerUnit: 100_000, published: "$1.00 / million", product: "Durable Objects", unit: "row written" },
+    doStorageGbMonths: { nanoCentsPerUnit: 20_000_000_000, published: "$0.20 / GB-month", product: "Durable Objects", unit: "GB-month" },
+    imagesDelivered: { nanoCentsPerUnit: 1_000_000, published: "$1.00 / 100,000", product: "Images", unit: "image delivered" },
+    imagesStored: { nanoCentsPerUnit: 5_000_000, published: "$5.00 / 100,000 / month", product: "Images", unit: "image stored" },
+    imagesTransformations: { nanoCentsPerUnit: 50_000_000, published: "$0.50 / 1,000", product: "Images", unit: "unique transformation" },
+    kvDeletes: { nanoCentsPerUnit: 500_000, published: "$5.00 / million", product: "Workers KV", unit: "key deleted" },
+    kvLists: { nanoCentsPerUnit: 500_000, published: "$5.00 / million", product: "Workers KV", unit: "list request" },
+    kvReads: { nanoCentsPerUnit: 50_000, published: "$0.50 / million", product: "Workers KV", unit: "key read" },
+    kvStorageGbMonths: { nanoCentsPerUnit: 50_000_000_000, published: "$0.50 / GB-month", product: "Workers KV", unit: "GB-month" },
+    kvWrites: { nanoCentsPerUnit: 500_000, published: "$5.00 / million", product: "Workers KV", unit: "key written" },
+    logEvents: { nanoCentsPerUnit: 60_000, published: "$0.60 / million", product: "Workers Logs", unit: "log event" },
+    logpushRequests: { nanoCentsPerUnit: 5000, published: "$0.05 / million", product: "Workers Logpush", unit: "request log" },
+    queueOperations: { nanoCentsPerUnit: 40_000, published: "$0.40 / million", product: "Queues", unit: "operation (64 KB)" },
+    r2ClassAOps: { nanoCentsPerUnit: 450_000, published: "$4.50 / million", product: "R2", unit: "Class A operation" },
+    r2ClassBOps: { nanoCentsPerUnit: 36_000, published: "$0.36 / million", product: "R2", unit: "Class B operation" },
+    r2StorageGbMonths: { nanoCentsPerUnit: 1_500_000_000, published: "$0.015 / GB-month", product: "R2", unit: "GB-month" },
+    requests: { nanoCentsPerUnit: 30_000, published: "$0.30 / million", product: "Workers for Platforms", unit: "request" },
+    vectorizeQueriedDimensions: { nanoCentsPerUnit: 1000, published: "$0.01 / million", product: "Vectorize", unit: "queried dimension" },
+    vectorizeStoredDimensions: { nanoCentsPerUnit: 50, published: "$0.05 / 100 million", product: "Vectorize", unit: "stored dimension" },
+    workersAiNeurons: { nanoCentsPerUnit: 1_100_000, published: "$0.011 / 1,000 Neurons", product: "Workers AI", unit: "Neuron" },
+    workflowSteps: { nanoCentsPerUnit: 800_000, published: "$0.80 / 100,000", product: "Workflows", unit: "step" },
+    workflowStorageGbMonths: { nanoCentsPerUnit: 20_000_000_000, published: "$0.20 / GB-month", product: "Workflows", unit: "GB-month" },
+};
+
+/** Every meter, in rate-card order — the canonical iteration order. */
+export const USAGE_METERS = Object.keys(RATE_CARD) as UsageMeter[];
+
+/** Whether an arbitrary string is a known meter (guards ledger rows from older writers). */
+export const isUsageMeter = (value: string): value is UsageMeter => value in RATE_CARD;
+
+/**
+ * Estimated period cost in nano-cents. Exact integer arithmetic over the whole
+ * rate card; a caller that wants money rounds once, at the end.
+ */
+export const estimatedSpendNanoCents = (usage: PeriodUsage): number => {
+    let total = 0;
+
+    for (const meter of USAGE_METERS) {
+        const quantity = usage[meter];
+
+        if (quantity !== undefined && Number.isFinite(quantity) && quantity > 0) {
+            total += quantity * RATE_CARD[meter].nanoCentsPerUnit;
+        }
+    }
+
+    return total;
+};
+
+/** Estimated period cost in minor units (cents), rounded once from the nano-cent total. */
+export const estimatedSpendMinor = (usage: PeriodUsage): number => Math.round(estimatedSpendNanoCents(usage) / NANO_CENTS_PER_CENT);
+
+export interface SpendLine {
+    meter: UsageMeter;
+    /** Exact cost of this line in nano-cents — the total is the sum of these, not of the rounded values. */
+    nanoCents: number;
+    product: string;
+    quantity: number;
+    unit: string;
+}
+
+/**
+ * Per-meter cost breakdown, most expensive first, omitting meters with no
+ * usage. This is what a "why am I being charged" view (and the agent-facing
+ * usage API) needs — a single number tells nobody which product ran away.
+ *
+ * Lines carry exact nano-cents rather than rounded cents on purpose: rounding
+ * each line and summing would disagree with {@link estimatedSpendMinor}, which
+ * rounds the total once.
+ */
+export const spendBreakdown = (usage: PeriodUsage): SpendLine[] => {
+    const lines: SpendLine[] = [];
+
+    for (const meter of USAGE_METERS) {
+        const quantity = usage[meter];
+
+        if (quantity === undefined || !Number.isFinite(quantity) || quantity <= 0) {
+            continue;
+        }
+
+        const rate = RATE_CARD[meter];
+
+        lines.push({ meter, nanoCents: quantity * rate.nanoCentsPerUnit, product: rate.product, quantity, unit: rate.unit });
+    }
+
+    return lines.toSorted((a, b) => b.nanoCents - a.nanoCents);
+};
 
 /** Default aggregate monthly caps (minor units, i.e. cents) per plan. `null` = uncapped. */
 export const DEFAULT_SPEND_CAP_MINOR: Record<string, null | number> = {
@@ -18,15 +221,6 @@ export const DEFAULT_SPEND_CAP_MINOR: Record<string, null | number> = {
     free: 500, // $5 — hobby blast-radius, ~x100 the free tier's expected usage
     pro: 20_000, // $200 — a runaway pro app stops before a four-digit bill
 };
-
-export interface PeriodUsage {
-    cpuMs: number;
-    requests: number;
-}
-
-/** Estimated period cost in minor units (cents) at the WfP cost basis. */
-export const estimatedSpendMinor = (usage: PeriodUsage): number =>
-    Math.round((usage.requests * REQUEST_CENTS_PER_MILLION + usage.cpuMs * CPU_MS_CENTS_PER_MILLION) / 1_000_000);
 
 export interface SpendCapInput {
     /** Org-level override; `undefined` falls back to the plan default. */

--- a/apps/cloud/src/billing/spend.ts
+++ b/apps/cloud/src/billing/spend.ts
@@ -1,7 +1,7 @@
 /**
  * Aggregate spend caps (GAPS.md C1) over the **full Cloudflare bill**.
  * Per-invocation runtime limits cap a single request; this caps an org's
- * aggregate* period spend so a compromised or abusive account can't rack up
+ * **aggregate** period spend so a compromised or abusive account can't rack up
  * unbounded usage. Pure: the evaluator takes the period usage and returns a
  * decision; the enforcement cron does the I/O.
  *

--- a/apps/cloud/src/billing/usage.ts
+++ b/apps/cloud/src/billing/usage.ts
@@ -2,9 +2,16 @@
  * Usage metering aggregation (CLOUD-PLAN.md §4). Metered events are summed per
  * billing period to drive quota + overage billing through `@lunora/payment`.
  * Pure — the control plane records events; this rolls them up.
+ *
+ * The meter set is {@link UsageMeter} from the rate card, so the ledger and the
+ * cost model can never drift apart: a meter the ledger can hold is a meter the
+ * rate card prices, and vice versa.
  */
 
-export type UsageKind = "cpuMs" | "requests" | "storageBytes";
+import type { PeriodUsage, UsageMeter } from "./spend";
+import { isUsageMeter, USAGE_METERS } from "./spend";
+
+export type UsageKind = UsageMeter;
 
 export interface UsageEvent {
     kind: UsageKind;
@@ -12,17 +19,47 @@ export interface UsageEvent {
     quantity: number;
 }
 
+/** Every meter, zero-filled — a stable shape so the console table never gains/loses columns. */
 export type UsageTotals = Record<UsageKind, number>;
 
-/** Sum the metered quantities for `periodStart`, by kind. */
+/** All meters at zero. */
+export const emptyUsageTotals = (): UsageTotals => {
+    const totals = {} as UsageTotals;
+
+    for (const meter of USAGE_METERS) {
+        totals[meter] = 0;
+    }
+
+    return totals;
+};
+
+/**
+ * Sum the metered quantities for `periodStart`, by kind. Rows carrying a kind
+ * the rate card does not know are skipped rather than crashing the roll-up —
+ * a ledger written by a newer writer must not be able to break the cap sweep
+ * that protects the platform from a runaway bill.
+ */
 export const aggregateUsage = (events: ReadonlyArray<UsageEvent>, periodStart: number): UsageTotals => {
-    const totals: UsageTotals = { cpuMs: 0, requests: 0, storageBytes: 0 };
+    const totals = emptyUsageTotals();
 
     for (const event of events) {
-        if (event.periodStart === periodStart) {
+        if (event.periodStart === periodStart && isUsageMeter(event.kind)) {
             totals[event.kind] += event.quantity;
         }
     }
 
     return totals;
+};
+
+/** Drop the zero meters — the sparse form the cost model and breakdown take. */
+export const toPeriodUsage = (totals: UsageTotals): PeriodUsage => {
+    const usage: PeriodUsage = {};
+
+    for (const meter of USAGE_METERS) {
+        if (totals[meter] > 0) {
+            usage[meter] = totals[meter];
+        }
+    }
+
+    return usage;
 };

--- a/apps/cloud/src/client/UsageSection.tsx
+++ b/apps/cloud/src/client/UsageSection.tsx
@@ -7,22 +7,66 @@ import { cn } from "@/lib/utils";
 
 import { api } from "../../lunora/_generated/api.js";
 import { includedUsageFor } from "../billing/overage";
+import { estimatedSpendMinor, spendBreakdown } from "../billing/spend";
+import type { UsageTotals } from "../billing/usage";
+import { toPeriodUsage } from "../billing/usage";
 import { formatDate, formatNumber } from "./format";
 import { COLUMN_LABEL } from "./section-ui";
 import type { SectionProps } from "./tabs";
 import { monthStart } from "./usage-period";
 
-const formatBytes = (bytes: number): string => {
-    const units = ["B", "KB", "MB", "GB", "TB"];
-    let value = bytes;
-    let unit = 0;
+/** Minor units → a plain dollar string. */
+const formatMinor = (minor: number): string => `$${(minor / 100).toFixed(2)}`;
 
-    while (value >= 1024 && unit < units.length - 1) {
-        value /= 1024;
-        unit += 1;
+/**
+ * Nano-cents → dollars for a single breakdown line. Lines carry exact
+ * nano-cents (the total rounds once, so rounding each line and summing would
+ * disagree with it), and a line worth a fraction of a cent still has to render
+ * as something other than zero.
+ */
+const formatNanoCents = (nanoCents: number): string => {
+    const dollars = nanoCents / 100_000_000_000;
+
+    if (dollars > 0 && dollars < 0.01) {
+        return "<$0.01";
     }
 
-    return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+    return `$${dollars.toFixed(2)}`;
+};
+
+/**
+ * Cost by product for the period. A single spend figure names no product, and
+ * the two quota meters above cover two of the ~35 dimensions the cap actually
+ * prices — so a period whose spend was all Durable Object duration would
+ * otherwise show nothing at all.
+ */
+const CostByProduct = ({ totals }: { totals: UsageTotals }): ReactElement => {
+    const usage = toPeriodUsage(totals);
+    const breakdown = spendBreakdown(usage);
+
+    return (
+        <div className="border-border flex flex-col gap-2 border-t pt-4">
+            <div className="flex items-baseline justify-between gap-4">
+                <span className={cn(COLUMN_LABEL, "text-muted-foreground")}>Estimated cost</span>
+                <span className="font-mono text-sm tabular-nums">{formatMinor(estimatedSpendMinor(usage))}</span>
+            </div>
+            {breakdown.length > 0 ? (
+                <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                    {breakdown.slice(0, 8).map((line) => (
+                        <li className="flex items-baseline justify-between gap-4" key={line.meter}>
+                            <span className="text-muted-foreground font-mono text-[11px]">
+                                {line.product} · {formatNumber(line.quantity)} {line.unit}
+                            </span>
+                            <span className="font-mono text-[11px] tabular-nums">{formatNanoCents(line.nanoCents)}</span>
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+            <p className="text-muted-foreground m-0 font-mono text-[11px]">
+                Estimated at Cloudflare&apos;s marginal rates — your invoice is the authoritative number.
+            </p>
+        </div>
+    );
 };
 
 type QuotaState = "ok" | "over" | "warn";
@@ -150,6 +194,8 @@ export const UsageSection = ({ organizationId, preloaded }: SectionProps<ReturnO
     const organizations = useQuery(api.organizations.list, {});
     const plan = organizations?.find((entry) => entry._id === organizationId)?.plan ?? "free";
     const included = includedUsageFor(plan);
+    const includedRequests = included.requests ?? 0;
+    const includedCpuMs = included.cpuMs ?? 0;
 
     return (
         <Card>
@@ -165,7 +211,7 @@ export const UsageSection = ({ organizationId, preloaded }: SectionProps<ReturnO
                         <span
                             className={cn(
                                 "font-mono text-5xl leading-none tracking-[-0.02em] tabular-nums",
-                                STATE_TEXT[quotaState(included.requests > 0 ? summary.requests / included.requests : 0)],
+                                STATE_TEXT[quotaState(includedRequests > 0 ? summary.requests / includedRequests : 0)],
                             )}
                         >
                             {formatNumber(summary.requests)}
@@ -174,17 +220,13 @@ export const UsageSection = ({ organizationId, preloaded }: SectionProps<ReturnO
                     </div>
 
                     <div className="flex flex-col gap-5">
-                        <Meter included={included.requests} label="Requests" used={summary.requests} />
-                        <Meter included={included.cpuMs} label="CPU ms" used={summary.cpuMs} />
+                        <Meter included={includedRequests} label="Requests" used={summary.requests} />
+                        <Meter included={includedCpuMs} label="CPU ms" used={summary.cpuMs} />
                     </div>
 
                     {series && series.length > 0 ? <UsageBars series={series} /> : null}
 
-                    {/* Unmetered against a plan quota, so it stays a plain stat row. */}
-                    <div className="border-border flex items-baseline justify-between gap-4 border-t pt-4">
-                        <span className={cn(COLUMN_LABEL, "text-muted-foreground")}>Storage</span>
-                        <span className="font-mono text-sm tabular-nums">{formatBytes(summary.storageBytes)}</span>
-                    </div>
+                    <CostByProduct totals={summary} />
                 </div>
             </CardContent>
         </Card>

--- a/apps/cloud/src/deploy/router.ts
+++ b/apps/cloud/src/deploy/router.ts
@@ -7,6 +7,7 @@ import type { ExecutionContextLike } from "@lunora/runtime";
 import { api, internal } from "../../lunora/_generated/api.js";
 import type { AlertDelivery } from "../../lunora/telemetry";
 import { proxyAdminRequest } from "../admin/proxy";
+import type { UsageMeter as UsageKind } from "../billing/spend";
 import { createHttpCloudflareApi } from "../cloudflare/api";
 import { createDohResolver, verifyDomain } from "../domains/verify";
 import { handleGitHubWebhook } from "../github/webhook";
@@ -72,8 +73,6 @@ interface AdminBody {
     organizationId?: string;
     path?: string;
 }
-
-type UsageKind = "cpuMs" | "requests" | "storageBytes";
 
 interface UsageBody {
     deployKey?: string;

--- a/apps/cloud/src/metering/analytics.ts
+++ b/apps/cloud/src/metering/analytics.ts
@@ -95,6 +95,22 @@ interface AnalyticsReaderOptions {
  * HTTP `AnalyticsUsageReader` over the Analytics Engine SQL API (via
  * `@lunora/bindings/analytics`'s read client). Runs at the edge (needs the account API
  * token); the SQL groups request counts per script over the window.
+ *
+ * **The aggregation must be `SUM(_sample_interval)`, not `SUM(double1)`.**
+ * Analytics Engine applies weighted adaptive sampling at write time: past a
+ * write rate it keeps one row in place of many, and each retained row carries
+ * the `_sample_interval` it stands in for. Summing `double1` bare therefore
+ * under-counts by the sample factor — and sampling engages precisely when a
+ * tenant's request rate spikes, i.e. in the runaway/compromised-account case
+ * the spend cap downstream of this ledger exists to stop. Cloudflare's own
+ * usage-based-billing recipe uses exactly this form.
+ *
+ * Because the dispatcher writes `index1 = scriptName` and one data point per
+ * request, summing the sample interval grouped by that index is not an
+ * approximation — it is the exact request count. Grouping on `blob1` would have
+ * been the sampled-and-therefore-approximate form; the index is also what makes
+ * per-tenant sampling equitable, so one enormous tenant cannot sample a small
+ * tenant's rows down to zero.
  */
 export const createHttpAnalyticsReader = (options: AnalyticsReaderOptions): AnalyticsUsageReader => {
     const sql = createAnalyticsSqlClient({ accountId: options.accountId, apiToken: options.apiToken, fetch: options.fetch });
@@ -103,7 +119,7 @@ export const createHttpAnalyticsReader = (options: AnalyticsReaderOptions): Anal
         readRequestUsage: async (sinceMs) => {
             const sinceSeconds = Math.floor(sinceMs / 1000);
             const result = await sql.query(
-                `SELECT blob1 AS scriptName, SUM(double1) AS requests FROM ${options.dataset} WHERE timestamp > toDateTime(${String(sinceSeconds)}) GROUP BY scriptName`,
+                `SELECT index1 AS scriptName, SUM(_sample_interval) AS requests FROM ${options.dataset} WHERE timestamp > toDateTime(${String(sinceSeconds)}) GROUP BY scriptName`,
             );
 
             return result.rows.map((row) => {

--- a/plans/306-cloud-spend-guardrails-and-anomaly-research.md
+++ b/plans/306-cloud-spend-guardrails-and-anomaly-research.md
@@ -1,0 +1,454 @@
+# Plan 306 — Cloud spend guardrails, anomaly alerting, recursion protection & agent-queryable billing
+
+**Baseline:** `48366a2` (2026-08-08)
+**Status:** TODO — research complete, build not started
+
+Research pass over five capabilities Vercel shipped as a bundle (soft/hard spend
+caps, anomaly alerting, function recursion protection, billing usage APIs for
+agents, always-on L3/L4/L7 DDoS mitigation), mapped against the OSS prior art and
+against what `apps/cloud` already has.
+
+## 0. Headline finding
+
+**Four of the five already have a working seam in `apps/cloud`; the fifth (recursion
+protection) has no equivalent anywhere in the repo. But the spend-cap chain that
+does exist is metering off a sampled source and reading it as if it were exact.**
+
+`src/dispatcher/worker.ts:131` writes one Analytics Engine data point per tenant
+request; `src/metering/rollback.ts` folds those counts into the `platformUsage`
+ledger; `lunora/usage.ts:172` (`enforceSpendCaps`) evaluates that ledger against
+the cap hourly and suspends the org. The read in that chain is:
+
+```sql
+SELECT blob1 AS scriptName, SUM(double1) AS requests FROM <dataset> …
+```
+
+— `src/metering/analytics.ts:55`. Workers Analytics Engine applies **adaptive
+sampling at high write volume**: each retained row carries a `_sample_interval`
+standing in for that many originals, and the documented aggregation is
+`SUM(_sample_interval * double1)` (or, when grouping by an index field,
+`SUM(_sample_interval)` for an _exact_ count). Summing `double1` bare under-counts
+by the sample factor.
+
+The repo already knows this — `src/telemetry/metrics-read.ts:9-14` says AE is a
+sampling store and is explicitly "**not for billing math**" — but the metering
+reader is exactly billing math, and it doesn't apply the multiplier.
+
+The failure mode is directional and unlucky: sampling kicks in **at high volume**,
+which is precisely the runaway-tenant / compromised-account scenario the hard cap
+exists to stop. The harder a tenant hammers the platform, the more the ledger
+under-reports, and the later (or never) the cap fires. Fixing this is a one-line
+query change and is a prerequisite for every other item below — a hard cap on a
+lying meter is not a hard cap.
+
+The dispatcher writes `index1 = scriptName`, so the exact form is available:
+
+```sql
+SELECT index1 AS scriptName, SUM(_sample_interval) AS requests FROM <dataset>
+WHERE timestamp > toDateTime(<since>) GROUP BY scriptName
+```
+
+## 1. Current state (audit)
+
+| Capability               | Status in `apps/cloud`                                                                                                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Hard cap**             | ✅ shipped, single-valued. `src/billing/spend.ts` (pure evaluator, per-plan defaults `free $5` / `pro $200` / `enterprise` uncapped, org override), `lunora/usage.ts:172` enforcement cron. |
+| **Soft cap**             | ❌ absent. No warn threshold, no notification before suspension. The org goes from serving traffic to a 503 with nothing in between.                                                        |
+| **Anomaly alerting**     | 🟡 threshold-only. `lunora/alerts.ts` + `src/telemetry/alerts.ts` give metric-window rules (`error_rate`, `latency_p95`, `llm_cost`) with static thresholds; no baseline, no score.         |
+| **Recursion protection** | ❌ absent. Nothing in the repo counts invocation depth or detects a tenant Worker looping through its own hostname. Only Cloudflare's own per-invocation subrequest cap applies.            |
+| **Billing usage API**    | 🟡 data exists, not agent-reachable. `usage.summary`, `lunora/cloudflare-billing.ts` (Billable Usage API), `src/mcp/tools.ts` — but the usage/cost routes are not `mcp`-opted-in.           |
+| **DDoS L3/L4/L7**        | ✅ inherited by construction (all tenant traffic is behind Cloudflare); ❌ invisible — no firewall events surfaced per tenant, no per-org ruleset config.                                   |
+
+Supporting detail:
+
+- **Suspension is binary and org-wide.** `lunora/deployments.ts:159-166` resolves a
+  suspended org to the sentinel plan `"suspended"`; `src/dispatcher/worker.ts:112`
+  serves a bare 503 for it. There is no per-project scope, no read-only mode, no
+  grace window.
+- **Enforcement latency is up to an hour.** `lunora/crons.ts:21` runs
+  `enforceSpendCaps` on an hourly interval; the AE readback checkpoint
+  (`src/metering/rollback.ts`) adds its own lag on top.
+- **The spend number is an estimate, not a bill.** `src/billing/spend.ts:12-13`
+  prices requests + CPU-ms at the Workers-for-Platforms cost basis. Storage,
+  Durable Object duration, D1 rows, and R2 ops are not in the estimate at all —
+  `platformUsage.kind` has a `storageBytes` variant but `estimatedSpendMinor` only
+  reads `requests` and `cpuMs`.
+- **A real cost source landed recently but is not wired to enforcement.**
+  `lunora/cloudflare-billing.ts` (commit `48366a2`) reads the org's _own_
+  Cloudflare account spend by product via the Billable Usage API. It backs a
+  read-only console tab; nothing feeds it back into the cap decision.
+- **Per-plan runtime limits already exist.** `src/dispatcher/worker.ts:117-119`
+  passes Workers-for-Platforms `limits` (CPU + subrequests) per plan on
+  `env.DISPATCHER.get(...)`. This is the natural mounting point for a lineage
+  header and a depth cap.
+- **A rate-of-change primitive already exists.** `src/telemetry/alerts.ts:271`
+  (`rateOfChangePercent`) is exported and unused by any rule target — the seam a
+  baseline-relative anomaly score would build on.
+
+## 2. Prior art
+
+### 2.1 Soft & hard caps
+
+Three shapes in the market, and they differ in _what the cap does_, not in how the
+number is computed:
+
+- **Vercel** — a team-level on-demand usage budget (default $200), configurable.
+  Notifications fire at percentage thresholds; on reaching the amount you choose
+  the action: notify, **pause all projects**, or **fire a webhook**. Pausing is
+  opt-in — setting an amount does not by itself stop usage. The "improved hard
+  caps" work was about making the pause land reliably and fast.
+- **Convex** — two explicit numbers per team: a **warning threshold** (email only,
+  no action) and a **disable threshold** (all projects disabled, functions throw).
+  Limits apply only to usage _beyond_ the plan's included amounts; seat fees are
+  excluded. Re-enable by raising or removing the limit.
+- **Supabase** — a single **Spend Cap boolean** on Pro, on by default. On means
+  usage beyond quota is throttled/blocked rather than billed, with a Fair-Use
+  grace period instead of a surprise invoice. Off means overages bill. Absent on
+  Team/Enterprise.
+- **Kubernetes** — the canonical enforcement model rather than a billing one:
+  `ResourceQuota` rejects at **admission time** (the request to create the
+  workload fails), `LimitRange` supplies per-object defaults and ceilings. The
+  lesson is placement, not policy: enforce at the point of admission, synchronously,
+  not in a reconciliation loop that runs later.
+- **OpenStack** — the same split at cloud scale: Nova/Cinder/Neutron quotas are
+  synchronous admission checks; **CloudKitty** is after-the-fact rating and
+  chargeback with pluggable fetchers/collectors/rating modules and _no_
+  enforcement. Metering and enforcement are deliberately different components.
+- **OpenCost** (CNCF) — allocation only; it documents _no_ budgets, no anomaly
+  alerts, no notifications, by design ("the Prometheus of cloud cost"). The
+  governance layer (budget thresholds, anomaly detection, Slack) is what the
+  proprietary Kubecost tier adds on top. Instructive: the OSS ecosystem
+  consistently ships the meter and leaves the guardrail to the product.
+- **OpenMeter** — the exception, and the closest analogue to what Cloud needs:
+  entitlements + balance, checked at request time ("usage gating"), so the cap is
+  a synchronous read rather than a periodic sweep.
+
+**Applies to Lunora Cloud:** the two-number model (Convex/Vercel) is strictly
+better than today's one-number model and costs one schema field plus a
+notification. The admission-time lesson (K8s/OpenStack/OpenMeter) says the cap
+check belongs where the plan lookup already happens — `resolveTenant` in the
+dispatcher — not only in an hourly cron.
+
+### 2.2 Anomaly alerting
+
+- **Vercel** — two alert families: _usage anomalies_ (unusual edge requests,
+  function duration) and _error anomalies_ (5xx spikes on a route). Rules scope by
+  project, alert type, metric, HTTP status code, and route. Two noise controls
+  matter: **platform-defined minimum activity thresholds** (low-volume traffic
+  can't produce an anomaly at all — not user-configurable, deliberately) and
+  **silencing rules** that make detection skip matched traffic entirely rather
+  than firing-and-hiding. Delivery to dashboard, email, Slack, webhook.
+- **Netdata** — 18 unsupervised ML models per metric, trained and evaluated **at
+  the edge** on the agent, on by default in every tier. Distributed: no central
+  training pipeline to run.
+- **VictoriaMetrics `vmanomaly`** — centralized service, configurable models
+  including an **online z-score with a decay factor**, emitting a single unified
+  `anomaly_score` metric. The alerting is then _ordinary threshold alerting on
+  that derived metric_ via vmalert/Alertmanager. (Enterprise-licensed, so it's a
+  design reference, not a dependency.)
+- **OpenSearch / Elastic** — streaming Random Cut Forest over shingled series;
+  same output shape (a score), same downstream (threshold rules).
+- **Prometheus / Alertmanager** — no anomaly detection at all, but the mature
+  noise-control primitives: `for:` duration before firing, grouping, inhibition,
+  and silences.
+
+**The consistent architecture across all of them:** anomaly detection produces a
+**derived score series**, and the existing threshold-alerting stack consumes it.
+Nobody builds a second alerting pipeline. That is directly reusable here —
+`fireMetricRules` in `src/telemetry/alerts.ts:417` already is that stack.
+
+### 2.3 Recursion protection
+
+- **AWS Lambda** — the reference implementation. An X-Ray trace-header **lineage**
+  counter is incremented by supported SDK/service integrations as an event flows
+  Lambda → SQS/SNS/Lambda-invoke → Lambda. Past **16** invocations of the same
+  triggering event, Lambda drops the next invocation, emits the
+  `RecursiveInvocationsDropped` CloudWatch metric, and returns
+  `RecursiveInvocationException` to synchronous callers. On by default;
+  configurable per function via `PutFunctionRecursionConfig` /
+  `GetFunctionRecursionConfig` (`Terminate` | `Allow`). Limits: only the supported
+  services, only with SDK versions that propagate the header, and it does not
+  catch a loop where the function synthesizes a _new_ event each hop.
+- **Vercel** — lighter and header-based rather than counter-based: outbound
+  requests carry the `x-vercel-id` of the request that originated them, so a
+  function fetching itself is detectable. Covers `fetch` and the `http` module in
+  the Node runtime, **including inside dependencies**; a bare `Socket` is not
+  protected. No code change required, but a redeploy is. Free on all plans.
+- **Cloudflare** — no lineage primitive. What exists is adjacent: per-invocation
+  subrequest caps (free: 50 external + 1000 to Cloudflare services; paid: 10,000
+  by default, raisable to 10M via the Wrangler `limits` config), and
+  `cf.worker.upstream_zone` in the Rules engine to distinguish a same-zone Worker
+  subrequest from a direct eyeball request. That field exists precisely because
+  same-zone Worker subrequests otherwise look like fresh traffic — which is also
+  why a loop is expensive: **every hop is a fully billed request**.
+
+**Applies to Lunora Cloud:** Cloud is better placed than a generic Workers user,
+because **all tenant traffic transits one dispatcher** (`src/dispatcher/worker.ts`).
+A Lambda-style lineage counter is implementable there without any tenant code
+change: stamp a lineage header on the way in, propagate it, refuse past a depth.
+The honest limitation to write down up front: it catches loops that **re-enter
+through the dispatcher** (worker → its own hostname → dispatcher → worker, which
+is the common accidental case and the expensive one). It does not see
+DO-to-DO calls or direct service bindings, which never touch the dispatcher.
+
+### 2.4 Billing usage APIs agents can query
+
+- **Lago** (OSS, self-hostable) — API-first metering + billing; every feature has a
+  REST endpoint, notably `GET /customers/{id}/current_usage` for _in-period_ usage
+  before an invoice exists, plus webhooks for invoice/usage events. The important
+  design point is that current-period usage is a first-class endpoint, not a
+  side-effect of invoicing.
+- **OpenMeter** (OSS) — CloudEvents ingest → Kafka → ClickHouse, with **one-minute
+  tumbling window pre-aggregation** so the query API answers in real time; exposes
+  balance/entitlement reads intended for gating, not just reporting.
+- **CloudKitty** — fetchers / collectors / rating modules as separate pluggable
+  stages; the value for us is the separation, not the code.
+- **OpenCost** — allocation API, no governance. Again: meter ≠ guardrail.
+
+**Applies to Lunora Cloud:** this is the cheapest of the five. The data is already
+there (`usage.summary`, `src/billing/spend.ts`, `lunora/cloudflare-billing.ts`),
+and there is already an agent transport — `src/mcp/tools.ts` exposes control-plane
+routes over `/v1/mcp` with **per-route `RouteSpec.mcp` opt-in** and a hard
+deny-list for `tokens`/`auth`/`mcp`. Making usage agent-queryable is mostly
+opting the right routes in and adding a projected-spend field, not new
+infrastructure. Note the deny-list is the security boundary to respect:
+`/v1/cloudflare-billing` is a _write_ route holding a credential and must stay
+denied; the read side (`status`, `summary`) is the part to expose.
+
+### 2.5 DDoS L3/L4/L7
+
+- **Cloudflare** — L3/L4 (SYN floods, UDP amplification) is unmetered and free on
+  **every** plan; the HTTP (L7) DDoS managed ruleset is likewise on every plan,
+  with advanced configuration gated to Business/Enterprise. Overrides set a
+  different action (log/block/challenge) or **sensitivity level** per rule, at zone
+  or account level — account-level overrides are **API-only**. Adaptive DDoS
+  Protection additionally profiles origin errors (default sensitivity ~1,000
+  errors/sec) and mitigates deviations.
+- **CrowdSec** (OSS) — the architecture worth copying: **detection is separated
+  from enforcement**. A central agent parses logs and makes decisions; "bouncers"
+  enforce at the edge (block, captcha, throttle, or even flip Cloudflare's attack
+  mode on demand). Crowdsourced IP reputation on top.
+- **Coraza** (OSS, Go, ModSecurity/OWASP-CRS successor) and **fail2ban** — the
+  request-inspection and ban-on-pattern layers; lower ceiling than a network with
+  anycast capacity, which is the part you cannot self-host.
+
+**Applies to Lunora Cloud:** Cloud gets the L3/L4/L7 floor for free by
+construction — every tenant is behind Cloudflare, so the claim is true on day one
+without building anything. But "true and invisible" isn't a feature. The work is
+(a) surfacing per-tenant firewall events in the console, (b) programmatic
+per-org ruleset sensitivity via the account-level override API, and (c) closing
+the CrowdSec loop — the anomaly detector from §2.2 is the "agent", and the
+existing suspension machinery plus a Cloudflare rate-limit rule are the
+"bouncers".
+
+### 2.6 On "OpenCloud"
+
+The named project (`opencloud-eu`, the Heinlein Group's Go rewrite of ownCloud
+Infinite Scale) is a **file sync & share** platform. It has no spend-cap,
+metering, function-recursion or DDoS surface, so it is not prior art for any of
+the five. The relevant OSS neighbourhood is the metering/billing/FinOps cluster
+(Lago, OpenMeter, Kill Bill, CloudKitty, OpenCost) and the detection/enforcement
+cluster (CrowdSec, Coraza, Netdata, VictoriaMetrics, Prometheus) — covered above.
+
+### 2.7 The streaming-data substrate
+
+Vercel's own framing is that all five rest on realtime ingest. The OSS consensus
+stack for that is Kafka → ClickHouse with pre-aggregated tumbling windows
+(OpenMeter, Lago) or Prometheus remote-write → a long-term store (Netdata,
+VictoriaMetrics). Cloud's substrate is Analytics Engine + the AE SQL API + Tail
+Workers (`tail.wrangler.jsonc`) + the `platformUsage` D1 ledger.
+
+That is a legitimate choice — AE writes are fire-and-forget and free of
+backpressure, which is exactly what a request-path meter needs — but it comes with
+two properties that must be designed around rather than discovered:
+
+1. **Sampling** (the §0 finding). Aggregate correctly or don't bill on it.
+2. **Bounded retention** (~90 days) and bucket-averaged reads. Fine for trends and
+   for month-scoped billing periods; not a system of record for anything longer.
+
+The `platformUsage` ledger is the durable side and already compacts closed periods
+(`lunora/usage.ts` `rollup`), so the shape is right — it just has to be fed
+accurate numbers.
+
+## 3. Existing seams (do not reinvent)
+
+| Seam                                                               | Use it for                                                                                       |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `src/billing/spend.ts` `evaluateSpendCap`                          | Extend to return a `level` (`ok` \| `warn` \| `breach`) rather than adding a second evaluator.   |
+| `lunora/usage.ts` `enforceSpendCaps` + `lunora/crons.ts:21`        | The sweep. Add the soft-threshold branch here; do not add a second cron.                         |
+| `src/dispatcher/worker.ts` `resolveTenant` / `planResolver`        | Already a per-request control-plane lookup — the admission point for a fast cap and for lineage. |
+| `src/dispatcher/worker.ts:117` per-plan `limits`                   | Where a depth cap belongs, alongside CPU/subrequest limits.                                      |
+| `src/telemetry/alerts.ts` `fireMetricRules`, `rateOfChangePercent` | The alerting stack an anomaly score feeds into; the rate-of-change primitive already exists.     |
+| `lunora/alerts.ts` rule CRUD + 4 channels (email/webhook/Slack/PD) | Delivery. New targets are new `RuleTarget` values, not a new pipeline.                           |
+| `src/mcp/tools.ts` `RouteSpec.mcp` opt-in + deny-list              | Agent-queryable billing. Opt routes in; keep `/v1/cloudflare-billing` (write) denied.            |
+| `lunora/cloudflare-billing.ts`                                     | Authoritative per-org Cloudflare spend, already decrypt-at-edge and fail-open.                   |
+| `src/billing/overage.ts` + `src/billing/reconcile.ts`              | Prepaid-credit exhaustion already drives suspension/recovery — the same hooks a cap should use.  |
+| `lunora/audit-log.ts`                                              | Every cap/suspension transition is already expected to land here (`organization.suspend`).       |
+
+## 4. Design decisions
+
+**D1 — Fix the meter before building on it.** Change
+`src/metering/analytics.ts:55` to `SELECT index1 AS scriptName,
+SUM(_sample_interval) AS requests … GROUP BY scriptName`. Chosen over multiplying
+`double1` because the dispatcher indexes by `scriptName` and writes exactly one
+data point of value 1 per request, so summing the interval over an index field is
+the _exact_ count, not an estimate. Chosen over "leave it, sampling only matters
+at volume" because volume is the case the cap exists for.
+
+**D2 — Two thresholds, org-configurable, not one plan-derived number.** Add
+`spendWarnMinor` beside the existing `spendCapMinor` (`lunora/schema.ts:66`) and
+have `evaluateSpendCap` return a level. Chosen over Supabase's boolean (too coarse
+for a control plane that also has prepaid credits) and over Vercel's
+free-form action list (premature — one action, notify, is what's missing).
+
+**D3 — Warn is a notification, breach is the existing suspension.** Route the warn
+level through `lunora/alerts.ts` as a new `RuleTarget` (`spend`) so it inherits
+email/webhook/Slack/PagerDuty delivery for free. Chosen over a bespoke email path
+in the billing module: a second delivery mechanism is exactly the centralization
+the repo conventions warn against.
+
+**D4 — Keep the hourly sweep as the authority; add a fast path at admission.** The
+cron stays the source of truth for the ledger comparison, but `resolveTenant`
+already does a per-request plan lookup, so a breached org can be short-circuited
+there in the same read. Chosen over moving enforcement wholly to the request path
+(a per-request usage sum is not affordable) and over shortening the cron interval
+(more D1 sweeps, same worst-case lag).
+
+**D5 — Anomaly detection emits a score; the existing rules consume it.** Compute a
+per-(org, metric) rolling baseline and emit an anomaly score as a derived metric;
+add `usage_anomaly` / `error_anomaly` rule targets that threshold _that_. Chosen
+over embedding statistics inside each rule evaluation (VictoriaMetrics/OpenSearch
+both converged on the score-as-metric shape, and it keeps `fireMetricRules`
+untouched).
+
+**D6 — Start with online z-score + a minimum-volume floor; no ML.** An online
+z-score with a decay factor is what `vmanomaly` ships as its baseline model and is
+implementable over the existing observation arrays. Adopt Vercel's
+platform-defined **minimum activity threshold** as a non-configurable floor:
+below N requests in the window, no anomaly can fire. Chosen over Netdata-style
+multi-model ML (no training substrate on Workers, and unjustifiable before a
+single detector has proven its false-positive rate).
+
+**D7 — Recursion protection as dispatcher-enforced lineage, Lambda-shaped.** Stamp
+`x-lunora-lineage: <rootRequestId>:<depth>` on entry, propagate on tenant-originated
+subrequests that re-enter the dispatcher, and refuse past a depth cap with
+`508 Loop Detected` + an audit/metric event. Per-org config `terminate` (default)
+| `allow`, mirroring `PutFunctionRecursionConfig`. Depth cap: start at 16
+(Lambda's number, and empirically sufficient) rather than inventing one. Chosen
+over Vercel's identity-match approach (`x-vercel-id` self-match) because a
+counter also catches A→B→A cycles, not just direct self-calls; and over doing
+nothing and relying on subrequest caps, because those are per-invocation and a
+loop is many invocations.
+
+**D8 — Document the lineage blind spot in the same change.** DO-to-DO calls and
+service bindings bypass the dispatcher and therefore bypass this. Write it down
+where the feature is described; AWS's own docs lead with the equivalent caveat,
+and an undocumented gap here reads as a guarantee we don't have.
+
+**D9 — DDoS: surface and configure, don't build.** No mitigation code. Ship (a) a
+firewall-events read into the console via the Cloudflare GraphQL Analytics API,
+(b) per-org L7 sensitivity overrides through the account-level managed-ruleset
+API, and (c) an anomaly → Cloudflare-rate-limit-rule action, which is the CrowdSec
+detect/enforce split with Cloudflare as the bouncer. Chosen over any self-hosted
+WAF: anycast capacity is the part that cannot be reimplemented, and it is already
+under every tenant.
+
+**D10 — Agent-queryable billing is an opt-in, not a new API.** Opt the existing
+usage/spend/cost read routes into `RouteSpec.mcp` and add current-period
+projection to the summary payload (Lago's `current_usage` shape: what's consumed
+in the open period, before any invoice exists). Chosen over a new REST surface —
+the MCP transport, auth, and deny-list already exist and are the thing agents
+actually speak.
+
+## 5. Workstreams
+
+| #   | Workstream                                                                                                                                                             | Size | Depends on |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ---------- |
+| W1  | **Fix AE metering aggregation** (D1) — `SUM(_sample_interval)` over `index1`, plus a test asserting a sampled fixture sums to the un-sampled total.                    | S    | —          |
+| W2  | **Soft cap** (D2, D3) — `spendWarnMinor` field, `evaluateSpendCap` → `level`, `spend` alert target, warn branch in `enforceSpendCaps`, console control.                | M    | W1         |
+| W3  | **Fast-path breach at admission** (D4) — carry the breach bit through `resolveTenant`'s plan lookup.                                                                   | S    | W2         |
+| W4  | **Anomaly score + targets** (D5, D6) — rolling baseline store, online z-score, min-volume floor, `usage_anomaly` / `error_anomaly` rule targets, silence rules.        | L    | W1         |
+| W5  | **Recursion protection** (D7, D8) — lineage header, depth cap in the dispatcher, `508` + metric + audit event, per-org `terminate`/`allow`, docs incl. the blind spot. | M    | —          |
+| W6  | **Agent-queryable billing** (D10) — MCP opt-in on the usage/spend/cost reads + current-period projection.                                                              | S    | W1         |
+| W7  | **DDoS visibility & config** (D9) — firewall-events read, per-org L7 sensitivity override, anomaly → rate-limit-rule action.                                           | M    | W4         |
+
+W1 gates W2/W3/W4/W6 — all four read the ledger it corrects. W5 is fully
+independent and is the only item with no existing seam, so it is the best
+candidate to run in parallel.
+
+## 6. Platform parity
+
+Nothing here adds a `ctx.*` surface or a provider binding — this is control-plane
+work in `apps/cloud`, which is a Cloudflare-only application, not a framework
+package. `PlatformCapabilities` in `@lunora/platform` is therefore untouched.
+
+The one item to re-check if it ever generalises is **W5**: dispatcher-enforced
+lineage depends on Workers-for-Platforms dispatch namespaces, which have no
+`@lunora/platform-node` equivalent. If recursion protection is ever pulled down
+into the framework (e.g. as a `ShardHost` concern), it needs a capability row
+rated `native` for Cloudflare and `unsupported` for Node at that time. It does not
+need one now, and adding a row for a surface that doesn't exist would be the
+premature-abstraction the conventions warn against.
+
+## 7. Open questions
+
+1. **Does the cap price the whole bill or just compute?** `estimatedSpendMinor`
+   covers requests + CPU-ms only. Storage, DO duration, D1, and R2 are unpriced,
+   so a storage-heavy runaway is invisible to the cap. Options: extend the
+   estimate, or switch the cap to read the authoritative Billable Usage numbers
+   from `lunora/cloudflare-billing.ts` for orgs that have connected an account
+   (and keep the estimate as the fallback). The second is more accurate and more
+   coupled — decide before W2 sets the schema.
+2. **Should breach degrade rather than suspend?** Today it's a 503 for the whole
+   org. A read-only mode (queries serve, mutations reject) is strictly friendlier
+   and is what a "hard cap" arguably should mean for a database-shaped product.
+   Costs a third plan sentinel alongside `"suspended"`.
+3. **Per-project caps?** Vercel pauses _all_ projects; Convex disables _all_
+   projects. Both chose team scope. Matching that is cheaper and matches how
+   `platformUsage` is keyed (org, not project) — but the ledger does carry
+   `deploymentId`, so per-project is not blocked, just unbuilt.
+4. **Where does the anomaly baseline live?** AE's ~90-day bounded retention and
+   bucket-averaged reads make it a poor baseline store. A small rolled-up
+   baseline table in the control-plane D1 is the obvious alternative; sizing it
+   is W4's first question.
+5. **Does the lineage header survive tenant code?** A tenant Worker that constructs
+   a fresh `Request` without copying headers drops the lineage. Lambda has the
+   same class of gap (unsupported SDK versions don't propagate). Accept and
+   document, or have the dispatcher re-derive depth from a short-TTL KV/DO counter
+   keyed by root request id — more robust, more expensive, per-request.
+
+## 8. Sources
+
+Spend caps — [Vercel Spend Management](https://vercel.com/docs/spend-management),
+[Convex Teams](https://docs.convex.dev/dashboard/teams/teams),
+[Supabase Billing FAQ](https://supabase.com/docs/guides/platform/billing-faq).
+
+Recursion — [AWS: detecting and stopping recursive loops in Lambda](https://aws.amazon.com/blogs/compute/detecting-and-stopping-recursive-loops-in-aws-lambda-functions/),
+[AWS: Lambda recursive loop detection APIs](https://aws.amazon.com/blogs/compute/aws-lambda-introduces-recursive-loop-detection-apis),
+[Vercel: automatic recursion protection](https://vercel.com/changelog/automatic-recursion-protection-for-vercel-serverless-functions),
+[Cloudflare: subrequest limits changelog](https://developers.cloudflare.com/changelog/post/2026-02-11-subrequests-limit/),
+[Cloudflare: rate-limiting troubleshooting (`cf.worker.upstream_zone`)](https://developers.cloudflare.com/waf/rate-limiting-rules/troubleshooting).
+
+Anomaly detection — [Vercel: anomaly alert configuration](https://vercel.com/changelog/anomaly-alert-configuration-now-available),
+[Vercel Alerts docs](https://vercel.com/docs/alerts),
+[VictoriaMetrics anomaly detection models](https://docs.victoriametrics.com/anomaly-detection/components/models/),
+[Netdata vs VictoriaMetrics](https://www.netdata.cloud/comparisons/victoriametrics/).
+
+Billing/metering APIs — [Lago (GitHub)](https://github.com/getlago/lago),
+[Lago: retrieve current usage](https://getlago.com/docs/api-reference/customer-usage/get-current),
+[OpenMeter: how metering works](https://openmeter.io/docs/metering/events/how-it-works),
+[OpenMeter on ClickHouse](https://openmeter.io/blog/how-openmeter-uses-clickhouse-for-usage-metering),
+[CloudKitty architecture](https://docs.openstack.org/cloudkitty/latest/admin/architecture.html),
+[OpenCost (GitHub)](https://github.com/opencost/opencost),
+[OpenCost FAQ](https://opencost.io/docs/faq/).
+
+DDoS — [Cloudflare HTTP DDoS managed ruleset](https://developers.cloudflare.com/ddos-protection/managed-rulesets/http/),
+[Cloudflare: configure HTTP DDoS protection via API](https://developers.cloudflare.com/ddos-protection/managed-rulesets/http/configure-api/),
+[Cloudflare Adaptive DDoS Protection](https://developers.cloudflare.com/ddos-protection/managed-rulesets/adaptive-protection/),
+[CrowdSec (GitHub)](https://github.com/crowdsecurity/crowdsec),
+[CrowdSec: mitigating DDoS](https://www.crowdsec.net/blog/mitigate-ddos-with-crowdsec).
+
+Analytics Engine sampling — [Sampling with Workers Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/sampling/),
+[Workers Analytics Engine SQL API](https://developers.cloudflare.com/analytics/analytics-engine/sql-api/).
+
+OpenCloud (assessed, not prior art) — [opencloud-eu discussion: distinction from oCIS](https://github.com/orgs/opencloud-eu/discussions/262).

--- a/plans/306-cloud-spend-guardrails-and-anomaly-research.md
+++ b/plans/306-cloud-spend-guardrails-and-anomaly-research.md
@@ -1,52 +1,84 @@
 # Plan 306 — Cloud spend guardrails, anomaly alerting, recursion protection & agent-queryable billing
 
 **Baseline:** `48366a2` (2026-08-08)
-**Status:** TODO — research complete, build not started
+**Status:** IN PROGRESS — W1 (metering fix) and W0 (full rate card) shipped;
+W2–W7 open
 
 Research pass over five capabilities Vercel shipped as a bundle (soft/hard spend
 caps, anomaly alerting, function recursion protection, billing usage APIs for
 agents, always-on L3/L4/L7 DDoS mitigation), mapped against the OSS prior art and
 against what `apps/cloud` already has.
 
-## 0. Headline finding
+## 0. Headline findings
 
-**Four of the five already have a working seam in `apps/cloud`; the fifth (recursion
-protection) has no equivalent anywhere in the repo. But the spend-cap chain that
-does exist is metering off a sampled source and reading it as if it were exact.**
+### 0.1 The meter under-reported exactly when it mattered (✅ fixed)
+
+**Four of the five capabilities already had a working seam in `apps/cloud`; the
+fifth (recursion protection) had no equivalent anywhere in the repo. But the
+spend-cap chain that did exist was metering off a sampled source and reading it
+as if it were exact.**
 
 `src/dispatcher/worker.ts:131` writes one Analytics Engine data point per tenant
 request; `src/metering/rollback.ts` folds those counts into the `platformUsage`
-ledger; `lunora/usage.ts:172` (`enforceSpendCaps`) evaluates that ledger against
-the cap hourly and suspends the org. The read in that chain is:
+ledger; `lunora/usage.ts` (`enforceSpendCaps`) evaluates that ledger against the
+cap hourly and suspends the org. The read in that chain was:
 
 ```sql
 SELECT blob1 AS scriptName, SUM(double1) AS requests FROM <dataset> …
 ```
 
-— `src/metering/analytics.ts:55`. Workers Analytics Engine applies **adaptive
-sampling at high write volume**: each retained row carries a `_sample_interval`
-standing in for that many originals, and the documented aggregation is
-`SUM(_sample_interval * double1)` (or, when grouping by an index field,
-`SUM(_sample_interval)` for an _exact_ count). Summing `double1` bare under-counts
-by the sample factor.
+Workers Analytics Engine applies **weighted adaptive sampling at write time**:
+past a write rate it keeps one row in place of many, and each retained row
+carries the `_sample_interval` it stands in for. Summing `double1` bare
+under-counts by the sample factor. Cloudflare's own
+[usage-based-billing recipe](https://developers.cloudflare.com/analytics/analytics-engine/recipes/usage-based-billing-for-your-saas-product/)
+uses `sum(_sample_interval)` grouped by the index for precisely this reason.
 
-The repo already knows this — `src/telemetry/metrics-read.ts:9-14` says AE is a
+The repo already knew this — `src/telemetry/metrics-read.ts:9-14` says AE is a
 sampling store and is explicitly "**not for billing math**" — but the metering
-reader is exactly billing math, and it doesn't apply the multiplier.
+reader _was_ billing math, and it didn't apply the multiplier.
 
-The failure mode is directional and unlucky: sampling kicks in **at high volume**,
-which is precisely the runaway-tenant / compromised-account scenario the hard cap
-exists to stop. The harder a tenant hammers the platform, the more the ledger
-under-reports, and the later (or never) the cap fires. Fixing this is a one-line
-query change and is a prerequisite for every other item below — a hard cap on a
-lying meter is not a hard cap.
+The failure mode was directional and unlucky: sampling engages **at high
+volume**, which is precisely the runaway-tenant / compromised-account scenario
+the hard cap exists to stop. The harder a tenant hammered the platform, the more
+the ledger under-reported, and the later (or never) the cap fired.
 
-The dispatcher writes `index1 = scriptName`, so the exact form is available:
+**Fixed** in `src/metering/analytics.ts`. Because the dispatcher writes
+`index1 = scriptName` and one data point per request, the corrected form is not
+an approximation — it is the exact count, and indexing per tenant is also what
+stops one enormous tenant from sampling a small tenant's rows to zero:
 
 ```sql
 SELECT index1 AS scriptName, SUM(_sample_interval) AS requests FROM <dataset>
 WHERE timestamp > toDateTime(<since>) GROUP BY scriptName
 ```
+
+### 0.2 Cloudflare has no hard cap to borrow — the stop must be built (⚠ open)
+
+Checked against the docs, and the answer is unambiguous. Cloudflare's two spend
+controls are both **informational by design**:
+
+> Budget alerts are informational only. **They do not pause or cap usage.** Your
+> monthly invoice remains the authoritative source for billing.
+> — [Budget alerts](https://developers.cloudflare.com/billing/manage/budget-alerts/)
+
+> The email notifications are for informational purposes only.
+> — [Usage-based billing notifications](https://developers.cloudflare.com/billing/understand/usage-based-billing/)
+
+There is no account-level "stop at $X". So a hard cap on Lunora Cloud is
+something the platform builds, and the only question is **where it intercepts** —
+which is an economic question, because:
+
+> **Only requests that hit a Worker will count against your limits and your
+> bill.**
+> — [Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/)
+
+Today's suspension serves a 503 from inside the dispatch Worker
+(`src/dispatcher/worker.ts:112`), so **every request of an attack against a
+suspended tenant still bills a Workers-for-Platforms request plus its CPU**. A
+WAF custom rule blocking the same hostname fires in the
+`http_request_firewall_custom` phase, before any Worker runs, and costs nothing.
+See §2.5 for the full interception ladder.
 
 ## 1. Current state (audit)
 
@@ -68,15 +100,22 @@ Supporting detail:
 - **Enforcement latency is up to an hour.** `lunora/crons.ts:21` runs
   `enforceSpendCaps` on an hourly interval; the AE readback checkpoint
   (`src/metering/rollback.ts`) adds its own lag on top.
-- **The spend number is an estimate, not a bill.** `src/billing/spend.ts:12-13`
-  prices requests + CPU-ms at the Workers-for-Platforms cost basis. Storage,
-  Durable Object duration, D1 rows, and R2 ops are not in the estimate at all —
-  `platformUsage.kind` has a `storageBytes` variant but `estimatedSpendMinor` only
-  reads `requests` and `cpuMs`.
+- **The spend number priced compute only** (✅ fixed — see §4a). `spend.ts`
+  priced requests + CPU-ms and nothing else: storage, Durable Object duration,
+  D1 rows, and R2 operations were absent, so a storage-shaped runaway was
+  invisible to the cap forever. `platformUsage.kind` had a `storageBytes`
+  variant that `estimatedSpendMinor` never read.
 - **A real cost source landed recently but is not wired to enforcement.**
   `lunora/cloudflare-billing.ts` (commit `48366a2`) reads the org's _own_
   Cloudflare account spend by product via the Billable Usage API. It backs a
-  read-only console tab; nothing feeds it back into the cap decision.
+  read-only console tab; nothing feeds it back into the cap decision. Three
+  documented limits bound how far that can go: the Billable Usage dashboard/API
+  is **Pay-as-you-go accounts only** (Enterprise contract accounts unsupported),
+  it requires the **Billing read** permission on the account, and its data is
+  **aligned to the account's billing cycle, not the calendar month** — whereas
+  `currentPeriodStart()` in `lunora/usage.ts` buckets on the UTC calendar month.
+  Any design that reconciles the two has to resolve that offset rather than
+  assume it away.
 - **Per-plan runtime limits already exist.** `src/dispatcher/worker.ts:117-119`
   passes Workers-for-Platforms `limits` (CPU + subrequests) per plan on
   `env.DISPATCHER.get(...)`. This is the natural mounting point for a lineage
@@ -215,15 +254,52 @@ infrastructure. Note the deny-list is the security boundary to respect:
 `/v1/cloudflare-billing` is a _write_ route holding a credential and must stay
 denied; the read side (`status`, `summary`) is the part to expose.
 
-### 2.5 DDoS L3/L4/L7
+### 2.5 What Cloudflare actually gives you to block traffic and usage
 
-- **Cloudflare** — L3/L4 (SYN floods, UDP amplification) is unmetered and free on
-  **every** plan; the HTTP (L7) DDoS managed ruleset is likewise on every plan,
-  with advanced configuration gated to Business/Enterprise. Overrides set a
-  different action (log/block/challenge) or **sensitivity level** per rule, at zone
-  or account level — account-level overrides are **API-only**. Adaptive DDoS
-  Protection additionally profiles origin errors (default sensitivity ~1,000
-  errors/sec) and mitigates deviations.
+Read off the docs, not inferred. The mechanisms, ordered by **where in the
+request pipeline they intercept** — which is the same as ordering them by what a
+blocked request costs, because only requests that reach a Worker are billed.
+
+The [phase order](https://developers.cloudflare.com/ruleset-engine/reference/phases-list/)
+is: `ddos_l4` (packets) → … → `ddos_l7` → `http_request_firewall_custom` →
+`http_ratelimit` → … → Workers.
+
+| Mechanism                                      | Intercepts at                       | Cost of a blocked request                                      | Granularity                                                                    | Gate                                                  |
+| ---------------------------------------------- | ----------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| L3/L4 + HTTP DDoS managed rulesets             | packet / `ddos_l7`                  | **none**                                                       | attack-shaped traffic only; sensitivity + action overridable                   | all plans, unmetered; advanced config Business+       |
+| **WAF custom rule, _Block_**                   | `http_request_firewall_custom`      | **none — never reaches the Worker**                            | any Rules-language expression, including `http.host`                           | all plans; rule count varies by plan                  |
+| Rate limiting rules                            | `http_ratelimit`                    | **none**                                                       | Free: path + IP, 10 s windows, 1 rule. Business+: host, method, longer windows | Pro+ for anything usable                              |
+| Custom **list** (`http.host in $suspended`)    | as above, one rule for many hosts   | none                                                           | thousands of hostnames in a single rule                                        | **hostname lists are Enterprise-only**                |
+| WfP **custom limits** (`{cpuMs, subRequests}`) | inside the invocation               | request **is** billed; the Worker throws                       | per user Worker, per invocation                                                | Workers for Platforms (already used, `worker.ts:117`) |
+| **Outbound Worker**                            | every `fetch()` a user Worker makes | subrequests aren't billed anyway; saves the _downstream_ spend | per namespace; sees all egress, and **disables `connect()`**                   | Workers for Platforms                                 |
+| Delete / retag the script in the namespace     | `dispatcher.get()` throws           | 1 dispatcher request                                           | per tenant; **tags** enable bulk-by-customer operations                        | Workers for Platforms                                 |
+| Dispatcher 503 (**what Cloud does today**)     | inside the dispatch Worker          | **1 WfP request + CPU, on every request**                      | per tenant                                                                     | —                                                     |
+
+Three things follow directly:
+
+1. **The current suspension is the most expensive option on the list.** Under a
+   sustained attack on a suspended tenant, Cloud pays for every 503 it serves.
+2. **A WAF _Block_ can keep the UX.** Custom Block responses support a
+   `application/json` body with a custom status code, so the "see your billing
+   page" payload the dispatcher returns today can be served by the rule itself.
+3. **The blocker for list-based blocking is plan, not API.** Hostname lists are
+   Enterprise-only, and per-plan custom-rule counts are small — so scaling
+   "block N suspended tenants" needs either an Enterprise zone, or (cheaper, and
+   available today) deactivating the tenant's **Cloudflare for SaaS custom
+   hostname**, which stops the request at the edge with no rule at all.
+
+Also worth writing down: rate limiting rules are explicitly _not_ a meter —
+"not designed to allow a precise number of requests", counters are per-data-centre
+with a delay of up to a few seconds, so excess requests can still land. They are
+a mitigation, never an accounting mechanism.
+
+- **Cloudflare DDoS** — "unmetered and unlimited DDoS protection at layers 3, 4,
+  and 7 to **all customers on all plans and services**" (verbatim from
+  [the docs](https://developers.cloudflare.com/ddos-protection/about/)).
+  Overrides set a different action (log/block/challenge) or **sensitivity level**
+  per rule, at zone or account level — account-level overrides are **API-only**.
+  Adaptive DDoS Protection additionally profiles origin errors (default
+  sensitivity ~1,000 errors/sec) and mitigates deviations.
 - **CrowdSec** (OSS) — the architecture worth copying: **detection is separated
   from enforcement**. A central agent parses logs and makes decisions; "bouncers"
   enforce at the edge (block, captcha, throttle, or even flip Cloudflare's attack
@@ -287,13 +363,45 @@ accurate numbers.
 
 ## 4. Design decisions
 
-**D1 — Fix the meter before building on it.** Change
-`src/metering/analytics.ts:55` to `SELECT index1 AS scriptName,
+**D1 — Fix the meter before building on it.** ✅ **Done.**
+`src/metering/analytics.ts` now reads `SELECT index1 AS scriptName,
 SUM(_sample_interval) AS requests … GROUP BY scriptName`. Chosen over multiplying
 `double1` because the dispatcher indexes by `scriptName` and writes exactly one
 data point of value 1 per request, so summing the interval over an index field is
 the _exact_ count, not an estimate. Chosen over "leave it, sampling only matters
-at volume" because volume is the case the cap exists for.
+at volume" because volume is the case the cap exists for. Pinned by a test that
+asserts the emitted SQL, since the failure is silent — a wrong aggregation
+returns a plausible number, never an error.
+
+**D1b — Price the whole bill, at marginal rates, without per-org allowances.**
+✅ **Done** (see §4a). Three sub-decisions worth their rejected alternatives:
+
+- _Rate card as data, not arithmetic in the evaluator._ `RATE_CARD` in
+  `src/billing/spend.ts` carries one entry per Cloudflare billing dimension with
+  the published rate string beside the derived integer, so a Cloudflare price
+  change is a one-line diff checkable against the pricing page. Chosen over
+  hand-written per-meter formulas, which is what let the old model quietly cover
+  two dimensions out of thirty-five.
+- _Integer nano-cents, rounded once._ Rates are held as nano-cents per unit
+  (1 cent = 1e9) and accumulated before rounding. Chosen over cents-per-million
+  floats because the cheapest published rate ($0.001 per million rows read) is
+  1e-7 cents per unit; rounding per meter would floor every row-read roll-up to
+  zero forever.
+- _Included allowances are **not** subtracted per org._ Cloudflare's free tiers
+  are granted once to _the platform's_ account, not once per tenant, so
+  subtracting a full allowance per org would let a hundred free orgs each
+  "spend" the entire included tier and stay under cap. Every unit is priced at
+  the marginal overage rate. That over-estimates a small tenant's true
+  incremental cost — the correct direction for a blast-radius control, which
+  should fire early rather than late.
+
+**D1c — The cap prices more than the invoice does, on purpose.** The cost model
+covers the full rate card; the customer-facing overage rate card
+(`src/billing/overage.ts`) still prices requests + CPU only. So an org can be
+capped for spend it was never charged for. Chosen over widening the overage rate
+card to match: what a customer is _billed_ is a pricing decision for the
+operator, not a side effect of a correctness fix. Both sides now carry a comment
+naming the asymmetry so nobody "fixes" one to match the other by accident.
 
 **D2 — Two thresholds, org-configurable, not one plan-derived number.** Add
 `spendWarnMinor` beside the existing `spendCapMinor` (`lunora/schema.ts:66`) and
@@ -329,21 +437,37 @@ below N requests in the window, no anomaly can fire. Chosen over Netdata-style
 multi-model ML (no training substrate on Workers, and unjustifiable before a
 single detector has proven its false-positive rate).
 
-**D7 — Recursion protection as dispatcher-enforced lineage, Lambda-shaped.** Stamp
-`x-lunora-lineage: <rootRequestId>:<depth>` on entry, propagate on tenant-originated
-subrequests that re-enter the dispatcher, and refuse past a depth cap with
-`508 Loop Detected` + an audit/metric event. Per-org config `terminate` (default)
-| `allow`, mirroring `PutFunctionRecursionConfig`. Depth cap: start at 16
-(Lambda's number, and empirically sufficient) rather than inventing one. Chosen
-over Vercel's identity-match approach (`x-vercel-id` self-match) because a
-counter also catches A→B→A cycles, not just direct self-calls; and over doing
-nothing and relying on subrequest caps, because those are per-invocation and a
-loop is many invocations.
+**D7 — Recursion protection belongs in an Outbound Worker, not on dispatcher
+re-entry.** _(Revised after reading the Workers-for-Platforms docs; the original
+form of this decision is below, and was worse.)_ An
+[Outbound Worker](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/outbound-workers/)
+sits between a user Worker and the public internet and sees **every** outgoing
+`fetch()`, with per-invocation context passed down from the dispatch Worker via
+the binding's `parameters`. So the dispatcher stamps a lineage `{rootRequestId,
+depth}` into the outbound parameters, and the Outbound Worker refuses a request
+that would re-enter the tenant's own hostname past a depth cap — `508 Loop
+Detected`, plus a metric and audit event. Per-org config `terminate` (default) |
+`allow`, mirroring Lambda's `PutFunctionRecursionConfig`. Depth cap starts at 16,
+Lambda's number, rather than an invented one.
 
-**D8 — Document the lineage blind spot in the same change.** DO-to-DO calls and
-service bindings bypass the dispatcher and therefore bypass this. Write it down
-where the feature is described; AWS's own docs lead with the equivalent caveat,
-and an undocumented gap here reads as a guarantee we don't have.
+Chosen over the original design (stamp a header, catch the loop when it
+re-enters the dispatcher), which was strictly worse in three ways: it only saw a
+loop after paying for the hop, it required the tenant's code to propagate a
+header it knows nothing about, and it missed loops to a non-dispatcher target.
+Chosen over Vercel's identity-match (`x-vercel-id` self-match) because a counter
+catches A→B→A cycles, not just direct self-calls. Chosen over relying on
+subrequest caps because those are per-invocation and a loop is many invocations.
+
+A bonus the docs make explicit: enabling an Outbound Worker **disables the
+`connect()` TCP-socket API** for user Workers, so all egress must go through it.
+That closes exactly the hole Vercel documents as unprotected ("requests using
+the bare `Socket` constructor are not protected against recursion").
+
+**D8 — Document the blind spot in the same change.** Durable-Object-to-Durable-Object
+calls and service bindings are not `fetch()` to the internet, so they do not pass
+through the Outbound Worker. Write it down where the feature is described; AWS's
+own docs lead with the equivalent caveat, and an undocumented gap here reads as a
+guarantee we don't have.
 
 **D9 — DDoS: surface and configure, don't build.** No mitigation code. Ship (a) a
 firewall-events read into the console via the Cloudflare GraphQL Analytics API,
@@ -353,6 +477,24 @@ detect/enforce split with Cloudflare as the bouncer. Chosen over any self-hosted
 WAF: anycast capacity is the part that cannot be reimplemented, and it is already
 under every tenant.
 
+**D11 — Promote suspension from a dispatcher 503 to an edge block.** Suspension
+should install a WAF _Block_ on the tenant's hostnames (custom JSON response
+carrying the billing link, so the UX is unchanged) and keep the dispatcher 503
+only as the always-works fallback. Chosen over leaving it as-is because the 503
+bills a Workers-for-Platforms request for every request of an attack, which
+inverts the purpose of a spend cap: the mechanism that exists to stop a runaway
+bill is itself metered by the runaway. Two rungs of fallback, in order of
+preference and availability:
+
+1. **Deactivate the tenant's Cloudflare for SaaS custom hostname** — free, works
+   on any plan, no rule budget consumed, stops the request at the edge.
+2. **A single custom rule against a hostname list** (`http.host in $suspended`) —
+   scales to thousands of tenants in one rule, but hostname lists are
+   **Enterprise-only**, so this is gated on the platform zone's plan.
+
+Chosen over a per-tenant custom rule: per-plan rule counts (5 on Free, 20 on Pro)
+run out long before tenants do.
+
 **D10 — Agent-queryable billing is an opt-in, not a new API.** Opt the existing
 usage/spend/cost read routes into `RouteSpec.mcp` and add current-period
 projection to the summary payload (Lago's `current_usage` shape: what's consumed
@@ -360,21 +502,66 @@ in the open period, before any invoice exists). Chosen over a new REST surface �
 the MCP transport, auth, and deny-list already exist and are the thing agents
 actually speak.
 
+## 4a. What shipped (W0 + W1)
+
+**W1 — AE metering aggregation.** `src/metering/analytics.ts` now aggregates
+`SUM(_sample_interval)` over `index1`. Pinned by a test asserting the emitted
+SQL, because a wrong aggregation here returns a plausible number rather than an
+error and would never be caught by a value assertion.
+
+**W0 — Full-bill rate card.** `src/billing/spend.ts` went from two hard-coded
+constants to a 35-meter `RATE_CARD` covering every Cloudflare billing dimension
+Lunora Cloud's products consume: Workers for Platforms, Durable Objects
+(requests / duration / rows / SQL storage), D1, R2, Workers KV, Queues,
+Workflows steps + storage, Vectorize, Workers AI Neurons, Analytics Engine,
+Workers Logs + Logpush, Browser Rendering, Containers, and Images. Each entry
+carries the published rate string beside the derived integer.
+
+Deliberately absent, so the card never implies the platform tracks something it
+does not: Hyperdrive (unlimited queries on Workers Paid — no marginal cost), R2
+egress (free), and DNS/TLS/bandwidth (included on all plans). Workflows
+invocations fold into `requests`/`cpuMs`, which bill at the same rates.
+
+What it touched:
+
+- `PeriodUsage` is now `Partial<Record<UsageMeter, number>>`; `estimatedSpendMinor`
+  sums the whole card, and `spendBreakdown` returns per-product lines sorted by
+  cost (what an agent-queryable usage API and a "why am I being charged" panel
+  both need — one number names no product).
+- `platformUsage.kind` widened from three literals to the full meter set
+  (`lunora/schema.ts`, `lunora/usage.ts`, regenerated `_generated/*`), so the
+  ledger can carry what the model prices.
+- `enforceSpendCaps` now accumulates **every** meter instead of filtering to
+  requests + CPU, and skips unknown kinds rather than throwing — the sweep that
+  protects the platform from a runaway bill must not be the thing that crashes
+  on an unexpected row.
+- `usage.series` gained `costMinor` per day; a day whose spend was all Durable
+  Object duration used to draw as a flat line at zero.
+- `UsageSection.tsx` replaced the single storage stat row with a per-product
+  cost breakdown.
+- The schema union, the function validator, and `UsageMeter` are pinned together
+  by a type-level assertion in `__tests__/spend.test.ts`, so adding a meter in
+  one place and forgetting another fails `lint:types` rather than production.
+
+Gates: `tsc --noEmit` clean, 464/464 cloud tests pass.
+
 ## 5. Workstreams
 
-| #   | Workstream                                                                                                                                                             | Size | Depends on |
-| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ---------- |
-| W1  | **Fix AE metering aggregation** (D1) — `SUM(_sample_interval)` over `index1`, plus a test asserting a sampled fixture sums to the un-sampled total.                    | S    | —          |
-| W2  | **Soft cap** (D2, D3) — `spendWarnMinor` field, `evaluateSpendCap` → `level`, `spend` alert target, warn branch in `enforceSpendCaps`, console control.                | M    | W1         |
-| W3  | **Fast-path breach at admission** (D4) — carry the breach bit through `resolveTenant`'s plan lookup.                                                                   | S    | W2         |
-| W4  | **Anomaly score + targets** (D5, D6) — rolling baseline store, online z-score, min-volume floor, `usage_anomaly` / `error_anomaly` rule targets, silence rules.        | L    | W1         |
-| W5  | **Recursion protection** (D7, D8) — lineage header, depth cap in the dispatcher, `508` + metric + audit event, per-org `terminate`/`allow`, docs incl. the blind spot. | M    | —          |
-| W6  | **Agent-queryable billing** (D10) — MCP opt-in on the usage/spend/cost reads + current-period projection.                                                              | S    | W1         |
-| W7  | **DDoS visibility & config** (D9) — firewall-events read, per-org L7 sensitivity override, anomaly → rate-limit-rule action.                                           | M    | W4         |
+| #   | Workstream                                                                                                                                                                                                            | Size | Depends on |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ---------- |
+| W0  | ✅ **Full-bill rate card** (D1b, D1c) — 35-meter `RATE_CARD`, widened ledger, per-product breakdown. **Done** — see §4a.                                                                                              | M    | —          |
+| W1  | ✅ **Fix AE metering aggregation** (D1) — `SUM(_sample_interval)` over `index1`, with a test asserting the emitted SQL. **Done** — see §4a.                                                                           | S    | —          |
+| W2  | **Soft cap** (D2, D3) — `spendWarnMinor` field, `evaluateSpendCap` → `level`, `spend` alert target, warn branch in `enforceSpendCaps`, console control.                                                               | M    | W1         |
+| W3  | **Fast-path breach at admission** (D4) — carry the breach bit through `resolveTenant`'s plan lookup.                                                                                                                  | S    | W2         |
+| W4  | **Anomaly score + targets** (D5, D6) — rolling baseline store, online z-score, min-volume floor, `usage_anomaly` / `error_anomaly` rule targets, silence rules.                                                       | L    | W1         |
+| W5  | **Recursion protection** (D7, D8) — Outbound Worker on the dispatch namespace, lineage in the outbound `parameters`, depth cap, `508` + metric + audit event, per-org `terminate`/`allow`, docs incl. the blind spot. | M    | —          |
+| W6  | **Agent-queryable billing** (D10) — MCP opt-in on the usage/spend/cost reads + current-period projection (`spendBreakdown` is the payload).                                                                           | S    | W0         |
+| W7  | **DDoS visibility & config** (D9) — firewall-events read, per-org L7 sensitivity override, anomaly → rate-limit-rule action.                                                                                          | M    | W4         |
+| W8  | **Edge-block suspension** (D11) — deactivate the custom hostname on suspend (and reactivate on recovery); WAF-list block where the zone plan allows; keep the 503 as fallback.                                        | M    | —          |
 
-W1 gates W2/W3/W4/W6 — all four read the ledger it corrects. W5 is fully
-independent and is the only item with no existing seam, so it is the best
-candidate to run in parallel.
+W0 and W1 are done. W2/W3/W4/W6 read the ledger those two corrected. W5 and W8
+are independent of everything else and of each other — the two best candidates
+to run in parallel.
 
 ## 6. Platform parity
 
@@ -392,13 +579,21 @@ premature-abstraction the conventions warn against.
 
 ## 7. Open questions
 
-1. **Does the cap price the whole bill or just compute?** `estimatedSpendMinor`
-   covers requests + CPU-ms only. Storage, DO duration, D1, and R2 are unpriced,
-   so a storage-heavy runaway is invisible to the cap. Options: extend the
-   estimate, or switch the cap to read the authoritative Billable Usage numbers
-   from `lunora/cloudflare-billing.ts` for orgs that have connected an account
-   (and keep the estimate as the fallback). The second is more accurate and more
-   coupled — decide before W2 sets the schema.
+1. ✅ **Answered — the cap prices the whole bill.** `RATE_CARD` covers all 35
+   dimensions (§4a). The follow-on question stays open: **should a connected org's
+   cap read the authoritative Billable Usage numbers instead of the estimate?**
+   More accurate, more coupled, and bounded by three documented limits — Billable
+   Usage is Pay-as-you-go-only, needs the Billing read scope, and is
+   billing-cycle-aligned rather than calendar-month-aligned (§1). A hybrid
+   (authoritative where connected, estimate everywhere else) means two period
+   definitions in one comparison, which is where this would go wrong.
+   1b. **Nothing populates the new meters yet.** The rate card prices 35
+   dimensions; the only meter with a live writer is `requests` (the AE readback).
+   Everything else reaches the ledger only if a tenant self-reports it over
+   `POST /v1/usage`. The cap is therefore _capable_ of seeing a storage-shaped
+   runaway and does not yet _see_ one. Closing that needs per-meter collectors —
+   Durable Object and D1 metrics via the GraphQL Analytics API, R2 via bucket
+   metrics — which is its own workstream and deliberately not folded into W0.
 2. **Should breach degrade rather than suspend?** Today it's a 503 for the whole
    org. A read-only mode (queries serve, mutations reject) is strictly friendlier
    and is what a "hard cap" arguably should mean for a database-shaped product.
@@ -449,6 +644,41 @@ DDoS — [Cloudflare HTTP DDoS managed ruleset](https://developers.cloudflare.co
 [CrowdSec: mitigating DDoS](https://www.crowdsec.net/blog/mitigate-ddos-with-crowdsec).
 
 Analytics Engine sampling — [Sampling with Workers Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/sampling/),
-[Workers Analytics Engine SQL API](https://developers.cloudflare.com/analytics/analytics-engine/sql-api/).
+[Workers Analytics Engine SQL API](https://developers.cloudflare.com/analytics/analytics-engine/sql-api/),
+[Usage-based billing recipe](https://developers.cloudflare.com/analytics/analytics-engine/recipes/usage-based-billing-for-your-saas-product/).
+
+Blocking traffic & usage on Cloudflare (§2.5) — [Budget alerts](https://developers.cloudflare.com/billing/manage/budget-alerts/),
+[Monitor billable usage](https://developers.cloudflare.com/billing/manage/billable-usage/),
+[Usage-based billing](https://developers.cloudflare.com/billing/understand/usage-based-billing/),
+[Ruleset Engine phases list](https://developers.cloudflare.com/ruleset-engine/reference/phases-list/),
+[WAF custom rules](https://developers.cloudflare.com/waf/custom-rules/),
+[Rate limiting rules](https://developers.cloudflare.com/waf/rate-limiting-rules/),
+[Custom lists (hostname lists are Enterprise-only)](https://developers.cloudflare.com/waf/tools/lists/custom-lists/),
+[Workers for Platforms custom limits](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/custom-limits/),
+[Outbound Workers](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/outbound-workers/),
+[Workers for Platforms tags (bulk operations by customer)](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/tags/).
+
+Pricing rate card (§4a) — [Workers for Platforms pricing](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/reference/pricing/),
+[Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/),
+[Durable Objects pricing](https://developers.cloudflare.com/durable-objects/platform/pricing/),
+[D1 pricing](https://developers.cloudflare.com/d1/platform/pricing/),
+[R2 pricing](https://developers.cloudflare.com/r2/pricing/),
+[KV pricing](https://developers.cloudflare.com/kv/platform/pricing/),
+[Queues pricing](https://developers.cloudflare.com/queues/platform/pricing/),
+[Workflows pricing](https://developers.cloudflare.com/workflows/reference/pricing/),
+[Vectorize pricing](https://developers.cloudflare.com/vectorize/platform/pricing/),
+[Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/),
+[Analytics Engine pricing](https://developers.cloudflare.com/analytics/analytics-engine/pricing/),
+[Containers pricing](https://developers.cloudflare.com/containers/pricing/),
+[Browser Rendering pricing](https://developers.cloudflare.com/browser-run/pricing/),
+[Images pricing](https://developers.cloudflare.com/images/pricing/),
+[Hyperdrive pricing](https://developers.cloudflare.com/hyperdrive/platform/pricing/),
+[How charges accrue](https://developers.cloudflare.com/billing/understand/how-charges-accrue/).
 
 OpenCloud (assessed, not prior art) — [opencloud-eu discussion: distinction from oCIS](https://github.com/orgs/opencloud-eu/discussions/262).
+
+> Cloudflare rates were read from the `cloudflare/cloudflare-docs` repository at
+> `production` on 2026-08-09 (the docs site itself is unreachable from this
+> environment's egress proxy). Rates change; `RATE_CARD.published` carries the
+> source string beside each derived integer so a re-check is a diff, not
+> arithmetic.

--- a/plans/365-cloud-spend-guardrails-and-anomaly-research.md
+++ b/plans/365-cloud-spend-guardrails-and-anomaly-research.md
@@ -1,6 +1,8 @@
-# Plan 306 — Cloud spend guardrails, anomaly alerting, recursion protection & agent-queryable billing
+# Plan 365 — Cloud spend guardrails, anomaly alerting, recursion protection & agent-queryable billing
 
-**Baseline:** `48366a2` (2026-08-08)
+**Baseline:** `18ec7965` — the head of [PR #85](https://github.com/anolilab/lunora/pull/85)
+(`claude/cloud-platform-dx-ojvkmu`), which carries `apps/cloud` itself. This plan
+stacks on that PR, not on `alpha`.
 **Status:** IN PROGRESS — W1 (metering fix) and W0 (full rate card) shipped;
 W2–W7 open
 
@@ -84,7 +86,7 @@ See §2.5 for the full interception ladder.
 
 | Capability               | Status in `apps/cloud`                                                                                                                                                                      |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Hard cap**             | ✅ shipped, single-valued. `src/billing/spend.ts` (pure evaluator, per-plan defaults `free $5` / `pro $200` / `enterprise` uncapped, org override), `lunora/usage.ts:172` enforcement cron. |
+| **Hard cap**             | ✅ shipped, single-valued. `src/billing/spend.ts` (pure evaluator, per-plan defaults `free $5` / `pro $200` / `enterprise` uncapped, org override), `lunora/usage.ts:220` enforcement cron. |
 | **Soft cap**             | ❌ absent. No warn threshold, no notification before suspension. The org goes from serving traffic to a 503 with nothing in between.                                                        |
 | **Anomaly alerting**     | 🟡 threshold-only. `lunora/alerts.ts` + `src/telemetry/alerts.ts` give metric-window rules (`error_rate`, `latency_p95`, `llm_cost`) with static thresholds; no baseline, no score.         |
 | **Recursion protection** | ❌ absent. Nothing in the repo counts invocation depth or detects a tenant Worker looping through its own hostname. Only Cloudflare's own per-invocation subrequest cap applies.            |
@@ -120,9 +122,14 @@ Supporting detail:
   passes Workers-for-Platforms `limits` (CPU + subrequests) per plan on
   `env.DISPATCHER.get(...)`. This is the natural mounting point for a lineage
   header and a depth cap.
-- **A rate-of-change primitive already exists.** `src/telemetry/alerts.ts:271`
-  (`rateOfChangePercent`) is exported and unused by any rule target — the seam a
-  baseline-relative anomaly score would build on.
+- **A rate-of-change primitive already exists, but only decorates the message.**
+  `src/telemetry/alerts.ts:271` (`rateOfChangePercent`) has exactly one caller —
+  `renderMetricAlert` at `:322`, which turns it into the "+42% vs the prior
+  window" clause in the alert body. No rule _target_ thresholds on it, so
+  window-over-window change is computed and then thrown away for
+  decision-making purposes. That is the seam a baseline-relative anomaly score
+  builds on, and it needs promoting from render-time to evaluate-time rather
+  than writing from scratch.
 
 ## 2. Prior art
 
@@ -678,7 +685,63 @@ Pricing rate card (§4a) — [Workers for Platforms pricing](https://developers.
 OpenCloud (assessed, not prior art) — [opencloud-eu discussion: distinction from oCIS](https://github.com/orgs/opencloud-eu/discussions/262).
 
 > Cloudflare rates were read from the `cloudflare/cloudflare-docs` repository at
-> `production` on 2026-08-09 (the docs site itself is unreachable from this
-> environment's egress proxy). Rates change; `RATE_CARD.published` carries the
-> source string beside each derived integer so a re-check is a diff, not
-> arithmetic.
+> `production` (the docs site itself is unreachable from this environment's
+> egress proxy). Rates change; `RATE_CARD.published` carries the source string
+> beside each derived integer so a re-check is a diff, not arithmetic.
+
+## 9. Re-validation log
+
+**2026-08-19.** The findings were re-checked twice: once against `alpha`
+(`d18ccd96`, 795 upstream commits) and once again after re-stacking onto the
+head of PR #85, which is where `apps/cloud` actually lives. Both passes used
+`cloudflare-docs@1ee6060` (that day's `production`).
+
+Held, unchanged:
+
+- All 35 rate-card entries match the current pricing pages, verbatim.
+- The four quoted doc claims still read as quoted: budget alerts "do not pause
+  or cap usage"; "only requests that hit a Worker will count against your …
+  bill"; DDoS "unmetered and unlimited … to all customers on all plans"; WAF
+  hostname lists "only available to Enterprise customers".
+- Cloudflare's own usage-based-billing recipe still uses `sum(_sample_interval)`
+  (five occurrences), which is what the §0.1 fix was derived from.
+- The dispatcher still writes one AE data point per request indexed by
+  `scriptName`, the rollback still folds it into `platformUsage`,
+  `enforceSpendCaps` still runs hourly, and the suspension path still serves a
+  billed 503 from inside the dispatch Worker.
+- `metrics-read.ts:9-14` still carries the "not for billing math" caveat that
+  corroborates §0.1.
+- Alert targets are still the same six, all static-threshold.
+- Still no lineage / loop-detection / depth cap anywhere in `apps/cloud`.
+- `currentPeriodStart()` still buckets on the UTC calendar month, so the
+  billing-cycle mismatch in §1 stands.
+
+**One finding was wrong and is corrected** (§1): `rateOfChangePercent` was
+described as "exported and unused by any rule target". It is not unused — it has
+one caller, `renderMetricAlert`, which renders the window-over-window change into
+the alert body. It was already used that way at the original baseline, so this
+was a research error, not upstream drift. The design consequence is unchanged and
+slightly better: the primitive exists and is wired, it just informs the _message_
+rather than the _decision_, so W4 promotes it from render-time to evaluate-time.
+
+One citation was stale and is corrected: the enforcement cron moved from
+`lunora/usage.ts:172` to `:220`, pushed down by W0's own widening of the meter
+union. Every other `file:line` in this plan was re-resolved and still points at
+what it names.
+
+Upstream drift affecting the work: none, on either base.
+
+The **alpha** pass touched only 7 of the 368 files that branch changed, none in
+`apps/cloud`, and conflicted in four: `packages/runtime/src/create-worker.ts`
+and `api-snapshots/runtime.api.md` (alpha's new `replicaReads` beside the cloud
+line's `queueHandler` — both kept), `pnpm-lock.yaml` (discarded and regenerated,
+never text-merged) and `plans/README.md` (both waves kept).
+
+The **re-stack onto PR #85** then reduced this branch to its own 4 commits / 19
+files, and conflicted in two — both places where PR #85 had already fixed a lint
+error this plan had recorded as pre-existing, so its side was taken in each:
+`UsageSection.tsx` (the dead `summary === undefined` guard, removed there) and
+`__tests__/reconcile.test.ts` (`ControlPlaneDb` → `ControlPlaneDatabase`).
+
+The plan was renumbered 306 → **365** and its wave 20 → **22**. Both numbers
+were taken on **both** bases, so the renumbering is correct either way.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1647,7 +1647,8 @@ target becomes real, and `@lunora/platform-node` is still experimental with no
 (#365) — 311 is the data left behind by the defect and now ships inside #365
 itself, while 312 was the price its fix paid — since executed (see the DONE &
 REMOVED note above); its open follow-ups live in 314 and 315.
-## Wave 20 — Cloud spend guardrails & abuse research (baseline `48366a2`, 2026-08-08)
+
+## Wave 22 — Cloud spend guardrails & abuse research (baseline `d18ccd96`, 2026-08-19)
 
 Research pass over the five platform-guardrail capabilities Vercel shipped as a
 bundle (soft/hard spend caps, anomaly alerting, function recursion protection,
@@ -1666,7 +1667,7 @@ for billing math" (`apps/cloud/src/telemetry/metrics-read.ts:9-14`).
 
 | Plan | Title                                                                              | Category       | Pkg   | Pri | Effort | Risk | Status                        |
 | ---- | ---------------------------------------------------------------------------------- | -------------- | ----- | --- | ------ | ---- | ----------------------------- |
-| 306  | Cloud spend guardrails, anomaly alerting, recursion protection & billing usage API | cloud/platform | cloud | P1  | L      | MED  | IN PROGRESS — W0 + W1 shipped |
+| 365  | Cloud spend guardrails, anomaly alerting, recursion protection & billing usage API | cloud/platform | cloud | P1  | L      | MED  | IN PROGRESS — W0 + W1 shipped |
 
 ### Notes
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -1647,6 +1647,45 @@ target becomes real, and `@lunora/platform-node` is still experimental with no
 (#365) — 311 is the data left behind by the defect and now ships inside #365
 itself, while 312 was the price its fix paid — since executed (see the DONE &
 REMOVED note above); its open follow-ups live in 314 and 315.
+## Wave 20 — Cloud spend guardrails & abuse research (baseline `48366a2`, 2026-08-08)
+
+Research pass over the five platform-guardrail capabilities Vercel shipped as a
+bundle (soft/hard spend caps, anomaly alerting, function recursion protection,
+agent-queryable billing usage APIs, always-on L3/L4/L7 DDoS mitigation), read
+against the OSS prior art — Lago, OpenMeter, CloudKitty, OpenCost, CrowdSec,
+Coraza, Netdata, VictoriaMetrics `vmanomaly`, Kubernetes `ResourceQuota` — and
+against what `apps/cloud` already ships. Four of the five have a working seam
+already; recursion protection has none.
+
+**The pass also turned up a live defect,** which is why this is a plan and not a
+memo: the spend-cap chain meters off Analytics Engine and sums `double1` without
+the `_sample_interval` multiplier (`apps/cloud/src/metering/analytics.ts:55`), so
+the `platformUsage` ledger under-counts exactly when AE starts sampling — i.e.
+during the runaway-tenant scenario the hard cap exists to stop. The same repo
+already documents AE as "not for billing math"
+(`apps/cloud/src/telemetry/metrics-read.ts:9-14`).
+
+| Plan | Title                                                                              | Category       | Pkg   | Pri | Effort | Risk | Status |
+| ---- | ---------------------------------------------------------------------------------- | -------------- | ----- | --- | ------ | ---- | ------ |
+| 306  | Cloud spend guardrails, anomaly alerting, recursion protection & billing usage API | cloud/platform | cloud | P1  | L      | MED  | TODO   |
+
+### Notes
+
+- **W1 gates most of the wave.** The metering fix (W1) is a one-line query change
+  and every ledger-reading workstream (soft cap, fast-path breach, anomaly score,
+  agent-queryable usage) depends on it. A hard cap on a lying meter is not a hard
+  cap.
+- **Recursion protection (W5) is fully independent** — no existing seam, no
+  dependency on W1 — so it is the item to run in parallel.
+- **DDoS is not a build.** L3/L4/L7 is inherited by construction (every tenant is
+  behind Cloudflare); the work is visibility (firewall events in the console),
+  per-org L7 sensitivity via the account-level managed-ruleset API, and closing
+  the CrowdSec-shaped detect→enforce loop with Cloudflare as the bouncer.
+- **"OpenCloud" was assessed and is not prior art** — `opencloud-eu` is a Go
+  rewrite of ownCloud Infinite Scale (file sync & share) with no metering,
+  spend-cap, or DDoS surface. The relevant OSS neighbourhood is the
+  metering/FinOps cluster and the detection/enforcement cluster, both surveyed in
+  §2 of the plan.
 
 ## Notes for executors (carried from prior waves)
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -1658,29 +1658,44 @@ against what `apps/cloud` already ships. Four of the five have a working seam
 already; recursion protection has none.
 
 **The pass also turned up a live defect,** which is why this is a plan and not a
-memo: the spend-cap chain meters off Analytics Engine and sums `double1` without
-the `_sample_interval` multiplier (`apps/cloud/src/metering/analytics.ts:55`), so
-the `platformUsage` ledger under-counts exactly when AE starts sampling — i.e.
-during the runaway-tenant scenario the hard cap exists to stop. The same repo
-already documents AE as "not for billing math"
-(`apps/cloud/src/telemetry/metrics-read.ts:9-14`).
+memo: the spend-cap chain metered off Analytics Engine and summed `double1`
+without the `_sample_interval` multiplier, so the `platformUsage` ledger
+under-counted exactly when AE starts sampling — i.e. during the runaway-tenant
+scenario the hard cap exists to stop. The same repo already documented AE as "not
+for billing math" (`apps/cloud/src/telemetry/metrics-read.ts:9-14`).
 
-| Plan | Title                                                                              | Category       | Pkg   | Pri | Effort | Risk | Status |
-| ---- | ---------------------------------------------------------------------------------- | -------------- | ----- | --- | ------ | ---- | ------ |
-| 306  | Cloud spend guardrails, anomaly alerting, recursion protection & billing usage API | cloud/platform | cloud | P1  | L      | MED  | TODO   |
+| Plan | Title                                                                              | Category       | Pkg   | Pri | Effort | Risk | Status                        |
+| ---- | ---------------------------------------------------------------------------------- | -------------- | ----- | --- | ------ | ---- | ----------------------------- |
+| 306  | Cloud spend guardrails, anomaly alerting, recursion protection & billing usage API | cloud/platform | cloud | P1  | L      | MED  | IN PROGRESS — W0 + W1 shipped |
 
 ### Notes
 
-- **W1 gates most of the wave.** The metering fix (W1) is a one-line query change
-  and every ledger-reading workstream (soft cap, fast-path breach, anomaly score,
-  agent-queryable usage) depends on it. A hard cap on a lying meter is not a hard
-  cap.
-- **Recursion protection (W5) is fully independent** — no existing seam, no
-  dependency on W1 — so it is the item to run in parallel.
+- **W0 + W1 shipped.** The metering aggregation is fixed
+  (`SUM(_sample_interval)` over `index1`, pinned by a test on the emitted SQL —
+  a wrong aggregation returns a plausible number, never an error), and
+  `src/billing/spend.ts` went from two hard-coded constants to a 35-meter rate
+  card covering the whole Cloudflare bill: Durable Objects (requests / duration /
+  rows / SQL storage), D1, R2, KV, Queues, Workflows, Vectorize, Workers AI,
+  Analytics Engine, Logs, Browser Rendering, Containers, Images. The ledger's
+  `kind` union widened to match, so a storage-shaped runaway is now visible to
+  the cap at all. 464/464 cloud tests, `tsc --noEmit` clean.
+- **Cloudflare has no hard cap to borrow.** Budget alerts and usage notifications
+  are both documented as informational — "they do not pause or cap usage" — so
+  the stop is Lunora's to build. Since only requests that reach a Worker are
+  billed, today's dispatcher 503 pays a Workers-for-Platforms request for every
+  request of an attack, while a WAF block in the `http_request_firewall_custom`
+  phase costs nothing. §2.5 of the plan is the full interception ladder; W8 is
+  the promotion.
+- **Recursion protection (W5) moved to an Outbound Worker.** The WfP docs make it
+  a first-class seam: it sees every `fetch()` a tenant Worker makes, takes
+  context from the dispatch Worker via the binding's `parameters`, and disables
+  `connect()` — closing the exact hole Vercel documents as unprotected. Still
+  fully independent of the rest of the wave.
 - **DDoS is not a build.** L3/L4/L7 is inherited by construction (every tenant is
-  behind Cloudflare); the work is visibility (firewall events in the console),
-  per-org L7 sensitivity via the account-level managed-ruleset API, and closing
-  the CrowdSec-shaped detect→enforce loop with Cloudflare as the bouncer.
+  behind Cloudflare — "all customers on all plans and services"); the work is
+  visibility (firewall events in the console), per-org L7 sensitivity via the
+  account-level managed-ruleset API, and closing the CrowdSec-shaped
+  detect→enforce loop with Cloudflare as the bouncer.
 - **"OpenCloud" was assessed and is not prior art** — `opencloud-eu` is a Go
   rewrite of ownCloud Infinite Scale (file sync & share) with no metering,
   spend-cap, or DDoS surface. The relevant OSS neighbourhood is the


### PR DESCRIPTION
> **Stacked on [#85](https://github.com/anolilab/lunora/pull/85)** (`claude/cloud-platform-dx-ojvkmu`), which carries `apps/cloud` itself. Base is that branch, not `alpha` — so this diff is **4 commits / 19 files** of new work, not the whole cloud app. Merge #85 first.

## Summary

Two defects in the spend cap, plus the research that found them.

**1. The cap was metering off a sampled source and reading it as exact.** The chain is dispatcher → Analytics Engine → `platformUsage` ledger → hourly `enforceSpendCaps`. The AE read was `SUM(double1)`, but Workers Analytics Engine applies weighted adaptive sampling at write time, and each retained row carries the `_sample_interval` it stands in for. Sampling engages **at high volume** — precisely the runaway/compromised-account case the cap exists to stop — so the ledger under-reported hardest exactly when it mattered. The branch already documented AE as "not for billing math" (`src/telemetry/metrics-read.ts:9-14`); the metering reader *was* billing math.

Fixed to `SUM(_sample_interval)` over `index1`. Because the dispatcher indexes by `scriptName` and writes one data point per request, that is the **exact** count, not an estimate — and per-tenant indexing is also what stops one enormous tenant from sampling a small tenant's rows to zero. It is the form Cloudflare's own [usage-based-billing recipe](https://developers.cloudflare.com/analytics/analytics-engine/recipes/usage-based-billing-for-your-saas-product/) uses.

**2. The cap priced compute only.** `src/billing/spend.ts` had two hard-coded constants (requests, CPU-ms), so any storage-shaped runaway — Durable Object duration, D1 row reads, R2 Class A operations — was invisible to it forever. It now carries a **35-meter `RATE_CARD`** covering every Cloudflare billing dimension this platform's products consume, each entry keeping the published rate string beside the derived integer so a price change is a diff, not arithmetic.

Three decisions worth a reviewer's attention:

- **Integer nano-cents, rounded once.** The cheapest published rate ($0.001/million rows read) is 1e-7 cents per unit; rounding per meter would floor every row-read roll-up to zero forever.
- **Included allowances are deliberately *not* subtracted per org.** Cloudflare grants free tiers once per *account*, not per tenant — subtracting a full allowance per org would let a hundred free orgs each "spend" the entire included tier and stay under cap. Every unit is priced at the marginal overage rate, which over-estimates a small tenant. That is the correct direction for a blast-radius control: it fires early, never late.
- **The cap prices more than the invoice does.** The customer-facing overage card still bills requests + CPU only, so an org can be capped for spend it was never charged for. Intentional — what a customer is billed is a pricing decision, not a side effect of a correctness fix — and both sides carry a comment naming the asymmetry.

`platformUsage.kind` widened from 3 literals to the full meter set (codegen regenerated); `enforceSpendCaps` accumulates every meter and skips unknown kinds rather than throwing; `usage.series` gained `costMinor`; the usage tab shows a per-product cost breakdown. The schema union, the function validator and `UsageMeter` are pinned together by a type-level assertion, so adding a meter and forgetting one of the three fails `lint:types` rather than production.

**3. `plans/365-cloud-spend-guardrails-and-anomaly-research.md`** — the research pass behind the above, over the five platform-guardrail capabilities (soft/hard caps, anomaly alerting, function recursion protection, agent-queryable billing APIs, L3/L4/L7 DDoS), read against the OSS prior art (Lago, OpenMeter, CloudKitty, OpenCost, CrowdSec, Coraza, Netdata, `vmanomaly`, Kubernetes `ResourceQuota`) and against the Cloudflare docs. §2.5 answers "can Cloudflare block traffic/usage for us?" — **no**: budget alerts and usage notifications are documented as informational ("they do not pause or cap usage"), so the hard stop is ours to build, and since only requests that reach a Worker are billed, today's dispatcher 503 pays for every request of an attack while a WAF block costs nothing.

## Linked issues

- Stacked on #85

## Test plan

Run after `pnpm install && pnpm --filter "@lunora/cloud..." run build` (stale `dist` produces misleading failures):

- [x] `tsc --noEmit` in `apps/cloud` — clean
- [x] `apps/cloud` Vitest — **478/478 pass**
- [x] `lunora codegen` regenerated cleanly; committed `_generated` output matches
- [x] `pnpm exec eslint` on every changed file — **0 errors**
- [ ] `pnpm run api:check` / `dist:check` — not re-run on this base. No `packages/*` source is touched by this PR, so no public API surface moves; both were green on the equivalent alpha-based revision.

Every Cloudflare rate and quotation was verified against `cloudflare/cloudflare-docs@production`; §9 of the plan is the re-validation log.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Added or updated tests covering the change — rate-card invariants, sub-cent accumulation, the meter/schema pairing, and a regression test asserting the **emitted AE SQL** (a wrong aggregation returns a plausible number rather than an error, so a value assertion would not catch it)
- [ ] Updated docs in `apps/docs` — N/A; control-plane internal, documented in `plans/`
- [x] No `packages/*` modified — this PR is entirely `apps/cloud/` + `plans/`
- [x] No new package added
- [ ] Migration impact — `platformUsage.kind` **widened only**: every existing value stays valid, existing rows read unchanged, no backfill required

## Notes for reviewers

**Start here, in order:**

1. `apps/cloud/src/metering/analytics.ts` — the one-line aggregation fix. Smallest diff, largest consequence.
2. `apps/cloud/src/billing/spend.ts` — the rate card and its three decisions.
3. `plans/365-*.md` §0 and §2.5 — the two headline findings and the Cloudflare interception ladder.

**Two conflicts during the re-stack, both resolved in this branch's favour of #85** — in each case #85 had already fixed a lint error this plan had recorded as pre-existing, so its side was taken: `UsageSection.tsx` (the dead `summary === undefined` guard, removed there) and `__tests__/reconcile.test.ts` (`ControlPlaneDb` → `ControlPlaneDatabase`).

**Known gaps, deferred deliberately** (all recorded in the plan):

- **The meters are capability, not coverage.** Only `requests` has a live writer; **`cpuMs` has never been written by anything** in the platform, before this change or after — the only in-platform writer is the AE rollback, and `POST /v1/usage` is tenant-facing with no caller in the repo. So the cap has always evaluated on requests alone. Collectors are follow-up work, and tractable: `src/provision.ts` already provisions per-tenant D1/R2 with deterministic names that give the attribution join key.
- **Gauge vs counter.** `aggregateUsage` sums every meter, which is right for counters but wrong for the five `*StorageGbMonths` meters, which are levels not increments — 30 daily samples of 100 GB-month would sum to 3000. Inert today (nothing writes them), but **must be fixed before the first storage collector lands** or that collector is born broken.
- Soft cap, recursion protection, anomaly scoring, agent-queryable usage, DDoS visibility and edge-block suspension are specified in the plan and unbuilt.