### PR TITLE
fix(docs): make llms.txt match the spec it advertises

### DIFF
--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,11 +1,25 @@
 import type { InferPageType } from "fumadocs-core/source";
 
 import type { source } from "@/lib/docs-source";
+import { siteConfig } from "~/site.config";
 
+/**
+ * Render one page for `llms-full.txt`.
+ *
+ * The `Source:` line is load-bearing rather than decorative. `llms-full.txt` is
+ * over a megabyte, so nothing reads it whole: it gets chunked, and a chunk that
+ * has drifted from its heading needs to still say where it came from. An
+ * absolute URL survives that, and it is what a model cites when it answers from
+ * this content. The path used to sit in the heading as a site-relative string,
+ * which is neither citable nor resolvable once the file is read away from the
+ * site.
+ */
 export const getLLMText = async (page: InferPageType<typeof source>): Promise<string> => {
     const processed = await page.data.getText("processed");
 
-    return `# ${page.data.title} (${page.url})
+    return `# ${page.data.title}
+
+Source: ${siteConfig.brand.url}${page.url}
 
 ${processed}`;
 };

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { llms } from "fumadocs-core/source";
 
 import { source } from "@/lib/docs-source";
+import { siteConfig } from "~/site.config";
 
 /**
  * Point agents at the live endpoint, not just the page index.
@@ -10,26 +11,57 @@ import { source } from "@/lib/docs-source";
  * which makes it the right place to say "there is an MCP server here." Without
  * it the endpoint is only discoverable by reading the docs — which is precisely
  * the thing an agent is trying to avoid doing one page at a time.
+ *
+ * It sits *below* the H1 and the summary, because llmstxt.org fixes that order:
+ * title, then a blockquote summary, then H2 sections. A section above the H1
+ * makes the title look like part of the body to anything parsing structurally.
  */
 const MCP_NOTICE = `## Model Context Protocol
 
-This documentation is also served over MCP at https://lunora.sh/mcp — an
+This documentation is also served over MCP at ${siteConfig.brand.url}/mcp — an
 unauthenticated Streamable HTTP endpoint exposing \`lunora_search_docs\`,
 \`lunora_get_doc\` and \`lunora_list_docs\`. Prefer it over crawling these pages:
 search returns the relevant sections directly.
 
-    claude mcp add --transport http lunora-docs https://lunora.sh/mcp
+    claude mcp add --transport http lunora-docs ${siteConfig.brand.url}/mcp
 
 Or run \`lunora mcp install\` inside a project to wire it into your editor
-alongside that project's own Lunora server.
+alongside that project's own Lunora server.`;
 
-`;
+/** The spec asks for a one or two sentence blockquote directly under the H1. */
+const SUMMARY = `> ${siteConfig.brand.description} Open source, and currently alpha.`;
+
+/**
+ * Normalise the generated index to what llmstxt.org describes.
+ *
+ * fumadocs emits a flat list: one H1, then link groups introduced by a bold
+ * list item rather than a heading, with site-relative hrefs. Both are fine in a
+ * browser and wrong here. `llms.txt` is read *detached* from the site — pasted
+ * into a prompt, fetched by an agent, chunked into a context window — and a
+ * relative path has nothing to resolve against once that happens.
+ */
+const GROUP_LABEL = /^- \*\*(.+?)\*\*$/gm;
+const RELATIVE_HREF = /\]\(\//g;
+const LEADING_HEADING = /^(#\s.+\n)/;
+
+const normalise = (index: string): string =>
+    index
+        // `- **Concepts**` introduces a group, so make it the heading it already is
+        .replaceAll(GROUP_LABEL, "## $1")
+        // site-relative hrefs cannot survive being read away from the site
+        .replaceAll(RELATIVE_HREF, `](${siteConfig.brand.url}/`);
 
 export const Route = createFileRoute("/llms.txt")({
     server: {
         handlers: {
             GET() {
-                return new Response(`${MCP_NOTICE}${llms(source).index()}`);
+                // Insert the summary and the MCP notice directly after the H1 that
+                // fumadocs emits, so the file reads title → summary → sections.
+                const index = normalise(llms(source).index()).replace(LEADING_HEADING, `$1\n${SUMMARY}\n\n${MCP_NOTICE}\n`);
+
+                return new Response(index, {
+                    headers: { "Content-Type": "text/plain; charset=utf-8" },
+                });
             },
         },
     },


### PR DESCRIPTION
## Summary

`robots.txt` points agents at `/llms.txt` and cites llmstxt.org, but the file did not follow that spec in four ways. Each costs something concrete when the file is read the way it is meant to be read: detached from the site, pasted into a prompt, or chunked into a context window.

Touches `apps/docs` only. No package code, no schema, no runtime.

**The four:**

1. **The MCP notice was prepended above the H1**, so the first heading in the file was a section and the title read as body text to anything parsing structurally. It now sits below the title, where a section belongs.
2. **No summary.** The spec puts a one or two sentence blockquote directly under the H1, and it is the part most likely to survive aggressive truncation. It now reuses `siteConfig.brand.description` rather than introducing a second copy of the pitch.
3. **All 89 links were site-relative.** A relative href has nothing to resolve against once the file leaves the site, which is the normal case for this file.
4. **Link groups were bold list items, not headings**, leaving one real `##` in the whole document. `- **Concepts**` is a heading wearing a list item's clothes.

`llms-full.txt` also gains a `Source:` line per document. At 1.5 MB nothing reads it whole, so a chunk needs to say where it came from once it is separated from its heading, and an absolute URL is what a model cites when it answers from the content. The site-relative path in the heading was neither citable nor resolvable.

**Measured against the live output:**

| | before | after |
| --- | --- | --- |
| H1 position | after an `##` | first line |
| summary blockquote | none | present |
| relative links | 89 | 0 |
| real `##` sections | 1 | 12 |
| links preserved | 89 | 89 |

## Linked issues

None.

## Test plan

- [x] `npx tsc --noEmit` clean for both changed files
- [x] `npx eslint` clean (fixed `prefer-string-replace-all`, `regexp/strict`, `e18e/prefer-static-regex`)
- [x] `npx prettier --check` clean
- [x] Transforms replayed against the live `lunora.sh/llms.txt` output: 89 links preserved, 0 relative remaining, 11 bold groups become headings, H1 first and blockquote second
- [x] Verified idempotent across repeated calls, since the `/g` regexes now live at module scope and carry `lastIndex`
- [ ] Reviewer: fetch `/llms.txt` and `/llms-full.txt` on a preview deploy and eyeball the head of each

## Checklist

- [x] Commit message follows Conventional Commits
- [ ] Added or updated tests covering the change — none added; these are two pure string transforms behind a route with no existing test harness in `apps/docs/__tests__`. Happy to add one if you want the shape locked in.
- [x] Updated relevant docs — the changed files are the docs output itself
- [x] No `package.json` files modified
- [x] No new package
- [x] No migration impact

## Notes for reviewers

The one judgement call worth a look is **item 3**. Making links absolute hardcodes the production origin into the generated file via `siteConfig.brand.url`, so a preview deployment will emit `https://lunora.sh/...` links rather than preview-origin ones. That is the right trade for this file, because the artifact is consumed off-site and a preview-origin link would be worse than a canonical one. Flagging it because it is a deliberate choice rather than an oversight.

The ungrouped links at the top (Overview, Getting started, Quickstarts) stay ungrouped — the spec allows links before the first section, and they read fine as a preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8m3KYmqAdVz1p1BstRUqb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `llms.txt` output with the site description, clearer section headings, and fully qualified links.
  * Added explicit source URLs to generated page content.
  * Included updated MCP connection information in the generated text.

* **Improvements**
  * Enhanced plain-text formatting for better readability and compatibility with external tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->