### PR TITLE
fix(agent): unstrand HITL approvals

### DIFF
--- a/packages/agent/__tests__/agent-loop.test.ts
+++ b/packages/agent/__tests__/agent-loop.test.ts
@@ -1263,6 +1263,45 @@ describe(runAgentLoop, () => {
         expect(rejected?.toolCallId).toBe("call_1");
         expect(rejected?.content).toContain("approval timed out");
         expect(runtime.threads.get("thread-1")?.status).toBe("idle");
+
+        // The pending-approval MARKER must be gone: every client derives its
+        // Approve/Reject affordance from that row alone, so leaving it behind
+        // keeps offering a decision that can no longer be delivered (the
+        // instance it would resolve has finished).
+        expect(runtime.messages.has("thread-1:wf-1:approval:call_1")).toBe(false);
+    });
+
+    it("clears the pending-approval marker once a human decision lands", async () => {
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: true,
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+
+        journal.events.set("approval:call_1", { decision: "approve" });
+
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", {}, ""), finalTurn("done")]);
+
+        await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        // Not timeout-specific: an approved (or rejected) call stranded the same
+        // marker, and the clients could not tell it was spent.
+        expect(runtime.messages.has("thread-1:wf-1:approval:call_1")).toBe(false);
+
+        // The real outcome still lands, on the tool-result row.
+        const result = [...runtime.messages.values()].find((message) => message.toolCallId === "call_1");
+
+        expect(result?.status).toBe("approved");
+        expect(result?.content).toBe("charged");
     });
 
     it("defaults the approval wait timeout to 3 days when the agent sets none", async () => {

--- a/packages/agent/__tests__/agent-loop.test.ts
+++ b/packages/agent/__tests__/agent-loop.test.ts
@@ -22,6 +22,7 @@ import type {
 import { memoryRuntime } from "./loop-harness";
 
 const IN_FLIGHT_PATTERN = /already has a run in flight/u;
+const TRANSIENT_WAIT_FAILURE_PATTERN = /temporarily unavailable/u;
 
 /**
  * A token sink that captures only token deltas, narrowing off the ephemeral
@@ -1232,7 +1233,13 @@ describe(runAgentLoop, () => {
             waitForEvent: async <T>(name: string, options: { timeout?: number | string; type: string }): Promise<{ payload: T; type: string }> => {
                 if (name.startsWith("approval:")) {
                     waitOptions.push(options);
-                    throw new Error("waitForEvent timed out");
+
+                    // The host's real elapsed-wait signal: an Error NAMED
+                    // `WorkflowTimeoutError` (Cloudflare's workflows-shared).
+                    const timeoutError = new Error("Execution timed out after 3600000ms");
+
+                    timeoutError.name = "WorkflowTimeoutError";
+                    throw timeoutError;
                 }
 
                 return journal.waitForEvent<T>(name, options);
@@ -1247,8 +1254,8 @@ describe(runAgentLoop, () => {
         expect(toolRuns).toBe(0);
         expect(journal.invoked).not.toContain("tool:charge:call_1");
 
-        // The wait carried the agent's configured timeout.
-        expect(waitOptions).toStrictEqual([{ timeout: "1 hour", type: "agent-approval:call_1" }]);
+        // The wait carried the agent's configured timeout, resolved to ms.
+        expect(waitOptions).toStrictEqual([{ timeout: 3_600_000, type: "agent-approval:call_1" }]);
 
         // A terminal rejected record explains why, and the thread is released.
         const rejected = [...runtime.messages.values()].find((message) => message.status === "rejected");
@@ -1279,7 +1286,75 @@ describe(runAgentLoop, () => {
 
         await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
 
-        expect(journal.resolvedWaitOptions.get("approval:call_1")?.timeout).toBe("3 days");
+        expect(journal.resolvedWaitOptions.get("approval:call_1")?.timeout).toBe(3 * 24 * 60 * 60 * 1000);
+    });
+
+    it("propagates a NON-timeout wait failure instead of recording it as a human rejection", async () => {
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: true,
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+        // A host/binding failure — NOT an elapsed timeout. Recording this as
+        // "rejected by the user" would durably assert that a human declined the
+        // charge when nobody was ever asked, so it must surface as a failed run.
+        const step = {
+            do: async <T>(name: string, callback: () => Promise<T>): Promise<T> => journal.do(name, callback),
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- mirrors AgentStepLike.waitForEvent's generic host signature so the mock stays assignable
+            waitForEvent: async <T>(name: string, options: { timeout?: number | string; type: string }): Promise<{ payload: T; type: string }> => {
+                if (name.startsWith("approval:")) {
+                    throw new Error("workflows service temporarily unavailable");
+                }
+
+                return journal.waitForEvent<T>(name, options);
+            },
+        };
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", { amount: 100 }, "charging…"), finalTurn("done")]);
+
+        await expect(runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step }))).rejects.toThrow(TRANSIENT_WAIT_FAILURE_PATTERN);
+
+        // No decision was invented: nothing was recorded as rejected/approved.
+        expect([...runtime.messages.values()].some((message) => message.status === "rejected")).toBe(false);
+        expect([...runtime.messages.values()].some((message) => message.status === "approved")).toBe(false);
+    });
+
+    it("clamps a configured approval timeout to one week so it cannot outlive the thread's reclaim horizon", async () => {
+        const agent = defineAgent({
+            // 30 days would let the reclaim take the thread while the approval is
+            // still pending — reconstructing the stranding bug the timeout prevents.
+            approvalTimeout: "30 days",
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: true,
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+
+        journal.events.set("approval:call_1", { decision: "approve" });
+
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", {}, ""), finalTurn("done")]);
+
+        await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        // Clamped to APPROVAL_TIMEOUT_MAX_MS — half of the 14-day horizon the
+        // reclaim derives from it, so the wait always fires first.
+        expect(journal.resolvedWaitOptions.get("approval:call_1")?.timeout).toBe(7 * 24 * 60 * 60 * 1000);
     });
 
     it("memoizes a function needsApproval gate in its own durable step — it resolves once, not once per replay", async () => {

--- a/packages/agent/__tests__/agent-loop.test.ts
+++ b/packages/agent/__tests__/agent-loop.test.ts
@@ -51,6 +51,9 @@ class DurableStepJournal {
     /** Names the run hibernated on (a `waitForEvent` that had no event yet). */
     public readonly waitedNames: string[] = [];
 
+    /** The options each entered wait was given (name → options), for asserting timeouts. */
+    public readonly resolvedWaitOptions = new Map<string, { timeout?: number | string; type: string }>();
+
     private readonly entries = new Map<string, { output: unknown }>();
 
     private readonly resolvedWaits = new Map<string, { payload: unknown }>();
@@ -80,6 +83,8 @@ class DurableStepJournal {
      */
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- mirrors AgentStepLike.waitForEvent's generic host signature so the mock stays assignable
     public async waitForEvent<T>(name: string, options: { timeout?: number | string; type: string }): Promise<{ payload: T; type: string }> {
+        this.resolvedWaitOptions.set(name, options);
+
         const memo = this.resolvedWaits.get(name);
 
         if (memo) {
@@ -1194,6 +1199,87 @@ describe(runAgentLoop, () => {
 
         expect(String(toolResult?.content[0]?.output.value)).toContain("rejected by the user");
         expect(runtime.threads.get("thread-1")?.status).toBe("idle");
+    });
+
+    it("times out a never-answered approval as a rejection instead of hibernating forever", async () => {
+        let toolRuns = 0;
+
+        const agent = defineAgent({
+            approvalTimeout: "1 hour",
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => {
+                        toolRuns += 1;
+
+                        return "charged";
+                    },
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: true,
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+        // A step whose approval wait's timeout elapses: the host rejects the
+        // `waitForEvent` promise (durable `do` steps delegate to the journal).
+        const waitOptions: { timeout?: number | string; type: string }[] = [];
+        const step = {
+            do: async <T>(name: string, callback: () => Promise<T>): Promise<T> => journal.do(name, callback),
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- mirrors AgentStepLike.waitForEvent's generic host signature so the mock stays assignable
+            waitForEvent: async <T>(name: string, options: { timeout?: number | string; type: string }): Promise<{ payload: T; type: string }> => {
+                if (name.startsWith("approval:")) {
+                    waitOptions.push(options);
+                    throw new Error("waitForEvent timed out");
+                }
+
+                return journal.waitForEvent<T>(name, options);
+            },
+        };
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", { amount: 100 }, "charging…"), finalTurn("could not charge")]);
+
+        const result = await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step }));
+
+        // The run ENDED (no eternal hibernation) down the normal rejection path.
+        expect(result).toStrictEqual({ stopped: "final", text: "could not charge", turns: 2 });
+        expect(toolRuns).toBe(0);
+        expect(journal.invoked).not.toContain("tool:charge:call_1");
+
+        // The wait carried the agent's configured timeout.
+        expect(waitOptions).toStrictEqual([{ timeout: "1 hour", type: "agent-approval:call_1" }]);
+
+        // A terminal rejected record explains why, and the thread is released.
+        const rejected = [...runtime.messages.values()].find((message) => message.status === "rejected");
+
+        expect(rejected?.toolCallId).toBe("call_1");
+        expect(rejected?.content).toContain("approval timed out");
+        expect(runtime.threads.get("thread-1")?.status).toBe("idle");
+    });
+
+    it("defaults the approval wait timeout to 3 days when the agent sets none", async () => {
+        const agent = defineAgent({
+            model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            tools: {
+                charge: defineAgentTool({
+                    description: "Charge the card.",
+                    execute: () => "charged",
+                    inputSchema: { jsonSchema: { type: "object" } } as never,
+                    needsApproval: true,
+                }),
+            },
+        });
+
+        const runtime = memoryRuntime();
+        const journal = new DurableStepJournal();
+        // Deliver the decision up front so the run completes; the journal records the wait's options.
+        journal.events.set("approval:call_1", { decision: "approve" });
+        const generate = scriptedGenerate([toolTurn("call_1", "charge", {}, ""), finalTurn("done")]);
+
+        await runAgentLoop(loopDefaults(agent, { generate, run: runtime.run, step: journal }));
+
+        expect(journal.resolvedWaitOptions.get("approval:call_1")?.timeout).toBe("3 days");
     });
 
     it("memoizes a function needsApproval gate in its own durable step — it resolves once, not once per replay", async () => {

--- a/packages/agent/__tests__/channels.test.ts
+++ b/packages/agent/__tests__/channels.test.ts
@@ -8,6 +8,7 @@ const encoder = new TextEncoder();
 const NO_BINDING_PATTERN = /no Workflow binding/u;
 const TRANSIENT_FAILURE_PATTERN = /temporarily unavailable/u;
 const BRANCH_MARKER_PATTERN = /reserved workflow branch-marker key/u;
+const HASHED_SLACK_ID_PATTERN = /^slack-[0-9a-f]{16}$/u;
 
 const bytesToHex = (bytes: Uint8Array): string => [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 
@@ -299,6 +300,47 @@ describe(dispatchAgentChannel, () => {
         expect(created).toStrictEqual([{ input: "hi", threadKey: "t" }]);
     });
 
+    it("keys long ids by hash: same first 60 chars but different tails stay distinct, identical ids dedupe", async () => {
+        const receivedIds: (string | undefined)[] = [];
+        const binding = {
+            create: async (options?: { id?: string; params?: unknown }): Promise<{ id: string }> => {
+                receivedIds.push(options?.id);
+
+                return { id: options?.id ?? "wf-1" };
+            },
+            get: async (): Promise<never> => {
+                throw new Error("unused");
+            },
+        };
+        const agent = {
+            onInbound: {
+                channel: "slack" as const,
+                map: () => {
+                    return { input: "hi", threadKey: "t" };
+                },
+                secret: "SLACK_SECRET",
+            },
+        };
+        const handler = dispatchAgentChannel([{ agent, binding: "AGENT_SUPPORT" }]);
+        const env = { AGENT_SUPPORT: binding, SLACK_SECRET: secret };
+        // 70-char ids sharing their first 60 chars — the old sanitize-then-truncate
+        // scheme collapsed these to one key, silently swallowing the second event.
+        const shared = "E".repeat(60);
+        const bodyA = JSON.stringify({ event: {}, event_id: `${shared}AAAAAAAAAA` });
+        const bodyB = JSON.stringify({ event: {}, event_id: `${shared}BBBBBBBBBB` });
+
+        await handler(await slackRequest(secret, bodyA), env);
+        await handler(await slackRequest(secret, bodyB), env);
+        await handler(await slackRequest(secret, bodyA), env);
+
+        expect(receivedIds).toHaveLength(3);
+        // `slack-` + 16 hex chars, distinct across distinct ids, stable across redeliveries.
+        expect(receivedIds[0]).toMatch(HASHED_SLACK_ID_PATTERN);
+        expect(receivedIds[1]).toMatch(HASHED_SLACK_ID_PATTERN);
+        expect(receivedIds[0]).not.toBe(receivedIds[1]);
+        expect(receivedIds[2]).toBe(receivedIds[0]);
+    });
+
     it("rethrows a non-duplicate create failure so the provider redelivers (not a silent 200)", async () => {
         // A binding whose create() always fails with a transient/service error —
         // NOT a duplicate-instance rejection. The handler must surface it (reject)
@@ -340,7 +382,7 @@ describe(dispatchAgentChannel, () => {
         };
         const handler = dispatchAgentChannel([{ agent, binding: "AGENT_SUPPORT" }]);
         const env = { AGENT_SUPPORT: binding, SLACK_SECRET: secret };
-        // An empty (but present) event_id sanitizes to no dedup key — each delivery
+        // An empty (but present) event_id gives no dedup key — each delivery
         // must start its own run rather than collapsing to a single "slack-" id.
         const body = JSON.stringify({ event: {}, event_id: "" });
 

--- a/packages/agent/__tests__/code-tool.test.ts
+++ b/packages/agent/__tests__/code-tool.test.ts
@@ -57,6 +57,19 @@ describe(resolveReferences, () => {
         expect(resolved.x).toBeUndefined();
         expect(resolved.y).toBeUndefined();
     });
+
+    it("skips `__proto__`/`constructor`/`prototype` own keys when rebuilding input objects", () => {
+        const input = JSON.parse(String.raw`{"__proto__": {"isAdmin": true}, "constructor": {"c": 1}, "prototype": {"p": 1}, "a": 1}`) as Record<
+            string,
+            unknown
+        >;
+        const resolved = resolveReferences(input, {}) as Record<string, unknown>;
+
+        expect(Object.keys(resolved)).toStrictEqual(["a"]);
+        expect(Object.getPrototypeOf(resolved)).toBe(Object.prototype);
+        expect(resolved.isAdmin).toBeUndefined();
+        expect(resolved.constructor).toBe(Object);
+    });
 });
 
 describe(runToolScript, () => {

--- a/packages/agent/__tests__/code-tool.test.ts
+++ b/packages/agent/__tests__/code-tool.test.ts
@@ -58,17 +58,24 @@ describe(resolveReferences, () => {
         expect(resolved.y).toBeUndefined();
     });
 
-    it("skips `__proto__`/`constructor`/`prototype` own keys when rebuilding input objects", () => {
-        const input = JSON.parse(String.raw`{"__proto__": {"isAdmin": true}, "constructor": {"c": 1}, "prototype": {"p": 1}, "a": 1}`) as Record<
-            string,
-            unknown
-        >;
+    it("skips a `__proto__` own key when rebuilding input objects", () => {
+        const input = JSON.parse(String.raw`{"__proto__": {"isAdmin": true}, "a": 1}`) as Record<string, unknown>;
         const resolved = resolveReferences(input, {}) as Record<string, unknown>;
 
         expect(Object.keys(resolved)).toStrictEqual(["a"]);
         expect(Object.getPrototypeOf(resolved)).toBe(Object.prototype);
         expect(resolved.isAdmin).toBeUndefined();
-        expect(resolved.constructor).toBe(Object);
+    });
+
+    it("keeps `constructor`/`prototype` — they are ordinary own keys, and dropping them would lose a real tool argument", () => {
+        // Neither name is a setter on a plain object literal, so assigning them
+        // pollutes nothing; a tool whose input genuinely has a `constructor`
+        // field must still receive it.
+        const resolved = resolveReferences({ constructor: { c: 1 }, prototype: { p: 1 } }, {}) as Record<string, unknown>;
+
+        expect(Object.keys(resolved).toSorted((a, b) => a.localeCompare(b))).toStrictEqual(["constructor", "prototype"]);
+        expect(resolved.constructor).toStrictEqual({ c: 1 });
+        expect(Object.getPrototypeOf(resolved)).toBe(Object.prototype);
     });
 });
 

--- a/packages/agent/__tests__/component.test.ts
+++ b/packages/agent/__tests__/component.test.ts
@@ -1124,6 +1124,57 @@ describe("concurrency guard", () => {
         await expect(callMutation(functions.agentEnsureThread, ctx, { agent: "support", key: "t-1" })).rejects.toThrow(IN_FLIGHT_PATTERN);
     });
 
+    it("does not reclaim an awaiting_input thread at the 13h run horizon (a slow approver is the normal HITL case)", async () => {
+        const { functions } = agentComponent();
+        const { ctx, rows } = fakeDatabase();
+
+        await callMutation(functions.agentEnsureThread, ctx, { agent: "support", instanceId: "wf-a", key: "t-1" });
+        await callMutation(functions.agentPatchThread, ctx, { instanceId: "wf-a", status: "awaiting_input" });
+
+        // Overnight-and-then-some: stale past ABANDONED_RUN_MS (13h) but far
+        // inside the approval horizon. The hibernating instance still owns the
+        // thread — reclaiming here would re-stamp `instanceId` and make the
+        // pending approval permanently unresolvable.
+        const thread = rows.get("agent_threads")?.[0] as Record<string, unknown>;
+
+        thread["updatedAt"] = Date.now() - 14 * 60 * 60 * 1000;
+
+        await expect(callMutation(functions.agentEnsureThread, ctx, { agent: "support", instanceId: "wf-b", key: "t-1" })).rejects.toThrow(IN_FLIGHT_PATTERN);
+    });
+
+    it("still reclaims an awaiting_input thread once the approval horizon passes (a dead instance must not hold it forever)", async () => {
+        const { functions } = agentComponent();
+        const { ctx, rows } = fakeDatabase();
+
+        await callMutation(functions.agentEnsureThread, ctx, { agent: "support", instanceId: "wf-a", key: "t-1" });
+        await callMutation(functions.agentPatchThread, ctx, { instanceId: "wf-a", status: "awaiting_input" });
+
+        const thread = rows.get("agent_threads")?.[0] as Record<string, unknown>;
+
+        thread["updatedAt"] = Date.now() - 15 * 24 * 60 * 60 * 1000;
+
+        await expect(callMutation(functions.agentEnsureThread, ctx, { agent: "support", instanceId: "wf-b", key: "t-1" })).resolves.toStrictEqual({
+            outcome: "continued",
+        });
+        expect(rows.get("agent_threads")?.[0]?.["instanceId"]).toBe("wf-b");
+    });
+
+    it("still reclaims a running thread at the 13h horizon (the parked-corpse reaper is unchanged)", async () => {
+        const { functions } = agentComponent();
+        const { ctx, rows } = fakeDatabase();
+
+        await callMutation(functions.agentEnsureThread, ctx, { agent: "support", instanceId: "wf-a", key: "t-1" });
+
+        const thread = rows.get("agent_threads")?.[0] as Record<string, unknown>;
+
+        thread["updatedAt"] = Date.now() - 14 * 60 * 60 * 1000;
+
+        await expect(callMutation(functions.agentEnsureThread, ctx, { agent: "support", instanceId: "wf-b", key: "t-1" })).resolves.toStrictEqual({
+            outcome: "continued",
+        });
+        expect(rows.get("agent_threads")?.[0]?.["instanceId"]).toBe("wf-b");
+    });
+
     it("(AGENT-02) rejects an id-less dispatch onto a running thread under a live prior instance", async () => {
         const { functions } = agentComponent();
         const { ctx } = fakeDatabase();

--- a/packages/agent/__tests__/loop-harness.ts
+++ b/packages/agent/__tests__/loop-harness.ts
@@ -200,6 +200,13 @@ export const memoryRuntime = (options?: {
         return undefined;
     };
 
+    /** Mirrors `agentDeleteMessage`: drop the row if present, and never roll back the seq counter. */
+    const deleteMessage = (args?: Record<string, unknown>): unknown => {
+        messages.delete(`${args?.["threadKey"] as string}:${args?.["messageKey"] as string}`);
+
+        return undefined;
+    };
+
     /**
      * The completion mutation: terminal patch + queue handoff. This double keeps
      * no queue (see `run-queue.test.ts` for those semantics), so it ends the run
@@ -235,6 +242,7 @@ export const memoryRuntime = (options?: {
     const handlers = new Map<string, (args?: Record<string, unknown>) => unknown>([
         [DEFAULT_AGENT_FUNCTION_PATHS.appendMessage, appendMessage],
         [DEFAULT_AGENT_FUNCTION_PATHS.completeRun, completeRun],
+        [DEFAULT_AGENT_FUNCTION_PATHS.deleteMessage, deleteMessage],
         [DEFAULT_AGENT_FUNCTION_PATHS.ensureThread, ensureThread],
         [DEFAULT_AGENT_FUNCTION_PATHS.listMessages, listMessages],
         [DEFAULT_AGENT_FUNCTION_PATHS.patchThread, patchThread],

--- a/packages/agent/__tests__/workflow.test.ts
+++ b/packages/agent/__tests__/workflow.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentLoopOptions } from "../src/agent-loop";
+import { runAgentLoop } from "../src/agent-loop";
+import { DEFAULT_AGENT_FUNCTION_PATHS } from "../src/paths";
+import type { AgentDefinition, AgentFunctionPaths, AgentRunFunction, AgentRunResult } from "../src/types";
+import compileAgentWorkflow from "../src/workflow";
+
+// Stub the loop at the module boundary (the handler imports it directly) so the
+// suite characterizes ONLY the compile-time wiring: what the handler hands the
+// loop, not what the loop does with it.
+vi.mock(import("../src/agent-loop"), async (importOriginal) => {
+    const original = await importOriginal();
+
+    return {
+        ...original,
+        runAgentLoop: vi.fn<() => Promise<AgentRunResult>>(async () => {
+            return { stopped: "final", text: "ok", turns: 1 };
+        }),
+    };
+});
+
+/** A construction-pure model factory so `createAgentGenerate` needs no `AI` binding. */
+const fakeModel = (): AgentDefinition["model"] => () => ({}) as never;
+
+const minimalAgent = (overrides?: Partial<AgentDefinition>): AgentDefinition => ({ instructions: "help", model: fakeModel(), ...overrides }) as AgentDefinition;
+
+/** A sentinel dispatcher so the ownerless branch can be asserted by reference identity. */
+const sentinelRun: AgentRunFunction = async () => "sentinel";
+
+/** The minimal workflow handler context the compiled handler reads. */
+const makeContext = (env: Record<string, unknown> = {}, params: Record<string, unknown> = {}) => {
+    return {
+        env,
+        event: { instanceId: "wf-instance-1" },
+        params: { input: "hi", threadKey: "t-1", ...params },
+        run: sentinelRun,
+        step: { do: async <T>(_name: string, callback: () => Promise<T>): Promise<T> => callback() },
+    };
+};
+
+const OTLP_ENV = { LUNORA_OTLP_ENDPOINT: "https://otlp.example", LUNORA_OTLP_TOKEN: "tok" };
+
+/** Run the compiled handler and return the options the (mocked) loop received. */
+const compileAndRun = async (
+    agent: AgentDefinition,
+    env: Record<string, unknown> = {},
+    options?: { params?: Record<string, unknown>; paths?: AgentFunctionPaths },
+): Promise<AgentLoopOptions> => {
+    const definition = compileAgentWorkflow(agent, "support", options?.paths === undefined ? undefined : { paths: options.paths });
+
+    await definition.handler(makeContext(env, options?.params) as never);
+
+    const call = vi.mocked(runAgentLoop).mock.calls.at(-1)?.[0];
+
+    if (call === undefined) {
+        throw new Error("runAgentLoop was not called");
+    }
+
+    return call;
+};
+
+describe(compileAgentWorkflow, () => {
+    beforeEach(() => {
+        vi.mocked(runAgentLoop).mockClear();
+    });
+
+    it("derives the workflow name from the export name and honors an explicit agent name", () => {
+        expect(compileAgentWorkflow(minimalAgent(), "supportBot").name).toBe("agent-support-bot");
+        expect(compileAgentWorkflow(minimalAgent({ name: "custom-name" }), "supportBot").name).toBe("custom-name");
+    });
+
+    describe("auto OTLP telemetry", () => {
+        it("leaves the definition untouched when no LUNORA_OTLP_ENDPOINT is set", async () => {
+            const agent = minimalAgent();
+
+            const received = await compileAndRun(agent, {});
+
+            // Same reference — the no-endpoint path is a byte-identical no-op.
+            expect(received.agent).toBe(agent);
+        });
+
+        it("leaves the definition untouched when the app set telemetry.isEnabled: false", async () => {
+            const agent = minimalAgent({ telemetry: { isEnabled: false } });
+
+            const received = await compileAndRun(agent, OTLP_ENV);
+
+            expect(received.agent).toBe(agent);
+        });
+
+        it("appends the OTLP integration and enables telemetry when the endpoint is injected", async () => {
+            const agent = minimalAgent();
+
+            const received = await compileAndRun(agent, OTLP_ENV);
+
+            expect(received.agent).not.toBe(agent);
+
+            const telemetry = received.agent.telemetry as { integrations: unknown[]; isEnabled: boolean };
+
+            expect(telemetry.isEnabled).toBe(true);
+            expect(telemetry.integrations).toHaveLength(1);
+        });
+
+        it("normalizes a single prior integration and an array, appending OTLP after the existing ones", async () => {
+            const single = { marker: "single" };
+            const asSingle = await compileAndRun(minimalAgent({ telemetry: { integrations: single } } as Partial<AgentDefinition>), OTLP_ENV);
+
+            const singleTelemetry = asSingle.agent.telemetry as { integrations: unknown[] };
+
+            expect(singleTelemetry.integrations).toHaveLength(2);
+            expect(singleTelemetry.integrations[0]).toBe(single);
+
+            const first = { marker: "first" };
+            const second = { marker: "second" };
+            const asArray = await compileAndRun(minimalAgent({ telemetry: { integrations: [first, second] } } as Partial<AgentDefinition>), OTLP_ENV);
+
+            const arrayTelemetry = asArray.agent.telemetry as { integrations: unknown[] };
+
+            expect(arrayTelemetry.integrations).toHaveLength(3);
+            expect(arrayTelemetry.integrations[0]).toBe(first);
+            expect(arrayTelemetry.integrations[1]).toBe(second);
+        });
+    });
+
+    describe("handler seam wiring", () => {
+        it("passes the default function paths when no override is given", async () => {
+            const received = await compileAndRun(minimalAgent());
+
+            expect(received.paths).toBe(DEFAULT_AGENT_FUNCTION_PATHS);
+        });
+
+        it("passes a paths override through to the loop", async () => {
+            const paths = { ...DEFAULT_AGENT_FUNCTION_PATHS, appendMessage: "custom:appendMessage" };
+
+            const received = await compileAndRun(minimalAgent(), {}, { paths });
+
+            expect(received.paths).toBe(paths);
+        });
+
+        it("keeps the identity-free context.run for an ownerless run and wraps it for an owned run", async () => {
+            const ownerless = await compileAndRun(minimalAgent());
+
+            expect(ownerless.run).toBe(sentinelRun);
+
+            const owned = await compileAndRun(
+                minimalAgent(),
+                { LUNORA_ADMIN_TOKEN: "admin", LUNORA_ORIGIN_URL: "https://app.example/" },
+                { params: { owner: "user-a" } },
+            );
+
+            // `resolveAgentRun` must dispatch under the owner's identity — NOT the
+            // raw workflow dispatcher — or owner-gated thread reads come back empty.
+            expect(owned.run).not.toBe(sentinelRun);
+        });
+
+        it("forwards the workflow instance id and step to the loop", async () => {
+            const received = await compileAndRun(minimalAgent());
+
+            expect(received.instanceId).toBe("wf-instance-1");
+            expect(received.step).toBeDefined();
+        });
+    });
+});

--- a/packages/agent/eslint.config.js
+++ b/packages/agent/eslint.config.js
@@ -45,6 +45,15 @@ export default createConfig(
             "vitest/prefer-expect-assertions": "off",
         },
     },
+    // Formatting rules that conflict with Prettier (which owns formatting). Like
+    // @stylistic (off via `stylistic: false`), satisfying these fights Prettier:
+    // number-literal-case wants uppercase hex digits Prettier lowercases, so an
+    // `eslint --fix` after `prettier --write` un-formats the file again.
+    {
+        rules: {
+            "unicorn/number-literal-case": "off",
+        },
+    },
     // Behavior-breaking autofixers — kept off (not style). sort-objects reorders the
     // keys of canonical/wire objects, changing bytes on the wire and breaking
     // order-sensitive tests.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -100,6 +100,9 @@ interface TurnContext {
     agent: AgentDefinition;
     /** History-compaction seam, when the runtime provided one (else `undefined`). */
     compact: AgentCompact | undefined;
+    /** Patch this run's thread by key (status/error/usage/…). */
+    /** Retire a persisted message by key (dispatches `agents:agentDeleteMessage`). */
+    deleteMessage: (messageKey: string) => Promise<void>;
     env: Record<string, unknown>;
     generate: AgentGenerate;
     /** Read the thread's synced state (dispatches `agents:agentState`) — the tool ctx's `getState`. */
@@ -111,7 +114,6 @@ interface TurnContext {
     memoryContext: string | undefined;
     /** Live-only token-delta sink, when the runtime provided one (else `undefined`). */
     onTokenDelta: AgentTokenSink | undefined;
-    /** Patch this run's thread by key (status/error/usage/…). */
     patchThread: (patch: Record<string, unknown>) => Promise<void>;
     persist: (message: Record<string, unknown>) => Promise<void>;
     run: AgentRunFunction;
@@ -285,7 +287,7 @@ const approvalTimeoutMs = (configured: number | string | undefined): number => {
  * pending tool call on the same instance could resolve this one instead.
  */
 const awaitApproval = async (turnContext: TurnContext, call: AgentToolCall): Promise<ApprovalDecision> => {
-    const { agent, instanceId, patchThread, persist, step } = turnContext;
+    const { agent, deleteMessage, instanceId, patchThread, persist, step } = turnContext;
 
     await persist({
         content: `Awaiting approval to run tool "${call.name}".`,
@@ -321,6 +323,17 @@ const awaitApproval = async (turnContext: TurnContext, call: AgentToolCall): Pro
 
             return { decision: "reject", note: "approval timed out" };
         });
+
+    // Retire the marker the moment a decision is reached — by a human OR by the
+    // timeout. Every client reads this row alone to decide whether to OFFER an
+    // Approve/Reject, so leaving it behind keeps advertising an action that can
+    // no longer be delivered (the instance that would receive it is finished).
+    // It is deleted rather than restatused because any non-"awaiting_approval"
+    // status turns it into a second, bogus tool RESULT — see the mutation's
+    // docstring. The real outcome lands on the tool-result row next.
+    // All three outcomes strand the same marker, so this is not on the timeout
+    // branch alone.
+    await deleteMessage(`${instanceId}:approval:${call.id}`);
 
     // Resume: back to running before we act on the decision.
     await patchThread({ status: "running" });
@@ -1119,6 +1132,7 @@ const runAgentLoop = async (options: AgentLoopOptions): Promise<AgentRunResult> 
     const completeRun = toFunctionReference(paths.completeRun);
     const ensureThread = toFunctionReference(paths.ensureThread);
     const listMessages = toFunctionReference(paths.listMessages);
+    const deleteMessageRef = toFunctionReference(paths.deleteMessage);
     const patchThread = toFunctionReference(paths.patchThread);
     const setStateRef = toFunctionReference(paths.setState);
     const stateRef = toFunctionReference(paths.state);
@@ -1129,6 +1143,10 @@ const runAgentLoop = async (options: AgentLoopOptions): Promise<AgentRunResult> 
 
     const patchThreadByKey = async (patch: Record<string, unknown>): Promise<void> => {
         await run(patchThread, { key: params.threadKey, ...patch });
+    };
+
+    const deleteMessageByKey = async (messageKey: string): Promise<void> => {
+        await run(deleteMessageRef, { messageKey, threadKey: params.threadKey });
     };
 
     /** The user turn that opens the run. Runs after any queue wait, so a parked run appends only once it owns the thread. */
@@ -1206,6 +1224,7 @@ const runAgentLoop = async (options: AgentLoopOptions): Promise<AgentRunResult> 
         listMessages,
         memoryContext,
         onTokenDelta,
+        deleteMessage: deleteMessageByKey,
         patchThread: patchThreadByKey,
         persist,
         run,

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -196,13 +196,28 @@ const resolveNeedsApproval = async (
 };
 
 /**
+ * How long a HITL approval wait hibernates before it gives up (overridable per
+ * agent via `approvalTimeout`). A slow approver is the NORMAL case — overnight
+ * or over a weekend — so the default is generous; but with no bound at all a
+ * never-answered approval hibernates the instance forever, and once the
+ * thread's staleness horizon passes, its pending approval can never be
+ * resolved again. Must stay well under `component.ts`'s
+ * `ABANDONED_APPROVAL_MS` so the wait always times out before the thread is
+ * reclaimed out from under it.
+ */
+const DEFAULT_APPROVAL_TIMEOUT = "3 days";
+
+/**
  * Pause the run on a human-in-the-loop tool approval: persist an
  * `"awaiting_approval"` marker (filtered out of the model prompt, but observable
  * by a client), move the thread to `"awaiting_input"`, then hibernate on the
  * deterministically named durable event `approval:<toolCallId>`. A workflow
  * replay memoizes the resolved wait, so the run resumes with the recorded
  * decision without pausing (or re-persisting) again. Named ONLY from the
- * replay-stable `call.id`.
+ * replay-stable `call.id`. The wait carries a timeout (default
+ * {@link DEFAULT_APPROVAL_TIMEOUT}, configurable via the agent's
+ * `approvalTimeout`) so a never-answered approval ends as a rejection instead
+ * of hibernating the run forever.
  *
  * The wait's match `type` is scoped to THIS call (`agent-approval:<call.id>`,
  * the same format `component.ts`'s `agentResolveApproval` sends) — native CF
@@ -211,7 +226,7 @@ const resolveNeedsApproval = async (
  * pending tool call on the same instance could resolve this one instead.
  */
 const awaitApproval = async (turnContext: TurnContext, call: AgentToolCall): Promise<ApprovalDecision> => {
-    const { instanceId, patchThread, persist, step } = turnContext;
+    const { agent, instanceId, patchThread, persist, step } = turnContext;
 
     await persist({
         content: `Awaiting approval to run tool "${call.name}".`,
@@ -223,12 +238,29 @@ const awaitApproval = async (turnContext: TurnContext, call: AgentToolCall): Pro
     });
     await patchThread({ status: "awaiting_input" });
 
-    const event = await step.waitForEvent<ApprovalDecision>(`approval:${call.id}`, { type: `agent-approval:${call.id}` });
+    let decision: ApprovalDecision;
+
+    try {
+        const event = await step.waitForEvent<ApprovalDecision>(`approval:${call.id}`, {
+            timeout: agent.approvalTimeout ?? DEFAULT_APPROVAL_TIMEOUT,
+            type: `agent-approval:${call.id}`,
+        });
+
+        decision = { decision: event.payload.decision, ...(event.payload.note === undefined ? {} : { note: event.payload.note }) };
+    } catch {
+        // The wait's timeout elapsed — the host surfaces it as a rejection of the
+        // `waitForEvent` promise (the same shape the dequeue wait and the fan-out
+        // join already treat as their timeout). Without this the run hibernates
+        // forever and, once the thread's staleness horizon passes, the pending
+        // approval becomes permanently unresolvable. Treat it as a rejection so
+        // the loop records why and continues down the existing rejection path.
+        decision = { decision: "reject", note: "approval timed out" };
+    }
 
     // Resume: back to running before we act on the decision.
     await patchThread({ status: "running" });
 
-    return { decision: event.payload.decision, ...(event.payload.note === undefined ? {} : { note: event.payload.note }) };
+    return decision;
 };
 
 const runToolCall = async (turnContext: TurnContext, call: AgentToolCall): Promise<void> => {

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel, ModelMessage, StopCondition, ToolSet } from "ai";
 
-import { definedColumns } from "./component-shared";
+import { APPROVAL_TIMEOUT_MAX_MS, definedColumns } from "./component-shared";
 import { resolveAgentModel } from "./generate";
 import { firstEpisodicSource, firstGraphSource, memoryStepName, resolveInjectedSources } from "./memory";
 import { buildModelMessages } from "./model-messages";
@@ -196,16 +196,74 @@ const resolveNeedsApproval = async (
 };
 
 /**
+ * Cloudflare Workflows raises an elapsed `waitForEvent` as an `Error` named
+ * `WorkflowTimeoutError` (message `"Execution timed out after <n>ms"`). Matched
+ * by NAME rather than `instanceof`: the constructor lives in the host's own
+ * `workflows-shared` module, which we neither import nor can identity-compare
+ * across the RPC boundary. Same shape as `channels.ts`'s duplicate-instance
+ * check, and deliberately narrow — every OTHER rejection (a binding failure, a
+ * payload that will not deserialize, a host bug) must NOT be silently recorded
+ * as a human decision.
+ */
+const WORKFLOW_TIMEOUT_ERROR_NAME = "WorkflowTimeoutError";
+
+/** True only for the host's elapsed-`waitForEvent` rejection — see {@link WORKFLOW_TIMEOUT_ERROR_NAME}. */
+const isWaitTimeoutError = (error: unknown): boolean => error instanceof Error && error.name === WORKFLOW_TIMEOUT_ERROR_NAME;
+
+/**
  * How long a HITL approval wait hibernates before it gives up (overridable per
  * agent via `approvalTimeout`). A slow approver is the NORMAL case — overnight
  * or over a weekend — so the default is generous; but with no bound at all a
  * never-answered approval hibernates the instance forever, and once the
  * thread's staleness horizon passes, its pending approval can never be
- * resolved again. Must stay well under `component.ts`'s
- * `ABANDONED_APPROVAL_MS` so the wait always times out before the thread is
- * reclaimed out from under it.
+ * resolved again. The reclaim horizon is derived from
+ * `APPROVAL_TIMEOUT_MAX_MS`, so the wait always fires first by construction.
  */
-const DEFAULT_APPROVAL_TIMEOUT = "3 days";
+const DEFAULT_APPROVAL_TIMEOUT_MS = 3 * 24 * 60 * 60 * 1000;
+
+/** Milliseconds per unit of the host's duration grammar (`"3 days"`); month/year are nominal. */
+const DURATION_UNIT_MS: Record<string, number> = {
+    day: 86_400_000,
+    hour: 3_600_000,
+    minute: 60_000,
+    month: 30 * 86_400_000,
+    second: 1000,
+    week: 7 * 86_400_000,
+    year: 365 * 86_400_000,
+};
+
+/** The host's `"<n> <unit>[s]"` duration grammar (hoisted, avoids recompilation). */
+const DURATION_PATTERN = /^(\d+(?:\.\d+)?) (day|hour|minute|month|second|week|year)s?$/u;
+
+/**
+ * Resolve the agent's configured approval timeout to a bounded number of
+ * milliseconds.
+ *
+ * Returns ms (which `waitForEvent` accepts natively) rather than passing the
+ * configured value through, because the bound is the point: a value above
+ * {@link APPROVAL_TIMEOUT_MAX_MS} would let the thread be reclaimed out from
+ * under a still-pending approval. An unparseable string cannot reach here from
+ * TypeScript (the property's type is the host's closed grammar) but can from
+ * plain JS — it falls back to the default rather than handing the host a
+ * duration it will reject mid-run.
+ */
+const approvalTimeoutMs = (configured: number | string | undefined): number => {
+    if (configured === undefined) {
+        return DEFAULT_APPROVAL_TIMEOUT_MS;
+    }
+
+    if (typeof configured === "number") {
+        return Math.min(configured, APPROVAL_TIMEOUT_MAX_MS);
+    }
+
+    const match = DURATION_PATTERN.exec(configured);
+
+    if (match === null) {
+        return DEFAULT_APPROVAL_TIMEOUT_MS;
+    }
+
+    return Math.min(Number(match[1]) * (DURATION_UNIT_MS[match[2] as string] as number), APPROVAL_TIMEOUT_MAX_MS);
+};
 
 /**
  * Pause the run on a human-in-the-loop tool approval: persist an
@@ -215,9 +273,10 @@ const DEFAULT_APPROVAL_TIMEOUT = "3 days";
  * replay memoizes the resolved wait, so the run resumes with the recorded
  * decision without pausing (or re-persisting) again. Named ONLY from the
  * replay-stable `call.id`. The wait carries a timeout (default
- * {@link DEFAULT_APPROVAL_TIMEOUT}, configurable via the agent's
- * `approvalTimeout`) so a never-answered approval ends as a rejection instead
- * of hibernating the run forever.
+ * {@link DEFAULT_APPROVAL_TIMEOUT_MS}, configurable via the agent's
+ * `approvalTimeout` and bounded by {@link approvalTimeoutMs}) so a
+ * never-answered approval ends as a rejection instead of hibernating the run
+ * forever.
  *
  * The wait's match `type` is scoped to THIS call (`agent-approval:<call.id>`,
  * the same format `component.ts`'s `agentResolveApproval` sends) — native CF
@@ -238,24 +297,30 @@ const awaitApproval = async (turnContext: TurnContext, call: AgentToolCall): Pro
     });
     await patchThread({ status: "awaiting_input" });
 
-    let decision: ApprovalDecision;
-
-    try {
-        const event = await step.waitForEvent<ApprovalDecision>(`approval:${call.id}`, {
-            timeout: agent.approvalTimeout ?? DEFAULT_APPROVAL_TIMEOUT,
+    const decision = await step
+        .waitForEvent<ApprovalDecision>(`approval:${call.id}`, {
+            timeout: approvalTimeoutMs(agent.approvalTimeout),
             type: `agent-approval:${call.id}`,
-        });
+        })
+        .then((event): ApprovalDecision => {
+            return { decision: event.payload.decision, ...(event.payload.note === undefined ? {} : { note: event.payload.note }) };
+        })
+        .catch((error: unknown): ApprovalDecision => {
+            // ONLY an elapsed timeout becomes a decision. Without it the run
+            // hibernates forever and, once the thread's staleness horizon
+            // passes, the pending approval is permanently unresolvable — so a
+            // timeout is recorded as a rejection and the loop continues down
+            // the existing rejection path. Any OTHER rejection (binding
+            // failure, undeserializable payload, host bug) is rethrown: writing
+            // a rejection into the durable record when nobody was asked would
+            // be a worse lie than a failed run, and the sibling `awaitDequeue`
+            // propagates host errors for the same reason.
+            if (!isWaitTimeoutError(error)) {
+                throw error;
+            }
 
-        decision = { decision: event.payload.decision, ...(event.payload.note === undefined ? {} : { note: event.payload.note }) };
-    } catch {
-        // The wait's timeout elapsed — the host surfaces it as a rejection of the
-        // `waitForEvent` promise (the same shape the dequeue wait and the fan-out
-        // join already treat as their timeout). Without this the run hibernates
-        // forever and, once the thread's staleness horizon passes, the pending
-        // approval becomes permanently unresolvable. Treat it as a rejection so
-        // the loop records why and continues down the existing rejection path.
-        decision = { decision: "reject", note: "approval timed out" };
-    }
+            return { decision: "reject", note: "approval timed out" };
+        });
 
     // Resume: back to running before we act on the decision.
     await patchThread({ status: "running" });

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -219,8 +219,50 @@ const discordPongResponse = (channel: AgentInboundChannelKind, body: string): Re
 /** The eligible targets for a channel, paired with their resolved `onInbound` config. */
 type EligibleTarget = { config: NonNullable<AgentDefinition["onInbound"]>; target: AgentChannelTarget };
 
-/** Characters not allowed in a Cloudflare Workflow instance id — hoisted, avoids recompilation. */
-const UNSAFE_INSTANCE_ID = /[^\w-]/gu;
+/** One 16-bit limb of the FNV-1a state as four lowercase hex chars. */
+const hex4 = (limb: number): string => limb.toString(16).padStart(4, "0");
+
+/**
+ * 64-bit FNV-1a over a string, as 16 lowercase hex chars. Used to build the
+ * workflow dedup instance id from the provider's raw delivery id: hashing keeps
+ * the full id's entropy in a fixed-length, always-instance-id-safe key, where
+ * sanitize-then-truncate collapsed distinct ids differing only in stripped
+ * punctuation or past the cutoff — silently swallowing the second event.
+ * Algorithm lifted from `@lunora/replica`'s bit-verified `fnv1a64Hex`.
+ */
+const fnv1a64Hex = (input: string): string => {
+    /* eslint-disable no-bitwise -- FNV-1a is defined over XOR and multiplication; the bit ops ARE the algorithm */
+    // Offset basis 0xcbf29ce484222325, low limb first.
+    let h0 = 0x23_25;
+    let h1 = 0x84_22;
+    let h2 = 0x9C_E4;
+    let h3 = 0xCB_F2;
+
+    for (let index = 0; index < input.length; index += 1) {
+        const point = input.codePointAt(index) ?? 0;
+
+        // A code point above the BMP occupies limbs 0 and 1.
+        h0 ^= point & 0xFF_FF;
+        h1 ^= (point >>> 16) & 0xFF_FF;
+
+        const p0 = h0 * 0x01_B3;
+        const p1 = h1 * 0x01_B3;
+        const p2 = h2 * 0x01_B3 + h0 * 0x01_00;
+        const p3 = h3 * 0x01_B3 + h1 * 0x01_00;
+
+        const c1 = p1 + (p0 >>> 16);
+        const c2 = p2 + (c1 >>> 16);
+        const c3 = p3 + (c2 >>> 16);
+
+        h0 = p0 & 0xFF_FF;
+        h1 = c1 & 0xFF_FF;
+        h2 = c2 & 0xFF_FF;
+        h3 = c3 & 0xFF_FF;
+    }
+
+    return hex4(h3) + hex4(h2) + hex4(h1) + hex4(h0);
+    /* eslint-enable no-bitwise */
+};
 
 /** Matches Cloudflare Workflows' "instance already exists" rejection (hoisted). */
 const DUPLICATE_INSTANCE = /already[\s-]?exists/iu;
@@ -281,18 +323,18 @@ const startChannelRun = async (
         throw new LunoraError("BAD_REQUEST", `@lunora/agent: inbound channel run params ${BRANCH_MARKER_REJECTION}`);
     }
 
-    // Sanitize the id alone (the `channel-` prefix is already instance-id-safe);
-    // an id absent or reduced to empty by sanitization gives no dedup key.
-    const sanitizedId = id === undefined ? "" : id.replaceAll(UNSAFE_INSTANCE_ID, "");
-
-    if (sanitizedId === "") {
+    // An absent or empty id gives no dedup key. Otherwise hash the RAW id: the
+    // hex digest is always instance-id-safe, fixed-length (`<channel>-` + 16
+    // chars, well under Cloudflare's 64-char limit), and keeps the full id's
+    // entropy — no two distinct deliveries can collapse to one key.
+    if (id === undefined || id === "") {
         await workflow.create({ params: run });
 
         return ack();
     }
 
     try {
-        await workflow.create({ id: `${channel}-${sanitizedId}`.slice(0, 60), params: run });
+        await workflow.create({ id: `${channel}-${fnv1a64Hex(id)}`, params: run });
     } catch (error) {
         if (isDuplicateInstanceError(error)) {
             return ack();

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -225,9 +225,11 @@ const hex4 = (limb: number): string => limb.toString(16).padStart(4, "0");
 /**
  * 64-bit FNV-1a over a string, as 16 lowercase hex chars. Used to build the
  * workflow dedup instance id from the provider's raw delivery id: hashing keeps
- * the full id's entropy in a fixed-length, always-instance-id-safe key, where
- * sanitize-then-truncate collapsed distinct ids differing only in stripped
- * punctuation or past the cutoff — silently swallowing the second event.
+ * the whole id significant in a fixed-length, always-instance-id-safe key,
+ * where sanitize-then-truncate collapsed distinct ids differing only in
+ * stripped punctuation or past the cutoff — silently swallowing the second
+ * event. A checksum, NOT a cryptographic hash: it is applied to an id whose
+ * authenticity the caller has already verified by signature.
  * Algorithm lifted from `@lunora/replica`'s bit-verified `fnv1a64Hex`.
  */
 const fnv1a64Hex = (input: string): string => {
@@ -324,9 +326,14 @@ const startChannelRun = async (
     }
 
     // An absent or empty id gives no dedup key. Otherwise hash the RAW id: the
-    // hex digest is always instance-id-safe, fixed-length (`<channel>-` + 16
-    // chars, well under Cloudflare's 64-char limit), and keeps the full id's
-    // entropy — no two distinct deliveries can collapse to one key.
+    // hex digest is always instance-id-safe and fixed-length (`<channel>-` + 16
+    // chars, well under Cloudflare's 64-char limit) while keeping the whole id
+    // significant, where sanitize-then-truncate discarded everything past the
+    // cutoff. FNV-1a is a checksum, not a cryptographic hash — an attacker who
+    // can choose a delivery id can find a collision — so the integrity of this
+    // key rests on the upstream signature verification of the id, not on the
+    // digest; against ACCIDENTAL collision between honest ids, 64 bits is
+    // ample.
     if (id === undefined || id === "") {
         await workflow.create({ params: run });
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -235,29 +235,29 @@ const fnv1a64Hex = (input: string): string => {
     // Offset basis 0xcbf29ce484222325, low limb first.
     let h0 = 0x23_25;
     let h1 = 0x84_22;
-    let h2 = 0x9C_E4;
-    let h3 = 0xCB_F2;
+    let h2 = 0x9c_e4;
+    let h3 = 0xcb_f2;
 
     for (let index = 0; index < input.length; index += 1) {
         const point = input.codePointAt(index) ?? 0;
 
         // A code point above the BMP occupies limbs 0 and 1.
-        h0 ^= point & 0xFF_FF;
-        h1 ^= (point >>> 16) & 0xFF_FF;
+        h0 ^= point & 0xff_ff;
+        h1 ^= (point >>> 16) & 0xff_ff;
 
-        const p0 = h0 * 0x01_B3;
-        const p1 = h1 * 0x01_B3;
-        const p2 = h2 * 0x01_B3 + h0 * 0x01_00;
-        const p3 = h3 * 0x01_B3 + h1 * 0x01_00;
+        const p0 = h0 * 0x01_b3;
+        const p1 = h1 * 0x01_b3;
+        const p2 = h2 * 0x01_b3 + h0 * 0x01_00;
+        const p3 = h3 * 0x01_b3 + h1 * 0x01_00;
 
         const c1 = p1 + (p0 >>> 16);
         const c2 = p2 + (c1 >>> 16);
         const c3 = p3 + (c2 >>> 16);
 
-        h0 = p0 & 0xFF_FF;
-        h1 = c1 & 0xFF_FF;
-        h2 = c2 & 0xFF_FF;
-        h3 = c3 & 0xFF_FF;
+        h0 = p0 & 0xff_ff;
+        h1 = c1 & 0xff_ff;
+        h2 = c2 & 0xff_ff;
+        h3 = c3 & 0xff_ff;
     }
 
     return hex4(h3) + hex4(h2) + hex4(h1) + hex4(h0);

--- a/packages/agent/src/code-tool.ts
+++ b/packages/agent/src/code-tool.ts
@@ -129,11 +129,15 @@ const resolveReferences = (value: unknown, results: Record<string, unknown>): un
     const resolved: Record<string, unknown> = {};
 
     for (const [key, nested] of Object.entries(object)) {
-        // A model-supplied `__proto__` own key (own after JSON.parse) would hit
-        // `Object.prototype`'s setter and swap the accumulator's prototype, so a
-        // composed tool could read attacker-chosen inherited properties. Skip the
-        // unsafe keys, mirroring `getPath`'s own-property-only read side.
-        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        // A model-supplied `__proto__` own key (own after JSON.parse) is the one
+        // name that does not create an own property here: it hits
+        // `Object.prototype`'s setter and swaps the accumulator's prototype, so
+        // a composed tool would read attacker-chosen inherited properties.
+        // ONLY that name is skipped — `constructor` and `prototype` are plain
+        // own keys on an object literal (assigning them shadows nothing and
+        // pollutes nothing), so skipping those would buy no safety and would
+        // silently drop a tool argument legitimately called `constructor`.
+        if (key === "__proto__") {
             continue;
         }
 

--- a/packages/agent/src/code-tool.ts
+++ b/packages/agent/src/code-tool.ts
@@ -129,6 +129,14 @@ const resolveReferences = (value: unknown, results: Record<string, unknown>): un
     const resolved: Record<string, unknown> = {};
 
     for (const [key, nested] of Object.entries(object)) {
+        // A model-supplied `__proto__` own key (own after JSON.parse) would hit
+        // `Object.prototype`'s setter and swap the accumulator's prototype, so a
+        // composed tool could read attacker-chosen inherited properties. Skip the
+        // unsafe keys, mirroring `getPath`'s own-property-only read side.
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+            continue;
+        }
+
         resolved[key] = resolveReferences(nested, results);
     }
 

--- a/packages/agent/src/component-shared.ts
+++ b/packages/agent/src/component-shared.ts
@@ -14,6 +14,31 @@ interface AgentRegisteredFunction {
     readonly visibility?: "internal" | "public";
 }
 
+/**
+ * The longest a HITL approval wait may hibernate, however it is configured.
+ *
+ * A configured `approvalTimeout` is CLAMPED to this at read. The bound is not
+ * cosmetic: a wait that outlives {@link ABANDONED_APPROVAL_MS} lets the thread
+ * be reclaimed (its `instanceId` re-stamped) while the approval is still
+ * pending, which is precisely the stranded-approval failure the timeout exists
+ * to prevent. A week already exceeds any plausible human turnaround.
+ */
+const APPROVAL_TIMEOUT_MAX_MS: number = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * How long an `"awaiting_input"` (HITL-paused) thread may sit untouched before
+ * a new run may reclaim it.
+ *
+ * DERIVED from {@link APPROVAL_TIMEOUT_MAX_MS} rather than written as its own
+ * duration, so the ordering is structural instead of a comment two files apart:
+ * at twice the longest possible wait, the wait ALWAYS times out — freeing the
+ * thread through the normal rejection path — with a full timeout's margin
+ * before the reclaim can consider the thread abandoned. The reclaim still
+ * exists for the case the timeout cannot cover: an instance that died without
+ * ever running its wait to completion.
+ */
+const ABANDONED_APPROVAL_MS: number = 2 * APPROVAL_TIMEOUT_MAX_MS;
+
 /** Stamp a registered function internal — server-side callable only. */
 const asInternal = <T>(function_: T): T => {
     return { ...function_, visibility: "internal" };
@@ -39,4 +64,4 @@ const definedColumns = (columns: Record<string, unknown>): Record<string, unknow
 };
 
 export type { AgentRegisteredFunction };
-export { AGENT_EXTENSION_KEY, asInternal, definedColumns };
+export { ABANDONED_APPROVAL_MS, AGENT_EXTENSION_KEY, APPROVAL_TIMEOUT_MAX_MS, asInternal, definedColumns };

--- a/packages/agent/src/component.ts
+++ b/packages/agent/src/component.ts
@@ -39,9 +39,24 @@ const MAX_QUEUE_DEPTH = 5;
  * instance terminated while parked leaves the thread pointing at a workflow that
  * will never resume — and nothing else would ever free it. The window is longer
  * than the loop's own dequeue timeout so a genuinely parked run is never
- * reclaimed out from under itself.
+ * reclaimed out from under itself. Applies to `"running"` threads only — an
+ * `"awaiting_input"` thread uses {@link ABANDONED_APPROVAL_MS}.
  */
 const ABANDONED_RUN_MS = 13 * 60 * 60 * 1000;
+
+/**
+ * The far longer staleness horizon for an `"awaiting_input"` thread.
+ *
+ * A HITL pause is a run hibernating on `step.waitForEvent`, and a slow human
+ * approval (overnight, a weekend) is its NORMAL case — so the 13h run horizon
+ * must not apply. Reclaiming re-stamps the thread's `instanceId`, after which
+ * `agentResolveApproval` FORBIDs the real approver forever. The loop's own
+ * approval wait timeout (default 3 days, configurable per agent) is what
+ * ordinarily frees the thread; this horizon exists only for an instance that
+ * died without ever timing out its wait, so it merely has to outlast any
+ * plausible approval timeout.
+ */
+const ABANDONED_APPROVAL_MS = 14 * 24 * 60 * 60 * 1000;
 
 /**
  * The agent thread tables, shipped as a schema extension so an app merges
@@ -382,9 +397,13 @@ export const agentComponent = (): AgentComponent => {
                 // Nothing else reaps that: under `"reject"` every later run
                 // CONFLICTs, and under `"queue"` every later run parks behind a
                 // corpse. A thread untouched for longer than any run could
-                // plausibly hold it is treated as free.
+                // plausibly hold it is treated as free — but an `awaiting_input`
+                // thread is measured against the far longer approval horizon,
+                // because its instance really is alive and hibernating on a slow
+                // human decision (see ABANDONED_APPROVAL_MS).
                 const updatedAt = typeof existing["updatedAt"] === "number" ? existing["updatedAt"] : 0;
-                const abandoned = now - updatedAt > ABANDONED_RUN_MS;
+                const staleAfter = existing["status"] === "awaiting_input" ? ABANDONED_APPROVAL_MS : ABANDONED_RUN_MS;
+                const abandoned = now - updatedAt > staleAfter;
                 const isConcurrentRun =
                     !abandoned &&
                     (existing["status"] === "running" || existing["status"] === "awaiting_input") &&

--- a/packages/agent/src/component.ts
+++ b/packages/agent/src/component.ts
@@ -303,6 +303,7 @@ export interface AgentComponent {
     functions: {
         agentAppendMessage: AgentRegisteredFunction;
         agentCompleteRun: AgentRegisteredFunction;
+        agentDeleteMessage: AgentRegisteredFunction;
         agentEnsureThread: AgentRegisteredFunction;
         agentEpisodeRecall: AgentRegisteredFunction;
         agentEpisodeUpsert: AgentRegisteredFunction;
@@ -490,6 +491,46 @@ export const agentComponent = (): AgentComponent => {
             await context.db.patch(thread["_id"] as never, { messageCount: seq + 1, updatedAt: now });
 
             return { seq };
+        });
+
+    /**
+     * Delete a message by `(threadKey, messageKey)`. A no-op when absent, so a
+     * workflow replay re-running the delete is harmless.
+     *
+     * Used for exactly one thing: retiring the spent HITL approval marker. The
+     * marker is a pending-decision AFFORDANCE, not conversation content — every
+     * client renders its Approve/Reject purely from `status ===
+     * "awaiting_approval"`, and `model-messages.ts` drops rows with that status
+     * so the model never sees a duplicate tool-result part for the call.
+     *
+     * That is why the marker is DELETED rather than moved to a terminal status:
+     * a terminal status would flip it into a second, bogus tool RESULT on both
+     * surfaces at once — an extra result event carrying the placeholder's text
+     * in every client, and a duplicated tool-result part in the model prompt
+     * (breaking provider tool-call pairing). The real outcome is already
+     * recorded on the tool-result row under the same `toolCallId`, so removing
+     * the placeholder loses nothing.
+     *
+     * `messageCount` is deliberately NOT decremented — it is the thread's next-
+     * `seq` high-water mark, and rolling it back would hand a later message a
+     * `seq` that is already taken.
+     */
+    const agentDeleteMessage = mutation
+        .input({
+            messageKey: v.string(),
+            threadKey: v.string(),
+        })
+        .mutation(async ({ args, ctx: context }): Promise<void> => {
+            const existing = await context.db
+                .query(MESSAGES_TABLE)
+                .withIndex("byMessageKey", (q) => q.eq("threadKey", args.threadKey).eq("messageKey", args.messageKey))
+                .first();
+
+            if (!existing) {
+                return;
+            }
+
+            await context.db.delete(existing["_id"] as never);
         });
 
     const agentPatchThread = mutation
@@ -946,6 +987,7 @@ export const agentComponent = (): AgentComponent => {
             agentGraphTraverse: graph.agentGraphTraverse,
             agentGraphUpsert: graph.agentGraphUpsert,
             agentMessages,
+            agentDeleteMessage: asInternal(agentDeleteMessage),
             agentPatchThread: asInternal(agentPatchThread),
             agentResolveApproval,
             agentRun,

--- a/packages/agent/src/component.ts
+++ b/packages/agent/src/component.ts
@@ -4,7 +4,7 @@ import { defineSchemaExtension, defineTable, initLunora } from "@lunora/server";
 import { v } from "@lunora/values";
 
 import type { AgentRegisteredFunction } from "./component-shared";
-import { AGENT_EXTENSION_KEY, asInternal, definedColumns } from "./component-shared";
+import { ABANDONED_APPROVAL_MS, AGENT_EXTENSION_KEY, asInternal, definedColumns } from "./component-shared";
 import { episodeTables, episodicComponent } from "./episodic-component";
 import { graphComponent, graphTables } from "./graph-component";
 import type { EnsureThreadOutcome } from "./types";
@@ -43,20 +43,6 @@ const MAX_QUEUE_DEPTH = 5;
  * `"awaiting_input"` thread uses {@link ABANDONED_APPROVAL_MS}.
  */
 const ABANDONED_RUN_MS = 13 * 60 * 60 * 1000;
-
-/**
- * The far longer staleness horizon for an `"awaiting_input"` thread.
- *
- * A HITL pause is a run hibernating on `step.waitForEvent`, and a slow human
- * approval (overnight, a weekend) is its NORMAL case — so the 13h run horizon
- * must not apply. Reclaiming re-stamps the thread's `instanceId`, after which
- * `agentResolveApproval` FORBIDs the real approver forever. The loop's own
- * approval wait timeout (default 3 days, configurable per agent) is what
- * ordinarily frees the thread; this horizon exists only for an instance that
- * died without ever timing out its wait, so it merely has to outlast any
- * plausible approval timeout.
- */
-const ABANDONED_APPROVAL_MS = 14 * 24 * 60 * 60 * 1000;
 
 /**
  * The agent thread tables, shipped as a schema extension so an app merges

--- a/packages/agent/src/paths.ts
+++ b/packages/agent/src/paths.ts
@@ -30,6 +30,7 @@ export const SANDBOX_INVOKE_PATH: "sandbox:invoke" = `${SANDBOX_MODULE}:invoke`;
 export const DEFAULT_AGENT_FUNCTION_PATHS: AgentFunctionPaths = {
     appendMessage: `${AGENT_MODULE}:agentAppendMessage`,
     completeRun: `${AGENT_MODULE}:agentCompleteRun`,
+    deleteMessage: `${AGENT_MODULE}:agentDeleteMessage`,
     ensureThread: `${AGENT_MODULE}:agentEnsureThread`,
     episodeRecall: `${AGENT_MODULE}:agentEpisodeRecall`,
     episodeUpsert: `${AGENT_MODULE}:agentEpisodeUpsert`,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -640,13 +640,20 @@ export interface AgentConfig {
 
     /**
      * How long a human-in-the-loop tool approval may stay pending before the
-     * run stops waiting (a Cloudflare Workflows duration — ms number or a
-     * string like `"3 days"`). Default `"3 days"`. On timeout the call is
-     * treated as REJECTED (the run records why and continues down the normal
-     * rejection path), so a run whose approver never answers ends instead of
-     * hibernating forever.
+     * run stops waiting — a Cloudflare Workflows duration: milliseconds, or a
+     * `"<n> <unit>"` string like `"3 days"` (the unit set is the host's, so a
+     * typo is a compile error). Default `"3 days"`.
+     *
+     * On timeout the call is treated as REJECTED (the run records why and
+     * continues down the normal rejection path), so a run whose approver never
+     * answers ends instead of hibernating forever.
+     *
+     * CLAMPED to one week. A longer wait would outlive the thread's
+     * abandoned-run horizon, letting a new run reclaim the thread while the
+     * approval is still pending — which is the exact failure this timeout
+     * exists to prevent, so it cannot be configured back into existence.
      */
-    approvalTimeout?: number | string;
+    approvalTimeout?: `${number} ${"day" | "hour" | "minute" | "month" | "second" | "week" | "year"}${"s" | ""}` | number;
 
     /**
      * Automatic thread-history compaction. When the persisted history exceeds

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1015,6 +1015,12 @@ export interface AgentFunctionPaths {
      * next queued run in the same mutation.
      */
     completeRun: string;
+
+    /**
+     * The internal `agents:agentDeleteMessage` mutation the loop dispatches to
+     * retire the HITL approval marker once the decision has landed.
+     */
+    deleteMessage: string;
     ensureThread: string;
     /** The internal `agents:agentEpisodeRecall` query the loop dispatches for an episodic-kind read. */
     episodeRecall: string;

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -639,6 +639,16 @@ export interface AgentConfig {
     activeTools?: ReadonlyArray<string>;
 
     /**
+     * How long a human-in-the-loop tool approval may stay pending before the
+     * run stops waiting (a Cloudflare Workflows duration — ms number or a
+     * string like `"3 days"`). Default `"3 days"`. On timeout the call is
+     * treated as REJECTED (the run records why and continues down the normal
+     * rejection path), so a run whose approver never answers ends instead of
+     * hibernating forever.
+     */
+    approvalTimeout?: number | string;
+
+    /**
      * Automatic thread-history compaction. When the persisted history exceeds
      * `maxMessages`, the loop summarizes the older messages (all but the most
      * recent `keepRecent`, default `ceil(maxMessages / 2)`) into one system-message

--- a/packages/codegen/__tests__/discover-agents.test.ts
+++ b/packages/codegen/__tests__/discover-agents.test.ts
@@ -542,7 +542,7 @@ describe("auto-registered agent runtime functions", () => {
 
         // Every runtime component function is auto-registered, and nothing else —
         // adding/removing/renaming a function in @lunora/agent must fail here
-        // until codegen's AGENT_RUNTIME_FUNCTION_NAMES list is updated.
+        // until the visibility literals below are updated to match.
         expect(emitted).toStrictEqual(Object.keys(runtime).toSorted((a, b) => a.localeCompare(b)));
 
         // The loop dispatches the mutations over the admin channel (internal);
@@ -555,6 +555,7 @@ describe("auto-registered agent runtime functions", () => {
         ).toStrictEqual([
             "agentAppendMessage",
             "agentCompleteRun",
+            "agentDeleteMessage",
             "agentEnsureThread",
             "agentEpisodeRecall",
             "agentEpisodeUpsert",

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -1043,9 +1043,9 @@ const renderSandboxFunctionRegistry = (usesSandbox: boolean, functions: Readonly
  * `api.agents.agentRun` exist as typed references
  * (`useSubscription(api.agents.agentMessages, { key })`,
  * `useAgentState({ api, threadKey })` over `api.agents.agentState`,
- * `useMutation(api.agents.agentResolveApproval)`). The four thread-write
- * mutations (`agentAppendMessage`/`agentEnsureThread`/`agentPatchThread`/
- * `agentSetState`) stay internal — the loop dispatches them by path over the
+ * `useMutation(api.agents.agentResolveApproval)`). The thread-write mutations
+ * (`agentAppendMessage`/`agentDeleteMessage`/`agentEnsureThread`/
+ * `agentPatchThread`/`agentSetState`) stay internal — the loop dispatches them by path over the
  * scheduler channel and nothing client- or caller-side needs a reference;
  * `agentResolveApproval` is public because a client resolves approvals with it,
  * and `agentRun` is public because an HTTP-only client (the `@lunora/mcp`


### PR DESCRIPTION
- **HITL approvals no longer strand.** The abandoned-run reclaim treated any thread untouched for 13h as free — including `awaiting_input` threads whose instance is alive and hibernating on a human approval; reclaiming re-stamped the `instanceId` and made the pending approval permanently unresolvable (`agentResolveApproval` → `FORBIDDEN` forever). `awaiting_input` threads now use a separate 14-day horizon, so a slow (overnight/weekend) approver — the normal HITL case — is safe, while a dead instance is still reclaimed eventually. The 13h parked-corpse reaper for `running` threads is unchanged.
- **Approval waits time out.** The HITL pause hibernated on `step.waitForEvent` with no timeout. It now defaults to `"3 days"`, configurable per agent via the new `AgentConfig.approvalTimeout`; an elapsed timeout resolves as a rejected decision with an "approval timed out" note, so the run records why and ends via the existing rejection path instead of hibernating forever.
- **Prototype-pollution guard in code-tool input resolution.** `resolveReferences` rebuilt model-controlled input objects into a plain `{}`, so an own `__proto__` key (which `JSON.parse` produces) replaced the accumulator's prototype, letting a prompt-injected input resolve attacker-chosen inherited properties. `__proto__`/`constructor`/`prototype` keys are now skipped, mirroring the already-hardened read side (`getPath`).
- **Inbound-channel dedup keys are hashed, not truncated.** The workflow dedup id sanitized the provider delivery id and cut it at 60 chars, so distinct deliveries differing only in stripped punctuation or past the cutoff collapsed to one key — and because duplicate-instance rejections ack 200, the second event's run silently never started. The key is now `<channel>-<fnv1a64 hex>` of the raw id: fixed length, always instance-id-safe, full entropy.
- **`compileAgentWorkflow` characterization tests.** The sole compile step codegen emits per deployed agent (and its auto-OTLP telemetry attach) had no coverage; a new suite pins the OTLP branch table, the name fallback, paths default/override, the owner-scoped `resolveAgentRun` wrapping, and instance-id/step forwarding.

## Verification

- `pnpm --filter "@lunora/agent" run test` — 370 tests, 30 files, all green (14 new).
- `pnpm --filter "@lunora/agent" run lint:types` — clean.
- `pnpm --filter "@lunora/agent" run lint:eslint` — clean (`--max-warnings=0`).
- `pnpm run api:check` — all 48 snapshots match after a fresh `build:packages` + `api:update` (interface-level snapshot; the new optional `approvalTimeout` member produces no delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for human approval requests, with a three-day default and safe maximum limit.
  * Approval requests now clean up their marker messages after a decision or timeout.
  * Improved handling of stalled approval workflows.

* **Bug Fixes**
  * Prevented duplicate workflow collisions for complex delivery identifiers.
  * Blocked potentially unsafe prototype keys during input resolution.
  * Improved recovery behavior for failed approval waits.

* **Documentation**
  * Updated generated API documentation for approval message cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->