### PR TITLE
fix(server): harden validation, presence, filters

### DIFF
--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -304,7 +304,7 @@ interface DefinePolicyInput<Context = unknown> {
 ```ts
 interface DefinePresenceOptions {
     disconnectGraceMs?: number;
-    maxMembers?: number;
+    maxSessions?: number;
     ttlMs?: number;
 }
 ```

--- a/api-snapshots/server.api.md
+++ b/api-snapshots/server.api.md
@@ -304,6 +304,7 @@ interface DefinePolicyInput<Context = unknown> {
 ```ts
 interface DefinePresenceOptions {
     disconnectGraceMs?: number;
+    maxMembers?: number;
     ttlMs?: number;
 }
 ```

--- a/packages/cli/src/commands/deploy/handler.ts
+++ b/packages/cli/src/commands/deploy/handler.ts
@@ -28,6 +28,7 @@ import { join } from "@visulima/path";
 import { Spinner } from "@visulima/spinner";
 import { Project } from "ts-morph";
 
+import { isSecretKeyName } from "../../../../../shared/secret-key";
 import { evaluateAdvisoryGate, resolveStrictAdvisories } from "../../util/advisory-gate";
 import type { ApiSpec } from "../../util/api-spec";
 import { parseApiSpec } from "../../util/api-spec";
@@ -533,9 +534,6 @@ const warnDevVariablesNotPushed = (cwd: string, logger: Logger): void => {
     );
 };
 
-/** A `.dev.vars` key whose value is a secret (vs. a plain config var like a URL). Module-scoped to avoid recompilation. */
-const SECRET_LIKE_KEY = /(?:KEY|PASSWORD|SECRET|TOKEN)$/u;
-
 /** The secret keys this project requires on the deployed worker: its packages' + any secret-typed local var. */
 const resolveRequiredSecretKeys = async (cwd: string): Promise<string[]> => {
     let packages: ReadonlyArray<string> = [];
@@ -558,7 +556,7 @@ const resolveRequiredSecretKeys = async (cwd: string): Promise<string[]> => {
             // a non-secret var (e.g. a URL) belongs in wrangler.jsonc `vars`, not secrets.
             fromLocal = parseDevVariableEntries(readFileSync(devVariablesPath, "utf8"))
                 .map((entry) => entry.key)
-                .filter((key) => SECRET_LIKE_KEY.test(key));
+                .filter((key) => isSecretKeyName(key));
         }
     } catch {
         // Unreadable .dev.vars → packages-only.

--- a/packages/cli/src/commands/doctor/handler.ts
+++ b/packages/cli/src/commands/doctor/handler.ts
@@ -5,6 +5,7 @@ import { DEV_VARS_FILE, discoverSchemaInfo, inferLunoraBindings, isPlaceholderVa
 import type { WranglerConfig } from "@lunora/config/cloudflare";
 import { collectExportGaps, findWranglerFile, readWranglerJsonc, validateWranglerConfig } from "@lunora/config/cloudflare";
 
+import { isSecretKeyName } from "../../../../../shared/secret-key";
 import type { CommandHandler } from "../../util/command";
 import { defineHandler } from "../../util/command";
 import type { Logger } from "../../util/logger";
@@ -79,9 +80,6 @@ interface RunDoctorOptions {
     executablePath?: string;
     logger: Logger;
 }
-
-/** Keys whose name looks like a secret — same heuristic the dev-vars scaffolder uses. */
-const SECRET_KEY_PATTERN = /(?:KEY|PASSWORD|SECRET|TOKEN)$/u;
 
 /** A D1 `database_id` placeholder that still needs `wrangler d1 create` run. */
 const isD1PlaceholderId = (databaseId: string): boolean => {
@@ -247,7 +245,7 @@ const checkDevVariables = (cwd: string, findings: Finding[]): void => {
     }
 
     const unfilled = parseDevVariableEntries(content)
-        .filter((entry) => SECRET_KEY_PATTERN.test(entry.key) && isPlaceholderValue(entry.value))
+        .filter((entry) => isSecretKeyName(entry.key) && isPlaceholderValue(entry.value))
         .map((entry) => entry.key);
 
     if (unfilled.length > 0) {

--- a/packages/config/__tests__/package-aware-scaffold.test.ts
+++ b/packages/config/__tests__/package-aware-scaffold.test.ts
@@ -8,7 +8,7 @@ import { PACKAGE_SECRETS_REGISTRY, secretsForPackages } from "../src/package-sec
 import { buildPackageSecretsBlock, ensureDevVariables, ensureDevVarsExample, isPlaceholderValue } from "../src/scaffold-dev-variables";
 
 /** Keys whose name implies a secret value — mirrors the scaffolder's SECRET_KEY regex. */
-const SECRET_KEY_PATTERN = /(?:KEY|PASSWORD|SECRET|TOKEN)$/u;
+const SECRET_KEY_PATTERN = /(?:^|[_-])(?:key|password|secret|token|KEY|PASSWORD|SECRET|TOKEN)$|[a-z](?:Key|Password|Secret|Token)$/u;
 
 /** Strip one layer of surrounding quotes from a raw value string. */
 const stripQuotes = (raw: string): string =>

--- a/packages/config/__tests__/package-aware-scaffold.test.ts
+++ b/packages/config/__tests__/package-aware-scaffold.test.ts
@@ -4,11 +4,9 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { isSecretKeyName } from "../../../shared/secret-key";
 import { PACKAGE_SECRETS_REGISTRY, secretsForPackages } from "../src/package-secrets-registry";
 import { buildPackageSecretsBlock, ensureDevVariables, ensureDevVarsExample, isPlaceholderValue } from "../src/scaffold-dev-variables";
-
-/** Keys whose name implies a secret value — mirrors the scaffolder's SECRET_KEY regex. */
-const SECRET_KEY_PATTERN = /(?:^|[_-])(?:key|password|secret|token|KEY|PASSWORD|SECRET|TOKEN)$|[a-z](?:Key|Password|Secret|Token)$/u;
 
 /** Strip one layer of surrounding quotes from a raw value string. */
 const stripQuotes = (raw: string): string =>
@@ -16,7 +14,7 @@ const stripQuotes = (raw: string): string =>
 
 /**
  * Parse a `.dev.vars` block and return the unquoted values of every
- * secret-keyed assignment (keys matching {@link SECRET_KEY_PATTERN}).
+ * secret-keyed assignment (keys {@link isSecretKeyName} accepts).
  * Uses a functional pipeline — no `if` branches in test scope.
  */
 const secretEntryValues = (text: string): string[] =>
@@ -31,7 +29,7 @@ const secretEntryValues = (text: string): string[] =>
         .map(({ trimmed, equalsIndex }) => {
             return { key: trimmed.slice(0, equalsIndex).trim(), rawValue: trimmed.slice(equalsIndex + 1).trim() };
         })
-        .filter(({ key }) => SECRET_KEY_PATTERN.test(key))
+        .filter(({ key }) => isSecretKeyName(key))
         .map(({ rawValue }) => stripQuotes(rawValue));
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -89,11 +87,11 @@ describe("packageSecretsRegistry", () => {
         expect.hasAssertions();
 
         // Reviewer-visible assertion: the registry can never emit a real secret
-        // value for keys that match the SECRET_KEY_PATTERN. Non-secret keys
+        // value for secret-named keys. Non-secret keys
         // (like AUTH_URL) may carry real default values (e.g. a localhost URL).
         const secretEntries = Object.values(PACKAGE_SECRETS_REGISTRY)
             .flat()
-            .filter((entry) => SECRET_KEY_PATTERN.test(entry.key));
+            .filter((entry) => isSecretKeyName(entry.key));
 
         for (const entry of secretEntries) {
             expect(isPlaceholderValue(entry.placeholderValue), `${entry.key}.placeholderValue must be a placeholder`).toBe(true);

--- a/packages/config/src/scaffold-dev-variables.ts
+++ b/packages/config/src/scaffold-dev-variables.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 import { LunoraError } from "@lunora/errors";
 
+import { isSecretKeyName } from "../../../shared/secret-key";
 import { DEV_VARS_EXAMPLE_FILE, DEV_VARS_FILE, DEV_VARS_NEWLINE, parseDevVariableEntries, parseDevVariableLine } from "./dev-variables-format";
 import type { SecretEntry } from "./package-secrets-registry";
 import { CORE_SECRETS, PACKAGE_SECRETS_REGISTRY, secretsForPackages } from "./package-secrets-registry";
@@ -31,16 +32,6 @@ const requiredSecrets = (packageNames: ReadonlyArray<string>): SecretEntry[] => 
 
 /** Bytes of entropy per generated secret — 32 bytes → 64 hex chars (matches `openssl rand -hex 32`). */
 const SECRET_BYTES = 32;
-
-/**
- * A key whose value is a secret we should generate rather than copy from the
- * example. Ends in key/password/secret/token as a real word — SCREAMING_SNAKE
- * (`API_KEY`), lower snake or bare (`api_key`, `password`), or camelCase
- * (`apiToken`) — with a boundary so `MONKEY`/`monkey` never match. Mirrors
- * `@lunora/server`'s `redactSecrets` regex (`packages/server/src/env.ts`,
- * `SECRET_KEY`); if you change this, change it there too.
- */
-const SECRET_KEY = /(?:^|[_-])(?:key|password|secret|token|KEY|PASSWORD|SECRET|TOKEN)$|[a-z](?:Key|Password|Secret|Token)$/u;
 
 /**
  * Markers that flag a value as a fill-me-in placeholder rather than a usable
@@ -128,7 +119,7 @@ const defaultRandomHex = (bytes: number): string => randomBytes(bytes).toString(
  */
 const PROVIDER_SECRET_KEYS: ReadonlySet<string> = new Set(
     [...CORE_SECRETS, ...Object.values(PACKAGE_SECRETS_REGISTRY).flat()]
-        .filter((entry) => SECRET_KEY.test(entry.key) && entry.placeholderValue.startsWith("<"))
+        .filter((entry) => isSecretKeyName(entry.key) && entry.placeholderValue.startsWith("<"))
         .map((entry) => entry.key),
 );
 
@@ -138,7 +129,7 @@ const PROVIDER_SECRET_KEYS: ReadonlySet<string> = new Set(
  * `LUNORA_ADMIN_TOKEN`, `STORAGE_SIGNING_SECRET`. False for provider-issued keys
  * ({@link PROVIDER_SECRET_KEYS}) and any non-secret key.
  */
-const isMintableSecretKey = (key: string): boolean => SECRET_KEY.test(key) && !PROVIDER_SECRET_KEYS.has(key);
+const isMintableSecretKey = (key: string): boolean => isSecretKeyName(key) && !PROVIDER_SECRET_KEYS.has(key);
 
 /**
  * The fresh secret to substitute for an example `key=value` entry, or `undefined`
@@ -653,7 +644,7 @@ const planDevSecretsFill = (input: { existingContent: string; randomHex?: (bytes
     const lines = fillSecretLines(input.existingContent, randomHex, filledKeys);
 
     // 2. Append any missing core secret (a present-but-empty one is already
-    //    handled by the fill pass — every CORE_SECRETS key matches SECRET_KEY).
+    //    handled by the fill pass — every CORE_SECRETS key is secret-named).
     const present = new Set(parseDevVariableEntries(input.existingContent).map((entry) => entry.key));
     const addedKeys: string[] = [];
     const additions: string[] = [];

--- a/packages/config/src/scaffold-dev-variables.ts
+++ b/packages/config/src/scaffold-dev-variables.ts
@@ -32,8 +32,15 @@ const requiredSecrets = (packageNames: ReadonlyArray<string>): SecretEntry[] => 
 /** Bytes of entropy per generated secret — 32 bytes → 64 hex chars (matches `openssl rand -hex 32`). */
 const SECRET_BYTES = 32;
 
-/** A key whose value is a secret we should generate rather than copy from the example. */
-const SECRET_KEY = /(?:KEY|PASSWORD|SECRET|TOKEN)$/u;
+/**
+ * A key whose value is a secret we should generate rather than copy from the
+ * example. Ends in key/password/secret/token as a real word — SCREAMING_SNAKE
+ * (`API_KEY`), lower snake or bare (`api_key`, `password`), or camelCase
+ * (`apiToken`) — with a boundary so `MONKEY`/`monkey` never match. Mirrors
+ * `@lunora/server`'s `redactSecrets` regex (`packages/server/src/env.ts`,
+ * `SECRET_KEY`); if you change this, change it there too.
+ */
+const SECRET_KEY = /(?:^|[_-])(?:key|password|secret|token|KEY|PASSWORD|SECRET|TOKEN)$|[a-z](?:Key|Password|Secret|Token)$/u;
 
 /**
  * Markers that flag a value as a fill-me-in placeholder rather than a usable

--- a/packages/server/__tests__/builder.test.ts
+++ b/packages/server/__tests__/builder.test.ts
@@ -311,12 +311,16 @@ describe("builder output", () => {
         await expect(fn.handler({}, {})).resolves.toEqual({ count: 1 });
     });
 
-    it("rejects when the handler result violates .output()", async () => {
-        expect.assertions(1);
+    it("re-tags an .output() mismatch as an internal error, not a client 400", async () => {
+        expect.assertions(2);
 
-        const fn = c.query.output(v.object({ count: v.number() })).query(() => ({ count: "nope" }) as unknown as { count: number });
+        const fn = c.query.output(v.object({ n: v.number() })).query(() => ({ n: "not-a-number" }) as unknown as { n: number });
 
-        await expect(fn.handler({}, {})).rejects.toBeInstanceOf(ValidationError);
+        // A contract violation is a server bug: the raw ValidationError (a
+        // 400 whose message embeds the offending server-side value) must not
+        // escape; `toErrorBody` redacts internal codes at the wire.
+        await expect(fn.handler({}, {})).rejects.toBeInstanceOf(LunoraError);
+        await expect(fn.handler({}, {})).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
     });
 
     it(".output() composes with .input() and middleware regardless of chain order", async () => {

--- a/packages/server/__tests__/env.test.ts
+++ b/packages/server/__tests__/env.test.ts
@@ -235,20 +235,39 @@ describe("redactSecrets", () => {
         expect(redactSecrets("DB_PASSWORD: short")).toContain("DB_PASSWORD=[redacted]");
     });
 
-    it("masks camelCase and lowercase secret-named keys", () => {
-        expect.assertions(4);
+    it("masks secret-named keys in every convention keys arrive in", () => {
+        expect.assertions(8);
 
+        // camelCase / lowercase — the spellings request bodies and thrown
+        // errors actually use.
         expect(redactSecrets("password: hunter2")).toBe("password=[redacted]");
         expect(redactSecrets("apiToken=abc123")).toBe("apiToken=[redacted]");
         expect(redactSecrets("authSecret: x")).toBe("authSecret=[redacted]");
+        // No-separator compounds: the suffix is not preceded by `_`, so a
+        // boundary-only rule silently misses these.
+        expect(redactSecrets("OPENAI_APIKEY=abc")).toBe("OPENAI_APIKEY=[redacted]");
+        expect(redactSecrets("APITOKEN=abc")).toBe("APITOKEN=[redacted]");
+        expect(redactSecrets("MYPASSWORD=abc")).toBe("MYPASSWORD=[redacted]");
+        expect(redactSecrets("AUTHSECRET=abc")).toBe("AUTHSECRET=[redacted]");
         expect(redactSecrets("TOKEN=abc")).toBe("TOKEN=[redacted]");
     });
 
-    it("does not treat words merely ending in a secret suffix as secret keys", () => {
-        expect.assertions(2);
+    it("masks Title-case and kebab separated secret keys", () => {
+        expect.assertions(1);
 
+        // `KEYED_VALUE` captures `[A-Za-z_]\w*`, so a kebab key is only ever
+        // seen from its last `-` segment (`Token` here) — which still redacts.
+        expect(redactSecrets("Api_Key=abc")).toBe("Api_Key=[redacted]");
+    });
+
+    it('does not treat ordinary words ending in "key" as secret keys', () => {
+        expect.assertions(3);
+
+        // `MONKEY` and `APIKEY` are structurally identical, so the exclusion is
+        // a word list rather than a boundary rule — see shared/secret-key.ts.
         expect(redactSecrets("MONKEY=banana")).toBe("MONKEY=banana");
         expect(redactSecrets("monkey: banana")).toBe("monkey: banana");
+        expect(redactSecrets("donkey=grey")).toBe("donkey=grey");
     });
 
     it("masks bare high-entropy >=24-char tokens", () => {

--- a/packages/server/__tests__/env.test.ts
+++ b/packages/server/__tests__/env.test.ts
@@ -260,14 +260,17 @@ describe("redactSecrets", () => {
         expect(redactSecrets("Api_Key=abc")).toBe("Api_Key=[redacted]");
     });
 
-    it('does not treat ordinary words ending in "key" as secret keys', () => {
+    it("over-redacts ordinary words ending in a secret suffix, by design", () => {
         expect.assertions(3);
 
-        // `MONKEY` and `APIKEY` are structurally identical, so the exclusion is
-        // a word list rather than a boundary rule — see shared/secret-key.ts.
-        expect(redactSecrets("MONKEY=banana")).toBe("MONKEY=banana");
-        expect(redactSecrets("monkey: banana")).toBe("monkey: banana");
-        expect(redactSecrets("donkey=grey")).toBe("donkey=grey");
+        // `MONKEY` and `APIKEY` are structurally identical — all-caps compound,
+        // suffix at the end, no separator — so no rule can mask one and not the
+        // other. Masking `MONKEY` costs a confusing log line; missing `APITOKEN`
+        // costs the credential, so redaction fails toward masking. See
+        // shared/secret-key.ts.
+        expect(redactSecrets("MONKEY=banana")).toBe("MONKEY=[redacted]");
+        expect(redactSecrets("monkey: banana")).toBe("monkey=[redacted]");
+        expect(redactSecrets("sortKey=created_at")).toBe("sortKey=[redacted]");
     });
 
     it("masks bare high-entropy >=24-char tokens", () => {

--- a/packages/server/__tests__/env.test.ts
+++ b/packages/server/__tests__/env.test.ts
@@ -247,7 +247,7 @@ describe("redactSecrets", () => {
         // boundary-only rule silently misses these.
         expect(redactSecrets("OPENAI_APIKEY=abc")).toBe("OPENAI_APIKEY=[redacted]");
         expect(redactSecrets("APITOKEN=abc")).toBe("APITOKEN=[redacted]");
-        expect(redactSecrets("MYPASSWORD=abc")).toBe("MYPASSWORD=[redacted]");
+        expect(redactSecrets("MYPASSWORD=abc")).toBe("MYPASSWORD=[redacted]"); // gitleaks:allow -- redaction test fixture, not a secret
         expect(redactSecrets("AUTHSECRET=abc")).toBe("AUTHSECRET=[redacted]");
         expect(redactSecrets("TOKEN=abc")).toBe("TOKEN=[redacted]");
     });

--- a/packages/server/__tests__/env.test.ts
+++ b/packages/server/__tests__/env.test.ts
@@ -235,6 +235,22 @@ describe("redactSecrets", () => {
         expect(redactSecrets("DB_PASSWORD: short")).toContain("DB_PASSWORD=[redacted]");
     });
 
+    it("masks camelCase and lowercase secret-named keys", () => {
+        expect.assertions(4);
+
+        expect(redactSecrets("password: hunter2")).toBe("password=[redacted]");
+        expect(redactSecrets("apiToken=abc123")).toBe("apiToken=[redacted]");
+        expect(redactSecrets("authSecret: x")).toBe("authSecret=[redacted]");
+        expect(redactSecrets("TOKEN=abc")).toBe("TOKEN=[redacted]");
+    });
+
+    it("does not treat words merely ending in a secret suffix as secret keys", () => {
+        expect.assertions(2);
+
+        expect(redactSecrets("MONKEY=banana")).toBe("MONKEY=banana");
+        expect(redactSecrets("monkey: banana")).toBe("monkey: banana");
+    });
+
     it("masks bare high-entropy >=24-char tokens", () => {
         expect.assertions(1);
 

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -200,6 +200,47 @@ describe("defineListArgs — contains is string-only", () => {
         expect(parsed.where).toEqual({ nickname: { contains: "bob" } });
     });
 
+    it("accepts contains on an enum column (a union of string literals)", () => {
+        expect.assertions(2);
+
+        // Judged by `kind` alone a union reads as non-string, which stripped
+        // `contains` and — since an emptied predicate is dropped — silently
+        // returned the UNFILTERED set for `?where[status][contains]=ope`.
+        const enumSpec = defineListArgs<{ _creationTime: number; status: "closed" | "open" }>()({
+            filter: { status: v.union(v.literal("open"), v.literal("closed")) },
+            orderBy: [],
+        });
+        const parsed = parseValidatorMap(enumSpec.args as never, { where: { status: { contains: "ope" } } }, "args");
+
+        expect(parsed.where).toEqual({ status: { contains: "ope" } });
+        expect(enumSpec.toQueryArgs({ where: { status: { contains: "ope" } } }).where).toEqual({ status: { contains: "ope" } });
+    });
+
+    it("accepts contains on a bare string literal and a nullable string union", () => {
+        expect.assertions(2);
+
+        const literalSpec = defineListArgs<{ _creationTime: number; tier: "pro" }>()({ filter: { tier: v.literal("pro") }, orderBy: [] });
+        const nullableSpec = defineListArgs<{ _creationTime: number; note: null | string }>()({
+            filter: { note: v.union(v.string(), v.null()) },
+            orderBy: [],
+        });
+
+        expect(literalSpec.toQueryArgs({ where: { tier: { contains: "pr" } } }).where).toEqual({ tier: { contains: "pr" } });
+        expect(nullableSpec.toQueryArgs({ where: { note: { contains: "hi" } } }).where).toEqual({ note: { contains: "hi" } });
+    });
+
+    it("still refuses contains on a union that is not entirely string-typed", () => {
+        expect.assertions(1);
+
+        // A mixed union would let `contains` reach non-string values.
+        const mixedSpec = defineListArgs<{ _creationTime: number; ref: number | string }>()({
+            filter: { ref: v.union(v.string(), v.number()) },
+            orderBy: [],
+        });
+
+        expect(mixedSpec.toQueryArgs({ where: { ref: { contains: "4", eq: "x" } } }).where).toEqual({ ref: { eq: "x" } });
+    });
+
     it("strips contains from a non-string column's operator object, like any undeclared key", () => {
         expect.assertions(1);
 

--- a/packages/server/__tests__/list-args.test.ts
+++ b/packages/server/__tests__/list-args.test.ts
@@ -181,6 +181,51 @@ describe("defineListArgs — no sortable columns declared", () => {
     });
 });
 
+describe("defineListArgs — contains is string-only", () => {
+    it("accepts contains on a string column", () => {
+        expect.assertions(1);
+
+        expect(parse({ where: { status: { contains: "ope" } } }).where).toEqual({ status: { contains: "ope" } });
+    });
+
+    it("accepts contains on a v.optional(v.string()) column, unwrapping the optional", () => {
+        expect.assertions(1);
+
+        const optionalSpec = defineListArgs<{ _creationTime: number; nickname?: string }>()({
+            filter: { nickname: v.optional(v.string()) },
+            orderBy: [],
+        });
+        const parsed = parseValidatorMap(optionalSpec.args as never, { where: { nickname: { contains: "bob" } } }, "args");
+
+        expect(parsed.where).toEqual({ nickname: { contains: "bob" } });
+    });
+
+    it("strips contains from a non-string column's operator object, like any undeclared key", () => {
+        expect.assertions(1);
+
+        // `score` is numeric: a substring test on it is semantically void and a
+        // non-sargable scan, so the operator object simply doesn't declare it.
+        expect(parse({ where: { score: { contains: "4", gte: 10 } } }).where).toEqual({ score: { gte: 10 } });
+    });
+
+    it("drops a contains-only predicate on a non-string column in toQueryArgs, bypassing the validator", () => {
+        expect.assertions(2);
+
+        const args = spec.toQueryArgs({ where: { score: { contains: "4" }, status: { contains: "ope" } } });
+
+        expect(args.where).toEqual({ status: { contains: "ope" } });
+        expect(args.where).not.toHaveProperty("score");
+    });
+
+    it("keeps the remaining operators when toQueryArgs drops contains on a non-string column", () => {
+        expect.assertions(1);
+
+        const args = spec.toQueryArgs({ where: { score: { contains: "4", gte: 10 } } });
+
+        expect(args.where).toEqual({ score: { gte: 10 } });
+    });
+});
+
 describe("defineListArgs — toQueryArgs hardening", () => {
     it("drops an undeclared field handed straight to toQueryArgs, bypassing the validator", () => {
         expect.assertions(2);

--- a/packages/server/__tests__/presence.test.ts
+++ b/packages/server/__tests__/presence.test.ts
@@ -211,11 +211,11 @@ describe("definePresence", () => {
         expect(present[0]?.userId).toBe("user-a");
     });
 
-    it("listPresent caps the read at maxMembers, keeping the newest heartbeats", async () => {
+    it("listPresent caps the read at maxSessions, keeping the newest heartbeats", async () => {
         expect.assertions(2);
 
         const db = createMemoryDb();
-        const presence = definePresence({ maxMembers: 3, ttlMs: 10_000 });
+        const presence = definePresence({ maxSessions: 3, ttlMs: 10_000 });
 
         // Five distinct anonymous sessions (no userId, so no dedup), each with
         // a fresher heartbeat than the last.
@@ -230,6 +230,50 @@ describe("definePresence", () => {
         expect(present).toHaveLength(3);
         // Newest-first and truncated from the oldest end: 1400, 1300, 1200.
         expect(present.map((member) => member.lastSeen)).toEqual([1400, 1300, 1200]);
+    });
+
+    it("counts maxSessions in session rows, so one user's tabs consume several", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const presence = definePresence({ maxSessions: 2, ttlMs: 10_000 });
+
+        // "multi" has two tabs (two rows) and heartbeats last, so it fills the
+        // whole cap and "solo" — equally live — falls off the bottom. This is
+        // why the option is named for sessions: sizing it by head count would
+        // drop currently-heartbeating members from "who's here".
+        vi.setSystemTime(1000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "solo"), { roomId: "room-1", sessionId: "solo-1" });
+        vi.setSystemTime(2000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "multi"), { roomId: "room-1", sessionId: "multi-1" });
+        vi.setSystemTime(3000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "multi"), { roomId: "room-1", sessionId: "multi-2" });
+
+        const present = await presence.functions.listPresent.handler(makeQueryContext(db), { roomId: "room-1" });
+
+        expect(present.map((member) => member.userId)).toEqual(["multi"]);
+
+        // Raising the cap past the session count restores the dropped member.
+        const roomy = definePresence({ maxSessions: 3, ttlMs: 10_000 });
+        const all = await roomy.functions.listPresent.handler(makeQueryContext(db), { roomId: "room-1" });
+
+        expect(all.map((member) => member.userId)).toEqual(["multi", "solo"]);
+    });
+
+    it("falls back to the default cap for a non-finite maxSessions", async () => {
+        expect.assertions(1);
+
+        const db = createMemoryDb();
+        // `Math.max(1, Math.floor(NaN))` is NaN, which would reach the reader
+        // as `LIMIT NaN` and return nothing.
+        const presence = definePresence({ maxSessions: Number.NaN, ttlMs: 10_000 });
+
+        vi.setSystemTime(1000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "user-1"), { roomId: "room-1", sessionId: "sess-1" });
+
+        const present = await presence.functions.listPresent.handler(makeQueryContext(db), { roomId: "room-1" });
+
+        expect(present.map((member) => member.userId)).toEqual(["user-1"]);
     });
 
     it("heartbeat reaps long-expired rows but never one inside the grace window", async () => {

--- a/packages/server/__tests__/presence.test.ts
+++ b/packages/server/__tests__/presence.test.ts
@@ -33,15 +33,37 @@ const createMemoryDb = (): MutationContext["db"] => {
     const makeReader = (table: string) => {
         const eqs: Eq[] = [];
         const predicates: Predicate[] = [];
+        let direction: "asc" | "desc" | undefined;
+
+        // The only ordered reads the presence handlers issue go through the
+        // `byRoomLastSeen` index with `roomId` eq-fixed, so ordering by
+        // `lastSeen` emulates the index order faithfully.
+        const sorted = (): Record<string, unknown>[] => {
+            const resolved = resolveRows(rows, table, eqs, predicates);
+
+            if (direction === undefined) {
+                return resolved;
+            }
+
+            return resolved.toSorted((a, b) =>
+                direction === "asc" ? (a["lastSeen"] as number) - (b["lastSeen"] as number) : (b["lastSeen"] as number) - (a["lastSeen"] as number),
+            );
+        };
 
         const reader = {
-            collect: async () => resolveRows(rows, table, eqs, predicates),
+            collect: async () => sorted(),
             filter(predicate: Predicate) {
                 predicates.push(predicate);
 
                 return reader;
             },
-            first: async () => resolveRows(rows, table, eqs, predicates)[0] ?? null,
+            first: async () => sorted()[0] ?? null,
+            order(requested: "asc" | "desc") {
+                direction = requested;
+
+                return reader;
+            },
+            take: async (limit: number) => sorted().slice(0, limit),
             withIndex(_name: string, range?: (q: unknown) => unknown) {
                 const builder = {
                     eq(field: string, value: unknown) {
@@ -187,6 +209,66 @@ describe("definePresence", () => {
 
         expect(present).toHaveLength(1);
         expect(present[0]?.userId).toBe("user-a");
+    });
+
+    it("listPresent caps the read at maxMembers, keeping the newest heartbeats", async () => {
+        expect.assertions(2);
+
+        const db = createMemoryDb();
+        const presence = definePresence({ maxMembers: 3, ttlMs: 10_000 });
+
+        // Five distinct anonymous sessions (no userId, so no dedup), each with
+        // a fresher heartbeat than the last.
+        for (let index = 0; index < 5; index += 1) {
+            vi.setSystemTime(1000 + index * 100);
+            // eslint-disable-next-line no-await-in-loop -- sequential heartbeats are the point
+            await presence.functions.heartbeat.handler(makeMutationContext(db), { roomId: "room-1", sessionId: `sess-${String(index)}` });
+        }
+
+        const present = await presence.functions.listPresent.handler(makeQueryContext(db), { roomId: "room-1" });
+
+        expect(present).toHaveLength(3);
+        // Newest-first and truncated from the oldest end: 1400, 1300, 1200.
+        expect(present.map((member) => member.lastSeen)).toEqual([1400, 1300, 1200]);
+    });
+
+    it("heartbeat reaps long-expired rows but never one inside the grace window", async () => {
+        expect.assertions(3);
+
+        const db = createMemoryDb();
+        const deleteSpy = vi.spyOn(db, "delete");
+        const presence = definePresence({ disconnectGraceMs: 5000, ttlMs: 10_000 });
+
+        // A row that will age far past every cutoff.
+        vi.setSystemTime(0);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "old"), { roomId: "room-1", sessionId: "ancient" });
+
+        // A gracefully-closed session: aged, but revivable within the grace window.
+        vi.setSystemTime(1000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "graced"), { roomId: "room-1", sessionId: "graced" });
+        await presence.functions.disconnect.handler(
+            makeMutationContext(db, "graced"),
+            lifecycleEvent({ context: { roomId: "room-1", sessionId: "graced" }, userId: "graced" }),
+        );
+
+        // At t=2_000 the reap cutoff is 2_000 - 10_000 - 10_000 = -18_000:
+        // neither "ancient" (lastSeen 0) nor the aged "graced" row (lastSeen
+        // -4_000) is old enough — a graced reconnect must keep working.
+        vi.setSystemTime(2000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "beater"), { roomId: "room-1", sessionId: "beater" });
+
+        expect(deleteSpy).not.toHaveBeenCalled();
+
+        // At t=50_000 the cutoff is 30_000: both aged-out rows are reclaimed by
+        // the next heartbeat, no sweep scheduled.
+        vi.setSystemTime(50_000);
+        await presence.functions.heartbeat.handler(makeMutationContext(db, "beater"), { roomId: "room-1", sessionId: "beater" });
+
+        expect(deleteSpy).toHaveBeenCalledTimes(2);
+
+        const present = await presence.functions.listPresent.handler(makeQueryContext(db), { roomId: "room-1" });
+
+        expect(present.map((member) => member.userId)).toEqual(["beater"]);
     });
 
     it("sweep hard-deletes only expired rows", async () => {
@@ -442,13 +524,14 @@ describe("presenceExtension", () => {
         expect(schema.tables).not.toHaveProperty("present");
     });
 
-    it("declares the (roomId, sessionId) and roomId indexes on the table", () => {
-        expect.assertions(2);
+    it("declares the (roomId, sessionId), roomId, and (roomId, lastSeen) indexes on the table", () => {
+        expect.assertions(3);
 
         const schema = defineSchema({ todos: defineTable({ title: v.string() }) }).extend(presenceExtension);
         const indexNames = schema.tables[PRESENCE_TABLE]?.indexes.map((index) => index.name);
 
         expect(indexNames).toContain("byRoomSession");
         expect(indexNames).toContain("byRoom");
+        expect(indexNames).toContain("byRoomLastSeen");
     });
 });

--- a/packages/server/__tests__/storage-rules.test.ts
+++ b/packages/server/__tests__/storage-rules.test.ts
@@ -122,6 +122,25 @@ describe("storageRules — read path", () => {
         expect(fake.calls).toEqual([]);
     });
 
+    it("returns getUrl's value synchronously — the one non-Promise guarded method", async () => {
+        expect.assertions(2);
+
+        const rule = defineStorageRule<TestContext>({ bucket: "avatars", on: "read", when: ({ key }) => key.startsWith("public/") });
+
+        const fake = createFakeStorage();
+        // Pin: `getUrl` is the only sync member of the guarded surface. If the
+        // wrapping loop is ever made async, the wrapped call would hand back a
+        // thenable instead of the string — this test exists to fail loudly then.
+        const handler = lunora.action.use(rulesForTest<TestContext>([rule])).action(async ({ ctx }) => {
+            const result: unknown = ctx.storage.getUrl("public/logo.png");
+
+            expect(typeof result).toBe("string");
+            expect((result as { then?: unknown }).then).toBeUndefined();
+        });
+
+        await handler.handler(makeContext(fake, "u1"), {});
+    });
+
     it("leaves an operation with no rules unrestricted (opt-in)", async () => {
         expect.assertions(1);
 

--- a/packages/server/src/apply-output.ts
+++ b/packages/server/src/apply-output.ts
@@ -1,0 +1,25 @@
+import type { Validator } from "@lunora/values";
+import { ValidationError } from "@lunora/values";
+
+import { LunoraError } from "./error";
+
+/**
+ * Parse the handler result through `.output()`. A mismatch here is a server
+ * contract bug, not a client error, so re-tag it as a 500. Every
+ * result-parsing site (RPC, REST, any future transport) must route through
+ * this helper rather than calling `output.parse` directly, so the re-tagging
+ * (and the wire-level redaction internal codes get) applies uniformly.
+ */
+const applyOutput = (output: Validator, result: unknown): unknown => {
+    try {
+        return output.parse(result);
+    } catch (error: unknown) {
+        if (error instanceof ValidationError) {
+            throw new LunoraError("INTERNAL_SERVER_ERROR", `Response did not match the declared output schema: ${error.message}`);
+        }
+
+        throw error;
+    }
+};
+
+export default applyOutput;

--- a/packages/server/src/builder/index.ts
+++ b/packages/server/src/builder/index.ts
@@ -1,5 +1,6 @@
 import type { Validator } from "@lunora/values";
 
+import applyOutput from "../apply-output";
 import { validateArgs } from "../functions";
 import { readMaskTag } from "../mask/policy-tag";
 import type { RlsTag } from "../rls/policy-tag";
@@ -73,9 +74,9 @@ const runMiddleware = (middlewares: ReadonlyArray<Middleware<unknown, unknown>>,
  * Adapt a user handler (`{ args, ctx }`) to the registered dispatch contract
  * (`(context, args)`). Args are revalidated here so a builder-produced function
  * is interchangeable with one from `query()` / `mutation()` / `action()`. When
- * `.output()` declared a validator, the handler's result is parsed through it
- * so a contract violation surfaces as a `ValidationError` at the source rather
- * than as malformed data downstream.
+ * `.output()` declared a validator, the handler's result is parsed through
+ * {@link applyOutput} so a contract violation surfaces as an internal error at
+ * the source rather than as malformed data downstream.
  */
 const makeHandler =
     <Args extends ArgsValidator, R>(
@@ -90,7 +91,7 @@ const makeHandler =
         const resolvedContext = await runMiddleware(middlewares, withMeta(context, meta));
         const result = await userHandler({ args: parsed, ctx: resolvedContext });
 
-        return (output ? output.parse(result) : result) as Awaited<R>;
+        return (output ? applyOutput(output, result) : result) as Awaited<R>;
     };
 
 /**

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -95,10 +95,16 @@ const REDACTED = "[redacted]";
  * is the app runtime and must not take a build/CLI-layer dependency on the config
  * package. If you change this, change it there too.
  *
- * Anchored at the end of the key (`…SECRET`, `…_TOKEN`) so `STRIPE_SECRET_KEY`
- * and `API_TOKEN` match while an innocuous `SECRETARY` does not.
+ * A key is secret-named when it ends in key/password/secret/token as a real
+ * WORD, in any of the conventions keys actually arrive in: SCREAMING_SNAKE
+ * (`API_KEY`, `TOKEN`), lower snake or bare (`api_key`, `password`), or
+ * camelCase (`apiToken`, `clientSecret`). Anchored at the end of the key so
+ * `SECRETARY` never matches, and requiring a `^`/`_`/`-` boundary (or a
+ * camel-hump `[a-z]Key`) so `MONKEY`/`monkey`/`donkey` (suffix mid-word) never
+ * match either. The camel boundary deliberately over-redacts `sortKey` /
+ * `idempotencyKey` — masking a non-secret beats leaking a secret.
  */
-const SECRET_KEY = /(?:KEY|PASSWORD|SECRET|TOKEN)$/u;
+const SECRET_KEY = /(?:^|[_-])(?:key|password|secret|token|KEY|PASSWORD|SECRET|TOKEN)$|[a-z](?:Key|Password|Secret|Token)$/u;
 
 /** Whether a value (already a string) looks like a credential by prefix or entropy. */
 const looksLikeSecretValue = (value: string): boolean => {

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -2,6 +2,8 @@ import { LunoraError } from "@lunora/errors";
 import type { Infer, Validator } from "@lunora/values";
 import { optionalInner } from "@lunora/values";
 
+import { isSecretKeyName } from "../../../shared/secret-key";
+
 /**
  * Typed, lazily-validated env accessor — the Lunora answer to void's
  * `defineEnv`. Validates `env` per key against a map of `v.*` validators, masks
@@ -87,25 +89,6 @@ const URL_CREDENTIAL = /\b([a-z][\w.+-]*:\/\/[\w.%+-]+):[\w.%+-]+@/gu;
 /** The fixed placeholder substituted for any redacted secret. */
 const REDACTED = "[redacted]";
 
-/**
- * Keys whose **value** is a secret. Mirrors `@lunora/config`'s `.dev.vars`
- * scaffolder regex (`packages/config/src/scaffold-dev-variables.ts`, `SECRET_KEY`)
- * so the runtime validator and the scaffolder agree on what "looks secret". Kept
- * as a small local copy rather than importing `@lunora/config` — `@lunora/server`
- * is the app runtime and must not take a build/CLI-layer dependency on the config
- * package. If you change this, change it there too.
- *
- * A key is secret-named when it ends in key/password/secret/token as a real
- * WORD, in any of the conventions keys actually arrive in: SCREAMING_SNAKE
- * (`API_KEY`, `TOKEN`), lower snake or bare (`api_key`, `password`), or
- * camelCase (`apiToken`, `clientSecret`). Anchored at the end of the key so
- * `SECRETARY` never matches, and requiring a `^`/`_`/`-` boundary (or a
- * camel-hump `[a-z]Key`) so `MONKEY`/`monkey`/`donkey` (suffix mid-word) never
- * match either. The camel boundary deliberately over-redacts `sortKey` /
- * `idempotencyKey` — masking a non-secret beats leaking a secret.
- */
-const SECRET_KEY = /(?:^|[_-])(?:key|password|secret|token|KEY|PASSWORD|SECRET|TOKEN)$|[a-z](?:Key|Password|Secret|Token)$/u;
-
 /** Whether a value (already a string) looks like a credential by prefix or entropy. */
 const looksLikeSecretValue = (value: string): boolean => {
     if (SECRET_VALUE_PREFIXES.some((prefix) => prefix.test(value))) {
@@ -161,7 +144,7 @@ const redactSecrets = (message: string): string => {
     out = out.replaceAll(KEYED_VALUE, (match: string, ...groups: unknown[]) => {
         const named = groups.at(-1) as { key?: string } | undefined;
 
-        return named?.key !== undefined && SECRET_KEY.test(named.key) ? `${named.key}=${REDACTED}` : match;
+        return named?.key !== undefined && isSecretKeyName(named.key) ? `${named.key}=${REDACTED}` : match;
     });
 
     out = out.replaceAll(HIGH_ENTROPY_TOKEN, REDACTED);
@@ -184,7 +167,7 @@ const redactSecrets = (message: string): string => {
 const redactValueForKey = (message: string, key: string, raw: unknown): string => {
     const masked = redactSecrets(message);
 
-    if (typeof raw === "string" && raw !== "" && SECRET_KEY.test(key)) {
+    if (typeof raw === "string" && raw !== "" && isSecretKeyName(key)) {
         return masked.replaceAll(raw, REDACTED);
     }
 

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -4,6 +4,7 @@ import { ValidationError } from "@lunora/values";
 import type { Context } from "hono";
 import { Hono } from "hono";
 
+import applyOutput from "./apply-output";
 import type { EmptyArgs } from "./builder/index";
 import { LunoraError } from "./error";
 import { parseValidatorMap } from "./functions";
@@ -348,22 +349,6 @@ const parseBody = async (validators: ArgsValidator, c: Context<LunoraHttpEnv>): 
     }
 
     return parseValidatorMap(validators, json as Record<string, unknown>, "body");
-};
-
-/**
- * Parse the handler result through `.output()`. A mismatch here is a server
- * contract bug, not a client error, so re-tag it as a 500.
- */
-const applyOutput = (output: Validator, result: unknown): unknown => {
-    try {
-        return output.parse(result);
-    } catch (error: unknown) {
-        if (error instanceof ValidationError) {
-            throw new LunoraError("INTERNAL_SERVER_ERROR", `Response did not match the declared output schema: ${error.message}`);
-        }
-
-        throw error;
-    }
 };
 
 /** Map a thrown error to its HTTP response, re-throwing anything unrecognised. */

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -33,7 +33,8 @@
  *
  *     Note what this does NOT promise: publishing only indexed columns bounds
  *     WHICH columns are reachable, not the cost of every predicate over them.
- *     `contains` compiles to a substring position test, and `ne` / `notIn` /
+ *     `contains` (offered on string-typed columns only) compiles to a substring
+ *     position test, and `ne` / `notIn` /
  *     `isNull: false` are likewise non-sargable — all of them scan whatever the
  *     column's index would otherwise have narrowed. `maxInValues` and `maxLimit`
  *     bound request size; they don't make a scan into a seek.
@@ -46,7 +47,7 @@
  * arguments are the same declaration.
  */
 import type { ColumnValidator, Infer, Validator } from "@lunora/values";
-import { v } from "@lunora/values";
+import { optionalInner, v } from "@lunora/values";
 
 import type { OrderBy, QueryArgs, WhereOperators } from "./data-model";
 
@@ -151,13 +152,26 @@ interface ListArgsSpec<TDocument, F, O extends string> {
     readonly toQueryArgs: (args: ListArgsValue<F, O>) => QueryArgs<TDocument>;
 }
 
+/**
+ * Validator kinds whose values are strings at the SQL layer — the only columns
+ * `contains` (a substring test) is meaningful on. On any other type the
+ * operator is semantically void AND a non-sargable scan, so it is simply not
+ * offered: the validator omits it and the sanitizer drops it.
+ */
+const STRING_KINDS = new Set(["id", "storage", "string"]);
+
+/** Whether a filter column holds string values, unwrapping a leading `v.optional(...)`. */
+const isStringColumn = (validator: Validator): boolean => STRING_KINDS.has((optionalInner(validator) ?? validator).kind);
+
 /** Build the operator object accepted alongside a bare value for one filter column. */
 const operatorsValidator = (value: Validator, maxInValues: number): Validator => {
     const bounded = (inner: Validator): Validator =>
         v.optional(v.array(inner).check((items) => items.length <= maxInValues, { message: `at most ${String(maxInValues)} values` }));
 
     return v.object({
-        contains: v.optional(v.string()),
+        // `contains` only exists on string-typed columns; `v.object` rejects it
+        // as an undeclared key everywhere else.
+        ...(isStringColumn(value) ? { contains: v.optional(v.string()) } : {}),
         eq: v.optional(value),
         gt: v.optional(value),
         gte: v.optional(value),
@@ -206,16 +220,28 @@ const OPERATOR_KEYS = new Set(["contains", "eq", "gt", "gte", "in", "isNull", "l
  * names no operator at all is left alone, so an object-valued column can still be
  * matched by equality.
  */
-const asOperators = (value: unknown, maxInValues: number): Record<string, unknown> | undefined => {
+const asOperators = (value: unknown, maxInValues: number, allowContains: boolean): Record<string, unknown> | undefined => {
     if (typeof value !== "object" || value === null || Array.isArray(value)) {
         return undefined;
     }
 
     const source = value as Record<string, unknown>;
     const operators: Record<string, unknown> = {};
+    let named = 0;
 
     for (const operator of OPERATOR_KEYS) {
         if (!Object.hasOwn(source, operator)) {
+            continue;
+        }
+
+        named += 1;
+
+        // `contains` is only offered on string columns (see `operatorsValidator`);
+        // dropping it here — while still COUNTING it as a named operator — keeps
+        // the programmatic path in step and stops `{ contains: … }` from falling
+        // through as a bare equality value the where-compiler would re-read as an
+        // operator object.
+        if (operator === "contains" && !allowContains) {
             continue;
         }
 
@@ -228,7 +254,7 @@ const asOperators = (value: unknown, maxInValues: number): Record<string, unknow
         operators[operator] = Array.isArray(operand) ? operand.slice(0, maxInValues) : operand;
     }
 
-    return Object.keys(operators).length === 0 ? undefined : operators;
+    return named === 0 ? undefined : operators;
 };
 
 /**
@@ -241,7 +267,12 @@ const asOperators = (value: unknown, maxInValues: number): Record<string, unknow
  * — including `__proto__` or `constructor` — has no path into the output at all,
  * and operator objects are reduced to recognised operators only.
  */
-const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<string>, maxInValues: number): Record<string, unknown> => {
+const sanitizeWhere = (
+    where: Record<string, unknown>,
+    filterable: ReadonlySet<string>,
+    stringFields: ReadonlySet<string>,
+    maxInValues: number,
+): Record<string, unknown> => {
     const out: Record<string, unknown> = {};
 
     for (const field of filterable) {
@@ -250,7 +281,13 @@ const sanitizeWhere = (where: Record<string, unknown>, filterable: ReadonlySet<s
         }
 
         const value = where[field];
-        const operators = asOperators(value, maxInValues);
+        const operators = asOperators(value, maxInValues, stringFields.has(field));
+
+        // A predicate reduced to nothing (e.g. `contains` alone on a non-string
+        // column) is dropped wholesale rather than passed on as `{}`.
+        if (operators !== undefined && Object.keys(operators).length === 0) {
+            continue;
+        }
 
         out[field] = operators ?? value;
     }
@@ -280,9 +317,14 @@ const defineListArgs =
         const maxOrderBy = normalizeBound(config.maxOrderBy, DEFAULT_MAX_ORDER_BY);
 
         const filterable = new Set(Object.keys(config.filter));
+        const stringFields = new Set<string>();
         const whereShape: Record<string, Validator> = {};
 
         for (const [field, validator] of Object.entries(config.filter) as [string, Validator][]) {
+            if (isStringColumn(validator)) {
+                stringFields.add(field);
+            }
+
             whereShape[field] = v.optional(v.union(validator, operatorsValidator(validator, maxInValues)));
         }
 
@@ -326,7 +368,8 @@ const defineListArgs =
 
             // Same reasoning as `orderBy` above: rebuilt from the allow-list rather
             // than trusted, because this function is reachable without the validator.
-            const where = value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable, maxInValues) as QueryArgs<TDocument>["where"]);
+            const where =
+                value.where === undefined ? undefined : (sanitizeWhere(value.where, filterable, stringFields, maxInValues) as QueryArgs<TDocument>["where"]);
 
             return {
                 ...(value.cursor === undefined ? {} : { cursor: typeof value.cursor === "number" ? String(value.cursor) : value.cursor }),

--- a/packages/server/src/list-args.ts
+++ b/packages/server/src/list-args.ts
@@ -160,8 +160,51 @@ interface ListArgsSpec<TDocument, F, O extends string> {
  */
 const STRING_KINDS = new Set(["id", "storage", "string"]);
 
-/** Whether a filter column holds string values, unwrapping a leading `v.optional(...)`. */
-const isStringColumn = (validator: Validator): boolean => STRING_KINDS.has((optionalInner(validator) ?? validator).kind);
+/**
+ * Internal view of the validator internals this reads. `v.literal` stashes its
+ * value and `v.union` its members on `_meta`; `@lunora/values` exposes an
+ * accessor for `optional`'s inner validator but not for these, and `http.ts`
+ * already reads `_meta` the same way for search-param coercion.
+ */
+interface ValidatorInternals {
+    readonly _meta?: { readonly members?: ReadonlyArray<Validator>; readonly value?: unknown };
+}
+
+/**
+ * Whether a filter column holds string values, unwrapping a leading
+ * `v.optional(...)`.
+ *
+ * An enum column — `v.union(v.literal("open"), v.literal("closed"))`, kind
+ * `"union"` — is as string-typed as `v.string()` is, and a bare
+ * `v.literal("x")` likewise. Judging those by their own `kind` alone stripped
+ * `contains` from an enum filter, and because a stripped operator leaves an
+ * empty predicate behind, the request then returned the UNFILTERED set instead
+ * of failing. A union counts when every member is itself string-typed
+ * (`v.null()` members are transparent, so a nullable string union still
+ * qualifies) — a mixed union does not, since `contains` would then reach
+ * non-string values.
+ */
+const isStringColumn = (validator: Validator): boolean => {
+    const unwrapped = optionalInner(validator) ?? validator;
+
+    if (STRING_KINDS.has(unwrapped.kind)) {
+        return true;
+    }
+
+    const meta = (unwrapped as ValidatorInternals)._meta;
+
+    if (unwrapped.kind === "literal") {
+        return typeof meta?.value === "string";
+    }
+
+    if (unwrapped.kind !== "union" || meta?.members === undefined) {
+        return false;
+    }
+
+    const { members } = meta;
+
+    return members.some((member) => isStringColumn(member)) && members.every((member) => member.kind === "null" || isStringColumn(member));
+};
 
 /** Build the operator object accepted alongside a bare value for one filter column. */
 const operatorsValidator = (value: Validator, maxInValues: number): Validator => {

--- a/packages/server/src/presence.ts
+++ b/packages/server/src/presence.ts
@@ -60,8 +60,13 @@ import type { MutationCtx as MutationContext, RegisteredLifecycleHook, Registere
 /** Default time-to-live for a presence row: a heartbeat keeps a member "present" for this long. */
 const DEFAULT_TTL_MS = 30_000;
 
-/** Default upper bound on rows `listPresent` reads per call — far above any realistic room. */
-const DEFAULT_MAX_MEMBERS = 512;
+/**
+ * Default upper bound on SESSION ROWS `listPresent` reads per call. Sized for
+ * sessions, not people: a user with three tabs open holds three rows, and the
+ * per-user dedup runs after the read, so the cap has to clear the room's
+ * expected tab count rather than its head count.
+ */
+const DEFAULT_MAX_SESSIONS = 1024;
 
 /**
  * How many of a room's oldest rows each heartbeat inspects for reaping. Small
@@ -124,12 +129,19 @@ interface DefinePresenceOptions {
     disconnectGraceMs?: number;
 
     /**
-     * Upper bound on rows `listPresent` reads per call. The read is
-     * newest-first over the `(roomId, lastSeen)` index, so the visible set is
-     * always the freshest heartbeats; a room with more rows than this has its
-     * oldest (least-live) entries truncated. Defaults to 512.
+     * Upper bound on SESSION ROWS `listPresent` reads per call — one row per
+     * `(roomId, sessionId)`, so one per open tab, NOT one per person. The read
+     * is newest-first over the `(roomId, lastSeen)` index, so the rows kept are
+     * always the freshest heartbeats and a room with more sessions than this
+     * has its stalest ones truncated.
+     *
+     * Because the multi-tab dedup collapses rows only AFTER the read, a cap
+     * below the room's live session count drops real, currently-heartbeating
+     * members off the bottom of the list. Size it against expected tabs (a
+     * 300-person room at two tabs each is 600 rows), not expected people.
+     * Defaults to 1024. A non-finite value falls back to the default.
      */
-    maxMembers?: number;
+    maxSessions?: number;
 
     /**
      * How long (ms) a heartbeat keeps a member present. `listPresent` excludes
@@ -237,7 +249,12 @@ const definePresence = (options: DefinePresenceOptions = {}): PresenceComponent 
     // A grace window longer than the TTL would never hide the row before the
     // TTL filter already does, so clamp it; negative values disable the grace.
     const disconnectGraceMs = Math.max(0, Math.min(options.disconnectGraceMs ?? 0, ttlMs));
-    const maxMembers = Math.max(1, Math.floor(options.maxMembers ?? DEFAULT_MAX_MEMBERS));
+    // `Number.isFinite` first: a `NaN` / `Infinity` option would otherwise flow
+    // through `Math.max`/`Math.floor` unchanged and reach the reader as
+    // `LIMIT NaN`.
+    const requestedSessions = options.maxSessions;
+    const maxSessions =
+        requestedSessions !== undefined && Number.isFinite(requestedSessions) ? Math.max(1, Math.floor(requestedSessions)) : DEFAULT_MAX_SESSIONS;
 
     const heartbeat = mutation
         .input({
@@ -306,14 +323,15 @@ const definePresence = (options: DefinePresenceOptions = {}): PresenceComponent 
         const cutoff = Date.now() - ttlMs;
 
         // Bounded newest-first read over the `(roomId, lastSeen)` index: cost
-        // scales with `maxMembers`, not with however many rows the room has
+        // scales with `maxSessions`, not with however many rows the room has
         // ever accumulated — this query re-runs for every subscriber on every
-        // heartbeat, so an unbounded `.collect()` here is the hot path.
+        // heartbeat, so an unbounded `.collect()` here is the hot path. The cap
+        // counts session rows; the dedup below then collapses a user's tabs.
         const rows = await context.db
             .query(PRESENCE_TABLE)
             .withIndex("byRoomLastSeen", (q) => q.eq("roomId", args.roomId))
             .order("desc")
-            .take(maxMembers);
+            .take(maxSessions);
 
         // Rows arrive newest heartbeat first, so the dedup below keeps the
         // freshest row per user and the returned list stays newest-first.

--- a/packages/server/src/presence.ts
+++ b/packages/server/src/presence.ts
@@ -18,12 +18,14 @@
  * re-sends only the changed row to subscribers, not the whole list.
  * - **TTL by read-time filter**: `listPresent` filters `lastSeen > now - ttl`,
  * so a client that stops heart-beating silently disappears from the list
- * without any reaper. The read filter only HIDES stale rows; it never deletes
- * them, so to keep the table from growing unbounded you SHOULD schedule the
- * sweep ({@link PresenceFunctions.sweep}) on a cron / `runAfter`. The heartbeat
+ * without any reaper. The read filter only HIDES stale rows; each heartbeat
+ * additionally reaps a small batch of its room's long-expired rows, so an
+ * active room's table self-cleans without any scheduling. The sweep
+ * ({@link PresenceFunctions.sweep}) remains as optional hardening for bulk
+ * cleanup of rooms that went quiet with stale rows left behind. The heartbeat
  * also bounds its `data` blob and refuses to write under another identity's
- * session, but a reaper is still required to reclaim aged-out rows. For
- * high-traffic rooms, wrap the presence functions with `@lunora/ratelimit`.
+ * session. For high-traffic rooms, wrap the presence functions with
+ * `@lunora/ratelimit`.
  *
  * # Wiring
  *
@@ -57,6 +59,17 @@ import type { MutationCtx as MutationContext, RegisteredLifecycleHook, Registere
 
 /** Default time-to-live for a presence row: a heartbeat keeps a member "present" for this long. */
 const DEFAULT_TTL_MS = 30_000;
+
+/** Default upper bound on rows `listPresent` reads per call — far above any realistic room. */
+const DEFAULT_MAX_MEMBERS = 512;
+
+/**
+ * How many of a room's oldest rows each heartbeat inspects for reaping. Small
+ * on purpose: the reap rides on the hot mutation path, so it must stay O(1) —
+ * a steady heartbeat stream still reclaims rows faster than it creates them
+ * (one insert per new session vs. up to this many deletes per beat).
+ */
+const REAP_BATCH = 8;
 
 /**
  * Cap on the serialized size (bytes) of a heartbeat `data` blob. The awareness
@@ -111,6 +124,14 @@ interface DefinePresenceOptions {
     disconnectGraceMs?: number;
 
     /**
+     * Upper bound on rows `listPresent` reads per call. The read is
+     * newest-first over the `(roomId, lastSeen)` index, so the visible set is
+     * always the freshest heartbeats; a room with more rows than this has its
+     * oldest (least-live) entries truncated. Defaults to 512.
+     */
+    maxMembers?: number;
+
+    /**
      * How long (ms) a heartbeat keeps a member present. `listPresent` excludes
      * rows whose `lastSeen` is older than `now - ttlMs`. Defaults to 30s.
      */
@@ -155,8 +176,10 @@ interface PresenceFunctions {
 
     /**
      * Internal mutation that hard-deletes every expired row for `roomId`. Stale
-     * rows already vanish from `listPresent` via the read-time TTL filter; this
-     * only reclaims storage. Schedule it (cron / `runAfter`) if you care.
+     * rows already vanish from `listPresent` via the read-time TTL filter, and
+     * active rooms self-clean via the heartbeat's opportunistic reap; this is
+     * optional hardening for bulk cleanup of rooms that went quiet with stale
+     * rows left behind (schedule it on a cron / `runAfter` if you care).
      */
     sweep: RegisteredMutation<{ roomId: ReturnType<typeof v.string> }, { deleted: number }>;
 }
@@ -184,8 +207,11 @@ const presenceExtension = defineSchemaExtension(PRESENCE_KEY, {
         })
             // Drives the heartbeat upsert lookup.
             .index("byRoomSession", ["roomId", "sessionId"])
-            // Drives the `listPresent` / `sweep` per-room scans.
-            .index("byRoom", ["roomId"]),
+            // Drives the `sweep` per-room scan.
+            .index("byRoom", ["roomId"])
+            // Drives `listPresent`'s bounded newest-first read and the
+            // heartbeat's oldest-first opportunistic reap.
+            .index("byRoomLastSeen", ["roomId", "lastSeen"]),
     },
 }) as unknown as SchemaExtension<{ [PRESENCE_BARE_TABLE]: ReturnType<typeof defineTable> }>;
 
@@ -211,6 +237,7 @@ const definePresence = (options: DefinePresenceOptions = {}): PresenceComponent 
     // A grace window longer than the TTL would never hide the row before the
     // TTL filter already does, so clamp it; negative values disable the grace.
     const disconnectGraceMs = Math.max(0, Math.min(options.disconnectGraceMs ?? 0, ttlMs));
+    const maxMembers = Math.max(1, Math.floor(options.maxMembers ?? DEFAULT_MAX_MEMBERS));
 
     const heartbeat = mutation
         .input({
@@ -256,20 +283,41 @@ const definePresence = (options: DefinePresenceOptions = {}): PresenceComponent 
             // insert+delete churn that would re-send the whole present list.
             await (existing ? context.db.patch(existing["_id"] as never, row) : context.db.insert(PRESENCE_TABLE, row));
 
+            // Self-reaping: each heartbeat reclaims a few of its room's aged-out
+            // rows so the table stays bounded without the app scheduling `sweep`.
+            // The reap cutoff sits a full max(grace, ttl) window behind the
+            // visibility cutoff (`now - ttlMs`), so a row the read-time filter
+            // could still show — or that a grace-window reconnect could revive —
+            // is never deleted.
+            const reapCutoff = lastSeen - ttlMs - Math.max(disconnectGraceMs, ttlMs);
+            const oldest = await context.db
+                .query(PRESENCE_TABLE)
+                .withIndex("byRoomLastSeen", (q) => q.eq("roomId", args.roomId))
+                .order("asc")
+                .take(REAP_BATCH);
+            const expired = oldest.filter((oldRow) => (oldRow["lastSeen"] as number) <= reapCutoff);
+
+            await Promise.all(expired.map((oldRow) => context.db.delete(oldRow["_id"] as never)));
+
             return { lastSeen };
         });
 
     const listPresent = query.input({ roomId: v.string() }).query(async ({ args, ctx: context }): Promise<PresenceMember[]> => {
         const cutoff = Date.now() - ttlMs;
 
+        // Bounded newest-first read over the `(roomId, lastSeen)` index: cost
+        // scales with `maxMembers`, not with however many rows the room has
+        // ever accumulated — this query re-runs for every subscriber on every
+        // heartbeat, so an unbounded `.collect()` here is the hot path.
         const rows = await context.db
             .query(PRESENCE_TABLE)
-            .withIndex("byRoom", (q) => q.eq("roomId", args.roomId))
-            .collect();
+            .withIndex("byRoomLastSeen", (q) => q.eq("roomId", args.roomId))
+            .order("desc")
+            .take(maxMembers);
 
-        // Newest heartbeat first, so the dedup below keeps the freshest row per
-        // user and the returned list stays newest-first.
-        const live = rows.filter((row) => (row["lastSeen"] as number) > cutoff).toSorted((a, b) => (b["lastSeen"] as number) - (a["lastSeen"] as number));
+        // Rows arrive newest heartbeat first, so the dedup below keeps the
+        // freshest row per user and the returned list stays newest-first.
+        const live = rows.filter((row) => (row["lastSeen"] as number) > cutoff);
 
         // Collapse multiple sessions of the same authenticated user — the
         // common multi-tab / multi-device case — to a single member so a "who's

--- a/packages/server/src/storage/middleware.ts
+++ b/packages/server/src/storage/middleware.ts
@@ -49,6 +49,15 @@ interface WrappableStorage {
     generateUploadUrl?: (key: string, options?: unknown) => Promise<string>;
     getMetadata?: (key: string) => Promise<unknown>;
     getSignedUrl?: (key: string, options?: unknown) => Promise<string>;
+
+    /**
+     * The one SYNCHRONOUS member of the guarded surface (every sibling returns
+     * a Promise). The wrapping loop must keep returning its value directly —
+     * making the wrapper `async` (or `await`ing the original) would silently
+     * turn `ctx.storage.getUrl` into a Promise for guarded procedures only.
+     * A test pins the sync return; if `getUrl` ever goes async upstream,
+     * delete that pin and this note in the same change.
+     */
     getUrl?: (key: string) => string;
     store?: (key: string, body: unknown, options?: unknown) => Promise<unknown>;
 }

--- a/shared/secret-key.ts
+++ b/shared/secret-key.ts
@@ -1,0 +1,59 @@
+/**
+ * Whether a KEY NAME implies its value is a secret (`API_KEY`, `apiToken`,
+ * `db_password`) rather than plain config (`PORT`, `DATABASE_URL`).
+ *
+ * One rule, four call sites that must agree or the product contradicts itself:
+ * `@lunora/server`'s `redactSecrets` (what gets masked in a log), the
+ * `.dev.vars` scaffolder in `@lunora/config` (what gets a freshly minted random
+ * value), `lunora deploy` (which secrets the deployed worker is expected to
+ * carry) and `lunora doctor` (which placeholders are reported unset). It lived
+ * as four copied regexes kept in step by a comment, and they drifted: two were
+ * updated to match camelCase keys and two were not, so `apiToken` in a
+ * `.dev.vars` was a secret to the runtime and ordinary config to the CLI.
+ *
+ * It lives in `shared/` rather than in any one package because
+ * `@lunora/server` (the app runtime) must not take a build/CLI-layer dependency
+ * on `@lunora/config`, and vice versa. Inlined by the bundler, so there is one
+ * definition and no dependency edge.
+ *
+ * # The rule
+ *
+ * The name ends in key / password / secret / token, case-insensitively, so
+ * every convention a key actually arrives in is covered: SCREAMING_SNAKE
+ * (`API_KEY`), no-separator caps (`OPENAI_APIKEY`), snake or kebab (`api_key`,
+ * `auth-token`), Title case (`Api_Key`), camelCase (`apiToken`) and bare
+ * (`password`). Anchored at the END, so `SECRETARY` is not a secret.
+ *
+ * Two deliberate consequences:
+ *
+ *   - **Over-redaction is accepted.** `sortKey` / `idempotencyKey` are treated
+ *     as secrets. Masking a non-secret costs a line of diagnostic text; missing
+ *     a secret costs the secret.
+ *   - **Ordinary English words ending in "key" are excluded** by name
+ *     ({@link ORDINARY_KEY_WORD}) — `MONKEY=banana` is not a credential. This
+ *     has to be a word list: `MONKEY` and `APIKEY` are structurally identical
+ *     (all-caps compound, suffix at the end, no separator), so no boundary rule
+ *     can separate them. Requiring a separator instead was tried and silently
+ *     un-redacted `OPENAI_APIKEY`, `APITOKEN` and `MYPASSWORD`.
+ *
+ * Adding a suffix (say `credential`) means adding it here, plus a case in each
+ * consumer's suite — never a fifth private copy.
+ */
+
+/** The four secret-implying suffixes, at the end of the name, in any casing. */
+const SECRET_SUFFIX = /(?:key|password|secret|token)$/iu;
+
+/**
+ * Ordinary words ending in "key" — the only false-positive class the suffix
+ * rule has, since nothing innocuous ends in password/secret/token.
+ */
+const ORDINARY_KEY_WORD = /(?:don|flun|hoc|joc|lac|malar|mic|mon|tur|whis)key$/iu;
+
+/**
+ * Whether the key's NAME implies a secret value.
+ * @param key the key name (env var, `.dev.vars` key, or a `key=value` capture).
+ * @returns `true` when the name ends in a secret-implying suffix.
+ */
+const isSecretKeyName = (key: string): boolean => SECRET_SUFFIX.test(key) && !ORDINARY_KEY_WORD.test(key);
+
+export { isSecretKeyName };

--- a/shared/secret-key.ts
+++ b/shared/secret-key.ts
@@ -18,23 +18,30 @@
  *
  * # The rule
  *
- * The name ends in key / password / secret / token, case-insensitively, so
- * every convention a key actually arrives in is covered: SCREAMING_SNAKE
- * (`API_KEY`), no-separator caps (`OPENAI_APIKEY`), snake or kebab (`api_key`,
- * `auth-token`), Title case (`Api_Key`), camelCase (`apiToken`) and bare
- * (`password`). Anchored at the END, so `SECRETARY` is not a secret.
+ * The name ends in key / password / secret / token, case-insensitively,
+ * **whatever precedes it**. That covers every convention a key actually
+ * arrives in — SCREAMING_SNAKE (`API_KEY`), no-separator caps
+ * (`OPENAI_APIKEY`), snake or kebab (`api_key`, `auth-token`), Title case
+ * (`Api_Key`), camelCase (`apiToken`) and bare (`password`) — and it is
+ * anchored at the END, so `SECRETARY` is not a secret.
  *
- * Two deliberate consequences:
+ * # Over-redaction is the deliberate failure direction
  *
- *   - **Over-redaction is accepted.** `sortKey` / `idempotencyKey` are treated
- *     as secrets. Masking a non-secret costs a line of diagnostic text; missing
- *     a secret costs the secret.
- *   - **Ordinary English words ending in "key" are excluded** by name
- *     ({@link ORDINARY_KEY_WORD}) — `MONKEY=banana` is not a credential. This
- *     has to be a word list: `MONKEY` and `APIKEY` are structurally identical
- *     (all-caps compound, suffix at the end, no separator), so no boundary rule
- *     can separate them. Requiring a separator instead was tried and silently
- *     un-redacted `OPENAI_APIKEY`, `APITOKEN` and `MYPASSWORD`.
+ * `MONKEY`, `sortKey` and `idempotencyKey` are treated as secrets. That is the
+ * chosen trade: masking a non-secret costs one confusing line of diagnostic
+ * text, missing `APITOKEN` costs the credential. The two are not separable by
+ * any positional rule — `MONKEY` and `APIKEY` are structurally identical
+ * (all-caps compound, suffix at the end, no separator) — and requiring a
+ * separator instead was tried and silently un-redacted `OPENAI_APIKEY`,
+ * `APITOKEN` and `MYPASSWORD`. Excluding ordinary words by name was tried too
+ * and is a trap: any such list is unbounded and instantly incomplete
+ * (`turnkey`, `hokey`, `lowkey`, `smokey` all end in "key"), so it buys the
+ * appearance of precision and none of the property.
+ *
+ * The consumer that WRITES rather than logs is safe under over-matching too:
+ * the scaffolder mints a value only where the example held a placeholder, so
+ * an over-match at worst fills a placeholder the user had to fill anyway — it
+ * never overwrites a real value.
  *
  * Adding a suffix (say `credential`) means adding it here, plus a case in each
  * consumer's suite — never a fifth private copy.
@@ -44,16 +51,10 @@
 const SECRET_SUFFIX = /(?:key|password|secret|token)$/iu;
 
 /**
- * Ordinary words ending in "key" — the only false-positive class the suffix
- * rule has, since nothing innocuous ends in password/secret/token.
- */
-const ORDINARY_KEY_WORD = /(?:don|flun|hoc|joc|lac|malar|mic|mon|tur|whis)key$/iu;
-
-/**
  * Whether the key's NAME implies a secret value.
  * @param key the key name (env var, `.dev.vars` key, or a `key=value` capture).
  * @returns `true` when the name ends in a secret-implying suffix.
  */
-const isSecretKeyName = (key: string): boolean => SECRET_SUFFIX.test(key) && !ORDINARY_KEY_WORD.test(key);
+const isSecretKeyName = (key: string): boolean => SECRET_SUFFIX.test(key);
 
 export { isSecretKeyName };


### PR DESCRIPTION
- **Output-schema mismatches are internal errors on the RPC path.** A builder procedure with `.output()` let the raw `ValidationError` (a 400 whose message embeds the offending server-side value) escape to the client. The REST path's `applyOutput` helper — which re-tags the mismatch as `INTERNAL_SERVER_ERROR`, redacted at the wire and logged server-side — now lives in `src/apply-output.ts` and both transports route through it. Args validation failures stay 400s.
- **`contains` is offered only on string-typed filter columns.** `defineListArgs` hardcoded `contains` into every column's operator object, so a published numeric/boolean/timestamp column accepted `?where[age][contains]=4` — semantically void and a non-sargable scan. The operator object now declares it only for string-typed columns, and the exported `toQueryArgs` sanitizer drops it elsewhere. String-typed includes enum columns (`v.union` of string literals) and bare `v.literal`s — judging those by `kind` alone would strip the operator and, since an emptied predicate is dropped, silently return the *unfiltered* set. **Breaking:** previously-accepted `contains` on non-string columns is stripped (consistent with the module's allow-list mechanism) and never reaches the SQL compiler.
- **One secret-key rule, in `shared/`.** Four copies of the "does this key name imply a secret" regex existed — the runtime redactor, the `.dev.vars` scaffolder, `lunora deploy` and `lunora doctor` — kept in step only by a comment, and they had drifted. They are now one zero-dep, bundler-inlined definition in `shared/secret-key.ts`: a case-insensitive suffix match, so the spellings that actually appear in request bodies and thrown errors (`password`, `apiToken`, `authSecret`) redact, as do no-separator compounds (`OPENAI_APIKEY`, `APITOKEN`) and Title-case keys. Over-redaction is the documented, deliberate failure direction — `MONKEY` and `APIKEY` are structurally identical, so masking a non-secret (one confusing log line) is chosen over missing a credential.
- **`storageRules`' one synchronous guarded method is documented and pinned.** `getUrl` is the only non-Promise member of the guarded surface; a future async refactor of the wrapping loop would silently turn `ctx.storage.getUrl` into a Promise for guarded procedures only. A comment states the invariant and a test asserts the wrapped call returns a plain string. No behaviour change.
- **`listPresent` is bounded and presence self-reaps.** The query collected every row a room ever accumulated (the TTL filter hides stale rows but never deletes them, and nothing schedules `sweep` by default). A new `(roomId, lastSeen)` index plus a `maxSessions` option makes the read newest-first with a hard cap, and each heartbeat reaps up to 8 of its room's oldest rows using a cutoff a full `max(grace, ttl)` window behind the visibility cutoff — a row the read filter could still show, or a grace-window reconnect could revive, is never deleted. The cap counts session rows (one per open tab) and the per-user dedup runs after the read, so it is named and documented for sessions and defaults to 1024; a non-finite value falls back to the default rather than reaching the reader as `LIMIT NaN`. `sweep` remains as optional bulk hardening.

## Verification

- `pnpm --filter "@lunora/server" run test` — 590 passed (24 new tests across builder, list-args, env, storage-rules, presence)
- `pnpm --filter "@lunora/config" run test` — 596 passed; `pnpm --filter "@lunora/cli" run test` — 1257 passed (both consume the shared secret-key rule)
- `lint:types` + `lint:eslint` clean for `@lunora/server`, `@lunora/config`, `@lunora/cli`; `pnpm run lint:package-json` clean
- `pnpm run build:packages && pnpm run api:check` — all 48 snapshots match (`DefinePresenceOptions.maxSessions` recorded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistent detection and redaction of secret-like environment keys across deployment, diagnostics, configuration, and server workflows.
  * Fixed filtering so `contains` is available only for supported string fields, while invalid predicates are safely excluded.
  * Improved handling of invalid server output, which now surfaces as a clear internal error.
* **Improvements**
  * Presence heartbeats now clean up stale sessions and support configurable session limits.
  * Added safer, bounded session reads for presence listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->