### PR TITLE
test(lunora): derive parity list from disk

### DIFF
--- a/packages/lunora/__tests__/re-exports.test.ts
+++ b/packages/lunora/__tests__/re-exports.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -199,8 +199,12 @@ describe("lunora umbrella package coverage", () => {
     it("every packages/* directory is either re-exported or opted out with a reason", () => {
         expect.assertions(3);
 
+        // Only directories holding a manifest are packages. A renamed or deleted
+        // package leaves its `packages/<dir>/node_modules` behind — untracked, so
+        // invisible to `git status` — and counting that as an unaccounted package
+        // would fail this test on one working copy while CI stays green.
         const dirs = readdirSync(monorepoPackagesRoot, { withFileTypes: true })
-            .filter((entry) => entry.isDirectory())
+            .filter((entry) => entry.isDirectory() && existsSync(join(monorepoPackagesRoot, entry.name, "package.json")))
             .map((entry) => entry.name);
 
         const unaccounted = dirs.filter((dir) => !UPSTREAM_PACKAGE_DIRS.includes(dir) && !PACKAGE_OPT_OUT.has(dir));

--- a/packages/lunora/__tests__/re-exports.test.ts
+++ b/packages/lunora/__tests__/re-exports.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -71,6 +71,60 @@ const ALIAS_SUFFIX = new Map<string, string>([
     [upstreamKey("@lunora/flags", "./providers/memory"), "/memory"],
 ]);
 
+/**
+ * Packages deliberately NOT re-exported by the umbrella, with the reason. Every
+ * `packages/*` directory must appear either in UPSTREAM_PACKAGE_DIRS or here —
+ * the completeness test below enforces it, so a new package cannot be silently
+ * absent from the umbrella without a recorded decision.
+ */
+const PACKAGE_OPT_OUT = new Map<string, string>([
+    ["advisor", "tooling — dev-time lints feeding the Studio, not a runtime re-export"],
+    ["agent", "add-on — installed directly when used"],
+    ["ai", "add-on — installed directly when used"],
+    ["angular", "framework adapter — installed per framework, not part of the base surface"],
+    ["astro", "framework adapter — installed per framework, not part of the base surface"],
+    ["auth", "add-on — installed directly when used"],
+    ["auth-ui", "internal, not published"],
+    ["bindings", "add-on — installed directly when used"],
+    ["browser", "add-on — installed directly when used"],
+    ["cli", "tooling — its runCli already ships through the umbrella's `lunora` bin (src/bin.ts), not as a module re-export"],
+    ["cloudflare-access", "add-on — installed directly when used"],
+    ["codegen", "tooling — dev-time, not a runtime re-export"],
+    ["config", "tooling — internal CLI+Vite config/scaffolding, not a runtime re-export"],
+    ["container", "add-on — installed directly when used"],
+    ["d1", "host/engine layer — .global() backend consumed by the runtime, never app code"],
+    ["db", "TanStack DB binding — installed alongside the framework adapter that uses it, not part of the base surface"],
+    ["dispatch", "internal, not published"],
+    ["fingerprint", "add-on — zero-dep error grouping, installed directly when used"],
+    ["hyperdrive", "add-on — installed directly when used"],
+    ["lunora", "the umbrella itself"],
+    ["mail", "add-on — installed directly when used"],
+    ["mcp", "add-on — installed directly when used"],
+    ["notify", "add-on — installed directly when used"],
+    ["nuxt", "framework adapter — installed per framework, not part of the base surface"],
+    ["payment", "optional add-on with heavy provider deps — installed directly"],
+    ["platform-cloudflare", "host/engine layer — consumed by @lunora/do, never app code"],
+    ["platform-node", "host/engine layer — experimental Node host, never app code"],
+    ["queue", "add-on — installed directly when used"],
+    ["react", "framework adapter — installed per framework, not part of the base surface"],
+    ["react-native", "framework adapter — installed per framework, not part of the base surface"],
+    ["replica", "local-first replica runtime — installed directly by apps that opt into local mirrors"],
+    ["scheduler", "add-on — installed directly when used"],
+    ["search-core", "internal, not published"],
+    ["seed", "tooling — dev-time seeding, installed directly where used"],
+    ["shard-engine", "host/engine layer — consumed by platform hosts, never app code"],
+    ["solid", "framework adapter — installed per framework, not part of the base surface"],
+    ["sql-store", "internal dialect-parameterized SQL store core — consumed by .global() backends, never app code"],
+    ["storage", "add-on — installed directly when used"],
+    ["studio", "tooling — the local admin UI, embedded by the CLI/Vite, not a runtime re-export"],
+    ["svelte", "framework adapter — installed per framework, not part of the base surface"],
+    ["testing", "tooling — test harness, installed directly by test suites"],
+    ["vite", "tooling — the Vite plugin is its own install, not a runtime re-export"],
+    ["vue", "framework adapter — installed per framework, not part of the base surface"],
+    ["workflow", "add-on — installed directly when used"],
+    ["x402", "optional add-on with heavy provider/chain deps — installed directly"],
+]);
+
 interface ReExportCase {
     umbrellaSpecifier: string;
     umbrellaSubpath: string;
@@ -139,4 +193,22 @@ describe("lunora umbrella re-exports", () => {
             expect(sorted(Object.keys(viaUmbrella))).toStrictEqual(sorted(Object.keys(direct)));
         },
     );
+});
+
+describe("lunora umbrella package coverage", () => {
+    it("every packages/* directory is either re-exported or opted out with a reason", () => {
+        expect.assertions(3);
+
+        const dirs = readdirSync(monorepoPackagesRoot, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name);
+
+        const unaccounted = dirs.filter((dir) => !UPSTREAM_PACKAGE_DIRS.includes(dir) && !PACKAGE_OPT_OUT.has(dir));
+        const stale = [...PACKAGE_OPT_OUT.keys()].filter((dir) => !dirs.includes(dir));
+        const doubled = UPSTREAM_PACKAGE_DIRS.filter((dir) => PACKAGE_OPT_OUT.has(dir));
+
+        expect(unaccounted, "add each to UPSTREAM_PACKAGE_DIRS or PACKAGE_OPT_OUT (with a reason)").toEqual([]);
+        expect(stale, "PACKAGE_OPT_OUT names dirs that no longer exist").toEqual([]);
+        expect(doubled, "a dir cannot be both re-exported and opted out").toEqual([]);
+    });
 });


### PR DESCRIPTION
Four hardening fixes across the CLI (plus the shared studio-host layer in `@lunora/config` and its Vite consumer):

- **Refuse symlinks when vendoring SDK transports.** `lunora sdk generate` copied the transport directory with a `cpSync` filter that only skipped test files; symlinks were copied verbatim, so a hostile or compromised transport source could plant a link (e.g. `config.py -> ~/.ssh/id_rsa`) inside the user's project. The copy filter now `lstat`s every entry and throws naming the offending relative path, matching the registry copy-in guard's refuse-don't-skip stance. Regression test included.
- **First test suite for `lunora sdk generate`.** The command writes into the user's project and had zero tests. Five end-to-end cases driven through the offline `--from` seam (no network): happy path (vendored files with test files filtered, stamp contents, generated surface, untyped-result count), empty-methods warning, invalid spec naming its path, unknown `--lang` naming the supported list, and the transport-first ordering (a missing transport fails before any generated file or stamp lands).
- **Line-numbered validation for every import envelope.** `lunora import` validated NDJSON envelopes with a line-numbered error only when a storage/document rewrite was configured; the plain invocation forwarded raw lines, so a corrupted file failed as a whole-batch server error with no way to find the offending line in a multi-GB file. Every envelope is now parsed through the same validation; with no rewrite the original string still passes through untouched (no re-serialisation, no double parse).
- **Cache headers on the CLI studio dev server.** The non-Vite studio host served the unhashed studio entry/stylesheet/chunks with only a `Content-Type`, so browsers heuristically cached them and served a rebuilt `@lunora/studio` stale until a hard reload — and the token-embedding SPA document was heuristically cacheable, putting the admin token in the browser's disk cache. The revalidation decision (stamp-keyed weak ETag + `If-None-Match`) and the two cache policies now live in `@lunora/config/studio-host` (`asset-cache.ts`), following the transport-guard consolidation; the Vite host routes its behaviour-identical ETag/304 block through the helper, and the CLI host now sends `no-cache` + ETag with 304s on assets and `no-store` (never an ETag) on the token-bearing document. `api-snapshots/config.api.md` updated for the new exports.

## Verification

- `pnpm --filter "@lunora/cli" run test` — 95 files, 1269 tests, all pass
- `pnpm --filter "@lunora/config" run test` — 38 files, 601 tests, all pass
- `pnpm --filter "@lunora/vite" run test` — 18 files, 197 tests, all pass (studio-plugin tests unchanged)
- `lint:types` + `lint:eslint` green for all three packages
- `pnpm run build:packages && pnpm run api:check` — all 48 snapshots match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG
