### PR TITLE
fix(workflow): reject reserved names on step.name

### DIFF
--- a/api-snapshots/workflow.api.md
+++ b/api-snapshots/workflow.api.md
@@ -88,6 +88,7 @@ interface RunFunctionOptions {
 ```ts
 interface RunStepOptions {
     config?: WorkflowStepConfigLike;
+    name?: string;
 }
 ```
 

--- a/packages/workflow/__tests__/run-context.test.ts
+++ b/packages/workflow/__tests__/run-context.test.ts
@@ -2,8 +2,9 @@ import { v } from "@lunora/values";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { defineWorkflowEvent } from "../src/define-event";
+import { defineStep } from "../src/define-step";
 import { createWorkflowRunContext } from "../src/run-context";
-import type { WorkflowEventLike, WorkflowStepLike } from "../src/types";
+import type { WorkflowEventLike, WorkflowStepContextLike, WorkflowStepLike } from "../src/types";
 
 const okResponse = (body: string): Response => new Response(body, { status: 200 });
 
@@ -69,6 +70,48 @@ describe("createWorkflowRunContext", () => {
 
         await expect(ctx.waitForEvent(orderApproved)).resolves.toStrictEqual({ approvedBy: "u1" });
         expect(waitForEvent).toHaveBeenCalledWith("event:order-approved", expect.objectContaining({ type: "order-approved" }));
+    });
+
+    it("runs one step repeatedly in a loop, as Cloudflare's (name, type, occurrence) step identity allows", async () => {
+        expect.assertions(2);
+
+        // A loop over items reusing one step name is a documented Workflows
+        // pattern: `step.count` counts the occurrences of a name within a run,
+        // and each occurrence caches independently. The context must not get in
+        // the way of it.
+        const names: string[] = [];
+        const step = {
+            do: async (name: string, callback: unknown) => {
+                names.push(name);
+
+                return (callback as (context: WorkflowStepContextLike) => Promise<unknown>)({
+                    attempt: 1,
+                    config: {},
+                    step: { count: names.filter((seen) => seen === name).length, name },
+                });
+            },
+            sleep: async () => undefined,
+            sleepUntil: async () => undefined,
+            waitForEvent: async () => {
+                return { payload: {}, type: "x" };
+            },
+        } as unknown as WorkflowStepLike;
+
+        const ctx = createWorkflowRunContext({ env: {}, event: makeEvent(), exportName: "orderPipeline", step });
+        const processItem = defineStep("processItem", {
+            args: { item: v.string() },
+            handler: async (_stepContext, { item }) => `done:${item}`,
+        });
+
+        const results: string[] = [];
+
+        for (const item of ["a", "b", "c"]) {
+            // eslint-disable-next-line no-await-in-loop -- sequential by design: this is the loop-over-items pattern under test
+            results.push(await ctx.runStep(processItem, { item }));
+        }
+
+        expect(results).toStrictEqual(["done:a", "done:b", "done:c"]);
+        expect(names).toStrictEqual(["processItem", "processItem", "processItem"]);
     });
 
     it("spawning a workflow with no matching WORKFLOW_* binding throws a helpful error", async () => {

--- a/packages/workflow/__tests__/run-step.test.ts
+++ b/packages/workflow/__tests__/run-step.test.ts
@@ -399,3 +399,39 @@ describe("createRunStep", () => {
         await expect(runStep(step, {})).rejects.toBe(portable);
     });
 });
+
+describe("durable step names", () => {
+    it("runs one StepDefinition repeatedly, and honors a per-call `name` override", async () => {
+        expect.assertions(4);
+
+        // Cloudflare keys a durable step by (name, type, occurrence) — `step.count`
+        // is "how many times step.do has been called with this name in the current
+        // run" — so a loop reusing one step name is a supported pattern and each
+        // occurrence caches independently. `name` is an opt-in override for callers
+        // who want distinct, addressable step names (e.g. for `instance.restart`).
+        const { calls, runStep } = make();
+        const greet = defineStep("greet", {
+            args: { name: v.string() },
+            handler: async (_ctx, { name }) => `hello ${name}`,
+        });
+
+        await expect(runStep(greet, { name: "ada" })).resolves.toBe("hello ada");
+        await expect(runStep(greet, { name: "bob" })).resolves.toBe("hello bob");
+        await expect(runStep(greet, { name: "cy" }, { name: "greet:2" })).resolves.toBe("hello cy");
+        expect(calls.map((call) => call.name)).toStrictEqual(["greet", "greet", "greet:2"]);
+    });
+
+    it("rejects a reserved framework name from either the override or the definition, without dispatching", async () => {
+        expect.assertions(3);
+
+        const { calls, runStep } = make();
+        const greet = defineStep("greet", { args: {}, handler: async () => "ok" });
+        // The resolved name is checked, so omitting the override does not slip past.
+        const reserved = defineStep("lunora:spawn:x", { args: {}, handler: async () => "ok" });
+
+        // `lunora:*` is the fan-out protocol's own durable-step namespace.
+        await expect(runStep(greet, {}, { name: "lunora:spawn:x" })).rejects.toThrow(/reserved/);
+        await expect(runStep(reserved, {})).rejects.toThrow(/reserved/);
+        expect(calls).toStrictEqual([]);
+    });
+});

--- a/packages/workflow/src/run-step.ts
+++ b/packages/workflow/src/run-step.ts
@@ -9,6 +9,7 @@
 import { isDeterministicDispatchFailure } from "@lunora/dispatch";
 import { parseValidatorMap } from "@lunora/values";
 
+import { RESERVED_EVENT_TYPE_PREFIX } from "./define-event";
 import type { NativeNonRetryableErrorConstructor } from "./errors";
 import { convertNonRetryableError, raiseNonRetryable } from "./errors";
 import type {
@@ -60,6 +61,19 @@ const createRunStep =
     (deps: RunStepDeps): WorkflowRunStepFunction =>
     async <A extends StepArgsValidator, Result>(step: StepDefinition<A, Result>, args: InferStepArgs<A>, options?: RunStepOptions): Promise<Result> => {
         const config = options?.config ?? step.config;
+        const stepName = options?.name ?? step.name;
+
+        // The step-name namespace is reserved alongside the event-type namespace:
+        // `lunora:*` steps belong to the fan-out protocol, and a user step that
+        // borrowed one would collide with it. Checked on the RESOLVED name, so a
+        // `defineStep("lunora:spawn:x", …)` cannot slip past by omitting `name`.
+        if (stepName.startsWith(RESERVED_EVENT_TYPE_PREFIX)) {
+            return raiseNonRetryable(
+                `@lunora/workflow: ctx.runStep step name "${stepName}" is reserved — the "${RESERVED_EVENT_TYPE_PREFIX}" prefix is used by the framework's own steps`,
+                undefined,
+                deps.nonRetryableErrorClass,
+            );
+        }
 
         // Validate once, here, and close over the result — the body and the
         // rollback (a separate durable replay) both run with the same validated
@@ -134,7 +148,7 @@ const createRunStep =
               }
             : undefined;
 
-        return config === undefined ? deps.step.do(step.name, callback, rollbackOptions) : deps.step.do(step.name, config, callback, rollbackOptions);
+        return config === undefined ? deps.step.do(stepName, callback, rollbackOptions) : deps.step.do(stepName, config, callback, rollbackOptions);
     };
 
 export { createRunStep, validateStepArgs };

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -274,6 +274,16 @@ export interface StepDefinition<A extends StepArgsValidator = StepArgsValidator,
 export interface RunStepOptions {
     /** Override the step's declared durability config for this call. */
     config?: WorkflowStepConfigLike;
+
+    /**
+     * Override the durable step name for this call. Cloudflare keys a durable
+     * step by name **and occurrence** (`step.count` counts the calls made under
+     * one name in a run), so reusing a name in a loop is fine and each
+     * occurrence caches independently — this is for giving a call its own
+     * addressable name, e.g. to target it with `instance.restart({ from })`.
+     * Must be deterministic across replays, like any step name.
+     */
+    name?: string;
 }
 
 /**


### PR DESCRIPTION
## What was wrong

`ctx.runStep` checked the reserved `lunora:` step-name prefix only on the per-call `name` override, never on the step definition's own name. Since the durable name resolves as `options?.name ?? step.name`, a `defineStep("lunora:spawn:x", …)` sailed straight through to `step.do` under a name the fan-out protocol uses for its own durable steps (`lunora:spawn:*` / `lunora:await:*`), where it can collide with `ctx.parallel`'s spawn/join bookkeeping. `ctx.waitForEvent` already guarded its equivalent; `ctx.runStep` only half did.

## What it does now

- The reserved-prefix check runs on the **resolved** step name, so it covers both the `name` override and the definition's name. Rejection is a `NonRetryableError` before any dispatch, matching `ctx.waitForEvent`'s existing behaviour.
- `RunStepOptions` gains `name?: string` — an explicit per-call durable step name. Useful on its own for giving a call an addressable identity (e.g. targeting it with `instance.restart({ from: { name, count } })`). Must be deterministic across replays, like any step name.

## A guard that was proposed here and deliberately dropped

An earlier revision of this branch also refused *duplicate* durable step names, on the premise that `step.do` memoizes by name and a second call under one name silently returns the first's result. **That premise is false, and the guard would have broken working workflows** — it is removed, and this section is here so it does not get re-proposed.

Cloudflare keys a durable step by **(name, type, occurrence)**, not name alone:

- `step.count` is documented as "how many times `step.do` has been called with this name in the current Workflow run (1-indexed)" — a counter that is meaningless if same-name calls collapsed.
- The docs describe `count` as "the 1-based index used when multiple steps share the same name and type (for example, inside a loop)" — repeated names are an explicitly supported pattern.
- `instance.restart({ from: { name, count } })` addresses a specific occurrence, which only parses under occurrence-keyed identity.
- This repo's own vendored type already said so: `types.ts` documents `step: { count, name }` as "the durable step's **identity** (name + invocation count)".

Each occurrence caches independently, so the loop below was never returning a stale result — but under the proposed guard, iteration 2 would have raised a **native** `NonRetryableError`, failing the instance immediately with no retry. Same for `Promise.all` over `runStep`, and for any loop of `waitForEvent` on one event type. Working workflows would have become permanently-dead instances.

```ts
for (const item of items) {
    await ctx.runStep(processItem, { item }); // supported; each call is its own occurrence
}
```

## Follow-up (out of scope)

`packages/advisor/src/lints/static/workflow-duplicate-step-name.ts` carries the same false premise. It is pre-existing and advisory-only (it warns rather than breaking anything), so it is untouched here — but it is currently telling users to rename legitimate loops and is worth a follow-up.

## Verification

- `pnpm --filter "@lunora/workflow" run test` — 97 passed. New coverage: one step run repeatedly under its own name **plus** a `name` override in the same body (asserting all three `step.do` calls land, two of them same-named); a reserved name rejected from *either* the override or the definition, with nothing dispatched; and a loop-over-items test through the real run context proving the repeated-name pattern works end to end.
- `pnpm --filter "@lunora/workflow" run lint:types` — clean
- `pnpm --filter "@lunora/workflow" run lint:eslint` — clean
- `pnpm run build:packages && pnpm run api:check` — all 48 snapshots match (`workflow.api.md` carries the one-line `RunStepOptions.name` addition)
- Docs cross-checked against Cloudflare's Workflows Workers API and Rules of Workflows pages for the step-identity semantics above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Durable workflow steps can now use an optional deterministic name, making them easier to address consistently.

* **Bug Fixes**
  * Prevented step names using reserved event-type prefixes from being accepted.
  * Improved consistency when executing steps with custom or declared names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->