### PR TITLE
fix(flags): key the flags memo per definition

### DIFF
--- a/api-snapshots/flags.api.md
+++ b/api-snapshots/flags.api.md
@@ -98,7 +98,7 @@ Re-exported from `@openfeature/server-sdk` — signature tracked at its source.
 ### `createFlags` (const)
 
 ```ts
-const createFlags: (options: CreateFlagsOptions) => LunoraFlags;
+const createFlags: (definition: FlagsDefinition, env: Record<string, unknown>, options: CreateFlagsOptions) => LunoraFlags;
 ```
 
 ### `defineFlags` (const)

--- a/api-snapshots/flags.api.md
+++ b/api-snapshots/flags.api.md
@@ -13,9 +13,7 @@ here is a public-API change and must be reviewed as one (SemVer applies).
 
 ```ts
 interface CreateFlagsOptions {
-    hooks?: Hook[];
-    logger?: Logger;
-    provider: () => Provider;
+    provider?: () => Provider | undefined;
     targetingKey?: (() => string | undefined) | string;
 }
 ```
@@ -98,7 +96,7 @@ Re-exported from `@openfeature/server-sdk` — signature tracked at its source.
 ### `createFlags` (const)
 
 ```ts
-const createFlags: (definition: FlagsDefinition, env: Record<string, unknown>, options: CreateFlagsOptions) => LunoraFlags;
+const createFlags: (definition: FlagsDefinition, env: Record<string, unknown>, options?: CreateFlagsOptions) => LunoraFlags;
 ```
 
 ### `defineFlags` (const)

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -3050,9 +3050,7 @@ const emitFlagsFragments = (hasFlags: boolean, flagsSpecifier: string): HelperFr
     return {
         build: `
             const flags: import("${flagsSpecifier}").LunoraFlags = createFlags(flagsConfig, env, {
-                hooks: flagsConfig.hooks,
-                logger: flagsConfig.logger,
-                provider: () => config.flags?.(env) ?? flagsConfig.provider(env),
+                provider: () => config.flags?.(env),
                 targetingKey: () => flagsConfig.identify?.({ identity: identity ?? null, userId: userId ?? null }),
             });
 `,
@@ -3171,9 +3169,7 @@ const emitFlagsOverrides = (
     const clientBuild = (targetingKey: string): string => `
             const env = (this.env ?? {}) as Record<string, unknown>;
             const flags: import("${flagsSpecifier}").LunoraFlags = createFlags(flagsConfig, env, {
-                hooks: flagsConfig.hooks,
-                logger: flagsConfig.logger,
-                provider: () => config.flags?.(env) ?? flagsConfig.provider(env),
+                provider: () => config.flags?.(env),
                 targetingKey: ${targetingKey},
             });`;
 

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -3049,7 +3049,7 @@ const emitFlagsFragments = (hasFlags: boolean, flagsSpecifier: string): HelperFr
 
     return {
         build: `
-            const flags: import("${flagsSpecifier}").LunoraFlags = createFlags({
+            const flags: import("${flagsSpecifier}").LunoraFlags = createFlags(flagsConfig, env, {
                 hooks: flagsConfig.hooks,
                 logger: flagsConfig.logger,
                 provider: () => config.flags?.(env) ?? flagsConfig.provider(env),
@@ -3170,7 +3170,7 @@ const emitFlagsOverrides = (
 
     const clientBuild = (targetingKey: string): string => `
             const env = (this.env ?? {}) as Record<string, unknown>;
-            const flags: import("${flagsSpecifier}").LunoraFlags = createFlags({
+            const flags: import("${flagsSpecifier}").LunoraFlags = createFlags(flagsConfig, env, {
                 hooks: flagsConfig.hooks,
                 logger: flagsConfig.logger,
                 provider: () => config.flags?.(env) ?? flagsConfig.provider(env),

--- a/packages/flags/__tests__/env-provider.test.ts
+++ b/packages/flags/__tests__/env-provider.test.ts
@@ -174,7 +174,7 @@ describe("envProvider", () => {
             // Codegen wraps a FlagsProviderFactory as `() => factory(env)`; mirror that.
             const factory = envProvider();
             const env = { FLAG_DARK_MODE: "true", FLAG_PAGE_SIZE: "25" };
-            const flags = createFlags(defineFlags({ provider: factory }), env, { provider: () => factory(env) });
+            const flags = createFlags(defineFlags({ provider: factory }), env);
 
             await expect(flags.boolean("dark-mode", false)).resolves.toBe(true);
             await expect(flags.number("page-size", 10)).resolves.toBe(25);

--- a/packages/flags/__tests__/env-provider.test.ts
+++ b/packages/flags/__tests__/env-provider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { defineFlags } from "../src/define-flags";
 import { createFlags, resetFlags } from "../src/flags";
 import { envProvider } from "../src/providers/env";
 
@@ -173,7 +174,7 @@ describe("envProvider", () => {
             // Codegen wraps a FlagsProviderFactory as `() => factory(env)`; mirror that.
             const factory = envProvider();
             const env = { FLAG_DARK_MODE: "true", FLAG_PAGE_SIZE: "25" };
-            const flags = createFlags({ provider: () => factory(env) });
+            const flags = createFlags(defineFlags({ provider: factory }), env, { provider: () => factory(env) });
 
             await expect(flags.boolean("dark-mode", false)).resolves.toBe(true);
             await expect(flags.number("page-size", 10)).resolves.toBe(25);

--- a/packages/flags/__tests__/flags.test.ts
+++ b/packages/flags/__tests__/flags.test.ts
@@ -402,6 +402,22 @@ describe("keyed client memo", () => {
         expect(logger.error).not.toHaveBeenCalled();
     });
 
+    it("binds once across context builds that each pass a fresh empty env", async () => {
+        expect.assertions(1);
+
+        // Generated workers build `this.env ?? {}`, so a nullish env yields a
+        // NEW object per context build. Keyed on that, every request would bind
+        // a fresh OpenFeature domain and the registry — which holds providers
+        // strongly — would grow without bound.
+        const factory = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
+        const definitionEmptyEnv = defineFlags({ provider: factory });
+
+        await createFlags(definitionEmptyEnv, {}).boolean("dark-mode", false);
+        await createFlags(definitionEmptyEnv, {}).boolean("dark-mode", false);
+
+        expect(factory).toHaveBeenCalledTimes(1);
+    });
+
     it("rebinds after resetFlags clears the cache", async () => {
         expect.assertions(1);
 

--- a/packages/flags/__tests__/flags.test.ts
+++ b/packages/flags/__tests__/flags.test.ts
@@ -47,16 +47,13 @@ const makeProvider = (values: Record<string, JsonValue>, options: { initFails?: 
 };
 
 /**
- * Stable identity keys for the client memo. The definition's own `provider` is
- * never invoked — `createFlags` binds through `options.provider`; the
- * definition object is purely the memo key (as in the generated worker, where
- * codegen passes the `lunora/flags.ts` default export).
+ * Stable identity keys for the client memo, standing in for the generated
+ * worker's `lunora/flags.ts` default export and its Worker `env`. Tests below
+ * drive values through the `options.provider` override (codegen's
+ * `config.flags` seam); the keyed-memo suite exercises the definition's own
+ * provider instead.
  */
-const definition = defineFlags({
-    provider: () => {
-        throw new Error("unreachable — options.provider is what binds");
-    },
-});
+const definition = defineFlags({ provider: () => makeProvider({}) });
 const env: Record<string, unknown> = {};
 
 describe("createFlags", () => {
@@ -328,69 +325,92 @@ describe("keyed client memo", () => {
 
         const provider = makeProvider({ "dark-mode": true });
         const factory = vi.fn<() => Provider>(() => provider);
+        const definitionA = defineFlags({ provider: factory });
 
-        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
-        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+        await createFlags(definitionA, env).boolean("dark-mode", false);
+        await createFlags(definitionA, env).boolean("dark-mode", false);
 
         expect(factory).toHaveBeenCalledTimes(1);
     });
 
-    it("gives a second definition its own bind instead of reusing the first's", async () => {
-        expect.assertions(2);
+    it("keeps each definition on its own provider — a later bind never hijacks an earlier client", async () => {
+        expect.assertions(3);
 
-        vi.spyOn(console, "warn").mockImplementation(() => {});
+        // The regression this keying exists for: under one shared OpenFeature
+        // domain, definition B's `setProviderAndWait` would replace A's provider
+        // in the global registry and A's cached client would silently start
+        // evaluating B's values.
+        const providerA = makeProvider({ "dark-mode": true });
+        const providerB = makeProvider({ "dark-mode": false });
+        const definitionA = defineFlags({ provider: () => providerA });
+        const definitionB = defineFlags({ provider: () => providerB });
 
-        const factoryA = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
-        const factoryB = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": false }));
-        const definitionB = defineFlags({
-            provider: () => {
-                throw new Error("unreachable — options.provider is what binds");
-            },
-        });
+        const flagsA = createFlags(definitionA, env);
 
-        await createFlags(definition, env, { provider: factoryA }).boolean("dark-mode", false);
-        await createFlags(definitionB, env, { provider: factoryB }).boolean("dark-mode", false);
-
-        expect(factoryA).toHaveBeenCalledTimes(1);
-        expect(factoryB).toHaveBeenCalledTimes(1);
+        await expect(flagsA.boolean("dark-mode", false)).resolves.toBe(true);
+        await expect(createFlags(definitionB, env).boolean("dark-mode", true)).resolves.toBe(false);
+        // A re-read AFTER B bound still resolves through A's provider.
+        await expect(createFlags(definitionA, env).boolean("dark-mode", false)).resolves.toBe(true);
     });
 
-    it("gives a second env its own bind under the same definition", async () => {
+    it("keeps each env on its own provider under one definition", async () => {
+        expect.assertions(2);
+
+        const definitionEnvAware = defineFlags({
+            provider: (candidate) => makeProvider({ "dark-mode": candidate.DARK === "on" }),
+        });
+
+        await expect(createFlags(definitionEnvAware, { DARK: "on" }).boolean("dark-mode", false)).resolves.toBe(true);
+        await expect(createFlags(definitionEnvAware, { DARK: "off" }).boolean("dark-mode", true)).resolves.toBe(false);
+    });
+
+    it("uses the options provider override when one is supplied (codegen's config.flags seam)", async () => {
+        expect.assertions(2);
+
+        const fromDefinition = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": false }));
+        const definitionOverridden = defineFlags({ provider: fromDefinition });
+
+        const flags = createFlags(definitionOverridden, env, { provider: () => makeProvider({ "dark-mode": true }) });
+
+        await expect(flags.boolean("dark-mode", false)).resolves.toBe(true);
+        expect(fromDefinition).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the definition's provider when the override returns undefined", async () => {
         expect.assertions(1);
 
-        const factory = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
+        const definitionFallback = defineFlags({ provider: () => makeProvider({ "dark-mode": true }) });
+        const flags = createFlags(definitionFallback, env, { provider: () => undefined });
 
-        await createFlags(definition, { A: 1 }, { provider: factory }).boolean("dark-mode", false);
-        await createFlags(definition, { B: 2 }, { provider: factory }).boolean("dark-mode", false);
-
-        expect(factory).toHaveBeenCalledTimes(2);
+        await expect(flags.boolean("dark-mode", false)).resolves.toBe(true);
     });
 
-    it("warns when a second distinct definition binds in the same isolate (registry collision)", async () => {
+    it("applies the definition's hooks and logger to the bound client", async () => {
         expect.assertions(2);
 
-        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-        const definitionB = defineFlags({
-            provider: () => {
-                throw new Error("unreachable — options.provider is what binds");
-            },
+        const before = vi.fn<() => undefined>(() => undefined);
+        const logger = { debug: vi.fn<() => undefined>(), error: vi.fn<() => undefined>(), info: vi.fn<() => undefined>(), warn: vi.fn<() => undefined>() };
+        const definitionHooked = defineFlags({
+            hooks: [{ before }],
+            logger,
+            provider: () => makeProvider({ "dark-mode": true }),
         });
 
-        await createFlags(definition, env, { provider: () => makeProvider({}) }).boolean("dark-mode", false);
-        await createFlags(definitionB, env, { provider: () => makeProvider({}) }).boolean("dark-mode", false);
+        await createFlags(definitionHooked, env).boolean("dark-mode", false);
 
-        expect(warn).toHaveBeenCalledTimes(1);
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining("second flags definition"));
+        expect(before).toHaveBeenCalledTimes(1);
+        expect(logger.error).not.toHaveBeenCalled();
     });
 
     it("rebinds after resetFlags clears the cache", async () => {
         expect.assertions(1);
 
         const factory = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
+        const definitionReset = defineFlags({ provider: factory });
 
-        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+        await createFlags(definitionReset, env).boolean("dark-mode", false);
         await resetFlags();
-        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+        await createFlags(definitionReset, env).boolean("dark-mode", false);
 
         expect(factory).toHaveBeenCalledTimes(2);
     });

--- a/packages/flags/__tests__/flags.test.ts
+++ b/packages/flags/__tests__/flags.test.ts
@@ -1,6 +1,7 @@
 import type { EvaluationContext, JsonValue, Provider, ResolutionDetails } from "@openfeature/server-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { defineFlags } from "../src/define-flags";
 import { createFlags, resetFlags } from "../src/flags";
 
 /**
@@ -45,6 +46,19 @@ const makeProvider = (values: Record<string, JsonValue>, options: { initFails?: 
     };
 };
 
+/**
+ * Stable identity keys for the client memo. The definition's own `provider` is
+ * never invoked — `createFlags` binds through `options.provider`; the
+ * definition object is purely the memo key (as in the generated worker, where
+ * codegen passes the `lunora/flags.ts` default export).
+ */
+const definition = defineFlags({
+    provider: () => {
+        throw new Error("unreachable — options.provider is what binds");
+    },
+});
+const env: Record<string, unknown> = {};
+
 describe("createFlags", () => {
     afterEach(async () => {
         await resetFlags();
@@ -60,7 +74,7 @@ describe("createFlags", () => {
             welcome: "hi",
             "dark-mode": true,
         });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await expect(flags.boolean("dark-mode", false)).resolves.toBe(true);
         await expect(flags.string("welcome", "fallback")).resolves.toBe("hi");
@@ -72,7 +86,7 @@ describe("createFlags", () => {
         expect.assertions(2);
 
         const provider = makeProvider({});
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await expect(flags.boolean("missing", false)).resolves.toBe(false);
         await expect(flags.string("missing", "default")).resolves.toBe("default");
@@ -82,7 +96,7 @@ describe("createFlags", () => {
         expect.assertions(4);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         const details = await flags.details.boolean("dark-mode", false);
 
@@ -96,7 +110,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider, targetingKey: "user-123" });
+        const flags = createFlags(definition, env, { provider: () => provider, targetingKey: "user-123" });
 
         await flags.boolean("dark-mode", false, { plan: "premium" });
 
@@ -107,7 +121,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider, targetingKey: "user-123" });
+        const flags = createFlags(definition, env, { provider: () => provider, targetingKey: "user-123" });
 
         await flags.boolean("dark-mode", false, { targetingKey: "user-999" });
 
@@ -118,7 +132,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider, targetingKey: () => "user-123" });
+        const flags = createFlags(definition, env, { provider: () => provider, targetingKey: () => "user-123" });
 
         await flags.boolean("dark-mode", false, { plan: "premium" });
 
@@ -129,7 +143,7 @@ describe("createFlags", () => {
         expect.assertions(2);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({
+        const flags = createFlags(definition, env, {
             provider: () => provider,
             targetingKey: () => {
                 throw new Error("identify blew up");
@@ -145,7 +159,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await Promise.all([flags.boolean("dark-mode", false), flags.boolean("dark-mode", false), flags.boolean("dark-mode", false)]);
 
@@ -156,7 +170,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await flags.boolean("dark-mode", false, { plan: "free" });
         await flags.boolean("dark-mode", false, { plan: "premium" });
@@ -172,7 +186,7 @@ describe("createFlags", () => {
         // semantically different contexts collapsed to one memo key and the
         // second read silently served the first's cached decision.
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await flags.boolean("dark-mode", false, { score: Number.NaN });
         await flags.boolean("dark-mode", false, { score: null });
@@ -184,7 +198,7 @@ describe("createFlags", () => {
         expect.assertions(2);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         const [first, second] = [flags.details.boolean("dark-mode", false), flags.details.boolean("dark-mode", false)];
 
@@ -199,7 +213,7 @@ describe("createFlags", () => {
         expect.assertions(2);
 
         const provider = makeProvider({ "dark-mode": true, "beta-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await Promise.all([flags.boolean("dark-mode", false), flags.boolean("beta-mode", false)]);
 
@@ -211,7 +225,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         // Logically identical contexts, nested keys in different orders. The
         // canonical stable-key encoder sorts at every depth, so both collapse to
@@ -228,7 +242,7 @@ describe("createFlags", () => {
         expect.assertions(2);
 
         const provider = makeProvider({ "dark-mode": true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         // A circular context makes the memo-key serialization throw synchronously.
         // The read must still resolve (never-throws contract) by skipping the memo.
@@ -248,7 +262,7 @@ describe("createFlags", () => {
         expect.assertions(1);
 
         const provider = makeProvider({});
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await Promise.all([flags.string("welcome", "a"), flags.string("welcome", "b")]);
 
@@ -259,7 +273,7 @@ describe("createFlags", () => {
         expect.assertions(4);
 
         const provider = makeProvider({ "dark-mode": true }, { resolveThrows: true });
-        const flags = createFlags({ provider: () => provider });
+        const flags = createFlags(definition, env, { provider: () => provider });
 
         await expect(flags.boolean("dark-mode", false)).resolves.toBe(false);
 
@@ -273,7 +287,7 @@ describe("createFlags", () => {
     it("fails closed to the default when provider construction throws", async () => {
         expect.assertions(1);
 
-        const flags = createFlags({
+        const flags = createFlags(definition, env, {
             provider: () => {
                 throw new Error("no binding");
             },
@@ -297,8 +311,87 @@ describe("createFlags", () => {
             return good;
         };
 
-        await expect(createFlags({ provider }).boolean("dark-mode", false)).resolves.toBe(false); // first bind fails → default
-        await expect(createFlags({ provider }).boolean("dark-mode", false)).resolves.toBe(true); // second request rebinds
+        await expect(createFlags(definition, env, { provider }).boolean("dark-mode", false)).resolves.toBe(false); // first bind fails → default
+        await expect(createFlags(definition, env, { provider }).boolean("dark-mode", false)).resolves.toBe(true); // second request rebinds
         expect(attempts).toBe(2);
+    });
+});
+
+describe("keyed client memo", () => {
+    afterEach(async () => {
+        await resetFlags();
+        vi.restoreAllMocks();
+    });
+
+    it("binds once per definition + env pair", async () => {
+        expect.assertions(1);
+
+        const provider = makeProvider({ "dark-mode": true });
+        const factory = vi.fn<() => Provider>(() => provider);
+
+        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+
+        expect(factory).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives a second definition its own bind instead of reusing the first's", async () => {
+        expect.assertions(2);
+
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const factoryA = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
+        const factoryB = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": false }));
+        const definitionB = defineFlags({
+            provider: () => {
+                throw new Error("unreachable — options.provider is what binds");
+            },
+        });
+
+        await createFlags(definition, env, { provider: factoryA }).boolean("dark-mode", false);
+        await createFlags(definitionB, env, { provider: factoryB }).boolean("dark-mode", false);
+
+        expect(factoryA).toHaveBeenCalledTimes(1);
+        expect(factoryB).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives a second env its own bind under the same definition", async () => {
+        expect.assertions(1);
+
+        const factory = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
+
+        await createFlags(definition, { A: 1 }, { provider: factory }).boolean("dark-mode", false);
+        await createFlags(definition, { B: 2 }, { provider: factory }).boolean("dark-mode", false);
+
+        expect(factory).toHaveBeenCalledTimes(2);
+    });
+
+    it("warns when a second distinct definition binds in the same isolate (registry collision)", async () => {
+        expect.assertions(2);
+
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const definitionB = defineFlags({
+            provider: () => {
+                throw new Error("unreachable — options.provider is what binds");
+            },
+        });
+
+        await createFlags(definition, env, { provider: () => makeProvider({}) }).boolean("dark-mode", false);
+        await createFlags(definitionB, env, { provider: () => makeProvider({}) }).boolean("dark-mode", false);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("second flags definition"));
+    });
+
+    it("rebinds after resetFlags clears the cache", async () => {
+        expect.assertions(1);
+
+        const factory = vi.fn<() => Provider>(() => makeProvider({ "dark-mode": true }));
+
+        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+        await resetFlags();
+        await createFlags(definition, env, { provider: factory }).boolean("dark-mode", false);
+
+        expect(factory).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/flags/__tests__/memory-provider.test.ts
+++ b/packages/flags/__tests__/memory-provider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { defineFlags } from "../src/define-flags";
 import { createFlags, resetFlags } from "../src/flags";
 import type { MemoryFlagValue } from "../src/providers/memory";
 import { memoryProvider } from "../src/providers/memory";
@@ -9,7 +10,7 @@ import { memoryProvider } from "../src/providers/memory";
 const flagsFor = (map: Record<string, MemoryFlagValue>) => {
     const factory = memoryProvider(map);
 
-    return createFlags({ provider: () => factory({}) });
+    return createFlags(defineFlags({ provider: factory }), {}, { provider: () => factory({}) });
 };
 
 describe("memoryProvider", () => {

--- a/packages/flags/__tests__/memory-provider.test.ts
+++ b/packages/flags/__tests__/memory-provider.test.ts
@@ -10,7 +10,7 @@ import { memoryProvider } from "../src/providers/memory";
 const flagsFor = (map: Record<string, MemoryFlagValue>) => {
     const factory = memoryProvider(map);
 
-    return createFlags(defineFlags({ provider: factory }), {}, { provider: () => factory({}) });
+    return createFlags(defineFlags({ provider: factory }), {});
 };
 
 describe("memoryProvider", () => {

--- a/packages/flags/src/flags.ts
+++ b/packages/flags/src/flags.ts
@@ -6,7 +6,7 @@ import { ErrorCode, OpenFeature } from "@openfeature/server-sdk";
 // code-point-stable, recursively-sorted cache-key encoder, so the flags memo
 // keys match the client/react/do dedup semantics.
 import { stableStringify } from "../../../shared/stable-key";
-import type { LunoraFlags } from "./types";
+import type { FlagsDefinition, LunoraFlags } from "./types";
 
 /**
  * OpenFeature domain the Lunora flags client is bound under. A dedicated domain
@@ -16,12 +16,26 @@ import type { LunoraFlags } from "./types";
 const DOMAIN = "lunora";
 
 /**
- * Per-isolate memo of the bound OpenFeature client. The provider is set +
- * initialized exactly once per DO isolate (not per request); subsequent requests
- * reuse this promise. A rejected bind (e.g. a provider whose `initialize` throws)
- * is cleared so the next request retries rather than failing forever.
+ * Per-isolate memo of bound OpenFeature clients, keyed on the
+ * {@link FlagsDefinition} identity (a module singleton — the `lunora/flags.ts`
+ * default export) then the Worker `env`, both stable for the isolate's
+ * lifetime. `WeakMap`s so a torn-down definition/env is collectable and tests
+ * using fresh objects never leak state into each other (mirrors
+ * `@lunora/notify`'s runtime cache). A rejected bind (e.g. a provider whose
+ * `initialize` throws) is deleted so the next request retries rather than
+ * failing forever.
+ *
+ * NOTE: OpenFeature's provider registry is still global under the single
+ * {@link DOMAIN} — this memo prevents a later definition/env's provider,
+ * logger, and hooks from being silently discarded, not the registry collision
+ * itself. Binding a second distinct definition in one isolate re-runs
+ * `setProviderAndWait` on the same domain (last writer wins in the registry);
+ * `lastBoundDefinition` makes that collision loud instead of silent.
  */
-let clientBinding: Promise<Client> | undefined;
+let clientCache = new WeakMap<FlagsDefinition, WeakMap<object, Promise<Client>>>();
+
+/** The definition most recently bound — exists only for the collision warning above. */
+let lastBoundDefinition: FlagsDefinition | undefined;
 
 interface BindOptions {
     hooks?: Hook[];
@@ -29,40 +43,67 @@ interface BindOptions {
     provider: () => Provider;
 }
 
-const bindClient = ({ hooks, logger, provider }: BindOptions): Promise<Client> => {
-    if (clientBinding === undefined) {
-        clientBinding = (async (): Promise<Client> => {
-            await OpenFeature.setProviderAndWait(DOMAIN, provider());
+const bindClient = (definition: FlagsDefinition, env: object, { hooks, logger, provider }: BindOptions): Promise<Client> => {
+    let byEnv = clientCache.get(definition);
 
-            const client = OpenFeature.getClient(DOMAIN);
-
-            if (logger) {
-                client.setLogger(logger);
-            }
-
-            if (hooks && hooks.length > 0) {
-                client.addHooks(...hooks);
-            }
-
-            return client;
-        })();
-
-        // Don't memoize a failed bind — let the next request re-attempt.
-        clientBinding.catch(() => {
-            clientBinding = undefined;
-        });
+    if (byEnv === undefined) {
+        byEnv = new WeakMap<object, Promise<Client>>();
+        clientCache.set(definition, byEnv);
     }
 
-    return clientBinding;
+    const existing = byEnv.get(env);
+
+    if (existing !== undefined) {
+        return existing;
+    }
+
+    if (lastBoundDefinition !== undefined && lastBoundDefinition !== definition) {
+        // eslint-disable-next-line no-console -- surfaces the registry last-writer-wins collision (see the cache docstring)
+        console.warn(
+            "@lunora/flags: binding a second flags definition in this isolate — OpenFeature's registry is global under one domain, so the last bound provider wins for every client.",
+        );
+    }
+
+    lastBoundDefinition = definition;
+
+    const scopedByEnv = byEnv;
+    const binding = (async (): Promise<Client> => {
+        await OpenFeature.setProviderAndWait(DOMAIN, provider());
+
+        const client = OpenFeature.getClient(DOMAIN);
+
+        if (logger) {
+            client.setLogger(logger);
+        }
+
+        if (hooks && hooks.length > 0) {
+            client.addHooks(...hooks);
+        }
+
+        return client;
+    })();
+
+    scopedByEnv.set(env, binding);
+
+    // Don't memoize a failed bind — let the next request re-attempt. Guarded on
+    // identity so a reset-then-rebind is never clobbered by a stale rejection.
+    binding.catch(() => {
+        if (scopedByEnv.get(env) === binding) {
+            scopedByEnv.delete(env);
+        }
+    });
+
+    return binding;
 };
 
 /**
- * Drops the per-isolate client binding and clears OpenFeature's provider
- * registry. Test-only — production code never needs to unbind (the isolate owns
- * a single, static provider for its lifetime).
+ * Drops every memoized client binding and clears OpenFeature's provider
+ * registry. Test-only — production code never needs to unbind (a definition and
+ * env live as long as their isolate).
  */
 const resetFlags = async (): Promise<void> => {
-    clientBinding = undefined;
+    clientCache = new WeakMap();
+    lastBoundDefinition = undefined;
 
     await OpenFeature.clearProviders();
 };
@@ -141,14 +182,18 @@ const resolveDetails = (
 };
 
 /**
- * Builds the `ctx.flags` facade for a single request. Evaluations resolve
- * through the OpenFeature client (the SDK applies hooks and never throws —
- * provider errors surface as the default value with an `errorCode`). The default
- * `targetingKey` is merged under any per-call context, and identical evaluations
- * within the request are memoized so repeated reads of the same flag are
- * internally consistent and hit the provider once.
+ * Builds the `ctx.flags` facade for a single request. The client bind is
+ * memoized per (`definition`, `env`) pair — both stable object identities for
+ * the isolate's lifetime — so each definition/env combination gets the
+ * provider, logger, and hooks it was configured with instead of silently
+ * reusing whichever bind happened first. Evaluations resolve through the
+ * OpenFeature client (the SDK applies hooks and never throws — provider errors
+ * surface as the default value with an `errorCode`). The default `targetingKey`
+ * is merged under any per-call context, and identical evaluations within the
+ * request are memoized so repeated reads of the same flag are internally
+ * consistent and hit the provider once.
  */
-const createFlags = (options: CreateFlagsOptions): LunoraFlags => {
+const createFlags = (definition: FlagsDefinition, env: Record<string, unknown>, options: CreateFlagsOptions): LunoraFlags => {
     const { hooks, logger, provider, targetingKey } = options;
 
     // Resolve the default targetingKey once. A user-supplied `identify` thunk
@@ -181,7 +226,7 @@ const createFlags = (options: CreateFlagsOptions): LunoraFlags => {
         };
 
         const run = (): Promise<EvaluationDetails<FlagValue>> =>
-            bindClient({ hooks, logger, provider })
+            bindClient(definition, env, { hooks, logger, provider })
                 .then((client) => resolveDetails(client, type, flagKey, defaultValue, merged))
                 .catch(failClosed);
 

--- a/packages/flags/src/flags.ts
+++ b/packages/flags/src/flags.ts
@@ -1,5 +1,5 @@
 import { LunoraError } from "@lunora/errors";
-import type { Client, EvaluationContext, EvaluationDetails, FlagValue, Hook, Logger, Provider } from "@openfeature/server-sdk";
+import type { Client, EvaluationContext, EvaluationDetails, FlagValue, Provider } from "@openfeature/server-sdk";
 import { ErrorCode, OpenFeature } from "@openfeature/server-sdk";
 
 // Repo-root inlined helper (see shared/stable-key.ts) — the canonical
@@ -9,11 +9,23 @@ import { stableStringify } from "../../../shared/stable-key";
 import type { FlagsDefinition, LunoraFlags } from "./types";
 
 /**
- * OpenFeature domain the Lunora flags client is bound under. A dedicated domain
- * keeps the flags provider isolated from any other OpenFeature usage in the same
- * isolate.
+ * OpenFeature domain the FIRST bound (definition, env) pair gets — the only
+ * case a real app hits, since a Worker isolate has one `lunora/flags.ts` and
+ * one `env`. Keeping the name stable means an external
+ * `OpenFeature.getClient("lunora")` reader still sees the app's provider.
+ * Additional pairs (a second definition, or a second env in tests) get
+ * `lunora-2`, `lunora-3`, … — see {@link bindClient}.
  */
-const DOMAIN = "lunora";
+const DEFAULT_DOMAIN = "lunora";
+
+/**
+ * One binding per (definition, env) pair: the OpenFeature domain it owns and
+ * the in-flight/settled client promise for it.
+ */
+interface Binding {
+    client?: Promise<Client>;
+    readonly domain: string;
+}
 
 /**
  * Per-isolate memo of bound OpenFeature clients, keyed on the
@@ -21,56 +33,58 @@ const DOMAIN = "lunora";
  * default export) then the Worker `env`, both stable for the isolate's
  * lifetime. `WeakMap`s so a torn-down definition/env is collectable and tests
  * using fresh objects never leak state into each other (mirrors
- * `@lunora/notify`'s runtime cache). A rejected bind (e.g. a provider whose
- * `initialize` throws) is deleted so the next request retries rather than
- * failing forever.
+ * `@lunora/notify`'s runtime cache).
  *
- * NOTE: OpenFeature's provider registry is still global under the single
- * {@link DOMAIN} — this memo prevents a later definition/env's provider,
- * logger, and hooks from being silently discarded, not the registry collision
- * itself. Binding a second distinct definition in one isolate re-runs
- * `setProviderAndWait` on the same domain (last writer wins in the registry);
- * `lastBoundDefinition` makes that collision loud instead of silent.
+ * Each pair also owns its own OpenFeature DOMAIN. That is what makes the
+ * isolation real: OpenFeature's provider registry is global per domain, so
+ * binding two definitions under one shared domain would leave the first
+ * definition's cached client silently evaluating against the second's
+ * provider. Per-pair domains mean a client always resolves through the
+ * provider, logger, and hooks it was bound with.
  */
-let clientCache = new WeakMap<FlagsDefinition, WeakMap<object, Promise<Client>>>();
+let clientCache = new WeakMap<FlagsDefinition, WeakMap<object, Binding>>();
 
-/** The definition most recently bound — exists only for the collision warning above. */
-let lastBoundDefinition: FlagsDefinition | undefined;
+/** Bindings allocated so far — numbers the suffixed domains (see {@link DEFAULT_DOMAIN}). */
+let boundCount = 0;
 
-interface BindOptions {
-    hooks?: Hook[];
-    logger?: Logger;
-    provider: () => Provider;
-}
-
-const bindClient = (definition: FlagsDefinition, env: object, { hooks, logger, provider }: BindOptions): Promise<Client> => {
+/**
+ * Bind (or reuse) the OpenFeature client for one (definition, env) pair.
+ * `provider` resolves the provider to bind — the definition's own factory,
+ * unless a caller overrode it.
+ *
+ * The domain is allocated once per pair and SURVIVES a failed bind, so a
+ * provider whose `initialize` throws retries on the same domain instead of
+ * renaming it (which would strand an external reader on a dead domain). Only
+ * the client promise is dropped on rejection, so the next request re-attempts.
+ */
+const bindClient = (definition: FlagsDefinition, env: object, provider: () => Provider): Promise<Client> => {
     let byEnv = clientCache.get(definition);
 
     if (byEnv === undefined) {
-        byEnv = new WeakMap<object, Promise<Client>>();
+        byEnv = new WeakMap<object, Binding>();
         clientCache.set(definition, byEnv);
     }
 
-    const existing = byEnv.get(env);
+    let binding = byEnv.get(env);
 
-    if (existing !== undefined) {
-        return existing;
+    if (binding === undefined) {
+        boundCount += 1;
+        binding = { domain: boundCount === 1 ? DEFAULT_DOMAIN : `${DEFAULT_DOMAIN}-${String(boundCount)}` };
+        byEnv.set(env, binding);
     }
 
-    if (lastBoundDefinition !== undefined && lastBoundDefinition !== definition) {
-        // eslint-disable-next-line no-console -- surfaces the registry last-writer-wins collision (see the cache docstring)
-        console.warn(
-            "@lunora/flags: binding a second flags definition in this isolate — OpenFeature's registry is global under one domain, so the last bound provider wins for every client.",
-        );
+    if (binding.client !== undefined) {
+        return binding.client;
     }
 
-    lastBoundDefinition = definition;
+    const entry = binding;
+    const { domain } = entry;
+    const { hooks, logger } = definition;
 
-    const scopedByEnv = byEnv;
-    const binding = (async (): Promise<Client> => {
-        await OpenFeature.setProviderAndWait(DOMAIN, provider());
+    const pending = (async (): Promise<Client> => {
+        await OpenFeature.setProviderAndWait(domain, provider());
 
-        const client = OpenFeature.getClient(DOMAIN);
+        const client = OpenFeature.getClient(domain);
 
         if (logger) {
             client.setLogger(logger);
@@ -83,17 +97,17 @@ const bindClient = (definition: FlagsDefinition, env: object, { hooks, logger, p
         return client;
     })();
 
-    scopedByEnv.set(env, binding);
+    entry.client = pending;
 
     // Don't memoize a failed bind — let the next request re-attempt. Guarded on
     // identity so a reset-then-rebind is never clobbered by a stale rejection.
-    binding.catch(() => {
-        if (scopedByEnv.get(env) === binding) {
-            scopedByEnv.delete(env);
+    pending.catch(() => {
+        if (entry.client === pending) {
+            entry.client = undefined;
         }
     });
 
-    return binding;
+    return pending;
 };
 
 /**
@@ -103,19 +117,23 @@ const bindClient = (definition: FlagsDefinition, env: object, { hooks, logger, p
  */
 const resetFlags = async (): Promise<void> => {
     clientCache = new WeakMap();
-    lastBoundDefinition = undefined;
+    boundCount = 0;
 
     await OpenFeature.clearProviders();
 };
 
-/** Options for `createFlags`. Built by codegen from `defineFlags(...)`. */
+/**
+ * Per-request extras for `createFlags`. Everything static — the provider
+ * factory, `hooks`, `logger` — is read from the {@link FlagsDefinition} itself,
+ * so this carries only what the definition cannot know: the test/config
+ * provider override and the request's targeting key.
+ */
 interface CreateFlagsOptions {
-    /** OpenFeature hooks applied when the provider is bound. */
-    hooks?: Hook[];
-    /** Logger for the OpenFeature client. */
-    logger?: Logger;
-    /** Lazily constructs the OpenFeature provider from `env` (invoked once per isolate). */
-    provider: () => Provider;
+    /**
+     * Overrides the definition's provider (codegen's `config.flags` test seam).
+     * Returning `undefined` falls back to `definition.provider(env)`.
+     */
+    provider?: () => Provider | undefined;
 
     /**
      * Default `targetingKey` for every evaluation (from `defineFlags({ identify })`).
@@ -182,19 +200,21 @@ const resolveDetails = (
 };
 
 /**
- * Builds the `ctx.flags` facade for a single request. The client bind is
- * memoized per (`definition`, `env`) pair — both stable object identities for
- * the isolate's lifetime — so each definition/env combination gets the
- * provider, logger, and hooks it was configured with instead of silently
- * reusing whichever bind happened first. Evaluations resolve through the
+ * Builds the `ctx.flags` facade for a single request. The provider, `hooks`,
+ * and `logger` come from `definition`; the client bind is memoized per
+ * (`definition`, `env`) pair — both stable object identities for the isolate's
+ * lifetime — and each pair owns its own OpenFeature domain, so a pair always
+ * evaluates against the provider it was configured with instead of whichever
+ * bind happened first. Evaluations resolve through the
  * OpenFeature client (the SDK applies hooks and never throws — provider errors
  * surface as the default value with an `errorCode`). The default `targetingKey`
  * is merged under any per-call context, and identical evaluations within the
  * request are memoized so repeated reads of the same flag are internally
  * consistent and hit the provider once.
  */
-const createFlags = (definition: FlagsDefinition, env: Record<string, unknown>, options: CreateFlagsOptions): LunoraFlags => {
-    const { hooks, logger, provider, targetingKey } = options;
+const createFlags = (definition: FlagsDefinition, env: Record<string, unknown>, options: CreateFlagsOptions = {}): LunoraFlags => {
+    const { provider: providerOverride, targetingKey } = options;
+    const provider = (): Provider => providerOverride?.() ?? definition.provider(env);
 
     // Resolve the default targetingKey once. A user-supplied `identify` thunk
     // that throws must not propagate — fail open to no targetingKey so a buggy
@@ -226,7 +246,7 @@ const createFlags = (definition: FlagsDefinition, env: Record<string, unknown>, 
         };
 
         const run = (): Promise<EvaluationDetails<FlagValue>> =>
-            bindClient(definition, env, { hooks, logger, provider })
+            bindClient(definition, env, provider)
                 .then((client) => resolveDetails(client, type, flagKey, defaultValue, merged))
                 .catch(failClosed);
 

--- a/packages/flags/src/flags.ts
+++ b/packages/flags/src/flags.ts
@@ -15,6 +15,14 @@ import type { FlagsDefinition, LunoraFlags } from "./types";
  * `OpenFeature.getClient("lunora")` reader still sees the app's provider.
  * Additional pairs (a second definition, or a second env in tests) get
  * `lunora-2`, `lunora-3`, … — see {@link bindClient}.
+ *
+ * Which pair wins the unsuffixed name is therefore ALLOCATION-ORDER dependent:
+ * if a test seam or a second env binds first, the app's own definition lands on
+ * `lunora-2` and an external reader of `"lunora"` reads the wrong provider.
+ * Nothing in this repo reads the domain by name, and "first *definition* wins"
+ * would be just as order-dependent, so the order-dependence is documented
+ * rather than papered over. Code that must address a specific client should be
+ * handed the client, not look it up by domain.
  */
 const DEFAULT_DOMAIN = "lunora";
 
@@ -48,6 +56,21 @@ let clientCache = new WeakMap<FlagsDefinition, WeakMap<object, Binding>>();
 let boundCount = 0;
 
 /**
+ * Stand-in identity for an `env` carrying no bindings.
+ *
+ * Generated workers build their env as `this.env ?? {}`, so a nullish `env`
+ * yields a FRESH object on every context build. Keyed on that, each request
+ * would miss the cache and bind a new `lunora-N` domain — and OpenFeature's
+ * registry holds a STRONG reference to every provider it is given, so the
+ * WeakMap being weak would not release them. Two envs with no bindings are
+ * indistinguishable to any provider factory anyway, so they share one key.
+ */
+const EMPTY_ENV: Record<string, never> = {};
+
+/** The identity an env is memoized under (see {@link EMPTY_ENV}). */
+const envKeyFor = (env: object): object => (Object.keys(env).length === 0 ? EMPTY_ENV : env);
+
+/**
  * Bind (or reuse) the OpenFeature client for one (definition, env) pair.
  * `provider` resolves the provider to bind — the definition's own factory,
  * unless a caller overrode it.
@@ -57,7 +80,9 @@ let boundCount = 0;
  * renaming it (which would strand an external reader on a dead domain). Only
  * the client promise is dropped on rejection, so the next request re-attempts.
  */
-const bindClient = (definition: FlagsDefinition, env: object, provider: () => Provider): Promise<Client> => {
+const bindClient = (definition: FlagsDefinition, rawEnv: object, provider: () => Provider): Promise<Client> => {
+    const env = envKeyFor(rawEnv);
+
     let byEnv = clientCache.get(definition);
 
     if (byEnv === undefined) {


### PR DESCRIPTION
## What was wrong

`createFlags` memoized its bound OpenFeature client in a bare module-level scalar, so the **first** call's `provider()`, `logger`, and `hooks` won forever — every later call with a different definition or a different Worker `env` silently reused them. In binding mode the provider factory resolves `env[bindingName]` inside the factory, so the memo permanently captured whichever request's `env` won the race. Test suites that forgot `resetFlags()` leaked a provider into the next file for the same reason: the memo was keyed on nothing.

Keying the memo alone would not have fixed it. Every binding went into the single global `"lunora"` OpenFeature domain, so a second definition's `setProviderAndWait` replaced the first's provider in the registry and the first's cached client silently began evaluating the second's values — a keyed cache would have *hidden* that collision instead of preventing it.

## What it does now

`createFlags(definition, env, options?)` takes the stable identities — the `defineFlags(...)` module singleton and the Worker `env` object — and binds through a `WeakMap<definition, WeakMap<env, Binding>>` cache. **Each (definition, env) pair owns its own OpenFeature domain**, which is what makes the isolation real: a pair always evaluates through the provider, logger, and hooks it was bound with.

- The first pair — the only case a real app hits, since an isolate has one `lunora/flags.ts` and one `env` — keeps the stable `"lunora"` domain, so an external `OpenFeature.getClient("lunora")` reader still sees the app's provider. Additional pairs get `"lunora-2"`, `"lunora-3"`, … (nothing in-repo, in docs, or in examples reads the domain literal; `getClient` appears only inside `flags.ts` itself).
- The domain is allocated once per pair and **survives a failed bind**, so a provider whose `initialize` throws retries on the same domain rather than renaming it and stranding readers on a dead domain. Only the client promise is dropped on rejection, identity-guarded so a reset-then-rebind is never clobbered by a stale rejection.
- `resetFlags()` reassigns the cache and resets the domain counter.
- An `env` carrying no bindings memoizes under a shared `EMPTY_ENV` key. Generated workers build `this.env ?? {}`, so a nullish env hands a fresh object to every context build; keyed on that, each request would miss the cache and bind another `lunora-N` domain — and OpenFeature's registry holds providers strongly, so a weak cache would not release them.
- Which pair wins the unsuffixed `"lunora"` name is allocation-order dependent. That is documented on `DEFAULT_DOMAIN` rather than papered over: "first *definition* wins" would be equally order-dependent, and code needing a specific client should be handed it rather than looking it up by domain.

`createFlags` also stopped taking config it was already handed: `hooks`, `logger`, and the provider factory are read from the definition. `CreateFlagsOptions` shrank to the genuinely per-request extras — the `config.flags` provider override (returning `undefined` falls back to `definition.provider(env)`) and the targeting-key thunk. Both codegen emission sites emit the smaller call.

**BREAKING CHANGE**: `createFlags(options)` → `createFlags(definition, env, options?)`; `CreateFlagsOptions` no longer accepts `hooks`/`logger`, and `provider` is an optional override returning `Provider | undefined`. All in-repo callers (codegen emission + tests) are updated here; there are no other production callers.

## Verification

- `pnpm --filter "@lunora/flags" run test` — 72 passed, including a regression test that pins the collision directly: definition A reads `true`, definition B binds and reads `false`, then A re-reads and still gets `true`. Temporarily collapsing the per-pair domains back to one shared `"lunora"` makes exactly that test fail, and nothing else.
- Also covered: one bind per pair, per-env provider isolation, the override path and its `undefined` fallback, definition hooks/logger applied to the bound client, rebind after `resetFlags()`, and a single bind across repeated context builds that each pass a fresh empty env (dropping the `EMPTY_ENV` key makes exactly that test fail).
- `pnpm --filter "@lunora/codegen" run test` — 1290 passed (100 files)
- Golden fixture regen (`capture-expected.ts`) — zero diff (the fixture app declares no flags)
- `lint:types` + `lint:eslint` — exit 0 for both `@lunora/flags` and `@lunora/codegen`
- `pnpm run build:packages` then `pnpm run api:check` — green after `api:update`; the snapshot diff is confined to the `createFlags` signature and `CreateFlagsOptions` in `api-snapshots/flags.api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature-flag clients now support definition- and environment-specific configurations.
  * Optional provider overrides are available when creating feature-flag clients.
  * Separate flag evaluation contexts improve isolation across environments.

* **Bug Fixes**
  * Failed feature-flag bindings can now be retried correctly.
  * Empty environments are handled consistently during client binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->