### PR TITLE
feat(svelte): accept reactive query args

### DIFF
--- a/api-snapshots/svelte.api.md
+++ b/api-snapshots/svelte.api.md
@@ -486,6 +486,18 @@ interface RateLimitOptions {
 }
 ```
 
+### `ReactiveArgs` (type)
+
+```ts
+type ReactiveArgs<F extends FunctionReference> = ArgsOf<F> | "skip" | Readable<ArgsOf<F> | "skip">;
+```
+
+### `ReactivePaginatedArgs` (type)
+
+```ts
+type ReactivePaginatedArgs<F extends FunctionReference> = "skip" | PaginatedArgs<F> | Readable<"skip" | PaginatedArgs<F>>;
+```
+
 ### `ReturnOf` (type)
 
 Re-exported from `@lunora/client` — signature tracked at its source.
@@ -700,9 +712,9 @@ const mutator: <TArgs = Record<string, unknown>>(handle: MutatorHandle<TArgs>) =
 ### `paginatedQuery` (function)
 
 ```ts
-function paginatedQuery<F extends FunctionReference>(function_: F, args: "skip" | PaginatedArgs<F>, options: PaginatedQueryOptions): PaginatedQueryHandle<PageItemOf<F>>;
+function paginatedQuery<F extends FunctionReference>(function_: F, args: ReactivePaginatedArgs<F>, options: PaginatedQueryOptions): PaginatedQueryHandle<PageItemOf<F>>;
 
-function paginatedQuery<F extends FunctionReference>(client: LunoraClient, function_: F, args: "skip" | PaginatedArgs<F>, options: PaginatedQueryOptions): PaginatedQueryHandle<PageItemOf<F>>;
+function paginatedQuery<F extends FunctionReference>(client: LunoraClient, function_: F, args: ReactivePaginatedArgs<F>, options: PaginatedQueryOptions): PaginatedQueryHandle<PageItemOf<F>>;
 ```
 
 ### `presence` (function)
@@ -716,9 +728,9 @@ function presence<H extends HeartbeatReference, L extends ListPresentReference>(
 ### `query` (function)
 
 ```ts
-function query<F extends FunctionReference>(function_: F, args: ArgsOf<F> | "skip", options?: QueryStoreOptions): QueryStore<F>;
+function query<F extends FunctionReference>(function_: F, args: ReactiveArgs<F>, options?: QueryStoreOptions): QueryStore<F>;
 
-function query<F extends FunctionReference>(client: LunoraClient, function_: F, args: ArgsOf<F> | "skip", options?: QueryStoreOptions): QueryStore<F>;
+function query<F extends FunctionReference>(client: LunoraClient, function_: F, args: ReactiveArgs<F>, options?: QueryStoreOptions): QueryStore<F>;
 ```
 
 ### `rateLimit` (const)
@@ -744,9 +756,9 @@ function stream<F extends FunctionReference<"stream">>(client: LunoraClient, fun
 ### `subscription` (function)
 
 ```ts
-function subscription<F extends FunctionReference>(function_: F, args: ArgsOf<F> | "skip", options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
+function subscription<F extends FunctionReference>(function_: F, args: ReactiveArgs<F>, options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
 
-function subscription<F extends FunctionReference>(client: LunoraClient, function_: F, args: ArgsOf<F> | "skip", options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
+function subscription<F extends FunctionReference>(client: LunoraClient, function_: F, args: ReactiveArgs<F>, options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
 ```
 
 ### `voiceAgent` (function)

--- a/packages/svelte/__tests__/paginated-query.test.ts
+++ b/packages/svelte/__tests__/paginated-query.test.ts
@@ -1,6 +1,6 @@
 import type { FunctionReference, LunoraClient, Unsubscribe } from "@lunora/client";
 import type { PaginationResult } from "@lunora/client/pagination";
-import { get } from "svelte/store";
+import { get, writable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
 import { infiniteQuery, paginatedQuery } from "../src/paginated-query";
@@ -573,6 +573,86 @@ describe("paginatedQuery — stableWireKey page keys (plan 285)", () => {
 
         expect(fake.subscribeCalls).toHaveLength(1);
         expect(get(status)).toBe("LoadingFirstPage");
+
+        stopStatus();
+        stopResults();
+    });
+});
+
+describe("paginatedQuery with reactive args", () => {
+    const createTrackingClient = () => {
+        const unsubCallCount = { value: 0 };
+        const subscribeCalls: { args: Record<string, unknown>; callback: (data: unknown) => void }[] = [];
+
+        const client = {
+            subscribe: (_fn: FunctionReference, args: Record<string, unknown>, callback: (data: unknown) => void) => {
+                subscribeCalls.push({ args, callback });
+
+                return () => {
+                    unsubCallCount.value += 1;
+                };
+            },
+        } as unknown as LunoraClient;
+
+        return { client, subscribeCalls, unsubCallCount };
+    };
+
+    it("an args emission tears down the old pages and rebuilds against the new args", async () => {
+        const { client, subscribeCalls, unsubCallCount } = createTrackingClient();
+        const argsStore = writable<Record<string, unknown> | "skip">({ room: "a" });
+
+        const { results, status } = paginatedQuery(client, fn, argsStore, { initialNumItems: NUM_ITEMS });
+
+        const stopStatus = status.subscribe(() => {});
+        const stopResults = results.subscribe(() => {});
+
+        expect(subscribeCalls).toHaveLength(1);
+        expect(subscribeCalls[0]?.args).toMatchObject({ room: "a" });
+
+        subscribeCalls[0]?.callback({ continueCursor: "cur-1", isDone: false, page: firstPageItems });
+        await flushAsync();
+
+        expect(get(results)).toStrictEqual(firstPageItems);
+
+        argsStore.set({ room: "b" });
+        await flushAsync();
+
+        // The old page subscription closed; a fresh first-page subscription
+        // opened against the new args with pagination reset to page one.
+        expect(unsubCallCount.value).toBe(1);
+        expect(subscribeCalls).toHaveLength(2);
+        expect(subscribeCalls[1]?.args).toMatchObject({
+            paginationOpts: { cursor: null, endCursor: null, numItems: NUM_ITEMS },
+            room: "b",
+        });
+        expect(get(status)).toBe("LoadingFirstPage");
+        expect(get(results)).toStrictEqual([]);
+
+        stopStatus();
+        stopResults();
+    });
+
+    it("a 'skip' emission tears down without re-opening", async () => {
+        const { client, subscribeCalls, unsubCallCount } = createTrackingClient();
+        const argsStore = writable<Record<string, unknown> | "skip">({ room: "a" });
+
+        const { results, status } = paginatedQuery(client, fn, argsStore, { initialNumItems: NUM_ITEMS });
+
+        const stopStatus = status.subscribe(() => {});
+        const stopResults = results.subscribe(() => {});
+
+        subscribeCalls[0]?.callback({ continueCursor: "cur-1", isDone: false, page: firstPageItems });
+        await flushAsync();
+
+        expect(get(results)).toStrictEqual(firstPageItems);
+
+        argsStore.set("skip");
+        await flushAsync();
+
+        expect(unsubCallCount.value).toBe(1);
+        expect(subscribeCalls).toHaveLength(1);
+        expect(get(status)).toBe("LoadingFirstPage");
+        expect(get(results)).toStrictEqual([]);
 
         stopStatus();
         stopResults();

--- a/packages/svelte/__tests__/query.test.ts
+++ b/packages/svelte/__tests__/query.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference, LunoraClient, SubscriptionErrorCallback } from "@lunora/client";
-import { get } from "svelte/store";
+import { get, writable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
 import { query } from "../src/query";
@@ -103,6 +103,50 @@ describe("query store", () => {
 
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError.mock.calls[0]?.[0]).toMatchObject({ message: "subscription failed" });
+
+        stop();
+    });
+});
+
+describe("query store with reactive args", () => {
+    it("re-subscribes with the new args when the args store emits", () => {
+        const { client, subscribe, unsubscribe } = createFakeClient();
+        const argsStore = writable<unknown>({ room: "general" });
+        const store = query(client, fnRef, argsStore);
+
+        const stop = store.subscribe(() => {});
+
+        expect(subscribe).toHaveBeenCalledTimes(1);
+        expect(subscribe.mock.calls[0]?.[1]).toStrictEqual({ room: "general" });
+
+        argsStore.set({ room: "random" });
+
+        // The previous subscription is torn down before the new one opens.
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        expect(subscribe).toHaveBeenCalledTimes(2);
+        expect(subscribe.mock.calls[1]?.[1]).toStrictEqual({ room: "random" });
+
+        stop();
+
+        expect(unsubscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it("tears down without re-opening and resets to undefined on a 'skip' emission", () => {
+        const { client, emit, subscribe, unsubscribe } = createFakeClient();
+        const argsStore = writable<unknown>({ room: "general" });
+        const store = query(client, fnRef, argsStore);
+
+        const stop = store.subscribe(() => {});
+
+        emit([{ id: 1 }]);
+
+        expect(get(store)).toStrictEqual([{ id: 1 }]);
+
+        argsStore.set("skip");
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        expect(subscribe).toHaveBeenCalledTimes(1);
+        expect(get(store)).toBeUndefined();
 
         stop();
     });

--- a/packages/svelte/__tests__/query.test.ts
+++ b/packages/svelte/__tests__/query.test.ts
@@ -1,4 +1,5 @@
 import type { FunctionReference, LunoraClient, SubscriptionErrorCallback } from "@lunora/client";
+import type { Readable } from "svelte/store";
 import { get, writable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
@@ -129,6 +130,56 @@ describe("query store with reactive args", () => {
         stop();
 
         expect(unsubscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not leak a subscription opened re-entrantly while `open` is still running", () => {
+        // A hand-rolled Readable. `isReadableStore` duck-types on `subscribe`, so any
+        // conforming store is a valid args source — and one without svelte/store's
+        // subscriber_queue can deliver an emission while `open` is still on the stack.
+        // A svelte `writable` cannot: its queue defers the callback until `open` has
+        // returned, which is why this needs a custom store to reproduce.
+        const live = new Set<number>();
+        let identifier = 0;
+        let emit: ((value: unknown) => void) | undefined;
+
+        const argumentsStore = {
+            subscribe: (run: (value: unknown) => void) => {
+                emit = run;
+                run({ room: "general" });
+
+                return () => {
+                    emit = undefined;
+                };
+            },
+        } as Readable<unknown>;
+
+        const subscribe = vi.fn<(function_: unknown, args: unknown) => () => void>((_function, _args) => {
+            identifier += 1;
+
+            const current = identifier;
+
+            live.add(current);
+
+            // Emitted from inside the first `open`, before it returns its teardown.
+            if (current === 1) {
+                emit?.({ room: "random" });
+            }
+
+            return () => {
+                live.delete(current);
+            };
+        });
+
+        const client = { subscribe } as unknown as LunoraClient;
+        const store = query(client, fnRef, argumentsStore);
+
+        const stop = store.subscribe(() => {});
+
+        stop();
+
+        // Both subscriptions were opened, and neither is still live.
+        expect(subscribe).toHaveBeenCalledTimes(2);
+        expect([...live]).toStrictEqual([]);
     });
 
     it("tears down without re-opening and resets to undefined on a 'skip' emission", () => {

--- a/packages/svelte/__tests__/subscription.test.ts
+++ b/packages/svelte/__tests__/subscription.test.ts
@@ -1,5 +1,5 @@
 import type { FunctionReference, LunoraClient } from "@lunora/client";
-import { get } from "svelte/store";
+import { get, writable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
 
 import { subscription } from "../src/subscription";
@@ -145,5 +145,49 @@ describe("subscription store", () => {
         expect(get(error)).toBeUndefined();
 
         stopError();
+    });
+});
+
+describe("subscription store with reactive args", () => {
+    it("re-subscribes with the new args when the args store emits", () => {
+        const { client, subscribeSpy, unsubscribeSpy } = createFakeClient();
+        const argsStore = writable<unknown>({ channelId: "c1" });
+        const { data } = subscription(client, fnRef, argsStore);
+
+        const stop = data.subscribe(() => {});
+
+        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+        expect(subscribeSpy.mock.calls[0]?.[1]).toStrictEqual({ channelId: "c1" });
+
+        argsStore.set({ channelId: "c2" });
+
+        // The previous subscription is torn down before the new one opens.
+        expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+        expect(subscribeSpy).toHaveBeenCalledTimes(2);
+        expect(subscribeSpy.mock.calls[1]?.[1]).toStrictEqual({ channelId: "c2" });
+
+        stop();
+
+        expect(unsubscribeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("tears down and clears data on a 'skip' emission", () => {
+        const { client, emit, subscribeSpy, unsubscribeSpy } = createFakeClient();
+        const argsStore = writable<unknown>({ channelId: "c1" });
+        const { data } = subscription(client, fnRef, argsStore);
+
+        const stop = data.subscribe(() => {});
+
+        emit({ unread: 3 });
+
+        expect(get(data)).toStrictEqual({ unread: 3 });
+
+        argsStore.set("skip");
+
+        expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+        expect(get(data)).toBeUndefined();
+
+        stop();
     });
 });

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -71,7 +71,6 @@
         "@lunora/client": "1.0.0-alpha.56",
         "@lunora/errors": "1.0.0-alpha.22",
         "@lunora/ratelimit": "1.0.0-alpha.25",
-        "@lunora/runtime": "1.0.0-alpha.69",
         "@visulima/storage-client": "catalog:storage"
     },
     "devDependencies": {

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -42,11 +42,19 @@ export type { MutationHandle } from "./mutation";
 export { mutation } from "./mutation";
 export type { MutatorHandle, MutatorHandleStore, MutatorTransaction } from "./mutator";
 export { mutator } from "./mutator";
-export type { InfiniteQueryHandle, InfiniteQueryOptions, PageItemOf, PaginatedArgs, PaginatedQueryHandle, PaginatedQueryOptions } from "./paginated-query";
+export type {
+    InfiniteQueryHandle,
+    InfiniteQueryOptions,
+    PageItemOf,
+    PaginatedArgs,
+    PaginatedQueryHandle,
+    PaginatedQueryOptions,
+    ReactivePaginatedArgs,
+} from "./paginated-query";
 export { infiniteQuery, paginatedQuery } from "./paginated-query";
 export type { HeartbeatReference, ListPresentReference, PresenceHandle, PresenceOptions } from "./presence";
 export { presence } from "./presence";
-export type { QueryStore, QueryStoreOptions } from "./query";
+export type { QueryStore, QueryStoreOptions, ReactiveArgs } from "./query";
 export { query } from "./query";
 export type { RateLimitHandle, RateLimitOptions } from "./rate-limit";
 export { rateLimit } from "./rate-limit";

--- a/packages/svelte/src/is-readable-store.ts
+++ b/packages/svelte/src/is-readable-store.ts
@@ -1,11 +1,10 @@
 import type { Readable } from "svelte/store";
 
 /**
- * Narrow an unknown value to a Svelte {@link Readable} store by its
- * `subscribe` function. Used by the query primitives (`query`,
- * `subscription`, `paginatedQuery`) to tell a reactive args source from a
- * plain args record or the `"skip"` sentinel.
+ * Narrow a maybe-reactive value to a Svelte `Readable` store by its
+ * `subscribe` function — how `subscribeReactiveArgs` tells a reactive args
+ * source from a plain args record or the `"skip"` sentinel.
  */
-// eslint-disable-next-line import/prefer-default-export -- named export so the query primitives share one guard by name; a default would not compose with their other named imports.
-export const isReadableStore = (value: unknown): value is Readable<unknown> =>
-    typeof value === "object" && value !== null && typeof (value as { subscribe?: unknown }).subscribe === "function";
+// eslint-disable-next-line import/prefer-default-export -- named export so it composes with the other named imports at its call sites; a default would not.
+export const isReadableStore = <T>(value: T | Readable<T>): value is Readable<T> =>
+    typeof (value as { subscribe?: unknown } | null | undefined)?.subscribe === "function";

--- a/packages/svelte/src/is-readable-store.ts
+++ b/packages/svelte/src/is-readable-store.ts
@@ -1,0 +1,11 @@
+import type { Readable } from "svelte/store";
+
+/**
+ * Narrow an unknown value to a Svelte {@link Readable} store by its
+ * `subscribe` function. Used by the query primitives (`query`,
+ * `subscription`, `paginatedQuery`) to tell a reactive args source from a
+ * plain args record or the `"skip"` sentinel.
+ */
+// eslint-disable-next-line import/prefer-default-export -- named export so the query primitives share one guard by name; a default would not compose with their other named imports.
+export const isReadableStore = (value: unknown): value is Readable<unknown> =>
+    typeof value === "object" && value !== null && typeof (value as { subscribe?: unknown }).subscribe === "function";

--- a/packages/svelte/src/paginated-query.ts
+++ b/packages/svelte/src/paginated-query.ts
@@ -8,6 +8,7 @@ import { stableWireKey } from "../../../shared/wire-key";
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
 import { isReadableStore } from "./is-readable-store";
+import { subscribeReactiveArgs } from "./subscribe-reactive-args";
 
 /** The args a paginated query exposes minus the framework-supplied page cursor. */
 type PaginatedArgs<F extends FunctionReference> = Omit<ArgsOf<F>, "paginationOpts">;
@@ -108,7 +109,7 @@ const createPaginatedEngine = <T>(
 
     // For a reactive args source this starts at `"skip"` and is replaced by the
     // store's first (synchronous) emission when `pageResults` gains a subscriber.
-    let currentBaseArgs: "skip" | Record<string, unknown> = isReadableStore(baseArgs) ? "skip" : baseArgs;
+    let currentBaseArgs: "skip" | Record<string, unknown> = isReadableStore<"skip" | Record<string, unknown>>(baseArgs) ? "skip" : baseArgs;
 
     const rebuildPageResults = (): void => {
         if (currentBaseArgs === "skip") {
@@ -302,31 +303,24 @@ const createPaginatedEngine = <T>(
         // Wire internal store updates through to this readable's subscribers.
         const unsubInternal = pageResultsInternal.subscribe(set);
 
-        let unsubscribeArgs: Unsubscribe | undefined;
-
-        if (isReadableStore(baseArgs)) {
-            // Reactive args: every emission is a full teardown + fresh
-            // construction — pagination resets to the first page, exactly as if
-            // the engine had been built anew with the emitted args.
-            unsubscribeArgs = baseArgs.subscribe((resolved) => {
-                teardownAll();
-                pagesStore.set(initialPages(initialNumItems));
-                currentBaseArgs = resolved;
-                syncSubscriptions();
-                rebuildPageResults();
-            });
-        } else if (currentBaseArgs !== "skip") {
-            // Eagerly open subscriptions now that someone is watching.
+        // Open the page subscriptions now that someone is watching. With a
+        // reactive args source every emission is a full teardown + fresh
+        // construction — the teardown resets pagination to the first page, so a
+        // new emission builds exactly as if the engine were new.
+        const stopArgs = subscribeReactiveArgs<"skip" | Record<string, unknown>>(baseArgs, (resolved) => {
+            currentBaseArgs = resolved;
             syncSubscriptions();
             rebuildPageResults();
-        }
+
+            return () => {
+                teardownAll();
+                pagesStore.set(initialPages(initialNumItems));
+            };
+        });
 
         return () => {
-            unsubscribeArgs?.();
+            stopArgs();
             unsubInternal();
-            teardownAll();
-            // Reset so a re-subscribe starts clean.
-            pagesStore.set(initialPages(initialNumItems));
             pageResultsInternal.set([]);
         };
     });

--- a/packages/svelte/src/paginated-query.ts
+++ b/packages/svelte/src/paginated-query.ts
@@ -7,9 +7,13 @@ import { derived, get, readable, writable } from "svelte/store";
 import { stableWireKey } from "../../../shared/wire-key";
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
+import { isReadableStore } from "./is-readable-store";
 
 /** The args a paginated query exposes minus the framework-supplied page cursor. */
 type PaginatedArgs<F extends FunctionReference> = Omit<ArgsOf<F>, "paginationOpts">;
+
+/** Paginated args, the skip sentinel, or a reactive (`Readable`) source of either. */
+type ReactivePaginatedArgs<F extends FunctionReference> = "skip" | PaginatedArgs<F> | Readable<"skip" | PaginatedArgs<F>>;
 
 /** The element type of the `page` array a paginated query returns. */
 type PageItemOf<F extends FunctionReference> = ReturnOf<F> extends { page: (infer T)[] } ? T : unknown;
@@ -78,7 +82,7 @@ const buildPageKey = (functionPath: string, pageArgs: Record<string, unknown>): 
 const createPaginatedEngine = <T>(
     client: LunoraClient,
     function_: FunctionReference,
-    baseArgs: "skip" | Record<string, unknown>,
+    baseArgs: "skip" | Record<string, unknown> | Readable<"skip" | Record<string, unknown>>,
     options: { initialNumItems: number; shardKey?: string },
 ): {
     loadMore: (numberItems: number) => void;
@@ -102,7 +106,9 @@ const createPaginatedEngine = <T>(
      */
     const pendingPageKeys = new Set<string>();
 
-    const currentBaseArgs: "skip" | Record<string, unknown> = baseArgs;
+    // For a reactive args source this starts at `"skip"` and is replaced by the
+    // store's first (synchronous) emission when `pageResults` gains a subscriber.
+    let currentBaseArgs: "skip" | Record<string, unknown> = isReadableStore(baseArgs) ? "skip" : baseArgs;
 
     const rebuildPageResults = (): void => {
         if (currentBaseArgs === "skip") {
@@ -111,8 +117,10 @@ const createPaginatedEngine = <T>(
             return;
         }
 
+        const baseArgsRecord = currentBaseArgs;
+
         const updated = get(pagesStore).map((page) => {
-            const key = buildPageKey(function_["__lunoraRef"], buildPageArgs(page, currentBaseArgs));
+            const key = buildPageKey(function_["__lunoraRef"], buildPageArgs(page, baseArgsRecord));
 
             return resultsByKey.get(key);
         });
@@ -138,7 +146,8 @@ const createPaginatedEngine = <T>(
             return;
         }
 
-        const keyOf = (page: Page): string => buildPageKey(function_["__lunoraRef"], buildPageArgs(page, currentBaseArgs));
+        const baseArgsRecord = currentBaseArgs;
+        const keyOf = (page: Page): string => buildPageKey(function_["__lunoraRef"], buildPageArgs(page, baseArgsRecord));
 
         for (const newPage of newPages) {
             const newKey = keyOf(newPage);
@@ -293,13 +302,27 @@ const createPaginatedEngine = <T>(
         // Wire internal store updates through to this readable's subscribers.
         const unsubInternal = pageResultsInternal.subscribe(set);
 
-        // Eagerly open subscriptions now that someone is watching.
-        if (currentBaseArgs !== "skip") {
+        let unsubscribeArgs: Unsubscribe | undefined;
+
+        if (isReadableStore(baseArgs)) {
+            // Reactive args: every emission is a full teardown + fresh
+            // construction — pagination resets to the first page, exactly as if
+            // the engine had been built anew with the emitted args.
+            unsubscribeArgs = baseArgs.subscribe((resolved) => {
+                teardownAll();
+                pagesStore.set(initialPages(initialNumItems));
+                currentBaseArgs = resolved;
+                syncSubscriptions();
+                rebuildPageResults();
+            });
+        } else if (currentBaseArgs !== "skip") {
+            // Eagerly open subscriptions now that someone is watching.
             syncSubscriptions();
             rebuildPageResults();
         }
 
         return () => {
+            unsubscribeArgs?.();
             unsubInternal();
             teardownAll();
             // Reset so a re-subscribe starts clean.
@@ -371,28 +394,32 @@ const createPaginatedEngine = <T>(
  *
  * Pass `client` explicitly, or omit it to resolve the ambient client from the
  * Svelte context.
+ *
+ * `args` may also be a `Readable` store: each emission tears the engine down
+ * and rebuilds it against the new args (pagination resets to the first page);
+ * a `"skip"` emission tears down without re-opening.
  */
 export function paginatedQuery<F extends FunctionReference>(
     function_: F,
-    args: "skip" | PaginatedArgs<F>,
+    args: ReactivePaginatedArgs<F>,
     options: PaginatedQueryOptions,
 ): PaginatedQueryHandle<PageItemOf<F>>;
 export function paginatedQuery<F extends FunctionReference>(
     client: LunoraClient,
     function_: F,
-    args: "skip" | PaginatedArgs<F>,
+    args: ReactivePaginatedArgs<F>,
     options: PaginatedQueryOptions,
 ): PaginatedQueryHandle<PageItemOf<F>>;
 export function paginatedQuery<F extends FunctionReference>(
     clientOrFunction: F | LunoraClient,
-    functionOrArguments: F | "skip" | PaginatedArgs<F>,
-    argumentsOrOptions: PaginatedQueryOptions | "skip" | PaginatedArgs<F>,
+    functionOrArguments: F | ReactivePaginatedArgs<F>,
+    argumentsOrOptions: PaginatedQueryOptions | ReactivePaginatedArgs<F>,
     maybeOptions?: PaginatedQueryOptions,
 ): PaginatedQueryHandle<PageItemOf<F>> {
     const hasExplicitClient = !isFunctionReference(clientOrFunction);
     const client = hasExplicitClient ? clientOrFunction : getLunoraClient();
     const functionRef = (hasExplicitClient ? functionOrArguments : clientOrFunction) as F;
-    const args = (hasExplicitClient ? argumentsOrOptions : functionOrArguments) as "skip" | PaginatedArgs<F>;
+    const args = (hasExplicitClient ? argumentsOrOptions : functionOrArguments) as ReactivePaginatedArgs<F>;
     const options = (hasExplicitClient ? maybeOptions : argumentsOrOptions) as PaginatedQueryOptions;
 
     const { loadMore, pageResults, status } = createPaginatedEngine<PageItemOf<F>>(client, functionRef, args, options);
@@ -457,4 +484,4 @@ export function infiniteQuery<F extends FunctionReference>(
     return { fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, pages, status };
 }
 
-export type { InfiniteQueryHandle, InfiniteQueryOptions, PageItemOf, PaginatedArgs, PaginatedQueryHandle, PaginatedQueryOptions };
+export type { InfiniteQueryHandle, InfiniteQueryOptions, PageItemOf, PaginatedArgs, PaginatedQueryHandle, PaginatedQueryOptions, ReactivePaginatedArgs };

--- a/packages/svelte/src/query.ts
+++ b/packages/svelte/src/query.ts
@@ -5,7 +5,7 @@ import { readable } from "svelte/store";
 
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
-import { isReadableStore } from "./is-readable-store";
+import { subscribeReactiveArgs } from "./subscribe-reactive-args";
 
 /** Query args, the skip sentinel, or a reactive (`Readable`) source of either. */
 export type ReactiveArgs<F extends FunctionReference> = ArgsOf<F> | "skip" | Readable<ArgsOf<F> | "skip">;
@@ -95,23 +95,6 @@ export function query<F extends FunctionReference>(
                 { shardKey: options.shardKey },
             );
 
-        if (!isReadableStore(args)) {
-            return open(args);
-        }
-
-        // Reactive args: each emission tears down the previous subscription
-        // BEFORE opening the next (so a `"skip"` emission cannot leak the old
-        // one — its `open("skip")` only fires the reset and returns a no-op).
-        let teardown: Unsubscribe = () => {};
-
-        const unsubscribeArgs = (args as Readable<ArgsOf<F> | "skip">).subscribe((resolved) => {
-            teardown();
-            teardown = open(resolved);
-        });
-
-        return () => {
-            unsubscribeArgs();
-            teardown();
-        };
+        return subscribeReactiveArgs<ArgsOf<F> | "skip">(args, open);
     });
 }

--- a/packages/svelte/src/query.ts
+++ b/packages/svelte/src/query.ts
@@ -1,10 +1,14 @@
-import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, SubscriptionErrorCallback } from "@lunora/client";
+import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, SubscriptionErrorCallback, Unsubscribe } from "@lunora/client";
 import { createQuerySubscription } from "@lunora/client/query";
 import type { Readable } from "svelte/store";
 import { readable } from "svelte/store";
 
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
+import { isReadableStore } from "./is-readable-store";
+
+/** Query args, the skip sentinel, or a reactive (`Readable`) source of either. */
+export type ReactiveArgs<F extends FunctionReference> = ArgsOf<F> | "skip" | Readable<ArgsOf<F> | "skip">;
 
 /** Options accepted by {@link query}. */
 export interface QueryStoreOptions {
@@ -41,13 +45,19 @@ export type QueryStore<F extends FunctionReference> = Readable<ReturnOf<F> | und
  * Pass `client` explicitly, or omit it to resolve the ambient client published
  * by `setLunoraClient` (which must therefore be called during component init,
  * before this runs).
+ *
+ * `args` may also be a `Readable` store (wrap runes state with `toStore` or
+ * `derived`): each emission tears down the previous subscription and opens a
+ * fresh one against the new args — the Svelte counterpart of Vue's
+ * `MaybeRefOrGetter` args. An emission of `"skip"` tears down without
+ * re-opening and resets the value to `undefined`.
  */
-export function query<F extends FunctionReference>(function_: F, args: ArgsOf<F> | "skip", options?: QueryStoreOptions): QueryStore<F>;
-export function query<F extends FunctionReference>(client: LunoraClient, function_: F, args: ArgsOf<F> | "skip", options?: QueryStoreOptions): QueryStore<F>;
+export function query<F extends FunctionReference>(function_: F, args: ReactiveArgs<F>, options?: QueryStoreOptions): QueryStore<F>;
+export function query<F extends FunctionReference>(client: LunoraClient, function_: F, args: ReactiveArgs<F>, options?: QueryStoreOptions): QueryStore<F>;
 export function query<F extends FunctionReference>(
     clientOrFunction: LunoraClient | F,
-    functionOrArguments: ArgsOf<F> | F | "skip",
-    argumentsOrOptions?: ArgsOf<F> | QueryStoreOptions | "skip",
+    functionOrArguments: F | ReactiveArgs<F>,
+    argumentsOrOptions?: QueryStoreOptions | ReactiveArgs<F>,
     maybeOptions?: QueryStoreOptions,
 ): QueryStore<F> {
     // Resolve the overload: when the first arg is a function reference (carries
@@ -56,32 +66,52 @@ export function query<F extends FunctionReference>(
     const hasExplicitClient = !isFunctionReference(clientOrFunction);
     const client = hasExplicitClient ? clientOrFunction : getLunoraClient();
     const functionRef = (hasExplicitClient ? functionOrArguments : clientOrFunction) as F;
-    const args = (hasExplicitClient ? argumentsOrOptions : functionOrArguments) as ArgsOf<F> | "skip";
+    const args = (hasExplicitClient ? argumentsOrOptions : functionOrArguments) as ReactiveArgs<F>;
     const options = (hasExplicitClient ? maybeOptions : (argumentsOrOptions as QueryStoreOptions | undefined)) ?? {};
 
-    return readable<ReturnOf<F> | undefined>(undefined, (set) =>
+    return readable<ReturnOf<F> | undefined>(undefined, (set) => {
         // The shared `@lunora/client/query` state machine owns the subscribe +
         // cleanup: it replays the last value synchronously when one exists and
         // pushes every subsequent delta into the store, and its returned teardown
         // is the store's stop callback, so the WS subscription closes when the
         // last `$`-reader detaches.
-        createQuerySubscription<F>(
-            client,
-            functionRef,
-            args,
-            {
-                onData: (value: ReturnOf<F>) => {
-                    set(value);
+        const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe =>
+            createQuerySubscription<F>(
+                client,
+                functionRef,
+                resolved,
+                {
+                    onData: (value: ReturnOf<F>) => {
+                        set(value);
+                    },
+                    onError: options.onError,
+                    // `args === "skip"` short-circuits inside the shared helper and
+                    // fires this reset — clear any prior value so a store that flips
+                    // to `"skip"` does not retain stale data.
+                    onReset: () => {
+                        set(undefined);
+                    },
                 },
-                onError: options.onError,
-                // `args === "skip"` short-circuits inside the shared helper and
-                // fires this reset — clear any prior value so a store that flips
-                // to `"skip"` does not retain stale data.
-                onReset: () => {
-                    set(undefined);
-                },
-            },
-            { shardKey: options.shardKey },
-        ),
-    );
+                { shardKey: options.shardKey },
+            );
+
+        if (!isReadableStore(args)) {
+            return open(args);
+        }
+
+        // Reactive args: each emission tears down the previous subscription
+        // BEFORE opening the next (so a `"skip"` emission cannot leak the old
+        // one — its `open("skip")` only fires the reset and returns a no-op).
+        let teardown: Unsubscribe = () => {};
+
+        const unsubscribeArgs = (args as Readable<ArgsOf<F> | "skip">).subscribe((resolved) => {
+            teardown();
+            teardown = open(resolved);
+        });
+
+        return () => {
+            unsubscribeArgs();
+            teardown();
+        };
+    });
 }

--- a/packages/svelte/src/subscribe-reactive-args.ts
+++ b/packages/svelte/src/subscribe-reactive-args.ts
@@ -17,6 +17,13 @@ import { isReadableStore } from "./is-readable-store";
  * `open` returns the teardown for the subscription it opened; anything a fresh
  * emission must reset (a stale error, pagination state) belongs in that
  * teardown or at the top of `open`, so each emission starts from a clean slate.
+ *
+ * Emissions are serialized. A source that emits *during* `open` — svelte/store's
+ * own queue rules that out, but the `Readable` contract is duck-typed and a
+ * hand-rolled store has no such queue — would otherwise open a subscription whose
+ * teardown the outer call then overwrites, leaking it. Such a value waits and is
+ * applied once the in-flight `open` has handed over its teardown, so the last
+ * emission always wins and every subscription it replaced is closed.
  */
 // eslint-disable-next-line import/prefer-default-export -- named export so it composes with the other named imports at its call sites; a default would not.
 export const subscribeReactiveArgs = <T>(args: T | Readable<T>, open: (value: T) => Unsubscriber): Unsubscriber => {
@@ -25,10 +32,35 @@ export const subscribeReactiveArgs = <T>(args: T | Readable<T>, open: (value: T)
     }
 
     let teardown: Unsubscriber = () => {};
+    let opening = false;
+    // A one-slot queue, not a value: `T` itself may legitimately be undefined.
+    let queued: [T] | undefined;
 
     const unsubscribeArgs = args.subscribe((resolved) => {
-        teardown();
-        teardown = open(resolved);
+        if (opening) {
+            // Re-entrant emission: `open` below has not returned its teardown yet,
+            // and the assignment that follows it would overwrite anything we stored
+            // here — leaking the subscription this emission opened. Hand the value
+            // to the loop that owns the teardown instead.
+            queued = [resolved];
+
+            return;
+        }
+
+        opening = true;
+
+        try {
+            let next: [T] | undefined = [resolved];
+
+            while (next) {
+                teardown();
+                teardown = open(next[0]);
+                next = queued;
+                queued = undefined;
+            }
+        } finally {
+            opening = false;
+        }
     });
 
     return () => {

--- a/packages/svelte/src/subscribe-reactive-args.ts
+++ b/packages/svelte/src/subscribe-reactive-args.ts
@@ -1,0 +1,38 @@
+import type { Readable, Unsubscriber } from "svelte/store";
+
+import { isReadableStore } from "./is-readable-store";
+
+/**
+ * Bind a maybe-reactive args source to a live subscription, and own the
+ * ordering the three query primitives (`query`, `subscription`,
+ * `paginatedQuery`) all depend on.
+ *
+ * A static value opens exactly once. A `Readable` source opens on every
+ * emission, tearing the previous subscription down **before** opening the
+ * next — so an emission that resolves to nothing (the `"skip"` sentinel, whose
+ * `open` returns a no-op teardown) cannot leak the subscription it replaced.
+ * The returned stop function detaches the args source and tears down whatever
+ * is currently open.
+ *
+ * `open` returns the teardown for the subscription it opened; anything a fresh
+ * emission must reset (a stale error, pagination state) belongs in that
+ * teardown or at the top of `open`, so each emission starts from a clean slate.
+ */
+// eslint-disable-next-line import/prefer-default-export -- named export so it composes with the other named imports at its call sites; a default would not.
+export const subscribeReactiveArgs = <T>(args: T | Readable<T>, open: (value: T) => Unsubscriber): Unsubscriber => {
+    if (!isReadableStore(args)) {
+        return open(args);
+    }
+
+    let teardown: Unsubscriber = () => {};
+
+    const unsubscribeArgs = args.subscribe((resolved) => {
+        teardown();
+        teardown = open(resolved);
+    });
+
+    return () => {
+        unsubscribeArgs();
+        teardown();
+    };
+};

--- a/packages/svelte/src/subscription.ts
+++ b/packages/svelte/src/subscription.ts
@@ -5,8 +5,8 @@ import { readable, writable } from "svelte/store";
 
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
-import { isReadableStore } from "./is-readable-store";
 import type { ReactiveArgs } from "./query";
+import { subscribeReactiveArgs } from "./subscribe-reactive-args";
 
 interface SubscriptionStoreOptions {
     onError?: (error: Error) => void;
@@ -65,8 +65,12 @@ function subscription<F extends FunctionReference>(
         // `onReset` (clearing `data`) and returns a no-op teardown without opening
         // a socket — so the reset path below is reachable, unlike a local early
         // return that would make it dead code.
-        const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe =>
-            createQuerySubscription(
+        const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe => {
+            // Each emission starts from a clean slate: drop the error the
+            // previous args produced before opening the new subscription.
+            errorStore.set(undefined);
+
+            return createQuerySubscription(
                 client,
                 functionRef,
                 resolved,
@@ -86,26 +90,12 @@ function subscription<F extends FunctionReference>(
                 },
                 { shardKey },
             );
+        };
 
-        let teardown: Unsubscribe;
-        let unsubscribeArgs: Unsubscribe | undefined;
-
-        if (isReadableStore(args)) {
-            // Reactive args: tear down the previous subscription BEFORE opening
-            // the next, and clear the stale error so each emission starts fresh.
-            teardown = () => {};
-            unsubscribeArgs = (args as Readable<ArgsOf<F> | "skip">).subscribe((resolved) => {
-                teardown();
-                errorStore.set(undefined);
-                teardown = open(resolved);
-            });
-        } else {
-            teardown = open(args);
-        }
+        const stopArgs = subscribeReactiveArgs<ArgsOf<F> | "skip">(args, open);
 
         return () => {
-            unsubscribeArgs?.();
-            teardown();
+            stopArgs();
             errorStore.set(undefined);
         };
     });

--- a/packages/svelte/src/subscription.ts
+++ b/packages/svelte/src/subscription.ts
@@ -1,10 +1,12 @@
-import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf } from "@lunora/client";
+import type { ArgsOf, FunctionReference, LunoraClient, ReturnOf, Unsubscribe } from "@lunora/client";
 import { createQuerySubscription } from "@lunora/client/query";
 import type { Readable } from "svelte/store";
 import { readable, writable } from "svelte/store";
 
 import { getLunoraClient } from "./context";
 import { isFunctionReference } from "./is-function-reference";
+import { isReadableStore } from "./is-readable-store";
+import type { ReactiveArgs } from "./query";
 
 interface SubscriptionStoreOptions {
     onError?: (error: Error) => void;
@@ -27,18 +29,22 @@ interface SubscriptionHandle<T> {
  * Passing `"skip"` as `args` keeps the stores connected but the subscription
  * dormant (`data` stays `undefined`). Pass an explicit `client` as the first
  * argument to bypass the ambient context (useful in tests).
+ *
+ * `args` may also be a `Readable` store: each emission tears down the previous
+ * subscription and opens a fresh one; a `"skip"` emission tears down without
+ * re-opening and resets `data` to `undefined`.
  */
-function subscription<F extends FunctionReference>(function_: F, args: ArgsOf<F> | "skip", options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
+function subscription<F extends FunctionReference>(function_: F, args: ReactiveArgs<F>, options?: SubscriptionStoreOptions): SubscriptionHandle<ReturnOf<F>>;
 function subscription<F extends FunctionReference>(
     client: LunoraClient,
     function_: F,
-    args: ArgsOf<F> | "skip",
+    args: ReactiveArgs<F>,
     options?: SubscriptionStoreOptions,
 ): SubscriptionHandle<ReturnOf<F>>;
 function subscription<F extends FunctionReference>(
     clientOrFunction: F | LunoraClient,
-    functionOrArgs: F | ArgsOf<F> | "skip",
-    argsOrOptions?: ArgsOf<F> | SubscriptionStoreOptions | "skip",
+    functionOrArgs: F | ReactiveArgs<F>,
+    argsOrOptions?: SubscriptionStoreOptions | ReactiveArgs<F>,
     maybeOptions?: SubscriptionStoreOptions,
 ): SubscriptionHandle<ReturnOf<F>> {
     // Resolve overloads: when the second argument is a FunctionReference, the
@@ -46,7 +52,7 @@ function subscription<F extends FunctionReference>(
     const hasExplicitClient = !isFunctionReference(clientOrFunction);
     const client = hasExplicitClient ? clientOrFunction : getLunoraClient();
     const functionRef = (hasExplicitClient ? functionOrArgs : clientOrFunction) as F;
-    const args = (hasExplicitClient ? argsOrOptions : functionOrArgs) as ArgsOf<F> | "skip";
+    const args = (hasExplicitClient ? argsOrOptions : functionOrArgs) as ReactiveArgs<F>;
     const options = (hasExplicitClient ? maybeOptions : (argsOrOptions as SubscriptionStoreOptions | undefined)) ?? {};
 
     const { shardKey, onError } = options;
@@ -59,29 +65,47 @@ function subscription<F extends FunctionReference>(
         // `onReset` (clearing `data`) and returns a no-op teardown without opening
         // a socket — so the reset path below is reachable, unlike a local early
         // return that would make it dead code.
-        const unsubscribe = createQuerySubscription(
-            client,
-            functionRef,
-            args,
-            {
-                onData: (value: ReturnOf<F>) => {
-                    set(value);
-                    errorStore.set(undefined);
+        const open = (resolved: ArgsOf<F> | "skip"): Unsubscribe =>
+            createQuerySubscription(
+                client,
+                functionRef,
+                resolved,
+                {
+                    onData: (value: ReturnOf<F>) => {
+                        set(value);
+                        errorStore.set(undefined);
+                    },
+                    onError: (subscriptionError) => {
+                        const error = new Error(subscriptionError.message);
+                        errorStore.set(error);
+                        onError?.(error);
+                    },
+                    onReset: () => {
+                        set(undefined);
+                    },
                 },
-                onError: (subscriptionError) => {
-                    const error = new Error(subscriptionError.message);
-                    errorStore.set(error);
-                    onError?.(error);
-                },
-                onReset: () => {
-                    set(undefined);
-                },
-            },
-            { shardKey },
-        );
+                { shardKey },
+            );
+
+        let teardown: Unsubscribe;
+        let unsubscribeArgs: Unsubscribe | undefined;
+
+        if (isReadableStore(args)) {
+            // Reactive args: tear down the previous subscription BEFORE opening
+            // the next, and clear the stale error so each emission starts fresh.
+            teardown = () => {};
+            unsubscribeArgs = (args as Readable<ArgsOf<F> | "skip">).subscribe((resolved) => {
+                teardown();
+                errorStore.set(undefined);
+                teardown = open(resolved);
+            });
+        } else {
+            teardown = open(args);
+        }
 
         return () => {
-            unsubscribe();
+            unsubscribeArgs?.();
+            teardown();
             errorStore.set(undefined);
         };
     });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -71,7 +71,6 @@
         "@lunora/client": "1.0.0-alpha.56",
         "@lunora/errors": "1.0.0-alpha.22",
         "@lunora/ratelimit": "1.0.0-alpha.25",
-        "@lunora/runtime": "1.0.0-alpha.69",
         "@visulima/storage-client": "catalog:storage"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4872,9 +4872,6 @@ importers:
       '@lunora/ratelimit':
         specifier: workspace:*
         version: link:../ratelimit
-      '@lunora/runtime':
-        specifier: workspace:*
-        version: link:../runtime
       '@visulima/storage-client':
         specifier: catalog:storage
         version: 1.0.2(@tanstack/react-query@5.101.4(react@19.2.8))(@tanstack/solid-query@5.101.3(solid-js@2.0.0-rc.0))(@tanstack/svelte-query@6.1.37(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@tanstack/vue-query@5.101.3(vue@3.5.41(typescript@6.0.3)))(react@19.2.8)(solid-js@1.9.14)(svelte@5.56.8(@typescript-eslint/types@8.67.0))(vue@3.5.41(typescript@6.0.3))
@@ -5056,9 +5053,6 @@ importers:
       '@lunora/ratelimit':
         specifier: workspace:*
         version: link:../ratelimit
-      '@lunora/runtime':
-        specifier: workspace:*
-        version: link:../runtime
       '@visulima/storage-client':
         specifier: catalog:storage
         version: 1.0.2(@tanstack/react-query@5.101.4(react@19.2.8))(@tanstack/solid-query@5.101.3(solid-js@2.0.0-rc.0))(@tanstack/svelte-query@6.1.37(svelte@5.56.8(@typescript-eslint/types@8.67.0)))(@tanstack/vue-query@5.101.3(vue@3.5.41(typescript@6.0.3)))(react@19.2.8)(solid-js@1.9.14)(svelte@5.56.8(@typescript-eslint/types@8.67.0))(vue@3.5.41(typescript@6.0.3))


### PR DESCRIPTION
## Changes

- `@lunora/svelte`'s `query`, `subscription`, and `paginatedQuery` now also accept a `Readable` args source (`ReactiveArgs<F>` / `ReactivePaginatedArgs<F>`). Each emission tears down the previous live subscription before opening one against the new args; a `"skip"` emission tears down without re-opening and resets the value to `undefined`; a paginated args change resets pagination to the first page. Static args behave exactly as before. This brings Svelte to parity with the other adapters (Vue `MaybeRefOrGetter`, Solid `Accessor`, Angular `Signal`) — previously a Svelte app whose query args depended on a route param or `$state` had to tear down and rebuild the store by hand.
- Dropped the unused `@lunora/runtime` dependency from `@lunora/vue` and `@lunora/svelte`. Neither package imports it (react/solid never declared it); it pulled the server-side Worker/DO runtime into every Vue/Svelte app's install graph and forced a no-op adapter release on every runtime release under independent per-package versioning.

## Verification

- `pnpm --filter "@lunora/svelte" run test` — 106 tests pass (6 new: store-args re-subscribe, `"skip"` teardown, and pagination reset per primitive)
- `pnpm --filter "@lunora/vue" run test` — 95 tests pass
- `lint:types` + `lint:eslint` green for both packages
- `pnpm run lint:package-json` — all 76 manifests sorted
- `pnpm run api:check` — snapshot regenerated from a fresh `build:packages`; the `svelte.api.md` diff is the three widened signatures plus their two supporting arg-type aliases, nothing else
- Both packages rebuild cleanly after the dependency removal; lockfile regenerated with `pnpm install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2mHUwAGcpzDrv4ZNd8MLG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Svelte queries, subscriptions, and paginated queries now accept reactive `Readable` stores as argument sources.
  * Results refresh automatically when reactive arguments change, with pagination resetting to the first page.
  * Added support for pausing operations with `"skip"` and resuming when arguments update.
  * Exported reactive argument types and a readable-store detection utility.
* **Bug Fixes**
  * Reactive subscriptions now clean up previous listeners and reset errors and results appropriately when arguments change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->