### PR TITLE
fix(deps): unblock alpha and stop the lockfile sync losing its push race

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -81,7 +81,7 @@
                   # `packageManager` field, so CI can't drift from the repo's version.
                   "run_install": false
 
-            - "name": "Use Node.js 22.14"
+            - "name": "Use Node.js 22.15"
               "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e" # v6.4.0
               "with":
                   "node-version": "22.15"
@@ -189,6 +189,17 @@
                       git reset --hard "origin/${BRANCH}"
 
                       pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts
+
+                      # Assert the result is what the next push will demand. Lint and Tests
+                      # run on pull_request/merge_group only, so nothing validates the branch
+                      # tip that a release creates — the first thing to notice a lockfile the
+                      # branch cannot install is the NEXT push, failing in its setup step. This
+                      # check costs ~1s and moves that discovery here, where the cause is
+                      # obvious and the job that caused it is still the one reporting it.
+                      if ! pnpm install --frozen-lockfile --lockfile-only --ignore-scripts; then
+                          echo "::error::pnpm-lock.yaml still fails --frozen-lockfile after regeneration. Not pushing it: a lockfile the branch cannot install breaks every later push. The mismatch is printed above."
+                          exit 1
+                      fi
 
                       if git diff --quiet -- pnpm-lock.yaml; then
                           echo "pnpm-lock.yaml already matches the manifests on ${BRANCH}."

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -150,22 +150,66 @@
             # each package.json (and any cross-package dependency ranges), but
             # @semantic-release/git only stages per-package assets — pnpm-lock.yaml lives at
             # the root and drifts. Frozen-lockfile installs on the next push then fail with
-            # ERR_PNPM_OUTDATED_LOCKFILE. Refresh here.
-            - "name": "Refresh pnpm-lock.yaml against released manifests"
-              "if": "success()"
+            # ERR_PNPM_OUTDATED_LOCKFILE, which blocks EVERY later push to the branch until
+            # a human regenerates the lockfile by hand. Refresh and push it here.
+            #
+            # This is a retry loop rather than a plain commit+push because the branch moves
+            # underneath the job: a release takes ~15 minutes, and any PR merged in that
+            # window advances the branch, so a single push loses the race with
+            # `! [rejected] (non-fast-forward)` — which is exactly how the lockfile went
+            # stale (run 32666543922: PR #457 landed mid-release, the sync commit was built
+            # on the pre-release tip, the push bounced, and every push after it failed at
+            # `pnpm install --frozen-lockfile`).
+            #
+            # Each attempt resets to the CURRENT remote tip before resolving, so the
+            # lockfile is always generated against the manifests that are actually on the
+            # branch — the release commits are already pushed by multi-semantic-release, and
+            # anything else merged meanwhile is honoured too.
+            #
+            # `!cancelled()` rather than `success()`: a release that fails partway has still
+            # pushed the release commits it completed, so the branch needs the sync more
+            # then, not less. The step commits nothing when the lockfile already matches.
+            - "name": "Sync pnpm-lock.yaml with released manifests"
+              "if": "!cancelled()"
               "shell": "bash"
               # --no-frozen-lockfile is intentional: this step exists to regenerate the
               # lockfile after multi-semantic-release bumps versions.
               # --ignore-scripts prevents any postinstall from running with the release
               # token in env (belt-and-suspenders alongside --lockfile-only).
-              "run": "pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts"
+              # core.hooksPath is neutralised here too: the step that disables the vis git
+              # hooks for release commits is skipped when an earlier step failed, and
+              # commitlint rejects this commit's `[skip ci]` header.
+              "env":
+                  "BRANCH": "${{ github.ref_name }}"
+              "run": |
+                  set -euo pipefail
 
-            - "name": "Commit refreshed lockfile"
-              "if": "success()"
-              "uses": "stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9" # v7.1.0
-              "with":
-                  "file_pattern": "pnpm-lock.yaml"
-                  "commit_message": "chore(deps): sync pnpm-lock.yaml with released manifests [skip ci]"
-                  "commit_user_name": "github-actions-shell"
-                  "commit_user_email": "github-actions[bot]@users.noreply.github.com"
-                  "commit_author": "github-actions-shell <github-actions[bot]@users.noreply.github.com>"
+                  for attempt in 1 2 3 4 5; do
+                      git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+                      git reset --hard "origin/${BRANCH}"
+
+                      pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts
+
+                      if git diff --quiet -- pnpm-lock.yaml; then
+                          echo "pnpm-lock.yaml already matches the manifests on ${BRANCH}."
+                          exit 0
+                      fi
+
+                      git -c core.hooksPath=/dev/null \
+                          -c "user.name=github-actions-shell" \
+                          -c "user.email=github-actions[bot]@users.noreply.github.com" \
+                          commit \
+                          --message "chore(deps): sync pnpm-lock.yaml with released manifests [skip ci]" \
+                          -- pnpm-lock.yaml
+
+                      if git push origin "HEAD:refs/heads/${BRANCH}"; then
+                          echo "Pushed the refreshed pnpm-lock.yaml on attempt ${attempt}."
+                          exit 0
+                      fi
+
+                      echo "Push rejected — ${BRANCH} moved during the release. Retrying."
+                      sleep "$((attempt * 5))"
+                  done
+
+                  echo "::error::Could not push the refreshed pnpm-lock.yaml after 5 attempts. ${BRANCH} is left with a lockfile that does not match its manifests, so every frozen-lockfile install on it will fail until it is regenerated (pnpm install --lockfile-only --no-frozen-lockfile) and pushed."
+                  exit 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3370,13 +3370,13 @@ importers:
         specifier: workspace:*
         version: link:../errors
       '@lunora/observability':
-        specifier: 1.0.0-alpha.33
+        specifier: 1.0.0-alpha.34
         version: link:../observability
       '@lunora/platform':
         specifier: workspace:*
         version: link:../platform
       '@lunora/platform-cloudflare':
-        specifier: 1.0.0-alpha.19
+        specifier: 1.0.0-alpha.20
         version: link:../platform-cloudflare
       '@lunora/shard-engine':
         specifier: workspace:*
@@ -3595,7 +3595,7 @@ importers:
         specifier: workspace:*
         version: link:../flags
       '@lunora/observability':
-        specifier: 1.0.0-alpha.33
+        specifier: 1.0.0-alpha.34
         version: link:../observability
       '@lunora/platform':
         specifier: workspace:*
@@ -3997,7 +3997,7 @@ importers:
         specifier: workspace:*
         version: link:../do
       '@lunora/platform-cloudflare':
-        specifier: 1.0.0-alpha.19
+        specifier: 1.0.0-alpha.20
         version: link:../platform-cloudflare
       '@lunora/runtime':
         specifier: workspace:*
@@ -4929,7 +4929,7 @@ importers:
         specifier: workspace:*
         version: link:../do
       '@lunora/observability':
-        specifier: 1.0.0-alpha.33
+        specifier: 1.0.0-alpha.34
         version: link:../observability
       '@types/node':
         specifier: catalog:types


### PR DESCRIPTION
## Summary

`alpha` is red: every push fails in its setup step with

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/do/package.json
  - @lunora/observability       (lockfile: 1.0.0-alpha.33, manifest: 1.0.0-alpha.34)
  - @lunora/platform-cloudflare (lockfile: 1.0.0-alpha.19, manifest: 1.0.0-alpha.20)
```

This affects both jobs that install dependencies on push — Semantic Release ([run 32667809564](https://github.com/anolilab/lunora/actions/runs/32667809564)) and CodSpeed ([run 32667809578](https://github.com/anolilab/lunora/actions/runs/32667809578)) — and has failed every push since 21:28 UTC on 2026-08-23. CodeQL and Code Quality don't install, which is why the breakage looked narrower than it is.

**The drift is not a bad merge.** The release run that bumped those versions ([run 32666543922](https://github.com/anolilab/lunora/actions/runs/32666543922)) *did* regenerate the lockfile correctly. Its push was then rejected:

```
 ! [rejected]          alpha -> alpha (non-fast-forward)
```

PR #457 landed on `alpha` during the ~15-minute release, so `git-auto-commit-action` had committed onto the tip the job checked out 20 minutes earlier. The corrected lockfile died on the runner, and `alpha` has been un-installable since — a state only a human regenerating the lockfile could exit.

Three commits, touching `pnpm-lock.yaml` and `.github/workflows/semantic-release.yml` only:

1. **`fix(deps)`** — regenerate the lockfile. The diff is the five drifted specifier strings across the `do`, `lunora`, `platform-node` and `testing` importers; no dependency churn.
2. **`ci(release)`** — replace `git-auto-commit-action` with a bash retry loop that `reset --hard`s to the *current* remote tip before each attempt, so the lockfile is resolved against the manifests actually on the branch and a push that loses the race is retried against the new tip. Five attempts, then the step fails loudly with the recovery command rather than leaving a silently broken branch. The gate also moves from `success()` to `!cancelled()`: a release that fails partway has still pushed the release commits it completed, so the branch needs the sync more then, not less.
3. **`ci(release)`** — assert the regenerated lockfile passes `--frozen-lockfile` before committing it, and fix the Node step's label (it read 22.14 while installing 22.15).

## Linked issues

- Refs #457 (the PR whose merge won the race)

## Test plan

Verified against the real repository state, not a hypothetical one:

- [x] `pnpm install --frozen-lockfile` **fails** on `alpha` today and **passes** with this branch's lockfile — this is the exact check that is failing in CI
- [x] The lockfile was regenerated with the workflow's own command (`pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts`); `git diff` confirms the five specifier lines and nothing else
- [x] The new `--frozen-lockfile --lockfile-only` guard was confirmed to actually fire on a stale lockfile (it exits 1 and prints the mismatch) — a guard that never fails is worse than none
- [x] `yamllint -c .yamllint.yaml --strict` passes on the workflow
- [x] `shellcheck` clean on the new `run:` block
- [x] `zizmor --min-severity medium` reports no findings (`github.ref_name` is passed via `env:`, not interpolated into the script)
- [x] `pnpm exec prettier --check` passes
- [x] Manifest gates all pass: `lint:package-json`, `lint:catalog-drift`, `lint:peer-catalog-refs`, `lint:project-json`, `lint:registry:sync`, `lint:generated`

Not run: `pnpm test` / `lint:types` / `lint:eslint`. No TypeScript changed — the diff is a lockfile and a workflow — and the suites will run here anyway via the PR trigger.

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change — n/a, CI configuration
- [ ] Updated relevant docs — n/a
- [x] No `package.json` files in `packages/*` modified outside the touched package (none modified)
- [ ] If a new package was added — n/a
- [ ] If migration impact — n/a

## Notes for reviewers

**The lockfile commit is the urgent half.** `alpha` stays red until this merges; the workflow change only affects the *next* release.

Two decisions worth a look:

- **`reset --hard origin/$BRANCH` rather than `pull --rebase`.** The release commits are already pushed by multi-semantic-release, so the remote tip is the truth and there is nothing local to preserve. A rebase would also be the wrong tool here: in the run that failed, git reported the local branch as 4128 commits diverged from the remote.
- **The `!cancelled()` gate means the sync now also runs after a *failed* run.** That is deliberate — it makes this class of breakage self-heal on the next push instead of needing a human. The step commits nothing when the lockfile already matches, so a run that failed for an unrelated reason pushes nothing.

Left alone deliberately: the `SECURITY TODO` on `harden-runner` (`egress-policy: audit` rather than `block`). The comment says the full allowlist can't be verified offline and an incomplete one breaks the release — that needs a maintainer with an audit run in hand, not a guess from me.

One structural thing this incident exposed, which I did **not** change: `lint.yml` and `test.yml` run on `pull_request` + `merge_group` only, with a documented rationale that holds for the contents of a merge but not for state that only exists after it — namely the release job's own commits. That is why a one-line lockfile drift survived six pushes. The `--frozen-lockfile` assertion in commit 3 closes the specific hole (the branch tip being un-installable) without adding push triggers to the whole suite; whether the broader gap deserves more is a maintainer call.


---
_Generated by [Claude Code](https://claude.ai/code/session_015e7KUWqF74MmqJXqqr48f2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release process to use a newer Node.js version.
  * Improved release reliability by validating generated package metadata and safely retrying publishing when conflicts occur.
  * No changes to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->