### PR TITLE
ci(release): refresh the codspeed baseline after a release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -33,6 +33,7 @@
             "issues": "write" # to comment on released issues
             "pull-requests": "write" # to comment on released pull requests
             "id-token": "write" # to enable OIDC for npm provenance
+            "actions": "write" # to dispatch the CodSpeed baseline run below
 
         "steps":
             - "name": "Harden Runner"
@@ -188,3 +189,33 @@
 
                   echo "::error::Could not push the refreshed pnpm-lock.yaml after 5 attempts. Every frozen-lockfile install on ${BRANCH} will fail until someone runs 'pnpm install --lockfile-only --no-frozen-lockfile' and pushes the result."
                   exit 1
+
+            # Every commit this job pushes carries `[skip ci]`, so GitHub dispatches no
+            # workflows for them and CodSpeed records no benchmark run at the new head.
+            # Its next PR report then finds no baseline on the branch, silently falls
+            # back to the last commit that did have one, and attributes everything that
+            # landed in between to the PR — a red "regression" in packages the PR never
+            # touched. Ask for a run on the new head explicitly.
+            #
+            # `codspeed.yml` already accepts `workflow_dispatch`, and its benchmark job
+            # is written to run when `files-changed` is skipped, which is what happens
+            # on a dispatch. Only the branches its `push:` trigger covers are worth
+            # dispatching — the others have no baseline to keep fresh.
+            - "name": "Refresh the CodSpeed baseline"
+              "if": "!cancelled() && (github.ref_name == 'main' || github.ref_name == 'alpha')"
+              "shell": "bash"
+              "env":
+                  "BRANCH": "${{ github.ref_name }}"
+                  "GH_TOKEN": "${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"
+              # Advisory: a missing baseline costs a noisy PR report, not a broken
+              # release, so this must never fail the job that just published.
+              "continue-on-error": true
+              "run": |
+                  set -euo pipefail
+
+                  git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+
+                  head="$(git rev-parse "origin/${BRANCH}")"
+
+                  echo "Dispatching a CodSpeed run for ${BRANCH} at ${head}."
+                  gh workflow run codspeed.yml --ref "${BRANCH}"


### PR DESCRIPTION
## Summary

CodSpeed has now failed three PRs with regressions those PRs did not cause — [#473](https://github.com/anolilab/lunora/pull/473), [#474](https://github.com/anolilab/lunora/pull/474), and [#467](https://github.com/anolilab/lunora/pull/467), the last flagging a `packages/do` benchmark from a diff that only touches `packages/svelte` and `packages/vue`. Each report carries CodSpeed's own footnote:

> No successful run was found on `alpha` (`5c3fb33`) during the generation of this report, so `0c68fc7` was used instead as the comparison base. There might be some changes unrelated to this pull request in this report.

**The cause is `[skip ci]`.** Every commit the release job pushes — each `chore(release):` bump and the lockfile sync — carries it, and GitHub dispatches no workflows for such commits. A release leaves `alpha` sitting on one, so no benchmark run is ever recorded at the branch head. CodSpeed then falls back to the last commit that *did* have a run, and everything merged in between is attributed to whichever PR is being evaluated.

`alpha`'s head is a `[skip ci]` release commit most of the time — the last twelve commits are ten releases and two merges — so this is the normal state, not an edge case.

**The fix** is one step at the end of the release job: dispatch a CodSpeed run against the new head. `codspeed.yml` already accepts `workflow_dispatch`, and its `benchmark` job is deliberately written to run when `files-changed` is skipped, which is exactly what a dispatch produces:

```yaml
"if": "!cancelled() && (github.event_name != 'pull_request' || needs.files-changed.outputs.benchmarks == 'true')"
```

Only the branches CodSpeed's `push:` trigger covers (`main`, `alpha`) are dispatched; the rest have no baseline to keep fresh. The job gains `actions: write` for the dispatch.

The step is **advisory** — `continue-on-error: true`. A stale baseline costs a noisy PR report; it must never fail a job that has already published to npm.

## Linked issues

- Refs #467 (currently red on exactly this)

## Test plan

- [x] `yamllint -c .yamllint.yaml --strict` passes
- [x] `shellcheck` clean on the new `run:` block
- [x] `zizmor --min-severity medium` — no findings (`github.ref_name` is bound through `env:`, never interpolated into the script)
- [x] `pnpm exec prettier --check` passes
- [x] Workflow parses; the job's step list ends with `Refresh the CodSpeed baseline` and the `if` resolves to `!cancelled() && (github.ref_name == 'main' || github.ref_name == 'alpha')`
- [x] Confirmed against the live repo that `codspeed.yml` declares `workflow_dispatch` and that its benchmark job runs on a dispatch rather than skipping with `files-changed`

Not verifiable before merge: that the dispatch itself succeeds. It needs the release job's token and `actions: write` in a real run, so the first release after this merges is the proof. `continue-on-error` bounds the downside to a log line.

## Checklist

- [x] Commit messages follow the [Conventional Commits](./commit-convention.md) style (`feat(scope): subject`)
- [ ] Added or updated tests covering the change — n/a, CI configuration
- [ ] Updated relevant docs — n/a
- [x] No `package.json` files in `packages/*` modified outside the touched package (none modified)
- [ ] If a new package was added — n/a
- [ ] If migration impact — n/a

## Notes for reviewers

Two things worth a second opinion:

- **`gh workflow run` vs. the REST API.** `gh` ships on the GitHub-hosted runner and reads `GH_TOKEN` from the environment, so it is the shortest path. A `curl` against `/actions/workflows/codspeed.yml/dispatches` would avoid depending on the preinstalled CLI, if you would rather not.
- **`actions: write` on a job that holds `NPM_TOKEN` and a PAT.** It is the minimum the dispatch needs, but it does widen a job the file already flags as security-sensitive. The alternative is a separate `workflow_run`-triggered workflow that dispatches CodSpeed after Semantic Release completes, keeping the permission out of the publishing job at the cost of another file.

This does not touch the CodSpeed check's failure threshold. A genuine regression still fails a PR, as it should — the point is only that the comparison is against the right base.

---
_Generated by [Claude Code](https://claude.ai/code/session_015e7KUWqF74MmqJXqqr48f2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release workflow permissions.
  * Added a best-effort performance baseline refresh after dependency lockfile updates.
  * Release processing continues even if the baseline refresh cannot be triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->