### PR TITLE
fix(codegen): honour .output() in the caller and see the aliases the printer reuses

### DIFF
--- a/packages/codegen/__tests__/discover-functions.test.ts
+++ b/packages/codegen/__tests__/discover-functions.test.ts
@@ -284,6 +284,106 @@ describe("discoverFunctions", () => {
             expect(result[0]?.returnType).toBe("{ id: string }[]");
         });
 
+        it("expands an alias the checker reuses from a declaration's syntax, which the type graph reports as absent", () => {
+            expect.assertions(2);
+
+            // TypeScript's node builder reuses the syntax of a property's declared
+            // type annotation whenever that annotation is in scope where the type
+            // is printed, so `{ action: AuditAction }` renders the alias verbatim.
+            // The same property fetched through the checker comes back with no
+            // alias symbol at all, fully resolved to its union — so a type-graph
+            // walk reported "nothing unreachable here" about text naming an alias
+            // on its face, and the bare name reached `_generated/` as a TS2304.
+            // Reproduced with the alias behind a conditional type (`Infer<typeof
+            // schema>`), the shape every Standard Schema wrapper produces.
+            writeFunction(
+                "lib/audit.ts",
+                `
+            export interface StandardSchema<O> { "~standard": { types?: { output: O } } }
+            export type Infer<S> = S extends StandardSchema<infer O> ? O : never;
+            export declare const AuditActionSchema: StandardSchema<"user.create" | "user.delete">;
+            export type AuditAction = Infer<typeof AuditActionSchema>;
+        `,
+            );
+
+            // `imported` names the alias through an import; `local` re-derives it
+            // in the handler's own module. Both are in scope at the handler, so
+            // both print bare.
+            writeFunction(
+                "audit.ts",
+                `
+            import { query } from "@lunora/server";
+            import { AuditActionSchema, type AuditAction, type Infer } from "./lib/audit";
+
+            type LocalAction = Infer<typeof AuditActionSchema>;
+
+            declare const loadImported: () => Promise<{ action: AuditAction }[]>;
+            declare const loadLocal: () => Promise<{ action: LocalAction }[]>;
+
+            export const imported = query({ args: {}, handler: async () => ({ isDone: true, logs: await loadImported() }) });
+            export const local = query({ args: {}, handler: async () => await loadLocal() });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+            const byName = new Map(discoverFunctions(project, workdir).map((f) => [f.exportName, f]));
+
+            expect(byName.get("imported")?.returnType).toBe('{ isDone: boolean; logs: { action: "user.create" | "user.delete" }[] }');
+            expect(byName.get("local")?.returnType).toBe('{ action: "user.create" | "user.delete" }[]');
+        });
+
+        it("expands a type declared inside the handler body, not just at module top level", () => {
+            expect.assertions(1);
+
+            // The rule is "declared in the handler's own module", at ANY nesting
+            // depth — a body-local `interface` is as unreachable from
+            // `_generated/` as a top-level one, and prints just as bare.
+            writeFunction(
+                "rows.ts",
+                `
+            import { query } from "@lunora/server";
+
+            export const get = query({ args: {}, handler: async () => {
+                interface Row { a: string; b: number }
+                const row: Row = { a: "", b: 1 };
+                return row;
+            } });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe("{ a: string; b: number }");
+        });
+
+        it("expands a user's own `Doc` — the dataModel exemption is by declaration path, never by name", () => {
+            expect.assertions(1);
+
+            // `Doc`/`Id` print correctly bare only because emit imports THOSE from
+            // `./dataModel.js`. Exempting the NAME instead of the declaration path
+            // is worse than the leak it guards: `referencedDataModelImports`
+            // triggers on `\bDoc<`, so a user's own generic `Doc` would be emitted
+            // bare AND given the generated import — silently bound to a different
+            // type, with no compile error anywhere to show for it.
+            writeFunction("lib/mydoc.ts", `export type Doc<T extends string> = { table: T; body: string };`);
+
+            writeFunction(
+                "posts.ts",
+                `
+            import { query } from "@lunora/server";
+            import type { Doc } from "./lib/mydoc";
+
+            declare const load: () => Promise<Doc<"posts">>;
+
+            export const get = query({ args: {}, handler: async () => await load() });
+        `,
+            );
+
+            const project = new Project({ skipAddingFilesFromTsConfig: true, useInMemoryFileSystem: false });
+
+            expect(discoverFunctions(project, workdir)[0]?.returnType).toBe('{ table: "posts"; body: string }');
+        });
+
         it("marks internalQuery/internalMutation/internalAction registrations as internal, mapping each to its kind", () => {
             expect.hasAssertions();
 

--- a/packages/codegen/__tests__/run-codegen.test.ts
+++ b/packages/codegen/__tests__/run-codegen.test.ts
@@ -2173,6 +2173,63 @@ export const raw = internalQuery
             expect(result.generated.api).toContain('raw: FunctionReference<"query", { id: string }, string>');
         });
 
+        it("keeps a stream on its handler's yield type — `.output()` is inert on that terminal", () => {
+            expect.assertions(3);
+
+            // `.output()` is not applied to a stream: `makeStreamHandler` is never
+            // given `state.output`, and the terminal is generic over its own yield
+            // type, so the builder does not type-check the declaration either.
+            // Preferring it would describe chunks the handler never yields — and
+            // preferring it in BOTH surfaces would only make the two agree on
+            // something untrue.
+            writeFileSync(
+                join(workdir, "lunora", "ticker.ts"),
+                `import { query, v } from "./_generated/server.js";
+
+export const tick = query
+    .input({ id: v.string() })
+    .output(v.object({ n: v.string() }))
+    .stream(async function* () {
+        yield { n: 1 };
+    });
+`,
+            );
+
+            const result = runCodegen({ projectRoot: workdir });
+
+            expect(result.generated.functions).toContain("tick: (args: { id: string }) => Promise<AsyncIterable<{ n: number; }>>;");
+            expect(result.generated.api).toContain("{ n: number; }");
+            expect(result.generated.api).not.toContain("{ n: string }");
+        });
+
+        it("types the CALLER from .output() too, not just the api reference", () => {
+            expect.assertions(3);
+
+            // `_generated/server.ts`'s `Caller` read the handler's inferred type
+            // directly while `api.ts` one function away read `.output()`, so the
+            // two descriptions of the same procedure disagreed: a field declared
+            // `v.optional(...)` typed as required through `ctx.run*`, and a
+            // `v.string()` narrowed to a branded `Id<...>`.
+            writeFileSync(
+                join(workdir, "lunora", "audit.ts"),
+                `import { internalQuery, v } from "./_generated/server.js";
+
+export const page = internalQuery
+    .input({ limit: v.number() })
+    .output(v.object({ cursor: v.optional(v.string()), id: v.string() }))
+    .query(async () => ({ cursor: "c", id: "abc" }));
+`,
+            );
+
+            const result = runCodegen({ projectRoot: workdir });
+
+            expect(result.generated.functions).toContain("page: (args: { limit: number }) => Promise<{ cursor?: string; id: string }>;");
+            // The declared `v.string()` stays opaque — it is not re-branded as an
+            // `Id<...>` by whatever the handler happened to return.
+            expect(result.generated.functions).not.toContain('Id<"audit">');
+            expect(result.generated.api).toContain("cursor?: string");
+        });
+
         it("registers a default-exported procedure as <module>.default", () => {
             expect.assertions(2);
 

--- a/packages/codegen/src/discover-functions.ts
+++ b/packages/codegen/src/discover-functions.ts
@@ -348,83 +348,123 @@ const argsFromCall = (call: CallExpression): Record<string, ValidatorIR> => {
 const GENERATED_DIRECTORY_SEGMENT = "/_generated/";
 
 /**
- * True when the checker will print this user-land named type as a BARE name at
+ * Whether the module at `node` imports `name` from `declarationFile` — the
+ * precise form of "the checker will print this bare".
+ *
+ * Deliberately NOT `type.getText(node).includes("import(")`: that renders the
+ * WHOLE type, type arguments and all, so an imported `Wrapper` wrapping an
+ * out-of-scope `Bar` renders text containing `import(` and the wrapper is
+ * wrongly cleared — printed bare into `_generated/` as a TS2304, one generic
+ * deep. Asking the source file directly is depth-independent, because the
+ * recursion visits each type on its own.
+ */
+const importsName = (handlerFile: SourceFile, declarationFile: SourceFile, name: string): boolean =>
+    handlerFile.getImportDeclarations().some((declaration) => {
+        if (declaration.getModuleSpecifierSourceFile() !== declarationFile) {
+            return false;
+        }
+
+        // A namespace import (`import * as t`) makes every exported name
+        // reachable, but only as `t.Bar` — which the checker prints qualified
+        // by a local alias that `_generated/` does not have either, so it
+        // counts as bare-nameable exactly like a named import.
+        return declaration.getNamespaceImport() !== undefined || declaration.getNamedImports().some((specifier) => specifier.getName() === name);
+    });
+
+/**
+ * True when `declaration` names a user-land type the checker can print BARE at
  * `node` — the case that does not resolve from `_generated/`.
  *
- * `_generated/api.ts` does not import the handler's modules; codegen only emits
- * an import for a qualifier the checker itself rendered as `import("…")` (plus
- * the fixed `dataModel` one, excluded below). So a bare name must be expanded
- * structurally rather than printed, or it lands in the generated file as an
- * undeclared identifier (TS2304).
- *
  * Two ways a name comes out bare, and both must be caught. One: the type is
- * declared in the handler's own module (`handlerFilePath`). Two: the type is
- * declared elsewhere in user code but IMPORTED into the handler's module, which
- * makes it equally nameable there. That second half was missing, so a shared
- * `./lib/types` interface — the ordinary way to write one — leaked into
- * `api.ts`/`functions.ts` unimported. It is detected by asking the checker what
- * it renders: an out-of-scope type comes back carrying an `import("…")`
- * qualifier, which the emitter rebases against the output directory instead, so
- * only the qualifier-free rendering is expanded here.
+ * declared in the handler's own module (`handlerFilePath`), at any nesting depth.
+ * Two: the type is declared elsewhere in user code but IMPORTED into the
+ * handler's module, which makes it equally nameable there. That second half was
+ * missing once, so a shared `./lib/types` interface — the ordinary way to write
+ * one — leaked into `api.ts`/`functions.ts` unimported.
  *
  * Exported declarations are included — being nameable from the handler is the
  * whole trigger, and `export` does not change that.
  */
-const printsAsUnimportedName = (type: Type, node: Node, handlerFilePath: string): boolean => {
-    const handlerFile = node.getSourceFile();
+const isBareNameable = (declaration: Node, node: Node, handlerFilePath: string): boolean => {
+    const declarationFile = declaration.getSourceFile();
 
-    /**
-     * Whether `handlerFile` imports `name` from `declarationPath` — the precise
-     * form of "the checker will print this bare".
-     *
-     * Deliberately NOT `type.getText(node).includes("import(")`: that renders the
-     * WHOLE type, type arguments and all, so an imported `Wrapper` wrapping an
-     * out-of-scope `Bar` renders text containing `import(` and the wrapper is
-     * wrongly cleared — printed bare into `_generated/` as a TS2304, one generic
-     * deep. Asking the source file directly is depth-independent, because the
-     * recursion visits each type on its own.
-     */
-    const importsName = (declarationFile: SourceFile, name: string): boolean =>
-        handlerFile.getImportDeclarations().some((declaration) => {
-            if (declaration.getModuleSpecifierSourceFile() !== declarationFile) {
-                return false;
-            }
+    if (declarationFile.isInNodeModules() || declarationFile.isDeclarationFile()) {
+        return false;
+    }
 
-            // A namespace import (`import * as t`) makes every exported name
-            // reachable, but only as `t.Bar` — which the checker prints qualified
-            // by a local alias that `_generated/` does not have either, so it
-            // counts as bare-nameable exactly like a named import.
-            return declaration.getNamespaceImport() !== undefined || declaration.getNamedImports().some((specifier) => specifier.getName() === name);
-        });
+    if (!Node.isInterfaceDeclaration(declaration) && !Node.isTypeAliasDeclaration(declaration)) {
+        return false;
+    }
 
-    const isBareNameable = (declaration: Node): boolean => {
-        const declarationFile = declaration.getSourceFile();
+    const declarationPath = declarationFile.getFilePath();
 
-        if (declarationFile.isInNodeModules() || declarationFile.isDeclarationFile()) {
-            return false;
-        }
+    // `Doc`/`Id` and friends: the generated files import these by name, so the
+    // bare rendering is correct there. Expanding them instead would discard a
+    // branded `Id` (not an expandable object) and fall all the way back to
+    // `unknown` — measured as every `Doc`/`Id`-shaped return type in the
+    // example apps collapsing at once. Keyed on the declaration PATH, never on
+    // the name: a user's own `Doc`/`Id` is a different type, and exempting it by
+    // name let `referencedDataModelImports` bind it to the generated one — a
+    // wrong type with no compile error anywhere.
+    if (declarationPath.includes(GENERATED_DIRECTORY_SEGMENT)) {
+        return false;
+    }
 
-        if (!Node.isInterfaceDeclaration(declaration) && !Node.isTypeAliasDeclaration(declaration)) {
-            return false;
-        }
+    return declarationPath === handlerFilePath || importsName(node.getSourceFile(), declarationFile, declaration.getName());
+};
 
-        const declarationPath = declarationFile.getFilePath();
-
-        // `Doc`/`Id` and friends: the generated files import these by name, so the
-        // bare rendering is correct there. Expanding them instead would discard a
-        // branded `Id` (not an expandable object) and fall all the way back to
-        // `unknown` — measured as every `Doc`/`Id`-shaped return type in the
-        // example apps collapsing at once.
-        if (declarationPath.includes(GENERATED_DIRECTORY_SEGMENT)) {
-            return false;
-        }
-
-        return declarationPath === handlerFilePath || importsName(declarationFile, declaration.getName());
-    };
-
-    return [type.getSymbol(), type.getAliasSymbol()]
+/**
+ * True when the checker will print this user-land named type as a BARE name at
+ * `node`.
+ *
+ * `_generated/api.ts` does not import the handler's modules; codegen only emits
+ * an import for a qualifier the checker itself rendered as `import("…")` (plus
+ * the fixed `dataModel` one, excluded above). So a bare name must be expanded
+ * structurally rather than printed, or it lands in the generated file as an
+ * undeclared identifier (TS2304).
+ */
+const printsAsUnimportedName = (type: Type, node: Node, handlerFilePath: string): boolean =>
+    [type.getSymbol(), type.getAliasSymbol()]
         .flatMap((candidate) => candidate?.getDeclarations() ?? [])
-        .some((declaration) => isBareNameable(declaration));
+        .some((declaration) => isBareNameable(declaration, node, handlerFilePath));
+
+/**
+ * True when a declaration's type ANNOTATION names something that would print
+ * bare — the half of the printing rule that the resolved type cannot reveal.
+ *
+ * TypeScript's node builder reuses the syntax of a declared annotation whenever
+ * that syntax resolves at the printing location, so `{ action: AuditAction }`
+ * prints the alias verbatim. The same property fetched back through the checker
+ * (`getTypeAtLocation`, `getTypeOfSymbol`) comes back with no alias symbol at
+ * all, fully resolved to its union — so walking resolved types alone reported
+ * "nothing unreachable here" about text that names an alias on its face, and the
+ * bare name reached `_generated/` as a TS2304 while `lunora codegen` exited 0.
+ * An alias behind a conditional type (`Infer<typeof schema>`, the shape every
+ * Standard Schema wrapper produces) leaked from every procedure that returned
+ * one. Walking the annotation as well as the type it resolves to is what closes
+ * that gap; it does not replace the resolved walk, because an inferred return
+ * with no annotation anywhere still has to be caught by the type.
+ */
+const annotationPrintsAsUnimportedName = (declaration: Node, node: Node, handlerFilePath: string): boolean => {
+    const annotation = Node.isPropertySignature(declaration) || Node.isPropertyDeclaration(declaration) ? declaration.getTypeNode() : undefined;
+
+    if (annotation === undefined) {
+        return false;
+    }
+
+    return [annotation, ...annotation.getDescendantsOfKind(SyntaxKind.TypeReference)]
+        .filter((candidate) => Node.isTypeReference(candidate))
+        .flatMap((reference) => {
+            // Resolved through `getAliasedSymbol()` for an `import type { X }`,
+            // exactly as `resolveValidatorAlias` does — otherwise the symbol is
+            // the `ImportSpecifier`, which is neither an interface nor a type
+            // alias, so every imported name read as reachable and the leak this
+            // walk exists to catch stayed open for the commonest spelling of it.
+            const symbol = reference.getTypeName().getSymbol();
+
+            return (symbol?.getAliasedSymbol() ?? symbol)?.getDeclarations() ?? [];
+        })
+        .some((referenced) => isBareNameable(referenced, node, handlerFilePath));
 };
 
 /** Composite child types of `type` (type arguments + union/intersection members) to recurse into. */
@@ -485,7 +525,15 @@ const referencesUnreachableLocalType = (type: Type, node: Node, handlerFilePath:
         return false;
     }
 
-    return type.getProperties().some((property) => referencesUnreachableLocalType(property.getTypeAtLocation(node), node, handlerFilePath, seen));
+    return type.getProperties().some((property) => {
+        // The annotation first: it is the syntax the printer reuses, and the
+        // resolved type below has already lost the alias by the time we see it.
+        if (property.getDeclarations().some((declaration) => annotationPrintsAsUnimportedName(declaration, node, handlerFilePath))) {
+            return true;
+        }
+
+        return referencesUnreachableLocalType(property.getTypeAtLocation(node), node, handlerFilePath, seen);
+    });
 };
 
 /** Is `property` declared optional (`name?: …`)? */

--- a/packages/codegen/src/emit.ts
+++ b/packages/codegen/src/emit.ts
@@ -749,6 +749,13 @@ const referencedDataModelImports = (body: string): ReadonlyArray<"Doc" | "Id"> =
  *
  * Falls back to the handler when no `.output()` is declared, so a project that
  * never uses it emits byte-identical output.
+ *
+ * A `stream` is the exception and keeps the handler's type. `.output()` is inert
+ * on that terminal — `makeStreamHandler` is never given `state.output`, and the
+ * terminal is generic over its own yield type, so the builder does not even
+ * type-check the declaration (`packages/server/src/builder/types.ts` says so on
+ * the `stream` member). Preferring an unenforced, untyped declaration there
+ * would describe chunks the handler does not yield.
  */
 const referenceReturnType = (definition: FunctionIR): string => {
     // `parseValidator` yields `{ kind: "any" }` for anything that is not a call
@@ -757,7 +764,7 @@ const referenceReturnType = (definition: FunctionIR): string => {
     // Preferring that over the handler would replace a precise inferred type
     // with `unknown` — reintroducing, on every procedure with a hoisted output
     // validator, exactly the leak this function exists to stop.
-    if (definition.output === undefined || definition.output.kind === "any") {
+    if (definition.output === undefined || definition.output.kind === "any" || definition.kind === "stream") {
         return definition.returnType;
     }
 
@@ -1642,6 +1649,14 @@ const renderFunctionRegistry = (
  * `(args) => Promise<Return>`; `args` is optional only when the function takes
  * none. The runtime leaves dispatch through `callRegistered`, which infers the
  * return type from the interface's contextual type.
+ *
+ * `Return` comes from {@link referenceReturnType}, so a declared `.output()`
+ * wins over the handler's inferred type here exactly as it does in `api.ts`.
+ * Reading `definition.returnType` directly is what let the two surfaces
+ * disagree: `ctx.run*` through the caller saw a field the validator declares
+ * `v.optional(...)` as required, and a `v.string()` narrowed to a branded
+ * `Id<...>` — while `api.ts`, one function away, described the same procedure
+ * correctly.
  */
 const renderCaller = (functions: ReadonlyArray<FunctionIR>): { implementation: string; types: string } => {
     const ordered = groupByFileSorted(functions);
@@ -1652,13 +1667,15 @@ const renderCaller = (functions: ReadonlyArray<FunctionIR>): { implementation: s
                 .map((definition) => {
                     const argsType = rebaseRelativeQualifiers(renderArgsType(definition.args), definition.filePath);
                     const optional = argsType === "{}" ? "?" : "";
-                    const returnType = rebaseRelativeQualifiers(definition.returnType, definition.filePath);
+                    const returnType = rebaseRelativeQualifiers(referenceReturnType(definition), definition.filePath);
 
                     // A `stream` handler returns an `AsyncIterable<T>` *synchronously*;
                     // `callRegistered` awaits the handler, and awaiting a non-thenable
                     // async-iterable yields the iterable itself. So the leaf resolves to
                     // `AsyncIterable<T>`, not a single element `T`. (Note `unwrapHandlerReturn`
-                    // already unwrapped the iterable to its element type in `returnType`.)
+                    // already unwrapped the iterable to its element type — and
+                    // `referenceReturnType` keeps a stream on that inferred type rather
+                    // than an inert `.output()`, so this is still the element type.)
                     if (definition.kind === "stream") {
                         return `        ${definition.exportName}: (args${optional}: ${argsType}) => Promise<AsyncIterable<${returnType}>>;`;
                     }


### PR DESCRIPTION
Closes #479.

Two ways the generated return type could contradict the code it describes. All in `@lunora/codegen`; no public surface change.

## 1. `.output()` was ignored by the caller

`api.ts` already preferred the declared validator over the handler's inferred type. The typed `Caller` in `_generated/server.ts` — `(args) => Promise<…>`, the surface `ctx.run*` infers from — read `definition.returnType` directly, so the same procedure had two descriptions that disagreed:

- a field declared `v.optional(...)` typed as **required**, so a caller trusting the type reads `undefined` at runtime;
- an opaque `v.string()` **narrowed** to a branded `Id<...>` the validator does not promise.

Routed through `referenceReturnType`, like `api.ts` does. `.output()` is genuinely enforced at runtime for query/mutation/action (`applyOutput` parses and strips), so it is the right source of truth.

A **`stream` is now excluded** on both surfaces. `.output()` is inert on that terminal: `makeStreamHandler` is never given `state.output`, and the terminal is generic over its own yield type, so the builder does not type-check the declaration either (`packages/server/src/builder/types.ts` says so outright). `api.ts` had been describing chunks the handler never yields; propagating that to the caller would only have made the two agree on something untrue.

## 2. The alias leak — the printer sees things the type graph cannot

Where no `.output()` is declared and inference is the only option, an inferred type could name something `_generated/` cannot resolve — an undeclared identifier in generated code (TS2304) while `lunora codegen` exits 0.

The existing guard walked **resolved types**, which is only half the printing rule. TypeScript's node builder reuses the syntax of a *declared annotation* whenever that syntax resolves at the printing location, so `{ action: AuditAction }` prints the alias verbatim — while the same property fetched back through the checker (`getTypeAtLocation`, `getTypeOfSymbol`) comes back with **no alias symbol at all**, fully resolved to its union. The walk therefore reported "nothing unreachable here" about text that names an alias on its face. That is why an alias behind `Infer<typeof schema>` — the shape every Standard Schema wrapper produces — leaked from every procedure returning one.

Fix: walk the annotation as well as the type it resolves to, resolving an `import type { X }` through `getAliasedSymbol()` (as `resolveValidatorAlias` already does) so the commonest spelling isn't read as reachable. The existing symbol/declaration-path model is otherwise untouched — it was right about nesting depth, about `Doc`/`Id`, and about `node_modules`.

## Not fixed here

The issue also reports names arriving from a **third-party package** leaking the same way. I tried including `node_modules` in the check and backed it out: it is the same names that are also ambient globals in a Workers project (`Blob`, `Response`, `Request`, `ReadableStream`, and `@cloudflare/workers-types` nominals), which `_generated/` resolves without any import. Flagging them turned a correct `{ b: Blob }` into `unknown`, and an `R2Object` into a structural blob. That trade is worse than the bug, so the third-party class stays open; it wants a "is this name ambient from the generated file's scope?" test, which is a separate change.

## Verification

- 1,328 tests in `@lunora/codegen`, `test:affected` (12 projects) and `lint:affected:types` (22 projects) green; eslint + prettier clean.
- Four regression tests, each confirmed to **fail** without its fix.
- Generated output regenerated for all 13 `examples/*` plus `apps/playground` under both the old and new emitter and diffed: **byte-identical**.

## Review history

The first version of this branch took a different approach — scanning the checker's *rendered text* for bare identifiers instead of walking types. Two review passes found it regressed four cases `alpha` handled correctly (a type declared inside a handler body; identifiers starting or ending with `$`; a user's own `Doc`/`Id`, which was silently rebound to the generated one; and ambient globals collapsing to `unknown`), plus a memoisation keyed on `SourceFile` identity that goes stale in the Vite dev loop, since `refreshFromFileSystemSync()` mutates in place. All five are reproduced and gone — the approach was replaced rather than patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
