### PR TITLE
feat(errors): add raise() for expression-position throws

### DIFF
--- a/api-snapshots/errors.api.md
+++ b/api-snapshots/errors.api.md
@@ -817,6 +817,12 @@ const isInternalCode: (code: string) => boolean;
 const isLunoraError: (error: unknown) => error is LunoraErrorLike;
 ```
 
+### `raise` (const)
+
+```ts
+const raise: (code: LunoraErrorCodeInput, message?: string, options?: LunoraErrorOptions) => never;
+```
+
 ### `resolveHint` (const)
 
 ```ts

--- a/api-snapshots/lunora.api.md
+++ b/api-snapshots/lunora.api.md
@@ -2559,6 +2559,10 @@ Re-exported from `@lunora/errors` — signature tracked at its source.
 
 Re-exported from `@lunora/errors` — signature tracked at its source.
 
+### `raise` (const)
+
+Re-exported from `@lunora/errors` — signature tracked at its source.
+
 ### `resolveHint` (const)
 
 Re-exported from `@lunora/errors` — signature tracked at its source.

--- a/packages/errors/__tests__/errors.test.ts
+++ b/packages/errors/__tests__/errors.test.ts
@@ -11,6 +11,7 @@ import {
     isInternalCode,
     isLunoraError,
     LunoraError,
+    raise,
     resolveHint,
     toErrorBody,
     unreachable,
@@ -402,5 +403,50 @@ describe("invariant / unreachable", () => {
         expect.assertions(1);
 
         expect(() => unreachable("branch")).toThrow(LunoraError);
+    });
+});
+
+describe("raise", () => {
+    it("throws the requested code with catalog defaults", () => {
+        expect.assertions(4);
+
+        let caught: unknown;
+
+        try {
+            raise("NOT_FOUND", "thread 7");
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(isLunoraError(caught)).toBe(true);
+        expect((caught as LunoraError).code).toBe("NOT_FOUND");
+        expect((caught as LunoraError).status).toBe(404);
+        expect((caught as Error).message).toBe("thread 7");
+    });
+
+    it("forwards options to the constructor", () => {
+        expect.assertions(2);
+
+        let caught: unknown;
+
+        try {
+            raise("BAD_REQUEST", "bad cursor", { data: { cursor: "x" }, status: 418 });
+        } catch (error) {
+            caught = error;
+        }
+
+        expect((caught as LunoraError).status).toBe(418);
+        expect((caught as LunoraError).data).toStrictEqual({ cursor: "x" });
+    });
+
+    it("narrows the value it is called through", () => {
+        expect.assertions(1);
+
+        const rows: ({ id: string } | undefined)[] = [{ id: "a" }];
+        // The point of the `never` annotation: `id` is `string`, not `string | undefined`,
+        // without a non-null assertion. A compile error here IS the failure.
+        const { id } = rows[0] ?? raise("NOT_FOUND", "row");
+
+        expect(id).toBe("a");
     });
 });

--- a/packages/errors/docs/index.mdx
+++ b/packages/errors/docs/index.mdx
@@ -41,6 +41,23 @@ choose the response status.
 `LunoraError`, so even "should never happen" assertions participate in the layer
 (redacted to a generic message on the wire, detailed in logs).
 
+## Throwing in expression position
+
+`throw` is a statement, so it can't sit on the right of `??` or in a ternary arm.
+`raise(code, message?, options?)` can, and — because its declaration is annotated
+`=> never` — it also ends the control-flow path, so the value flowing through it
+narrows:
+
+```ts
+import { raise } from "@lunora/errors";
+
+const thread = (await ctx.db.threads.get(id)) ?? raise("NOT_FOUND", `thread ${id}`);
+//    ^ non-nullable, no assertion needed
+```
+
+Unlike `invariant`/`unreachable`, which are pinned to `INTERNAL`, `raise` takes
+the code — use it for failures the caller can act on.
+
 ## Rendering
 
 `LunoraError` mirrors `@visulima/error`'s error model (`type: "VisulimaError"`

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -23,6 +23,6 @@ export {
 } from "./catalog";
 export type { LunoraErrorLike } from "./guards";
 export { isLunoraError } from "./guards";
-export { invariant, unreachable } from "./invariant";
+export { invariant, raise, unreachable } from "./invariant";
 export type { ErrorBody, ToErrorBodyOptions, ToErrorBodyResult } from "./to-error-body";
 export { toErrorBody } from "./to-error-body";

--- a/packages/errors/src/invariant.ts
+++ b/packages/errors/src/invariant.ts
@@ -35,7 +35,11 @@ export const unreachable: (message: string) => never = (message) => {
  * arm — the two places a missing value is most naturally rejected. Unlike
  * {@link invariant} and {@link unreachable}, which are pinned to `INTERNAL`, this
  * takes the code, which is what a client-actionable failure needs.
- * @param code machine-readable reason, keyed into `ERROR_CATALOG`
+ *
+ * Any string is a valid `code`. A well-known `ERROR_CATALOG` key fills in the
+ * status, title and hint; a package-specific code with no catalog entry defaults
+ * to status 500 and no hint, so pass those in `options` instead.
+ * @param code machine-readable reason
  * @param message human-readable detail; defaults to `code`
  * @param options status/title/hint/data overrides
  * @example

--- a/packages/errors/src/invariant.ts
+++ b/packages/errors/src/invariant.ts
@@ -5,12 +5,13 @@
  * invariant breach is a bug, not a client-actionable error) while staying rich in
  * server logs and the CLI.
  *
- * All three are declared as `const name: (…) => never = …` rather than
- * `const name = (…): never => …`. TypeScript only lets a call end a control-flow
- * path when the callee is a name whose *declaration* carries the annotation; an
- * inferred `const` does not qualify, the same restriction assertion functions
- * have. With the annotation on the arrow instead, `if (!row) { raise(…); }` would
- * leave `row` possibly-`null` on the next line.
+ * Each is annotated on the **declaration** rather than on the arrow —
+ * `const name: (…) => never = …`, and `invariant` the assertion-function
+ * equivalent `(…) => asserts condition`. TypeScript only lets a call narrow or
+ * end a control-flow path when the callee is a name whose declaration carries
+ * that annotation; an inferred `const` does not qualify. Written the other way
+ * round (`const raise = (…): never => …`), `if (!row) { raise(…); }` would leave
+ * `row` possibly-`null` on the next line, with nothing to warn you.
  */
 import type { LunoraErrorCodeInput, LunoraErrorOptions } from "./base";
 import { LunoraError } from "./base";

--- a/packages/errors/src/invariant.ts
+++ b/packages/errors/src/invariant.ts
@@ -1,10 +1,18 @@
 /**
- * Assertion helpers that throw a unified {@link LunoraError} instead of a bare
- * `Error`, so even "should never happen" invariants participate in the error
- * layer: they carry the `INTERNAL` code (redacted to a generic message on the
- * wire — an invariant breach is a bug, not a client-actionable error) while
- * staying rich in server logs and the CLI.
+ * Helpers that throw a unified {@link LunoraError} instead of a bare `Error`, so
+ * even "should never happen" invariants participate in the error layer: they
+ * carry the `INTERNAL` code (redacted to a generic message on the wire — an
+ * invariant breach is a bug, not a client-actionable error) while staying rich in
+ * server logs and the CLI.
+ *
+ * All three are declared as `const name: (…) => never = …` rather than
+ * `const name = (…): never => …`. TypeScript only lets a call end a control-flow
+ * path when the callee is a name whose *declaration* carries the annotation; an
+ * inferred `const` does not qualify, the same restriction assertion functions
+ * have. With the annotation on the arrow instead, `if (!row) { raise(…); }` would
+ * leave `row` possibly-`null` on the next line.
  */
+import type { LunoraErrorCodeInput, LunoraErrorOptions } from "./base";
 import { LunoraError } from "./base";
 
 /** Throw an `INTERNAL` {@link LunoraError} when `condition` is falsy. */
@@ -15,6 +23,26 @@ export const invariant: (condition: unknown, message: string) => asserts conditi
 };
 
 /** Throw an `INTERNAL` {@link LunoraError} for an unreachable branch. */
-export const unreachable = (message: string): never => {
+export const unreachable: (message: string) => never = (message) => {
     throw new LunoraError("INTERNAL", message, { name: "InvariantError" });
+};
+
+/**
+ * Throw a {@link LunoraError} from expression position.
+ *
+ * `throw` is a statement, so it cannot sit on the right of `??` or in a ternary
+ * arm — the two places a missing value is most naturally rejected. Unlike
+ * {@link invariant} and {@link unreachable}, which are pinned to `INTERNAL`, this
+ * takes the code, which is what a client-actionable failure needs.
+ * @param code machine-readable reason, keyed into `ERROR_CATALOG`
+ * @param message human-readable detail; defaults to `code`
+ * @param options status/title/hint/data overrides
+ * @example
+ * ```ts
+ * const thread = (await ctx.db.threads.get(id)) ?? raise("NOT_FOUND", `thread ${id}`);
+ * // thread is non-nullable here
+ * ```
+ */
+export const raise: (code: LunoraErrorCodeInput, message?: string, options?: LunoraErrorOptions) => never = (code, message, options) => {
+    throw new LunoraError(code, message, options);
 };


### PR DESCRIPTION
## What

Adds `raise(code, message?, options?)` to `@lunora/errors` — throw a `LunoraError` from expression position.

```ts
import { raise } from "@lunora/errors";

const thread = (await ctx.db.threads.get(id)) ?? raise("NOT_FOUND", `thread ${id}`);
//    ^ non-nullable here, no assertion needed
```

## Why

`throw` is a statement, so it cannot sit on the right of `??` or in a ternary arm — the two places a missing value is most naturally rejected. Every non-trivial backend ends up writing the same local helper for this.

The part that is easy to get wrong: a helper that throws only *ends the control-flow path* for the type checker when its **declaration** carries an explicit `never` annotation. TypeScript does not accept an inferred one — the same restriction assertion functions have.

```ts
const raise = (code: string): never => { throw new LunoraError(code); };  // ✗ does not narrow
const raise: (code: string) => never = (code) => { throw new LunoraError(code); };  // ✓
```

With the annotation on the arrow instead of the const, `if (!row) { raise("NOT_FOUND"); }` leaves `row` possibly-`null` on the next line and nothing warns. Getting that right once, here, is worth more than each consumer rediscovering it.

`invariant` and `unreachable` already cover the boolean-condition and impossible-branch cases, but both are pinned to `INTERNAL`. `raise` is the one that lets the caller pick the code, which is what a client-actionable failure needs. `unreachable` moves to the same declaration form for consistency; behaviour unchanged.

## Scope

Additive. No existing export changes shape.

- `packages/errors/src/invariant.ts` — `raise`, plus the annotation-form note as a module comment
- `packages/errors/src/index.ts` — export
- `packages/errors/__tests__/errors.test.ts` — 3 tests, one of which is a *compile-time* assertion: it destructures through `rows[0] ?? raise(…)`, so if the narrowing regresses the suite fails to typecheck
- `packages/errors/docs/index.mdx` — new "Throwing in expression position" section
- `api-snapshots/{errors,lunora}.api.md` — regenerated after a full `build:packages`

## Checks

- `pnpm --filter "@lunora/errors" run test` — 592 passed
- `pnpm --filter "@lunora/errors" run lint:types` — clean
- `pnpm --filter "@lunora/errors" run lint:eslint` — clean
- `pnpm run api:update` after `pnpm run build:packages`; the only diff is the `raise` entry in the two affected snapshots

The package stays zero-dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `raise` helper for throwing application errors with a caller-selected code, optional message, and options.
  * Improved control-flow handling for unreachable code and raised errors.
* **Documentation**
  * Added usage documentation and examples for the new helper, including expression-based usage and nullish coalescing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->