### PR TITLE
feat(values): add v.partial() for patch-style shapes

### DIFF
--- a/api-snapshots/values.api.md
+++ b/api-snapshots/values.api.md
@@ -368,6 +368,7 @@ const v: {
     number: typeof number;
     object: typeof objectValidator;
     optional: typeof optional;
+    partial: typeof partial;
     record: typeof record;
     storage: typeof storage;
     string: typeof string;

--- a/packages/values/__tests__/v.test.ts
+++ b/packages/values/__tests__/v.test.ts
@@ -822,3 +822,52 @@ describe("isOrWrapsFromValidator", () => {
         expect(isOrWrapsFromValidator(metaless)).toBe(false);
     });
 });
+
+describe("v.partial", () => {
+    it("makes every member optional", () => {
+        expect.assertions(3);
+
+        const shape = v.partial({ done: v.boolean(), title: v.string() });
+        const object = v.object(shape);
+
+        expect(object.parse({})).toStrictEqual({});
+        expect(object.parse({ title: "a" })).toStrictEqual({ title: "a" });
+        expect(object.parse({ done: true, title: "a" })).toStrictEqual({ done: true, title: "a" });
+    });
+
+    it("still rejects a present member of the wrong type", () => {
+        expect.assertions(1);
+
+        const object = v.object(v.partial({ title: v.string() }));
+
+        expect(() => object.parse({ title: 1 })).toThrow(ValidationError);
+    });
+
+    it("passes an already-optional member through instead of double-wrapping", () => {
+        expect.assertions(2);
+
+        const inner = v.optional(v.string());
+        const shape = v.partial({ title: inner });
+
+        expect(shape.title).toBe(inner);
+        expect(v.object(shape).parse({})).toStrictEqual({});
+    });
+
+    it("infers every key as optional", () => {
+        expect.assertions(3);
+
+        const object = v.object(v.partial({ done: v.boolean(), title: v.string() }));
+
+        type Inferred = Infer<typeof object>;
+
+        // Compile-time: each member keeps its type, widened by `undefined`…
+        const doneCheck: Assert<Equal<Inferred["done"], boolean | undefined>> = true;
+        // …and every KEY is optional, or neither literal below would assign.
+        const empty: Inferred = {};
+        const some: Inferred = { title: "a" };
+
+        expect(doneCheck).toBe(true);
+        expect(empty).toStrictEqual({});
+        expect(some).toStrictEqual({ title: "a" });
+    });
+});

--- a/packages/values/docs/index.mdx
+++ b/packages/values/docs/index.mdx
@@ -63,6 +63,23 @@ Every factory returns a `Validator` with `parse(value)` (throws
 [`ValidationError`](#validationerror)) and `safeParse(value)` (returns
 `{ ok: true, value } | { ok: false, error }`).
 
+### `v.partial(shape)`
+
+Wraps every member of a shape in `v.optional(...)` — the "any subset of these
+columns" shape a patch-style procedure takes. It works on a shape _record_, so
+the same call serves an args map and a nested object:
+
+```ts
+mutation.input(v.partial(schema.tables.threads.shape)).mutation(…)
+
+v.object(v.partial({ done: v.boolean(), title: v.string() }));
+//        ^ { done?: boolean; title?: string }
+```
+
+Deriving it beats writing the optional copy by hand: when the two drift, a column
+added to the table is silently not accepted by the patch and nothing fails. A
+member that is already `v.optional(...)` is passed through, so it is idempotent.
+
 <Callout type="warn">
     `v.from(...)` validators are **args-only**: pass them to `query`/`mutation`/`action` args, never to a `defineTable` column. `defineTable` rejects them
     (anywhere in the column, including nested) because a Standard Schema value has no SQL column type. The wrapped `validate` must be synchronous; an async

--- a/packages/values/docs/index.mdx
+++ b/packages/values/docs/index.mdx
@@ -66,19 +66,26 @@ Every factory returns a `Validator` with `parse(value)` (throws
 ### `v.partial(shape)`
 
 Wraps every member of a shape in `v.optional(...)` — the "any subset of these
-columns" shape a patch-style procedure takes. It works on a shape _record_, so
-the same call serves an args map and a nested object:
+fields" shape a patch-style procedure takes. It works on a shape _record_, so the
+same call serves an args map and a nested object:
 
 ```ts
-mutation.input(v.partial(schema.tables.threads.shape)).mutation(…)
+const editable = { body: v.string(), title: v.string() };
+
+mutation.input({ id: v.id("threads"), ...v.partial(editable) }).mutation(…);
 
 v.object(v.partial({ done: v.boolean(), title: v.string() }));
 //        ^ { done?: boolean; title?: string }
 ```
 
-Deriving it beats writing the optional copy by hand: when the two drift, a column
-added to the table is silently not accepted by the patch and nothing fails. A
-member that is already `v.optional(...)` is passed through, so it is idempotent.
+A member that is already `v.optional(...)` is passed through, so it is
+idempotent.
+
+<Callout type="warn">
+    Pass the fields a caller may patch — not `schema.tables.x.shape`. Spreading a whole table's shape into a patch procedure makes every present **and future**
+    column client-writable: add `ownerId`, `role`, or `isVerified` to the table later and it silently joins the patch, with no diff on the procedure for a
+    reviewer to catch. Row-level policies don't close this — they decide which row you may write, not which fields — so the allow-list belongs here.
+</Callout>
 
 <Callout type="warn">
     `v.from(...)` validators are **args-only**: pass them to `query`/`mutation`/`action` args, never to a `defineTable` column. `defineTable` rejects them

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -1059,6 +1059,38 @@ const optional = <V extends Validator>(inner: V): ColumnValidator<Infer<V> | und
     );
 };
 
+/** Every member of a shape made optional — the result of {@link partial}. */
+type PartialShape<S extends ObjectShape> = { [K in keyof S]: ColumnValidator<Infer<S[K]> | undefined, Infer<S[K]> | undefined> };
+
+/**
+ * Wrap every member of a shape in {@link optional}.
+ *
+ * A patch-style procedure takes "any subset of these columns" — the same shape
+ * the table declares, with nothing required. Spelling that out by hand means a
+ * second copy of the shape that has to be kept in step with the first, and the
+ * failure when it drifts is quiet: a column added to the table is simply not
+ * accepted by the patch, and nothing typechecks it against the table.
+ *
+ * Takes and returns a *shape record* rather than a `v.object(...)`, so the one
+ * function serves both positions — a procedure's args map (`.input(...)`) and a
+ * nested object (`v.object(v.partial(shape))`).
+ *
+ * A member that is already `v.optional(...)` is passed through rather than
+ * double-wrapped, so this is idempotent.
+ * @example
+ * ```ts
+ * mutation.input(v.partial(schema.tables.threads.shape)).mutation(…)
+ * ```
+ */
+const partial = <S extends ObjectShape>(shape: S): PartialShape<S> =>
+    // `Object.fromEntries` defines data properties (CreateDataPropertyOrThrow),
+    // so a `__proto__` member round-trips as a plain key instead of hitting the
+    // Object.prototype setter the way `out[key] = …` would. `v.object` rejects
+    // that field name anyway, but this helper also feeds args maps, which do not.
+    Object.fromEntries(
+        Object.entries(shape).map(([key, member]) => [key, toInternal(member).kind === "optional" ? member : optional(member)]),
+    ) as PartialShape<S>;
+
 const any = (): ColumnValidator<unknown, unknown> => asColumn(createValidator<unknown>("any", (value) => value));
 
 /**
@@ -1294,6 +1326,7 @@ const v: {
     number: typeof number;
     object: typeof objectValidator;
     optional: typeof optional;
+    partial: typeof partial;
     record: typeof record;
     storage: typeof storage;
     string: typeof string;
@@ -1314,6 +1347,7 @@ const v: {
     number,
     object: objectValidator,
     optional,
+    partial,
     record,
     storage,
     string,
@@ -1339,6 +1373,7 @@ export type {
     MetaOptions,
     NumberColumnValidator,
     OptionalizeShape,
+    PartialShape,
     SelectShape,
     ServerDefaultContext,
     StringColumnValidator,

--- a/packages/values/src/v.ts
+++ b/packages/values/src/v.ts
@@ -1077,9 +1077,18 @@ type PartialShape<S extends ObjectShape> = { [K in keyof S]: ColumnValidator<Inf
  *
  * A member that is already `v.optional(...)` is passed through rather than
  * double-wrapped, so this is idempotent.
+ *
+ * **Pass the fields a caller may patch, not a whole table's shape.** Handing this
+ * `schema.tables.x.shape` makes every present and *future* column client-writable:
+ * add `ownerId`, `role`, or `isVerified` to the table later and it silently joins
+ * the patch, with no diff on the procedure to review. Row-level policies do not
+ * close that — they decide which ROW you may write, not which fields — so the
+ * allow-list has to be here.
  * @example
  * ```ts
- * mutation.input(v.partial(schema.tables.threads.shape)).mutation(…)
+ * const editable = { body: v.string(), title: v.string() };
+ *
+ * mutation.input({ id: v.id("threads"), ...v.partial(editable) }).mutation(…)
  * ```
  */
 const partial = <S extends ObjectShape>(shape: S): PartialShape<S> =>


### PR DESCRIPTION
## What

Adds `v.partial(shape)` to `@lunora/values` — every member of a shape wrapped in `v.optional(...)`.

```ts
mutation.input(v.partial(schema.tables.threads.shape)).mutation(…)

v.object(v.partial({ done: v.boolean(), title: v.string() }));
//        ^ { done?: boolean; title?: string }
```

## Why

A patch-style procedure takes "any subset of these columns" — the table's own shape with nothing required. Spelling that out by hand means a second copy of the shape that has to be kept in step with the first, and the failure mode when it drifts is quiet: a column added to the table is simply not accepted by the patch, nothing typechecks the copy against the original, and it surfaces as "why doesn't this field save".

## Design notes

- **Shape record in, shape record out** — not `v.partial(v.object(…))`. A procedure's `.input()` takes an args map, which *is* a shape record, so the record form serves both positions with one function; `v.object(v.partial(shape))` covers the nested case. The object-in/object-out form would need a second helper for args.
- **Idempotent.** A member that is already `v.optional(...)` is returned as-is rather than double-wrapped, so `v.partial(v.partial(x))` is `v.partial(x)` and the identity is observable (`shape.title === inner`, pinned in a test).
- **`Object.fromEntries`, not `out[key] = …`.** `fromEntries` uses `CreateDataPropertyOrThrow`, so a `__proto__` member round-trips as a plain key instead of invoking the `Object.prototype` accessor and vanishing. `v.object` rejects that field name at construction, but args maps do not go through `v.object`.
- No new `ValidatorKind` — the result is made of ordinary `optional` validators, so codegen, JSON Schema export, and the AOT validator path all handle it already.

## Scope

Additive. No existing export changes shape.

- `packages/values/src/v.ts` — `partial` + `PartialShape`, registered on the `v` namespace
- `packages/values/__tests__/v.test.ts` — 4 tests (runtime optionality, wrong-type still rejected, idempotence, and a compile-time check that every key infers optional)
- `packages/values/docs/index.mdx` — new `v.partial(shape)` section
- `api-snapshots/values.api.md` — regenerated after a full `build:packages`; one line

## Checks

- `pnpm --filter "@lunora/values" run test` — 177 passed
- `pnpm --filter "@lunora/values" run lint:types` — clean
- `pnpm --filter "@lunora/values" run lint:eslint` — clean
- `pnpm run api:update` after `pnpm run build:packages`; the only diff is the `partial` member


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `v.partial` for creating patch-style object validators with optional fields.
  * Supports nested object shapes, argument maps, and preserves fields that are already optional.
  * Exported the associated shape type for improved type support.

* **Documentation**
  * Added usage documentation and examples for `v.partial`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->